### PR TITLE
[IMP] mail: fix attachment image scaling

### DIFF
--- a/addons/mail/static/src/core/common/attachment_list.scss
+++ b/addons/mail/static/src/core/common/attachment_list.scss
@@ -1,11 +1,13 @@
+$o-mail-attachment-height: 10em;
+
 .o-mail-AttachmentContainer {
     &.o-inMessage.o-isImage:not(.o-inChatter) {
         min-width: 13em;
-        min-height: 10em;
+        min-height: $o-mail-attachment-height;
     }
     &:not(.o-inMessage.o-isImage), &.o-inChatter.o-inMessage.o-isImage {
         width: 13em;
-        height: 10em;
+        height: $o-mail-attachment-height;
     }
     background-color: $gray-200;
 
@@ -38,8 +40,12 @@
     line-height: 1.25;
 }
 
-.o-mail-AttachmentImage.o-inMessage {
+.o-mail-AttachmentImage.o-inMessage:not(.o-inComposer) {
     max-height: 300px;
+}
+
+.o-mail-AttachmentImage.o-inComposer {
+    max-height: $o-mail-attachment-height;
 }
 
 .o-viewable {

--- a/addons/mail/static/src/core/common/attachment_list.xml
+++ b/addons/mail/static/src/core/common/attachment_list.xml
@@ -44,6 +44,7 @@
                         t-elif="attachment.isImage"
                         class="o-mail-AttachmentImage img img-fluid w-100 rounded-3"
                         t-att-class="{
+                            'o-inComposer': env.inComposer,
                             'o-inMessage': env.inMessage,
                             'o-inChatter': env.inChatter,
                             'object-fit-contain': !env.inChatter and env.inMessage,


### PR DESCRIPTION
When editing a message, newly attached images were displayed larger than the attachment cards.

This commit forces attachment images to use the same height as the attachment cards.

Task-5867464 (part of point 53)

Before
<img width="1007" height="515" alt="image" src="https://github.com/user-attachments/assets/fbd07db9-2f6d-4de8-8d1c-951e04d10d67" />
After
<img width="807" height="358" alt="image" src="https://github.com/user-attachments/assets/f0d9c87f-e6b7-45d1-b477-2f0b45fe8b88" />