### PR TITLE
[IMP] website_payment: log donation comment on payment

### DIFF
--- a/addons/website_payment/controllers/portal.py
+++ b/addons/website_payment/controllers/portal.py
@@ -73,6 +73,7 @@ class PaymentPortal(payment_portal.PaymentPortal):
             })
         elif not tx_sudo.partner_country_id:
             tx_sudo.partner_country_id = int(kwargs['partner_details']['country_id'])
+        request.session['donation_comment'] = kwargs.get('donation_comment')
         # the user can change the donation amount on the payment page,
         # therefor we need to recompute the access_token
         access_token = payment_utils.generate_access_token(

--- a/addons/website_payment/models/payment_transaction.py
+++ b/addons/website_payment/models/payment_transaction.py
@@ -3,6 +3,7 @@
 from markupsafe import Markup
 
 from odoo import _, fields, models
+from odoo.http import request
 
 
 class PaymentTransaction(models.Model):
@@ -22,6 +23,10 @@ class PaymentTransaction(models.Model):
                     if hasattr(value, 'name'):
                         value = value.name
                     msg.append(Markup('<br/>- %s: %s') % (field_name, value))
+            # To be removed in the forward port, as starting from version 19.2
+            # it is handled through a custom field in the donation form.
+            if request and request.session.get('donation_comment'):
+                msg.append(Markup('<br/>- Donation Comment: %s') % (request.session.pop('donation_comment')))
             donation_tx.payment_id._message_log(body=Markup().join(msg))
 
     def _send_donation_email(self, is_internal_notification=False, comment=None, recipient_email=None):


### PR DESCRIPTION
This PR aims to store the donation comment on the transaction and log it on the payment when available, ensuring it can be used for fiscal attestation and traceability purposes.

task-3114722