### PR TITLE
[FIX] snailmail: fix fetch attachment access error

### DIFF
--- a/addons/snailmail/models/snailmail_letter.py
+++ b/addons/snailmail/models/snailmail_letter.py
@@ -165,9 +165,9 @@ class SnailmailLetter(models.Model):
                 self.env.ref(f'web.external_layout_{layout}')
                 for layout in ('bubble', 'wave', 'folder')
             }:
-                self.company_id.external_report_layout_id = self.env.ref('web.external_layout_standard')
+                self.company_id.sudo().external_report_layout_id = self.env.ref('web.external_layout_standard')
             filename, pdf_bin = self._generate_report_pdf(report)
-            self.company_id.external_report_layout_id = prev
+            self.company_id.sudo().external_report_layout_id = prev
 
             pdf_bin = self._overwrite_margins(pdf_bin)
             if self.cover:


### PR DESCRIPTION
Issue:
Before this commit, when sending a follow up report by post, an access error is thrown if the user doesn't have enough access to modify the res.company model

Fix:
modifying the external_report_layout_id as sudo

opw-5482855