### PR TITLE
[FIX] web: keeps ends_with operator selected in DomainSelector

### DIFF
--- a/addons/web/static/src/core/tree_editor/tree_editor.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor.js
@@ -45,6 +45,8 @@ function collectDifferences(tree, otherTree) {
                 return [{ type: "replacement", tree, operator: "set" }];
             } else if (tree.operator === "=" && otherTree.operator === "not_set") {
                 return [{ type: "replacement", tree, operator: "not_set" }];
+            } else if (tree.operator === "starts_with" && otherTree.operator === "ends_with") {
+                return [{ type: "replacement", tree, operator: "ends_with" }];
             } else {
                 return [{ type: "other" }];
             }

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -403,6 +403,26 @@ test("set [(1, '=', 1)] or [(0, '=', 1)] as domain with the debug textarea", asy
     expect(getCurrentValue()).toBe("1");
 });
 
+test("ends_with stays selected", async () => {
+    await makeDomainSelector({
+        domain: `[['foo', '=', '']]`,
+        update: (domain) => {
+            expect.step(domain);
+        },
+    });
+
+    await selectOperator("ends_with");
+    expect.verifySteps(['[("foo", "=ilike", "%")]']);
+
+    expect(getCurrentOperator()).toBe("ends with");
+    await editValue("abc");
+    expect.verifySteps(['[("foo", "=ilike", "%abc")]']);
+
+    await selectOperator("starts_with");
+    expect(getCurrentOperator()).toBe("starts with");
+    expect.verifySteps(['[("foo", "=ilike", "abc%")]']);
+});
+
 test("operator fallback (mode readonly)", async () => {
     await makeDomainSelector({
         domain: `[['foo', 'like', 'kikou']]`,


### PR DESCRIPTION
Steps to reproduce
==================

- Go to Sign
- Add a custom filter
- Select the Display Name field
- Select the "ends with" operator

-> The "starts with" operator ends up being selected

Cause of the issue
==================

The ends_with operator is a virtual operator that should be restored after a render

opw-5714125