### PR TITLE
[FIX] website_sale_stock: fix image size in product availability mail

### DIFF
--- a/addons/website_sale_stock/data/template_email.xml
+++ b/addons/website_sale_stock/data/template_email.xml
@@ -6,7 +6,7 @@
             <p>The following product is now available.</p>
             <div style="display: flex; justify-content: center; width: 100%;">
                 <a t-attf-href="#{product.website_url}">
-                    <img t-attf-src="/web/image/product.product/#{product.id}/image_1920"/>
+                    <img t-attf-src="/web/image/product.product/#{product.id}/image_256"/>
                 </a>
             </div>
             <div style="display: flex; flex-direction: row; align-items: center; justify-content: center; width: 100%;">


### PR DESCRIPTION
Steps to reproduce in local:
1. Install `website_sale_stock`
2. Make a product variant with an image
3. To make it easy set field `Back in stock Notifications`'s value on this product with the help of the studio
4. Add a person to receive notification in this field
5. Don't set Outgoing email server
6. Run cron `Product: send email regarding products availability` manually
7. To Check sent email go to `Setting > Technical > Email > Emails`

Issue:
- The image is a full-size image


<table>
    <tr>
        <th style="text-align: center;">Before</th>
        <th style="text-align: center;">After</th>
    </tr>
    <tr>
        <td style="text-align: center;">
            <img width="1395" height="728" alt="Before" 
                 src="https://github.com/user-attachments/assets/a3fe3b38-c4a5-4a78-a63a-552c96cfdf84" />
        </td>
        <td style="text-align: center;">
            <img width="1383" height="662" alt="After" 
                 src="https://github.com/user-attachments/assets/8c346302-4295-44f2-8172-6a01072b23c7" />
        </td>
    </tr>
</table>

opw-5915587