### PR TITLE
[FIX] mail: prevent editing mailbox thread name when channel is undefined

### DIFF
--- a/addons/mail/static/src/core/public_web/discuss_content.xml
+++ b/addons/mail/static/src/core/public_web/discuss_content.xml
@@ -27,7 +27,7 @@
                         </div>
                         <AutoresizeInput
                             className="'o-mail-DiscussContent-threadName fw-bold flex-shrink-1 py-0 ' + (showsChatLocalDateTime ? 'fs-5' : 'fs-4')"
-                            enabled="thread.channel?.isAllowedToRename"
+                            enabled="!!thread.channel?.isAllowedToRename"
                             onValidate.bind="renameThread"
                             value="thread.displayName || ''"
                         />

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -760,6 +760,7 @@ test("basic top bar rendering", async () => {
     await openDiscuss("mail.box_inbox");
     await contains("button:disabled:text('Mark all read')");
     await contains(".o-mail-DiscussContent-threadName", { value: "Inbox" });
+    await contains(".o-mail-DiscussContent-threadName:disabled");
     await click("button:text('Starred messages')");
     await contains("button:disabled:text('Unstar all')");
     await contains(".o-mail-DiscussContent-threadName", { value: "Starred messages" });


### PR DESCRIPTION
Steps to reproduce:

- Open Discuss.
- Go to Starred, Inbox, or History.
- Try to update the thread name.

The thread name input is editable even when no channel exists, causing a traceback when rename is called on an undefined channel.

This happens because `enabled` defaults to `true` and `thread.channel?.isAllowedToRename` return `undefined`. This commit ensures `enabled` is a boolean.

Task-5940328
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
