### PR TITLE
[FIX] web: prevent crash when ContactImageField has no value

### DIFF
--- a/addons/web/static/src/views/fields/contact_image/contact_image_field.js
+++ b/addons/web/static/src/views/fields/contact_image/contact_image_field.js
@@ -9,7 +9,8 @@ export class ContactImageField extends ImageField {
     getUrl(imageFieldName) {
         if (
             this.props.previewImage &&
-            (!this.props.record.data[this.props.name] || !this.state.isValid)
+            (!this.props.record.data[this.props.name] || !this.state.isValid) &&
+            this.props.record.data[imageFieldName]
         ) {
             if (isBinarySize(this.props.record.data[imageFieldName])) {
                 this.lastURL = imageUrl(

--- a/addons/web/static/tests/views/fields/contact_image_field.test.js
+++ b/addons/web/static/tests/views/fields/contact_image_field.test.js
@@ -1,0 +1,33 @@
+import { expect, test } from "@odoo/hoot";
+import { defineModels, fields, models, mountView } from "@web/../tests/web_test_helpers";
+
+class Partner extends models.Model {
+    name = fields.Char();
+    image_1920 = fields.Binary();
+    image_128 = fields.Binary();
+
+    _records = [
+        { id: 1, name: "first record" },
+        { id: 2, name: "second record" },
+    ];
+}
+
+defineModels([Partner]);
+
+test("ContactImageField renders a placeholder when no value is present", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 2,
+        arch: `
+            <form>
+                <field name="image_1920" widget="contact_image" options="{'preview_image': 'image_128'}"/>
+            </form>`,
+    });
+
+    expect('div[name="image_1920"] img').toHaveAttribute(
+        "data-src",
+        "/web/static/img/placeholder.png",
+        { message: "the image should have the correct src" }
+    );
+});


### PR DESCRIPTION
Steps to reproduce
==================

- Go to contacts
- Open studio
- Switch to the form view
- Open the x2many form view

=> TypeError: Cannot read properties of undefined (reading '0')

opw-5885953