### PR TITLE
[FIX] account: disallow untrusted accounts on is_inbound() invoices + log bank account

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -800,10 +800,9 @@ class AccountMove(models.Model):
     @api.depends('bank_partner_id')
     def _compute_partner_bank_id(self):
         for move in self:
-            # This will get the trusted bank accounts from the partner
             bank_ids = move.bank_partner_id.bank_ids.filtered(
-                lambda bank: (not bank.company_id or bank.company_id == move.company_id) and bank.allow_out_payment)
-            move.partner_bank_id = bank_ids[:1]
+                lambda bank: not bank.company_id or bank.company_id == move.company_id)
+            move.partner_bank_id = bank_ids[0] if bank_ids else False
 
     @api.depends('partner_id')
     def _compute_invoice_payment_term_id(self):
@@ -3546,10 +3545,6 @@ class AccountMove(models.Model):
                 raise UserError(_(
                     "The recipient bank account linked to this invoice is archived.\n"
                     "So you cannot confirm the invoice."
-                ))
-            if invoice.partner_bank_id and invoice.is_inbound() and not invoice.partner_bank_id.allow_out_payment:
-                raise UserError(_(
-                    "The company bank account linked to this invoice is not trusted, please double-check and trust it before confirming, or remove it"
                 ))
             if float_compare(invoice.amount_total, 0.0, precision_rounding=invoice.currency_id.rounding) < 0:
                 raise UserError(_(

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -800,9 +800,10 @@ class AccountMove(models.Model):
     @api.depends('bank_partner_id')
     def _compute_partner_bank_id(self):
         for move in self:
+            # This will get the trusted bank accounts from the partner
             bank_ids = move.bank_partner_id.bank_ids.filtered(
-                lambda bank: not bank.company_id or bank.company_id == move.company_id)
-            move.partner_bank_id = bank_ids[0] if bank_ids else False
+                lambda bank: (not bank.company_id or bank.company_id == move.company_id) and bank.allow_out_payment)
+            move.partner_bank_id = bank_ids[:1]
 
     @api.depends('partner_id')
     def _compute_invoice_payment_term_id(self):
@@ -3545,6 +3546,10 @@ class AccountMove(models.Model):
                 raise UserError(_(
                     "The recipient bank account linked to this invoice is archived.\n"
                     "So you cannot confirm the invoice."
+                ))
+            if invoice.partner_bank_id and invoice.is_inbound() and not invoice.partner_bank_id.allow_out_payment:
+                raise UserError(_(
+                    "The company bank account linked to this invoice is not trusted, please double-check and trust it before confirming, or remove it"
                 ))
             if float_compare(invoice.amount_total, 0.0, precision_rounding=invoice.currency_id.rounding) < 0:
                 raise UserError(_(

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1150,6 +1150,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         bank1 = self.env['res.partner.bank'].create({
             'acc_number': 'BE43798822936101',
             'partner_id': self.company_data['company'].partner_id.id,
+            'allow_out_payment': True,
         })
 
         move_reversal = self.env['account.move.reversal'].with_context(active_model="account.move", active_ids=self.invoice.ids).create({

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1150,7 +1150,6 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
         bank1 = self.env['res.partner.bank'].create({
             'acc_number': 'BE43798822936101',
             'partner_id': self.company_data['company'].partner_id.id,
-            'allow_out_payment': True,
         })
 
         move_reversal = self.env['account.move.reversal'].with_context(active_model="account.move", active_ids=self.invoice.ids).create({

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -1794,7 +1794,6 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         bank1 = self.env['res.partner.bank'].create({
             'acc_number': 'BE43798822936101',
             'partner_id': self.partner_a.id,
-            "allow_out_payment": True,
         })
 
         move_reversal = self.env['account.move.reversal'].with_context(active_model="account.move", active_ids=self.invoice.ids).create({
@@ -4237,13 +4236,11 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             "bank_name": "FAKE",
             "acc_number": "1234567890",
             "partner_id": company_1.partner_id.id,
-            "allow_out_payment": True,
         })
         bank_2 = self.env["res.partner.bank"].create({
             "bank_name": "FAKE 2",
             "acc_number": "1234567890",
             "partner_id": company_2.partner_id.id,
-            "allow_out_payment": True,
         })
         invoice_new = self.env["account.move"].with_context(default_move_type="out_invoice").new({
             "company_id": company_1.id,

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -1794,6 +1794,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         bank1 = self.env['res.partner.bank'].create({
             'acc_number': 'BE43798822936101',
             'partner_id': self.partner_a.id,
+            "allow_out_payment": True,
         })
 
         move_reversal = self.env['account.move.reversal'].with_context(active_model="account.move", active_ids=self.invoice.ids).create({
@@ -4236,11 +4237,13 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             "bank_name": "FAKE",
             "acc_number": "1234567890",
             "partner_id": company_1.partner_id.id,
+            "allow_out_payment": True,
         })
         bank_2 = self.env["res.partner.bank"].create({
             "bank_name": "FAKE 2",
             "acc_number": "1234567890",
             "partner_id": company_2.partner_id.id,
+            "allow_out_payment": True,
         })
         invoice_new = self.env["account.move"].with_context(default_move_type="out_invoice").new({
             "company_id": company_1.id,

--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -1199,7 +1199,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         active_ids = (invoice_1 + invoice_2 + refund_1 + refund_2).ids
         payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
             'group_payment': False,
-        })._create_payments()
+        })._create_payments().sorted('ref')
 
         self.assertRecordValues(payments[0], [
             {

--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -1199,7 +1199,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         active_ids = (invoice_1 + invoice_2 + refund_1 + refund_2).ids
         payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
             'group_payment': False,
-        })._create_payments().sorted('ref')
+        })._create_payments()
 
         self.assertRecordValues(payments[0], [
             {

--- a/addons/account/wizard/account_move_reversal.py
+++ b/addons/account/wizard/account_move_reversal.py
@@ -115,21 +115,10 @@ class AccountMoveReversal(models.TransientModel):
         moves = self.move_ids
 
         # Create default values.
-        partners = moves.company_id.partner_id + moves.commercial_partner_id
-
-        bank_ids = self.env['res.partner.bank'].search([
-            ('partner_id', 'in', partners.ids),
-            ('company_id', 'in', moves.company_id.ids + [False]),
-        ], order='sequence DESC')
-        partner_to_bank = {bank.partner_id: bank for bank in bank_ids}
         default_values_list = []
         for move in moves:
-            if move.is_outbound():
-                partner = move.company_id.partner_id
-            else:
-                partner = move.commercial_partner_id
             default_values_list.append({
-                'partner_bank_id': partner_to_bank.get(partner, self.env['res.partner.bank']).id,
+                'partner_bank_id': False,  # Resets the partner_bank_id as we'll force its recomputation
                 **self._prepare_default_reversal(move),
             })
 
@@ -148,12 +137,14 @@ class AccountMoveReversal(models.TransientModel):
         moves_to_redirect = self.env['account.move']
         for moves, default_values_list, is_cancel_needed in batches:
             new_moves = moves._reverse_moves(default_values_list, cancel=is_cancel_needed)
+            new_moves._compute_partner_bank_id()
 
             if self.refund_method == 'modify':
                 moves_vals_list = []
                 for move in moves.with_context(include_business_fields=True):
                     moves_vals_list.append(move.copy_data({'date': self.date if self.date_mode == 'custom' else move.date})[0])
                 new_moves = self.env['account.move'].create(moves_vals_list)
+                new_moves._compute_partner_bank_id()
 
             moves_to_redirect |= new_moves
 

--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -351,44 +351,9 @@ class AccountEdiCommon(models.AbstractModel):
                 invoice.partner_id.vat = vat
 
     def _import_retrieve_and_fill_partner_bank_details(self, invoice, bank_details):
-        """ Retrieve the bank account, if no matching bank account is found, create it
-        """
-
-        # clear the context, because creation of partner when importing should not depend on the context default values
-        ResPartnerBank = self.env['res.partner.bank'].with_env(self.env(context=clean_context(self.env.context)))
-        bank_details = list(map(sanitize_account_number, bank_details))
-
-        if invoice.move_type in ('out_refund', 'in_invoice'):
-            partner = invoice.partner_id
-        elif invoice.move_type in ('out_invoice', 'in_refund'):
-            partner = self.env.company.partner_id
-        else:
-            return
-
-        banks_to_create = []
-        acc_number_partner_bank_dict = {
-            bank.sanitized_acc_number: bank
-            for bank in ResPartnerBank.with_context(active_test=False).search(
-                [('company_id', 'in', [False, invoice.company_id.id]), ('acc_number', 'in', bank_details)]
-            )
-        }
-
-        for account_number in bank_details:
-            partner_bank = acc_number_partner_bank_dict.get(account_number, ResPartnerBank)
-
-            if partner_bank.partner_id == partner:
-                if not partner_bank.active:
-                    partner_bank.active = True
-                invoice.partner_bank_id = partner_bank
-                return
-            elif not partner_bank and account_number:
-                banks_to_create.append({
-                    'acc_number': account_number,
-                    'partner_id': partner.id,
-                })
-
-        if banks_to_create:
-            invoice.partner_bank_id = ResPartnerBank.create(banks_to_create)[0]
+        """ Log the bank account numbers"""
+        body = _("The following bank account numbers got retrieved during the import : %s", ", ".join(bank_details))
+        invoice.with_context(no_new_invoice=True).message_post(body=body)
 
     def _import_fill_invoice_allowance_charge(self, tree, invoice, journal, qty_factor):
         logs = []

--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -351,9 +351,44 @@ class AccountEdiCommon(models.AbstractModel):
                 invoice.partner_id.vat = vat
 
     def _import_retrieve_and_fill_partner_bank_details(self, invoice, bank_details):
-        """ Log the bank account numbers"""
-        body = _("The following bank account numbers got retrieved during the import : %s", ", ".join(bank_details))
-        invoice.with_context(no_new_invoice=True).message_post(body=body)
+        """ Retrieve the bank account, if no matching bank account is found, create it
+        """
+
+        # clear the context, because creation of partner when importing should not depend on the context default values
+        ResPartnerBank = self.env['res.partner.bank'].with_env(self.env(context=clean_context(self.env.context)))
+        bank_details = list(map(sanitize_account_number, bank_details))
+
+        if invoice.move_type in ('out_refund', 'in_invoice'):
+            partner = invoice.partner_id
+        elif invoice.move_type in ('out_invoice', 'in_refund'):
+            partner = self.env.company.partner_id
+        else:
+            return
+
+        banks_to_create = []
+        acc_number_partner_bank_dict = {
+            bank.sanitized_acc_number: bank
+            for bank in ResPartnerBank.with_context(active_test=False).search(
+                [('company_id', 'in', [False, invoice.company_id.id]), ('acc_number', 'in', bank_details)]
+            )
+        }
+
+        for account_number in bank_details:
+            partner_bank = acc_number_partner_bank_dict.get(account_number, ResPartnerBank)
+
+            if partner_bank.partner_id == partner:
+                if not partner_bank.active:
+                    partner_bank.active = True
+                invoice.partner_bank_id = partner_bank
+                return
+            elif not partner_bank and account_number:
+                banks_to_create.append({
+                    'acc_number': account_number,
+                    'partner_id': partner.id,
+                })
+
+        if banks_to_create:
+            invoice.partner_bank_id = ResPartnerBank.create(banks_to_create)[0]
 
     def _import_fill_invoice_allowance_charge(self, tree, invoice, journal, qty_factor):
         logs = []

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
@@ -272,6 +272,8 @@ class AccountEdiXmlCII(models.AbstractModel):
             bank_detail_node.findtext('{*}PayeePartyCreditorFinancialAccount/{*}IBANID')
             or bank_detail_node.findtext('{*}PayeePartyCreditorFinancialAccount/{*}ProprietaryID')
             for bank_detail_node in bank_detail_nodes
+            if bank_detail_node.findtext('{*}PayeePartyCreditorFinancialAccount/{*}IBANID')
+            or bank_detail_node.findtext('{*}PayeePartyCreditorFinancialAccount/{*}ProprietaryID')
         ]
 
         if bank_details:

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -652,7 +652,11 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         # ==== Bank Details ====
 
         bank_detail_nodes = tree.findall('.//{*}PaymentMeans')
-        bank_details = [bank_detail_node.findtext('{*}PayeeFinancialAccount/{*}ID') for bank_detail_node in bank_detail_nodes]
+        bank_details = [
+            bank_detail_node.findtext('{*}PayeeFinancialAccount/{*}ID')
+            for bank_detail_node in bank_detail_nodes
+            if bank_detail_node.findtext('{*}PayeeFinancialAccount/{*}ID')
+        ]
 
         if bank_details:
             self._import_retrieve_and_fill_partner_bank_details(invoice, bank_details=bank_details)

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -207,3 +207,20 @@ class TestAccountEdiUblCii(AccountTestInvoicingCommon):
             'quantity': 1.0,
             'tax_ids': self.env['account.tax'],
         }])
+
+    def test_bank_details_import(self):
+        acc_number = '1234567890'
+        partner_bank = self.env['res.partner.bank'].create({
+            'active': False,
+            'acc_number': acc_number,
+            'partner_id': self.partner_a.id
+        })
+        invoice = self.env['account.move'].create({
+            'partner_id': self.partner_a.id,
+            'move_type': 'in_invoice',
+            'invoice_line_ids': [Command.create({'product_id': self.product_a.id})],
+        })
+        # will not raise sql constraint because the sql is not commited yet
+        self.env['account.edi.common']._import_retrieve_and_fill_partner_bank_details(invoice, [acc_number])
+        self.assertEqual(invoice.partner_bank_id, partner_bank, "Partner bank must be the same")
+        self.assertTrue(partner_bank.active, "Partner bank must be the activated")

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -207,20 +207,3 @@ class TestAccountEdiUblCii(AccountTestInvoicingCommon):
             'quantity': 1.0,
             'tax_ids': self.env['account.tax'],
         }])
-
-    def test_bank_details_import(self):
-        acc_number = '1234567890'
-        partner_bank = self.env['res.partner.bank'].create({
-            'active': False,
-            'acc_number': acc_number,
-            'partner_id': self.partner_a.id
-        })
-        invoice = self.env['account.move'].create({
-            'partner_id': self.partner_a.id,
-            'move_type': 'in_invoice',
-            'invoice_line_ids': [Command.create({'product_id': self.product_a.id})],
-        })
-        # will not raise sql constraint because the sql is not commited yet
-        self.env['account.edi.common']._import_retrieve_and_fill_partner_bank_details(invoice, [acc_number])
-        self.assertEqual(invoice.partner_bank_id, partner_bank, "Partner bank must be the same")
-        self.assertTrue(partner_bank.active, "Partner bank must be the activated")

--- a/addons/account_qr_code_sepa/tests/test_sepa_qr.py
+++ b/addons/account_qr_code_sepa/tests/test_sepa_qr.py
@@ -18,7 +18,6 @@ class TestSEPAQRCode(AccountTestInvoicingCommon):
         cls.acc_sepa_iban = cls.env['res.partner.bank'].create({
             'acc_number': 'BE15001559627230',
             'partner_id': cls.company_data['company'].partner_id.id,
-            'allow_out_payment': True,
         })
 
         cls.acc_non_sepa_iban = cls.env['res.partner.bank'].create({

--- a/addons/account_qr_code_sepa/tests/test_sepa_qr.py
+++ b/addons/account_qr_code_sepa/tests/test_sepa_qr.py
@@ -18,6 +18,7 @@ class TestSEPAQRCode(AccountTestInvoicingCommon):
         cls.acc_sepa_iban = cls.env['res.partner.bank'].create({
             'acc_number': 'BE15001559627230',
             'partner_id': cls.company_data['company'].partner_id.id,
+            'allow_out_payment': True,
         })
 
         cls.acc_non_sepa_iban = cls.env['res.partner.bank'].create({

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_cii_fr.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_cii_fr.py
@@ -20,7 +20,7 @@ class TestCIIFR(TestUBLCommon):
             'city': "Paris",
             'vat': 'FR05677404089',
             'country_id': cls.env.ref('base.fr').id,
-            'bank_ids': [(0, 0, {'acc_number': 'FR15001559627230', 'allow_out_payment': True})],
+            'bank_ids': [(0, 0, {'acc_number': 'FR15001559627230'})],
             'phone': '+1 (650) 555-0111',
             'email': "partner1@yourcompany.com",
             'ref': 'ref_partner_1',
@@ -33,7 +33,7 @@ class TestCIIFR(TestUBLCommon):
             'city': "Colombey-les-Deux-Églises",
             'vat': 'FR35562153452',
             'country_id': cls.env.ref('base.fr').id,
-            'bank_ids': [(0, 0, {'acc_number': 'FR90735788866632', 'allow_out_payment': True})],
+            'bank_ids': [(0, 0, {'acc_number': 'FR90735788866632'})],
             'ref': 'ref_partner_2',
         })
 
@@ -120,7 +120,6 @@ class TestCIIFR(TestUBLCommon):
         acc_bank = self.env['res.partner.bank'].create({
             'acc_number': 'FR15001559627231',
             'partner_id': self.company_data['company'].partner_id.id,
-            'allow_out_payment': True,
         })
         invoice = self.env['account.move'].create({
             'move_type': 'out_invoice',

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_cii_fr.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_cii_fr.py
@@ -20,7 +20,7 @@ class TestCIIFR(TestUBLCommon):
             'city': "Paris",
             'vat': 'FR05677404089',
             'country_id': cls.env.ref('base.fr').id,
-            'bank_ids': [(0, 0, {'acc_number': 'FR15001559627230'})],
+            'bank_ids': [(0, 0, {'acc_number': 'FR15001559627230', 'allow_out_payment': True})],
             'phone': '+1 (650) 555-0111',
             'email': "partner1@yourcompany.com",
             'ref': 'ref_partner_1',
@@ -33,7 +33,7 @@ class TestCIIFR(TestUBLCommon):
             'city': "Colombey-les-Deux-Églises",
             'vat': 'FR35562153452',
             'country_id': cls.env.ref('base.fr').id,
-            'bank_ids': [(0, 0, {'acc_number': 'FR90735788866632'})],
+            'bank_ids': [(0, 0, {'acc_number': 'FR90735788866632', 'allow_out_payment': True})],
             'ref': 'ref_partner_2',
         })
 
@@ -120,6 +120,7 @@ class TestCIIFR(TestUBLCommon):
         acc_bank = self.env['res.partner.bank'].create({
             'acc_number': 'FR15001559627231',
             'partner_id': self.company_data['company'].partner_id.id,
+            'allow_out_payment': True,
         })
         invoice = self.env['account.move'].create({
             'move_type': 'out_invoice',

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_au.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_au.py
@@ -22,7 +22,7 @@ class TestUBLAU(TestUBLCommon):
             'phone': '+31 180 6 225789',
             'email': 'info@outlook.au',
             'country_id': cls.env.ref('base.au').id,
-            'bank_ids': [(0, 0, {'acc_number': '000099998B57', 'allow_out_payment': True})],
+            'bank_ids': [(0, 0, {'acc_number': '000099998B57'})],
             'ref': 'ref_partner_1',
         })
 
@@ -33,7 +33,7 @@ class TestUBLAU(TestUBLCommon):
             'city': "Canberra",
             'vat': '53 930 548 027',
             'country_id': cls.env.ref('base.au').id,
-            'bank_ids': [(0, 0, {'acc_number': '93999574162167', 'allow_out_payment': True})],
+            'bank_ids': [(0, 0, {'acc_number': '93999574162167'})],
             'ref': 'ref_partner_2',
         })
 

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_au.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_au.py
@@ -22,7 +22,7 @@ class TestUBLAU(TestUBLCommon):
             'phone': '+31 180 6 225789',
             'email': 'info@outlook.au',
             'country_id': cls.env.ref('base.au').id,
-            'bank_ids': [(0, 0, {'acc_number': '000099998B57'})],
+            'bank_ids': [(0, 0, {'acc_number': '000099998B57', 'allow_out_payment': True})],
             'ref': 'ref_partner_1',
         })
 
