### PR TITLE
[FIX] website: make dropped inner button links translatable

### DIFF
--- a/addons/website/static/src/builder/plugins/options/navtabs_style_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/navtabs_style_option_plugin.js
@@ -130,6 +130,14 @@ class NavTabsStyleOptionPlugin extends Plugin {
     }
 }
 
+export class NavTabsTranslationPlugin extends Plugin {
+    static id = "navTabsTranslation";
+    /** @type {import("plugins").WebsiteResources} */
+    resources = {
+        force_background_translation_state_selectors: ".s_tabs_nav a",
+    };
+}
+
 const getTabsEl = (editingElement) => editingElement.querySelector(".s_tabs_nav");
 
 export class BaseNavtabsStyleOption extends BuilderAction {

--- a/addons/website/static/src/builder/plugins/translate_link_inline_plugin.js
+++ b/addons/website/static/src/builder/plugins/translate_link_inline_plugin.js
@@ -1,5 +1,6 @@
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
+import { selectElements } from "@html_editor/utils/dom_traversal";
 
 export class TranslateLinkInlinePlugin extends Plugin {
     static id = "translateLinkInline";
@@ -12,6 +13,19 @@ export class TranslateLinkInlinePlugin extends Plugin {
         },
         on_replaced_media_handlers: ({ newMediaEl }) => {
             this.markTranslateInline(newMediaEl);
+        },
+        on_snippet_dropped_handlers: ({ snippetEl }) => {
+            for (const linkEl of selectElements(snippetEl, "a")) {
+                // Links inside `.o_not_editable` are not editable in
+                // translation mode, so they should not be marked as inline
+                // translatable.
+                // This notably avoids issues with `s_table_of_content`,
+                // whose navbar links are inside `.o_not_editable`.
+                const closestNotEditableEl = linkEl.closest(".o_not_editable");
+                if (!closestNotEditableEl) {
+                    linkEl.classList.add("o_translate_inline");
+                }
+            }
         },
     };
 

--- a/addons/website/static/src/builder/translate.inside.scss
+++ b/addons/website/static/src/builder/translate.inside.scss
@@ -29,6 +29,13 @@ html[lang] > body.editor_enable [data-oe-translation-state] {
     }
 }
 
+.s_share, .s_social_media {
+    > span[data-oe-translation-state] > * {
+        display: inline-block;
+        vertical-align: middle;
+    }
+}
+
 html[data-edit_translations="1"] {
     .o_translate_mode_hidden {
         display: none !important;

--- a/addons/website/static/src/builder/website_builder.js
+++ b/addons/website/static/src/builder/website_builder.js
@@ -19,6 +19,7 @@ import { HighlightPlugin } from "./plugins/highlight/highlight_plugin";
 import { RepeatTranslationStatePlugin } from "./plugins/translation/repeat_translation_state_plugin";
 import { BadgeTranslationPlugin } from "./plugins/options/badge_option_plugin";
 import { ButtonTranslationPlugin } from "./plugins/options/button_option_plugin";
+import { NavTabsTranslationPlugin } from "./plugins/options/navtabs_style_option_plugin";
 import { PopupVisibilityPlugin } from "./plugins/popup_visibility_plugin";
 import { SaveTranslationPlugin } from "./plugins/save_translation_plugin";
 import { TranslateLinkInlinePlugin } from "./plugins/translate_link_inline_plugin";
@@ -64,6 +65,7 @@ const TRANSLATION_PLUGINS = [
     RepeatTranslationStatePlugin,
     BadgeTranslationPlugin,
     ButtonTranslationPlugin,
+    NavTabsTranslationPlugin,
     OperationPlugin,
     EditInteractionPlugin,
     TranslateTableOfContentOptionPlugin,

--- a/addons/website/static/tests/builder/website_builder/button_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/button_option.test.js
@@ -32,7 +32,7 @@ test("Drag & drop a 'Button' snippet in a <div> should put it inside a <p>", asy
     await drop(getDragHelper());
     await waitForEndOfOperation();
     expect(contentEl).toHaveInnerHTML(
-        `<div><p>\ufeff<a class="btn btn-primary" href="#">\ufeffButton\ufeff</a>\ufeff</p><p>Text</p></div>`
+        `<div><p>\ufeff<a class="btn btn-primary o_translate_inline" href="#">\ufeffButton\ufeff</a>\ufeff</p><p>Text</p></div>`
     );
     expect(".o-website-builder_sidebar .fa-undo").toBeEnabled();
 });
@@ -61,7 +61,7 @@ test("Drag & drop a 'Button' snippet should align the button style with the butt
     await drop(getDragHelper());
     await waitForEndOfOperation();
     expect(contentEl).toHaveInnerHTML(
-        `<div class="o-paragraph"><a href="http://test.com" class="btn btn-fill-secondary mb-2" style="line-height: 50px;"> ButtonStyled </a> <a class="btn mb-2 btn-fill-secondary" href="#"> Button </a></div>`
+        `<div class="o-paragraph"><a href="http://test.com" class="btn btn-fill-secondary mb-2" style="line-height: 50px;"> ButtonStyled </a> <a class="btn mb-2 btn-fill-secondary o_translate_inline" href="#"> Button </a></div>`
     );
     expect(".o-website-builder_sidebar .fa-undo").toBeEnabled();
 });
@@ -100,7 +100,7 @@ test("Drag & drop a 'Button' snippet over a dropzone should preview it correctly
     expect(contentEl).toHaveInnerHTML(
         `<div><a href="http://test.com" class="btn btn-fill-secondary"> ButtonStyled </a>
          <p style="padding-bottom: 50px;"><a href="http://test.com" class="btn btn-fill-secondary"> ButtonStyled in a p </a></p>
-         <p><a class="btn btn-primary" href="#"> Button </a></p></div>`
+         <p><a class="btn btn-primary o_translate_inline" href="#"> Button </a></p></div>`
     );
     expect(".o-website-builder_sidebar .fa-undo").toBeEnabled();
 });
@@ -134,7 +134,7 @@ test("Custom button is not wrapped in <p> when dropped near sibling button", asy
     await waitForEndOfOperation();
     expect(getEditableContent()).toHaveInnerHTML(
         `<section class="o_colored_level">
-            <a class="btn btn-primary o_default_snippet_text s_custom_snippet mb-2" href="#" data-bs-original-title="" title="">Custom Button</a>
+            <a class="btn btn-primary o_default_snippet_text s_custom_snippet mb-2 o_translate_inline" href="#" data-bs-original-title="" title="">Custom Button</a>
             <a class="btn btn-primary mb-2" href="#">Button</a>
         </section>`
     );


### PR DESCRIPTION
Before this commit, links on `Button` inner snippets dropped from the sidebar (not through powerbox) were never translatable.

`o_translate_inline` was only added in link insert flows or when already present in snippet template, not when dropping inner button snippets. As a result, dropped button anchors were missing `o_translate_inline` and were filtered out from translatable inline links.

Steps to reproduce:
- Enter edit mode.
- Drag and drop a `Button` inner snippet.
- Save.
- Switch to translation mode.
- Try to edit the button link: it cannot be edited.

This commit adds handling on snippet drop to tag dropped anchors with `o_translate_inline`.

task-5943645