### PR TITLE
[FIX] html_builder: specify selector to target anchor buttons only

### DIFF
--- a/addons/html_builder/static/src/plugins/button_style_option.js
+++ b/addons/html_builder/static/src/plugins/button_style_option.js
@@ -28,7 +28,7 @@ class ButtonStyleOptionPlugin extends Plugin {
 
 export class ButtonStyleOption extends BaseOptionComponent {
     static template = "html_builder.ButtonStyleOption";
-    static selector = ".btn";
+    static selector = "a.btn";
     static dependencies = [];
     static components = {
         BuilderColorPicker,


### PR DESCRIPTION
This PR  fixes an oversight from Commit[^1].

The `ButtonStyleOption` was using `.btn` which would match both anchor tags and button elements. This caused the functionality to incorrectly target all button (e.g `website_sale` product card button which use `<button class="btn">`), not just user content button (which use`<a class="btn">`).

Changed the selector to `a.btn` to specifically target only anchor elements with the `.btn` class, which are the actual user-created CTA buttons in website content that should be styled with these options. This prevents conflicts with the generic UI buttons.

Steps to reproduce (e.g):

- Go to `website_blog`
- Open a blog post and set the layout to `title inside cover`
- Scroll down and click on the next article element => button is editable

| Visual Result |
|--------|
| Master (19.2) |
| <img width="1320" height="430" alt="image" src="https://github.com/user-attachments/assets/037bd925-a240-43ba-889a-9c412ab12701" /> |
| This PR |
| <img width="1356" height="462" alt="image" src="https://github.com/user-attachments/assets/2abb9e9d-f561-4aa3-8aec-7792705815ad" /> | 

[^1]:https://github.com/odoo/odoo/commit/2bf1db001b195480b963b338583c170aa1c009a3

task-5946341

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
