### PR TITLE
[18.0][FIX] website_sale_stock: use _get_product_available_qty in _get_cart_and_free_qty

### DIFF
--- a/addons/website_sale_stock/models/sale_order.py
+++ b/addons/website_sale_stock/models/sale_order.py
@@ -76,10 +76,7 @@ class SaleOrder(models.Model):
         if not line and not product:
             return 0, 0
         cart_qty = sum(self._get_common_product_lines(line, product).mapped('product_uom_qty'))
-        free_qty = (product or line.product_id).with_context(
-            warehouse_id=self.website_id.warehouse_id.id
-        ).free_qty
-
+        free_qty = self.website_id._get_product_available_qty(product or line.product_id)
         return cart_qty, free_qty
 
     def _get_common_product_lines(self, line=None, product=None):


### PR DESCRIPTION
**Description of the issue:**                                                                                                                                                                     
  _get_cart_and_free_qty duplicates inline the same logic already provided by _get_product_available_qty, bypassing the intended extension point.                                               
                                                                                                                                                                                                
**Current behavior:**
  _all_product_available delegates to _get_product_available_qty, but _get_cart_and_free_qty calls free_qty directly, causing inconsistent stock availability results within the same cart flow.
                                                                                                                                                                                                
**Desired behavior:**                                                                                                                                                                             
  _get_cart_and_free_qty delegates to _get_product_available_qty, making it the single extension point for all stock availability queries in the cart.

@tecnativa TT60862
@carlosdauden @pedrobaeza 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
