### PR TITLE
[FIX] l10n_es_edi_facturae: use currency dependent rounding for amounts

### DIFF
--- a/addons/l10n_es_edi_facturae/data/facturae_templates.xml
+++ b/addons/l10n_es_edi_facturae/data/facturae_templates.xml
@@ -135,13 +135,13 @@
                 <Quantity t-out="line['Quantity']"/>
                 <UnitOfMeasure t-out="line.get('UnitOfMeasure')"/>
                 <UnitPriceWithoutTax t-out="float_repr(refund_multiplier*line['UnitPriceWithoutTax'], 8)"/>
-                <TotalCost t-out="float_repr(refund_multiplier*line['TotalCost'], 8)"/>
+                <TotalCost t-out="float_repr(refund_multiplier*line['TotalCost'], file_currency.decimal_places)"/>
                 <DiscountsAndRebates t-if="line.get('DiscountsAndRebates')">
                     <t t-foreach="line['DiscountsAndRebates']" t-as="discount">
                         <Discount>
                             <DiscountReason t-out="discount['DiscountReason']"/>
                             <DiscountRate t-out="discount.get('DiscountRate')"/>
-                            <DiscountAmount t-out="float_repr(refund_multiplier*discount['DiscountAmount'], 8)"/>
+                            <DiscountAmount t-out="float_repr(refund_multiplier*discount['DiscountAmount'], file_currency.decimal_places)"/>
                         </Discount>
                     </t>
                 </DiscountsAndRebates>
@@ -150,11 +150,11 @@
                         <Charge>
                             <ChargeReason t-out="charge['ChargeReason']"/>
                             <ChargeRate t-out="charge.get('ChargeRate')"/>
-                            <ChargeAmount t-out="float_repr(refund_multiplier*charge['ChargeAmount'], 8)"/>
+                            <ChargeAmount t-out="float_repr(refund_multiplier*charge['ChargeAmount'], file_currency.decimal_places)"/>
                         </Charge>
                     </t>
                 </Charges>
-                <GrossAmount t-out="float_repr(refund_multiplier*line['GrossAmount'], 8)"/>
+                <GrossAmount t-out="float_repr(refund_multiplier*line['GrossAmount'], file_currency.decimal_places)"/>
                 <TaxesWithheld t-if="line.get('TaxesWithheld')">
                     <t t-foreach="line['TaxesWithheld']" t-as="tax"><t t-call="l10n_es_edi_facturae.tax_type"/></t>
                 </TaxesWithheld>

--- a/addons/l10n_es_edi_facturae/tests/data/expected_ac_document.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_ac_document.xml
@@ -136,8 +136,8 @@
           <Quantity>1.0</Quantity>
           <UnitOfMeasure>01</UnitOfMeasure>
           <UnitPriceWithoutTax>100.00000000</UnitPriceWithoutTax>
-          <TotalCost>100.00000000</TotalCost>
-          <GrossAmount>100.00000000</GrossAmount>
+          <TotalCost>100.00</TotalCost>
+          <GrossAmount>100.00</GrossAmount>
           <TaxesOutputs>
             <Tax>
               <TaxTypeCode>01</TaxTypeCode>

--- a/addons/l10n_es_edi_facturae/tests/data/expected_in_invoice_document.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_in_invoice_document.xml
@@ -137,8 +137,8 @@
           <Quantity>1.0</Quantity>
           <UnitOfMeasure>01</UnitOfMeasure>
           <UnitPriceWithoutTax>100.00000000</UnitPriceWithoutTax>
-          <TotalCost>100.00000000</TotalCost>
-          <GrossAmount>100.00000000</GrossAmount>
+          <TotalCost>100.00</TotalCost>
+          <GrossAmount>100.00</GrossAmount>
           <TaxesOutputs>
             <Tax>
               <TaxTypeCode>01</TaxTypeCode>
@@ -158,8 +158,8 @@
           <Quantity>1.0</Quantity>
           <UnitOfMeasure>01</UnitOfMeasure>
           <UnitPriceWithoutTax>100.00000000</UnitPriceWithoutTax>
-          <TotalCost>100.00000000</TotalCost>
-          <GrossAmount>100.00000000</GrossAmount>
+          <TotalCost>100.00</TotalCost>
+          <GrossAmount>100.00</GrossAmount>
           <TaxesOutputs>
             <Tax>
               <TaxTypeCode>01</TaxTypeCode>
