### PR TITLE
[REF] base: Index attachment content asynchronously via cron

### DIFF
--- a/odoo/addons/base/data/ir_cron_data.xml
+++ b/odoo/addons/base/data/ir_cron_data.xml
@@ -19,4 +19,14 @@
         <field name='interval_type'>days</field>
         <field name="priority">8</field>
     </record>
+
+    <record id="ir_cron_ir_attachment_index" model="ir.cron">
+        <field name="name">Base: Index attachment content</field>
+        <field name="code">model._cron_index()</field>
+        <field name="interval_number" eval="10"/>
+        <field name="interval_type">minutes</field>
+        <field name="model_id" ref="model_ir_attachment"/>
+        <field name="priority" eval="10"/>
+        <field name="state">code</field>
+    </record>
 </odoo>

--- a/odoo/addons/base/tests/test_ir_attachment.py
+++ b/odoo/addons/base/tests/test_ir_attachment.py
@@ -284,6 +284,14 @@ class TestIrAttachment(TransactionCaseWithUserDemo):
             )
             self.assertEqual(patch_file_read.call_count, 0)
 
+    def test_20_attachment_cron_index(self):
+        a1 = self.Attachment.create({'name': 'a1', 'raw': self.blob1})
+        self.assertFalse(a1.index_checksum)
+        self.assertFalse(a1.index_content)
+        a1._cron_index(limit=None)
+        self.assertEqual(a1.index_content, self.blob1.decode())
+        self.assertEqual(a1.checksum, a1.index_checksum)
+
 
 @tagged('at_install', '-post_install')  # LEGACY at_install
 class TestPermissions(TransactionCaseWithUserDemo):


### PR DESCRIPTION
# Description of the issue/feature this PR addresses:


Indexing attachment content can significantly slow down record creation across all Odoo modules.

This change delegates the indexing process to a scheduled cron job,
preventing blocking operations during attachment creation and improving overall system responsiveness when handling file attachments.


# Current behavior before PR:

# Desired behavior after PR is merged:


# TODO:

- [ ] Check default domain for binary searching attachments
- [ ] read_group by checksum
- [ ] Copy based on checksum + index_content instaed of call index directly
