### PR TITLE
[FIX] account, l10n_sa: fix RTL direction in portal preview and subtotal layout

### DIFF
--- a/addons/account/controllers/portal.py
+++ b/addons/account/controllers/portal.py
@@ -172,6 +172,10 @@ class PortalAccount(CustomerPortal):
         elif report_type in ('html', 'pdf', 'text'):
             has_generated_invoice = bool(invoice_sudo.invoice_pdf_report_id)
             request.update_context(proforma_invoice=not has_generated_invoice)
+            # If the partner's language is RTL, set the context language to match, ensuring the report shows the correct text direction.
+            partner_lang = invoice_sudo.partner_id.lang
+            if partner_lang and request.env['res.lang']._get_data(code=partner_lang).direction == 'rtl':
+                request.update_context(lang=partner_lang)
             # Use the template set on the related partner if there is.
             # This is not perfect as the invoice can still have been computed with another template, but it's a slight fix/imp for stable.
             pdf_report_name = invoice_sudo.partner_id.invoice_template_pdf_report_id.report_name or 'account.account_invoices'

--- a/addons/l10n_sa/views/report_invoice.xml
+++ b/addons/l10n_sa/views/report_invoice.xml
@@ -186,7 +186,7 @@
         <!-- End Credit/Debit notes reasons -->
         <!-- Call custom tax totals templates -->
          <div id="right-elements" position="attributes">
-            <attribute name="t-attf-class">#{'col-6 mt-5' if report_type == 'pdf' else 'col-12 col-md-5'} ms-5 d-inline-block float-end</attribute>
+            <attribute name="t-attf-class">#{'col-7 mt-5' if report_type == 'pdf' else 'col-12 col-md-7'} ms-5 d-inline-block float-end</attribute>
          </div>
         <t t-call="l10n_gcc_invoice.l10n_gcc_document_tax_totals" position="attributes">
             <attribute name="t-call">l10n_sa.l10n_sa_document_tax_totals</attribute>


### PR DESCRIPTION
When opening invoice HTML preview in the portal, the layout was displayed in LTR
even if the invoice partner language was RTL (e.g. Arabic). This happened when
the portal user language was LTR. PDF structure was correct, but HTML preview had
wrong text flow and alignment.

Root cause was that RTL asset processing depends on `env.lang`, not on `t-lang`
in templates. Since the ORM context language remained the portal user’s language,
CSS was compiled in LTR and hardcoded `direction: ltr;` rules from `report.scss`
were overriding the `<html dir="rtl">`.

To fix this, the portal controller now checks the partner language and, if it is
RTL, updates the request context before rendering. This ensures `_render_qweb_html`
runs with the correct `env.lang`, triggering proper RTL CSS conversion via rtlcss.

Additionally, the subtotal section in the Saudi invoice report could have its
values visually cut due to insufficient width allocated to the tax totals
column. The column width has been slightly increased to ensure totals are
properly displayed.

task-5878719