### PR TITLE
[FIX] account: Prevent ensure_installed from raising

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -415,9 +415,7 @@ class AccountTestInvoicingCommon(ProductCommon):
 
     @classmethod
     def ensure_installed(cls, module_name: str):
-        module = cls.env['ir.module.module']._get(module_name)
-        assert module, f"Module '{module}' does not exist!"
-        if module.state != 'installed':
+        if cls.env['ir.module.module']._get(module_name).state != 'installed':
             raise SkipTest(f"Module required for the test is not installed ({module_name})")
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
When the module pointed by ensure_installed is not installed, the caller test is skipped. In 19.1, this helper is raising if the module is not found. It was a great idea to detect if the corresponding module exists or not but is an issue in some runbot builds when the targeted module is in the enterprise version.

So let's prevent the raising to make runbot happy again!

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
