### PR TITLE
[FIX] hr_holidays: fix access error for my department filter

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -258,8 +258,8 @@ class HrEmployee(models.Model):
         return [('id', 'in', holidays.employee_id.ids)]
 
     def _search_part_of_department(self, operator, value):
-        version_ids = self.env['hr.version'].sudo()._search([('member_of_department', operator, value)])
-        return [('version_ids', 'in', version_ids)]
+        versions = self.env['hr.version'].sudo().search([('member_of_department', operator, value)])
+        return [('id', 'in', versions.employee_id.ids)]
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/hr_holidays/static/tests/tours/time_off_overview_my_department_tour.js
+++ b/addons/hr_holidays/static/tests/tours/time_off_overview_my_department_tour.js
@@ -1,0 +1,37 @@
+import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_utils";
+
+registry.category("web_tour.tours").add("time_off_overview_my_department_tour", {
+    url: "/odoo",
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        {
+            content: "Open Time Off app",
+            trigger: '.o_app[data-menu-xmlid="hr_holidays.menu_hr_holidays_root"]',
+            run: "click",
+        },
+        {
+            content: "Open Overview menu",
+            trigger: ".o-dropdown-item[data-menu-xmlid='hr_holidays\\.menu_hr_holidays_dashboard']",
+            run: "click",
+            tooltipPosition: "bottom",
+        },
+        {
+            content: "Click on the search bar",
+            trigger: ".o_searchview_input",
+            run: "click",
+            tooltipPosition: "bottom",
+        },
+        {
+            content: "Select 'My Department' filter",
+            trigger: ".o_dropdown_container:nth-child(1) > .o-dropdown-item:nth-child(3)",
+            run: "click",
+            tooltipPosition: "bottom",
+        },
+        {
+            content: "Ensure the 'My Department' filter is applied with no access errors",
+            trigger: "body:not(:has(.o_error_dialog))",  
+        },
+    ],
+});
+

--- a/addons/hr_holidays/tests/__init__.py
+++ b/addons/hr_holidays/tests/__init__.py
@@ -36,3 +36,4 @@ from . import test_multi_contract
 from . import test_time_off_allocation_tour
 from . import test_flexible_resource_calendar
 from . import test_calendar_leaves_count
+from . import test_timeoff_overview_my_department_tour

--- a/addons/hr_holidays/tests/test_timeoff_overview_my_department_tour.py
+++ b/addons/hr_holidays/tests/test_timeoff_overview_my_department_tour.py
@@ -1,0 +1,10 @@
+from odoo.tests import HttpCase, tagged, new_test_user
+
+
+@tagged("post_install", "-at_install")
+class TestTimeOffOverviewMyDepartmentTour(HttpCase):
+
+    def test_time_off_overview_my_department_tour(self):
+
+        user_employee = new_test_user(self.env, login="employee", groups="base.group_user")
+        self.start_tour("/", "time_off_overview_my_department_tour", login=user_employee.login)


### PR DESCRIPTION
Steps to reproduce:
1- Install Time off app with demo data
2- Log in as Marc Demo
3- Go to Time Off > Overview
4- Enable My Department filter

Issue:
An access error is raised because of not having enough rights to access the field version_id on hr.employee.

task-5948520


