### PR TITLE
[ADD] base_import_module: add the line of code field

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -41,6 +41,12 @@ class IrModuleModule(models.Model):
         ('official', 'Official Apps'),
         ('industries', 'Industries'),
     ], default='official')
+    total_lines_of_code = fields.Integer(
+        string="Extra lines of Code",
+        store=False,  # info is retrieved from the appstore in web_read
+        help="Number of lines of code that may be billed under an Enterprise subscription."
+            " For exact pricing details, please contact your account manager or visit odoo.com/pricing.",
+    )
 
     @api.model
     @ormcache(cache='stable')

--- a/addons/base_import_module/views/ir_module_views.xml
+++ b/addons/base_import_module/views/ir_module_views.xml
@@ -60,6 +60,9 @@
                 <xpath expr="//button[@name='button_immediate_upgrade']" position="attributes">
                     <attribute name="invisible">state != 'installed' or (module_type and module_type != 'official')</attribute>
                 </xpath>
+                <field name="installed_version" position="after">
+                    <field name="total_lines_of_code" invisible="module_type != 'industries'"/>
+                </field>
             </field>
         </record>
         <record model="ir.ui.view" id="view_module_filter_apps_inherit">


### PR DESCRIPTION
In this PR we have added a field to display the total number of lines of code installed with the module. 
Previously, this information was only available on apps.odoo.com.

Task-5489905