### PR TITLE
[FIX] mail: avoid missing border on mention

### DIFF
--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -364,9 +364,10 @@ $o-mail-utilities: map-merge(
 a.o_mail_redirect, a.o_channel_redirect, a.o-discuss-mention, a.o_message_redirect_transformed {
     user-select: none;
     border-radius: $btn-border-radius-sm;
-    padding: 0rem 0.1rem;
-    margin: 0rem 0.0875rem;
+    padding: 0rem 0.15rem;
+    margin: 0rem 0.025rem;
     outline: 1px solid;
+    outline-offset: -1px;
     font-weight: $font-weight-bold;
     display: inline-block;
 }

--- a/addons/mail/static/tests/inline/convert_inline.test.js
+++ b/addons/mail/static/tests/inline/convert_inline.test.js
@@ -1514,7 +1514,7 @@ describe("Should not convert blacklisted class to inline styles", () => {
         classToStyle(editable, getCSSRules(editable.ownerDocument));
 
         expect(editable).toHaveInnerHTML(
-            `<a contenteditable="false" href="#" class="o_mail_redirect" style="text-decoration: none; padding: 0rem 0.1rem; margin: 0rem 0.0875rem; box-sizing: border-box; overflow-wrap: unset;">@Marc Demo</a> Testing!`,
+            `<a contenteditable="false" href="#" class="o_mail_redirect" style="text-decoration: none; padding: 0rem 0.15rem; margin: 0rem 0.025rem; box-sizing: border-box; overflow-wrap: unset;">@Marc Demo</a> Testing!`,
             {
                 message: "blacklisted class styles should remain unconverted",
             }
@@ -1530,7 +1530,7 @@ describe("Should not convert blacklisted class to inline styles", () => {
         editable.innerHTML = `<a contenteditable="false" href="#" class="o_mail_redirect test-style">@Marc Demo</a> Testing!`;
         classToStyle(editable, getCSSRules(editable.ownerDocument));
         expect(editable).toHaveInnerHTML(
-            `<a contenteditable="false" href="#" class="o_mail_redirect test-style" style="text-decoration: none; padding: 0rem 0.1rem; margin: 0rem 0.0875rem; box-sizing: border-box; background-color: yellow; overflow-wrap: unset;"> @Marc Demo </a> Testing!`,
+            `<a contenteditable="false" href="#" class="o_mail_redirect test-style" style="text-decoration: none; padding: 0rem 0.15rem; margin: 0rem 0.025rem; box-sizing: border-box; background-color: yellow; overflow-wrap: unset;"> @Marc Demo </a> Testing!`,
             { message: "styles marked !important should override blacklisted class restrictions" }
         );
     });
@@ -1544,7 +1544,7 @@ describe("Should not convert blacklisted class to inline styles", () => {
         editable.innerHTML = `<a contenteditable="false" href="#" class="o_mail_redirect test-color">@Marc Demo</a> Testing!`;
         classToStyle(editable, getCSSRules(editable.ownerDocument));
         expect(editable).toHaveInnerHTML(
-            `<a contenteditable="false" href="#" class="o_mail_redirect test-color" style="text-decoration: none; padding: 0rem 0.1rem; margin: 0rem 0.0875rem; box-sizing: border-box; overflow-wrap: unset;"> @Marc Demo </a> Testing!`,
+            `<a contenteditable="false" href="#" class="o_mail_redirect test-color" style="text-decoration: none; padding: 0rem 0.15rem; margin: 0rem 0.025rem; box-sizing: border-box; overflow-wrap: unset;"> @Marc Demo </a> Testing!`,
             {
                 message:
                     "should ignore styles from lower specificity class in favor of blacklisted class",


### PR DESCRIPTION
Before this PR, the border from the mention element was missing at the top and bottom.
This is caused by the inline-block property. `<a>` is already an inline element and doesn't need this property.

Task-5867464 (point 68)

Before
<img width="234" height="65" alt="image" src="https://github.com/user-attachments/assets/9502ac28-6cfd-4f3f-8f1c-933ed74c425d" />
After
<img width="252" height="74" alt="image" src="https://github.com/user-attachments/assets/968814bf-337f-42aa-9b2e-590cb68988f7" />
