### PR TITLE
[FIX] account: prevent error on setting accounting period for tax returns

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -776,6 +776,8 @@ class AccountChartTemplate(models.AbstractModel):
         if bank_fees:
             bank_fees.line_ids.sudo().write({'account_id': self._get_bank_fees_reco_account(company).id})
 
+        company._initiate_account_onboardings()
+
     def _get_bank_fees_reco_account(self, company):
         # We want a bank fees account if possible and the first expense account as a fallback.
         AccountAccount = self.env['account.account'].with_company(company)


### PR DESCRIPTION
Currently, an error occurs when a user tries to set the accounting period.

**Step to Reproduce:**
1. Install Invoicing without demo data and log-in as a super user. 
   (from v19.0, no need to log-in as super user)
2. Invoicing > Accounting > Tax Returns.
3. Set an Opening Date in the wizard and try to apply the accounting period.

**Error:**
`ValueError - Expected singleton: onboarding.progress()`

**Cause:**
PR 1, added `_initiate_account_onboardings()` in the accountant (**accounting**) module. However, the onboarding progress should be initialized in the account (**invoicing**) module.

**Fix:**
This commit ensures that `_initiate_account_onboardings()` is called from the `account` module instead of the `accountant` module.

[1] - odoo/enterprise#101442
Enterprise PR: https://github.com/odoo/enterprise/pull/107476

sentry-7064593163