### PR TITLE
[FIX] web: tooltip_service: do not kill tooltip if still in target

### DIFF
--- a/addons/web/static/src/core/tooltip/tooltip_service.js
+++ b/addons/web/static/src/core/tooltip/tooltip_service.js
@@ -131,6 +131,9 @@ export const tooltipService = {
                 return;
             }
             const element = el.closest("[data-tooltip], [data-tooltip-template]");
+            if (element && element === target) {
+                return;
+            }
             if (elementsWithTooltips.has(el)) {
                 openTooltip(el, elementsWithTooltips.get(el));
             } else if (element) {
@@ -162,7 +165,7 @@ export const tooltipService = {
         }
 
         function cleanupTooltip(ev) {
-            if (target === ev.target.closest("[data-tooltip], [data-tooltip-template]")) {
+            if (target == ev.target) {
                 cleanup();
             }
         }

--- a/addons/web/static/tests/core/tooltip/tooltip_service.test.js
+++ b/addons/web/static/tests/core/tooltip/tooltip_service.test.js
@@ -386,3 +386,40 @@ test("touch rendering - tap-to-show", async () => {
     await animationFrame();
     expect(".o_popover").toHaveCount(0);
 });
+
+test.tags("desktop");
+test("tooltip from and to child element", async () => {
+    class MyComponent extends Component {
+        static props = ["*"];
+        static template = xml`
+        <div class="no-tooltip">space</div>
+        <div class="p-5" data-tooltip="hello">
+            <button>Action</button>
+        </div>`;
+    }
+
+    await mountWithCleanup(MyComponent);
+    expect(".o_popover").toHaveCount(0);
+
+    await pointerDown("div[data-tooltip]");
+    await advanceTime(SHOW_AFTER_DELAY);
+    await advanceTime(OPEN_DELAY);
+    expect(".o_popover").toHaveCount(1);
+    const popover = queryOne(".o_popover");
+
+    await pointerDown("button");
+    await advanceTime(SHOW_AFTER_DELAY);
+    await advanceTime(OPEN_DELAY);
+    expect(".o_popover").toHaveCount(1);
+    expect(queryOne(".o_popover")).toBe(popover);
+
+    await pointerDown("div[data-tooltip]");
+    await advanceTime(SHOW_AFTER_DELAY);
+    await advanceTime(OPEN_DELAY);
+    expect(queryOne(".o_popover")).toBe(popover);
+
+    await pointerDown(".no-tooltip");
+    await advanceTime(SHOW_AFTER_DELAY);
+    await advanceTime(OPEN_DELAY);
+    expect(".o_popover").toHaveCount(0);
+});


### PR DESCRIPTION
Have a tooltip on a parent.
Hover on a child of that parent.
Now, leave the child but stay in parent.

Before this commit, the tooltip would be killed and never respawn.

After this commit, the tooltip is not even killed if we stayed within the parent's physical space.

task-5346498

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
