### PR TITLE
[FIX] sale: remove duplicated Delivery Date in SO report preview

### DIFF
--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -602,10 +602,6 @@
                                 <th t-else="" class="ps-0 pb-0">Date:</th>
                                 <td class="w-100 pb-0 text-wrap"><span t-field="sale_order.date_order" t-options='{"widget": "date"}'/></td>
                             </tr>
-                            <tr t-if="sale_order.commitment_date and sale_order.state in ['sent', 'sale']">
-                                <th class="ps-0 pb-0">Delivery Date:</th>
-                                <td class="w-100 pb-0 text-wrap"><span t-field="sale_order.commitment_date" t-options='{"widget": "date"}'/></td>
-                            </tr>
                             <tr t-if="sale_order.validity_date and sale_order.state in ['draft', 'sent']">
                                 <th class="ps-0 pb-0">Expiration Date:</th>
                                 <td class="w-100 pb-0 text-wrap"><span t-field="sale_order.validity_date" t-options='{"widget": "date"}'/></td>
@@ -614,7 +610,7 @@
                                 <th class="ps-0 pb-0">Your Reference:</th>
                                 <td class="w-100 pb-0 text-wrap"><span t-field="sale_order.client_order_ref"/></td>
                             </tr>
-                            <tr t-if="sale_order.commitment_date">
+                            <tr t-if="sale_order.commitment_date and sale_order.state in ['sent', 'sale']">
                                 <th class="ps-0 pb-0">Delivery Date:</th>
                                 <td class="w-100 pb-0 text-wrap">
                                     <span


### PR DESCRIPTION
**Steps to reproduce:**
1. Install modules sale_management
2. Go to Settings, Configure Document Layout and set layout to DIN 5008
3. Create a new Sale Order
4. Set a customer, add a product, and fill in the Delivery Date (Other Info)
5. Click on Print and Preview

**Issue:**
The Delivery Date (commitment_date) is printed twice in the report.

**Solution:**
Remove duplicated Delivery Date entry from this module to avoid rendering it twice.

Issues : https://github.com/odoo/odoo/issues/247522

**opw-5490651**
