### PR TITLE
[FIX] resource_mail: add a default value for resource_type when sample data

### DIFF
--- a/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.js
+++ b/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.js
@@ -78,7 +78,7 @@ const WithResourceFieldMixin = (T) => class ResourceFieldMixin extends T {
         return {
             ...super.getTagProps(...arguments),
             color: record.data.color,
-            type: record.data.resource_type,
+            type: !record.model.useSampleModel ? record.data.resource_type : "material",
             imageUrl: record.data.resource_type === "user"
                 ? `/web/image/${this.relation}/${record.resId}/avatar_128`
                 : undefined,


### PR DESCRIPTION
When triggering the sample data in planning slot list and kanban views (e.g. by having many filters enabled on list view), the resource_type field of sample resource records is not set (it equals "false" instead of "user" or "material"). This was causing an issue in many2many_avatar_resource_field props validation, which expected a resource_type (required) The fix is to set a default value ("material" for instance) for resource_type when using the sample data.

runbot-error: https://runbot.odoo.com/odoo/runbot.build.error/239951 
task-5946310

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
