### PR TITLE
[FIX] account: avoid access error for purchase users in vendor bill

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -856,7 +856,8 @@
                                     class="oe_stat_button"
                                     icon="fa-bars"
                                     type="object"
-                                    invisible="not payment_count">
+                                    invisible="not payment_count"
+                                    groups="account.group_account_readonly">
                                     <field name="payment_count" string="Payments" widget="statinfo"/>
                             </button>
                             <button name="open_reconcile_view"


### PR DESCRIPTION
The button `open_payments` requires computation of `payment_count`, which requires access to the model `account.payment`. Only accounting users have access to this model so purchase only users were blocked from opening vendor bills. Same issue occurs for sales only users accessing their invoices.

Steps to reproduce:

- have an admin set a user's (i.e. demo) access rights to "Purchase: User" and everything else to "No" where possible
- create a new Purchase Order as the user and only purchase a "Service" product
- "Confirm Order" > "Upload Bill" > choose any pdf

Expected result:
PDF is uploaded, Vendor Bill is created, and the bill (account.move) form view should open

Actual result:
PDF is uploaded, Vendor Bill is created, access error occurs when trying to open the bill form view

opw-5420938
upg-3857107



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
