### PR TITLE
[FIX] website_sale: product_published_with_category tour

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_product_publish.js
+++ b/addons/website_sale/static/tests/tours/website_sale_product_publish.js
@@ -60,6 +60,9 @@ registerWebsitePreviewTour(
             run: 'click',
         },
         {
+            trigger: '.modal-dialog .o_field_widget[name="public_categ_ids"] .badge:contains("Test Category")',
+        },
+        {
             trigger: '.modal-footer button.btn-primary',
             run: 'click',
         },

--- a/addons/website_sale/views/product_product_add.xml
+++ b/addons/website_sale/views/product_product_add.xml
@@ -12,6 +12,7 @@
             </xpath>
             <xpath expr="//field[@name='company_id']" position="before">
                 <field name="website_url" invisible="1"/>
+                <field name="website_published" invisible="1"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Error:
AssertionError: False is not true
self.assertTrue(product.website_published)

Cause:
Commit https://github.com/odoo/odoo/commit/ca198cfc7c41a8c15b2734518016007aa1c16457 relies on _onchange_public_categ_ids to set
website_published=True when a category is assigned. Two issues:
1. website_published was not in the dialog form view, so its onchange
   value was never tracked or sent to the server on save.
2. The tour clicks Save before the onchange response is received,
   so the product is saved without website_published=True.

Fix:
- Add website_published as an invisible field in the dialog form view
  so its value is tracked and sent on save.
- Wait for the category badge to appear before submitting, ensuring
  the onchange has completed before save.

runbot-237976
