### PR TITLE
[IMP] calendar: add 'linked to' field in calendar form view

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -153,6 +153,14 @@ class CalendarEvent(models.Model):
         start = now + (datetime.min - now) % timedelta(minutes=30)
         return start + timedelta(hours=duration_hours)
 
+    @api.model
+    def _get_model_selection(self):
+        return [
+            (model.model, model.name)
+            for model in self.env['ir.model'].sudo().search(
+                [('is_mail_thread', '=', True), ('abstract', '=', False), ('transient', '=', False)])
+        ]
+
     # description
     name = fields.Char('Meeting Subject', required=True)
     description = fields.Html('Description',
@@ -222,6 +230,8 @@ class CalendarEvent(models.Model):
     res_model = fields.Char(
         'Document Model Name', related='res_model_id.model', readonly=True, store=True)
     res_model_name = fields.Char(related='res_model_id.name')
+    res_record = fields.Reference(string="Linked to", selection='_get_model_selection',
+         compute='_compute_res_record', inverse='_inverse_res_record')
     # messaging
     meeting_activity_ids = fields.One2many('mail.activity', 'calendar_event_id', string='Meeting Activities')
     # attendees
@@ -421,6 +431,23 @@ class CalendarEvent(models.Model):
     def _compute_duration(self):
         for event in self:
             event.duration = self._get_duration(event.start, event.stop)
+
+    @api.depends('res_model', 'res_id')
+    def _compute_res_record(self):
+        for event in self:
+            event.res_record = (
+                f"{event.res_model},{event.res_id}"
+                if event.res_model and event.res_id else False
+            )
+
+    def _inverse_res_record(self):
+        for event in self:
+            if not event.res_record:
+                event.res_model_id = False
+                event.res_id = False
+                continue
+            event.res_model_id = self.env['ir.model']._get_id(event.res_record._name)
+            event.res_id = event.res_record.id
 
     @api.depends('start', 'duration')
     def _compute_stop(self):

--- a/addons/calendar/tests/test_access_rights.py
+++ b/addons/calendar/tests/test_access_rights.py
@@ -372,3 +372,84 @@ class TestAccessRights(TransactionCase):
             form.partner_ids.add(self.raoul.partner_id)
 
         self.assertIn(self.raoul.partner_id.id, recurring_event.partner_ids.ids, "Partner should be added as attendee")
+
+    def test_res_record_with_allowed_records_for_non_admin(self):
+        """Ensure res_record compute and inverse behave correctly for accessible records."""
+        event = self.create_event(
+            user=self.john,
+            res_model_id=self.env['ir.model']._get_id('res.partner'),
+            res_id=self.george.partner_id.id,
+        )
+
+        record = event.with_user(self.john).res_record
+        self.assertEqual(record._name, 'res.partner')
+        self.assertEqual(record.id, self.george.partner_id.id)
+        self.assertEqual(
+            event.with_user(self.john).read(['res_record'])[0]['res_record'],
+            f'res.partner,{self.george.partner_id.id}',
+        )
+
+        event.with_user(self.john).write({
+            'res_record': f'res.partner,{self.raoul.partner_id.id}',
+        })
+
+        self.assertEqual(event.res_model_id.model, 'res.partner')
+        self.assertEqual(event.res_id, self.raoul.partner_id.id)
+        self.assertEqual(
+            event.with_user(self.john).read(['res_record'])[0]['res_record'],
+            f'res.partner,{self.raoul.partner_id.id}',
+        )
+
+    def test_res_record_with_not_allowed_records_for_non_admin(self):
+        """Ensure res_record works even if target records are not accessible."""
+        restricted_company = self.env['res.company'].create({
+            'name': 'Restricted Calendar Company',
+        })
+        restricted_partner = self.env['res.partner'].create({
+            'name': 'Restricted Calendar Partner',
+            'company_id': restricted_company.id,
+        })
+
+        # using server action as it is restricted to non admin users
+        restricted_record = self.env['ir.actions.server'].create({
+            'name': 'Restricted Server Action',
+            'model_id': self.env['ir.model']._get_id('calendar.event'),
+            'state': 'code',
+            'code': 'action = None',
+        })
+
+        cases = [
+            ('res.partner', restricted_partner.id, restricted_partner),
+            ('ir.actions.server', restricted_record.id, restricted_record),
+        ]
+
+        for model, res_id, target in cases:
+            with self.subTest(model=model):
+                with self.assertRaises(AccessError):
+                    target.with_user(self.john).check_access('read')
+
+                compute_event = self.create_event(self.john)
+                compute_event.write({
+                    'res_model_id': self.env['ir.model']._get_id(model),
+                    'res_id': res_id,
+                })
+
+                record = compute_event.with_user(self.john).res_record
+                self.assertEqual(record._name, model)
+                self.assertEqual(record.id, res_id)
+                self.assertEqual(
+                    compute_event.with_user(self.john).read(['res_record'])[0]['res_record'],
+                    f'{model},{res_id}',
+                )
+
+                inverse_event = self.create_event(self.john)
+                inverse_event.with_user(self.john).write({
+                    'res_record': f'{model},{res_id}',
+                })
+
+                self.assertEqual(inverse_event.res_model_id.model, model)
+                self.assertEqual(inverse_event.res_id, res_id)
+                self.assertEqual(
+                    inverse_event.with_user(self.john).read(['res_record'])[0]['res_record'],
+                    f'{model},{res_id}',
+                )

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -111,11 +111,6 @@
                     <field name="recurrence_update" widget="radio" options="{'horizontal': True}"/>
                 </div>
                 <sheet>
-                    <div class="oe_button_box" name="button_box">
-                        <button icon="fa-bars" type="object" name="action_open_calendar_event" invisible="not (res_id and res_model_name)">
-                            <field name="res_model_name"/>
-                        </button>
-                    </div>
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                     <field name="active" invisible="1"/>
                     <field name="user_can_edit" invisible="1"/>
@@ -162,7 +157,7 @@
                                     </button>
                                 </div>
                             </div>
-                            <field name="res_id" string="Linked to" invisible="not res_id" readonly="1" />
+                            <field name="res_record"/>
                             <field name="res_model" invisible="1"/>
                             <field name="videocall_source" invisible="1"/>
                             <field name="access_token" invisible="1" force_save="1"/>

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -169,6 +169,15 @@
             flex: 1 1 auto;
             width: auto !important;
         }
+
+        .o_field_reference .o_row {
+            select.o_input, .o_many2one {
+                flex: 1;
+            }
+            select.o_input {
+                padding-right: 1rem;
+            }
+        }
     }
 
     .o_form_view_container {


### PR DESCRIPTION
**Purpose:**
Users should be able to link a calendar event to a record from any specified model.

**Specifications:**
Add a `Linked to` field.
- It should display a linked record
- Able to link a record later if none was defined initially.
- Select Model -> Select Record

Task-5106718