### PR TITLE
[FIX] website: prevent error when sending digest email without website

### DIFF
--- a/addons/website/models/digest.py
+++ b/addons/website/models/digest.py
@@ -55,7 +55,7 @@ class Digest(models.Model):
         all_websites = Website.browse(
             list({website.id for websites in websites_per_company.values() for website in websites}))
         value_per_website = get_value_per_website(all_websites, start, end)
-        return {company: sum(value_per_website.get(website, 0) for website in websites_per_company[company])
+        return {company: sum(value_per_website.get(website, 0) for website in websites_per_company.get(company, Website))
                 for company in companies}
 
     def _compute_kpi_website_track_count_value(self):

--- a/addons/website/tests/test_digest.py
+++ b/addons/website/tests/test_digest.py
@@ -2,7 +2,7 @@
 
 from datetime import timedelta
 
-from odoo import fields
+from odoo import Command, fields
 from odoo.addons.digest.tests.common import TestDigestCommon
 from odoo.tests import tagged
 
@@ -77,3 +77,14 @@ class TestWebsiteDigest(TestDigestCommon):
                     digest.with_context(start_datetime=start, end_datetime=end).kpi_website_track_count_value,
                     expected_count,
                     f'{digest.name}, period {period_idx}')
+
+    def test_send_digest_mail_without_website(self):
+        company = self.env['res.company'].create({'name': 'Test Company'})
+        self.digest_1.write({
+            'kpi_website_visitor_count': True,
+            'company_id': company.id,
+            'user_ids': [Command.link(self.user_admin.id)],
+        })
+        with self.mock_mail_gateway():
+            self.digest_1.action_send()
+        self.assertEqual(len(self._new_mails), 1, "A new Email should have been created")


### PR DESCRIPTION
When a company has no website configured, sending a digest email raises a traceback.

Steps to reproduce the error:
- Install ``website`` module
- Create a new company and switch to it
- Create a new digest email > In KPIs, Enable Visitors > Add recipient > Save
- Click on Send Now button

Traceback:
```py
KeyError: res.company(1,)
```

https://github.com/odoo/odoo/blob/dee3fdee0326db032d95639eb8ee9386bb1762d4/addons/website/models/digest.py#L49-L59
If no website exists for the company, ``websites_per_company`` becomes an empty dictionary.
Therefore, accessing ``websites_per_company[company]`` raises the above traceback.

sentry-7239108433

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
