### PR TITLE
[IMP] {test_}mail: improve activity handling and add reuse support

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -628,6 +628,7 @@ class MailActivity(models.Model):
                             'feedback': feedback,
                             'display_assignee': activity.user_id != self.env.user
                         },
+                        mail_activity_id=activity.id,
                         mail_activity_type_id=activity.activity_type_id.id,
                         subtype_xmlid='mail.mt_activities',
                     )

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -228,6 +228,7 @@ class MailMessage(models.Model):
     mail_activity_type_id = fields.Many2one(
         'mail.activity.type', 'Mail Activity Type',
         index='btree_not_null', ondelete='set null')
+    mail_activity_id = fields.Many2one('mail.activity', 'Mail Activity', index='btree_not_null')
     is_internal = fields.Boolean('Employee Only', help='Hide to public / portal users, independently from subtype configuration.')
     # origin
     email_from = fields.Char('From', help="Email address of the sender. This field is set when no matching partner is found and replaces the author_id field in the chatter.")
@@ -1183,6 +1184,7 @@ class MailMessage(models.Model):
         res.attr("subject")
         # sudo: mail.message.subtype - reading subtype on accessible message is allowed
         res.one("subtype_id", ["description"], sudo=True)
+        res.one("mail_activity_id", ["activity_type_id", "summary", "note"], predicate=lambda m: m.mail_activity_id)
         res.attr("write_date")
         self._store_linked_messages_fields(res)
         self._store_message_link_previews_fields(res)

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3132,6 +3132,7 @@ class MailThread(models.AbstractModel):
             'incoming_email_to',
             'is_internal',
             'mail_activity_type_id',
