### PR TITLE
[FIX] account_peppol: use correct company context

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -169,7 +169,7 @@ class AccountEdiProxyClientUser(models.Model):
                     ('company_id', '=', company.id),
                     ('type', '=', 'purchase')
                 ], limit=1)
-
+            journal = journal.with_company(company)
             need_retrigger = need_retrigger or len(message_uuids) > job_count
             message_uuids = message_uuids[:job_count]
             proxy_acks = []


### PR DESCRIPTION
Currently, the created move does not always use the company context of the related move/proxy user. As a result, default values may be taken from another company, which can lead to cross-company inconsistencies and access errors.

Steps to reproduce:
- Set up two companies, A and B
- In company A, configure a default value for the partner.company_id field, applicable only to company A
- When a Peppol invoice arrives for company B but is processed using the context of company A, and a new partner must be created, the partner is created with company A as the default value
- This results in an incompatible companies on record error

This fix ensures that the company context of the move or EDI user is used when creating the move, preventing cross-company issues.

opw-5473233