### PR TITLE
[REF] base: deprecate legacy const_eval and old opcodes from safe_eval

### DIFF
--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -417,12 +417,12 @@ token.tok_name[token.QWEB] = 'QWEB'
 
 # security safe eval opcodes for generated expression validation, used in `_compile_expr`
 _SAFE_QWEB_OPCODES = _EXPR_OPCODES.union(to_opcodes([
-    'MAKE_FUNCTION', 'CALL_FUNCTION', 'CALL_FUNCTION_KW', 'CALL_FUNCTION_EX',
-    'CALL_METHOD', 'LOAD_METHOD',
+    'MAKE_FUNCTION', 'CALL_FUNCTION_EX',
+    'LOAD_METHOD',
 
     'GET_ITER', 'FOR_ITER', 'YIELD_VALUE',
-    'JUMP_FORWARD', 'JUMP_ABSOLUTE', 'JUMP_BACKWARD',
-    'JUMP_IF_FALSE_OR_POP', 'JUMP_IF_TRUE_OR_POP', 'POP_JUMP_IF_FALSE', 'POP_JUMP_IF_TRUE',
+    'JUMP_FORWARD', 'JUMP_BACKWARD',
+    'POP_JUMP_IF_FALSE', 'POP_JUMP_IF_TRUE',
 
     'LOAD_NAME', 'LOAD_ATTR',
     'LOAD_FAST', 'STORE_FAST', 'UNPACK_SEQUENCE',
@@ -430,18 +430,11 @@ _SAFE_QWEB_OPCODES = _EXPR_OPCODES.union(to_opcodes([
     'LOAD_GLOBAL',
     'EXTENDED_ARG',
     # Following opcodes were added in 3.11 https://docs.python.org/3/whatsnew/3.11.html#new-opcodes
-    'RESUME',
     'CALL',
-    'PRECALL',
     'PUSH_NULL',
     'KW_NAMES',
     'FORMAT_VALUE', 'BUILD_STRING',
     'RETURN_GENERATOR',
-    'SWAP',
-    'POP_JUMP_FORWARD_IF_FALSE', 'POP_JUMP_FORWARD_IF_TRUE',
-    'POP_JUMP_BACKWARD_IF_FALSE', 'POP_JUMP_BACKWARD_IF_TRUE',
-    'POP_JUMP_FORWARD_IF_NONE', 'POP_JUMP_FORWARD_IF_NOT_NONE',
-    'POP_JUMP_BACKWARD_IF_NONE', 'POP_JUMP_BACKWARD_IF_NOT_NONE',
     # 3.12 https://docs.python.org/3/whatsnew/3.12.html#new-opcodes
     'END_FOR',
     'LOAD_FAST_AND_CLEAR',

--- a/odoo/addons/test_tools/tests/test_safe_eval.py
+++ b/odoo/addons/test_tools/tests/test_safe_eval.py
@@ -7,7 +7,6 @@ from odoo import Command
 from odoo.tests.common import tagged, BaseCase, TransactionCase
 from odoo.tools import mute_logger
 from odoo.tools.safe_eval import (
-    const_eval,
     expr_eval,
     safe_eval,
     UnsafeObjectError,
@@ -17,14 +16,6 @@ from odoo.tools.safe_eval import (
 
 @tagged('at_install', '-post_install')
 class TestSafeEval(BaseCase):
-    def test_const(self):
-        # NB: True and False are names in Python 2 not consts
-        expected = (1, {"a": {2.5}}, [None, u"foo"])
-        actual = const_eval('(1, {"a": {2.5}}, [None, u"foo"])')
-        self.assertEqual(actual, expected)
-        # Test RETURN_CONST
-        self.assertEqual(const_eval('10'), 10)
-
     def test_expr(self):
         # NB: True and False are names in Python 2 not consts
         expected = 3 * 4

--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -38,12 +38,12 @@ from psycopg2 import OperationalError
 
 import odoo.exceptions
 from .config import config
-from .func import lazy
+from .func import deprecated, lazy
 from .misc import OrderedSet
 
 unsafe_eval = eval
 
-__all__ = ['const_eval', 'safe_eval']
+__all__ = ['const_eval', 'expr_eval', 'safe_eval']
 
 _logger = logging.getLogger(__name__)
 _logger_runtime = logging.getLogger(f'{__name__}.runtime')
@@ -341,10 +341,11 @@ def compile_codeobj(expr: str, /, filename: str = '<unknown>', mode: typing.Lite
         raise ValueError('%r while compiling\n%r' % (e, expr))
 
 
+@deprecated("Since 20.0, use ast.literal_eval instead")
 def const_eval(expr):
     """const_eval(expression) -> value
 
-    Safe Python constant evaluation
+    Safe Python constant evaluation, equivalent to `ast.literal_eval`.
 
     Evaluates a string that contains an expression describing
     a Python constant. Strings that are not valid Python expressions
@@ -357,11 +358,10 @@ def const_eval(expr):
     >>> const_eval("1+2")
     Traceback (most recent call last):
     ...
-    ValueError: opcode BINARY_ADD not allowed
+    ValueError: malformed node or string on line 1: <ast.BinOp object at 0xdeadbeef>
     """
-    c = compile_codeobj(expr)
-    assert_valid_codeobj(_CONST_OPCODES, c, expr)
-    return unsafe_eval(c)
+    return ast.literal_eval(expr)
+
 
 def expr_eval(expr):
     """expr_eval(expression) -> value
@@ -384,6 +384,7 @@ def expr_eval(expr):
     c = compile_codeobj(expr)
     assert_valid_codeobj(_EXPR_OPCODES, c, expr)
     return unsafe_eval(c)
+
 
 _BUILTINS = {
     '__import__': _import,

--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -151,7 +151,7 @@ _BLACKLIST = set(to_opcodes([
 # opcodes necessary to build literal values
 _CONST_OPCODES = set(to_opcodes([
     # stack manipulations
-    'POP_TOP', 'ROT_TWO', 'ROT_THREE', 'ROT_FOUR', 'DUP_TOP', 'DUP_TOP_TWO',
+    'POP_TOP',
     'LOAD_CONST',
     'RETURN_VALUE',  # return the result of the literal/expr evaluation
     # literal collections
@@ -171,17 +171,10 @@ _CONST_OPCODES = set(to_opcodes([
     'LOAD_SMALL_INT',
 ])) - _BLACKLIST
 
-# operations which are both binary and inplace, same order as in doc'
-_operations = [
-    'POWER', 'MULTIPLY',  # 'MATRIX_MULTIPLY', # matrix operator (3.5+)
-    'FLOOR_DIVIDE', 'TRUE_DIVIDE', 'MODULO', 'ADD',
-    'SUBTRACT', 'LSHIFT', 'RSHIFT', 'AND', 'XOR', 'OR',
-]
 # operations on literal values
 _EXPR_OPCODES = _CONST_OPCODES.union(to_opcodes([
-    'UNARY_POSITIVE', 'UNARY_NEGATIVE', 'UNARY_NOT', 'UNARY_INVERT',
-    *('BINARY_' + op for op in _operations), 'BINARY_SUBSCR',
-    *('INPLACE_' + op for op in _operations),
+    'UNARY_NEGATIVE', 'UNARY_NOT', 'UNARY_INVERT',
+    'BINARY_SUBSCR',
     'BUILD_SLICE',
     # comprehensions
     'LIST_APPEND', 'MAP_ADD', 'SET_ADD',
@@ -189,8 +182,6 @@ _EXPR_OPCODES = _CONST_OPCODES.union(to_opcodes([
     # specialised comparisons
     'IS_OP', 'CONTAINS_OP',
     'DICT_MERGE', 'DICT_UPDATE',
-    # Basically used in any "generator literal"
-    'GEN_START',  # added in 3.10 but already removed from 3.11.
     # Added in 3.11, replacing all BINARY_* and INPLACE_*
     'BINARY_OP',
     'BINARY_SLICE',
@@ -199,42 +190,27 @@ _EXPR_OPCODES = _CONST_OPCODES.union(to_opcodes([
 _SAFE_OPCODES = _EXPR_OPCODES.union(to_opcodes([
     'POP_BLOCK', 'POP_EXCEPT',
 
-    # note: removed in 3.8
-    'SETUP_LOOP', 'SETUP_EXCEPT', 'BREAK_LOOP', 'CONTINUE_LOOP',
-
     'EXTENDED_ARG',  # P3.6 for long jump offsets.
-    'MAKE_FUNCTION', 'CALL_FUNCTION', 'CALL_FUNCTION_KW', 'CALL_FUNCTION_EX',
+    'MAKE_FUNCTION', 'CALL_FUNCTION_EX',
     # Added in P3.7 https://bugs.python.org/issue26110
-    'CALL_METHOD', 'LOAD_METHOD',
+    'LOAD_METHOD',
 
     'GET_ITER', 'FOR_ITER', 'YIELD_VALUE',
-    'JUMP_FORWARD', 'JUMP_ABSOLUTE', 'JUMP_BACKWARD',
-    'JUMP_IF_FALSE_OR_POP', 'JUMP_IF_TRUE_OR_POP', 'POP_JUMP_IF_FALSE', 'POP_JUMP_IF_TRUE',
-    'SETUP_FINALLY', 'END_FINALLY',
-    # Added in 3.8 https://bugs.python.org/issue17611
-    'BEGIN_FINALLY', 'CALL_FINALLY', 'POP_FINALLY',
+    'JUMP_FORWARD', 'JUMP_BACKWARD',
+    'POP_JUMP_IF_FALSE', 'POP_JUMP_IF_TRUE',
+    'SETUP_FINALLY',
 
     'RAISE_VARARGS', 'LOAD_NAME', 'STORE_NAME', 'DELETE_NAME', 'LOAD_ATTR',
     'LOAD_FAST', 'STORE_FAST', 'DELETE_FAST', 'UNPACK_SEQUENCE',
     'STORE_SUBSCR',
     'LOAD_GLOBAL',
-
-    'RERAISE', 'JUMP_IF_NOT_EXC_MATCH',
+    'RERAISE',
 
     # Following opcodes were Added in 3.11
-    # replacement of opcodes CALL_FUNCTION, CALL_FUNCTION_KW, CALL_METHOD
-    'PUSH_NULL', 'PRECALL', 'CALL', 'KW_NAMES',
-    # replacement of POP_JUMP_IF_TRUE and POP_JUMP_IF_FALSE
-    'POP_JUMP_FORWARD_IF_FALSE', 'POP_JUMP_FORWARD_IF_TRUE',
-    'POP_JUMP_BACKWARD_IF_FALSE', 'POP_JUMP_BACKWARD_IF_TRUE',
-    # special case of the previous for IS NONE / IS NOT NONE
-    'POP_JUMP_FORWARD_IF_NONE', 'POP_JUMP_BACKWARD_IF_NONE',
-    'POP_JUMP_FORWARD_IF_NOT_NONE', 'POP_JUMP_BACKWARD_IF_NOT_NONE',
-    # replacement of JUMP_IF_NOT_EXC_MATCH
-    'CHECK_EXC_MATCH',
-    # new opcodes
+    'PUSH_NULL', 'CALL', 'KW_NAMES', 'CHECK_EXC_MATCH',
     'RETURN_GENERATOR',
     'PUSH_EXC_INFO',
+
     'NOP',
     'FORMAT_VALUE', 'BUILD_STRING',
     # 3.12 https://docs.python.org/3/whatsnew/3.12.html#cpython-bytecode-changes

--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -137,6 +137,8 @@ def to_opcodes(opnames, _opmap=opmap):
     for x in opnames:
         if x in _opmap:
             yield _opmap[x]
+
+
 # opcodes which absolutely positively must not be usable in safe_eval,
 # explicitly subtracted from all sets of valid opcodes just in case
 _BLACKLIST = set(to_opcodes([
@@ -148,8 +150,9 @@ _BLACKLIST = set(to_opcodes([
     # no reason to allow this
     'STORE_GLOBAL', 'DELETE_GLOBAL',
 ]))
-# opcodes necessary to build literal values
-_CONST_OPCODES = set(to_opcodes([
+
+# operations on literal values
+_EXPR_OPCODES = set(to_opcodes([
     # stack manipulations
     'POP_TOP',
     'LOAD_CONST',
@@ -159,20 +162,7 @@ _CONST_OPCODES = set(to_opcodes([
     # 3.6: literal map with constant keys https://bugs.python.org/issue27140
     'BUILD_CONST_KEY_MAP',
     'LIST_EXTEND', 'SET_UPDATE',
-    # 3.11 replace DUP_TOP, DUP_TOP_TWO, ROT_TWO, ROT_THREE, ROT_FOUR
-    'COPY', 'SWAP',
-    # Added in 3.11 https://docs.python.org/3/whatsnew/3.11.html#new-opcodes
-    'RESUME',
-    # 3.12 https://docs.python.org/3/whatsnew/3.12.html#cpython-bytecode-changes
-    'RETURN_CONST',
-    # 3.13
-    'TO_BOOL',
-    # 3.14 https://docs.python.org/3/whatsnew/3.14.html#cpython-bytecode-changes
-    'LOAD_SMALL_INT',
-])) - _BLACKLIST
 
-# operations on literal values
-_EXPR_OPCODES = _CONST_OPCODES.union(to_opcodes([
     'UNARY_NEGATIVE', 'UNARY_NOT', 'UNARY_INVERT',
     'BINARY_SUBSCR',
     'BUILD_SLICE',
@@ -182,9 +172,19 @@ _EXPR_OPCODES = _CONST_OPCODES.union(to_opcodes([
     # specialised comparisons
     'IS_OP', 'CONTAINS_OP',
     'DICT_MERGE', 'DICT_UPDATE',
+    # 3.11 replace DUP_TOP, DUP_TOP_TWO, ROT_TWO, ROT_THREE, ROT_FOUR
+    'COPY', 'SWAP',
+    # Added in 3.11 https://docs.python.org/3/whatsnew/3.11.html#new-opcodes
+    'RESUME',
     # Added in 3.11, replacing all BINARY_* and INPLACE_*
     'BINARY_OP',
     'BINARY_SLICE',
+    # 3.12 https://docs.python.org/3/whatsnew/3.12.html#cpython-bytecode-changes
+    'RETURN_CONST',
+    # 3.13
+    'TO_BOOL',
+    # 3.14 https://docs.python.org/3/whatsnew/3.14.html#cpython-bytecode-changes
+    'LOAD_SMALL_INT',
 ])) - _BLACKLIST
 
 _SAFE_OPCODES = _EXPR_OPCODES.union(to_opcodes([


### PR DESCRIPTION
This PR removes the legacy `const_eval` function. Its purpose was the same as `ast.literal_eval` and is (almost) equivalent.
For example, unpacking is possible inside `const_eval`, but not in `literal_eval`:
```python
>>> const_eval("[1, 2, *[3]]")
[1, 2, 3]
>>> literal_eval("[1, 2, *[3]]")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
...
ValueError: malformed node or string on line 1: <ast.Starred object at 0x7a3494817bd0>
```
On the other hand, `const_eval` has no support for empty sets:
```python
>>> const_eval("set()")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
...
ValueError: forbidden opcode(s) in 'set()': PUSH_NULL, CALL, LOAD_NAME

>>> literal_eval("set()")
set()
```

Additionally, this PR also removes all the legacy opcodes, that were removed before Python 3.12. All information about the removal of opcodes is documented on the commit message.
