### PR TITLE
[FIX] account_peppol: Add wildcard support during partner check

### DIFF
--- a/addons/account_peppol/models/res_partner.py
+++ b/addons/account_peppol/models/res_partner.py
@@ -162,12 +162,17 @@ class ResPartner(models.Model):
 
     @api.model
     def _peppol_lookup_participant(self, edi_identification):
+        # TODO: Remove in master
+        return self._peppol_lookup_participant_formats_accepted(edi_identification, None)
+
+    @api.model
+    def _peppol_lookup_participant_formats_accepted(self, edi_identification, formats):
         """NAPTR DNS peppol participant lookup through Odoo's Peppol proxy"""
         if (edi_mode := self.env.company._get_peppol_edi_mode()) == 'demo':
             return
 
         origin = self.env['account_edi_proxy_client.user']._get_proxy_urls()['peppol'][edi_mode]
-        query = parse.urlencode({'peppol_identifier': edi_identification.lower()})
+        query = parse.urlencode({'peppol_identifier': edi_identification.lower(), 'formats': formats})
         endpoint = f'{origin}/api/peppol/1/lookup?{query}'
 
         try:
@@ -194,6 +199,8 @@ class ResPartner(models.Model):
         return decoded_response.get('result')
 
     def _check_document_type_support(self, participant_info, ubl_cii_format):
+        # DEPRECATED: TODO Remove in master
+
         if self.env.context.get('check_self_billing_support'):
             # This context key can be `True` only if the `account_peppol_selfbilling` module is installed.
             expected_customization_id = self.env['account.edi.xml.ubl_bis3']._get_selfbilling_customization_ids()[ubl_cii_format]
@@ -312,19 +319,31 @@ class ResPartner(models.Model):
             return 'not_verified'
 
         edi_identification = f"{peppol_eas}:{peppol_endpoint}".lower()
-        participant_info = self._peppol_lookup_participant(edi_identification)
+
+        if self.env.context.get('check_self_billing_support'):
+            # This context key can be `True` only if the `account_peppol_selfbilling` module is installed.
+            formats = self.env['account.edi.xml.ubl_bis3']._get_selfbilling_customization_ids()
+        else:
+            formats = self.env['account.edi.xml.ubl_21']._get_customization_ids()
+
+        format_str = ",".join(formats.values())
+        participant_info = self._peppol_lookup_participant_formats_accepted(edi_identification, format_str)
+
         if participant_info is None:
             return 'not_valid'
-        else:
-            is_participant_on_network = self._check_peppol_participant_exists(participant_info, edi_identification)
-            if is_participant_on_network:
-                is_valid_format = self._check_document_type_support(participant_info, invoice_edi_format)
-                if is_valid_format:
-                    return 'valid'
-                else:
-                    return 'not_valid_format'
-            else:
-                return 'not_valid'
+
+        accepted_formats = []
+        for service in participant_info.get('services', []):
+            accepted_formats += service['formats']
+
+        if formats[invoice_edi_format] not in accepted_formats:
+            return 'not_valid_format'
+
+        is_participant_on_network = self._check_peppol_participant_exists(participant_info, edi_identification)
+        if not is_participant_on_network:
+            return 'not_valid'
+
+        return 'valid'
 
     def _get_partners_to_skip_peppol_computation(self):
         return self.env['res.company'].search([

--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -116,6 +116,7 @@ class TestPeppolMessageCommon(TestAccountMoveSendCommon):
                             {
                                 "href": f"http://iap-services.odoo.com/iso6523-actorid-upis%3A%3A{url_quoted_peppol_identifier}/services/busdox-docid-qns%3A%3Aurn%3Aoasis%3Anames%3Aspecification%3Aubl%3Aschema%3Axsd%3AInvoice-2%3A%3AInvoice%23%23urn%3Acen.eu%3Aen16931%3A2017%23compliant%23urn%3Afdc%3Apeppol.eu%3A2017%3Apoacc%3Abilling%3A3.0%3A%3A2.1",
                                 "document_id": "urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0::2.1",
+                                "formats": ["urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0"],
                             },
                         ],
                     },
