### PR TITLE
[IMP] hr:  filter working schedules by country

### DIFF
--- a/addons/hr/models/hr_payroll_structure_type.py
+++ b/addons/hr/models/hr_payroll_structure_type.py
@@ -7,8 +7,10 @@ class HrPayrollStructureType(models.Model):
 
     name = fields.Char('Salary Structure Type')
     default_resource_calendar_id = fields.Many2one(
-        'resource.calendar', 'Working Hours',
-        default=lambda self: self.env.company.resource_calendar_id)
+        'resource.calendar',
+        string='Working Hours',
+        default=lambda self: self.env.company.resource_calendar_id,
+        domain=lambda self: [('company_id', 'in', [False] + self.env.companies.ids)])
     country_id = fields.Many2one(
         'res.country',
         string='Country',


### PR DESCRIPTION
Restrict the Working Hours selection on structure type so that it only shows global calendars or calendars belonging to companies for the selected country.

task-5940094

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
