### PR TITLE
[FIX] mrp: provide access to product variants in test

### DIFF
--- a/addons/mrp/tests/test_mrp_reports.py
+++ b/addons/mrp/tests/test_mrp_reports.py
@@ -6,6 +6,10 @@ from odoo.fields import Command
 class TestReportBom(HttpCase):
 
     def test_mrp_report_bom_variant_selection(self):
+        self.env.ref('base.user_admin').write({'group_ids': [
+            Command.link(self.env.ref('product.group_product_variant').id),
+        ]})
+
         attribute = self.env['product.attribute'].create({'name': 'Size'})
         value_S, value_L = self.env['product.attribute.value'].create([
             {'name': 'S', 'attribute_id': attribute.id},


### PR DESCRIPTION
The _/mrp:TestReportBom.test_mrp_report_bom_variant_selection_ test was failling because administrator user couldn't use the product variants. The needed dropdown menu to switch variant wasn't displayed and the test failed.

We add the "product.group_product_variant" rights to the user.

Runbot error: 238917

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
