### PR TITLE
[FIX] hr_applicant: prevent edit properties when no job_id

### DIFF
--- a/addons/hr_recruitment/static/src/web/form_controller_patch.js
+++ b/addons/hr_recruitment/static/src/web/form_controller_patch.js
@@ -1,0 +1,12 @@
+import { FormController } from "@web/views/form/form_controller";
+import { patch } from "@web/core/utils/patch";
+
+patch(FormController.prototype, {
+    getStaticActionMenuItems() {
+        const menuItems = super.getStaticActionMenuItems();
+        if (this.props.resModel === 'hr.applicant' && !this.model.root.data.job_id) {
+            menuItems.addPropertyFieldValue.isAvailable = () => false;
+        }
+        return menuItems;
+    },
+});


### PR DESCRIPTION
# How to reproduce
- Go to the Talen Pool sub-menu of the recuitment app
- Create a new Talent
- Click on the cog button, then on "Edit Properties"

# The problem
A not very descriptive error message is displayed

# Why
The hr.applicant model has a Properties field that allows the edition of its properties directly in the UI. This field needs to be linked to a PropertiesDefintion field in another model. In our case, that definition is in the hr.job model linked to the hr.applicant model via the field job_id. To be able to edit the properties of the hr.applicant model, it needs to be linked to a job, which is not always the case.

A fix was made in master to allow the edition of properties even when there is no job_id (https://github.com/odoo/odoo/commit/99aa75bc64ee8898a0815163603e5861c35b0b94) but that fix is not applicable to a stable version.

The fix I implemented instead hides the button when editing the properties would fail.

opw-5932666

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
