### PR TITLE
[FIX] orm: speedup getting prefetch ids

### DIFF
--- a/odoo/addons/base/tests/test_api.py
+++ b/odoo/addons/base/tests/test_api.py
@@ -334,7 +334,7 @@ class TestAPI(SavepointCaseWithUserDemo):
         self.assertEqual(prefetch_ids, partners.with_context(active_test=False)._prefetch_ids)
         self.assertEqual(prefetch_ids, part.with_prefetch(prefetch_ids)._prefetch_ids)
         self.assertEqual(set(prefetch_ids), set(partners.filtered('country_id')._prefetch_ids))
-        self.assertEqual(set(prefetch_ids), set(partners[0]._prefetch_ids))
+        self.assertEqual(prefetch_ids, partners[0]._prefetch_ids)
         self.assertEqual(set(prefetch_ids), set(partners[:5]._prefetch_ids))
 
         # iteration and relational fields should use the same prefetch set
@@ -414,14 +414,13 @@ class TestAPI(SavepointCaseWithUserDemo):
             self.assertEqual(len(list(result._prefetch_ids)), main_size)
 
             # get the children
-            # adding CHILDREN for current UnionPrefetch
             children = partners[0].child_ids
             main_size = RECORDS * CHILDREN  # total number of children
-            self.assertEqual(len(list(children._prefetch_ids)), main_size + CHILDREN)
+            self.assertEqual(len(list(children._prefetch_ids)), main_size)
 
             # union with all children
             children |= children.parent_id.child_ids
-            main_size = ((main_size + CHILDREN) * (CHILDREN + 1))  # FIXME should not grow this much
+            main_size *= (CHILDREN + 1)  # FIXME should not grow this much
             self.assertEqual(len(list(children._prefetch_ids)), main_size + CHILDREN)
 
             # now incrementally build
@@ -435,7 +434,7 @@ class TestAPI(SavepointCaseWithUserDemo):
             result = partners.country_id.browse()
             for partner in partners[:11]:
                 result += partner.child_ids[0].country_id
-            main_size = RECORDS * CHILDREN * 11 + 79 * 11  # FIXME too much
+            main_size = RECORDS * CHILDREN + (CHILDREN + 1) * 11
             self.assertEqual(len(list(result._prefetch_ids)), main_size)
 
         # when building subsets of large recordsets, prefetch in priority the

--- a/odoo/addons/base/tests/test_api.py
+++ b/odoo/addons/base/tests/test_api.py
@@ -420,7 +420,7 @@ class TestAPI(SavepointCaseWithUserDemo):
 
             # union with all children
             children |= children.parent_id.child_ids
-            main_size *= (CHILDREN + 1)  # FIXME should not grow this much
+            main_size *= 2  # because PrefetchUnion has both prefetch and ids
             self.assertEqual(len(list(children._prefetch_ids)), main_size + CHILDREN)
 
             # now incrementally build
@@ -434,7 +434,7 @@ class TestAPI(SavepointCaseWithUserDemo):
             result = partners.country_id.browse()
             for partner in partners[:11]:
                 result += partner.child_ids[0].country_id
-            main_size = RECORDS * CHILDREN + (CHILDREN + 1) * 11
+            main_size = RECORDS * CHILDREN + 11
             self.assertEqual(len(list(result._prefetch_ids)), main_size)
 
         # when building subsets of large recordsets, prefetch in priority the

--- a/odoo/addons/base/tests/test_api.py
+++ b/odoo/addons/base/tests/test_api.py
@@ -427,8 +427,7 @@ class TestAPI(SavepointCaseWithUserDemo):
             result = partners.browse()
             for child in children:
                 result += child
-            main_size = ((main_size + 1) * CHILDREN)  # FIXME should not grow this much
-            self.assertEqual(len(list(result._prefetch_ids)), main_size)
+            self.assertEqual(len(list(result._prefetch_ids)), main_size + CHILDREN)
 
             # country of first child (harder case)
             result = partners.country_id.browse()

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -6004,8 +6004,13 @@ class BaseModel(metaclass=MetaModel):
         if isinstance(key, str):
             # important: one must call the field's getter
             return self._fields[key].__get__(self)
-        ids = self._ids[key] if isinstance(key, slice) else (self._ids[key],)
-        return self.__class__(self.env, ids, Prefetch.union(ids, self._prefetch_ids))
+        if isinstance(key, slice):
+            ids = self._ids[key]
+            prefetch_ids = Prefetch.union(ids, self._prefetch_ids)
+        else:
+            ids = (self._ids[key],)
+            prefetch_ids = self._prefetch_ids
+        return self.__class__(self.env, ids, prefetch_ids)
 
     def __setitem__(self, key: str, value: typing.Any):
         """ Assign the field ``key`` to ``value`` in record ``self``. """

--- a/odoo/orm/utils.py
+++ b/odoo/orm/utils.py
@@ -5,7 +5,7 @@ from collections.abc import Set as AbstractSet
 import dateutil.relativedelta
 
 from odoo.exceptions import ValidationError
-from odoo.tools import SQL
+from odoo.tools import SQL, unique
 
 regex_alphanumeric = re.compile(r'^[a-z0-9_]+$')
 regex_object_name = re.compile(r'^[a-z0-9_.]+$')
@@ -145,7 +145,7 @@ class PrefetchRelational(Reversible):  # noqa: PLW1641
                 if (coid := field_cache.get(id_)) is not None:
                     yield coid
         else:
-            for id_ in self._records._prefetch_ids:
+            for id_ in unique(self._records._prefetch_ids):
                 if (coids := field_cache.get(id_)):
                     yield from coids
 
@@ -156,7 +156,7 @@ class PrefetchRelational(Reversible):  # noqa: PLW1641
                 if (coid := field_cache.get(id_)) is not None:
                     yield coid
         else:
-            for id_ in reversed(self._records._prefetch_ids):
+            for id_ in unique(reversed(self._records._prefetch_ids)):
                 if (coids := field_cache.get(id_)):
                     yield from coids
 


### PR DESCRIPTION
Various improvements to avoid non-linear growth of returned values when iterating over prefetches.  Traversing a relational field introduces a duplication factor in the returned values.

`records |= more` is syntactic sugar for `records = records | more`, which does not modify the recordset in place but makes one from scratch.  Therefore the time complexity is not `O(len(more))` but `O(len(records) + len(more))`, which is what makes it quadratic when used in a loop.

Since refactor in https://github.com/odoo/odoo/pull/229057, this quadratic complexity is introduced in the prefetching, too.

Changes:
- Keep same prefetch when accessing a single key as when iterating over a recordset. Small gain and more consistent results.
- When iterating over prefetches, deduplicate at source. Without this, the overhead of the generator can be huge for each returned value, since the same value might be returned many times.

In less trivial cases (like traversing two relational fields and making unions with it), the time speedup is several orders of magnitude.