### PR TITLE
[FIX] l10n_*: properly compute is_company based on identification type

### DIFF
--- a/addons/l10n_br/models/res_partner.py
+++ b/addons/l10n_br/models/res_partner.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ResPartner(models.Model):
@@ -15,3 +15,16 @@ class ResPartner(models.Model):
         frontend_writable_fields.update({'city_id', 'street_number', 'street_name', 'street_number2'})
 
         return frontend_writable_fields
+
+    @api.depends('l10n_latam_identification_type_id')
+    def _compute_is_company(self):
+        cnpj = self.env.ref('l10n_br.cnpj', raise_if_not_found=False)
+        l10n_br_partners = self.filtered(lambda p: p.country_code == 'BR')
+
+        # Partners with CNPJ are legal entities => companies
+        for partner in l10n_br_partners:
+            partner.is_company = bool(
+                cnpj and partner.l10n_latam_identification_type_id == cnpj
+            )
+
+        super(ResPartner, self - l10n_br_partners)._compute_is_company()

--- a/addons/l10n_ec/models/res_partner.py
+++ b/addons/l10n_ec/models/res_partner.py
@@ -88,6 +88,19 @@ class ResPartner(models.Model):
                         partner.l10n_ec_vat_validation = _("The VAT %s seems to be invalid as the tenth digit doesn't comply with the validation algorithm "
                                                            "(SRI has stated that this validation is not required anymore for some VAT numbers)", partner.vat)
 
+    @api.depends('l10n_latam_identification_type_id')
+    def _compute_is_company(self):
+        ec_ruc = self.env.ref('l10n_ec.ec_ruc', raise_if_not_found=False)
+        l10n_ec_partners = self.filtered(lambda p: p.country_code == 'EC')
+
+        # Partners with RUC are legal entities => companies
+        for partner in l10n_ec_partners:
+            partner.is_company = bool(
+                ec_ruc and partner.l10n_latam_identification_type_id == ec_ruc
+            )
+
+        super(ResPartner, self - l10n_ec_partners)._compute_is_company()
+
     def _l10n_ec_get_identification_type(self):
         """Maps Odoo identification types to Ecuadorian ones.
         Useful for document type domains, electronic documents, ats, others.


### PR DESCRIPTION
`is_company` was not correctly computed in some localization modules.

This commit adds a compute method for:

- l10n_br*: Company if identification type is CNPJ

- l10n_ec*: Company if identification type is RUC

For foreign partners (country ≠ BR/EC), a partner is considered a company if a VAT is provided.

Follow-up of: https://github.com/odoo/odoo/pull/211043

Task-5947797

