### PR TITLE
[FIX] website: ensure footer copyright applies before mega footers

### DIFF
--- a/addons/html_editor/models/ir_ui_view.py
+++ b/addons/html_editor/models/ir_ui_view.py
@@ -338,7 +338,7 @@ class IrUiView(models.Model):
                     node.set('class', node.get('class') + ' col-md')
                     has_change = True
             if has_change:
-                ancestor.with_context(no_cow=True).write({'arch': etree.tostring(arch, encoding='unicode')})
+                ancestor.with_context(no_cow=True, delayed_translations=False).write({'arch': etree.tostring(arch, encoding='unicode')})
 
         new_arch = self.replace_arch_section(xpath, arch_section)
         old_arch = etree.fromstring(self.arch.encode('utf-8'))

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -2453,7 +2453,7 @@
     </xpath>
 </template>
 
-<template id="footer_copyright_company_name" inherit_id="website.layout">
+<template id="footer_copyright_company_name" inherit_id="website.layout" priority="15">
     <xpath expr="//footer//span[hasclass('o_footer_copyright_name')]" position="replace">
         <span class="o_footer_copyright_name me-2 small">Copyright &amp;copy; Company name</span>
     </xpath>


### PR DESCRIPTION
Steps to reproduce:
===================
1. Go to website and switch footer to mega footer
2. Add a language & edit copyright text
3. Save & change the language

=> breaks

Cause:
======
Editing triggers Odoo's Copy-On-Write (COW) mechanism, creating a
customized template with a higher database ID. This causes it to
execute after the mega footer templates, which expect col-sm classes
that were already changed to col-md. The xpaths fail and the footer
breaks.

The existing patch in html_editor/models/ir_ui_view.py (from [1])
that re-adds col-md when saving one of the affected views
was not working in this case because the write was done with
delayed_translations=True in context, causing the ancestor patch to be
skipped.

Solution:
=========
- Add `delayed_translations=False` to the ancestor write in `ir_ui_view.py`
  so the patch is applied immediately when editing the footer. This
  prevents the issue without requiring a module update.
- Add priority="15" to `footer_copyright_company_name` so that even for
  already-broken databases (where COW was created before this fix),
  the template runs before mega footer templates after a module update.
  The priority is inherited by COW-generated views.

[1]: https://github.com/odoo/odoo/commit/2d6699b4c460084110ccada0392845156af4a135
opw-5485986