### PR TITLE
[FIX] html_builder, mass_mailing: quick UX fixes followup

### DIFF
--- a/addons/html_builder/static/src/snippets/add_snippet_dialog.js
+++ b/addons/html_builder/static/src/snippets/add_snippet_dialog.js
@@ -125,8 +125,12 @@ export class AddSnippetDialog extends Component {
             ...editorPreviewAssetsBundles.map((assetsBundle) =>
                 loadCSSBundleFromEditor(assetsBundle, loadOptions)
             ),
-            loadBundle("html_builder.iframe_add_dialog", loadOptions),
+            ...this.getDefaultAssets().map((assetName) => loadBundle(assetName, loadOptions)),
         ]);
+    }
+
+    getDefaultAssets() {
+        return ["html_builder.iframe_add_dialog"];
     }
 
     get snippetGroups() {

--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -139,6 +139,7 @@
             'mass_mailing/static/src/builder/**/*.inside.scss'
         ],
         'mass_mailing.iframe_add_dialog': [
+            ('include', 'html_builder.iframe_add_dialog'),
             'mass_mailing/static/src/builder/snippet_viewer/*.scss',
         ],
         'mass_mailing.mailing_assets': [

--- a/addons/mass_mailing/static/src/builder/snippet_viewer/add_snippet_dialog.js
+++ b/addons/mass_mailing/static/src/builder/snippet_viewer/add_snippet_dialog.js
@@ -9,6 +9,10 @@ export class AddSnippetDialogSandboxed extends AddSnippetDialog {
         return isBrowserSafari();
     }
 
+    getDefaultAssets() {
+        return [];
+    }
+
     renderIframeHead() {
         const iframe = this.iframeRef.el;
         iframe.contentDocument.head.prepend(renderToFragment("mass_mailing.IframeHead"));

--- a/addons/mass_mailing/static/src/builder/snippet_viewer/snippet_viewer.scss
+++ b/addons/mass_mailing/static/src/builder/snippet_viewer/snippet_viewer.scss
@@ -1,8 +1,11 @@
-.o_snippets_preview_row {
+.o_add_snippets_preview .o_snippets_preview_row {
     transform: scale(0.6) !important;
     width: 166% !important;
     .o_snippet_preview_wrap {
         min-height: auto !important;
+        &[data-label]:not([data-label=""])::before {
+            transform: scale(1.7); // Result in the same size as Website
+        }
     }
 
     .o_mail_footer_links {

--- a/addons/mass_mailing_sale/views/snippets_themes.xml
+++ b/addons/mass_mailing_sale/views/snippets_themes.xml
@@ -1,10 +1,10 @@
 <odoo>
     <data>
         <template id="email_designer_snippets" inherit_id="mass_mailing.email_designer_snippets">
-            <xpath expr="//t[@t-snippet='mass_mailing.s_call_to_action']" position="after">
-                <t t-snippet="mass_mailing_sale.s_product_columns" group="marketing" label="Auto-filled from Product" string="Products List"/>
-                <t t-snippet="mass_mailing_sale.s_product_card" group="marketing" label="Auto-filled from Product" string="Product Card"/>
-                <t t-snippet="mass_mailing_sale.s_product_aside" group="marketing" label="Auto-filled from Product" string="Product Aside"/>
+            <xpath expr="//t[@t-snippet='mass_mailing.s_coupon_code']" position="after">
+                <t t-snippet="mass_mailing_sale.s_product_columns" group="website" label="Auto-filled from Product" string="Products List"/>
+                <t t-snippet="mass_mailing_sale.s_product_card" group="website" label="Auto-filled from Product" string="Product Card"/>
+                <t t-snippet="mass_mailing_sale.s_product_aside" group="website" label="Auto-filled from Product" string="Product Aside"/>
             </xpath>
         </template>
     </data>

--- a/addons/website_mass_mailing_event/views/snippets_themes.xml
+++ b/addons/website_mass_mailing_event/views/snippets_themes.xml
@@ -1,10 +1,10 @@
 <odoo>
     <data>
         <template id="email_designer_snippets" inherit_id="mass_mailing.email_designer_snippets">
-            <xpath expr="//t[@t-snippet='mass_mailing.s_call_to_action']" position="after">
-                <t t-snippet="website_mass_mailing_event.s_event_card" group="marketing" label="Auto-filled from Event" string="Event Card"/>
-                <t t-snippet="website_mass_mailing_event.s_event_aside" group="marketing" label="Auto-filled from Event" string="Event Aside"/>
-                <t t-snippet="website_mass_mailing_event.s_event_columns" group="marketing" label="Auto-filled from Event" string="Events List"/>
+            <xpath expr="//t[@t-snippet='mass_mailing.s_coupon_code']" position="after">
+                <t t-snippet="website_mass_mailing_event.s_event_card" group="website" label="Auto-filled from Event" string="Event Card"/>
+                <t t-snippet="website_mass_mailing_event.s_event_aside" group="website" label="Auto-filled from Event" string="Event Aside"/>
+                <t t-snippet="website_mass_mailing_event.s_event_columns" group="website" label="Auto-filled from Event" string="Events List"/>
             </xpath>
         </template>
     </data>


### PR DESCRIPTION
This commit fixes some issues introduced by [1] and [2] when both were merged in master. As the tasks impacted the same files there were conflicts in those.

This commit changes the category of the new record_snapshot snippets so that they are displayed. Plus we also fix the sizing of the label in the AddSnippetDialog when in mass_mailing builder.

followup of task-4247666
followup of task-5380615

[1]: https://github.com/odoo/odoo/commit/33685d7dfd8b232802a5c46ed78d9411f328a5d3
[2]: https://github.com/odoo/odoo/commit/f8c5b1423c698f996aa2738d3c3b34d71541d2b1
