### PR TITLE
[FIX] website: fix KeyError `manual` while submitting form with studio file field

### DIFF
--- a/addons/website/models/website_form.py
+++ b/addons/website/models/website_form.py
@@ -54,7 +54,7 @@ class IrModel(models.Model):
         """ Return the fields of the given model name as a mapping like method `fields_get`. """
         model = self.env[model_name]
         fields_get = model.fields_get(attributes=[
-            'required', 'domain', 'readonly', 'type', 'relation',
+            'required', 'domain', 'readonly', 'type', 'relation', 'manual',
             'definition_record', 'definition_record_field', 'string', 'selection',
         ])
 


### PR DESCRIPTION
Currently an exception is generated when the user tries to submit
a job application through the form.

Steps to produce an error:
- Install the `web_studio` and `website_hr_recruitment` modules
- Add a new File field to the `hr.applicant` module with the studio.
- Go to the website editor and add the form `Apply for a Job` and
  add the recently created field into the form and save it
- An error will occur when submitting the form with the added field

Error: `KeyError: 'manual'`

This issue occurs because the `manual` key(attribute) is not included in the
`authorized_fields` variable, which is generated by the `get_authorized_fields`
method. After the recent refactoring introduced in commit [1], the code
was changed to fetch only a limited set of attributes instead of all attributes,
and the manual attribute was not added to this list.

This commit resolves the above issue by including the `manual` attribute when
retrieving model fields, which was not added in commit [1].

[1]: https://github.com/odoo/odoo/commit/bfae7140d3951bec93fb7f2e49018649045edd40

Sentry-7271118700
opw-5933992