### PR TITLE
[FIX] html_editor: avoid infinite loop when removing icon format

### DIFF
--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -13,6 +13,7 @@ import { fillEmpty, unwrapContents } from "@html_editor/utils/dom";
 import {
     isEmptyBlock,
     isEmptyTextNode,
+    isIconElement,
     isRedundantElement,
     isTextNode,
     isWhitespace,
@@ -184,6 +185,7 @@ export class ColorPlugin extends Plugin {
                         .filter(
                             (n) =>
                                 (isTextNode(n) ||
+                                    isIconElement(n) ||
                                     n.matches?.(`t, ${PROTECTED_QWEB_SELECTOR}`) ||
                                     (mode === "backgroundColor" &&
                                         n.classList.contains("o_selected_td"))) &&
@@ -290,7 +292,7 @@ export class ColorPlugin extends Plugin {
                     closestElement(node, "span") ||
                     closestElement(node, (node) => hasTextColorClass(node, mode));
 
-                const faNodes = font?.querySelectorAll(".fa");
+                const faNodes = font ? [...selectElements(font, ".fa")] : [];
                 if (faNodes && Array.from(faNodes).some((faNode) => faNode.contains(node))) {
                     return font;
                 }

--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -579,9 +579,9 @@ test("should be able to apply color on icon along with text", async () => {
             '<p>a[bc\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeffde]f</p>',
         stepFunction: setColor("rgb(255, 0, 0)", "color"),
         contentAfterEdit:
-            '<p>a<font style="color: rgb(255, 0, 0);">[bc</font><font style="color: rgb(255, 0, 0);">\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeff</font><font style="color: rgb(255, 0, 0);">de]</font>f</p>',
+            '<p>a<font style="color: rgb(255, 0, 0);">[bc</font>\ufeff<span class="fa fa-glass" contenteditable="false" style="color: rgb(255, 0, 0);">\u200b</span>\ufeff<font style="color: rgb(255, 0, 0);">de]</font>f</p>',
         contentAfter:
-            '<p>a<font style="color: rgb(255, 0, 0);">[bc</font><font style="color: rgb(255, 0, 0);"><span class="fa fa-glass"></span></font><font style="color: rgb(255, 0, 0);">de]</font>f</p>',
+            '<p>a<font style="color: rgb(255, 0, 0);">[bc</font><span class="fa fa-glass" style="color: rgb(255, 0, 0);"></span><font style="color: rgb(255, 0, 0);">de]</font>f</p>',
     });
 });
 

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -100,7 +100,7 @@ test("default opacity should get applied when applying background color to icon"
     await expectElementCount(".o-we-toolbar", 1);
     expect(".o_font_color_selector").toHaveCount(0); // selector closed
     expect(getContent(el)).toBe(
-        `<p><font style="background-color: rgba(255, 0, 0, 0.6);">[ab</font><font style="background-color: rgba(255, 0, 0, 0.6);">\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeff</font><font style="background-color: rgba(255, 0, 0, 0.6);">cd]</font></p>`
+        `<p><font style="background-color: rgba(255, 0, 0, 0.6);">[ab</font>\ufeff<span class="fa fa-glass" contenteditable="false" style="background-color: rgba(255, 0, 0, 0.6);">\u200b</span>\ufeff<font style="background-color: rgba(255, 0, 0, 0.6);">cd]</font></p>`
     );
 });
 

--- a/addons/html_editor/static/tests/format/remove_format.test.js
+++ b/addons/html_editor/static/tests/format/remove_format.test.js
@@ -977,3 +977,11 @@ describe("removeFormat must not remove non-style classes", () => {
         });
     }
 });
+
+test("should remove format on content with colored icon element", async () => {
+    const { el, editor } = await setupEditor(
+        '<p>[<i class="fa fa-user bg-o-color-1" contenteditable="false"></i>]</p>'
+    );
+    execCommand(editor, "removeFormat");
+    expect(el.querySelector("i.fa").classList.contains("bg-o-color-1")).toBe(false);
+});

--- a/addons/html_editor/static/tests/icon.test.js
+++ b/addons/html_editor/static/tests/icon.test.js
@@ -189,7 +189,7 @@ test("Can set icon color", async () => {
     await expectElementCount(".o-we-toolbar", 1);
     expect(".o_font_color_selector").toHaveCount(0); // selector closed
     expect(getContent(el)).toBe(
-        `<p>[<font style="color: rgb(107, 173, 222);">\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeff</font>]</p>`
+        `<p>\ufeff[<span class="fa fa-glass" contenteditable="false" style="color: rgb(107, 173, 222);">\u200b</span>]\ufeff</p>`
     );
 });
 


### PR DESCRIPTION
Steps to reproduce:
===================
1. Open the To-do app and pick any task.
2. In the description add text and an icon with a bg color.
`(you can add this: <i class="fa rounded rounded-circle fa-user
bg-o-color-1 fa-4x" contenteditable="false">​</i>)`
3. Select all and click "Remove format".

Result:
-> Traceback due to an infinite loop.

Cause:
======
Remove format calls `removeAllColor()`, which loops forever at:
https://github.com/odoo/odoo/blob/626bde21a25366d0bb29662bae2057c247a1638e/addons/html_editor/static/src/main/font/color_plugin.js#L194-L194

Why:
_applyColor doesn't remove the icon's background class, so
hasAnySelectedNodeColor keeps returning true and the removal loop
never terminates.
This happens because `font` is already the `<i>` element with the `fa`
class, using `querySelectorAll` on it won't include the element itself,
so the icon is never checked or updated.
https://github.com/odoo/odoo/blob/6cdc6f55886ea48e90f9023a6c6142bf072745b9/addons/html_editor/static/src/main/font/color_plugin.js#L290

Solution:
=========
Check if the font itself has the fa class before doing the
`querySelectorAll`, and include it in the nodes to check for color.

Test Impact:
============
Before this fix, a `<span>` containing an icon was wrapped in a `<font>`
when applying color, treating the icon as a normal span (without size)
instead of applying the color directly.
https://github.com/odoo/odoo/blob/8792c2d38eb0aadac8d778d83fd76f270404ecd5/addons/html_editor/static/src/main/font/color_plugin.js#L397

opw-5928627