@@ -33,7 +33,7 @@ class TestUBLAU(TestUBLCommon):
             'city': "Canberra",
             'vat': '53 930 548 027',
             'country_id': cls.env.ref('base.au').id,
-            'bank_ids': [(0, 0, {'acc_number': '93999574162167'})],
+            'bank_ids': [(0, 0, {'acc_number': '93999574162167', 'allow_out_payment': True})],
             'ref': 'ref_partner_2',
         })
 

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
@@ -25,7 +25,7 @@ class TestUBLBE(TestUBLCommon):
             'city': "Ramillies",
             'vat': 'BE0202239951',
             'country_id': cls.env.ref('base.be').id,
-            'bank_ids': [(0, 0, {'acc_number': 'BE15001559627230'})],
+            'bank_ids': [(0, 0, {'acc_number': 'BE15001559627230', 'allow_out_payment': True})],
             'ref': 'ref_partner_1',
         })
 
@@ -37,7 +37,7 @@ class TestUBLBE(TestUBLCommon):
             'city': "Ramillies",
             'vat': 'BE0477472701',
             'country_id': cls.env.ref('base.be').id,
-            'bank_ids': [(0, 0, {'acc_number': 'BE90735788866632'})],
+            'bank_ids': [(0, 0, {'acc_number': 'BE90735788866632', 'allow_out_payment': True})],
             'ref': 'ref_partner_2',
         })
 
