### PR TITLE
[FIX] html_editor: restore avatar alignment on list items

### DIFF
--- a/addons/html_editor/static/src/others/collaboration/collaboration_selection_avatar_plugin.js
+++ b/addons/html_editor/static/src/others/collaboration/collaboration_selection_avatar_plugin.js
@@ -1,5 +1,6 @@
 import { Plugin } from "@html_editor/plugin";
 import { closestBlock, isBlock } from "@html_editor/utils/blocks";
+import { isProtecting } from "@html_editor/utils/dom_info";
 import { closestElement } from "@html_editor/utils/dom_traversal";
 import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";
@@ -79,11 +80,18 @@ export class CollaborationSelectionAvatarPlugin extends Plugin {
         if (!anchorNode || !focusNode || !anchorNode.isConnected || !focusNode.isConnected) {
             return;
         }
-        const anchorBlock =
-            closestElement(anchorNode, (el) => isBlock(el) && el.parentElement === this.editable) ||
-            closestBlock(anchorNode);
+        let anchorBlock = closestBlock(anchorNode);
         if (!anchorBlock) {
             return;
+        }
+        if (isProtecting(anchorBlock)) {
+            const rootAnchorBlock = closestElement(
+                anchorNode,
+                (el) => isBlock(el) && el.parentElement === this.editable
+            );
+            if (rootAnchorBlock) {
+                anchorBlock = rootAnchorBlock;
+            }
         }
 
         const containerRect = this.avatarOverlay.getBoundingClientRect();


### PR DESCRIPTION
Since [1] when using collaboration, the position of the avatar for list items is always displayed on the first line - instead of following the user's focus.

This commit fixes this by only applying the patch of [1] when inside an embedded component.

Steps to reproduce:
- Go to a "To do" note
- Add a checked list with indented items
- Access the same note from another window
- Move around the checked list and observe avatar in other window

=> Avatar remained on first line while moving around list items

[1]: https://github.com/odoo/odoo/commit/9863cb25d6dfdba224897f21634bdaaf3eca91a7

task-5930388