### PR TITLE
[FIX] hr_expense: Fix double entry recording

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1,16 +1,15 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import re
-
-from markupsafe import Markup
 import logging
-import werkzeug
-
-from odoo import api, fields, Command, models, _
-from odoo.exceptions import RedirectWarning, UserError, ValidationError
-from odoo.tools import clean_context, email_normalize, float_repr, float_round, is_html_empty, format_amount, format_date
+import re
 from datetime import timedelta
 
+import werkzeug
+from markupsafe import Markup
+
+from odoo import Command, _, api, fields, models
+from odoo.exceptions import RedirectWarning, UserError, ValidationError
+from odoo.tools import clean_context, email_normalize, float_repr, float_round, format_amount, format_date, is_html_empty
 
 _logger = logging.getLogger(__name__)
 
@@ -253,13 +252,15 @@ class HrExpense(models.Model):
         tracking=True,
     )
     vendor_id = fields.Many2one(comodel_name='res.partner', string="Vendor")
+    is_paid_by_company_match_bill = fields.Boolean(string="Existing bill")
     account_id = fields.Many2one(
         comodel_name='account.account',
         string="Account",
         compute='_compute_account_id', precompute=True, store=True, readonly=False,
         check_company=True,
-        domain="[('account_type', 'not in', ('asset_receivable', 'liability_payable', 'asset_cash', 'liability_credit_card'))]",
-        help="An expense account is expected",
+        domain="[('account_type', 'not in', ('asset_receivable', 'asset_cash', 'liability_credit_card'))]",
+        help="An expense account is expected for employee paid expenses and company paid expenses without a matched bill.\n"
+             "For company paid expenses with a matched bill, the account needs to be the payable account of the bill.",
     )
     tax_ids = fields.Many2many(
         comodel_name='account.tax',
@@ -580,12 +581,18 @@ class HrExpense(models.Model):
             expense.currency_rate = expense.total_amount / expense.total_amount_currency if expense.total_amount_currency else 1.0
             expense.price_unit = expense.total_amount / expense.quantity if expense.quantity else expense.total_amount
 
-    @api.depends('product_id', 'company_id')
+    @api.depends('product_id', 'company_id', 'is_paid_by_company_match_bill')
     def _compute_tax_ids(self):
-        for _expense in self.filtered('company_id'):   # Avoid a traceback, the field is required anyway
-            expense = _expense.with_company(_expense.company_id)
+        for expense_ in self.filtered('company_id'):  # Avoid a traceback, the field is required anyway
+            expense = expense_.with_company(expense_.company_id)
             # taxes only from the same company
-            expense.tax_ids = expense.product_id.supplier_taxes_id.filtered_domain(self.env['account.tax']._check_company_domain(expense.company_id))
+            if expense.is_paid_by_company_match_bill:
+                expense.tax_ids = False
+            else:
+                taxes = expense.product_id.supplier_taxes_id.filtered_domain(
+                    self.env['account.tax']._check_company_domain(expense.company_id)
+                )
+                expense.tax_ids = taxes
 
     @api.depends('total_amount_currency', 'tax_ids')
     def _compute_tax_amount_currency(self):
@@ -689,16 +696,28 @@ class HrExpense(models.Model):
                     ('journal_id.active', '=', True),
                 ])
 
-    @api.depends('product_id', 'company_id')
+    @api.onchange('payment_mode')
+    def _onchange_is_paid_by_company_match_bill(self):
+        for expense in self:
+            if expense.payment_mode == 'own_account':
+                expense.is_paid_by_company_match_bill = False
+            else:
+                expense.is_paid_by_company_match_bill = expense.is_paid_by_company_match_bill
+
+    @api.depends('product_id', 'company_id', 'vendor_id', 'is_paid_by_company_match_bill')
     def _compute_account_id(self):
         for _expense in self:
             expense = _expense.with_company(_expense.company_id)
-            if not expense.product_id:
-                expense.account_id = _expense.company_id.expense_account_id
-                continue
-            account = expense.product_id.product_tmpl_id._get_product_accounts()['expense']
-            if account:
+            account = expense.product_id and expense.product_id.product_tmpl_id._get_product_accounts()['expense']
+            if expense.is_paid_by_company_match_bill:
+                # "Regular" supplier account, the product account line will be in the matched bill
+                account = (
+                    self.vendor_id.commercial_partner_id.property_account_payable_id
+                    or self.env['ir.default']._get('res.partner', 'property_account_payable_id', company_id=expense.company_id)
+                )
                 expense.account_id = account
+            else:
+                expense.account_id = account or expense.company_id.expense_account_id
 
     @api.depends('company_id')
     def _compute_employee_id(self):
@@ -827,7 +846,15 @@ class HrExpense(models.Model):
         if any(field in vals for field in {'is_editable', 'can_approve', 'can_refuse'}):
             raise UserError(_("You cannot edit the security fields of an expense manually"))
 
