### PR TITLE
[IMP] account: try country_code to override the original one from base

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -106,7 +106,7 @@ class AccountBankStatementLine(models.Model):
         store=True,
     )
     country_code = fields.Char(
-        related='company_id.account_fiscal_country_id.code'
+        related='company_id.country_code'
     )
 
     # Technical field used to store the internal reference of the statement line for fast indexing and easier comparing

--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -165,7 +165,7 @@ class AccountJournal(models.Model):
     currency_id = fields.Many2one('res.currency', help='The currency used to enter statement', string="Currency")
     company_id = fields.Many2one('res.company', string='Company', required=True, readonly=True, index=True, default=lambda self: self.env.company,
         help="Company related to this journal")
-    country_code = fields.Char(related='company_id.account_fiscal_country_id.code', readonly=True)
+    country_code = fields.Char(related='company_id.country_code', readonly=True)
     account_fiscal_country_group_codes = fields.Json(related="company_id.account_fiscal_country_group_codes")
 
     refund_sequence = fields.Boolean(

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -335,7 +335,7 @@ class AccountMove(models.Model):
     made_sequence_gap = fields.Boolean(compute='_compute_made_sequence_gap', store=True)  # store wether this is the first move breaking the natural sequencing
     show_name_warning = fields.Boolean(store=False)
     type_name = fields.Char('Type Name', compute='_compute_type_name')
-    country_code = fields.Char(related='company_id.account_fiscal_country_id.code', readonly=True, depends=['company_id'])
+    country_code = fields.Char(related='company_id.country_code', readonly=True)
     account_fiscal_country_group_codes = fields.Json(related="company_id.account_fiscal_country_group_codes")
     company_price_include = fields.Selection(related='company_id.account_price_include', readonly=True)
     attachment_ids = fields.One2many('ir.attachment', 'res_id', domain=[('res_model', '=', 'account.move')], string='Attachments')

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -197,7 +197,7 @@ class AccountPayment(models.Model):
     # used to know whether the field `partner_bank_id` needs to be required or not in the payments form views
     require_partner_bank_account = fields.Boolean(
         compute='_compute_show_require_partner_bank')
-    country_code = fields.Char(related='company_id.account_fiscal_country_id.code')
+    country_code = fields.Char(related='company_id.country_code', depends=['company_id'])
     amount_signed = fields.Monetary(
         currency_field='currency_id', compute='_compute_amount_signed', tracking=True,
         help='Negative value of amount field if payment_type is outbound')

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -222,6 +222,8 @@ class ResCompany(models.Model):
         readonly=False,
         help="The country to use the tax reports from for this company")
     account_fiscal_country_group_codes = fields.Json(compute="_compute_account_fiscal_country_group_codes")
+    # OVERRIDE country_code
+    country_code = fields.Char(related='account_fiscal_country_id.code', depends=['account_fiscal_country_id'])
 
     account_enabled_tax_country_ids = fields.Many2many(
         string="l10n-used countries",

--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -152,7 +152,7 @@ class ResConfigSettings(models.TransientModel):
     )
 
     # Technical field to hide country specific fields from accounting configuration
-    country_code = fields.Char(related='company_id.account_fiscal_country_id.code', readonly=True)
+    country_code = fields.Char(related='company_id.country_code', readonly=True)
 
     # Storno Accounting
     account_storno = fields.Boolean(string="Storno accounting", readonly=False, related='company_id.account_storno')

--- a/addons/account/wizard/account_move_reversal.py
+++ b/addons/account/wizard/account_move_reversal.py
@@ -28,7 +28,7 @@ class AccountMoveReversal(models.TransientModel):
     )
     company_id = fields.Many2one('res.company', required=True, readonly=True)
     available_journal_ids = fields.Many2many('account.journal', compute='_compute_available_journal_ids')
-    country_code = fields.Char(related='company_id.country_id.code')
+    country_code = fields.Char(related='company_id.country_code')
 
     # computed fields
     residual = fields.Monetary(compute="_compute_from_moves")

