### PR TITLE
[FIX] sale: services & materials – cleanup and fixes

### DIFF
--- a/addons/sale/models/account_analytic_line.py
+++ b/addons/sale/models/account_analytic_line.py
@@ -47,14 +47,20 @@ class AccountAnalyticLine(models.Model):
     def create(self, vals_list):
         lines = super().create(vals_list)
         if self.env.context.get('from_services_and_material'):
+            lines_with_manual_amount = self.env['account.analytic.line']
             lines._sync_so_accounts_and_partners()
+            for line, vals in zip(lines, vals_list):
+                if vals.get('amount'):
+                    lines_with_manual_amount |= line
             lines._sync_so_lines()
+            lines_with_manual_amount._sync_so_lines_price_unit()
         return lines
 
     def write(self, vals):
         if self and self.env.context.get('from_services_and_material'):
             order_changed_aals = self.env['account.analytic.line']
             product_changed_aals = self.env['account.analytic.line']
+            amount_changed_aals = self.env['account.analytic.line']
 
             if vals.get('order_id'):
                 order_changed_aals = self.filtered(
@@ -66,15 +72,19 @@ class AccountAnalyticLine(models.Model):
                     lambda aal: aal.product_id.id != vals['product_id']
                 )
 
+            if vals.get('amount'):
+                amount_changed_aals = self.filtered(
+                    lambda aal: aal.amount != vals['amount']
+                )
+
             product_or_order_changed_aals = order_changed_aals | product_changed_aals
 
             res = super().write(vals)
 
-            # if order changed then we need to reassign accounts and partners
             order_changed_aals._sync_so_accounts_and_partners()
-
             product_or_order_changed_aals._unsync_so_lines()
             product_or_order_changed_aals._sync_so_lines()
+            amount_changed_aals._sync_so_lines_price_unit()
         else:
             res = super().write(vals)
         return res
@@ -148,34 +158,41 @@ class AccountAnalyticLine(models.Model):
         return self.order_id.order_line.filtered(
             lambda line: line.product_id == self.product_id
             and line.product_uom_id == self.product_uom_id
-            and line._is_reinvoicing_line()
+            and line._is_analytic_reinvoice_line()
         )[:1]
 
     def _create_so_line(self):
         """Create a new sale order line corresponding to this analytic line.
 
-        The created line is initialized with delivered quantity based on the
-        analytic line amount, unit price derived from the product's expense
-        policy, and an optional custom description.
+        The created line is initialized with quantity based on the
+        analytic line_amount, and an optional custom description.
 
         :rtype: sale.order.line
         :return: The newly created sale order line record.
         """
         self.ensure_one()
-        values = {
+
+        return self.env['sale.order.line'].create({
             'order_id': self.order_id.id,
             'product_id': self.product_id.id,
             'product_uom_id': self.product_uom_id.id,
             'product_uom_qty': 0,
-        }
+        })
 
-        if self.product_id.expense_policy == 'cost':
-            product = self.product_id.with_company(self.order_id.company_id)
-            values['price_unit'] = product.currency_id._convert(
-                product.standard_price, self.order_id.currency_id, round=False
+    def _sync_so_lines_price_unit(self):
+        """Update the sale order line unit price to match the analytic line amount.
+
+        This method is used when the analytic line amount is manually adjusted,
+        ensuring the corresponding sale order line remains consistent.
+        """
+        for line in self:
+            if not line.unit_amount or not line.so_line:
+                continue
+            product = line.product_id.with_company(line.order_id.company_id)
+            unit_price = -line.amount / line.unit_amount
+            line.so_line.price_unit = product.currency_id._convert(
+                unit_price, line.order_id.currency_id, round=False
             )
-
-        return self.env['sale.order.line'].create(values)
 
     def _unsync_so_lines(self):
         """Revert synchronization of delivered quantities on related sale order lines.
@@ -187,7 +204,7 @@ class AccountAnalyticLine(models.Model):
         of the `qty_delivered` field on the linked so lines .
         """
         for line in self.filtered(lambda line: line.so_line):
-            if not line.so_line._is_reinvoicing_line():
+            if not line.so_line._is_analytic_reinvoice_line():
                 continue
             if (
                 line.product_id.expense_policy == 'cost'

--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -55,10 +55,14 @@ class AccountMove(models.Model):
 
     @api.depends('line_ids.sale_line_ids')
     def _compute_service_line_count(self):
+        service_data = self.env['account.analytic.line']._read_group(
+            self._domain_services_analytic_line(),
+            ['reinvoice_move_id'],
+            ['__count'],
+        )
+        mapped_services_data = dict(service_data)
         for move in self:
-            move.service_line_count = self.env['account.analytic.line'].search_count(
-                move._domain_services_analytic_line(),
-            )
+            move.service_line_count = mapped_services_data.get(move, 0)
 
     @api.depends('partner_id.name', 'partner_id.sale_warn_msg', 'invoice_line_ids.product_id.sale_line_warn_msg', 'invoice_line_ids.product_id.display_name')
     def _compute_sale_warning_text(self):

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -970,7 +970,7 @@ class SaleOrderLine(models.Model):
         # compute for analytic lines
         delivered_qties = defaultdict(float)
         lines_by_analytic = self.filtered(
-            lambda sol: sol.qty_delivered_method == 'analytic' or sol._is_reinvoicing_line()
+            lambda sol: sol.qty_delivered_method == 'analytic' or sol._is_analytic_reinvoice_line()
         )
         domain = lines_by_analytic._get_delivered_quantity_by_analytic_domain()
         mapping = lines_by_analytic._get_delivered_quantity_by_analytic(domain)
@@ -1871,7 +1871,7 @@ class SaleOrderLine(models.Model):
         self.ensure_one()
         return self.product_uom_id.rounding
 
-    def _is_reinvoicing_line(self):
+    def _is_analytic_reinvoice_line(self):
         self.ensure_one()
         return (
             not self.is_expense

--- a/addons/sale/views/account_analytic_line_views.xml
+++ b/addons/sale/views/account_analytic_line_views.xml
@@ -29,7 +29,6 @@
         <field name="model">account.analytic.line</field>
         <field name="arch" type="xml">
             <list string="Services &amp; Material" editable="top" multi_edit="1">
-                <field name="date" string="Date"/>
                 <field
                     name="order_id"
                     string="Customer Order"
@@ -66,6 +65,7 @@
                 <field name="partner_id" optional="hide"/>
                 <field name="amount" optional="hide"/>
                 <field name="name" string="Description"/>
+                <field name="date" string="Date"/>
                 <field name="company_id" groups="base.group_multi_company" optional="hide"/>
             </list>
         </field>


### PR DESCRIPTION
This commit cleans up and fixes a few minor issues introduced by the **Services and Materials** feature added in [1]. It includes repositioning the Date column, switching to `_price_compute` for computing the `price_unit` on sale order lines to ensure proper currency conversion, and renaming confusing methods (such as `_is_reinvoicing_line` and `_is_line_reinvoicable`) to better reflect their uses.

1 - odoo/odoo@cd6325d

task-5490517

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