@@ -93,6 +93,7 @@ class TestUBLBE(TestUBLCommon):
         cls.acc_bank = cls.env['res.partner.bank'].create({
             'acc_number': 'BE15001559627231',
             'partner_id': cls.company_data['company'].partner_id.id,
+            'allow_out_payment': True,
         })
 
         cls.invoice = cls.env['account.move'].create({

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
@@ -25,7 +25,7 @@ class TestUBLBE(TestUBLCommon):
             'city': "Ramillies",
             'vat': 'BE0202239951',
             'country_id': cls.env.ref('base.be').id,
-            'bank_ids': [(0, 0, {'acc_number': 'BE15001559627230', 'allow_out_payment': True})],
+            'bank_ids': [(0, 0, {'acc_number': 'BE15001559627230'})],
             'ref': 'ref_partner_1',
         })
 
@@ -37,7 +37,7 @@ class TestUBLBE(TestUBLCommon):
             'city': "Ramillies",
             'vat': 'BE0477472701',
             'country_id': cls.env.ref('base.be').id,
-            'bank_ids': [(0, 0, {'acc_number': 'BE90735788866632', 'allow_out_payment': True})],
+            'bank_ids': [(0, 0, {'acc_number': 'BE90735788866632'})],
             'ref': 'ref_partner_2',
         })
 
