### PR TITLE
[IMP] website_sale_collect: display in-store dm's name on the widget

### DIFF
--- a/addons/website_sale_collect/static/src/js/click_and_collect_availability/click_and_collect_availability.js
+++ b/addons/website_sale_collect/static/src/js/click_and_collect_availability/click_and_collect_availability.js
@@ -20,6 +20,7 @@ export class ClickAndCollectAvailability extends Component {
         countryCode: { type: String, optional: true },
         deliveryMethodId: Number,
         deliveryMethodType: String,
+        deliveryMethodName: String,
     }
     static defaultProps = {
         active: true,

--- a/addons/website_sale_collect/static/src/js/click_and_collect_availability/click_and_collect_availability.xml
+++ b/addons/website_sale_collect/static/src/js/click_and_collect_availability/click_and_collect_availability.xml
@@ -14,7 +14,7 @@
                         t-if="this.state.selectedLocationData.id"
                         t-out="this.state.selectedLocationData.name"
                     />
-                    <t t-else="">Click and Collect</t>
+                    <t t-else="" t-out="this.props.deliveryMethodName"/>
                 </h6>
                 <div class="d-flex justify-content-between">
                     <t t-if="this.state.inStoreStockData?.in_stock">

--- a/addons/website_sale_collect/views/templates.xml
+++ b/addons/website_sale_collect/views/templates.xml
@@ -38,6 +38,7 @@
                     'deliveryStockData': combination_info.get('delivery_stock_data', {}),
                     'deliveryMethodId': delivery_method.id,
                     'deliveryMethodType': delivery_method.delivery_type,
+                    'deliveryMethodName': delivery_method.name,
                 })"
                 t-attf-class="d-flex o_not_editable mb-4 #{'w-100' if not is_50_pc else 'w-100 w-sm-75'}"
             />


### PR DESCRIPTION
To allow more flexibility to users, instead of hardcoded text display the name of the in-store delivery method on the widget.

