### PR TITLE
[FIX] pos_event: use pricelist for event tickets in pos

### DIFF
--- a/addons/pos_event/static/src/app/models/pos_order.js
+++ b/addons/pos_event/static/src/app/models/pos_order.js
@@ -6,8 +6,4 @@ patch(PosOrder.prototype, {
     get eventRegistrations() {
         return this.lines.flatMap((line) => line.event_registration_ids);
     },
-    getLinesToCompute() {
-        // Override to ensure orderline price of event tickets are not recomputed
-        return super.getLinesToCompute().filter((line) => !line.event_ticket_id);
-    },
 });

--- a/addons/pos_event/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/pos_event/static/src/app/screens/product_screen/product_screen.js
@@ -188,10 +188,19 @@ patch(ProductScreen.prototype, {
 
         for (const [ticketId, data] of Object.entries(result.byRegistration)) {
             const ticket = this.pos.models["event.event.ticket"].get(parseInt(ticketId));
+            const priceExtra = ticket.price - ticket.product_id.lst_price;
+            const priceUnit = ticket.product_id.getPrice(
+                this.pos.getOrder().pricelist_id,
+                1,
+                priceExtra,
+                false,
+                ticket.product_id
+            );
             const line = await this.pos.addLineToCurrentOrder({
                 product_id: ticket.product_id,
                 product_tmpl_id: ticket.product_id.product_tmpl_id,
-                price_unit: ticket.price,
+                price_unit: priceUnit,
+                price_extra: priceExtra,
                 price_type: "original",
                 qty: data.length,
                 event_ticket_id: ticket,

--- a/addons/pos_event/static/tests/tours/pos_event_tour.js
+++ b/addons/pos_event/static/tests/tours/pos_event_tour.js
@@ -62,6 +62,32 @@ registry.category("web_tour.tours").add("SellingEventInPosWithChoiceAnswers", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("CheckEventTicketPrice", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("My Awesome Event"),
+            EventTourUtils.increaseQuantityOfTicket("Ticket VIP"),
+            Dialog.confirm(),
+            EventTourUtils.answerTicketSelectQuestion("1", "Question1", "Q1-Answer1"),
+            EventTourUtils.answerGlobalSelectQuestion("Question2", "Q2-Answer1"),
+            Dialog.confirm(),
+            ProductScreen.totalAmountIs("200.00"),
+            ProductScreen.clickPriceList("Special Pricelist"),
+            ProductScreen.totalAmountIs("120.00"),
+            ProductScreen.clickDisplayedProduct("My Awesome Event"),
+            EventTourUtils.increaseQuantityOfTicket("Ticket VIP"),
+            Dialog.confirm(),
+            EventTourUtils.answerTicketSelectQuestion("1", "Question1", "Q1-Answer1"),
+            EventTourUtils.answerGlobalSelectQuestion("Question2", "Q2-Answer1"),
+            Dialog.confirm(),
+            ProductScreen.totalAmountIs("240.00"),
+            ProductScreen.clickPriceList("Test Pricelist"),
+            ProductScreen.totalAmountIs("400.00"),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("test_selling_multiple_ticket_saved", {
     steps: () =>
         [

--- a/addons/pos_event/tests/test_frontend.py
+++ b/addons/pos_event/tests/test_frontend.py
@@ -140,6 +140,37 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.assertEqual(len(event_registration.registration_answer_ids), 3)
         self.assertEqual(event_answer_name, ['Q1-Answer1', 'Q2-Answer1', 'Q3-Answer1'])
 
+    def test_event_pricelist_pos(self):
+        self.pos_user.write({
+            'group_ids': [
+                (4, self.env.ref('event.group_event_user').id),
+            ]
+        })
+        self.main_pos_config.write({
+            "limit_categories": True,
+            "iface_available_categ_ids": [(6, 0, [self.event_category.id])],
+        })
+        self.event_ticket_product = self.test_event.event_ticket_ids[0].product_id
+        self.special_pricelist = self.env['product.pricelist'].create({
+            'name': 'Special Pricelist',
+            'item_ids': [Command.create({
+                'compute_price': 'fixed',
+                'applied_on': '1_product',
+                'fixed_price': 120,
+                'product_id': self.event_ticket_product.id,
+            })],
+        })
+        self.event_ticket_product.product_tmpl_id.write({
+            'list_price': 50,
+        })
+
+        self.main_pos_config.write({
+            'pricelist_id': self.pricelist,
+            'available_pricelist_ids': [(6, 0, [self.pricelist.id, self.special_pricelist.id])],
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'CheckEventTicketPrice', login="pos_user")
+
     def test_selling_multislot_event_in_pos(self):
         self.pos_user.write({
             'group_ids': [
@@ -222,7 +253,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'iface_available_categ_ids': [(6, 0, [self.event_category.id])],
         })
         self.env['res.partner'].search([('name', '=', 'Partner Test 1')]).write({
-            'property_product_pricelist': self.main_pos_config.available_pricelist_ids.filtered(lambda pl: pl.item_ids)[0],
+            'property_product_pricelist': self.main_pos_config.available_pricelist_ids.filtered(lambda pl: pl.item_ids)[1],
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_orderline_price_remain_same_as_ticket_price')


### PR DESCRIPTION
Event tickets in POS would have their price locked to the price defined in the event itself. They would be filtered out of any price recalculation inside the POS to keep the POS from recalculating the price based on the `product_template` and to keep the price defined in the event itself.

This PR will add event tickets back into price recalculation. It will set the price to the price defined inside the event if no pricelist is applicable, or use the pricelist to calculate the price if there is one applicable.

Task-[5092613](https://www.odoo.com/odoo/project/1737/tasks/5092613)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
