### PR TITLE
[FIX] mail: chatter should jump when navigating to a specific message link

### DIFF
--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -340,9 +340,6 @@ export function useMessageScrolling(duration = 2000) {
          * @param {import("models").Thread} thread
          */
         async highlightMessage(message, thread) {
-            if (thread.model !== "mail.box" && thread.notEq(message.thread)) {
-                return;
-            }
             state.initiated = true;
             let messageScrollDirection;
             if (message.notIn(thread.messages)) {

--- a/addons/mail/static/tests/thread/message_highlight.test.js
+++ b/addons/mail/static/tests/thread/message_highlight.test.js
@@ -1,5 +1,6 @@
 import {
     click,
+    contains,
     defineMailModels,
     isInViewportOf,
     openDiscuss,
@@ -10,7 +11,9 @@ import { Thread } from "@mail/core/common/thread";
 import { describe, test } from "@odoo/hoot";
 import { advanceTime, Deferred, tick, waitFor } from "@odoo/hoot-dom";
 import { disableAnimations } from "@odoo/hoot-mock";
-import { patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { router, routerBus } from "@web/core/browser/router";
+import { range } from "@web/core/utils/numbers";
+import { mountWebClient, patchWithCleanup } from "@web/../tests/web_test_helpers";
 
 defineMailModels();
 describe.current.tags("desktop");
@@ -102,4 +105,27 @@ test("highlight scrolls to beginning of long message", async () => {
         ".o-mail-Message:contains('long message') .o-mail-Message-avatar", // avatar is at beginning of message
         ".o-mail-Thread"
     );
+});
+
+test("Chatter jumps when navigating to a specific message link", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "John Doe" });
+    const messageIds = range(0, 31).map((i) =>
+        pyEnv["mail.message"].create({
+            body: `message ${i}`,
+            model: "res.partner",
+            res_id: partnerId,
+        })
+    );
+    await mountWebClient();
+    router.pushState(
+        router.urlToState(
+            new URL(
+                `${window.location.origin}/odoo/res.partner/${partnerId}?highlight_message_id=${messageIds[0]}`
+            )
+        ),
+        { sync: true }
+    );
+    routerBus.trigger("ROUTE_CHANGE");
+    await contains(".o-mail-Message.o-highlighted .o-mail-Message-content", { text: "message 0" });
 });


### PR DESCRIPTION
PR #223362 removes the early return for checking the origin thread in
`highlightMessage()` while PR #234659 adds it again through the FW ports of
a fix intended for mailbox (which has not been needed from 19.0 onwards).

Since the auto-highlight of message is triggered when the thread is 1st loaded,
i.e. has loaded 30 most recent messages, if the targeted message to highlight is
not in the loaded messages, then the `highlightMessage()` call would be
mistakenly and silently ignored by this early return. This trigger of
`highlightMessage()` is done only once, hence the failed attempt to highlight
the message. This PR removes reliance on the origin thread.

Steps to reproduce the bug:
- Send more than 30 messages in a chatter.
- Copy the first message link and paste it into the browser to go to the message as a highlighted one.
- Thread doesn't jump to the targeted message.

task-5929780