@@ -93,7 +93,6 @@ class TestUBLBE(TestUBLCommon):
         cls.acc_bank = cls.env['res.partner.bank'].create({
             'acc_number': 'BE15001559627231',
             'partner_id': cls.company_data['company'].partner_id.id,
-            'allow_out_payment': True,
         })
 
         cls.invoice = cls.env['account.move'].create({

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_de.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_de.py
@@ -24,7 +24,7 @@ class TestUBLDE(TestUBLCommon):
             'phone': '+49 180 6 225789',
             'email': 'info@legoland.de',
             'country_id': cls.env.ref('base.de').id,
-            'bank_ids': [(0, 0, {'acc_number': 'DE48500105176424548921', 'allow_out_payment': True})],
+            'bank_ids': [(0, 0, {'acc_number': 'DE48500105176424548921'})],
             'ref': 'ref_partner_1',
         })
 
@@ -35,7 +35,7 @@ class TestUBLDE(TestUBLCommon):
             'city': "Rust",
             'vat': 'DE186775212',
             'country_id': cls.env.ref('base.de').id,
-            'bank_ids': [(0, 0, {'acc_number': 'DE50500105175653254743', 'allow_out_payment': True})],
+            'bank_ids': [(0, 0, {'acc_number': 'DE50500105175653254743'})],
             'ref': 'ref_partner_2',
         })
 
