### PR TITLE
[FIX] mail: send correct missed presences

### DIFF
--- a/addons/mail/models/mail_presence.py
+++ b/addons/mail/models/mail_presence.py
@@ -101,7 +101,7 @@ class MailPresence(models.Model):
                 "bus.bus/im_status_updated",
                 {
                     "presence_status": im_status or presence.status,
-                    "im_status": target.im_status,
+                    "im_status": presence.guest_id.im_status or presence.user_id.partner_id.im_status,
                     "guest_id": presence.guest_id.id,
                     "partner_id": presence.user_id.partner_id.id,
                 },


### PR DESCRIPTION
Before this commit, the missed presences flow incorrectly sent the current user's `im_status` for partners whose presences were missed.

This happens because, since [1], presence updates send the bus target's `im_status`, which corresponds to the current user in this subscription flow.

This commit fixes the issue by always retrieving the `im_status` from the presence record's identity field.

[1] https://github.com/odoo/odoo/pull/204485