### PR TITLE
[FIX] mrp_subcontracting_landed_costs: compute correct landed cost su…

### DIFF
--- a/addons/mrp_subcontracting_landed_costs/models/__init__.py
+++ b/addons/mrp_subcontracting_landed_costs/models/__init__.py
@@ -1,3 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import models
+from . import stock_landed_cost

--- a/addons/mrp_subcontracting_landed_costs/models/stock_landed_cost.py
+++ b/addons/mrp_subcontracting_landed_costs/models/stock_landed_cost.py
@@ -1,0 +1,18 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+from odoo.tools import OrderedSet
+
+
+class StockLandedCost(models.Model):
+    _inherit = 'stock.landed.cost'
+
+    def _get_targeted_move_ids(self):
+        res = super()._get_targeted_move_ids()
+        target_moves_ids = OrderedSet()
+        for move in res:
+            if move.is_subcontract:
+                target_moves_ids.update(move.move_orig_ids.ids)
+            else:
+                target_moves_ids.add(move.id)
+        return self.env['stock.move'].browse(target_moves_ids)

--- a/addons/mrp_subcontracting_landed_costs/tests/test_subcontracting_landed_costs.py
+++ b/addons/mrp_subcontracting_landed_costs/tests/test_subcontracting_landed_costs.py
@@ -2,14 +2,15 @@ from unittest import skip
 
 from odoo.exceptions import ValidationError
 from odoo.tests import Form, tagged
+from odoo import Command
 
 from odoo.addons.mrp_subcontracting.tests.common import TestMrpSubcontractingCommon
 
 
 @tagged('post_install', '-at_install')
-@skip('Temporary to fast merge new valuation')
 class TestSubcontractingLandedCosts(TestMrpSubcontractingCommon):
 