@@ -231,7 +231,6 @@ class TestUBLDE(TestUBLCommon):
         acc_bank = self.env['res.partner.bank'].create({
             'acc_number': 'BE15001559627232',
             'partner_id': self.company_data['company'].partner_id.id,
-            'allow_out_payment': True,
         })
         invoice = self.env['account.move'].create({
             'move_type': 'out_invoice',

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_de.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_de.py
@@ -24,7 +24,7 @@ class TestUBLDE(TestUBLCommon):
             'phone': '+49 180 6 225789',
             'email': 'info@legoland.de',
             'country_id': cls.env.ref('base.de').id,
-            'bank_ids': [(0, 0, {'acc_number': 'DE48500105176424548921'})],
+            'bank_ids': [(0, 0, {'acc_number': 'DE48500105176424548921', 'allow_out_payment': True})],
             'ref': 'ref_partner_1',
         })
 
@@ -35,7 +35,7 @@ class TestUBLDE(TestUBLCommon):
             'city': "Rust",
             'vat': 'DE186775212',
             'country_id': cls.env.ref('base.de').id,
-            'bank_ids': [(0, 0, {'acc_number': 'DE50500105175653254743'})],
+            'bank_ids': [(0, 0, {'acc_number': 'DE50500105175653254743', 'allow_out_payment': True})],
             'ref': 'ref_partner_2',
         })
 
