### PR TITLE
[IMP] mass_mailing: mailing preview modal design fixup

### DIFF
--- a/addons/mail/static/src/views/web/fields/mail_preview_record_field/mail_preview_record_field.xml
+++ b/addons/mail/static/src/views/web/fields/mail_preview_record_field/mail_preview_record_field.xml
@@ -3,7 +3,7 @@
     <t t-name="mail.MailPreviewRecordField" t-inherit="web.ReferenceField" t-inherit-mode="primary">
         <xpath expr="//t[@t-if='relation']" position="replace">
             <div t-if="relation" class="d-flex align-items-stretch gap-1">
-                <div class="d-flex border px-1 align-items-center">$0</div>
+                <div class="d-flex px-1 align-items-center">$0</div>
                 <div class="d-flex ps-1 justify-content-center text-nowrap">
                     <Pager t-props="pagerProps"/>
                 </div>

--- a/addons/mail/wizard/mail_template_preview_views.xml
+++ b/addons/mail/wizard/mail_template_preview_views.xml
@@ -16,17 +16,19 @@
                         <group class="align-items-stretch mx-0">
                             <group class="px-0">
                                 <field name="email_from" invisible="not email_from"/>
-                                <field name="subject" class="fw-bold"/>
+                                <label for="subject" string="Subject"/>
+                                <field name="subject" class="fw-bold" invisible="not subject" nolabel="1"/>
+                                <span class="fst-italic" invisible="subject">Unspecified</span>
                                 <label for="recipient_names" string="To"/>
                                 <field name="recipient_names" invisible="not recipient_names" nolabel="1"/>
-                                <span invisible="recipient_names">(unspecified)</span>
+                                <span class="fst-italic" invisible="recipient_names">Unspecified</span>
                                 <field name="reply_to" invisible="not reply_to"/>
                                 <field name="scheduled_date" invisible="not scheduled_date"/>
                             </group>
                             <div class="d-flex justify-content-end flex-column px-0">
                                 <div class="d-flex gap-1 justify-content-end align-items-stretch">
                                     <field name="lang"
-                                        class="p-1 d-flex w-25 align-items-center border"
+                                        class="p-1 d-flex w-25 align-items-center"
                                         invisible="not has_several_languages_installed" nolabel="1"/>
                                     <field name="resource_ref" nolabel="1"
                                         options="{'hide_model': True, 'no_create': True, 'no_open': True, 'model_field': 'model_id'}"

--- a/addons/mass_mailing/static/src/components/mailing_preview_mode_toggle/mailing_preview_mode_toggle.xml
+++ b/addons/mass_mailing/static/src/components/mailing_preview_mode_toggle/mailing_preview_mode_toggle.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mass_mailing.MailingPreviewModeToggle">
-        <div class="d-flex gap-1" t-if="!state.isSmall">
+        <div class="d-flex gap-1 pb-1" t-if="!state.isSmall">
             <button type="button" class="btn py-0 px-1" t-on-click="() => this.onTogglePreviewMode(false)"
                     t-att-class="!state.isMobileMode? 'btn-primary' : 'btn-secondary'">
                 <i class="fa fa-desktop" title="Desktop Preview"/>

--- a/addons/mass_mailing/wizard/mailing_mailing_test.py
+++ b/addons/mass_mailing/wizard/mailing_mailing_test.py
@@ -165,12 +165,12 @@ class MailingMailingTest(models.TransientModel):
         failed_count = total - success_count
         if failed_count > 0:
             notif_message = _(
-                'Test mailing successfully sent to %(success)s recipients, and %(failed)s failed.',
+                'Test email sent to %(success)s recipient(s), could not send to %(failed)s.',
                 success=success_count, failed=failed_count,
             )
         else:
             notif_message = _(
-                'Test mailing successfully sent to %(success)s recipients.',
+                'Test email sent to %(success)s recipient(s).',
                 success=success_count,
             )
 

--- a/addons/mass_mailing/wizard/mailing_mailing_test_views.xml
+++ b/addons/mass_mailing/wizard/mailing_mailing_test_views.xml
@@ -18,8 +18,8 @@
                     </group>
                     <div class="row">
                         <div class="col-12 col-lg-8 d-flex align-items-center gap-2">
-                            <label for="email_to" string="Send a copy to" class="text-nowrap"/>
-                            <field name="email_to" widget="char" class="border p-1 m-0 w-50"
+                            <label for="email_to" string="Send test to" class="text-nowrap"/>
+                            <field name="email_to" widget="char" class="o_field_highlight m-0 w-50"
                                 placeholder="email1@example.com, email2@example.com"/>
                             <button name="send_mail_test" type="object" string="Send Test" class="btn-secondary text-nowrap"/>
                         </div>


### PR DESCRIPTION
This is a follow-up of [commit]

This makes small improvements in the mailing preview design. Remove border and force underline in email input for better visibility, and provide clearer feedback about test emails.

[commit]: https://www.odoo.com/odoo/project.task/4898430

Task-5941035
