### PR TITLE
[FIX] resource: Compute average hours with duration-based schedule

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -695,7 +695,10 @@ class ResourceCalendar(models.Model):
         self.ensure_one()
         hour_count = 0.0
         for attendance in self._get_global_attendances():
-            hour_count += attendance.duration_hours
+            if self.duration_based:
+                hour_count += attendance.duration_hours
+            else:
+                hour_count += attendance.hour_to - attendance.hour_from
         return hour_count / 2 if self.two_weeks_calendar else hour_count
 
     def _get_hours_per_day(self):

--- a/addons/resource/tests/test_resource_calendar.py
+++ b/addons/resource/tests/test_resource_calendar.py
@@ -192,3 +192,34 @@ class TestResourceCalendar(TransactionCase):
         calendar_form.save()
         self.assertEqual(calendar.hours_per_day, 7)
         self.assertEqual(calendar.hours_per_week, 21)
+
+    def test_duration_based_average_hours(self):
+        """Checks that the average hours for days and weeks are correctly computed when the option Define Amount of
+        Hours per Day has been checked."""
+        calendar = self.env['resource.calendar'].create({
+            'name': 'Duration based Calendar',
+            'attendance_ids': False,
+            'duration_based': True,
+        })
+        with Form(calendar) as form:
+            with form.attendance_ids.new() as monday_attendance:
+                monday_attendance.name = 'Mon'
+                monday_attendance.dayofweek = '0'
+                monday_attendance.day_period = 'full_day'
+                monday_attendance.duration_hours = 4.0
+
+            with form.attendance_ids.new() as tuesday_attendance:
+                tuesday_attendance.name = 'Tue'
+                tuesday_attendance.dayofweek = '1'
+                tuesday_attendance.day_period = 'full_day'
+                tuesday_attendance.duration_hours = 4.0
+
+            with form.attendance_ids.new() as wednesday_attendance:
+                wednesday_attendance.name = 'Wed'
+                wednesday_attendance.dayofweek = '2'
+                wednesday_attendance.day_period = 'full_day'
+                wednesday_attendance.duration_hours = 4.0
+            self.assertEqual(
+                (form.hours_per_week, form.hours_per_day),
+                (12, 4),
+            )


### PR DESCRIPTION
## Short functional explanation of the error
When editing attendances of a schedule for which we checked the box `Define Amount of Hours per Day`, the resulting average hours per day and hours per week fields aren't computed correctly.

## Reproduction Steps
1. Go to Employee > configuration > Working Schedules.
2. Create a working schedule. Check the box Define Amount of Hours per day and in the Working Hours tab, remove all intendances.
3. Add a line for Monday, set the day period to Full Day and the duration in hours to 4.
4. Repeat the operation for tuesday and wednesday.

### Expected behavior
As we have 3 days during which we work 4 hours, the average hours per day should be 4, and the total hours per week should be 12.

### Unexpected behavior
The average hours per day and hours per week don't show the correct numbers.

## Origin of the issue
We compute the hours per week with this method:
https://github.com/odoo/odoo/blob/ae9fd7cc7d434d4b222c81aa58515c57d7426b65/addons/resource/models/resource_calendar.py#L690-L696 However, when we check the box `Define Amount of Hours per Day`, we don't set the attendances starting and ending hours. Instead, we work with duration hours.
Therefore, when the box is checked, we have to compute the weekly hours with the field `duration_hours`, and not `hour_from` / `hour_to`.

__
opw-5885571