### PR TITLE
[FIX] website: fix image-related failing tests

### DIFF
--- a/addons/website/static/tests/builder/image_test_helpers.js
+++ b/addons/website/static/tests/builder/image_test_helpers.js
@@ -1,8 +1,13 @@
 import { before, globals } from "@odoo/hoot";
 import { onRpc } from "@web/../tests/web_test_helpers";
 
-function onRpcReal(route) {
-    onRpc(route, () => globals.fetch.call(window, route));
+// Pre-fetch image routes so they're cached and available faster during tests
+const imgCache = new Map();
+function onRpcImg(route) {
+    if (!imgCache.has(route)) {
+        imgCache.set(route, globals.fetch.call(window, route));
+    }
+    onRpc(route, async () => (await imgCache.get(route)).clone());
 }
 
 export const testImgSrc = "/web/image/website.s_text_image_default_image";
@@ -50,14 +55,14 @@ export function mockImageRequests() {
                 },
             };
         });
-        onRpcReal("/html_builder/static/image_shapes/geometric/geo_shuriken.svg");
-        onRpcReal("/html_builder/static/image_shapes/pattern/pattern_wave_4.svg");
-        onRpcReal("/html_builder/static/image_shapes/geometric/geo_tetris.svg");
-        onRpcReal("/web/image/website.s_text_image_default_image");
-        onRpcReal("/website/static/src/img/snippets_demo/s_text_image.jpg");
-        onRpcReal("/website/static/src/img/snippets_options/header_effect_fade_out.gif");
-        onRpcReal("/web/image/123/transparent.png");
-        onRpcReal("/website/static/src/svg/hover_effects.svg");
-        onRpcReal("/html_builder/static/image_shapes/geometric/geo_square.svg");
+        onRpcImg("/html_builder/static/image_shapes/geometric/geo_shuriken.svg");
+        onRpcImg("/html_builder/static/image_shapes/pattern/pattern_wave_4.svg");
+        onRpcImg("/html_builder/static/image_shapes/geometric/geo_tetris.svg");
+        onRpcImg("/web/image/website.s_text_image_default_image");
+        onRpcImg("/website/static/src/img/snippets_demo/s_text_image.jpg");
+        onRpcImg("/website/static/src/img/snippets_options/header_effect_fade_out.gif");
+        onRpcImg("/web/image/123/transparent.png");
+        onRpcImg("/website/static/src/svg/hover_effects.svg");
+        onRpcImg("/html_builder/static/image_shapes/geometric/geo_square.svg");
     });
 }


### PR DESCRIPTION
Background option tests were failing in nightly builds sometimes because of the network hang.
This commit aims to fix the errors by prefetching the images and caching them.
Here's the `background_option` test suite and the total time it took to finish with a throttled network (fast 4G) before and after the commit, respectively.

| Before commit | With commit |
|--------|--------|
|<img width="610" height="224" alt="image" src="https://github.com/user-attachments/assets/a98fb1fe-27a1-4f73-901f-7d7ade8ecd86" />|<img width="610" height="224" alt="image" src="https://github.com/user-attachments/assets/c9ed0948-8112-4f2b-b843-c887c9302b76" />|
| 26.7 (s) | 15.4 (s) | 


runbot-237641