### PR TITLE
[FIX] html_builder, website: prevent invalid fields and show notification instead of tracebacks

### DIFF
--- a/addons/html_builder/static/src/core/save_plugin.js
+++ b/addons/html_builder/static/src/core/save_plugin.js
@@ -3,6 +3,7 @@ import { withSequence } from "@html_editor/utils/resource";
 import { groupBy } from "@web/core/utils/arrays";
 import { uniqueId } from "@web/core/utils/functions";
 import { isZWS } from "@html_editor/utils/dom_info";
+import { _t } from "@web/core/l10n/translation";
 
 /** @typedef {import("plugins").CSSSelector} CSSSelector */
 /**
@@ -95,6 +96,15 @@ export class SavePlugin extends Plugin {
             );
             await this._save(groupedElements);
             skipAfterSaveHandlers = await shouldSkipAfterSaveHandlers();
+        } catch (error) {
+            if (error.exceptionName === "odoo.exceptions.ValidationError") {
+                this.services.notification.add(_t("Previous values restored."), {
+                    title: _t("One or more fields were not valid"),
+                    type: "warning",
+                });
+            } else {
+                throw error;
+            }
         } finally {
             if (!skipAfterSaveHandlers) {
                 this.trigger("on_saved_handlers");

--- a/addons/html_builder/static/src/core/save_plugin.js
+++ b/addons/html_builder/static/src/core/save_plugin.js
@@ -2,6 +2,7 @@ import { Plugin } from "@html_editor/plugin";
 import { withSequence } from "@html_editor/utils/resource";
 import { groupBy } from "@web/core/utils/arrays";
 import { uniqueId } from "@web/core/utils/functions";
+import { isZWS } from "@html_editor/utils/dom_info";
 
 /** @typedef {import("plugins").CSSSelector} CSSSelector */
 /**
@@ -47,7 +48,19 @@ export class SavePlugin extends Plugin {
         // Do not change the sequence of this resource, it must stay the first
         // one to avoid marking dirty when not needed during the drag and drop.
         on_prepare_drag_handlers: withSequence(0, this.ignoreDirty.bind(this)),
+        on_will_save_handlers: this.removeZWSPFromEmbeddedFields.bind(this),
     };
+
+    removeZWSPFromEmbeddedFields(editableEl) {
+        // Remove zero-width spaces left by DeletePlugin.fillEmptyInlines on
+        // embedded fields to prevent saving blank model fields.
+        const selector = '[data-oe-model]:not([data-oe-model="ir.ui.view"])';
+        for (const el of editableEl.querySelectorAll(selector)) {
+            if (isZWS(el)) {
+                el.innerHTML = "";
+            }
+        }
+    }
 
     setup() {
         this.canObserve = false;

--- a/addons/website/static/tests/builder/save.test.js
+++ b/addons/website/static/tests/builder/save.test.js
@@ -9,6 +9,7 @@ import {
     models,
     onRpc,
     patchWithCleanup,
+    makeServerError,
 } from "@web/../tests/web_test_helpers";
 import { WebsiteBuilderClientAction } from "@website/client_actions/website_preview/website_builder_action";
 import {
@@ -597,4 +598,46 @@ test("Modifying an element inside '.o_not_editable' should not mark this element
     await contains(`:iframe .test`).click();
     await contains("[data-class-action='x']").click();
     expect(":iframe [data-oe-model='model']").not.toHaveClass("o_dirty");
+});
+
+test("Validation errors are caught on save", async () => {
+    onRpc("ir.ui.view", "save", () => {
+        throw makeServerError({
+            message: "A Validation Error",
+            type: "ValidationError",
+        });
+    });
+    const { getEditor } = await setupWebsiteBuilder(`
+        <h2 class="test-target">
+            <span>Text</span>
+        </h2>
+    `);
+    // Change the span text content and save
+    const el = queryOne(":iframe .test-target");
+    setSelection({ anchorNode: el.childNodes[0], anchorOffset: 1 });
+    await insertText(getEditor(), "x");
+    await contains(".o-snippets-top-actions button:contains(Save)").click();
+    expect(
+        ".o_notification_manager .o_notification_content:contains('One or more fields were not valid.')"
+    ).toHaveCount(1);
+});
+
+test("Errors different than validation errors are not caught on save", async () => {
+    expect.errors(1);
+    onRpc("ir.ui.view", "save", () => {
+        throw makeServerError({
+            message: "Not A Validation Error",
+        });
+    });
+    const { getEditor } = await setupWebsiteBuilder(`
+        <h2 class="test-target">
+            <span>Text</span>
+        </h2>
+    `);
+    // Change the span text content and save
+    const el = queryOne(":iframe .test-target");
+    setSelection({ anchorNode: el.childNodes[0], anchorOffset: 1 });
+    await insertText(getEditor(), "x");
+    await contains(".o-snippets-top-actions button:contains(Save)").click();
+    expect.verifyErrors(["RPC_ERROR: Not A Validation Error"]);
 });


### PR DESCRIPTION
This PR improves the handling of invalid field values in the website editor, particularly for event and product names.

Before this PR, deleting a name in pages such as “/event”, “/product”, “/blog”, or entering invalid values (e.g., wrong prices in “/shop”) could lead to inconsistent behavior.
1. Due to `DeletePlugin.fillEmptyInlines`, deleting a title left a zero-width space in the DOM. The backend considers a single zero-width space as a valid string, allowing apparently empty names to be saved without validation errors.
2. When actual validation errors occurred, saving triggered a traceback popup. After closing it, the editor remained open, valid changes were already saved, and “discard” did not properly restore the previous state.

This PR introduces two improvements:

1. Embedded fields consisting of a single zero-width space are converted to empty strings before save.
2. Validation errors during save now display a sticky warning notification instead of a traceback. The editor closes correctly, valid changes are preserved and invalid fields are restored to their original values.

task-5387282
