### PR TITLE
[FIX] html_builder: make inner drop zones thinner than block ones

### DIFF
--- a/addons/html_builder/static/src/core/builder_overlay/builder_overlay.scss
+++ b/addons/html_builder/static/src/core/builder_overlay/builder_overlay.scss
@@ -42,7 +42,7 @@ div[data-oe-local-overlay-id="builder-overlay-container"] {
             animation: o_hover_overlay_fade_in 0.1s ease-in-out forwards;
             .o_side {
                 &::before {
-                    background: rgb(126, 114, 114) !important;
+                    background: $o-we-hover-overlay-color !important;
                 }
                 background-color: transparent !important;
                 border-bottom: none !important;
@@ -69,6 +69,14 @@ div[data-oe-local-overlay-id="builder-overlay-container"] {
                 }
                 &.o_side_x {
                     width: $o-we-handle-edge-size;
+
+                    &::before {
+                        // It’s needed for "pixel-perfect" overlay corners.
+                        // Otherwise, the colors can overlap and not look good
+                        // depending on the background color behind the overlay.
+                        border-top: $o-we-handle-border-width/2 solid $o-we-handles-accent-color;
+                        border-bottom: $o-we-handle-border-width/2 solid $o-we-handles-accent-color;
+                    }
                 }
                 &.w {
                     inset: $o-we-handles-offset-to-hide auto $o-we-handles-offset-to-hide * -1 $o-we-handle-border-width * 0.5;
@@ -77,6 +85,10 @@ div[data-oe-local-overlay-id="builder-overlay-container"] {
 
                     body.o_rtl & {
                         transform: translateX(50%);
+                    }
+
+                    &::before {
+                        border-right: $o-we-handle-contrast-border;
                     }
                 }
                 &.e {
@@ -87,6 +99,10 @@ div[data-oe-local-overlay-id="builder-overlay-container"] {
                     body.o_rtl & {
                         transform: translateX(-50%);
                     }
+
+                    &::before {
+                        border-left: $o-we-handle-contrast-border;
+                    }
                 }
                 &.n {
                     inset: $o-we-handles-offset-to-hide 0 auto 0;
@@ -95,9 +111,13 @@ div[data-oe-local-overlay-id="builder-overlay-container"] {
                     &.o_grid_handle {
                         transform: translateY(-50%);
 
-                        &:before {
+                        &::before {
                             transform: translateY($o-we-handle-border-width * 0.5);
                         }
+                    }
+
+                    &::before {
+                        border-bottom: $o-we-handle-contrast-border;
                     }
                 }
                 &.s {
@@ -110,6 +130,10 @@ div[data-oe-local-overlay-id="builder-overlay-container"] {
                         &:before {
                             transform: translateY($o-we-handle-border-width * -0.5);
                         }
+                    }
+
+                    &::before {
+                        border-top: $o-we-handle-contrast-border;
                     }
                 }
                 &.ne {
@@ -172,15 +196,14 @@ div[data-oe-local-overlay-id="builder-overlay-container"] {
                 }
 
                 &.o_column_handle.o_side_y {
-                    background-color: rgba($o-we-handles-accent-color, .1);
-
                     &::after {
                         content: '';
                         position: absolute;
                         height: $o-we-handles-btn-size;
                     }
                     &.n {
-                        border-bottom: dashed $o-we-handle-border-width * 0.5 rgba($o-we-handles-accent-color, 0.5);
+                        background-color: rgba($o-we-handles-accent-color, 0.1);
+                        border-bottom: dashed $o-we-handle-border-width * 0.5 rgba($o-we-contrast-border-color, 0.7);
 
                         &::after {
                             inset: 0 0 auto 0;
@@ -188,7 +211,8 @@ div[data-oe-local-overlay-id="builder-overlay-container"] {
                         }
                     }
                     &.s {
-                        border-top: dashed $o-we-handle-border-width * 0.5 rgba($o-we-handles-accent-color, 0.5);
+                        background-color: rgba($o-we-handles-accent-color, 0.1);
+                        border-top: dashed $o-we-handle-border-width * 0.5 rgba($o-we-contrast-border-color, 0.7);
 
                         &::after {
                             inset: auto 0 0 0;
@@ -222,7 +246,6 @@ div[data-oe-local-overlay-id="builder-overlay-container"] {
                         &.n::before {
                             margin: 0 auto auto;
                         }
-
                         &.s::before {
                             margin: auto auto 0;
                         }

--- a/addons/html_builder/static/src/core/drop_zone_plugin.edit.scss
+++ b/addons/html_builder/static/src/core/drop_zone_plugin.edit.scss
@@ -1,19 +1,19 @@
 .oe_drop_zone {
     background: $o-we-dropzone-bg-color;
-    animation: dropZoneInsert 1s linear 0s infinite alternate;
+    // TODO: avoid duplication
+    outline: $o-we-dropzone-border;
+    outline-offset: -$o-we-dropzone-border-width;
+    border: 1px solid $o-we-dropzone-accent-color;
+    border-radius: $o-we-dropzone-border-radius;
 
     &.oe_insert {
         position: relative;
         width: 100%;
-        border-radius: $border-radius-lg;
-        outline: $o-we-dropzone-border-width dashed $o-we-dropzone-accent-color;
-        outline-offset: -$o-we-dropzone-border-width;
-        z-index: 2000; // TODO use $o-we-overlay-zindex instead
+        z-index: $o-we-dropzone-z-index;
     }
 
     &.o_dropzone_highlighted {
-        filter: brightness(1.5);
-        transition: 200ms;
+        filter: brightness(1.2);
     }
 }
 
@@ -33,24 +33,71 @@
     }
 
     &.oe_sanitized_drop_zone {
+        @extend %o-editor-messages;
         position: absolute;
-        top: 0px;
-        height: 100%;
-        padding: 15px;
+        display: flex;
         margin: 0px;
-        backdrop-filter: blur(15px);
-        background-color: rgba($o-we-bg-lighter, 0.15);
-        color: white;
-        outline-color: $o-we-bg-lighter;
-        z-index: 1999; // TODO
+        border: 1px solid rgba($o-we-dropzone-sanitized-color, 0.6) !important;
+        border-radius: $o-we-dropzone-border-radius;
+        outline: $o-we-dropzone-border-width dashed mix(white, $o-we-dropzone-sanitized-color, 50%) !important;
+        height: auto;
+        min-height: 100% !important;
+        padding: 0;
+        background: repeating-linear-gradient(
+            135deg,
+            $o-we-dropzone-sanitized-color,
+            $o-we-dropzone-sanitized-color 5px,
+            rgba($o-we-dropzone-sanitized-color, 0.6) 5px,
+            rgba($o-we-dropzone-sanitized-color, 0.6) 10px
+        ) !important;
+        backdrop-filter: blur(7px);
 
-        > p {
-            position: absolute;
-            top: 50%;
-            transform: translateY(-50%);
-            width: calc(100% - 30px);
-            text-shadow: 0px 0px 4px black;
-            font-size: 20px;
+        &::before {
+            padding: 10px;
+            width: 100%;
+            align-content: center;
+            font-size: 16px !important;
+            text-shadow: 0 0 5px $o-we-dropzone-sanitized-color !important;
+        }
+    }
+}
+
+:has(> .oe_sanitized_drop_zone) {
+    position: relative;
+    overflow: visible !important;
+}
+
+:not(.oe_structure):not([data-oe-type="html"]) {
+    // "Inner content" drop zones.
+    > .oe_drop_zone.oe_insert:not(.oe_grid_zone):not(.oe_sanitized_drop_zone) {
+        height: $o-we-inner-content-dropzone-size;
+        min-height: $o-we-inner-content-dropzone-size;
+        margin: (-$o-we-inner-content-dropzone-size/2) 0;
+        outline: unset;
+        border: unset;
+
+        &:not(.oe_vertical) {
+            border-bottom: $o-we-inner-content-dropzone-border;
+        }
+
+        &.oe_vertical {
+            width: $o-we-inner-content-dropzone-size;
+            min-width: $o-we-inner-content-dropzone-size;
+            margin: 0 (-$o-we-inner-content-dropzone-size/2);
+            border-right: $o-we-inner-content-dropzone-border;
+        }
+    }
+
+    // zero-width text nodes around inline buttons can create extra line boxes.
+    // Without this "line-height: 0", the editable area will become too tall if
+    // it contains buttons when the dropzones appear.
+    &:has(> .btn) {
+        &:has(
+            > .oe_drop_zone.oe_insert:not(.oe_grid_zone):not(.oe_sanitized_drop_zone)
+        ) {
+            &:not(:has(> :not(.oe_drop_zone, .btn))) {
+                line-height: 0;
+            }
         }
     }
 }

--- a/addons/html_builder/static/src/core/drop_zone_plugin.js
+++ b/addons/html_builder/static/src/core/drop_zone_plugin.js
@@ -365,9 +365,9 @@ export class DropZonePlugin extends Plugin {
             "text-center",
             "text-uppercase"
         );
-        const messageEl = this.document.createElement("p");
-        messageEl.textContent = _t("For technical reasons, this block cannot be dropped here");
-        dropzoneEl.prepend(messageEl);
+        dropzoneEl.dataset.editorMessage = _t(
+            "For technical reasons, this block cannot be dropped here"
+        );
         return dropzoneEl;
     }
 
@@ -517,7 +517,6 @@ export class DropZonePlugin extends Plugin {
 
         // Inserting a sanitized dropzone for each sanitized area.
         for (const sanitizedZoneEl of selectorSanitized) {
-            sanitizedZoneEl.style.position = "relative";
             sanitizedZoneEl.prepend(this.createSanitizedDropzone());
         }
         this.sanitizedZoneEls = selectorSanitized;

--- a/addons/html_builder/static/src/core/editor.edit.scss
+++ b/addons/html_builder/static/src/core/editor.edit.scss
@@ -7,14 +7,20 @@ $-editor-messages-margin-x: 2%;
 %o-editor-messages {
     background: $o-we-dropzone-bg-color;
     text-align: center;
-    color: #fff;
-    outline: $o-we-dropzone-border-width dashed $o-we-dropzone-accent-color;
+    color: $o-we-dropzone-text-color;
+    min-height: $o-we-dropzone-size;
+    outline: $o-we-dropzone-border;
     outline-offset: -$o-we-dropzone-border-width;
+    border: 1px solid $o-we-dropzone-accent-color;
+    border-radius: $o-we-dropzone-border-radius;
 
     &:before {
         content: attr(data-editor-message);
         display: block;
-        font-size: 20px;
+        font-size: 18px;
+         // Required to prevent the theme font family from being applied.
+        font-family: $o-we-font-family;
+        text-shadow: 0 0 5px $o-we-dropzone-accent-color;
     }
 
     // Show the default editor message only for "empty" elements
@@ -74,22 +80,23 @@ $-editor-messages-margin-x: 2%;
             @extend %o-editor-messages;
             padding: 112px 0px;
             margin: 20px $-editor-messages-margin-x;
-            border-radius: $border-radius-lg;
+            font-size: 18px;
         }
 
         // Exception 2: empty wrap during drag & drop (override of base case)
         &#wrap > .oe_drop_zone.oe_insert:not(.oe_vertical):not(.oe_sanitized_drop_zone):only-child {
             padding: 112px 0px;
-            text-shadow: none;
+            font-size: 18px;
         }
-
         > p:empty:only-child {
-            color: #aaa;
+            color: #aaa; // TODO: is it useful ?
         }
     }
 
     &[data-oe-type=html].oe_empty:empty {
         @extend %o-editor-messages;
+        padding: 12px 0;
+        margin: 20px $-editor-messages-margin-x;
     }
 }
 

--- a/addons/html_builder/static/src/core/overlay_buttons/overlay_buttons_plugin.js
+++ b/addons/html_builder/static/src/core/overlay_buttons/overlay_buttons_plugin.js
@@ -50,13 +50,13 @@ export class OverlayButtonsPlugin extends Plugin {
                         const iframeRect = this.iframe.getBoundingClientRect();
                         if (this.target && position.top < iframeRect.top) {
                             const targetRect = this.target.getBoundingClientRect();
-                            const newTop = iframeRect.top + targetRect.bottom + 15;
+                            const newTop = iframeRect.top + targetRect.bottom + 1;
                             position.top = newTop;
                             overlayEl.style.top = `${newTop}px`;
                         }
                         return;
                     },
-                    margin: 15,
+                    margin: 1,
                     flip: false,
                 },
                 closeOnPointerdown: false,

--- a/addons/html_builder/static/src/scss/builder.variables.scss
+++ b/addons/html_builder/static/src/scss/builder.variables.scss
@@ -36,6 +36,8 @@ $o-social-colors: (
     "threads": #000000,
 );
 
+$o-we-contrast-border-color: mix(white, $o-we-color-accent, 50%) !default;
+
 // Needed to be changed to be high enough to not overflow when a user
 // has a page with a lot of content (10000px was proven to be too small)
 $o-we-handles-offset-to-hide: 100000px !default;
@@ -45,12 +47,22 @@ $o-we-handles-accent-color-preview: $o-enterprise-color !default;
 $o-we-handle-edge-size: $o-we-handles-btn-size !default;
 $o-we-handle-border-width: 2px !default;
 $o-we-handle-inside-line-width: 3px !default;
+$o-we-handle-contrast-border: 1px solid $o-we-contrast-border-color !default;
+
+$o-we-hover-overlay-color: $o-we-contrast-border-color !default;
 
 $o-we-dropzone-size: 30px !default; // $grid-gutter-width (todo: allow to use the variable)
-$o-we-dropzone-border-width: 2px !default;
-$o-we-dropzone-border: $o-we-dropzone-border-width dashed $o-brand-odoo !default;
+$o-we-dropzone-border-width: 1px !default;
+$o-we-dropzone-border: $o-we-dropzone-border-width dashed $o-we-contrast-border-color !default;
+$o-we-dropzone-border-radius: 3px !default;
 $o-we-dropzone-accent-color: $o-we-color-accent !default;
 $o-we-dropzone-bg-color: rgba($o-we-dropzone-accent-color, .5) !default;
+$o-we-dropzone-z-index: 1029 !default;
+$o-we-dropzone-text-color: white !default;
+$o-we-dropzone-sanitized-color: rgba(#646464, .5) !default;
+
+$o-we-inner-content-dropzone-size: 4px !default;
+$o-we-inner-content-dropzone-border: $o-we-inner-content-dropzone-size/2 solid rgba($o-we-contrast-border-color, .5) !default;
 
 $o-we-toolbar-height: 40px !default;
 $o-we-toolbar-color-accent: #018597 !default;

--- a/addons/website/static/src/scss/website.edit.scss
+++ b/addons/website/static/src/scss/website.edit.scss
@@ -1,0 +1,23 @@
+// --------------------------------------------------------------------------
+// This file contains the website-specific logic for the editing elements
+// shown on the frontend in edit mode, such as the dropzones, overlay, etc.
+// --------------------------------------------------------------------------
+
+// When the page hasn’t been scrolled, we want the first dropzone inside the
+// #wrap to be positioned on top of the header, so it’s more visible. In all
+// other cases, once the page has been scrolled, the dropzones should be placed
+// below the header.
+header#top:not(.o_header_is_scrolled) + main #wrap > .oe_drop_zone:first-child {
+    z-index: $o-we-dropzone-z-index + 1;
+}
+
+// The first and last dropzones in the “parallax” snippet are in the same place
+// as the dropzones just before and after it, so we move them.
+.parallax > .oe_structure > .oe_drop_zone {
+    &:first-child {
+        top: $o-we-dropzone-size/2;
+    }
+    &:last-child {
+        bottom: $o-we-dropzone-size/2;
+    }
+}


### PR DESCRIPTION
Before this PR, block and inner drop zones had the same thickness.

After this PR, inner snippet drop zones are thinner than block drop
zones.

task-5921283