### PR TITLE
[IMP] mail: reduce marging for chatter search button

### DIFF
--- a/addons/mail/static/src/core/common/search_message_input.xml
+++ b/addons/mail/static/src/core/common/search_message_input.xml
@@ -15,7 +15,7 @@
                 </button>
             </div>
             <Dropdown t-if="env.inChatter">
-                <button class="btn btn-outline-secondary ms-3" aria-label="Filter Messages" title="Filter Messages">
+                <button class="btn btn-outline-secondary ms-2" aria-label="Filter Messages" title="Filter Messages">
                     <i class="fa fa-filter" role="img"/>
                 </button>
                 <t t-set-slot="content">
@@ -27,7 +27,7 @@
                     </t>
                 </t>
             </Dropdown>
-            <button t-if="env.inChatter" class="btn btn-outline-secondary ms-3" t-on-click="() => this.clear()" aria-label="Close button">
+            <button t-if="env.inChatter" class="btn btn-outline-secondary ms-2" t-on-click="() => this.clear()" aria-label="Close button">
                 <i class="o_searchview_icon oi oi-close cursor-pointer" role="img" aria-label="Close search" title="Close"/>
             </button>
         </div>


### PR DESCRIPTION
This commit reduces the margin between the search button in the chatter search.

Task-5867464 (point 73)
Before
<img width="489" height="160" alt="image" src="https://github.com/user-attachments/assets/e63ca773-781f-49d1-b444-da0317086d2d" />

After
<img width="511" height="177" alt="image" src="https://github.com/user-attachments/assets/ef273931-6876-47b0-a0fc-88758e449352" />

