### PR TITLE
[FIX] hr_holidays: fix traceback when creating group allocation

### DIFF
--- a/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard.py
+++ b/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard.py
@@ -23,10 +23,7 @@ class HrLeaveAllocationGenerateMultiWizard(models.TransientModel):
         return domain
 
     def _domain_work_entry_type_id(self):
-        domain = [
-            ('company_id', 'in', self.env.companies.ids + [False]),
-            ('requires_allocation', '=', True),
-        ]
+        domain = [('requires_allocation', '=', True)]
         if self.env.user.has_group('hr_holidays.group_hr_holidays_user'):
             return domain
         return Domain.AND([domain, [('employee_requests', '=', True)]])


### PR DESCRIPTION
The issue is caused by domaining the work_entry_type_id on company_id which doesn't exist. This is because in odoo/odoo#244436 the field hr_holdiday_status_id was replaced with work_entry_type_id but the domain was not adjusted.

task-5940200
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
