### PR TITLE
[FIX] im_livechat: close demo livechat sessions for coherent info panel

### DIFF
--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_1.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_1.xml
@@ -7,6 +7,7 @@
             <field name="livechat_channel_id" ref="support_bot_channel_demo"/>
             <field name="name">Visiteur #301, Support</field>
             <field name="create_date" eval="datetime.now() - timedelta(minutes=5)"/>
+            <field name="livechat_end_dt" eval="datetime.now() - timedelta(seconds=5)"/>
         </record>
         <record id="support_bot_session_1_history_member_bot_demo" model="im_livechat.channel.member.history">
             <field name="channel_id" ref="support_bot_session_1_demo"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_6.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_6.xml
@@ -6,6 +6,7 @@
             <field name="livechat_channel_id" ref="support_bot_channel_demo"/>
             <field name="name">Visitor #306, Support</field>
             <field name="create_date" eval="datetime.now() - timedelta(minutes=6)"/>
+            <field name="livechat_end_dt" eval="datetime.now() + timedelta(seconds=20)"/>
         </record>
         <record id="support_bot_session_6_history_member_bot_demo" model="im_livechat.channel.member.history">
             <field name="channel_id" ref="support_bot_session_6_demo"/>


### PR DESCRIPTION
**Description of the issue this PR addresses:**
----------------------------------------------
Some livechat demo sessions included feedback/ratings but were still
displayed as active conversations in the info side panel. This created
inconsistent demo data where closed conversations appeared with options
meant for ongoing chats (e.g., status shown instead of outcome).

**Current behavior before PR:**
----------------------------------------------
- Certain demo livechat sessions had ratings applied but no explicit livechat_end_dt set.
- As a result, the info side panel treated them as ongoing conversations.
- This caused mismatched UI information for demo data.

**Desired behavior after PR is merged:**
----------------------------------------------
- Demo livechat sessions that received feedback are explicitly marked as ended using livechat_end_dt.
- The info side panel correctly reflects closed conversations with coherent outcome information.

Task-5412081

----------------------------------------------
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
