### PR TITLE
[FIX] mass_mailing: preserve changes when switching form tabs

### DIFF
--- a/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.js
+++ b/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.js
@@ -253,6 +253,7 @@ export class MassMailingIframe extends Component {
         this.iframeRef.el.contentWindow.addEventListener("beforeUnload", () => {
             this.iframeRef.el.removeAttribute("is-ready");
         });
+        this.iframeRef.el.contentWindow.addEventListener("blur", this.onBlur.bind(this));
         this.iframeLoaded.resolve({
             iframe: this.iframeRef.el,
             bundleControls: this.bundleControls,

--- a/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.xml
+++ b/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.xml
@@ -12,7 +12,7 @@
                         <iframe t-att-sandbox="this.isBrowserSafari ? 'allow-same-origin allow-scripts' : 'allow-same-origin'"
                             t-att-scrolling="this.state.isMobile ? '' : 'no'"
                             t-att-class="{ 'd-none': props.showThemeSelector or props.showCodeView }"
-                            t-ref="iframeRef" t-on-blur="onBlur"/>
+                            t-ref="iframeRef"/>
                     </div>
                 </div>
                 <div t-if="!props.readonly and props.withBuilder and !props.showThemeSelector and !props.showCodeView">


### PR DESCRIPTION
Problem:
While editing an email marketing record, switching tabs in the form view causes the last changes in the editor to be lost.

Cause:
The `blur` event on the iframe is not triggered when clicking outside of it. If the iframe is not fully ready when listeners are attached, the required events are not properly registered, so the latest changes are not saved before switching tabs.

Solution:
Attach the `blur` listener only once the iframe is fully loaded, ensuring that changes are correctly detected and saved when focus is lost.

Steps to reproduce:
- Create a new email marketing record.
- Add a text snippet.
- Change the text and save.
- Modify the text again.
- Switch to another tab in the form view, then return to the "Mail body" tab.
- Observe that the last changes are lost.

opw-5921800

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
