### PR TITLE
[FIX] hw_drivers: fix printer usb exception

### DIFF
--- a/addons/hw_drivers/iot_handlers/interfaces/USBInterface_L.py
+++ b/addons/hw_drivers/iot_handlers/interfaces/USBInterface_L.py
@@ -28,6 +28,8 @@ class USBInterface(Interface):
             return dev.product != "USB2.0-Ser!"
         except ValueError:
             return True
+        except core.USBError:  # Thrown for some printers like POS80D
+            return False
 
     def get_devices(self):
         """


### PR DESCRIPTION
Seen on https://laloux-j.odoo.com/ 12/2 with a POS80D printer the printer triggers a core.USBError.

This PR catches the corresponding exception
2026-02-12 04:21:12,496 1117 ERROR ? odoo.addons.iot_drivers.exception_logger: usb.core.USBError: [Errno None] Invalid descriptor

task-5932720
