### PR TITLE
[FIX] l10n_latam_base: changes identification type on country change

### DIFF
--- a/addons/l10n_latam_base/models/res_partner.py
+++ b/addons/l10n_latam_base/models/res_partner.py
@@ -28,6 +28,17 @@ class ResPartner(models.Model):
         super(ResPartner, partners_vat)._check_vat(validation=validation)
         (self - partners_vat)._run_check_identification(validation=validation)
 
+    @api.onchange('country_id')
+    def _onchange_country_id(self):
+        country = self.country_id or self.company_id.account_fiscal_country_id or self.env.company.account_fiscal_country_id
+        identification_type = self.l10n_latam_identification_type_id
+        if not identification_type or identification_type.country_id != country:
+            self.l10n_latam_identification_type_id = (
+                self.env['l10n_latam.identification.type'].search(
+                [('country_id', '=', country.id), ('is_vat', '=', True)], limit=1) or
+                self.env.ref('l10n_latam_base.it_vat', raise_if_not_found=False)
+            )
+
     @api.onchange('vat', 'country_id', 'l10n_latam_identification_type_id')
     def _onchange_vat(self):
         super()._onchange_vat()


### PR DESCRIPTION
**PROBLEM**
PR: https://github.com/odoo/odoo/pull/179078
Removed _onchange_country_id() which was used to set the identification type according to the country of the partner.
This PR reintroduce it, so id type and country remains consistent.

**STEP TO REPRODUCE**
1. install l10n_ar and l10n_co.
2. create a new partner.
3. set its country to Argentina, and select an argentinian id type.
4. set the country to Colombia and save. You end up with a partner from Colombia, with a id type that is used for Argentinian partners which shouldn't be possible.

opw-5801824