### PR TITLE
[IMP] point_of_sale: add resilience to paymentMethodImage

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -343,12 +343,12 @@ export class PaymentScreen extends Component {
         this.numberBuffer.reset();
     }
 
-    paymentMethodImage(id) {
-        if (this.paymentMethod.image) {
-            return `/web/image/pos.payment.method/${id}/image`;
-        } else if (this.paymentMethod.type === "cash") {
+    paymentMethodImage(paymentMethod) {
+        if (paymentMethod.image) {
+            return `/web/image/pos.payment.method/${paymentMethod.id}/image`;
+        } else if (paymentMethod.type === "cash") {
             return "/point_of_sale/static/src/img/money.png";
-        } else if (this.paymentMethod.type === "pay_later") {
+        } else if (paymentMethod.type === "pay_later") {
             return "/point_of_sale/static/src/img/pay-later.png";
         } else {
             return "/point_of_sale/static/src/img/card-bank.png";

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
@@ -136,7 +136,7 @@
                         <t t-if="pos.config.canInvoice">Invoice</t>
                         <t t-else="">Not available</t>
                     </span>
-                    <i class="fa me-2" t-attf-class="{{ currentOrder.isToInvoice() ? 'fa-check-square text-action' : 'fa-square-o' }}" /> 
+                    <i class="fa me-2" t-attf-class="{{ currentOrder.isToInvoice() ? 'fa-check-square text-action' : 'fa-square-o' }}" />
                 </button>
             </div>
             <div t-if="(pos.config.iface_tipproduct and pos.config.tip_product_id) or pos.config.iface_cashdrawer or pos.config.ship_later" class="d-flex flex-column gap-1 w-100">
@@ -171,7 +171,7 @@
                         t-att-class="{'opacity-50': this.pos.paymentTerminalInProgress and paymentMethod.use_payment_terminal, 'd-flex justify-content-between align-items-center': true}"
                         t-on-click="() => this.addNewPaymentLine(paymentMethod)">
                         <div class="payment-method-display d-flex align-items-center gap-2 text-wrap text-start lh-sm">
-                            <img class="payment-method-icon" t-att-src="paymentMethodImage(paymentMethod.id)" />
+                            <img class="payment-method-icon" t-att-src="this.paymentMethodImage(paymentMethod)" />
                             <span class="payment-name" t-esc="paymentMethod.name" />
                         </div>
                         <span class="text-muted" t-esc="pos.getPaymentMethodFmtAmount(paymentMethod, currentOrder)"/>


### PR DESCRIPTION
In preparation for owl3, we had to manually refactor the `paymentMethodImage` which was a bit fragile.

BEFORE:
`paymentMethodImage` uses `this.paymentMethod.image` even if paymentMethod is a template variable and not a componenent variable.

NOW:
`paymentMethodImage` uses `paymnentMethod.image` making it clear the variable is coming from the template.

task: OWL3 prep - add this. to template variables


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
