### PR TITLE
[FIX] base: use NumberObject for embedded file /Size in PDF/A-3

### DIFF
--- a/odoo/tools/pdf/__init__.py
+++ b/odoo/tools/pdf/__init__.py
@@ -621,7 +621,7 @@ class OdooPdfFileWriter(PdfFileWriter):
                 DictionaryObject({
                     NameObject('/CheckSum'): createStringObject(md5(attachment['content']).hexdigest()),
                     NameObject('/ModDate'): createStringObject(datetime.now().strftime(DEFAULT_PDF_DATETIME_FORMAT)),
-                    NameObject('/Size'): NameObject(f"/{len(attachment['content'])}"),
+                    NameObject('/Size'): NumberObject(len(attachment['content'])),
                 }),
         })
         if attachment.get('subtype'):


### PR DESCRIPTION
The `/Size` parameter in embedded file `/Params` was being set using `NameObject` instead of `NumberObject`, resulting in the size value being stored as a PDF Name Object (e.g., `/19410`) rather than a numeric integer (`19410`).
This causes PDF/A-3 validators to report zero-size or invalid attachments, breaking compliance with ISO 19005-3 (PDF/A-3A).

Steps to reproduce:
- Generate an e-invoice PDF with XML attachments (e.g., Factur-X)
- Validate the PDF with veraPDF or Adobe Acrobat Preflight
- Embedded file size is reported as zero or invalid

Fix:
```diff
- NameObject('/Size'): NameObject(f"/{len(attachment['content'])}"),
+ NameObject('/Size'): NumberObject(len(attachment['content'])),

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
