### PR TITLE
[FIX] mail: auto-scroll to top of new very long message

### DIFF
--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -441,6 +441,24 @@ export class Thread extends Component {
         ) {
             let value;
             if (typeof thread.scrollTop === "string" && thread.scrollTop?.includes("bottom")) {
+                if (newerMessages) {
+                    const firstNewerMessage = thread.getFirstNewerMessage({
+                        from_message_id: this.newestPersistentMessage.id,
+                    });
+                    if (firstNewerMessage) {
+                        const firstNewestMessageRef = this.refByMessageId.get(firstNewerMessage.id);
+                        firstNewestMessageRef.el
+                            .querySelector(".o-mail-Message-jumpTarget")
+                            .scrollIntoView({
+                                behavior: "instant",
+                                block: this.props.order === "asc" ? "start" : "end",
+                            });
+                        thread.scrollTop = this.isAtBottom
+                            ? "bottom"
+                            : this.scrollableRef.el.scrollTop;
+                        return;
+                    }
+                }
                 value =
                     this.props.order === "asc"
                         ? this.scrollableRef.el.scrollHeight - this.scrollableRef.el.clientHeight

--- a/addons/mail/static/tests/thread/thread.test.js
+++ b/addons/mail/static/tests/thread/thread.test.js
@@ -398,6 +398,30 @@ test("should scroll to bottom on receiving new message if the list is initially 
     );
     await contains(".o-mail-Message", { count: 12 });
     await contains(".o-mail-Thread", { scroll: "bottom" });
+    // simulate receiving a very long message
+    withUser(userId, () =>
+        rpc("/mail/message/post", {
+            post_data: { body: "hello".repeat(10000), message_type: "comment" },
+            thread_id: channelId,
+            thread_model: "discuss.channel",
+        })
+    );
+    await contains(".o-mail-Message", { count: 13 });
+    await tick(); // wait for the scroll to first unread to complete
+    // simulate receiving another short message
+    withUser(userId, () =>
+        rpc("/mail/message/post", {
+            post_data: { body: "end-msg", message_type: "comment" },
+            thread_id: channelId,
+            thread_model: "discuss.channel",
+        })
+    );
+    await contains(".o-mail-Message", { count: 14 });
+    await tick(); // wait in case of an auto-scroll to happen
+    const scrollTop = queryFirst(".o-mail-Thread").scrollTop; // around 590px with chat window sizing
+    const scrollHeight = queryFirst(".o-mail-Thread").scrollHeight; // around 20000px with chat window sizing
+    const clientHeight = queryFirst(".o-mail-Thread").clientHeight; // around 540px with chat window sizing
+    expect(scrollHeight / 4).toBeGreaterThan(scrollTop + clientHeight); // viewport is still at least in the 1st quarter, meaning no scroll to bottom
 });
 
 test("should not scroll on receiving new message if the list is initially scrolled anywhere else than bottom (asc order)", async () => {


### PR DESCRIPTION
Before this commit, whenever there are newer messages in message list and the view had message list at present, i.e. at the very bottom for channels, the message list was always scrolling at the bottom again.

This behaviour is meant for passive readers that can read new messages without requiring any manual labour.

While this works well to keep auto-scroll to bottom of message list on newer messages most of the time, for very long messages this has the drawback that some content can be missed unless user manually scroll up to see content.

The case of new very long message requires necessarily some manual scrolling from user. The most natural behavior is to preserve the scroll at the top of this very long message, even if this means newer messages come later and require manual scroll to reach the bottom and read everything.

This commit fine-tune the strategy for auto-scroll bottom of message list: this scrolls to the top of first newer message instead of necessarily at the bottom. For smaller messages, i.e. messages whose content is smaller than the viewport height of message list scrollable, the behaviour of auto-scroll is unchanged. For longer messages, i.e. newer messages whose content is bigger than viewport height, this stops the auto-scroll to the top of this first message and saves this scrolltop position.

Task-5900898