### PR TITLE
[FIX] crm: leads' stage must always be "New"

### DIFF
--- a/addons/crm/data/crm_lead_demo.xml
+++ b/addons/crm/data/crm_lead_demo.xml
@@ -815,7 +815,7 @@ Andrew</p>]]></field>
             <field name="date_open" eval="False"/>
             <field name="team_id" eval="False"/>
             <field name="user_id" eval="False"/>
-            <field name="stage_id" ref="stage_lead2"/>
+            <field name="stage_id" ref="stage_lead1"/>
             <field name="campaign_id" ref="utm.utm_campaign_christmas_special"/>
             <field name="medium_id" ref="utm.utm_medium_email"/>
             <field name="source_id" ref="utm.utm_source_mailing"/>
@@ -935,7 +935,7 @@ Andrew</p>]]></field>
             <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" eval="False"/>
             <field name="user_id" eval="False"/>
-            <field name="stage_id" ref="crm.stage_lead2"/>
+            <field name="stage_id" ref="crm.stage_lead1"/>
             <field name="campaign_id" ref="utm.utm_campaign_christmas_special"/>
             <field name="medium_id" ref="utm.utm_medium_email"/>
             <field name="source_id" ref="utm.utm_source_google"/>
@@ -957,7 +957,7 @@ Andrew</p>]]></field>
             <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" eval="False"/>
             <field name="user_id" eval="False"/>
-            <field name="stage_id" ref="crm.stage_lead3"/>
+            <field name="stage_id" ref="crm.stage_lead1"/>
             <field name="campaign_id" ref="utm.utm_campaign_christmas_special"/>
             <field name="medium_id" ref="utm.utm_medium_email"/>
             <field name="source_id" ref="utm.utm_source_google"/>
@@ -979,7 +979,7 @@ Andrew</p>]]></field>
             <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" eval="False"/>
             <field name="user_id" eval="False"/>
-            <field name="stage_id" ref="crm.stage_lead2"/>
+            <field name="stage_id" ref="crm.stage_lead1"/>
             <field name="campaign_id" ref="utm.utm_campaign_christmas_special"/>
             <field name="medium_id" ref="utm.utm_medium_email"/>
             <field name="source_id" ref="utm.utm_source_google"/>
@@ -1000,7 +1000,7 @@ Andrew</p>]]></field>
             <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" eval="False"/>
             <field name="user_id" eval="False"/>
-            <field name="stage_id" ref="crm.stage_lead2"/>
+            <field name="stage_id" ref="crm.stage_lead1"/>
             <field name="campaign_id" ref="utm.utm_campaign_christmas_special"/>
             <field name="medium_id" ref="utm.utm_medium_email"/>
             <field name="source_id" ref="utm.utm_source_google"/>
@@ -1022,7 +1022,7 @@ Andrew</p>]]></field>
             <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" eval="False"/>
             <field name="user_id" eval="False"/>
-            <field name="stage_id" ref="crm.stage_lead2"/>
+            <field name="stage_id" ref="crm.stage_lead1"/>
             <field name="campaign_id" ref="utm.utm_campaign_christmas_special"/>
             <field name="medium_id" ref="utm.utm_medium_email"/>
             <field name="source_id" ref="utm.utm_source_google"/>
@@ -1044,7 +1044,7 @@ Andrew</p>]]></field>
             <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" eval="False"/>
             <field name="user_id" eval="False"/>
-            <field name="stage_id" ref="crm.stage_lead2"/>
+            <field name="stage_id" ref="crm.stage_lead1"/>
             <field name="campaign_id" ref="utm.utm_campaign_christmas_special"/>
             <field name="medium_id" ref="utm.utm_medium_email"/>
             <field name="source_id" ref="utm.utm_source_google"/>
@@ -1088,7 +1088,7 @@ Andrew</p>]]></field>
             <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" ref="sales_team.team_sales_department"/>
             <field name="user_id" ref="base.user_admin"/>
-            <field name="stage_id" ref="crm.stage_lead2"/>
+            <field name="stage_id" ref="crm.stage_lead1"/>
             <field name="campaign_id" ref="utm.utm_campaign_christmas_special"/>
             <field name="medium_id" ref="utm.utm_medium_email"/>
             <field name="source_id" ref="utm.utm_source_google"/>
@@ -1110,7 +1110,7 @@ Andrew</p>]]></field>
             <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" eval="False"/>
             <field name="user_id" eval="False"/>
-            <field name="stage_id" ref="crm.stage_lead3"/>
+            <field name="stage_id" ref="crm.stage_lead1"/>
             <field name="campaign_id" ref="utm.utm_campaign_christmas_special"/>
             <field name="medium_id" ref="utm.utm_medium_email"/>
             <field name="source_id" ref="utm.utm_source_google"/>
@@ -1132,7 +1132,7 @@ Andrew</p>]]></field>
             <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" eval="False"/>
             <field name="user_id" eval="False"/>
-            <field name="stage_id" ref="crm.stage_lead2"/>
+            <field name="stage_id" ref="crm.stage_lead1"/>
             <field name="campaign_id" ref="utm.utm_campaign_christmas_special"/>
             <field name="medium_id" ref="utm.utm_medium_email"/>
             <field name="source_id" ref="utm.utm_source_google"/>
@@ -1154,7 +1154,7 @@ Andrew</p>]]></field>
             <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" eval="False"/>
             <field name="user_id" eval="False"/>
-            <field name="stage_id" ref="crm.stage_lead3"/>
+            <field name="stage_id" ref="crm.stage_lead1"/>
             <field name="campaign_id" ref="utm.utm_campaign_christmas_special"/>
             <field name="medium_id" ref="utm.utm_medium_email"/>
             <field name="source_id" ref="utm.utm_source_google"/>
@@ -1176,7 +1176,7 @@ Andrew</p>]]></field>
             <field name="date_deadline" eval="(DateTime.today() + relativedelta(weeks=2)).strftime('%Y-%m-%d %H:%M')"/>
             <field name="team_id" eval="False"/>
             <field name="user_id" eval="False"/>
-            <field name="stage_id" ref="crm.stage_lead3"/>
+            <field name="stage_id" ref="crm.stage_lead1"/>
             <field name="campaign_id" ref="utm.utm_campaign_christmas_special"/>
             <field name="medium_id" ref="utm.utm_medium_email"/>
             <field name="source_id" ref="utm.utm_source_google"/>


### PR DESCRIPTION
This PR corrects the stage_id of some crm.lead demo data. It must be "New" for crm.lead records of lead type as they are the first step of the prospecting. When the leads have chance of succeeding, they are converted in opportunity and then the stage can change.

Task-5380531