### PR TITLE
[FIX] web : notify user when request body size exceeds server limit

### DIFF
--- a/addons/web/static/src/core/errors/error_dialogs.js
+++ b/addons/web/static/src/core/errors/error_dialogs.js
@@ -95,6 +95,12 @@ export class NetworkErrorDialog extends ErrorDialog {}
 NetworkErrorDialog.title = _t("Odoo Network Error");
 
 // -----------------------------------------------------------------------------
+// Request Entity Too Large Dialog
+// -----------------------------------------------------------------------------
+export class RequestEntityTooLargeErrorDialog extends ErrorDialog {}
+RequestEntityTooLargeErrorDialog.title = _t("The request sent to the server was too large");
+
+// -----------------------------------------------------------------------------
 // RPC Error Dialog
 // -----------------------------------------------------------------------------
 export class RPCErrorDialog extends ErrorDialog {

--- a/addons/web/static/src/core/errors/error_handlers.js
+++ b/addons/web/static/src/core/errors/error_handlers.js
@@ -1,6 +1,6 @@
 import { _t } from "@web/core/l10n/translation";
 import { browser } from "../browser/browser";
-import { ConnectionLostError, RPCError, rpc } from "../network/rpc";
+import { ConnectionLostError, RPCError, RequestEntityTooLargeError, rpc } from "../network/rpc";
 import { registry } from "../registry";
 import { session } from "@web/session";
 import { user } from "@web/core/user";
@@ -8,6 +8,7 @@ import {
     ClientErrorDialog,
     ErrorDialog,
     NetworkErrorDialog,
+    RequestEntityTooLargeErrorDialog,
     RPCErrorDialog,
 } from "./error_dialogs";
 import { UncaughtClientError, ThirdPartyScriptError, UncaughtPromiseError } from "./error_service";
@@ -129,6 +130,27 @@ export function lostConnectionHandler(env, error, originalError) {
     }
 }
 errorHandlerRegistry.add("lostConnectionHandler", lostConnectionHandler, { sequence: 98 });
+
+// -----------------------------------------------------------------------------
+// Request entity too large errors
+// -----------------------------------------------------------------------------
+
+/**
+ * @param {OdooEnv} env
+ * @param {UncaughError} error
+ * @param {Error} originalError
+ * @returns {boolean}
+ */
+export function requestEntityTooLargeHandler(env, error, originalError) {
+    if (!(error instanceof UncaughtPromiseError)) {
+        return false;
+    }
+    if (originalError instanceof RequestEntityTooLargeError) {
+        env.services.dialog.add(RequestEntityTooLargeErrorDialog);
+        return true;
+    }
+}
+errorHandlerRegistry.add("requestEntityTooLargeHandler", requestEntityTooLargeHandler, { sequence: 99 });
 
 // -----------------------------------------------------------------------------
 // Default handler

--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -14,6 +14,7 @@ import {
     parseServerValue,
 } from "./utils";
 import { FetchRecordError } from "./errors";
+import { RequestEntityTooLargeError } from "@web/core/network/rpc";
 
 export class Record extends DataPoint {
     static type = "Record";
@@ -1071,7 +1072,7 @@ export class Record extends DataPoint {
                 kwargs
             );
         } catch (e) {
-            if (onError) {
+            if (onError && !(e instanceof RequestEntityTooLargeError)) {
                 return onError(e, { discard: () => this._discard() });
             }
             if (!this.isInEdition) {


### PR DESCRIPTION
# How to reproduce
- A reverse proxy needs to be set up between the client and the backend (for localhost, you can use nginx)
- This reverse proxy needs to have a request max body size set below 128mb (for nginx : client_max_body_size)
- If the system parameter web.max_file_upload_size is set, delete it and refresh your page
- Pick any form view and add a file field with studio
- Upload a file larger than the limit set in the proxy, but smaller than 128mb
- Save the form

# The problem
The form is not saved and depending on the version, a Traceback will be shown (18.X) or a Connection Lost notification will be shown for a short period of time (19.0+)

# Why
When the system parameter web.max_file_upload_size is not set, the check for file size uses the default 128mb. A binary field added to a form via studio will upload its file in the json of the post request. This is done by encoding the file in base64. Our nginx servers set a limit for the request body size (usually 64mb).

So if you add a file between 64mb and 128mb, it will bypass the default front-end size check but be stopped by the nginx reverse proxy. The proxy will send back an HTTP response with error code 413 to the client. Theses http responses are not correctly handled by the framework and are interpreted as a Connection Lost error because the response content cannot be parsed to json.

Additionally, since we use base64 for the encoding and then use gzip to compress the json request, it's not really feasible to synchronize the front-end limit with the nginx one.

opw-5891662

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
