### PR TITLE
[FIX] mail: increase timeout of waitStoreFetch

### DIFF
--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -874,10 +874,11 @@ export function listenStoreFetch(nameOrNames = [], { logParams = [], onRpc: onRp
  * @param {boolean} [options.ignoreOrder=false]
  * @param {string[]} [options.stepsAfter=[]]
  * @param {string[]} [options.stepsBefore=[]]
+ * @param {number} [options.timeout=5000]
  */
 export async function waitStoreFetch(
     nameOrNames = [],
-    { ignoreOrder = false, stepsAfter = [], stepsBefore = [] } = {}
+    { ignoreOrder = false, stepsAfter = [], stepsBefore = [], timeout = 5000 } = {}
 ) {
     await expect.waitForSteps(
         [
@@ -894,7 +895,7 @@ export async function waitStoreFetch(
             ),
             ...stepsAfter,
         ],
-        { ignoreOrder }
+        { ignoreOrder, timeout }
     );
     /**
      * Extra tick necessary to ensure the RPC is fully processed before resolving.


### PR DESCRIPTION
The following tests fail no-deterministically on runbot.

The issue cannot be reproduced locally with more than 500 runs and the tests show no obvious coding issue.

The most realistic explanation is simply that heavy load would make some async steps timeout before they actually resolve: the expected payload is not caught at the start of the test when it should, but it is later caught at the end of the test.

runbot-239937
runbot-240553