### PR TITLE
[FIX] l10n_{hr,ro}_edi: Fix dependency to Peppol BIS3 constraints

### DIFF
--- a/addons/l10n_hr_edi/models/account_edi_xml_ubl_hr.py
+++ b/addons/l10n_hr_edi/models/account_edi_xml_ubl_hr.py
@@ -63,7 +63,11 @@ class AccountEdiXmlUBLHR(models.AbstractModel):
         return nsmap
 
     def _export_invoice_constraints_new(self, invoice, vals):
-        constraints = super()._export_invoice_constraints_new(invoice, vals)
+        # OVERRIDE 'account.edi.xml.ubl_bis3': don't apply Peppol rules
+        constraints = self.env['account.edi.xml.ubl_20']._export_invoice_constraints(invoice, vals)
+        constraints.update(
+            self._invoice_constraints_cen_en16931_ubl_new(invoice, vals)
+        )
         constraints.update(
             self._invoice_constraints_eracun_new(invoice, vals)
         )

--- a/addons/l10n_ro_edi/models/account_edi_xml_ubl_ciusro.py
+++ b/addons/l10n_ro_edi/models/account_edi_xml_ubl_ciusro.py
@@ -239,6 +239,10 @@ class AccountEdiXmlUBLRO(models.AbstractModel):
             }]
 
     def _export_invoice_constraints_new(self, invoice, vals):
-        constraints = super()._export_invoice_constraints_new(invoice, vals)
+        # OVERRIDE 'account.edi.xml.ubl_bis3': don't apply Peppol rules
+        constraints = self.env['account.edi.xml.ubl_20']._export_invoice_constraints(invoice, vals)
+        constraints.update(
+            self._invoice_constraints_cen_en16931_ubl_new(invoice, vals)
+        )
         constraints.update(self._export_invoice_constraints_ciusro(vals))
         return constraints

--- a/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_no_prefix_vat.xml
+++ b/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_no_prefix_vat.xml
@@ -52,7 +52,6 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="9947">___ignore___</cbc:EndpointID>
       <cac:PartyIdentification>
         <cbc:ID>ref_partner_a</cbc:ID>
       </cac:PartyIdentification>

--- a/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
+++ b/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
@@ -178,7 +178,7 @@ class TestUBLRO(TestUBLROCommon):
 
     def test_export_no_vat_but_have_company_registry_without_prefix(self):
         self.company_data['company'].write({'vat': False, 'company_registry': '1234567897'})
-        self.partner_a.write({'vat': False})
+        self.partner_a.write({'vat': False, 'peppol_eas': False, 'peppol_endpoint': False})
         invoice = self.create_move("out_invoice", currency_id=self.company.currency_id.id)
         attachment = self.get_attachment(invoice)
         self._assert_invoice_attachment(attachment, xpaths=None, expected_file_path='from_odoo/ciusro_out_invoice_no_prefix_vat.xml')


### PR DESCRIPTION
The CIUS RO and CIUS HR depends on the BIS3 which is fundamentally incorrect. This was probably made out of lazyness to redefine things that are almost the same in both these CIUS and the BIS3.
Now, in previous PR [1], we added contraints for the Peppol BIS 3 that are impacting those formats. Indeed, the EndpointID can be empty in the context of CIUS RO and CIUS HR. In particular, it's breaking the sending to physical person at the moment.

[1]: https://github.com/odoo/odoo/pull/246961

opw-5943698
