### PR TITLE
[FIX] web: resize `RedirectWarningDialog` to sm

### DIFF
--- a/addons/web/static/src/core/errors/error_dialogs.xml
+++ b/addons/web/static/src/core/errors/error_dialogs.xml
@@ -13,7 +13,7 @@
     </t>
 
     <t t-name="web.RedirectWarningDialog">
-        <Dialog title="title" size="'xl'" contentClass="'o_error_dialog'">
+        <Dialog title="title" size="'sm'" contentClass="'o_error_dialog'">
             <div role="alert">
                 <p t-esc="message" class="text-prewrap"/>
             </div>


### PR DESCRIPTION
Currently `RedirectWarningDialog` are using `xl` size which is way too big for the content it displays. Dialog sizes were reviewed in commit[1], the RedirectWarning should follow the same styling.

task-5477287

[1]: odoo/odoo@01741aa2619998078bd19aca848146ac75c027fc


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
