### PR TITLE
[FIX] account: persist reply_to from mail template in send & print

### DIFF
--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -89,6 +89,7 @@ class AccountMoveSend(models.AbstractModel):
                 'mail_body': get_setting('mail_body', default_value=self._get_default_mail_body(move, mail_template, mail_lang)),
                 'mail_subject': get_setting('mail_subject', default_value=self._get_default_mail_subject(move, mail_template, mail_lang)),
                 'mail_partner_ids': get_setting('mail_partner_ids', default_value=self._get_default_mail_partner_ids(move, mail_template, mail_lang).ids),
+                'reply_to': get_setting('reply_to') or self._get_mail_default_field_value_from_template(mail_template, mail_lang, move, 'reply_to'),
             })
         # Add mail attachments if sending methods support them
         if self._display_attachments_widget(vals['invoice_edi_format'], vals['sending_methods']):
@@ -601,13 +602,16 @@ class AccountMoveSend(models.AbstractModel):
             for attachment in self.env['ir.attachment'].browse(list(seen_attachment_ids)).exists()
         ]
 
-        return {
+        params = {
             'author_id': move_data['author_partner_id'],
             'body': move_data['mail_body'],
             'subject': move_data['mail_subject'],
             'partner_ids': move_data['mail_partner_ids'],
             'attachments': mail_attachments,
         }
+        if move_data.get('reply_to'):
+            params['reply_to'] = move_data['reply_to']
+        return params
 
     @api.model
     def _generate_dynamic_reports(self, moves_data):

--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -1258,3 +1258,23 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
                 'name': attachments_data[0][2]['name'],
                 'raw': attachments_data[0][2]['raw'],
             }])
+
+    def test_invoice_send_reply_to_persistence(self):
+        """ Test that the reply_to set on the mail template is correctly
+        propagated through the wizard to the final mail message. """
+        invoice = self.init_invoice("out_invoice", amounts=[1000], post=True)
+        custom_reply_to = "custom_reply_address@example.com"
+
+        template = self.env.ref('account.email_template_edi_invoice')
+        template.reply_to = custom_reply_to
+
+        wizard = self.create_send_and_print(
+            invoice,
+            sending_methods=['email'],
+            template_id=template.id
+        )
+
+        wizard.action_send_and_print()
+
+        message = self._get_mail_message(invoice)
+        self.assertEqual(message.reply_to, custom_reply_to)


### PR DESCRIPTION
Steps to reproduce:
1. Go to an Email Template (e.g., 'Invoice: Send by email') and set a specific 'Reply-To' address.
2. Open a posted Invoice and click the 'Send & Print' button.
3. Ensure the 'Email' method is selected and click 'Send'.
4. Observe the sent email in the chatter or the mail queue. Observation: The 'Reply-To' header is overwritten by the system's catchall or author email, ignoring the template setting.

Cause:
The 'account.move.send' logic processes email data via the '_get_mail_params' method. This method manually constructs a dictionary of parameters to be passed to 'message_post'. However, it only explicitly includes a fixed set of fields (author_id, body, subject, partner_ids, and attachments), effectively filtering out the 'reply_to' value. When 'message_post' is called without this key, Odoo's mail thread logic defaults to the standard '_notify_get_reply_to' calculation, causing the custom template configuration to be lost.

Solution:
Update the '_get_mail_params' method to safely extract the 'reply_to' value from the move data and include it in the parameters dictionary passed to the mail engine.

opw-5922963