### PR TITLE
[IMP] mail: cleanup poll votes panel

### DIFF
--- a/addons/mail/controllers/webclient.py
+++ b/addons/mail/controllers/webclient.py
@@ -77,13 +77,6 @@ class WebclientController(ThreadController):
                     fields_params={"request_list": params["request_list"]},
                     as_thread=True,
                 )
-        if name == "/mail/poll/options":
-            poll_id = params.get("poll_id")
-            # sudo - mail.poll: validated by "_get_thread_with_access" afterwards.
-            if poll_sudo := request.env["mail.poll"].sudo().search([("id", "=", poll_id)]):
-                message = poll_sudo.start_message_id
-                if self._get_thread_with_access(message.model, message.res_id, mode="read"):
-                    store.add(poll_sudo.option_ids, ["number_of_votes", "option_label"])
         if name == "/mail/poll_option/votes":
             option_id = params.get("poll_option_id")
             # sudo - mail.poll.option: validated by "_get_thread_with_access" afterwards.

--- a/addons/mail/static/src/core/common/mail_poll_model.js
+++ b/addons/mail/static/src/core/common/mail_poll_model.js
@@ -27,18 +27,6 @@ export class MailPollModel extends Record {
         return this.store.self_user?.eq(this.create_uid);
     }
 
-    async fetchPollOptionsCached() {
-        if (!this.optionsFetched) {
-            try {
-                this.optionsFetched = true;
-                await this.store.fetchStoreData("/mail/poll/options", { poll_id: this.id });
-            } catch (e) {
-                this.optionsFetched = false;
-                throw e;
-            }
-        }
-    }
-
     get numberOfVotes() {
         return this.option_ids.reduce((sum, option) => sum + option.number_of_votes, 0);
     }

--- a/addons/mail/static/src/core/common/mail_poll_option_model.js
+++ b/addons/mail/static/src/core/common/mail_poll_option_model.js
@@ -4,6 +4,16 @@ import { Record } from "@mail/model/record";
 export class MailPollOptionModel extends Record {
     static _name = "mail.poll.option";
 
+    static new() {
+        const option = super.new(...arguments);
+        option.fetchPollVotesCached = option.store.makeCachedFetchData("/mail/poll_option/votes", {
+            poll_option_id: option.id,
+        });
+        return option;
+    }
+
+    /** @type {ReturnType<import("models").Store['makeCachedFetchData']>} */
+    fetchPollVotesCached;
     /** @type {number} */
     id;
     /** @type {number} */
@@ -16,19 +26,5 @@ export class MailPollOptionModel extends Record {
     vote_ids = fields.Many("mail.poll.vote", { inverse: "option_id" });
     /** @type {number} */
     vote_percentage;
-
-    async fetchPollVotesCached() {
-        if (!this.votesFetched) {
-            try {
-                this.votesFetched = true;
-                await this.store.fetchStoreData("/mail/poll_option/votes", {
-                    poll_option_id: this.id,
-                });
-            } catch (e) {
-                this.votesFetched = false;
-                throw e;
-            }
-        }
-    }
 }
 MailPollOptionModel.register();

--- a/addons/mail/static/src/core/common/poll_votes_panel.js
+++ b/addons/mail/static/src/core/common/poll_votes_panel.js
@@ -2,7 +2,7 @@ import { TabHeader, TabPanel, Tabs } from "@mail/core/common/tabs";
 import { attClassObjectToString } from "@mail/utils/common/format";
 import { onExternalClick } from "@mail/utils/common/hooks";
 
-import { Component, onWillStart, onWillUpdateProps } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 
 import { Dialog } from "@web/core/dialog/dialog";
 import { useChildRef, useService } from "@web/core/utils/hooks";
@@ -27,19 +27,11 @@ export class PollVotesPanel extends Component {
                 this.props.close?.();
             }
         });
-        onWillStart(() => {
-            this.props.poll.fetchPollOptionsCached();
-        });
-        onWillUpdateProps((next) => {
-            if (next.poll?.notEq(this.props.poll)) {
-                next.poll.fetchPollOptionsCached();
-            }
-        });
     }
 
     /** @param {import("models").MailPollOptionModel} option */
     onTabPanelVisible(option) {
-        option.fetchPollVotesCached();
+        option.fetchPollVotesCached.fetch();
     }
 
     get contentClass() {

--- a/addons/mail/static/src/core/common/poll_votes_panel.scss
+++ b/addons/mail/static/src/core/common/poll_votes_panel.scss
@@ -1,3 +1,8 @@
 .o-mail-PollVotesPanel-avatar.o_avatar {
     --Avatar-size: #{$o-mail-Avatar-size};
 }
+
+.o-mail-PollVotesPanel-emptyEmoji {
+    font-size: 5rem;
+    filter: grayscale(1);
+}

--- a/addons/mail/static/src/core/common/poll_votes_panel.xml
+++ b/addons/mail/static/src/core/common/poll_votes_panel.xml
@@ -24,6 +24,10 @@
                             <img class="rounded o-mail-PollVotesPanel-avatar o_avatar" t-att-src="persona.avatarUrl"/>
                             <span class="mx-2 text-truncate fs-6" t-esc="props.poll.start_message_id.getPersonaName(persona)"/>
                         </div>
+                        <div t-if="option.vote_ids.length === 0 and option.fetchPollVotesCached.status === 'fetched'" class="w-100 h-100 d-flex flex-column justify-content-center align-items-center text-center">
+                            <span class="o-mail-PollVotesPanel-emptyEmoji">😅</span>
+                            <span class="text-muted">There are no votes for this answer</span>
+                        </div>
                     </TabPanel>
                 </t>
             </Tabs>

--- a/addons/mail/static/src/core/common/tabs.xml
+++ b/addons/mail/static/src/core/common/tabs.xml
@@ -29,7 +29,7 @@
 </t>
 
 <t t-name="mail.TabPanel">
-    <div t-if="env.tabsContext.isActive(props.id)" class="p-2">
+    <div t-if="env.tabsContext.isActive(props.id)" class="p-2 h-100">
         <t t-slot="default"/>
     </div>
 </t>


### PR DESCRIPTION
This PR cleans up the poll votes panel:
- Remove useless option fetch when opening the panel: polls are always sent alongside their options (number of votes and label).
- Rely on `makeCachedFetchData` instead of custom caching.
- Add an empty placeholder.

<img width="442" height="297" alt="image" src="https://github.com/user-attachments/assets/b3d11ab0-81b3-4c1c-84dc-7ca2119b8be1" />

