### PR TITLE
[FIX] point_of_sale: prevent error when cancelling an empty order

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -50,7 +50,11 @@
                 <button t-if="this.pos.isSelectedLineCombo" class="break-combo-button" t-att-class="buttonClass" t-on-click="() => this.breakSelectedCombo()">
                     <i class="fa fa-outdent" role="img" aria-label="Break combo" title="Brean combo" /> Break combo
                 </button>
-                <button t-if="this.pos.cashier._role != 'minimal'" t-att-class="buttonClass" t-on-click="() => this.pos.onDeleteOrder(this.pos.getOrder())">
+                <button
+                    t-if="this.pos.cashier._role != 'minimal'"
+                    t-att-class="buttonClass" t-on-click="() => this.pos.onDeleteOrder(this.pos.getOrder())"
+                    t-att-disabled="!pos.getOrder()?.getOrderlines()?.length"
+                >
                     <i class="fa fa-trash me-1" role="img" /> Cancel Order
                 </button>
             </div>

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2875,8 +2875,7 @@ export class PosStore extends WithLazyGetterTrap {
     }
 
     get isSelectedLineCombo() {
-        const selectedOrderline = this.selectedOrder.getSelectedOrderline();
-        return selectedOrderline && selectedOrderline.isPartOfCombo();
+        return Boolean(this.selectedOrder?.getSelectedOrderline()?.isPartOfCombo());
     }
 
     /**

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -28,6 +28,15 @@ registry.category("web_tour.tours").add("ProductScreenTour", {
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
             OfflineUtil.setOfflineMode(),
+            inLeftSide([
+                ...ProductScreen.clickControlButtonMore(),
+                // check that cancel order button is disabled if there is no orderline in the order
+                {
+                    content: "Check that cancel order button is disabled",
+                    trigger: ".control-buttons button:contains('Cancel Order'):disabled",
+                },
+                Dialog.cancel(),
+            ]),
             ProductScreen.firstProductIsFavorite("Whiteboard Pen"),
             // Make sure we don't have any scroll bar on the product list
             {


### PR DESCRIPTION
Steps:
---
- Open a Restaurant session.
- Open a table with no order.
- Click the control button and click Cancel Order.

Issue:
---
- A traceback occurs when cancelling an order.

Cause:
--
- The order is cancelled first, and then `isSelectedLineCombo` tries to access the current order, which is already null.

Fix:
---
- Safely check for the selected order before accessing combo data.
- Disable the Cancel Order button when there are no order lines.

task-5934004


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
