### PR TITLE
[IMP] tests: centralize requests mocking

### DIFF
--- a/addons/account_peppol/tests/common.py
+++ b/addons/account_peppol/tests/common.py
@@ -1,194 +1,246 @@
-import requests
+import json
+from base64 import b64encode
+from contextlib import ExitStack, contextmanager
+from textwrap import dedent
+from urllib.parse import quote_plus, urlencode
 
-from contextlib import contextmanager
-from unittest.mock import Mock, patch
-from urllib.parse import parse_qs, quote_plus
+from requests import PreparedRequest
 
-from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests.common import MockHTTPClient
+from odoo.tools import file_open
 
-ID_CLIENT = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+__all__ = [
+    'mock_ack',
+    'mock_can_connect',
+    'mock_cancel_peppol_registration',
+    'mock_connect',
+    'mock_documents_retrieval',
+    'mock_get_participant_status',
+    'mock_lookup_not_found',
+    'mock_lookup_success',
+    'mock_register_sender',
+    'mock_register_sender_as_receiver',
+    'mock_send_document',
+    'mock_update_user',
+]
 
 
-class PeppolConnectorCommon(AccountTestInvoicingCommon):
+@contextmanager
+def _mock_simple_api_response(url, success=True):
+    with MockHTTPClient(
+        url=url,
+        return_json={'result': {}} if success else {'error': {'code': "spoutch", 'message': "failure"}}
+    ) as mock_response:
+        yield mock_response
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.env['ir.config_parameter'].sudo().set_str('account_peppol.edi.mode', 'test')
 
-    @staticmethod
-    def forge_id_client(company_id):
-        id_str = str(company_id).rjust(len(ID_CLIENT.split('x')) - 1, '0')
-        new_id_client_blocks = []
-        index = 0
-        for block in ID_CLIENT.split('-'):
-            new_id_client_blocks.append(id_str[index:index + len(block)])
-            index += len(block)
-        return '-'.join(new_id_client_blocks)
+@contextmanager
+def mock_lookup_success(peppol_identifier, services=None):
+    expected_url = f'https://peppol.test.odoo.com/api/peppol/1/lookup?{urlencode({"peppol_identifier": peppol_identifier})}'
+    if services is None:
+        services = [
+            'urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0::2.1',
+            'urn:oasis:names:specification:ubl:schema:xsd:CreditNote-2::CreditNote##urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0::2.1',
+        ]
+    json_response = {
+        "result": {
+            'identifier': peppol_identifier,
+            'smp_base_url': "http://iap-services.odoo.com",
+            'ttl': 60,
+            'service_group_url': f'http://iap-services.odoo.com/iso6523-actorid-upis%3A%3A{quote_plus(peppol_identifier)}',
+            'services': [
+                {
+                    "href": f"http://iap-services.odoo.com/iso6523-actorid-upis%3A%3A{quote_plus(peppol_identifier)}/services/busdox-docid-qns%3A%3A{quote_plus(service)}",
+                    "document_id": service,
+                }
+                for service in services
+            ],
+        },
+    }
 
-    def _default_error_code(self):
-        return {'error': {'code': "spoutch", 'message': "failure"}}
+    lookup_mock = MockHTTPClient(url=expected_url, return_json=json_response)
+    service_group_mocks = []
 
-    def _empty_result_or_error(self, success=True):
-        if success:
-            return {'result': {}}
-        else:
-            return self._default_error_code()
+    # also mock services for SMP name extractions
+    for service in json_response['result']['services']:
+        response = '''
+            <smp:SignedServiceMetadata xmlns:smp="http://busdox.org/serviceMetadata/publishing/1.0/"
+                xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                xmlns:id="http://busdox.org/transport/identifiers/1.0/"
+                xmlns:wsa="http://www.w3.org/2005/08/addressing">
+                <smp:ServiceMetadata>
+                    <smp:ServiceInformation>
+                        <smp:ProcessList>
+                            <smp:Process>
+                                <smp:ServiceEndpointList>
+                                    <smp:Endpoint transportProfile="peppol-transport-as4-v2_0">
+                                        <smp:ServiceDescription>Definitely not Odoo</smp:ServiceDescription>
+                                    </smp:Endpoint>
+                                </smp:ServiceEndpointList>
+                            </smp:Process>
+                        </smp:ProcessList>
+                    </smp:ServiceInformation>
+                </smp:ServiceMetadata>
+            </smp:SignedServiceMetadata>
+        '''
+        service_group_mocks.append(MockHTTPClient(url=service['href'], return_body=dedent(response)))
+    with ExitStack() as stack:
+        stack.enter_context(lookup_mock)
+        for mock in service_group_mocks:
+            stack.enter_context(mock)
+        yield lookup_mock, service_group_mocks
 
