### PR TITLE
[FIX] website_sale_loyalty: prevent random shop_sale_ewallet tour failure

### DIFF
--- a/addons/website_sale_loyalty/static/tests/tours/test_ewallet_tour.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_ewallet_tour.js
@@ -24,6 +24,12 @@ registry.category("web_tour.tours").add('shop_sale_ewallet', {
                 }
             },
         },
+        {
+            trigger: '#order_total .oe_currency_value:not(:contains("50.00"))',
+        },
+        {
+            trigger: '.oe_website_sale_gift_card .alert-success:contains("You have successfully applied the following code:")',
+        },
         tourUtils.goToCheckout(),
         tourUtils.pay(),
         {


### PR DESCRIPTION
In the `shop_sale_ewallet` tour, a Runbot error was triggered because the test would add a $50 product to the cart and immediately click the checkout button after selecting eWallet.
This sometimes caused the eWallet to not be applied in time, leaving the total amount not updated to $0, and later the pay button could not be found.

Solution:
Ensure that after clicking on eWallet, the tour waits for the total amount to be $0 and for a success message confirming the code has been applied before proceeding to checkout.

runbot-145574
