### PR TITLE
[FIX] base: resetting crons timeout_counter on timeout

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -167,7 +167,7 @@ class IrCron(models.Model):
 
         with ListLogHandler(_logger, logging.ERROR) as capture:
             self._process_job(cron_cr, job)
-        if log_record := next((lr for lr in capture if hasattr(lr, 'exc_info')), None):
+        if log_record := next((lr for lr in capture if getattr(lr, 'exc_info', None)), None):
             _exc_type, exception, _traceback = log_record.exc_info
             e = RuntimeError()
             e.__cause__ = exception


### PR DESCRIPTION
CronJobs timed_out_counter is not getting reset when reaching the CONSECUTIVE_TIMEOUT_FOR_FAILURE due to a transaction rollback. This commit introduces a fix to ensure only records with an actual exception tuple pass through in method: 'method_direct_trigger'.

Description of the issue/feature this PR addresses:
When a cron job reaches the timeout threshold (timed_out_counter >= 3), method_direct_trigger crashes because the ListLogHandler filter matches log records that have exc_info = None. But the original filter only checked hasattr(lr, 'exc_info') which is true for all LogRecord objects. This caused a TypeError when attempting to unpack exc_info (None) on the next line, which rolled back the transaction and prevented timed_out_counter from being reset.

Current behavior before PR:
Clicking "Run Manually" on a timed-out cron (timed_out_counter >= 3) raises TypeError: cannot unpack non-iterable NoneType object, rolling back the transaction. The timed_out_counter is never reset, leaving the cron permanently stuck.

Desired behavior after PR is merged:
The filter correctly skips log records where exc_info is None (i.e., non-exception errors like timeouts). method_direct_trigger returns True, the transaction commits, and timed_out_counter is properly reset to 0.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
