### PR TITLE
[FIX] mrp, mrp_account: compute cost variant using work center efficiency

### DIFF
--- a/addons/mrp/models/mrp_routing.py
+++ b/addons/mrp/models/mrp_routing.py
@@ -103,12 +103,17 @@ class MrpRoutingWorkcenter(models.Model):
 
         for operation in self:
             workcenter = self.env.context.get('workcenter', operation.workcenter_id)
-            product = self.env.context.get('product', operation.bom_id.product_id or operation.bom_id.product_tmpl_id.product_variant_ids)
+            product = (
+                self.env.context.get('product', operation.bom_id.product_id)
+                or self.env.context.get(
+                    'action_button_product',
+                    operation.bom_id.product_tmpl_id.product_variant_ids.filtered(
+                        lambda p: p.product_template_attribute_value_ids <= operation.bom_product_template_attribute_value_ids,
+                    ),
+                )
+            )
             if len(product) > 1:
-                operation.cycle_number = 1
-                operation.time_total = workcenter.time_start + workcenter.time_stop + operation.time_cycle_manual
-                operation.show_time_total = False
-                continue
+                product = product[0]
             quantity = self.env.context.get('quantity', operation.bom_id.product_qty or 1)
             unit = self.env.context.get('unit', operation.bom_id.product_uom_id)
             (capacity, setup, cleanup) = workcenter._get_capacity(product, unit, operation.bom_id.product_qty or 1)

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -157,6 +157,7 @@ class TestBoM(TestMrpCommon):
         mrp_order_form.product_id = self.product_7_3
         mrp_order = mrp_order_form.save()
         self.assertEqual(mrp_order.bom_id, test_bom)
+        self.assertEqual(mrp_order.bom_id.operation_ids[0].time_total, 165)
         self.assertEqual(len(mrp_order.workorder_ids), 1)
         self.assertEqual(mrp_order.workorder_ids.operation_id, test_bom.operation_ids[0])
         self.assertEqual(len(mrp_order.move_byproduct_ids), 1)

--- a/addons/mrp_account/models/product.py
+++ b/addons/mrp_account/models/product.py
@@ -41,12 +41,12 @@ class ProductProduct(models.Model):
 
     def button_bom_cost(self):
         self.ensure_one()
-        self._set_price_from_bom()
+        self.with_context(action_button_product=self)._set_price_from_bom()
 
     def action_bom_cost(self):
         boms_to_recompute = self.env['mrp.bom'].search(['|', ('product_id', 'in', self.ids), '&', ('product_id', '=', False), ('product_tmpl_id', 'in', self.mapped('product_tmpl_id').ids)])
         for product in self:
-            product._set_price_from_bom(boms_to_recompute)
+            product.with_context(action_button_product=product)._set_price_from_bom(boms_to_recompute)
 
     def _set_price_from_bom(self, boms_to_recompute=False):
         self.ensure_one()


### PR DESCRIPTION
**Issue**
Computing the price from BOM can be incorrect when the BOM is defined on a multi-variant product.

**Steps to reproduce**
- Create a product with several variants
- Create a BOM for that product without specifying the product variant
- Define an operation restricted to a specific variant V
- Associate the operation with a workcenter with:
    - Non-null cost per hour (e.g. 100)
    - Time efficiency lower than 100% (e.g. 50%)
- Go to the product page > Variants > variant V
- Click on "Compute price from BOM"
-> The result will be 100 instead of 200 in this example.

Please notice that the price is correctly computed in the BOM overview

**Cause**
Accessing the BOM triggers a `web_read` including `operation_ids`,
which requires computing `time_total`:
https://github.com/odoo/odoo/blob/233316f322d891ebaadb51412ea0df039bfd312a/addons/mrp/models/mrp_routing.py#L77

During this computation, the associated product is retrieved:
https://github.com/odoo/odoo/blob/233316f322d891ebaadb51412ea0df039bfd312a/addons/mrp/models/mrp_routing.py#L106

But since no product is given in the context and the BOM has been created without specifying the product variant
(`bom_id.product_id` is empty), then it retrieves all the product variant associated to the BOM, which leads to
arbitrary default value that ignores work center efficiency:
https://github.com/odoo/odoo/blob/233316f322d891ebaadb51412ea0df039bfd312a/addons/mrp/models/mrp_routing.py#L107-L111
While clicking on "Compute price from BOM":
https://github.com/odoo/odoo/blob/233316f322d891ebaadb51412ea0df039bfd312a/addons/mrp_account/models/product.py#L33
it will ultimately needs to compute the cost:
https://github.com/odoo/odoo/blob/233316f322d891ebaadb51412ea0df039bfd312a/addons/mrp_account/models/product.py#L74
which relies on `time_total`:
https://github.com/odoo/odoo/blob/233316f322d891ebaadb51412ea0df039bfd312a/addons/mrp/models/mrp_routing.py#L131
and since no context is provided, `time_total` is already in the cache, so the default value is used.
Please notice that in BOM overview, the problem does not occur because the provided context retriggers the compute method:
https://github.com/odoo/odoo/blob/233316f322d891ebaadb51412ea0df039bfd312a/addons/mrp/report/mrp_report_bom_structure.py#L806
https://github.com/odoo/odoo/blob/233316f322d891ebaadb51412ea0df039bfd312a/addons/mrp/report/mrp_report_bom_structure.py#L835

opw-5909570