### PR TITLE
[FIX] resource: avoid overriding tz with `False` value

### DIFF
--- a/addons/resource/models/resource_mixin.py
+++ b/addons/resource/models/resource_mixin.py
@@ -38,7 +38,7 @@ class ResourceMixin(models.AbstractModel):
                 resources_vals_list.append(
                     self._prepare_resource_values(
                         vals,
-                        vals.get('tz', False) or companies_tz.get(vals.get('company_id'))
+                        vals.pop('tz', False) or companies_tz.get(vals.get('company_id'))
                     )
                 )
             elif not vals.get('tz'):


### PR DESCRIPTION
Steps to reproduce
===============
1. Open appointment of resource type
2. Create a new resource from resource tags.
3. Give the resource a name and save. ----> ValidationError will be shown.

Technical
=======
From [commit], the [line] used `get` to access the tz. For the resource created from the above steps have tz value `False`, therefore using `get` keeps the `False` value of tz during creation and prevents ORM from applying default value for it.

After this commit, we pop the tz value from the create so that if provided tz is falsy ORM can apply the default value for it.
Even if the non-falsy value is popped, the tz is related field and will get this non-falsy value from the resource.

[commit]: https://github.com/odoo/odoo/commit/2dff65ab8b5a9db21d5b476065a72755cc4625be#diff-383adcc851bbfe8d26da4afe280f276eb39b70cbe79ba972cbcbb21a6b9fdceeR41
[line]: https://github.com/odoo/odoo/blob/2dff65ab8b5a9db21d5b476065a72755cc4625be/addons/resource/models/resource_mixin.py#L41

Task-5712786