### PR TITLE
[FIX] web: many2one field chains with incorrect field data

### DIFF
--- a/addons/web/static/src/core/model_field_selector/model_field_selector_popover.js
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector_popover.js
@@ -174,7 +174,7 @@ export class ModelFieldSelectorPopover extends Component {
     async followRelation(fieldDef) {
         const { modelsInfo } = await this.keepLast.add(
             this.fieldService.loadPath(
-                fieldDef.relation || this.state.page.resModel,
+                fieldDef.is_property ? fieldDef.relation : this.state.page.resModel,
                 `${fieldDef.name}.*`
             )
         );

--- a/addons/web/static/tests/core/model_field_selector.test.js
+++ b/addons/web/static/tests/core/model_field_selector.test.js
@@ -919,3 +919,39 @@ test("showDebugInput = false", async () => {
     await openModelFieldSelectorPopover();
     expect(".o_model_field_selector_debug").toHaveCount(0);
 });
+
+test("models with a m2o of the same name should show the correct page data", async () => {
+    class Cat extends models.Model {
+        cat_name = fields.Char();
+        link = fields.Many2one({ relation: "dog" });
+    }
+
+    class Dog extends models.Model {
+        dog_name = fields.Char();
+        link = fields.Many2one({ relation: "fish" });
+    }
+
+    class Fish extends models.Model {
+        fish_name = fields.Char();
+    }
+    defineModels([Cat, Dog, Fish]);
+
+    await mountWithCleanup(ModelFieldSelector, {
+        props: {
+            readonly: false,
+            path: "link",
+            resModel: "cat",
+        },
+    });
+
+    await openModelFieldSelectorPopover();
+    await contains(".o_model_field_selector_popover_relation_icon").click();
+    expect(getDisplayedFieldNames()).toEqual([
+        "Created on",
+        "Display name",
+        "Dog name",
+        "Id",
+        "Last Modified on",
+        "Link",
+    ]);
+});


### PR DESCRIPTION
You cannot create a related field with a related field chain that has two or more fields with the same name in a row. When you click the relation icon for a field the wrong model will be displayed if the related model you are trying to show has a many2one with the same name as the field that was selected.

Steps to reproduce
1. Create two many2one fields with studio that have the same name, one of the fields must link to the model the other field is on. i.e. `model_a.x_studio_test(relation=model_b),
model_b.x_studio_test(relation=other_model)`.
2. Create a related field on model_a and click the related icon for the test field.
3. The popover will now be displaying the fields for other_model instead of model_b.

Cause:
This behavior was introduced by adding support for properties in this [pr](https://github.com/odoo/odoo/pull/189841). 

Solution:
Check if `fieldDef` is a property or not in order to decide what to pass to `loadPath`.

opw-ticket 5459944