### PR TITLE
[FIX] pos_loyalty: multi physical gift cards

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -214,14 +214,14 @@ patch(PosStore.prototype, {
                 }, {});
 
                 oldChanges.forEach((pointObj) => {
-                    const { points, barcode = "", gift_code = "" } = pointObj;
+                    const { points, barcode = "", code = "" } = pointObj;
                     const key =
-                        barcode && gift_code
-                            ? `${points}-${barcode}-${gift_code}`
+                        barcode && code
+                            ? `${points}-${barcode}-${code}`
                             : barcode
                             ? `${points}-${barcode}`
-                            : gift_code
-                            ? `${points}--${gift_code}`
+                            : code
+                            ? `${points}--${code}`
                             : `${points}`;
 
                     if (pointsCount[key] && pointsCount[key] > 0) {

--- a/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
@@ -222,3 +222,17 @@ registry.category("web_tour.tours").add("test_coupon_code_stays_set", {
             Chrome.endTour(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_multiple_physical_gift_card_sale", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("Gift Card", "1", "0", "0"),
+            PosLoyalty.createManualGiftCard("test-card-0000", 125),
+            ProductScreen.selectedOrderlineHas("Gift Card", "1.00", "125"),
+            ProductScreen.addOrderline("Gift Card", "1", "0", "0"),
+            PosLoyalty.createManualGiftCard("test-card-0001", 100),
+            PosLoyalty.finalizeOrder("Cash", "225"),
+        ].flat(),
+});

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -3256,3 +3256,23 @@ class TestUi(TestPointOfSaleHttpCommon):
         trusted_pos_config.trusted_config_ids += self.main_pos_config
         self.start_pos_tour("test_loyalty_in_trusted_pos_make_order", login="pos_user")
         self.start_pos_tour("test_loyalty_in_trusted_pos", login="pos_user", pos_config=trusted_pos_config)
+
+    def test_multiple_physical_gift_card_sale(self):
+        """
+        Test that the manual gift card sold has been correctly generated.
+        """
+        LoyaltyProgram = self.env['loyalty.program']
+        # Deactivate all other programs to avoid interference and activate the gift_card_product_50
+        LoyaltyProgram.search([]).write({'pos_ok': False})
+        self.env.ref('loyalty.gift_card_product_50').write({'active': True})
+
+        # Create gift card program
+        gift_card_program = self.create_programs([('arbitrary_name', 'gift_card')])['arbitrary_name']
+
+        # Run the tour
+        self.start_tour(
+            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "test_multiple_physical_gift_card_sale",
+            login="pos_user",
+        )
+        self.assertEqual(len(gift_card_program.coupon_ids), 2)


### PR DESCRIPTION
When selling mutliple physical gift cards in the same PoS order, no gift cards were created.

Steps to reproduce:
-------------------
* Open PoS
* Add a gift card to the order
* Click on the gift card line and set a physical gift card with a value of 100€
* Add another gift card to the order
* Click on the gift card line and set a physical gift card with a value of 50€
* Validate the order
> Observation: No gift card is created in the backend

Why the fix:
------------
When looking for the `oldChanges` we tried to retrieve the gift card code as `gift_code` but the key name is `code`. Because of this the `pointsCount` was wrong.

opw-5928320