### PR TITLE
[FIX] account: portal bill report no proforma

### DIFF
--- a/addons/account/controllers/portal.py
+++ b/addons/account/controllers/portal.py
@@ -143,8 +143,8 @@ class PortalAccount(CustomerPortal):
             return request.make_response(attachments.raw, list(headers.items()))
 
         elif report_type in ('html', 'pdf', 'text'):
-            has_generated_invoice = bool(invoice_sudo.invoice_pdf_report_id)
-            request.update_context(proforma_invoice=not has_generated_invoice)
+            proforma = not invoice_sudo.invoice_pdf_report_id and invoice_sudo.is_sale_document()
+            request.update_context(proforma_invoice=proforma)
             return self._show_report(model=invoice_sudo, report_type=report_type, report_ref='account.account_invoices', download=download)
 
         values = self._invoice_get_page_view_values(invoice_sudo, access_token, **kw)

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4724,10 +4724,11 @@ class AccountMove(models.Model):
         if self.invoice_pdf_report_id:
             attachments = self.env['account.move.send']._get_invoice_extra_attachments(self)
         else:
-            content, _ = self.env['ir.actions.report']._render('account.account_invoices', self.ids, data={'proforma': True})
+            proforma = self.is_sale_document(())
+            content, _ = self.env['ir.actions.report']._render('account.account_invoices', self.ids, data={'proforma': proforma})
             attachments = self.env['ir.attachment'].new({
                 'raw': content,
-                'name': self._get_invoice_proforma_pdf_report_filename(),
+                'name': self._get_invoice_proforma_pdf_report_filename() if proforma else self._get_invoice_report_filename(),
                 'mimetype': 'application/pdf',
                 'res_model': self._name,
                 'res_id': self.id,


### PR DESCRIPTION
When accessing to a bill via the portal, we display a proforma vendor
bill, same when we download from the portal, it should not be the case

Steps:

- Create and confirm a vendor bill
- Via the menu action, click on "Share" and copy the link
- Open the link
-> a proforma vendor bill is displayed
- Download the bill
-> we get a proforma vendor bill

Fix:

Allow proforma only for invoices/credit notes

opw-5882732
