### PR TITLE
[REF] bus, mail: use user rather than partner as bus target

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -755,14 +755,16 @@ class AccountTestInvoicingCommon(ProductCommon):
         )
 
     @classmethod
-    def _create_account_move_send_wizard_single(cls, move, **kwargs):
+    def _create_account_move_send_wizard_single(cls, move, *, as_user=None, **kwargs):
         return cls.env['account.move.send.wizard']\
+            .with_user(as_user)\
             .with_context(active_model='account.move', active_ids=move.ids)\
             .create(kwargs)
 
     @classmethod
-    def _create_account_move_send_wizard_multi(cls, moves, **kwargs):
+    def _create_account_move_send_wizard_multi(cls, moves, *, as_user=None, **kwargs):
         return cls.env['account.move.send.batch.wizard']\
+            .with_user(as_user)\
             .with_context(active_model='account.move', active_ids=moves.ids)\
             .create(kwargs)
 

--- a/addons/base_geolocalize/tests/test_geolocalize.py
+++ b/addons/base_geolocalize/tests/test_geolocalize.py
@@ -43,12 +43,11 @@ class TestPartnerGeoLocalization(TransactionCase):
     def test_geo_localization_notification(self):
         """ Warning message is sent to the user when geolocation fails. """
         partner = self.env['res.partner']
-        user_partner = self.env.user.partner_id
 
         with patch.object(self.env.registry['bus.bus'], '_sendone') as mock_send:
             partner1 = partner.create({'name': 'Test A'})
             partner1.with_context(force_geo_localize=True).geo_localize()
