### PR TITLE
[FIX] auth_signup: prevent error when sending the password reset link

### DIFF
--- a/addons/auth_signup/models/res_users.py
+++ b/addons/auth_signup/models/res_users.py
@@ -211,7 +211,7 @@ class ResUsers(models.Model):
                         model='res.users', res_ids=user.ids,
                         engine='qweb_view', options={'post_process': True})[user.id]
                     body_html = self.env['mail.render.mixin'].with_context(lang=user_lang)._render_encapsulate(
-                        'mail.mail_notification_layout', body, context_record=self,
+                        'mail.mail_notification_layout', body, context_record=user,
                         add_context={
                             'email_add_signature': True,
                             'email_notification_force_header': True,


### PR DESCRIPTION
Currently, an error occurs when sending the password reset link to multiple users.

**Steps to Reproduce:**
 - Install `auth_signup` module.
 - Go to `Users` and make sure there are at least two user records.
 - In the `list view`, select both users.
 - Go to `Actions` > click `Send Password Reset Instructions`.

`ValueError: ValueError('Expected singleton: res.users(24, 23)') while evaluating 'records.action_reset_password()'`

This error occurs when generating the email body_html [1]. It passes multiple user 
records (self) as the context record, but _render_encapsulate expects a single user 
record to render the email body. which raise the error here[2].

This commit passes a single user record when rendering body_html.

[1]: https://github.com/odoo/odoo/blob/39c6e3a2578c4f7058dddb6acf12231d8716e7fd/addons/auth_signup/models/res_users.py#L214

[2]: https://github.com/odoo/odoo/blob/39c6e3a2578c4f7058dddb6acf12231d8716e7fd/addons/mail/models/mail_render_mixin.py#L187

sentry-7271437735


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
