### PR TITLE
[FIX] account_peppol: use correct company context

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -160,7 +160,7 @@ class AccountEdiProxyClientUser(models.Model):
                     *self.env['account.journal']._check_company_domain(company),
                     ('type', '=', 'purchase')
                 ], limit=1)
-
+            journal = journal.with_company(company)
             need_retrigger = need_retrigger or len(message_uuids) > job_count
             message_uuids = message_uuids[:job_count]
             proxy_acks = []

--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -359,6 +359,30 @@ class TestPeppolMessage(TestAccountMoveSendCommon):
                 'move_type': 'in_invoice',
             }])
 
+    def test_peppol_document_retrieval_with_company_context(self):
+        # Ensure that the bill creation is done using the move company/proxy user context
+
+        other_company = self.company_data_2["company"]
+        self.env["ir.default"].create({
+            'company_id': other_company.id,
+            'field_id': self.env['ir.model.fields']._get('res.partner', 'company_id').id,
+            'json_value': other_company.id,
+        })
+        initial_company = self.env.company
+        other_companies = self.env.companies
+        self.env['account_edi_proxy_client.user']\
+            .with_company(other_company)\
+            .with_context(allowed_company_ids=other_companies.ids)\
+            ._cron_peppol_get_new_documents()
+
+        move = self.env['account.move'].search([('peppol_message_uuid', '=', FAKE_UUID[1])])
+        self.assertRecordValues(
+            move, [{
+                'company_id': initial_company.id,
+                'peppol_move_state': 'done',
+                'move_type': 'in_invoice',
+            }])
+
     def test_validate_partner(self):
         new_partner = self.env['res.partner'].create({
             'name': 'Deanna Troi',


### PR DESCRIPTION
Currently, the created move does not always use the company context of the related move/proxy user. As a result, default values may be taken from another company, which can lead to cross-company inconsistencies and access errors.

Steps to reproduce:
- Set up two companies, A and B
- In company A, configure a default value for the partner.company_id field, applicable only to company A
- When a Peppol invoice arrives for company B but is processed using the context of company A, and a new partner must be created, the partner is created with company A as the default value
- This results in an incompatible companies on record error

This fix ensures that the company context of the move or EDI user is used when creating the move, preventing cross-company issues.

opw-5473233