### PR TITLE
[FIX] pos_sale: Downpayment account id not reflecting on sales order invoice

### DIFF
--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -177,6 +177,9 @@ class PosOrder(models.Model):
             inv_line_vals["name"] = origin_line.name
             origin_line._set_analytic_distribution(inv_line_vals)
 
+        if self.config_id.down_payment_product_id == pos_line.product_id:
+            inv_line_vals["is_downpayment"] = True
+
         return inv_line_vals
 
     def write(self, vals):

--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -248,3 +248,12 @@ class SaleOrderLine(models.Model):
                     downpayment_sol.name = _("%(line_description)s (Cancelled)", line_description=downpayment_sol.name)
             else:
                 super()._compute_name()
+
+    def _prepare_invoice_line(self, **optional_values):
+        res = super()._prepare_invoice_line(**optional_values)
+        if not self.is_downpayment:
+            return res
+        downpayment_lines = self.sudo().pos_order_line_ids.order_id.account_move.invoice_line_ids.filtered('is_downpayment')
+        if downpayment_lines:
+            res['account_id'] = downpayment_lines.account_id[:1].id
+        return res

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -1047,6 +1047,8 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
             final_invoice_downpayment_line._get_downpayment_lines(),
             downpayment_invoice.invoice_line_ids,
         )
+        for line in downpayment_invoice.invoice_line_ids.filtered(self.main_pos_config.down_payment_product_id.id == "product_id"):
+            self.assertTrue(line.is_downpayment)
 
     def test_settle_order_ship_later_effect_on_so(self):
         """This test create an order, settle it in the PoS and ship it later.
@@ -2201,3 +2203,53 @@ class TestPoSSalePayment(TestPointOfSaleHttpCommon, PaymentCommon):
         self.main_pos_config.down_payment_product_id = self.env.ref("pos_sale.default_downpayment_product")
         self.main_pos_config.open_ui()
         self.start_pos_tour('test_pos_settle_so_with_downpayment', login="accountman")
+
+    def test_pos_downpayment_sale_invoice_creation(self):
+        account = self.env['account.account'].create({'name': 'Test Downpayment Income Account',
+                                                      'code': '12345',
+                                                      'account_type': "income"})
+        downpayment_product = self.env['product.product'].create({'name': 'Test Down Payment (POS)',
+                                                                  "available_in_pos": False,
+                                                                  'standard_price': 0.00,
+                                                                  'list_price': 0.00,
+                                                                  'weight': 0.00,
+                                                                  'type': 'service',
+                                                                  'purchase_ok': False,
+                                                                  'property_account_income_id': account.id
+                                                                  })
+
+        sale_order = self.env['sale.order'].sudo().create({
+            'partner_id': self.partner_a.id,
+            'order_line': [
+                (0, 0, {
+                    'name': self.product_a.name,
+                    'product_id': self.product_a.id,
+                    'product_uom_qty': 1.0,
+                    'price_unit': 100,
+                    'tax_ids': False,
+                })],
+        })
+        sale_order.action_confirm()
+        self.main_pos_config.open_ui()
+        self.main_pos_config.down_payment_product_id = downpayment_product
+        self.start_pos_tour('PoSApplyDownpaymentInvoice')
+        invoice = sale_order._create_invoices(final=True)
+        invoice.action_post()
+
+        downpayment_invoice = sale_order.pos_order_line_ids.order_id.account_move
+        self.assertTrue(downpayment_invoice._is_downpayment())
+
+        final_invoice_downpayment_line = sale_order.invoice_ids.invoice_line_ids.filtered(lambda r: r.quantity < 0)
+
+        self.assertEqual(
+            final_invoice_downpayment_line._get_downpayment_lines(),
+            downpayment_invoice.invoice_line_ids,
+        )
+
+        downpayment_invoice_lines = downpayment_invoice.invoice_line_ids.filtered(self.main_pos_config.down_payment_product_id.id == "product_id")
+        self.assertTrue(downpayment_invoice_lines.is_downpayment)
+        self.assertEqual(downpayment_invoice_lines.account_id.id, account.id)
+
+        so_downpayment_lines = invoice.invoice_line_ids.filtered('is_downpayment')
+        self.assertTrue(so_downpayment_lines.is_downpayment)
+        self.assertEqual(so_downpayment_lines.account_id.id, account.id)


### PR DESCRIPTION
[Issue]
1) When a POS downpayment is created, it doesn't set the account.move.lines.is_downpayment = true. So, no POS invoice line was being marked as a down payment. 2) When preparing to create the invoice lines for the sales order, it never checks the original POS Invoice lines for down payments.

[Fix]
1) When creating the invoice lines for the down payment through the POS, set the 'is_downpayment' based on if the product is the POS's down payment product. 2) Create _prepare_invoice_lin,e then filter through the POS invoice lines for downpayments and then set them accordingly.

Steps to Replicate:
1) User creates a Sales Order for a customer,
2) Transfers it to the POS, and the customer makes a down payment. 3) The user creates an invoice on the Sales order to pay the remainder of the bill 4) The account Id on the account.move.line does not match the original account on the POS invoice for the original account.move.line

Video Demo of the issue:
https://drive.google.com/file/d/1FszCJRUF-cCgg8otxu1jj1kmdKauwTGL/view?usp=drive_link

Video Demo of Solution:
https://drive.google.com/file/d/1yrYBdQZFw7YeKxsgsQQx5gHkuGER-7BN/view?usp=drive_link