@@ -231,6 +231,7 @@ class TestUBLDE(TestUBLCommon):
         acc_bank = self.env['res.partner.bank'].create({
             'acc_number': 'BE15001559627232',
             'partner_id': self.company_data['company'].partner_id.id,
+            'allow_out_payment': True,
         })
         invoice = self.env['account.move'].create({
             'move_type': 'out_invoice',

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_nl.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_nl.py
@@ -25,7 +25,7 @@ class TestUBLNL(TestUBLCommon):
             'phone': '+31 180 6 225789',
             'email': 'info@outlook.nl',
             'country_id': cls.env.ref('base.nl').id,
-            'bank_ids': [(0, 0, {'acc_number': 'NL000099998B57'})],
+            'bank_ids': [(0, 0, {'acc_number': 'NL000099998B57', 'allow_out_payment': True})],
             'l10n_nl_kvk': '77777677',
             'ref': 'ref_partner_1',
         })
@@ -37,7 +37,7 @@ class TestUBLNL(TestUBLCommon):
             'city': "Rotterdam",
             'vat': 'NL41452B11',
             'country_id': cls.env.ref('base.nl').id,
-            'bank_ids': [(0, 0, {'acc_number': 'NL93999574162167'})],
+            'bank_ids': [(0, 0, {'acc_number': 'NL93999574162167', 'allow_out_payment': True})],
             'l10n_nl_kvk': '1234567',
             'ref': 'ref_partner_2',
         })

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_nl.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_nl.py
@@ -25,7 +25,7 @@ class TestUBLNL(TestUBLCommon):
             'phone': '+31 180 6 225789',
             'email': 'info@outlook.nl',
             'country_id': cls.env.ref('base.nl').id,
