### PR TITLE
[FIX] hr: fix doc name changes to file size in employee

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -272,6 +272,8 @@ class HrEmployee(models.Model):
     message_main_attachment_id = fields.Many2one(groups="hr.group_hr_user")
     id_card = fields.Binary(string="ID Card Copy", groups="hr.group_hr_user")
     driving_license = fields.Binary(string="Driving License", groups="hr.group_hr_user")
+    id_card_name = fields.Char(groups="hr.group_hr_user")
+    driving_license_name = fields.Char(groups="hr.group_hr_user")
     currency_id = fields.Many2one('res.currency', related='company_id.currency_id', readonly=True, groups="hr.group_hr_user")
     related_partners_count = fields.Integer(compute="_compute_related_partners_count", groups="hr.group_hr_user")
     # properties

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -341,8 +341,10 @@
                                         <field name="study_field" placeholder="e.g. Engineering, Commerce, Business Administration, ..."/>
                                     </group>
                                     <group string="Documents" name="hr_document_group">
-                                        <field name="id_card"/>
-                                        <field name="driving_license"/>
+                                        <field name="id_card_name" invisible="1"/>
+                                        <field name="driving_license_name" invisible="1"/>
+                                        <field name="id_card" filename="id_card_name"/>
+                                        <field name="driving_license" filename="driving_license_name"/>
                                     </group>
                                 </group>
                             </page>


### PR DESCRIPTION
Steps to reproduce:
----------------------------------
1. Install Employees module
2. Go to any Employee > Personal Tab
3. In the Documents section, upload any file in the ID Card field
4. Save the record

Observation:
----------------------------------
File name changed to file size

Issue:
----------------------------------
The `filename` attribute was missing in the view, preventing the proper computation of the document filename.

Solution:
----------------------------------
Add computed fields for the document filenames and Set these fields in the `filename` attribute of the corresponding binary fields in the view

Related Enterprise PR: https://github.com/odoo/enterprise/pull/107664

opw-5905408