### PR TITLE
[FIX] dependencies: bump cbor2 dependency for py < 3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ asn1crypto==1.5.1 ; python_version >= '3.11'
 Babel==2.9.1 ; python_version < '3.11'  # min version = 2.6.0 (Focal with security backports)
 Babel==2.10.3 ; python_version >= '3.11' and python_version < '3.13'
 Babel==2.17.0 ; python_version >= '3.13'
-cbor2==5.4.2 ; python_version < '3.12'
+cbor2==5.4.3 ; python_version < '3.12'
 cbor2==5.6.2 ; python_version >= '3.12'
 chardet==4.0.0 ; python_version < '3.11'  # (Jammy)
 chardet==5.2.0 ; python_version >= '3.11'


### PR DESCRIPTION
cbor2 5.4.2 build system depends on pkg_resources which has been removed in setuptools 82. cbor2 5.4.3 improves their build system and has otherwise no functional changes.

fixes #248315

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
