### PR TITLE
[FIX] delivery_stock_picking_batch: auto batch pickings with carrier set after confirmation to correct batch

### DIFF
--- a/addons/delivery_stock_picking_batch/tests/test_delivery_picking_batch.py
+++ b/addons/delivery_stock_picking_batch/tests/test_delivery_picking_batch.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import Command
-from odoo.tests import common, tagged
+from odoo.tests import common, tagged, Form
 
 
 @tagged('-at_install', 'post_install')
@@ -74,3 +74,48 @@ class TestDeliveryPickingBatch(common.TransactionCase):
         package = pack_wizard.action_put_in_pack()
         batch.action_done()
         self.assertEqual(package.weight, 3.0)
+
+    def test_auto_batch_carrier_change_after_confirmation(self):
+        """
+            Test an auto batch scenario where pickings correctly join the correct batches when carrier is set after confirmation.
+            The pickings looks like this:
+            - pick_1: confirmed with self.local_delivery_carrier
+            - pick_2: confirmed with carrier = False > self.local_delivery_carrier is set after confirmation
+            The expected result is:
+            - pick_1, pick_2 are in the same batch
+        """
+        warehouse = self.picking_type_out.warehouse_id
+        warehouse.delivery_steps = 'pick_ship'
+        warehouse.out_type_id.write({'auto_batch': True, 'batch_group_by_carrier': True})
+
+        partner_1, partner_2 = self.env['res.partner'].create([{
+            'name': f'{partner}',
+        } for partner in ('bob', 'marley')])
+        self.env['stock.quant']._update_available_quantity(self.product_a, self.stock_location, 40)
+        carrier_1 = self.local_delivery_carrier
+        pick_1, pick_2 = self.env['stock.picking'].create([{
+            'name': f"Pick {carrier_1.name if carrier else 'with no carrier'}",
+            'partner_id': partner,
+            'picking_type_id': warehouse.pick_type_id.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': warehouse.wh_output_stock_loc_id.id,
+            'carrier_id': carrier,
+            'move_ids': [Command.create({
+                'product_id': self.product_a.id,
+                'product_uom_qty': 1,
+                'location_id': self.stock_location.id,
+                'location_dest_id': warehouse.wh_output_stock_loc_id.id,
+            })]
+        } for carrier, partner in [(carrier_1.id, partner_1.id), (False, partner_2.id)]])
+
+        pick_1.action_confirm()
+        pick_1.button_validate()
+        ship_1 = pick_1.move_ids.move_dest_ids.picking_id
+        self.assertEqual(ship_1, ship_1.batch_id.picking_ids)
+
+        pick_2.action_confirm()
+        with Form(pick_2) as picking_form:
+            picking_form.carrier_id = self.local_delivery_carrier
+        pick_2.button_validate()
+        ship_2 = pick_2.move_ids.move_dest_ids.picking_id
+        self.assertEqual(ship_1.batch_id.picking_ids, ship_1 | ship_2)

--- a/addons/stock_delivery/models/stock_move.py
+++ b/addons/stock_delivery/models/stock_move.py
@@ -41,6 +41,10 @@ class StockMove(models.Model):
     def _get_new_picking_values(self):
         vals = super(StockMove, self)._get_new_picking_values()
         carrier_id = self.reference_ids.sale_ids.carrier_id.id
+        # check if the previous picking have a carrier_id, then take carrier from that
+        # earlier we were taking carrier from sale but since carrier can be changed or updated in next steps so now we take carrier from prev picking
+        if len(self.move_orig_ids.picking_id.carrier_id) == 1:
+            carrier_id = self.move_orig_ids.picking_id.carrier_id.id
         vals['carrier_id'] = any(rule.propagate_carrier for rule in self.rule_id) and carrier_id
         return vals
 


### PR DESCRIPTION
**Problem:**
If you have group by carrier option in automatic batches, when you create an SO with a stocked product, confirm the order, and in the delivery step you set/change a carrier, it creates a new batch transfer, and it doesn't group it with the appropriate batch with that carrier.

**Steps to reproduce:**
1) In the settings enable: Batch, Wave & Cluster transfers
2) Inventory > Configuration > Warehouse Management > Operation types
3) Enable Auto-batches, Batch grouping by carrier on Delivery orders
4) Make sure there is no batches made before contains the carrier you're going to use (to cleanly test this issue)
5) Make a sales order, add storable product, press on 'Add shipping' button and add 'standard delivery'
6) Go to the delivery of the pick from the smart button > validate it
7) Go to the next transfer to see the batch number
8) Make a new sales order, add storable product > confirm it > go to the delivery step > additional info
9) Add 'standard delivery' in the carrier field > validate the delivery > go to the next transfer button
10) check the batch it got added to, you will find it is a new one and didn't get grouped to the last batch created with the same carrier.

**Expected behaviour:**
It should get grouped in the batch containing that same carrier.

**Cause:**
When the SO is confirmed without a carrier, and then you edit the carrier in the delivery step (pick) then press on validate, it gets the carrier from the vals in the SO (blank), then along the way while validating the pick, `find_auto_batch` gets called with the empty carrier, so it creates a new batch, *AND then* it propagates the carrier from the SO to the pick using `get_new_picking_values` method, but by then it's too late as the batch is already created with the blank carrier.


**Solution:**
The problem happened because of this commit: https://github.com/odoo/odoo/commit/7c32adcd82119c35485addd1b198a7fcc0053c9f
We need to add the propagation of the carrier_id to the vals if it was already changed or set before the validation of the pick.

opw-5882310