### PR TITLE
[FIX] website_mass_mailing_event: correct aside fragment name

### DIFF
--- a/addons/website_mass_mailing_event/static/src/builder/options/event_snapshot_fragments.xml
+++ b/addons/website_mass_mailing_event/static/src/builder/options/event_snapshot_fragments.xml
@@ -100,7 +100,7 @@
 
     <t t-name="website_mass_mailing_event.event_address_template">
         <t t-set="has_city" t-value="address.city"/>
-        <t t-set="has_state" t-value="state and country.state_required"/>
+        <t t-set="has_state" t-value="state and country and country.state_required"/>
 
         <span class="fa fa-map-marker"></span> <t t-if="has_city">
             <t t-out="address.city"/><t t-if="address.country_id">, </t>
@@ -108,6 +108,8 @@
         <t t-if="has_state">
             <t t-out="state.code"/>,
         </t>
-        <t t-out="country.name"/>
+        <t t-if="country">
+            <t t-out="country.name"/>
+        </t>
     </t>
 </templates>

--- a/addons/website_mass_mailing_event/static/src/builder/options/event_snapshot_snippet_info.js
+++ b/addons/website_mass_mailing_event/static/src/builder/options/event_snapshot_snippet_info.js
@@ -19,11 +19,16 @@ async function getAddressData(addressId, orm) {
         [addressId],
         ["city", "country_id", "state_id"]
     );
-    const countryData = await orm.read(
-        "res.country",
-        [addressData[0].country_id[0]],
-        ["name", "state_required"]
-    );
+
+    let countryData;
+    if (addressData[0].country_id) {
+        countryData = await orm.read(
+            "res.country",
+            [addressData[0].country_id[0]],
+            ["name", "state_required"]
+        );
+    }
+
     let stateData;
     if (addressData[0].state_id) {
         stateData = await orm.read("res.country.state", [addressData[0].state_id[0]], ["code"]);
@@ -31,7 +36,7 @@ async function getAddressData(addressId, orm) {
 
     return {
         address: addressData[0],
-        country: countryData[0],
+        country: countryData && countryData[0],
         state: stateData && stateData[0],
     };
 }
@@ -55,7 +60,7 @@ export const eventSnapshotSnippetInfo = {
             case "card":
                 return "website_mass_mailing_event.s_event_snapshot_card_fragment";
             case "aside":
-                return "website_mass_mailing_event.s_event_snapshot_event_aside_fragment";
+                return "website_mass_mailing_event.s_event_snapshot_aside_fragment";
         }
     },
     additionalRenderingContext: async (record, services) => {


### PR DESCRIPTION
Commit [33685d7dfd8b](https://github.com/odoo/odoo/commit/33685d7dfd8b232802a5c46ed78d9411f328a5d3) added autofill email snippets
for products and events.

The name of one of the event fragments had a typo, resulting in
the autofill plugin trying to reach a template that doesn't exist.

This commit fixes that issue.

This commit also fixes an edge case issue that would occur if an event
had an associated "address" partner that didn't have a country,
resulting in an error when trying to select that event.

task-5940938