### PR TITLE
[FIX] l10n_sa_edi_pos: prevent error when order has no payment

### DIFF
--- a/addons/l10n_sa_edi_pos/models/account_edi_xml_ubl_21_zatca.py
+++ b/addons/l10n_sa_edi_pos/models/account_edi_xml_ubl_21_zatca.py
@@ -9,6 +9,6 @@ class AccountEdiXmlUBL21Zatca(models.AbstractModel):
             Return payment means code to be used to set the value on the XML file
         """
         res = super()._l10n_sa_get_payment_means_code(invoice)
-        if invoice._l10n_sa_is_simplified() and invoice.sudo().pos_order_ids:
+        if invoice._l10n_sa_is_simplified() and invoice.sudo().pos_order_ids.payment_ids:
             res = invoice.sudo().pos_order_ids.payment_ids[0].payment_method_id.type
         return res


### PR DESCRIPTION
Before this commit, when an order was fully discounted and therefore had no payment, the generation of the XML file for ZATCA would fail.

opw-5928185

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
