### PR TITLE
[IMP] mail: add copy suffix when duplicating canned responses

### DIFF
--- a/addons/mail/models/mail_canned_response.py
+++ b/addons/mail/models/mail_canned_response.py
@@ -71,6 +71,12 @@ class MailCannedResponse(models.Model):
         self._broadcast(delete=True)
         return super().unlink()
 
+    def copy_data(self, default=None):
+        vals_list = super().copy_data(default=default)
+        if "source" not in (default or {}):
+            return [dict(vals, source=self.env._("%s (copy)", rec.source)) for rec, vals in zip(self, vals_list)]
+        return vals_list
+
     def _broadcast(self, /, *, delete=False):
         for canned_response in self:
             stores = [Store(bus_channel=group) for group in canned_response.group_ids]

--- a/addons/mail/tests/__init__.py
+++ b/addons/mail/tests/__init__.py
@@ -9,6 +9,7 @@ from . import test_ir_websocket
 from . import test_kpi_provider
 from . import test_link_preview
 from . import test_mail_activity
+from . import test_mail_canned_response
 from . import test_mail_composer
 from . import test_mail_mail
 from . import test_mail_message

--- a/addons/mail/tests/test_mail_canned_response.py
+++ b/addons/mail/tests/test_mail_canned_response.py
@@ -1,0 +1,20 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.mail.tests.common import MailCommon
+from odoo.tests.common import tagged
+
+
+@tagged("mail_canned_response")
+class TestMailCannedResponse(MailCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.canned_responses = cls.env["mail.canned.response"].create([
+            {"source": "hello", "substitution": "Hello, how may I help you?"},
+            {"source": "bye", "substitution": "Goodbye, have a nice day!"},
+        ])
+
+    def test_mail_canned_response_copy(self):
+        copied_responses = self.canned_responses.copy()
+        self.assertEqual(copied_responses.mapped("source"), ["hello (copy)", "bye (copy)"])


### PR DESCRIPTION
**Description of the issue this PR addresses:**
Previously, duplicating canned responses did not add any indication that 
the record was duplicated, making it difficult to distinguish 
between original and copied records.

**Desired behavior after PR is merged:**
- Adds `(copy)` suffix to the source field when duplicating canned responses.

task-[5873772](https://www.odoo.com/odoo/project/1519/tasks/5873772)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
