### PR TITLE
[FIX] payment_authorize: prevent OTS token consumption

### DIFF
--- a/addons/payment_authorize/controllers/main.py
+++ b/addons/payment_authorize/controllers/main.py
@@ -28,8 +28,20 @@ class AuthorizeController(http.Controller):
         if not payment_utils.check_access_token(access_token, reference, partner_id):
             raise ValidationError("Authorize.Net: " + _("Received tampered payment request data."))
 
-        # Make the payment request to Authorize.Net
+        # Retrieve the transaction
         tx_sudo = request.env['payment.transaction'].sudo().search([('reference', '=', reference)])
+        if not tx_sudo:
+            raise ValidationError(_("Transaction not found."))
+
+        # Lock the transaction row to prevent concurrent updates (e.g., from cron jobs)
+        # This prevents sql concurrent updates, which stops ORM from automatically
+        # retrying the route and consuming the single-use OTS token a second time.
+        tx_sudo.env.cr.execute(
+            "SELECT 1 FROM payment_transaction WHERE id = %s FOR NO KEY UPDATE",
+            [tx_sudo.id]
+        )
+
+        # Make the payment request to Authorize.Net
         response_content = tx_sudo._authorize_create_transaction_request(opaque_data)
 
         # Handle the payment request response


### PR DESCRIPTION
Currently, when processing a payment through Authorize.Net, a concurrent update (e.g., from a background cron job) can trigger a PostgreSQL `SERIALIZATION_FAILURE` right after the API request succeeds. Because Odoo automatically retries the request upon this failure, the second attempt sends the same One-Time-Use (OTS) token. Authorize.Net rejects the reused token ("Invalid OTS Token"), causing a successful charge to be incorrectly marked as failed in Odoo.

This commit introduces a pessimistic lock (`FOR NO KEY UPDATE`) on the `payment_transaction` record before making the call to Authorize.Net. This serializes access to the transaction row, ensuring that any lock waits or serialization failures occur *before* the single-use token is consumed, allowing Odoo's automatic retry mechanism to succeed safely.

opw-5475032

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
