### PR TITLE
[FIX] point_of_sale: missing parameter in module model field listing

### DIFF
--- a/addons/point_of_sale/models/ir_module_module.py
+++ b/addons/point_of_sale/models/ir_module_module.py
@@ -5,7 +5,7 @@ class IrModuleModule(models.Model):
     _inherit = 'ir.module.module'
 
     @api.model
-    def _load_pos_data_fields(self):
+    def _load_pos_data_fields(self, config_id):
         return ['id', 'name', 'state']
 
     @api.model
@@ -14,8 +14,8 @@ class IrModuleModule(models.Model):
 
     def _load_pos_data(self, data):
         domain = self._load_pos_data_domain()
-        fields = self._load_pos_data_fields()
+        fields = self._load_pos_data_fields(data['pos.config']['data'][0]['id'])
         return {
             'data': self.search_read(domain, fields, load=False),
-            'fields': self._load_pos_data_fields(),
+            'fields': fields,
         }

--- a/doc/cla/corporate/batista10.md
+++ b/doc/cla/corporate/batista10.md
@@ -1,0 +1,17 @@
+Spain, 2025-07-14
+
+Be Ten IT Solutions S.L. (Batista10) agrees to the terms of the Odoo Corporate
+Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Marc Tormo i Bochaca gerencia@batista10.cat https://github.com/B10Serveis
+
+List of contributors:
+
+Marc Tormo i Bochaca batista10.info@gmail.com https://github.com/B10Serveis
+Joan Llimiñana i Sabaté gestio@batista10.com https://github.com/Batista10-G
+Ivan Vilata i Balaguer ivan@selidor.net https://github.com/ivilata


### PR DESCRIPTION
This fixes an issue introduced in commit 282a667b, by adding a `config_id` parameter to `IrModuleModule._load_pos_data_fields()` method, as used elsewhere in PoS modules.  An invocation in `_load_pos_data()` is also fixed.

The missing parameter caused invocations of these methods to fail, for instance when `PosSession.load_data()` got an `AccessError` (as demonstrated in OCA/pos#1429).

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