@@ -179,8 +179,8 @@
           <Quantity>1.0</Quantity>
           <UnitOfMeasure>01</UnitOfMeasure>
           <UnitPriceWithoutTax>200.00000000</UnitPriceWithoutTax>
-          <TotalCost>200.00000000</TotalCost>
-          <GrossAmount>200.00000000</GrossAmount>
+          <TotalCost>200.00</TotalCost>
+          <GrossAmount>200.00</GrossAmount>
           <TaxesOutputs>
             <Tax>
               <TaxTypeCode>01</TaxTypeCode>
@@ -200,15 +200,15 @@
           <Quantity>1.0</Quantity>
           <UnitOfMeasure>01</UnitOfMeasure>
           <UnitPriceWithoutTax>1000.00000000</UnitPriceWithoutTax>
-          <TotalCost>1000.00000000</TotalCost>
+          <TotalCost>1000.00</TotalCost>
           <DiscountsAndRebates>
             <Discount>
               <DiscountReason>/</DiscountReason>
               <DiscountRate>10.00</DiscountRate>
-              <DiscountAmount>100.00000000</DiscountAmount>
+              <DiscountAmount>100.00</DiscountAmount>
             </Discount>
           </DiscountsAndRebates>
-          <GrossAmount>900.00000000</GrossAmount>
+          <GrossAmount>900.00</GrossAmount>
           <TaxesOutputs>
             <Tax>
               <TaxTypeCode>01</TaxTypeCode>
@@ -228,15 +228,15 @@
           <Quantity>1.0</Quantity>
           <UnitOfMeasure>01</UnitOfMeasure>
           <UnitPriceWithoutTax>1000.00000000</UnitPriceWithoutTax>
-          <TotalCost>1000.00000000</TotalCost>
+          <TotalCost>1000.00</TotalCost>
           <Charges>
             <Charge>
               <ChargeReason>/</ChargeReason>
               <ChargeRate>10.00</ChargeRate>
-              <ChargeAmount>100.00000000</ChargeAmount>
+              <ChargeAmount>100.00</ChargeAmount>
             </Charge>
           </Charges>
-          <GrossAmount>1100.00000000</GrossAmount>
+          <GrossAmount>1100.00</GrossAmount>
           <TaxesOutputs>
             <Tax>
               <TaxTypeCode>01</TaxTypeCode>

--- a/addons/l10n_es_edi_facturae/tests/data/expected_invoice_payment_means.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_invoice_payment_means.xml
@@ -97,8 +97,8 @@
           <Quantity>1.0</Quantity>
           <UnitOfMeasure>01</UnitOfMeasure>
           <UnitPriceWithoutTax>100.00000000</UnitPriceWithoutTax>
-          <TotalCost>100.00000000</TotalCost>
-          <GrossAmount>100.00000000</GrossAmount>
+          <TotalCost>100.00</TotalCost>
+          <GrossAmount>100.00</GrossAmount>
           <TaxesOutputs>
             <Tax>
               <TaxTypeCode>01</TaxTypeCode>

--- a/addons/l10n_es_edi_facturae/tests/data/expected_invoice_period_document.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_invoice_period_document.xml
@@ -101,8 +101,8 @@
           <Quantity>1.0</Quantity>
           <UnitOfMeasure>01</UnitOfMeasure>
           <UnitPriceWithoutTax>100.00000000</UnitPriceWithoutTax>
-          <TotalCost>100.00000000</TotalCost>
-          <GrossAmount>100.00000000</GrossAmount>
+          <TotalCost>100.00</TotalCost>
+          <GrossAmount>100.00</GrossAmount>
           <TaxesOutputs>
             <Tax>
               <TaxTypeCode>01</TaxTypeCode>

--- a/addons/l10n_es_edi_facturae/tests/data/expected_out_invoice_4_decimals.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_out_invoice_4_decimals.xml
@@ -97,8 +97,8 @@
           <Quantity>22.0</Quantity>
           <UnitOfMeasure>01</UnitOfMeasure>
           <UnitPriceWithoutTax>2.05909091</UnitPriceWithoutTax>
-          <TotalCost>45.30000000</TotalCost>
-          <GrossAmount>45.30000000</GrossAmount>
+          <TotalCost>45.30</TotalCost>
+          <GrossAmount>45.30</GrossAmount>
           <TaxesOutputs>
             <Tax>
               <TaxTypeCode>01</TaxTypeCode>

