### PR TITLE
[IMP] mail: split start and end date fields for out-of-office period

### DIFF
--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -153,6 +153,11 @@ class ResUsers(models.Model):
                 else 'default'
             )
 
+    @api.onchange('out_of_office_from')
+    def _onchange_out_of_office_from(self):
+        if not self.out_of_office_from:
+            self.out_of_office_to = False
+
     # ------------------------------------------------------------
     # CRUD
     # ------------------------------------------------------------

--- a/addons/mail/views/res_users_views.xml
+++ b/addons/mail/views/res_users_views.xml
@@ -38,8 +38,9 @@
                     <group name="calendar_preferences" position="inside">
                         <label for="out_of_office_from" string="Out-of-office" />
                         <div class="o_row">
-                            <field name="out_of_office_from" widget="daterange" options="{'end_date_field': 'out_of_office_to', 'show_time': False}" placeholder="None planned"/>
-                            <field name="out_of_office_to" invisible="1"/> <!-- otherwise it is visible, smort -->
+                            <field name="out_of_office_from" placeholder="None planned"/>
+                            <i class="fa fa-arrow-right mx-2" invisible="not out_of_office_from" title="to"/>
+                            <field name="out_of_office_to" invisible="not out_of_office_from" placeholder="Forever"/>
                         </div>
                         <field name="out_of_office_message" string="" options="{'height': 112}" class="border border-secondary w-100" placeholder="Your out-of-office message..."/>
                     </group>
@@ -70,8 +71,9 @@
                     <group name="calendar_preferences" position="inside">
                         <label for="out_of_office_from" string="Out-of-office" />
                         <div class="o_row">
-                            <field name="out_of_office_from" widget="daterange" options="{'end_date_field': 'out_of_office_to', 'show_time': False}" placeholder="None planned"/>
-                            <field name="out_of_office_to" invisible="1"/> <!-- otherwise it is visible, smort -->
+                            <field name="out_of_office_from" placeholder="None planned"/>
+                            <i class="fa fa-arrow-right mx-2" invisible="not out_of_office_from" title="to"/>
+                            <field name="out_of_office_to" invisible="not out_of_office_from" placeholder="Forever"/>
                         </div>
                         <field name="out_of_office_message" string="" options="{'height': 112}" class="border border-secondary w-100" placeholder="Your out-of-office message..."/>
                     </group>


### PR DESCRIPTION
In the user preference panel, the end date of the out-of-office period is not displayed by default. To define an end date, users must first click the field and then select the "Range" option in the calendar picker. Because these steps are not intuitive, users may enter only a start date and omit the end date, inadvertently creating an unlimited out-of-office period.

To address this issue, we will introduce two separate fields: one for the start date and one for the end date. The end date field will appear only after a start date has been selected. This approach clarifies the workflow, reduces the risk of incomplete entries, and keeps the form view concise.

Task-5435466

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr