### PR TITLE
Master mail this binding jesc

### DIFF
--- a/addons/mail/static/src/core/common/attachment_list.js
+++ b/addons/mail/static/src/core/common/attachment_list.js
@@ -115,7 +115,7 @@ export class AttachmentList extends Component {
 
     getActions(attachment) {
         const res = [];
-        if (this.showDelete) {
+        if (this.showDelete(attachment)) {
             res.push({
                 label: _t("Remove"),
                 icon: "fa fa-trash",
@@ -132,12 +132,12 @@ export class AttachmentList extends Component {
         return res;
     }
 
-    get showDelete() {
+    showDelete(attachment) {
         // in the composer they should all be implicitly deletable
         if (this.env.inComposer) {
             return true;
         }
-        if (!this.attachment.isDeletable) {
+        if (!attachment.isDeletable) {
             return false;
         }
         // in messages users are expected to delete the message instead of just the attachment

--- a/addons/mail/static/src/core/common/attachment_list.xml
+++ b/addons/mail/static/src/core/common/attachment_list.xml
@@ -32,7 +32,7 @@
                         paused="attachment.gifPaused"
                         alt="attachment.name"
                         class="
-                            'o-mail-AttachmentImage img img-fluid w-100 rounded-3' 
+                            'o-mail-AttachmentImage img img-fluid w-100 rounded-3'
                             + (env.inMessage ? ' o-inMessage' : '')
                             + (env.inChatter ? ' o-inChatter' : '')
                             + (!env.inChatter and env.inMessage ? ' object-fit-contain' : '')
@@ -83,7 +83,7 @@
                             <button t-elif="canDownload(attachment)" class="btn bg-500 w-100 h-100 o-p-1_5 d-flex justify-content-center align-items-center shadow-sm" t-on-click.stop="() => this.onClickDownload(attachment)" title="Download">
                                 <i class="fa fa-download o-text-white" role="img" aria-label="Download"/>
                             </button>
-                            <button t-if="showDelete" class="o-mail-Attachment-unlink btn bg-500 w-100 h-100 o-p-1_5 d-flex ms-2 justify-content-center align-items-center shadow-sm" t-att-class="{ 'o-inComposer': env.inComposer }" t-on-click.stop="() => this.onClickUnlink(attachment)" title="Remove">
+                            <button t-if="showDelete(attachment)" class="o-mail-Attachment-unlink btn bg-500 w-100 h-100 o-p-1_5 d-flex ms-2 justify-content-center align-items-center shadow-sm" t-att-class="{ 'o-inComposer': env.inComposer }" t-on-click.stop="() => this.onClickUnlink(attachment)" title="Remove">
                                 <i class="fa fa-trash o-text-white" role="img" aria-label="Remove"/>
                             </button>
                         </div>

--- a/addons/mail/static/src/discuss/call/public_web/discuss_app/sidebar/call_participants.js
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_app/sidebar/call_participants.js
@@ -70,7 +70,7 @@ export class DiscussSidebarCallParticipants extends Component {
         return sessions[0];
     }
 
-    get attClass() {
+    attClass(session) {
         return {
             "justify-content-center bg-inherit": this.compact,
         };

--- a/addons/mail/static/src/discuss/call/public_web/discuss_app/sidebar/call_participants.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_app/sidebar/call_participants.xml
@@ -65,7 +65,7 @@
     </t>
 
     <t t-name="mail.DiscussSidebarCallParticipants.participant">
-        <div class="o-mail-DiscussSidebarCallParticipants-participant d-flex text-reset overflow-hidden align-items-center" t-att-class="attClass" t-on-click="(ev) => this.onClickParticipant(ev, session)">
+        <div class="o-mail-DiscussSidebarCallParticipants-participant d-flex text-reset overflow-hidden align-items-center" t-att-class="this.attClass(session)" t-on-click="(ev) => this.onClickParticipant(ev, session)">
             <div class="bg-inherit position-relative d-flex flex-shrink-0" style="width:26px;height:26px;margin:1px;">
                 <img class="o-mail-DiscussSidebarCallParticipants-avatar w-100 h-100 rounded-circle object-fit-cover" t-att-src="session.channel_member_id?.avatarUrl" t-att-class="{'o-isTalking': !session.isMute and session.isTalking}" alt="Participant avatar" t-att-title="session.channel_member_id?.name"/>
             </div>

--- a/addons/mail/static/src/discuss/call/web/discuss_app/sidebar/call_participants_patch.js
+++ b/addons/mail/static/src/discuss/call/web/discuss_app/sidebar/call_participants_patch.js
@@ -11,10 +11,10 @@ patch(DiscussSidebarCallParticipants.prototype, {
             position: "right",
         });
     },
-    get attClass() {
+    attClass(session) {
         return {
             ...super.attClass,
-            "o-active cursor-pointer rounded-4": this.session.persona?.main_user_id,
+            "o-active cursor-pointer rounded-4": session.persona?.main_user_id,
         };
     },
     onClickParticipant(ev, session) {


### PR DESCRIPTION
In preparation for owl3, where template variables will need to use
`.this` to target component variables, there are manual changes we
have to do as well as running a script.

In this case we had to refactor two methods to stop using a template
variable with `this.` inside the template and instead pass them 
explicitly from the template as arguments.

task: OWL3 prep - add this. to template variables
