### PR TITLE
[FIX] project_timesheet_holidays: fix timesheet generation for flexible employee

### DIFF
--- a/addons/project_timesheet_holidays/models/hr_leave.py
+++ b/addons/project_timesheet_holidays/models/hr_leave.py
@@ -36,11 +36,11 @@ class HrLeave(models.Model):
             calendar = leave.resource_calendar_id
             calendar_timezone = pytz.timezone((calendar or leave.employee_id).tz)
 
-            if calendar.flexible_hours and (leave.request_unit_hours or leave.request_unit_half or leave.date_from.date() == leave.date_to.date()):
+            if calendar.flexible_hours and leave.date_from.date() == leave.date_to.date():
                 leave_date = leave.date_from.astimezone(calendar_timezone).date()
                 if leave.request_unit_hours:
                     hours = leave.request_hour_to - leave.request_hour_from
-                elif leave.request_unit_half:
+                elif leave.request_unit_half and leave.request_date_from_period == leave.request_date_to_period:
                     hours = calendar.hours_per_day / 2
                 else:  # Single-day leave
                     hours = calendar.hours_per_day

--- a/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
+++ b/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
@@ -54,6 +54,12 @@ class TestTimesheetHolidays(TestCommonTimesheet):
             'time_type': 'other',
         })
 
+        self.hr_leave_type_half_day = self.env['hr.leave.type'].sudo().create({
+            'name': 'Time Off Type (half day)',
+            'requires_allocation': False,
+            'request_unit': 'half_day',
+        })
+
         # HR Officer allocates some leaves to the employee 1
         self.Requests = self.env['hr.leave'].with_context(mail_create_nolog=True, mail_notrack=True)
         self.Allocations = self.env['hr.leave.allocation'].with_context(mail_create_nolog=True, mail_notrack=True)
@@ -449,3 +455,50 @@ class TestTimesheetHolidays(TestCommonTimesheet):
         self.assertTrue(len(current_leave.timesheet_ids), 1)
         self.assertEqual(past_leave.timesheet_ids.unit_amount, 8, "The timesheet for the past contract should have 8 hours")
         self.assertEqual(current_leave.timesheet_ids.unit_amount, 7, "The timesheet for the Current contract should have 7 hours")
+
+    def test_timesheet_generation_for_flexible_employee_with_half_day_time_off_type(self):
+        """
+        Ensure timesheet entries are generated correctly for employees
+        with flexible schedules using a 'half-day' leave type:
+            - A full-day request creates an 8h entry.
+            - A half-day request creates a 4h entry.
+            - Multi-day requests aggregate correctly across days.
+        """
+        self.empl_employee.resource_calendar_id.flexible_hours = True
+
+        # Create 3 scenarios: Full Day, Single Half Day, and Multi-Day
+        time_off, time_off_half_day, time_off_multi_day = self.Requests.with_user(self.user_employee).create([
+            {
+                'name': 'Test Full Day',
+                'employee_id': self.empl_employee.id,
+                'holiday_status_id': self.hr_leave_type_half_day.id,
+                'request_date_from': datetime(2026, 2, 9),
+                'request_date_to': datetime(2026, 2, 9),
+            },
+            {
+                'name': 'Test Single Half Day',
+                'employee_id': self.empl_employee.id,
+                'holiday_status_id': self.hr_leave_type_half_day.id,
+                'request_date_from': datetime(2026, 2, 10),
+                'request_date_to': datetime(2026, 2, 10),
+                'request_date_from_period': 'am',
+                'request_date_to_period': 'am',
+            },
+            {
+                'name': 'Test Multi-Day',
+                'employee_id': self.empl_employee.id,
+                'holiday_status_id': self.hr_leave_type_half_day.id,
+                'request_date_from': datetime(2026, 2, 11),
+                'request_date_to': datetime(2026, 2, 12),
+            }]
+        )
+
+        (time_off | time_off_half_day | time_off_multi_day).with_user(SUPERUSER_ID).action_approve()
+        validation_data = [
+            (time_off, 1, 8.0),
+            (time_off_half_day, 1, 4.0),
+            (time_off_multi_day, 2, 16.0),
+        ]
+        for leave, expected_entries, expected_hours in validation_data:
+            self.assertEqual(len(leave.timesheet_ids), expected_entries, f"{leave.name}: incorrect number of timesheet entries.")
+            self.assertEqual(sum(leave.timesheet_ids.mapped('unit_amount')), expected_hours, f"{leave.name}: incorrect total timesheet hours.")


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Install Timesheets and Time Off.
2. Create a new Time Off type with duration type "Half Day"
(disable "Require allocation" to skip allocations).
3. Enable "Timesheets" in Timesheets > Configuration.
4. Ensure the employee is configured with a "Flexible" working schedule.
5. Create a multi-day Time Off request (2 days) using this type and approve it.
6. Check the timesheet entries for the employee.

Issue:
------
When a multi-day time off request is submitted for a "Half Day" time off type,
the system fails to generate individual daily timesheet entries. Instead, it generates
a single timesheet entry with a duration calculated as calendar.hours_per_day / 2,
regardless of the actual number of days requested.

(e.g., if hours_per_day is 8, it generates one entry of 4 hours for a 2-day leave),

Cause:
------
After this commit 9512832, multi-day requests were allowed for time off types
where the **request_unit** is "half day" or "hours". However, the logic in `_generate_timesheets`
for flexible calendars was not updated to account for this.

Previously, `request_unit_half` was computed as:
https://github.com/odoo/odoo/blob/feb3cd520d7a736996621f7765184edca6ac390c/addons/hr_holidays/models/hr_leave.py#L319-L323

But now, the condition is:
https://github.com/odoo/odoo/blob/14ccd1f54e21c07ac68593c8dec7682371f8663c/addons/hr_holidays/models/hr_leave.py#L467-L470

Since `request_unit_half` now stays **True** regardless of the request duration
(as long as the Type is 'half_day'), the following condition in `_generate_timesheets`:
https://github.com/odoo/odoo/blob/14ccd1f54e21c07ac68593c8dec7682371f8663c/addons/project_timesheet_holidays/models/hr_leave.py#L39 always evaluates to **True**. This traps multi-day requests in the
"single-day" logic, preventing the code from reaching `_list_work_time_per_day`.

Solution:
---------
Update the condition to strictly check if the request is a single day before applying
the simplified single-entry logic. If the request spans multiple days, it will now
correctly fall into the else block, utilizing `_list_work_time_per_day` to generate
one timesheet entry per day of the leave.

opw-5715197



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
