### PR TITLE
[FIX] l10n_fr_hr_holidays: compute time off for partial time employee

### DIFF
--- a/addons/l10n_fr_hr_holidays/models/hr_leave.py
+++ b/addons/l10n_fr_hr_holidays/models/hr_leave.py
@@ -153,18 +153,15 @@ class HrLeave(models.Model):
                     date_end = leave.date_to
                     while not leave.resource_calendar_id._works_on_date(date_start):
                         date_start += relativedelta(days=1)
-                    extended_date_end = date_end
-                    while not company_cal._works_on_date(extended_date_end + relativedelta(days=1)):
-                        extended_date_end += relativedelta(days=1)
                     # Count number of days in company calendar
                     current = date_start.date()
-                    end_date = extended_date_end.date()
+                    end_date = date_end.date()
                     legal_days = 0.0
                     while current <= end_date:
                         if current in holidays_days_list:
                             current += relativedelta(days=1)
                             continue
-                        if company_cal._works_on_date(current):
+                        if current.weekday() < 6:
                             legal_days += 1.0
                         current += relativedelta(days=1)
                     standard_duration = super()._get_durations(resource_calendar=resource_calendar)

--- a/addons/l10n_fr_hr_holidays/tests/test_french_leaves.py
+++ b/addons/l10n_fr_hr_holidays/tests/test_french_leaves.py
@@ -581,3 +581,105 @@ class TestFrenchLeaves(TransactionCase):
         self.assertEqual(leave.date_from.date(), date(2026, 1, 12))
         self.assertEqual(leave.date_to.date(), date(2026, 1, 12))
         self.assertEqual(leave.number_of_hours, 8.0, 'Duration should be 8 hours (one working day)')
