### PR TITLE
[FIX] html_editor: fix toolbar position on selected table

### DIFF
--- a/addons/html_editor/static/src/core/overlay.js
+++ b/addons/html_editor/static/src/core/overlay.js
@@ -29,6 +29,7 @@ export class EditorOverlay extends Component {
         history: Object,
         close: Function,
         isOverlayOpen: Function,
+        getCustomRect: { type: Function, optional: true },
 
         // Props from createOverlay
         positionOptions: { type: Object, optional: true },
@@ -122,7 +123,10 @@ export class EditorOverlay extends Component {
             }
             range = this.lastSelection.range;
         }
-        let rect = range.getBoundingClientRect();
+        let rect =
+            this.props.getCustomRect?.() ||
+            this.lastSelection.rect ||
+            range.getBoundingClientRect();
         if (rect.x === 0 && rect.width === 0 && rect.height === 0) {
             // Attention, using disableObserver and enableObserver is always dangerous (when we add or remove nodes)
             // because if another mutation uses the target that is not observed, that mutation can never be applied

--- a/addons/html_editor/static/src/core/overlay_plugin.js
+++ b/addons/html_editor/static/src/core/overlay_plugin.js
@@ -31,6 +31,7 @@ export class OverlayPlugin extends Plugin {
             this.container = this.getScrollContainer();
         });
         this.addDomListener(this.topDocument.defaultView, "resize", this.throttledUpdateContainer);
+        this.targetRectProviders = this.getResource("overlay_selection_target_rect_providers");
     }
 
     destroy() {
@@ -65,6 +66,15 @@ export class OverlayPlugin extends Plugin {
             this.topDocument.documentElement
         );
     }
+
+    getCustomRect() {
+        for (const cb of this.targetRectProviders) {
+            const rect = cb();
+            if (rect) {
+                return rect;
+            }
+        }
+    }
 }
 
 export class Overlay {
@@ -94,8 +104,10 @@ export class Overlay {
             const selection = this.plugin.editable.ownerDocument.getSelection();
             let initialSelection;
             if (selection && selection.type !== "None") {
+                const rect = this.plugin.getCustomRect();
                 initialSelection = {
                     range: selection.getRangeAt(0),
+                    rect,
                 };
             }
             this._remove = this.plugin.services.overlay.add(
@@ -107,6 +119,7 @@ export class Overlay {
                     props,
                     target,
                     initialSelection,
+                    getCustomRect: this.plugin.getCustomRect.bind(this.plugin),
                     bus: this.bus,
                     getContainer: this.getContainer,
                     close: this.close.bind(this),

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -10,7 +10,7 @@ import {
 } from "@html_editor/utils/dom_info";
 import { ancestors, closestElement, descendants, lastLeaf } from "@html_editor/utils/dom_traversal";
 import { parseHTML } from "@html_editor/utils/html";
-import { leftPos, rightPos, nodeSize } from "@html_editor/utils/position";
+import { leftPos, rightPos, nodeSize, DIRECTIONS } from "@html_editor/utils/position";
 import { withSequence } from "@html_editor/utils/resource";
 import { findInSelection } from "@html_editor/utils/selection";
 import { getColumnIndex, getRowIndex } from "@html_editor/utils/table";
@@ -95,6 +95,7 @@ export class TablePlugin extends Plugin {
         fully_selected_node_predicates: (node) => !!closestElement(node, ".o_selected_td"),
         traversed_nodes_processors: this.adjustTraversedNodes.bind(this),
         normalize_handlers: this.distributeTableColorsToAllCells.bind(this),
+        overlay_selection_target_rect_providers: this.getTableSelectionRangeRect.bind(this),
     };
 
     setup() {
@@ -476,6 +477,25 @@ export class TablePlugin extends Plugin {
         }
 
         return false;
+    }
+
+    getTableSelectionRangeRect() {
+        const selection = this.dependencies.selection.getEditableSelection();
+        if (closestElement(selection.commonAncestorContainer, "table.o_selected_table")) {
+            let [startTd, endTd] = [
+                closestElement(selection.anchorNode, "td"),
+                closestElement(selection.focusNode, "td"),
+            ];
+            if (selection.direction === DIRECTIONS.LEFT) {
+                [startTd, endTd] = [endTd, startTd];
+            }
+            const startTdRect = startTd.getBoundingClientRect();
+            const endTdRect = endTd.getBoundingClientRect();
+            const { left, top } = startTdRect;
+            const { bottom, right } = endTdRect;
+            const rect = new DOMRect(left, top, right - left, bottom - top);
+            return rect;
+        }
     }
 
     /**

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -11,6 +11,7 @@ import {
     press,
     queryAll,
     queryAllTexts,
+    queryFirst,
     queryOne,
     waitFor,
     waitForNone,
@@ -542,6 +543,34 @@ test("toolbar open on single selected cell in table", async () => {
     await tick();
     expect(targetTd).toHaveClass("o_selected_td");
     await expectElementCount(".o-we-toolbar", 1);
+});
+
+test.tags("desktop");
+test("Position toolbar correctly on table selection", async () => {
+    const contentBefore = unformat(`
+        <p>abcd</p>
+        <p>abcd</p>
+        <table class="table table-bordered o_table">
+            <tbody>
+                <tr>
+                    <td><p><br></p></td>
+                    <td><p>[<br></p></td>
+                </tr>
+                <tr>
+                    <td><p><br></p></td>
+                    <td><p>]<br></p></td>
+                </tr>
+            </tbody>
+        </table>
+    `);
+
+    await setupEditor(contentBefore);
+    await waitFor(".o-we-toolbar");
+    const firstTd = queryFirst("td.o_selected_td");
+    const toolbarOverlay = queryOne(".o-we-toolbar").parentElement;
+    const toolbarRect = toolbarOverlay.getBoundingClientRect();
+    const cellRect = firstTd.getBoundingClientRect();
+    expect([toolbarRect.left, toolbarRect.bottom]).toMatch([cellRect.left, cellRect.top]);
 });
 
 test("should select table single cell when entire content is selected via mouse movement", async () => {


### PR DESCRIPTION
**Current behavior before PR:**

Steps to reproduce:

- Create a 3 x 3 table.
- Select 3rd column and wait for toolbar.

Currently, the toolbar is positioned at the start of the table even when the last column is selected. This happens because selecting cells in the 3rd column creates a DOM selection range that starts at the first cell and ends at the last cell of the column, traversing all intermediate elements. As a result, browser's range rectangle does not match the actual custom-selection rect.

**Desired behavior after PR is merged:**

Now, Toolbar is positioned correctly above the custom selected cells.

task-5935587




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