--- a/addons/l10n_es_edi_facturae/tests/data/expected_out_invoice_negative.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_out_invoice_negative.xml
@@ -129,8 +129,8 @@
           <Quantity>1.0</Quantity>
           <UnitOfMeasure>01</UnitOfMeasure>
           <UnitPriceWithoutTax>1000.00000000</UnitPriceWithoutTax>
-          <TotalCost>1000.00000000</TotalCost>
-          <GrossAmount>1000.00000000</GrossAmount>
+          <TotalCost>1000.00</TotalCost>
+          <GrossAmount>1000.00</GrossAmount>
           <TaxesWithheld>
             <Tax>
               <TaxTypeCode>04</TaxTypeCode>
@@ -162,8 +162,8 @@
           <Quantity>1.0</Quantity>
           <UnitOfMeasure>01</UnitOfMeasure>
           <UnitPriceWithoutTax>-100.00000000</UnitPriceWithoutTax>
-          <TotalCost>-100.00000000</TotalCost>
-          <GrossAmount>-100.00000000</GrossAmount>
+          <TotalCost>-100.00</TotalCost>
+          <GrossAmount>-100.00</GrossAmount>
           <TaxesWithheld>
             <Tax>
               <TaxTypeCode>04</TaxTypeCode>

--- a/addons/l10n_es_edi_facturae/tests/data/expected_out_invoice_round_glob.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_out_invoice_round_glob.xml
@@ -127,8 +127,8 @@
                     <Quantity>25.0</Quantity>
                     <UnitOfMeasure>01</UnitOfMeasure>
                     <UnitPriceWithoutTax>2.02000000</UnitPriceWithoutTax>
-                    <TotalCost>50.50000000</TotalCost>
-                    <GrossAmount>50.50000000</GrossAmount>
+                    <TotalCost>50.50</TotalCost>
+                    <GrossAmount>50.50</GrossAmount>
                     <TaxesOutputs>
                         <Tax>
                             <TaxTypeCode>01</TaxTypeCode>
@@ -148,8 +148,8 @@
                     <Quantity>2.0</Quantity>
                     <UnitOfMeasure>01</UnitOfMeasure>
                     <UnitPriceWithoutTax>7.29000000</UnitPriceWithoutTax>
-                    <TotalCost>14.58000000</TotalCost>
-                    <GrossAmount>14.58000000</GrossAmount>
+                    <TotalCost>14.58</TotalCost>
+                    <GrossAmount>14.58</GrossAmount>
                     <TaxesOutputs>
                         <Tax>
                             <TaxTypeCode>01</TaxTypeCode>
@@ -169,8 +169,8 @@
                     <Quantity>5.0</Quantity>
                     <UnitOfMeasure>01</UnitOfMeasure>
                     <UnitPriceWithoutTax>7.32000000</UnitPriceWithoutTax>
-                    <TotalCost>36.60000000</TotalCost>
-                    <GrossAmount>36.60000000</GrossAmount>
+                    <TotalCost>36.60</TotalCost>
+                    <GrossAmount>36.60</GrossAmount>
                     <TaxesOutputs>
                         <Tax>
                             <TaxTypeCode>01</TaxTypeCode>
@@ -190,8 +190,8 @@
                     <Quantity>25.0</Quantity>
                     <UnitOfMeasure>01</UnitOfMeasure>
                     <UnitPriceWithoutTax>9.50000000</UnitPriceWithoutTax>
-                    <TotalCost>237.50000000</TotalCost>
-                    <GrossAmount>237.50000000</GrossAmount>
+                    <TotalCost>237.50</TotalCost>
+                    <GrossAmount>237.50</GrossAmount>
                     <TaxesOutputs>
                         <Tax>
                             <TaxTypeCode>01</TaxTypeCode>

--- a/addons/l10n_es_edi_facturae/tests/data/expected_out_invoice_withhold.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_out_invoice_withhold.xml
@@ -97,8 +97,8 @@
           <Quantity>1.0</Quantity>
           <UnitOfMeasure>01</UnitOfMeasure>
           <UnitPriceWithoutTax>100.00000000</UnitPriceWithoutTax>
-          <TotalCost>100.00000000</TotalCost>
-          <GrossAmount>100.00000000</GrossAmount>
+          <TotalCost>100.00</TotalCost>
+          <GrossAmount>100.00</GrossAmount>
           <TaxesWithheld>
             <Tax>
               <TaxTypeCode>04</TaxTypeCode>

