### PR TITLE
[FIX] web_editor: improve performance by simplifying dirty check

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -1046,6 +1046,7 @@ export class OdooEditor extends EventTarget {
         if (!this.observer) {
             this.observer = new MutationObserver(records => {
                 this.observerIdSet(records);
+                this.dispatchEvent(new Event('dirty'));
                 records = this.filterMutationRecords(records);
                 if (!records.length) return;
                 this.dispatchEvent(new Event('contentChanged'));
@@ -3784,6 +3785,7 @@ export class OdooEditor extends EventTarget {
     //--------------------------------------------------------------------------
 
     _onBeforeInput(ev) {
+        this.dispatchEvent(new Event('dirty'));
         this._lastBeforeInputType = ev.inputType;
         // For chrome when we have this structure
         // <div contenteditable="true">
@@ -3822,6 +3824,7 @@ export class OdooEditor extends EventTarget {
         if (newSelection.anchorNode && isProtected(newSelection.anchorNode)) {
             return;
         }
+        this.dispatchEvent(new Event('dirty'));
         const shouldOpenPowerbox = newSelection.isCollapsed && newSelection.rangeCount &&
             ev.data === '/' && this.powerbox && !this.powerbox.isOpen &&
             (!this.options.getPowerboxElement || !!this.options.getPowerboxElement());
@@ -5224,6 +5227,7 @@ export class OdooEditor extends EventTarget {
             return;
         }
         ev.preventDefault();
+        this.dispatchEvent(new Event('dirty'));
         const files = getImageFiles(ev.clipboardData);
         const odooEditorHtml = ev.clipboardData.getData('text/odoo-editor');
         const clipboardHtml = ev.clipboardData.getData('text/html');


### PR DESCRIPTION
Problem:
When editing heavy content, each interaction can take up to 600 ms, sometimes freezing the editor completely.

Cause:
The `_isDirty` check is computationally expensive and is executed on every history step. This is unnecessary and leads to poor performance when handling large documents.

Solution:
Instead of recomputing `_isDirty` on each history step, directly mark the field as dirty whenever a history step is triggered. This provides a simpler and more efficient approach.

Before fix:
Each keyboard interaction to next paint takes around 200ms.
<img width="596" height="272" alt="image" src="https://github.com/user-attachments/assets/6145a532-3148-46fd-ac5a-cd3f4c726067" />

After fix:
Each keyboard interaction to next paint takes around 40ms.
<img width="610" height="178" alt="image" src="https://github.com/user-attachments/assets/1ff9ca36-457b-4015-9f30-4fed990c2ba3" />

opw-5892291

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr