### PR TITLE
18.0 fix  render qweb pdf prepare streams

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -955,6 +955,7 @@ class IrActionsReport(models.Model):
                     for res_id in res_ids_wo_stream:
                         individual_collected_stream = self._render_qweb_pdf_prepare_streams(report_ref=report_ref, data=data, res_ids=[res_id])
                         collected_streams[res_id]['stream'] = individual_collected_stream[res_id]['stream']
+                    return collected_streams
             collected_streams[False] = {'stream': pdf_content_stream, 'attachment': None}
 
         return collected_streams


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Avoid double print of report having no h1 tag

Current behavior before PR:
a report having no h1 tag in the template get printed twice

Desired behavior after PR is merged:
a report having no h1 tag should only get printed once




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