+
+    def test_employee_partial_time_holidays(self):
+        """checks that days off are correctly computed for employees with partial time schedules.
+        Law can be found here: https://code.travail.gouv.fr/fiche-service-public/quelle-est-lincidence-sur-les-droits-a-conges-payes-dun-salarie-a-temps-partiel"""
+        part_time_calendar = self.env['resource.calendar'].create({
+            'name': 'Part Time Calendar',
+            'company_id': self.company.id,
+            'attendance_ids': [
+                (0, 0, {'name': 'Monday Morning', 'dayofweek': '0', 'hour_from': 8.0, 'hour_to': 12.0, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Monday Lunch', 'dayofweek': '0', 'hour_from': 12.0, 'hour_to': 13.0, 'day_period': 'lunch'}),
+                (0, 0, {'name': 'Monday Afternoon', 'dayofweek': '0', 'hour_from': 13.0, 'hour_to': 17.0, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Tuesday Morning', 'dayofweek': '1', 'hour_from': 8.0, 'hour_to': 12.0, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Tuesday Lunch', 'dayofweek': '1', 'hour_from': 12.0, 'hour_to': 13.0, 'day_period': 'lunch'}),
+                (0, 0, {'name': 'Tuesday Afternoon', 'dayofweek': '1', 'hour_from': 13.0, 'hour_to': 17.0, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Thursday Morning', 'dayofweek': '3', 'hour_from': 8.0, 'hour_to': 12.0, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Thursday Lunch', 'dayofweek': '3', 'hour_from': 12.0, 'hour_to': 13.0, 'day_period': 'lunch'}),
+                (0, 0, {'name': 'Thursday Afternoon', 'dayofweek': '3', 'hour_from': 13.0, 'hour_to': 17.0, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Friday Morning', 'dayofweek': '4', 'hour_from': 8.0, 'hour_to': 12.0, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Friday Lunch', 'dayofweek': '4', 'hour_from': 12.0, 'hour_to': 13.0, 'day_period': 'lunch'}),
+                (0, 0, {'name': 'Friday Afternoon', 'dayofweek': '4', 'hour_from': 13.0, 'hour_to': 17.0, 'day_period': 'afternoon'})]
+        })
+        self.time_off_type.request_unit = 'day'
+        self.employee.resource_calendar_id = part_time_calendar
+        leave_0 = self.env['hr.leave'].create({
+            'name': 'Test',
+            'holiday_status_id':  self.time_off_type.id,
+            'employee_id': self.employee.id,
+            'request_date_from': '2026-02-16 00:00:00',
+            'request_date_to': '2026-02-17 23:59:59',
+        })
+        self.assertEqual(leave_0.duration_display, "3 days")
+
+        leave_1 = self.env['hr.leave'].create({
+            'name': 'Test',
+            'holiday_status_id':  self.time_off_type.id,
+            'employee_id': self.employee.id,
+            'request_date_from': '2026-02-26 00:00:00',
+            'request_date_to': '2026-02-27 23:59:59',
+        })
+        self.assertEqual(leave_1.duration_display, "3 days")
+        leave_2 = self.env['hr.leave'].create({
+            'name': 'Test',
+            'holiday_status_id':  self.time_off_type.id,
+            'employee_id': self.employee.id,
+            'request_date_from': '2026-03-02 00:00:00',
+            'request_date_to': '2026-03-08 23:59:59',
+        })
+        self.assertEqual(leave_2.duration_display, "6 days")
+
+    def test_employee_full_time_holidays(self):
+        """checks that days off are correctly computed for employees with partial time schedules.
+        Law can be found here: https://www.urssaf.fr/accueil/particulier/particulier-employeur/gerer-les-absences/gestion-conges-payes.html
+        "Lorsqu'un salarié pose son vendredi, le samedi est automatiquement décompté des 30 jours ouvrables." source:
+        https://www.juritravail.com/Actualite/decompte-du-nombre-de-jours-de-conges-payes-les-jours-ouvrables-et-les-jours-ouvres-comment-faire/Id/2161
+        """
+        full_time_calendar = self.env['resource.calendar'].create({
+            'name': 'Part Time Calendar',
+            'company_id': self.company.id,
+            'attendance_ids': [
+                (0, 0, {'name': 'Monday Morning', 'dayofweek': '0', 'hour_from': 8.0, 'hour_to': 12.0, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Monday Lunch', 'dayofweek': '0', 'hour_from': 12.0, 'hour_to': 13.0, 'day_period': 'lunch'}),
+                (0, 0, {'name': 'Monday Afternoon', 'dayofweek': '0', 'hour_from': 13.0, 'hour_to': 17.0, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Tuesday Morning', 'dayofweek': '1', 'hour_from': 8.0, 'hour_to': 12.0, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Tuesday Lunch', 'dayofweek': '1', 'hour_from': 12.0, 'hour_to': 13.0, 'day_period': 'lunch'}),
+                (0, 0, {'name': 'Tuesday Afternoon', 'dayofweek': '1', 'hour_from': 13.0, 'hour_to': 17.0, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Wednesday Morning', 'dayofweek': '2', 'hour_from': 8.0, 'hour_to': 12.0, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Wednesday Lunch', 'dayofweek': '2', 'hour_from': 12.0, 'hour_to': 13.0, 'day_period': 'lunch'}),
+                (0, 0, {'name': 'Wednesday Afternoon', 'dayofweek': '2', 'hour_from': 13.0, 'hour_to': 17.0, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Thursday Morning', 'dayofweek': '3', 'hour_from': 8.0, 'hour_to': 12.0, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Thursday Lunch', 'dayofweek': '3', 'hour_from': 12.0, 'hour_to': 13.0, 'day_period': 'lunch'}),
+                (0, 0, {'name': 'Thursday Afternoon', 'dayofweek': '3', 'hour_from': 13.0, 'hour_to': 17.0, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Friday Morning', 'dayofweek': '4', 'hour_from': 8.0, 'hour_to': 12.0, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Friday Lunch', 'dayofweek': '4', 'hour_from': 12.0, 'hour_to': 13.0, 'day_period': 'lunch'}),
+                (0, 0, {'name': 'Friday Afternoon', 'dayofweek': '4', 'hour_from': 13.0, 'hour_to': 17.0, 'day_period': 'afternoon'})]
+        })
+        self.time_off_type.request_unit = 'day'
+        self.employee.resource_calendar_id = full_time_calendar
+        leave_0 = self.env['hr.leave'].create({
+            'name': 'Test',
+            'holiday_status_id':  self.time_off_type.id,
+            'employee_id': self.employee.id,
+            'request_date_from': '2026-02-16 00:00:00',
+            'request_date_to': '2026-02-17 23:59:59',
+        })
+        self.assertEqual(leave_0.duration_display, "2 days")
+
+        leave_1 = self.env['hr.leave'].create({
+            'name': 'Test',
+            'holiday_status_id':  self.time_off_type.id,
+            'employee_id': self.employee.id,
+            'request_date_from': '2026-02-26 00:00:00',
+            'request_date_to': '2026-02-27 23:59:59',
+        })
+        self.assertEqual(leave_1.duration_display, "3 days")
+        leave_2 = self.env['hr.leave'].create({
+            'name': 'Test',
+            'holiday_status_id':  self.time_off_type.id,
+            'employee_id': self.employee.id,
+            'request_date_from': '2026-03-02 00:00:00',
+            'request_date_to': '2026-03-08 23:59:59',
+        })
+        self.assertEqual(leave_2.duration_display, "6 days")


### PR DESCRIPTION
## Short functional explanation of the error
When setting time off for a french employee whose working schedule is part time, some computations aren't performed correctly. Indeed, when we create a new working schedule, of type Fully Fixed, but we remove a day from the schedule, it will be considered as part time.
According to the french law:
https://code.travail.gouv.fr/fiche-service-public/quelle-est-lincidence-sur-les-droits-a-conges-payes-dun-salarie-a-temps-partiel when in this case, we create 2 days of time off on thursday and friday, 3 days are supposed to be deducted from the time off balance of the employee. Currently, only 2 days are deducted.

## Reproduction Steps
1. Create a part time working schedule for a french company, where the non-working days are Wednesday, Saturday
and Sunday.
2. Create an employee to which you assign this working schedule.
3. Go to Time Off. In Settings, in the French Time Off Localization block, make sure that the Company Paid Time Off Type is set to Paid Time Off. Make also sure that the Company Working Hours is srt at a full-time schedule, NOT to the part-time schedule you just created.
4. On the Management type, click Allocations. Create a new allocation for the employee you just created and validate it.
5. Click on Management > Time off. Click on new. Select the employee you just created and Paid Time off as Time Off Type.
6. Select the start date to be a Thursday and an end date to be a Friday.

### Expected behavior
In compliance with the French law about part-time working schedules, the duration of the time off should be 3 days.

### Unexpected behavior
The duration shown is 2 days.
Moreover, if we select an entire week, the duration will be 5 days instead of 6.

## Origin of the issue
In `_get_durations()` of the module, we haven't implemented the feature that takes into account that specific french law for part-time workers.

__
opw-5911616


