### PR TITLE
[FIX] hr_attendance: fix access issue

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -434,11 +434,11 @@ class HrAttendance(models.Model):
     def write(self, vals):
         if vals.get('employee_id') and \
             vals['employee_id'] not in self.env.user.employee_ids.ids and \
-            not self.env.user.has_group('hr_attendance.group_hr_attendance_officer') or \
-            vals.get('employee_id') and self.env['hr.employee'].sudo().browse(vals['employee_id']).attendance_manager_id.id != self.env.user.id:
+            not self.env.user.has_group('hr_attendance.group_hr_attendance_manager') and \
+            self.env['hr.employee'].sudo().browse(vals['employee_id']).attendance_manager_id.id != self.env.user.id:
             raise AccessError(_("Do not have access, user cannot edit the attendances that are not their own or if they are not the attendance manager of the employee."))
         attendances_dates = self._get_attendances_dates()
-        result = super(HrAttendance, self).write(vals)
+        result = super().write(vals)
         if any(field in vals for field in ['employee_id', 'check_in', 'check_out']):
             # Merge attendance dates before and after write to recompute the
             # overtime if the attendances have been moved to another day

--- a/addons/hr_attendance/tests/test_hr_attendance_manager.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_manager.py
@@ -1,8 +1,8 @@
-# addons/hr_attendance/tests/test_hr_attendance_manager.py
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests.common import TransactionCase, tagged
-from odoo.tests import new_test_user
 from odoo.exceptions import AccessError
+from odoo.tests import new_test_user
+from odoo.tests.common import TransactionCase, tagged
 
 
 @tagged('post_install', '-at_install')
@@ -11,7 +11,10 @@ class TestAttendanceManager(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        # Create a test user
+        # Create an attendance manager
+        cls.luisa = new_test_user(cls.env, login='luisa', groups='hr_attendance.group_hr_attendance_manager')
+
+        # Create a normal user
         cls.marc = new_test_user(cls.env, login='marc', groups='base.group_user')
         cls.marc_employee = cls.env['hr.employee'].create({
             'name': 'Marc Employee',
@@ -20,37 +23,46 @@ class TestAttendanceManager(TransactionCase):
         cls.marc_employee.attendance_manager_id = cls.marc
 
         # Create another employee
-        cls.abigail = cls.env['hr.employee'].create({
-            'name': 'Abigail Employee',
-        })
+        cls.abigail_employee, cls.ryan_employee = cls.env['hr.employee'].create([
+            {
+                'name': 'Abigail Employee',
+                'attendance_manager_id': cls.marc.id,
+            },
+            {
+                'name': 'Ryan Employee',
+                'attendance_manager_id': cls.luisa.id,
+            },
+        ])
 
-    def setUp(self):
-        super().setUp()
         # Create an attendance for Marc Demo's employee
-        self.attendance = self.env['hr.attendance'].create({
-            'employee_id': self.marc_employee.id,
+        cls.attendance = cls.env['hr.attendance'].create({
+            'employee_id': cls.marc_employee.id,
             'check_in': '2025-09-09 08:00:00',
             'check_out': '2025-09-09 12:00:00',
         })
 
-    def test_cannot_change_employee_without_manager_rights(self):
+    def test_attendance_officer_rights(self):
         """Marc Demo should NOT be able to change the employee on his attendance
         if he is not assigned as attendance manager of that employee.
         """
         attendance_as_marc = self.attendance.with_user(self.marc)
+
+        # Marc can change the employee to Abigail
+        attendance_as_marc.write({'employee_id': self.abigail_employee.id})
+        self.assertEqual(self.attendance.employee_id, self.abigail_employee)
+
+        # Marc cannot change the employee to Ryan
         with self.assertRaises(AccessError):
-            attendance_as_marc.write({'employee_id': self.abigail.id})
+            attendance_as_marc.write({'employee_id': self.ryan_employee.id})
 
-    def test_can_change_employee_with_manager_rights(self):
-        """Marc Demo should be able to change the employee on attendance
-        once he is set as attendance manager of Abigail.
+    def test_attendance_manager_rights(self):
+        """Luisa should be able to change the employee on attendance without the need
+        of being set as attendance_manager since she has the attendance_manager group.
         """
-        # Assign Marc Demo as attendance manager of Abigail
-        self.abigail.attendance_manager_id = self.marc
+        attendance_as_luisa = self.attendance.with_user(self.luisa)
 
-        attendance_as_marc = self.attendance.with_user(self.marc)
-        # This should succeed now
-        attendance_as_marc.write({'employee_id': self.abigail.id})
+        attendance_as_luisa.write({'employee_id': self.abigail_employee.id})
+        self.assertEqual(self.attendance.employee_id, self.abigail_employee)
 
-        # Verify the employee_id has actually changed
-        self.assertEqual(attendance_as_marc.employee_id, self.abigail)
+        attendance_as_luisa.write({'employee_id': self.ryan_employee.id})
+        self.assertEqual(self.attendance.employee_id, self.ryan_employee)


### PR DESCRIPTION
The commit https://github.com/odoo/odoo/commit/d115cca1296c0bd20a2875bdaadf2a9136c33dda introduced the opportunity for attendance managers to edit their subordinates attendances, but the condition was lacking parenthesis, leading to an unexpected behaviour.

This commit changes the condition so that it is possible both for a manager and an officer to do the edition.
It also rewrite the tests in order to be more thorough.

No related task