### PR TITLE
[FIX] point_of_sale: kit using different UoM

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -967,7 +967,7 @@ class PosSession(models.Model):
                         product_accounts = move.product_id._get_product_accounts()
                         exp_key = product_accounts['expense']
                         stock_key = product_accounts['stock_valuation']
-                        signed_product_qty = move.quantity
+                        signed_product_qty = move.product_uom._compute_quantity(move.quantity, move.product_id.uom_id, round=False)
                         if move._is_in():
                             signed_product_qty *= -1
                         amount = signed_product_qty * move._get_price_unit()


### PR DESCRIPTION
When selling a kit product in POS, if the component of the kit use a different UoM than the UoM defined on the product, the stock valuation lines are wrong.

Steps to reproduce:
-------------------
* Create a storable product A with a UoM "Dozen" and a cost price of 10€
* Create a kit product B with a BoM of 1 unit of product A
* Sell 1 unit of product B in POS
> Observation: The valuation lines have the wrong value

Why the fix:
------------
The product qty was not considering the UoM when computing the expense and stock valuation lines.

opw-5471923