### PR TITLE
[FIX] sale: fix status order in sales kanban view

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -69,6 +69,7 @@ class SaleOrder(models.Model):
         string="Status",
         readonly=True, copy=False, index=True,
         tracking=3,
+        group_expand=True,
         default='draft')
     locked = fields.Boolean(default=False, copy=False, help="Locked orders cannot be modified.")
 


### PR DESCRIPTION
Steps to produce:
---
- Install sales module.
- Open sales module > orders > switch to kanban view.
- Then make it group by status.

Observation:
---
- The order of status is not proper.
- It comes as Cancelled, Quatation, Sale order, Quatation sent.

Root cause:
---
- When we perform Group By > Status, the method `web_read_group()` is executed. then in chain `_web_read_group()` calls `read_group()` without providing any explicit `orderby`. Inside `read_group()`, if orderby is not provided, it sets the order to the grouped field itself.
- Inside `_read_group()`, the SQL query constructed with an order by clause on the grouped field (state). Therefore, the values are retrieved in alphabetical order  as `cancel, draft, sale, sent`.

Solution:
---
- Define `group_expand` on the `state` field. During `read_group()`, `_read_group_fill_results()` calls this method and reorders the groups accordingly.
- This overrides the alphabetical SQL order returned by `_read_group()` and ensures the correct logical status order in Kanban view.

opw-5497664

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
