### PR TITLE
[FIX] web: signature field notification service

### DIFF
--- a/addons/web/static/src/views/fields/signature/signature_field.js
+++ b/addons/web/static/src/views/fields/signature/signature_field.js
@@ -28,7 +28,7 @@ export class SignatureField extends Component {
 
     setup() {
         this.displaySignatureRatio = 3;
-
+        this.notification = useService("notification");
         this.dialogService = useService("dialog");
         this.state = useState({
             isValid: true,

--- a/addons/web/static/tests/views/fields/signature_field.test.js
+++ b/addons/web/static/tests/views/fields/signature_field.test.js
@@ -1,6 +1,6 @@
 import { NameAndSignature } from "@web/core/signature/name_and_signature";
 
-import { expect, test } from "@odoo/hoot";
+import { expect, queryOne, test } from "@odoo/hoot";
 import { animationFrame, runAllTimers } from "@odoo/hoot-mock";
 import { click, drag, edit, queryFirst, waitFor } from "@odoo/hoot-dom";
 import {
@@ -341,4 +341,23 @@ test("signature field should render initials", async () => {
         message: 'should open a modal with "Auto" button',
     });
     expect.verifySteps(["V.B."]);
+});
+
+test("error loading url", async () => {
+    Partner._records = [{
+        id: 1,
+        sign: "1 kb",
+    }]
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: /* xml */ `
+            <form>
+                <field name="sign" widget="signature" />
+            </form>`,
+    });
+    const img = queryOne(".o_field_widget img");
+    img.dispatchEvent(new Event("error"));
+    await waitFor(".o_notification:has(.bg-danger):contains(Could not display the selected image)");
 });


### PR DESCRIPTION
The notification service is later used in this [method](https://github.com/odoo/odoo/blob/04f3473da52ec74f3955cadd58eb016537497d44/addons/web/static/src/views/fields/signature/signature_field.js#L120), but it was never declared so it was causing an error.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