+            'mail_activity_id',
             'mail_server_id',
             'message_id',
             'message_type',

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -499,7 +499,7 @@ class ResUsers(models.Model):
             model = self.env["ir.model"]._get(model_name).with_prefetch(model_ids)
             user_activities[model_name] = {
                 "id": model.id,
-                "name": model.name if model_name != "mail.activity" else _("Other activities"),
+                "name": model.name if model_name != "mail.activity" else _("Other Activities"),
                 "model": model_name,
                 "type": "activity",
                 "icon": icon,

--- a/addons/mail/static/src/core/web/activity_list_popover.js
+++ b/addons/mail/static/src/core/web/activity_list_popover.js
@@ -51,6 +51,8 @@ export class ActivityListPopover extends Component {
                 this.props.resModel,
                 this.props.resIds ? this.props.resIds : [this.props.resId],
                 this.props.defaultActivityTypeId
+                    ? { default_activity_type_id: this.props.defaultActivityTypeId }
+                    : {}
             )
             .then(() => this.props.onActivityChanged());
         this.props.close();

--- a/addons/mail/static/src/core/web/activity_menu.js
+++ b/addons/mail/static/src/core/web/activity_menu.js
@@ -23,6 +23,7 @@ export class ActivityMenu extends Component {
         this.userId = user.userId;
         this.ui = useService("ui");
         this.dropdown = useDropdownState();
+        this.effect = useService("effect");
         useCommand(_t("Activity"), () => this.store.scheduleActivity(false, false), {
             category: "activity",
             hotkey: "alt+shift+a",
@@ -37,6 +38,15 @@ export class ActivityMenu extends Component {
 
     onBeforeOpen() {
         this.store.fetchStoreData("systray_get_activities");
+    }
+
+    onOpened() {
+        if (!this.store.activityGroups.length) {
+            this.effect.add({
+                message: "Congratulations, you're done with your activities.",
+                type: "rainbow_man",
+            });
+        }
     }
 
     availableViews(group) {

--- a/addons/mail/static/src/core/web/activity_menu.xml
+++ b/addons/mail/static/src/core/web/activity_menu.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.ActivityMenu">
-    <Dropdown position="'bottom-end'" state="this.dropdown" beforeOpen.bind="this.onBeforeOpen" menuClass="this.discussSystray.menuClass" bottomSheet="false">
+    <Dropdown position="'bottom-end'" state="this.dropdown" beforeOpen.bind="this.onBeforeOpen" menuClass="this.discussSystray.menuClass" bottomSheet="false" onOpened.bind="this.onOpened">
         <button>
             <i class="fa fa-lg fa-clock-o" role="img" aria-label="Activities"></i>
             <span t-if="this.store.activityCounter" class="o-mail-ActivityMenu-counter badge rounded-pill"><t t-out="this.store.activityCounter"/></span>
@@ -35,7 +35,7 @@
                         </div>
                     </t>
                     <span class="list-group-item list-group-item-action border-0 text-primary text-center cursor-pointer" t-custom-click="(ev, isMiddleClick) => this.openMyActivities(isMiddleClick)">
-                        View all activities
+                        View all Activities
                     </span>
                 </div>
             </div>

--- a/addons/mail/static/src/core/web/activity_model_patch.js
+++ b/addons/mail/static/src/core/web/activity_model_patch.js
@@ -75,7 +75,15 @@ patch(Activity.prototype, {
         return action;
     },
     remove({ broadcast = true } = {}) {
-        this.delete();
+        // Only delete the activity if no message is linked to it.
+        // We keep it when marked as done because reuse action needs mail_activity_id.
+        if (
+            !Object.values(this.store["mail.message"].records).some(
+                (m) => m.mail_activity_id?.id === this.id
+            )
+        ) {
+            this.delete();
+        }
         if (broadcast) {
             this.activityBroadcastChannel?.postMessage({
                 type: "DELETE",

--- a/addons/mail/static/src/core/web/message_actions_patch.js
+++ b/addons/mail/static/src/core/web/message_actions_patch.js
@@ -106,3 +106,10 @@ registerMessageAction("forward", {
     },
     sequence: 72,
 });
+registerMessageAction("reuse-activity", {
+    condition: ({ message }) => message.isActivity,
+    icon: "fa fa-recycle",
+    name: _t("Reuse"),
+    onSelected: ({ message }) => message.reuseActivity(),
+    sequence: 125,
+});

--- a/addons/mail/static/src/core/web/message_model_patch.js
+++ b/addons/mail/static/src/core/web/message_model_patch.js
@@ -1,9 +1,15 @@
 import { Message } from "@mail/core/common/message_model";
+import { fields } from "@mail/model/export";
 
 import { patch } from "@web/core/utils/patch";
 
 /** @type {import("models").Message} */
 const messagePatch = {
+    setup() {
+        super.setup();
+        this.mail_activity_id = fields.One("mail.activity");
+    },
+
     /** @param {import("models").Thread} thread the thread where the message is shown */
     canReplyAll(thread) {
         return this.canForward(thread) && !this.isNote;
@@ -17,6 +23,20 @@ const messagePatch = {
             !["discuss.channel", "mail.box"].includes(thread.model) &&
             ["comment", "email"].includes(this.message_type)
         );
+    },
+
+    get isActivity() {
+        return !!this.mail_activity_id;
+    },
+
+    async reuseActivity() {
+        const context = {
+            default_activity_type_id: this.mail_activity_id.activity_type_id.id,
+            default_summary: this.mail_activity_id.summary,
+            default_note: this.mail_activity_id.note,
+        };
+        await this.store.scheduleActivity(this.thread.model, [this.thread.id], context);
+        this.thread.fetchThreadData(["activities", "messages"]);
     },
 };
 patch(Message.prototype, messagePatch);

--- a/addons/mail/static/src/core/web/store_service_patch.js
+++ b/addons/mail/static/src/core/web/store_service_patch.js
@@ -89,16 +89,14 @@ const StorePatch = {
     /**
      * @param {string} resModel
      * @param {number[]} resIds
-     * @param {number|undefined} defaultActivityTypeId
+     * @param {Object} [defaultContextValues] default values to pass in the activity form view.
      */
-    async scheduleActivity(resModel, resIds, defaultActivityTypeId = undefined) {
+    async scheduleActivity(resModel, resIds, defaultContextValues = {}) {
         const context = {
             active_model: resModel,
             active_ids: resIds,
             active_id: resIds[0],
-            ...(defaultActivityTypeId !== undefined
-                ? { default_activity_type_id: defaultActivityTypeId }
-                : {}),
+            ...defaultContextValues,
         };
         await new Promise((resolve) =>
             this.env.services.action.doAction(

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -277,7 +277,7 @@
                 <field name="date_deadline" widget="remaining_days"/>
                 <field name="date_done" string="Done Date" optional="hide"/>
                 <field name="feedback" optional="hide"/>
-                <widget name="mail_activity_list_reschedule_dropdown"/>
+                <widget name="mail_activity_list_reschedule_dropdown" invisible="not active"/>
                 <button name="action_done" type="object" string="Done" icon="fa-check" invisible="active == False"/>
             </list>
         </field>

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -261,6 +261,7 @@ class TestActivityFlow(TestActivityCommon):
 
     def test_activity_flow_employee(self):
         with self.with_user('employee'):
+            activity_type_id = self.env.ref('mail.mail_activity_data_email')
             test_record = self.env['mail.test.activity'].browse(self.test_record.id)
             self.assertEqual(test_record.activity_ids, self.env['mail.activity'])
 
@@ -268,7 +269,7 @@ class TestActivityFlow(TestActivityCommon):
             activity = self.env['mail.activity'].create({
                 'summary': 'Test Activity',
                 'date_deadline': date.today() + relativedelta(days=1),
-                'activity_type_id': self.env.ref('mail.mail_activity_data_email').id,
+                'activity_type_id': activity_type_id.id,
                 'res_model_id': self.env['ir.model']._get(test_record._name).id,
                 'res_id': test_record.id,
             })
@@ -285,7 +286,10 @@ class TestActivityFlow(TestActivityCommon):
             activity.action_feedback(feedback='So much feedback')
             self.assertEqual(activity.feedback, 'So much feedback')
             self.assertEqual(test_record.activity_ids, self.env['mail.activity'])
-            self.assertEqual(test_record.message_ids[0].subtype_id, self.env.ref('mail.mt_activities'))
+            last_message = test_record.message_ids[0]
+            self.assertEqual(last_message.subtype_id, self.env.ref('mail.mt_activities'))
+            self.assertEqual(last_message.mail_activity_type_id, activity_type_id)
+            self.assertEqual(last_message.mail_activity_id, activity)
 
     @mute_logger('odoo.addons.mail.models.mail_mail')
     def test_activity_notify_other_user(self):


### PR DESCRIPTION
This PR makes the following improvements for the activities.

- Remove the reschedule button from the done activities.
- Add a rainbow_man effect for empty systray opening.
- Add support to reuse the done activity from the posted message record.
- Add the mail_activity_id field on the message, as earlier the activity
  and message were never connected so this feature will not work for the older
  messages.

Task-5344015