@@ -137,10 +138,12 @@ class TestPeppolMessageCommon(TestAccountMoveSendCommon):
                             {
                                 "href": f"http://iap-services.odoo.com/iso6523-actorid-upis%3A%3A{url_quoted_peppol_identifier}/services/busdox-docid-qns%3A%3Aurn%3Aoasis%3Anames%3Aspecification%3Aubl%3Aschema%3Axsd%3AInvoice-2%3A%3AInvoice%23%23urn%3Acen.eu%3Aen16931%3A2017%23compliant%23urn%3Afdc%3Apeppol.eu%3A2017%3Apoacc%3Abilling%3A3.0%3A%3A2.1",
                                 "document_id": "urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0::2.1",
+                                "formats": ["urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0"],
                             },
                             {
                                 "href": f"http://iap-services.odoo.com/iso6523-actorid-upis%3A%3A{url_quoted_peppol_identifier}/services/busdox-docid-qns%3A%3Aurn%3Aoasis%3Anames%3Aspecification%3Aubl%3Aschema%3Axsd%3AInvoice-2%3A%3AInvoice%23%23urn%3Acen.eu%3Aen16931%3A2017%23compliant%23urn%3Afdc%3Apeppol.eu%3A2017%3Apoacc%3Aselfbilling%3A3.0%3A%3A2.1",
                                 "document_id": "urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:selfbilling:3.0::2.1",
+                                "formats": ["urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:selfbilling:3.0"],
                             },
                         ],
                     },
@@ -283,15 +286,15 @@ class TestPeppolMessage(TestPeppolMessageCommon):
         self.assertTrue(wizard.sending_method_checkboxes['peppol']['readonly'])  # peppol is not possible to select
         self.assertFalse(wizard.alerts)  # there is no alerts
 
-    @patch('odoo.addons.account_peppol.models.res_partner.ResPartner._check_document_type_support', return_value=False)
-    def test_send_peppol_alerts_not_valid_format_partner(self, mocked_check):
+    def test_send_peppol_alerts_not_valid_format_partner(self):
+        ''' Tries to send using the NLCIUS format but the partner only accepts BIS3 '''
+        self.valid_partner.invoice_edi_format = 'nlcius'
         move = self.create_move(self.valid_partner)
         move.action_post()
-        wizard = self.create_send_and_print(move, sending_methods=['peppol'])  # partner can't receive BIS3 so Peppol not checked by default, force it
-
-        self.assertEqual(wizard.invoice_edi_format, 'ubl_bis3')
-        self.assertEqual(self.valid_partner.peppol_verification_state, 'not_valid_format')  # on peppol but can't receive bis3
+        wizard = self.create_send_and_print(move, sending_methods=['peppol'])  # Peppol not checked by default, force it
+        self.assertEqual(wizard.invoice_edi_format, 'nlcius')
         self.assertTrue('account_peppol_warning_partner' in wizard.alerts)
+        self.assertEqual(self.valid_partner.peppol_verification_state, 'not_valid_format')  # on peppol but can't receive NLCIUS
 
     def test_send_peppol_alerts_invalid_partner(self):
         """If there's already account_edi_ubl_cii_configure_partner, the warning should not appear."""

--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -116,6 +116,7 @@ class TestPeppolMessageCommon(TestAccountMoveSendCommon):
                             {
                                 "href": f"http://iap-services.odoo.com/iso6523-actorid-upis%3A%3A{url_quoted_peppol_identifier}/services/busdox-docid-qns%3A%3Aurn%3Aoasis%3Anames%3Aspecification%3Aubl%3Aschema%3Axsd%3AInvoice-2%3A%3AInvoice%23%23urn%3Acen.eu%3Aen16931%3A2017%23compliant%23urn%3Afdc%3Apeppol.eu%3A2017%3Apoacc%3Abilling%3A3.0%3A%3A2.1",
                                 "document_id": "urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0::2.1",
+                                "formats": ["urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0"],
                             },
                         ],
                     },
