### PR TITLE
[REF] mail: add resilience to hasActionsMenu

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -64,11 +64,12 @@ export class ChatWindow extends Component {
     }
 
     get hasActionsMenu() {
+        const partition = this.threadActions.partition;
         return (
-            this.partitionedActions.group.length > 0 ||
-            this.partitionedActions.other.length > 0 ||
-            (this.ui.isSmall && this.partitionedActions.quick.length > 2) ||
-            (!this.ui.isSmall && this.partitionedActions.quick.length > 3)
+            partition.group.length > 0 ||
+            partition.other.length > 0 ||
+            (this.ui.isSmall && partition.quick.length > 2) ||
+            (!this.ui.isSmall && partition.quick.length > 3)
         );
     }
 

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -11,7 +11,7 @@
         tabindex="1"
     >
         <div class="o-mail-ChatWindow-header d-flex align-items-center flex-shrink-0 bg-100 z-1 border-bottom border-dark o-border-opacity-15" t-on-click="onClickHeader" t-att-class="{ 'cursor-pointer': !ui.isSmall and !props.chatWindow.actionsDisabled }">
-            <t t-if="hasActionsMenu">
+            <t t-if="this.hasActionsMenu">
                 <div class="d-flex text-truncate bg-inherit">
                     <Dropdown position="ui.isSmall ? 'bottom-end' : 'left-start'" onStateChanged="isOpen => this.onActionsMenuStateChanged(isOpen)" menuClass="store.discussDropdownMenuClass(this)">
                         <button


### PR DESCRIPTION
In preparation for owl3, we had to manually refactor the hasActionsMenu which was a bit fragile.

BEFORE:
hasActionsMenu uses this.partitionedAction even if partitionedAction is a template variable and not a componenent variable.

NOW:
hasActionsMenu uses this.threadActions.partition,
an actual component variable

task: OWL3 prep - add this. to template variables

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
