### PR TITLE
[FIX] html_editor: map alignments also in opposite direction from user

### DIFF
--- a/addons/html_editor/static/tests/align.test.js
+++ b/addons/html_editor/static/tests/align.test.js
@@ -158,6 +158,16 @@ describe("start", () => {
                 '<div contenteditable="true" style="text-align: center;"><h1 style="text-align: start;">a[]b</h1></div>',
         });
     });
+
+    test("should END align an RTL container within an editable that is center-aligned", async () => {
+        await testEditor({
+            contentBefore:
+                '<div contenteditable="true" style="text-align: center;"><h1 dir="rtl">a[]b</h1></div>',
+            stepFunction: alignStart,
+            contentAfter:
+                '<div contenteditable="true" style="text-align: center;"><h1 dir="rtl" style="text-align: end;">a[]b</h1></div>',
+        });
+    });
 });
 
 describe("center", () => {
@@ -373,6 +383,16 @@ describe("end", () => {
             stepFunction: alignEnd,
             contentAfter:
                 '<div contenteditable="true" style="text-align: center;"><h1 style="text-align: end;">a[]b</h1></div>',
+        });
+    });
+
+    test("should START align an RTL container within an editable that is center-aligned", async () => {
+        await testEditor({
+            contentBefore:
+                '<div contenteditable="true" style="text-align: center;"><h1 dir="rtl">a[]b</h1></div>',
+            stepFunction: alignEnd,
+            contentAfter:
+                '<div contenteditable="true" style="text-align: center;"><h1 dir="rtl" style="text-align: start;">a[]b</h1></div>',
         });
     });
 });


### PR DESCRIPTION
When adapting the text alignment to better support RTL in [1], a specific scenario was missed: when the logged in user is in the opposite RTL/LTR direction from the edited content.

In that case, the UI of the toolbar follows the user's language, but it is counter-intuitive that the "align left" icon actually always aligns to the `start`. Typically, if you select several paragraphs that have various directions, then click on the icon, you want the correct `start` or `end` to be chosen by paragraph.

This commit fixes this by swapping alignments when the user's direction is different from the edited block's direction. This swap needs to be done when converting the DOM style value to the selected icon, and when applying the change when clicking on the icon.

Steps to reproduce:
- Install an RTL language, but keep the user in English
- Go to a "To do" note
- Enter some alphabetical text
- Enter some RTL text in another paragraph (if needed, use `/switch`)
- Select all
- Align to left / Align to right

=> The RTL paragraph was put on the wrong side.

[1]: https://github.com/odoo/odoo/commit/f27ec8b59ede1413f42eda132f71f5531f4d45e3

task-5933243
