### PR TITLE
[FIX] website_slides: Allow users to create section in slides

### DIFF
--- a/addons/website_slides/static/src/slide_category_one2many_field.js
+++ b/addons/website_slides/static/src/slide_category_one2many_field.js
@@ -19,6 +19,7 @@ class SlideCategoryOneToManyField extends X2ManyField {
 
 registry.category("fields").add("slide_category_one2many", {
     ...x2ManyField,
+    relatedFields: [{ name: "is_category", type: "boolean", readonly: false }],
     component: SlideCategoryOneToManyField,
     additionalClasses: [...x2ManyField.additionalClasses || [], "o_field_one2many"],
 });


### PR DESCRIPTION
Steps:
- Install `website_slides`
- Edit a course
- Add a section in the slides
- Save
- Section is automatically changed into document slide

The problem stems from the fact that the widget that manages sections in website_slides uses the `is_category` field to function (display certain fields in the list view).

However, this `is_category` field has been removed since saas-19.1 in the following [diff](https://github.com/odoo/odoo/pull/230098/changes#diff-87985c6cb54c5ab6dd4b71da844d0478e70c3c8247d54c943113ba75a4af0188L85 )
with a view to getting rid of invisible fields in views and adding them automatically in `ir_ui_view`.

But in `IrUiView::_add_missing_fields`, this field is added as read-only.

https://github.com/odoo/odoo/blob/02af5899563ddc362d04522339a5bdb793e01b52/odoo/addons/base/models/ir_ui_view.py#L1530-L1545

On the client side, when saving a `web_save` is performed by omitting `is_category`, because we are not supposed to save/write read-only fields.

Since the field has a default value of false, we end up with a slide that is not a section

```py
    is_category = fields.Boolean(`Is a category`, default=False)
```

To fix this problem, we directly correct `slide_category_one2many` which uses is_category without ever checking that the field is available by adding a relatedFields that specifies that we need is_category and not readonly.

Note: we have exactly the same problem with section_and_note in the `account` module, which uses the `display_type` field, but here it works because in its view we kept the field when deleting all invisible fields.

https://github.com/odoo/odoo/blob/8128a1bfbdd7b2f7cdc8ccbf1ddf78219a809e38/addons/sale/views/sale_order_views.xml#L568-L569

opw-5898399