### PR TITLE
[IMP] pos_restaurant: remove payment selection step from deposit tour

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_config.js
+++ b/addons/point_of_sale/static/src/app/models/pos_config.js
@@ -105,6 +105,10 @@ export class PosConfig extends Base {
         }
         return Array.from(available_pricelists);
     }
+
+    get paymentMethods() {
+        return this.payment_method_ids.slice().sort((a, b) => a.sequence - b.sequence);
+    }
 }
 
 registry.category("pos_available_models").add(PosConfig.pythonModel, PosConfig);

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -44,7 +44,7 @@ export class PaymentScreen extends Component {
     }
 
     get configPaymentMethods() {
-        return this.pos.config.payment_method_ids.slice().sort((a, b) => a.sequence - b.sequence);
+        return this.pos.config.paymentMethods;
     }
 
     onMounted() {

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -835,11 +835,6 @@ registry.category("web_tour.tours").add("test_no_kitchen_confirmation_for_deposi
             ProductScreen.clickPartnerButton(),
             PartnerList.clickPartnerOptions("A powerful PoS man!"),
             PartnerList.clickDropDownItemText("Deposit money"),
-            {
-                content: "select payment method for deposit money",
-                trigger: ".o_dialog .selection-item:contains('bank')",
-                run: "click",
-            },
             PaymentScreen.clickNumpad("+10"),
             PaymentScreen.fillPaymentLineAmountMobile("bank", "10.0"),
             PaymentScreen.clickValidate(),


### PR DESCRIPTION
### In this commit:
- Remove the payment method selection step from `test_no_kitchen_confirmation_for_deposit_money`
as deposits now automatically use the first available non–pay later payment method.

Task:5927077

Related PR:
- Enterprise: https://github.com/odoo/enterprise/pull/107368