--- a/addons/l10n_es_edi_facturae/tests/data/expected_refund_document.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_refund_document.xml
@@ -124,8 +124,8 @@
           <Quantity>1.0</Quantity>
           <UnitOfMeasure>01</UnitOfMeasure>
           <UnitPriceWithoutTax>-100.00000000</UnitPriceWithoutTax>
-          <TotalCost>-100.00000000</TotalCost>
-          <GrossAmount>-100.00000000</GrossAmount>
+          <TotalCost>-100.00</TotalCost>
+          <GrossAmount>-100.00</GrossAmount>
           <TaxesOutputs>
             <Tax>
               <TaxTypeCode>01</TaxTypeCode>
@@ -148,8 +148,8 @@
           <Quantity>1.0</Quantity>
           <UnitOfMeasure>01</UnitOfMeasure>
           <UnitPriceWithoutTax>-100.00000000</UnitPriceWithoutTax>
-          <TotalCost>-100.00000000</TotalCost>
-          <GrossAmount>-100.00000000</GrossAmount>
+          <TotalCost>-100.00</TotalCost>
+          <GrossAmount>-100.00</GrossAmount>
           <TaxesOutputs>
             <Tax>
               <TaxTypeCode>01</TaxTypeCode>

--- a/addons/l10n_es_edi_facturae/tests/data/expected_signed_document.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_signed_document.xml
@@ -137,8 +137,8 @@
           <Quantity>1.0</Quantity>
           <UnitOfMeasure>01</UnitOfMeasure>
           <UnitPriceWithoutTax>100.00000000</UnitPriceWithoutTax>
-          <TotalCost>100.00000000</TotalCost>
-          <GrossAmount>100.00000000</GrossAmount>
+          <TotalCost>100.00</TotalCost>
+          <GrossAmount>100.00</GrossAmount>
           <TaxesOutputs>
             <Tax>
               <TaxTypeCode>01</TaxTypeCode>
@@ -158,8 +158,8 @@
           <Quantity>1.0</Quantity>
           <UnitOfMeasure>01</UnitOfMeasure>
           <UnitPriceWithoutTax>100.00000000</UnitPriceWithoutTax>
-          <TotalCost>100.00000000</TotalCost>
-          <GrossAmount>100.00000000</GrossAmount>
+          <TotalCost>100.00</TotalCost>
+          <GrossAmount>100.00</GrossAmount>
           <TaxesOutputs>
             <Tax>
               <TaxTypeCode>01</TaxTypeCode>
@@ -179,8 +179,8 @@
           <Quantity>1.0</Quantity>
           <UnitOfMeasure>01</UnitOfMeasure>
           <UnitPriceWithoutTax>200.00000000</UnitPriceWithoutTax>
-          <TotalCost>200.00000000</TotalCost>
-          <GrossAmount>200.00000000</GrossAmount>
+          <TotalCost>200.00</TotalCost>
+          <GrossAmount>200.00</GrossAmount>
           <TaxesOutputs>
             <Tax>
               <TaxTypeCode>01</TaxTypeCode>
@@ -200,15 +200,15 @@
           <Quantity>1.0</Quantity>
           <UnitOfMeasure>01</UnitOfMeasure>
           <UnitPriceWithoutTax>1000.00000000</UnitPriceWithoutTax>
-          <TotalCost>1000.00000000</TotalCost>
+          <TotalCost>1000.00</TotalCost>
           <DiscountsAndRebates>
             <Discount>
               <DiscountReason>/</DiscountReason>
               <DiscountRate>10.00</DiscountRate>
-              <DiscountAmount>100.00000000</DiscountAmount>
+              <DiscountAmount>100.00</DiscountAmount>
             </Discount>
           </DiscountsAndRebates>
-          <GrossAmount>900.00000000</GrossAmount>
+          <GrossAmount>900.00</GrossAmount>
           <TaxesOutputs>
             <Tax>
               <TaxTypeCode>01</TaxTypeCode>
@@ -228,15 +228,15 @@
           <Quantity>1.0</Quantity>
           <UnitOfMeasure>01</UnitOfMeasure>
           <UnitPriceWithoutTax>1000.00000000</UnitPriceWithoutTax>
-          <TotalCost>1000.00000000</TotalCost>
+          <TotalCost>1000.00</TotalCost>
           <Charges>
             <Charge>
               <ChargeReason>/</ChargeReason>
               <ChargeRate>10.00</ChargeRate>
-              <ChargeAmount>100.00000000</ChargeAmount>
+              <ChargeAmount>100.00</ChargeAmount>
             </Charge>
           </Charges>
