### PR TITLE
[IMP] core: random serial for testing

### DIFF
--- a/addons/account/tests/test_account_journal.py
+++ b/addons/account/tests/test_account_journal.py
@@ -53,7 +53,7 @@ class TestAccountJournal(AccountTestInvoicingCommon, HttpCase):
         invoice_invalid.journal_id = journal
         invoice_invalid.action_post()
         self.assertTrue(invoice_invalid.payment_reference, "A payment reference should be generated.")
-        self.assertIn(str(journal.id), invoice_invalid.payment_reference, "The reference should fall back to using the journal ID.")
+        self.assertIn(str(journal.id), ''.join(invoice_invalid.payment_reference.split()), "The reference should fall back to using the journal ID.")
 
         # Case 3: Code is non-ASCII but alphanumeric (e.g., Greek letter 'INVα'). # noqa: RUF003
         journal.code = 'INVα'
@@ -61,7 +61,7 @@ class TestAccountJournal(AccountTestInvoicingCommon, HttpCase):
         invoice_unicode.journal_id = journal
         invoice_unicode.action_post()
         self.assertTrue(invoice_unicode.payment_reference, "A payment reference should be generated.")
-        self.assertIn(str(journal.id), invoice_unicode.payment_reference, "The reference should fall back to using the journal ID for non-ASCII codes.")
+        self.assertIn(str(journal.id), ''.join(invoice_unicode.payment_reference.split()), "The reference should fall back to using the journal ID for non-ASCII codes.")
 
     def test_changing_journal_company(self):
         ''' Ensure you can't change the company of an account.journal if there are some journal entries '''
@@ -455,7 +455,7 @@ class TestAccountJournalAlias(AccountTestInvoicingCommon, MailCommon):
 
         expected_id = str(invoice_non_latin.journal_id.id)
         ref_parts_non_latin = invoice_non_latin.payment_reference.split()
-        self.assertEqual(ref_parts_non_latin[1][:len(expected_id)], expected_id, "The reference should start with " + expected_id)
+        self.assertEqual(''.join(ref_parts_non_latin[1:])[:len(expected_id)], expected_id, "The reference should start with " + expected_id)
 
         ref_parts_latin = invoice_latin.payment_reference.split()
         self.assertIn(ref_parts_latin[1][:3], latin_code, f"Expected journal code '{latin_code}' in second part of reference")

--- a/addons/account/tests/test_sequence_mixin.py
+++ b/addons/account/tests/test_sequence_mixin.py
@@ -51,6 +51,11 @@ class TestSequenceMixinCommon(AccountTestInvoicingCommon):
 
 @tagged('post_install', '-at_install')
 class TestSequenceMixin(TestSequenceMixinCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env.ref('base.partner_root').company_id = cls.env.company
+
     def assertNameAtDate(self, date, name):
         test = self.create_move(date=date)
         test.action_post()
@@ -92,7 +97,7 @@ class TestSequenceMixin(TestSequenceMixinCommon):
         self.env.company.fiscalyear_last_month = '12'
 
         bill = self.env['account.move'].create({
-            'partner_id': 1,
+            'partner_id': self.ref('base.partner_root'),
             'move_type': 'in_invoice',
             'date': '2016-01-01',
             'line_ids': [
@@ -115,7 +120,7 @@ class TestSequenceMixin(TestSequenceMixinCommon):
             self.assertMoveName(bill_form, 'BILL/16-17/01/0001')
 
         invoice = self.env['account.move'].create({
-            'partner_id': 1,
+            'partner_id': self.ref('base.partner_root'),
             'move_type': 'out_invoice',
             'date': '2016-01-01',
             'line_ids': [
@@ -140,7 +145,7 @@ class TestSequenceMixin(TestSequenceMixinCommon):
         self.env.company.quick_edit_mode = 'in_invoices'
 
         bill_1 = self.env['account.move'].create({
-            'partner_id': 1,
+            'partner_id': self.ref('base.partner_root'),
             'move_type': 'in_invoice',
             'date': '2016-01-01',
             'invoice_date': '2016-01-01',
@@ -368,7 +373,7 @@ class TestSequenceMixin(TestSequenceMixinCommon):
         )
         (invoice + invoice2 + refund + refund2).write({
             'journal_id': self.company_data['default_journal_sale'].id,
-            'partner_id': 1,
+            'partner_id': self.ref('base.partner_root'),
             'invoice_date': '2016-01-01',
         })
         (invoice + invoice2).move_type = 'out_invoice'
@@ -601,7 +606,7 @@ class TestSequenceMixin(TestSequenceMixinCommon):
         # First bill in second half of first month of the fiscal year, which is
         # the start of the fiscal year
         bill = self.env['account.move'].create({
-            'partner_id': 1,
+            'partner_id': self.ref('base.partner_root'),
             'move_type': 'in_invoice',
             'date': '2024-04-17',
             'line_ids': [

--- a/addons/analytic/data/analytic_data.xml
+++ b/addons/analytic/data/analytic_data.xml
@@ -15,5 +15,6 @@
             <field name="name">Project</field>
             <field name="default_applicability">optional</field>
         </record>
+        <function model="ir.config_parameter" name="set_int" eval="('analytic.project_plan', ref('analytic_plan_projects'))"/>
     </data>
 </odoo>

--- a/addons/analytic/models/analytic_plan.py
+++ b/addons/analytic/models/analytic_plan.py
@@ -106,6 +106,9 @@ class AccountAnalyticPlan(models.Model):
         if not project_plan:
             raise UserError(_("A 'Project' plan needs to exist and its id needs to be set as `analytic.project_plan` in the system variables"))
         other_plans = self.sudo().search([('parent_id', '=', False)]) - project_plan
+        if project_plan.id == 1 and not self.env.registry.ready and not project_plan.exists():
+            # temporary fix during load
+            project_plan, other_plans = other_plans[0], other_plans[1:]
         return project_plan.id, other_plans.ids
 
     def _get_all_plans(self):

--- a/addons/analytic/models/ir_config_parameter.py
+++ b/addons/analytic/models/ir_config_parameter.py
@@ -23,6 +23,8 @@ class IrConfigParameter(models.Model):
         ):
             raise UserError(_('The value for %s must be the ID to a valid analytic plan that is not a subplan', param.key))
         res = super().write(vals)
-        self.env['account.analytic.plan'].browse(int(old_plan_id))._sync_all_plan_column()
-        plan_field.unlink()
+        old_plan = self.env['account.analytic.plan'].browse(int(old_plan_id))
+        if not (old_plan.id == 1 and not self.env.registry.ready and not old_plan.exists()):
+            old_plan._sync_all_plan_column()
+            plan_field.unlink()
         return res

--- a/addons/base_automation/tests/test_mail_composer.py
+++ b/addons/base_automation/tests/test_mail_composer.py
@@ -21,7 +21,7 @@ class TestMailFullComposer(MailCommon, HttpCase):
             'name': 'Test',
             'active': True,
             'trigger': 'on_change',
-            'on_change_field_ids': (4, self.ref('mail.field_mail_compose_message__template_id'),),
+            'on_change_field_ids': [(4, self.ref('mail.field_mail_compose_message__template_id'))],
             'model_id': self.env.ref('mail.model_mail_compose_message').id,
         })
         server_action = self.env['ir.actions.server'].create({
@@ -62,7 +62,7 @@ class TestMailFullComposer(MailCommon, HttpCase):
             'name': 'Test',
             'active': True,
             'trigger': 'on_change',
-            'on_change_field_ids': (4, self.ref('mail.field_mail_compose_message__template_id')),
+            'on_change_field_ids': [(4, self.ref('mail.field_mail_compose_message__template_id'))],
             'model_id': self.env.ref('mail.model_mail_compose_message').id,
         })
         server_action = self.env['ir.actions.server'].create({

--- a/addons/crm/models/crm_stage.py
+++ b/addons/crm/models/crm_stage.py
@@ -1,7 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import _, api, fields, models
+from odoo.tools import sql
 
 AVAILABLE_PRIORITIES = [
     ('0', 'Low'),
@@ -34,6 +34,15 @@ class CrmStage(models.Model):
     # This field for interface only
     team_count = fields.Integer('team_count', compute='_compute_team_count')
     color = fields.Integer(string='Color', export_string_translation=False)
+
+    def _auto_init(self):
+        # TODO stop hardcoding ids in tests and remove this
+        cr = self.env.cr
+        reset_sequence = self._auto and not sql.table_exists(cr, self._table)
+        res = super()._auto_init()
+        if reset_sequence:
+            cr.execute("SELECT setval(pg_get_serial_sequence(%s, 'id'), 1, false)", (self._table,))
+        return res
 
     @api.depends('team_ids')
     def _compute_team_count(self):

--- a/addons/gamification/tests/test_challenge.py
+++ b/addons/gamification/tests/test_challenge.py
@@ -150,7 +150,7 @@ class test_challenge(TestGamificationCommon):
             'name': 'test',
             'state': 'draft',
             'user_domain': '[("active", "=", True)]', #Include all active users to get a least one participant
-            'reward_id': 1,
+            'reward_id': self.badge_good_job.id,
         })
 
         model = self.env['ir.model'].search([('model', '=', 'gamification.badge')])[0]
@@ -218,7 +218,7 @@ class test_challenge(TestGamificationCommon):
             'name': 'test1',
             'state': 'draft',
             'user_domain': '[("active", "=", True)]',
-            'reward_id': 1,
+            'reward_id': self.badge_good_job.id,
             'visibility_mode': 'ranking'
         })
 

--- a/addons/google_address_autocomplete/tests/test_ui.py
+++ b/addons/google_address_autocomplete/tests/test_ui.py
@@ -152,16 +152,17 @@ class TestUI(HttpCase):
             headers={"Content-Type": "application/json"},
         )
 
+        australia = self.env.ref('base.au')
         res = json.loads(res.content)
         self.assertEqual(
             res["result"],
             {
-                "country": [13, "Australia"],
+                "country": [australia.id, "Australia"],
                 "number": "48",
                 "city": "Pyrmont",
                 "street": "Pirrama Road",
                 "zip": "2009",
-                "state": [2, "New South Wales"],
+                "state": [australia.state_ids[1].id, "New South Wales"],
                 "formatted_street_number": "48 Pirrama Road",
             },
         )

--- a/addons/google_calendar/tests/test_sync_google2odoo.py
+++ b/addons/google_calendar/tests/test_sync_google2odoo.py
@@ -1508,8 +1508,8 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
             'allday': False,
             'google_id': google_id,
             'need_sync': False,
-            'user_id': self.env.user.partner_id.id,
-            'partner_ids': [(6, 0, [self.env.user.partner_id.id, partner1.id, partner2.id, partner3.id, partner4.id],)]
+            'user_id': self.env.user.id,
+            'partner_ids': [(6, 0, [self.env.user.partner_id.id, partner1.id, partner2.id, partner3.id, partner4.id])]
             # current user is attendee
         })
         recurrence = self.env['calendar.recurrence'].create({
@@ -1548,7 +1548,7 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
         self.sync(gevent)
         # User attendee removed but gevent owner might be added after synch.
         mails = event.attendee_ids.mapped('email')
-        self.assertFalse(mails)
+        self.assertEqual(mails, ['odoobot@example.com'])
 
         self.assertGoogleAPINotCalled()
 

--- a/addons/hr_holidays/tests/test_access_rights.py
+++ b/addons/hr_holidays/tests/test_access_rights.py
@@ -7,7 +7,7 @@ from datetime import date
 from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
 
-from odoo import tests
+from odoo import api, tests
 from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.tools import date_utils
@@ -351,7 +351,7 @@ class TestAccessRightsWrite(TestHrHolidaysAccessRightsCommon):
             'work_entry_type_id': self.work_entry_type.id,
             'state': 'confirm',
         }
-        self.employee_hrmanager.leave_manager_id = self.env['res.users'].browse(1)
+        self.employee_hrmanager.leave_manager_id = api.SUPERUSER_ID
         leave_date = date_utils.start_of(date.today() + relativedelta(days=7), 'week')
         hr_leave = self.request_leave(self.user_hruser_id, leave_date, 1, values)
 

--- a/addons/hr_work_entry/tests/test_work_entry_type_data.py
+++ b/addons/hr_work_entry/tests/test_work_entry_type_data.py
@@ -49,16 +49,17 @@ class TestWorkEntryTypeData(TransactionCase):
         This is to test the implemention of automatically populating newly created
         work calendar with the default work calendar.
         """
+        work_entries = self.env['hr.work.entry.type'].search([], order='id')
         default_calendar = self.env['resource.calendar'].create({
             'name': '40 hours/week',
             'hours_per_day': 8,
             'full_time_required_hours': 40,
             'attendance_ids': [
-                (0, 0, {'dayofweek': '0', 'duration_hours': 8, 'hour_from': 0, 'hour_to': 0, 'work_entry_type_id': 9}),
-                (0, 0, {'dayofweek': '1', 'duration_hours': 8, 'hour_from': 0, 'hour_to': 0, 'work_entry_type_id': 2}),
-                (0, 0, {'dayofweek': '2', 'duration_hours': 8, 'hour_from': 0, 'hour_to': 0, 'work_entry_type_id': 3}),
-                (0, 0, {'dayofweek': '3', 'duration_hours': 8, 'hour_from': 0, 'hour_to': 0, 'work_entry_type_id': 1}),
-                (0, 0, {'dayofweek': '4', 'duration_hours': 8, 'hour_from': 0, 'hour_to': 0, 'work_entry_type_id': 5}),
+                (0, 0, {'dayofweek': '0', 'duration_hours': 8, 'hour_from': 0, 'hour_to': 0, 'work_entry_type_id': work_entries[8].id}),
+                (0, 0, {'dayofweek': '1', 'duration_hours': 8, 'hour_from': 0, 'hour_to': 0, 'work_entry_type_id': work_entries[1].id}),
+                (0, 0, {'dayofweek': '2', 'duration_hours': 8, 'hour_from': 0, 'hour_to': 0, 'work_entry_type_id': work_entries[2].id}),
+                (0, 0, {'dayofweek': '3', 'duration_hours': 8, 'hour_from': 0, 'hour_to': 0, 'work_entry_type_id': work_entries[0].id}),
+                (0, 0, {'dayofweek': '4', 'duration_hours': 8, 'hour_from': 0, 'hour_to': 0, 'work_entry_type_id': work_entries[4].id}),
             ],
         })
         # Assigning the created calendar to the company resource calendar

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_6.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_6.xml
@@ -108,7 +108,7 @@
         </record>
         <record id="support_bot_session_6_member_history_admin" model="im_livechat.channel.member.history">
             <field name="channel_id" ref="support_bot_session_6_demo"/>
-            <field name="partner_id" ref="base.user_admin"/>
+            <field name="partner_id" ref="base.partner_admin"/>
             <field name="livechat_member_type">agent</field>
             <field name="create_date" eval="datetime.now() - timedelta(seconds=10)"/>
             <field name="response_time_hour" eval="5/3600"/>

--- a/addons/mrp_subcontracting/data/mrp_subcontracting_demo.xml
+++ b/addons/mrp_subcontracting/data/mrp_subcontracting_demo.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
         <record id="mrp_bom_subcontract" model="mrp.bom">
-            <field name="product_tmpl_id" ref="product.product_delivery_02"/>
+            <field name="product_tmpl_id" ref="product.product_delivery_02_product_template"/>
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="type">subcontract</field>
             <field name="subcontractor_ids" eval="[(4, ref('base.res_partner_12')), (4, ref('base.partner_demo_portal'))]"/>

--- a/addons/point_of_sale/static/tests/pos/tours/pos_self_invoicing_portal_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_self_invoicing_portal_tour.js
@@ -76,9 +76,14 @@ registry.category("web_tour.tours").add("invoicePoSOrderWithSelfInvocing", {
             run: function () {
                 const countrySelect = document.querySelector("select[name='country_id']");
                 if (Array.from(countrySelect.classList).includes("d-none")) {
-                    throw new Error("The language selector must not be hidden.");
+                    throw new Error("The country selector must not be hidden.");
                 }
-                countrySelect.value = "233";
+                const option = Array.from(countrySelect.options).find(
+                    (opt) => opt.textContent.trim() === "United States"
+                );
+                if (option) {
+                    countrySelect.value = option.value;
+                }
             },
         },
         {
@@ -86,9 +91,14 @@ registry.category("web_tour.tours").add("invoicePoSOrderWithSelfInvocing", {
             run: function () {
                 const stateSelect = document.querySelector("select[name='state_id']");
                 if (Array.from(stateSelect.classList).includes("d-none")) {
-                    throw new Error("The language selector must not be hidden.");
+                    throw new Error("The country state selector must not be hidden.");
                 }
-                stateSelect.value = "19";
+                const option = Array.from(stateSelect.options).find(
+                    (opt) => opt.textContent.trim() === "Georgia"
+                );
+                if (option) {
+                    stateSelect.value = option.value;
+                }
             },
         },
         {

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -118,7 +118,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'use_pricelist': False,
         })
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.product_b.uom_id = 1
+        self.product_b.uom_id = self.ref('uom.product_uom_unit')
 
     def create_programs(self, details):
         """

--- a/addons/project_sms/tests/test_project_sharing.py
+++ b/addons/project_sms/tests/test_project_sharing.py
@@ -25,7 +25,7 @@ class TestProjectSharingWithSms(TestProjectSharingCommon, SMSCommon):
             'body': '{{ object.name }}',
             'model_id': cls.env['ir.model'].sudo().search([('model', '=', 'project.project')]).id,
         })
-        cls.project_stage_with_sms = cls.project_portal.stage_id.browse(2)
+        cls.project_stage_with_sms = cls.env.ref('project.project_project_stage_1')
         cls.project_stage_with_sms.write({'sms_template_id': cls.sms_template_2.id})
 
         cls.project_portal.write({

--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -50,7 +50,7 @@ class TestReorderingRule(TransactionCase):
             - Increase the quantity on the PO, the extra quantity should follow the push rules
             - There should be one move supplier -> input and two moves input -> stock
         """
-        warehouse_1 = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)
+        warehouse_1 = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
         warehouse_1.reception_steps = 'two_steps'
         warehouse_2 = self.env['stock.warehouse'].create({'name': 'WH 2', 'code': 'WH2', 'company_id': self.env.company.id, 'partner_id': self.env.company.partner_id.id, 'reception_steps': 'one_step'})
 
@@ -143,7 +143,7 @@ class TestReorderingRule(TransactionCase):
         """
         # Required for `warehouse_id` to be visible in the view
         self.env.user.group_ids += self.env.ref('stock.group_stock_multi_locations')
-        warehouse_1 = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)
+        warehouse_1 = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
         subloc_1 = self.env['stock.location'].create({'name': 'subloc_1', 'location_id': warehouse_1.lot_stock_id.id})
         subloc_2 = self.env['stock.location'].create({'name': 'subloc_2', 'location_id': warehouse_1.lot_stock_id.id})
 
@@ -206,7 +206,7 @@ class TestReorderingRule(TransactionCase):
         """
             trigger a reordering rule with a route to a location without warehouse
         """
-        warehouse_1 = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)
+        warehouse_1 = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
 
         outside_loc = self.env['stock.location'].create({
             'name': 'outside',
@@ -250,8 +250,8 @@ class TestReorderingRule(TransactionCase):
 
         # create reordering rules
         # Required for `warehouse_id` to be visible in the view
-        self.env['res.users'].browse(2).group_ids += self.env.ref('stock.group_stock_multi_locations')
-        orderpoint_form = Form(self.env['stock.warehouse.orderpoint'].with_user(2))
+        self.env.ref('base.user_admin').group_ids += self.env.ref('stock.group_stock_multi_locations')
+        orderpoint_form = Form(self.env['stock.warehouse.orderpoint'].with_user(self.ref('base.user_admin')))
         orderpoint_form.warehouse_id = warehouse_1
         orderpoint_form.location_id = outside_loc
         orderpoint_form.product_id = product
@@ -286,7 +286,7 @@ class TestReorderingRule(TransactionCase):
     def test_reordering_rule_4(self):
         """ Test that a reordering rule where the min qty is larger than
          the max qty cannot be created """
-        warehouse_1 = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)
+        warehouse_1 = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
 
         with self.assertRaises(ValidationError, msg="The minimum quantity must be less than or equal to the maximum quantity."):
             self.env['stock.warehouse.orderpoint'].create({
@@ -306,7 +306,7 @@ class TestReorderingRule(TransactionCase):
         - The qty to order of the RR should be zero
         """
         today = Date.context_today(self.env.user)
-        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
         stock_location = warehouse.lot_stock_id
         out_type = warehouse.out_type_id
         customer_location = self.env.ref('stock.stock_location_customers')
@@ -811,7 +811,7 @@ class TestReorderingRule(TransactionCase):
         """
         # Required for `warehouse_id` to be visible in the view
         self.env.user.group_ids += self.env.ref('stock.group_stock_multi_locations')
-        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
         stock_location = warehouse.lot_stock_id
         sub_location = self.env['stock.location'].create({'name': 'subloc_1', 'location_id': stock_location.id})
 
@@ -1026,7 +1026,7 @@ class TestReorderingRule(TransactionCase):
         """
         self.env.company.horizon_days = 4
         # create reordering rule
-        wh = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)
+        wh = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
         op = self.env['stock.warehouse.orderpoint'].create({
             'warehouse_id': wh.id,
             'location_id': wh.lot_stock_id.id,
@@ -1064,7 +1064,7 @@ class TestReorderingRule(TransactionCase):
         """ Checks that the horizon days are properly shown on the info wizard & the orderpoint forecast. """
         self.env.company.horizon_days = 3
         today = dt.today()
-        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
         orderpoint = self.env['stock.warehouse.orderpoint'].create({
             'warehouse_id': warehouse.id,
             'location_id': warehouse.lot_stock_id.id,
@@ -1330,7 +1330,7 @@ class TestReorderingRule(TransactionCase):
                 }),
             ],
         })
-        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
 
         po_line = self.env["purchase.order.line"].search(
             [("product_id", "=", self.product_01.id)])

--- a/addons/purchase_stock/tests/test_routes.py
+++ b/addons/purchase_stock/tests/test_routes.py
@@ -1,4 +1,3 @@
-from odoo import Command
 from odoo.tests import tagged, Form, TransactionCase
 
 
@@ -15,12 +14,12 @@ class TestRoutes(TransactionCase):
 
         location_1 = self.env['stock.location'].create({
             'name': 'loc1',
-            'location_id': warehouse.id
+            'location_id': warehouse.lot_stock_id.id
         })
 
         location_2 = self.env['stock.location'].create({
             'name': 'loc2',
-            'location_id': warehouse.id
+            'location_id': warehouse.lot_stock_id.id
         })
 
         receipt_1 = self.env['stock.picking.type'].create({

--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -93,7 +93,7 @@ class TestStockValuation(TransactionCase):
             'product_tmpl_id': self.product1.product_tmpl_id.id,
             'uom_id': ap.id,
             'quantity': replenishment_uom_qty,
-            'warehouse_id': self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1).id,
+            'warehouse_id': self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1).id,
         })
         genrated_picking = replenish_wizard.launch_replenishment()
         links = genrated_picking.get("params", {}).get("links")

--- a/addons/sale/tests/test_product_configurator_data.py
+++ b/addons/sale/tests/test_product_configurator_data.py
@@ -18,7 +18,7 @@ class TestProductConfiguratorData(HttpCaseWithUserDemo, ProductVariantsCommon, S
                 "params": {
                     "product_template_id": product_template.id,
                     "quantity": 1.0,
-                    "currency_id": 1,
+                    "currency_id": self.ref('base.USD'),
                     "so_date": str(self.env.cr.now()),
                     "product_uom_id": None,
                     "company_id": None,

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -908,7 +908,7 @@ class TestSalesTeam(SaleCommon):
             "login": "team0user",
             "name": "User in Team 0",
         })
-        cls.sale_team.write({"member_ids": [4, cls.user_in_team.id]})
+        cls.sale_team.write({"member_ids": [(4, cls.user_in_team.id)]})
         cls.user_not_in_team = cls.env["res.users"].create({
             "email": "noteamuser@example.com",
             "login": "noteamuser",

--- a/addons/sale/tests/test_sale_product_attribute_value_config.py
+++ b/addons/sale/tests/test_sale_product_attribute_value_config.py
@@ -39,7 +39,7 @@ class TestSaleProductAttributeValueConfig(TestProductAttributeValueCommon):
             # Create a dummy SO to prevent the variant from being deleted by
             # _create_variant_ids() because the variant is a related field that
             # is required on the SO line
-            so = self.env["sale.order"].create({"partner_id": 1})
+            so = self.env['sale.order'].create({'partner_id': self.ref('base.partner_root')})
             self.env["sale.order.line"].create({
                 "order_id": so.id,
                 "name": "test",

--- a/addons/sale_management/models/sale_order_template.py
+++ b/addons/sale_management/models/sale_order_template.py
@@ -203,7 +203,7 @@ class SaleOrderTemplate(models.Model):
                 "product_uom_qty": 0,
             }),
             Command.create({
-                "product_id": self.env.ref("product.product_template_dining_table").id
+                "product_id": self.env.ref("product.product_template_dining_table").product_variant_id.id
             }),
             Command.create({"product_id": self.env.ref("product.monitor_stand").id}),
             Command.create({

--- a/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
@@ -336,7 +336,7 @@ class TestSaleMrpKitBom(BaseCommon):
             a bom_line_id
         """
 
-        wh = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)
+        wh = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
         wh.write({'delivery_steps': 'pick_ship'})
 
         kitA = self._create_product('Kit Product', True, 0.00)
@@ -390,7 +390,7 @@ class TestSaleMrpKitBom(BaseCommon):
            is correct for each products.
         """
 
-        wh = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)
+        wh = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
         wh.write({'delivery_steps': 'pick_ship'})
 
         kitAB = self._create_product('Kit AB', True, 0.00)

--- a/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
+++ b/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
@@ -95,7 +95,7 @@ class TestPDFQuoteBuilder(SaleManagementCommon):
             new_form_fields[2]: "11/04/2020",  # date
             new_form_fields[3]: "",  # datetime missing
             new_form_fields[4]: "1.0",  # float
-            new_form_fields[5]: "1",  # integer
+            new_form_fields[5]: str(self.env.company.color),  # integer
             new_form_fields[6]: dict(self.sale_order._fields["state"].selection)[
                 "draft"
             ],  # selection

--- a/addons/sale_stock/tests/test_sale_order_dates.py
+++ b/addons/sale_stock/tests/test_sale_order_dates.py
@@ -20,23 +20,24 @@ class TestSaleExpectedDate(ValuationReconciliationTestCommon):
         """ Test expected date and effective date of Sales Orders """
         Product = self.env['product.product']
 
+        unit = self.ref('uom.product_uom_unit')
         product_A = Product.create({
             'name': 'Product A',
             'is_storable': True,
             'sale_delay': 5,
-            'uom_id': 1,
+            'uom_id': unit,
         })
         product_B = Product.create({
             'name': 'Product B',
             'is_storable': True,
             'sale_delay': 10,
-            'uom_id': 1,
+            'uom_id': unit,
         })
         product_C = Product.create({
             'name': 'Product C',
             'is_storable': True,
             'sale_delay': 15,
-            'uom_id': 1,
+            'uom_id': unit,
         })
 
         self.env['stock.quant']._update_available_quantity(product_A, self.company_data['default_warehouse'].lot_stock_id, 10)

--- a/addons/stock/tests/test_proc_rule.py
+++ b/addons/stock/tests/test_proc_rule.py
@@ -365,7 +365,7 @@ class TestProcRule(TransactionCase):
             'inventory_quantity': 14.5,
         }).action_apply_inventory()
 
-        orderpoint = self.env['stock.warehouse.orderpoint'].with_user(self.env['res.users'].browse(2)).create({
+        orderpoint = self.env['stock.warehouse.orderpoint'].with_user(self.env.ref('base.user_admin')).create({
             'name': 'ProductA RR',
             'product_id': self.productA.id,
             'product_min_qty': 15.0,
@@ -604,7 +604,7 @@ class TestProcRule(TransactionCase):
         orderpoint.unlink()
 
     def test_replenishment_order_to_max(self):
-        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.user.id)], limit=1)
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
         self.product.is_storable = True
         self.env['stock.quant']._update_available_quantity(self.product, warehouse.lot_stock_id, 10)
         orderpoint = self.env['stock.warehouse.orderpoint'].create({

--- a/addons/stock_fleet/data/stock_fleet_demo.xml
+++ b/addons/stock_fleet/data/stock_fleet_demo.xml
@@ -41,7 +41,7 @@
         <field name="color">Black</field>
         <field name="location">Millersburg Ohio (US) 44654</field>
         <field name="doors">2</field>
-        <field name="driver_id" ref="base.user_admin" />
+        <field name="driver_id" ref="base.partner_admin" />
         <field name="acquisition_date" eval="(DateTime.now() - timedelta(days=336)).strftime('%Y-%m-%d')" />
         <field name="state_id" ref="fleet.fleet_vehicle_state_registered"/>
         <field name="odometer">18000</field>

--- a/addons/test_base_automation/tests/test_flow.py
+++ b/addons/test_base_automation/tests/test_flow.py
@@ -302,7 +302,7 @@ if env.context.get('old_values', None): # on write only
                 'code': """
 if env.context.get('old_values', None):  # on write
     if 'user_id' in env.context['old_values'][record.id]:
-        record.write({'is_assigned_to_admin': (record.user_id.id == 1)})""",
+        record.write({'is_assigned_to_admin': (record.user_id == record.env.ref('base.user_root'))})""",
                 },
             )
 
@@ -1492,7 +1492,7 @@ class TestCompute(common.TransactionCase):
         })
 
         ext_partner = self.env["res.partner"].create({"name": "ext", "email": "email@server.com"})
-        internal_partner = self.env["res.users"].browse(2).partner_id
+        internal_partner = self.env.ref('base.user_admin').partner_id
 
         obj = self.env["base.automation.lead.thread.test"].create({"name": "test"})
         obj.message_subscribe([ext_partner.id, internal_partner.id])
@@ -1555,7 +1555,7 @@ class TestCompute(common.TransactionCase):
         })
 
         ext_partner = self.env["res.partner"].create({"name": "ext", "email": "email@server.com"})
