### PR TITLE
[FIX] project : Avoid override recurrence values with defaults

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1073,7 +1073,8 @@ class Task(models.Model):
     def _load_records_create(self, vals_list):
         for vals in vals_list:
             if vals.get('recurring_task'):
-                if not vals.get('recurrence_id'):
+                rec_fields = vals.keys() & self._get_recurrence_fields()
+                if not vals.get('recurrence_id') and not rec_fields:
                     default_val = self.default_get(self._get_recurrence_fields())
                     vals.update(**default_val)
             project_id = vals.get('project_id')


### PR DESCRIPTION
### Steps to reproduce:
	- Create a xlsx sheet with some fsm_tasks values with recurrence values
	- Import the sheet to Field Service > Tasks
	- Navigate to the created tasks
	- Notice the recurrence values is the default ones not the ones in the imported sheet

### Cause:
If we are importing records without recurrence_id value we will set the recurrence fields' values to the default values while we might already have values for those fields

### Fix:
Check if we have values for recurrence fields we don't set the defaults and let the create method create the project.task.recurrence record and set the recurrence_id

opw-5925546