### PR TITLE
[FIX] product: fix Arabic alignment in Product Catalog

### DIFF
--- a/addons/product/static/src/product_catalog/order_line/order_line.xml
+++ b/addons/product/static/src/product_catalog/order_line/order_line.xml
@@ -4,8 +4,10 @@
         <!-- Replace the element found using the css selector by the content of the portalled
              template.  -->
         <t t-portal="`#product-${props.productId}-price`">
-            <span t-if="showPrice" t-out="price" class="o_product_catalog_price fw-bold me-4"/>
-            <span t-if="props.code" t-out="props.code" class="text-muted"/>
+            <div class="d-inline-flex align-items-baseline">
+                <span t-if="showPrice" t-out="price" class="o_product_catalog_price fw-bold me-4"/>
+                <span t-if="props.code" t-out="props.code" class="text-muted"/>
+            </div>
         </t>
         <div 
             t-if="props.readOnly and props.warning"


### PR DESCRIPTION
Steps to reproduce:
1. Switch the user language to Arabic.
2. Open the Product Catalog from a Sales/Purchase order.
3. Observe that the Name, Internal Reference, and Price collapse into a single line with inconsistent ordering due to unmanaged horizontal inline flow.

Cause:
The use of generic span elements inside a portal encourages horizontal inline flow that fails to mirror correctly in RTL without explicit flex instructions.

Solution:
Update the Order Line portal template to use 'd-inline-flex' and 'align-items-baseline'. This treats the price and reference as a logical unit that respects the global direction and ensures consistent text alignment in both English and Arabic.

opw-5867434