### PR TITLE
[FIX] account: cumulated balance not working on general ledger

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -813,7 +813,10 @@ class AccountMoveLine(models.Model):
                     # Ignore date and display_type filters as they do not impact the cumulated balance
                     if (
                         (field == 'date' and operator in ('>=', '<=', '=', '>', '<'))
-                        or (field == 'display_type' and operator == 'not in' and value == ('line_section', 'line_subsection', 'line_note'))
+                        or (
+                            field == 'display_type' and operator == 'not in' and isinstance(value, (set, list, tuple))
+                            and len(set(value) - {'line_section', 'line_subsection', 'line_note'}) == 0
+                        )
                     ):
                         continue
                 # Ignore AND operators


### PR DESCRIPTION
All cumulated balance are at 0 when opening the Journal Items from an account from the general ledger.

To reproduce:
- Open the general ledger
- Select "Journal Items" with any account with moves during the period
- Show the optional "cumulated_balance" column
- All values are at 0

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
