### PR TITLE
[FIX] hr_holidays: count valid allocations starting previous year

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -294,12 +294,11 @@ class HolidaysType(models.Model):
             holiday_status.virtual_remaining_leaves = leave_type_tuple[1].get('virtual_remaining_leaves', 0)
 
     def _compute_allocation_count(self):
-        min_datetime = fields.Datetime.to_string(datetime.now().replace(month=1, day=1, hour=0, minute=0, second=0, microsecond=0))
-        max_datetime = fields.Datetime.to_string(datetime.now().replace(month=12, day=31, hour=23, minute=59, second=59))
+        today = fields.Date.to_string(date.today())
         domain = [
             ('holiday_status_id', 'in', self.ids),
-            ('date_from', '>=', min_datetime),
-            ('date_from', '<=', max_datetime),
+            ('date_from', '<=', today),
+            '|', ('date_to', '=', False), ('date_to', '>=', today),
             ('state', 'in', ('confirm', 'validate')),
         ]
 

--- a/addons/hr_holidays/tests/test_allocations.py
+++ b/addons/hr_holidays/tests/test_allocations.py
@@ -570,3 +570,16 @@ class TestAllocations(TestHrHolidaysCommon):
             allocation_form.number_of_hours_display = 7.2
             allocation = allocation_form.save()
             self.assertEqual(allocation.duration_display, '7.2 hours')
+
+    @freeze_time('2024-03-25')
+    def test_allocation_count_date_previous_year(self):
+        """Checks that the allocation count is calculated correctly when an employee has an allocation starting during
+        the prevous year, but which hasn't expired yet."""
+
+        self.env['hr.leave.allocation'].create({
+            'employee_id': self.employee.id,
+            'holiday_status_id': self.leave_type.id,
+            'allocation_type': 'regular',
+            'date_from': '2023-12-25'
+        })
+        self.assertEqual(1, self.leave_type.allocation_count)


### PR DESCRIPTION
__

## Short functional explanation of the error
When setting the start date for a time off allocation to the previous year, it is not taken into account when computing the count of employee allocations on the time off type page.

## Reproduction Steps
1. Go to Time off > Configuration > Time off Types and click on any time off type.
2. A smart button Allocations should appear with a number in it. Note the number and click on the button.
3. If no allocation exists yet, create one. Otherwise, click on an already existing allocation.
4. Set the start date of the validity period to any date last year. Set the ending date so that the allocation is still valid as of now.
5. Go back to the Time off type page and look at the number on the Allocations smart button.

### Expected behavior
As the allocation we set is still valid, the number shouldn't have changed.

### Unexpected behavior
The allocation number has been decreased. However, when we click on the smart button, the same number of valid allocations will show. This creates an inconsistency between the smart button and the allocation page, as the smart button should show the number of valid allocations, and when landing on the allocation page, the results are automatically filtered by validity.

## Origin of the issue
The domain of the allocations to take into account when computing the count of valid allocations is defined here:
https://github.com/odoo/odoo/blob/2264f330859b79010b227e3a9fda1075de8ed4e8/addons/hr_holidays/models/hr_leave_type.py#L297-L304 This doesn't take into account valid allocations that started during the previous year.
The inconsistency with the allocation page can be seen here: https://github.com/odoo/odoo/blob/2264f330859b79010b227e3a9fda1075de8ed4e8/addons/hr_holidays/views/hr_leave_allocation_views.xml#L40-L46 Where the filter is defined based on today, rather than on the whole year, unlike above.
__
opw-5504272

