### PR TITLE
[FIX] html_editor: prevent history_dialog issues with toggle

### DIFF
--- a/addons/html_editor/models/diff_utils.py
+++ b/addons/html_editor/models/diff_utils.py
@@ -201,6 +201,7 @@ def generate_comparison(new_content, old_content):
                     comparison.insert(start_index, addition_flagged_line)
                 elif (
                     line.split(">")[0] != comparison[start_index].split(">")[0]
+                    or line.startswith("/")
                 ):
                     comparison.insert(start_index, line)
 

--- a/addons/html_editor/tests/test_diff_utils.py
+++ b/addons/html_editor/tests/test_diff_utils.py
@@ -353,3 +353,23 @@ class TestPatchUtils(BaseCase):
             "<added>A</added><removed>B</removed>"
             "</i></p></div>",
         )
+
+    def test_double_closing_div_between_repeated_content(self):
+        initial_content = (
+            "<div data-embedded='wrapper'>"
+            "<div data-embedded-editable='content'>"
+            "<p>repeated</p>"
+            "</div></div>"
+            "<p>repeated</p>"
+        )
+        new_content = "<h1><br></h1>"
+        comparison = generate_comparison(new_content, initial_content)
+        self.assertEqual(
+            comparison,
+            "<div data-embedded='wrapper'>"
+            "<div data-embedded-editable='content'>"
+            "<p><added>repeated</added></p>"
+            "</div></div>"
+            "<p><added>repeated</added></p>"
+            "<h1><br></h1>"
+        )


### PR DESCRIPTION
There is an issue with the history dialog in very specific scenarios where a
toggle (or any similar block) is involved, resulting in an incorrect
"comparison" being displayed.

How to reproduce:
- create a new Knowledge article, and replace the title with a toggle block
- in the "content" section of the toggle, write a word, e.g. "word" in the
  paragraph.
- exactly below the toggle block, write the exact same word ("word") in a
  paragraph.
- save the article
- open the version history
- click on the oldest entry (there should be 2 of them), and click "view
  comparison"

Issue:
- the paragraph below the toggle is not shown.

Technical explanation:
- There is an incomplete constraint in `generate_comparison`, which is related
  to a trade-off (see `test_replace_nested_divs`), which was supposed to ignore
  identical successive `opening` tags. However, it also ignores `closing` tags,
  which it shouldn't do (it causes this issue).
- This issue produces invalid html which could also cause owl crashes (in
  addition to the incorrect comparison), if embedded components were present in
  the invalid html part.

task-5933410