### PR TITLE
[FIX] l10n_cl: skip numeric folio validation for miscellaneous journal entries

### DIFF
--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -22,6 +22,7 @@ class AccountMove(models.Model):
         for move in self:
             if (
                 move.company_id.country_id.code == "CL"
+                and move.l10n_latam_use_documents
                 and move.l10n_latam_document_number
                 and not re.fullmatch(r"[0-9]+", move.l10n_latam_document_number)
             ):

--- a/addons/l10n_cl/tests/test_latam_document_type.py
+++ b/addons/l10n_cl/tests/test_latam_document_type.py
@@ -81,3 +81,11 @@ class TestClLatamDocumentType(AccountTestInvoicingCommon):
             'partner_id': self.cl_partner_a.id,
             'l10n_latam_document_type_id': document_type_46.id,
         }])
+
+    def test_miscellaneous_journal_skip_numeric_folio_validation(self):
+        """Ensure numeric folio validation is skipped for miscellaneous entries."""
+        self.env['account.move'].create({
+            'move_type': 'entry',
+            'journal_id': self.env['account.journal'].search([('type', '=', 'general')], limit=1).id,
+            'l10n_latam_document_number': 'ABC123',
+        })


### PR DESCRIPTION
Currently, editing a posted `miscellaneous` journal entry in Chile 
localization incorrectly raises a validation error.

**Steps to reproduce:**
- Install the `l10n_cl` module and switch to the `CL company`.
- Go to Accounting > Accounting > Journal Entries.
- Create a balanced entry using the `Miscellaneous journal `and `post` it.
- Reset it to draft, modify the `name`, and try to `save` it.

**Observation:**
`Validation error`: `The DTE document number (folio) must contain only digits.`

**Root cause:**
At [1], the constraint validation is applied to all journal entries in 
Chilean companies, including `miscellaneous` journals. However, 
`miscellaneous journals (move_type = 'entry')` are not linked to Chilean 
electronic documents, so the numeric folio validation should not apply to them.

**Fix:**
This commit ensures that the validation is not raised for `miscellaneous` journal 
types by excluding miscellaneous journals from the numeric folio validation constraint.

[1]:
https://github.com/odoo/odoo/blob/f39785bcddd1eb5b7fb503d053c9bb66e2a0f15c/addons/l10n_cl/models/account_move.py#L20-L30

opw-5926773