### PR TITLE
[FIX] l10n_latam_check: prevent premature "Paid" status for multiple checks

### DIFF
--- a/addons/l10n_latam_check/models/account_payment.py
+++ b/addons/l10n_latam_check/models/account_payment.py
@@ -131,8 +131,9 @@ class AccountPayment(models.Model):
 
     def _l10n_latam_check_split_move(self):
         for payment in self.filtered(lambda x: x.payment_method_code == 'own_checks' and x.payment_type == 'outbound'):
+            pay_with_signal = payment.with_context(skip_check_search=True)
             if len(payment.l10n_latam_new_check_ids) == 1:
-                liquidity_line = payment._seek_for_lines()[0]
+                liquidity_line = pay_with_signal._seek_for_lines()[0]
                 payment.l10n_latam_new_check_ids.outstanding_line_id = liquidity_line.id
                 continue
 
@@ -141,7 +142,7 @@ class AccountPayment(models.Model):
                 'move_type': 'entry',
                 'line_ids': [],
             }
-            payment_liquidity_line = payment._seek_for_lines()[0]
+            payment_liquidity_line = pay_with_signal._seek_for_lines()[0]
 
             # One line per check
             checks_total = sum(payment.l10n_latam_new_check_ids.mapped('amount'))
@@ -199,6 +200,21 @@ class AccountPayment(models.Model):
             check.outstanding_line_id.move_id.button_draft()
             check.outstanding_line_id.move_id.unlink()
 
+    def _seek_for_lines(self):
+        """
+        Overridden to return the check lines when using own checks so the payment status
+        depends on the check status and not on the payment line (which is reconciled against the split move)
+        """
+        # EXTENDS account
+        res = super()._seek_for_lines()
+        if self.env.context.get('skip_check_search'):
+            return res
+
+        if self.payment_method_code == 'own_checks' and self.payment_type == 'outbound' and self.l10n_latam_new_check_ids and len(self.l10n_latam_new_check_ids) > 1:
+            res[0] = self.l10n_latam_new_check_ids.outstanding_line_id
+
+        return res
+
     @api.depends(
         'payment_method_line_id', 'state', 'date', 'amount', 'currency_id', 'company_id',
         'l10n_latam_move_check_ids.issuer_vat', 'l10n_latam_move_check_ids.bank_id', 'l10n_latam_move_check_ids.payment_id.date',
@@ -238,6 +254,11 @@ class AccountPayment(models.Model):
     def _get_trigger_fields_to_synchronize(self):
         res = super()._get_trigger_fields_to_synchronize()
         return res + ('l10n_latam_new_check_ids',)
+
+    @api.depends("l10n_latam_new_check_ids.outstanding_line_id.amount_residual")
+    def _compute_reconciliation_status(self):
+        # EXTENDS account
+        super()._compute_reconciliation_status()
 
     def _prepare_move_line_default_vals(self, write_off_line_vals=None, force_balance=None):
         """ Add check name and operation on liquidity line """

--- a/addons/l10n_latam_check/tests/test_own_checks.py
+++ b/addons/l10n_latam_check/tests/test_own_checks.py
@@ -8,6 +8,21 @@ from odoo import Command, fields
 @tagged('post_install_l10n', 'post_install', '-at_install')
 class TestOwnChecks(L10nLatamCheckTest):
 
+    def _reconcile_check_with_statement(self, check, journal):
+        """Create a bank statement line and reconcile it against the check's outstanding line."""
+        st_line = self.env['account.bank.statement.line'].create({
+            'payment_ref': f"Clear {check.name}",
+            'journal_id': journal.id,
+            'amount': -check.amount,
+            'date': check.payment_date,
+            'partner_id': self.partner_a.id,
+        })
+        _st_liq, st_suspense, _st_other = st_line.with_context(
+            skip_account_move_synchronization=True
+        )._seek_for_lines()
+        st_suspense.account_id = check.outstanding_line_id.account_id
+        (st_suspense + check.outstanding_line_id).reconcile()
+
     def test_01_pay_with_own_checks(self):
         """ Create and post a manual checks with deferred date """
 
@@ -92,3 +107,83 @@ class TestOwnChecks(L10nLatamCheckTest):
         })
         payment.action_post()
         self.assertEqual(payment.amount, 120)
