### PR TITLE
[FIX] web: fix SessionExpiredException handling after http split

### DIFF
--- a/addons/web/static/src/core/errors/error_dialogs.js
+++ b/addons/web/static/src/core/errors/error_dialogs.js
@@ -229,6 +229,6 @@ registry
     .add("odoo.exceptions.UserError", WarningDialog)
     .add("odoo.exceptions.ValidationError", WarningDialog)
     .add("odoo.exceptions.RedirectWarning", RedirectWarningDialog)
-    .add("odoo.http.SessionExpiredException", SessionExpiredDialog)
+    .add("odoo.http.session.SessionExpiredException", SessionExpiredDialog)
     .add("werkzeug.exceptions.Forbidden", SessionExpiredDialog)
     .add("504", Error504Dialog);

--- a/addons/web/static/src/public/error_notifications.js
+++ b/addons/web/static/src/public/error_notifications.js
@@ -26,7 +26,7 @@ const sessionExpired = {
 
 registry
     .category("error_notifications")
-    .add("odoo.http.SessionExpiredException", sessionExpired)
+    .add("odoo.http.session.SessionExpiredException", sessionExpired)
     .add("werkzeug.exceptions.Forbidden", sessionExpired)
     .add("504", {
         title: _t("Request timeout"),


### PR DESCRIPTION
Steps to Reproduce:
1) Open Attendance app > Configuration > Settings
2) Open the Kiosk URL in another window
3) Go back to module in old window and try to interect with UI 4) A traceback appears instead of a proper session expired message

Issue:
- A traceback was shown when a session expired after switching kiosk configuration.
- After the recent odoo.http refactor, the exception path of SessionExpiredException changed from odoo.http.SessionExpiredException to odoo.http.session.SessionExpiredException.
- The web error registry still used the old path, causing full RPC tracebacks on session expiry instead of the expected session expired dialog/notification.
- Ref: PR #240683

Fix:
- Updated the web error registry to handle the new exception path odoo.http.session.SessionExpiredException, restoring the expected session expired behavior and preventing traceback.

task-5936753