### PR TITLE
[IMP] l10n_in: optimize tax tag lookup

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -721,6 +721,8 @@ class AccountMove(models.Model):
 
     def _get_sync_stack(self, container):
         stack, update_containers = super()._get_sync_stack(container)
+        if all(move.country_code != 'IN' for move in self):
+            return stack, update_containers
         _tax_container, invoice_container, misc_container = update_containers()
         moves = invoice_container['records'] + misc_container['records']
         stack.append((9, self._sync_l10n_in_gstr_section(moves)))

--- a/addons/l10n_in/models/account_move_line.py
+++ b/addons/l10n_in/models/account_move_line.py
@@ -83,16 +83,17 @@ class AccountMoveLine(models.Model):
         return False
 
     def _get_l10n_in_tax_tag_ids(self):
-
-        def get_tag_ids(*refs):
-            return [self.env.ref(ref).id for ref in refs]
-
+        xmlid_to_res_id = self.env['ir.model.data']._xmlid_to_res_id
+        tag_refs = {
+            'sgst': ['l10n_in.tax_tag_base_sgst', 'l10n_in.tax_tag_sgst'],
+            'cgst': ['l10n_in.tax_tag_base_cgst', 'l10n_in.tax_tag_cgst'],
+            'igst': ['l10n_in.tax_tag_base_igst', 'l10n_in.tax_tag_igst'],
+            'cess': ['l10n_in.tax_tag_base_cess', 'l10n_in.tax_tag_cess'],
+            'eco_9_5': ['l10n_in.tax_tag_eco_9_5'],
+        }
         return {
-            'sgst': get_tag_ids('l10n_in.tax_tag_base_sgst', 'l10n_in.tax_tag_sgst'),
-            'cgst': get_tag_ids('l10n_in.tax_tag_base_cgst', 'l10n_in.tax_tag_cgst'),
-            'igst': get_tag_ids('l10n_in.tax_tag_base_igst', 'l10n_in.tax_tag_igst'),
-            'cess': get_tag_ids('l10n_in.tax_tag_base_cess', 'l10n_in.tax_tag_cess'),
-            'eco_9_5': get_tag_ids('l10n_in.tax_tag_eco_9_5'),
+            categ: [xmlid_to_res_id(xml_id) for xml_id in ref]
+            for categ, ref in tag_refs.items()
         }
 
     def _get_l10n_in_gstr_section(self, tax_tags_dict):


### PR DESCRIPTION
Before this commit:
- `_get_l10n_in_tax_tag_ids()` was executed for moves unrelated to Indian localization, causing unnecessary processing.
- Profiling showed repeated `env.ref` lookups (>≈1.6% transactions each) even for a simple invoice flow (create → add products → post).

After this commit:
- Restrict execution to Indian-specific moves only.
- Replace `env.ref` with `_xmlid_to_res_id` for faster XMLID resolution.

task-5935607