### PR TITLE
[FIX] mail: prevent duplicate dropdown in pinned messages panel

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -109,7 +109,7 @@ export class Message extends Component {
             emailHeaderOpen: false,
         });
         this.rightClickDropdownState = useDropdownState({
-            onClose: () => this.props.messageSelection.clearSelected(),
+            onClose: () => this.props.messageSelection?.clearSelected(),
         });
         this.rightClickAnchor = useChildRef("rightClickAnchor");
         /** @type {ShadowRoot} */


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
----------------------------------------------
When multiple messages are pinned, repeatedly right-clicking different
messages in the pinned messages panel can open multiple context dropdowns
simultaneously. This may lead to UI inconsistencies and potential crashes.

**Current behavior before PR:**
----------------------------------------------
- Multiple pinned messages can be right-clicked consecutively
- Each right-click may open an additional dropdown menu
- Duplicate dropdowns can remain visible at the same time
- This can cause unstable or inconsistent UI behavior

**Desired behavior after PR is merged:**
----------------------------------------------
- Only one dropdown menu is displayed at a time in the pinned messages panel
- Repeated right-clicks properly reuse or replace the existing dropdown
- Prevents duplicate dropdowns and avoids potential UI crashes

Task-5935503

----------------------------------------------

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
