### PR TITLE
[FIX] stock: do not set current user on quant when setting qty to zero

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -552,7 +552,8 @@ class StockQuant(models.Model):
         self.inventory_quantity = 0
         if self.env.context.get('inventory_report_mode'):
             self._apply_inventory()
-        self.user_id = self.env.user.id
+        else:
+            self.user_id = self.env.user.id
 
     @api.depends('location_id', 'lot_id', 'package_id', 'owner_id')
     def _compute_display_name(self):


### PR DESCRIPTION
Steps to reproduce:
- Create a storable product "P1"
- Click on Quantity On Hand
- Set the quantity to 10 and save
- Set the quantity to 0
- Go back to the quant list view by clicking on Quantity On Hand
- The quant is deleted by: https://github.com/odoo/odoo/blob/08015c2a15704b30c7815b62612b71b8970e3ac2/addons/stock/models/stock_quant.py#L1076-L1079

- Set the quantity to 10 again and save
- Select the quant
- Action > Set to 0

Problem:
The function `action_set_inventory_quantity_zero` sets the current user on the quant even on inventory mode. This prevents the quant from being deleted when `_unlink_zero_quants` is called.

opw-5906681