### PR TITLE
[FIX] point_of_sale: allow barcode scan for product packaging

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -687,6 +687,13 @@ export class PosStore extends WithLazyGetterTrap {
             let product;
             if (opts.code) {
                 product = this.models["product.product"].getBy("barcode", opts.code.base_code);
+                if (!product) {
+                    const productPackaging = this.models["product.uom"].getBy(
+                        "barcode",
+                        opts.code.base_code
+                    );
+                    product = productPackaging && productPackaging.product_id;
+                }
             } else {
                 product = opts.presetVariant;
             }

--- a/addons/point_of_sale/static/tests/pos/tours/barcode_scanning_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/barcode_scanning_tour.js
@@ -1,6 +1,7 @@
 import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
+import * as ProductConfigurator from "@point_of_sale/../tests/pos/tours/utils/product_configurator_util";
 import { registry } from "@web/core/registry";
 import { scan_barcode } from "@point_of_sale/../tests/generic_helpers/utils";
 
@@ -52,6 +53,12 @@ registry.category("web_tour.tours").add("BarcodeScanningProductPackagingTour", {
             ProductScreen.selectedOrderlineHas("Packaging Product", 12),
             scan_barcode("12345610"),
             ProductScreen.selectedOrderlineHas("Packaging Product", 22),
+
+            // Add Product which has no barcode, but it's packaging has one
+            scan_barcode("12345618"),
+            ProductConfigurator.pickMulti("Cushion"),
+            Dialog.confirm(),
+            ProductScreen.selectedOrderlineHas("Packaging Product2", 10),
             Chrome.endTour(),
         ].flat(),
 });

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1234,6 +1234,49 @@ class TestUi(TestPointOfSaleHttpCommon):
             'product_id': product.id,
             'uom_id': pack_of_10.id,
         })
+        # product has no barcode, it's variant's packaging has it
+        product_templ_2 = self.env['product.template'].create({
+            'name': 'Packaging Product2',
+            'available_in_pos': True,
+            'list_price': 10,
+            'taxes_id': False,
+        })
+        color_attribute = self.env['product.attribute'].create({
+            'name': 'Color always',
+            'create_variant': 'always',
+            'value_ids': [(0, 0, {
+                'name': 'Red',
+                'sequence': 1,
+            }), (0, 0, {
+                'name': 'Blue',
+                'sequence': 2,
+            })],
+        })
+
+        self.env['product.template.attribute.line'].create([
+            {
+                'product_tmpl_id': product_templ_2.id,
+                'attribute_id': color_attribute.id,
+                'value_ids': [(6, 0, color_attribute.value_ids.ids)]
+            },
+            {
+                'product_tmpl_id': product_templ_2.id,
+                'attribute_id': self.chair_addons_attribute.id,
+                'value_ids': [(6, 0, [self.chair_addon_cushion.id, self.chair_addon_cupholder.id])]
+            }
+        ])
+        self.env['product.uom'].create([
+            {
+                'barcode': '12345618',
+                'product_id': product_templ_2.product_variant_ids[0].id,
+                'uom_id': pack_of_10.id,
+            },
+            {
+                'barcode': '12345619',
+                'product_id': product_templ_2.product_variant_ids[1].id,
+                'uom_id': pack_of_10.id,
+            }
+        ])
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'BarcodeScanningProductPackagingTour', login="pos_user")


### PR DESCRIPTION
Step to reproduce
- Create a product
- Add two attributes:
1. One with Instantly creation mode
2. One with Never creation mode
- Define packaging from the Sales tab
- Add a barcode on the variant packaging ex: 111356,11357
- Scan the packaging barcode in POS

Observation:
- we get a traceback `TypeError: Cannot read properties of undefined (reading 'product_template_attribute_value_ids')`

Cause:
- when we do not have barcode on product, when opening `openConfigurator`
- (as we have few varianst) product get undefined.
https://github.com/odoo/odoo/blob/f229f23d7bf3d837ff5577c36145bf2ba410ea22/addons/point_of_sale/static/src/app/services/pos_store.js#L738
- Hence the traceback

Fix:
- For the case, when packaging has barcode but not the product,
we search for product in that case too.

opw-5886570

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
