### PR TITLE
[FIX] hr_work_entry: Typo in work entry type name

### DIFF
--- a/addons/hr_work_entry/data/hr_work_entry_type_data.xml
+++ b/addons/hr_work_entry/data/hr_work_entry_type_data.xml
@@ -193,7 +193,7 @@
 
 <!-- BE : Belgium -->
     <record id="l10n_be_work_entry_type_overtime_no_onss" model="hr.work.entry.type">
-        <field name="name">Overtime Hours not suject to social security contribution</field>
+        <field name="name">Overtime Hours not subject to social security contribution</field>
         <field name="color">4</field>
         <field name="code">OVERTIMENOONSS</field>
     </record>


### PR DESCRIPTION
Version: saas-19.1

Fix typo in belgian work entry type name:

- from "Overtime Hours not suject to social security contribution" to "Overtime Hours not subject to social security contribution"

Task-5946323