### PR TITLE
[FIX] pos_mrp: do not ask lot/serial for kit product on POS

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -28,6 +28,10 @@ export class ProductProduct extends Base {
     isTracked() {
         const pickingType = this.models["stock.picking.type"].readAll()[0];
 
+        if (this.has_phantom_bom) {
+            return false;
+        }
+
         return (
             ["serial", "lot"].includes(this.tracking) &&
             (pickingType.use_create_lots || pickingType.use_existing_lots)

--- a/addons/pos_mrp/models/__init__.py
+++ b/addons/pos_mrp/models/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import pos_order
+from . import product

--- a/addons/pos_mrp/models/product.py
+++ b/addons/pos_mrp/models/product.py
@@ -1,0 +1,27 @@
+from odoo import api, fields, models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    has_phantom_bom = fields.Boolean(
+        string="Has Phantom BOM",
+        compute="_compute_has_phantom_bom",
+    )
+
+    @api.depends("product_tmpl_id")
+    def _compute_has_phantom_bom(self):
+        Bom = self.env["mrp.bom"]
+        for product in self:
+            bom = Bom._bom_find(
+                product,
+                company_id=product.company_id.id,
+                bom_type="phantom",
+            ).get(product)
+            product.has_phantom_bom = bool(bom)
+
+    @api.model
+    def _load_pos_data_fields(self, config_id):
+        params = super()._load_pos_data_fields(config_id)
+        params += ['has_phantom_bom']
+        return params

--- a/addons/pos_mrp/static/tests/tours/pos_mrp_tour.js
+++ b/addons/pos_mrp/static/tests/tours/pos_mrp_tour.js
@@ -32,3 +32,14 @@ registry.category("web_tour.tours").add("test_ship_later_kit_and_mto_manufacture
             ReceiptScreen.receiptIsThere(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_pos_mrp_kit_does_not_ask_lot", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Kit Product"),
+            Dialog.isNot(),
+            ProductScreen.selectedOrderlineHas("Kit Product", "1"),
+        ].flat(),
+});


### PR DESCRIPTION
Selling a kit product (phantom BOM) that was tracked by lots in the Point of Sale incorrectly opened the lot/serial popup for the kit line. Only the kit's components should drive stock moves and lots; the kit product itself must not require a lot on the order line.

Steps to reproduce:
-------------------
* Create a product "Kit" with tracking = By Lots.
* Create a phantom BOM (type Kit) for that product with a component that is also tracked by lots; add stock and a lot for the component.
* Open a POS session and add the kit product to the order.

> Observation:
The Lot/Serial Number(s) Required popup appears for the kit product. After payment, stock moves are correctly created for the components (and their lots), so the popup on the kit line is wrong.

Why the fix:
------------
POS was using product.tracking only when deciding to show the lot popup, and did not treat phantom-kit products differently. With pos_mrp, stock moves for a kit line come from the BOM components, not from the kit product, so the frontend must not ask for a lot on the kit line. We add a computed flag pos_has_phantom_bom on product.product in pos_mrp and make isTracked() return false when that flag is set so the lot popup is skipped for kit products.

opw-5917964