### PR TITLE
[FIX] website, *: adapt snippet products arrows position

### DIFF
--- a/addons/website/static/src/snippets/s_dynamic_snippet_carousel/000.scss
+++ b/addons/website/static/src/snippets/s_dynamic_snippet_carousel/000.scss
@@ -24,7 +24,7 @@
         width: auto;
     }
 
-    &:where(:not(.o_carousel_multi_items)) {
+    &:where(:not(.o_carousel_multi_items)) > :where(:not(.container-fluid)) {
         .s_dynamic_snippet_title_aside + .s_dynamic_snippet_content {
             .s_dynamic_snippet_arrows {
                 @include media-breakpoint-up(lg) {

--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.scss
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.scss
@@ -33,15 +33,17 @@
         }
 
         @include media-breakpoint-up(lg) {
-            &:where(:not(.o_carousel_multi_items):has(.s_dynamic_snippet_title_aside)) {
-                .o_carousel_arrow_wrap {
-                    --o-wsale-card-thumb-aspect-ratio: none;
+            &:where(:not(.o_carousel_multi_items)) > :where(:not(.container-fluid)) {
+                .s_dynamic_snippet_title_aside + .s_dynamic_snippet_content {
+                    .o_carousel_arrow_wrap {
+                        --o-wsale-card-thumb-aspect-ratio: none;
+                    }
                 }
             }
         }
     }
 }
-.s_dynamic_snippet_products .container-fluid .s_dynamic_snippet_content {
+.s_dynamic_snippet_products:not(.o_arrows_bottom) .container-fluid .s_dynamic_snippet_content {
     @include media-breakpoint-up(md) {
         // Prevented horizontal overflow of control buttons.
         .carousel-control-prev {


### PR DESCRIPTION
*: website_sale

Since commit [1], the position of the arrows in the product snippet was broken when they were set to appear at the bottom.
It also fixes the arrow positioning when the snippet is set to full width, with the title displayed on the side and "Scrolling Mode" set to "All."
This commit correctly adjusts the arrow positioning.

[1]: https://github.com/odoo/odoo/commit/54fde5da6c229a7173c5b4c042b3330598db3904

task-5935743

| Before | After |
|--------|--------|
| <img width="1617" height="635" alt="Capture d’écran 2026-02-13 à 09 40 36" src="https://github.com/user-attachments/assets/21e3545c-e243-4ee7-9fd5-51ca06b8c496" /> | <img width="1620" height="664" alt="Capture d’écran 2026-02-13 à 09 39 14" src="https://github.com/user-attachments/assets/6dcdfc0f-6dc8-4293-9d23-ea36d19fc2b4" /> |
| <img width="1921" height="719" alt="Capture d’écran 2026-02-13 à 11 12 22" src="https://github.com/user-attachments/assets/8916438c-8108-43ec-a70a-aba8c83ba881" /> | <img width="1918" height="654" alt="Capture d’écran 2026-02-13 à 11 17 21" src="https://github.com/user-attachments/assets/df872f4a-5674-4fff-a0de-b6c99f30acb2" /> |



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
