### PR TITLE
[FIX] account: Allow access for Invoicing & Banks group to basic reports

### DIFF
--- a/addons/account/views/account_menuitem.xml
+++ b/addons/account/views/account_menuitem.xml
@@ -41,7 +41,7 @@
                 <menuitem id="menu_action_account_invoice_report_all" name="Invoice Analysis" action="action_account_invoice_report_all" sequence="1"/>
                 <menuitem id="menu_action_analytic_reporting" name="Analytic Report" action="action_analytic_reporting" groups="account.group_account_readonly"/>
             </menuitem>
-            <menuitem id="account_reports_legal_statements_menu" name="Statement Reports" sequence="1" groups="account.group_account_readonly"/>
+            <menuitem id="account_reports_legal_statements_menu" name="Statement Reports" sequence="1" groups="account.group_account_readonly,account.group_account_basic"/>
         </menuitem>
         <menuitem id="menu_finance_configuration" name="Configuration" sequence="35" groups="account.group_account_manager">
             <menuitem id="menu_account_config" name="Settings" action="action_account_config" groups="base.group_system" sequence="0"/>


### PR DESCRIPTION
In enterprise, we are allowing the Invoicing & Banks group to have access to basic reports including 'Stetment Reports'

task-5925567

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
