### PR TITLE
[FIX] pos_loyalty: remove undeterministicTour in gift card tours

### DIFF
--- a/addons/point_of_sale/static/tests/generic_helpers/dialog_util.js
+++ b/addons/point_of_sale/static/tests/generic_helpers/dialog_util.js
@@ -1,7 +1,20 @@
 import { negate } from "@point_of_sale/../tests/generic_helpers/utils";
 
+function buildTrigger({ title, body } = {}) {
+    let selector = `.modal:not(.o_inactive_modal)`;
+
+    if (title) {
+        selector += `:has(.modal-title:contains("${title}"))`;
+    }
+
+    if (body) {
+        selector += `:has(.modal-body:contains("${body}"))`;
+    }
+    return selector;
+}
+
 export function confirm(confirmationText, button = ".btn-primary") {
-    let trigger = `.modal:not(.o_inactive_modal) .modal-footer ${button}`;
+    let trigger = `${buildTrigger()} .modal-footer ${button}`;
     if (confirmationText) {
         trigger += `:contains("${confirmationText}")`;
     }
@@ -11,29 +24,35 @@ export function confirm(confirmationText, button = ".btn-primary") {
         run: "click",
     };
 }
-export function cancel({ title } = {}) {
+
+export function proceed({ title, body, button, buttonClass = ".btn-primary" } = {}) {
+    let trigger = `${buildTrigger({ title, body })} .modal-footer ${buttonClass}`;
+    if (button) {
+        trigger += `:contains("${button}")`;
+    }
+    return {
+        content: "proceed click action on dialog",
+        trigger,
+        run: "click",
+    };
+}
+
+export function cancel({ title, body } = {}) {
     return {
         content: "cancel dialog",
-        trigger: `.modal .modal-header${
-            title ? `:contains(${title})` : ""
-        } button[aria-label="Close"]`,
+        trigger: `${buildTrigger({ title, body })} .modal-header button[aria-label="Close"]`,
         run: "click",
     };
 }
-export function discard({ title } = {}) {
+export function discard({ title, body } = {}) {
     return {
         content: "discard dialog",
-        trigger: `.modal${
-            title ? `:has(.modal-title:contains(${title}))` : ``
-        } .modal-footer button:contains("Discard")`,
+        trigger: `${buildTrigger({ title, body })} .modal-footer button:contains("Discard")`,
         run: "click",
     };
 }
-export function is({ title } = {}) {
-    let trigger = ".modal .modal-content";
-    if (title) {
-        trigger += ` .modal-header:contains("${title}")`;
-    }
+export function is({ title, body } = {}) {
+    const trigger = buildTrigger({ title, body });
     return {
         content: "dialog is open",
         trigger,

--- a/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
@@ -58,7 +58,6 @@ registry.category("web_tour.tours").add("GiftCardWithRefundtTour", {
 });
 
 registry.category("web_tour.tours").add("GiftCardProgramPriceNoTaxTour", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -66,7 +65,7 @@ registry.category("web_tour.tours").add("GiftCardProgramPriceNoTaxTour", {
             // Use gift card
             ProductScreen.addOrderline("Magnetic Board", "1", "1.98", "1.98"),
             PosLoyalty.enterCode("043123456"),
-            Dialog.confirm(),
+            Dialog.proceed({ title: "unpaid gift card" }),
             ProductScreen.clickOrderline("Gift Card"),
             ProductScreen.selectedOrderlineHas("Gift Card", "1", "-1.00"),
             PosLoyalty.orderTotalIs("0.98"),
@@ -74,7 +73,6 @@ registry.category("web_tour.tours").add("GiftCardProgramPriceNoTaxTour", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyPointsGiftcard", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -110,7 +108,6 @@ registry.category("web_tour.tours").add("PosLoyaltyGiftCardTaxes", {
 });
 
 registry.category("web_tour.tours").add("PhysicalGiftCardProgramSaleTour", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -134,7 +131,6 @@ registry.category("web_tour.tours").add("PhysicalGiftCardProgramSaleTour", {
 });
 
 registry.category("web_tour.tours").add("MultiplePhysicalGiftCardProgramSaleTour", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -223,7 +219,6 @@ registry.category("web_tour.tours").add("EmptyProductScreenTour", {
 });
 
 registry.category("web_tour.tours").add("test_physical_gift_card", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -239,13 +234,17 @@ registry.category("web_tour.tours").add("test_physical_gift_card", {
 
             // Use gift_card_generated_but_not_sold - Warning is triggered
             PosLoyalty.enterCode("gift_card_generated_but_not_sold"),
-            Dialog.cancel(),
+            Dialog.cancel({ title: "unpaid gift card" }),
 
             // Sell the unsold gift card
             PosLoyalty.useExistingLoyaltyCard("gift_card_generated_but_not_sold", true),
             ProductScreen.selectedOrderlineHas("Gift Card", "1", "60.00"),
             ProductScreen.clickNumpad("2"), // Cannot edit a physical gift card
-            Dialog.confirm(), // Warning is triggered
+            Dialog.proceed({
+                title: "gift card",
+                body: "you cannot change the quantity or the price of a physical gift card.",
+                button: "ok",
+            }), // Warning is triggered
             PosLoyalty.orderTotalIs("60.00"),
             PosLoyalty.finalizeOrder("Cash", "60"),
 

--- a/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
+++ b/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
@@ -4,7 +4,6 @@ import * as TextInputPopup from "@point_of_sale/../tests/generic_helpers/text_in
 import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
 import * as FeedbackScreen from "@point_of_sale/../tests/pos/tours/utils/feedback_screen_util";
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
-import { negate } from "@point_of_sale/../tests/generic_helpers/utils";
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 
 export function selectRewardLine(rewardName) {
@@ -173,20 +172,19 @@ export function useExistingLoyaltyCard(code, valid = true) {
         },
         {
             content: "Not loading",
-            trigger: negate(".gift-card-loading"),
+            trigger: `.modal:not(:has(.gift-card-loading))`,
         },
     ];
 
     if (!valid) {
-        steps.push(Dialog.confirm("Ok"));
-        steps.push(Dialog.cancel());
+        steps.push(Dialog.proceed({ title: "invalid gift card code", button: "Ok" }));
+        steps.push(Dialog.cancel({ title: "sell/manage physical gift card" }));
         steps.push({
             trigger: `a:contains("Sell physical gift card?")`,
-            run: () => {},
         });
     } else {
         steps.push(...Chrome.waitRequest());
-        steps.push(Dialog.confirm());
+        steps.push(Dialog.proceed({ button: "add existing gift card" }));
     }
 
     return steps;
@@ -202,6 +200,13 @@ export function createManualGiftCard(code, amount, date = false) {
             content: `Input code '${code}'`,
             trigger: `input[id="code"]`,
             run: `edit ${code}`,
+        },
+        {
+            content: "Editing the code involves verifications",
+            trigger: `.modal:has(.gift-card-loading)`,
+        },
+        {
+            trigger: `.modal input[id="code"]:value(${code})`,
         },
         {
             content: `Input amount '${amount}'`,


### PR DESCRIPTION
With this commit, we remove undeterministicTour key that allows delay
between steps.
The problem stems from the fact that `Dialog.confirm()` or
`Dialog.cancel()` are used repeatedly but are too generic.
This means a modal can be closed inadvertently (not necessarily the one
intended). This commit allows us to be more precise about which modal
is being closed.