### PR TITLE
[FIX] html_editor: ensure table borders are visible in printed PDFs

### DIFF
--- a/addons/html_editor/static/src/scss/base_style.scss
+++ b/addons/html_editor/static/src/scss/base_style.scss
@@ -8,6 +8,16 @@ li.oe-nested {
         padding: 0.5rem;
     }
 }
+
+.table-bordered {
+    > :not(caption) > * {
+        border-width: 1px 0;
+        > * {
+            border-width: 0 1px;
+        }
+    }
+}
+
 $sizes: '', 'xs-', 'sm-', 'md-', 'lg-', 'xl-', 'xxl-';
 .o_text_columns {
     max-width: 100% !important;


### PR DESCRIPTION
Problem:
When adding a table in the Sale Quotation description and printing it, the generated PDF shows no table borders when opened in Firefox.

Cause:
Some PDF viewers (e.g., Firefox) do not render table borders correctly of a PDF created by `wkhtmltopdf` without an explicit border width.

Solution:
Explicitly define the border width in the `base_style` of `html_editor` to ensure consistent rendering in generated PDFs.

Steps to reproduce:
- Create a new Sale Order.
- Add a table in the description.
- Print the quotation.
- Open the generated PDF in Firefox.
- Observe that the table appears borderless.

opw-5857255

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