-            mock_send.assert_called_with(user_partner, 'simple_notification', {
+            mock_send.assert_called_with(self.env.user, 'simple_notification', {
                 'type': 'danger',
                 'title': "Warning",
                 'message': "No match found for Test A address(es).",
@@ -57,7 +56,7 @@ class TestPartnerGeoLocalization(TransactionCase):
 
             partner2 = partner.create({'name': "", 'parent_id': partner1.id, 'type': 'other'})
             partner2.with_context(force_geo_localize=True).geo_localize()
-            mock_send.assert_called_with(user_partner, 'simple_notification', {
+            mock_send.assert_called_with(self.env.user, 'simple_notification', {
                 'type': 'danger',
                 'title': "Warning",
                 'message': "No match found for Test A, Other address(es).",

--- a/addons/bus/controllers/home.py
+++ b/addons/bus/controllers/home.py
@@ -13,8 +13,8 @@ def _admin_password_warn(uid):
     if ipaddress.ip_address(request.httprequest.remote_addr).is_private:
         return
     env = request.env(user=SUPERUSER_ID, su=True)
-    admin = env.ref('base.partner_admin')
-    if uid not in admin.user_ids.ids:
+    admin = env.ref("base.user_admin")
+    if uid != admin.id:
         return
     has_demo = bool(env['ir.module.module'].search_count([('demo', '=', True)]))
     if has_demo:

--- a/addons/bus/models/bus.py
+++ b/addons/bus/models/bus.py
@@ -140,6 +140,12 @@ class BusBus(models.Model):
         """
         self._ensure_hooks()
         channel = channel_with_db(self.env.cr.dbname, target)
+        if isinstance(channel, tuple) and len(channel) == 3 and channel[1] == "res.partner":
+            _logger.warning(
+                "Sending bus notifications on res.partner records is deprecated."
+                " Partners do not receive notifications unless they have dedicated user(s)."
+                " So please send on the expected res.users instead.",
+            )
         self.env.cr.precommit.data["bus.bus.values"].append(
             {
                 "channel": json_dump(channel),

--- a/addons/bus/models/bus_listener_mixin.py
+++ b/addons/bus/models/bus_listener_mixin.py
@@ -14,17 +14,12 @@ class BusListenerMixin(models.AbstractModel):
 
     def _bus_send(self, notification_type, message, /, *, subchannel=None):
         """Send a notification to the webclient."""
-        for record in self:
-            main_channel = record
-            while (new_main_channel := main_channel._bus_channel()) != main_channel:
-                main_channel = new_main_channel
+        for main_channel in self._bus_channels():
             assert isinstance(main_channel, models.Model)
-            if not main_channel:
-                continue
             main_channel.ensure_one()
             channel = main_channel if subchannel is None else (main_channel, subchannel)
             # _sendone: channel is safe (record or tuple with record)
             self.env["bus.bus"]._sendone(channel, notification_type, message)
 
-    def _bus_channel(self):
+    def _bus_channels(self):
         return self

--- a/addons/bus/models/ir_attachment.py
+++ b/addons/bus/models/ir_attachment.py
@@ -7,5 +7,5 @@ class IrAttachment(models.Model):
     _name = 'ir.attachment'
     _inherit = ["ir.attachment", "bus.listener.mixin"]
 
-    def _bus_channel(self):
-        return self.env.user
+    def _bus_channels(self):
+        return self.env.user._bus_channels()

--- a/addons/bus/models/ir_websocket.py
+++ b/addons/bus/models/ir_websocket.py
@@ -25,6 +25,7 @@ class IrWebsocket(models.AbstractModel):
         channels.extend(self.env.user.all_group_ids)
         if req.session.uid:
             channels.append(self.env.user.partner_id)
+            channels.append(self.env.user)
         return channels
 
     def _serve_ir_websocket(self, event_name, data):

--- a/addons/bus/models/res_partner.py
+++ b/addons/bus/models/res_partner.py
@@ -6,3 +6,7 @@ from odoo import models
 class ResPartner(models.Model):
     _name = "res.partner"
     _inherit = ["res.partner", "bus.listener.mixin"]
+
+    def _bus_channels(self):
+        # sudo: res.partner - can find all active users linked to partner when sending a bus notification
+        return self.sudo().with_context(active_test=True).user_ids._bus_channels()

--- a/addons/bus/models/res_users.py
+++ b/addons/bus/models/res_users.py
@@ -6,6 +6,3 @@ from odoo import models
 class ResUsers(models.Model):
     _name = "res.users"
     _inherit = ["res.users", "bus.listener.mixin"]
-
-    def _bus_channel(self):
-        return self.partner_id

--- a/addons/bus/models/res_users_settings.py
+++ b/addons/bus/models/res_users_settings.py
@@ -7,5 +7,5 @@ class ResUsersSettings(models.Model):
     _name = 'res.users.settings'
     _inherit = ["res.users.settings", "bus.listener.mixin"]
 
-    def _bus_channel(self):
-        return self.user_id
+    def _bus_channels(self):
+        return self.user_id._bus_channels()

--- a/addons/bus/tests/test_ir_websocket.py
+++ b/addons/bus/tests/test_ir_websocket.py
@@ -28,7 +28,7 @@ class TestIrWebsocket(WebsocketCase):
             channels = set(ir_websocket_model._build_bus_channel_list(["test_channel"]))
         expected_channels = {
             "test_channel",
-            test_user.partner_id,
+            test_user,
             self.env.ref("base.group_system"),
             self.env.ref("base.group_user"),
         }

--- a/addons/bus/tests/test_websocket_caryall.py
+++ b/addons/bus/tests/test_websocket_caryall.py
@@ -235,7 +235,7 @@ class TestWebsocketCaryall(WebsocketCase):
             self.assertEqual(mock.call_args[0][2], client_last_notification_id)
 
     def test_subscribe_to_custom_channel(self):
-        channel = self.env["res.partner"].create({"name": "John"})
+        channel = new_test_user(self.env, "John")
         websocket = self.websocket_connect()
         with patch.object(IrWebsocket, "_build_bus_channel_list", return_value=[channel]):
             self.subscribe(websocket, [], self.env['bus.bus']._bus_last_id())

--- a/addons/calendar/tests/test_event_notifications.py
+++ b/addons/calendar/tests/test_event_notifications.py
@@ -281,7 +281,7 @@ class TestEventNotifications(CalendarMailCommon):
 
         def get_bus_params():
             return (
-                [(self.env.cr.dbname, "res.partner", self.partner.id)],
+                [self.user],
                 [
                     {
                         "type": "calendar.alarm",
@@ -591,7 +591,7 @@ class TestEventNotifications(CalendarMailCommon):
 
         def get_bus_params():
             return (
-                [(self.env.cr.dbname, "res.partner", self.partner.id)],
+                [self.user],
                 [
                     {
                         "type": "calendar.alarm",

--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -953,7 +953,7 @@ class TestTimesheet(TestCommonTimesheet):
                 } for day in days for employee in (self.empl_employee, self.empl_employee2)])
 
             def assert_notification(mock_send, notification_type, message):
-                mock_send.assert_called_with(self.env.user.partner_id, 'simple_notification', {
+                mock_send.assert_called_with(self.env.user, 'simple_notification', {
                     'type': notification_type,
                     'message': message,
                 })

--- a/addons/im_livechat/models/discuss_channel_member.py
+++ b/addons/im_livechat/models/discuss_channel_member.py
@@ -157,9 +157,9 @@ class DiscussChannelMember(models.Model):
         ])
         sessions_to_be_unpinned = members.filtered(lambda m: m.message_unread_counter == 0)
         sessions_to_be_unpinned.channel_id.livechat_end_dt = fields.Datetime.now()
-        stores = lazymapping(lambda member: Store(bus_channel=member._bus_channel()))
-        for member in sessions_to_be_unpinned:
-            stores[member].add(member.channel_id, {"close_chat_window": True})
+        stores = lazymapping(lambda bus_channel: Store(bus_channel=bus_channel))
+        for member, store in sessions_to_be_unpinned._get_member_store_list(stores):
+            store.add(member.channel_id, {"close_chat_window": True})
         for store in stores.values():
             store.bus_send()
         sessions_to_be_unpinned.unpin_dt = fields.Datetime.now()

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -220,7 +220,7 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                 lambda m: m.partner_id == self.partner_employee
             )
             # data in-between join and leave
-            store = Store(bus_channel=member_emp._bus_channel())
+            store = Store(bus_channel=member_emp)
             store.add(discuss_channel, "_store_channel_fields")
             channel_data_join = store.get_result()
             channel_data_join["discuss.channel"][0]["livechat_outcome"] = "no_agent"
@@ -275,15 +275,15 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
             ).id
             channels, message_items = (
                 [
-                    (self.cr.dbname, "discuss.channel", discuss_channel.id),
-                    (self.cr.dbname, "discuss.channel", discuss_channel.id),
-                    (self.cr.dbname, "res.partner", self.partner_employee.id),
-                    (self.cr.dbname, "discuss.channel", discuss_channel.id),
-                    (self.cr.dbname, "discuss.channel", discuss_channel.id),
-                    (self.cr.dbname, "discuss.channel", discuss_channel.id),
-                    (self.cr.dbname, "discuss.channel", discuss_channel.id),
-                    (self.cr.dbname, "discuss.channel", discuss_channel.id),
-                    (self.cr.dbname, "res.partner", self.partner_employee.id),
+                    discuss_channel,  # discuss.channel/new_message (transfer)
+                    discuss_channel,  # mail.record/insert
+                    self.user_employee,  # discuss.channel/joined
+                    discuss_channel,  # discuss.channel/new_message (joined)
+                    discuss_channel,  # mail.record/insert
+                    discuss_channel,  # mail.record/insert"
+                    discuss_channel,  # mail.record/insert"
+                    discuss_channel,  # mail.record/insert"
+                    self.user_employee,  # mail.record/insert"
                 ],
                 [
                     {

--- a/addons/im_livechat/tests/test_discuss_channel.py
+++ b/addons/im_livechat/tests/test_discuss_channel.py
@@ -81,7 +81,7 @@ class TestDiscussChannel(TestImLivechatCommon, TestGetOperatorCommon, MailCase):
         )
         channel = self.env["discuss.channel"].browse(data["channel_id"])
         with self.assertBus(
-            [(self.cr.dbname, "discuss.channel", channel.id, "internal_users")],
+            [(channel, "internal_users")],
             [
                 {
                     "type": "mail.record/insert",
@@ -106,7 +106,7 @@ class TestDiscussChannel(TestImLivechatCommon, TestGetOperatorCommon, MailCase):
         )
         channel = self.env["discuss.channel"].browse(data["channel_id"])
         with self.assertBus(
-            [(self.cr.dbname, "discuss.channel", channel.id, "internal_users")],
+            [(channel, "internal_users")],
             [
                 {
                     "type": "mail.record/insert",
@@ -133,12 +133,9 @@ class TestDiscussChannel(TestImLivechatCommon, TestGetOperatorCommon, MailCase):
             {"channel_id": self.livechat_channel.id},
         )
         channel = self.env["discuss.channel"].browse(data["channel_id"])
-        group_id = self.env.ref("im_livechat.im_livechat_group_user").id
+        group = self.env.ref("im_livechat.im_livechat_group_user")
         with self.assertBus(
-            [
-                (self.cr.dbname, "discuss.channel", channel.id, "internal_users"),
-                (self.cr.dbname, "res.groups", group_id, "LOOKING_FOR_HELP"),
-            ]
+            [(channel, "internal_users"), (group, "LOOKING_FOR_HELP")],
         ):
             channel.livechat_status = "need_help"
 

--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -249,10 +249,8 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
             rating = self.env["rating.rating"].sudo().search([], order="id desc", limit=1)
             return (
                 [
-                    # unread counter/new message separator (not asserted below)
-                    (self.env.cr.dbname, "res.partner", self.env.user.partner_id.id),
-                    # new_message
-                    (self.env.cr.dbname, "discuss.channel", channel.id),
+                    self.env.user,  # unread counter/new message separator (not asserted below)
+                    channel,  # new_message
                 ],
                 [
                     {

--- a/addons/l10n_in/models/res_partner.py
+++ b/addons/l10n_in/models/res_partner.py
@@ -149,7 +149,7 @@ class ResPartner(models.Model):
         except AccessError:
             raise UserError(_("Unable to connect with GST network"))
         if response.get('error') and any(e.get('code') == 'no-credit' for e in response['error']):
-            return self.env["bus.bus"]._sendone(self.env.user.partner_id, "iap_notification",
+            return self.env.user._bus_send("iap_notification",
                 {
                     "type": "no_credit",
                     "title": _("Not enough credits to check GSTIN status"),

--- a/addons/l10n_tr_nilvera/models/res_config_settings.py
+++ b/addons/l10n_tr_nilvera/models/res_config_settings.py
@@ -32,22 +32,22 @@ class ResConfigSettings(models.TransientModel):
             if response.status_code == 200:
                 nilvera_registered_tax_number = response.json().get('TaxNumber')
                 if self.env.company.vat == nilvera_registered_tax_number:
-                    self.env['bus.bus']._sendone(self.env.user.partner_id, 'simple_notification', {
+                    self.env.user._bus_send('simple_notification', {
                         'type': 'success',
                         'message': _("Nilvera connection successful!"),
                     })
                 else:
-                    self.env['bus.bus']._sendone(self.env.user.partner_id, 'simple_notification', {
+                    self.env.user._bus_send('simple_notification', {
                         'type': 'success',
                         'message': _("Nilvera connection successful but the tax number on Nilvera and Odoo doesn't match. Check Nilvera."),
                     })
             elif response.status_code == 401:
-                self.env['bus.bus']._sendone(self.env.user.partner_id, 'simple_notification', {
+                self.env.user._bus_send('simple_notification', {
                     'type': 'danger',
                     'message': _("Nilvera connection was unsuccessful, check the API key."),
                 })
             else:
-                self.env['bus.bus']._sendone(self.env.user.partner_id, 'simple_notification', {
+                self.env.user._bus_send('simple_notification', {
                     'type': 'danger',
                     'message': _("An error occurred. Try again later."),
                 })

--- a/addons/mail/models/discuss/bus_sync_mixin.py
+++ b/addons/mail/models/discuss/bus_sync_mixin.py
@@ -38,18 +38,19 @@ class BusSyncMixin(models.AbstractModel):
             """Get the current values of the fields to sync."""
             result = defaultdict(dict)
             for bus_target, field_descriptions in fields_to_sync.items():
-                target = (
+                target, sub_channel = (
                     (record[bus_target[0]], bus_target[1])
                     if isinstance(bus_target, tuple)
-                    else (record._bus_channel(), bus_target)
+                    else (record, bus_target)
                 )
-                result[target] = {
-                    Store.get_field_name(field_description): (
-                        get_field_value(record, field_description),
-                        field_description,
-                    )
-                    for field_description in field_descriptions
-                }
+                for bus_channel in target._bus_channels():
+                    result[bus_channel, sub_channel] = {
+                        Store.get_field_name(field_description): (
+                            get_field_value(record, field_description),
+                            field_description,
+                        )
+                        for field_description in field_descriptions
+                    }
             return result
 
         self._sync_field_names(fields_to_sync := defaultdict(Store.FieldList))

--- a/addons/mail/models/discuss/discuss_channel_rtc_session.py
+++ b/addons/mail/models/discuss/discuss_channel_rtc_session.py
@@ -97,8 +97,8 @@ class DiscussChannelRtcSession(models.Model):
             store.bus_send()
         return super().unlink()
 
-    def _bus_channel(self):
-        return self.channel_member_id._bus_channel()
+    def _bus_channels(self):
+        return self.channel_member_id._bus_channels()
 
     def _update_and_broadcast(self, values):
         """ Updates the session and notifies all members of the channel

--- a/addons/mail/models/discuss/ir_attachment.py
+++ b/addons/mail/models/discuss/ir_attachment.py
@@ -9,14 +9,14 @@ class IrAttachment(models.Model):
 
     voice_ids = fields.One2many("discuss.voice.metadata", "attachment_id")
 
-    def _bus_channel(self):
+    def _bus_channels(self):
         self.ensure_one()
         if self.res_model == "discuss.channel" and self.res_id:
-            return self.env["discuss.channel"].browse(self.res_id)
+            return self.env["discuss.channel"].browse(self.res_id)._bus_channels()
         guest = self.env["mail.guest"]._get_guest_from_context()
         if self.env.user._is_public() and guest:
-            return guest
-        return super()._bus_channel()
+            return guest._bus_channels()
+        return super()._bus_channels()
 
     def _store_attachment_fields(self, res: Store.FieldList):
         super()._store_attachment_fields(res)

--- a/addons/mail/models/discuss/mail_message.py
+++ b/addons/mail/models/discuss/mail_message.py
@@ -45,11 +45,11 @@ class MailMessage(models.Model):
                 sudo=True,
             )
 
-    def _bus_channel(self):
+    def _bus_channels(self):
         self.ensure_one()
         if self.channel_id:
-            return self.channel_id
+            return self.channel_id._bus_channels()
         guest = self.env["mail.guest"]._get_guest_from_context()
         if self.env.user._is_public() and guest:
-            return guest
-        return super()._bus_channel()
+            return guest._bus_channels()
+        return super()._bus_channels()

--- a/addons/mail/models/ir_websocket.py
+++ b/addons/mail/models/ir_websocket.py
@@ -104,7 +104,7 @@ class IrWebsocket(models.AbstractModel):
     def _after_subscribe_data(self, data):
         user, guest = self.env["res.users"]._get_current_persona()
         if user or guest:
-            data["missed_presences"]._send_presence(bus_target=user.partner_id or guest)
+            data["missed_presences"]._send_presence(bus_target=user or guest)
 
     def _on_websocket_closed(self, cookies):
         super()._on_websocket_closed(cookies)

--- a/addons/mail/models/mail_link_preview.py
+++ b/addons/mail/models/mail_link_preview.py
@@ -97,7 +97,7 @@ class MailLinkPreview(models.Model):
             ]
         )
         (message.sudo().message_link_preview_ids - message_link_previews_ok)._unlink_and_notify()
-        Store(bus_channel=message._bus_channel()).add(message, "_store_message_link_previews_fields").bus_send()
+        Store(bus_channel=message).add(message, "_store_message_link_previews_fields").bus_send()
 
     @api.model
     def _is_link_preview_enabled(self):

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1025,7 +1025,7 @@ class MailMessage(models.Model):
         self._bus_send_reaction_group(content)
 
     def _bus_send_reaction_group(self, content):
-        store = Store(bus_channel=self._bus_channel())
+        store = Store(bus_channel=self)
         store.add(self, "_store_reaction_group_fields", fields_params={"content": content})
         store.bus_send()
 
@@ -1353,8 +1353,8 @@ class MailMessage(models.Model):
                 store.add(user_messages, "_store_notification_fields")
                 store.bus_send()
 
-    def _bus_channel(self):
-        return self.env.user
+    def _bus_channels(self):
+        return self.env.user._bus_channels()
 
     # ------------------------------------------------------
     # TOOLS

--- a/addons/mail/models/mail_message_link_preview.py
+++ b/addons/mail/models/mail_message_link_preview.py
@@ -20,21 +20,21 @@ class MessageMailLinkPreview(models.Model):
 
     _unique_message_link_preview = models.UniqueIndex("(message_id, link_preview_id)")
 
-    def _bus_channel(self):
-        return self.message_id._bus_channel()
+    def _bus_channels(self):
+        return self.message_id._bus_channels()
 
     def _hide_and_notify(self):
         if not self:
             return
         self.is_hidden = True
         for message_link_preview in self:
-            Store(bus_channel=self._bus_channel()).delete(message_link_preview).bus_send()
+            Store(bus_channel=self).delete(message_link_preview).bus_send()
 
     def _unlink_and_notify(self):
         if not self:
             return
         for message_link_preview in self:
-            Store(bus_channel=self._bus_channel()).delete(message_link_preview).bus_send()
+            Store(bus_channel=self).delete(message_link_preview).bus_send()
         self.unlink()
 
     def _store_message_link_preview_fields(self, res: Store.FieldList):

--- a/addons/mail/models/mail_presence.py
+++ b/addons/mail/models/mail_presence.py
@@ -97,16 +97,17 @@ class MailPresence(models.Model):
         :param im_status: 'online', 'away' or 'offline'
         """
         for presence in self:
-            target = bus_target or presence.guest_id or presence.user_id.partner_id
-            target._bus_send(
+            persona = presence.guest_id or presence.user_id.partner_id
+            target = bus_target or (persona, "presence")
+            self.env["bus.bus"]._sendone(
+                target,
                 "bus.bus/im_status_updated",
                 {
                     "presence_status": im_status or presence.status,
-                    "im_status": target.im_status,
+                    "im_status": im_status or persona.im_status,
                     "guest_id": presence.guest_id.id,
                     "partner_id": presence.user_id.partner_id.id,
                 },
-                subchannel="presence" if not bus_target else None,
             )
 
     @api.autovacuum

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2974,7 +2974,7 @@ class MailThread(models.AbstractModel):
             "UPDATE mail_message SET pinned_at=%(pinned_at)s WHERE id=%(id)s",
             {"pinned_at": fields.Datetime.now() if pinned else None, "id": message.id},
         )
-        Store(bus_channel=message._bus_channel()).add(message, ["pinned_at"]).bus_send()
+        Store(bus_channel=message).add(message, ["pinned_at"]).bus_send()
         return True
 
     # ------------------------------------------------------------
@@ -5061,7 +5061,7 @@ class MailThread(models.AbstractModel):
             self.env["mail.message.translation"].sudo().search(
                 [("message_id", "=", message.id)],
             ).unlink()
-        Store(bus_channel=message._bus_channel()).add(
+        Store(bus_channel=message).add(
             message,
             lambda res: (
                 res.many("attachment_ids", "_store_attachment_fields", sort="id"),

--- a/addons/mail/tests/discuss/test_discuss_category.py
+++ b/addons/mail/tests/discuss/test_discuss_category.py
@@ -15,9 +15,7 @@ class TestDiscussCategory(MailCommon, HttpCase):
 
         def get_assign_channel_category_bus():
             return (
-                [
-                    (self.cr.dbname, "discuss.channel", self.channel.id),
-                ],
+                [self.channel],
                 [
                     {
                         "type": "mail.record/insert",

--- a/addons/mail/tests/discuss/test_guest.py
+++ b/addons/mail/tests/discuss/test_guest.py
@@ -33,11 +33,7 @@ class TestGuest(MailCase):
             }
 
             return (
-                [
-                    (self.cr.dbname, "discuss.channel", channel_1.id),
-                    (self.cr.dbname, "discuss.channel", channel_2.id),
-                    (self.cr.dbname, "mail.guest", guest.id),
-                ],
+                [channel_1, channel_2, guest],
                 [message, message, message],
             )
 

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -42,15 +42,15 @@ class TestChannelRTC(MailCommon, HttpCase):
         with self.assertBus(
             [
                 # end of old sessions
-                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
+                self.user_employee,
                 # delete of old sessions, update history with duration of previous session
-                (self.cr.dbname, "discuss.channel", channel.id),
+                channel,
                 # new_message_separator (message post)
-                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
+                self.user_employee,
                 # start call notification (message post) (not asserted below)
-                (self.cr.dbname, "discuss.channel", channel.id),
+                channel,
                 # insert new session, new call history
-                (self.cr.dbname, "discuss.channel", channel.id),
+                channel,
             ],
             [
                 {
@@ -157,15 +157,15 @@ class TestChannelRTC(MailCommon, HttpCase):
         with self.assertBus(
             [
                 # update new message separator (message_post) (not asserted below)
-                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
+                self.user_employee,
                 # message_post "started a live conference" (not asserted below)
-                (self.cr.dbname, "discuss.channel", channel.id),
+                channel,
                 # update new session, update call history
-                (self.cr.dbname, "discuss.channel", channel.id),
+                channel,
                 # incoming invitation
-                (self.cr.dbname, "res.partner", test_user.partner_id.id),
+                test_user,
                 # update list of invitations (not asserted below)
-                (self.cr.dbname, "discuss.channel", channel.id),
+                channel,
             ],
             [
                 {
@@ -270,17 +270,17 @@ class TestChannelRTC(MailCommon, HttpCase):
         with self.assertBus(
             [
                 # update new message separator (not asserted below)
-                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
+                self.user_employee,
                 # message_post "started a live conference" (not asserted below)
-                (self.cr.dbname, "discuss.channel", channel.id),
+                channel,
                 # update new session, update call history
-                (self.cr.dbname, "discuss.channel", channel.id),
+                channel,
                 # incoming invitation
-                (self.cr.dbname, "res.partner", test_user.partner_id.id),
+                test_user,
                 # incoming invitation
-                (self.cr.dbname, "mail.guest", test_guest.id),
+                test_guest,
                 # update list of invitations
-                (self.cr.dbname, "discuss.channel", channel.id),
+                channel,
             ],
             [
                 {
@@ -448,12 +448,9 @@ class TestChannelRTC(MailCommon, HttpCase):
         last_rtc_session_id = channel_member.rtc_session_ids.id
         with self.assertBus(
             [
-                # update invitation
-                (self.cr.dbname, "res.partner", test_user.partner_id.id),
-                # update list of invitations
-                (self.cr.dbname, "discuss.channel", channel.id),
-                # update sessions
-                (self.cr.dbname, "discuss.channel", channel.id),
+                test_user,  # update invitation
+                channel,  # update list of invitations
+                channel,  # update sessions
             ],
             [
                 {
@@ -548,12 +545,9 @@ class TestChannelRTC(MailCommon, HttpCase):
         channel_member_test_guest = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.guest_id == test_guest)
         with self.assertBus(
             [
-                # update invitation
-                (self.cr.dbname, "mail.guest", test_guest.id),
-                # update list of invitations
-                (self.cr.dbname, "discuss.channel", channel.id),
-                # update sessions
-                (self.cr.dbname, "discuss.channel", channel.id),
+                test_guest,  # update invitation
+                channel,  # update list of invitations
+                channel,  # update sessions
             ],
             [
                 {
@@ -653,10 +647,8 @@ class TestChannelRTC(MailCommon, HttpCase):
         channel_member_test_user = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == test_user.partner_id)
         with self.assertBus(
             [
-                # update invitation
-                (self.cr.dbname, "res.partner", test_user.partner_id.id),
-                # update list of invitations
-                (self.cr.dbname, "discuss.channel", channel.id),
+                test_user,  # update invitation
+                channel,  # update list of invitations
             ],
             [
                 {
@@ -712,10 +704,8 @@ class TestChannelRTC(MailCommon, HttpCase):
         channel_member_test_guest = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.guest_id == test_guest)
         with self.assertBus(
             [
-                # update invitation
-                (self.cr.dbname, "mail.guest", test_guest.id),
-                # update list of invitations
-                (self.cr.dbname, "discuss.channel", channel.id),
+                test_guest,  # update invitation
+                channel,  # update list of invitations
             ],
             [
                 {
@@ -781,16 +771,11 @@ class TestChannelRTC(MailCommon, HttpCase):
         last_rtc_session_id = channel_member.rtc_session_ids.id
         with self.assertBus(
             [
-                # update invitation
-                (self.cr.dbname, "res.partner", test_user.partner_id.id),
-                # update invitation
-                (self.cr.dbname, "mail.guest", test_guest.id),
-                # update list of invitations
-                (self.cr.dbname, "discuss.channel", channel.id),
-                # end session
-                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
-                # update sessions, update call history
-                (self.cr.dbname, "discuss.channel", channel.id),
+                test_user,  # update invitation
+                test_guest,  # update invitation
+                channel,  # update list of invitations
+                self.user_employee,  # end session
+                channel,  # update sessions, update call history
             ],
             [
                 {
@@ -923,27 +908,27 @@ class TestChannelRTC(MailCommon, HttpCase):
         found_bus_notifs = self.assertBusNotifications(
             [
                 # mail.record/insert - discuss.channel (channel_name_member_ids)
-                (self.cr.dbname, "discuss.channel", channel.id),
+                channel,
                 # discuss.channel/joined
-                (self.cr.dbname, "res.partner", test_user.partner_id.id),
+                test_user,
                 # mail.record/insert - discuss.channel.member (message_unread_counter, new_message_separator, …)
-                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
+                self.user_employee,
                 # discuss.channel/new_message
-                (self.cr.dbname, "discuss.channel", channel.id),
+                channel,
                 # discuss.channel/joined
-                (self.cr.dbname, "mail.guest", test_guest.id),
+                test_guest,
                 # mail.record/insert - discuss.channel.member (message_unread_counter, new_message_separator, …)
-                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
+                self.user_employee,
                 # discuss.channel/new_message
-                (self.cr.dbname, "discuss.channel", channel.id),
+                channel,
                 # mail.record/insert - discuss.channel (member_count), discuss.channel.member
-                (self.cr.dbname, "discuss.channel", channel.id),
+                channel,
                 # mail.record/insert - discuss.channel.member (rtc_inviting_session_id)
-                (self.cr.dbname, "res.partner", test_user.partner_id.id),
+                test_user,
                 # mail.record/insert - discuss.channel.member (rtc_inviting_session_id)
-                (self.cr.dbname, "mail.guest", test_guest.id),
+                test_guest,
                 # mail.record/insert - discuss.channel (invited_member_ids), discuss.channel.member
-                (self.cr.dbname, "discuss.channel", channel.id),
+                channel,
             ],
             message_items=[
                 {
@@ -1104,10 +1089,8 @@ class TestChannelRTC(MailCommon, HttpCase):
         last_rtc_session_id = channel_member.rtc_session_ids.id
         with self.assertBus(
             [
-                # end session
-                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
-                # update list of sessions, update call history
-                (self.cr.dbname, "discuss.channel", channel.id),
+                self.user_employee,  # end session
+                channel,  # update list of sessions, update call history
             ],
             [
                 {
@@ -1151,10 +1134,8 @@ class TestChannelRTC(MailCommon, HttpCase):
         last_rtc_session_id = channel_member.rtc_session_ids.id
         with self.assertBus(
             [
-                # session ended
-                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
-                # update list of sessions, update call history duration
-                (self.cr.dbname, "discuss.channel", channel.id),
+                self.user_employee,  # session ended
+                channel,  # update list of sessions, update call history duration
             ],
             [
                 {
@@ -1194,10 +1175,8 @@ class TestChannelRTC(MailCommon, HttpCase):
         last_rtc_session_id = channel_member.rtc_session_ids.id
         with self.assertBus(
             [
-                # session ended
-                (self.cr.dbname, "res.partner", self.user_employee.partner_id.id),
-                # update list of sessions, update call history duration
-                (self.cr.dbname, "discuss.channel", channel.id),
+                self.user_employee,  # session ended
+                channel,  # update list of sessions, update call history duration
             ],
             [
                 {
@@ -1246,10 +1225,8 @@ class TestChannelRTC(MailCommon, HttpCase):
         unused_ids = [9998, 9999]
         with self.assertBus(
             [
-                # session ended
-                (self.cr.dbname, "mail.guest", test_guest.id),
-                # update list of sessions
-                (self.cr.dbname, "discuss.channel", channel.id),
+                test_guest,  # session ended
+                channel,  # update list of sessions
             ],
             [
                 {

--- a/addons/mail/tests/test_ir_websocket.py
+++ b/addons/mail/tests/test_ir_websocket.py
@@ -83,7 +83,7 @@ class TestIrWebsocket(WebsocketCase):
         bus_record = self.env["bus.bus"].search([("id", "=", int(notification["id"]))])
         self.assertEqual(
             bus_record.channel,
-            json_dump(channel_with_db(self.env.cr.dbname, bob.partner_id)),
+            json_dump(channel_with_db(self.env.cr.dbname, bob)),
         )
         self.assertEqual(notification["message"]["type"], "bus.bus/im_status_updated")
         self.assertEqual(notification["message"]["payload"]["im_status"], "online")

--- a/addons/mail/tests/test_link_preview.py
+++ b/addons/mail/tests/test_link_preview.py
@@ -144,7 +144,7 @@ class TestLinkPreview(MailCommon):
 
             def get_bus_params():
                 return (
-                    [(self.cr.dbname, "res.partner", self.env.user.partner_id.id)],
+                    [self.env.user],
                     [
                         {
                             "type": "mail.record/insert",

--- a/addons/mail/tests/test_mail_message.py
+++ b/addons/mail/tests/test_mail_message.py
@@ -45,8 +45,9 @@ class TestMailMessage(common.MailCommon, HttpCase):
         self.assertIn(message_c1, search_result)
         self.assertNotIn(message_c2, search_result)
 
+    @users("employee")
     def test_unlink_failure_message_notify_author(self):
-        recipient = new_test_user(self.env, login="Bob", email="invalid_email_addr")
+        recipient = new_test_user(self.env(su=True), login="Bob", email="invalid_email_addr")
         with self.mock_mail_gateway():
             message = self.env.user.partner_id.message_post(
                 body="Hello world!", partner_ids=recipient.partner_id.ids
@@ -55,10 +56,7 @@ class TestMailMessage(common.MailCommon, HttpCase):
         self.assertEqual(message.notification_ids.res_partner_id, recipient.partner_id)
         self.assertEqual(message.notification_ids.author_id, self.env.user.partner_id)
         with self.assertBus(
-            [
-                (self.cr.dbname, "res.partner", recipient.partner_id.id),
-                (self.cr.dbname, "res.partner", self.env.user.partner_id.id),
-            ],
+            [recipient, self.env.user],
             [
                 {"type": "mail.message/delete", "payload": {"message_ids": [message.id]}},
                 {"type": "mail.message/delete", "payload": {"message_ids": [message.id]}},

--- a/addons/mail/tests/test_res_users.py
+++ b/addons/mail/tests/test_res_users.py
@@ -7,8 +7,8 @@ from unittest import skip
 from unittest.mock import patch
 
 from odoo.addons.base.models.res_users import ResUsersPatchedInTest
-from odoo.addons.mail.tests.common import MailCommon, mail_new_test_user
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
+from odoo.addons.mail.tests.common import MailCommon, mail_new_test_user
 from odoo.tests import RecordCapturer, tagged, users
 from odoo.tools import mute_logger
 
@@ -249,7 +249,7 @@ class TestUserSettings(MailCommon):
         settings.channel_notifications = False
 
         with self.assertBus(
-                [(self.cr.dbname, 'res.partner', self.partner_employee.id)],
+                [self.user_employee],
                 [{
                     'type': 'res.users.settings',
                     'payload': {

--- a/addons/mail/tests/test_websocket_controller.py
+++ b/addons/mail/tests/test_websocket_controller.py
@@ -54,7 +54,7 @@ class TestWebsocketController(HttpCaseWithUserDemo):
         )["notifications"][0]
         bus_record = self.env["bus.bus"].search([("id", "=", int(notification["id"]))])
         self.assertEqual(
-            bus_record.channel, json_dump(channel_with_db(self.env.cr.dbname, self.partner_demo))
+            bus_record.channel, json_dump(channel_with_db(self.env.cr.dbname, self.user_demo)),
         )
         self.assertEqual(notification["message"]["type"], "bus.bus/im_status_updated")
         self.assertEqual(notification["message"]["payload"]["partner_id"], self.partner_demo.id)

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -342,6 +342,8 @@ class Store:
             assert channel is None or isinstance(channel, models.Model), (
                 f"channel should be None or a record: {channel}"
             )
+            if channel is not None:
+                channel = channel._bus_channels()
             assert channel is None or len(channel) <= 1, (
                 f"channel should be empty or should be a single record: {channel}"
             )

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -446,7 +446,7 @@ class TestPointOfSaleFlow(CommonPosTest):
         # Making the invoice draft should send a warning notification to the user
         with patch.object(self.env.registry['bus.bus'], '_sendone') as mock_send:
             invoice.button_draft()
-            mock_send.assert_called_with(self.env.user.partner_id, 'simple_notification', {
+            mock_send.assert_called_with(self.env.user, 'simple_notification', {
                 'type': 'danger',
                 'message': "You can't reset this invoice to draft because the POS session is still open. Please close the ongoing session first, then try again.",
                 'sticky': True,

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import date, datetime, timedelta, UTC
@@ -666,7 +665,7 @@ class TestActivitySystrayBusNotify(TestActivityCommon):
         users = self.env.user + self.user_employee_2
 
         expected_create_notifs = [
-            ([(self.env.cr.dbname, user.partner_id._name, user.partner_id.id)], [{
+            ([user], [{
                 "type": "mail.activity/updated",
                 "payload": {
                     "activity_created": True,
@@ -676,7 +675,7 @@ class TestActivitySystrayBusNotify(TestActivityCommon):
             for user in users
         ]
         expected_unlink_notifs = [
-            ([(self.env.cr.dbname, user.partner_id._name, user.partner_id.id)], [{
+            ([user], [{
                 "type": "mail.activity/updated",
                 "payload": {
                     "activity_deleted": True,
@@ -714,7 +713,7 @@ class TestActivitySystrayBusNotify(TestActivityCommon):
         expected_notifs = [
             # transfer 4 activities to the second employee, 2 todos taken and 2 given
             [
-                ([(self.env.cr.dbname, user.partner_id._name, user.partner_id.id)], [{
+                ([user], [{
                     "type": "mail.activity/updated",
                     "payload": {
                         "count_diff": count_diff,
@@ -725,7 +724,7 @@ class TestActivitySystrayBusNotify(TestActivityCommon):
             ],
             # transfer 4 activities to the second employee, 2 todos are taken and 4 are given
             [
-                ([(self.env.cr.dbname, user.partner_id._name, user.partner_id.id)], [{
+                ([user], [{
                     "type": "mail.activity/updated",
                     "payload": {
                         "count_diff": count_diff,
@@ -735,7 +734,7 @@ class TestActivitySystrayBusNotify(TestActivityCommon):
                 in zip(self.user_employee + self.user_employee_2, [-2, 4])
             ],
         ] + [[
-                ([(self.env.cr.dbname, self.user_employee.partner_id._name, self.user_employee.partner_id.id)], [{
+                ([self.user_employee], [{
                     "type": "mail.activity/updated",
                     "payload": {
                         "count_diff": count_diff,

--- a/addons/test_mail/tests/test_mail_multicompany.py
+++ b/addons/test_mail/tests/test_mail_multicompany.py
@@ -3,13 +3,11 @@
 import socket
 
 from itertools import product
-from freezegun import freeze_time
 from unittest.mock import patch
 from werkzeug.urls import url_parse
 
 from odoo.addons.mail.models.mail_message import MailMessage
 from odoo.addons.mail.tests.common import MailCommon, mail_new_test_user
-from odoo.addons.test_mail.models.test_mail_corner_case_models import MailTestMultiCompanyWithActivity
 from odoo.addons.test_mail.tests.common import TestRecipients
 from odoo.exceptions import AccessError
 from odoo.tests import tagged, users, HttpCase
@@ -258,7 +256,7 @@ class TestMultiCompanySetup(TestMailMCCommon, HttpCase):
     def test_recipients_multi_company(self):
         """Test mentioning a partner with no common company."""
         test_records_mc_c2 = self.test_records_mc[1]
-        with self.assertBus([(self.cr.dbname, "res.partner", self.user_employee_c3.partner_id.id)]):
+        with self.assertBus([self.user_employee_c3]):
             test_records_mc_c2.with_user(self.user_employee_c2).with_context(
                 allowed_company_ids=self.company_2.ids
             ).message_post(

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -1176,7 +1176,7 @@ class TestDiscuss(MailCommon, TestRecipients):
             # mark all as read clear needactions
             msg1 = self.test_record.message_post(body='Test', message_type='comment', subtype_xmlid='mail.mt_comment', partner_ids=[employee_partner.id])
             with self.assertBus(
-                    [(self.cr.dbname, 'res.partner', employee_partner.id)],
+                    [self.user_employee],
                     message_items=[{
                         'type': 'mail.message/mark_as_read',
                         'payload': {
@@ -1202,7 +1202,7 @@ class TestDiscuss(MailCommon, TestRecipients):
             self.assertEqual(na_count, 1, "message not accessible is currently still counted")
 
             with self.assertBus(
-                    [(self.cr.dbname, 'res.partner', employee_partner.id)],
+                    [self.user_employee],
                     message_items=[{
                         'type': 'mail.message/mark_as_read',
                         'payload': {

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1584,10 +1584,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                 lambda n: n.res_partner_id == self.user_follower_emp_inbox.partner_id
             )
             return (
-                [
-                    (self.cr.dbname, "res.partner", self.user_emp_inbox.partner_id.id),
-                    (self.cr.dbname, "res.partner", self.user_follower_emp_inbox.partner_id.id),
-                ],
+                [self.user_emp_inbox, self.user_follower_emp_inbox],
                 [
                     {
                         "type": "mail.message/inbox",


### PR DESCRIPTION
Going from user to partner is easy (`partner_id` is a one). Going from partner to user is complex (`user_ids` is a many).

We should therefore keep relations with users and pass users to method as much as possible.

In particular we have several places where we define bus target and we have to check access of the receiving target to avoid leaking data, this check is clear when the target is a user, but is more complex when the target is a partner as we have to check all the users linked to this partner, and we can't easily split the payload for each specific user.

Side-changes:

- `_bus_channel()` is transformed into `_bus_channels()` because sending on partner needs to return multiple users to keep the same behavior.
- `Store` now calls `_bus_channels()` internally, as the extra step was only to allow receiving users and not transforming them into partners too early, which is no longer happening.
- `_bus_send()` no longer needs to recursively check channels for the same reason.
- Fixed issues in the presence code that relied on target (which for user was partner) when it should explicitly send on partner instead.
- simplified assert bus API in tests, as it was extremely redundant. Business tests only care about the business channel, not the internal bus format.

Note: sending on partner with `_bus_send()` still works after this PR, it just sends to all users linked to the partner, which is the same behavior as before the PR.

Manual send with `_sendone()` where partner is provided will keep working too as the partner itself is kept as a subscriber for now. This is only to avoid breaking old custom code, but business code should eventually be adapted to avoid `_sendone()` in favor of `_bus_send()`.

Note 2: sending on `self.env.user` will now only send to the currently logged in user and no longer to all other users linked to the same partner.

task-5946430

https://github.com/odoo/enterprise/pull/107705