### PR TITLE
[FIX] l10n_hr: Receivable and Payable account swapped

### DIFF
--- a/addons/l10n_hr/data/template/account.tax.group-hr.csv
+++ b/addons/l10n_hr/data/template/account.tax.group-hr.csv
@@ -1,4 +1,4 @@
-"id","name","country_id","name@hr","tax_payable_account_id","tax_receivable_account_id"
+"id","name","country_id","name@hr","tax_receivable_account_id","tax_payable_account_id"
 "tax_group_pdv_0","PDV 0%","base.hr","PDV 0%","hr_158000","hr_226000"
 "tax_group_pdv_5","PDV 5%","base.hr","PDV 5%","hr_158000","hr_226000"
 "tax_group_pdv_13","PDV 13%","base.hr","PDV 13%","hr_158000","hr_226000"


### PR DESCRIPTION
The receivable accounts were wrongly setup where the receivable account of the tax group was set with the payable account, ...

task-5045769

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
