### PR TITLE
[FIX] l10n_it_edi_doi: Remove check on DOI tax being the only one on the line

### DIFF
--- a/addons/l10n_it_edi_doi/models/account_move.py
+++ b/addons/l10n_it_edi_doi/models/account_move.py
@@ -193,9 +193,6 @@ class AccountMove(models.Model):
             if declaration_lines and not declaration:
                 errors.append(_('Given the tax %s is applied, there should be a Declaration of Intent selected.',
                                 declaration_of_intent_tax.name))
-            if any(line.tax_ids != declaration_of_intent_tax for line in declaration_lines):
-                errors.append(_('A line using tax %s should not contain any other taxes',
-                                declaration_of_intent_tax.name))
         if errors:
             raise UserError('\n'.join(errors))
 


### PR DESCRIPTION
We should be able to add more taxes with the 0% on the same line, like the Enasarco and 23% RIT. Indeed in italy it is possible to have invoices with Dichiarazione d'intento togheter with a withholding and Enasarco taxes.

See also: odoo/odoo#236251

Ticket [link](https://www.odoo.com/odoo/project.task/5933699)
opw-5933699