### PR TITLE
[FIX] point_of_sale: Phone Number in arabic receipt formatting

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml
@@ -9,7 +9,7 @@
                 <!-- contact address -->
                 <div t-if="props.data.company.name" t-esc="props.data.company.name" />
                 <t t-if="props.data.company.phone">
-                    <div>Tel:<t t-esc="props.data.company.phone" /></div>
+                    <div>Tel:<span dir="ltr"><t t-esc="props.data.company.phone" /></span></div>
                 </t>
                 <t t-if="props.data.company.vat">
                     <div t-esc="vatText"/>


### PR DESCRIPTION
# Steps to reproduce:
- Open the company, change the language to Arabic
- Go to POS, open the shop
- Buy anything and click on receipt

# Problem:
When clicking on the receipt, you would find the phone number is written right to left, although it should be printed left to right.

# Cause:
Normally when another language is selected, this line will adapt to it, and translate the whole block "Tel: `props.data.company.phone`" to arabic (right to left)
https://github.com/odoo/odoo/blob/5fc1e34d174f7f61d692d086d0ff65fbfc72b013/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml#L12

# Fix:
We need to specify the direction of the phone number to be Left to right.
```
<div>Tel:<span dir="ltr"><t t-esc="props.data.company.phone" /></span></div>
```
**Result:**
<img width="167" height="86" alt="HATEF" src="https://github.com/user-attachments/assets/4fe0bdd0-fe77-430f-9136-cd7086c4d5d9" />

There is also alternative fixes:
# First alternative fix:
Replace the '+' with '00' (there is no difference when trying to copy), and make a function in js that preserve the whole thing in a string variable.
```
    get phoneText() {
        return _t("Tel:") + " " + this.props.data.company.phone.replace("+", "00");
    }
```
**Result:**
<img width="215" height="148" alt="hatef2" src="https://github.com/user-attachments/assets/e9cb4415-baad-4d66-a04b-ecdb308e3e72" />

**Drawback:**
- The inconsistency between how the number is stored and how we view it.

# Second alternative fix:
**File:** `/home/odoo/codebase/odoo/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.js`
```diff
import { _t } from "@web/core/l10n/translation";
import { Component } from "@odoo/owl";
+ import { localization } from "@web/core/l10n/localization";
```
```diff
+    get direction() {
+        return localization.direction;
+    }
```

**File:** `/home/odoo/codebase/odoo/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.xml`
```diff
                <t t-if="props.data.company.phone">
-                    <div>Tel:<t t-esc="props.data.company.phone" /></div>
+                    <t t-if="direction == 'ltr'">
+                        <div>Tel:<t t-esc="props.data.company.phone" /></div>
+                   </t>
+                    <t t-elif="direction == 'rtl'">
+                       <div><t t-esc="props.data.company.phone" />Tel:</div>
                    </t>
                </t>
```

**Drawback:**
- Too much code for a small issue that probably won't bother the client.
- The need to change in multiple translation files for all RTL languages in odoo.
- Readability


opw-5881503

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
