### PR TITLE
[FIX] base: allow changing contact name without changing account holder name

### DIFF
--- a/addons/portal/tests/test_portal.py
+++ b/addons/portal/tests/test_portal.py
@@ -23,6 +23,13 @@ class TestUsersHttp(HttpCase):
             'acc_type': 'bank',
         })
 
+        bank_account_2 = self.env['res.partner.bank'].create({
+            'acc_number': '987654321',
+            'partner_id': portal_user.partner_id.id,
+            'acc_holder_name': 'Partner A',
+            'acc_type': 'bank',
+        })
+
         common_data = {
             'phone': '1234567890',
             'email': 'test@example.com',
@@ -37,11 +44,13 @@ class TestUsersHttp(HttpCase):
         response = self.url_open(url='/my/account', data={**common_data, 'name': portal_user.partner_id.name, 'csrf_token': Request.csrf_token(self)})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(bank_account.acc_holder_name, 'Partner A Holder')
+        self.assertEqual(bank_account_2.acc_holder_name, 'Partner A')
 
         # request 2: request with changed partner name
         response2 = self.url_open(url='/my/account', data={**common_data, 'name': 'Partner New Name', 'csrf_token': Request.csrf_token(self)})
         self.assertEqual(response2.status_code, 200)
-        self.assertEqual(bank_account.acc_holder_name, 'Partner New Name')
+        self.assertEqual(bank_account.acc_holder_name, 'Partner A Holder')
+        self.assertEqual(bank_account_2.acc_holder_name, 'Partner New Name')
 
     def test_deactivate_portal_user(self):
         # Create a portal user with data which should be removed on deactivation

--- a/odoo/addons/base/models/res_bank.py
+++ b/odoo/addons/base/models/res_bank.py
@@ -101,7 +101,7 @@ class ResPartnerBank(models.Model):
         for bank in self:
             bank.acc_type = self.retrieve_acc_type(bank.acc_number)
 
-    @api.depends('partner_id.name')
+    @api.depends('partner_id')
     def _compute_account_holder_name(self):
         for bank in self:
             bank.acc_holder_name = bank.partner_id.name

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -749,6 +749,11 @@ class Partner(models.Model):
             vals['website'] = self._clean_website(vals['website'])
         if vals.get('parent_id'):
             vals['company_name'] = False
+        if vals.get('name'):
+            for partner in self:
+                for bank in partner.bank_ids:
+                    if bank.acc_holder_name == partner.name:
+                        bank.acc_holder_name = vals['name']
         if 'company_id' in vals:
             company_id = vals['company_id']
             for partner in self:


### PR DESCRIPTION
**steps to reproduce:**
1. Create a contact
2. On the accounting tab, add one bank account
3. Change the name of the contact
4. The record's name updates automatically the field "Account Holder Name"

**problem:**
When changing a profile's name in the contacts app, the account holder name changes to be the same as the profile's name.

**expected behaviour:**
"Make the account holder name update if partner.name is changed ONLY if they were the same before the change. Otherwise keep the account holder name as is." - Referenced from the feature ticket: 5222712

That means if contact's name is the same as the account holder name, then any change to the contact's name, should as well update 'account holder name' accordingly, but if you changed the account holder name itself, then you change contact's name (if they're not the same) then the account holder name shouldn't be updated to match the contact's name.

**cause:**
The account holder name depends on `partner_id.name`
https://github.com/odoo/odoo/blob/2394a9a7f0ece2d5a2185fa4e715d943fc044733/odoo/addons/base/models/res_bank.py#L104-L107

So whenever you change the contact's name, the account holder name changes accordingly.

**Fix:**
Upon creation, the account holder name is set to the partner name if no name is provided. Additionally, when the partner name changes, the account holder name is updated only if it previously matched the partnername; otherwise, it is left unchanged.

**NOTE:**
This is a backport of this PR: https://github.com/odoo/odoo/pull/233965

opw-5913464

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
