### PR TITLE
[FIX] web_editor: fix isDirty freezing the editor

### DIFF
--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -291,11 +291,16 @@ export class HtmlField extends Component {
             !(!lastValue && stripHistoryIds(value) === "<p><br></p>") &&
             stripHistoryIds(value) !== stripHistoryIds(lastValue)
         ) {
+            this.isDirty = false;
             this.props.record.model.bus.trigger("FIELD_IS_DIRTY", false);
             this.currentEditingValue = value;
             const contentMetadata = getHtmlFieldMetadata(lastValue);
             let restoredData = setHtmlFieldMetadata(value, contentMetadata);
             await this.props.record.update({ [this.props.name]: restoredData });
+            if (this.wysiwyg.odooEditor) {
+                this.wysiwyg.odooEditor.lastSavePoint =
+                    this.wysiwyg.odooEditor._historySteps.at(-1).id;
+            }
         }
     }
     async startWysiwyg(wysiwyg) {
@@ -314,9 +319,26 @@ export class HtmlField extends Component {
             this.wysiwyg.toolbarEl.append($codeviewButtonToolbar[0]);
             $codeviewButtonToolbar.click(this.toggleCodeView.bind(this));
         }
-        this.wysiwyg.odooEditor.addEventListener("historyStep", () =>
-            this.props.record.model.bus.trigger("FIELD_IS_DIRTY", this._isDirty())
-        );
+        this.wysiwyg.odooEditor.lastSavePoint = null;
+        this.isDirty = false;
+        this.wysiwyg.odooEditor.addEventListener("historyStep", () => {
+            if (!this.wysiwyg.odooEditor.lastSavePoint) {
+                this.wysiwyg.odooEditor.lastSavePoint = this.wysiwyg.odooEditor._historySteps[0].id;
+            }
+            const lastStep = this.wysiwyg.odooEditor._historySteps.at(-1);
+            this.isDirty = true;
+            if (lastStep.isReset) {
+                this.wysiwyg.odooEditor.lastSavePoint = lastStep.id;
+                this.isDirty = false;
+            } else if (
+                lastStep.restoredStepId &&
+                lastStep.restoredStepId === this.wysiwyg.odooEditor.lastSavePoint
+            ) {
+                this.wysiwyg.odooEditor.lastSavePoint = lastStep.id;
+                this.isDirty = false;
+            }
+            this.props.record.model.bus.trigger("FIELD_IS_DIRTY", this._isDirty());
+        });
 
         if (this.props.isCollaborative) {
             this.wysiwyg.odooEditor.addEventListener("onExternalHistorySteps", () =>
@@ -439,32 +461,7 @@ export class HtmlField extends Component {
         this.Wysiwyg = wysiwygModule.Wysiwyg;
     }
     _isDirty() {
-        const strippedPropValue = stripHistoryIds(String(this.props.record.data[this.props.name]));
-        const strippedEditingValue = stripHistoryIds(this.getEditingValue());
-        const domParser = new DOMParser();
-        const codeViewEl = this._getCodeViewEl();
-        let parsedPreviousValue;
-        // If the wysiwyg is active, we need to clean the content of the
-        // initialValue as the editingValue will be cleaned.
-        if (!codeViewEl && this.wysiwyg) {
-            const editable = domParser.parseFromString(strippedPropValue || '<p><br></p>', 'text/html').body;
-            // Temporarily append the editable to the DOM because the
-            // wysiwyg.getValue can indirectly call methods that needs to have
-            // access the node.ownerDocument.defaultView.getComputedStyle.
-            // By appending the editable to the dom, the node.ownerDocument will
-            // have a `defaultView`.
-            const div = document.createElement('div');
-            div.style.display = 'none';
-            div.append(editable);
-            document.body.append(div);
-            const editableValue = stripHistoryIds(this.wysiwyg.getValue({ $layout: $(editable) }));
-            div.remove();
-            parsedPreviousValue = domParser.parseFromString(editableValue, 'text/html').body;
-        } else {
-            parsedPreviousValue = domParser.parseFromString(strippedPropValue || '<p><br></p>', 'text/html').body;
-        }
-        const parsedNewValue = domParser.parseFromString(strippedEditingValue, 'text/html').body;
-        return !this.props.readonly && parsedPreviousValue.innerHTML !== parsedNewValue.innerHTML;
+        return !this.props.readonly && this.isDirty;
     }
     _getCodeViewEl() {
         return this.state.showCodeView && this.codeViewRef.el;

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -339,6 +339,8 @@ export class OdooEditor extends EventTarget {
         }
         this.initElementForEdition(editable);
 
+        this.lastSavePoint = null;
+
         // Convention: root node is ID root.
         editable.oid = 'root';
         this._idToNodeMap.set(1, editable);
@@ -898,7 +900,7 @@ export class OdooEditor extends EventTarget {
         value = value || '<p><br></p>';
         this.editable.innerHTML = fixInvalidHTML(value);
         this.sanitize(this.editable);
-        this.historyStep(true);
+        this.historyStep(true, { isReset: true });
         // The unbreakable protection mechanism detects an anomaly and attempts
         // to trigger a rollback when the content is reset using `innerHTML`.
         // Prevent this rollback as it would otherwise revert the new content.
@@ -1052,7 +1054,7 @@ export class OdooEditor extends EventTarget {
                 clearTimeout(this.observerTimeout);
                 if (this._observerTimeoutUnactive.size === 0) {
                     this.observerTimeout = setTimeout(() => {
-                        this.historyStep();
+                        this.historyStep(false);
                     }, 100);
                 }
                 this.observerApply(records);
@@ -1331,7 +1333,7 @@ export class OdooEditor extends EventTarget {
     }
 
     // One step completed: apply to vDOM, setup next history step
-    historyStep(skipRollback = false, { stepId } = {}) {
+    historyStep(skipRollback = false, { stepId, restoredStepId, isReset } = {}) {
         if (!this._historyStepsActive) {
             return;
         }
@@ -1352,6 +1354,8 @@ export class OdooEditor extends EventTarget {
         const previousStep = peek(this._historySteps);
         currentStep.clientId = this._collabClientId;
         currentStep.previousStepId = previousStep.id;
+        currentStep.isReset = isReset;
+        currentStep.restoredStepId = restoredStepId;
 
         this._historySteps.push(currentStep);
         if (this.options.onHistoryStep) {
@@ -1470,7 +1474,7 @@ export class OdooEditor extends EventTarget {
             // Consider the last position of the history as an undo.
             const stepId = this._generateId();
             this._historyStepsStates.set(stepId, 'undo');
-            this.historyStep(true, { stepId });
+            this.historyStep(true, { stepId, restoredStepId: this._historySteps[pos].previousStepId });
             this.dispatchEvent(new Event('historyUndo'));
         }
     }
@@ -1494,7 +1498,7 @@ export class OdooEditor extends EventTarget {
             this.historySetSelection(this._historySteps[pos]);
             const stepId = this._generateId();
             this._historyStepsStates.set(stepId, 'redo');
-            this.historyStep(true, { stepId });
+            this.historyStep(true, { stepId, restoredStepId: this._historySteps[pos].previousStepId });
             this.dispatchEvent(new Event('historyRedo'));
         }
     }

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -3480,6 +3480,7 @@ export class Wysiwyg extends Component {
     async resetValue(value) {
         this.setValue(value);
         this.odooEditor.historyReset();
+        this.odooEditor.lastSavePoint = this.odooEditor._historyIds.at(-1);
         this._historyShareId = Math.floor(Math.random() * Math.pow(2,52)).toString();
         this._serverLastStepId = value && this._getLastHistoryStepId(value);
         if (this._serverLastStepId) {


### PR DESCRIPTION
Problem:
When editing heavy content, each interaction can take up to 600 ms, sometimes freezing the editor completely.

Cause:
The `_isDirty` check is computationally expensive and is executed on every history step. This is unnecessary and leads to poor performance when handling large documents.

Solution:
Instead of recomputing `_isDirty` on each history step, directly mark the field as dirty whenever a history step is triggered. This provides a simpler and more efficient approach.

Before fix:
Each keyboard interaction to next paint takes around 200ms.
<img width="582" height="306" alt="image" src="https://github.com/user-attachments/assets/bb215a97-f651-4e39-8419-06953aba2b8d" />

After fix:
Each keyboard interaction to next paint takes around 40ms.
<img width="610" height="178" alt="image" src="https://github.com/user-attachments/assets/1ff9ca36-457b-4015-9f30-4fed990c2ba3" />

opw-5892291

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
