### PR TITLE
[FIX] sale: round so global discounted amount

### DIFF
--- a/addons/sale/wizard/sale_order_discount.py
+++ b/addons/sale/wizard/sale_order_discount.py
@@ -123,7 +123,9 @@ class SaleOrderDiscount(models.TransientModel):
             taxes = line.tax_id.flatten_taxes_hierarchy()
             fixed_taxes = taxes.filtered(lambda t: t.amount_type == 'fixed')
             taxes -= fixed_taxes
-            total_price_per_tax_groups[taxes] += line.price_unit * (1 - (line.discount or 0.0) / 100) * line.product_uom_qty
+            total_price_per_tax_groups[taxes] += self.company_id.currency_id.round(
+                line.price_unit * (1 - (line.discount or 0.0) / 100) * line.product_uom_qty
+            )
 
         discount_dp = self.env['decimal.precision'].precision_get('Discount')
         context = {'lang': self.sale_order_id._get_lang()}  # noqa: F841


### PR DESCRIPTION
Issue:
---
Global discount is not rounded as SOLs amounts, resulting non-zero total amount when price 100% global discount is applied.

Steps to reproduce:
---
1- Create a SO.
2- Add two lines:
   - qty:4, price_unit:2.8207, tax:15%
   - qty:5, price_unit:2.8207, tax:15%

3- Using Discount action button, apply 100% global discount.

As you see the total amount is not zero.

Cause:
---
Sol's `price_total`, `price_subtotal` are rounded to currency decimals `_add_tax_details_in_base_line`:
https://github.com/odoo/odoo/blob/ef3c443837b02badc9e20bdec7544c34ed402ef3/addons/account/models/account_tax.py#L1551-L1560

However, the same rounding is not applied in discount calculation, leading to this mismatch.

opw-5886749