@@ -137,10 +138,12 @@ class TestPeppolMessageCommon(TestAccountMoveSendCommon):
                             {
                                 "href": f"http://iap-services.odoo.com/iso6523-actorid-upis%3A%3A{url_quoted_peppol_identifier}/services/busdox-docid-qns%3A%3Aurn%3Aoasis%3Anames%3Aspecification%3Aubl%3Aschema%3Axsd%3AInvoice-2%3A%3AInvoice%23%23urn%3Acen.eu%3Aen16931%3A2017%23compliant%23urn%3Afdc%3Apeppol.eu%3A2017%3Apoacc%3Abilling%3A3.0%3A%3A2.1",
                                 "document_id": "urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0::2.1",
+                                "formats": ["urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0"],
                             },
                             {
                                 "href": f"http://iap-services.odoo.com/iso6523-actorid-upis%3A%3A{url_quoted_peppol_identifier}/services/busdox-docid-qns%3A%3Aurn%3Aoasis%3Anames%3Aspecification%3Aubl%3Aschema%3Axsd%3AInvoice-2%3A%3AInvoice%23%23urn%3Acen.eu%3Aen16931%3A2017%23compliant%23urn%3Afdc%3Apeppol.eu%3A2017%3Apoacc%3Aselfbilling%3A3.0%3A%3A2.1",
                                 "document_id": "urn:oasis:names:specification:ubl:schema:xsd:Invoice-2::Invoice##urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:selfbilling:3.0::2.1",
+                                "formats": ["urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:selfbilling:3.0"],
                             },
                         ],
                     },
@@ -274,15 +277,15 @@ class TestPeppolMessage(TestPeppolMessageCommon):
         self.assertTrue(wizard.sending_method_checkboxes['peppol']['readonly'])  # peppol is not possible to select
         self.assertFalse(wizard.alerts)  # there is no alerts
 
-    @patch('odoo.addons.account_peppol.models.res_partner.ResPartner._check_document_type_support', return_value=False)
-    def test_send_peppol_alerts_not_valid_format_partner(self, mocked_check):
+    def test_send_peppol_alerts_not_valid_format_partner(self):
+        ''' Tries to send using the NLCIUS format but the partner only accepts BIS3 '''
+        self.valid_partner.invoice_edi_format = 'nlcius'
         move = self.create_move(self.valid_partner)
         move.action_post()
-        wizard = self.create_send_and_print(move, sending_methods=['peppol'])  # partner can't receive BIS3 so Peppol not checked by default, force it
-
-        self.assertEqual(wizard.invoice_edi_format, 'ubl_bis3')
-        self.assertEqual(self.valid_partner.peppol_verification_state, 'not_valid_format')  # on peppol but can't receive bis3
+        wizard = self.create_send_and_print(move, sending_methods=['peppol'])  # Peppol not checked by default, force it
+        self.assertEqual(wizard.invoice_edi_format, 'nlcius')
         self.assertTrue('account_peppol_warning_partner' in wizard.alerts)
+        self.assertEqual(self.valid_partner.peppol_verification_state, 'not_valid_format')  # on peppol but can't receive NLCIUS
 
     def test_send_peppol_alerts_invalid_partner(self):
         """If there's already account_edi_ubl_cii_configure_partner, the warning should not appear."""


### PR DESCRIPTION
Problem
---------
Currently, we support wildcard services on the IAP side. However, we do
not support wildcard support comparison on the client-side.

Objective
---------
Make it so that both sides can compare `document_id` to wildcarded
services.

Solution
---------
Update the `lookup` route so that it can be given a set of available
document IDs. The `lookup` will compare then compare it against the
services supported by customer. It will return the supported sub-set of
those document IDs.

no-task

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
