### PR TITLE
[FIX] hr_holidays: fix invalid time display for hourly time off

### DIFF
--- a/addons/hr_holidays/static/src/components/float_time_selection/float_time_selection.js
+++ b/addons/hr_holidays/static/src/components/float_time_selection/float_time_selection.js
@@ -44,9 +44,21 @@ export class FloatTimeSelectionField extends FloatTimeField {
 
     get formattedValue() {
         const unitAmount = super.formattedValue;
-        return DateTime
-            .fromFormat(unitAmount, 'hh:mm', { numberingSystem: 'latn', zone: 'default'})
-            .toLocaleString({ hour: 'numeric', minute: 'numeric'});
+        let hours = 0;
+        let minutes = 0;
+
+        unitAmount.split(" ").forEach((data) => {
+            if (data.endsWith("h")) {
+                hours = parseInt(data);
+            } else if (data.endsWith("m")) {
+                minutes = parseInt(data);
+            }
+        });
+
+        return DateTime.fromObject(
+            { hour: hours, minute: minutes },
+            { numberingSystem: "latn", zone: "default" }
+        ).toFormat("h:mm a");
     }
 
     onCharHoursClick(ev) {


### PR DESCRIPTION
**Issue**:
- When users selected time off based on hours, "InvalidDateTime" was shown instead of the correct "From" and "To" time.
This happened after a recent
refactor:https://github.com/odoo/odoo/pull/240555/changes#diff-0beecbb730e1c7762f2a8d5f7038c02e123da10a85dec2e5d16a02748373f2fe of getFormatValue, which now returns
DateTime in a different format than before.

Fix:
- Updated  the method and adapt the new refactored format.

Impact:
- The correct DateTime values are now displayed instead of "InvalidDateTime".

Task-5940185