### PR TITLE
[FIX] hr_holidays: remove init function on report

### DIFF
--- a/addons/hr_holidays/report/hr_leave_employee_report.py
+++ b/addons/hr_holidays/report/hr_leave_employee_report.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, tools
+from odoo import fields, models
 from odoo.tools import SQL
 
 python_to_sql_types = {
@@ -32,10 +32,6 @@ class HrLeaveEmployeeReport(models.Model):
         ('cancel', 'Cancelled'),
     ])
     color = fields.Integer(string="Color", related='holiday_status_id.color')
-
-    def init(self):
-        tools.drop_view_if_exists(self.env.cr, self._table)
-        self.env.cr.execute(SQL("""CREATE or REPLACE VIEW %s as (%s)""", SQL.identifier(self._table), self._table_query))
 
     @property
     def _table_query(self):


### PR DESCRIPTION
Avoid creating the table with a snapshot of current data and just return an empty table when needed

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
