### PR TITLE
[FIX] pos_self_order: fix worldline stuck

### DIFF
--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -799,6 +799,8 @@ export class SelfOrder extends Reactive {
                 access_token: this.access_token,
             });
             return;
+        } else if (typeof error === "string") {
+            message = error;
         }
 
         this.notification.add(message, {


### PR DESCRIPTION
This PR fixes some payments in pos kiosk being stuck with iot worldline terminal.
It allows to succesfully interpret when the terminal is disconnected and adapts the error messages to the information received fromthe terminal instead of the current generic "An error has occurred"

enterprise: https://github.com/odoo/enterprise/pull/107709
task-5946033
