### PR TITLE
[FIX] mail, web: add 💯 emoji shortcode and improve helper text

### DIFF
--- a/addons/mail/static/tests/emoji/emoji.test.js
+++ b/addons/mail/static/tests/emoji/emoji.test.js
@@ -175,9 +175,11 @@ test("search matches only frequently used emojis", async () => {
     await contains(".o-EmojiPicker-sectionIcon", { count: 0 }); // await search performed
     await contains(".o-EmojiPicker-content .o-Emoji:eq(0)", { text: "🥦" });
     await contains(".o-EmojiPicker-content .o-Emoji", { count: 1 });
-    await contains(".o-EmojiPicker-content", { text: "No emoji matches your search", count: 0 });
+    await contains(".o-EmojiPicker-content:has(:text('No emojis match your search'))", {
+        count: 0,
+    });
     await insertText(".o-EmojiPicker-search input", "2");
-    await contains(".o-EmojiPicker-content", { text: "No emoji matches your search" });
+    await contains(".o-EmojiPicker-content:has(:text('No emojis match your search'))");
 });
 
 test("emoji usage amount orders frequent emojis", async () => {

--- a/addons/web/static/src/core/emoji_picker/emoji_data.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_data.js
@@ -2265,6 +2265,7 @@ const _getEmojisData1 = () => `{
     ],
     "name": "` + _t("hundred points") + `",
     "shortcodes": [
+        ":100:",
         ":hundred_points:"
     ]
 },

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.xml
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.xml
@@ -22,7 +22,7 @@
             <div class="o-EmojiPicker-content overflow-auto d-flex flex-grow-1 w-100 flex-wrap align-items-center user-select-none mt-1" t-att-class="emojisFromSearch.length === 0 ? 'flex-column justify-content-center' : 'align-content-start'" t-ref="emoji-grid" t-on-scroll="highlightActiveCategory">
                 <t t-if="searchTerm and emojisFromSearch.length === 0" class="d-flex flex-column">
                     <span class="o-EmojiPicker-empty">😢</span>
-                    <span class="fs-5 text-muted">No emoji matches your search</span>
+                    <span class="fs-5 text-muted">No emojis match your search</span>
                 </t>
                 <t t-if="recentEmojis.length > 0">
                     <t t-if="!searchTerm" t-call="web.EmojiPicker.section">


### PR DESCRIPTION
Purpose of this PR:

Before this PR, the 💯 emoji could only be found using the`:hundred_points:` shortcode, which is less commonly used.

This PR adds the `:100:` shortcode to improve discoverability. Additionally, the empty-state helper text in the emoji picker is adjusted from `"No emoji matches your search"` to `"No emojis match your search"` for better wording.

task-5873748

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
