### PR TITLE
[FIX] product: allow users with read access to print labels

### DIFF
--- a/addons/product/tests/test_common.py
+++ b/addons/product/tests/test_common.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.exceptions import AccessError
 from odoo.tests import tagged
 
 from odoo.addons.product.tests.common import ProductCommon
@@ -24,3 +25,20 @@ class TestProduct(ProductCommon):
             self.pricelist,
         )
         self.assertEqual(self.pricelist.currency_id.name, self.currency.name)
+
+    def test_any_user_can_print_product_labels(self):
+        base_user = self.env['res.users'].create({
+            'name': 'Base user',
+            'login': 'base_user',
+            'email': 'base.user@test.com',
+            'group_ids': self.group_user,
+        })
+        print_label_action = self.env.ref('product.action_product_template_print_labels')
+        context = {
+            'active_model': 'product.template',
+            'active_id': self.product.product_tmpl_id,
+        }
+        try:
+            print_label_action.with_user(base_user).with_context(context).run()
+        except AccessError:
+            self.fail("AccessError raised while printing product label with base user.")

--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -197,6 +197,7 @@
     <record id="action_product_template_print_labels" model="ir.actions.server">
         <field name="name">Print Labels</field>
         <field name="model_id" ref="product.model_product_template"/>
+        <field name="group_ids" eval="[(4, ref('base.group_user'))]"/>
         <field name="binding_model_id" ref="product.model_product_template"/>
         <field name="state">code</field>
         <field name="code">


### PR DESCRIPTION
## Issue
Users who do not have the "write" right access on `product.template` cannot print product labels.

## Steps to reproduce
1. Install *Sales* (`sale_management`)
2. In Settings > User & Companies > Users, make sure Marc Demo does not have any write access on `product.template`
3. Log in as Marc Demo
4. In Sales > Products > Products, open a product and click *Print Labels* from the cogwheel menu
5. **An Access Error is shown, saying that the operation is allowed for the `Products/Create` group.**

## Cause
[This commit](https://github.com/odoo/odoo/commit/95ace0a694eaf83329b50e6b89f774f0c59fec5e) removed Products-related rights from the `base.group_user`. This made a difference in terms of access rights, as the `IrActionServe.run` method checks for the "write" access by calling `_can_execute_action_on_records`:

https://github.com/odoo/odoo/blob/d15685304f479541879fabd55ea1cae4252a2a90/odoo/addons/base/models/ir_actions.py#L1230-L1239

When a `group_ids` field is added to the action, this check is no longer performed.

opw-5914988