### PR TITLE
[FIX] html_editor: fix traceback from rectifySelection

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -967,7 +967,7 @@ export class SelectionPlugin extends Plugin {
             isProtecting(node) || (isProtected(node) && !isUnprotecting(node));
         if (
             focusTarget !== anchorTarget &&
-            focusTarget.previousSibling === anchorTarget &&
+            focusTarget?.previousSibling === anchorTarget &&
             protectionCheck(anchorTarget)
         ) {
             return;


### PR DESCRIPTION
Before this commit: in rectifySelection, the focusTarget can be null and causing an error when calling the previousSibling

After this commit: now we do an optional chaining(?.) on previousSibling

task-5481248



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
