### PR TITLE
[FIX] sale: ensure update prices button visibility after saving quotation

### DIFF
--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -463,6 +463,7 @@
                             nolabel="1"
                             invisible="state in ['draft', 'sent']"
                             readonly="state in ['cancel', 'sale']"/>
+                        <field name="show_update_pricelist" invisible="1"/>
                         <label for="pricelist_id"
                                groups="product.group_product_pricelist"
                                invisible="not has_active_pricelist"/>


### PR DESCRIPTION
Steps to produce:
---
- Install sales module.
- Go to Settings and enable Pricelists (make sure we have 2 pricelists
  so that we able to change the pricelist value in quotation).
- Create a new quotation > Add a customer and product.
- Change the pricelist.
- Save the record.

Issue:
---
- After saving the quotation, the `Update Prices` button becomes invisible.

Root cause:
---
- The field `show_update_pricelist`, which controls the visibility of the button, is not present in the view. As a result, when the record is saved, the field is not included in the form data and its value is not properly maintained, causing the button to become invisible.
- The field is removed from the view in this [commit].

Solution:
---
- Added the `show_update_pricelist` field to the view to ensure its value is properly maintained. This allows the `Update Prices` button to remain visible when applicable.

[commit]: https://github.com/odoo/odoo/commit/da4b588b272432095f549c012e0a0d7238f00dc0

**Enterprice PR:** https://github.com/odoo/enterprise/pull/107621

opw-5927659

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
