### PR TITLE
[FIX] hr_attendance: only consider past attendances in `last_attendance_id`

### DIFF
--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -147,9 +147,11 @@ class HrEmployee(models.Model):
 
     @api.depends('attendance_ids')
     def _compute_last_attendance_id(self):
+        current_datetime = fields.Datetime.now()
         for employee in self:
             employee.last_attendance_id = self.env['hr.attendance'].search([
                 ('employee_id', 'in', employee.ids),
+                ('check_in', '<=', current_datetime),
             ], order="check_in desc", limit=1)
 
     @api.depends('last_attendance_id.check_in', 'last_attendance_id.check_out', 'last_attendance_id')


### PR DESCRIPTION
### Issue:
When having an attendance in the future, the employee cannot checkout anymore.

### Steps to reproduce:
- In Attendances, create an attendance in the future for an employee
- Go in the kiosk mode
- Manually select the employee to check in
- Do the same to check out
- An error pops up

### Cause:
The field `last_attendance_id` of the employee contains his future attendance. The field `attendance_state` use `last_attendance_id` in its computation, so it's always "checked_out", even if an attendance is curently open for the employee.

So when trying to check out an exception is raised in [`_check_validity()`](https://github.com/odoo/odoo/blob/fee6b32a8a57577bd8229c80dff6f93964f9f556/addons/hr_attendance/models/hr_attendance.py#L224-L234).

### Solution:
Add a condition in the domain of `_compute_last_attendance_id()` to only consider the last **past** attendance.

opw-5491867