### PR TITLE
[IMP] resource: don't copy global leaves when duplicating calendars

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -73,7 +73,7 @@ class ResourceCalendar(models.Model):
     global_leave_ids = fields.One2many(
         'resource.calendar.leaves', 'calendar_id', 'Global Time Off',
         compute='_compute_global_leave_ids', store=True, readonly=False,
-        domain=[('resource_id', '=', False)], copy=True,
+        domain=[('resource_id', '=', False)],
     )
     hours_per_day = fields.Float("Average Hour per Day", store=True, compute="_compute_hours_per_day", digits=(2, 2), readonly=False,
         help="Average hours per day a resource is supposed to work with this calendar.")


### PR DESCRIPTION
If you duplicate the working schedule, it will also duplicate global leaves.

This commit prevents that.

Task-5895007