### PR TITLE
[FIX] website: handle menu URLs without leading slash and warn on spaces

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -666,7 +666,10 @@ class Website(Home):
         # If that URL is also a menu, we update it accordingly.
         # NB: we don't want to slugify on menu creation as it could redirect
         # towards files (with spaces, apostrophes, etc.).
-        menu = request.env['website.menu'].search([('url', '=', '/' + path), ('page_id', '=', False)])
+        # When searching for a menu, we also match URLs with or without a
+        # leading slash to prevent mismatches when records were created without
+        # a leading slash.
+        menu = request.env['website.menu'].search([('url', 'in', ['/' + path, path]), ('page_id', '=', False)])
         if menu:
             menu.page_id = page['page_id']
 

--- a/addons/website/static/src/components/dialog/edit_menu.xml
+++ b/addons/website/static/src/components/dialog/edit_menu.xml
@@ -17,6 +17,11 @@
             <div class="col-md-9">
                 <input id="url_input" t-ref="url-input" type="text" t-model="url.input.value" class="form-control" t-att-class="{ 'is-invalid': url.input.hasError }"/>
                 <small class="form-text">Hint: Type '/' to search an existing page and '#' to link to an anchor.</small>
+                <!-- TODO (19.0): Remove this warning once URLs are auto-filled
+                     from a slugified title. -->
+                <small class="text-warning d-block" t-att-class="{'invisible': !url.input.value?.includes(' ') || new RegExp('^[a-z]+:', 'i').test(url.input.value)}">
+                    Spaces are not allowed in URL.
+                </small>
             </div>
         </div>
     </WebsiteDialog>

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -72,10 +72,35 @@ wTourUtils.registerWebsitePreviewTour('edit_menus', {
         trigger: '.modal-footer .btn-primary',
     },
     {
-        content: "It didn't save without a url. Fill url input.",
+        content: "It didn't save without a url. Enter a relative URL containing a space",
         trigger: '.modal-dialog .o_website_dialog input:eq(1)',
         extra_trigger: '.modal-dialog .o_website_dialog input.is-invalid',
-        run: 'text #',
+        run: "text /url with space",
+    },
+    {
+        content: "Check that a warning is shown for relative URLs with spaces",
+        trigger: ".modal-dialog .o_website_dialog small.text-warning:not(.invisible)",
+        run: () => {}, // It's a check.
+    },
+    {
+        content: "Enter an absolute URL with spaces (should not show warning)",
+        trigger: ".modal-dialog .o_website_dialog input:eq(1)",
+        run: "text http://example.com/url with space",
+    },
+    {
+        content: "Verify the warning is hidden for absolute URLs with spaces",
+        trigger: ".modal-dialog .o_website_dialog small.text-warning.invisible",
+        run: () => {}, // It's a check.
+    },
+    {
+        content: "Clear the URL and enter a valid one without spaces",
+        trigger: ".modal-dialog .o_website_dialog input:eq(1)",
+        run: "text #",
+    },
+    {
+        content: "Verify the warning remains hidden when the URL has no spaces",
+        trigger: ".modal-dialog .o_website_dialog small.text-warning.invisible",
+        run: () => {}, // It's a check.
     },
     {
         content: "Confirm the new menu entry",

--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -581,3 +581,29 @@ class TestNewPage(common.TransactionCase):
         pages = self.env['website.page'].search([('url', '=', '/snippets')])
         self.assertEqual(len(pages), 1, "Exactly one page should be at /snippets.")
         self.assertNotEqual(pages.key, "website.snippets", "Page's key cannot be website.snippets.")
+
+    def test_pagenew_links_menu_without_leading_slash(self):
+        website = self.env.ref('website.default_website')
+        controller = Website()
+
+        menus = self.env['website.menu'].create([
+            {
+                'name': 'Without space and slash',
+                'url': 'foobar',
+                'website_id': website.id,
+            },
+            {
+                'name': 'With space and without slash',
+                'url': 'bar baz',
+                'website_id': website.id,
+            },
+        ])
+
+        with MockRequest(self.env, website=website):
+            for menu in menus:
+                controller.pagenew(path=menu.url)
+
+                self.assertTrue(
+                    menu.page_id,
+                    f"Menu '{menu.name}' was not linked to the created page."
+                )


### PR DESCRIPTION
When a menu item URL contains a space and has no leading slash (e.g.,
"some url"), creating a page from its 404 screen does not link the menu
to the newly created page. The menu keeps pointing to a 404.


**Steps to reproduce**:
1. Create a menu item with a URL containing spaces and no leading slash
   (e.g., "some url").
2. Click the menu item -> a 404 page is displayed (expected).
3. Click "Create Page" -> the page is created and saved.
4. Click the menu item again -> it still returns a 404 (unexpected).


**Issue**:
During page creation, the path is slugified (e.g., "some url" ->
"/some-url"). The controller then tries to link the menu to the new page
by setting `page_id`. However, `pagenew()` only searches for menu URLs
with a leading slash, so a menu saved as "some url" is not found when
searching for "/some url". As a result, `page_id` is never set, and
`_clean_url()` keeps resolving the menu to "/some url" instead of the
page's actual URL "/some-url".

Menus without spaces (e.g., "mypage") have the same issue where
`page_id` is not set, but since `_clean_url()` prepends "/" and renders
"/mypage", which matches the new page URL, the menu still resolves
correctly.


**Fix**:
Match both URL formats (with and without leading slash) when linking a
menu to a newly created page.

Additionally, a warning is now shown in the menu editor when a URL
contains spaces, since spaces are slugified during page creation,
which could cause confusion. (Note: this is only a warning - URLs with
spaces are still allowed.)

task-[5095646](https://www.odoo.com/odoo/project/974/tasks/5095646)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
