### PR TITLE
[FIX] html_editor: misc URL autoconvert fixes

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -231,8 +231,15 @@ export class LinkPlugin extends Plugin {
         power_buttons: { commandId: "toggleLinkTools" },
 
         /** Handlers */
-        beforeinput_handlers: withSequence(5, this.onBeforeInput.bind(this)),
-        input_handlers: this.onInputDeleteNormalizeLink.bind(this),
+        beforeinput_handlers: [
+            withSequence(5, this.onBeforeInputPrepareConvertToLink.bind(this)),
+            this.onBeforeInputFixFirefoxSelection.bind(this),
+            withSequence(20, this.onBeforeInputConvertToLink.bind(this)),
+        ],
+        input_handlers: [
+            this.onInputDeleteNormalizeLink.bind(this),
+            this.onInputConvertToLink.bind(this),
+        ],
         before_delete_handlers: this.updateCurrentLinkSyncState.bind(this),
         delete_handlers: this.onInputDeleteNormalizeLink.bind(this),
         before_paste_handlers: this.updateCurrentLinkSyncState.bind(this),
@@ -813,36 +820,17 @@ export class LinkPlugin extends Plugin {
         }
     }
 
-    onBeforeInput(ev) {
-        if (ev.inputType === "insertParagraph" || ev.inputType === "insertLineBreak") {
-            const nodeForSelectionRestore = this.handleAutomaticLinkInsertion();
-            if (nodeForSelectionRestore) {
-                this.dependencies.selection.setCursorStart(nodeForSelectionRestore);
-                this.dependencies.history.addStep();
-            }
+    onBeforeInputPrepareConvertToLink(ev) {
+        if (
+            ev.inputType === "insertParagraph" ||
+            ev.inputType === "insertLineBreak" ||
+            (ev.inputType === "insertText" && ev.data === " ")
+        ) {
+            this.convertToLink = this.prepareConvertToLink();
         }
-        if (ev.inputType === "insertText" && ev.data === " ") {
-            const nodeForSelectionRestore = this.handleAutomaticLinkInsertion();
-            if (nodeForSelectionRestore) {
-                // Since we manually insert a space here, we will be adding a history step
-                // after link creation with selection at the end of the link and another
-                // after inserting the space. So first undo will remove the space, and the
-                // second will undo the link creation.
-                this.dependencies.selection.setSelection({
-                    anchorNode: nodeForSelectionRestore,
-                    anchorOffset: 0,
-                });
-                this.dependencies.history.addStep();
-                nodeForSelectionRestore.textContent =
-                    "\u00A0" + nodeForSelectionRestore.textContent;
-                this.dependencies.selection.setSelection({
-                    anchorNode: nodeForSelectionRestore,
-                    anchorOffset: 1,
-                });
-                this.dependencies.history.addStep();
-                ev.preventDefault();
-            }
-        }
+    }
+
+    onBeforeInputFixFirefoxSelection(ev) {
         // Firefox: avoid corrupted selection inside link.
         const selection = this.document.getSelection();
         if (
@@ -857,6 +845,26 @@ export class LinkPlugin extends Plugin {
             selection.collapse(selection.anchorNode, offset);
         }
         this.updateCurrentLinkSyncState();
+    }
+
+    onBeforeInputConvertToLink(ev) {
+        if (this.convertToLink) {
+            if (ev.inputType === "insertParagraph" || ev.inputType === "insertLineBreak") {
+                this.convertToLink();
+                this.dependencies.history.addStep();
+                delete this.convertToLink;
+            }
+        }
+    }
+
+    onInputConvertToLink(ev) {
+        if (this.convertToLink) {
+            if (ev.inputType === "insertText" && ev.data === " ") {
+                this.convertToLink();
+                this.dependencies.history.addStep();
+                delete this.convertToLink;
+            }
+        }
     }
 
     onInputDeleteNormalizeLink() {
@@ -894,8 +902,23 @@ export class LinkPlugin extends Plugin {
     /**
      * Inserts a link in the editor. Called after pressing space or (shif +) enter.
      * Performs a regex check to determine if the url has correct syntax.
+     * TODO Delete in master: kept for stable
      */
     handleAutomaticLinkInsertion() {
+        const convertToLink = this.prepareConvertToLink();
+        if (convertToLink) {
+            return convertToLink();
+        }
+    }
+
+    /**
+     * If a link must be inserted after pressing space or (shift +) enter,
+     * returns information that will be needed to insert the link.
+     * Performs a regex check to determine if the url has correct syntax.
+     *
+     * @returns {Function} that performs the link conversion
+     */
+    prepareConvertToLink() {
         let selection = this.dependencies.selection.getEditableSelection();
         if (
             isHtmlContentSupported(selection.anchorNode) &&
@@ -923,12 +946,16 @@ export class LinkPlugin extends Plugin {
                     startOffset,
                     startOffset + match[0].length
                 );
-                const link = this.createLink(url, text);
                 // split the text node and replace the url text with the link
                 const textNodeToReplace = selection.anchorNode.splitText(startOffset);
                 textNodeToReplace.splitText(match[0].length);
-                selection.anchorNode.parentElement.replaceChild(link, textNodeToReplace);
-                return nodeForSelectionRestore;
+                const link = this.createLink(url, text);
+                return () => {
+                    textNodeToReplace.splitText(match[0].length); // this will keep the space (that will have been added in the meantime)
+                    textNodeToReplace.parentNode.replaceChild(link, textNodeToReplace);
+                    // TODO Remove in master: kept for stable
+                    return nodeForSelectionRestore;
+                };
             }
         }
     }

--- a/addons/html_editor/static/src/main/link/utils.js
+++ b/addons/html_editor/static/src/main/link/utils.js
@@ -26,7 +26,7 @@ const tldWhitelist = [
 
 const urlRegexBase = `|(?:www.))[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-zA-Z][a-zA-Z0-9]{1,62}|(?:[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.(?:${tldWhitelist.join(
     "|"
-)})\\b))(?:(?:[/?#])[^\\s]*[^!.,})\\]'"\\s]|(?:[^!(){}.,[\\]'"\\s]+))?`;
+)})\\b))(?:(?:[/?#])[^\\s]*[^!.,})\\]'"\`\\s]|(?:[^!(){}.,[\\]'"\`\\s]+))?`;
 const httpCapturedRegex = `(https?:\\/\\/)`;
 
 export const URL_REGEX = new RegExp(`((?:(?:${httpCapturedRegex}${urlRegexBase})`, "i");

--- a/addons/html_editor/static/tests/_helpers/user_actions.js
+++ b/addons/html_editor/static/tests/_helpers/user_actions.js
@@ -72,6 +72,47 @@ export async function insertText(editor, text) {
     }
 }
 
+/**
+ * @param {Editor} editor
+ */
+export async function insertSpace(editor) {
+    const keydownEvent = await manuallyDispatchProgrammaticEvent(editor.editable, "keydown", {
+        key: " ",
+    });
+    if (keydownEvent.defaultPrevented) {
+        return;
+    }
+    // InputEvent is required to simulate the insert text.
+    const [beforeinputEvent] = await manuallyDispatchProgrammaticEvent(
+        editor.editable,
+        "beforeinput",
+        {
+            inputType: "insertText",
+            data: " ",
+        }
+    );
+    if (beforeinputEvent.defaultPrevented) {
+        return;
+    }
+    const range = editor.document.getSelection().getRangeAt(0);
+    if (!range.collapsed) {
+        throw new Error("need to implement something... maybe");
+    }
+
+    // mimic the behavior of the browser when inserting a &nbsp
+    document.execCommand("insertText", false, " ");
+
+    const [inputEvent] = await manuallyDispatchProgrammaticEvent(editor.editable, "input", {
+        inputType: "insertText",
+        data: " ",
+    });
+    if (inputEvent.defaultPrevented) {
+        return;
+    }
+    // KeyUpEvent is not required but is triggered like the browser would.
+    await manuallyDispatchProgrammaticEvent(editor.editable, "keyup", { key: " " });
+}
+
 /** @param {Editor} editor */
 export function deleteForward(editor) {
     execCommand(editor, "deleteForward");

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -17,7 +17,13 @@ import { contains, onRpc, patchWithCleanup } from "@web/../tests/web_test_helper
 import { setupEditor } from "../_helpers/editor";
 import { cleanLinkArtifacts } from "../_helpers/format";
 import { getContent, setContent, setSelection } from "../_helpers/selection";
-import { insertLineBreak, insertText, splitBlock, undo } from "../_helpers/user_actions";
+import {
+    insertLineBreak,
+    insertSpace,
+    insertText,
+    splitBlock,
+    undo,
+} from "../_helpers/user_actions";
 import { execCommand } from "../_helpers/userCommands";
 import { expectElementCount } from "../_helpers/ui_expectations";
 
@@ -249,7 +255,7 @@ describe("Link creation", () => {
         test("typing valid URL + space should convert to link", async () => {
             const { editor, el } = await setupEditor("<p>[]</p>");
             await insertText(editor, "http://google.co.in");
-            await insertText(editor, " ");
+            await insertSpace(editor);
             expect(cleanLinkArtifacts(getContent(el))).toBe(
                 '<p><a href="http://google.co.in">http://google.co.in</a>&nbsp;[]</p>'
             );

--- a/addons/html_editor/static/tests/link/transform.test.js
+++ b/addons/html_editor/static/tests/link/transform.test.js
@@ -137,9 +137,7 @@ test("transform text url into link and undo it", async () => {
     );
 
     undo(editor);
-    expect(cleanLinkArtifacts(getContent(el))).toBe(
-        '<p><a href="http://www.abc.jpg">www.abc.jpg</a>[]</p>'
-    );
+    expect(cleanLinkArtifacts(getContent(el))).toBe("<p>www.abc.jpg&nbsp;[]</p>");
 
     undo(editor);
     expect(cleanLinkArtifacts(getContent(el))).toBe("<p>www.abc.jpg[]</p>");

--- a/addons/html_editor/static/tests/link/transform.test.js
+++ b/addons/html_editor/static/tests/link/transform.test.js
@@ -3,66 +3,8 @@ import { manuallyDispatchProgrammaticEvent } from "@odoo/hoot-dom";
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { setupEditor, testEditor } from "../_helpers/editor";
 import { cleanLinkArtifacts } from "../_helpers/format";
-import { getContent, setSelection } from "../_helpers/selection";
-import { insertText, undo } from "../_helpers/user_actions";
-
-async function insertSpace(editor) {
-    const keydownEvent = await manuallyDispatchProgrammaticEvent(editor.editable, "keydown", {
-        key: " ",
-    });
-    if (keydownEvent.defaultPrevented) {
-        return;
-    }
-    // InputEvent is required to simulate the insert text.
-    const [beforeinputEvent] = await manuallyDispatchProgrammaticEvent(
-        editor.editable,
-        "beforeinput",
-        {
-            inputType: "insertText",
-            data: " ",
-        }
-    );
-    if (beforeinputEvent.defaultPrevented) {
-        return;
-    }
-    const range = editor.document.getSelection().getRangeAt(0);
-    if (!range.collapsed) {
-        throw new Error("need to implement something... maybe");
-    }
-    let offset = range.startOffset;
-    const node = range.startContainer;
-    // mimic the behavior of the browser when inserting a &nbsp
-    const twoSpace = " \u00A0";
-    node.textContent = (
-        node.textContent.slice(0, offset) +
-        " " +
-        node.textContent.slice(offset)
-    ).replaceAll("  ", twoSpace);
-
-    if (
-        node.nextSibling &&
-        node.nextSibling.textContent.startsWith(" ") &&
-        node.textContent.endsWith(" ")
-    ) {
-        node.nextSibling.textContent = "\u00A0" + node.nextSibling.textContent.slice(1);
-    }
-
-    offset++;
-    setSelection({
-        anchorNode: node,
-        anchorOffset: offset,
-    });
-
-    const [inputEvent] = await manuallyDispatchProgrammaticEvent(editor.editable, "input", {
-        inputType: "insertText",
-        data: " ",
-    });
-    if (inputEvent.defaultPrevented) {
-        return;
-    }
-    // KeyUpEvent is not required but is triggered like the browser would.
-    await manuallyDispatchProgrammaticEvent(editor.editable, "keyup", { key: " " });
-}
+import { getContent } from "../_helpers/selection";
+import { insertSpace, insertText, undo } from "../_helpers/user_actions";
 
 /**
  * Automatic link creation when pressing Space, Enter or Shift+Enter after an url
@@ -173,7 +115,7 @@ test("should not transform an email url after space", async () => {
     await testEditor({
         contentBefore: "<p>user@domain.com[]</p>",
         stepFunction: (editor) => insertSpace(editor),
-        contentAfter: "<p>user@domain.com []</p>",
+        contentAfter: "<p>user@domain.com&nbsp;[]</p>",
     });
 });
 
@@ -188,7 +130,8 @@ test("should not transform url after two space", async () => {
 
 test("transform text url into link and undo it", async () => {
     const { el, editor } = await setupEditor(`<p>[]</p>`);
-    await insertText(editor, "www.abc.jpg ");
+    await insertText(editor, "www.abc.jpg");
+    await insertSpace(editor);
     expect(cleanLinkArtifacts(getContent(el))).toBe(
         '<p><a href="http://www.abc.jpg">www.abc.jpg</a>&nbsp;[]</p>'
     );

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -3181,6 +3181,16 @@ describe("link", () => {
                 contentAfter: "<pre>http://www.xyz.com[]</pre>",
             });
         });
+
+        test("should paste and transform an URL between backticks", async () => {
+            await testEditor({
+                contentBefore: "<p>ab[]cd</p>",
+                stepFunction: async (editor) => {
+                    pasteText(editor, "`http://www.xyz.com`");
+                },
+                contentAfter: '<p>ab`<a href="http://www.xyz.com">http://www.xyz.com</a>`[]cd</p>',
+            });
+        });
     });
 
     describe("range not collapsed", () => {

--- a/addons/html_editor/static/tests/utils/user_actions.test.js
+++ b/addons/html_editor/static/tests/utils/user_actions.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "@odoo/hoot";
 import { setupEditor } from "../_helpers/editor";
 import { getContent } from "../_helpers/selection";
-import { simulateArrowKeyPress } from "../_helpers/user_actions";
+import { insertSpace, simulateArrowKeyPress } from "../_helpers/user_actions";
 
 describe("simulateArrowKeyPress method", () => {
     describe("move", () => {
@@ -107,5 +107,33 @@ describe("simulateArrowKeyPress method", () => {
                 );
             });
         });
+    });
+});
+
+describe("insertSpace method", () => {
+    test("insert first space", async () => {
+        const { editor, el } = await setupEditor("<p>a[]b</p>");
+        await insertSpace(editor);
+        expect(getContent(el)).toBe("<p>a []b</p>");
+    });
+    test("insert space after space", async () => {
+        const { editor, el } = await setupEditor("<p>a []b</p>");
+        await insertSpace(editor);
+        expect(getContent(el)).toBe("<p>a&nbsp; []b</p>");
+    });
+    test("insert space before space", async () => {
+        const { editor, el } = await setupEditor("<p>a[] b</p>");
+        await insertSpace(editor);
+        expect(getContent(el)).toBe("<p>a&nbsp;[] b</p>");
+    });
+    test("insert space at begin", async () => {
+        const { editor, el } = await setupEditor("<p>[]a</p>");
+        await insertSpace(editor);
+        expect(getContent(el)).toBe("<p>&nbsp;[]a</p>");
+    });
+    test("insert space at end", async () => {
+        const { editor, el } = await setupEditor("<p>a[]</p>");
+        await insertSpace(editor);
+        expect(getContent(el)).toBe("<p>a&nbsp;[]</p>");
     });
 });


### PR DESCRIPTION
[FIX] html_editor: undo link autoconvert before space insertion

When adding a space after an URL, the URL text is converted to an URL.
When pressing undo, first the space is undone, then the link is undone.
This is wrong because if the user did not want a link, after undoing the
link, inserting a new space will again convert to a link.

This commit splits `handleAutomaticLinkInsertion` into two parts:
determining if a link must be created, and actually inserting the link.
This makes it possible to execute code within the condition before and
after the insertion.
To fix the similar behavior for enter and shift-enter, another before
input handler is also added in order to let the default before input be
executed before creating the link.

Steps to reproduce:
- Go to a "To do" note
- Type "odoo.com"
- Press space/enter/shift-enter
- Undo a single time

=> The insertion was undone instead of the link transform.

task-5936310


[FIX] html_editor: not include surrounding backtick in pasted URL

When pasting an URL surrounded by backticks, the ending backtick is included inside the link's HREF.

This commit fixes the regex for URL to also exclude backticks (like it did with `"` and `'`).

Steps to reproduce:
- Copy the following text in the clipboard:
```
`odoo.com`
```
- Go to a "To do" note
- Paste

=> The link's URL was
```
odoo.com`
```

task-5936310
