### PR TITLE
[FIX] mail: stabilize chatter search panels test due to thread not loaded

### DIFF
--- a/addons/mail/static/tests/chatter/web/chatter_search.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter_search.test.js
@@ -95,7 +95,7 @@ test("opening search in chatter hides files and pinned messages panels", async (
     });
     await start();
     await openFormView("res.partner", partnerId);
-    await click("button[aria-label='Attach files']");
+    await click("button[aria-label='Attach files']:text('1')");
     await click("button[title='Pinned Messages']");
     await contains(".o-mail-AttachmentBox");
     await contains(".o-mail-pinnedMessages");


### PR DESCRIPTION
The test "opening search in chatter hides files and pinned messages panels"
was flaky due to a race condition.

The attachment box toggle can be clicked before attachments are loaded, 
so the click is ignored and the assertion on `.o-mail-AttachmentBox` times out.

Fix by waiting for deterministic preconditions before toggling:
- wait for attach-files counter to display `1`
 
issue generated from this [PR](
https://github.com/odoo/odoo/pull/248141
)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
