### PR TITLE
[FIX] hr_holidays: Fix Report By Employee on Test Click All

### DIFF
--- a/addons/hr_holidays/report/hr_leave_employee_report.py
+++ b/addons/hr_holidays/report/hr_leave_employee_report.py
@@ -100,7 +100,20 @@ class HrLeaveEmployeeReport(models.Model):
     def _generate_report_query(self, report_records):
         report_records = [report_record for report_record in report_records if report_record.get('number_of_days', 0) > 0]
         if not report_records:
-            return ""
+            return SQL("""
+                SELECT
+                    NULL::INTEGER as id,
+                    NULL::INTEGER as leave_id,
+                    NULL::INTEGER as employee_id,
+                    NULL::TIMESTAMP as working_schedule_aligned_date_from,
+                    NULL::REAL as number_of_days,
+                    NULL::REAL as number_of_hours,
+                    NULL::TEXT as description,
+                    NULL::INTEGER as holiday_status_id,
+                    NULL::VARCHAR as state,
+                    NULL::INTEGER as color
+                WHERE FALSE
+            """)
 
         column_names = list(report_records[0].keys())
         report_records_tuples = []


### PR DESCRIPTION
Since odoo/odoo#215798 , Click All test has been failing, this commit aims to fix it by returning an empty table instead of a string to avoid the traceback
task-5907217

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
