### PR TITLE
[IMP] web-js: add scale option to the percentage widget

### DIFF
--- a/addons/web/static/src/views/fields/formatters.js
+++ b/addons/web/static/src/views/fields/formatters.js
@@ -360,12 +360,13 @@ formatMonetary.extractOptions = ({ options }) => ({
  * @returns {string}
  */
 export function formatPercentage(value, options = {}) {
+    const scale = options.scale ?? 100;
     value = value || 0;
     options = Object.assign({ trailingZeros: false, thousandsSep: "" }, options);
     if (!options.digits && options.field) {
         options.digits = options.field.digits;
     }
-    const formatted = formatFloatNumber(value * 100, options);
+    const formatted = formatFloatNumber(value * scale, options);
     return `${formatted}${options.noSymbol ? "" : "%"}`;
 }
 formatPercentage.extractOptions = formatFloat.extractOptions;

--- a/addons/web/static/src/views/fields/percentage/percentage_field.js
+++ b/addons/web/static/src/views/fields/percentage/percentage_field.js
@@ -13,13 +13,21 @@ export class PercentageField extends Component {
     static props = {
         ...standardFieldProps,
         digits: { type: Array, optional: true },
+        scale: { type: Number, optional: true },
+    };
+    static defaultProps = {
+        scale: 100,
     };
 
     setup() {
+        if (!Number.isInteger(this.props.scale) || this.props.scale < 1 || this.props.scale > 100) {
+            throw new Error("scale must be an integer between 1 and 100");
+        }
         useInputField({
             getValue: () =>
                 formatPercentage(this.props.record.data[this.props.name], {
                     digits: this.props.digits,
+                    scale: this.props.scale,
                     noSymbol: true,
                     field: this.props.record.fields[this.props.name],
                 }),
@@ -32,6 +40,7 @@ export class PercentageField extends Component {
     get formattedValue() {
         return formatPercentage(this.props.record.data[this.props.name], {
             digits: this.props.digits,
+            scale: this.props.scale,
             field: this.props.record.fields[this.props.name],
         });
     }
@@ -41,18 +50,33 @@ export const percentageField = {
     component: PercentageField,
     displayName: _t("Percentage"),
     supportedTypes: ["integer", "float"],
+    supportedOptions: [
+        {
+            label: _t("Scale"),
+            name: "scale",
+            type: "integer",
+            help: _t("Scale of the percentage (e.g., 100 for values in [0..1])"),
+            default: 100,
+            optional: true,
+        },
+    ],
     extractProps: ({ attrs, options }) => {
         // Sadly, digits param was available as an option and an attr.
         // The option version could be removed with some xml refactoring.
         let digits;
+        let scale;
         if (attrs.digits) {
             digits = JSON.parse(attrs.digits);
         } else if (options.digits) {
             digits = options.digits;
         }
+        if (options.scale) {
+            scale = options.scale;
+        }
 
         return {
             digits,
+            scale,
         };
     },
 };

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -770,6 +770,9 @@ export class ListRenderer extends Component {
                 if (currencyId) {
                     formatOptions.currencyId = currencyId;
                 }
+                if (column.options && column.options.scale) {
+                    formatOptions.scale = column.options.scale;
+                }
                 aggregates[fieldName] = {
                     help: multiCurrency ? "" : attrs[func],
                     value: formatter ? formatter(aggregatedValue, formatOptions) : aggregatedValue,


### PR DESCRIPTION
## PURPOSE

The purpose of this commit is to add a scale option to the percentage widget: `<field ... widget="percentage" options="{'scale': value}"`, in order to specify the scale of the rendered percentage value.

## CURRENT LIMITAION

In the old behavior, the percentage widget always multiplies the given value by 100, asserting that any given value is in the range of [0..1]. This behavior will give wrong results if the given value is already scaled to the correct percentage value. For example, if the value is 70 (for 70%), the output result will be 7000% (70 * 100).

Below is an example of the rendered percentages:
<img width="1917" height="264" alt="wrong-percentage-vals" src="https://github.com/user-attachments/assets/d1c673c9-f81f-4f9e-b9b9-4703dde1e9f0" />


## SOLUTION

Added a new option named `scale` to the `percentage` widget, defaults to 100. The value of the scale will be the multiplication factor for the given field value. For example, if the field value is 50 and `scale: 1`, the output result will be 50%. The same output can be obtained if the value is 0.5 and `scale: 100`;

The `scale` option check is also added to the average (aggregation) calculation in the `list_renderer`.

Now, when we have percentage values, between 0 and 100, we can render them using the `scale: ` option in the `percentage` widget:
```xml
<field name="field_name" widget="percentage" options="{'scale': 1}" string="col_name (%)" avg="Average"/>
```

The corresponding output will be:
<img width="1917" height="278" alt="image" src="https://github.com/user-attachments/assets/06b75480-faf1-4426-bc89-2fe10c89bb81" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
