### PR TITLE
[IMP] html_editor: apply format/color to block if completely selected

### DIFF
--- a/addons/html_builder/static/tests/editor.test.js
+++ b/addons/html_builder/static/tests/editor.test.js
@@ -257,7 +257,7 @@ describe("toolbar dropdowns", () => {
         click(".o-we-toolbar .btn[name='font_size']");
         await focusAndClick(".dropdown-menu .dropdown-item");
         await animationFrame();
-        expect(p.firstChild).toHaveClass("test-font-size");
+        expect(p).toHaveClass("test-font-size");
     });
 
     test("font selector dropdown should not have normal as an option", async () => {

--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -4,7 +4,7 @@ import { callbacksForCursorUpdate } from "@html_editor/utils/selection";
 import { _t } from "@web/core/l10n/translation";
 import { Plugin } from "../plugin";
 import { closestBlock, isBlock } from "../utils/blocks";
-import { cleanTextNode, fillEmpty, removeClass, splitTextNode, unwrapContents } from "../utils/dom";
+import { cleanTextNode, fillEmpty, splitTextNode, unwrapContents } from "../utils/dom";
 import {
     areSimilarElements,
     hasVisibleContent,
@@ -20,6 +20,7 @@ import {
     isVisibleTextNode,
     isZwnbsp,
     isZWS,
+    paragraphRelatedElementsSelector,
     previousLeaf,
     PROTECTED_QWEB_SELECTOR,
 } from "../utils/dom_info";
@@ -32,7 +33,14 @@ import {
     selectElements,
 } from "../utils/dom_traversal";
 import { formatsSpecs, FORMATTABLE_TAGS } from "../utils/formatting";
-import { boundariesIn, boundariesOut, DIRECTIONS, leftPos, rightPos } from "../utils/position";
+import {
+    boundariesIn,
+    boundariesOut,
+    DIRECTIONS,
+    leftPos,
+    nodeSize,
+    rightPos,
+} from "../utils/position";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 const allWhitespaceRegex = /^[\s\u200b]*$/;
@@ -92,14 +100,14 @@ export class FormatPlugin extends Plugin {
                 id: "formatUnderline",
                 description: _t("Toggle underline"),
                 icon: "fa-underline",
-                run: this.formatSelection.bind(this, "underline"),
+                run: this.formatSelection.bind(this, "underline", { applyToBlock: false }),
                 isAvailable: this.canFormatContent.bind(this),
             },
             {
                 id: "formatStrikethrough",
                 description: _t("Toggle strikethrough"),
                 icon: "fa-strikethrough",
-                run: this.formatSelection.bind(this, "strikeThrough"),
+                run: this.formatSelection.bind(this, "strikeThrough", { applyToBlock: false }),
                 isAvailable: this.canFormatContent.bind(this),
             },
             {
@@ -260,13 +268,14 @@ export class FormatPlugin extends Plugin {
      * @returns {boolean}
      */
     hasSelectionFormat(format, targetedNodes = this.dependencies.selection.getTargetedNodes()) {
-        const targetedTextNodes = targetedNodes.filter(
+        const relevantNodes = targetedNodes.filter(
             (node) =>
                 node.matches?.(PROTECTED_QWEB_SELECTOR) ||
-                (isTextNode(node) && (isVisibleTextNode(node) || isZWS(node)))
+                (isTextNode(node) && (isVisibleTextNode(node) || isZWS(node))) ||
+                isEmptyBlock(node)
         );
         const isFormatted = formatsSpecs[format].isFormatted;
-        return targetedTextNodes.some((n) => isFormatted(n, { editable: this.editable }));
+        return relevantNodes.some((n) => isFormatted(n, { editable: this.editable }));
     }
     /**
      * Return true if the current selection on the editable appears as the given
@@ -281,15 +290,15 @@ export class FormatPlugin extends Plugin {
         const isFormatted = formatsSpecs[format].isFormatted;
         const isNonFormattedWhiteSpaces = (node) =>
             /^(\s|\n)+$/.test(node.nodeValue) && !isFormatted(node, { editable: this.editable });
-        const targetedTextNodes = targetedNodes.filter(
+        const relevantNodes = targetedNodes.filter(
             (node) =>
-                isTextNode(node) &&
+                (isTextNode(node) || isEmptyBlock(node)) &&
                 !isNonFormattedWhiteSpaces(node) &&
                 this.dependencies.selection.isNodeEditable(node)
         );
         return (
-            targetedTextNodes.length &&
-            targetedTextNodes.every(
+            relevantNodes.length &&
+            relevantNodes.every(
                 (node) =>
                     isZwnbsp(node) ||
                     isEmptyTextNode(node) ||
@@ -322,7 +331,7 @@ export class FormatPlugin extends Plugin {
     }
 
     // @todo phoenix: refactor this method.
-    _formatSelection(formatName, { applyStyle, formatProps } = {}) {
+    _formatSelection(formatName, { applyStyle, formatProps, applyToBlock = true } = {}) {
         const deepSelection = this.dependencies.selection.getSelectionData().deepEditableSelection;
         const anchorElement = deepSelection.anchorNode;
         const focusElement = deepSelection.focusNode;
@@ -334,7 +343,6 @@ export class FormatPlugin extends Plugin {
             return;
         }
         this.dependencies.selection.selectAroundNonEditable();
-        // note: does it work if selection is in opposite direction?
         const selection = this.dependencies.split.splitSelection();
         if (typeof applyStyle === "undefined") {
             applyStyle = !this.isSelectionFormat(formatName);
@@ -351,7 +359,8 @@ export class FormatPlugin extends Plugin {
         }
 
         let zws;
-        if (selection.isCollapsed) {
+        const isAnchorEmptyBlock = isEmptyBlock(selection.anchorNode);
+        if (selection.isCollapsed && (!isAnchorEmptyBlock || !applyToBlock)) {
             if (isTextNode(selection.anchorNode) && selection.anchorNode.textContent === "\u200b") {
                 zws = selection.anchorNode;
                 this.dependencies.selection.setSelection({
@@ -365,111 +374,149 @@ export class FormatPlugin extends Plugin {
             }
         }
 
+        const targetedNodes = this.dependencies.selection.getTargetedNodes();
+
         const systemNodesSelector = this.getResource("system_node_selectors").join(", ");
         const selectedTextNodes = /** @type { Text[] } **/ (
-            this.dependencies.selection
-                .getTargetedNodes()
-                .filter(
-                    (n) =>
-                        (!systemNodesSelector || !closestElement(n, systemNodesSelector)) &&
-                        this.dependencies.selection.areNodeContentsFullySelected(n) &&
-                        ((isTextNode(n) && (isVisibleTextNode(n) || isZWS(n))) ||
-                            (n.nodeName === "BR" &&
-                                (isFakeLineBreak(n) ||
-                                    previousLeaf(n, closestBlock(n))?.nodeName === "BR"))) &&
-                        isContentEditable(n)
-                )
+            targetedNodes.filter(
+                (n) =>
+                    (!systemNodesSelector || !closestElement(n, systemNodesSelector)) &&
+                    this.dependencies.selection.areNodeContentsFullySelected(n) &&
+                    ((isTextNode(n) && (isVisibleTextNode(n) || isZWS(n))) ||
+                        (n.nodeName === "BR" &&
+                            (isFakeLineBreak(n) ||
+                                previousLeaf(n, closestBlock(n))?.nodeName === "BR"))) &&
+                    isContentEditable(n)
+            )
         );
-        const unformattedTextNodes = selectedTextNodes.filter((n) => !formattedNodes.has(n));
+
+        const seenBlocks = new WeakSet();
+        let unformattedNodes;
+        if (selection.isCollapsed && isAnchorEmptyBlock && applyToBlock) {
+            unformattedNodes = [selection.anchorNode];
+        } else {
+            unformattedNodes = selectedTextNodes.flatMap((n) => {
+                if (formattedNodes.has(n)) {
+                    return [];
+                }
+                const block =
+                    closestElement(n, "LI") || closestElement(n, paragraphRelatedElementsSelector);
+                if (seenBlocks.has(block)) {
+                    return [];
+                }
+                if (
+                    block &&
+                    isContentEditable(block) &&
+                    applyToBlock &&
+                    this.dependencies.selection.areNodeContentsFullySelected(block)
+                ) {
+                    seenBlocks.add(block);
+                    return [block];
+                }
+                return [n];
+            });
+        }
+
         const formatSpec = formatsSpecs[formatName];
-        for (const node of unformattedTextNodes) {
-            const inlineAncestors = [];
-            /** @type { Node } */
-            let currentNode = node;
-            let parentNode = node.parentElement;
+        const formattedBlocks = [];
+        for (const node of unformattedNodes) {
+            if (isBlock(node)) {
+                const nodesToUnformat = descendants(node).filter((n) => {
+                    if (!isElement(n)) {
+                        return false;
+                    }
+                    const block =
+                        closestElement(n, "LI") ||
+                        closestElement(n, paragraphRelatedElementsSelector);
+                    return block === node;
+                });
+                for (const n of [node, ...nodesToUnformat]) {
+                    removeFormat(n, formatSpec);
+                }
+                if (applyStyle && !formatSpec.isFormatted(node, formatProps)) {
+                    formatSpec.addStyle(node, formatProps);
+                } else if (
+                    !applyStyle &&
+                    formatSpec.isFormatted(node, formatProps) &&
+                    formatSpec.addNeutralStyle
+                ) {
+                    formatSpec.addNeutralStyle && formatSpec.addNeutralStyle(node);
+                }
+                formattedBlocks.push(node);
+            } else {
+                const inlineAncestors = [];
+                /** @type { Node } */
+                let currentNode = node;
+                let parentNode = node.parentElement;
 
-            // Remove the format on all inline ancestors until a block or an element
-            // with a class that is not indicated as splittable.
-            const isClassListSplittable = (classList) =>
-                [...classList].every(
-                    (className) =>
-                        this.checkPredicates("is_format_class_predicates", className) ?? false
-                );
-
-            // Special case: if the parent node is unsplittable and fully selected,
-            // we should make sure the span is applied outside of it.
-            if (
-                parentNode &&
-                !isBlock(parentNode) &&
-                this.dependencies.split.isUnsplittable(parentNode) &&
-                this.dependencies.selection.areNodeContentsFullySelected(parentNode)
-            ) {
-                inlineAncestors.push(parentNode);
-            }
-
-            while (
-                parentNode &&
-                !isBlock(parentNode) &&
-                !this.dependencies.split.isUnsplittable(parentNode) &&
-                (parentNode.classList.length === 0 || isClassListSplittable(parentNode.classList))
-            ) {
-                const isUselessZws =
-                    parentNode.tagName === "SPAN" &&
-                    parentNode.hasAttribute("data-oe-zws-empty-inline") &&
-                    parentNode.getAttributeNames().length === 1;
-
-                if (isUselessZws) {
-                    unwrapContents(parentNode);
-                } else {
-                    const newLastAncestorInlineFormat = this.dependencies.split.splitAroundUntil(
-                        currentNode,
-                        parentNode
+                // Remove the format on all inline ancestors until a block or
+                // an element with a class that is not indicated as splittable.
+                const isClassListSplittable = (classList) =>
+                    [...classList].every(
+                        (className) =>
+                            this.checkPredicates("is_format_class_predicates", className) ?? false
                     );
-                    removeFormat(newLastAncestorInlineFormat, formatSpec);
-                    if (["setFontSizeClassName", "fontSize"].includes(formatName) && applyStyle) {
-                        removeClass(newLastAncestorInlineFormat, "o_default_font_size");
-                    }
-                    if (newLastAncestorInlineFormat.isConnected) {
-                        inlineAncestors.push(newLastAncestorInlineFormat);
-                        currentNode = newLastAncestorInlineFormat;
-                    }
+
+                // Special case: if the parent node is unsplittable and fully selected,
+                // we should make sure the span is applied outside of it.
+                if (
+                    parentNode &&
+                    !isBlock(parentNode) &&
+                    this.dependencies.split.isUnsplittable(parentNode) &&
+                    this.dependencies.selection.areNodeContentsFullySelected(parentNode)
+                ) {
+                    inlineAncestors.push(parentNode);
                 }
 
-                parentNode = currentNode.parentElement;
-            }
-
-            const firstBlockOrClassHasFormat = formatSpec.isFormatted(parentNode, formatProps);
-            if (firstBlockOrClassHasFormat && !applyStyle) {
-                const isParentNodeBlockAndCompletelySelected =
-                    isBlock(parentNode) &&
-                    this.dependencies.selection.areNodeContentsFullySelected(parentNode);
-                if (
-                    isParentNodeBlockAndCompletelySelected &&
-                    formatName === "setFontSizeClassName"
+                while (
+                    parentNode &&
+                    !isBlock(parentNode) &&
+                    !this.dependencies.split.isUnsplittable(parentNode) &&
+                    (parentNode.classList.length === 0 ||
+                        isClassListSplittable(parentNode.classList))
                 ) {
-                    for (const node of [parentNode, ...descendants(parentNode).filter(isElement)]) {
-                        removeFormat(node, formatSpec);
+                    const isUselessZws =
+                        parentNode.tagName === "SPAN" &&
+                        parentNode.hasAttribute("data-oe-zws-empty-inline") &&
+                        parentNode.getAttributeNames().length === 1;
+
+                    if (isUselessZws) {
+                        unwrapContents(parentNode);
+                    } else {
+                        const newLastAncestorInlineFormat =
+                            this.dependencies.split.splitAroundUntil(currentNode, parentNode);
+                        removeFormat(newLastAncestorInlineFormat, formatSpec);
+                        if (newLastAncestorInlineFormat.isConnected) {
+                            inlineAncestors.push(newLastAncestorInlineFormat);
+                            currentNode = newLastAncestorInlineFormat;
+                        }
                     }
-                } else {
+
+                    parentNode = currentNode.parentElement;
+                }
+
+                const firstBlockOrClassHasFormat = formatSpec.isFormatted(parentNode, formatProps);
+                if (firstBlockOrClassHasFormat && !applyStyle) {
                     formatSpec.addNeutralStyle &&
                         formatSpec.addNeutralStyle(getOrCreateSpan(node, inlineAncestors));
-                }
-            } else if (
-                (!firstBlockOrClassHasFormat || parentNode.nodeName === "LI") &&
-                applyStyle
-            ) {
-                const tag = formatSpec.tagName && this.document.createElement(formatSpec.tagName);
-                if (tag) {
-                    node.after(tag);
-                    tag.append(node);
+                } else if (!firstBlockOrClassHasFormat && applyStyle) {
+                    const tag =
+                        formatSpec.tagName && this.document.createElement(formatSpec.tagName);
+                    if (tag) {
+                        node.after(tag);
+                        tag.append(node);
 
-                    if (!formatSpec.isFormatted(tag, formatProps)) {
-                        tag.after(node);
-                        tag.remove();
+                        if (!formatSpec.isFormatted(tag, formatProps)) {
+                            tag.after(node);
+                            tag.remove();
+                            formatSpec.addStyle(
+                                getOrCreateSpan(node, inlineAncestors),
+                                formatProps
+                            );
+                        }
+                    } else if (formatName !== "fontSize" || formatProps.size !== undefined) {
                         formatSpec.addStyle(getOrCreateSpan(node, inlineAncestors), formatProps);
                     }
-                } else if (formatName !== "fontSize" || formatProps.size !== undefined) {
-                    formatSpec.addStyle(getOrCreateSpan(node, inlineAncestors), formatProps);
                 }
             }
         }
@@ -478,8 +525,8 @@ export class FormatPlugin extends Plugin {
             const siblings = [...zws.parentElement.childNodes];
             if (
                 !isBlock(zws.parentElement) &&
-                unformattedTextNodes.includes(siblings[0]) &&
-                unformattedTextNodes.includes(siblings[siblings.length - 1])
+                unformattedNodes.includes(siblings[0]) &&
+                unformattedNodes.includes(siblings[siblings.length - 1])
             ) {
                 zws.parentElement.setAttribute("data-oe-zws-empty-inline", "");
             } else {
@@ -489,13 +536,14 @@ export class FormatPlugin extends Plugin {
                 span.append(zws);
             }
         }
+        this.trigger("on_block_formatted_handlers", formattedBlocks, formatName, applyStyle);
 
         if (
-            unformattedTextNodes.length === 1 &&
-            unformattedTextNodes[0] &&
-            unformattedTextNodes[0].textContent === "\u200B"
+            selectedTextNodes.length === 1 &&
+            selectedTextNodes[0] &&
+            selectedTextNodes[0].textContent === "\u200B"
         ) {
-            this.dependencies.selection.setCursorEnd(unformattedTextNodes[0]);
+            this.dependencies.selection.setCursorEnd(selectedTextNodes[0]);
         } else if (selectedTextNodes.length) {
             const firstNode = selectedTextNodes[0];
             const lastNode = selectedTextNodes[selectedTextNodes.length - 1];
@@ -505,12 +553,12 @@ export class FormatPlugin extends Plugin {
                     anchorNode: firstNode,
                     anchorOffset: 0,
                     focusNode: lastNode,
-                    focusOffset: lastNode.length,
+                    focusOffset: nodeSize(lastNode),
                 };
             } else {
                 newSelection = {
                     anchorNode: lastNode,
-                    anchorOffset: lastNode.length,
+                    anchorOffset: nodeSize(lastNode),
                     focusNode: firstNode,
                     focusOffset: 0,
                 };

--- a/addons/html_editor/static/src/core/shortcut_plugin.js
+++ b/addons/html_editor/static/src/core/shortcut_plugin.js
@@ -38,7 +38,7 @@ import { closestElement } from "@html_editor/utils/dom_traversal";
 
 export class ShortCutPlugin extends Plugin {
     static id = "shortcut";
-    static dependencies = ["userCommand", "selection", "split", "dom", "history"];
+    static dependencies = ["userCommand", "selection", "split", "dom", "history", "delete"];
 
     /** @type {import("plugins").EditorResources} */
     resources = {
@@ -150,7 +150,7 @@ export class ShortCutPlugin extends Plugin {
         if (ev.data !== " ") {
             return;
         }
-        const selection = this.dependencies.selection.getEditableSelection();
+        let selection = this.dependencies.selection.getEditableSelection();
         const leftDOMPath = leftLeafOnlyNotBlockPath(selection.anchorNode);
         let spaceOffset = selection.anchorOffset;
         let lineBreak;
@@ -190,9 +190,8 @@ export class ShortCutPlugin extends Plugin {
                     this.dependencies.selection.modifySelection("extend", "backward", "character");
                     offset--;
                 }
-                this.dependencies.selection.extractContent(
-                    this.dependencies.selection.getEditableSelection()
-                );
+                this.dependencies.delete.deleteSelection();
+                selection = this.dependencies.selection.getEditableSelection();
                 fillEmpty(closestElement(selection.focusNode));
                 command.run(matchedShortcut.commandParams);
             }

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -6,20 +6,23 @@ import {
     hasColor,
     TEXT_CLASSES_REGEX,
 } from "@html_editor/utils/color";
-import { fillEmpty, unwrapContents } from "@html_editor/utils/dom";
+import { fillEmpty, removeClass, removeStyle, unwrapContents } from "@html_editor/utils/dom";
 import {
+    isContentEditable,
+    isElement,
     isEmptyBlock,
     isRedundantElement,
     isTextNode,
     isVisibleTextNode,
     isWhitespace,
     isZWS,
+    paragraphRelatedElementsSelector,
 } from "@html_editor/utils/dom_info";
 import { closestElement, descendants, selectElements } from "@html_editor/utils/dom_traversal";
 import { isColorGradient, rgbaToHex } from "@web/core/utils/colors";
 import { backgroundImageCssToParts, backgroundImagePartsToCss } from "@html_editor/utils/image";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
-import { isBlock } from "@html_editor/utils/blocks";
+import { closestBlock, isBlock } from "@html_editor/utils/blocks";
 import { callbacksForCursorUpdate } from "@html_editor/utils/selection";
 
 const COLOR_COMBINATION_CLASSES = [1, 2, 3, 4, 5].map((i) => `o_cc${i}`);
@@ -132,7 +135,7 @@ export class ColorPlugin extends Plugin {
                                 nodes.add(colorNode);
                             }
                         }
-                        if (isTextNode(node)) {
+                        if (isTextNode(node) || isEmptyBlock(node)) {
                             nodes.add(node);
                         }
                     }
@@ -168,9 +171,10 @@ export class ColorPlugin extends Plugin {
             return;
         }
         const selection = this.dependencies.selection.getEditableSelection();
+        const isGradientColor = isColorGradient(color);
         let targetedNodes;
         // Get the <font> nodes to color
-        if (selection.isCollapsed) {
+        if (selection.isCollapsed && !isEmptyBlock(selection.anchorNode)) {
             let zws;
             if (
                 selection.anchorNode.nodeType === Node.TEXT_NODE &&
@@ -190,12 +194,32 @@ export class ColorPlugin extends Plugin {
             targetedNodes = [zws];
         } else {
             this.dependencies.split.splitSelection();
-            targetedNodes = this.dependencies.selection
-                .getTargetedNodes()
-                .filter(
-                    (node) =>
-                        this.dependencies.selection.isNodeEditable(node) && node.nodeName !== "T"
-                );
+            const seenBlocks = new WeakSet();
+            targetedNodes = this.dependencies.selection.getTargetedNodes().flatMap((node) => {
+                let block;
+                if (mode === "color" && !isGradientColor) {
+                    block =
+                        closestElement(node, "LI") ||
+                        closestElement(node, paragraphRelatedElementsSelector);
+                }
+                if (block) {
+                    if (seenBlocks.has(block)) {
+                        return [];
+                    }
+                    if (
+                        isContentEditable(node) &&
+                        this.dependencies.selection.areNodeContentsFullySelected(block)
+                    ) {
+                        seenBlocks.add(block);
+                        return [block];
+                    }
+                }
+                return !isBlock(node) &&
+                    this.dependencies.selection.isNodeEditable(node) &&
+                    node.nodeName !== "T"
+                    ? [node]
+                    : [];
+            });
             if (isEmptyBlock(selection.endContainer)) {
                 targetedNodes.push(selection.endContainer, ...descendants(selection.endContainer));
             }
@@ -222,6 +246,14 @@ export class ColorPlugin extends Plugin {
             })
             .map((node) => findTopMostDecoration(node));
 
+        const targetedFieldNodes = new Set(
+            this.dependencies.selection
+                .getTargetedNodes()
+                .map((n) => closestElement(n, "*[t-field],*[t-out],*[t-esc]"))
+                .filter((n) => !selectedNodes.includes(closestBlock(n)))
+                .filter(Boolean)
+        );
+
         const alreadyWithinFont = new Set();
         const getFonts = (selectedNodes) =>
             selectedNodes.flatMap((node) => {
@@ -247,38 +279,29 @@ export class ColorPlugin extends Plugin {
                     !(
                         font.classList.contains("text-gradient") &&
                         mode === "backgroundColor" &&
-                        isColorGradient(color)
+                        isGradientColor
                     )
                 ) {
                     font = null;
                 }
                 const children = font && descendants(font);
-                if (font && !this.dependencies.split.isUnsplittable(font)) {
+                if (
+                    node &&
+                    mode === "color" &&
+                    !isGradientColor &&
+                    (node.matches?.(paragraphRelatedElementsSelector) || node.nodeName === "LI")
+                ) {
+                    font = [node];
+                } else if (
+                    font &&
+                    !this.dependencies.split.isUnsplittable(font) &&
+                    !isBlock(font)
+                ) {
                     // Partially selected <font>: split it.
                     const selectedChildren = children.filter(
                         (child) => child.isConnected && selectedNodes.includes(child)
                     );
                     if (selectedChildren.length) {
-                        if (isBlock(font)) {
-                            const colorStyles = ["color", "background-color", "background-image"];
-                            const newFont = this.document.createElement("font");
-                            for (const style of colorStyles) {
-                                const styleValue = font.style[style];
-                                if (styleValue) {
-                                    this.colorElement(newFont, styleValue, style);
-                                    font.style.removeProperty(style);
-                                }
-                            }
-                            font.classList.forEach((className) => {
-                                if (TEXT_CLASSES_REGEX.test(className)) {
-                                    font.classList.remove(className);
-                                    newFont.classList.add(className);
-                                }
-                            });
-                            newFont.append(...font.childNodes);
-                            font.append(newFont);
-                            font = newFont;
-                        }
                         font = this.dependencies.split.splitAroundUntil(selectedChildren, font);
                     } else {
                         font = [];
@@ -338,10 +361,40 @@ export class ColorPlugin extends Plugin {
         // Color the selected <font>s and remove uncolored fonts.
         const fontsSet = new Set(fonts);
         for (const font of fontsSet) {
+            if (isBlock(font)) {
+                [...descendants(font)].forEach((child) => {
+                    if (
+                        isElement(child) &&
+                        (hasColor(child, mode) || child.classList.contains("o_default_color"))
+                    ) {
+                        this.colorElement(child, "", mode);
+                        if (
+                            ["FONT", "SPAN"].includes(child.nodeName) &&
+                            child.getAttributeNames().length === 0
+                        ) {
+                            cursors.update(callbacksForCursorUpdate.unwrap(child));
+                            unwrapContents(child);
+                        }
+                    }
+                });
+            }
+            const closestColoredElement = closestElement(
+                font,
+                (node) => isBlock(node) || node.classList.contains("o_default_color")
+            );
+            if (
+                !color &&
+                !isBlock(font) &&
+                mode === "color" &&
+                hasColor(closestColoredElement, "color")
+            ) {
+                color = "o_default_color";
+            }
             this.colorElement(font, color, mode);
             if (
                 !hasColor(font, "color") &&
                 !hasColor(font, "backgroundColor") &&
+                !font.classList.contains("o_default_color") &&
                 ["FONT", "SPAN"].includes(font.nodeName) &&
                 (!font.hasAttribute("style") || !color)
             ) {
@@ -373,7 +426,7 @@ export class ColorPlugin extends Plugin {
         const hasGradientStyle = element.style.backgroundImage.includes("-gradient");
         if (mode === "backgroundColor") {
             if (!color) {
-                element.classList.remove("o_cc", ...COLOR_COMBINATION_CLASSES);
+                removeClass(element, "o_cc", ...COLOR_COMBINATION_CLASSES);
             }
             const hasGradient = getComputedStyle(element).backgroundImage.includes("-gradient");
             delete parts.gradient;
@@ -383,15 +436,20 @@ export class ColorPlugin extends Plugin {
                 newBackgroundImage = "none";
             }
             element.style.backgroundImage = newBackgroundImage;
-            element.style["background-color"] = "";
+            removeStyle(element, "background-color");
         }
 
         const newClassName = oldClassName
             .replace(mode === "color" ? TEXT_CLASSES_REGEX : BG_CLASSES_REGEX, "")
             .replace(/\btext-gradient\b/g, "") // cannot be combined with setting a background
-            .replace(/\s+/, " ");
+            .replace(/\bo_default_color\b/g, "") // cannot be combined with setting a color
+            .replace(/\s+/, " ")
+            .trim();
         if (oldClassName !== newClassName) {
-            element.setAttribute("class", newClassName);
+            element.removeAttribute("class");
+            if (newClassName) {
+                element.setAttribute("class", newClassName);
+            }
         }
         const isTextGradient = closestElement(element, ".text-gradient");
         // If the nearest <font> has a text gradient, its
@@ -402,11 +460,14 @@ export class ColorPlugin extends Plugin {
         } else if (isColorGradient(color) || color === "") {
             element.style.webkitTextFillColor = "";
         }
-        if (isColorGradient(color)) {
-            element.style[mode] = "";
+        if (color.startsWith("text") || color.startsWith("bg-") || color === "o_default_color") {
+            removeStyle(element, mode);
+            element.classList.add(color);
+        } else if (isColorGradient(color)) {
+            removeStyle(element, mode);
             parts.gradient = color;
             if (mode === "color") {
-                element.style["background-color"] = "";
+                removeStyle(element, "background-color");
                 element.classList.add("text-gradient");
             }
             this.applyColorStyle(
@@ -418,7 +479,7 @@ export class ColorPlugin extends Plugin {
         } else {
             delete parts.gradient;
             if (hasGradientStyle && !backgroundImagePartsToCss(parts)) {
-                element.style["background-image"] = "";
+                removeStyle(element, "background-image");
             }
             if (color.startsWith("text") || color.startsWith("bg-")) {
                 element.style[mode] = "";
@@ -449,6 +510,7 @@ export class ColorPlugin extends Plugin {
         }
 
         this.fixColorCombination(element, color);
+        this.trigger("on_element_colored_handlers", element, color, mode);
     }
     /**
      * There is a limitation with css. The defining a background image and a
@@ -496,7 +558,11 @@ export class ColorPlugin extends Plugin {
         if (this.delegateTo("apply_color_style_overrides", element, mode, color, params)) {
             return;
         }
-        element.style[mode] = color;
+        if (color) {
+            element.style[mode] = color;
+        } else {
+            removeStyle(element, mode);
+        }
     }
 }
 

--- a/addons/html_editor/static/src/main/font/color_ui_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_ui_plugin.js
@@ -43,6 +43,7 @@ export class ColorUIPlugin extends Plugin {
             },
         ],
         on_selectionchange_handlers: this.updateSelectedColor.bind(this),
+        on_element_colored_handlers: this.updateSelectedColor.bind(this),
         background_color_processors: this.getBackgroundColorProcessor.bind(this),
         apply_background_color_processors: this.applyBackgroundColorProcessor.bind(this),
     };

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -11,7 +11,6 @@ import {
 import {
     getDeepestEditablePosition,
     getDeepestPosition,
-    isElement,
     isEmptyBlock,
     isListElement,
     isListItemElement,
@@ -19,7 +18,6 @@ import {
     isPhrasingContent,
     isProtected,
     isProtecting,
-    isVisibleTextNode,
     listElementSelector,
 } from "@html_editor/utils/dom_info";
 import {
@@ -50,7 +48,6 @@ import { composeToolbarButton } from "../toolbar/toolbar";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 import { pick } from "@web/core/utils/objects";
 import { weakMemoize } from "@html_editor/utils/functions";
-import { isColorGradient } from "@web/core/utils/colors";
 
 const listSelectorItems = [
     {
@@ -189,6 +186,7 @@ export class ListPlugin extends Plugin {
         on_deleted_handlers: this.adjustListPaddingOnDelete.bind(this),
         on_will_insert_separator_handlers: this.exitList.bind(this),
         on_block_formatted_handlers: this.postFormatAppliedOnList.bind(this),
+        on_element_colored_handlers: this.postColorAppliedOnList.bind(this),
 
         /** Processors */
         normalize_processors: this.normalize.bind(this),
@@ -203,7 +201,6 @@ export class ListPlugin extends Plugin {
         tab_overrides: this.handleTab.bind(this),
         shift_tab_overrides: this.handleShiftTab.bind(this),
         split_element_block_overrides: this.handleSplitBlock.bind(this),
-        apply_color_overrides: this.applyColorToListItem.bind(this),
         triple_click_overrides: this.handleTripleClick.bind(this),
 
         is_node_fully_selected_predicates: (node, selection, range) => {
@@ -430,7 +427,10 @@ export class ListPlugin extends Plugin {
         }
         // Copy some classes from base container to li.
         for (const className of [...baseContainer.classList]) {
-            if ([...FONT_SIZE_CLASSES, ...TEXT_STYLE_CLASSES].includes(className)) {
+            if (
+                [...FONT_SIZE_CLASSES, ...TEXT_STYLE_CLASSES].includes(className) ||
+                TEXT_CLASSES_REGEX.test(className)
+            ) {
                 list.firstElementChild.classList.add(className);
                 removeClass(baseContainer, className);
             }
@@ -1142,68 +1142,16 @@ export class ListPlugin extends Plugin {
         );
     }
 
-    applyColorToListItem(color, mode, coloredNodes) {
-        this.dependencies.split.splitSelection();
-        const targetedNodes = this.dependencies.selection.getTargetedNodes();
-        const listItems = new Set(
-            targetedNodes.map((n) => closestElement(n, "li")).filter(Boolean)
-        );
-        if (!listItems.size || mode !== "color" || isColorGradient(color)) {
+    postColorAppliedOnList(coloredElement, color, mode) {
+        if (mode !== "color" || color === "o_default_color" || color === "") {
             return;
         }
-        const cursors = this.dependencies.selection.preserveSelection();
-        for (const listItem of listItems) {
-            if (this.dependencies.selection.areNodeContentsFullySelected(listItem)) {
-                const listItemDescendants = descendants(listItem);
-                for (const node of [
-                    listItem,
-                    ...listItemDescendants.filter(
-                        (n) => isElement(n) && closestElement(n, "LI") === listItem
-                    ),
-                ]) {
-                    // Remove any color-related classes.
-                    const classesToRemove = [...node.classList].filter(
-                        (cls) => cls === "o_default_color" || TEXT_CLASSES_REGEX.test(cls)
-                    );
-                    removeClass(node, ...classesToRemove);
-
-                    if (node.style.color) {
-                        removeStyle(node, "color");
-                    }
-                }
-
-                const sublists = childNodes(listItem).filter(isListElement);
-                coloredNodes.add(listItem);
-                listItemDescendants
-                    .filter((n) => !sublists.some((list) => list.contains(n)))
-                    .forEach((n) => coloredNodes.add(n));
-                if (color) {
-                    this.dependencies.color.colorElement(listItem, color, mode);
-                    for (const list of sublists) {
-                        list.classList.add("o_default_color");
-                    }
-                }
-            } else if (
-                color === "" &&
-                (listItem.style.color ||
-                    [...listItem.classList].some((cls) => TEXT_CLASSES_REGEX.test(cls)))
-            ) {
-                const textNodes = targetedNodes.filter(
-                    (n) => isVisibleTextNode(n) && closestElement(n, "li") === listItem
-                );
-                // Remove inline color from partial selection by
-                // wrapping in font with default color.
-                for (const node of textNodes) {
-                    const font = this.document.createElement("font");
-                    font.classList.add("o_default_color");
-                    node.before(font);
-                    cursors.update(callbacksForCursorUpdate.before(node, font));
-                    font.append(node);
-                    cursors.update(callbacksForCursorUpdate.append(font, node));
-                }
+        if (isListItem(coloredElement)) {
+            const sublists = childNodes(coloredElement).filter(isListElement);
+            for (const list of sublists) {
+                list.classList.add("o_default_color");
             }
         }
-        cursors.restore();
     }
 
     postFormatAppliedOnList(formattedBlocks, formatName, applyStyle) {

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -37,8 +37,13 @@ import { _t } from "@web/core/l10n/translation";
 import { compareListTypes, createList, insertListAfter, isListItem } from "./utils";
 import { callbacksForCursorUpdate } from "@html_editor/utils/selection";
 import { withSequence } from "@html_editor/utils/resource";
-import { FONT_SIZE_CLASSES, getFontSizeOrClass, getHtmlStyle } from "@html_editor/utils/formatting";
-import { getTextColorOrClass, TEXT_CLASSES_REGEX } from "@html_editor/utils/color";
+import {
+    FONT_SIZE_CLASSES,
+    TEXT_STYLE_CLASSES,
+    getFontSizeOrClass,
+    getHtmlStyle,
+} from "@html_editor/utils/formatting";
+import { TEXT_CLASSES_REGEX } from "@html_editor/utils/color";
 import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
 import { ListSelector } from "./list_selector";
 import { composeToolbarButton } from "../toolbar/toolbar";
@@ -183,6 +188,7 @@ export class ListPlugin extends Plugin {
         on_step_added_handlers: this.updateToolbarButtons.bind(this),
         on_deleted_handlers: this.adjustListPaddingOnDelete.bind(this),
         on_will_insert_separator_handlers: this.exitList.bind(this),
+        on_block_formatted_handlers: this.postFormatAppliedOnList.bind(this),
 
         /** Processors */
         normalize_processors: this.normalize.bind(this),
@@ -198,7 +204,6 @@ export class ListPlugin extends Plugin {
         shift_tab_overrides: this.handleShiftTab.bind(this),
         split_element_block_overrides: this.handleSplitBlock.bind(this),
         apply_color_overrides: this.applyColorToListItem.bind(this),
-        format_selection_overrides: this.applyFormatToListItem.bind(this),
         triple_click_overrides: this.handleTripleClick.bind(this),
 
         is_node_fully_selected_predicates: (node, selection, range) => {
@@ -406,11 +411,29 @@ export class ListPlugin extends Plugin {
     baseContainerToList(baseContainer, mode) {
         const cursors = this.dependencies.selection.preserveSelection();
         const list = insertListAfter(this.document, baseContainer, mode, childNodes(baseContainer));
-        const textAlign = baseContainer.style.getPropertyValue("text-align");
-        if (textAlign) {
-            // Copy text-align style from base container to li.
-            list.firstElementChild.style.setProperty("text-align", textAlign);
-            baseContainer.style.removeProperty("text-align");
+        // Copy some styles from base container to li.
+        const propertiesToMove = [
+            "text-align",
+            "font-size",
+            "font-weight",
+            "font-style",
+            "text-decoration-line",
+            "font-family",
+            "color",
+        ];
+        for (const property of propertiesToMove) {
+            const value = baseContainer.style.getPropertyValue(property);
+            if (value) {
+                list.firstElementChild.style.setProperty(property, value);
+                removeStyle(baseContainer, property);
+            }
+        }
+        // Copy some classes from base container to li.
+        for (const className of [...baseContainer.classList]) {
+            if ([...FONT_SIZE_CLASSES, ...TEXT_STYLE_CLASSES].includes(className)) {
+                list.firstElementChild.classList.add(className);
+                removeClass(baseContainer, className);
+            }
         }
         this.dependencies.dom.copyAttributes(baseContainer, list);
         this.adjustListPadding(list);
@@ -758,37 +781,34 @@ export class ListPlugin extends Plugin {
         }
         // Preserve style properties
         const dir = li.getAttribute("dir") || ul.getAttribute("dir");
-        const textAlign = li.style.getPropertyValue("text-align");
-        const liColorStyle = getTextColorOrClass(li);
-        const liFontSizeStyle = getFontSizeOrClass(li);
-        const wrapChildren = (parent, tag) => {
-            const wrapper = this.document.createElement(tag);
-            wrapper.append(...parent.childNodes);
-            parent.replaceChildren(wrapper);
-            cursors.remapNode(parent, wrapper);
-            return wrapper;
-        };
         for (const block of blocksToMove) {
             // text direction
             if (dir && !block.getAttribute("dir")) {
                 block.setAttribute("dir", dir);
             }
-            // text alignment
-            if (textAlign && !block.style.getPropertyValue("text-align")) {
-                block.style.setProperty("text-align", textAlign);
+            // Copy some styles from li to base container.
+            const propertiesToMove = [
+                "text-align",
+                "font-size",
+                "font-weight",
+                "font-style",
+                "text-decoration-line",
+                "font-family",
+                "color",
+            ];
+            for (const property of propertiesToMove) {
+                const value = li.style.getPropertyValue(property);
+                if (value) {
+                    block.style.setProperty(property, value);
+                }
             }
-            // text color
-            if (liColorStyle) {
-                const font = wrapChildren(block, "font");
-                this.dependencies.color.colorElement(font, liColorStyle.value, "color");
-            }
-            // font-size
-            if (liFontSizeStyle && !isEmptyBlock(block)) {
-                const span = wrapChildren(block, "span");
-                if (liFontSizeStyle.type === "font-size") {
-                    span.style.fontSize = liFontSizeStyle.value;
-                } else if (liFontSizeStyle.type === "class") {
-                    span.classList.add(liFontSizeStyle.value);
+            // Copy some classes from li to base container.
+            for (const className of [...li.classList]) {
+                if (
+                    [...FONT_SIZE_CLASSES, ...TEXT_STYLE_CLASSES].includes(className) ||
+                    TEXT_CLASSES_REGEX.test(className)
+                ) {
+                    block.classList.add(className);
                 }
             }
         }
@@ -1186,81 +1206,22 @@ export class ListPlugin extends Plugin {
         cursors.restore();
     }
 
-    applyFormatToListItem(formatName, formattedNodes, { formatProps, applyStyle } = {}) {
+    postFormatAppliedOnList(formattedBlocks, formatName, applyStyle) {
         if (!["setFontSizeClassName", "fontSize"].includes(formatName)) {
             return;
         }
-        this.dependencies.split.splitSelection();
-        const targetedNodes = this.dependencies.selection.getTargetedNodes();
-        const listItems = new Set(
-            targetedNodes.map((n) => closestElement(n, "li")).filter(Boolean)
-        );
-        if (!listItems.size) {
-            return false;
-        }
         const listsSet = new Set();
-        const cursors = this.dependencies.selection.preserveSelection();
-        for (const listItem of listItems) {
-            // Skip list items with block descendants other than base
-            // container or a list related elements or no font size formatting
-            // to remove.
-            const hasOnlyBaseBlocks = [...descendants(listItem)]
-                .filter(isBlock)
-                .every((n) => n.matches(`${baseContainerGlobalSelector}, ol, ul, li`));
-            const hasExistingFontSize =
-                FONT_SIZE_CLASSES.some((c) => listItem.classList.contains(c)) ||
-                listItem.style.fontSize;
-            if (!hasOnlyBaseBlocks || (!applyStyle && !hasExistingFontSize)) {
-                continue;
-            }
-
-            if (this.dependencies.selection.areNodeContentsFullySelected(listItem)) {
-                const listItemDescendants = descendants(listItem);
-                for (const node of [
-                    listItem,
-                    ...listItemDescendants.filter(
-                        (n) => isElement(n) && closestElement(n, "LI") === listItem
-                    ),
-                ]) {
-                    removeClass(node, ...FONT_SIZE_CLASSES, "o_default_font_size");
-                    if (node.style.fontSize) {
-                        node.style.fontSize = "";
-                    }
-                }
-
-                const sublists = childNodes(listItem).filter(isListElement);
-                formattedNodes.add(listItem);
-                listItemDescendants
-                    .filter((n) => !sublists.some((list) => list.contains(n)))
-                    .forEach((n) => formattedNodes.add(n));
-                if (applyStyle) {
-                    if (formatName === "setFontSizeClassName") {
-                        listItem.classList.add(formatProps.className);
-                    } else if (formatName === "fontSize") {
-                        listItem.style.fontSize = formatProps.size;
-                    }
-                    for (const list of sublists) {
+        for (const node of formattedBlocks) {
+            if (isListItem(node)) {
+                const sublists = childNodes(node).filter(isListElement);
+                for (const list of sublists) {
+                    if (applyStyle) {
                         list.classList.add("o_default_font_size");
                     }
                 }
-            } else if (!applyStyle && hasExistingFontSize) {
-                const textNodes = targetedNodes.filter(
-                    (n) => isVisibleTextNode(n) && closestElement(n, "li") === listItem
-                );
-                // Remove inline font size from partial selection by
-                // wrapping in span with default font size.
-                for (const node of textNodes) {
-                    const span = this.document.createElement("span");
-                    span.classList.add("o_default_font_size");
-                    node.before(span);
-                    cursors.update(callbacksForCursorUpdate.before(node, span));
-                    span.append(node);
-                    cursors.update(callbacksForCursorUpdate.append(span, node));
-                }
+                listsSet.add(node.parentElement);
             }
-            listsSet.add(listItem.parentElement);
         }
-        cursors.restore();
         for (const list of listsSet) {
             this.adjustListPadding(list);
         }

--- a/addons/html_editor/static/src/utils/color.js
+++ b/addons/html_editor/static/src/utils/color.js
@@ -162,17 +162,3 @@ export function hasAnyNodesColor(nodes, mode) {
     }
     return false;
 }
-
-export function getTextColorOrClass(node) {
-    if (!node) {
-        return null;
-    }
-    if (node.style.color) {
-        return { type: "style", value: node.style.color };
-    }
-    const textColorClass = [...node.classList].find((cls) => TEXT_CLASSES_REGEX.test(cls));
-    if (textColorClass) {
-        return { type: "class", value: textColorClass };
-    }
-    return null;
-}

--- a/addons/html_editor/static/src/utils/formatting.js
+++ b/addons/html_editor/static/src/utils/formatting.js
@@ -113,15 +113,24 @@ export const formatsSpecs = {
             )?.style["font-size"];
             return props?.size ? fontSize === props.size : fontSize;
         },
-        hasStyle: (node) => node.style && node.style["font-size"],
+        hasStyle: (node) =>
+            node.style?.["font-size"] || node.classList?.contains("o_default_font_size"),
         addStyle: (node, props) => {
             node.style["font-size"] = props.size;
             removeClass(node, ...FONT_SIZE_CLASSES);
-            node.classList.toggle("o_rfs", props.size && props.size.startsWith("clamp("));
+            node.classList.toggle("o_rfs", !!props.size && props.size.startsWith("clamp("));
         },
         removeStyle: (node) => {
             removeStyle(node, "font-size");
-            removeClass(node, "o_rfs");
+            removeClass(node, "o_rfs", "o_default_font_size");
+        },
+        addNeutralStyle: function (node) {
+            const block = closestBlock(node);
+            if (["H1", "H2", "H3", "H4", "H5", "H6"].includes(block.nodeName)) {
+                node.classList.add(block.nodeName.toLowerCase());
+            } else {
+                node.classList.add("o_default_font_size");
+            }
         },
     },
     setFontSizeClassName: {
@@ -154,7 +163,7 @@ export const formatsSpecs = {
         },
         removeStyle: (node) => {
             removeStyle(node, "font-size");
-            removeClass(node, ...FONT_SIZE_CLASSES);
+            removeClass(node, ...FONT_SIZE_CLASSES, "o_default_font_size");
             // Typography classes should be preserved on block elements since
             // they act as semantic equivalents of <h1>, <h2>, etc., not just
             // removable styles.

--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -67,10 +67,13 @@ test("should apply a color on empty selection", async () => {
         contentBefore: "<p>[<br></p><p><br></p><p>]<br></p>",
         stepFunction: setColor("rgb(255, 0, 0)", "color"),
         contentAfterEdit:
-            '<p>[<font data-oe-zws-empty-inline="" style="color: rgb(255, 0, 0);">\u200B</font></p>' +
-            '<p><font data-oe-zws-empty-inline="" style="color: rgb(255, 0, 0);">\u200B</font></p>' +
-            '<p>]<font data-oe-zws-empty-inline="" style="color: rgb(255, 0, 0);">\u200B</font></p>',
-        contentAfter: "<p>[<br></p><p><br></p><p>]<br></p>",
+            '<p style="color: rgb(255, 0, 0);">[<br></p>' +
+            '<p style="color: rgb(255, 0, 0);"><br></p>' +
+            '<p style="color: rgb(255, 0, 0);">]<br></p>',
+        contentAfter:
+            '<p style="color: rgb(255, 0, 0);">[<br></p>' +
+            '<p style="color: rgb(255, 0, 0);"><br></p>' +
+            '<p style="color: rgb(255, 0, 0);">]<br></p>',
     });
 });
 
@@ -101,8 +104,7 @@ test("should not merge line on color change", async () => {
         contentBefore: "<p><strong>[abcd</strong><br><strong>efghi]</strong></p>",
         stepFunction: setColor("rgb(255, 0, 0)", "color"),
         contentAfter:
-            '<p><font style="color: rgb(255, 0, 0);"><strong>[abcd</strong></font><br>' +
-            '<font style="color: rgb(255, 0, 0);"><strong>efghi]</strong></font></p>',
+            '<p style="color: rgb(255, 0, 0);"><strong>[abcd</strong><br><strong>efghi]</strong></p>',
     });
 });
 
@@ -111,9 +113,9 @@ test("should not apply color on an uneditable element", async () => {
         contentBefore: '<p>[a</p><p contenteditable="false">b</p><p>c]</p>',
         stepFunction: setColor("rgb(255, 0, 0)", "color"),
         contentAfter: unformat(`
-                <p><font style="color: rgb(255, 0, 0);">[a</font></p>
+                <p style="color: rgb(255, 0, 0);">[a</p>
                 <p contenteditable="false">b</p>
-                <p><font style="color: rgb(255, 0, 0);">c]</font></p>
+                <p style="color: rgb(255, 0, 0);">c]</p>
             `),
     });
 });
@@ -183,7 +185,7 @@ test("should not apply background color on an uneditable selected cell in a tabl
     });
 });
 
-test("should not apply font tag to t nodes (protects if else nodes separation)", async () => {
+test("should not apply font tag to t nodes (protects if else nodes separation) (1)", async () => {
     await testEditor({
         contentBefore: unformat(`[
             <p>
@@ -197,14 +199,14 @@ test("should not apply font tag to t nodes (protects if else nodes separation)",
         ]`),
         stepFunction: setColor("red", "color"),
         contentAfter: unformat(`[
-            <p>
+            <p style="color: red;">
                 <t t-if="object.partner_id.parent_id">
-                    <t t-out="object.partner_id.parent_id.name or ''" style="color: red;">
+                    <t t-out="object.partner_id.parent_id.name or ''">
                         Azure Interior
                     </t>
                 </t>
                 <t t-else="">
-                    <t t-out="object.partner_id.name or ''" style="color: red;">
+                    <t t-out="object.partner_id.name or ''">
                         Brandon Freeman
                     </t>
                 </t>
@@ -214,9 +216,40 @@ test("should not apply font tag to t nodes (protects if else nodes separation)",
     });
 });
 
+test("should not apply font tag to t nodes (protects if else nodes separation) (2)", async () => {
+    await testEditor({
+        contentBefore: unformat(`
+            <p>
+                [<t t-if="object.partner_id.parent_id">
+                   <t t-out="object.partner_id.parent_id.name or ''">Azure Interior</t>
+                </t>]
+                <t t-else="">
+                    <t t-out="object.partner_id.name or ''">Brandon Freeman</t>
+                </t>
+            </p>
+        `),
+        stepFunction: setColor("red", "color"),
+        contentAfter: unformat(`
+            <p>
+                [<t t-if="object.partner_id.parent_id">
+                    <t t-out="object.partner_id.parent_id.name or ''" style="color: red;">
+                        Azure Interior
+                    </t>
+                </t>]
+                <t t-else="">
+                    <t t-out="object.partner_id.name or ''">
+                        Brandon Freeman
+                    </t>
+                </t>
+            </p>
+        `),
+        config: { Plugins: [...MAIN_PLUGINS, QWebPlugin] },
+    });
+});
+
 test("should remove font tag after removing font color (1)", async () => {
     await testEditor({
-        contentBefore: '<p><font style="color: rgb(255, 0, 0);">[abcabc]</font></p>',
+        contentBefore: '<p style="color: rgb(255, 0, 0);">[abcabc]</p>',
         stepFunction: setColor("", "color"),
         contentAfter: "<p>[abcabc]</p>",
     });
@@ -224,7 +257,15 @@ test("should remove font tag after removing font color (1)", async () => {
 
 test("should remove font tag after removing font color (2)", async () => {
     await testEditor({
-        contentBefore: '<p><font class="text-400">[abcabc]</font></p>',
+        contentBefore: '<p class="text-400">[abcabc]</p>',
+        stepFunction: setColor("", "color"),
+        contentAfter: "<p>[abcabc]</p>",
+    });
+});
+
+test("should remove font tag after removing font color (3)", async () => {
+    await testEditor({
+        contentBefore: '<p><font style="color: rgb(255, 0, 0);">[abcabc]</font></p>',
         stepFunction: setColor("", "color"),
         contentAfter: "<p>[abcabc]</p>",
     });
@@ -401,7 +442,7 @@ test("should apply text color whithout interrupting gradient background color on
             '<p><font style="background-image: linear-gradient(135deg, rgb(214, 255, 127) 0%, rgb(0, 179, 204) 100%);">[abcde]</font></p>',
         stepFunction: setColor("rgb(255, 0, 0)", "color"),
         contentAfter:
-            '<p><font style="background-image: linear-gradient(135deg, rgb(214, 255, 127) 0%, rgb(0, 179, 204) 100%);"><font style="color: rgb(255, 0, 0);">[abcde]</font></font></p>',
+            '<p style="color: rgb(255, 0, 0);"><font style="background-image: linear-gradient(135deg, rgb(214, 255, 127) 0%, rgb(0, 179, 204) 100%);">[abcde]</font></p>',
     });
 });
 test("should apply background color whithout interrupting gradient text color on selected text", async () => {
@@ -522,9 +563,9 @@ test("should apply gradient text color on selected text", async () => {
 test("should remove text gradient and apply new text color if gradient is fully selected (1)", async () => {
     await testEditor({
         contentBefore:
-            '<p><font style="background-image: linear-gradient(135deg, rgb(255, 174, 127) 0%, rgb(109, 204, 0) 100%);" class="text-gradient">[abcd]</font></p>',
+            '<p style="background-image: linear-gradient(135deg, rgb(255, 174, 127) 0%, rgb(109, 204, 0) 100%);" class="text-gradient">[abcd]</p>',
         stepFunction: setColor("#ff0000", "color"),
-        contentAfter: '<p><font style="color: rgb(255, 0, 0);">[abcd]</font></p>',
+        contentAfter: '<p style="color: rgb(255, 0, 0);">[abcd]</p>',
     });
 });
 test("should remove text gradient and apply new text color if gradient is fully selected (2)", async () => {
@@ -532,7 +573,7 @@ test("should remove text gradient and apply new text color if gradient is fully 
         contentBefore:
             '<p><font style="background-image: linear-gradient(135deg, rgb(255, 174, 127) 0%, rgb(109, 204, 0) 100%);" class="text-gradient">[abcd]</font></p>',
         stepFunction: setColor("text-o-color-1", "color"),
-        contentAfter: '<p><font class="text-o-color-1">[abcd]</font></p>',
+        contentAfter: '<p class="text-o-color-1">[abcd]</p>',
     });
 });
 test("should remove background gradient and apply new background color if gradient is fully selected", async () => {
@@ -585,8 +626,8 @@ test("should not apply color on an invisible text node", async () => {
         `,
         stepFunction: setColor("rgb(255, 0, 0)", "color"),
         contentAfter: `
-            <p><font style="color: rgb(255, 0, 0);">[a</font></p>
-            <p><font style="color: rgb(255, 0, 0);">c]</font></p>
+            <p style="color: rgb(255, 0, 0);">[a</p>
+            <p style="color: rgb(255, 0, 0);">c]</p>
         `,
     });
 });
@@ -793,7 +834,7 @@ describe("colorElement", () => {
                             "backgroundColor"
                         );
                     },
-                    contentAfter: `<div style="background-image: ${redToBlueGradient};" class="o_cc o_cc1">a</div>`,
+                    contentAfter: `<div class="o_cc o_cc1" style="background-image: ${redToBlueGradient};">a</div>`,
                 });
             });
             test("should write o_cc1 gradient when bg-900 is already present", async () => {
@@ -819,7 +860,7 @@ describe("colorElement", () => {
                             "backgroundColor"
                         );
                     },
-                    contentAfter: `<div style="background-image: ${redToBlueGradient};" class="o_cc o_cc1">a</div>`,
+                    contentAfter: `<div class="o_cc o_cc1" style="background-image: ${redToBlueGradient};">a</div>`,
                 });
             });
         });
@@ -874,7 +915,7 @@ test("should not split unsplittable element when applying color (1)", async () =
         contentBefore: '<div style="color: rgb(255, 0, 0);"><p>[test]</p></div>',
         stepFunction: setColor("rgb(0, 0, 255)", "color"),
         contentAfter:
-            '<div style="color: rgb(255, 0, 0);"><p><font style="color: rgb(0, 0, 255);">[test]</font></p></div>',
+            '<div style="color: rgb(255, 0, 0);"><p style="color: rgb(0, 0, 255);">[test]</p></div>',
     });
 });
 test("should not split unsplittable element when applying color (2)", async () => {

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -37,7 +37,7 @@ test("can set foreground color", async () => {
     await animationFrame();
     await expectElementCount(".o-we-toolbar", 1);
     expect(".o_font_color_selector").toHaveCount(0); // selector closed
-    expect(getContent(el)).toBe(`<p><font style="color: rgb(107, 173, 222);">[test]</font></p>`);
+    expect(getContent(el)).toBe(`<p style="color: rgb(107, 173, 222);">[test]</p>`);
 });
 
 test("can set background color", async () => {
@@ -84,7 +84,7 @@ test("should add opacity to custom background colors but not to theme colors", a
 
     await contains(".o_color_button[data-color='o-color-1']").click(); // Select a theme color
     await waitFor(".o-we-toolbar");
-    expect(getContent(el)).toBe(`<p><font style="" class="bg-o-color-1">[test]</font></p>`);
+    expect(getContent(el)).toBe(`<p><font class="bg-o-color-1">[test]</font></p>`);
     // Verify computed background color has no opacity.
     expect(queryFirst("p font", { root: el })).toHaveStyle({
         backgroundColor: "rgb(113, 75, 103)",
@@ -239,12 +239,12 @@ test("select hex color and apply it", async () => {
     await animationFrame();
     expect("button[data-color='#017E84']").toHaveCount(1);
     expect("button[data-color='#017E84']").toHaveStyle({ backgroundColor: "rgb(1, 126, 132)" });
-    expect(getContent(el)).toBe(`<p><font style="color: rgb(1, 126, 132);">test</font></p>`);
+    expect(getContent(el)).toBe(`<p style="color: rgb(1, 126, 132);">test</p>`);
 
     await click(".odoo-editor-editable");
     await animationFrame();
     expect(".o_font_color_selector").toHaveCount(0);
-    expect(getContent(el)).toBe(`<p><font style="color: rgb(1, 126, 132);">[test]</font></p>`);
+    expect(getContent(el)).toBe(`<p style="color: rgb(1, 126, 132);">[test]</p>`);
 });
 
 test("should be able to apply hex color with opacity component", async () => {
@@ -268,14 +268,12 @@ test("should be able to apply hex color with opacity component", async () => {
     expect("button[data-color='#017E8480']").toHaveStyle({
         backgroundColor: "rgba(1, 126, 132, 0.5)",
     });
-    expect(getContent(el)).toBe(`<p><font style="color: rgba(1, 126, 132, 0.5);">test</font></p>`);
+    expect(getContent(el)).toBe(`<p style="color: rgba(1, 126, 132, 0.5);">test</p>`);
 
     await click(".odoo-editor-editable");
     await animationFrame();
     expect(".o_font_color_selector").toHaveCount(0);
-    expect(getContent(el)).toBe(
-        `<p><font style="color: rgba(1, 126, 132, 0.5);">[test]</font></p>`
-    );
+    expect(getContent(el)).toBe(`<p style="color: rgba(1, 126, 132, 0.5);">[test]</p>`);
 });
 
 test("custom color tab should be opened by default if selected color is a custom color", async () => {
@@ -496,7 +494,7 @@ test("clicking on button color parent does not crash", async () => {
     await animationFrame();
     await click(".o_color_button[data-color='#6BADDE']");
     await animationFrame();
-    expect(getContent(el)).toBe(`<p><font style="color: rgb(107, 173, 222);">[test]</font></p>`);
+    expect(getContent(el)).toBe(`<p style="color: rgb(107, 173, 222);">[test]</p>`);
 });
 
 test("gradient picker should be closed by default when switching gradient tab", async () => {
@@ -700,7 +698,7 @@ test("solid tab color navigation using keys", async () => {
     await press("ArrowUp");
     expect('.o_font_color_selector button[data-color="#000000"]').toBeFocused();
     await press("Enter");
-    expect(getContent(el)).toBe(`<p><font style="color: rgb(0, 0, 0);">[test]</font></p>`);
+    expect(getContent(el)).toBe(`<p style="color: rgb(0, 0, 0);">[test]</p>`);
 });
 
 test("custom tab color navigation using keys", async () => {
@@ -726,7 +724,7 @@ test("custom tab color navigation using keys", async () => {
     await press("ArrowDown");
     expect('.o_font_color_selector button[data-color="black"]').toBeFocused(); // Should do nothing
     await press("Enter");
-    expect(getContent(el)).toBe(`<p><font style="" class="text-black">[test]</font></p>`);
+    expect(getContent(el)).toBe(`<p class="text-black">[test]</p>`);
 });
 
 describe.tags("desktop");
@@ -902,11 +900,10 @@ describe("color preview", () => {
         await animationFrame();
         await hover("button[data-color='o-color-1']");
         await animationFrame();
-        expect("font").toHaveCount(1);
-        expect("font").toHaveClass("text-o-color-1");
+        expect("p").toHaveClass("text-o-color-1");
         await hover(".o-we-toolbar .o-select-color-foreground");
         await animationFrame();
-        expect("font").toHaveCount(0);
+        expect("p").not.toHaveClass("text-o-color-1");
     });
 
     test("preview color and close dropdown should revert the preview", async () => {
@@ -918,11 +915,10 @@ describe("color preview", () => {
         await animationFrame();
         await hover("button[data-color='o-color-1']");
         await animationFrame();
-        expect("font").toHaveCount(1);
-        expect("font").toHaveClass("text-o-color-1");
+        expect("p").toHaveClass("text-o-color-1");
         await press("escape");
         await animationFrame();
-        expect("font").toHaveCount(0);
+        expect("p").not.toHaveClass("text-o-color-1");
     });
 
     test("preview color and then apply works with undo/redo", async () => {
@@ -934,22 +930,22 @@ describe("color preview", () => {
         await animationFrame();
         await hover("button[data-color='o-color-1']");
         await animationFrame();
-        expect("font").toHaveCount(1);
-        expect("font").toHaveClass("text-o-color-1");
+        expect("p").toHaveClass("text-o-color-1");
         await hover("button[data-color='o-color-2']");
         await animationFrame();
-        expect("font").toHaveCount(1);
-        expect("font").toHaveClass("text-o-color-2");
+        expect("p").not.toHaveClass("text-o-color-1");
+        expect("p").toHaveClass("text-o-color-2");
         await click("button[data-color='o-color-2']");
         await animationFrame();
-        expect("font").toHaveCount(1);
-        expect("font").toHaveClass("text-o-color-2");
+        expect("p").not.toHaveClass("text-o-color-1");
+        expect("p").toHaveClass("text-o-color-2");
         await animationFrame();
         execCommand(editor, "historyUndo");
-        expect("font").toHaveCount(0);
+        expect("p").not.toHaveClass("text-o-color-1");
+        expect("p").not.toHaveClass("text-o-color-2");
         execCommand(editor, "historyRedo");
-        expect("font").toHaveCount(1);
-        expect("font").toHaveClass("text-o-color-2");
+        expect("p").not.toHaveClass("text-o-color-1");
+        expect("p").toHaveClass("text-o-color-2");
     });
 
     test("preview color are not restored when undo", async () => {
@@ -961,17 +957,18 @@ describe("color preview", () => {
         await animationFrame();
         await hover("button[data-color='o-color-1']");
         await animationFrame();
-        expect("font").toHaveCount(1);
-        expect("font").toHaveClass("text-o-color-1");
+        expect("p").toHaveClass("text-o-color-1");
         await hover("button[data-color='o-color-2']");
         await animationFrame();
-        expect("font").toHaveCount(1);
-        expect("font").toHaveClass("text-o-color-2");
+        expect("p").not.toHaveClass("text-o-color-1");
+        expect("p").toHaveClass("text-o-color-2");
         await press("escape");
         await animationFrame();
-        expect("font").toHaveCount(0);
+        expect("p").not.toHaveClass("text-o-color-1");
+        expect("p").not.toHaveClass("text-o-color-2");
         execCommand(editor, "historyUndo");
-        expect("font").toHaveCount(0);
+        expect("p").not.toHaveClass("text-o-color-1");
+        expect("p").not.toHaveClass("text-o-color-2");
     });
 
     test("should preview color in table on hover in solid tab", async () => {

--- a/addons/html_editor/static/tests/format/bold.test.js
+++ b/addons/html_editor/static/tests/format/bold.test.js
@@ -39,7 +39,7 @@ test("should make two paragraphs bold", async () => {
     await testEditor({
         contentBefore: "<p>[abc</p><p>def]</p>",
         stepFunction: bold,
-        contentAfter: `<p><strong>[abc</strong></p><p><strong>def]</strong></p>`,
+        contentAfter: `<p style="font-weight: bolder;">[abc</p><p style="font-weight: bolder;">def]</p>`,
     });
 });
 
@@ -110,14 +110,14 @@ test("should make a whole heading not bold after a triple click (heading is cons
     });
     await tripleClick(el.querySelector("h1"));
     bold(editor);
-    expect(getContent(el)).toBe(`<h1><span style="font-weight: normal;">[ab]</span></h1><p>cd</p>`);
+    expect(getContent(el)).toBe(`<h1 style="font-weight: normal;">[ab]</h1><p>cd</p>`);
 });
 
 test("should make a selection starting with bold text fully bold", async () => {
     await testEditor({
         contentBefore: `<p><strong>[ab</strong></p><p>c]d</p>`,
         stepFunction: bold,
-        contentAfter: `<p><strong>[ab</strong></p><p><strong>c]</strong>d</p>`,
+        contentAfter: `<p style="font-weight: bolder;">[ab</p><p><strong>c]</strong>d</p>`,
     });
 });
 
@@ -125,7 +125,7 @@ test("should make a selection with bold text in the middle fully bold", async ()
     await testEditor({
         contentBefore: `<p>[a<strong>b</strong></p><p><strong>c</strong>d]e</p>`,
         stepFunction: bold,
-        contentAfter: `<p><strong>[ab</strong></p><p><strong>cd]</strong>e</p>`,
+        contentAfter: `<p style="font-weight: bolder;">[ab</p><p><strong>cd]</strong>e</p>`,
     });
 });
 
@@ -208,7 +208,7 @@ test("should not format non-editable text (bold)", async () => {
     await testEditor({
         contentBefore: '<p>[a</p><p contenteditable="false">b</p><p>c]</p>',
         stepFunction: bold,
-        contentAfter: `<p><strong>[a</strong></p><p contenteditable="false">b</p><p><strong>c]</strong></p>`,
+        contentAfter: `<p style="font-weight: bolder;">[a</p><p contenteditable="false">b</p><p style="font-weight: bolder;">c]</p>`,
     });
 });
 
@@ -240,9 +240,9 @@ test("should make a few characters bold inside table (bold)", async () => {
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr>
-                        <td class="o_selected_td"><p><strong>[abc</strong></p></td>
-                        <td class="o_selected_td"><p><strong>def</strong></p></td>
-                        <td class="o_selected_td"><p><strong>]<br></strong></p></td>
+                        <td class="o_selected_td"><p style="font-weight: bolder;">[abc</p></td>
+                        <td class="o_selected_td"><p style="font-weight: bolder;">def</p></td>
+                        <td class="o_selected_td"><p style="font-weight: bolder;">]<br></p></td>
                     </tr>
                     <tr>
                         <td><p><br></p></td>
@@ -268,8 +268,8 @@ test("should make two paragraphs (separated with whitespace) bold", async () => 
         `,
         stepFunction: bold,
         contentAfter: `
-            <p><strong>[abc</strong></p>
-            <p><strong>def]</strong></p>
+            <p style="font-weight: bolder;">[abc</p>
+            <p style="font-weight: bolder;">def]</p>
         `,
     });
 });
@@ -297,8 +297,8 @@ test("should make two paragraphs (separated with whitespace) bold, then not bold
         stepFunction: async (editor, { assertContentEquals }) => {
             bold(editor);
             assertContentEquals(`
-            <p><strong>[abc</strong></p>
-            <p><strong>def]</strong></p>
+            <p style="font-weight: bolder;">[abc</p>
+            <p style="font-weight: bolder;">def]</p>
         `);
             bold(editor);
         },
@@ -309,17 +309,14 @@ test("should make two paragraphs (separated with whitespace) bold, then not bold
     });
 });
 
-test("should insert a span zws when toggling a formatting command twice", () =>
+test("should remove bold format on formatting bold twice", () =>
     testEditor({
         contentBefore: `<p>[]<br></p>`,
         stepFunction: async (editor) => {
             bold(editor);
             bold(editor);
         },
-        // todo: It would be better to remove the zws entirely so that
-        // the P could have the "/" hint but that behavior might be
-        // complex with the current implementation.
-        contentAfterEdit: `<p o-we-hint-text='Type "/" for commands' class="o-we-hint"><span data-oe-zws-empty-inline="">\u200B[]</span></p>`,
+        contentAfterEdit: `<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`,
     }));
 
 // This test uses execCommand to reproduce as closely as possible the browser's
@@ -469,20 +466,18 @@ test("should remove multiple formatted empty bold tag when changing selection", 
     expect(getContent(el)).toBe(`<p>a[]bcd</p>`);
 });
 
-test("should not remove empty bold tag in an empty block when changing selection", async () => {
+test("should not remove bold from an empty block when changing selection", async () => {
     const { editor, el } = await setupEditor("<p>abcd</p><p>[]<br></p>");
 
     bold(editor);
     await tick();
     expect(getContent(el)).toBe(
-        `<p>abcd</p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><strong data-oe-zws-empty-inline="">\u200B[]</strong></p>`
+        `<p>abcd</p><p style="font-weight: bolder;" o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`
     );
 
     await simulateArrowKeyPress(editor, "ArrowUp");
     await tick(); // await selectionchange
-    expect(getContent(el)).toBe(
-        `<p>[]abcd</p><p><strong data-oe-zws-empty-inline="">\u200B</strong></p>`
-    );
+    expect(getContent(el)).toBe(`<p>[]abcd</p><p style="font-weight: bolder;"><br></p>`);
 });
 
 test("should not add history step for bold on collapsed selection", async () => {
@@ -603,7 +598,7 @@ test("should toggle bold around non editable", async () => {
     const { el, editor } = await setupEditor(`<p>[a</p><p contenteditable="false">b</p><p>c]</p>`);
     bold(editor);
     expect(getContent(el)).toBe(
-        `<p><strong>[a</strong></p><p contenteditable="false">b</p><p><strong>c]</strong></p>`
+        `<p style="font-weight: bolder;">[a</p><p contenteditable="false">b</p><p style="font-weight: bolder;">c]</p>`
     );
     bold(editor);
     expect(getContent(el)).toBe(`<p>[a</p><p contenteditable="false">b</p><p>c]</p>`);
@@ -630,7 +625,7 @@ test("should toggle bold across nested spans", async () => {
     const { el, editor } = await setupEditor(`<p><span><span>[A</span> </span></p><p>B]</p>`);
     bold(editor);
     expect(getContent(el)).toBe(
-        `<p><span><span><strong>[A</strong></span> </span></p><p><strong>B]</strong></p>`
+        `<p style="font-weight: bolder;"><span><span>[A</span> </span></p><p style="font-weight: bolder;">B]</p>`
     );
     bold(editor);
     expect(getContent(el)).toBe(`<p><span><span>[A</span> </span></p><p>B]</p>`);

--- a/addons/html_editor/static/tests/format/font_family.test.js
+++ b/addons/html_editor/static/tests/format/font_family.test.js
@@ -35,7 +35,7 @@ test("should give two paragraphs a fontFamily", async () => {
     await testEditor({
         contentBefore: "<p>[abc</p><p>def]</p>",
         stepFunction: setFontFamily("testFont"),
-        contentAfter: `<p><span style="font-family: testFont;">[abc</span></p><p><span style="font-family: testFont;">def]</span></p>`,
+        contentAfter: `<p style="font-family: testFont;">[abc</p><p style="font-family: testFont;">def]</p>`,
     });
 });
 

--- a/addons/html_editor/static/tests/format/font_size.test.js
+++ b/addons/html_editor/static/tests/format/font_size.test.js
@@ -35,7 +35,7 @@ test("should change the font size of a whole heading after a triple click", asyn
             await tripleClick(editor.editable.querySelector("h1"));
             setFontSize("36px")(editor);
         },
-        contentAfter: '<h1><span style="font-size: 36px;">[ab]</span></h1><p>cd</p>',
+        contentAfter: '<h1 style="font-size: 36px;">[ab]</h1><p>cd</p>',
     });
 });
 
@@ -130,7 +130,7 @@ test("should add font size in selected table cells", async () => {
             '<table><tbody><tr><td class="o_selected_td"><p>[<br></p></td><td class="o_selected_td"><p><br></p>]</td></tr><tr><td><p><br></p></td><td><p><br></p></td></tr></tbody></table>',
         stepFunction: setFontSize("48px"),
         contentAfter:
-            '<table><tbody><tr><td><p><span style="font-size: 48px;">[<br></span></p></td><td><p><span style="font-size: 48px;">]<br></span></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td></tr></tbody></table>',
+            '<table><tbody><tr><td><p style="font-size: 48px;">[<br></p></td><td><p style="font-size: 48px;">]<br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td></tr></tbody></table>',
     });
 });
 
@@ -140,7 +140,7 @@ test("should add font size in all table cells", async () => {
             '<table><tbody><tr><td class="o_selected_td"><p>[<br></p></td><td class="o_selected_td"><p><br></p></td></tr><tr><td class="o_selected_td"><p><br></p></td><td class="o_selected_td"><p><br>]</p></td></tr></tbody></table>',
         stepFunction: setFontSize("36px"),
         contentAfter:
-            '<table><tbody><tr><td><p><span style="font-size: 36px;">[<br></span></p></td><td><p><span style="font-size: 36px;"><br></span></p></td></tr><tr><td><p><span style="font-size: 36px;"><br></span></p></td><td><p><span style="font-size: 36px;">]<br></span></p></td></tr></tbody></table>',
+            '<table><tbody><tr><td><p style="font-size: 36px;">[<br></p></td><td><p style="font-size: 36px;"><br></p></td></tr><tr><td><p style="font-size: 36px;"><br></p></td><td><p style="font-size: 36px;">]<br></p></td></tr></tbody></table>',
     });
 });
 
@@ -150,7 +150,7 @@ test("should add font size in selected table cells with h1 as first child", asyn
             '<table><tbody><tr><td class="o_selected_td"><h1>[<br></h1></td><td class="o_selected_td"><h1><br>]</h1></td></tr><tr><td><h1><br></h1></td><td><h1><br></h1></td></tr></tbody></table>',
         stepFunction: setFontSize("18px"),
         contentAfter:
-            '<table><tbody><tr><td><h1><span style="font-size: 18px;">[<br></span></h1></td><td><h1><span style="font-size: 18px;">]<br></span></h1></td></tr><tr><td><h1><br></h1></td><td><h1><br></h1></td></tr></tbody></table>',
+            '<table><tbody><tr><td><h1 style="font-size: 18px;">[<br></h1></td><td><h1 style="font-size: 18px;">]<br></h1></td></tr><tr><td><h1><br></h1></td><td><h1><br></h1></td></tr></tbody></table>',
     });
 });
 
@@ -216,8 +216,7 @@ test("should update the font size currectly if already has one", async () => {
     await testEditor({
         contentBefore: '<h2 style="font-size: 14px;">[abcdefg]</h2>',
         stepFunction: setFontSize("18px"),
-        contentAfter:
-            '<h2 style="font-size: 14px;"><span style="font-size: 18px;">[abcdefg]</span></h2>',
+        contentAfter: '<h2 style="font-size: 18px;">[abcdefg]</h2>',
     });
 });
 
@@ -230,11 +229,11 @@ test("should add style to br except line-break br (2)", async () => {
     );
 });
 
-test("should update the font class if the parent already has one", async () => {
+test("should update the font class if the block already has one", async () => {
     await testEditor({
         contentBefore: '<h2 class="h4-fs">[abcdefg]</h2>',
         stepFunction: setFontSizeClassName("h3-fs"),
-        contentAfter: '<h2 class="h4-fs"><span class="h3-fs">[abcdefg]</span></h2>',
+        contentAfter: '<h2 class="h3-fs">[abcdefg]</h2>',
     });
 });
 

--- a/addons/html_editor/static/tests/format/italic.test.js
+++ b/addons/html_editor/static/tests/format/italic.test.js
@@ -35,7 +35,7 @@ test("should make two paragraphs italic", async () => {
     await testEditor({
         contentBefore: "<p>[abc</p><p>def]</p>",
         stepFunction: italic,
-        contentAfter: `<p><em>[abc</em></p><p><em>def]</em></p>`,
+        contentAfter: `<p style="font-style: italic;">[abc</p><p style="font-style: italic;">def]</p>`,
     });
 });
 
@@ -64,7 +64,7 @@ test("should make a whole heading italic after a triple click", async () => {
             await tripleClick(editor.editable.querySelector("h1"));
             italic(editor);
         },
-        contentAfter: `<h1><em>[ab]</em></h1><p>cd</p>`,
+        contentAfter: `<h1 style="font-style: italic;">[ab]</h1><p>cd</p>`,
     });
 });
 
@@ -84,7 +84,7 @@ test("should make a selection starting with italic text fully italic", async () 
     await testEditor({
         contentBefore: `<p><em>[ab</em></p><p>c]d</p>`,
         stepFunction: italic,
-        contentAfter: `<p><em>[ab</em></p><p><em>c]</em>d</p>`,
+        contentAfter: `<p style="font-style: italic;">[ab</p><p><em>c]</em>d</p>`,
     });
 });
 
@@ -92,7 +92,7 @@ test("should make a selection with italic text in the middle fully italic", asyn
     await testEditor({
         contentBefore: `<p>[a<em>b</em></p><p><em>c</em>d]e</p>`,
         stepFunction: italic,
-        contentAfter: `<p><em>[ab</em></p><p><em>cd]</em>e</p>`,
+        contentAfter: `<p style="font-style: italic;">[ab</p><p><em>cd]</em>e</p>`,
     });
 });
 
@@ -100,7 +100,7 @@ test("should make a selection ending with italic text fully italic", async () =>
     await testEditor({
         contentBefore: `<p>[ab</p><p><em>c]d</em></p>`,
         stepFunction: italic,
-        contentAfter: `<p><em>[ab</em></p><p><em>c]d</em></p>`,
+        contentAfter: `<p style="font-style: italic;">[ab</p><p><em>c]d</em></p>`,
     });
 });
 
@@ -112,8 +112,8 @@ test("should make two paragraphs (separated with whitespace) italic", async () =
         `,
         stepFunction: italic,
         contentAfter: `
-            <p><em>[abc</em></p>
-            <p><em>def]</em></p>
+            <p style="font-style: italic;">[abc</p>
+            <p style="font-style: italic;">def]</p>
         `,
     });
 });
@@ -141,8 +141,8 @@ test("should make two paragraphs (separated with whitespace) italic, then not it
         stepFunction: async (editor, { assertContentEquals }) => {
             italic(editor);
             assertContentEquals(`
-            <p><em>[abc</em></p>
-            <p><em>def]</em></p>
+            <p style="font-style: italic;">[abc</p>
+            <p style="font-style: italic;">def]</p>
         `);
             italic(editor);
         },
@@ -175,7 +175,7 @@ test("should not format non-editable text (italic)", async () => {
     await testEditor({
         contentBefore: '<p>[a</p><p contenteditable="false">b</p><p>c]</p>',
         stepFunction: italic,
-        contentAfter: `<p><em>[a</em></p><p contenteditable="false">b</p><p><em>c]</em></p>`,
+        contentAfter: `<p style="font-style: italic;">[a</p><p contenteditable="false">b</p><p style="font-style: italic;">c]</p>`,
     });
 });
 
@@ -219,17 +219,17 @@ test("should make a few characters italic inside table (italic)", async () => {
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr>
-                        <td class="o_selected_td"><p><em>[abc</em></p></td>
+                        <td class="o_selected_td"><p style="font-style: italic;">[abc</p></td>
                         <td><p><br></p></td>
                         <td><p><br></p></td>
                     </tr>
                     <tr>
-                        <td class="o_selected_td"><p><em>def</em></p></td>
+                        <td class="o_selected_td"><p style="font-style: italic;">def</p></td>
                         <td><p><br></p></td>
                         <td><p><br></p></td>
                     </tr>
                     <tr>
-                        <td class="o_selected_td"><p><em>]<br></em></p></td>
+                        <td class="o_selected_td"><p style="font-style: italic;">]<br></p></td>
                         <td><p><br></p></td>
                         <td><p><br></p></td>
                     </tr>

--- a/addons/html_editor/static/tests/format/remove_format.test.js
+++ b/addons/html_editor/static/tests/format/remove_format.test.js
@@ -518,7 +518,7 @@ test("should remove background color with shortcut", async () => {
 test("should remove the background image when clear the format", async () => {
     await testEditor({
         contentBefore:
-            '<div><p><font class="text-gradient" style="background-image: linear-gradient(135deg, rgb(255, 204, 51) 0%, rgb(226, 51, 255) 100%);">[ab]</font></p></div>',
+            '<div><p class="text-gradient" style="background-image: linear-gradient(135deg, rgb(255, 204, 51) 0%, rgb(226, 51, 255) 100%);">[ab]</p></div>',
         stepFunction: (editor) => execCommand(editor, "removeFormat"),
         contentAfter: "<div><p>[ab]</p></div>",
     });
@@ -746,7 +746,7 @@ test("should remove font-size style from multiple sized selected text", async ()
 
 test("should remove font size and color styles (1)", async () => {
     await testEditor({
-        contentBefore: `<p><span class="display-1-fs"><font class="text-gradient" style="background-image: linear-gradient(135deg, rgb(214, 255, 127) 0%, rgb(0, 179, 204) 100%);">[abcdefg]</font></span></p>`,
+        contentBefore: `<p class="display-1-fs text-gradient" style="background-image: linear-gradient(135deg, rgb(214, 255, 127) 0%, rgb(0, 179, 204) 100%);">[abcdefg]</p>`,
         stepFunction: (editor) => execCommand(editor, "removeFormat"),
         contentAfter: `<p>[abcdefg]</p>`,
     });
@@ -815,7 +815,7 @@ test("should remove color only from selected text within a heading", async () =>
         contentBefore: '<div><h1 style="color: rgb(255, 0, 0);">a[bc]d</h1></div>',
         stepFunction: (editor) => execCommand(editor, "removeFormat"),
         contentAfter:
-            '<div><h1><font style="color: rgb(255, 0, 0);">a</font>[bc]<font style="color: rgb(255, 0, 0);">d</font></h1></div>',
+            '<div><h1 style="color: rgb(255, 0, 0);">a<font class="o_default_color">[bc]</font>d</h1></div>',
     });
 });
 
@@ -860,7 +860,7 @@ test("should remove text color from empty element in a single selected cell", as
 test("should remove all formats when having multiple formats", async () => {
     await testEditor({
         contentBefore:
-            '<p><span class="display-4-fs"><font style="color: rgb(255, 156, 0);"><strong>[test]</strong></font></span></p>',
+            '<p class="display-4-fs" style="color: rgb(255, 156, 0);"><strong>[test]</strong></p>',
         stepFunction: (editor) => execCommand(editor, "removeFormat"),
         contentAfter: "<p>[test]</p>",
     });
@@ -869,7 +869,7 @@ test("should remove all formats when having multiple formats", async () => {
 test("should remove all formats when having multiple formats (2)", async () => {
     await testEditor({
         contentBefore:
-            '<p><span style="font-size: 24px"><font style="color: rgb(255, 156, 0);"><strong>[test]</strong></font></span></p>',
+            '<p style="font-size: 24px; color: rgb(255, 156, 0);"><strong>[test]</strong></p>',
         stepFunction: (editor) => execCommand(editor, "removeFormat"),
         contentAfter: "<p>[test]</p>",
     });
@@ -877,8 +877,7 @@ test("should remove all formats when having multiple formats (2)", async () => {
 
 test("should remove all formats when having multiple formats (3)", async () => {
     await testEditor({
-        contentBefore:
-            '<p><span class="display-4-fs"><font class="text-o-color-1"><strong>[test]</strong></font></span></p>',
+        contentBefore: '<p class="display-4-fs text-o-color-1"><strong>[test]</strong></p>',
         stepFunction: (editor) => execCommand(editor, "removeFormat"),
         contentAfter: "<p>[test]</p>",
     });
@@ -1019,7 +1018,7 @@ describe("Toolbar", () => {
         );
         await removeFormatClick();
         expect(getContent(el)).toBe(
-            `<p data-selection-placeholder=""><br></p><table class="table table-bordered o_table o_selected_table"><tbody><tr><td style="" class="o_selected_td"><p>[\u200b</p></td><td style="" class="o_selected_td"><p>]\u200b</p></td></tr></tbody></table><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+            `<p data-selection-placeholder=""><br></p><table class="table table-bordered o_table o_selected_table"><tbody><tr><td class="o_selected_td"><p>[\u200b</p></td><td class="o_selected_td"><p>]\u200b</p></td></tr></tbody></table><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         );
     });
 
@@ -1143,7 +1142,7 @@ describe("removeFormat must not remove non-style classes", () => {
     for (const cls of classes) {
         test(`removes ${cls} color class`, async () => {
             await testEditor({
-                contentBefore: `<p><font class="${cls}">[test]</font></p>`,
+                contentBefore: `<p class="${cls}">[test]</p>`,
                 stepFunction: (editor) => execCommand(editor, "removeFormat"),
                 contentAfter: "<p>[test]</p>",
             });

--- a/addons/html_editor/static/tests/list/automatic_list_detection.test.js
+++ b/addons/html_editor/static/tests/list/automatic_list_detection.test.js
@@ -49,7 +49,7 @@ test("typing '1. ' should keep cursor inside formatting element when creating a 
         unformat(
             `<ol>
                 <li o-we-hint-text="List" class="o-we-hint">
-                    <strong><u data-oe-zws-empty-inline="">[]\u200b</u></strong>
+                    <strong><u data-oe-zws-empty-inline="">[]\u200b</u></strong><br>
                 </li>
             </ol>`
         )

--- a/addons/html_editor/static/tests/list/color_list.test.js
+++ b/addons/html_editor/static/tests/list/color_list.test.js
@@ -66,7 +66,7 @@ test("should apply color to completely selected list items and paragraph tag", a
         contentBefore: "<ul><li>[abc</li><li>def</li></ul><p>ghi]</p>",
         stepFunction: setColor("rgb(255, 0, 0", "color"),
         contentAfter:
-            '<ul><li style="color: rgb(255, 0, 0);">[abc</li><li style="color: rgb(255, 0, 0);">def</li></ul><p><font style="color: rgb(255, 0, 0);">ghi]</font></p>',
+            '<ul><li style="color: rgb(255, 0, 0);">[abc</li><li style="color: rgb(255, 0, 0);">def</li></ul><p style="color: rgb(255, 0, 0);">ghi]</p>',
     });
 });
 

--- a/addons/html_editor/static/tests/list/color_list.test.js
+++ b/addons/html_editor/static/tests/list/color_list.test.js
@@ -120,8 +120,7 @@ test("should carry color of list item to paragraph", async () => {
     await testEditor({
         contentBefore: '<ol><li style="color: rgb(255, 0, 0);">[]abc</li><li>def</li></ol>',
         stepFunction: toggleOrderedList,
-        contentAfter:
-            '<p><font style="color: rgb(255, 0, 0);">[]abc</font></p><ol><li>def</li></ol>',
+        contentAfter: '<p style="color: rgb(255, 0, 0);">[]abc</p><ol><li>def</li></ol>',
     });
 });
 
@@ -131,7 +130,7 @@ test("should carry color of list item to paragraph (2)", async () => {
             '<ul><li style="color: rgb(255, 0, 0);">abc</li><li style="color: rgb(0, 0, 255);">[]def</li><li>ghi</li></ul>',
         stepFunction: toggleUnorderedList,
         contentAfter:
-            '<ul><li style="color: rgb(255, 0, 0);">abc</li></ul><p><font style="color: rgb(0, 0, 255);">[]def</font></p><ul><li>ghi</li></ul>',
+            '<ul><li style="color: rgb(255, 0, 0);">abc</li></ul><p style="color: rgb(0, 0, 255);">[]def</p><ul><li>ghi</li></ul>',
     });
 });
 
@@ -151,7 +150,7 @@ test("should carry color of list item to paragraph (4)", async () => {
             '<ol><li style="color: rgb(255, 0, 0);">abc<font style="color: rgb(0, 255, 0)">def</font>ghi[]</li></ol>',
         stepFunction: toggleOrderedList,
         contentAfter:
-            '<p><font style="color: rgb(255, 0, 0);">abc<font style="color: rgb(0, 255, 0)">def</font>ghi[]</font></p>',
+            '<p style="color: rgb(255, 0, 0);">abc<font style="color: rgb(0, 255, 0)">def</font>ghi[]</p>',
     });
 });
 
@@ -159,7 +158,7 @@ test("should carry class-defined color of list item to paragraph", async () => {
     await testEditor({
         contentBefore: '<ol><li class="text-o-color-1">[]abc</li><li>def</li></ol>',
         stepFunction: toggleOrderedList,
-        contentAfter: '<p><font class="text-o-color-1">[]abc</font></p><ol><li>def</li></ol>',
+        contentAfter: '<p class="text-o-color-1">[]abc</p><ol><li>def</li></ol>',
     });
 });
 

--- a/addons/html_editor/static/tests/list/list_font_size.test.js
+++ b/addons/html_editor/static/tests/list/list_font_size.test.js
@@ -77,7 +77,7 @@ test("should apply font-size to completely selected list items and paragraph tag
         contentBefore: "<ul><li>[abc</li><li>def</li></ul><p>ghi]</p>",
         stepFunction: (editor) =>
             execCommand(editor, "formatFontSizeClassName", { className: "h2-fs" }),
-        contentAfter: `<ul><li class="h2-fs">[abc</li><li class="h2-fs">def</li></ul><p><span class="h2-fs">ghi]</span></p>`,
+        contentAfter: `<ul><li class="h2-fs">[abc</li><li class="h2-fs">def</li></ul><p class="h2-fs">ghi]</p>`,
     });
 });
 
@@ -129,7 +129,7 @@ test("should carry font-size of list item to paragraph", async () => {
     await testEditor({
         contentBefore: '<ol><li style="font-size: 18px;">[]abc</li><li>def</li></ol>',
         stepFunction: toggleOrderedList,
-        contentAfter: '<p><span style="font-size: 18px;">[]abc</span></p><ol><li>def</li></ol>',
+        contentAfter: '<p style="font-size: 18px;">[]abc</p><ol><li>def</li></ol>',
     });
 });
 
@@ -138,7 +138,7 @@ test("should carry font-size of list item to paragraph (2)", async () => {
         contentBefore:
             '<ul><li class="h2-fs">abc</li><li class="h2-fs">[]def</li><li>ghi</li></ul>',
         stepFunction: toggleUnorderedList,
-        contentAfter: `<ul><li class="h2-fs">abc</li></ul><p><span class="h2-fs">[]def</span></p><ul><li>ghi</li></ul>`,
+        contentAfter: `<ul><li class="h2-fs">abc</li></ul><p class="h2-fs">[]def</p><ul><li>ghi</li></ul>`,
     });
 });
 
@@ -157,7 +157,7 @@ test("should carry font-size of list item to paragraph (4)", async () => {
             '<ol><li style="font-size: 18px;">abc<span style="font-size: 32px;">def</span>ghi[]</li></ol>',
         stepFunction: toggleOrderedList,
         contentAfter:
-            '<p><span style="font-size: 18px;">abc<span style="font-size: 32px;">def</span>ghi[]</span></p>',
+            '<p style="font-size: 18px;">abc<span style="font-size: 32px;">def</span>ghi[]</p>',
     });
 });
 
@@ -285,7 +285,7 @@ test("should remove font-size and its classes from partially selected list item 
         styleContent: "ol { font: 14px Roboto }",
         contentBefore: `<ol><li>a</li><li style="font-size: 56px;">b[c]d</li><li>e</li></ol>`,
         stepFunction: (editor) => execCommand(editor, "removeFormat"),
-        contentAfter: `<ol style="padding-inline-start: 60px;"><li>a</li><li style="font-size: 56px;">b<span class="o_default_font_size">[c]</span>d</li><li>e</li></ol>`,
+        contentAfter: `<ol><li>a</li><li style="font-size: 56px;">b<span class="o_default_font_size">[c]</span>d</li><li>e</li></ol>`,
     });
 });
 

--- a/addons/html_editor/static/tests/list/outdent.test.js
+++ b/addons/html_editor/static/tests/list/outdent.test.js
@@ -532,7 +532,7 @@ describe("with selection collapsed", () => {
                     <li>[]<br></li>
                 </ul>`),
             stepFunction: (editor) => {
-                bold(editor); // produces a <strong> tag with zws inside
+                bold(editor);
                 deleteBackward(editor); // removes the marker
                 deleteBackward(editor); // outdents the list item
             },
@@ -540,7 +540,7 @@ describe("with selection collapsed", () => {
                 <ul>
                     <li>a</li>
                 </ul>
-                <p>[]<br></p>`),
+                <p style="font-weight: bolder;">[]<br></p>`),
         });
     });
     test("should correctly merge list items when outdenting nested list", async () => {

--- a/addons/html_editor/static/tests/syntax_highlighting.test.js
+++ b/addons/html_editor/static/tests/syntax_highlighting.test.js
@@ -173,32 +173,32 @@ test("inserting an empty code block activates syntax highlighting plugin with an
     });
 });
 
-test("inserting a code block in an empty paragraph with a style placeholder activates syntax highlighting plugin with an empty textarea", async () => {
+test("inserting a code block in an empty styled paragraph activates syntax highlighting plugin with an empty textarea", async () => {
     await testEditorWithHighlightedContent({
         contentBefore: "<p><br>[]</p>",
         stepFunction: async (editor) => {
             await pressAndWait(["ctrl", "b"]);
             expect(getContent(editor.editable)).toBe(
-                `<p o-we-hint-text='Type "/" for commands' class="o-we-hint"><strong data-oe-zws-empty-inline="">\u200B[]</strong></p>`,
+                `<p style="font-weight: bolder;" o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`,
                 { message: "The style placeholder was inserted." }
             );
             splitBlock(editor);
             expect(getContent(editor.editable)).toBe(
-                `<p><strong data-oe-zws-empty-inline="">\u200B</strong></p>` +
-                    `<p o-we-hint-text='Type "/" for commands' class="o-we-hint"><strong data-oe-zws-empty-inline="">[]\u200B</strong></p>`,
+                `<p style="font-weight: bolder;"><br></p>` +
+                    `<p style="font-weight: bolder;" o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`,
                 { message: "The paragraph was split." }
             );
             await insertPre(editor);
         },
         contentAfterEdit: unformat(
-            `<p><strong data-oe-zws-empty-inline="">\u200B</strong></p>
+            `<p style="font-weight: bolder;"><br></p>
             ${highlightedPre({
                 value: "", // There should be no content (the zws is stripped)
                 textareaRange: 0,
             })}
             <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
         ),
-        contentAfter: `<p><br></p><pre data-embedded="readonlySyntaxHighlighting" data-language-id="plaintext"><br></pre>[]`,
+        contentAfter: `<p style="font-weight: bolder;"><br></p><pre data-embedded="readonlySyntaxHighlighting" data-language-id="plaintext"><br></pre>[]`,
     });
 });
 

--- a/addons/html_editor/static/tests/table/selection.test.js
+++ b/addons/html_editor/static/tests/table/selection.test.js
@@ -467,9 +467,7 @@ describe("select a full table on cross over", () => {
                             </td>
                         </tr></tbody>
                     </table>
-                    <p>
-                        <font style="color: aquamarine;">abc</font>
-                    </p>
+                    <p style="color: aquamarine;">abc</p>
                     <table class="o_selected_table">
                         <tbody><tr>
                             <td class="o_selected_td">
@@ -521,7 +519,7 @@ describe("select a full table on cross over", () => {
                             </td>
                         </tr></tbody>
                     </table>
-                    <p><font style="color: aquamarine;">abc</font></p>
+                    <p style="color: aquamarine;">abc</p>
                     <table class="o_selected_table">
                         <tbody><tr>
                             <td class="o_selected_td">

--- a/addons/html_editor/static/tests/table/selection.test.js
+++ b/addons/html_editor/static/tests/table/selection.test.js
@@ -277,7 +277,7 @@ describe("select a full table on cross over", () => {
                     '<td class="o_selected_td"><strong>cd</strong></td>' +
                     '<td class="o_selected_td"><strong>ef</strong></td>' +
                     "</tr></tbody></table>" +
-                    "<p><strong>abc</strong></p>" +
+                    '<p style="font-weight: bolder;">abc</p>' +
                     '<table class="o_selected_table"><tbody><tr>' +
                     '<td class="o_selected_td"><strong>ab</strong></td>' +
                     '<td class="o_selected_td"><strong>cd</strong></td>' +
@@ -311,7 +311,7 @@ describe("select a full table on cross over", () => {
                     '<td class="o_selected_td"><strong>cd</strong></td>' +
                     '<td class="o_selected_td"><strong>ef</strong></td>' +
                     "</tr></tbody></table>" +
-                    "<p><strong>abc</strong></p>" +
+                    '<p style="font-weight: bolder;">abc</p>' +
                     '<table class="o_selected_table"><tbody><tr>' +
                     '<td class="o_selected_td"><strong>ab</strong></td>' +
                     '<td class="o_selected_td"><strong>cd</strong></td>' +

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -178,7 +178,7 @@ test("toolbar works: can format bold", async () => {
 
     // click on toggle bold
     await contains(".btn[name='bold']").click();
-    expect(getContent(el)).toBe("<p><strong>[test]</strong></p>");
+    expect(getContent(el)).toBe('<p style="font-weight: bolder;">[test]</p>');
 });
 
 test.tags("iframe");
@@ -194,7 +194,7 @@ test("toolbar in an iframe works: can format bold", async () => {
 
     // click on toggle bold
     await contains(".btn[name='bold']").click();
-    expect(getContent(el)).toBe("<p><strong>[test]</strong></p>");
+    expect(getContent(el)).toBe('<p style="font-weight: bolder;">[test]</p>');
 });
 
 test("toolbar buttons react to selection change", async () => {
@@ -454,12 +454,12 @@ test("toolbar works: can select font size", async () => {
     expect(queryAllTexts(".o_font_size_selector_menu .dropdown-item")).toEqual([...sizes]);
     const h1Size = getFontSizeFromVar("h1-font-size").toString();
     await contains(`.o_font_size_selector_menu .dropdown-item:contains('${h1Size}')`).click();
-    expect(getContent(el)).toBe(`<p><span class="h1-fs">[test]</span></p>`);
+    expect(getContent(el)).toBe(`<p class="h1-fs">[test]</p>`);
     expect(inputEl).toHaveValue(h1Size);
     await contains(".o-we-toolbar [name='font_size'].dropdown-toggle").click();
     const oSmallSize = getFontSizeFromVar("small-font-size").toString();
     await contains(`.o_font_size_selector_menu .dropdown-item:contains('${oSmallSize}')`).click();
-    expect(getContent(el)).toBe(`<p><span class="o_small-fs">[test]</span></p>`);
+    expect(getContent(el)).toBe(`<p class="o_small-fs">[test]</p>`);
     expect(inputEl).toHaveValue(oSmallSize);
 });
 
@@ -536,7 +536,7 @@ test("should focus the editable area after selecting a font size item", async ()
     await contains(".o_font_size_selector_menu .dropdown-item:contains('21')").click();
     expect(editor.editable).toBeFocused();
     expect(inputEl).not.toBeFocused();
-    expect(getContent(el)).toBe(`<p><span class="h2-fs">[test]</span></p>`);
+    expect(getContent(el)).toBe(`<p class="h2-fs">[test]</p>`);
 });
 
 test.tags("mobile");
@@ -554,7 +554,7 @@ test("should focus the editable area after selecting a font size item on mobile"
     await contains(".o_font_size_selector_menu .dropdown-item:contains('21')").click();
     expect(editor.editable).toBeFocused();
     expect(inputEl).not.toBeFocused();
-    expect(getContent(el)).toBe(`<p><span class="h2-fs">[test]</span></p>`);
+    expect(getContent(el)).toBe(`<p class="h2-fs">[test]</p>`);
 });
 
 test.tags("desktop");
@@ -570,7 +570,7 @@ test("should not create empty extra nodes while changing format of link", async 
     await waitFor(".o_font_size_selector_menu .dropdown-item:contains('80')");
     await contains(".o_font_size_selector_menu .dropdown-item:contains('80')").click();
     expect(getContent(el)).toBe(
-        `<p><span class="display-1-fs">\ufeff<a href="http://test.com" class="o_link_in_selection">\ufeff[test.com]\ufeff</a>\ufeff</span></p>`
+        `<p class="display-1-fs">\ufeff<a href="http://test.com" class="o_link_in_selection">\ufeff[test.com]\ufeff</a>\ufeff</p>`
     );
 });
 
@@ -588,7 +588,7 @@ test("should not create empty extra nodes while changing format of link on mobil
     await waitFor(".o_font_size_selector_menu .dropdown-item:contains('80')");
     await contains(".o_font_size_selector_menu .dropdown-item:contains('80')").click();
     expect(getContent(el)).toBe(
-        `<p><span class="display-1-fs">\ufeff<a href="http://test.com" class="o_link_in_selection">\ufeff[test.com]\ufeff</a>\ufeff</span></p>`
+        `<p class="display-1-fs">\ufeff<a href="http://test.com" class="o_link_in_selection">\ufeff[test.com]\ufeff</a>\ufeff</p>`
     );
 });
 
@@ -614,8 +614,8 @@ test("toolbar works: display correct font size on select all", async () => {
     await animationFrame();
     const h1Size = getFontSizeFromVar("h1-font-size").toString();
     await contains(`.o_font_size_selector_menu .dropdown-item:contains('${h1Size}')`).click();
-    expect(getContent(el)).toBe(`<p><span class="h1-fs">[test]</span></p>`);
-    setContent(el, `<p><span class="h1-fs">te[]st</span></p>`);
+    expect(getContent(el)).toBe(`<p class="h1-fs">[test]</p>`);
+    setContent(el, `<p class="h1-fs">te[]st</p>`);
     await waitForNone(".o-we-toolbar");
     await press(["ctrl", "a"]); // Select all
     await waitFor(".o-we-toolbar");
@@ -646,7 +646,7 @@ test("toolbar works: displays correct font size on input", async () => {
     inputEl.blur();
     await animationFrame();
     // Responsive font-size: check for o_rfs class and clamp() value
-    const rfsSpan = el.querySelector("span.o_rfs");
+    const rfsSpan = el.querySelector("p.o_rfs");
     expect(rfsSpan !== null).toBe(true);
     expect(rfsSpan.style.fontSize.startsWith("clamp(")).toBe(true);
     await expectElementCount(".o-we-toolbar", 1);
@@ -1947,7 +1947,7 @@ test("toolbar update should be run only once", async () => {
     counter = 0;
     click(".o-we-toolbar .btn[name='bold']");
     await waitFor(".btn[name='bold'].active");
-    expect(getContent(el)).toBe("<p><strong>[test]</strong></p>");
+    expect(getContent(el)).toBe('<p style="font-weight: bolder;">[test]</p>');
     expect(counter).toBe(1);
 });
 

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -132,9 +132,12 @@ test("edit a message styling", async () => {
     await press("Control+i");
     await click(".o-mail-Message button:text('save')");
     await contains(".o-mail-Message[data-persistent] strong:contains(Hello world)", { count: 0 });
-    await contains(".o-mail-Message[data-persistent] em:contains(Hello world)", {
-        count: 1,
-    });
+    await contains(
+        ".o-mail-Message[data-persistent] div.o-paragraph[style='font-style: italic;']:contains(Hello world)",
+        {
+            count: 1,
+        }
+    );
     await contains(".o-mail-Message-content:text('Hello world (edited)')");
 });
 

--- a/addons/mail/static/tests/tours/mail_html_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_html_composer_test_tour.js
@@ -80,7 +80,8 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_html_compo
         },
         {
             content: "The italicized text is in the full composer",
-            trigger: ".o_mail_composer_message em:contains(Hello)",
+            trigger:
+                ".o_mail_composer_message div.o-paragraph[style='font-style: italic;']:contains(Hello)",
         },
         {
             content: "Close full composer",
@@ -94,7 +95,8 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_html_compo
         },
         {
             content: "The italicized text is in the composer",
-            trigger: ".o-mail-Composer-html.odoo-editor-editable em:contains(Hello)",
+            trigger:
+                ".o-mail-Composer-html.odoo-editor-editable div.o-paragraph[style='font-style: italic;']:contains(Hello)",
         },
     ],
 });

--- a/addons/mass_mailing/static/tests/tours/mailing_editor_theme.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_editor_theme.js
@@ -137,7 +137,7 @@ registry.category("web_tour.tours").add('mailing_editor_theme', {
         },
         {
             content: "Check that color was applied",
-            trigger: ':iframe p font.text-o-color-1',
+            trigger: ':iframe p.text-o-color-1',
         },
         ...stepUtils.saveForm(),
         {

--- a/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
@@ -154,6 +154,7 @@ export class HighlightPlugin extends Plugin {
         this.dependencies.format.formatSelection("highlight", {
             formatProps: { highlightId, colorToRestore, thicknessToRestore },
             applyStyle: true,
+            applyToBlock: false,
         });
 
         this.updateSelectedHighlight();

--- a/addons/website/static/tests/tours/website_text_edition.js
+++ b/addons/website/static/tests/tours/website_text_edition.js
@@ -54,16 +54,11 @@ registerWebsitePreviewTour(
             content: "Check that paragraph now uses the main color *class*",
             trigger: ":iframe .s_text_block p",
             run: function (actions) {
-                const fontEl = this.anchor.querySelector("font");
-                if (!fontEl) {
-                    console.error("A background color should have been applied");
-                    return;
-                }
-                if (fontEl.style.backgroundColor) {
+                if (this.anchor.style.backgroundColor) {
                     console.error("The paragraph should not have an inline style background color");
                     return;
                 }
-                const rgbColor = fontEl.style.getPropertyValue("color");
+                const rgbColor = this.anchor.style.getPropertyValue("color");
                 const hexColor = rgbToHex(rgbColor);
                 if (hexColor.toUpperCase() !== WEBSITE_MAIN_COLOR) {
                     console.error("The paragraph should have the right background color class");


### PR DESCRIPTION
Description of the issue this PR addresses:

When a paragraph-related element is fully selected, formatting commands (e.g. font-size, font-style, font-weight, etc.) and color are applied directly on the block element instead of new span or font element.

List items already behaved this way; this change aligns other block elements with the same behavior.

Applying the format on the block simplifies the DOM structure and ensures consistent behavior when formatting entire blocks.

task-5215987

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
