### PR TITLE
[FIX] web_editor: properly parse pasted XML in email templates

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -47,6 +47,7 @@ import {
 import { isCSSColor } from '@web/core/utils/colors';
 import { EmojiPicker } from '@web/core/emoji_picker/emoji_picker';
 import { Tooltip } from "@web/core/tooltip/tooltip";
+import { fixInvalidHTML } from "../editor/odoo-editor/src/OdooEditor";
 
 const OdooEditor = OdooEditorLib.OdooEditor;
 const getDeepRange = OdooEditorLib.getDeepRange;
@@ -344,7 +345,7 @@ export class Wysiwyg extends Component {
 
         this.$editable ??= this.$el;
         if (options.value) {
-            this.$editable.html(options.value);
+            this.$editable.html(fixInvalidHTML(options.value));
         }
 
         this._isDocumentStale = false;


### PR DESCRIPTION
Problem:
Pasted HTML in email templates is not properly parsed.

Cause:
The pasted content can be valid XML. In that case, some self-closing elements (e.g. self-closing `t` tags) are not correctly parsed by the editor, leading to malformed content.

Solution:
Call the `fixInvalidHTML` utility when starting the edition to normalize the content and properly handle self-closing tags.

Steps to reproduce:
- Open an email template.
- Add some content.
- Toggle to code view.
- Paste XML containing a self-closing `t` tag.
- Observe that the content is not properly parsed.

opw-5089487

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
