### PR TITLE
[FIX] hr_attendance: hide archived employees

### DIFF
--- a/addons/hr_attendance/static/src/views/attendance_list_view.js
+++ b/addons/hr_attendance/static/src/views/attendance_list_view.js
@@ -1,0 +1,25 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { listView } from "@web/views/list/list_view";
+
+export class AttendanceListModel extends listView.Model {
+
+    /** @override **/
+    async load(params = {}) {
+        const activeDomainParam = params.domain &&
+            params.domain.some((item) => Array.isArray(item) && item[0] === "employee_id.active");
+        if (!activeDomainParam) {
+            params.domain = params.domain || [];
+            params.domain.push(["employee_id.active", "=", true]);
+        }
+        return super.load(params);
+    }
+}
+
+export const attendanceListView = {
+    ...listView,
+    Model: AttendanceListModel,
+};
+
+registry.category("views").add("attendance_list_view", attendanceListView);

--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -7,7 +7,7 @@
         <field name="name">hr.attendance.tree</field>
         <field name="model">hr.attendance</field>
         <field name="arch" type="xml">
-            <tree string="Employee attendances" decoration-success="color == 10" decoration-danger="color == 1" sample="1" duplicate="false">
+            <tree string="Employee attendances" decoration-success="color == 10" decoration-danger="color == 1" sample="1" duplicate="false" js_class="attendance_list_view">
                 <field name="employee_id" widget="many2one_avatar_user"/>
                 <field name="check_in"/>
                 <field name="check_out" options="{}"/>
@@ -212,6 +212,16 @@
                         context_today() + datetime.timedelta(days=-7)
                         )
                     )]"/>
+                <separator/>
+                <filter
+                    string="Active Employees"
+                    name="activeemployees"
+                    domain="[('employee_id.active', '=', True)]"/>
+                <filter
+                    string="Archived Employees"
+                    name="archivedemployees"
+                    domain="[('employee_id.active', '=', False)]"/>
+                <separator invisible="1"/>
                 <filter string="Last 3 Months" invisible="1" name="last_three_months" domain="[(
                     'check_in','&gt;=', (
                         context_today() + datetime.timedelta(days=-90)
@@ -256,6 +266,7 @@
             {
                 "search_default_groupby_name" : 1,
                 "search_default_employee": 1,
+                "search_default_activeemployees": 1,
                 "search_default_last_three_months": 1
             }
         </field>


### PR DESCRIPTION
**Problem:**
When an employee is archived, their attendance records still appear in the attendance list and reporting views.

**Steps to reproduce:**
1. Create an employee and record some attendances
2. Archive the employee
3. Go to Attendances > Overview
4. Observe the archived employee still appears in the list

**Current behavior:**
Archived employees remain visible in all attendance views.

**Expected behavior:**
Archived employees should be hidden by default, with an option to view them via search filters.

**Cause of the issue:**
The hr.attendance model has no `active` field itself, so the ORM never auto-filters records of archived employees. The list view loads all attendance records regardless of the employee's active status.

**Fix:**
A custom JS list model injects `employee_id.active = True` into the domain on every load, filtering out archived employees by default. Search filters allow toggling between active and archived employees when needed.

Backport of: 3d6d89a49a9d168eb87587f82c33f279a4ff22a3

opw-5930149