### PR TITLE
[FIX] account_peppol: Avoid commercial_partner_id being empty

### DIFF
--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -39,6 +39,9 @@ class ResPartner(models.Model):
 
     @api.onchange('invoice_edi_format', 'peppol_endpoint', 'peppol_eas')
     def _onchange_verify_peppol_status(self):
+        if not self.commercial_partner_id:
+            # avoid issue when commercial_partner_id is on the view
+            self._compute_commercial_partner()
         self.button_account_peppol_check_partner_endpoint()
 
     # -------------------------------------------------------------------------

--- a/addons/account_peppol/tests/test_peppol_participant.py
+++ b/addons/account_peppol/tests/test_peppol_participant.py
@@ -374,7 +374,7 @@ class TestPeppolParticipant(PeppolConnectorCommon):
                 default_property_account_receivable_id=receivable.id,
                 default_property_account_payable_id=payable.id
             ))
-        with Form(env_partner, view = partner_view) as partner_form:
+        with Form(env_partner, view=partner_view) as partner_form:
             self.assertEqual(partner_form.peppol_verification_state, "not_verified")
             partner_form.name = "test"
             partner_form.vat = "BE0477472701"


### PR DESCRIPTION
Before this commit, when commercial_partner_id is on the view (possible with web_studio), the value by default is False.

When the autocomplete widget is used, many fields could be autofilled and raise _onchange_verify_peppol_status, that requires this field.

To avoid this issue we review that the value has been filled.

Steps to Reproduce:
1. Open the Contacts app
2. Open Studio on the contact form view
3. Add the field commercial_partner_id to the form view (make it visible)
4. Create a new contact
5. Type a name
6. Select a suggestion from the IAP autocomplete
7. An error is raised immediately

OPW-[5896847](https://www.odoo.com/odoo/action-4043/5896847)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
