### PR TITLE
[IMP] *: modularize rate limiting

### DIFF
--- a/addons/auth_totp/models/res_users.py
+++ b/addons/auth_totp/models/res_users.py
@@ -6,8 +6,6 @@ import logging
 import os
 import re
 
-from datetime import datetime, timedelta
-
 from odoo import _, api, fields, models
 from odoo.addons.base.models.res_users import check_identity
 from odoo.exceptions import AccessDenied, UserError
@@ -20,11 +18,6 @@ from odoo.addons.auth_totp.models.totp import TOTP, TOTP_SECRET_SIZE
 _logger = logging.getLogger(__name__)
 
 compress = functools.partial(re.sub, r'\s', '')
-
-TOTP_RATE_LIMITS = {
-    'send_email': (5, 3600),
-    'code_check': (5, 3600),
-}
 
 
 class ResUsers(models.Model):
@@ -73,7 +66,8 @@ class ResUsers(models.Model):
 
     def _check_credentials(self, credentials, env):
         if credentials['type'] == 'totp':
-            self._totp_rate_limit('code_check')
+            ip = request.httprequest.environ['REMOTE_ADDR']
+            self.env['rate.limit.log']._rate_limit_check('totp_code_check', ip, identity_key=str(self.id))
             sudo = self.sudo()
             key = base64.b32decode(sudo.totp_secret)
             match = TOTP(key).match(credentials['token'])
@@ -87,7 +81,7 @@ class ResUsers(models.Model):
 
             sudo.totp_last_counter = match
             _logger.info("2FA check: SUCCESS for %s %r", self, sudo.login)
