### PR TITLE
[FIX] point_of_sale: ensure amounts are properly rounded

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -719,7 +719,10 @@ export class PosOrder extends Base {
     }
 
     get_total_with_tax() {
-        return this.taxTotals.order_sign * this.taxTotals.order_total;
+        return roundPrecision(
+            this.taxTotals.order_sign * this.taxTotals.order_total,
+            this.currency.rounding
+        );
     }
 
     get_total_without_tax() {
@@ -893,7 +896,7 @@ export class PosOrder extends Base {
         if (this.config.cash_rounding) {
             remaining = this.getRoundedRemaining(this.config.rounding_method, remaining);
         }
-        return -order_sign * remaining;
+        return roundPrecision(-order_sign * remaining, this.currency.rounding);
     }
 
     get_due() {

--- a/addons/point_of_sale/static/tests/tours/receipt_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/receipt_screen_tour.js
@@ -306,3 +306,16 @@ registry.category("web_tour.tours").add("test_receipt_screen_edit_payment_lines"
             },
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_amount_total_is_rounded", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Test Product"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.receiptIsThere(),
+        ].flat(),
+});


### PR DESCRIPTION
Before this commit, the total amount of an order could be not properly rounded in some cases, and would get stored in the database with more decimal places than allowed by the currency.

opw-5919317

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
