### PR TITLE
[FIX] stock_dropshipping : Prevent false partner_ids assignment

### DIFF
--- a/addons/stock_dropshipping/models/stock.py
+++ b/addons/stock_dropshipping/models/stock.py
@@ -89,10 +89,11 @@ class StockLot(models.Model):
 
     def _compute_partner_ids(self):
         delivery_ids_by_lot = self._find_delivery_ids_by_lot()
+        all_picking_ids = tuple(id_ for ids in delivery_ids_by_lot.values() for id_ in ids)
         for lot in self:
             if delivery_ids_by_lot.get(lot.id, []):
-                picking_ids = self.env['stock.picking'].browse(delivery_ids_by_lot[lot.id]).sorted(key='date_done', reverse=True)
-                lot.partner_ids = list(p.sale_id.partner_shipping_id.id if p.is_dropship else p.partner_id.id for p in picking_ids)
+                picking_ids = self.env['stock.picking'].browse(delivery_ids_by_lot[lot.id]).with_prefetch(all_picking_ids).sorted(key='date_done', reverse=True)
+                lot.partner_ids = picking_ids.mapped(lambda p: p.sale_id.partner_shipping_id if p.is_dropship and p.sale_id.partner_shipping_id else p.partner_id)
             else:
                 lot.partner_ids = False
 


### PR DESCRIPTION
**Issue:**
The error is produced due the changes introduced in this https://github.com/odoo/odoo/commit/4290724a4c8c57fba4f4d3d688d38f65dadcc38f commit. Particularly because of this assertion checking :
https://github.com/odoo/odoo/blob/b5d3970e6b05e2c35ce16e972e659d152c4de70e/odoo/orm/models.py#L5207


This assertion is failing because of the condition related to `is_dropship`. When `is_dropship` is `True`, the `partner_id` is expected to be `p.sale_id.partner_shipping_id.id`
https://github.com/odoo/odoo/blob/b5d3970e6b05e2c35ce16e972e659d152c4de70e/addons/stock_dropshipping/models/stock.py#L95
However, for the specific picking record in some cases, `sale_id` is not set
https://github.com/odoo/odoo/blob/b5d3970e6b05e2c35ce16e972e659d152c4de70e/addons/sale_stock/models/stock.py#L190
As a result of the current implementation, the [expression](https://github.com/odoo/odoo/blob/b5d3970e6b05e2c35ce16e972e659d152c4de70e/addons/stock_dropshipping/models/stock.py#L95) evaluates to **False**. That False value is then included in the generated list.
**For example** : lot.partner_ids = [2, False, 5, 6]
With the recent changes, when this assignment happens, it **no longer ignores False values**. Instead, during the write process, the ORM internally calls **browse()** on the provided IDs. Since False is not a valid ID, the assertion inside browse() **fails**, this can be seen in the **traceback**.

This shows that when the field is being written, the ORM validates the IDs by calling browse(), and since False is included in the list, the assertion fails.

**Solution:**
To resolve this issue, I have use `mapped. As 'mapped()' will filter out all the empty(False) values from the recordset.

By switching to **mapped()** and returning a recordset instead of a list of IDs, False values are automatically excluded. As a result, no invalid IDs are passed to browse(), and the assertion error is avoided.

I have also added the if `p.is_dropship and p.sale_id.partner_shipping_id` condition because it fallback to the picking partner if there is no sale order partner to use

**Other Optimization:**
I have used `with_prefetch` to fetching `picking_ids`, it is just the purely ORM friendly optimization.
It ensures that all related records are prefetched efficiently across lots. It is not related to the bug above mentioned.

**Traceback:**
```python

   File "/home/odoo/src/odoo/saas-19.1/addons/stock_dropshipping/models/stock.py", line 95, in _compute_partner_ids
    lot.partner_ids = list(p.sale_id.partner_shipping_id.id if p.is_dropship else p.partner_id.id for p in picking_ids)
    ^^^^^^^^^^^^^^^
   File "/home/odoo/src/odoo/saas-19.1/odoo/orm/fields.py", line 1866, in __set__
    self.write(protected_records, value)
   File "/home/odoo/src/odoo/saas-19.1/odoo/orm/fields_relational.py", line 765, in write
    self.write_batch([(records, value)])
   File "/home/odoo/src/odoo/saas-19.1/odoo/orm/fields_relational.py", line 786, in write_batch
    self.write_real(records_commands_list, create)
   File "/home/odoo/src/odoo/saas-19.1/odoo/orm/fields_relational.py", line 1553, in write_real
    comodel.browse(
   File "/home/odoo/src/odoo/saas-19.1/odoo/orm/models.py", line 5202, in browse
    assert all(ids) or all(isinstance(x, NewId) or x for x in ids), "Invalid falsy real id"
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 AssertionError: Invalid falsy real id
```
opw: 5922525
upg: 3889582
tgb: 2449

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
