### PR TITLE
[IMP] mail: open avatar card when clicking follower in follower list

### DIFF
--- a/addons/mail/static/src/core/web/follower.js
+++ b/addons/mail/static/src/core/web/follower.js
@@ -1,7 +1,9 @@
 import { useService } from "@web/core/utils/hooks";
 import { Component } from "@odoo/owl";
 import { FollowerSubtypeDialog } from "@mail/core/web/follower_subtype_dialog";
+import { AvatarCardPopover } from "@mail/discuss/web/avatar_card/avatar_card_popover";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { usePopover } from "@web/core/popover/popover_hook";
 
 /**
  * @typedef {Object} Props
@@ -17,14 +19,17 @@ export class Follower extends Component {
 
     setup() {
         this.store = useService("mail.store");
+        this.avatarCard = usePopover(AvatarCardPopover, { position: "right" });
     }
 
-    onClickDetails() {
-        this.store.openDocument({
+    onClickDetails(ev) {
+        if (this.avatarCard.isOpen) {
+            return;
+        }
+        this.avatarCard.open(ev.currentTarget, {
             id: this.props.follower.partner_id.id,
-            model: "res.partner"
+            model: "res.partner",
         });
-        this.props.close?.();
     }
 
     async onClickEdit() {

--- a/addons/mail/static/src/core/web/follower.xml
+++ b/addons/mail/static/src/core/web/follower.xml
@@ -3,7 +3,7 @@
 
     <t t-name="mail.Follower">
         <DropdownItem class="'o-mail-Follower d-flex justify-content-between p-0'">
-            <a class="o-mail-Follower-details d-flex align-items-center flex-grow-1 px-3 o-min-width-0" t-att-class="{ 'o-inactive opacity-75 text-reset text-decoration-line-through': !props.follower.is_active }" href="#" role="menuitem" t-on-click.prevent="(ev) => this.onClickDetails(ev)">
+            <a class="o-mail-Follower-details d-flex align-items-center flex-grow-1 px-3 o-min-width-0" t-att-class="{ 'o-inactive opacity-75 text-reset text-decoration-line-through': !props.follower.is_active }" href="#" role="menuitem" t-on-click.prevent.stop="(ev) => this.onClickDetails(ev)">
                 <img class="o-mail-Follower-avatar o_avatar me-2 rounded" t-att-src="props.follower.partner_id.avatarUrl" alt=""/>
                 <span class="flex-shrink text-truncate" t-esc="props.follower.partner_id.name"/>
             </a>

--- a/addons/mail/static/tests/chatter/web/follower.test.js
+++ b/addons/mail/static/tests/chatter/web/follower.test.js
@@ -9,8 +9,7 @@ import {
     startServer,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, expect, test } from "@odoo/hoot";
-import { Deferred } from "@odoo/hoot-mock";
-import { mockService, onRpc } from "@web/../tests/web_test_helpers";
+import { onRpc } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -56,27 +55,14 @@ test("base rendering editable", async () => {
     await contains("[title='Remove this follower']");
 });
 
-test("click on partner follower details", async () => {
+test("click on partner follower opens avatar card", async () => {
     const pyEnv = await startServer();
-    const [threadId, partnerId] = pyEnv["res.partner"].create([{}, {}]);
+    const [threadId, partnerId] = pyEnv["res.partner"].create([{}, { name: "Batman" }]);
     pyEnv["mail.followers"].create({
         is_active: true,
         partner_id: partnerId,
         res_id: threadId,
         res_model: "res.partner",
-    });
-    const openFormDef = new Deferred();
-    mockService("action", {
-        doAction(action) {
-            if (action?.res_id !== partnerId) {
-                return super.doAction(...arguments);
-            }
-            expect.step("do_action");
-            expect(action.res_id).toBe(partnerId);
-            expect(action.res_model).toBe("res.partner");
-            expect(action.type).toBe("ir.actions.act_window");
-            openFormDef.resolve();
-        },
     });
     await start();
     await openFormView("res.partner", threadId);
@@ -84,8 +70,7 @@ test("click on partner follower details", async () => {
     await contains(".o-mail-Follower");
     await contains(".o-mail-Follower-details");
     await click(".o-mail-Follower-details:first");
-    await openFormDef;
-    await expect.waitForSteps(["do_action"]); // redirect to partner profile
+    await contains(".o_avatar_card:contains('Batman')");
 });
 
 test("click on edit follower", async () => {


### PR DESCRIPTION
Before this commit, clicking on a follower in the chatter always opened the partner form view.

This commit changes the behaviour to open the avatar card.

enterprise-https://github.com/odoo/enterprise/pull/107393
task-[5873738](https://www.odoo.com/odoo/project/1519/tasks/5873738)
