### PR TITLE
[FIX] iot_drivers: scale compatibility for <v19

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/serial_scale_driver.py
+++ b/addons/iot_drivers/iot_handlers/drivers/serial_scale_driver.py
@@ -126,8 +126,10 @@ class ScaleDriver(SerialDriver):
         answer = self._get_raw_response(self._connection)
         match = re.search(self._protocol.measureRegexp, answer)
         if match:
+            weight_on_scale = float(match.group(1))
             self.data.update({
-                'result': float(match.group(1)),
+                'result': weight_on_scale,
+                'value': weight_on_scale,  # TODO: remove this when v18 is deprecated
                 'status': self._status,
             })
         else:


### PR DESCRIPTION
This PR adds the scale commands compatibility for the iot box images in >= saas-19.1 with the dbs in v18.0 and less

In v18.0 we read 'value' key sent by the iot box but the iot box doesn't send it anymore in 19.1
This PR makes the iot box send both 'result' as exepcted in v19 and 'value' expected in v18

Enterprise PR: https://github.com/odoo/enterprise/pull/107641