### PR TITLE
[FIX] mail: fix attachment box closing

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -153,16 +153,12 @@ const chatterPatch = {
             () => [this.state.thread, this.state.thread?.isLoadingAttachments]
         );
         useEffect(
-            () => {
-                if (
-                    this.state.thread &&
-                    !["new", "loading"].includes(this.state.thread.status) &&
-                    this.attachments.length === 0
-                ) {
+            (status, attachmentsLength) => {
+                if (!["new", "loading"].includes(status) && attachmentsLength === 0) {
                     this.state.isAttachmentBoxOpened = false;
                 }
             },
-            () => [this.state.thread?.status, this.attachments]
+            () => [this.state.thread?.status, this.attachments.length]
         );
         useEffect(
             () => {

--- a/addons/mail/static/tests/chatter/web/attachment_box.test.js
+++ b/addons/mail/static/tests/chatter/web/attachment_box.test.js
@@ -209,3 +209,30 @@ test("attachment box auto-closed on switch to record wih no attachments", async 
     await click(".o_pager_next");
     await contains(".o-mail-AttachmentBox", { count: 0 });
 });
+
+test("removing the last attachment should close the attachment box", async () => {
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({});
+    pyEnv["ir.attachment"].create({
+        mimetype: "text/plain",
+        name: "Blah.txt",
+        res_id: partnerId,
+        res_model: "res.partner",
+    });
+    await start();
+    await openFormView("res.partner", partnerId, {
+        arch: `
+            <form>
+                <sheet></sheet>
+                <chatter open_attachments="True"/>
+            </form>`,
+    });
+    await contains(".o-mail-AttachmentBox");
+    await click("button[title='Remove']");
+    await contains(
+        ".modal-body:text('Are you sure you want to delete \"Blah.txt\"? This action cannot be undone.')"
+    );
+    // Confirm the deletion
+    await click(".modal-footer .btn-primary");
+    await contains(".o-mail-AttachmentBox", { count: 0 });
+});


### PR DESCRIPTION
This commit fixes the closing of the attachment box when no attachments are present.
Before this commit, the `useEffect` responsible for checking the attachments length and closing the box did not properly observe `attachments.length`.

Task-5867464 (point 74)
