### PR TITLE
[FIX] mrp: Fix Gantt view

### DIFF
--- a/addons/mrp/data/mrp_data.xml
+++ b/addons/mrp/data/mrp_data.xml
@@ -74,6 +74,22 @@
             <field name="sequence">0</field>
         </record>
 
+        <record id="mrp_workcenter_calendar" model="resource.calendar">
+            <field name="name">Work Center 40 hours/week</field>
+            <field name="company_id" eval="False"/>
+            <field name="hours_per_day">8</field>
+            <field name="attendance_ids"
+                eval="[(5, 0, 0),
+                    (0, 0, {'dayofweek': '0', 'duration_hours': 8, 'hour_from': 8, 'hour_to': 16}),
+                    (0, 0, {'dayofweek': '1', 'duration_hours': 8, 'hour_from': 8, 'hour_to': 16}),
+                    (0, 0, {'dayofweek': '2', 'duration_hours': 8, 'hour_from': 8, 'hour_to': 16}),
+                    (0, 0, {'dayofweek': '3', 'duration_hours': 8, 'hour_from': 8, 'hour_to': 16}),
+                    (0, 0, {'dayofweek': '4', 'duration_hours': 8, 'hour_from': 8, 'hour_to': 16}),
+                ]"
+            />
+            <field name="full_time_required_hours">40</field>
+        </record>
+
     </data>
 
 </odoo>

--- a/addons/mrp/data/mrp_demo.xml
+++ b/addons/mrp/data/mrp_demo.xml
@@ -19,17 +19,17 @@
 
         <record id="mrp_workcenter_3" model="mrp.workcenter">
             <field name="name">Assembly 1</field>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std"/>
+            <field name="resource_calendar_id" ref="mrp.mrp_workcenter_calendar"/>
         </record>
 
         <record id="mrp_workcenter_1" model="mrp.workcenter">
             <field name="name">Drill 1</field>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std"/>
+            <field name="resource_calendar_id" ref="mrp.mrp_workcenter_calendar"/>
         </record>
 
         <record id="mrp_workcenter_2" model="mrp.workcenter">
             <field name="name">Assembly 2</field>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std"/>
+            <field name="resource_calendar_id" ref="mrp.mrp_workcenter_calendar"/>
         </record>
 
         <!-- Resource: mrp.bom -->

--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -78,7 +78,7 @@ class MrpWorkcenter(models.Model):
     capacity_ids = fields.One2many('mrp.workcenter.capacity', 'workcenter_id', string='Product Capacities',
         help="Specific number of pieces that can be produced in parallel per product.", copy=True)
     kanban_dashboard_graph = fields.Text(compute='_compute_kanban_dashboard_graph')
-    resource_calendar_id = fields.Many2one(check_company=True)
+    resource_calendar_id = fields.Many2one(check_company=True, default=lambda self: self.env.ref('mrp.mrp_workcenter_calendar'))
 
     def _compute_display_name(self):
         super()._compute_display_name()

--- a/addons/mrp/tests/common.py
+++ b/addons/mrp/tests/common.py
@@ -132,18 +132,21 @@ class TestMrpCommon(TestStockCommon):
                 'time_stop': 5,
                 'time_efficiency': 80,
                 'tz': 'UTC',
+                'resource_calendar_id': cls.env.company.resource_calendar_id.id,
             }, {
                 'name': 'Simple Workcenter',
                 'time_start': 0,
                 'time_stop': 0,
                 'time_efficiency': 100,
                 'tz': 'UTC',
+                'resource_calendar_id': cls.env.company.resource_calendar_id.id,
             }, {
                 'name': 'Double Workcenter',
                 'time_start': 0,
                 'time_stop': 0,
                 'time_efficiency': 100,
                 'tz': 'UTC',
+                'resource_calendar_id': cls.env.company.resource_calendar_id.id,
             }
         ])
         for (workcenter, default_capacity) in [(cls.workcenter_1, 2), (cls.workcenter_2, 1), (cls.workcenter_3, 2)]:

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -39,21 +39,6 @@
         </field>
     </record>
 
-    <record model="ir.actions.act_window" id="action_mrp_workorder_production_specific">
-        <field name="name">Work Orders</field>
-        <field name="res_model">mrp.workorder</field>
-        <field name="view_mode">list,form,calendar,pivot,graph</field>
-        <field name="domain">[('production_id', '=', active_id)]</field>
-        <field name="help" type="html">
-          <p class="o_view_nocontent_smiling_face">
-            No work orders to do!
-          </p><p>
-            Work orders are operations to do as part of a manufacturing order.
-            Operations are defined in the bill of materials or added in the manufacturing order directly.
-          </p>
-        </field>
-    </record>
-
     <record model="ir.ui.view" id="mrp_production_workorder_tree_editable_view">
         <field name="name">mrp.production.work.order.list.editable</field>
         <field name="model">mrp.workorder</field>


### PR DESCRIPTION
- Use the old 'workcenter' gantt view rather than the 'production' (and remove it)
- Create a new Work Center calendar
- Add variant name in workorder display name
- Add the falsy label to employee_assigned_ids (for Gantt view mainly)
- Restore the possibility of not planning the 'blocked by' workorders
- Reload after Plan in Gantt view

task: 5946267

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
