### PR TITLE
[IMP] mail,web,*: simplify breadcrumbs and prevent control panel button wrapping

### DIFF
--- a/addons/mail/static/tests/tours/create_channel_tour.js
+++ b/addons/mail/static/tests/tours/create_channel_tour.js
@@ -19,7 +19,12 @@ registry.category("web_tour.tours").add("can_create_channel_from_form_view", {
             run: "edit Test channel",
         },
         {
-            trigger: ".breadcrumb-item:contains('OdooBot')",
+            trigger: '.breadcrumb .dropdown-toggle',
+            content: 'Open the breadcrumb dropdown',
+            run: "click",
+        },
+        {
+            trigger: '.o-overlay-container .dropdown-menu a:contains("OdooBot")',
             run: "click",
         },
         {

--- a/addons/web/static/src/scss/primary_variables.scss
+++ b/addons/web/static/src/scss/primary_variables.scss
@@ -205,7 +205,7 @@ $o-list-group-active-bg: lighten(saturate(adjust-hue($o-info, 15), 1.8), 50) !de
 
 // Breadcrumbs
 
-$o-breadcrumb-item-padding-x: .5rem !default;
+$o-breadcrumb-item-padding-x: .25rem !default;
 
 
 // == Badges

--- a/addons/web/static/src/search/breadcrumbs/breadcrumbs.xml
+++ b/addons/web/static/src/search/breadcrumbs/breadcrumbs.xml
@@ -3,23 +3,22 @@
 
     <t t-name="web.Breadcrumbs">
         <t t-set="currentBreadcrumbs" t-value="props.breadcrumbs.slice(-1)"/>
-        <t t-set="visiblePathBreadcrumbs" t-value="props.breadcrumbs.slice(-3, -1)"/>
-        <t t-set="collapsedBreadcrumbs" t-value="props.breadcrumbs.slice(0, -3).reverse()"/>
+        <t t-set="previousBreadcrumb" t-value="props.breadcrumbs.at(-2)"/>
+        <t t-set="collapsedBreadcrumbs" t-value="props.breadcrumbs.slice(0, -2).reverse()"/>
         <t t-set="breadcrumb" t-value="currentBreadcrumbs[0] || {}"/>
 
-        <div t-if="collapsedBreadcrumbs.length || visiblePathBreadcrumbs.length" class="o_breadcrumb d-flex flex-row flex-md-column align-self-stretch justify-content-between min-w-0">
+        <div t-if="collapsedBreadcrumbs.length || previousBreadcrumb" class="o_breadcrumb d-flex flex-row flex-md-column align-self-stretch justify-content-between min-w-0">
             <t t-if="env.isSmall">
-                <t t-set="previousBreadcrumb" t-value="visiblePathBreadcrumbs.at(-1)"/>
                 <button class="o_back_button btn btn-link d-print-none px-1 py-0" t-on-click.prevent="previousBreadcrumb.onSelected">
                     <i class="oi oi-fw oi-arrow-left"/>
                 </button>
             </t>
             <t t-else="">
                 <ol class="breadcrumb flex-nowrap text-nowrap lh-sm">
-                    <li t-if="collapsedBreadcrumbs.length" class="breadcrumb-item d-inline-flex min-w-0">
+                    <li t-if="collapsedBreadcrumbs.length" class="breadcrumb-item d-inline-flex">
                         <Dropdown>
                             <button class="btn btn-light btn-sm px-1 p-0">
-                                <i class="oi oi-ellipsis-h"/>
+                                <i class="oi oi-ellipsis-h align-middle"/>
                             </button>
                             <t t-set-slot="content">
                                 <t t-foreach="collapsedBreadcrumbs" t-as="breadcrumb" t-key="breadcrumb.jsId">
@@ -30,11 +29,13 @@
                             </t>
                         </Dropdown>
                     </li>
-                    <t t-foreach="visiblePathBreadcrumbs" t-as="breadcrumb" t-key="breadcrumb.jsId">
-                        <li class="breadcrumb-item d-inline-flex min-w-0" t-att-class="{ o_back_button: breadcrumb_last }" t-att-data-hotkey="breadcrumb_last and 'b'" t-on-click.prevent="breadcrumb.onSelected">
-                            <a t-att-href="breadcrumb.url" class="fw-bold text-truncate" t-att-data-tooltip="'Back to &quot;' + breadcrumb.name + '&quot;' + (breadcrumb.isFormView ? ' form' : '')"><t t-call="web.Breadcrumb.Name"/></a>
-                        </li>
-                    </t>
+                    <li t-if="previousBreadcrumb" class="breadcrumb-item d-inline-flex min-w-0 o_back_button" data-hotkey="b" t-on-click.prevent="previousBreadcrumb.onSelected">
+                        <a t-att-href="previousBreadcrumb.url" class="fw-bold text-truncate" t-att-data-tooltip="'Back to &quot;' + previousBreadcrumb.name + '&quot;' + (previousBreadcrumb.isFormView ? ' form' : '')">
+                            <t t-call="web.Breadcrumb.Name">
+                                <t t-set="breadcrumb" t-value="previousBreadcrumb"/>
+                            </t>
+                        </a>
+                    </li>
                 </ol>
             </t>
             <div class="d-flex gap-1 text-truncate">

--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -21,7 +21,7 @@
             </Transition>
             <div class="o_control_panel_main d-flex flex-wrap flex-lg-nowrap justify-content-between align-items-lg-start gap-2 gap-lg-3 flex-grow-1">
                 <div class="o_control_panel_breadcrumbs d-flex align-items-center gap-1 order-0 h-lg-100">
-                    <div class="o_control_panel_main_buttons d-flex gap-1 d-empty-none d-print-none" t-on-keydown="onMainButtonsKeydown">
+                    <div class="o_control_panel_main_buttons d-flex gap-1 d-empty-none d-print-none text-nowrap" t-on-keydown="onMainButtonsKeydown">
                         <t t-if="display.buttons" t-slot="control-panel-buttons"/>
                         <Dropdown t-if="env.isSmall" menuClass="'o-control-panel-adaptive-dropdown'" onOpened.bind="dropdownifyButtons">
                             <button class="btn btn-secondary o-control-panel-adaptive-dropdown" title="More">

--- a/addons/web/static/tests/webclient/actions/client_action.test.js
+++ b/addons/web/static/tests/webclient/actions/client_action.test.js
@@ -273,7 +273,7 @@ test("ClientAction receives breadcrumbs and exports title", async () => {
     expect(".my_action").toHaveCount(1);
     await contains(".my_action").click();
     await getService("action").doAction(3);
-    expect(".o_breadcrumb").toHaveText("Partners Action 1\nnewTitle\nPartners");
+    expect(".o_breadcrumb").toHaveText("newTitle\nPartners");
 });
 
 test("ClientAction receives arbitrary props from doAction", async () => {

--- a/addons/web/static/tests/webclient/actions/load_state.test.js
+++ b/addons/web/static/tests/webclient/actions/load_state.test.js
@@ -1282,19 +1282,17 @@ describe(`new urls`, () => {
         ]);
 
         await contains(`.breadcrumb .dropdown-toggle`).click();
-        expect(`.o-overlay-container .dropdown-menu`).toHaveText("Partners Action 27");
-        expect(queryAllTexts`.breadcrumb-item, .o_breadcrumb .active`).toEqual([
-            "",
-            "Second record",
+        expect(`.o-overlay-container .dropdown-menu`).toHaveText(
+            "Second record\nPartners Action 27"
+        );
+        expect(queryAllTexts`.breadcrumb-item a, .o_breadcrumb .active`).toEqual([
             "Partners Action 28",
             "First record",
         ]);
-        expect(`.o-overlay-container .dropdown-menu a`).toHaveAttribute(
-            "data-tooltip",
-            "Back to “Partners Action 27”"
+        expect(queryAllAttributes(".o-overlay-container .dropdown-menu a", "data-tooltip")).toEqual(
+            ["Back to “Second record” form", "Back to “Partners Action 27”"]
         );
         expect(queryAllAttributes(".o_breadcrumb li.breadcrumb-item a", "data-tooltip")).toEqual([
-            'Back to "Second record" form',
             'Back to "Partners Action 28"',
         ]);
     });
@@ -1659,11 +1657,12 @@ describe(`new urls`, () => {
         expect(browser.location.href).toBe(
             "http://example.com/odoo/action-200/5/action-300/action-100/1"
         );
-        expect(queryAllTexts`.breadcrumb-item, .o_breadcrumb .active`).toEqual([
-            "Kanban Partners",
+        expect(queryAllTexts`.breadcrumb-item a, .o_breadcrumb .active`).toEqual([
             "List Partners with active id",
             "First record",
         ]);
+        await contains(`.breadcrumb .dropdown-toggle`).click();
+        expect(`.o-overlay-container .dropdown-menu`).toHaveText("Kanban Partners");
         expect(router.current.actionStack).toEqual([
             {
                 action: 200,
@@ -1747,11 +1746,12 @@ describe(`new urls`, () => {
         expect(browser.location.href).toBe(
             "http://example.com/odoo/action-200/5/action-300/action-100/1"
         );
-        expect(queryAllTexts`.breadcrumb-item, .o_breadcrumb .active`).toEqual([
-            "Kanban Partners",
+        expect(queryAllTexts`.breadcrumb-item a, .o_breadcrumb .active`).toEqual([
             "List Partners with active id",
             "First record",
         ]);
+        await contains(`.breadcrumb .dropdown-toggle`).click();
+        expect(`.o-overlay-container .dropdown-menu`).toHaveText("Kanban Partners");
         expect.verifySteps([
             "get menu_id-null",
             "get current_lang-en",

--- a/addons/web/static/tests/webclient/actions/target.test.js
+++ b/addons/web/static/tests/webclient/actions/target.test.js
@@ -679,7 +679,7 @@ describe("fullscreen", () => {
         await animationFrame(); // wait for the webclient template to be re-rendered
         expect("nav.o_main_navbar").toHaveCount(0);
 
-        await contains(queryAll(".breadcrumb li a")[1]).click();
+        await contains(queryAll(".breadcrumb li a")[0]).click();
         await animationFrame(); // wait for the webclient template to be re-rendered
         expect("nav .o_menu_brand").toHaveCount(1);
         expect("nav .o_menu_brand").toHaveText("MAIN APP");

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -466,7 +466,7 @@ test("breadcrumbs are updated when switching between views", async () => {
 
     // open a record in form view
     await contains(".o_kanban_view .o_kanban_record").click();
-    expect(queryAllTexts(".breadcrumb-item, .o_breadcrumb .active")).toEqual([
+    expect(queryAllTexts(".breadcrumb-item a, .o_breadcrumb .active")).toEqual([
         "Partners",
         "First record",
     ]);
@@ -890,8 +890,7 @@ test('reverse breadcrumb works on accesskey "b"', async () => {
     // open a record in form view
     await contains(".o_list_view .o_data_cell").click();
     await contains(".o_form_view button:contains(Execute action)").click();
-    expect(queryAllTexts(".breadcrumb-item, .o_breadcrumb .active")).toEqual([
-        "Partners",
+    expect(queryAllTexts(".breadcrumb-item a, .o_breadcrumb .active")).toEqual([
         "First record",
         "Partners Action 4",
     ]);
@@ -1131,8 +1130,7 @@ test("execute_action of type action are handled", async () => {
         "First record",
     ]);
     await contains(".o_form_view button:contains(Execute action)").click();
-    expect(queryAllTexts(".breadcrumb-item, .o_breadcrumb .active")).toEqual([
-        "Partners",
+    expect(queryAllTexts(".breadcrumb-item a, .o_breadcrumb .active")).toEqual([
         "First record",
         "Partners Action 4",
     ]);
@@ -1546,30 +1544,29 @@ test("go back to a previous action using the breadcrumbs", async () => {
 
     // push another action on top of the first one, and come back to the form view
     await getService("action").doAction(4);
-    expect(queryAllTexts(".breadcrumb-item, .o_breadcrumb .active")).toEqual([
-        "Partners",
+    expect(queryAllTexts(".breadcrumb-item a, .o_breadcrumb .active")).toEqual([
         "First record",
         "Partners Action 4",
     ]);
 
     // go back using the breadcrumbs
-    await contains(".o_control_panel .breadcrumb a:eq(1)").click();
-    expect(queryAllTexts(".breadcrumb-item, .o_breadcrumb .active")).toEqual([
+    await contains(".o_control_panel .breadcrumb a").click();
+    expect(queryAllTexts(".breadcrumb-item a, .o_breadcrumb .active")).toEqual([
         "Partners",
         "First record",
     ]);
 
     // push again the other action on top of the first one, and come back to the list view
     await getService("action").doAction(4);
-    expect(queryAllTexts(".breadcrumb-item, .o_breadcrumb .active")).toEqual([
-        "Partners",
+    expect(queryAllTexts(".breadcrumb-item a, .o_breadcrumb .active")).toEqual([
         "First record",
         "Partners Action 4",
     ]);
 
     // go back using the breadcrumbs
-    await contains(".o_control_panel .breadcrumb a:first").click();
-    expect(queryAllTexts(".breadcrumb-item, .o_breadcrumb .active")).toEqual(["Partners"]);
+    await contains(".o_control_panel .breadcrumb .dropdown-toggle").click();
+    await contains(".o-overlay-container .dropdown-menu a:contains(Partners)").click();
+    expect(queryAllTexts(".breadcrumb-item a, .o_breadcrumb .active")).toEqual(["Partners"]);
 });
 
 test.tags("desktop");
@@ -1585,7 +1582,7 @@ test("form views are restored in edit when coming back in breadcrumbs", async ()
     await getService("action").doAction(4);
 
     // go back to form view
-    await contains(".o_control_panel .breadcrumb a:eq(1)").click();
+    await contains(".o_control_panel .breadcrumb a").click();
     expect(".o_form_view .o_form_editable").toHaveCount(1);
 });
 
@@ -1603,7 +1600,7 @@ test("form views restore the correct id in url when coming back in breadcrumbs",
     expect(router.current).not.toInclude("resId");
 
     // go back to form view
-    await contains(".o_control_panel .breadcrumb a:eq(1)").click();
+    await contains(".o_control_panel .breadcrumb a").click();
     expect(router.current.resId).toBe(1);
 });
 
@@ -2004,13 +2001,12 @@ test("execute action from dirty, new record, and come back", async () => {
     await contains(".o_field_widget[name=foo] input").edit("val");
     await contains(".o_form_uri").click();
     expect(".o_form_view .o_form_editable").toHaveCount(1);
-    expect(queryAllTexts(".breadcrumb-item, .o_breadcrumb .active")).toEqual([
-        "Partners",
+    expect(queryAllTexts(".breadcrumb-item a, .o_breadcrumb .active")).toEqual([
         "test",
         "First record",
     ]);
     // go back to test using the breadcrumbs
-    await contains(".o_control_panel .breadcrumb-item a:eq(1)").click();
+    await contains(".o_control_panel .breadcrumb-item a").click();
     expect(".o_form_view .o_form_editable").toHaveCount(1);
     expect(queryAllTexts(".breadcrumb-item, .o_breadcrumb .active")).toEqual(["Partners", "test"]);
     expect.verifySteps([
@@ -2728,8 +2724,10 @@ test("click on breadcrumb of a deleted record", async () => {
 
     await contains(".o_data_row .o_data_cell").click();
     expect(".o_form_view").toHaveCount(1);
-    expect(queryAllTexts(".breadcrumb-item")).toEqual(["", "First record", "Partners"]);
-    expect(".o_breadcrumb .active").toHaveText("First record");
+    expect(queryAllTexts(".breadcrumb-item a, .o_breadcrumb .active")).toEqual([
+        "Partners",
+        "First record",
+    ]);
     // open action menu and delete
     await contains(".o_cp_action_menus .fa-cog").click();
     await toggleMenuItem("Delete");
@@ -2739,15 +2737,18 @@ test("click on breadcrumb of a deleted record", async () => {
     await contains(".o_dialog .modal-footer .btn-danger").click();
 
     expect(".o_form_view").toHaveCount(1);
-    expect(queryAllTexts(".breadcrumb-item")).toEqual(["", "First record", "Partners"]);
+    expect(queryAllTexts(".breadcrumb-item a, .o_breadcrumb .active")).toEqual([
+        "Partners",
+        "Second record",
+    ]);
     expect(".o_breadcrumb .active").toHaveText("Second record");
 
     // click on "First record" in breadcrumbs, which doesn't exist anymore
-    await contains(".breadcrumb-item a").click();
+    await contains(".breadcrumb .dropdown-toggle").click();
+    await contains(".o-overlay-container .dropdown-menu a:contains(First record)").click();
     await animationFrame();
     expect(".o_list_view").toHaveCount(1);
-    expect(queryAllTexts(".breadcrumb-item")).toEqual([]);
-    expect(".o_breadcrumb .active").toHaveText("Partners");
+    expect(queryAllTexts(".breadcrumb-item a, .o_breadcrumb .active")).toEqual(["Partners"]);
     expect.verifyErrors([
         "It seems the records with IDs 1 cannot be found. They might have been deleted.",
     ]);

--- a/addons/web/static/tests/webclient/settings_form_view/settings_form_view.test.js
+++ b/addons/web/static/tests/webclient/settings_form_view/settings_form_view.test.js
@@ -1596,7 +1596,7 @@ test("execute action from settings view with several actions in the breadcrumb",
 
     def.resolve();
     await animationFrame();
-    expect(".o_breadcrumb").toHaveText("First action\nSettings\nOther action");
+    expect(".o_breadcrumb").toHaveText("Settings\nOther action");
 });
 
 test("settings can contain one2many fields", async () => {

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -1161,9 +1161,14 @@ stepUtils.autoExpandMoreButtons(true),
 },
 {
     isActive: ["desktop"],
-    trigger: '.breadcrumb-item:nth-child(2) a',
-    content: _t('Back to the sale order'),
-    tooltipPosition: 'bottom',
+    trigger: '.breadcrumb .breadcrumb-item .dropdown-toggle',
+    content: 'Open the breadcrumb dropdown',
+    run: "click",
+},
+{
+    isActive: ["desktop"],
+    trigger: '.o-overlay-container .dropdown-menu a',
+    content: 'Back to the sale order',
     run: "click",
 },
 {


### PR DESCRIPTION
*test_main_flows

Only the most recent breadcrumb remains visible, while older navigation steps are grouped under the dropdown to reduce clutter in deep navigation path. This keeps the breadcrumb clean in deep navigation paths.

Control panel buttons now keep their text on one line so labels are easier to read and the layout stays even.

Enterprise PR: https://github.com/odoo/enterprise/pull/107663

task-5933463

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
