### PR TITLE
[FIX] point_of_sale: only show LNA checkbox for ePOS

### DIFF
--- a/addons/point_of_sale/views/pos_printer_view.xml
+++ b/addons/point_of_sale/views/pos_printer_view.xml
@@ -16,7 +16,7 @@
                         <group>
                             <field name="use_type" widget="radio" options="{'horizontal': True}" class="pb-1"/>
                             <field name="epson_printer_ip" invisible="printer_type != 'epson_epos'" placeholder="10.100.50.87" required="printer_type == 'epson_epos'"/>
-                            <field name="use_lna"/>
+                            <field name="use_lna" invisible="printer_type != 'epson_epos'"/>
                             <field name="product_categories_ids" invisible="use_type != 'preparation'" widget="many2many_tags" required="use_type == 'preparation'"/>
                         </group>
                     </group>


### PR DESCRIPTION
This commit ensures the LNA checkbox in the POS printer form only shows for ePOS printers. This is due to IoT printers now showing their own checkbox which comes from the field on the IoT box.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
