### PR TITLE
[FIX] spreadsheet: cannot undo a list duplication

### DIFF
--- a/addons/spreadsheet/static/src/list/index.js
+++ b/addons/spreadsheet/static/src/list/index.js
@@ -56,6 +56,7 @@ inverseCommandRegistry
     .add("UPDATE_ODOO_LIST", identity)
     .add("RE_INSERT_ODOO_LIST", identity)
     .add("RENAME_ODOO_LIST", identity)
-    .add("REMOVE_ODOO_LIST", identity);
+    .add("REMOVE_ODOO_LIST", identity)
+    .add("DUPLICATE_ODOO_LIST", identity);
 
 export { ListCorePlugin, ListUIPlugin };

--- a/addons/spreadsheet/static/tests/lists/list_plugin.test.js
+++ b/addons/spreadsheet/static/tests/lists/list_plugin.test.js
@@ -1043,6 +1043,10 @@ test("Can duplicate a list", async () => {
     const listIds = model.getters.getListIds();
     expect(model.getters.getListIds().length).toBe(2);
 
+    undo(model);
+    expect(model.getters.getListIds().length).toBe(1);
+    redo(model);
+
     const expectedDuplicatedDefinition = {
         ...model.getters.getListDefinition(listId),
         id: "2",


### PR DESCRIPTION
How to reproduce:
- insert an odoo list in a spreadsheet
- duplicate the list from the sidepanel
- undo with Ctrl+z

-> crash

The command "DUPLICATE_ODOO_LIST" was not supported in the inverseCommand registry.

Task-5943688

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
