### PR TITLE
[IMP] mail,web,crm: foundations for the new Odoo Phone Service

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4046,12 +4046,12 @@ class MailThread(models.AbstractModel):
             return devices_su, None, None
         return devices_su.search([("partner_id", "in", partner_ids)]), vapid_private_key, vapid_public_key
 
-    def _web_push_send_notification(self, devices, private_key, public_key, payload_by_lang=None, payload=None):
+    def _web_push_send_notification(self, devices, private_key, public_key, payload_by_lang=None, payload=None, force_direct_send=False):
         """
         :param payload: JSON serializable dict following the notification api specs https://notifications.spec.whatwg.org/#api
         :param payload_by_lang a dict mapping payload by lang, either this or payload must be provided
         """
-        if len(devices) < MAX_DIRECT_PUSH:
+        if len(devices) < MAX_DIRECT_PUSH or force_direct_send is True:
             session = Session()
             devices_to_unlink = set()
             for device in devices:

--- a/addons/mail/static/src/service_worker.js
+++ b/addons/mail/static/src/service_worker.js
@@ -160,40 +160,40 @@ async function openDiscussChannel(channelId, { action, joinCall = false, source 
     }
 }
 
-self.addEventListener("notificationclick", (event) => {
+async function handleNotificationClick(event) {
+    const { action, model, res_id } = event.notification.data;
+    if (model === "discuss.channel") {
+        if (event.action === PUSH_NOTIFICATION_ACTION.DECLINE) {
+            return fetch("/mail/rtc/channel/leave_call", {
+                headers: { "Content-type": "application/json" },
+                body: JSON.stringify({
+                    id: 1,
+                    jsonrpc: "2.0",
+                    method: "call",
+                    params: { channel_id: res_id },
+                }),
+                method: "POST",
+                mode: "cors",
+                credentials: "include",
+            });
+        }
+        return openDiscussChannel(res_id, {
+            action,
+            joinCall: event.action === PUSH_NOTIFICATION_ACTION.ACCEPT,
+        });
+    } else {
+        const modelPath = model.includes(".") ? model : `m-${model}`;
+        return clients.openWindow(`/odoo/${modelPath}/${res_id}`);
+    }
+}
+
+self.addEventListener("notificationclick", async (event) => {
     event.notification.close();
     if (event.notification.data) {
-        const { action, model, res_id } = event.notification.data;
-        if (model === "discuss.channel") {
-            if (event.action === PUSH_NOTIFICATION_ACTION.DECLINE) {
-                event.waitUntil(
-                    fetch("/mail/rtc/channel/leave_call", {
-                        headers: { "Content-type": "application/json" },
-                        body: JSON.stringify({
-                            id: 1,
-                            jsonrpc: "2.0",
-                            method: "call",
-                            params: { channel_id: res_id },
-                        }),
-                        method: "POST",
-                        mode: "cors",
-                        credentials: "include",
-                    })
-                );
-                return;
-            }
-            event.waitUntil(
-                openDiscussChannel(res_id, {
-                    action,
-                    joinCall: event.action === PUSH_NOTIFICATION_ACTION.ACCEPT,
-                })
-            );
-        } else {
-            const modelPath = model.includes(".") ? model : `m-${model}`;
-            event.waitUntil(clients.openWindow(`/odoo/${modelPath}/${res_id}`));
-        }
+        event.waitUntil(handleNotificationClick(event));
     }
 });
+
 self.addEventListener("push", async (event) => {
     const notification = event.data.json();
     switch (notification.options?.data?.type) {

--- a/addons/web/static/src/views/fields/phone/phone_field.js
+++ b/addons/web/static/src/views/fields/phone/phone_field.js
@@ -45,6 +45,7 @@ export class PhoneField extends Component {
     get actionButtons() {
         return [
             {
+                href: this.value ? this.phoneHref : undefined,
                 icon: "phone",
                 onSelected: () => this.onLinkClicked(),
                 name: _t("Call"),

--- a/addons/web/static/src/views/fields/phone/phone_field.scss
+++ b/addons/web/static/src/views/fields/phone/phone_field.scss
@@ -1,6 +1,6 @@
 body:not(.o_touch_device) .o_field_phone {
     &:not(:hover):not(:focus-within) {
-        &:has(input:not(:hover)) span button {
+        &:has(input:not(:hover)) span .o_phone_form_link {
             display: none !important;
         }
     }

--- a/addons/web/static/src/views/fields/phone/phone_field.xml
+++ b/addons/web/static/src/views/fields/phone/phone_field.xml
@@ -24,20 +24,26 @@
     <t t-name="web.PhoneFieldActions">
         <span class="d-flex flex-nowrap">
             <t t-foreach="this.actionButtons" t-as="btn" t-key="btn.name">
-                <button
+                <t
+                    t-tag="btn.href ? 'a' : 'button'"
                     t-if="this.value"
-                    t-on-click.stop="btn.onSelected"
+                    t-att-href="btn.href"
+                    t-on-click.prevent.stop="btn.onSelected"
                     class="o_phone_form_link btn btn-sm btn-link p-1 py-0 text-nowrap"
                 >
                     <i class="oi oi-filled" t-att-data-icon="btn.icon"/><small class="fw-bold ms-1"><t t-out="btn.name"/></small>
-                </button>
+                </t>
             </t>
         </span>
         <Dropdown>
             <button class="btn oi" data-icon="more_vert"/>
             <t t-set-slot="content">
                     <t t-foreach="this.actionButtons" t-as="btn" t-key="btn.name">
-                        <DropdownItem class="'o_phone_form_link d-flex align-items-baseline gap-1'" onSelected="(ev) => btn.onSelected()">
+                        <DropdownItem
+                            class="'o_phone_form_link d-flex align-items-baseline gap-1'"
+                            attrs="{ href: btn.href }"
+                            onSelected="(ev) => btn.onSelected()"
+                        >
                             <i t-attf-class="oi oi-filled" t-att-data-icon="btn.icon" /><t t-out="btn.name"/>
                         </DropdownItem>
                     </t>

--- a/addons/web/static/tests/views/fields/phone_field.test.js
+++ b/addons/web/static/tests/views/fields/phone_field.test.js
@@ -26,6 +26,7 @@ class Partner extends models.Model {
 defineModels([Partner]);
 
 async function assertUrl(target, url) {
+    expect(target).toHaveAttribute("href", url);
     await contains(target, {
         visible: false,
     }).click();
@@ -76,8 +77,8 @@ test("PhoneField in form view on normal screens (edit)", async () => {
     });
     expect(`input[type="tel"]`).toHaveCount(1);
     expect(`input[type="tel"]`).toHaveValue("yop");
-    expect(".o_field_phone button i[data-icon='phone']").toHaveCount(1);
-    await assertUrl(`.o_field_widget button i[data-icon='phone']`, "tel:yop");
+    expect(".o_field_phone a i[data-icon='phone']").toHaveCount(1);
+    await assertUrl(`.o_field_widget a.o_phone_form_link`, "tel:yop");
 
     // change value in edit mode
     await click(`input[type="tel"]`);


### PR DESCRIPTION
Small set of community-side adjustments required by the companion enterprise PR (odoo/enterprise#107700).                                                                                                  

 - mail: force direct send of notifications, expose handleNotificationClick for override
 - web: let the service worker wait for a message from a given client
 - crm: remove the legacy Ringover VoIP phone setting

 Task-6264142