### PR TITLE
[FIX] core: superfluous image processing

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -2516,7 +2516,14 @@ class Image(Binary):
         records.env.cache.update(records, self, itertools.repeat(cache_value), dirty=dirty)
 
     def _image_process(self, value):
-        if self.readonly and not self.max_width and not self.max_height:
+        if self.readonly and (
+            (not self.max_width and not self.max_height)
+            or (
+                self.related_field
+                and self.max_width == self.related_field.max_width
+                and self.max_height == self.related_field.max_height
+            )
+        ):
             # no need to process images for computed fields, or related fields
             return value
         try:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Because of the way `Pillow` manages memory, excessive image processing quickly leads to MemoryError, e.g. during upgrades.

Current behavior before PR:

When a readonly Image field with definied dimensions relates to another Image field of the same dimensions, there is no need to ever process the former one, since the processing will already have happened on the latter one. Still, the current code will process the image superfluously in these cases.

Desired behavior after PR is merged:

Extending the condition for skipping superfluous image processing to cover these cases will lead to reduced compute time and memory use.