### PR TITLE
[FIX] l10n_be: correct the sign of 61 in VAT report

### DIFF
--- a/addons/l10n_be/data/account_tax_report_data.xml
+++ b/addons/l10n_be/data/account_tax_report_data.xml
@@ -574,7 +574,7 @@
                                     <record id="tax_report_line_61_tag" model="account.report.expression">
                                         <field name="label">balance</field>
                                         <field name="engine">tax_tags</field>
-                                        <field name="formula">61</field>
+                                        <field name="formula">-61</field>
                                     </record>
                                 </field>
                             </record>


### PR DESCRIPTION
Currently, in the Belgian VAT report, `61 – Various VAT regularizations in favor of the State` 
is displayed with a negative amount under `Taxes > IV Due`, which triggers a warning in the report.

**Steps to reproduce:**
- Install the `l10n_be` module and switch to the `BE company CoA`.
- Navigate to `Invoicing > Configuration > Taxes` and open any tax (e.g., 6%).
- Replace the `Tax Grid` with `61` on the second line under `Distribution for Invoices`, then `save`.
- Navigate to `Customers > Invoices` and create and confirm an invoice using this `tax`.
- Navigate to `Reporting > Tax Report` and select the current month.

**Observation:**
- The report shows a warning: `The report contains negative amounts. This is normally not allowed and could cause the tax authorities to reject it.`
- Case `61` under `Taxes > IV Due` displays a `negative` value.

**Root Cause:**
At [1], all formulas under `IV Due` use a negative sign (-XX) except for case `61`, 
which uses `61` instead of `-61`. Since the concept of `inverted tax tags` was 
removed in v19 in PR [2], case `61` must follow the same sign convention 
as the other `IV Due` cases to ensure correct reporting behavior.

**Fix:**
This commit updates the formula of case `61` to `-61`, aligning it with the 
other `IV Due` lines. As a result, the VAT report no longer displays an incorrect 
negative amount for case `61` and prevents the related `warning` from appearing.

[1]:
https://github.com/odoo/odoo/blob/f229f23d7bf3d837ff5577c36145bf2ba410ea22/addons/l10n_be/data/account_tax_report_data.xml#L497-L596

[2]:
https://github.com/odoo/odoo/pull/225252

opw-5866225