### PR TITLE
Follow up fold options

### DIFF
--- a/addons/html_builder/static/src/core/builder_overlay/builder_overlay_plugin.js
+++ b/addons/html_builder/static/src/core/builder_overlay/builder_overlay_plugin.js
@@ -195,6 +195,9 @@ export class BuilderOverlayPlugin extends Plugin {
             return;
         }
         this.removeHoverOverlay();
+        if (this.overlays.find((overlay) => overlay.overlayTarget === el && overlay.isActive())) {
+            return;
+        }
         const overlay = new BuilderOverlay(el, {
             iframe: this.iframe,
             overlayContainer: this.overlayContainer,

--- a/addons/html_builder/static/src/core/builder_overlay/builder_overlay_plugin.js
+++ b/addons/html_builder/static/src/core/builder_overlay/builder_overlay_plugin.js
@@ -150,9 +150,11 @@ export class BuilderOverlayPlugin extends Plugin {
 
     removeHoverOverlay() {
         if (this.hoverOverlay) {
+            if (!this.overlays.find((o) => o.overlayTarget === this.hoverOverlay.overlayTarget)) {
+                this.resizeObserver.unobserve(this.hoverOverlay.overlayTarget);
+            }
             this.hoverOverlay.destroy();
             this.hoverOverlay.overlayElement.remove();
-            this.resizeObserver.unobserve(this.hoverOverlay.overlayTarget);
             this.hoverOverlay = null;
         }
     }

--- a/addons/html_builder/static/src/core/builder_overlay/builder_overlay_plugin.js
+++ b/addons/html_builder/static/src/core/builder_overlay/builder_overlay_plugin.js
@@ -2,7 +2,6 @@ import { Plugin } from "@html_editor/plugin";
 import { throttleForAnimation } from "@web/core/utils/timing";
 import { getScrollingElement, getScrollingTarget } from "@web/core/utils/scrolling";
 import { BuilderOverlay, sizingY, sizingX, sizingGrid } from "./builder_overlay";
-import { withSequence } from "@html_editor/utils/resource";
 
 function isResizable(el) {
     const isResizableY = el.matches(sizingY.selector) && !el.matches(sizingY.exclude);
@@ -26,7 +25,6 @@ export class BuilderOverlayPlugin extends Plugin {
     resources = {
         step_added_handlers: this.refreshOverlays.bind(this),
         change_current_options_containers_listeners: this.openBuilderOverlays.bind(this),
-        on_mobile_preview_clicked: withSequence(20, this.refreshOverlays.bind(this)),
         has_overlay_options: { hasOption: (el) => isResizable(el) },
     };
 
@@ -53,6 +51,8 @@ export class BuilderOverlayPlugin extends Plugin {
 
         // Recompute the overlay when the window is resized.
         this.addDomListener(window, "resize", this._refreshOverlays);
+        this.documentResizeObserver = new ResizeObserver(() => this._refreshOverlays());
+        this.documentResizeObserver.observe(this.document.documentElement);
 
         // On keydown, hide the overlay and then show it again when the mouse
         // moves.
@@ -97,6 +97,7 @@ export class BuilderOverlayPlugin extends Plugin {
         this._cleanups.push(() => {
             this.removeBuilderOverlays();
             this.resizeObserver.disconnect();
+            this.documentResizeObserver.disconnect();
         });
     }
 
@@ -170,6 +171,7 @@ export class BuilderOverlayPlugin extends Plugin {
     }
 
     refreshOverlays() {
+        this.hoverOverlay?.refreshPosition();
         this.overlays.forEach((overlay) => {
             overlay.refreshPosition();
             overlay.refreshHandles();

--- a/addons/website/static/src/builder/plugins/layout_option/grid_column_option.js
+++ b/addons/website/static/src/builder/plugins/layout_option/grid_column_option.js
@@ -1,13 +1,6 @@
-import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
+import { BaseOptionComponent } from "@html_builder/core/utils";
 
 export class GridColumnsOption extends BaseOptionComponent {
     static template = "website.GridColumnsOption";
-    static selector = ".row:not(.s_col_no_resize) > div";
-
-    setup() {
-        super.setup();
-        this.state = useDomState((editingElement) => ({
-            isGridMode: editingElement.parentElement.classList.contains("o_grid_mode"),
-        }));
-    }
+    static selector = ".row.o_grid_mode > div.o_grid_item";
 }

--- a/addons/website/static/src/builder/plugins/layout_option/grid_column_option.xml
+++ b/addons/website/static/src/builder/plugins/layout_option/grid_column_option.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="website.GridColumnsOption">
-    <BuilderRow t-if="this.state.isGridMode" label.translate="Padding" tooltip.translate="Vertical and Horizontal padding">
+    <BuilderRow label.translate="Padding" tooltip.translate="Vertical and Horizontal padding">
         <BuilderNumberInput action="'setGridColumnsPadding'" actionParam="'--grid-item-padding-y'" unit="'px'" prefixIcon="'oi oi-arrows-v'"/>
         <BuilderNumberInput action="'setGridColumnsPadding'" actionParam="'--grid-item-padding-x'" unit="'px'" prefixIcon="'oi oi-arrows-h'"/>
     </BuilderRow>

--- a/addons/website/static/tests/builder/builder_overlay.test.js
+++ b/addons/website/static/tests/builder/builder_overlay.test.js
@@ -31,6 +31,34 @@ test("Show an overlay when hovering an element with options", async () => {
     expect(".oe_overlay.o_hover_overlay").toHaveRect(":iframe .col-lg-3");
 });
 
+test("Do not show the hover overlay for an element with another overlay", async () => {
+    await setupWebsiteBuilder(`
+        <section>
+            <div class="container">
+                <div class="row">
+                    <div class="col-lg-3">
+                        <p>TEST</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+    `);
+    expect(".oe_overlay").toHaveCount(0);
+    await contains(":iframe section").hover();
+    expect(".oe_overlay.o_hover_overlay").toHaveCount(1);
+    await contains(":iframe .col-lg-3").hover();
+    expect(".oe_overlay.o_hover_overlay").toHaveCount(1);
+
+    await contains(":iframe .col-lg-3").click();
+    expect(".oe_overlay.oe_active").toHaveCount(1);
+    expect(".oe_overlay.o_hover_overlay").toHaveCount(0);
+
+    await contains(":iframe section").hover();
+    expect(".oe_overlay.o_hover_overlay").toHaveCount(1);
+    await contains(":iframe .col-lg-3").hover();
+    expect(".oe_overlay.o_hover_overlay").toHaveCount(0);
+});
+
 test("Toggle the overlays when clicking on an option element", async () => {
     // TODO improve when more options will be defined.
     await setupWebsiteBuilder(`


### PR DESCRIPTION
### [FIX] website: avoid empty option for grid

Commit 64d35ccd6fade9e0473686b8484f561b5f4215ce added folding for groups
of options, and folds them automatically, except the last group. But
in some cases, the last container with options did not have any options
displayed, and thus the last group shown was not unfolded.

This commit fixes the issue for the case it was found by avoiding
having the option completely (instead of having it, but being empty), by
changing the selector.

Steps to reproduce:
- Open website builder on `/jobs`
- Click on the bottom of the right column
- Bug: the last group is not unfolded

task-5946692

### [FIX] html_builder: avoid hover overlay on top of active overlay

Commit 53ae0a9f646808632ca1ca396466e1c0bb5a73c7 adds overlays on hover
on elements with option. But it showed it also when there is already
another active overlay, which preventing correct dragging of handles and
caused an ugly color.

This commit avoid showing the hover overlay if there is another overlay
active for that element.

Steps to reproduce:
- Open website builder
- Drop the `s_banner` snippet
- Click on the column with text
- Drag a handle to resize it
- Bug: the overlay does not moved when dragged
  (the column is correctly resized)

- Open website builder
- Drop the `s_banner` snippet
- Click on the column with text
- Move the cursor a bit (stay inside the column)
- Bug: The hover overlay is shown in addition to the "resize" overlay

task-5946671

### [FIX] html_builder: keep oberver of overlays when removing hover one

Commit 53ae0a9f646808632ca1ca396466e1c0bb5a73c7 adds overlays on hover
on elements with option. To adapt the size, it adds them to the resize
observer with the other overlay. But when the hover overlay is removed,
it removed the element from the observer even if it was also used for
another overlay.

This commit only removes the element targetted by the hover overlay from
the observer if there is no other overlays for that same element. There
is no issues the other way because the hover overlay disappears for any
action that would remove the other overlays.

Steps to reproduce:
- Open website builder
- Click on the "Contact Us" button in the header
- Click in the blank space in the sidebar
- Press `escape`
- Bug: The overlay moves away from the button

task-5942812

### [FIX] html_builder: refresh overlays when document resizes

When the iframe is resized because the user opens the builder, or
hides the sidebar, the overlays were not always correctly following the
elements which they were targetting.

This commit adds a resize observer on the document. This observer
makes the listener for `resize` events and implementation of
`on_mobile_preview_clicked` both redundant, thus they are removed.

Steps to reproduce:
- Open the website builder while moving the pointer over a column in
  the footer
- Bug: the hover overlay moves not following the column

- Find (or create) a page with no options on any element covering
  the whole page, but with elements with options, whose size are not
  affected by the size of the page.
- Open website builder
- Click on the element with the option
- Click in the blank space in the sidebar
- Press `escape`
- Bug: The overlay moves away from the element

task-5942812

