### PR TITLE
[FIX] mail: replace object-fit-scale-down by object-fit-scale

### DIFF
--- a/addons/mail/static/src/core/common/attachment_list.xml
+++ b/addons/mail/static/src/core/common/attachment_list.xml
@@ -37,7 +37,7 @@
                             + (env.inChatter ? ' o-inChatter' : '')
                             + (!env.inChatter and env.inMessage ? ' object-fit-contain' : '')
                             + (!env.inChatter and !env.inMessage ? '  object-fit-cover' : '')
-                            + (env.inChatter ? ' object-fit-scale-down' : '')
+                            + (env.inChatter ? ' object-fit-scale' : '')
                         "
                     />
                     <img
@@ -48,7 +48,7 @@
                             'o-inChatter': env.inChatter,
                             'object-fit-contain': !env.inChatter and env.inMessage,
                             'object-fit-cover': !env.inChatter and !env.inMessage,
-                            'object-fit-scale-down': env.inChatter,
+                            'object-fit-scale': env.inChatter,
                         }"
                         t-att-src="getImageUrl(attachment)"
                         t-att-alt="attachment.name"


### PR DESCRIPTION
The SCSS rule `object-fit: scale-down` has bootstrap equivalent. We'd expect it to be named `object-fit-scale-down`, but it's actually `object-fit-scale`. This PR fixes new occurrences that were not working due to picking the wrong classname.

Before / After
<img width="256" height="209" alt="Screenshot 2026-02-17 at 15 49 11" src="https://github.com/user-attachments/assets/107af330-8037-4adb-9195-e369e4bb06e6" /> <img width="258" height="211" alt="Screenshot 2026-02-17 at 15 48 47" src="https://github.com/user-attachments/assets/81c7aff8-b3e3-4ee3-b2db-eb1aede159e0" />