-    def _mock_can_connect(self, with_auth=False):
-        def replacement_method(url, **kwargs):
-            auth_vals = {
-                'available_auths': {
-                    'itsme': {'authorization_url': 'test_authorization_url'},
+
+@contextmanager
+def mock_lookup_not_found(peppol_identifier):
+    expected_url = f'https://peppol.test.odoo.com/api/peppol/1/lookup?{urlencode({"peppol_identifier": peppol_identifier})}'
+    json_response = {"error": {"code": "NOT_FOUND", "message": "no naptr record", "retryable": False}}
+    with MockHTTPClient(url=expected_url, return_status=404, return_json=json_response) as mock_response:
+        yield mock_response
+
+
+@contextmanager
+def mock_can_connect(with_auth=False):
+    expected_url = 'https://peppol.test.odoo.com/api/peppol/2/can_connect'
+    auth_vals = {
+        'available_auths': {
+            'itsme': {'authorization_url': 'test_authorization_url'},
+        },
+    } if with_auth else {}
+    with MockHTTPClient(url=expected_url, return_json={
+        'auth_required': with_auth,
+        **auth_vals,
+    }) as mock_response:
+        yield mock_response
+
+
+@contextmanager
+def mock_connect(success=True, peppol_state='smp_registration', id_client='test_id_client'):
+    expected_url = 'https://peppol.test.odoo.com/api/peppol/2/connect'
+    if peppol_state == 'rejected':
+        json_response = {
+            'code': 201,
+            'message': 'Unable to register, please contact our support team at peppol.support@odoo.com.',
+        }
+        status_code = 403
+    elif success:
+        json_response = {'id_client': id_client, 'refresh_token': 'test_refresh_token', 'peppol_state': peppol_state}
+        status_code = 200
+    else:
+        json_response = {
+            'code': 208,
+            'message': 'The Authentication failed',
+        }
+        status_code = 401
+    with MockHTTPClient(url=expected_url, return_json=json_response, return_status=status_code) as mock_response:
+        yield mock_response
+
+
+@contextmanager
+def mock_ack():
+    with _mock_simple_api_response('https://peppol.test.odoo.com/api/peppol/1/ack') as mock_response:
+        yield mock_response
+
+
+@contextmanager
+def mock_register_sender(success=True):
+    with _mock_simple_api_response('https://peppol.test.odoo.com/api/peppol/1/register_sender', success) as mock_response:
+        yield mock_response
+
+
+@contextmanager
+def mock_register_sender_as_receiver(success=True):
+    with _mock_simple_api_response('https://peppol.test.odoo.com/api/peppol/1/register_sender_as_receiver', success) as mock_response:
+        yield mock_response
+
+
+@contextmanager
+def mock_get_participant_status(peppol_state: str | None):
+    expected_url = 'https://peppol.test.odoo.com/api/peppol/2/participant_status'
+    if peppol_state:
+        json_response = {'result': {'peppol_state': peppol_state}}
+    else:
+        json_response = {
+            'result': {
+                'error': {
+                    'code': "client_gone",
+                    'message': "Your registration for this service is no longer valid. "
+                               "If you see this message, please update the related Odoo app. "
+                               "You will then be able to re-register if needed.",
                 },
-            } if with_auth else {}
-            return {
-                'auth_required': with_auth,
-                **auth_vals,
-            }
+            },
+        }
+    with MockHTTPClient(url=expected_url, return_json=json_response) as mock_response:
+        yield mock_response
 
-        return (
-            'https://peppol.test.odoo.com/api/peppol/2/can_connect',
-            replacement_method,
-        )
 
-    def _mock_connect(self, success=True, peppol_state='smp_registration', id_client='test_id_client'):
-        def replacement_method(url, **kwargs):
-            if peppol_state == 'rejected':
-                return {
-                    'status_code': 403,
-                    'code': 201,
-                    'message': 'Unable to register, please contact our support team at peppol.support@odoo.com.'
-                }
-            if success:
-                return {'id_client': id_client, 'refresh_token': 'test_refresh_token', 'peppol_state': peppol_state}
-            else:
-                return {
-                    'status_code': 401,
-                    'code': 208,
-                    'message': 'The Authentication failed',
-                }
+@contextmanager
+def mock_cancel_peppol_registration(success=True):
+    with _mock_simple_api_response('https://peppol.test.odoo.com/api/peppol/1/cancel_peppol_registration', success) as mock_response:
+        yield mock_response
 
-        return (
-            'https://peppol.test.odoo.com/api/peppol/2/connect',
-            replacement_method,
-        )
 
-    def _mock_register_sender(self, success=True):
-        return (
-            'https://peppol.test.odoo.com/api/peppol/1/register_sender',
-            lambda url, **kwargs: self._empty_result_or_error(success=success),
-        )
+@contextmanager
+def mock_update_user(success=True):
+    with _mock_simple_api_response('https://peppol.test.odoo.com/api/peppol/1/update_user', success) as mock_response:
+        yield mock_response
 
-    def _mock_register_sender_as_receiver(self, success=True):
-        return (
-            'https://peppol.test.odoo.com/api/peppol/1/register_sender_as_receiver',
-            lambda url, **kwargs: self._empty_result_or_error(success=success),
-        )
 
-    def _mock_lookup_participant(self, already_exists=False):
+@contextmanager
+def mock_send_document(messages: list[dict] | None = None):
+    def return_json(request: PreparedRequest):
+        body = json.loads(request.body)
+        num_invoices = len(body['params']['documents'])
+        returned_messages = messages if messages is not None else [{'message_uuid': '11111111-1111-4111-8111-111111111111'}] * num_invoices
+        assert len(returned_messages) == num_invoices, f"Expected {num_invoices} messages but got {len(returned_messages)}"
+        return {'result': {'messages': returned_messages}}
+    with MockHTTPClient(method='POST', url='https://peppol.test.odoo.com/api/peppol/1/send_document', return_json=return_json) as mock_response:
+        yield mock_response
 
-        def replacement_method(url, **kwargs):
-            if not already_exists:
-                return {
-                    'status_code': 404,
-                    'error': {
-                        'code': "NOT_FOUND",
-                        'message': "no naptr record",
-                        'retryable': False,
-                    },
-                }
-            else:
-                peppol_identifier = parse_qs(url.rsplit('?')[1])['peppol_identifier'][0]
-                return {
-                    'ok': True,
-                    'result': {
-                        "identifier": peppol_identifier,
-                        "smp_base_url": "http://example.com/smp",
-                        "ttl": 60,
-                        "service_group_url": "http://example.com/smp/iso6523-actorid-upis%3A%3A" + quote_plus(peppol_identifier),
-                        "services": [],
-                    },
-                }
 
-        return (
-            'https://peppol.test.odoo.com/api/peppol/1/lookup',
-            replacement_method,
-        )
+@contextmanager
+def mock_documents_retrieval(messages=None):
+    if messages is None:
+        messages = [
+            {'uuid': '11111111-1111-4111-8111-111111111111', 'direction': 'incoming', 'filename': 'incoming_invoice', 'state': 'done', 'sender': '0208:2718281828'},
+        ]
 
-    def _mock_participant_status(self, peppol_state, exists=True):
+    all_documents_json = {
+        'result': {
+            'messages': [
+                {
+                    'accounting_supplier_party': message.get('sender', False),
+                    'filename': f"{message.get('filename', 'incoming_invoice')}.xml",
+                    'uuid': message['uuid'],
+                    'state': message.get('state', 'done'),
+                    'direction': message.get('direction', 'incoming'),
+                    'document_type': 'Invoice',
+                    'sender': message.get('sender', '0208:2718281828'),
+                    'receiver': '0208:0477472701',
+                    'timestamp': '2022-12-30',
+                    'error': 'Test error' if message.get('state') == 'error' else False,
+                } for message in messages
+            ],
+        }
+    }
 
-        def replacement_method(url, **kwargs):
-            assert peppol_state
-            if exists:
-                return {
-                    'result': {
-                        'peppol_state': peppol_state,
-                    },
-                }
-            else:
-                return {
-                    'result': {
-                        'error': {
-                            'code': "client_gone",
-                            'message': "Your registration for this service is no longer valid. "
-                                       "If you see this message, please update the related Odoo app. "
-                                       "You will then be able to re-register if needed.",
-                        }
-                    },
-                }
+    def get_document_response_json(request: PreparedRequest):
+        uuid = json.loads(request.body)['params']['message_uuids'][0]
+        message_params = next((m for m in messages if m['uuid'] == uuid), {})
+        direction = message_params.get('direction') or 'incoming'
 
-        return (
-            'https://peppol.test.odoo.com/api/peppol/2/participant_status',
-            replacement_method,
-        )
+        return {'result': {uuid: {
+            'accounting_supplier_party': message_params.get('sender', False),
+            'filename': f"{message_params.get('filename', 'incoming_invoice')}.xml",
+            'enc_key': file_open('account_peppol/tests/assets/enc_key', mode='r').read() if direction == 'incoming' else '',
+            'document': b64encode(file_open(f'account_peppol/tests/assets/{message_params.get("filename", "incoming_invoice")}', mode='rb').read()).decode('utf-8') if direction == 'incoming' else '',
+            'state': message_params.get('state', 'done'),
+            'direction': direction,
+            'document_type': 'Invoice',
+        }}}
 
-    def _mock_cancel_peppol_registration(self, success=True):
-        return (
-            'https://peppol.test.odoo.com/api/peppol/1/cancel_peppol_registration',
-            lambda url, **kwargs: self._empty_result_or_error(success=success),
-        )
-
-    def _mock_get_all_documents(self, success=True):
-        return (
-            'https://peppol.test.odoo.com/api/peppol/1/get_all_documents',
-            lambda url, **kwargs: self._empty_result_or_error(success=success),
-        )
-
-    def _mock_update_user(self, success=True):
-        return (
-            'https://peppol.test.odoo.com/api/peppol/1/update_user',
-            lambda url, **kwargs: self._empty_result_or_error(success=success),
-        )
-
-    @contextmanager
-    def _mock_requests(self, mocks_methods):
-        mocks = dict(mocks_methods)
-        called_urls = set()
-        mock_results = {'called': {}}
-
-        def mock_request(url, **kwargs):
-            for mocked_url, replacement_method in mocks.items():
-                if url.startswith(mocked_url):
-                    called_urls.add(mocked_url)
-                    mock_results['called'][mocked_url] = {
-                        'url': url,
-                        'kwargs': kwargs,
-                    }
-                    results = replacement_method(url, **kwargs)
-                    mocked_request = Mock()
-                    mocked_request.status_code = results.get('status_code', 200)
-                    results.pop('status_code', None)
-                    if not (200 <= mocked_request.status_code < 300):
-                        mocked_request.raise_for_status.side_effect = requests.exceptions.HTTPError()
-                    mocked_request.json.return_value = results
-                    return mocked_request
-            self.assertFalse(url, "Missing mock!")
-
-        def mock_request_2(method, url, **kwargs):
-            return mock_request(url, **kwargs)
-
-        with patch('requests.get', mock_request), patch('requests.post', mock_request), patch('requests.request', mock_request_2):
-            yield mock_results
-
-        self.assertFalse([url for url in mocks if url not in called_urls], "URLs mocked but not called")
+    with (
+        MockHTTPClient(method='POST', url='https://peppol.test.odoo.com/api/peppol/1/get_all_documents', return_json=all_documents_json),
+        MockHTTPClient(method='POST', url='https://peppol.test.odoo.com/api/peppol/1/get_document', return_json=get_document_response_json),
+    ):
+        yield

--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -1,32 +1,29 @@
-import json
-from contextlib import contextmanager
 from lxml import etree
 from unittest.mock import patch
-from urllib import parse
-
-from requests import PreparedRequest, Response, Session
 
 from odoo import Command
-from odoo.exceptions import UserError
-from odoo.tests.common import tagged, freeze_time
+from odoo.tests.common import freeze_time, tagged
 
 from odoo.addons.account.tests.test_account_move_send import TestAccountMoveSendCommon
+from odoo.addons.account_peppol.tests.common import (
+    mock_ack,
+    mock_documents_retrieval,
+    mock_lookup_not_found,
+    mock_lookup_success,
+    mock_send_document,
+)
 from odoo.addons.mail.tests.common import MailCommon
 
-ID_CLIENT = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
-FAKE_UUID = ['yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy',
-             'zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz']
-FILE_PATH = 'account_peppol/tests/assets'
 
 @freeze_time('2023-01-01')
 @tagged('-at_install', 'post_install')
 class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
+    MESSAGE_UUID = '87b3d068-4da3-49c8-845c-ff2540e6b7d9'
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.env['ir.config_parameter'].sudo().set_str('account_peppol.edi.mode', 'test')
-        cls.mocked_incoming_invoice_fname = 'incoming_invoice'
 
         cls.env.company.write({
             'country_id': cls.env.ref('base.be').id,
@@ -38,15 +35,15 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
         edi_identification = cls.env['account_edi_proxy_client.user']._get_proxy_identification(cls.env.company, 'peppol')
         cls.private_key = cls.env['certificate.key'].create({
             'name': 'Test key PEPPOL',
-            'content': cls.file_read(f'{FILE_PATH}/private_key.pem'),
+            'content': cls.file_read('account_peppol/tests/assets/private_key.pem'),
         })
         cls.proxy_user = cls.env['account_edi_proxy_client.user'].create({
-            'id_client': ID_CLIENT,
+            'id_client': 'test_id_client',
             'proxy_type': 'peppol',
             'edi_mode': 'test',
             'edi_identification': edi_identification,
             'private_key_id': cls.private_key.id,
-            'refresh_token': FAKE_UUID[0],
+            'refresh_token': 'deadbeef-0000-0000-0000-000000000000',
         })
 
         cls.invalid_partner, cls.valid_partner = cls.env['res.partner'].create([{
@@ -89,137 +86,6 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
             ],
         })
 
-    @contextmanager
-    def _set_context(self, other_context):
-        cls = self.__class__
-        env = cls.env(context=dict(cls.env.context, **other_context))
-        with patch.object(cls, "env", env):
-            yield
-
-    @classmethod
-    def _request_handler(cls, s: Session, r: PreparedRequest, /, **kw):
-        response = Response()
-        response.status_code = 200
-        url = r.path_url.lower()
-        if r.path_url.startswith('/api/peppol/1/lookup'):
-            peppol_identifier = parse.parse_qs(r.path_url.rsplit('?')[1])['peppol_identifier'][0].lower()
-            url_quoted_peppol_identifier = parse.quote_plus(peppol_identifier)
-            if peppol_identifier == '0208:0477472701':
-                response.status_code = 200
-                response.json = lambda: {
-                    "result": {
-                        'identifier': peppol_identifier,
-                        'smp_base_url': "http://iap-services.odoo.com",
-                        'ttl': 60,
-                        'service_group_url': f'http://iap-services.odoo.com/iso6523-actorid-upis%3A%3A{url_quoted_peppol_identifier}',
-                        'services': [
-                            {
-                                "href": f"http://iap-services.odoo.com/iso6523-actorid-upis%3A%3A{url_quoted_peppol_identifier}/services/busdox-docid-qns%3A%3Aurn%3Aoasis%3Anames%3Aspecification%3Aubl%3Aschema%3Axsd%3AInvoice-2%3A%3AInvoice%23%23urn%3Acen.eu%3Aen16931%3A2017%23compliant%23urn%3Afdc%3Apeppol.eu%3A2017%3Apoacc%3Abilling%3A3.0%3A%3A2.1",
-                                "document_id": "urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0::2.1",
-                            },
-                        ],
-                    },
-                }
-                return response
-            if peppol_identifier == '0208:2718281828':
-                response.status_code = 200
-                response.json = lambda: {
-                    "result": {
-                        'identifier': peppol_identifier,
-                        'smp_base_url': "http://iap-services.odoo.com",
-                        'ttl': 60,
-                        'service_group_url': f'http://iap-services.odoo.com/iso6523-actorid-upis%3A%3A{url_quoted_peppol_identifier}',
-                        'services': [
-                            {
-                                "href": f"http://iap-services.odoo.com/iso6523-actorid-upis%3A%3A{url_quoted_peppol_identifier}/services/busdox-docid-qns%3A%3Aurn%3Aoasis%3Anames%3Aspecification%3Aubl%3Aschema%3Axsd%3AInvoice-2%3A%3AInvoice%23%23urn%3Acen.eu%3Aen16931%3A2017%23compliant%23urn%3Afdc%3Apeppol.eu%3A2017%3Apoacc%3Abilling%3A3.0%3A%3A2.1",
-                                "document_id": "urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0::2.1",
-                            }
-                        ],
-                    },
-                }
-                return response
-
-            if peppol_identifier == '0198:dk16356706':
-                response.status_code = 200
-                response.json = lambda: {"result": {
-                        'identifier': peppol_identifier,
-                        'smp_base_url': "http://iap-services.odoo.com",
-                        'ttl': 60,
-                        'service_group_url': f'http://iap-services.odoo.com/iso6523-actorid-upis%3A%3A{url_quoted_peppol_identifier}',
-                        'services': [],
-                    },
-                }
-                return response
-            else:
-                response.status_code = 404
-                response.json = lambda: {"error": {"code": "NOT_FOUND", "message": "no naptr record", "retryable": False}}
-                return response
-
-        body = json.loads(r.body)
-        if url == '/api/peppol/1/send_document':
-            if not body['params']['documents']:
-                raise UserError('No documents were provided')
-            num_invoices = len(body['params']['documents'])
-            response.json = lambda: {
-                'result': {
-                    'messages': [{'message_uuid': FAKE_UUID[0]}] * num_invoices
-                }
-            }
-            return response
-
-        if url == '/api/peppol/1/ack':
-            response.json = lambda: {'result': {}}
-            return response
-
-        if url == '/api/peppol/1/get_all_documents':
-            response.json = lambda: {
-                'result': {
-                    'messages': [
-                        {
-                            'accounting_supplier_party': '0198:dk16356706',
-                            'filename': 'test_incoming.xml',
-                            'uuid': FAKE_UUID[1],
-                            'state': 'done',
-                            'direction': 'incoming',
-                            'document_type': 'Invoice',
-                            'sender': '0198:dk16356706',
-                            'receiver': '0208:0477472701',
-                            'timestamp': '2022-12-30',
-                            'error': False if not cls.env.context.get('error') else 'Test error',
-                        }
-                    ],
-                }
-            }
-            return response
-
-        if url == '/api/peppol/1/get_document':
-            uuid = body['params']['message_uuids'][0]
-            if uuid == FAKE_UUID[0]:
-                response_content = {
-                    'accounting_supplier_party': False,
-                    'filename': 'test_outgoing.xml',
-                    'enc_key': '',
-                    'document': '',
-                    'state': 'done' if not cls.env.context.get('error') else 'error',
-                    'direction': 'outgoing',
-                    'document_type': 'Invoice',
-                }
-            elif uuid == FAKE_UUID[1]:
-                response_content = {
-                    'accounting_supplier_party': '0198:dk16356706',
-                    'filename': 'test_incoming',
-                    'enc_key': cls.file_read(f'{FILE_PATH}/enc_key').decode(),
-                    'document': cls.file_read(f'{FILE_PATH}/{cls.mocked_incoming_invoice_fname}').to_base64(),
-                    'state': 'done' if not cls.env.context.get('error') else 'error',
-                    'direction': 'incoming',
-                    'document_type': 'Invoice',
-                }
-
-            response.json = lambda: {'result': {uuid: response_content}}
-            return response
-
-        return super()._request_handler(s, r, **kw)
-
     def test_non_xml_compatible_characters(self):
         """
         Test that non xml compatible characters doesn't block Peppol Invoice sending
@@ -233,16 +99,21 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
         move.invoice_line_ids[0].product_id = product_a
         move.action_post()
 
-        wizard = self.create_send_and_print(move, sending_methods=['peppol'])
+        with mock_lookup_success('0208:2718281828'):
+            wizard = self.create_send_and_print(move, sending_methods=['peppol'])
         self.assertEqual(wizard.invoice_edi_format, 'ubl_bis3')
-        wizard.action_send_and_print()
+
+        with mock_send_document():
+            wizard.action_send_and_print()
         self.assertEqual(self._get_mail_message(move).preview, 'The invoice has been sent to the Peppol Access Point. The following attachments were sent with the XML:')
 
+    @mock_lookup_success('0208:2718281828')
     def test_attachment_placeholders(self):
         move = self.create_move(self.valid_partner)
         move.action_post()
 
-        wizard = self.create_send_and_print(move, default=True)
+        with mock_lookup_success('0208:2718281828'):
+            wizard = self.create_send_and_print(move, default=True)
         self.assertEqual(wizard.invoice_edi_format, 'ubl_bis3')
 
         # the ubl xml placeholder should be generated
@@ -260,14 +131,19 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
         ])
 
         wizard.sending_methods = ['peppol']
-        wizard.action_send_and_print()
+        with mock_send_document():
+            wizard.action_send_and_print()
         self.assertEqual(self._get_mail_message(move).preview, 'The invoice has been sent to the Peppol Access Point. The following attachments were sent with the XML:')
 
     def test_send_peppol_alerts_not_valid_partner(self):
         move = self.create_move(self.invalid_partner)
         self.invalid_partner.invoice_edi_format = 'ubl_bis3'
         move.action_post()
-        wizard = self.create_send_and_print(move, default=True)
+        with (
+            mock_lookup_not_found('0208:3141592654'),
+            mock_lookup_not_found('9925:be3141592654'),
+        ):
+            wizard = self.create_send_and_print(move, default=True)
 
         self.assertEqual(wizard.invoice_edi_format, 'ubl_bis3')
         self.assertEqual(self.invalid_partner.peppol_verification_state, 'not_valid')  # not on peppol at all
@@ -275,11 +151,14 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
         self.assertTrue(wizard.sending_method_checkboxes['peppol']['readonly'])  # peppol is not possible to select
         self.assertFalse(wizard.alerts)  # there is no alerts
 
-    @patch('odoo.addons.account_peppol.models.res_partner.ResPartner._check_document_type_support', return_value=False)
-    def test_send_peppol_alerts_not_valid_format_partner(self, mocked_check):
+    def test_send_peppol_alerts_not_valid_format_partner(self):
         move = self.create_move(self.valid_partner)
         move.action_post()
-        wizard = self.create_send_and_print(move, sending_methods=['peppol'])
+        with (
+            mock_lookup_success('0208:2718281828', services=[]),
+            mock_lookup_not_found('9925:be2718281828'),
+        ):
+            wizard = self.create_send_and_print(move, sending_methods=['peppol'])
 
         self.assertEqual(wizard.invoice_edi_format, 'ubl_bis3')
         self.assertEqual(self.valid_partner.peppol_verification_state, 'not_valid_format')  # on peppol but can't receive bis3
@@ -290,7 +169,11 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
         move = self.create_move(self.invalid_partner)
         move.action_post()
         self.invalid_partner.peppol_endpoint = False
-        wizard = self.create_send_and_print(move, default=True)
+        with (
+            mock_lookup_not_found('0208:3141592654'),
+            mock_lookup_not_found('9925:be3141592654'),
+        ):
+            wizard = self.create_send_and_print(move, default=True)
         self.assertFalse(wizard.sending_methods and 'peppol' in wizard.sending_methods)  # by default peppol is not selected for non-valid partners
         wizard.sending_method_checkboxes = {**wizard.sending_method_checkboxes, 'peppol': {'checked': True}}
         self.assertTrue(wizard.sending_methods and 'peppol' in wizard.sending_methods)
@@ -302,28 +185,35 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
         move = self.create_move(self.valid_partner)
         move.action_post()
 
-        wizard = self.create_send_and_print(move, default=True)
+        with mock_lookup_success('0208:2718281828'):
+            wizard = self.create_send_and_print(move, default=True)
+
         self.assertEqual(wizard.invoice_edi_format, 'ubl_bis3')
         self.assertTrue(wizard.sending_methods and 'peppol' in wizard.sending_methods)
-        with self._set_context({'error': True}):
+        with mock_send_document(messages=[{'message_uuid': self.MESSAGE_UUID}]):
             wizard.with_env(self.env).action_send_and_print()
 
+        with mock_documents_retrieval([{'uuid': self.MESSAGE_UUID, 'direction': 'outgoing', 'state': 'error'}]), mock_ack():
             self.env['account_edi_proxy_client.user']._cron_peppol_get_message_status()
-            self.assertRecordValues(
-                move, [{
-                    'peppol_move_state': 'error',
-                    'peppol_message_uuid': FAKE_UUID[0],
-                }])
+
+        self.assertRecordValues(
+            move, [{
+                'peppol_move_state': 'error',
+                'peppol_message_uuid': self.MESSAGE_UUID,
+            }])
 
         # we can't send the ubl document again unless we regenerate the pdf
         move.invoice_pdf_report_id.unlink()
-        wizard = self.create_send_and_print(move, default=True)
+        with mock_lookup_success('0208:2718281828'):
+            wizard = self.create_send_and_print(move, default=True)
         self.assertEqual(wizard.invoice_edi_format, 'ubl_bis3')
         self.assertTrue(wizard.sending_methods and 'peppol' in wizard.sending_methods)
 
-        wizard.action_send_and_print()
+        with mock_send_document(messages=[{'message_uuid': self.MESSAGE_UUID}]):
+            wizard.action_send_and_print()
 
-        self.env['account_edi_proxy_client.user']._cron_peppol_get_message_status()
+        with mock_documents_retrieval([{'uuid': self.MESSAGE_UUID, 'direction': 'incoming'}]), mock_ack():
+            self.env['account_edi_proxy_client.user']._cron_peppol_get_message_status()
         self.assertEqual(move.peppol_move_state, 'done')
 
     def test_send_success_message(self):
@@ -333,16 +223,19 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
         move = self.create_move(self.valid_partner)
         move.action_post()
 
-        wizard = self.create_send_and_print(move, default=True)
+        with mock_lookup_success('0208:2718281828'):
+            wizard = self.create_send_and_print(move, default=True)
         self.assertEqual(wizard.invoice_edi_format, 'ubl_bis3')
         self.assertTrue(wizard.sending_methods and 'peppol' in wizard.sending_methods)
 
-        wizard.action_send_and_print()
+        with mock_send_document(messages=[{'message_uuid': self.MESSAGE_UUID}]):
+            wizard.action_send_and_print()
 
-        self.env['account_edi_proxy_client.user']._cron_peppol_get_message_status()
+        with mock_documents_retrieval([{'uuid': self.MESSAGE_UUID, 'direction': 'outgoing'}]), mock_ack():
+            self.env['account_edi_proxy_client.user']._cron_peppol_get_message_status()
         self.assertRecordValues(move, [{
                 'peppol_move_state': 'done',
-                'peppol_message_uuid': FAKE_UUID[0],
+                'peppol_message_uuid': self.MESSAGE_UUID,
             }],
         )
         self.assertTrue(bool(move.ubl_cii_xml_id))
@@ -353,27 +246,28 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
 
         move = self.create_move(self.valid_partner)
         move.action_post()
-
-        wizard = self.create_send_and_print(move, default=True)
+        with mock_lookup_success('0208:2718281828'):
+            wizard = self.create_send_and_print(move, default=True)
         self.assertTrue('peppol' not in wizard.sending_method_checkboxes)
 
     def test_receive_error_peppol(self):
         # an error peppol message should be created
-        with self._set_context({'error': True}):
+        with mock_documents_retrieval([{'uuid': self.MESSAGE_UUID, 'direction': 'incoming', 'filename': 'incoming_invoice', 'state': 'error'}]), mock_ack():
             self.env['account_edi_proxy_client.user']._cron_peppol_get_new_documents()
 
-            move = self.env['account.move'].search([('peppol_message_uuid', '=', FAKE_UUID[1])])
-            self.assertRecordValues(
-                move, [{
-                    'peppol_move_state': 'error',
-                    'move_type': 'in_invoice',
-                }])
+        move = self.env['account.move'].search([('peppol_message_uuid', '=', self.MESSAGE_UUID)])
+        self.assertRecordValues(
+            move, [{
+                'peppol_move_state': 'error',
+                'move_type': 'in_invoice',
+            }])
 
     def test_receive_success_peppol(self):
         # a correct move should be created
-        self.env['account_edi_proxy_client.user']._cron_peppol_get_new_documents()
+        with mock_documents_retrieval([{'uuid': self.MESSAGE_UUID, 'direction': 'incoming'}]), mock_ack():
+            self.env['account_edi_proxy_client.user']._cron_peppol_get_new_documents()
 
-        move = self.env['account.move'].search([('peppol_message_uuid', '=', FAKE_UUID[1])])
+        move = self.env['account.move'].search([('peppol_message_uuid', '=', self.MESSAGE_UUID)])
         self.assertRecordValues(
             move, [{
                 'peppol_move_state': 'done',
@@ -385,7 +279,7 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
         peppol_purchase_journal.incoming_einvoice_notification_email = 'oops_another_bill@example.com'
         self.env.company.email = 'hq@example.com'
 
-        with self.mock_mail_gateway():
+        with self.mock_mail_gateway(), mock_documents_retrieval([{'uuid': self.MESSAGE_UUID, 'direction': 'incoming'}]), mock_ack():
             self.env['account_edi_proxy_client.user']._cron_peppol_get_new_documents()
 
         self.assertSentEmail(
@@ -404,12 +298,16 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
             'json_value': other_company.id,
         })
         initial_company = self.env.company
-        self.env['account_edi_proxy_client.user']\
-            .with_company(other_company)\
-            .with_context(allowed_company_ids=[other_company.id, self.env.company.id])\
-            ._cron_peppol_get_new_documents()
+        with (
+            mock_documents_retrieval([{'uuid': '11111111-1111-4111-8111-111111111111'}]),
+            mock_ack(),
+        ):
+            self.env['account_edi_proxy_client.user']\
+                .with_company(other_company)\
+                .with_context(allowed_company_ids=[other_company.id, self.env.company.id])\
+                ._cron_peppol_get_new_documents()
 
-        move = self.env['account.move'].search([('peppol_message_uuid', '=', FAKE_UUID[1])])
+        move = self.env['account.move'].search([('peppol_message_uuid', '=', '11111111-1111-4111-8111-111111111111')])
         self.assertRecordValues(
             move, [{
                 'company_id': initial_company.id,
@@ -431,7 +329,8 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
             }])
 
         new_partner.peppol_endpoint = '0477472701'
-        new_partner.button_account_peppol_check_partner_endpoint()
+        with mock_lookup_success('0208:0477472701'):
+            new_partner.button_account_peppol_check_partner_endpoint()
         self.assertRecordValues(
             new_partner, [{
                 'peppol_verification_state': 'valid',
@@ -440,7 +339,11 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
             }])
 
         new_partner.peppol_endpoint = '3141592654'
-        new_partner.button_account_peppol_check_partner_endpoint()
+        with (
+            mock_lookup_not_found('0208:3141592654'),
+            mock_lookup_not_found('9925:be3141592654'),
+        ):
+            new_partner.button_account_peppol_check_partner_endpoint()
         self.assertRecordValues(
             new_partner, [{
                 'peppol_verification_state': 'not_valid',
@@ -453,13 +356,17 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
             'invoice_edi_format': 'xrechnung',
             'peppol_endpoint': '0477472701',
         })
-        new_partner.button_account_peppol_check_partner_endpoint()
-        self.assertRecordValues(
-            new_partner, [{
-                'peppol_verification_state': 'not_valid_format',
-                'peppol_eas': '0208',
-                'peppol_endpoint': '0477472701',
-            }])
+        with (
+            mock_lookup_success('0208:0477472701'),
+            mock_lookup_not_found('9925:be0477472701'),
+        ):
+            new_partner.button_account_peppol_check_partner_endpoint()
+            self.assertRecordValues(
+                new_partner, [{
+                    'peppol_verification_state': 'not_valid_format',
+                    'peppol_eas': '0208',
+                    'peppol_endpoint': '0477472701',
+                }])
 
     def test_peppol_send_multi_async(self):
         company_2 = self.setup_other_company()['company']
@@ -468,14 +375,14 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
             'peppol_endpoint': 'C2584563200',
             'country_id': self.env.ref('base.be').id,
         })
-
-        new_partner = self.env['res.partner'].create({
-            'name': 'Deanna Troi',
-            'city': 'Namur',
-            'country_id': self.env.ref('base.be').id,
-            'peppol_endpoint': '0477472701',
-            'invoice_edi_format': 'ubl_bis3',
-        })
+        with mock_lookup_success('0208:0477472701'):
+            new_partner = self.env['res.partner'].create({
+                'name': 'Deanna Troi',
+                'city': 'Namur',
+                'country_id': self.env.ref('base.be').id,
+                'peppol_endpoint': '0477472701',
+                'invoice_edi_format': 'ubl_bis3',
+            })
 
         # partner is valid for company 1
         self.assertRecordValues(new_partner, [{
@@ -486,7 +393,11 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
         }])
         # but not valid for company 2
         new_partner.with_company(company_2).invoice_edi_format = 'nlcius'
-        new_partner.button_account_peppol_check_partner_endpoint(company=company_2)
+        with (
+            mock_lookup_success('0208:0477472701'),
+            mock_lookup_not_found('9925:be0477472701'),
+        ):
+            new_partner.button_account_peppol_check_partner_endpoint(company=company_2)
         self.assertRecordValues(new_partner.with_company(company_2), [{
             'peppol_verification_state': 'not_valid_format',
             'peppol_eas': '0208',
@@ -498,11 +409,19 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
         move_3 = self.create_move(new_partner, company_2)
         (move_1 + move_2 + move_3).action_post()
 
-        wizard = self.create_send_and_print(move_1 + move_2 + move_3)
-        wizard.action_send_and_print()
+        with (
+            mock_lookup_success('0208:0477472701'),
+            mock_lookup_not_found('9925:be0477472701'),
+        ):
+            wizard = self.create_send_and_print(move_1 + move_2 + move_3)
+        with mock_send_document():
+            wizard.action_send_and_print()
         self.assertEqual((move_1 + move_2 + move_3).mapped('is_being_sent'), [True, True, True])
         # the cron is ran asynchronously and should be agnostic from the current self.env.company
-        with self.enter_registry_test_mode():
+        with (
+            self.enter_registry_test_mode(),
+            mock_send_document(),
+        ):
             self.env.ref('account.ir_cron_account_move_send').with_company(company_2).method_direct_trigger()
         # only move 1 & 2 should be processed, move_3 is related to an invalid partner (with regard to company_2) thus should not be sent
         self.assertRecordValues((move_1 + move_2 + move_3), [
@@ -531,12 +450,16 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
         move_1 = self.create_move(peppol_partner)
         move_2 = self.create_move(not_peppol_partner)
         (move_1 + move_2).action_post()
-        wizard = self.create_send_and_print(move_1 + move_2)
+        with mock_lookup_success('0208:0477472701'):
+            wizard = self.create_send_and_print(move_1 + move_2)
         self.assertEqual(peppol_partner.peppol_verification_state, 'valid')
         self.assertEqual(not_peppol_partner.peppol_verification_state, 'not_verified')
         wizard.action_send_and_print()
         self.assertEqual((move_1 + move_2).mapped('is_being_sent'), [True, True])
-        with self.enter_registry_test_mode():
+        with (
+            self.enter_registry_test_mode(),
+            mock_send_document(),
+        ):
             self.env.ref('account.ir_cron_account_move_send').method_direct_trigger()
         self.assertRecordValues((move_1 + move_2), [
             {'peppol_move_state': 'processing', 'is_move_sent': True},
@@ -563,10 +486,12 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
 
         move = self.create_move(self.valid_partner)
         move.action_post()
-        wizard = self.create_send_and_print(move, default=True)
+        with mock_lookup_success('0208:2718281828'):
+            wizard = self.create_send_and_print(move, default=True)
         self.assertTrue(wizard.sending_methods and 'peppol' in wizard.sending_methods)
         self.assertEqual(wizard.invoice_edi_format, 'ubl_bis3')
-        wizard.action_send_and_print()
+        with mock_send_document():
+            wizard.action_send_and_print()
         self.assertTrue(move.ubl_cii_xml_id)
         self.assertEqual(move.peppol_move_state, 'processing')
 
@@ -581,13 +506,17 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
         move_2 = self.create_move(self.valid_partner)
         moves = (move_1 + move_2)
         moves.action_post()
-        wizard = self.create_send_and_print(moves, default=True)
+        with mock_lookup_success('0208:2718281828'):
+            wizard = self.create_send_and_print(moves, default=True)
         self.assertEqual(wizard.summary_data, {
             'email': {'count': 2, 'label': 'by Email'},
             'peppol': {'count': 2, 'label': 'by Peppol'},
         })
         wizard.action_send_and_print()
-        with self.enter_registry_test_mode():
+        with (
+            mock_send_document(),
+            self.enter_registry_test_mode(),
+        ):
             self.env.ref('account.ir_cron_account_move_send').method_direct_trigger()
 
         self.assertEqual(len(moves.ubl_cii_xml_id), 2)
@@ -605,12 +534,16 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
         move_2 = self.create_move(self.valid_partner)
         (move_1 + move_2).action_post()
 
-        wizard = self.create_send_and_print(move_1 + move_2)
-        with patch(
-            'odoo.addons.account_edi_ubl_cii.models.account_edi_xml_ubl_20.AccountEdiXmlUBL20._export_invoice_constraints',
-            mocked_export_invoice_constraints
-        ), self.enter_registry_test_mode():
-            wizard.action_send_and_print()
+        with mock_lookup_success('0208:2718281828'):
+            wizard = self.create_send_and_print(move_1 + move_2)
+        wizard.action_send_and_print()
+        with (
+            patch(
+                'odoo.addons.account_edi_ubl_cii.models.account_edi_xml_ubl_20.AccountEdiXmlUBL20._export_invoice_constraints',
+                mocked_export_invoice_constraints,
+            ),
+            self.enter_registry_test_mode(),
+        ):
             self.env.ref('account.ir_cron_account_move_send').method_direct_trigger()
         self.assertEqual(move_1.peppol_move_state, 'error')
 
@@ -634,40 +567,46 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
             },
         ])
         self.cr.precommit.run()  # load the COA
-        self.valid_partner.button_account_peppol_check_partner_endpoint()
+        with mock_lookup_success('0208:2718281828'):
+            self.valid_partner.button_account_peppol_check_partner_endpoint()
         self.env['account_edi_proxy_client.user'].create([
             {
                 'company_id': branch_spoiled.id,
-                'id_client': ID_CLIENT.replace('x', 'a'),
+                'id_client': 'test_id_client_spoiled',
                 'proxy_type': 'peppol',
                 'edi_mode': 'test',
                 'edi_identification': self.env['account_edi_proxy_client.user']._get_proxy_identification(branch_spoiled, 'peppol'),
                 'private_key_id': self.private_key.id,
-                'refresh_token': FAKE_UUID[1],
+                'refresh_token': '00000000-beef-4dad-0000-000000000000',
             },
             {
                 'company_id': branch_independent.id,
-                'id_client': ID_CLIENT.replace('x', 'b'),
+                'id_client': 'test_id_client_independent',
                 'proxy_type': 'peppol',
                 'edi_mode': 'test',
                 'edi_identification': self.env['account_edi_proxy_client.user']._get_proxy_identification(branch_independent, 'peppol'),
                 'private_key_id': self.private_key.id,
-                'refresh_token': FAKE_UUID[1],
+                'refresh_token': '00000000-beef-4dad-0000-000000000000',
             }
         ])
 
         # Branch uses parent's active peppol connection
         spoiled_move = self.create_move(self.valid_partner, company=branch_spoiled)
         spoiled_move.action_post()
-        wizard = self.create_send_and_print(spoiled_move, sending_methods=['peppol'])
-        wizard.action_send_and_print()
+        with mock_lookup_success('0208:2718281828'):
+            wizard = self.create_send_and_print(spoiled_move, sending_methods=['peppol'])
+        with mock_send_document():
+            wizard.action_send_and_print()
         self.assertEqual(spoiled_move.peppol_move_state, 'processing')
 
         # Branch uses peppol configuration independent of their parent
         independent_move = self.create_move(self.valid_partner, company=branch_independent)
         independent_move.action_post()
-        wizard = self.create_send_and_print(independent_move, sending_methods=['peppol'])
-        wizard.action_send_and_print()
+        with mock_lookup_success('0208:2718281828'):
+            wizard = self.create_send_and_print(independent_move, sending_methods=['peppol'])
+
+        with mock_send_document():
+            wizard.action_send_and_print()
         self.assertEqual(independent_move.peppol_move_state, 'processing')
 
     def test_compute_available_peppol_eas_multi_partner(self):
@@ -723,18 +662,21 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
         self.assertTrue(vendor_bill._is_exportable_as_self_invoice())
 
         # Create and configure the send wizard
-        wizard = self.create_send_and_print(vendor_bill, default=True)
+        with mock_lookup_success('0208:2718281828'):
+            wizard = self.create_send_and_print(vendor_bill, default=True)
         self.assertEqual(wizard.invoice_edi_format, 'ubl_bis3')
         self.assertTrue(wizard.sending_methods and 'peppol' in wizard.sending_methods)
 
         # Send the self-billed invoice
-        wizard.action_send_and_print()
+        with mock_send_document(messages=[{'message_uuid': self.MESSAGE_UUID}]):
+            wizard.action_send_and_print()
 
         # Verify the invoice was sent successfully
-        self.env['account_edi_proxy_client.user']._cron_peppol_get_message_status()
+        with mock_documents_retrieval([{'uuid': self.MESSAGE_UUID, 'direction': 'outgoing'}]), mock_ack():
+            self.env['account_edi_proxy_client.user']._cron_peppol_get_message_status()
         self.assertRecordValues(vendor_bill, [{
                 'peppol_move_state': 'done',
-                'peppol_message_uuid': FAKE_UUID[0],
+                'peppol_message_uuid': self.MESSAGE_UUID,
             }],
         )
         self.assertTrue(bool(vendor_bill.ubl_cii_xml_id))
@@ -769,13 +711,15 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
 
         # Verify the bill is exportable as self-invoice
         self.assertTrue(vendor_bill._is_exportable_as_self_invoice())
+        with mock_lookup_success('0208:2718281828') as (mocked_lookup, _mocked_service_groups):
+            # Test that the constraint 'not_sale_document' is removed for self-billed invoices
+            wizard = self.create_send_and_print(vendor_bill, default=True)
+            mocked_lookup.assert_called_once()
+            self.assertTrue(wizard.sending_methods and 'peppol' in wizard.sending_methods)
 
-        # Test that the constraint 'not_sale_document' is removed for self-billed invoices
-        wizard = self.create_send_and_print(vendor_bill, default=True)
-        self.assertTrue(wizard.sending_methods and 'peppol' in wizard.sending_methods)
-
-        # Test that vendor bills can be sent as soon as the format allows (bis3) and the journal is in self-billing
-        self.create_send_and_print(vendor_bill, default=True)
+            # Test that vendor bills can be sent as soon as the format allows (bis3) and the journal is in self-billing
+            self.create_send_and_print(vendor_bill, default=True)
+            mocked_lookup.assert_called(n_times=2)
 
     def test_receive_self_billed_invoice_from_peppol(self):
         """Test receiving a self-billed invoice from Peppol.
@@ -786,19 +730,13 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
         # Set up the 21% VAT sale tax which should be put on the invoice line
         tax_21 = self.percent_tax(21.0, type_tax_use='sale')
 
-        cls = self.__class__
-        cls.mocked_incoming_invoice_fname = 'incoming_self_billed_invoice'
-
-        def restore_mocked_incoming_invoice_fname():
-            cls.mocked_incoming_invoice_fname = 'incoming_invoice'
-        self.addCleanup(restore_mocked_incoming_invoice_fname)
-
         # Receive the self-billed invoice (using existing mock data)
         # The mock data already includes a document that will be processed
-        self.env['account_edi_proxy_client.user']._cron_peppol_get_new_documents()
+        with mock_documents_retrieval([{'uuid': self.MESSAGE_UUID, 'direction': 'incoming', 'filename': 'incoming_self_billed_invoice'}]), mock_ack():
+            self.env['account_edi_proxy_client.user']._cron_peppol_get_new_documents()
 
         # Verify the self-billed invoice was created correctly
-        move = self.env['account.move'].search([('peppol_message_uuid', '=', FAKE_UUID[1])])
+        move = self.env['account.move'].search([('peppol_message_uuid', '=', self.MESSAGE_UUID)])
         self.assertRecordValues(move, [{
             'peppol_move_state': 'done',
             'move_type': 'out_invoice',
@@ -835,18 +773,20 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
         self.ensure_installed('sale')
         tax = self.percent_tax(21.0)
         product = self._create_product(lst_price=100.0, taxes_id=tax)
-        partner = self.env['res.partner'].create({
-            'name': 'partner_be',
-            'street': "Rue des Bourlottes 9",
-            'zip': "1367",
-            'city': "Ramillies",
-            'vat': 'BE0477472701',
-            'company_registry': '0477472701',
-            'invoice_sending_method': 'peppol',
-            'invoice_edi_format': 'ubl_bis3',
-            'company_id': self.env.company.id,
-            'country_id': self.env.ref('base.be').id,
-        })
+
+        with mock_lookup_success('0208:0477472701'):
+            partner = self.env['res.partner'].create({
+                'name': 'partner_be',
+                'street': "Rue des Bourlottes 9",
+                'zip': "1367",
+                'city': "Ramillies",
+                'vat': 'BE0477472701',
+                'company_registry': '0477472701',
+                'invoice_sending_method': 'peppol',
+                'invoice_edi_format': 'ubl_bis3',
+                'company_id': self.env.company.id,
+                'country_id': self.env.ref('base.be').id,
+            })
         self.env.user.group_ids |= self.env.ref('sales_team.group_sale_salesman')
 
         self.env['ir.config_parameter'].sudo().set_bool('sale.automatic_invoice', True)
@@ -876,7 +816,8 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
             'partner_id': partner.id,
             'sale_order_ids': [Command.set(so.ids)],
         })
-        transaction.sudo()._post_process()
+        with mock_send_document():
+            transaction.sudo()._post_process()
 
         self.assertRecordValues(partner, [{'peppol_verification_state': 'valid'}])
 
@@ -887,13 +828,16 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
         """
         move = self.create_move(self.valid_partner)
         move.action_post()
-        wizard_email = self.create_send_and_print(move, sending_methods=['email'])
+        with mock_lookup_not_found('0208:2718281828'), mock_lookup_not_found('9925:be2718281828'):
+            wizard_email = self.create_send_and_print(move, sending_methods=['email'])
         wizard_email.action_send_and_print()
         self.assertTrue(move.invoice_pdf_report_id, "PDF should be generated after sending by email")
 
-        wizard_peppol = self.create_send_and_print(move, sending_methods=['peppol'])
+        with mock_lookup_success('0208:2718281828'):
+            wizard_peppol = self.create_send_and_print(move, sending_methods=['peppol'])
         self.assertEqual(wizard_peppol.invoice_edi_format, 'ubl_bis3')
-        wizard_peppol.action_send_and_print()
+        with mock_send_document(messages=[{'message_uuid': self.MESSAGE_UUID}]):
+            wizard_peppol.action_send_and_print()
         self.assertTrue(move.ubl_cii_xml_id, "UBL XML should be generated")
 
         root = etree.fromstring(move.ubl_cii_xml_id.raw.content)

--- a/addons/account_peppol/tests/test_peppol_out_of_sync_resolution.py
+++ b/addons/account_peppol/tests/test_peppol_out_of_sync_resolution.py
@@ -12,8 +12,6 @@ class TestTokenSyncResolution(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.env['ir.config_parameter'].sudo().set_str('account_peppol.edi.mode', 'test')
-
         cls.env.company.write({'peppol_eas': '0208', 'peppol_endpoint': '0239843188'})
         edi_identification = cls.env['account_edi_proxy_client.user']._get_proxy_identification(
             cls.env.company, 'peppol'

--- a/addons/account_peppol/tests/test_peppol_participant.py
+++ b/addons/account_peppol/tests/test_peppol_participant.py
@@ -1,14 +1,26 @@
+import json
+
 from odoo import Command
 from odoo.exceptions import UserError, ValidationError
-from odoo.tests.common import tagged, freeze_time
+from odoo.tests.common import TransactionCase, freeze_time, tagged
 from odoo.tests.form import Form
 
-from odoo.addons.account_peppol.tests.common import PeppolConnectorCommon
+from odoo.addons.account_peppol.tests.common import (
+    mock_can_connect,
+    mock_cancel_peppol_registration,
+    mock_connect,
+    mock_documents_retrieval,
+    mock_get_participant_status,
+    mock_lookup_not_found,
+    mock_lookup_success,
+    mock_register_sender_as_receiver,
+    mock_update_user,
+)
 
 
 @freeze_time('2023-01-01')
 @tagged('-at_install', 'post_install')
-class TestPeppolParticipant(PeppolConnectorCommon):
+class TestPeppolParticipant(TransactionCase):
 
     @classmethod
     def setUpClass(cls):
@@ -27,10 +39,7 @@ class TestPeppolParticipant(PeppolConnectorCommon):
         })
 
     def test_ignore_archived_edi_users(self):
-        with self._mock_requests([
-            self._mock_can_connect(),
-            self._mock_connect(peppol_state='sender'),
-        ]):
+        with mock_can_connect(), mock_connect(peppol_state='sender'):
             wizard = self.env['peppol.registration'].create({})
             wizard.button_register_peppol_participant()
 
@@ -44,9 +53,7 @@ class TestPeppolParticipant(PeppolConnectorCommon):
             'proxy_type': 'peppol',
             'edi_mode': 'demo',
         }])
-        with self._mock_requests([
-            self._mock_lookup_participant(),
-        ]):
+        with mock_lookup_success(peppol_identifier='0208:0239843188'):
             self.env.company.with_context(active_test=False).partner_id.button_account_peppol_check_partner_endpoint()
 
     def test_create_participant_missing_data(self):
@@ -60,52 +67,52 @@ class TestPeppolParticipant(PeppolConnectorCommon):
 
     def test_register_participant_for_the_first_time_as_sender_then_receiver_then_unregister(self):
         # Register the use for the very first time as sender.
-        with self._mock_requests([
-            self._mock_can_connect(),
-            self._mock_connect(peppol_state='sender'),
-            self._mock_lookup_participant(already_exists=True),
-        ]):
+        with (
+            mock_can_connect(),
+            mock_connect(peppol_state='sender'),
+            mock_lookup_success(peppol_identifier='0208:0239843188'),
+        ):
             wizard = self.env['peppol.registration'].create({})
             self.assertRecordValues(wizard, [{'smp_registration': False}])
             wizard.button_register_peppol_participant()
         self.assertRecordValues(self.env.company, [{'account_peppol_proxy_state': 'sender'}])
 
-        # sender -> receiver.
+        # sender -> receiver (simulate the user already unregistered)
         settings = self.env['res.config.settings'].create({})
-        with self._mock_requests([
-            self._mock_lookup_participant(),
-            self._mock_register_sender_as_receiver(),
-            self._mock_participant_status('receiver'),
-        ]):
+        with (
+            mock_register_sender_as_receiver(),
+            mock_get_participant_status(peppol_state='receiver'),
+            mock_lookup_not_found(peppol_identifier='0208:0239843188'),
+        ):
             settings.peppol_participation_role = 'sending_and_receiving'
         self.assertRecordValues(self.env.company, [{'account_peppol_proxy_state': 'receiver'}])
 
         # receiver -> not_registered.
-        with self._mock_requests([
-            self._mock_participant_status('receiver'),
-            self._mock_get_all_documents(),
-            self._mock_cancel_peppol_registration(),
-        ]):
+        with (
+            mock_get_participant_status(peppol_state='receiver'),
+            mock_documents_retrieval(messages=[]),
+            mock_cancel_peppol_registration(),
+        ):
             settings.button_peppol_deregister()
         self.assertRecordValues(self.env.company, [{'account_peppol_proxy_state': 'not_registered'}])
 
     def test_register_participant_already_exists_on_peppol_as_sender(self):
-        with self._mock_requests([
-            self._mock_can_connect(),
-            self._mock_connect(peppol_state='sender'),
-            self._mock_lookup_participant(),
-        ]):
+        with (
+            mock_can_connect(),
+            mock_connect(peppol_state='sender'),
+            mock_lookup_not_found(peppol_identifier='0208:0239843188'),
+        ):
             wizard = self.env['peppol.registration'].create({})
             self.assertRecordValues(wizard, [{'smp_registration': True}])
             wizard.button_register_peppol_participant()
         self.assertRecordValues(self.env.company, [{'account_peppol_proxy_state': 'sender'}])
 
     def test_register_participant_already_exists_on_peppol_as_receiver(self):
-        with self._mock_requests([
-            self._mock_can_connect(),
-            self._mock_connect(peppol_state='sender'),
-            self._mock_lookup_participant(already_exists=True),
-        ]):
+        with (
+            mock_can_connect(),
+            mock_connect(peppol_state='sender'),
+            mock_lookup_success(peppol_identifier='0208:0239843188'),
+        ):
             wizard = self.env['peppol.registration'].create({})
             self.assertRecordValues(wizard, [{'smp_registration': False}])
             wizard.button_register_peppol_participant()
@@ -113,11 +120,9 @@ class TestPeppolParticipant(PeppolConnectorCommon):
 
     def test_register_participant_rejected(self):
         with (
-            self._mock_requests([
-                self._mock_can_connect(),
-                self._mock_connect(peppol_state='rejected'),
-                self._mock_lookup_participant(),
-            ]),
+            mock_can_connect(),
+            mock_connect(peppol_state='rejected'),
+            mock_lookup_not_found(peppol_identifier='0208:0239843188'),
             self.assertRaisesRegex(UserError, "There was an issue with the Peppol Participant"),
         ):
             wizard = self.env['peppol.registration'].create({})
@@ -126,10 +131,7 @@ class TestPeppolParticipant(PeppolConnectorCommon):
         self.assertRecordValues(self.env.company, [{'account_peppol_proxy_state': 'not_registered'}])
 
     def test_config_update_email(self):
-        with self._mock_requests([
-            self._mock_can_connect(),
-            self._mock_connect(peppol_state='sender'),
-        ]):
+        with mock_can_connect(), mock_connect(peppol_state='sender'):
             wizard = self.env['peppol.registration'].create({})
             wizard.button_register_peppol_participant()
         self.assertRecordValues(self.env.company, [{
@@ -139,10 +141,11 @@ class TestPeppolParticipant(PeppolConnectorCommon):
 
         # Change the email.
         settings = self.env['res.config.settings'].create({})
-        with self._mock_requests([self._mock_update_user()]) as mocks_results:
+        with mock_update_user() as mock_response:
             settings.account_peppol_contact_email = 'another@email.be'
+            http_params = json.loads(mock_response.calls[0].body)
             self.assertEqual(
-                mocks_results['called']['https://peppol.test.odoo.com/api/peppol/1/update_user']['kwargs']['json']['params']['update_data']['peppol_contact_email'],
+                http_params['params']['update_data']['peppol_contact_email'],
                 'another@email.be',
             )
 
@@ -177,10 +180,7 @@ class TestPeppolParticipant(PeppolConnectorCommon):
             wizard.button_register_peppol_participant()
 
         wizard.peppol_endpoint = '0477472701'
-        with self._mock_requests([
-            self._mock_can_connect(),
-            self._mock_connect(peppol_state='sender'),
-        ]):
+        with mock_can_connect(), mock_connect(peppol_state='sender'):
             wizard.button_register_peppol_participant()
 
         self.assertRecordValues(branch, [{
@@ -198,10 +198,7 @@ class TestPeppolParticipant(PeppolConnectorCommon):
         }])
 
         # Disconnect from the network.
-        with self._mock_requests([
-            self._mock_participant_status('sender'),
-            self._mock_cancel_peppol_registration(),
-        ]):
+        with mock_get_participant_status(peppol_state='sender'), mock_cancel_peppol_registration():
             settings.button_peppol_deregister()
         self.assertRecordValues(settings, [{
             'account_peppol_proxy_state': 'not_registered',
@@ -251,10 +248,7 @@ class TestPeppolParticipant(PeppolConnectorCommon):
             'display_use_parent_connection_selection': False,
             'use_parent_connection_selection': 'use_self',
         }])
-        with self._mock_requests([
-            self._mock_can_connect(),
-            self._mock_connect(peppol_state='receiver'),
-        ]):
+        with mock_can_connect(), mock_connect(peppol_state='receiver'):
             wizard.button_register_peppol_participant()
 
         settings = self.env['res.config.settings'].with_context(allowed_company_ids=self.env.company.ids).create({})
@@ -276,10 +270,7 @@ class TestPeppolParticipant(PeppolConnectorCommon):
             'phone_number': self.env.company.account_peppol_phone_number,
             'contact_email': self.env.company.account_peppol_contact_email,
         }])
-        with self._mock_requests([
-            self._mock_can_connect(),
-            self._mock_connect(peppol_state='sender', id_client='test_id_client_branch'),
-        ]):
+        with mock_can_connect(), mock_connect(peppol_state='sender', id_client='test_id_client_branch'):
             wizard.button_register_peppol_participant()
 
         self.assertRecordValues(branch, [{
@@ -295,11 +286,11 @@ class TestPeppolParticipant(PeppolConnectorCommon):
         }])
 
         # Disconnect from the network.
-        with self._mock_requests([
-            self._mock_cancel_peppol_registration(),
-            self._mock_get_all_documents(),
-            self._mock_participant_status('sender'),
-        ]):
+        with (
+            mock_cancel_peppol_registration(),
+            mock_get_participant_status(peppol_state='sender'),
+            mock_documents_retrieval(messages=[])
+        ):
             settings.button_peppol_deregister()
         self.assertRecordValues(settings, [{
             'account_peppol_proxy_state': 'not_registered',
@@ -322,20 +313,22 @@ class TestPeppolParticipant(PeppolConnectorCommon):
 
     def test_deregister_with_client_gone_error(self):
         """Test deregistration succeeds even when proxy returns client_gone error"""
-        with self._mock_requests([
-            self._mock_can_connect(),
-            self._mock_lookup_participant(),
-            self._mock_connect(peppol_state='smp_registration'),
-        ]):
+        with (
+            mock_can_connect(),
+            mock_lookup_not_found('0208:0239843188'),
+            mock_lookup_not_found('9925:be0239843188'),
+            mock_connect(peppol_state='smp_registration'),
+        ):
             wizard = self.env['peppol.registration'].create({})
             self.assertTrue(wizard.smp_registration)
             wizard.button_register_peppol_participant()
         self.assertEqual(self.env.company.account_peppol_proxy_state, 'smp_registration')
 
         settings = self.env['res.config.settings'].create({})
-        with self._mock_requests([
-            self._mock_participant_status('smp_registration', exists=False)
-        ]):
+        with (
+            mock_get_participant_status(peppol_state='smp_registration'),
+            mock_cancel_peppol_registration(),
+        ):
             settings.button_peppol_deregister()
 
         # Should successfully deregister despite Exception
@@ -390,10 +383,11 @@ class TestPeppolParticipant(PeppolConnectorCommon):
             'country_id': be_country.id,
             'vat': 'BE0477472701',
         })
-        with self._mock_requests([
-            self._mock_can_connect(),
-            self._mock_connect(peppol_state='sender'),
-        ]):
+        with (
+            mock_lookup_success(peppol_identifier='0088:88888888888'),
+            mock_can_connect(),
+            mock_connect(peppol_state='sender'),
+        ):
             wizard = self.env['peppol.registration'].create({
                 'peppol_eas': '0088',
                 'peppol_endpoint': '88888888888',

--- a/addons/payment/tests/test_payment_provider.py
+++ b/addons/payment/tests/test_payment_provider.py
@@ -6,7 +6,7 @@ import requests
 
 from odoo.exceptions import ValidationError
 from odoo.fields import Command
-from odoo.tests import tagged
+from odoo.tests.common import MockHTTPClient, tagged
 from odoo.tools import mute_logger
 
 from odoo.addons.payment.const import REPORT_REASONS_MAPPING
@@ -451,11 +451,9 @@ class TestPaymentProvider(PaymentCommon):
     @mute_logger("odoo.addons.payment.models.payment_provider")
     def test_parsing_non_json_response_falls_back_to_text_response(self):
         """Test that a non-JSON response is smoothly parsed as a text response."""
-        response = requests.Response()
-        response.status_code = 502
-        response._content = b"<html><body>Cloudflare Error</body></html>"
         with (
-            patch("requests.request", return_value=response),
+            MockHTTPClient(return_status=502, return_body=b"<html><body>Cloudflare Error</body></html>"),
+            patch.object(self.env.registry["payment.provider"], "_build_request_url", return_value="https://example.com/dummy"),
             patch(
                 "odoo.addons.payment.models.payment_provider.PaymentProvider._parse_response_error",
                 new=lambda _self, response_: response_.json(),

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -33,7 +33,7 @@ import unittest
 import warnings
 from collections import defaultdict, deque
 from concurrent.futures import CancelledError, Future, InvalidStateError, wait
-from contextlib import ExitStack, contextmanager
+from contextlib import AbstractContextManager, ExitStack, contextmanager
 from copy import deepcopy
 from datetime import datetime
 from functools import cache, partial, wraps
@@ -52,6 +52,7 @@ import requests
 from lxml import etree, html
 from passlib.context import CryptContext
 from requests import PreparedRequest, Session
+from urllib3.util import parse_url
 from werkzeug.exceptions import BadRequest
 
 import odoo.cli
@@ -332,6 +333,191 @@ class BlockedRequest(requests.exceptions.ConnectionError):
 
 
 _super_send = requests.Session.send
+
+
+class MockHTTPClient(AbstractContextManager):
+    """Mock ``requests`` calls and return a fake ``requests.Response``.
+
+    This context manager patches ``requests.sessions.Session.send``.
+    Each outgoing request is checked against the match criteria. If it
+    matches, the request is recorded in ``calls``, the optional
+    ``side_effect`` is executed, and a mocked response is returned. If
+    it does not match, the request is delegated to the previously active
+    ``send`` (either the real ``requests`` implementation, or an outer
+    ``MockHTTPClient`` when you nest mocks), so multiple
+    ``MockHTTPClient`` instances can be composed.
+
+    A request matches when all checks pass:
+
+    * ``method`` (if passed): matches the HTTP method (case-insensitive)
+    * ``url`` (if passed):  limits which requests this mock will catch.
+      Use ``"https://api.example.com/v1/items"`` to match that
+      host + path; include more (e.g. a query string) to make it
+      stricter. Anything you omit is treated as "don't care" and won't
+      affect matching.
+    * ``matcher(request)`` (if passed): a custom function predicate for
+      anything beyond method/URL (headers, JSON body, etc.).
+
+    The response is built from ``return_status`` and ``return_headers``
+    (both can be values or callables).
+    The body comes from ``return_json`` (JSON-encoded and defaults
+    ``Content-Type`` to ``application/json``) or from ``return_body``
+    when ``return_json`` is ``None``.
+
+    Examples
+    --------
+    Mock an auth flow and return dynamic JSON based on headers
+
+    .. code-block:: python
+        def is_body_authorized(req):
+            token = req.headers.get('Authorization')
+            if token == 'Bearer super-secure-token':
+                return "Authorized!"
+            return "Not authorized :("
+
+        def check_auth_header(req):
+            self.assertIn(
+                'Authorization',
+                req.headers,
+                "Missing Authorization header",
+            )
+
+        with (
+            MockHTTPClient(
+                url='https://auth.example.com/token',
+                return_json={'token': 'super-secure-token'},
+            ) as auth_mock,
+            MockHTTPClient(
+                url='https://api.example.com/am-i-authorized',
+                return_body=is_body_authorized,
+                side_effect=check_auth_header,
+            ) as api_mock,
+        ):
+            token = requests.get(
+                'https://auth.example.com/token',
+            ).json()['token']
+            auth_mock.assert_called_once()
+
+            resp = requests.get(
+                'https://api.example.com/am-i-authorized',
+                headers={'Authorization': f'Bearer {token}'},
+            )
+            api_mock.assert_called_once()
+            assert resp.text == "Authorized!"
+    """
+
+    def __init__(
+        self,
+        url: str | None = None,
+        *,
+        method: str | None = None,
+        matcher: typing.Callable[[requests.PreparedRequest], bool] | None = None,
+        return_status: int | typing.Callable[[requests.PreparedRequest], int] = 200,
+        return_json: dict | typing.Callable[[requests.PreparedRequest], dict] | None = None,
+        return_body: bytes | str | typing.Callable[[requests.PreparedRequest], bytes | str] | None = None,
+        return_headers: dict | typing.Callable[[requests.PreparedRequest], dict] | None = None,
+        side_effect: typing.Callable[[requests.PreparedRequest], None] | None = None,
+    ):
+        self.url = parse_url(url) if url else None
+        if url and not self.url.host:
+            raise ValueError(f"URL '{url}' is not valid: missing host")
+        self.method = method.upper() if method else None
+        self.matcher = matcher
+        self.return_status = return_status if callable(return_status) else lambda _req: return_status
+
+        self.return_json = None
+        if callable(return_json):
+            self.return_json = return_json
+        elif return_json is not None:
+            self.return_json = lambda _req: return_json
+        if self.return_json is not None and return_body is not None:
+            raise ValueError("Cannot specify both return_json and return_body")
+
+        self.return_body = return_body if callable(return_body) else lambda _req: return_body
+        self.return_headers = return_headers if callable(return_headers) else lambda _req: return_headers or {}
+        self.side_effect = side_effect
+        self.calls = []
+        self.super_send = None
+
+    def _request_matches(self, req: requests.PreparedRequest) -> bool:
+        if self.method and self.method != req.method.upper():
+            return False
+        if self.url and req.url:
+            request_url = parse_url(req.url)
+            if any((
+                self.url.scheme and self.url.scheme != request_url.scheme,
+                self.url.host and self.url.host != request_url.host,
+                self.url.port and self.url.port != request_url.port,
+                self.url.path and self.url.path != request_url.path,
+                self.url.query and self.url.query != request_url.query,
+            )):
+                return False
+        return self.matcher is None or self.matcher(req)
+
+    def __enter__(self):
+        self.super_send = requests.sessions.Session.send
+        self.calls = []
+
+        def send(session, req: requests.PreparedRequest, **kw):
+            if not self._request_matches(req):
+                return self.super_send(session, req, **kw)
+
+            self.calls.append(req)
+            if self.side_effect:
+                self.side_effect(req)
+
+            resp = requests.Response()
+            resp.status_code = self.return_status(req)
+            resp.url = req.url or ''
+            resp.request = req
+            resp.headers.update(self.return_headers(req))
+            if self.return_json is not None:
+                resp.headers.setdefault('Content-Type', 'application/json')
+                resp.encoding = 'utf-8'
+                resp._content = json.dumps(self.return_json(req), ensure_ascii=False).encode()
+            else:
+                return_body = self.return_body(req)
+                resp._content = return_body.encode() if isinstance(return_body, str) else return_body or b''
+
+            return resp
+
+        self.patcher = patch.object(requests.sessions.Session, 'send', send)
+        self.patcher.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.patcher.stop()
+        self.super_send = None
+        return False
+
+    def __repr__(self) -> str:
+        return (
+            'MockHTTPClient('
+            f'method={str(self.method)!r}, '
+            f'url={str(self.url.url) if self.url is not None else None!r}, '
+            f'matcher={"set" if self.matcher else None!r}, '
+            f'side_effect={"set" if self.side_effect else None!r}, '
+            f'body={"json" if self.return_json is not None else "body"!r}, '
+            f'calls={len(self.calls)})'
+        )
+
+    def assert_called(self, n_times=None):
+        if n_times == 0:
+            if self.calls:
+                raise AssertionError(f"Expected 0 calls. Called {len(self.calls)} times.")
+            return
+
+        if not self.calls:
+            raise AssertionError("Expected to have been called at least once. No calls were made.")
+
+        if n_times is not None and len(self.calls) != n_times:
+            raise AssertionError(f"Expected {n_times} calls. Called {len(self.calls)} times.")
+
+    def assert_called_once(self):
+        self.assert_called(n_times=1)
+
+    def assert_not_called(self):
+        self.assert_called(n_times=0)
 
 
 class DummyRLock:


### PR DESCRIPTION
Centralize all requests-related mocking in one place

This is a first step in our effort to centralise requests/responses/session objects in order to have better control on what should and should not be accessible to internal and to server action developers, as well as improve defaults.

Creating a facade for most requests/responses & session objects breaks a lot of tests, as each module mocks responses in their own way, and thus makes building minimal facades difficult.

task-4930532

Related: https://github.com/odoo/enterprise/pull/107701