--- a/addons/account_debit_note/wizard/account_debit_note.py
+++ b/addons/account_debit_note/wizard/account_debit_note.py
@@ -25,7 +25,7 @@ class AccountDebitNote(models.TransientModel):
     # computed fields
     move_type = fields.Char(compute="_compute_from_moves")
     journal_type = fields.Char(compute="_compute_journal_type")
-    country_code = fields.Char(related='move_ids.company_id.country_id.code')
+    country_code = fields.Char(related='move_ids.company_id.country_code')
 
     @api.model
     def default_get(self, fields):

--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from odoo import Command
 from odoo.tests.common import freeze_time, tagged
 
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.account.tests.test_account_move_send import TestAccountMoveSendCommon
 from odoo.addons.account_peppol.tests.common import (
     mock_ack,
@@ -15,23 +16,23 @@ from odoo.addons.account_peppol.tests.common import (
 from odoo.addons.mail.tests.common import MailCommon
 
 
+
 @freeze_time('2023-01-01')
 @tagged('-at_install', 'post_install')
 class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
     MESSAGE_UUID = '87b3d068-4da3-49c8-845c-ff2540e6b7d9'
 
     @classmethod
+    @AccountTestInvoicingCommon.setup_country('be')
     def setUpClass(cls):
         super().setUpClass()
         cls.env['ir.config_parameter'].sudo().set_str('account_peppol.edi.mode', 'test')
 
         cls.env.company.write({
-            'country_id': cls.env.ref('base.be').id,
             'peppol_eas': '0208',
             'peppol_endpoint': '0477472701',
             'account_peppol_proxy_state': 'receiver',
         })
-
         edi_identification = cls.env['account_edi_proxy_client.user']._get_proxy_identification(cls.env.company, 'peppol')
         cls.private_key = cls.env['certificate.key'].create({
             'name': 'Test key PEPPOL',
@@ -486,7 +487,7 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
         ])
 
     def test_available_peppol_sending_methods(self):
-        company_us = self.setup_other_company()['company']  # not a valid Peppol country
+        company_us = self.setup_other_company(country_id=self.env.ref('base.us').id)['company']  # not a valid Peppol country
         self.assertTrue('peppol' in self.valid_partner.with_company(self.env.company).available_peppol_sending_methods)
         self.assertFalse('peppol' in self.valid_partner.with_company(company_us).available_peppol_sending_methods)
 

--- a/addons/l10n_es_pos/tests/test_frontend.py
+++ b/addons/l10n_es_pos/tests/test_frontend.py
@@ -3,18 +3,20 @@
 
 import odoo.tests
 from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo import Command
 
 
 @odoo.tests.tagged('post_install_l10n', 'post_install', '-at_install')
 class TestUi(TestPointOfSaleHttpCommon):
+
     @classmethod
-    def _get_main_company(cls):
-        cls.company_data["company"].country_id = cls.env.ref("base.es").id
+    @AccountTestInvoicingCommon.setup_country('es')
+    def setUpClass(cls):
+        super().setUpClass()
         cls.company_data["company"].currency_id = cls.env.ref("base.EUR").id
         cls.company_data["company"].vat = "ESA12345674"
         cls.company_data["company"].state_id = cls.env.ref("base.state_es_ba").id
-        return cls.company_data["company"]
 
     def test_spanish_pos(self):
         split_payment_method = self.env['pos.payment.method'].create({


### PR DESCRIPTION
We override, original country_code from base
from `country_id.code` to `account_fiscal_country_id.code`
because most of the fields are visible based on account_fiscal_country_id
in `account` and `l10n` modules. Which makes more sense the field should
be moreover visible on my fiscal country rather than my company country_id

for account_peppol and l10n_es_pos-
we fix the test cases

Possible effect after this commit technically, modules
not using account but using country_code should create
a new company during the test rather than using the existing one

task-5454775

Co-authored-by: Harsh Modi <hamo@odoo.com>


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
