### PR TITLE
[FIX] stock : Fix MemoryError in delivery propagation

### DIFF
--- a/addons/stock/models/stock_lot.py
+++ b/addons/stock/models/stock_lot.py
@@ -351,10 +351,10 @@ class StockLot(models.Model):
         while lots_to_propagate:
             lot_id = lots_to_propagate.pop()
 
-            parent_ids = parent_map[lot_id]
-            for parent_id in parent_ids:
-                if not delivery_by_lot[lot_id].issubset(delivery_by_lot[parent_id]):
-                    delivery_by_lot[parent_id].update(delivery_by_lot[lot_id])
+            for parent_id in parent_map.get(lot_id, []):
+                new_deliveries = delivery_by_lot[lot_id] - delivery_by_lot[parent_id]
+                if new_deliveries:
+                    delivery_by_lot[parent_id].update(new_deliveries)
                     lots_to_propagate.add(parent_id)
 
         return {lot_id: list(delivery_by_lot[lot_id]) for lot_id in delivery_by_lot}


### PR DESCRIPTION
- Some lots were found to contain very large delivery sets (7k+ picking IDs) with multiple parents.
- Updating parent sets in a single operation caused a MemoryError for large datasets.

```sql

Traceback (most recent call last):
   File "/tmp/tmpe5fq5baf/migrations/base/tests/test_mock_crawl.py", line 333, in crawl_menu
    self.mock_action(action_vals)
   File "/tmp/tmpe5fq5baf/migrations/base/tests/test_mock_crawl.py", line 346, in mock_action
    return self.mock_act_window(action)
   File "/tmp/tmpe5fq5baf/migrations/base/tests/test_mock_crawl.py", line 506, in mock_act_window
    mock_method(model, view, fields_list, domain, group_by)
   File "/tmp/tmpe5fq5baf/migrations/base/tests/test_mock_crawl.py", line 539, in mock_view_form
    [data] = record.read(fields_list)
   File "/home/odoo/src/odoo/18.0/odoo/models.py", line 3858, in read
    return self._read_format(fnames=fields, load=load)
   File "/home/odoo/src/odoo/18.0/odoo/models.py", line 4089, in _read_format
    vals[name] = convert(record[name], record, use_display_name)
   File "/home/odoo/src/odoo/18.0/odoo/models.py", line 7078, in __getitem__
    return self._fields[key].__get__(self)
   File "/home/odoo/src/odoo/18.0/odoo/fields.py", line 1311, in __get__
    self.compute_value(recs)
   File "/home/odoo/src/odoo/18.0/odoo/fields.py", line 1493, in compute_value
    records._compute_field_value(self)
   File "/home/odoo/src/odoo/18.0/addons/mail/models/mail_thread.py", line 442, in _compute_field_value
    return super()._compute_field_value(field)
   File "/home/odoo/src/odoo/18.0/odoo/models.py", line 5297, in _compute_field_value
    fields.determine(field.compute, self)
   File "/home/odoo/src/odoo/18.0/odoo/fields.py", line 110, in determine
    return needle(*args)
   File "/home/odoo/src/odoo/18.0/addons/stock/models/stock_lot.py", line 149, in _compute_delivery_ids
    delivery_ids_by_lot = self._find_delivery_ids_by_lot_iterative()
   File "/home/odoo/src/odoo/18.0/addons/stock/models/stock_lot.py", line 385, in _find_delivery_ids_by_lot_iterative
    delivery_by_lot[parent_id].update(delivery_by_lot[lot_id])
 MemoryError

(Pdb)len(all_lot_ids)
22166
(Pdb)len(barren_lines)
9682
(Pdb)len(lots_to_propagate)
9682

Lot_id 11412: delivery_by_lot size = 7420, parents = 3

Lot_id 11753: delivery_by_lot size = 0, parents = 7

Lot_id 12845: delivery_by_lot size = 11, parents = 5

Lot_id 14646: delivery_by_lot size = 12, parents = 2

Lot_id 15801: delivery_by_lot size = 1700, parents = 3

Lot_id 19817: delivery_by_lot size = 0, parents = 4

Lot_id 22370: delivery_by_lot size = 0, parents = 1

Lot_id 25072: delivery_by_lot size = 6827, parents = 2

Lot_id 25134: delivery_by_lot size = 3, parents = 2

Lot_id 25135: delivery_by_lot size = 1, parents = 2
```
- Previous fix adds all child deliveries, even if some already exist, but this new patch adds only the missing ones

UPG - 3869661
OPW - 5900313

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
