### PR TITLE
[FIX] sale: services & materials – cleanup and fixes

### DIFF
--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -55,10 +55,14 @@ class AccountMove(models.Model):
 
     @api.depends('line_ids.sale_line_ids')
     def _compute_service_line_count(self):
+        services_data = self.env['account.analytic.line']._read_group(
+            self._domain_services_analytic_line(),
+            ['reinvoice_move_id'],
+            ['__count'],
+        )
+        mapped_services_data = dict(services_data)
         for move in self:
-            move.service_line_count = self.env['account.analytic.line'].search_count(
-                move._domain_services_analytic_line(),
-            )
+            move.service_line_count = mapped_services_data.get(move, 0)
 
     @api.depends('partner_id.name', 'partner_id.sale_warn_msg', 'invoice_line_ids.product_id.sale_line_warn_msg', 'invoice_line_ids.product_id.display_name')
     def _compute_sale_warning_text(self):

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -970,7 +970,7 @@ class SaleOrderLine(models.Model):
         # compute for analytic lines
         delivered_qties = defaultdict(float)
         lines_by_analytic = self.filtered(
-            lambda sol: sol.qty_delivered_method == 'analytic' or sol._is_reinvoicing_line()
+            lambda sol: sol.qty_delivered_method == 'analytic' or sol._is_analytic_reinvoice_line()
         )
         domain = lines_by_analytic._get_delivered_quantity_by_analytic_domain()
         mapping = lines_by_analytic._get_delivered_quantity_by_analytic(domain)
@@ -1871,7 +1871,7 @@ class SaleOrderLine(models.Model):
         self.ensure_one()
         return self.product_uom_id.rounding
 
-    def _is_reinvoicing_line(self):
+    def _is_analytic_reinvoice_line(self):
         self.ensure_one()
         return (
             not self.is_expense

--- a/addons/sale/views/account_analytic_line_views.xml
+++ b/addons/sale/views/account_analytic_line_views.xml
@@ -29,7 +29,6 @@
         <field name="model">account.analytic.line</field>
         <field name="arch" type="xml">
             <list string="Services &amp; Material" editable="top" multi_edit="1">
-                <field name="date" string="Date"/>
                 <field
                     name="order_id"
                     string="Customer Order"
@@ -66,6 +65,7 @@
                 <field name="partner_id" optional="hide"/>
                 <field name="amount" optional="hide"/>
                 <field name="name" string="Description"/>
+                <field name="date" string="Date"/>
                 <field name="company_id" groups="base.group_multi_company" optional="hide"/>
             </list>
         </field>


### PR DESCRIPTION
This commit cleans up and fixes a few minor issues introduced by the **Services and Materials** feature added in [1].

Fixes:
- repositioning the `Date` column
- renaming confusing methods (such as `_is_reinvoicing_line` and `_is_line_reinvoicable`) to better reflect their uses.
- support custom unit price on SOL from AAL when explicitely specified.
- use _read_group for computing service_line_count on AM

1 - odoo/odoo@cd6325d

task-5490517

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
