### PR TITLE
[FIX] delivery, website_sale_collect: fix case formatting in pick-up

### DIFF
--- a/addons/delivery/static/src/js/location_selector/location_schedule/location_schedule.js
+++ b/addons/delivery/static/src/js/location_selector/location_schedule/location_schedule.js
@@ -24,7 +24,8 @@ export class LocationSchedule extends Component {
      * @return {Object} the localized name of the day (long version).
      */
     getWeekDay(weekday) {
-        return luxon.Info.weekdays()[weekday]
+        const dayName = luxon.Info.weekdays()[weekday];
+        return dayName.charAt(0).toUpperCase() + dayName.slice(1);
     }
 
     get closedLabel() {

--- a/addons/website_sale_collect/models/delivery_carrier.py
+++ b/addons/website_sale_collect/models/delivery_carrier.py
@@ -87,9 +87,9 @@ class DeliveryCarrier(models.Model):
             try:
                 pickup_location_values = {
                     'id': wh.id,
-                    'name': wh_location['name'].title(),
-                    'street': wh_location['street'].title(),
-                    'city': wh_location.city.title(),
+                    'name': wh_location['name'],
+                    'street': wh_location['street'],
+                    'city': wh_location.city,
                     'zip_code': wh_location.zip or '',
                     'country_code': wh_location.country_code,
                     'state': wh_location.state_id.code,


### PR DESCRIPTION
Issue:
---
In pick-up point list, the case formatting should be:
1- Pick-up point's `name`, `street` and `city` should not be auto-capitalized.
2- Weekdays should must be always capitalized regardless of language.

Steps to reproduce:
---
1- Create a second Company named `store`.
2- Create a wh for the created company and add the wh to click-and-collect pick-up points. (There should be more than 1 pick-up points)
3- In the website, add Dutch lang.
4- In website, open a product and, open the `Click and Collect`.

Outcome:
---
Name is capitalized to `Store` and the days are not capitalized if you switch to dutch lang.

Cause:
---
Due to CLDR, luxon doesn't capitalize weekdays in some languages.

opw-5941830
