### PR TITLE
[FIX] l10n_in: Show related tax only in TDS Entry Wizard

### DIFF
--- a/addons/l10n_in/models/account_tax.py
+++ b/addons/l10n_in/models/account_tax.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 
 from odoo import api, fields, models
+from odoo.fields import Domain
 from odoo.tools import frozendict
 
 
@@ -33,6 +34,13 @@ class AccountTax(models.Model):
     l10n_in_section_id = fields.Many2one('l10n_in.section.alert', string="Section")
     l10n_in_tds_feature_enabled = fields.Boolean(related='company_id.l10n_in_tds_feature')
     l10n_in_tcs_feature_enabled = fields.Boolean(related='company_id.l10n_in_tcs_feature')
+
+    @api.model
+    @api.readonly
+    def name_search(self, name='', domain=None, operator='ilike', limit=100):
+        if tds_tcs_section_ids := self.env.context.get('l10n_in_applicable_tds_tcs_section_ids'):
+            domain = Domain(domain or Domain.TRUE) & Domain('l10n_in_section_id', 'in', tds_tcs_section_ids)
+        return super().name_search(name, domain, operator, limit)
 
     @api.depends('country_code', 'invoice_repartition_line_ids.tag_ids')
     def _compute_l10n_in_gst_tax_type(self):

--- a/addons/l10n_in/wizard/l10n_in_withhold_wizard.py
+++ b/addons/l10n_in/wizard/l10n_in_withhold_wizard.py
@@ -93,6 +93,11 @@ class L10n_InWithholdWizard(models.TransientModel):
         string="TDS Amount",
         compute='_compute_amount',
     )
+    l10n_in_applicable_tds_tcs_section_ids = fields.Many2many(
+        comodel_name='l10n_in.section.alert',
+        string="Applicable TDS/TCS Sections",
+        compute='_compute_l10n_in_applicable_tds_tcs_section_ids',
+    )
 
     #  ===== Constraints =====
     @api.constrains('base')
@@ -208,6 +213,10 @@ class L10n_InWithholdWizard(models.TransientModel):
                 )
                 tax_amount = taxes_res['total_included'] - taxes_res['total_excluded']
             wizard.amount = abs(tax_amount)
+
+    def _compute_l10n_in_applicable_tds_tcs_section_ids(self):
+        for wizard in self:
+            wizard.l10n_in_applicable_tds_tcs_section_ids = wizard.related_move_id.invoice_line_ids.l10n_in_tds_tcs_section_id
 
     def _get_withhold_type(self):
         if self.related_move_id:

--- a/addons/l10n_in/wizard/l10n_in_withhold_wizard.xml
+++ b/addons/l10n_in/wizard/l10n_in_withhold_wizard.xml
@@ -24,8 +24,11 @@
                             <field name="date" string="Entry Date"/>
                             <label for="tax_id" string="TDS Section"/>
                             <div>
-                                <field name="tax_id" class="oe_inline" domain="[('l10n_in_tax_type', '=', l10n_in_tds_tax_type)]" required="True"
-                                options="{'no_create': True, 'no_open': True}"/>
+                                <field name="tax_id" class="oe_inline" required="True"
+                                       domain="[('l10n_in_tax_type', '=', l10n_in_tds_tax_type)]"
+                                       options="{'no_create': True, 'no_open': True}"
+                                       context="{'l10n_in_applicable_tds_tcs_section_ids': l10n_in_applicable_tds_tcs_section_ids}"
+                                />
                                 <field name="tds_deduction" class="oe_inline"
                                        decoration-success="tds_deduction == 'lower'"
                                        decoration-danger="tds_deduction == 'higher'"


### PR DESCRIPTION
Currently, when creating TDS entry via the TDS Wizard, the "TDS Section" field shows all the TDS sections, and all of them might not be relevant to the user.

This commit fixes this issue by showing only those taxes initially whose TDS Section matches with the ones set on the Account of the invoice lines.

task-5940892

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