-            'bank_ids': [(0, 0, {'acc_number': 'NL000099998B57', 'allow_out_payment': True})],
+            'bank_ids': [(0, 0, {'acc_number': 'NL000099998B57'})],
             'l10n_nl_kvk': '77777677',
             'ref': 'ref_partner_1',
         })
@@ -37,7 +37,7 @@ class TestUBLNL(TestUBLCommon):
             'city': "Rotterdam",
             'vat': 'NL41452B11',
             'country_id': cls.env.ref('base.nl').id,
-            'bank_ids': [(0, 0, {'acc_number': 'NL93999574162167', 'allow_out_payment': True})],
+            'bank_ids': [(0, 0, {'acc_number': 'NL93999574162167'})],
             'l10n_nl_kvk': '1234567',
             'ref': 'ref_partner_2',
         })

--- a/addons/l10n_ch/tests/test_gen_isr_reference.py
+++ b/addons/l10n_ch/tests/test_gen_isr_reference.py
@@ -28,6 +28,7 @@ class TestGenISRReference(AccountTestInvoicingCommon):
                 "l10n_ch_isr_subscription_chf": "01-162-8",
                 "bank_id": cls.bank.id,
                 "partner_id": cls.partner_a.id,
+                'allow_out_payment': True,
             }
         )
         cls.bank_acc_qriban = cls.env["res.partner.bank"].create(
@@ -35,6 +36,7 @@ class TestGenISRReference(AccountTestInvoicingCommon):
                 "acc_number": QR_IBAN,
                 "bank_id": cls.bank.id,
                 "partner_id": cls.partner_a.id,
+                'allow_out_payment': True,
             }
         )
         cls.product_a.taxes_id = cls.product_b.taxes_id = None

--- a/addons/l10n_ch/tests/test_gen_isr_reference.py
+++ b/addons/l10n_ch/tests/test_gen_isr_reference.py
@@ -28,7 +28,6 @@ class TestGenISRReference(AccountTestInvoicingCommon):
                 "l10n_ch_isr_subscription_chf": "01-162-8",
                 "bank_id": cls.bank.id,
                 "partner_id": cls.partner_a.id,
-                'allow_out_payment': True,
             }
         )
         cls.bank_acc_qriban = cls.env["res.partner.bank"].create(
@@ -36,7 +35,6 @@ class TestGenISRReference(AccountTestInvoicingCommon):
                 "acc_number": QR_IBAN,
                 "bank_id": cls.bank.id,
                 "partner_id": cls.partner_a.id,
-                'allow_out_payment': True,
             }
         )
         cls.product_a.taxes_id = cls.product_b.taxes_id = None

