### PR TITLE
[FIX] mail: right-click on pinned message panel should no show actions

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -467,7 +467,7 @@ export class Message extends Component {
             // Mobile OS long press is handled with useLongPress()
             return;
         }
-        if (ev.target.tagName === "A") {
+        if (ev.target.tagName === "A" || !this.props.hasActions) {
             return;
         }
         this.showRightClickMessageActions(ev);


### PR DESCRIPTION
Before this commit, when some messages are pinned and the pinned messages panel is open, right-click on a message in pinned panel shows the message actions.

The actions are not made visible in pinned messages panel, as intended by the props `hasActions=false` in this panel. However, the right-click showing of message actions lack condition based on this props, which is what this commit fixes.

Task-5935503

Before / After (shows right-click of system)
<img width="317" height="301" alt="Screenshot 2026-02-18 at 12 14 39" src="https://github.com/user-attachments/assets/e81d5118-09f1-4a67-907d-119e813cbac4" />
<img width="291" height="125" alt="Screenshot 2026-02-18 at 12 15 12" src="https://github.com/user-attachments/assets/417070a2-b926-4558-8479-aacf61a86948" />
