### PR TITLE
[FIX] product: do not auto-set "supplierinfo.product_id" for single variant

### DIFF
--- a/addons/product/models/product_supplierinfo.py
+++ b/addons/product/models/product_supplierinfo.py
@@ -84,8 +84,6 @@ class ProductSupplierinfo(models.Model):
         for rec in self:
             if self.env.get('default_product_id'):
                 rec.product_id = self.env.get('default_product_id')
-            elif not rec.product_id and rec.product_variant_count == 1:
-                rec.product_id = rec.product_tmpl_id.product_variant_id
 
     @api.onchange('product_tmpl_id')
     def _onchange_product_tmpl_id(self):

--- a/addons/product/tests/test_variants.py
+++ b/addons/product/tests/test_variants.py
@@ -1683,3 +1683,37 @@ class TestVariantsExclusion(ProductVariantsCommon):
         ]
         self.assertEqual(len(product_template.product_variant_ids), 2)
         self.assertTrue(variant_to_archive.active)
+
+    def test_supplierinfo_with_dynamic_attribute(self):
+        """
+        Ensure that supplierinfo.product_id is never automatically set when
+        variants are created dynamically.
+
+        The supplierinfo should remain template-level (product_id = False)
+        unless the user explicitly assigns a specific variant manually,
+        even if only one variant exists initially.
+        """
+        product_template = self.env['product.template'].create({
+            'name': 'Test dynamic',
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': self.dynamic_attribute.id,
+                    'value_ids': [Command.set(self.dynamic_attribute.value_ids.ids)],
+                }),
+            ]
+        })
+        self.assertFalse(product_template.product_variant_ids)
+
+        supplierinfo = self.env['product.supplierinfo'].create({
+            'partner_id': self.partner.id,
+            'product_tmpl_id': product_template.id,
+        })
+        self.assertFalse(product_template.product_variant_ids)
+
+        product_template._create_product_variant(product_template.attribute_line_ids.product_template_value_ids[0])
+        self.assertEqual(len(product_template.product_variant_ids), 1)
+        self.assertFalse(supplierinfo.product_id)
+
+        product_template._create_product_variant(product_template.attribute_line_ids.product_template_value_ids[1])
+        self.assertEqual(len(product_template.product_variant_ids), 2)
+        self.assertFalse(supplierinfo.product_id)


### PR DESCRIPTION
Steps to reproduce the bug:
- Create an attribute "Test":
  - Display type: Radio
  - Attribute values: X1 and X2
  - Variant creation: Dynamically

- Create a storable product "P1":
  - Attribute & variants: add X1 and X2
  - Add any vendor
  - Route: MTO

- Create a sale order with one unit of P1-X1
  - Confirm it -> the purchase order is created

- Create a second sale order with one unit of P1-X2
  - Confirm it -> the purchase order is not created

Problem:
When the Buy route is triggered, a check whether a vendor is linked to the product variant being used. However, since "product.supplierinfo" is linked to the template and also to the first variant (P1-X1), no supplier is found for the other variants, so no PO is created.

https://github.com/odoo/odoo/blob/60993a956f127af5bf988b056f9df948a5437d8b/addons/purchase_stock/models/stock_rule.py#L52-L55

https://github.com/odoo/odoo/blob/4759c5f1649b2a9bd3378b6e29cd2b806e86ea37/addons/product/models/product_supplierinfo.py#L113-L114

Solution:
When the number of variants changes for a product template, the compute of product_id in the model product.supplierinfo is triggered. In this case, product_id must be set to False when multiple variants are linked to the product template.

opw-5871195