### PR TITLE
[IMP] Allow multiple services on google_account oauth2callback

### DIFF
--- a/doc/cla/individual/romanbarczynski.md
+++ b/doc/cla/individual/romanbarczynski.md
@@ -1,0 +1,11 @@
+Poland, 2026-02-15
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Roman Barczyński <romanb@leanlab.pl> https://github.com/romanbarczynski


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This PR allows services to have separate implementation of saving tokens returned by Oauth2 callback.

Current behavior before PR:

Currently `google_account` allows storage of multiple `client_id`/`client_secret` depending on service.
However, when comes to provided callback it always saves to `google_calendar_rtoken` and `google_calendar_token` as it defaults to calling `_set_google_auth_tokens` on `res.users.settings`.

This forces module developers to write custom controller callbacks and duplicate otherwise good callback provided by `google_account`.

Desired behavior after PR is merged:

`google_account` oauth2callback can now call any service to handle saving its tokens without overwriting `calendar` ones.
By doing so it provides similar extensibility as GoogleService does for storing `client_id` and `client_secret`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
