### PR TITLE
[FIX] html_editor: open link popover when selecting icon inside link

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -821,7 +821,7 @@ export class LinkPlugin extends Plugin {
         } else if (!selection.isCollapsed) {
             // Open the link tool only if we have an image selected and the selection
             // is fully contained in the image parent link.
-            const imageNode = findInSelection(selection, "img");
+            const imageNode = findInSelection(selection, "img, .fa");
             const parentElement = imageNode?.parentElement;
             const linkContainingImage = imageNode && closestElement(imageNode, "a");
             if (

--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -425,7 +425,9 @@ export class LinkPopover extends Component {
             const internalMetadata = await this.props
                 .getInternalMetaData(url.href)
                 .catch((error) => {
-                    console.warn(`Error fetching internal metadata for ${url.href}:`, error);
+                    if (!session.test_mode) {
+                        console.warn(`Error fetching internal metadata for ${url.href}:`, error);
+                    }
                     return {};
                 });
             if (internalMetadata.favicon) {

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -14,7 +14,7 @@ import { animationFrame, tick } from "@odoo/hoot-mock";
 import { markup } from "@odoo/owl";
 import { contains, dataURItoBlob, onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { setupEditor } from "../_helpers/editor";
-import { cleanLinkArtifacts } from "../_helpers/format";
+import { cleanLinkArtifacts, unformat } from "../_helpers/format";
 import { getContent, setContent, setSelection } from "../_helpers/selection";
 import { expectElementCount } from "../_helpers/ui_expectations";
 import { insertLineBreak, insertText, splitBlock, undo } from "../_helpers/user_actions";
@@ -98,6 +98,24 @@ describe("should open a popover", () => {
         queryOne(".o_we_href_input_link").focus();
         await animationFrame();
         expect(queryOne(".o-we-linkpopover").parentElement).toHaveAttribute("style", style);
+    });
+    test("link popover should open and switch to editing if selection inside links", async () => {
+        await setupEditor(
+            unformat(
+                `<div class="o-paragraph">
+                    \ufeff
+                    <a href="https://test" class="btn btn-primary">
+                        \ufeffHello\ufeff[
+                            <span class="fa fa-glass" contenteditable="false">\u200b</span>
+                        ]\ufeffWorld\ufeff
+                    </a>
+                    \ufeff
+                </div>`
+            )
+        );
+        await expectElementCount(".o-we-linkpopover", 1);
+        await click(".o_we_edit_link");
+        await expectElementCount(".o_link_popover_container", 1);
     });
     test("link popover should close when clicking on a contenteditable false element", async () => {
         await setupEditor(


### PR DESCRIPTION
Problem:
When a link contains an icon, clicking on the icon does not properly open the link popover. The popover opens and immediately closes.

Cause:
The logic for opening the link popover does not handle the case where the selection is not collapsed and is around an icon inside a link. This scenario was not covered in the existing conditions.

Solution:
Handle the non-collapsed selection case similarly to images: if the selection is around an icon inside a link, the link popover should open correctly.

Steps to reproduce:
- Add a link.
- Insert an icon inside the link.
- Click on the icon.
- Observe that the link popover opens and closes immediately.

task-5921393

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
