### PR TITLE
[FIX] sale_stock: Fix incoming move calculation

### DIFF
--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -2725,3 +2725,82 @@ class TestSaleStock(TestSaleStockCommon, ValuationReconciliationTestCommon):
         invoice.action_post()
 
         self.assertEqual(invoice.state, 'posted')
+
+    def test_manufacturing_quantity_update_multi_warehouse_route(self):
+        """
+        When a product has an MTO, and a confirmed sales order creates a manufacturing order
+        check to make sure incoming moves are calculated correctly if the delivery moves between
+        multiple warehouses.
+        """
+        warehouse1 = self.env['stock.warehouse'].create({
+            'partner_id': self.partner_a.id,
+            'name': 'warehouse 1',
+            'code': 'WH1',
+        })
+        warehouse2 = self.env['stock.warehouse'].create({
+            'partner_id': self.partner_a.id,
+            'name': 'warehouse 2',
+            'code': 'WH2',
+        })
+        customer_location = self.env.ref('stock.stock_location_customers')
+
+        route_manufacture, route_mto = self.env['stock.route'].create([
+            {
+                'name': 'Manufacture Test',
+                'rule_ids': [
+                    Command.create({
+                        'name': 'WH2 Manufacture',
+                        'action': 'manufacture',
+                        'picking_type_id': warehouse2.manu_type_id.id,
+                        'location_src_id': warehouse2.lot_stock_id.id,
+                        'location_dest_id': warehouse2.lot_stock_id.id,
+                        'procure_method': 'make_to_stock',
+                        'warehouse_id': False,
+                    })
+                ],
+            },
+            {
+                'name': 'Replenish on Order (MTO) Test',
+                'rule_ids': [
+                    Command.create({
+                        'name': 'Transit to Customer',
+                        'action': 'pull',
+                        'picking_type_id': warehouse1.out_type_id.id,
+                        'location_src_id': warehouse1.lot_stock_id.id,
+                        'location_dest_id': customer_location.id,
+                        'procure_method': 'make_to_order',
+                        'warehouse_id': warehouse1.id,
+                    }),
+                    Command.create({
+                        'name': 'WH2 to WH(1)',
+                        'action': 'pull',
+                        'picking_type_id': warehouse1.int_type_id.id,
+                        'location_src_id': warehouse2.lot_stock_id.id,
+                        'location_dest_id': warehouse1.lot_stock_id.id,
+                        'procure_method': 'mts_else_mto',
+                        'warehouse_id': False,
+                    }),
+                ],
+            },
+        ])
+        self.new_product.route_ids = [Command.set([route_manufacture.id, route_mto.id])]
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.env['res.partner'].create({'name': 'My Partner'}).id,
+            'order_line': [Command.create({
+                'product_id': self.new_product.id,
+                'product_uom_qty': 1.0,
+                'route_ids': [route_manufacture.id, route_mto.id],
+            })],
+        })
+
+        sale_order.action_confirm()
+        sale_order.order_line.write({
+            'product_uom_qty': 2
+        })
+
+        mo_id = sale_order.mrp_production_ids.id
+        manufacturing_order = self.env['mrp.production'].search([('id', '=', mo_id)])
+        mo_quantity = manufacturing_order.product_qty
+
+        self.assertEqual(mo_quantity, 2)


### PR DESCRIPTION
Incoming moves are collected in _get_outgoing_incoming_moves. This adds
any move with a rule listed in the triggering rule ids. These ids are
collected from each warehouse. In the event a delivery has two moves
with different warehouses (or one has none), both of these would be added.

In the case where the delivery route moved between two locations. When a
sales order is created and confirmed, a manufacturing order is
created with the proper amount. However, if the sale order quantity were
increased, the MO would add the entire new quantity to the old quantity.

Steps to reproduce:

1. Create new warehouse (WH2)
2. Set WH2 Manufacture to Resupply as True
3. Under Routes:
4. Manufacture:
5. Set the rule to manufacture with the destination location WH2
6. Replenish on Order (MTO):
7. Pull - Source Location: WH2/Stock, Destination Location: WH1/Stock, Picking Type: WH1/Internal Transfer, Warehouse: None
8. Pull - Source Location: WH1/Stock, Destination Location: Customers, Picking Type: WH1/Delivery, Warehouse: WH1
9. Create a product with MTO and a manufacturing route
10. Create and confirm an SO with the product with a quantity of 1
11. Update SO quantity to 2
12. MO will now be 3 instead of 2

opw-5885741