### PR TITLE
[FIX] purchase_mrp: fix kit cost calculation for multi-unit POs

### DIFF
--- a/addons/purchase_mrp/models/stock_move.py
+++ b/addons/purchase_mrp/models/stock_move.py
@@ -14,7 +14,15 @@ class StockMove(models.Model):
         if self.bom_line_id.bom_id.type == "phantom":
             uom_quantity = self.product_uom._compute_quantity(self.quantity, self.product_id.uom_id)
             if not self.product_uom.is_zero(uom_quantity):
-                return (self.cost_share / 100) * quantity / uom_quantity
+                unit_kit_purchase = 1
+                if self.purchase_line_id:
+                    active_moves = self.purchase_line_id.move_ids.filtered(lambda m:
+                        m.state != 'cancel' and m.product_id == self.product_id and m.picking_id != self.picking_id,
+                    )
+                    active_quantity = quantity + sum(active_moves.mapped('quantity'))
+                    if active_quantity:
+                        unit_kit_purchase = (quantity / active_quantity) * self.purchase_line_id.product_qty
+                return (self.cost_share / 100) * (quantity / uom_quantity) * unit_kit_purchase
         return super()._get_cost_ratio(quantity)
 
     def _get_value_from_bill(self, aml):

--- a/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
+++ b/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
@@ -416,7 +416,7 @@ class TestAngloSaxonValuationPurchaseMRP(TestStockValuationCommon):
         component01, component02, component03, component04, component05 = self.env['product.product'].create([{
             'name': 'Component %s' % name,
             'categ_id': avco_category.id,
-        } for name in ('01', '02 ', '03', '04', '05')])
+        } for name in ('01', '02', '03', '04', '05')])
 
         giga_kit, super_kit, kit, sub_kit, phantom_kit, triple_kit = self.env['product.product'].create([{
             'name': name,
@@ -470,13 +470,16 @@ class TestAngloSaxonValuationPurchaseMRP(TestStockValuationCommon):
             ],
         }])
         vendor = self.env['res.partner'].create({'name': 'Super vendor'})
-        purchase_order = self.env['purchase.order'].create({
-            'partner_id': vendor.id,
-            'order_line': [
-                Command.create({'product_id': super_kit.id, 'product_qty': 1, 'price_unit': 1000})
-            ],
-        })
-        purchase_order.button_confirm()
+        purchase_orders = self.env['purchase.order'].create([
+            {
+                'partner_id': vendor.id,
+                'order_line': [
+                    Command.create({'product_id': super_kit.id, 'product_qty': qty, 'price_unit': 1000}),
+                ],
+            }
+            for qty in [1, 3]
+        ])
+        purchase_orders.button_confirm()
 
         # Actual cost shares:
         # Component01:
@@ -496,9 +499,19 @@ class TestAngloSaxonValuationPurchaseMRP(TestStockValuationCommon):
         #   1.0 * 0.6 * 0.5 * 0.5 (0%) = 0.15 -> 15%
         #   1.0 * 0.2 * 0.5 (0%) = 0.1 -> 10%
         #   1.0 * 0.0 * 1.0 = 0.0 -> 0%
-        self.assertEqual(sum(purchase_order.order_line.move_ids.mapped('cost_share')), 100.0)
-        receipt = purchase_order.picking_ids
-        receipt.button_validate()
+        self.assertEqual(
+            [
+                sum(moves.mapped('cost_share'))
+                for moves in purchase_orders.order_line.move_ids.grouped('picking_id').values()
+            ], [100, 100])
+        receipts = purchase_orders.picking_ids
+        # Create a backorder by receiving only the half of component01
+        receipts[1].move_line_ids.filtered(lambda ml: ml.product_id.id == component01.id).quantity = 3
+        res = receipts.button_validate()
+        self.env[res["res_model"]].with_context(res["context"]).create({}).process()
+        receipts = purchase_orders.picking_ids
+        receipts[2].button_validate()
+
         expected_values = [
             {'product_id': component01.id, 'cost_share': 3.33, 'value': 33.3},
             {'product_id': component02.id, 'cost_share': 3.33, 'value': 33.3},
@@ -512,14 +525,19 @@ class TestAngloSaxonValuationPurchaseMRP(TestStockValuationCommon):
             {'product_id': component05.id, 'cost_share': 10.0, 'value': 100.0},
             {'product_id': component05.id, 'cost_share': 15.0, 'value': 150.0},
         ]
-        self.assertRecordValues(receipt.move_ids.sorted(lambda m: (m.product_id.id, m.cost_share)), expected_values)
+        expected_values += [
+            {**item, 'value': item['value'] * (1.5 if item['product_id'] == component01.id else 3)} for item in expected_values
+        ]
+        expected_values.append({'product_id': component01.id, 'cost_share': 3.33, 'value': 49.95})
+
+        self.assertRecordValues(receipts.move_ids.sorted(lambda m: (m.picking_id, m.product_id.id, m.cost_share)), expected_values)
 
         move_form = Form(self.env['account.move'].with_context(default_move_type='in_invoice'))
-        move_form.purchase_vendor_bill_id = self.env['purchase.bill.union'].browse(-purchase_order.id)
+        move_form.purchase_vendor_bill_id = self.env['purchase.bill.union'].browse(-purchase_orders[0].id)
         move_form.invoice_date = Datetime.today()
         move = move_form.save()
         move.action_post()
-        self.assertRecordValues(receipt.move_ids.sorted(lambda m: (m.product_id.id, m.cost_share)), expected_values)
+        self.assertRecordValues(receipts.move_ids.sorted(lambda m: (m.picking_id, m.product_id.id, m.cost_share)), expected_values)
 
     def test_kit_bom_cost_share_constraint_with_variants(self):
         """


### PR DESCRIPTION
**Issue**:
A PO of several units of kit product can lead to a wrong BOM cost

**Steps to reproduce**:
- Create a kit product (by creating a BOM) with AVCO valuation
- Create a purchase order with 3 units and a unit price of 10
- Confirm it and confirm the associated receipt
- Go to the BOM of the kit product and check BOM overview 
-> The cost is 3.33 instead of 10

This also works with FIFO valuation

**Cause**:
While computing the value of the move:
https://github.com/odoo/odoo/blob/2e4a4f2d063f9b09263e6c137e1c04358020c668/addons/stock_account/models/stock_move.py#L282 https://github.com/odoo/odoo/blob/2e4a4f2d063f9b09263e6c137e1c04358020c668/addons/stock_account/models/stock_move.py#L313-L314 It checks the value of the PO:
https://github.com/odoo/odoo/blob/2e4a4f2d063f9b09263e6c137e1c04358020c668/addons/stock_account/models/stock_move.py#L371-L372 Which relies on the `cost_ratio`:
https://github.com/odoo/odoo/blob/2e4a4f2d063f9b09263e6c137e1c04358020c668/addons/purchase_stock/models/stock_move.py#L221-L222 Which is computed this way:
https://github.com/odoo/odoo/blob/2e4a4f2d063f9b09263e6c137e1c04358020c668/addons/purchase_mrp/models/stock_move.py#L17 And does not take the number of received units into account.

This means that the value of the move is 10 instead of 30, which makes the valuation computation wrong: https://github.com/odoo/odoo/blob/2e4a4f2d063f9b09263e6c137e1c04358020c668/addons/stock_account/models/product.py#L393

opw-5924940