### PR TITLE
[FIX] html_editor: preserve vertical video option on reopen

### DIFF
--- a/addons/html_editor/static/src/main/media/media_dialog/video_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/video_selector.js
@@ -147,9 +147,8 @@ export class VideoSelector extends Component {
                     if (!src.startsWith("https:") && !src.startsWith("http:")) {
                         this.state.urlInput = "https:" + this.state.urlInput;
                     }
-                    this.state.isVertical = !!closestElement(
-                        this.props.media,
-                        ".media_iframe_video"
+                    this.state.isVertical = !!closestElement(this.props.media, (el) =>
+                        el.matches('div[data-embedded="video"], .media_iframe_video')
                     )?.dataset.isVertical;
                     await this.syncOptionsWithUrl();
                     if (status(this) === "destroyed") {


### PR DESCRIPTION
#### Description of the issue this PR addresses:

- In this [PR](https://github.com/odoo/odoo/pull/242219), `.media_iframe_video` class removed from embedded video.
- No common selector for website video and embedded video block

#### Steps to reproduce:

- Insert a video from media dialog
- Enable Vertical option
- Reopen dialog via Replace action
- Vertical option is not preserved

task-5931717

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