-        internal_partner = self.env["res.users"].browse(2).partner_id
+        internal_partner = self.env.ref('base.user_admin').partner_id
 
         obj = self.env["base.automation.lead.thread.test"].create({"name": "test"})
         obj.message_subscribe([ext_partner.id, internal_partner.id])

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -1358,7 +1358,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 ],
                 "record_name": "General",
                 "reply_to": '"Ernest Employee" <catchall.test@test.mycompany.com>',
-                "res_id": 1,
+                "res_id": self.channel_general.id,
                 "scheduledDatetime": False,
                 "is_bookmarked": False,
                 "subject": False,

--- a/addons/test_mail/tests/test_mail_activity_mixin.py
+++ b/addons/test_mail/tests/test_mail_activity_mixin.py
@@ -35,6 +35,8 @@ class TestActivityMixin(TestActivityCommon):
         )
         cls.user_australia.tz = 'Australia/Sydney'
 
+        cls.activity_type = cls.env['mail.activity.type'].search([], limit=1).ensure_one()
+
     @mute_logger('odoo.addons.mail.models.mail_mail')
     def test_activity_mixin(self):
         self.user_employee.tz = self.user_admin.tz
@@ -259,7 +261,7 @@ class TestActivityMixin(TestActivityCommon):
         test_record = self.env['mail.test.activity'].browse(self.test_record.ids)
 
         activity = self.env['mail.activity'].create({
-            'activity_type_id': 1,
+            'activity_type_id': self.activity_type.id,
             'res_id': test_record.id,
             'res_model_id': self.env['ir.model']._get_id('mail.test.activity'),
             'summary': 'Test',
@@ -310,7 +312,7 @@ class TestActivityMixin(TestActivityCommon):
             today_utc = datetime.today()
             activity_1 = self.env['mail.activity'].create({
                 'summary': 'Test',
-                'activity_type_id': 1,
+                'activity_type_id': self.activity_type.id,
                 'res_model_id': self.env.ref('test_mail.model_mail_test_activity').id,
                 'res_id': record.id,
                 'date_deadline': today_utc,
@@ -485,7 +487,7 @@ class TestActivityMixin(TestActivityCommon):
             today_utc = datetime.today()
             origin_1_activity_1 = self.env['mail.activity'].create({
                 'summary': 'Test',
-                'activity_type_id': 1,
+                'activity_type_id': self.activity_type.id,
                 'res_model_id': self.env.ref('test_mail.model_mail_test_activity').id,
                 'res_id': origin_1.id,
                 'date_deadline': today_utc + relativedelta(hours=2),

--- a/addons/test_website/data/test_website_data.xml
+++ b/addons/test_website/data/test_website_data.xml
@@ -141,7 +141,7 @@
             <t t-out="country.name"/>
             <t t-if="not env.user._is_public()" t-out="'Logged In'"/>
             <!-- `href` is send through `url_for` for non editor users -->
-            <a href="/test_website/country/andorra-1">I am a link</a>
+            <a t-attf-href="/test_website/country/andorra-{{ env.ref('base.ad').id }}">I am a link</a>
         </template>
         <template id="test_redirect_view_qs">
             <a href="/empty_controller_test?a=a">Home</a>

--- a/addons/test_website/tests/test_controller_args.py
+++ b/addons/test_website/tests/test_controller_args.py
@@ -43,11 +43,11 @@ class TestWebsiteControllerArgs(odoo.tests.HttpCase):
 class TestWebsiteControllers(odoo.tests.TransactionCase):
 
     def test_01_sitemap(self):
-        website = self.env['website'].browse(1)
+        website = self.env.ref('website.default_website')
         locs = website.with_user(website.user_id)._enumerate_pages(query_string='test_website_sitemap')
         self.assertEqual(len(list(locs)), 1, "The same URL should only be shown once")
 
     def test_02_search_controller(self):
-        website = self.env['website'].browse(1)
+        website = self.env.ref('website.default_website')
         res = website._enumerate_pages(query_string="/test_website/country/elgium")
         self.assertIn('/test_website/country/belgium', next(res).get('loc'))

--- a/addons/test_website/tests/test_form.py
+++ b/addons/test_website/tests/test_form.py
@@ -7,8 +7,9 @@ from odoo.tests import tagged, HttpCase
 class TestForm(HttpCase):
 
     def test_form_conditional_visibility_record_field(self):
+        item_id = self.env['test.model'].search([], limit=1).ensure_one().id
         self.start_tour(
-            self.env['website'].get_client_action_url('/test_website/model_item/1', True),
+            self.env['website'].get_client_action_url(f'/test_website/model_item/{item_id}', True),
             'test_form_conditional_visibility_record_field',
             login='admin',
         )

--- a/addons/test_website/tests/test_fuzzy.py
+++ b/addons/test_website/tests/test_fuzzy.py
@@ -16,7 +16,7 @@ class TestAutoComplete(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.website = cls.env['website'].browse(1)
+        cls.website = cls.env.ref('website.default_website')
         cls.WebsiteController = Website()
 
     def _autocomplete(self, term, expected_count, expected_fuzzy_term, search_type="test", options=None):
@@ -90,13 +90,13 @@ class TestAutoComplete(TransactionCase):
                 _logger.warning("pg_trgm extension can't be installed, which is required to run this test")
                 return
 
-        with MockRequest(self.env, website=self.env['website'].browse(1)):
+        with MockRequest(self.env, website=self.env.ref('website.default_website')):
             # This should not crash. This ensures that when searching on `name`
             # field of `website.page` model, it works properly when `pg_trgm` is
             # activated.
             # Indeed, `name` is a field of `website.page` record but only at the
             # ORM level, not in SQL, due to how `inherits` works.
-            self.env['website'].browse(1)._search_with_fuzzy(
+            self.env.ref('website.default_website')._search_with_fuzzy(
                 'pages', 'test', limit=5, order='name asc, website_id desc, id', options={
                     'displayDescription': False, 'displayDetail': False,
                     'displayExtraDetail': False, 'displayExtraLink': False,

--- a/addons/test_website/tests/test_is_multilang.py
+++ b/addons/test_website/tests/test_is_multilang.py
@@ -27,7 +27,7 @@ class TestIsMultiLang(odoo.tests.HttpCase):
             self.assertEqual('/get_post_nomultilang', body.find('./a[@id="get_post_nomultilang"]').get('href'))
 
     def test_02_url_lang_code_underscore(self):
-        website = self.env['website'].browse(1)
+        website = self.env.ref('website.default_website')
         it = self.env.ref('base.lang_it').sudo()
         en = self.env.ref('base.lang_en').sudo()
         be = self.env.ref('base.lang_fr_BE').sudo()

--- a/addons/test_website/tests/test_menu.py
+++ b/addons/test_website/tests/test_menu.py
@@ -18,7 +18,7 @@ class TestWebsiteMenu(HttpCase):
         }])
 
         controller_url = '/test_website/model_item/'
-        website = self.env['website'].browse(1)
+        website = self.env.ref('website.default_website')
 
         # First render to fill the cache.
         self.url_open(f"{controller_url}{records[0].id}")

--- a/addons/test_website/tests/test_page.py
+++ b/addons/test_website/tests/test_page.py
@@ -1,14 +1,13 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests import HttpCase, tagged
+from odoo.tests import HttpCase
 from odoo.tools import mute_logger
 
 
-@tagged('-at_install', 'post_install')
 class WithContext(HttpCase):
     def test_01_homepage_url(self):
         # Setup
-        website = self.env['website'].browse([1])
+        website = self.env.ref('website.default_website')
         website.write({
             'name': 'Test Website',
             'domain': self.base_url(),

--- a/addons/test_website/tests/test_reset_views.py
+++ b/addons/test_website/tests/test_reset_views.py
@@ -41,7 +41,7 @@ class TestWebsiteResetViews(odoo.tests.HttpCase):
         self.test_page_view = self.Website.viewref('test_website.test_page_view')
         total_views = self.View.search_count([('type', '=', 'qweb')])
         # Trigger COW then break the QWEB XML on it
-        break_view(self.test_page_view.with_context(website_id=1))
+        break_view(self.test_page_view.with_context(website_id=self.ref('website.default_website')))
         self.assertEqual(total_views + 1, self.View.search_count([('type', '=', 'qweb')]), "Missing COW view")
         self.fix_it('/test_page_view')
 
@@ -50,7 +50,7 @@ class TestWebsiteResetViews(odoo.tests.HttpCase):
         total_views = self.View.search_count([('type', '=', 'qweb')])
         # Trigger COW then break the QWEB XML on it
         # `t-att-data="no_record.exist"` will test the case where exception.html contains branding
-        break_view(self.test_view.with_context(website_id=1), to='<p t-att-data="no_record.exist" />')
+        break_view(self.test_view.with_context(website_id=self.ref('website.default_website')), to='<p t-att-data="no_record.exist" />')
         self.assertEqual(total_views + 1, self.View.search_count([('type', '=', 'qweb')]), "Missing COW view")
         self.fix_it('/test_view')
 
@@ -60,7 +60,7 @@ class TestWebsiteResetViews(odoo.tests.HttpCase):
 
         total_views = self.View.search_count([('type', '=', 'qweb')])
         # Trigger COW then break the QWEB XML on it
-        break_view(self.test_view_to_be_t_called.with_context(website_id=1))
+        break_view(self.test_view_to_be_t_called.with_context(website_id=self.ref('website.default_website')))
         break_view(self.test_view, to='<t t-call="test_website.test_view_to_be_t_called"/>')
         self.assertEqual(total_views + 1, self.View.search_count([('type', '=', 'qweb')]), "Missing COW view")
         self.fix_it('/test_view')
@@ -71,7 +71,7 @@ class TestWebsiteResetViews(odoo.tests.HttpCase):
 
         # Activate and break the inherited view
         self.test_view_child_broken.active = True
-        break_view(self.test_view_child_broken.with_context(website_id=1, load_all_views=True))
+        break_view(self.test_view_child_broken.with_context(website_id=self.ref('website.default_website'), load_all_views=True))
 
         self.fix_it('/test_view')
 
@@ -80,7 +80,7 @@ class TestWebsiteResetViews(odoo.tests.HttpCase):
     # def test_05_reset_specific_view_controller_broken_request(self):
     #     total_views = self.View.search_count([('type', '=', 'qweb')])
     #     # Trigger COW then break the QWEB XML on it
-    #     break_view(self.test_view.with_context(website_id=1), to='<t t-out="request.env[\'website\'].browse(\'a\').name" />')
+    #     break_view(self.test_view.with_context(website_id=self.ref('website.default_website')), to='<t t-out="request.env[\'website\'].browse(\'a\').name" />')
     #     self.assertEqual(total_views + 1, self.View.search_count([('type', '=', 'qweb')]), "Missing COW view (1)")
     #     self.fix_it('/test_view')
 
@@ -89,7 +89,7 @@ class TestWebsiteResetViews(odoo.tests.HttpCase):
     def test_06_reset_specific_view_controller_inexisting_template(self):
         total_views = self.View.search_count([('type', '=', 'qweb')])
         # Trigger COW then break the QWEB XML on it
-        break_view(self.test_view.with_context(website_id=1), to='<t t-call="no_record.exist"/>')
+        break_view(self.test_view.with_context(website_id=self.ref('website.default_website')), to='<t t-call="no_record.exist"/>')
         self.assertEqual(total_views + 1, self.View.search_count([('type', '=', 'qweb')]), "Missing COW view (2)")
         self.fix_it('/test_view')
 
@@ -105,9 +105,9 @@ class TestWebsiteResetViews(odoo.tests.HttpCase):
         self.test_page_view = self.Website.viewref('test_website.test_page_view')
         total_views = self.View.search_count([('type', '=', 'qweb')])
         # Trigger COW then break the QWEB XML on it
-        break_view(self.test_page_view.with_context(website_id=1))
+        break_view(self.test_page_view.with_context(website_id=self.ref('website.default_website')))
         # Break it again to have a previous arch different than file arch
-        break_view(self.test_page_view.with_context(website_id=1))
+        break_view(self.test_page_view.with_context(website_id=self.ref('website.default_website')))
         self.assertEqual(total_views + 1, self.View.search_count([('type', '=', 'qweb')]), "Missing COW view")
 
         with self.assertRaises(AssertionError):

--- a/addons/test_website/tests/test_restricted_editor.py
+++ b/addons/test_website/tests/test_restricted_editor.py
@@ -12,7 +12,7 @@ class TestRestrictedEditor(HttpCaseWithWebsiteUser):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        website = cls.env['website'].search([], limit=1)
+        website = cls.env.ref('website.default_website')
         fr = cls.env.ref('base.lang_fr').sudo()
         en = cls.env.ref('base.lang_en').sudo()
 
@@ -21,9 +21,10 @@ class TestRestrictedEditor(HttpCaseWithWebsiteUser):
         website.default_lang_id = en
         website.language_ids = en + fr
 
+        item_id = cls.env['test.model'].search([], limit=1).ensure_one().id
         cls.env['website.menu'].create({
             'name': 'Model item',
-            'url': '/test_website/model_item/1',
+            'url': f'/test_website/model_item/{item_id}',
             'parent_id': website.menu_id.id,
             'sequence': 100,
         })

--- a/addons/test_website/tests/test_systray.py
+++ b/addons/test_website/tests/test_systray.py
@@ -1,8 +1,8 @@
 
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests.common import HOST, new_test_user, tagged
-from odoo.tools import config, mute_logger
+from odoo.tests.common import new_test_user, tagged
+from odoo.tools import mute_logger
 
 from odoo.addons.base.tests.common import HttpCase
 
@@ -33,38 +33,39 @@ class TestSystray(HttpCase):
             """
         })
         # Remain on page when switching website
-        cls.env['website'].search([]).homepage_url = '/test_model/1'
+        model = cls.env['test.model'].search([], limit=1).ensure_one()
+        other_website.search([]).homepage_url = cls.homepage_url = f'/test_model/{model.id}'
 
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
     def test_01_admin(self):
-        self.start_tour(self.env['website'].get_client_action_url('/test_model/1'), 'test_systray_admin', login="admin")
+        self.start_tour(self.env['website'].get_client_action_url(self.homepage_url), 'test_systray_admin', login="admin")
 
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
     def test_02_reditor_tester(self):
         self.user_test.group_ids |= self.group_restricted_editor
         self.user_test.group_ids |= self.group_tester
-        self.start_tour(self.env['website'].get_client_action_url('/test_model/1'), 'test_systray_reditor_tester', login="testtest")
+        self.start_tour(self.env['website'].get_client_action_url(self.homepage_url), 'test_systray_reditor_tester', login="testtest")
 
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
     def test_03_reditor_not_tester(self):
         self.user_test.group_ids |= self.group_restricted_editor
         self.user_test.group_ids = self.user_test.group_ids.filtered(lambda group: group != self.group_tester)
         self.assertNotIn(self.group_tester.id, self.user_test.group_ids.ids, "User should not be a group_tester")
-        self.start_tour(self.env['website'].get_client_action_url('/test_model/1'), 'test_systray_reditor_not_tester', login="testtest")
+        self.start_tour(self.env['website'].get_client_action_url(self.homepage_url), 'test_systray_reditor_not_tester', login="testtest")
 
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
     def test_04_not_reditor_tester(self):
         self.user_test.group_ids = self.user_test.group_ids.filtered(lambda group: group != self.group_restricted_editor)
         self.user_test.group_ids |= self.group_tester
         self.assertNotIn(self.group_restricted_editor.id, self.user_test.group_ids.ids, "User should not be a group_restricted_editor")
-        self.start_tour(self.env['website'].get_client_action_url('/test_model/1'), 'test_systray_not_reditor_tester', login="testtest")
+        self.start_tour(self.env['website'].get_client_action_url(self.homepage_url), 'test_systray_not_reditor_tester', login="testtest")
 
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
     def test_05_not_reditor_not_tester(self):
         self.user_test.group_ids = self.user_test.group_ids.filtered(lambda group: group not in [self.group_restricted_editor, self.group_tester])
         self.assertNotIn(self.group_restricted_editor.id, self.user_test.group_ids.ids, "User should not be a group_restricted_editor")
         self.assertNotIn(self.group_tester.id, self.user_test.group_ids.ids, "User should not be a group_tester")
-        self.start_tour(self.env['website'].get_client_action_url('/test_model/1'), 'test_systray_not_reditor_not_tester', login="testtest")
+        self.start_tour(self.env['website'].get_client_action_url(self.homepage_url), 'test_systray_not_reditor_not_tester', login="testtest")
 
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
     def test_06_single_website(self):
@@ -72,7 +73,7 @@ class TestSystray(HttpCase):
             website = self.env['website'].search([], limit=1)
             websites_to_remove = self.env['website'].search([('id', '!=', website.id)])
             websites_to_remove.unlink()
-        self.start_tour(self.env['website'].get_client_action_url('/test_model/1'), 'test_systray_single_website', login="admin")
+        self.start_tour(self.env['website'].get_client_action_url(self.homepage_url), 'test_systray_single_website', login="admin")
 
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
     def test_07_multi_website(self):
@@ -80,4 +81,4 @@ class TestSystray(HttpCase):
             self.env['website'].create({
                 'name': 'My Website 2',
             })
-        self.start_tour(self.env['website'].get_client_action_url('/test_model/1'), 'test_systray_multi_website', login="admin")
+        self.start_tour(self.env['website'].get_client_action_url(self.homepage_url), 'test_systray_multi_website', login="admin")

--- a/addons/test_website/tests/test_views_during_module_operation.py
+++ b/addons/test_website/tests/test_views_during_module_operation.py
@@ -55,7 +55,7 @@ def test_01_cow_views_unlink_on_module_update(env):
     })
 
     # Trigger COW on child view
-    update_module_child_view.with_context(website_id=1).write({'name': 'Child View (W1)'})
+    update_module_child_view.with_context(website_id=env.ref('website.default_website').id).write({'name': 'Child View (W1)'})
 
     # Ensure views are correctly setup
     msg = "View '%s' does not exist!"
@@ -115,8 +115,8 @@ def test_02_copy_ids_views_unlink_on_module_update(env):
     ThemeView = env['theme.ir.ui.view']
     Imd = env['ir.model.data']
 
-    website_1 = env['website'].browse(1)
-    website_2 = env['website'].browse(2)
+    website_1 = env.ref('website.default_website')
+    website_2 = website_1.search([('id', '>', website_1.id)], order='id', limit=1).ensure_one()
     theme_default = env.ref('base.module_theme_default')
 
     # Install theme_default on website 1 and website 2
@@ -190,8 +190,8 @@ def test_02_copy_ids_views_unlink_on_module_update(env):
     ThemeView = env['theme.ir.ui.view']
     Imd = env['ir.model.data']
 
-    website_1 = env['website'].browse(1)
-    website_2 = env['website'].browse(2)
+    website_1 = env.ref('website.default_website')
+    website_2 = website_1.search([('id', '>', website_1.id)], order='id', limit=1).ensure_one()
     theme_default = env.ref('base.module_theme_default')
 
     # Ensure the theme.ir.ui.view got removed (since there is an IMD but not

--- a/addons/test_website/tests/test_website_controller_page.py
+++ b/addons/test_website/tests/test_website_controller_page.py
@@ -72,7 +72,7 @@ class TestWebsiteControllerPage(HttpCase):
         self.env["ir.model.access"].search([("model_id", "=", self.model.id)]).perm_read = False
 
         with self.assertRaises(AccessError) as cm:
-            self.env["website.controller.page"].with_user(2).create({
+            self.env["website.controller.page"].with_user(self.ref('base.user_admin')).create({
                 "name": "Exposed Model Read",
                 "website_id": False,
                 "view_id": self.single_view.id,

--- a/addons/test_website/tests/test_website_field_sanitize.py
+++ b/addons/test_website/tests/test_website_field_sanitize.py
@@ -1,12 +1,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import odoo
 import odoo.tests
 
 
 @odoo.tests.tagged('-at_install', 'post_install')
 class TestWebsiteFieldSanitize(odoo.tests.HttpCase):
     def test_sanitize_video_iframe(self):
+        item_id = self.env['test.model'].search([], limit=1).ensure_one().id
         self.env['res.users'].create({
             'name': 'Restricted Editor',
             'login': 'restricted',
@@ -20,13 +20,13 @@ class TestWebsiteFieldSanitize(odoo.tests.HttpCase):
 
         # Add a video to an HTML field (admin).
         self.start_tour(
-            self.env['website'].get_client_action_url('/test_website/model_item/1', True),
+            self.env['website'].get_client_action_url(f'/test_website/model_item/{item_id}', True),
             'website_designer_iframe_video',
             login='admin'
         )
         # Make sure a user can still edit the content (restricted editor).
         self.start_tour(
-            self.env['website'].get_client_action_url('/test_website/model_item/1', True),
+            self.env['website'].get_client_action_url(f'/test_website/model_item/{item_id}', True),
             'website_restricted_editor_iframe_video',
             login='restricted'
         )

--- a/addons/test_website/tests/test_website_page_properties.py
+++ b/addons/test_website/tests/test_website_page_properties.py
@@ -10,7 +10,8 @@ class TestWebsitePageProperties(HttpCase):
         self.start_tour(self.env["website"].get_client_action_url('/test_view'), 'website_page_properties_common', login='admin')
 
     def test_website_page_properties_can_publish(self):
-        self.start_tour(self.env["website"].get_client_action_url('/test_website/model_item/1'), 'website_page_properties_can_publish', login='admin')
+        item_id = self.env['test.model'].search([], limit=1).ensure_one().id
+        self.start_tour(self.env["website"].get_client_action_url(f'/test_website/model_item/{item_id}'), 'website_page_properties_can_publish', login='admin')
 
     def test_website_page_properties_website_page(self):
         # Create a website page with a different URL to be tested for dependency

--- a/addons/test_website_modules/tests/test_performance.py
+++ b/addons/test_website_modules/tests/test_performance.py
@@ -246,7 +246,7 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
                 "product_template_id": self.productC.product_tmpl_id.id,
                 "product_id": self.productC.id,
                 "quantity": 1,
-                "uom_id": 1,
+                "uom_id": self.productC.uom_id.id,
                 "product_custom_attribute_values": [],
                 "no_variant_attribute_value_ids": [],
                 "linked_products": []
@@ -332,7 +332,7 @@ class TestWebsiteAllPerformance(TestWebsitePerformanceCommon, TestWebsitePriceLi
             query_count += 1
             queries['product_product'] += 1
 
-        tax = self.env.ref('account.1_sale_tax_template', raise_if_not_found=False)
+        tax = self.env.ref(f'account.{self.env.company.id}_sale_tax_template', raise_if_not_found=False)
         if tax and tax.name == '15%':
             query_count += 2
             queries['account_tax_repartition_line'] = 2

--- a/addons/web/tests/test_image.py
+++ b/addons/web/tests/test_image.py
@@ -199,14 +199,17 @@ class TestImage(HttpCase):
             res = self.url_open(f"/web/image/{attachment.id}?access_token={token}")
             res.raise_for_status()
             self.assertEqual(res.headers["Content-Disposition"], "inline; filename=placeholder.png")
+
         # within a 14-days period, the same token is generated
         start_of_period = datetime(2021, 2, 18, 0, 0, 0)  # 14-days period 2021-02-18 to 2021-03-04
         base_result = datetime(2021, 3, 24, 15, 25, 40)
+        attachment2, attachment3 = attachment.browse([2, 3])  # hardcoded ids for access token jitter
         for i in range(14):
             with freeze_time(start_of_period + timedelta(days=i, hours=i % 24, minutes=i % 60)):
                 self.assertEqual(
-                    get_datetime_from_token(self.env["ir.attachment"].browse(2)._get_raw_access_token()),
+                    get_datetime_from_token(attachment2._get_raw_access_token()),
                     base_result,
+                    f"Token regenerated for day {i}",
                 )
         # on each following 14-days period another token is generated, valid for exactly 14 extra
         # days from the previous token
@@ -216,7 +219,7 @@ class TestImage(HttpCase):
             ):
                 self.assertEqual(
                     get_datetime_from_token(
-                        self.env["ir.attachment"].browse(2)._get_raw_access_token()
+                        attachment2._get_raw_access_token()
                     ),
                     base_result + timedelta(days=14 * i),
                 )
@@ -224,21 +227,21 @@ class TestImage(HttpCase):
             # at the same time...
             self.assertEqual(
                 get_datetime_from_token(
-                    self.env["ir.attachment"].browse(2)._get_raw_access_token()
+                    attachment2._get_raw_access_token()
                 ),
                 base_result,
             )
             # a different record generates a different token
-            record_res = self.env["ir.attachment"].browse(3)._get_raw_access_token()
+            record_res = attachment3._get_raw_access_token()
             self.assertNotIn(record_res, [base_result])
             # a different field generates a different token
             field_res = get_datetime_from_token(
-                limited_field_access_token(self.env["ir.attachment"].browse(3), "mimetype", scope="binary")
+                limited_field_access_token(attachment3, "mimetype", scope="binary")
             )
             self.assertNotIn(field_res, [base_result, record_res])
             # a different model generates a different token
             model_res = get_datetime_from_token(
-                limited_field_access_token(self.env["res.partner"].browse(3), "raw", scope="binary")
+                limited_field_access_token(attachment3, "raw", scope="binary")
             )
             self.assertNotIn(model_res, [base_result, record_res, field_res])
 

--- a/addons/web/tests/test_translate.py
+++ b/addons/web/tests/test_translate.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests.common import tagged, TransactionCase
@@ -13,7 +12,7 @@ class TestTranslationOverride(TransactionCase):
         cls.custom = cls.env['ir.model.fields'].create({
             'name': 'x_html_test',
             'ttype': 'html',
-            'model_id': cls.category.id,
+            'model_id': cls.env['ir.model']._get(cls.category._name).id,
             'translate': 'html_translate',
         })
 

--- a/addons/website/static/tests/tours/link_to_document.js
+++ b/addons/website/static/tests/tours/link_to_document.js
@@ -15,7 +15,8 @@ const patchStep = {
         const uploadService = odoo.__WOWL_DEBUG__.root.env.services.uploadLocalFiles;
         unpatch = patch(uploadService, {
             async upload() {
-                return [{ id: 1, name: "file.txt", public: true, checksum: "123" }];
+                // hardcoded id for test_03_link_to_document
+                return [{ id: 437296, name: "file.txt", public: true, checksum: "123" }];
             },
         });
     },

--- a/addons/website/tests/test_attachment.py
+++ b/addons/website/tests/test_attachment.py
@@ -40,12 +40,14 @@ class TestWebsiteAttachment(odoo.tests.HttpCase):
         self.start_tour(self.env['website'].get_client_action_url('/', True), 'website_image_quality', login="admin")
 
     def test_03_link_to_document(self):
-        text = b'Lorem Ipsum'
-        self.env['ir.attachment'].create({
+        Attachment = self.env['ir.attachment']
+        # hardcoded id for JS tour
+        self.env.cr.execute("SELECT setval(pg_get_serial_sequence(%s, 'id'), 437296, false)", (Attachment._table,))
+        Attachment.create({
             'name': 'sample.txt',
             'public': True,
             'mimetype': 'text/plain',
-            'raw': text,
+            'raw': b'Lorem Ipsum',
         })
         self.start_tour(self.env['website'].get_client_action_url('/', True), 'test_link_to_document', login="admin")
 

--- a/addons/website/tests/test_auth_signup_uninvited.py
+++ b/addons/website/tests/test_auth_signup_uninvited.py
@@ -7,6 +7,6 @@ from odoo.tests import common, tagged
 class TestAuthSignupUninvited(common.TransactionCase):
 
     def test_01_auth_signup_uninvited(self):
-        self.env['website'].browse(1).auth_signup_uninvited = 'b2c'
+        self.env.ref('website.default_website').auth_signup_uninvited = 'b2c'
         config = self.env['res.config.settings'].create({})
         self.assertEqual(config.auth_signup_uninvited, 'b2c')

--- a/addons/website/tests/test_fuzzy.py
+++ b/addons/website/tests/test_fuzzy.py
@@ -110,7 +110,7 @@ class TestAutoComplete(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.website = cls.env['website'].browse(1)
+        cls.website = cls.env.ref('website.default_website')
         cls.WebsiteController = Website()
         cls.options = {
             'displayDescription': True,

--- a/addons/website/tests/test_menu.py
+++ b/addons/website/tests/test_menu.py
@@ -52,7 +52,7 @@ class TestMenu(common.TransactionCase):
                 'is_mega_menu': False,
             }
         ]
-        Menu.save(1, {'data': data, 'to_delete': []})
+        Menu.save(self.ref('website.default_website'), {'data': data, 'to_delete': []})
 
         self.assertEqual(total_menu_items + 2, Menu.search_count([]), "Creating 2 new menus should create only 2 menus records")
 
@@ -128,7 +128,7 @@ class TestMenu(common.TransactionCase):
 
     def test_06_menu_active(self):
         Menu = self.env['website.menu']
-        website_1 = self.env['website'].browse(1)
+        website_1 = self.env.ref('website.default_website')
         menu = Menu.create({
             'name': 'Page Specific menu',
             'url': '/contactus',
@@ -318,7 +318,7 @@ class TestMenuHttp(common.HttpCase):
         self.page_url = '/page_specific'
         self.page = self.env['website.page'].create({
             'url': self.page_url,
-            'website_id': 1,
+            'website_id': self.ref('website.default_website'),
             # ir.ui.view properties
             'name': 'Base',
             'type': 'qweb',
@@ -329,13 +329,13 @@ class TestMenuHttp(common.HttpCase):
             'name': 'Page Specific menu',
             'page_id': self.page.id,
             'url': self.page_url,
-            'website_id': 1,
+            'website_id': self.ref('website.default_website'),
         })
         self.headers = {"Content-Type": "application/json"}
 
     def simulate_rpc_save_menu(self, data, to_delete=None):
         self.authenticate("admin", "admin")
-        # `Menu.save(1, {'data': [data], 'to_delete': []})` would have been
+        # `Menu.save(self.ref('website.default_website'), {'data': [data], 'to_delete': []})` would have been
         # ideal but need a full frontend context to generate routing maps,
         # router and registry, even MockRequest is not enough
         self.url_open('/web/dataset/call_kw', data=json.dumps({
@@ -365,7 +365,7 @@ class TestMenuHttp(common.HttpCase):
 
         # 3. Edit the menu URL back to the page URL
         data['url'] = self.page_url
-        self.env['website.menu'].save(1, {'data': [data], 'to_delete': []})
+        self.env['website.menu'].save(self.ref('website.default_website'), {'data': [data], 'to_delete': []})
         self.assertEqual(self.menu.page_id, self.page,
                          "M2o should have been set back, as there was a page found with the new URL set on the menu.")
         self.assertTrue(self.page.url == self.menu.url == self.page_url)
@@ -407,7 +407,7 @@ class TestMenuHttp(common.HttpCase):
         self.authenticate('admin', 'admin')
         fr = self.env['res.lang']._activate_lang('fr_FR')
         Menu = self.env['website.menu']
-        website = self.env['website'].browse(1)
+        website = self.env.ref('website.default_website')
         website.language_ids += fr
         menu = Menu.create({
             'name': 'Test Mega Menu Content Translation Edit Mode',

--- a/addons/website/tests/test_page_manager.py
+++ b/addons/website/tests/test_page_manager.py
@@ -27,7 +27,7 @@ class TestWebsitePageManager(odoo.tests.HttpCase):
         Page = self.env['website.page']
         Website = self.env['website']
 
-        website = Website.browse(1)
+        website = self.env.ref('website.default_website')
         generic_page = Page.create({
             'name': 'Test Diverged',
             'type': 'qweb',
@@ -67,7 +67,7 @@ class TestWebsitePageManager(odoo.tests.HttpCase):
             'view_id': test_view.id,
             'url': '/test-duplicate',
             'name': 'Test Duplicate',
-            'website_id': 1,
+            'website_id': self.ref('website.default_website'),
         })
 
         pages = Page.search([('name', 'like', 'Test Duplicate')])

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -124,21 +124,23 @@ class TestStandardPerformance(UtilPerf):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.env['res.users'].browse(2).image_1920 = BinaryBytes(PNG_RAW)
+        cls.env.ref('base.user_admin').image_1920 = BinaryBytes(PNG_RAW)
 
     @mute_logger('odoo.http')
     def test_10_perf_sql_img_controller(self):
         self.authenticate('demo', 'demo')
         # not published user, get the not found image placeholder
-        self.assertEqual(self.env['res.users'].sudo().browse(2).website_published, False)
-        url = '/web/image/res.users/2/image_256'
+        self.assertEqual(self.env.ref('base.user_admin').sudo().website_published, False)
+        user_id = self.ref('base.user_admin')
+        url = f'/web/image/res.users/{user_id}/image_256'
         self.assertEqual(self._get_url_hot_query(url), 7)
 
     @mute_logger('odoo.http')
     def test_11_perf_sql_img_controller(self):
         self.authenticate('demo', 'demo')
-        self.env['res.users'].sudo().browse(2).website_published = True
-        url = '/web/image/res.users/2/image_256'
+        self.env.ref('base.user_admin').sudo().website_published = True
+        user_id = self.ref('base.user_admin')
+        url = f'/web/image/res.users/{user_id}/image_256'
         select_tables_perf = {
             'orm_signaling_registry': 1,
             'res_users': 2,
@@ -149,7 +151,8 @@ class TestStandardPerformance(UtilPerf):
 
     @mute_logger('odoo.http')
     def test_20_perf_sql_img_controller_bis(self):
-        url = '/web/image/website/1/favicon'
+        website_id = self.ref('website.default_website')
+        url = f'/web/image/website/{website_id}/favicon'
         select_tables_perf = {
             'orm_signaling_registry': 1,
             'website': 2,
@@ -175,7 +178,7 @@ class TestWebsitePerformanceCommon(UtilPerf):
 
     def _create_page_with_menu(self, url):
         name = url[1:]
-        website = self.env['website'].browse(1)
+        website = self.env.ref('website.default_website')
         page = self.env['website.page'].create({
             'url': url,
             'name': name,

--- a/addons/website/tests/test_qweb.py
+++ b/addons/website/tests/test_qweb.py
@@ -52,14 +52,14 @@ class TestQweb(TransactionCaseWithUserDemo):
         rendered = self.env['ir.qweb']._render(template.id)
         self.assertEqual(rendered.strip(), result.strip(), 'First rendering (without website_id)')
 
-        rendered = self.env['ir.qweb'].with_context(website_id=1)._render(template.id)
-        self.assertEqual(rendered.strip(), result.strip(), 'Second rendering (with website_id=1)')
+        rendered = self.env['ir.qweb'].with_context(website_id=self.ref('website.default_website'))._render(template.id)
+        self.assertEqual(rendered.strip(), result.strip(), 'Second rendering (with website_id=default)')
 
         rendered = self.env['ir.qweb'].with_context(website_id=None)._render(template.id)
         self.assertEqual(rendered.strip(), result.strip(), 'Third rendering (with website_id=None)')
 
-        rendered = self.env['ir.qweb'].with_context(website_id=1)._render(template.id)
-        self.assertEqual(rendered.strip(), result.strip(), 'Fourth rendering (with website_id=1)')
+        rendered = self.env['ir.qweb'].with_context(website_id=self.ref('website.default_website'))._render(template.id)
+        self.assertEqual(rendered.strip(), result.strip(), 'Fourth rendering (with website_id=default)')
 
     def test_render_query_count(self):
         """
@@ -78,10 +78,10 @@ class TestQweb(TransactionCaseWithUserDemo):
             'key': 'base.testing_header_0',
             'arch_db': '''<span>0</span>''',
         })
-        IrUiView.create([{  # website_id=1
+        IrUiView.create([{  # website_id=default
             'name': 'test',
             'type': 'qweb',
-            'website_id': 1,
+            'website_id': self.ref('website.default_website'),
             'key': 'base.testing_header_1',
             'arch_db': '''<span>WITH WEBSITE</span>''',
         }, {  # same key but website_id=False
@@ -118,10 +118,10 @@ class TestQweb(TransactionCaseWithUserDemo):
                     <footer>footer</footer>
                 <t t-call="base.testing_footer_1"/>
             </t>''',
-        }, {  # website_id=1
+        }, {  # website_id=default
             'name': 'test',
             'type': 'qweb',
-            'website_id': 1,
+            'website_id': self.ref('website.default_website'),
             'key': 'base.testing_footer',
             'arch_db': '''<t t-name="base.testing_footer">
                 <t t-call="base.testing_footer_0"/>
@@ -146,7 +146,7 @@ class TestQweb(TransactionCaseWithUserDemo):
             'key': 'base.testing_content',
             'arch_db': '''<t t-call="base.testing_layout"><div><t t-call="base.testing_header_0"/><t t-out="doc"/></div></t>''',
         })
-        website = self.env['website'].browse(1)
+        website = self.env.ref('website.default_website')
         other_website = self.env['website'].create({'name': 'testing'})
 
         expected = """
@@ -552,7 +552,7 @@ class TestQwebDataSnippet(TransactionCase):
     def test_call_query_count_snippets_template(self):
         actual_queries = []
         with contextmanager(lambda: self._patchExecute(actual_queries))():
-            with MockRequest(self.env, website=self.env['website'].browse(1)):
+            with MockRequest(self.env, website=self.env.ref('website.default_website')):
                 render = self.env['ir.ui.view'].render_public_asset('website.snippets')
                 self.assertTrue('name="Blockquote"' in render)
 

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -27,7 +27,7 @@ class TestSnippets(HttpCase):
         self.start_tour(self.env['website'].get_client_action_url('/', True), 'default_shape_gets_palette_colors', login='admin')
 
     def test_03_snippets_all_drag_and_drop(self):
-        with MockRequest(self.env, website=self.env['website'].browse(1)):
+        with MockRequest(self.env, website=self.env.ref('website.default_website')):
             snippets_template = self.env['ir.ui.view'].render_public_asset('website.snippets')
         html_template = html.fromstring(snippets_template)
         data_snippet_els = html_template.xpath("//*[snippets and not(hasclass('d-none'))]//*[@data-oe-snippet-key]")
@@ -76,7 +76,7 @@ class TestSnippets(HttpCase):
         create_image_attachment(self.env, '/web/image/website.s_banner_default_image', 's_banner_default_image.jpg')
         self.start_tour(self.env['website'].get_client_action_url('/', True), 'snippet_social_media', login="admin")
         self.assertEqual(
-            self.env['website'].browse(1).social_instagram,
+            self.env.ref('website.default_website').social_instagram,
             'https://instagram.com/odoo.official/',
             'Social media should have been updated'
         )

--- a/addons/website/tests/test_theme.py
+++ b/addons/website/tests/test_theme.py
@@ -15,7 +15,7 @@ class TestTheme(common.TransactionCase):
 
     def test_02_disable_view(self):
         """This test ensure only one template header can be active at a time."""
-        website_id = self.env['website'].browse(1)
+        website_id = self.env.ref('website.default_website')
         ThemeUtils = self.env['theme.utils'].with_context(website_id=website_id.id)
 
         ThemeUtils._reset_default_config()

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -29,7 +29,7 @@ class TestUiCustomizeTheme(odoo.tests.HttpCase):
         Page = self.env['website.page']
         Attachment = self.env['ir.attachment']
 
-        website_default = Website.browse(1)
+        website_default = self.env.ref('website.default_website')
         website_test = Website.create({'name': 'Website Test'})
 
         # simulate attachment state when editing 2 theme through customize
@@ -141,7 +141,7 @@ class TestUiHtmlEditor(HttpCaseWithUserDemo):
         self.assertEqual(View.search_count([('key', '=', 'test.generic_view')]), 2, "homepage view should have been COW'd")
         self.assertTrue(generic_page.arch == oe_structure_layout, "Generic homepage view should be untouched")
         self.assertEqual(len(generic_page.inherit_children_ids.filtered(lambda v: 'oe_structure' in v.name)), 0, "oe_structure view should have been deleted when aboutus was COW")
-        specific_page = Website.with_context(website_id=1).viewref('test.generic_view')
+        specific_page = Website.with_context(website_id=self.ref('website.default_website')).viewref('test.generic_view')
         self.assertTrue(specific_page.arch != oe_structure_layout, "Specific homepage view should have been changed")
         self.assertEqual(len(specific_page.inherit_children_ids.filtered(lambda v: 'oe_structure' in v.name)), 1, "oe_structure view should have been created on the specific tree")
 
@@ -443,7 +443,7 @@ class TestUi(HttpCaseWithWebsiteUser):
 
     def test_12_edit_translated_page_redirect(self):
         lang = self.env['res.lang']._activate_lang('nl_NL')
-        self.env['website'].browse(1).write({'language_ids': [(4, lang.id, 0)]})
+        self.env.ref('website.default_website').write({'language_ids': [(4, lang.id, 0)]})
         self.start_tour("/nl/contactus", 'edit_translated_page_redirect', login='admin')
 
     def test_14_carousel_snippet_content_removal(self):
@@ -661,7 +661,7 @@ class TestUi(HttpCaseWithWebsiteUser):
         self.start_tour(self.env['website'].get_client_action_url('/', True), 'website_powerbox_keyword', login='admin')
 
     def test_website_no_dirty_lazy_image(self):
-        website = self.env['website'].browse(1)
+        website = self.env.ref('website.default_website')
         # Enable multiple langs to reduce the chance of the test being silently
         # broken by ensuring that it receives a lot of extra o_dirty elements.
         # This is done to account for potential later changes in the number of
@@ -694,7 +694,7 @@ class TestUi(HttpCaseWithWebsiteUser):
         self.start_tour(self.env["website"].get_client_action_url("/", True), 'website_no_dirty_lazy_image', login='admin')
 
     def test_website_edit_menus_delete_parent(self):
-        website = self.env['website'].browse(1)
+        website = self.env.ref('website.default_website')
         self.env['website.menu'].create({
             'name': 'Test Child Menu',
             'url': '/test-child',
@@ -789,7 +789,7 @@ class TestUi(HttpCaseWithWebsiteUser):
     def test_background_color_gradient_precedence(self):
         # Configure CC1 with a gradient and apply it to the header, then set a
         # different gradient directly on the header background.
-        self.env['website.assets'].with_context(website_id=1).make_scss_customization(
+        self.env['website.assets'].with_context(website_id=self.ref('website.default_website')).make_scss_customization(
             '/website/static/src/scss/options/user_values.scss',
             {
                 'o-cc1-bg-gradient': 'linear-gradient(rgb(0, 0, 0), rgb(1, 1, 1))',

--- a/addons/website/tests/test_unsplash_beacon.py
+++ b/addons/website/tests/test_unsplash_beacon.py
@@ -14,7 +14,7 @@ class TestUnsplashBeacon(odoo.tests.HttpCase):
     def test_01_beacon(self):
         self.env['ir.config_parameter'].sudo().set_str('unsplash.app_id', '123456')
         # Create page with unsplash image.
-        page = self.env['website.page'].search([('url', '=', '/'), ('website_id', '=', 1)])
+        page = self.env['website.page'].search([('url', '=', '/'), ('website_id', '=', self.ref('website.default_website'))])
         page.arch = '''<t name="Homepage" t-name="website.homepage1">
         <t t-call="website.layout" pageName.f="homepage">
             <div id="wrap" class="oe_structure oe_empty">

--- a/addons/website/tests/test_views.py
+++ b/addons/website/tests/test_views.py
@@ -217,7 +217,7 @@ class TestViewSaving(TestViewSavingCommon):
             self.eq(ca, cb)
 
     def setUp(self):
-        super(TestViewSaving, self).setUp()
+        super().setUp()
         self.arch = h.DIV(
             h.DIV(
                 h.H3("Column 1"),
@@ -229,8 +229,8 @@ class TestViewSaving(TestViewSavingCommon):
                 h.H3("Column 2"),
                 h.UL(
                     h.LI("Item 1"),
-                    h.LI(h.SPAN("My Company", attrs(model='res.company', id=1, field='name', type='char'))),
-                    h.LI(h.SPAN("+00 00 000 00 0 000", attrs(model='res.company', id=1, field='phone', type='char')))
+                    h.LI(h.SPAN("My Company", attrs(model='res.company', id=self.env.company.id, field='name', type='char'))),
+                    h.LI(h.SPAN("+00 00 000 00 0 000", attrs(model='res.company', id=self.env.company.id, field='phone', type='char')))
                 ))
         )
         self.view_id = self.env['ir.ui.view'].create({
@@ -239,30 +239,31 @@ class TestViewSaving(TestViewSavingCommon):
             'key': 'website.test_view',
             'arch': ET.tostring(self.arch, encoding='unicode')
         })
+        self.website_ctx = {'website_id': self.ref('website.default_website')}
 
     def test_embedded_extraction(self):
         fields = self.env['ir.ui.view'].extract_embedded_fields(self.arch)
 
         expect = [
-            h.SPAN("My Company", attrs(model='res.company', id=1, field='name', type='char')),
-            h.SPAN("+00 00 000 00 0 000", attrs(model='res.company', id=1, field='phone', type='char')),
+            h.SPAN("My Company", attrs(model='res.company', id=self.env.company.id, field='name', type='char')),
+            h.SPAN("+00 00 000 00 0 000", attrs(model='res.company', id=self.env.company.id, field='phone', type='char')),
         ]
         for actual, expected in zip_longest(fields, expect):
             self.eq(actual, expected)
 
     def test_embedded_save(self):
         embedded = h.SPAN("+00 00 000 00 0 000", attrs(
-            model='res.company', id=1, field='phone', type='char'))
+            model='res.company', id=self.env.company.id, field='phone', type='char'))
 
         self.env['ir.ui.view'].save_embedded_field(embedded)
 
-        company = self.env['res.company'].browse(1)
+        company = self.env.ref('base.main_company')
         self.assertEqual(company.phone, "+00 00 000 00 0 000")
 
     @unittest.skip("save conflict for embedded (saved by third party or previous version in page) not implemented")
     def test_embedded_conflict(self):
-        e1 = h.SPAN("My Company", attrs(model='res.company', id=1, field='name'))
-        e2 = h.SPAN("Leeroy Jenkins", attrs(model='res.company', id=1, field='name'))
+        e1 = h.SPAN("My Company", attrs(model='res.company', id=self.env.company.id, field='name'))
+        e2 = h.SPAN("Leeroy Jenkins", attrs(model='res.company', id=self.env.company.id, field='name'))
 
         View = self.env['ir.ui.view']
 
@@ -282,7 +283,7 @@ class TestViewSaving(TestViewSavingCommon):
     def test_to_field_ref_keep_attributes(self):
         View = self.env['ir.ui.view']
 
-        att = attrs(expression="bob", model="res.company", id=1, field="name")
+        att = attrs(expression="bob", model="res.company", id=self.env.company.id, field="name")
         att['id'] = "whop"
         att['class'] = "foo bar"
         embedded = h.SPAN("My Company", att)
@@ -319,8 +320,8 @@ class TestViewSaving(TestViewSavingCommon):
                 h.H3("Column 2"),
                 h.UL(
                     h.LI("Item 1"),
-                    h.LI(h.SPAN("My Company", attrs(model='res.company', id=1, field='name', type='char'))),
-                    h.LI(h.SPAN("+00 00 000 00 0 000", attrs(model='res.company', id=1, field='phone', type='char')))
+                    h.LI(h.SPAN("My Company", attrs(model='res.company', id=self.env.company.id, field='name', type='char'))),
+                    h.LI(h.SPAN("+00 00 000 00 0 000", attrs(model='res.company', id=self.env.company.id, field='phone', type='char')))
                 ))
         ))
 
@@ -329,8 +330,6 @@ class TestViewSaving(TestViewSavingCommon):
             self.view_id.replace_arch_section('/div/div/h3', h.H6("Lol nope"))
 
     def test_save(self):
-        Company = self.env['res.company']
-
         # create an xmlid for the view
         imd = self._create_imd(self.view_id)
         self.assertEqual(self.view_id.model_data_id, imd)
@@ -340,22 +339,22 @@ class TestViewSaving(TestViewSavingCommon):
             h.H3("Column 2"),
             h.UL(
                 h.LI("wob wob wob"),
-                h.LI(h.SPAN("Acme Corporation", attrs(model='res.company', id=1, field='name', expression="bob", type='char'))),
-                h.LI(h.SPAN("+12 3456789", attrs(model='res.company', id=1, field='phone', expression="edmund", type='char'))),
+                h.LI(h.SPAN("Acme Corporation", attrs(model='res.company', id=self.env.company.id, field='name', expression="bob", type='char'))),
+                h.LI(h.SPAN("+12 3456789", attrs(model='res.company', id=self.env.company.id, field='phone', expression="edmund", type='char'))),
             )
         ), encoding='unicode')
 
-        self.view_id.with_context(website_id=1).save(value=replacement, xpath='/div/div[2]')
+        self.view_id.with_context(website_id=self.ref('website.default_website')).save(value=replacement, xpath='/div/div[2]')
         self.assertFalse(imd.noupdate, "view's xml_id shouldn't be set to 'noupdate' in a website context as `save` method will COW")
         # remove newly created COW view so next `save()`` wont be redirected to COW view
-        self.env['website'].with_context(website_id=1).viewref(self.view_id.key).unlink()
+        self.env['website'].with_context(website_id=self.ref('website.default_website')).viewref(self.view_id.key).unlink()
 
         self.view_id.save(value=replacement, xpath='/div/div[2]')
 
         # the xml_id of the view should be flagged as 'noupdate'
         self.assertTrue(imd.noupdate)
 
-        company = Company.browse(1)
+        company = self.env.ref('base.main_company')
         self.assertEqual(company.name, "Acme Corporation")
         self.assertEqual(company.phone, "+12 3456789")
         self.eq(
@@ -440,13 +439,13 @@ class TestViewSaving(TestViewSavingCommon):
                         <p>Hello World!</p>
                    </div>''' % base.id
 
-        base.with_context(website_id=1).save(value=value, xpath='/xpath/div')
+        base.with_context(**self.website_ctx).save(value=value, xpath='/xpath/div')
 
-        self.assertEqual(len(base.with_context(website_id=1).inherit_children_ids), 1)
-        self.assertEqual(base.with_context(website_id=1).inherit_children_ids.mode, 'extension')
+        self.assertEqual(len(base.with_context(**self.website_ctx).inherit_children_ids), 1)
+        self.assertEqual(base.with_context(**self.website_ctx).inherit_children_ids.mode, 'extension')
         self.assertIn(
             '<p>Hello World!</p>',
-            base.with_context(website_id=1).inherit_children_ids.get_combined_arch(),
+            base.with_context(**self.website_ctx).inherit_children_ids.get_combined_arch(),
         )
 
     def test_save_oe_structure_with_attr(self):
@@ -454,7 +453,7 @@ class TestViewSaving(TestViewSavingCommon):
         view = self.env['ir.ui.view'].create({
             'arch': u'<t t-name="dummy"><div class="oe_structure" t-att-test="1" data-test="1" id="oe_structure_test"/></t>',
             'type': 'qweb'
-        }).with_context(website_id=1, load_all_views=True)
+        }).with_context(**self.website_ctx, load_all_views=True)
         replacement = u'<div class="oe_structure" data-test="1" id="oe_structure_test" data-oe-id="55" test="2">hello</div>'
         view.save(replacement, xpath='/t/div')
         # branding data-oe-* should be stripped
@@ -466,7 +465,7 @@ class TestViewSaving(TestViewSavingCommon):
 
     def test_save_only_embedded(self):
         Company = self.env['res.company']
-        company_id = 1
+        company_id = self.ref('base.main_company')
         company = Company.browse(company_id)
         company.write({'name': "Foo Corporation"})
 
@@ -481,7 +480,7 @@ class TestViewSaving(TestViewSavingCommon):
     def test_field_tail(self):
         replacement = ET.tostring(
             h.LI(h.SPAN("+12 3456789", attrs(
-                        model='res.company', id=1, type='char',
+                        model='res.company', id=self.env.company.id, type='char',
                         field='phone', expression="edmund")),
                  "whop whop"
                  ), encoding="utf-8")
@@ -500,7 +499,7 @@ class TestViewSaving(TestViewSavingCommon):
                     h.H3("Column 2"),
                     h.UL(
                         h.LI("Item 1"),
-                        h.LI(h.SPAN("My Company", attrs(model='res.company', id=1, field='name', type='char'))),
+                        h.LI(h.SPAN("My Company", attrs(model='res.company', id=self.env.company.id, field='name', type='char'))),
                         h.LI(h.SPAN({'t-field': "edmund"}), "whop whop"),
                     ))
             )
@@ -510,7 +509,7 @@ class TestViewSaving(TestViewSavingCommon):
 @tagged('-at_install', 'post_install')
 class TestCowViewSaving(TestViewSavingCommon, HttpCase):
     def setUp(self):
-        super(TestCowViewSaving, self).setUp()
+        super().setUp()
         View = self.env['ir.ui.view']
 
         self.base_view = View.create({
@@ -528,16 +527,18 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
             'key': 'website.extension_view',
         })
         self.headers = {"Content-Type": "application/json"}
+        self.website_ctx = {'website_id': self.ref('website.default_website')}
+        self.website_domain = [('website_id', '=', self.website_ctx['website_id'])]
 
     def test_cow_on_base_after_extension(self):
         View = self.env['ir.ui.view']
-        self.inherit_view.with_context(website_id=1).write({'name': 'Extension Specific'})
+        self.inherit_view.with_context(**self.website_ctx).write({'name': 'Extension Specific'})
         v1 = self.base_view
         v2 = self.inherit_view
-        v3 = View.search([('website_id', '=', 1), ('name', '=', 'Extension Specific')])
+        v3 = View.search([*self.website_domain, ('name', '=', 'Extension Specific')])
         v4 = self.inherit_view.copy({'name': 'Second Extension'})
         v5 = self.inherit_view.copy({'name': 'Third Extension (Specific)'})
-        v5.write({'website_id': 1})
+        v5.write({'website_id': self.ref('website.default_website')})
 
         # id | name                        | website_id | inherit  | key
         # ------------------------------------------------------------------------
@@ -552,7 +553,7 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         self.assertEqual('website.extension_view' in v3.key and 'website.extension_view' in v4.key and 'website.extension_view' in v5.key, True, "The copied views should have the key from the view it was copied from but with an unique suffix")
 
         total_views = View.search_count([])
-        v1.with_context(website_id=1).write({'name': 'Base Specific'})
+        v1.with_context(**self.website_ctx).write({'name': 'Base Specific'})
 
         # id | name                        | website_id | inherit  | key
         # ------------------------------------------------------------------------
@@ -566,10 +567,10 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         # 8  | Second Extension            |     1      |     6    |  website.extension_view_a5f579d5
         # 9  | Third Extension (Specific)  |     1      |     6    |  website.extension_view_5gr87e6c
 
-        v6 = View.search([('website_id', '=', 1), ('name', '=', 'Base Specific')])
-        v7 = View.search([('website_id', '=', 1), ('name', '=', 'Extension Specific')])
-        v8 = View.search([('website_id', '=', 1), ('name', '=', 'Second Extension')])
-        v9 = View.search([('website_id', '=', 1), ('name', '=', 'Third Extension (Specific)')])
+        v6 = View.search([*self.website_domain, ('name', '=', 'Base Specific')])
+        v7 = View.search([*self.website_domain, ('name', '=', 'Extension Specific')])
+        v8 = View.search([*self.website_domain, ('name', '=', 'Second Extension')])
+        v9 = View.search([*self.website_domain, ('name', '=', 'Third Extension (Specific)')])
 
         self.assertEqual(total_views + 4 - 2, View.search_count([]), "It should have duplicated the view tree with a website_id, taking only most specific (only specific `b` key), and removing website_specific from generic tree")
         self.assertEqual(len((v3 + v5).exists()), 0, "v3 and v5 should have been deleted as they were already specific and copied to the new specific base")
@@ -577,7 +578,7 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         self.assertEqual((v1 + v2 + v4).mapped('website_id').ids, [])
         self.assertEqual((v2 + v4).mapped('inherit_id'), v1)
         # Check specific tree
-        self.assertEqual((v6 + v7 + v8 + v9).mapped('website_id').ids, [1])
+        self.assertEqual((v6 + v7 + v8 + v9).mapped('website_id').ids, [self.website_ctx['website_id']])
         self.assertEqual((v7 + v8 + v9).mapped('inherit_id'), v6)
         # Check key
         self.assertEqual(v6.key == v1.key, True)
@@ -597,23 +598,23 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         self.assertEqual(arch, '<div>modified content</div>')
 
         # edit on frontend, copy just the leaf
-        self.inherit_view.with_context(website_id=1).write({'arch': '<div position="replace"><div>website 1 content</div></div>'})
+        self.inherit_view.with_context(**self.website_ctx).write({'arch': '<div position="replace"><div>website 1 content</div></div>'})
         inherit_views = View.search([('key', '=', 'website.extension_view')])
         self.assertEqual(View.search_count([('key', '=', 'website.base_view')]), 1)
         self.assertEqual(len(inherit_views), 2)
-        self.assertEqual(len(inherit_views.filtered(lambda v: v.website_id.id == 1)), 1)
+        self.assertEqual(len(inherit_views.filtered(lambda v: v.website_id.id == self.website_ctx['website_id'])), 1)
 
         # read in backend should be unaffected
         arch = self.base_view.get_combined_arch()
         self.assertEqual(arch, '<div>modified content</div>')
         # read on website should reflect change
-        arch = self.base_view.with_context(website_id=1).get_combined_arch()
+        arch = self.base_view.with_context(**self.website_ctx).get_combined_arch()
         self.assertEqual(arch, '<div>website 1 content</div>')
 
         # website-specific inactive view should take preference over active generic one when viewing the website
         # this is necessary to make customize_show=True templates work correctly
-        inherit_views.filtered(lambda v: v.website_id.id == 1).write({'active': False})
-        arch = self.base_view.with_context(website_id=1).get_combined_arch()
+        inherit_views.filtered(lambda v: v.website_id.id == self.website_ctx['website_id']).write({'active': False})
+        arch = self.base_view.with_context(**self.website_ctx).get_combined_arch()
         self.assertEqual(arch, '<div>base content</div>')
 
     def test_cow_root(self):
@@ -625,21 +626,21 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         self.assertEqual(View.search_count([('key', '=', 'website.extension_view')]), 1)
 
         # edit on frontend, copy the entire tree
-        self.base_view.with_context(website_id=1).write({'arch': '<div>website 1 content</div>'})
+        self.base_view.with_context(**self.website_ctx).write({'arch': '<div>website 1 content</div>'})
 
         generic_base_view = View.search([('key', '=', 'website.base_view'), ('website_id', '=', False)])
-        website_specific_base_view = View.search([('key', '=', 'website.base_view'), ('website_id', '=', 1)])
+        website_specific_base_view = View.search([('key', '=', 'website.base_view'), *self.website_domain])
         self.assertEqual(len(generic_base_view), 1)
         self.assertEqual(len(website_specific_base_view), 1)
 
         inherit_views = View.search([('key', '=', 'website.extension_view')])
         self.assertEqual(len(inherit_views), 2)
-        self.assertEqual(len(inherit_views.filtered(lambda v: v.website_id.id == 1)), 1)
+        self.assertEqual(len(inherit_views.filtered(lambda v: v.website_id.id == self.ref('website.default_website'))), 1)
 
         arch = generic_base_view.with_context(load_all_views=True).get_combined_arch()
         self.assertEqual(arch, '<div>modified base content, extended content</div>')
 
-        arch = website_specific_base_view.with_context(load_all_views=True, website_id=1).get_combined_arch()
+        arch = website_specific_base_view.with_context(load_all_views=True, **self.website_ctx).get_combined_arch()
         self.assertEqual(arch, '<div>website 1 content, extended content</div>')
 
     # # As there is a new SQL constraint that prevent QWeb views to have an empty `key`, this test won't work
@@ -654,7 +655,7 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
     #     self.assertEqual(self.base_view.key, False, "Writing on a keyless view should not set a key on it if there is no website in context")
     #
     #     # edit on frontend, copy just the leaf
-    #     self.base_view.with_context(website_id=1).write({'arch': '<div position="replace"><div>website 1 content</div></div>'})
+    #     self.base_view.with_context(**self.website_ctx).write({'arch': '<div position="replace"><div>website 1 content</div></div>'})
     #     self.assertEqual('website.key_' in self.base_view.key, True, "Writing on a keyless view should set a key on it if there is a website in context")
     #     total_views_with_key = View.search_count([('key', '=', self.base_view.key)])
     #     self.assertEqual(total_views_with_key, 2, "It should have set the key on generic view then copy to specific view (with they key)")
@@ -673,11 +674,11 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         })
 
         total_views = View.with_context(active_test=False).search_count([])
-        base_view.with_context(website_id=1).write({'name': 'New Name'})  # This will not write on `base_view` but will copy it to a specific view on which the `name` change will be applied
+        base_view.with_context(**self.website_ctx).write({'name': 'New Name'})  # This will not write on `base_view` but will copy it to a specific view on which the `name` change will be applied
         specific_view = View.search([['name', '=', 'New Name'], ['website_id', '=', 1]])
-        base_view.with_context(website_id=1).write({'name': 'Another New Name'})
+        base_view.with_context(**self.website_ctx).write({'name': 'Another New Name'})
         specific_view.active = False
-        base_view.with_context(website_id=1).write({'name': 'Yet Another New Name'})
+        base_view.with_context(**self.website_ctx).write({'name': 'Yet Another New Name'})
         self.assertEqual(total_views + 1, View.with_context(active_test=False).search_count([]), "Subsequent writes should have written on the view copied during first write")
 
         # 2. Test with calling save() from ir.ui.view
@@ -699,8 +700,8 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         })
 
         total_views = View.with_context(active_test=False).search_count([])
-        second_view.with_context(website_id=1).save('<div class="editable_part" data-oe-id="%s" data-oe-xpath="/t[1]/t[1]/div[1]/div[1]" data-oe-field="arch" data-oe-model="ir.ui.view">First editable_part</div>' % second_view.id, "/t[1]/t[1]/div[1]/div[1]")
-        second_view.with_context(website_id=1).save('<div class="editable_part" data-oe-id="%s" data-oe-xpath="/t[1]/t[1]/div[1]/div[3]" data-oe-field="arch" data-oe-model="ir.ui.view">Second editable_part</div>' % second_view.id, "/t[1]/t[1]/div[1]/div[3]")
+        second_view.with_context(**self.website_ctx).save('<div class="editable_part" data-oe-id="%s" data-oe-xpath="/t[1]/t[1]/div[1]/div[1]" data-oe-field="arch" data-oe-model="ir.ui.view">First editable_part</div>' % second_view.id, "/t[1]/t[1]/div[1]/div[1]")
+        second_view.with_context(**self.website_ctx).save('<div class="editable_part" data-oe-id="%s" data-oe-xpath="/t[1]/t[1]/div[1]/div[3]" data-oe-field="arch" data-oe-model="ir.ui.view">Second editable_part</div>' % second_view.id, "/t[1]/t[1]/div[1]/div[3]")
         self.assertEqual(total_views + 1, View.with_context(active_test=False).search_count([]), "Second save should have written on the view copied during first save")
 
         total_specific_view = View.with_context(active_test=False).search_count([('arch_db', 'like', 'First editable_part'), ('arch_db', 'like', 'Second editable_part')])
@@ -718,7 +719,7 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         # 1  | Base      |  Hi     |     /      |     /    |  website.base_view
         # 2  | Extension |  World  |     /      |     1    |  website.extension_view
 
-        arch = self.base_view.with_context(website_id=1).get_combined_arch()
+        arch = self.base_view.with_context(**self.website_ctx).get_combined_arch()
         self.assertIn('Hi World', arch)
 
         self.base_view.write({'arch': '<div>Hello</div>'})
@@ -728,10 +729,10 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         # 1  | Base      |  Hello  |     /      |     /    |  website.base_view
         # 2  | Extension |  World  |     /      |     1    |  website.extension_view
 
-        arch = self.base_view.with_context(website_id=1).get_combined_arch()
+        arch = self.base_view.with_context(**self.website_ctx).get_combined_arch()
         self.assertIn('Hello World', arch)
 
-        self.base_view.with_context(website_id=1).write({'arch': '<div>Bye</div>'})
+        self.base_view.with_context(**self.website_ctx).write({'arch': '<div>Bye</div>'})
 
         # id | name      | content | website_id | inherit  | key
         # -------------------------------------------------------
@@ -740,8 +741,8 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         # 2  | Extension |  World  |     /      |     1    |  website.extension_view
         # 4  | Extension |  World  |     1      |     3    |  website.extension_view
 
-        base_specific = View.search([('key', '=', self.base_view.key), ('website_id', '=', 1)]).with_context(load_all_views=True)
-        extend_specific = View.search([('key', '=', self.inherit_view.key), ('website_id', '=', 1)])
+        base_specific = View.search([('key', '=', self.base_view.key), *self.website_domain]).with_context(load_all_views=True)
+        extend_specific = View.search([('key', '=', self.inherit_view.key), *self.website_domain])
         self.assertEqual(total_views + 2, View.search_count([]), "Should have copied Base & Extension with a website_id")
         self.assertEqual(self.base_view.key, base_specific.key)
         self.assertEqual(self.inherit_view.key, extend_specific.key)
@@ -755,10 +756,10 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         # 2  | Extension |  World  |     /      |     1    |  website.extension_view
         # 4  | Extension |  All    |     1      |     3    |  website.extension_view
 
-        arch = base_specific.with_context(website_id=1).get_combined_arch()
+        arch = base_specific.with_context(**self.website_ctx).get_combined_arch()
         self.assertEqual('Bye All' in arch, True)
 
-        self.inherit_view.with_context(website_id=1).write({'arch': '<div position="inside"> Nobody</div>'})
+        self.inherit_view.with_context(**self.website_ctx).write({'arch': '<div position="inside"> Nobody</div>'})
 
         # id | name      | content | website_id | inherit  | key
         # -------------------------------------------------------
@@ -767,11 +768,11 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         # 2  | Extension |  World  |     /      |     1    |  website.extension_view
         # 4  | Extension |  Nobody |     1      |     3    |  website.extension_view
 
-        arch = base_specific.with_context(website_id=1).get_combined_arch()
+        arch = base_specific.with_context(**self.website_ctx).get_combined_arch()
         self.assertEqual('Bye Nobody' in arch, True, "Write on generic `inherit_view` should have been diverted to already existing specific view")
 
         base_arch = self.base_view.get_combined_arch()
-        base_arch_w1 = self.base_view.with_context(website_id=1).get_combined_arch()
+        base_arch_w1 = self.base_view.with_context(**self.website_ctx).get_combined_arch()
         self.assertEqual('Hello World' in base_arch, True)
         self.assertEqual(base_arch, base_arch_w1, "Reading a top level view with or without a website_id in the context should render that exact view..")  # ..even if there is a specific view for that one, as get_combined_arch is supposed to render specific inherited view over generic but not specific top level instead of generic top level
 
@@ -803,15 +804,15 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         })
 
         # These line doing `write()` are the real tests, it should not be changed and should not crash on xpath.
-        child_view_2.with_context(website_id=1).write({'arch': '<xpath expr="//p" position="replace"><span>D</span></xpath>'})
+        child_view_2.with_context(**self.website_ctx).write({'arch': '<xpath expr="//p" position="replace"><span>D</span></xpath>'})
         self.assertEqual(total_views + 3 + 1, View.search_count([]), "It should have created the 3 initial generic views and created a child_view_2 specific view")
-        main_view.with_context(website_id=1).write({'arch': '<body>SPECIFIC<div>Z</div></body>'})
+        main_view.with_context(**self.website_ctx).write({'arch': '<body>SPECIFIC<div>Z</div></body>'})
         self.assertEqual(total_views + 3 + 3, View.search_count([]), "It should have duplicated the Main View tree as a specific tree and then removed the specific view from the generic tree as no more needed")
 
         generic_view = View.with_context(website_id=None)._get_template_view("website.main_view")
-        specific_view = View.with_context(website_id=1)._get_template_view("website.main_view")
+        specific_view = View.with_context(**self.website_ctx)._get_template_view("website.main_view")
         generic_view_arch = generic_view.with_context(load_all_views=True).get_combined_arch()
-        specific_view_arch = specific_view.with_context(load_all_views=True, website_id=1).get_combined_arch()
+        specific_view_arch = specific_view.with_context(load_all_views=True, **self.website_ctx).get_combined_arch()
         self.assertEqual(generic_view_arch, '<body>GENERIC<div>VIEW<span>C</span></div></body>')
         self.assertEqual(specific_view_arch, '<body>SPECIFIC<div>VIEW<span>D</span></div></body>', "Writing on top level view hierarchy with a website in context should write on the view and clone it's inherited views")
 
@@ -823,23 +824,23 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
             child over the generic active one.
         '''
         View = self.env['ir.ui.view'].with_context(active_test=False)
-        self.inherit_view.with_context(website_id=1).write({'active': False})
+        self.inherit_view.with_context(**self.website_ctx).write({'active': False})
 
         # Test _get_template_view() return the inactive specific over active generic
         inherit_view = View._get_template_view(self.inherit_view.key)
         self.assertEqual(inherit_view.active, True, "_get_template_view should return the generic one")
-        inherit_view = View.with_context(website_id=1)._get_template_view(self.inherit_view.key)
+        inherit_view = View.with_context(**self.website_ctx)._get_template_view(self.inherit_view.key)
         self.assertEqual(inherit_view.active, False, "_get_template_view should return the specific one")
 
         # Test get_related_views() return the inactive specific over active generic
         # Note that we cannot test get_related_views without a website in context as it will fallback on a website with get_current_website()
-        views = View.with_context(website_id=1).get_related_views(self.base_view.key)
+        views = View.with_context(**self.website_ctx).get_related_views(self.base_view.key)
         self.assertEqual(views.mapped('active'), [True, False], "get_related_views should return the specific child")
 
         # Test filter_duplicate() return the inactive specific over active generic
         view = View.with_context(active_test=False).search([('key', '=', self.inherit_view.key)]).filter_duplicate()
         self.assertEqual(view.active, True, "filter_duplicate should return the generic one")
-        view = View.with_context(active_test=False, website_id=1).search([('key', '=', self.inherit_view.key)]).filter_duplicate()
+        view = View.with_context(active_test=False, **self.website_ctx).search([('key', '=', self.inherit_view.key)]).filter_duplicate()
         self.assertEqual(view.active, False, "filter_duplicate should return the specific one")
 
     def test_get_related_views_tree(self):
@@ -868,7 +869,7 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         self.inherit_view.active = True
 
         # Second, test multi-website
-        self.inherit_view.with_context(website_id=1).write({'name': 'Extension'})  # Trigger cow on hierarchy
+        self.inherit_view.with_context(**self.website_ctx).write({'name': 'Extension'})  # Trigger cow on hierarchy
         View.create({
             'name': 'II2',
             'mode': 'extension',
@@ -884,7 +885,7 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         #   / \     |
         # II  II2   II'
 
-        views = View.with_context(website_id=1).get_related_views('B')
+        views = View.with_context(**self.website_ctx).get_related_views('B')
         self.assertEqual(views.mapped('key'), ['B', 'I', 'II'], "Should only return the specific tree")
 
     def test_get_related_views_tree_recursive_t_call_and_inherit_inactive(self):
@@ -950,11 +951,11 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
             ''',
         })
 
-        views = View.with_context(website_id=1).get_related_views('_website_sale.products')
+        views = View.with_context(**self.website_ctx).get_related_views('_website_sale.products')
         self.assertEqual(views, products + products_item + add_to_wishlist + products_list_view, "The four views should be returned.")
-        add_to_wishlist.with_context(website_id=1).write({'active': False})  # Trigger cow on hierarchy
-        add_to_wishlist_cow = Website.with_context(website_id=1).viewref(add_to_wishlist.key)
-        views = View.with_context(website_id=1).get_related_views('_website_sale.products')
+        add_to_wishlist.with_context(**self.website_ctx).write({'active': False})  # Trigger cow on hierarchy
+        add_to_wishlist_cow = Website.with_context(**self.website_ctx).viewref(add_to_wishlist.key)
+        views = View.with_context(**self.website_ctx).get_related_views('_website_sale.products')
         self.assertEqual(views, products + products_item + add_to_wishlist_cow + products_list_view, "The generic wishlist view should have been replaced by the COW one.")
 
     def test_cow_inherit_children_order(self):
@@ -970,7 +971,7 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
             'arch': '<div position="replace"><p>COMPARE</p></div>',
         })
         # Next line should not crash, COW loop on inherit_children_ids should be sorted correctly
-        self.base_view.with_context(website_id=1).write({'name': 'Product (W1)'})
+        self.base_view.with_context(**self.website_ctx).write({'name': 'Product (W1)'})
 
     def test_write_order_vs_cow_inherit_children_order(self):
         """ When both a specific inheriting view and a non-specific base view
@@ -979,10 +980,10 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
             the base view.
         """
         View = self.env['ir.ui.view']
-        self.inherit_view.with_context(website_id=1).write({'name': 'Specific Inherited View Changed First'})
+        self.inherit_view.with_context(**self.website_ctx).write({'name': 'Specific Inherited View Changed First'})
         specific_view = View.search([('name', '=', 'Specific Inherited View Changed First')])
         views = View.browse([self.base_view.id, specific_view.id])
-        views.with_context(website_id=1).write({'active': False})
+        views.with_context(**self.website_ctx).write({'active': False})
         new_specific_view = View.search([('name', '=', 'Specific Inherited View Changed First')])
         self.assertTrue(specific_view.id != new_specific_view.id, "Should have a new id")
         self.assertFalse(new_specific_view.active, "Should have been deactivated")
@@ -992,10 +993,10 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
             opposite order.
         """
         View = self.env['ir.ui.view']
-        self.inherit_view.with_context(website_id=1).write({'name': 'Specific Inherited View Changed First'})
+        self.inherit_view.with_context(**self.website_ctx).write({'name': 'Specific Inherited View Changed First'})
         specific_view = View.search([('name', '=', 'Specific Inherited View Changed First')])
         views = View.browse([specific_view.id, self.base_view.id])
-        views.with_context(website_id=1).write({'active': False})
+        views.with_context(**self.website_ctx).write({'active': False})
         new_specific_view = View.search([('name', '=', 'Specific Inherited View Changed First')])
         self.assertTrue(specific_view.id != new_specific_view.id, "Should have a new id")
         self.assertFalse(new_specific_view.active, "Should have been deactivated")
@@ -1018,7 +1019,7 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         # Simulate website_sale product view
         self.base_view.write({'name': 'Product', 'key': '_website_sale.product'})
         # Trigger cow on website_sale hierarchy for website 1
-        self.base_view.with_context(website_id=1).write({'name': 'Product (W1)'})
+        self.base_view.with_context(**self.website_ctx).write({'name': 'Product (W1)'})
 
         # Simulate website_sale_comparison install
         View._load_records([dict(xml_id='_website_sale_comparison.product_add_to_compare', values={
@@ -1033,17 +1034,17 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         # Simulate end of installation/update
         View._create_all_specific_views(['_website_sale_comparison'])
 
-        specific_view = Website.with_context(load_all_views=True, website_id=1).viewref('_website_sale.product')
+        specific_view = Website.with_context(load_all_views=True, **self.website_ctx).viewref('_website_sale.product')
         self.assertEqual(self.base_view.key, specific_view.key, "Ensure it is equal as it should be for the rest of the test so we test the expected behaviors")
         specific_view_arch = specific_view.get_combined_arch()
-        self.assertEqual(specific_view.website_id.id, 1, "Ensure we got specific view to perform the checks against")
+        self.assertEqual(specific_view.website_id.id, self.website_ctx['website_id'], "Ensure we got specific view to perform the checks against")
         self.assertEqual(specific_view_arch, '<p>COMPARE</p>', "When a module creates an inherited view (on a generic tree), it should also create that view in the specific COW'd tree.")
 
         # Simulate website_sale_comparison update
         View._load_records([dict(xml_id='_website_sale_comparison.product_add_to_compare', values={
             'arch': '<div position="replace"><p>COMPARE EDITED</p></div>',
         })])
-        specific_view_arch = Website.with_context(load_all_views=True, website_id=1).viewref('_website_sale.product').get_combined_arch()
+        specific_view_arch = Website.with_context(load_all_views=True, **self.website_ctx).viewref('_website_sale.product').get_combined_arch()
         self.assertEqual(specific_view_arch, '<p>COMPARE EDITED</p>', "When a module updates an inherited view (on a generic tree), it should also update the copies of that view (COW).")
 
         # Test fields that should not be COW'd
@@ -1053,9 +1054,9 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
             'inherit_id': random_views[0].id,
         })])
 
-        w1_specific_child_view = Website.with_context(load_all_views=True, website_id=1).viewref('_website_sale_comparison.product_add_to_compare')
+        w1_specific_child_view = Website.with_context(load_all_views=True, **self.website_ctx).viewref('_website_sale_comparison.product_add_to_compare')
         generic_child_view = Website.with_context(load_all_views=True).viewref('_website_sale_comparison.product_add_to_compare')
-        self.assertEqual(w1_specific_child_view.website_id.id, 1, "website_id is a prohibited field when COWing views during _load_records")
+        self.assertEqual(w1_specific_child_view.website_id.id, self.website_ctx['website_id'], "website_id is a prohibited field when COWing views during _load_records")
         self.assertEqual(generic_child_view.inherit_id, random_views[0], "prohibited fields only concerned write on COW'd view. Generic should still considere these fields")
         self.assertEqual(w1_specific_child_view.inherit_id, random_views[0], "inherit_id update should be repliacated on cow views during _load_records")
 
@@ -1121,7 +1122,7 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         })
 
         # Trigger cow on website_sale hierarchy for website 1
-        base_view.with_context(website_id=1).write({'name': 'Main Frontend Layout (W1)'})
+        base_view.with_context(**self.website_ctx).write({'name': 'Main Frontend Layout (W1)'})
 
         # Simulate website_sale_comparison install, that's the real test, it
         # should not crash.
@@ -1143,14 +1144,14 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         """
         View = self.env['ir.ui.view']
 
-        self.inherit_view.website_id = 1
+        self.inherit_view.website_id = self.ref('website.default_website')
         inherit_view_2 = View.create({
             'name': 'Extension 2',
             'mode': 'extension',
             'inherit_id': self.inherit_view.id,
             'arch': '<div position="inside">, extended content 2</div>',
             'key': 'website.extension_view_2',
-            'website_id': 1,
+            'website_id': self.ref('website.default_website'),
         })
 
         total_views = View.search_count([])
@@ -1161,7 +1162,7 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         # 2  | Extension   |  , extended content   |     1      |     1    |  website.extension_view
         # 3  | Extension 2 |  , extended content 2 |     1      |     2    |  website.extension_view_2
 
-        self.base_view.with_context(website_id=1).write({'arch': '<div>modified content</div>'})
+        self.base_view.with_context(**self.website_ctx).write({'arch': '<div>modified content</div>'})
 
         # 2 views are created, one is deleted
         self.assertEqual(View.search_count([]), total_views + 1)
@@ -1169,8 +1170,8 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         self.assertTrue(inherit_view_2.exists())
 
         # Verify the inheritance
-        base_specific = View.search([('key', '=', self.base_view.key), ('website_id', '=', 1)]).with_context(load_all_views=True)
-        extend_specific = View.search([('key', '=', 'website.extension_view'), ('website_id', '=', 1)])
+        base_specific = View.search([('key', '=', self.base_view.key), *self.website_domain]).with_context(load_all_views=True)
+        extend_specific = View.search([('key', '=', 'website.extension_view'), *self.website_domain])
         self.assertEqual(extend_specific.inherit_id, base_specific)
         self.assertEqual(inherit_view_2.inherit_id, extend_specific)
 
@@ -1203,7 +1204,7 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         self._create_imd(v2)
 
         # multiwebsite specific
-        v1.with_context(website_id=1).write({'name': 'Extension Specific'})
+        v1.with_context(**self.website_ctx).write({'name': 'Extension Specific'})
 
         self.patch(self.registry, 'ready', True)
 
@@ -1221,7 +1222,7 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         self.base_view.with_context(lang='en_US').arch_db = '<div>hello</div>'
         self.base_view.update_field_translations('arch_db', {'fr_BE': {'hello': 'bonjour'}})
         self.assertEqual(self.base_view.with_context(lang='fr_BE').arch, '<div>bonjour</div>')
-        self.base_view.with_context(website_id=1).write({'active': True})
+        self.base_view.with_context(**self.website_ctx).write({'active': True})
         specific_view = self.base_view._get_specific_views() - self.base_view
 
         self.assertEqual(specific_view.with_context(lang='fr_BE').arch, '<div>bonjour</div>',
@@ -1263,9 +1264,9 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         fr_BE = self.env['res.lang']._activate_lang('fr_BE')
         self.base_view.with_context(lang='en_US').arch_db = '<div>hello</div>'
         self.assertFalse(self.base_view.website_id)
-        website = self.env['website'].browse(1)
+        website = self.env.ref('website.default_website')
         website.default_lang_id = fr_BE
-        self.base_view.with_context(website_id=1).write({'active': True})
+        self.base_view.with_context(**self.website_ctx).write({'active': True})
         specific_view = self.base_view._get_specific_views() - self.base_view
 
         # generic view without website_id but with website for request
@@ -1292,7 +1293,7 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
             ('key', '=', 'website.footer_custom'),
             ('website_id', '=', False),
         ], limit=1)
-        base_footer.with_context(website_id=1).write({'active': True})
+        base_footer.with_context(**self.website_ctx).write({'active': True})
         specific_footer = base_footer._get_specific_views()
         specific_footer.with_context(lang='en_US').arch_db = '<div>hello</div>'
         specific_footer.update_field_translations('arch_db', {'fr_BE': {'hello': 'bonjour'}})
@@ -1316,7 +1317,7 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         """
         View = self.env['ir.ui.view']
 
-        View.with_context(website_id=1).create({
+        View.with_context(**self.website_ctx).create({
             'name': 'Name',
             'key': 'website.no_website_id',
             'type': 'qweb',
@@ -1325,10 +1326,10 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         # Get created views by searching to consider potential unwanted COW
         created_views = View.search([('key', '=', 'website.no_website_id')])
         self.assertEqual(len(created_views), 1, "Should only have created one view")
-        self.assertEqual(created_views.website_id.id, 1, "The created view should be specific to website 1")
+        self.assertEqual(created_views.website_id.id, self.website_ctx['website_id'], "The created view should be specific to default website")
 
         with self.assertRaises(ValueError, msg="Should not allow to create generic view explicitely from website 1 specific context"):
-            View.with_context(website_id=1).create({
+            View.with_context(**self.website_ctx).create({
                 'name': 'Name',
                 'key': 'website.explicit_no_website_id',
                 'type': 'qweb',
@@ -1337,7 +1338,7 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
             })
 
         with self.assertRaises(ValueError, msg="Should not allow to create specific view for website 2 from website 1 specific context"):
-            View.with_context(website_id=1).create({
+            View.with_context(**self.website_ctx).create({
                 'name': 'Name',
                 'key': 'website.different_website_id',
                 'type': 'qweb',
@@ -1379,10 +1380,10 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         # invalidate cache to recompute xml_id, or it will still be empty
         self.inherit_view.invalidate_model()
         base_view_2 = self.base_view.copy({'key': 'website.base_view2', 'arch': '<div>base2 content</div>'})
-        self.base_view.with_context(website_id=1).write({'arch': '<div>website 1 content</div>'})
-        specific_view = Website.with_context(load_all_views=True, website_id=1).viewref(self.base_view.key)
-        specific_view.inherit_children_ids.with_context(website_id=1).write({'arch': '<div position="inside">, extended content website 1</div>'})
-        specific_child_view = Website.with_context(load_all_views=True, website_id=1).viewref(self.inherit_view.key)
+        self.base_view.with_context(**self.website_ctx).write({'arch': '<div>website 1 content</div>'})
+        specific_view = Website.with_context(load_all_views=True, **self.website_ctx).viewref(self.base_view.key)
+        specific_view.inherit_children_ids.with_context(**self.website_ctx).write({'arch': '<div position="inside">, extended content website 1</div>'})
+        specific_child_view = Website.with_context(load_all_views=True, **self.website_ctx).viewref(self.inherit_view.key)
         # 2. Ensure view trees are as expected
         self.assertEqual(self.base_view.inherit_children_ids, self.inherit_view, "D should be under A")
         self.assertEqual(specific_view.inherit_children_ids, specific_child_view, "D' should be under A'")
@@ -1410,9 +1411,9 @@ class TestCowViewSaving(TestViewSavingCommon, HttpCase):
         # Make sure res.lang.get_installed is recomputed
         self.env.registry.clear_cache()
 
-        View = self.env['ir.ui.view'].with_context(lang=french.code, website_id=1)
+        View = self.env['ir.ui.view'].with_context(lang=french.code, **self.website_ctx)
         old_specific_views = View.search([('website_id', '!=', None)])
-        view = self.base_view.with_context(lang=french.code, website_id=1)
+        view = self.base_view.with_context(lang=french.code, **self.website_ctx)
 
         root = html.fromstring(self.base_view.arch, parser=html.HTMLParser(encoding="utf-8"))
         to_translate = root.text_content()

--- a/addons/website/tests/test_views_inherit_module_update.py
+++ b/addons/website/tests/test_views_inherit_module_update.py
@@ -23,7 +23,7 @@ def test_01_cow_views_inherit_on_module_update(env):
 
     # 1. Setup hierarchy as comment above
     View = env['ir.ui.view']
-    View.with_context(force_delete=True, active_test=False).search([('website_id', '=', 1)]).unlink()
+    View.with_context(force_delete=True, active_test=False).search([('website_id', '=', env.ref('website.default_website').id)]).unlink()
     child_view = env.ref('portal.footer_language_selector')
     parent_view = env.ref('portal.portal_back_in_edit_mode')
     # Remove any possibly existing COW view (another theme etc)
@@ -32,7 +32,7 @@ def test_01_cow_views_inherit_on_module_update(env):
     # Change `inherit_id` so the module update will set it back to the XML value
     child_view.write({'inherit_id': parent_view.id, 'arch': child_view.arch_db.replace('o_footer_copyright_name', 'text-center')})
     # Trigger COW on view
-    child_view.with_context(website_id=1).write({'name': 'COW Website 1'})
+    child_view.with_context(website_id=env.ref('website.default_website').id).write({'name': 'COW Website 1'})
     child_cow_view = child_view._get_specific_views()
 
     # 2. Ensure setup is as expected
@@ -58,15 +58,15 @@ def test_02_cow_views_inherit_on_module_update(env):
 
     # 1. Setup hierarchy as comment above
     View = env['ir.ui.view']
-    View.with_context(force_delete=True, active_test=False).search([('website_id', '=', 1)]).unlink()
+    View.with_context(force_delete=True, active_test=False).search([('website_id', '=', env.ref('website.default_website').id)]).unlink()
     view_D = env.ref('portal.my_account_link')
     view_A = env.ref('portal.message_thread')
     # Change `inherit_id` so the module update will set it back to the XML value
     view_D.write({'inherit_id': view_A.id, 'arch_db': view_D.arch_db.replace('o_logout_divider', 'discussion')})
     # Trigger COW on view
     view_B = env.ref('portal.user_dropdown')  # XML data
-    view_D.with_context(website_id=1).write({'name': 'D Website 1'})
-    view_B.with_context(website_id=1).write({'name': 'B Website 1'})
+    view_D.with_context(website_id=env.ref('website.default_website').id).write({'name': 'D Website 1'})
+    view_B.with_context(website_id=env.ref('website.default_website').id).write({'name': 'B Website 1'})
     view_Dcow = view_D._get_specific_views()
 
     # 2. Ensure setup is as expected

--- a/addons/website/tests/test_website_form_editor.py
+++ b/addons/website/tests/test_website_form_editor.py
@@ -84,7 +84,7 @@ class TestWebsiteForm(TransactionCase):
         })
 
     def test_website_form_html_escaping(self):
-        website = self.env['website'].browse(1)
+        website = self.env.ref('website.default_website')
         WebsiteFormController = WebsiteForm()
         with MockRequest(self.env, website=website):
             WebsiteFormController.insert_record(

--- a/addons/website/tests/test_website_visitor.py
+++ b/addons/website/tests/test_website_visitor.py
@@ -162,7 +162,7 @@ class WebsiteVisitorTestsCommon(MockVisitor, HttpCaseWithUserDemo):
         return {
             'lang_id': self.env.ref('base.lang_en').id,
             'country_id': self.env.ref('base.be').id,
-            'website_id': 1,
+            'website_id': self.ref('website.default_website'),
             'access_token': self.partner_admin.id,
             'website_track_ids': [(0, 0, {
                 'page_id': self.tracked_page.id,
@@ -174,7 +174,7 @@ class WebsiteVisitorTestsCommon(MockVisitor, HttpCaseWithUserDemo):
         return {
             'lang_id': self.env.ref('base.lang_en').id,
             'country_id': self.env.ref('base.be').id,
-            'website_id': 1,
+            'website_id': self.ref('website.default_website'),
             'access_token': '%032x' % random.randrange(16**32),
             'website_track_ids': [(0, 0, {
                 'page_id': self.tracked_page_2.id,
@@ -370,13 +370,13 @@ class WebsiteVisitorTests(WebsiteVisitorTestsCommon):
         inactive_visitors = self.env['website.visitor'].create([{
             'lang_id': self.env.ref('base.lang_en').id,
             'country_id': self.env.ref('base.be').id,
-            'website_id': 1,
+            'website_id': self.ref('website.default_website'),
             'last_connection_datetime': datetime.now() - timedelta(days=8),
             'access_token': 'f9d2b14b21be669518b14a9590cb62ed',
         }, {
             'lang_id': self.env.ref('base.lang_en').id,
             'country_id': self.env.ref('base.be').id,
-            'website_id': 1,
+            'website_id': self.ref('website.default_website'),
             'last_connection_datetime': datetime.now() - timedelta(days=15),
             'access_token': 'f9d2d261a725da7f596574ca84e52f47',
         }])
@@ -384,13 +384,13 @@ class WebsiteVisitorTests(WebsiteVisitorTestsCommon):
         active_visitors = self.env['website.visitor'].create([{
             'lang_id': self.env.ref('base.lang_en').id,
             'country_id': self.env.ref('base.be').id,
-            'website_id': 1,
+            'website_id': self.ref('website.default_website'),
             'last_connection_datetime': datetime.now() - timedelta(days=1),
             'access_token': 'f9d2526d9c15658bdc91d2119e54b554',
         }, {
             'lang_id': self.env.ref('base.lang_en').id,
             'country_id': self.env.ref('base.be').id,
-            'website_id': 1,
+            'website_id': self.ref('website.default_website'),
             'partner_id': self.partner_demo.id,
             'last_connection_datetime': datetime.now() - timedelta(days=15),
             'access_token': self.partner_demo.id,

--- a/addons/website_blog/tests/test_performance.py
+++ b/addons/website_blog/tests/test_performance.py
@@ -32,7 +32,7 @@ class TestBlogPerformance(UtilPerf):
             "name": "Post Test",
             "subtitle": "Subtitle Test",
             "blog_id": blog.id,
-            "author_id": self.env.user.id,
+            "author_id": self.env.user.partner_id.id,
             "tag_ids": [(4, tag.id) for tag in blog_tags],
             "is_published": True,
             "cover_properties": """{"background-image": "url('/website_blog/static/src/img/cover_1.jpg')", "resize_class": "o_record_has_cover o_half_screen_height", "opacity": "0"}""",

--- a/addons/website_blog/tests/test_ui.py
+++ b/addons/website_blog/tests/test_ui.py
@@ -27,7 +27,7 @@ class TestWebsiteBlogUi(odoo.tests.HttpCase, TestWebsiteBlogCommon):
             "name": "Post Test",
             "subtitle": "Subtitle Test",
             "blog_id": blog.id,
-            "author_id": cls.env.user.id,
+            "author_id": cls.env.user.partner_id.id,
             "tag_ids": [(4, blog_tag.id)],
             "is_published": True,
             "cover_properties": """{"background-image": "url('/website_blog/static/src/img/cover_1.jpg')", "resize_class": "o_record_has_cover o_half_screen_height", "opacity": "0"}""",
@@ -111,7 +111,7 @@ class TestWebsiteBlogUi(odoo.tests.HttpCase, TestWebsiteBlogCommon):
         blog_post_1 = Post.create({
             'name': 'First Blog Post',
             'blog_id': Blog1.id,
-            'author_id': self.env.user.id,
+            'author_id': self.env.user.partner_id.id,
             'is_published': True,
             'published_date': datetime(2025, 2, 10, 12, 0, 0),
         })
@@ -120,7 +120,7 @@ class TestWebsiteBlogUi(odoo.tests.HttpCase, TestWebsiteBlogCommon):
         blog_post_2 = Post.create({
             'name': 'Second Blog Post',
             'blog_id': Blog2.id,
-            'author_id': self.env.user.id,
+            'author_id': self.env.user.partner_id.id,
             'is_published': True,
             'published_date': datetime(2025, 1, 15, 14, 30, 0),
         })

--- a/addons/website_blog/tests/test_website_blog_flow.py
+++ b/addons/website_blog/tests/test_website_blog_flow.py
@@ -197,8 +197,8 @@ class TestWebsiteBlogTranslationFlow(HttpCase, TestWebsiteBlogCommon):
         # Setup
         br_lang = self.env['res.lang']._activate_lang('pt_BR')
         en_lang = self.env['res.lang']._activate_lang('en_US')
-        
-        website = self.env['website'].browse(1)
+
+        website = self.env.ref('website.default_website')
         website.language_ids += br_lang
         website.default_lang_id = br_lang
 
@@ -215,7 +215,7 @@ class TestWebsiteBlogTranslationFlow(HttpCase, TestWebsiteBlogCommon):
         })
         self.assertEqual('Todos os blogs', blog_post.with_context(lang=br_lang.code).content)
         self.assertEqual('All blogs', blog_post.with_context(lang=en_lang.code).content)
-        
+
         # Test updating translation
         payload = self.build_rpc_payload({
             'model': blog_post._name,
@@ -235,7 +235,7 @@ class TestWebsiteBlogTranslationFlow(HttpCase, TestWebsiteBlogCommon):
             'name': 'Test Blog Post',
             'blog_id': blog.id,
             'tag_ids': [(6, 0, [blog_tag.id])],
-            'author_id': self.env.user.id,
+            'author_id': self.env.user.partner_id.id,
             'is_published': True,
         })
         response = self.url_open('/blog/tag/demo')

--- a/addons/website_crm/tests/test_website_visitor.py
+++ b/addons/website_crm/tests/test_website_visitor.py
@@ -76,7 +76,7 @@ class TestWebsiteVisitor(TestCrmCommon, WebsiteVisitorTestsCommon):
         active_visitors = self.env['website.visitor'].create([{
             'lang_id': self.env.ref('base.lang_en').id,
             'country_id': self.env.ref('base.be').id,
-            'website_id': 1,
+            'website_id': self.ref('website.default_website'),
             'last_connection_datetime': datetime.now() - timedelta(days=8),
             'access_token': 'f9d28aad05ebee0bca215837b129aa00',
             'lead_ids': [(0, 0, {

--- a/addons/website_crm_partner_assign/tests/test_partner_assign.py
+++ b/addons/website_crm_partner_assign/tests/test_partner_assign.py
@@ -303,7 +303,7 @@ class TestPartnerLeadPortal(TestCrmCommon, HttpCase):
             )
 
         with self.with_user(self.user_portal.login), MockRequest(
-            self.env, website=self.env["website"].browse(1)
+            self.env, website=self.env.ref('website.default_website')
         ) as mock_request:
             mock_request.render = render_function
             WebsiteAccount().portal_my_opportunities(filterby="today")
@@ -337,7 +337,7 @@ class TestPartnerLeadPortal(TestCrmCommon, HttpCase):
             self.assertIn(non_mexican_partner, values['partners'], "Non-Mexican Partner is not present when rendering partners from Mexico; fallback protection (protecting from no results) didn't work.")
             return 'rendered'
 
-        with MockRequest(self.env, website=self.env['website'].browse(1)) as mock_request:
+        with MockRequest(self.env, website=self.env.ref('website.default_website')) as mock_request:
             mock_request.render = render_function
             res = WebsiteCrmPartnerAssign().partners()
             self.assertEqual([b'rendered'], res.response, "render_function wasn't called")

--- a/addons/website_event/tests/test_event_visitor.py
+++ b/addons/website_event/tests/test_event_visitor.py
@@ -17,7 +17,7 @@ class TestEventVisitor(TestEventOnlineCommon, WebsiteVisitorTestsCommon):
         active_visitors = self.env['website.visitor'].create([{
             'lang_id': self.env.ref('base.lang_en').id,
             'country_id': self.env.ref('base.be').id,
-            'website_id': 1,
+            'website_id': self.ref('website.default_website'),
             'last_connection_datetime': datetime.now() - timedelta(days=8),
             'access_token': 'f9d2af99f543874642f89bd334fa4a49',
             'event_registration_ids': [(0, 0, {

--- a/addons/website_event_track/tests/test_website_visitor.py
+++ b/addons/website_event_track/tests/test_website_visitor.py
@@ -23,7 +23,7 @@ class WebsiteVisitorTestsEventTrack(TestEventOnlineCommon, WebsiteVisitorTestsCo
             'name': 'Wishlister Alex',
             'lang_id': self.env.ref('base.lang_en').id,
             'country_id': self.env.ref('base.be').id,
-            'website_id': 1,
+            'website_id': self.ref('website.default_website'),
             'last_connection_datetime': datetime.now() - timedelta(days=8),
             'access_token': 'f9d2b93591d6f602e5e8afa238e35a6c',
             'event_track_visitor_ids': [(0, 0, {

--- a/addons/website_forum/tests/test_forum_karma_access.py
+++ b/addons/website_forum/tests/test_forum_karma_access.py
@@ -62,7 +62,7 @@ class TestForumCRUD(TestForumCommon):
 
         # One should not be able to give his vote to someone else
         self.employee_vote_on_admin_post.with_user(self.user_employee).write({
-            'user_id': 1,
+            'user_id': self.ref('base.user_root'),
         })
         self.assertEqual(self.employee_vote_on_admin_post.user_id, self.user_employee, 'User employee should not be able to give its vote ownership to someone else')
         # One should not be able to change his vote's post to a post of his own (would be self voting)
@@ -73,7 +73,7 @@ class TestForumCRUD(TestForumCommon):
 
         # One should not be able to give his vote to someone else
         self.portal_vote_on_admin_post.with_user(self.user_portal).write({
-            'user_id': 1,
+            'user_id': self.ref('base.user_root'),
         })
         self.assertEqual(self.portal_vote_on_admin_post.user_id, self.user_portal, 'User portal should not be able to give its vote ownership to someone else')
         # One should not be able to change his vote's post to a post of his own (would be self voting)
@@ -112,14 +112,14 @@ class TestForumCRUD(TestForumCommon):
         # One should not be able to create a vote for someone else
         new_employee_vote = Vote.with_user(self.user_employee).create({
             'post_id': self.portal_post.id,
-            'user_id': 1,
+            'user_id': self.ref('base.user_root'),
             'vote': '1',
         })
         self.assertEqual(new_employee_vote.user_id, self.user_employee, 'Creating a vote for someone else should not be allowed. It should create it for yourself instead')
         # One should not be able to create a vote for someone else
         new_portal_vote = Vote.with_user(self.user_portal).create({
             'post_id': self.employee_post.id,
-            'user_id': 1,
+            'user_id': self.ref('base.user_root'),
             'vote': '1',
         })
         self.assertEqual(new_portal_vote.user_id, self.user_portal, 'Creating a vote for someone else should not be allowed. It should create it for yourself instead')

--- a/addons/website_forum/tests/test_forum_tours.py
+++ b/addons/website_forum/tests/test_forum_tours.py
@@ -10,21 +10,22 @@ class TestUi(HttpCaseGamification):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.env['forum.post'].create({
+        post = cls.env['forum.post'].create({
             'name': 'Very Smart Question',
             'forum_id': cls.env.ref('website_forum.forum_help').id,
         })
         cls.env.ref('base.user_admin').write({
             'email': 'mitchell.admin@example.com',
         })
+        cls.forum_id = post.forum_id.id
 
     def test_01_admin_forum_tour(self):
-        self.start_tour("/forum/1", 'question_tour', login="admin")
+        self.start_tour(f"/forum/{self.forum_id}", 'question_tour', login="admin")
 
     def test_02_demo_question(self):
         forum = self.env.ref('website_forum.forum_help')
         demo = self.user_demo
         demo.karma = forum.karma_post + 1
-        self.start_tour("/forum/help-1", 'forum_question', login="demo")
+        self.start_tour(f"/forum/help-{self.forum_id}", 'forum_question', login="demo")
         tags = self.env['forum.tag'].search([('name', 'in', ['Tag', 'tag', 'test tag'])])
         self.assertEqual(len(tags), 3)

--- a/addons/website_forum/tests/test_sitemap.py
+++ b/addons/website_forum/tests/test_sitemap.py
@@ -11,7 +11,7 @@ from odoo.tests import tagged
 class TestWebsiteControllers(TestForumCommon):
 
     def test_01_forum_sitemap(self):
-        website = self.env['website'].browse(1)
+        website = self.env.ref('website.default_website')
 
         # Simulate post from 2023-05-31
         datetime = '2023-05-31'

--- a/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
+++ b/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
@@ -78,7 +78,7 @@ class TestWebsiteHrRecruitmentForm(odoo.tests.HttpCase):
             },
         ])
         WebsiteHrRecruitmentController = WebsiteHrRecruitment()
-        with MockRequest(self.env, website=self.env['website'].browse(1)):
+        with MockRequest(self.env, website=self.env.ref('website.default_website')):
             response = WebsiteHrRecruitmentController.jobs()
         self.assertEqual(response.status, '200 OK')
 

--- a/addons/website_sale/tests/test_abandoned_cart.py
+++ b/addons/website_sale/tests/test_abandoned_cart.py
@@ -230,7 +230,7 @@ class TestWebsiteSaleCartAbandoned(TestWebsiteSaleCartAbandonedCommon):
             "order_line": order_line,
         })
         transaction = self.env["payment.transaction"].create({
-            "provider_id": 15,
+            'provider_id': self.ref('payment.payment_provider_demo'),
             "payment_method_id": self.payment_method_id,
             "partner_id": self.customer.id,
             "reference": abandoned_sale_order.name,

--- a/addons/website_sale/tests/test_cart.py
+++ b/addons/website_sale/tests/test_cart.py
@@ -149,7 +149,7 @@ class TestWebsiteSaleCart(ProductVariantsCommon, WebsiteSaleCommon):
     def test_check_order_delivery_before_payment(self):
         with self.mock_request():
             sale_order = self.env["sale.order"].create({
-                "partner_id": self.public_user.id,
+                "partner_id": self.public_user.partner_id.id,
                 "order_line": [Command.create({"product_id": self.product.id})],
                 "access_token": "test_token",
             })
@@ -461,7 +461,7 @@ class TestWebsiteSaleCart(ProductVariantsCommon, WebsiteSaleCommon):
     def test_checkout_no_delivery_method_available(self):
         portal_user = self.user_portal
         portal_user.write(self.dummy_partner_address_values)
-        self.carrier.country_ids = [Command.set((2,))]
+        self.carrier.country_ids = [Command.set(self.env.ref('base.be').ids)]
         self.product.type = "consu"
         with (
             self.mock_request(user=portal_user) as request,

--- a/addons/website_sale/tests/test_pricelist.py
+++ b/addons/website_sale/tests/test_pricelist.py
@@ -485,7 +485,10 @@ class TestWebsitePriceList(WebsiteSaleCommon):
         self.assertEqual(order_sudo.pricelist_id, list_benelux_2)
 
 
-def simulate_frontend_context(self, website_id=1):
+def simulate_frontend_context(self, website_id=None):
+    if website_id is None:
+        website_id = self.env.ref('website.default_website').id
+
     # Mock this method will be enough to simulate frontend context in most methods
     def get_request_website():
         return self.env["website"].browse(website_id)

--- a/addons/website_sale/tests/test_sale_process.py
+++ b/addons/website_sale/tests/test_sale_process.py
@@ -146,7 +146,7 @@ class TestSaleProcess(HttpCaseWithUserDemo, WebsiteSaleCommon, HttpCaseWithWebsi
                 Command.create({"attribute_id": attribute.id, "value_ids": attribute.value_ids})
             ],
         })
-        self.env["website"].browse(1).write({"google_analytics_key": "G-XXXXXXXXXXX"})
+        self.env.ref('website.default_website').write({"google_analytics_key": "G-XXXXXXXXXXX"})
         self.start_tour("/shop?search=Colored T-Shirt", "website_sale.google_analytics_view_item")
         # Data for google_analytics_add_to_cart
         self.env["product.template"].create({

--- a/addons/website_sale/tests/test_website_editor.py
+++ b/addons/website_sale/tests/test_website_editor.py
@@ -32,7 +32,7 @@ class TestProductPictureController(HttpCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.website = cls.env["website"].browse(1)
+        cls.website = cls.env.ref('website.default_website')
         cls.WebsiteSaleController = WebsiteSale()
         cls.product = cls.env["product.product"].create({
             "name": "Storage Test Box",
@@ -266,7 +266,7 @@ class TestProductVideoUpload(HttpCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.website = cls.env["website"].browse(1)
+        cls.website = cls.env.ref('website.default_website')
         cls.WebsiteSaleController = WebsiteSale()
         cls.product = cls.env["product.product"].create({
             "name": "Test Video Product",

--- a/addons/website_sale_collect/tests/test_sale_order.py
+++ b/addons/website_sale_collect/tests/test_sale_order.py
@@ -28,7 +28,7 @@ class TestSaleOrder(ClickAndCollectCommon):
 
     def test_warehouse_is_not_reset_on_public_user_checkout(self):
         warehouse_2 = self._create_warehouse()
-        so = self._create_in_store_delivery_order(partner_id=self.public_user.id)
+        so = self._create_in_store_delivery_order(partner_id=self.public_user.partner_id.id)
         so._set_pickup_location('{"id":' + str(warehouse_2.id) + "}")
         # change the partner_id as would happen in a checkout
         so.partner_id = self.partner.id

--- a/addons/website_sale_loyalty/tests/test_sale_coupon_multiwebsite.py
+++ b/addons/website_sale_loyalty/tests/test_sale_coupon_multiwebsite.py
@@ -13,8 +13,8 @@ class TestSaleCouponMultiwebsite(TestSaleCouponNumbersCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.website = cls.env["website"].browse(1)
-        cls.website2 = cls.env["website"].create({"name": "website 2"})
+        cls.website = cls.env.ref('website.default_website')
+        cls.website2 = cls.env['website'].create({'name': 'website 2'})
 
     def test_01_multiwebsite_checks(self):
         """Ensure the multi website compliance of programs and coupons, both in

--- a/addons/website_sale_slides/data/sale_order_demo.xml
+++ b/addons/website_sale_slides/data/sale_order_demo.xml
@@ -12,7 +12,7 @@
         <field name="user_id" ref="base.user_admin"/>
         <field name="date_order" eval="DateTime.now() - relativedelta(days=30)"/>
         <field name="team_id" ref="sales_team.salesteam_website_sales"/>
-        <field name="website_id" eval="1"/>
+        <field name="website_id" ref="website.default_website"/>
         <field name="tag_ids" eval="[(4, ref('sales_team.categ_oppor2')), (4, ref('sales_team.categ_oppor5'))]"/>
     </record>
     <record id="sale_order_course_1_line_1" model="sale.order.line">
@@ -29,7 +29,7 @@
         <field name="user_id" ref="base.user_admin"/>
         <field name="date_order" eval="DateTime.now() - relativedelta(days=100)"/>
         <field name="team_id" ref="sales_team.salesteam_website_sales"/>
-        <field name="website_id" eval="1"/>
+        <field name="website_id" ref="website.default_website"/>
     </record>
     <record id="sale_order_course_2_line_1" model="sale.order.line">
         <field name="order_id" ref="sale_order_course_2"/>
@@ -53,7 +53,7 @@
         <field name="user_id" ref="base.user_admin"/>
         <field name="date_order" eval="DateTime.now() - relativedelta(days=30)"/>
         <field name="team_id" ref="sales_team.salesteam_website_sales"/>
-        <field name="website_id" eval="1"/>
+        <field name="website_id" ref="website.default_website"/>
     </record>
     <record id="sale_order_course_3_line_1" model="sale.order.line">
         <field name="order_id" ref="sale_order_course_3"/>

--- a/odoo/addons/base/data/base_data.sql
+++ b/odoo/addons/base/data/base_data.sql
@@ -119,22 +119,22 @@ CREATE TABLE res_partner (
 ---------------------------------
 -- Default data
 ---------------------------------
-insert into res_currency (id, name, symbol) VALUES (1, 'USD', '$');
-insert into ir_model_data (name, module, model, noupdate, res_id) VALUES ('USD', 'base', 'res.currency', true, 1);
-select setval('res_currency_id_seq', 1);
+insert into res_currency (id, name, symbol) VALUES (97, 'USD', '$');
+insert into ir_model_data (name, module, model, noupdate, res_id) VALUES ('USD', 'base', 'res.currency', true, 97);
+select setval('res_currency_id_seq', 97);
 
-insert into res_company (id, name, partner_id, currency_id, sequence, create_date) VALUES (1, 'My Company', 1, 1, 10, now() at time zone 'UTC');
-insert into ir_model_data (name, module, model, noupdate, res_id) VALUES ('main_company', 'base', 'res.company', true, 1);
-select setval('res_company_id_seq', 1);
+insert into res_company (id, name, partner_id, currency_id, sequence, create_date) VALUES (21, 'My Company', 11, 97, 10, now() at time zone 'UTC');
+insert into ir_model_data (name, module, model, noupdate, res_id) VALUES ('main_company', 'base', 'res.company', true, 21);
+select setval('res_company_id_seq', 21);
 
-insert into res_partner (id, name, company_id, create_date) VALUES (1, 'My Company', 1, now() at time zone 'UTC');
-insert into ir_model_data (name, module, model, noupdate, res_id) VALUES ('main_partner', 'base', 'res.partner', true, 1);
-select setval('res_partner_id_seq', 1);
+insert into res_partner (id, name, company_id, create_date) VALUES (11, 'My Company', 21, now() at time zone 'UTC');
+insert into ir_model_data (name, module, model, noupdate, res_id) VALUES ('main_partner', 'base', 'res.partner', true, 11);
+select setval('res_partner_id_seq', 11);
 
-insert into res_users (id, login, password, active, partner_id, company_id, create_date) VALUES (1, '__system__', NULL, false, 1, 1, now() at time zone 'UTC');
+insert into res_users (id, login, password, active, partner_id, company_id, create_date) VALUES (1, '__system__', NULL, false, 11, 21, now() at time zone 'UTC');
 insert into ir_model_data (name, module, model, noupdate, res_id) VALUES ('user_root', 'base', 'res.users', true, 1);
 select setval('res_users_id_seq', 1);
 
-insert into res_groups (id, name) VALUES (1, '{"en_US": "Employee"}');
-insert into ir_model_data (name, module, model, noupdate, res_id) VALUES ('group_user', 'base', 'res.groups', true, 1);
-select setval('res_groups_id_seq', 1);
+insert into res_groups (id, name) VALUES (71, '{"en_US": "Employee"}');
+insert into ir_model_data (name, module, model, noupdate, res_id) VALUES ('group_user', 'base', 'res.groups', true, 71);
+select setval('res_groups_id_seq', 71);

--- a/odoo/addons/base/tests/test_ir_sequence.py
+++ b/odoo/addons/base/tests/test_ir_sequence.py
@@ -256,14 +256,14 @@ class TestIrSequenceGenerate(BaseCase):
 @tagged('at_install', '-post_install')  # LEGACY at_install
 class TestIrSequenceInit(common.TransactionCase):
 
-    def test_00(self):
+    def test_00_read_next_sequence(self):
         """ test whether the read method returns the right number_next value
             (from postgreSQL sequence and not ir_sequence value)
         """
         # first creation of sequence (normal)
         seq = self.env['ir.sequence'].create({
             'number_next': 1,
-            'company_id': 1,
+            'company_id': self.ref('base.main_company'),
             'padding': 4,
             'number_increment': 1,
             'implementation': 'standard',

--- a/odoo/addons/base/tests/test_ir_ui_view.py
+++ b/odoo/addons/base/tests/test_ir_ui_view.py
@@ -3954,11 +3954,12 @@ class TestViewTranslations(common.TransactionCase):
             "mode": "extension",
         })
 
+        group_id = self.ref('base.group_user')
         with self.assertRaises(ValidationError):
-            view.write({'group_ids': [1]})
+            view.write({'group_ids': [group_id]})
 
         view.write({'mode': 'primary'})
-        view.write({'group_ids': [1]})
+        view.write({'group_ids': [group_id]})
 
         with self.assertRaises(ValidationError):
             view.write({'mode': 'extension'})

--- a/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
+++ b/odoo/addons/test_assetsbundle/tests/test_assetsbundle.py
@@ -2054,7 +2054,7 @@ class AssetsNodeOrmCacheUsage(TransactionCase):
         self.assertEqual(asset_keys_length, 1)
         self.assertEqual(qweb_keys_length, 1)
 
-        self.env['ir.qweb'].with_context(website_id=1)._get_asset_nodes('test_assetsbundle.manifest1')
+        self.env['ir.qweb'].with_context(website_id=self.ref('website.default_website'))._get_asset_nodes('test_assetsbundle.manifest1')
         asset_keys, qweb_keys = self.cache_keys()
         # The content may be different for different websites, even if it is not
         # always the case.

--- a/odoo/addons/test_inherit/tests/test_inherit.py
+++ b/odoo/addons/test_inherit/tests/test_inherit.py
@@ -80,7 +80,7 @@ class test_inherits(common.TransactionCase):
     def test_60_inherit_with_python(self):
         self.assertEqual(self.env['test.inherit.mother'].foo(), 42)
         self.assertEqual(self.env[TestInheritMother._name].foo(), 42)
-        self.assertEqual(self.env['test.inherit.mother'].browse(1).surname, 'Mother A')
+        self.assertEqual(self.env.ref('test_inherit.mother_a').surname, 'Mother A')
 
 
 @tagged('at_install', '-post_install')  # LEGACY at_install

--- a/odoo/addons/test_main_flows/tests/test_flow.py
+++ b/odoo/addons/test_main_flows/tests/test_flow.py
@@ -112,7 +112,7 @@ class TestUi(BaseTestUi):
     def test_company_switch_access_error(self):
         company1 = self.env.company
         company2 = self.env["res.company"].create({"name":"second company"})
-        self.env["res.users"].browse(2).write({
+        self.env.ref('base.user_admin').write({
             "company_ids": [Command.clear(), Command.link(company1.id), Command.link(company2.id)]
         })
 
@@ -142,7 +142,7 @@ class TestUi(BaseTestUi):
     def test_company_access_error_redirect(self):
         company1 = self.env.company
         company2 = self.env["res.company"].create({"name": "second company"})
-        self.env["res.users"].browse(2).write({
+        self.env.ref('base.user_admin').write({
             "company_ids": [Command.clear(), Command.link(company1.id), Command.link(company2.id)]
         })
 
@@ -173,7 +173,7 @@ class TestUi(BaseTestUi):
         # This test is identical to test_company_switch_access_error, but with debug mode enabled
         company1 = self.env.company
         company2 = self.env["res.company"].create({"name": "second company"})
-        self.env["res.users"].browse(2).write({
+        self.env.ref('base.user_admin').write({
             "company_ids": [Command.clear(), Command.link(company1.id), Command.link(company2.id)]
         })
 

--- a/odoo/addons/test_orm/models/test_orm.py
+++ b/odoo/addons/test_orm/models/test_orm.py
@@ -2129,7 +2129,7 @@ class TestOrmPrecomputeMonetary(models.Model):
             record.amount = 12.333
 
     def _compute_currency_id(self):
-        self.currency_id = 1  # EUR
+        self.currency_id = self.env.ref('base.EUR')
 
 
 class TestOrmPrefetch(models.Model):

--- a/odoo/addons/test_orm/tests/test_acl.py
+++ b/odoo/addons/test_orm/tests/test_acl.py
@@ -97,7 +97,7 @@ class TestACL(TransactionCaseWithUserDemo):
     @mute_logger('odoo.models')
     def test_field_crud_restriction(self):
         "Read/Write RPC access to restricted field should be forbidden"
-        partner = self.env['res.partner'].browse(1).with_user(self.user_demo)
+        partner = self.env.ref('base.main_partner').with_user(self.user_demo)
 
         # Verify the test environment first
         has_group_test = self.user_demo.has_group(self.TEST_GROUP)

--- a/odoo/addons/test_orm/tests/test_domain_expression.py
+++ b/odoo/addons/test_orm/tests/test_domain_expression.py
@@ -686,7 +686,7 @@ class TestExpression(SavepointCaseWithUserDemo, TransactionExpressionCase):
         currency = Currency.create({'name': 'ZZZ', 'symbol': 'ZZZ', 'rounding': 1.0})
         currency_rate = CurrencyRate.create({'name': '2010-01-01', 'currency_id': currency.id, 'rate': 1.0})
         non_currency_id = currency_rate.id + 1000
-        default_currency = Currency.browse(1)
+        default_currency = Currency.env.ref('base.USD')
 
         # search the currency via its rates one2many (the one2many must point back at the currency)
         currency_rate1 = self._search(CurrencyRate, [('currency_id', 'not like', 'probably_unexisting_name')])
@@ -1939,7 +1939,7 @@ class TestMany2one(TransactionCase):
         super().setUp()
         self.Partner = self.env['res.partner'].with_context(active_test=False)
         self.User = self.env['res.users'].with_context(active_test=False)
-        self.company = self.env['res.company'].browse(1)
+        self.company = self.env.ref('base.main_company')
 
     def test_inherited(self):
         with self.assertQueries(['''
@@ -2488,7 +2488,7 @@ class TestMany2many(TransactionCase):
     def setUp(self):
         super().setUp()
         self.User = self.env['res.users'].with_context(active_test=False)
-        self.company = self.env['res.company'].browse(1)
+        self.company = self.env.ref('base.main_company')
 
     def test_regular(self):
         group = self.env.ref('base.group_user')

--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -4228,7 +4228,7 @@ class TestMany2oneReference(TransactionExpressionCase):
         reference.res_model = record._name
 
         # the model field 'res_model' is not in database yet
-        self.assertIn(record.id, self.env._field_dirty[reference._fields['res_model']])
+        self.assertIn(reference.id, self.env._field_dirty[reference._fields['res_model']])
 
         # searching on the one2many should flush the field 'res_model'
         records = record.search([('model_ids.create_date', '!=', False)])
@@ -5148,6 +5148,7 @@ class TestPrecompute(TransactionCase):
 
         fnames = [fname for fname, field in currency._fields.items() if field.prefetch]
         QUERIES = [
+            'SELECT "res_currency"."id" FROM "res_currency" WHERE "res_currency"."id" IN %s',  # env.ref for currency
             select(currency, *fnames),
             insert(model, 'amount', 'currency_id'),
             select(model, 'currency_id'),

--- a/odoo/addons/test_orm/tests/test_html_converter.py
+++ b/odoo/addons/test_orm/tests/test_html_converter.py
@@ -74,7 +74,7 @@ class TestIntegerExport(TestBasicExport):
 class TestFloatExport(TestBasicExport):
     def setUp(self):
         super().setUp()
-        self.env['res.lang'].browse(1).write({'grouping': '[3,0]'})
+        self.env.ref('base.lang_en').write({'grouping': '[3,0]'})
 
     def test_float(self):
         converter = self.get_converter('float')

--- a/odoo/addons/test_orm/tests/test_one2many.py
+++ b/odoo/addons/test_orm/tests/test_one2many.py
@@ -442,10 +442,7 @@ class One2manyCase(TransactionExpressionCase):
         member2 = Member.create({'name': 'Noura', 'team_id': team3.id})
         Member.create({'name': 'Ivan', 'team_id': team2.id})
 
-        # In this specific case...
-        self.assertEqual(member2.id, member2.team_id.parent_id.id)
-
-        # ...we had an infinite recursion on making the following search, but not anymore
+        # Make sure we don't have an infinite recursion on making the following search
         Team.search([('member_ids', 'child_of', member2.id)])
 
         # Also, test a simple infinite loop if record is marked as a parent of itself

--- a/odoo/addons/test_orm/tests/test_read_group_private.py
+++ b/odoo/addons/test_orm/tests/test_read_group_private.py
@@ -248,18 +248,19 @@ class TestPrivateReadGroup(common.TransactionCase):
 
     def test_array_read_groups(self):
         Model = self.env['test_read_group.aggregate']
-        Model.create({'partner_id': 1})
-        Model.create({'partner_id': 1})
-        Model.create({'partner_id': 2})
+        p1, p2 = self.ref('base.partner_root'), self.ref('base.partner_admin')
+        Model.create({'partner_id': p1})
+        Model.create({'partner_id': p1})
+        Model.create({'partner_id': p2})
 
         self.assertEqual(
             Model._read_group([], aggregates=['partner_id:array_agg']),
-            [([1, 1, 2],)],
+            [([p1, p1, p2],)],
         )
 
         self.assertEqual(
             Model._read_group([], aggregates=['partner_id:recordset']),
-            [(self.env['res.partner'].browse([1, 2]),)],
+            [(self.env['res.partner'].browse([p1, p2]),)],
         )
 
     def test_flush_read_group(self):

--- a/odoo/addons/test_orm/tests/test_search_order.py
+++ b/odoo/addons/test_orm/tests/test_search_order.py
@@ -148,7 +148,7 @@ class TestSearch(TransactionCase):
 
         # Create test users
         u = Users.create({'name': '__search', 'login': '__search', 'group_ids': [Command.set([group_employee.id])]})
-        a = Users.create({'name': '__test_A', 'login': '__test_A', 'country_id': country_be.id, 'state_id': country_be.id})
+        a = Users.create({'name': '__test_A', 'login': '__test_A', 'country_id': country_be.id, 'state_id': country_be.state_ids[0].id})
         b = Users.create({'name': '__test_B', 'login': '__a_test_B', 'country_id': country_us.id, 'state_id': states_us[1].id})
         c = Users.create({'name': '__test_B', 'login': '__z_test_B', 'country_id': country_us.id, 'state_id': states_us[0].id})
 

--- a/odoo/addons/test_web/tests/test_onchange.py
+++ b/odoo/addons/test_web/tests/test_onchange.py
@@ -555,10 +555,11 @@ class TestOnchange(SavepointCaseWithUserDemo):
     def test_onchange_related(self):
         user = self.env.user
 
+        message_id = self.env['test_orm.message'].search([], limit=1).ensure_one().id
         values = {
-            'message': 1,
+            'message': message_id,
             'message_name': False,
-            'message_currency': 2,
+            'message_currency': self.ref('base.EUR'),
         }
         fields_spec = {
             'message': {'fields': {'display_name': {}}},
@@ -790,7 +791,7 @@ class TestOnchange(SavepointCaseWithUserDemo):
         self.assertEqual(result['value']['messages'], [
             Command.create({
                 'name': f'[{{generate_dummy_message}}] {USER.name}',
-                'author': {'id': 1, 'display_name': f'{USER.name}'},
+                'author': {'id': USER.id, 'display_name': f'{USER.name}'},
                 'discussion': False,  # this value is False because the main record does not exist yet
             }),
         ])

--- a/odoo/modules/db.py
+++ b/odoo/modules/db.py
@@ -411,7 +411,7 @@ def _initialize_db(
             if '@' in user_login:
                 main_company_values['email'] = user_login
             if main_company_values:
-                env['res.company'].browse(1).write(main_company_values)
+                env.ref('base.main_company').write(main_company_values)
 
         # update admin's password and lang and login
         values = {'password': user_password, 'lang': lang}

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -2459,6 +2459,17 @@ class BaseModel(metaclass=MetaModel):
                     for field in sorted(self._fields.values(), key=lambda f: f.column_order)
                     if field.name != 'id' and field.store and field.column_type
                 ])
+                if not self._name.startswith('test'):
+                    # Randomize first sequence number to avoid having records
+                    # with similar ids when testing. For example, avoid having
+                    # first res_users and res_partner sharing the same id.
+                    # Just using the number of existing tables multiplied by a
+                    # prime.
+                    cr.execute("""
+                        SELECT setval(
+                            pg_get_serial_sequence(%s, 'id'),
+                            abs(hashtext(%s)) %% 97 + 103)""",
+                        (self._table, self._table))
 
             if self._parent_store:
                 if not sql.column_exists(cr, self._table, 'parent_path'):


### PR DESCRIPTION
When testing avoid having the first created user and partner having `id=1`. This detects bugs in tests where the id is compared and it matches by chance.

Types of errors:
- mixin related objects like
  - `company_id = self.env.user`
  - `user_id = self.env.user.partner_id.id`
  - product.product/product.template
  - etc.
- `record.abc_ids = (4, some_id)`

https://github.com/odoo/enterprise/pull/107420

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