-        if any(field in vals for field in {'tax_ids', 'analytic_distribution', 'account_id', 'manager_id'}):
+        restricted_fields = {
+            'analytic_distribution',
+            'account_id',
+            'is_paid_by_company_match_bill',
+            'manager_id',
+            'tax_ids',
+            'vendor_id',
+        }
+        if any(field in vals for field in restricted_fields):
             if any((not expense.is_editable and not self.env.su) for expense in self):
                 raise UserError(_(
                     "Uh-oh! You can’t edit this expense.\n\n"
@@ -1769,14 +1796,19 @@ class HrExpense(models.Model):
         3. expense account of the company
         4. expense account on the purchase journal for employee expense
         """
+        self.ensure_one()
 
         # expense account of the expense itself
         account = self.account_id
         if account:
             return account
 
-        # expense account of the product then the product category
-        if self.product_id:
+        if self.is_paid_by_company_match_bill:
+            account = (
+                self.vendor_id.commercial_partner_id.property_account_payable_id
+                or self.env['ir.default']._get('res.partner', 'property_account_payable_id', company_id=self.company_id)
+            )
+        elif self.product_id:  # expense account of the product then the product category
             account = self.product_id.with_company(self.company_id).product_tmpl_id._get_product_accounts()['expense']
         else:
             account = self.env.company.expense_account_id

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -12,6 +12,7 @@
                     <field name="is_multiple_currency" column_invisible="True"/>
                     <field name="product_has_cost" column_invisible="True"/>
                     <field name="selectable_payment_method_line_ids" column_invisible="True"/>
+                    <field name="is_paid_by_company_match_bill" column_invisible="True"/>
 
                     <!--  Always Shown start -->
                     <field name="employee_id" widget="many2one_avatar_employee" readonly="not is_editable"/>
@@ -41,7 +42,7 @@
                     <field name="quantity" optional="hide" readonly="not is_editable or not product_has_cost"/>
                     <field name="tax_ids" optional="hide" widget="many2many_tax_tags"
                            groups="account.group_account_invoice,account.group_account_readonly"
-                           readonly="not is_editable or not product_has_cost"/>
+                           readonly="not is_editable or not product_has_cost or is_paid_by_company_match_bill"/>
                     <field name="tax_amount" sum="Total Taxes" readonly="True"
                            optional="hide" groups="account.group_account_invoice,account.group_account_readonly"/>
                     <field name="nb_attachment" widget="nb_attachment" nolabel="1" readonly="True"/>
@@ -240,7 +241,7 @@
                                 <field name="tax_ids"
                                        force_save="1"
                                        widget="many2many_tax_tags"
-                                       readonly="not is_editable"
+                                       readonly="not is_editable or is_paid_by_company_match_bill"
                                        options="{'no_create': True}"/>
                                 <field name="tax_amount_currency"/>
                             </div>
@@ -263,10 +264,19 @@
                             <field name="manager_id" widget="many2one_avatar_user" readonly="state != 'draft'" placeholder="Auto-validation"/>
                             <field name="department_id" invisible="1" readonly="not is_editable"
                                    context="{'default_company_id': company_id}"/>
-                            <field name="vendor_id" invisible="payment_mode != 'company_account'"/>
+                            <field name="vendor_id" invisible="payment_mode != 'company_account'" readonly="not is_editable"/>
+                            <field name="is_paid_by_company_match_bill" widget="boolean_radio" invisible="payment_mode != 'company_account'"
+                                   options="{'no_label_element_id': 'direct_expense', 'yes_label_element_id': 'match_bill'}"
+                                   readonly="not is_editable" groups="account.group_account_readonly" class="w-auto" />
+                            <template id="direct_expense">No (Direct Expense)</template>
+                            <template id="match_bill">Yes (Match to Bill)</template>
                             <field name="account_id" options="{'no_create': True}"
                                    domain="[('account_type', 'not in', ('asset_receivable','liability_payable','asset_cash','liability_credit_card')), ('company_ids', 'parent_of', company_id)]"
-                                   groups="account.group_account_readonly" readonly="not is_editable"
+                                   groups="account.group_account_readonly" readonly="not is_editable" invisible="is_paid_by_company_match_bill"
+                                   context="{'default_company_id': company_id}"/>
+                            <field name="account_id" options="{'no_create': True}"
+                                   domain="[('account_type', '=', 'liability_payable'), ('company_ids', 'parent_of', company_id)]"
+                                   groups="account.group_account_readonly" readonly="not is_editable" invisible=" not is_paid_by_company_match_bill"
                                    context="{'default_company_id': company_id}"/>
                             <field name="payment_method_line_id"
                                    options="{'no_open': True, 'no_create': True}"


### PR DESCRIPTION
Context:
- You create an expense paid by company -> post the entry
- The vendor sends you the bill through an EDI
- You have recorded the changes on the base and tax accounts twice

Fix:
Add a field to make the expense paid by company act like
a regular payment instead.
Using the supplier payable and outstanding payment accounts

task-id: 5877568