### PR TITLE
[FIX] website: prevent adding invalid domains to the website

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -405,8 +405,11 @@ class Website(models.Model):
     @api.constrains('domain')
     def _check_domain(self):
         for record in self:
+            if not record.domain:
+                continue
             try:
                 urlparse(record.domain)
+                record._idna_url(record.domain)
             except ValueError:
                 raise ValidationError(_("The provided website domain is not a valid URL."))
 

--- a/addons/website/tests/test_base_url.py
+++ b/addons/website/tests/test_base_url.py
@@ -157,3 +157,6 @@ class TestGetBaseUrl(odoo.tests.TransactionCase):
 
         with self.assertRaises(ValidationError):
             website.write({'domain': 'https://my-website.net['})
+
+        with self.assertRaises(ValidationError):
+            website.write({'domain': 'https://.net'})


### PR DESCRIPTION
Currently an error is generated when the user tries to open the website after
adding the invalid domain like `https://.com`

Steps to produce an error:
- Go to website settings and set the domain as `https://.com`
- Open the website page >>> Error occurs

Error: `UnicodeError: label empty or too long`

This error occurs during IDNA encoding/decoding because the domain contains an
empty second-level label, as seen in the above-mentioned domain.

The error is triggered in the `_idna_url` method during IDNA encoding when the extracted
base domain includes an empty second-level domain in the above-mentioned URL.

This commit fixes the above issue by handling the existing `ValueError`
(`since UnicodeError is a subclass of ValueError`) in the constraint, where a
`ValidationError is raised when an error occurs during execution of the `_idna_url` method.

sentry-7265749008
