### PR TITLE
[FIX] hr_timesheet: Sort timesheet lines in PDF

### DIFF
--- a/addons/hr_timesheet/report/report_timesheet_templates.xml
+++ b/addons/hr_timesheet/report/report_timesheet_templates.xml
@@ -24,7 +24,7 @@
                         </tr>
                    </thead>
                    <tbody>
-                        <tr t-foreach="lines" t-as="line" t-att-style="'background-color: #F1F1F1;' if line_index % 2 == 0 else ''">
+                        <tr t-foreach="lines.sorted('date')" t-as="line" t-att-style="'background-color: #F1F1F1;' if line_index % 2 == 0 else ''">
                             <td class="align-middle">
                                <span t-field="line.date">2021-09-01</span>
                             </td>


### PR DESCRIPTION
## Behavior before the PR:
The printed version of the timesheet always displayed the account_analytic_lines in the same order as in the view. This meant that if a user added a new line to the timesheet and then printed it, the order of the lines could be incorrect.

## Expected behavior after the PR:
The timesheet is automatically sorted before being printed, ensuring the correct order of lines.

task-[5349814](https://www.odoo.com/odoo/project/4105/tasks/5349814)





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
