### PR TITLE
[IMP] test_mail: adjust query count

### DIFF
--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -344,7 +344,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
             # voip module read activity_type during create leading to one less query in enterprise on action_feedback
             _category = activity.activity_type_id.category
 
-        with self.assertQueryCount(admin=9, employee=9):  # tm: 7 / 7
+        with self.assertQueryCount(admin=10, employee=10):  # tm: 7 / 7
             activity.action_feedback(feedback='Zizisse Done !')
 
     @warmup
@@ -379,7 +379,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
 
         record.write({'name': 'Dupe write'})
 
-        with self.assertQueryCount(admin=12, employee=12):  # tm: 10 / 10
+        with self.assertQueryCount(admin=13, employee=13):  # tm: 10 / 10
             record.action_close('Dupe feedback')
 
         self.assertEqual(record.activity_ids, self.env['mail.activity'])
@@ -405,7 +405,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
 
         record.write({'name': 'Dupe write'})
 
-        with self.assertQueryCount(admin=14, employee=14):  # tm: 12 / 12
+        with self.assertQueryCount(admin=15, employee=15):  # tm: 12 / 12
             record.action_close('Dupe feedback', attachment_ids=attachments.ids)
 
         # notifications


### PR DESCRIPTION
Following the change in the documents_account, we update the query count in test_mail because the override of mail_activity.action_done searches document (domain: [('request_activity_id', 'in', self.ids)]) which triggers _search_user_permission using the field is_company_allowed and the search on that field is overridden in documents_account with a clause in the domain as follow: Domain('id', 'in', self.env['documents.account.folder.setting'].sudo() ._search([]).select('folder_id'))
After recording the queries for those 3 tests with and without the PR changes, we have noticed that the only change is that sub query. So there is actually no additional queries but the tests count an additional one each.

Task-5363821