### PR TITLE
[FIX] calendar: prevent blocking viewing a contact in multicompany environment

### DIFF
--- a/addons/calendar/models/res_partner.py
+++ b/addons/calendar/models/res_partner.py
@@ -48,7 +48,7 @@ class Partner(models.Model):
             # Add the events linked to the children of the partner
             for p in self.browse(meetings.keys()):
                 partner = p
-                while partner.parent_id:
+                while partner.parent_id and partner.parent_id in all_partners:
                     partner = partner.parent_id
                     if partner in self:
                         meetings[partner.id] = meetings.get(partner.id, set()) | meetings[p.id]

--- a/addons/calendar/models/res_partner.py
+++ b/addons/calendar/models/res_partner.py
@@ -25,9 +25,10 @@ class Partner(models.Model):
     def _compute_meeting(self):
         if self.ids:
             # prefetch 'parent_id'
-            all_partners = self.with_context(active_test=False).search_fetch(
+            all_partners = self.with_context(active_test=False).sudo().search_fetch(
                 [('id', 'child_of', self.ids)], ['parent_id'],
             )
+            parent_map = {p.id: p.parent_id.id for p in all_partners if p.parent_id}
 
             query = self.env['calendar.event']._search([])  # ir.rules will be applied
             meeting_data = self.env.execute_query(SQL("""
@@ -46,12 +47,13 @@ class Partner(models.Model):
                 meetings.setdefault(p_id, set()).add(m_id)
 
             # Add the events linked to the children of the partner
-            for p in self.browse(meetings.keys()):
-                partner = p
-                while partner.parent_id:
-                    partner = partner.parent_id
-                    if partner in self:
-                        meetings[partner.id] = meetings.get(partner.id, set()) | meetings[p.id]
+            children_meetings = list(meetings.items())
+            for p_id, p_meetings in children_meetings:
+                ancestor_id = parent_map.get(p_id)
+                while ancestor_id:
+                    if ancestor_id in self._ids:
+                        meetings.setdefault(ancestor_id, set()).update(p_meetings)
+                    ancestor_id = parent_map.get(ancestor_id)
             return {p_id: list(meetings.get(p_id, set())) for p_id in self.ids}
         return {}
 

--- a/addons/calendar/tests/test_res_partner.py
+++ b/addons/calendar/tests/test_res_partner.py
@@ -3,6 +3,7 @@
 
 from odoo.tests.common import TransactionCase
 from odoo.tests.common import new_test_user
+from odoo.addons.mail.tests.common import mail_new_test_user
 
 
 class TestResPartner(TransactionCase):
@@ -76,3 +77,43 @@ class TestResPartner(TransactionCase):
         self.assertEqual(test_partner_5.meeting_count, 2)
         self.assertEqual(test_partner_6.meeting_count, 1)
         self.assertEqual(test_partner_7.meeting_count, 1)
+
+    def test_view_multicompany_contact_with_inaccessible_meeting_parent(self):
+        """Check the partner's meeting accesses in a multi-company environment."""
+
+        company1 = self.env.ref('base.main_company')
+        company2 = self.env['res.company'].create({'name': 'OtherCompany'})
+
+        company1.partner_id.company_id = company1
+
+        # create two users
+        allcompany_user = mail_new_test_user(
+            self.env,
+            name='All company User',
+            login='allcompany_user',
+            company_id=company1.id,
+            company_ids=[company1.id, company2.id],
+            groups='base.group_user',
+        )
+        company1_user = mail_new_test_user(
+            self.env,
+            name='Restricted Kanban User',
+            login='restricted_kanban_user',
+            company_id=company1.id,
+            company_ids=[company1.id, company2.id],
+            groups='base.group_user',
+        )
+        company1_user.partner_id.write({'company_id': company1.id, 'parent_id': company1.partner_id.id})
+
+        # create an event that includes both users' partners (imitates the provided payload)
+        self.env['calendar.event'].create({
+            'name': 'test',
+            'start': '2026-02-16 17:00:00',
+            'stop': '2026-02-16 18:00:00',
+            'partner_ids': [allcompany_user.partner_id.id, company1_user.partner_id.id],
+        })
+
+        # compute the meeting_count as seen from another company
+        self.env.invalidate_all()
+        c1_partner_seen_from_c2 = company1_user.partner_id.with_user(allcompany_user).with_company(company2)
+        self.assertEqual(c1_partner_seen_from_c2.meeting_count, 1, "Should compute meeting count without access error as partner is accessible in all companies")

--- a/addons/calendar/tests/test_res_partner.py
+++ b/addons/calendar/tests/test_res_partner.py
@@ -76,3 +76,55 @@ class TestResPartner(TransactionCase):
         self.assertEqual(test_partner_5.meeting_count, 2)
         self.assertEqual(test_partner_6.meeting_count, 1)
         self.assertEqual(test_partner_7.meeting_count, 1)
+
+    def test_view_multicompany_contact_with_inaccessible_meeting_parent(self):
+        """Check the partner's meeting accesses in a multi-company environment."""
+
+        company1 = self.env.ref('base.main_company')
+        company2 = self.env['res.company'].create({'name': 'OtherCompany'})
+
+        parent, child = self.env['res.partner'].create([
+            {
+                'name': 'Company A',
+                'company_id': company1.id
+            },
+            {
+                'name': 'test_user',
+                'company_id': company1.id,
+            }
+        ])
+        child.parent_id = parent.id
+
+        # create two users
+        group_user = self.env.ref('base.group_user').id
+        main_user, fake_user = self.env['res.users'].create([
+            {
+                'name': 'Main User',
+                'login': 'main_user',
+                'company_id': company1.id,
+                'company_ids': [(6, 0, [company1.id, company2.id])],
+                'groups_id': [(6, 0, [group_user])],
+            },
+            {
+                'name': 'Restricted Kanban User',
+                'login': 'restricted_kanban_user',
+                'company_id': company1.id,
+                'company_ids': [(6, 0, [company1.id, company2.id])],
+                'groups_id': [(6, 0, [group_user])],
+            }
+        ])
+        fake_user.partner_id = child
+
+        # create an event that includes both users' partners (imitates the provided payload)
+        self.env['calendar.event'].create({
+            'name': 'test',
+            'start': '2026-02-16 17:00:00',
+            'stop': '2026-02-16 18:00:00',
+            'duration': 1,
+            'allday': False,
+            'partner_ids': [main_user.partner_id.id, fake_user.partner_id.id],
+        })
+
+        # compute the meeting_count for the fake user's partner
+        child_rec = self.env['res.partner'].with_user(main_user).with_company(company2).browse(child.id)
+        self.assertEqual(child_rec.meeting_count, 1)


### PR DESCRIPTION
### Steps to reproduce:
- Download Calendar and Contacts app
- Go to the Setting -> Companies -> Manage companies; make sure there are at least two companies
- Go to the Setting -> Users -> Manage users; make sure the current logged-in user has access to both companies
- Create a another user who also have access to both companies
- Search for the new user in contacts -> Assign the current company to the contact -> Through the internal link of the company, go to sales and purchase tab -> assign the same company in the company field
- Switch the company of the logged in user to the other company
- Open the test contact form, use the meeting smart button and create a new meeting
- Open the kanban contact view

 **> Access Error: Uh-oh! Looks like you have stumbled upon some top-secret records.**
### Cause of Issue:
When trying to view the search results in kanban view, the `meeting_count` is calculated for each contact. Hence,`_compute_meeting_count()` is called which calls `_compute_meeting()`. https://github.com/odoo/odoo/blob/f39785bcddd1eb5b7fb503d053c9bb66e2a0f15c/addons/calendar/models/res_partner.py#L49-L54 Since the above section tries to access `partner.parent_id` each loop, it reaches a `parent_id` that's not accessible for the current user.

### Fix:
Since we need to access `parent_id` to be able to calculate meeting count for the full tree of partners, `sudo()` is used to get all partners, but meetings are computed for ancestors who are in `self_ids` only so that we still remain within scope.
Same old logic is used to propagate meetings for every ancestor, but dictionary lookups are used to enhance performance.

opw-5874204