### PR TITLE
[IMP] hr_work_entry: remove shortcut behavior from work entries

### DIFF
--- a/addons/hr_work_entry/data/hr_work_entry_type_data.xml
+++ b/addons/hr_work_entry/data/hr_work_entry_type_data.xml
@@ -14,7 +14,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
     </record>
 
     <record id="generic_hr_work_entry_type_out_of_contract" model="hr.work.entry.type">
@@ -22,7 +21,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
     </record>
 
     <record id="generic_work_entry_type_leave" model="hr.work.entry.type">
@@ -88,7 +86,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.ae"/>
     </record>
 
@@ -97,7 +94,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.ae"/>
     </record>
 
@@ -178,7 +174,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.au"/>
     </record>
 
@@ -187,7 +182,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.au"/>
     </record>
 
@@ -370,7 +364,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.be"/>
     </record>
 
@@ -379,7 +372,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.be"/>
     </record>
 
@@ -1271,7 +1263,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.bd"/>
     </record>
 
@@ -1280,7 +1271,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.bd"/>
     </record>
 
@@ -1353,7 +1343,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.ch"/>
     </record>
 
@@ -1362,7 +1351,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.ch"/>
     </record>
 
@@ -1578,7 +1566,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.eg"/>
     </record>
 
@@ -1587,7 +1574,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.eg"/>
     </record>
 
@@ -1740,7 +1726,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.fr"/>
     </record>
 
@@ -1749,7 +1734,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.fr"/>
     </record>
 
@@ -1823,7 +1807,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.hk"/>
     </record>
 
@@ -1832,7 +1815,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.hk"/>
     </record>
 
@@ -1997,7 +1979,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.id"/>
     </record>
 
@@ -2006,7 +1987,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.id"/>
     </record>
 
@@ -2120,7 +2100,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.in"/>
     </record>
 
@@ -2129,7 +2108,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.in"/>
     </record>
 
@@ -2203,7 +2181,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.it"/>
     </record>
 
@@ -2212,7 +2189,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.it"/>
     </record>
 
@@ -2286,7 +2262,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.ke"/>
     </record>
 
@@ -2295,7 +2270,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.ke"/>
     </record>
 
@@ -2369,7 +2343,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.lt"/>
     </record>
 
@@ -2378,7 +2351,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.lt"/>
     </record>
 
@@ -2452,7 +2424,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.jo"/>
     </record>
 
@@ -2461,7 +2432,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.jo"/>
     </record>
 
@@ -2599,7 +2569,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.lu"/>
     </record>
 
@@ -2608,7 +2577,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.lu"/>
     </record>
 
@@ -2730,7 +2698,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.ma"/>
     </record>
 
@@ -2739,7 +2706,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.ma"/>
     </record>
 
@@ -2813,7 +2779,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.mx"/>
     </record>
 
@@ -2822,7 +2787,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.mx"/>
     </record>
 
@@ -2928,7 +2892,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.my"/>
     </record>
 
@@ -2937,7 +2900,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.my"/>
     </record>
 
@@ -3011,7 +2973,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.nl"/>
     </record>
 
@@ -3020,7 +2981,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.nl"/>
     </record>
 
@@ -3094,7 +3054,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.pk"/>
     </record>
 
@@ -3103,7 +3062,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.pk"/>
     </record>
 
@@ -3177,7 +3135,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.pl"/>
     </record>
 
@@ -3186,7 +3143,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.pl"/>
     </record>
 
@@ -3269,7 +3225,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.ro"/>
     </record>
 
@@ -3278,7 +3233,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.ro"/>
     </record>
 
@@ -3352,7 +3306,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.sa"/>
     </record>
 
@@ -3361,7 +3314,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.sa"/>
     </record>
 
@@ -3493,7 +3445,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.sk"/>
     </record>
 
@@ -3502,7 +3453,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.sk"/>
     </record>
 
@@ -3620,7 +3570,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.tr"/>
     </record>
 
@@ -3629,7 +3578,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.tr"/>
     </record>
 
@@ -3738,7 +3686,6 @@
         <field name="color">4</field>
         <field name="display_code">OT</field>
         <field name="code">OVERTIME</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.us"/>
     </record>
 
@@ -3747,7 +3694,6 @@
         <field name="color">0</field>
         <field name="display_code">OoC</field>
         <field name="code">OUT</field>
-        <field name="shortcut_behavior">add</field>
         <field name="country_id" ref="base.us"/>
     </record>
 

--- a/addons/hr_work_entry/models/hr_work_entry_type.py
+++ b/addons/hr_work_entry/models/hr_work_entry_type.py
@@ -41,12 +41,6 @@ class HrWorkEntryType(models.Model):
         string="Added to Monthly Pay",
         help="Check this setting if you want the hours to be considered as extra time and added as a bonus to the basic salary.")
     description = fields.Text(translate=True)
-    shortcut_behavior = fields.Selection(
-        [('add', 'Add'), ('replace', 'Replace')],
-        string="Shortcut Behavior", default='replace', required=True,
-        help="This field decides the behavior of the shortcut in the gantt view of the work entries. Add will always "
-             "prompt a duration and will be added to the existing work entries while replace will simply replace all "
-             "work entries of that day")
 
     @api.constrains('code', 'country_id')
     def _check_code_unicity(self):

--- a/addons/hr_work_entry/views/hr_work_entry_type_views.xml
+++ b/addons/hr_work_entry/views/hr_work_entry_type_views.xml
@@ -79,7 +79,6 @@
                                         <field style='width: 4em;' name="amount_rate" widget="percentage"/>
                                     </div>
                                     <field name="is_extra_hours"/>
-                                    <field name="shortcut_behavior" widget="radio" options="{'horizontal': True}"/>
                                     <field string="Considered as" name="count_as" widget="radio" options="{'horizontal': True}" />
                                 </group>
                                 <group string="Display">


### PR DESCRIPTION
Before this change, the shortcut behavior field had two options: add and replace allowing leave entries in the Gantt view to either add to or replace existing entries.

This change completes a missing part of the Work Entries Apocalypse task.

Since attendance work entries are no longer created by default, we no longer need different shortcut behaviors. Work entries should always be added, not replaced.

Therefore, the shortcut_behavior field has been removed, and add is now the only behavior.

Task-5942542