### PR TITLE
[FIX] l10n_ro_edi_stock: fix report crash in non-English languages

### DIFF
--- a/addons/l10n_ro_edi_stock/report/report_deliveryslip.xml
+++ b/addons/l10n_ro_edi_stock/report/report_deliveryslip.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <template id="l10n_ro_edi_stock_report_delivery_document" inherit_id="stock.report_delivery_document" priority="100">
-        <xpath expr="//div/strong[text()='Tracking Number']/.. | //div/strong[text()='Total Weight']/.." position="after">
+        <xpath expr="//div[div[@t-field='o.carrier_tracking_ref']] | //div[div[span[@t-field='o.shipping_weight']]]" position="after">
             <div t-if="o.l10n_ro_edi_stock_enable and o.l10n_ro_edi_stock_document_uit" class="col-auto" name="div_etransport_uit">
                 <strong>eTransport UIT</strong>
                 <p t-field="o.l10n_ro_edi_stock_document_uit"/>


### PR DESCRIPTION
Steps to reproduce:
1. Switch the partner language to Spanish.
2. Print the Delivery Slip.
3. The report crashes due to translated XPath anchors.

Cause:
XPath targeted hardcoded English strings 'Tracking Number' and 'Total Weight'.

Solution:
Target technical fields o.carrier_tracking_ref and o.shipping_weight instead of text labels.

opw-5493498