### PR TITLE
[IMP] website_livechat: improve recent conversations formatting

### DIFF
--- a/addons/website_livechat/static/src/core/web/livechat_channel_info_list_patch.js
+++ b/addons/website_livechat/static/src/core/web/livechat_channel_info_list_patch.js
@@ -2,7 +2,7 @@ import { LivechatChannelInfoList } from "@im_livechat/core/web/livechat_channel_
 
 import { compareDatetime } from "@mail/utils/common/misc";
 
-import { formatDateTime } from "@web/core/l10n/dates";
+import { toLocaleDateTimeString } from "@web/core/l10n/dates";
 import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
@@ -17,7 +17,7 @@ const livechatChannelInfoListPatch = {
             );
     },
     CLOSED_ON_TEXT(channel) {
-        return _t("(closed on: %(date)s)", { date: formatDateTime(channel.livechat_end_dt) });
+        return toLocaleDateTimeString(channel.livechat_end_dt);
     },
     get countryLanguageLabel() {
         return _t("Country & Language");

--- a/addons/website_livechat/static/src/core/web/livechat_channel_info_list_patch.xml
+++ b/addons/website_livechat/static/src/core/web/livechat_channel_info_list_patch.xml
@@ -23,7 +23,7 @@
                 <div class="btn btn-group o-rounded-bubble d-flex flex-column w-100 p-0 m-0" style="gap: 1px;">
                     <a
                         t-foreach="recentConversations" t-as="channel" t-key="channel.localId"
-                        class="o-livechat-LivechatChannelInfoList-recentConversation btn btn-sm btn-secondary btn-group-item d-flex align-items-center justify-content-start gap-1 w-100 m-0 px-3 py-1"
+                        class="o-livechat-LivechatChannelInfoList-recentConversation btn btn-sm btn-secondary btn-group-item d-flex flex-column w-100 m-0 px-3 py-1"
                         t-attf-href="/odoo/discuss?active_id=discuss.channel_{{channel.id}}"
                         target="_blank"
                         t-att-class="{
@@ -33,9 +33,14 @@
                             'rounded-bottom-0 border-bottom': !channel_last,
                         }"
                     >
-                        <i class="fa fa-external-link opacity-75"/>
-                        <span class="ms-1 fw-bold" t-esc="channel.displayName"/>
-                        <span t-if="channel.livechat_end_dt" class="o-xsmaller text-muted" t-out="CLOSED_ON_TEXT(channel)"/>
+                        <div class="d-flex align-items-center">
+                            <i class="fa fa-external-link me-2 o-mt-0_5 opacity-75"/>
+                            <span>
+                                <t t-if="channel.livechat_end_dt" t-out="CLOSED_ON_TEXT(channel)"/>
+                                <t t-else="">Conversation ongoing</t>
+                            </span>
+                        </div>
+                        <span t-if="channel.description" class="text-start text-muted smaller text-truncate" t-out="channel.description"/>
                     </a>
                 </div>
             </div>

--- a/addons/website_livechat/static/tests/livechat_channel_info_list_patch.test.js
+++ b/addons/website_livechat/static/tests/livechat_channel_info_list_patch.test.js
@@ -65,12 +65,14 @@ test("Show recent conversations in channel info list", async () => {
         {
             channel_member_ids: [],
             channel_type: "livechat",
+            description: "question about the live chat app",
             livechat_status: "in_progress",
             livechat_visitor_id: visitorId,
         },
         {
             channel_member_ids: [],
             channel_type: "livechat",
+            description: "question about the discuss app",
             livechat_status: "in_progress",
             livechat_visitor_id: visitorId,
         },
@@ -107,6 +109,12 @@ test("Show recent conversations in channel info list", async () => {
     await openDiscuss(channelIds.at(-1));
     await contains(".o-livechat-LivechatChannelInfoList-recentConversation", {
         count: 2,
-        text: "Bob",
+        text: "Conversation ongoing",
     });
+    await contains(
+        ".o-livechat-LivechatChannelInfoList-recentConversation :text('question about the discuss app')"
+    );
+    await contains(
+        ".o-livechat-LivechatChannelInfoList-recentConversation :text('question about the live chat app')"
+    );
 });


### PR DESCRIPTION
- Conversation name is usually the same as the visitor, remove it.
- Closed on text is hard to read, shorten it.
- Description is missing, add it.

part of task-5867464

| Before | After |
| ---|---|
|<img width="287" height="304" alt="image" src="https://github.com/user-attachments/assets/74032a14-92c2-418c-bfd9-45f766fffd38" />|<img width="291" height="305" alt="image" src="https://github.com/user-attachments/assets/55485f5d-0225-4df1-9e74-5a5554a71772" />|