### PR TITLE
[FIX] mail: auto-scroll to top of new very long message

### DIFF
--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -436,6 +436,11 @@ export class Thread extends Component {
         ) {
             let value;
             if (typeof thread.scrollTop === "string" && thread.scrollTop?.includes("bottom")) {
+                if (newerMessages && this.channel) {
+                    if (this.applyScrollContextuallyNewerChannelMessages(thread)) {
+                        return;
+                    }
+                }
                 value =
                     this.props.order === "asc"
                         ? this.scrollableRef.el.scrollHeight - this.scrollableRef.el.clientHeight
@@ -459,6 +464,29 @@ export class Thread extends Component {
                 });
             }
         }
+    }
+
+    /**
+     * @param {import("models").Thread} thread
+     * @returns {Boolean} true when fully handled, false otherwise.
+     */
+    applyScrollContextuallyNewerChannelMessages(thread) {
+        const firstNewerMessage = this.channel.getFirstNewerMessage({
+            from_message_id: this.newestPersistentMessage.id + 1,
+        });
+        if (!firstNewerMessage) {
+            return false;
+        }
+        const firstNewestMessageRef = this.messageRefs.get(firstNewerMessage.id);
+        if (!firstNewestMessageRef) {
+            return false;
+        }
+        firstNewestMessageRef.el.querySelector(".o-mail-Message-jumpTarget").scrollIntoView({
+            behavior: "instant",
+            block: this.props.order === "asc" ? "start" : "end",
+        });
+        thread.scrollTop = this.isAtBottom ? "bottom" : this.scrollableRef.el.scrollTop;
+        return true;
     }
 
     fetchInitialMessages() {

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -290,26 +290,31 @@ export class DiscussChannel extends Record {
     get hasAttachmentPanel() {
         return true;
     }
+    getFirstNewerMessage({ from_message_id = this.self_member_id?.new_message_separator_ui } = {}) {
+        if (!this.self_member_id) {
+            return null;
+        }
+        const messages = this.messages.filter((m) => !m.isNotification);
+        const separator = from_message_id;
+        if (separator === 0 && !this.loadOlder) {
+            return messages[0];
+        }
+        if (!separator || messages.length === 0 || messages.at(-1).id < separator) {
+            return null;
+        }
+        // try to find a perfect match according to the member's separator
+        let message = this.store["mail.message"].get({ id: separator });
+        if (!message || this.notEq(message.channel_id)) {
+            message = nearestGreaterThanOrEqual(messages, separator, (msg) => msg.id);
+        }
+        return message;
+    }
     firstUnreadMessage = fields.One("mail.message", {
         /** @this {import("models").DiscussChannel} */
         compute() {
-            if (!this.self_member_id) {
-                return null;
-            }
-            const messages = this.messages.filter((m) => !m.isNotification);
-            const separator = this.self_member_id.new_message_separator_ui;
-            if (separator === 0 && !this.loadOlder) {
-                return messages[0];
-            }
-            if (!separator || messages.length === 0 || messages.at(-1).id < separator) {
-                return null;
-            }
-            // try to find a perfect match according to the member's separator
-            let message = this.store["mail.message"].get({ id: separator });
-            if (!message || this.notEq(message.channel_id)) {
-                message = nearestGreaterThanOrEqual(messages, separator, (msg) => msg.id);
-            }
-            return message;
+            return this.getFirstNewerMessage({
+                from_message_id: this.self_member_id?.new_message_separator_ui,
+            });
         },
     });
     hasOtherMembersTyping = fields.Attr(false, {


### PR DESCRIPTION
Before this commit, whenever there are newer messages in message list and the view had message list at present, i.e. at the very bottom for channels, the message list was always scrolling at the bottom again.

This behaviour is meant for passive readers that can read new messages without requiring any manual labour.

While this works well to keep auto-scroll to bottom of message list on newer messages most of the time, for very long messages this has the drawback that some content can be missed unless user manually scroll up to see content.

The case of new very long message requires necessarily some manual scrolling from user. The most natural behavior is to preserve the scroll at the top of this very long message, even if this means newer messages come later and require manual scroll to reach the bottom and read everything.

This commit fine-tune the strategy for auto-scroll bottom of message list: this scrolls to the top of first newer message instead of necessarily at the bottom. For smaller messages, i.e. messages whose content is smaller than the viewport height of message list scrollable, the behaviour of auto-scroll is unchanged. For longer messages, i.e. newer messages whose content is bigger than viewport height, this stops the auto-scroll to the top of this first message and saves this scrolltop position.

Task-5900898