### PR TITLE
[FIX] web: x2many: prevent crash with many create

### DIFF
--- a/addons/web/static/src/model/relational_model/static_list.js
+++ b/addons/web/static/src/model/relational_model/static_list.js
@@ -477,7 +477,7 @@ export class StaticList extends DataPoint {
                     const record = this._createRecordDatapoint(command[2], { virtualId });
                     this.records.push(record);
                     addOwnCommand([CREATE, virtualId]);
-                    const index = this.offset + this.limit + this._tmpIncreaseLimit;
+                    const index = this.offset + this.limit;
                     this._currentIds.splice(index, 0, virtualId);
                     this._tmpIncreaseLimit = Math.max(this.records.length - this.limit, 0);
                     const nextLimit = this.limit + this._tmpIncreaseLimit;

--- a/addons/web/static/tests/views/fields/one2many_field.test.js
+++ b/addons/web/static/tests/views/fields/one2many_field.test.js
@@ -11982,6 +11982,70 @@ test("new record, receive more create commands than limit", async () => {
     expect(".o_x2m_control_panel .o_pager").toHaveCount(0);
 });
 
+test("existing record: receive more create commands than limit", async () => {
+    Partner._records = [
+        { id: 1, name: "Initial Record 1", p: [1, 2, 3, 4] },
+        { id: 2, name: "Initial Record 2" },
+        { id: 3, name: "Initial Record 3" },
+        { id: 4, name: "Initial Record 4" },
+    ]
+    Partner._onChanges = {
+        int_field: function (obj) {
+            if (obj.int_field === 16) {
+                obj.p = [
+                    [0, 0, { display_name: "Record 1" }],
+                    [0, 0, { display_name: "Record 2" }],
+                    [0, 0, { display_name: "Record 3" }],
+                    [0, 0, { display_name: "Record 4" }],
+                ];
+            }
+        },
+    };
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `
+            <form>
+                <field name="int_field"/>
+                <group>
+                    <field name="p">
+                        <list limit="2">
+                            <field name="display_name"/>
+                        </list>
+                    </field>
+                </group>
+            </form>`,
+    });
+
+    expect(queryAllTexts(".o_data_cell.o_list_char")).toEqual([
+        "Initial Record 1",
+        "Initial Record 2",
+    ]);
+
+    await contains("[name=int_field] input").edit("16", { confirm: "blur" });
+
+    expect(queryAllTexts(".o_data_cell.o_list_char")).toEqual([
+        "Initial Record 1",
+        "Initial Record 2",
+        "Record 1",
+        "Record 2",
+        "Record 3",
+        "Record 4",
+    ]);
+
+    await contains(".o_data_row :text('Record 3') ~ .o_list_record_remove").click();
+
+    expect(queryAllTexts(".o_data_cell.o_list_char")).toEqual([
+        "Initial Record 1",
+        "Initial Record 2",
+        "Record 1",
+        "Record 2",
+        "Record 4",
+        "Initial Record 3",
+    ]);
+});
+
 test("active actions are passed to o2m field", async () => {
     Partner._records[0].turtles = [1, 2, 3];
 


### PR DESCRIPTION
Steps to reproduce
==================

- Edit the Vendor Bill form view to set a limit of 2 on the invoice_line_ids field.
- Create 2 purchase orders with the same vendor and 4 products
- Create a vendor bill
- Set the same vendor
- Using the autocomplete field, select the first purchase order
- Save the form
- Select the other purchase order in the autocomplete field
- Delete the record before the last one

=> Got duplicate key in t-foreach: datapoint_12

Cause of the issue
==================

Before inserting the last 4 lines:
`this._currentIds = [1, 2, 3, 4]`

After the second insert, we have
`this._currentIds = [1, 2, virtual_1, 3, virtual 2, virtual_3, virtual_4, 4]`

Only the first record is inserted at the correct place, following ones are off by one.

opw-5264594