+
+    def test_single_check_invoice_status(self):
+        """ Verify that a Bill paid with a Single Own Check remains 'in_payment' until the bank statement clears it. """
+        invoice = self._create_invoice_one_line(
+            move_type='in_invoice',
+            company_id=self.bank_journal.company_id.id,
+            l10n_latam_document_number='00001-00000002',
+            l10n_latam_document_type_id=1,
+            name="Single Product Test",
+            price_unit=1000.0,
+            post=True,
+        )
+
+        own_checks_method = self.bank_journal._get_available_payment_method_lines('outbound').filtered(lambda x: x.code == 'own_checks')[:1]
+        payment = self._register_payment(
+            invoice,
+            journal_id=self.bank_journal.id,
+            payment_method_line_id=own_checks_method.id,
+            l10n_latam_new_check_ids=[
+                Command.create({
+                    'name': "CHK-SINGLE-001",
+                    'amount': 1000.0,
+                    'payment_date': fields.Date.today(),
+                }),
+            ],
+        )
+
+        self.assertEqual(payment.l10n_latam_new_check_ids.issue_state, 'handed')
+        self.assertEqual(invoice.payment_state, 'in_payment')
+
+        self._reconcile_check_with_statement(payment.l10n_latam_new_check_ids, self.bank_journal)
+
+        invoice.invalidate_recordset(['payment_state'])
+        self.assertEqual(invoice.payment_state, 'paid')
+
+    def test_multi_check_invoice_status(self):
+        """Verify that a Bill paid with multiple Own Checks remains 'in_payment' until cleared by the bank,
+        validating that the bill correctly tracks the unreconciled status of individual check lines."""
+        invoice = self._create_invoice_one_line(
+            move_type='in_invoice',
+            company_id=self.bank_journal.company_id.id,
+            l10n_latam_document_number='00001-00000001',
+            l10n_latam_document_type_id=1,
+            name="Test Product",
+            price_unit=500.0,
+            post=True,
+        )
+
+        own_checks_method = self.bank_journal._get_available_payment_method_lines('outbound').filtered(lambda x: x.code == 'own_checks')[:1]
+        payment = self._register_payment(
+            invoice,
+            journal_id=self.bank_journal.id,
+            payment_method_line_id=own_checks_method.id,
+            l10n_latam_new_check_ids=[
+                Command.create({
+                    'name': "Check001",
+                    'amount': 250.0,
+                    'payment_date': fields.Date.today(),
+                }),
+                Command.create({
+                    'name': "Check002",
+                    'amount': 250.0,
+                    'payment_date': fields.Date.today(),
+                }),
+            ],
+        )
+
+        self.assertEqual(invoice.payment_state, 'in_payment')
+
+        check_1 = payment.l10n_latam_new_check_ids[0]
+        self._reconcile_check_with_statement(check_1, self.bank_journal)
+
+        invoice.invalidate_recordset(['payment_state'])
+        self.assertEqual(invoice.payment_state, 'in_payment')
+
+        check_2 = payment.l10n_latam_new_check_ids[1]
+        self._reconcile_check_with_statement(check_2, self.bank_journal)
+
+        invoice.invalidate_recordset(['payment_state'])
+        self.assertEqual(invoice.payment_state, 'paid')


### PR DESCRIPTION
Steps to reproduce:
1. Create a Vendor Bill for 1000 ARS.
2. Register a payment using "Own Checks".
3. Add two checks (e.g., 500 ARS each).
4. Create and Post the payment.
5. Observe that the Bill ribbon immediately shows "Paid".

Cause:
When processing multiple own checks, Odoo creates a "Split Move" entry to handle individual check maturity dates. To balance the books, it reconciles the original payment liquidity line with a counterpart line in this split entry. Because Odoo's core payment state logic monitors this original liquidity line, it sees the reconciliation as a "clearing" event and incorrectly flips the bill status to "Paid" before the checks have actually cleared the bank.

Solution:
Override _seek_for_lines to redirect Odoo's "status sensor." By pointing the liquidity line target to the individual check lines in the split move instead of the original payment line, the payment state now correctly depends on whether those specific checks have been reconciled with a bank statement. A context guard (skip_check_search) is used during the split move creation to allow the builder to access the original payment line without interference.

opw-5482766