### PR TITLE
[IMP] web: support for multi-select inner filter

### DIFF
--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -180,6 +180,29 @@ test("navigation with facets", async () => {
 });
 
 test.tags("desktop");
+test("Inner filter: facets are 'or' separated", async () => {
+    await mountWithSearch(SearchBar, {
+        resModel: "partner",
+        searchMenuTypes: ["filter"],
+        searchViewId: false,
+        searchViewArch: `
+            <search>
+                <filter string="Garf">
+                    <filter string="Meow" name="meow" domain="[('garf', '=', 'meow')]"/>
+                    <filter string="Woof" name="woof" domain="[('garf', '=', 'woof')]"/>
+                </filter>
+            </search>
+        `,
+    });
+
+    await toggleSearchBarMenu();
+    await toggleMenuItem("Garf");
+    await contains(`.o_item_option:eq(0)`).click();
+    await contains(`.o_item_option:eq(1)`).click();
+    expect(getFacetTexts().map((str) => str.replace(/\s+/g, " "))).toEqual(["Meow or Woof"]);
+});
+
+test.tags("desktop");
 test("navigation with facets (2)", async () => {
     await mountWithSearch(SearchBar, {
         resModel: "partner",

--- a/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
+++ b/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
@@ -564,7 +564,11 @@ test("Inner filter: toggle", async () => {
 
     await contains(`.o_item_option:eq(0)`).click();
     expect(isItemSelected("Foo")).toBe(true);
-    expect(searchBarMenu.env.searchModel.domain).toEqual([["foo", "=", "abcd"]]);
+    expect(searchBarMenu.env.searchModel.domain).toEqual([
+        "|",
+        ["foo", "=", "abcd"],
+        ["foo", "=", "qsdf"],
+    ]);
 });
 
 test("Inner filter: domain is correctly combined with other filters", async () => {


### PR DESCRIPTION
Previously, the parents filter could only have one inner filter active at the same time.
This commits adds support for multi-select inner filters by combining their domain with an OR.

see #241459 

task-5933887
