### PR TITLE
[FIX] web_editor: shaped gifs shouldn't be able to be stretched

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -7550,7 +7550,7 @@ registry.ImageTools = ImageHandlerOption.extend({
             return !shapeImgSquareWidget.isActive();
         }
         if (widgetName === "toggle_stretch_opt") {
-            return this._isCropRequired();
+            return this._isCropRequired() && !this._originalOrCurrentImageIsGif(this._getImg());
         }
         return this._super(...arguments);
     },
@@ -7753,6 +7753,18 @@ registry.ImageTools = ImageHandlerOption.extend({
             return !isGif(this._getImageMimetype(this._getImg()));
         }
         return this._super(...arguments);
+    },
+    /**
+     * @private
+     * @param {HTMLImageElement} [img]
+     * @returns {boolean}
+     */
+    _originalOrCurrentImageIsGif(img) {
+        const originalSrc = img.dataset.originalSrc || "";
+        if (originalSrc) {
+            return originalSrc.toLowerCase().endsWith(".gif");
+        }
+        return img.src.toLowerCase().endsWith(".gif");
     },
     /**
      * Flips the image shape (vertically or/and horizontally).


### PR DESCRIPTION
Bug:
When setting a shape to a gif, the user can switch the stretch toggle, so the gif freezes.
The same happens when the user crop the image or change the format.

Steps to reproduce:
- in website editor
- add a gif to a image snippet
- add a shape to the gif
- toggle "stretch"
- the gif freezes

Why:
Stretching a gif shouldn't be doable in the builder, because modifying the gifs transforms it into a png.

Fix:
Hid the stretch toggle if the original image the shape is applied to is a gif.

task-5914466