--- a/addons/l10n_ch/tests/test_l10n_ch_isr_print.py
+++ b/addons/l10n_ch/tests/test_l10n_ch_isr_print.py
@@ -47,6 +47,7 @@ class ISRTest(AccountTestInvoicingCommon):
             'acc_number': "ISR {} number",
             'partner_id': self.env.company.partner_id.id,
             'l10n_ch_isr_subscription_chf': '01-39139-1',
+            'allow_out_payment': True,
         })
 
         invoice_chf = self.env['account.move'].create({

--- a/addons/l10n_ch/tests/test_l10n_ch_isr_print.py
+++ b/addons/l10n_ch/tests/test_l10n_ch_isr_print.py
@@ -47,7 +47,6 @@ class ISRTest(AccountTestInvoicingCommon):
             'acc_number': "ISR {} number",
             'partner_id': self.env.company.partner_id.id,
             'l10n_ch_isr_subscription_chf': '01-39139-1',
-            'allow_out_payment': True,
         })
 
         invoice_chf = self.env['account.move'].create({

--- a/addons/l10n_ch/tests/test_l10n_ch_qr_print.py
+++ b/addons/l10n_ch/tests/test_l10n_ch_qr_print.py
@@ -24,7 +24,6 @@ class QRPrintTest(AccountTestInvoicingCommon):
             'acc_number': "CH4431999123000889012",
             'partner_id': cls.env.company.partner_id.id,
             'l10n_ch_isr_subscription_chf': '01-39139-1',
-            'allow_out_payment': True,
         })
         cls.correct_invoice_chf = cls.env['account.move'].create({
             'move_type': 'out_invoice',

--- a/addons/l10n_ch/tests/test_l10n_ch_qr_print.py
+++ b/addons/l10n_ch/tests/test_l10n_ch_qr_print.py
@@ -24,6 +24,7 @@ class QRPrintTest(AccountTestInvoicingCommon):
             'acc_number': "CH4431999123000889012",
             'partner_id': cls.env.company.partner_id.id,
             'l10n_ch_isr_subscription_chf': '01-39139-1',
+            'allow_out_payment': True,
         })
         cls.correct_invoice_chf = cls.env['account.move'].create({
             'move_type': 'out_invoice',

--- a/addons/l10n_ch/tests/test_swissqr.py
+++ b/addons/l10n_ch/tests/test_swissqr.py
@@ -89,7 +89,6 @@ class TestSwissQR(AccountTestInvoicingCommon):
             {
                 'acc_number': number,
                 'partner_id': self.env.user.company_id.partner_id.id,
-                'allow_out_payment': True,
             }
         )
 

--- a/addons/l10n_ch/tests/test_swissqr.py
+++ b/addons/l10n_ch/tests/test_swissqr.py
@@ -89,6 +89,7 @@ class TestSwissQR(AccountTestInvoicingCommon):
             {
                 'acc_number': number,
                 'partner_id': self.env.user.company_id.partner_id.id,
+                'allow_out_payment': True,
             }
         )
 

--- a/addons/l10n_it_edi/tests/common.py
+++ b/addons/l10n_it_edi/tests/common.py
@@ -27,6 +27,7 @@ class TestItEdi(AccountEdiTestCommon):
             'acc_number': 'IT1212341234123412341234123',
             'bank_name': 'BIG BANK',
             'bank_bic': 'BIGGBANQ',
+            'allow_out_payment': True,
         })
 
         cls.company.l10n_it_tax_system = "RF01"

--- a/addons/l10n_it_edi/tests/common.py
+++ b/addons/l10n_it_edi/tests/common.py
@@ -27,7 +27,6 @@ class TestItEdi(AccountEdiTestCommon):
             'acc_number': 'IT1212341234123412341234123',
             'bank_name': 'BIG BANK',
             'bank_bic': 'BIGGBANQ',
-            'allow_out_payment': True,
         })
 
         cls.company.l10n_it_tax_system = "RF01"


### PR DESCRIPTION
Revert and fix in one commit, to avoid issues with empty node

Fixed some tests and remove the computation logic from account_move_reversal wizard, to rely on existing compute method.
Log them instead of trying to unarchive/create them.

task-5923591