-          <GrossAmount>1100.00000000</GrossAmount>
+          <GrossAmount>1100.00</GrossAmount>
           <TaxesOutputs>
             <Tax>
               <TaxTypeCode>01</TaxTypeCode>

--- a/addons/l10n_es_edi_facturae/tests/data/expected_simplified_document.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_simplified_document.xml
@@ -97,8 +97,8 @@
           <Quantity>1.0</Quantity>
           <UnitOfMeasure>01</UnitOfMeasure>
           <UnitPriceWithoutTax>100.00000000</UnitPriceWithoutTax>
-          <TotalCost>100.00000000</TotalCost>
-          <GrossAmount>100.00000000</GrossAmount>
+          <TotalCost>100.00</TotalCost>
+          <GrossAmount>100.00</GrossAmount>
           <TaxesOutputs>
             <Tax>
               <TaxTypeCode>01</TaxTypeCode>

--- a/addons/l10n_es_edi_facturae/tests/data/import_multiple_invoices.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/import_multiple_invoices.xml
@@ -113,8 +113,8 @@
           <Quantity>1.0</Quantity>
           <UnitOfMeasure>01</UnitOfMeasure>
           <UnitPriceWithoutTax>320.00000000</UnitPriceWithoutTax>
-          <TotalCost>320.00000000</TotalCost>
-          <GrossAmount>320.00000000</GrossAmount>
+          <TotalCost>320.00</TotalCost>
+          <GrossAmount>320.00</GrossAmount>
           <TaxesOutputs>
             <Tax>
               <TaxTypeCode>01</TaxTypeCode>
@@ -133,8 +133,8 @@
           <Quantity>1.0</Quantity>
           <UnitOfMeasure>01</UnitOfMeasure>
           <UnitPriceWithoutTax>1799.00000000</UnitPriceWithoutTax>
-          <TotalCost>1799.00000000</TotalCost>
-          <GrossAmount>1799.00000000</GrossAmount>
+          <TotalCost>1799.00</TotalCost>
+          <GrossAmount>1799.00</GrossAmount>
           <TaxesOutputs>
             <Tax>
               <TaxTypeCode>01</TaxTypeCode>
@@ -197,8 +197,8 @@
           <Quantity>3.0</Quantity>
           <UnitOfMeasure>01</UnitOfMeasure>
           <UnitPriceWithoutTax>320.00000000</UnitPriceWithoutTax>
-          <TotalCost>960.00000000</TotalCost>
-          <GrossAmount>960.00000000</GrossAmount>
+          <TotalCost>960.00</TotalCost>
+          <GrossAmount>960.00</GrossAmount>
           <TaxesOutputs>
             <Tax>
               <TaxTypeCode>01</TaxTypeCode>

--- a/addons/l10n_es_edi_facturae/tests/data/import_withholding_invoice.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/import_withholding_invoice.xml
@@ -115,8 +115,8 @@
           <Quantity>1.0</Quantity>
           <UnitOfMeasure>01</UnitOfMeasure>
           <UnitPriceWithoutTax>320.00000000</UnitPriceWithoutTax>
-          <TotalCost>320.00000000</TotalCost>
-          <GrossAmount>320.00000000</GrossAmount>
+          <TotalCost>320.00</TotalCost>
+          <GrossAmount>320.00</GrossAmount>
           <TaxesOutputs>
             <Tax>
               <TaxTypeCode>01</TaxTypeCode>


### PR DESCRIPTION
Steps to reproduce:
- Have facturae modules installed
- Generate invoice with any amount
- Send to Facturae

Issue:
Resulting XML has 8 digits after the decimal point on several fields, such as unit price, gross amount, and total cost.

When trying to validate such an XML, this results in validation error: "RCF06001: En facturas emitidas en euros, alguno de los importes de las líneas tiene más de dos decimales (regla 6a del anexo II de la Orden HAP/1650/2015)."

According to regulation HAP/1650/2015 [1]: For invoices issued in euros, it will be validated that the total line amounts related to the total cost are numeric and rounded, according to the common rounding method, to two decimal places.
This commit introduces dynamic decimal precision: 2 places for EUR and 8 places (the previous default) for other currencies.

[1] https://www.boe.es/diario_boe/txt.php?id=BOE-A-2015-8844
Machine translated [BOE-A-2015-8844 (1).pdf](https://github.com/user-attachments/files/25345382/BOE-A-2015-8844.1.pdf)


opw-5927356
