### PR TITLE
[FIX] html_editor: gifs shouldn't have a srcset

### DIFF
--- a/addons/html_editor/static/src/main/media/image_save_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_save_plugin.js
@@ -129,7 +129,14 @@ export class ImageSavePlugin extends Plugin {
         }
         el.classList.remove("o_b64_image_to_save");
     }
-
+    imageIsGif(el) {
+        if (el.dataset.mimetype === "image/svg+xml") {
+            const rawData = getImageSrc(el).split(",")[1];
+            const svgData = atob(rawData);
+            return svgData.includes("data:image/gif");
+        }
+        return el.dataset.mimetype === "image/gif";
+    }
     /**
      * Saves a modified image as an attachment.
      *
@@ -181,12 +188,7 @@ export class ImageSavePlugin extends Plugin {
                 }
             }
         }
-        if (
-            !isImageField &&
-            !isBackground &&
-            el.dataset.mimetype !== "image/gif" &&
-            !el.dataset.hoverEffect
-        ) {
+        if (!isImageField && !isBackground && !this.imageIsGif(el) && !el.dataset.hoverEffect) {
             // We are using these sizes instead of the normally used 128, 256, ...
             // because we want to optimize smartphone data usage and loading time.
             // Each sizes in smallerSizes fits a certain category of smartphone,


### PR DESCRIPTION
Bug:
When setting a shape to a gif, the gif gets a srcset attribute, so when resizing the page, the gif freezes.

Steps to reproduce:
- in website editor
- add a gif to an image snippet
- add a shape to the gif
- save
- resize the window, the gif freezes

Why:
The bug exist since this commit odoo@82ce749, when srcset got added. Gifs should not get srcset because we can't resize gifs, but only pure base64 gifs were excluded.
So gifs embeded into a base64 svg were going through and could get a srcset.

Fix:
Added a condition to check if the svg data has a gif inside.

task-5914466