+    @skip('Temporary to fast merge new valuation')
     def test_subcontracting_landed_cost_receipts_flow(self):
         """
             This test verifies that landed costs can be applied to subcontracting receipts
@@ -134,3 +135,75 @@ class TestSubcontractingLandedCosts(TestMrpSubcontractingCommon):
         # confirm the landed cost
         stock_landed_cost.button_validate()
         self.assertEqual(stock_landed_cost.state, "done")
+
+    def test_subcontracting_landed_cost_valuation_and_amls(self):
+        """
+            This test verifies that the account move line created after the validation
+            of a landed cost applied to the receipt of  subcontracted product take into
+            account the pro rata of the products still in stock.
+        """
+        warehouse = self.env['stock.warehouse'].search([
+            ('company_id', '=', self.env.company.id),
+        ], limit=1)
+        product_category_all = self.env.ref('product.product_category_goods')
+        self._setup_category_stock_journals()
+        product_category_all.property_cost_method = 'average'
+        product_category_all.property_valuation = 'real_time'
+        self.finished.categ_id = product_category_all
+
+        # create and confirm PO
+        po = self.env['purchase.order'].create({
+            'partner_id': self.subcontractor_partner1.id,
+            'order_line': [(0, 0, {
+                'name': self.finished.name,
+                'product_id': self.finished.id,
+                'product_qty': 10,
+                'product_uom_id': self.finished.uom_id.id,
+                'price_unit': 10,
+            })],
+        })
+        po.button_confirm()
+
+        # validate outgoing move to have only partial quantity remaining
+        receipt = po.picking_ids[0]
+        receipt.button_validate()
+        move = self.env['stock.move'].create({
+            'product_id': self.finished.id,
+            'location_id': warehouse.lot_stock_id.id,
+            'location_dest_id': self.env.ref('stock.stock_location_customers').id,
+            'product_uom_qty': 3,
+            'picking_type_id': warehouse.out_type_id.id,
+            'move_line_ids': [Command.create({
+                'quantity': 3,
+                'product_id': self.finished.id,
+            })]
+        })
+        move.picked = True
+        move._action_done()
+        self.assertEqual(self.finished.standard_price, 10)
+
+        # create a landed cost for the incoming picking and validate it
+        freight_charges = self.env['product.product'].create({
+            'name': 'Freight Charges',
+            'categ_id': self.product_category.id,
+        })
+        stock_landed_cost = self.env['stock.landed.cost'].create({
+            'picking_ids': [receipt.id],
+            'cost_lines': [(0, 0, {
+                'product_id': freight_charges.id,
+                'name': 'equal split',
+                'split_method': 'equal',
+                'price_unit': 10,
+            })],
+        })
+        stock_landed_cost.compute_landed_cost()
+        stock_landed_cost.button_validate()
+
+        # check the amls created and price post landed cost
+        self.assertEqual(self.finished.standard_price, 11)
+        stock_valu_acc_id = product_category_all.property_stock_valuation_account_id.id
+        expense_acc_id = product_category_all.property_account_expense_categ_id.id
+        self.assertRecordValues(stock_landed_cost.account_move_id.line_ids, [
+            {'account_id': stock_valu_acc_id,   'product_id': self.finished.id,    'debit': 7.0,  'credit': 0.0},
+            {'account_id': expense_acc_id,     'product_id': self.finished.id,    'debit': 0.0,   'credit': 7.0},
+        ])


### PR DESCRIPTION
…bcontracted

**Problem:**
Landed cost added on the receipt of a subcontracted product
do not increase the valuation of the product and do not create 
account move lines.

**Steps to reproduce:**
- create a tracked product with avco perpetual category
- create a subcontracted bom for this product with no comp
- create and confirm a PO for 10 unit of this product at a unit price 
of 1$ with the same partner as the subcontractor of the bom
- validate the receipt
- navigate to inventory/operations/adjustments/landed costs
- create a new landed cost
- select the receipt from the PO
- add a landed cost of 10$ and validate
- navigate to inventory/reporting/stock
- search for your product and click on the unit cost

**Current behavior:**
1) the valuation of the product was not increased by the value 
of the landed cost
2) open journal items : no account move lines were created for the 
landed cost

**Expected behavior:**
1) the valuation of the product should have been increased:
in the unit cost view, the SBC move should have gone from a 
value of 10 to 20
2) account move lines should have been created with a value 
of 10

**Cause of the issue:**
both issues come from the fact that when creating the 
stock valuation adjustment line, the move linked is the receipt move
when it should be the move of the subcontracted MO linked to the 
receipt.

**fix:** 
if we create the adjustement line with move_id as the move of the MO
(instead of the move of the receipt as it is the case currently) : 
when button_validate is called on the landed cost : 
- when using the remaining quantity, it will be the correct one 
(in our case 10, instead of 0 for the move of the receipt because it's 
actually an internal move) so the account move line are going to 
be created
https://github.com/odoo/odoo/blob/9c85d7265d7b1ca0b212f46c20aa1e8119c33a22/addons/stock_landed_costs/models/stock_landed_cost.py#L129-L130
https://github.com/odoo/odoo/blob/9c85d7265d7b1ca0b212f46c20aa1e8119c33a22/addons/stock_landed_costs/models/stock_landed_cost.py#L372-L373
which solves problem 2) 

-  when calling _set_value on the move (which will be the move of 
the MO thanks to this fix), 
https://github.com/odoo/odoo/blob/064407d32f998ceb08601f9e0a6356c94ad10347/addons/stock_landed_costs/models/stock_landed_cost.py#L152
get_value_data will call _get_value_from_extra,
https://github.com/odoo/odoo/blob/9c85d7265d7b1ca0b212f46c20aa1e8119c33a22/addons/stock_account/models/stock_move.py#L392
which uses _get_landed_cost to fetch the landed cost
https://github.com/odoo/odoo/blob/9c85d7265d7b1ca0b212f46c20aa1e8119c33a22/addons/stock_landed_costs/models/stock_move.py#L18
before this fix the landed cost created from the receipt were linked to 
the receipt move so they were not fetched inside _get_landed_cost
which caused problem 1) but now the move_id of the adjustment lines 
is the move of the MO so they are fetched inside _get_landed_cost
https://github.com/odoo/odoo/blob/9c85d7265d7b1ca0b212f46c20aa1e8119c33a22/addons/stock_landed_costs/models/stock_move.py#L7-L12
So now the adjustment lines do impact the valuation of the move of 
the MO which solves problem 1)

opw-5723126