### PR TITLE
[FIX] resource: Correctly shade time off for employees with flexible hours

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -588,6 +588,8 @@ class ResourceCalendar(models.Model):
         for resource in resources_list:
             if resource and resource._is_fully_flexible():
                 continue
+            elif resource and resource._is_flexible():
+                resources_work_intervals[resource.id] = Intervals([(start_dt, end_dt, self.env['resource.calendar'])]) - self._leave_intervals(start_dt, end_dt, resource, domain, tz)
             work_intervals = [(start, stop) for start, stop, meta in resources_work_intervals[resource.id]]
             # start + flatten(intervals) + end
             work_intervals = [start_dt] + list(chain.from_iterable(work_intervals)) + [end_dt]


### PR DESCRIPTION
Problem:
The Time Off app incorrectly shades some days and shows them as
days off for employees with flexible hours.

Cause:
The time off shades
the days off for employees with flexible hours based on an assumption
that they work the average hours per day each day. So, if an employee
with 40 flexible hours (8h per day as average) starts on Tuesday, the
time off app assumes they worked 8h on Tuesday, Wednesday, Thursday,
Friday and Saturday. As a result, it would shade Sunday and Monday as
days off because the total of 40h per week was reached.

Solution:
In a
method that calculates unavailable intervals for employees, the method
was edited to treat employees with calendars with flexible hours as
always available, except for the days they have time off. This way, the
time off app will only shade the days that the employee has time off,
and not the days that they are assumed to be working based
on an average.

Steps to reproduce:
- Create or choose an employee with flexible
hours.
- Open time off app and go to overview
- Notice how some days are
shaded although the employee has flexible hours and may work on them.

opw-5922451