-            self._totp_rate_limit_purge('code_check')
+            self.env['rate.limit.log']._rate_limit_purge('totp_code_check', identity_key=str(self.id))
             return {
                 'uid': self.env.user.id,
                 'auth_method': 'totp',
@@ -116,40 +110,6 @@ class ResUsers(models.Model):
 
         _logger.info("2FA enable: SUCCESS for %s %r", self, self.login)
         return True
-
-    def _totp_rate_limit(self, limit_type):
-        self.ensure_one()
-        assert request, "A request is required to be able to rate limit TOTP related actions"
-        limit, interval = TOTP_RATE_LIMITS[limit_type]
-        RateLimitLog = self.env['auth.totp.rate.limit.log'].sudo()
-        ip = request.httprequest.environ['REMOTE_ADDR']
-        domain = [
-            ('user_id', '=', self.id),
-            ('create_date', '>=', datetime.now() - timedelta(seconds=interval)),
-            ('limit_type', '=', limit_type),
-        ]
-        count = RateLimitLog.search_count(domain)
-        if count >= limit:
-            descriptions = {
-                'send_email': _('You reached the limit of authentication mails sent for your account, please try again later.'),
-                'code_check': _('You reached the limit of code verifications for your account, please try again later.'),
-            }
-            description = descriptions[limit_type]
-            raise AccessDenied(description)
-        RateLimitLog.create({
-            'user_id': self.id,
-            'ip': ip,
-            'limit_type': limit_type,
-        })
-
-    def _totp_rate_limit_purge(self, limit_type):
-        self.ensure_one()
-        assert request, "A request is required to be able to rate limit TOTP related actions"
-        RateLimitLog = self.env['auth.totp.rate.limit.log'].sudo()
-        RateLimitLog.search([
-            ('user_id', '=', self.id),
-            ('limit_type', '=', limit_type),
-        ]).unlink()
 
     @check_identity
     def action_totp_disable(self):

--- a/addons/auth_totp/security/ir.model.access.csv
+++ b/addons/auth_totp/security/ir.model.access.csv
@@ -1,4 +1,3 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
 "access_auth_totp_device_access_employee","TOTP Device access employees","model_auth_totp_device","base.group_user",1,0,0,0
 "access_auth_totp_device_access_portal","TOTP Device access portal","model_auth_totp_device","base.group_portal",1,0,0,0
-"access_auth_totp_rate_limit_log","access_auth_totp_rate_limit_log","model_auth_totp_rate_limit_log","base.group_user",0,0,0,0

--- a/addons/web/models/__init__.py
+++ b/addons/web/models/__init__.py
@@ -7,6 +7,7 @@ from . import ir_model
 from . import ir_ui_menu
 from . import ir_ui_view
 from . import models
+from . import rate_limit_log
 from . import base_document_layout
 from . import res_config_settings
 from . import res_partner

--- a/addons/web/models/rate_limit_log.py
+++ b/addons/web/models/rate_limit_log.py
@@ -1,0 +1,114 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime, timedelta
+
+from odoo import _, models, fields
+from odoo.exceptions import AccessDenied
+
+
+class RateLimitLog(models.TransientModel):
+    _name = 'rate.limit.log'
+    _description = 'Rate limit logs'
+
+    _scope_identity_key_ip_create_date_idx = models.Index(
+        "(scope, identity_key, ip, create_date)"
+    )
+
+    ip = fields.Char(readonly=True)
+    scope = fields.Char(required=True, readonly=True)
+    identity_key = fields.Char(readonly=True)
+
+    def _rate_limit_check(self, scope, ip, identity_key=False):
+        """Check rate limit for the given scope and log the attempt.
+
+        Raises AccessDenied if the rate limit has been exceeded.
+
+        :param str scope: the rate limit scope (e.g. 'totp_code_check')
+        :param str ip: the IP address of the request
+        :param str identity_key: optional identity to rate limit on instead
+            of IP alone (e.g. user id, email address)
+        """
+        limit, interval = self._rate_limit_get_config(scope)
+        domain = self._rate_limit_build_domain(scope, ip, identity_key, interval)
+        if self.sudo().search_count(domain) >= limit:
+            raise AccessDenied(self._rate_limit_get_error_message(scope))
+        self.sudo().create(self._rate_limit_prepare_log_values(scope, ip, identity_key))
+
+    def _rate_limit_purge(self, scope, identity_key=False):
+        """Clear rate limit logs for the given scope after a successful action.
+
+        :param str scope: the rate limit scope
+        :param str identity_key: if provided, only purge logs matching this key
+        """
+        domain = [('scope', '=', scope)]
+        if identity_key:
+            domain.append(('identity_key', '=', identity_key))
+        self.sudo().search(domain).unlink()
+
+    # --------------------------------------------------
+    # Overridable hooks
+    # --------------------------------------------------
+
+    def _rate_limit_get_config(self, scope):
+        """Return (max_attempts, interval_in_seconds) for the given scope.
+
+        Override this method via ``_inherit`` to register your own scopes.
+
+        :param str scope: the rate limit scope
+        :return: tuple (limit, interval)
+        :raises ValueError: if the scope is unknown
+        """
+        raise ValueError("Unknown rate limit scope: %s" % scope)
+
+    def _rate_limit_get_error_message(self, scope):
+        """Return the user-facing error message when the limit is exceeded.
+
+        Override this method via ``_inherit`` to provide scope-specific
+        messages.
+
+        :param str scope: the rate limit scope
+        :return: str
+        """
+        return _("Too many attempts, please try again later.")
+
+    def _rate_limit_build_domain(self, scope, ip, identity_key, interval):
+        """Build the search domain used to count recent attempts.
+
+        When an ``identity_key`` is provided the limit is enforced per
+        identity (e.g. per user or per email).  Otherwise it falls back to
+        per-IP limiting.
+
+        Override this method if you need a different strategy (e.g. limit
+        by both IP and identity simultaneously).
+
+        :param str scope: the rate limit scope
+        :param str ip: the IP address
+        :param str identity_key: optional identity value
+        :param int interval: the time window in seconds
+        :return: list of domain tuples
+        """
+        domain = [
+            ('scope', '=', scope),
+            ('create_date', '>=', datetime.now() - timedelta(seconds=interval)),
+        ]
+        if identity_key:
+            domain.append(('identity_key', '=', identity_key))
+        else:
+            domain.append(('ip', '=', ip))
+        return domain
+
+    def _rate_limit_prepare_log_values(self, scope, ip, identity_key):
+        """Prepare the values dict for creating a rate limit log entry.
+
+        Override to add extra data to the log record.
+
+        :param str scope: the rate limit scope
+        :param str ip: the IP address
+        :param str identity_key: optional identity value
+        :return: dict
+        """
+        return {
+            'scope': scope,
+            'ip': ip,
+            'identity_key': identity_key or False,
+        }

--- a/addons/web/security/ir.model.access.csv
+++ b/addons/web/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 "access_base_document_layout","access.base.document.layout","model_base_document_layout","base.group_system",1,1,1,0
 access_res_users_settings_embedded_action_user,res.users.settings.embedded.action,model_res_users_settings_embedded_action,base.group_user,1,1,1,1
+access_rate_limit_log,rate.limit.log,model_rate_limit_log,base.group_user,0,0,0,0


### PR DESCRIPTION
WIP :)

## Modular rate limiting

This PR extracts the TOTP rate-limiting logic into a reusable model:

```
rate.limit.log (web)
```

TOTP now only **registers scopes**, instead of implementing its own
rate-limiting system.



## Before

```
auth_totp
 └─ custom rate-limit model + logic
```

## After

```
web
 └─ rate.limit.log (generic engine)

auth_totp
 └─ defines TOTP scopes
```



## Example usage

```python
self.env['rate.limit.log']._rate_limit_check(scope, ip, identity_key)
```



## Notes

* No behavior change
* Same limits and messages
* Just moved to a reusable implementation


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
