### PR TITLE
[FIX] point_of_sale: error when combo contains archived product

### DIFF
--- a/addons/point_of_sale/models/product_combo_item.py
+++ b/addons/point_of_sale/models/product_combo_item.py
@@ -9,7 +9,10 @@ class ProductComboItem(models.Model):
 
     @api.model
     def _load_pos_data_domain(self, data, config):
-        return [('id', 'in', list(set().union(*[combo.get('combo_item_ids') for combo in data['product.combo']])))]
+        return [
+            ('product_id.active', '=', True),
+            ('id', 'in', list(set().union(*[combo.get('combo_item_ids') for combo in data['product.combo']]))),
+        ]
 
     @api.model
     def _load_pos_data_fields(self, config):

--- a/addons/point_of_sale/tests/common_setup_methods.py
+++ b/addons/point_of_sale/tests/common_setup_methods.py
@@ -50,7 +50,7 @@ def setup_product_combo_items(self):
         }
     )
 
-    combo_product_2 = self.env["product.product"].create(
+    self.combo_product_2 = self.env["product.product"].create(
         {
             "name": "Combo Product 2",
             "is_storable": True,
@@ -81,7 +81,7 @@ def setup_product_combo_items(self):
                     "extra_price": 0,
                 }),
                 Command.create({
-                    "product_id": combo_product_2.id,
+                    "product_id": self.combo_product_2.id,
                     "extra_price": 0,
                 }),
                 Command.create({

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1215,6 +1215,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'qty_free': 2,
             'qty_max': 5,
         })
+        self.combo_product_2.active = False
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('ProductComboMaxFreeQtyTour')
 


### PR DESCRIPTION
Steps to reproduce:
- Archive a product used in a combo.
- Open Point of Sale.
- Create a new order.
- A blank screen appears (error in console)

Cause:
- The system attempts to access fields of an archived product included in a combo choice.

Fix:
- Skip loading the combo choice whose product is archived.

Task-5936290