### PR TITLE
[FIX] point_of_sale: prioritize server date for when pos is online

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -86,6 +86,10 @@ class PosOrder(models.Model):
         if not order.get('company_id'):
             order['company_id'] = pos_session.config_id.company_id.id
 
+        if self.env.context.get('current_order_uuid') and order['uuid'] == self.env.context['current_order_uuid']:
+            # Prioritize the server date for the order that is currently being processed
+            order['date_order'] = fields.Datetime.now()
+
         pos_order = False
         record_uuid_mapping = order.pop('relations_uuid_mapping', {})
 
@@ -132,8 +136,8 @@ class PosOrder(models.Model):
 
         for model_name, mapping in record_uuid_mapping.items():
             owner_records = self.env[model_name].search([('uuid', 'in', mapping.keys())])
-            for uuid, fields in mapping.items():
-                for name, uuids in fields.items():
+            for uuid, field_names in mapping.items():
+                for name, uuids in field_names.items():
                     params = self.env[model_name]._fields[name]
                     if params.type in ['one2many', 'many2many']:
                         records = self.env[params.comodel_name].search([('uuid', 'in', uuids)])

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1410,6 +1410,7 @@ export class PosStore extends WithLazyGetterTrap {
         return {
             config_id: this.config.id,
             device_identifier: this.device.identifier,
+            current_order_uuid: this.getOrder()?.uuid,
             ...(options.context || {}),
         };
     }

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -1051,10 +1051,10 @@ registry.category("web_tour.tours").add("test_preset_timing_retail", {
             Chrome.createFloatingOrder(),
             ProductScreen.clickDisplayedProduct("Desk Organizer"),
             Chrome.clickOrders(),
-            TicketScreen.nthRowContains(1, "A simple PoS man!"),
-            TicketScreen.nthRowContains(1, "Delivery", false),
-            TicketScreen.nthRowContains(2, "002"),
-            TicketScreen.nthRowContains(2, "Dine in", false),
+            TicketScreen.nthRowContains(2, "A simple PoS man!"),
+            TicketScreen.nthRowContains(2, "Delivery", false),
+            TicketScreen.nthRowContains(1, "002"),
+            TicketScreen.nthRowContains(1, "Dine in", false),
         ].flat(),
 });
 


### PR DESCRIPTION
Before this commit, if the PoS device had a wrong date, the orders created while being online would have a wrong date_order. This commit prioritizes the server date for the order that is currently being processed when the PoS is online.

opw-5884498

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
