### PR TITLE
[FIX] stock: prevent errors on generating lots

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -996,8 +996,10 @@ Please change the quantity done or the rounding precision of your unit of measur
         default_vals = {}
 
         def generate_lot_qty(quantity, qty_per_lot):
-            if qty_per_lot <= 0:
-                raise UserError(_("The quantity per lot should always be a positive value."))
+            if not qty_per_lot or qty_per_lot <= 0:
+                raise UserError(self.env._("The quantity per lot should always be a positive value."))
+            if not quantity or quantity <= 0:
+                raise UserError(self.env._("The quantity received should always be a positive value."))
             line_count = int(quantity // qty_per_lot)
             leftover = quantity % qty_per_lot
             qty_array = [qty_per_lot] * line_count

--- a/addons/stock/tests/test_stock_lot.py
+++ b/addons/stock/tests/test_stock_lot.py
@@ -4,7 +4,7 @@
 from odoo import Command
 from odoo.addons.stock.tests.common import TestStockCommon
 from odoo.tests import Form
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 
 
 class TestLotSerial(TestStockCommon):
@@ -90,6 +90,25 @@ class TestLotSerial(TestStockCommon):
         self.assertEqual(vals[1]['quantity'], 4)
         self.assertEqual(vals[2]['lot_name'], 'wxc')
         self.assertEqual(vals[2]['quantity'], 1, "default lot qty")
+
+    def test_lot_generation_with_none_values_raise_usererror(self):
+        with self.assertRaises(UserError):
+            # when quantity is received as None, UserError should be raised
+            self.MoveObj.action_generate_lot_line_vals({
+                'default_tracking': 'lot',
+                'default_product_id': self.productA.id,
+                'default_location_dest_id': self.locationC.id,
+                'default_quantity': None,
+            }, "generate", "", 3, "test")
+
+        with self.assertRaises(UserError):
+            # when quantity per lot is received as None, UserError should be raised
+            self.MoveObj.action_generate_lot_line_vals({
+                'default_tracking': 'lot',
+                'default_product_id': self.productA.id,
+                'default_location_dest_id': self.locationC.id,
+                'default_quantity': 2,
+            }, "generate", "", None, "test")
 
     def test_lot_no_company(self):
         """ check the lot created in a receipt should not have a company if the product is not


### PR DESCRIPTION
Currently, an error occurs when user tries to generate lots on a picking receipt for a product that is tracked by lots.

Steps to replicate:
- Install `stock` and create a product `test` tracked `by lots`.
- Open Inventory > Operation > Receipts , create a new one with product `test` and quantity 3.
- Open the form view of the stock move for `test` using the `view` button.
- Click `Generate Serials/Lots` and type `a` in `Quantity received` and click generate. (Error-1 will occur.)
- Click `Generate Serials/Lots` and type `a` in `Quantity per lot` and click generate. (Error-2 will occur.)

Error-1 :
```
File '/home/odoo/odoo18/community/addons/stock/models/stock_move.py', line 1055, in generate_lot_qty
    line_count = int(quantity // qty_per_lot)
                     ~~~~~~~~~^^~~~~~~~~~~~~
TypeError: unsupported operand type(s) for //: 'NoneType' and 'int'
```

Error-2 :
```
File '/home/odoo/odoo18/community/addons/stock/models/stock_move.py', line 1053, in generate_lot_qty
    if qty_per_lot <= 0:
       ^^^^^^^^^^^^^^^^
TypeError: '<=' not supported between instances of 'NoneType' and 'int'
```

Cause:
- As the user typed in alphabets the [parsefloat] returns `NaN` which will be translated to `None` python side.
- As quantity is received as None the [line1] raises Error-1.
- As qty_per_lot is recieved as None the [line2] raises Error-2.

Solution:
- Raised Usererror when quantity received or quantity per lot is either negative or not a number.

[parsefloat]: https://github.com/odoo/odoo/blob/2da791df55762ae4dc1c06d2a43fad25b09dc11b/addons/stock/static/src/widgets/generate_serial.js#L50-L51

[line1]: https://github.com/odoo/odoo/blob/2da791df55762ae4dc1c06d2a43fad25b09dc11b/addons/stock/models/stock_move.py#L1001

[line2]: https://github.com/odoo/odoo/blob/2da791df55762ae4dc1c06d2a43fad25b09dc11b/addons/stock/models/stock_move.py#L999


related-sentry-7254849206

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
