### PR TITLE
[IMP] l10n_tr_nilvera{_einvoice}: Improvements and bug fixes

### DIFF
--- a/addons/l10n_tr_nilvera/views/res_partner_views.xml
+++ b/addons/l10n_tr_nilvera/views/res_partner_views.xml
@@ -15,6 +15,7 @@
                                     class="btn btn-secondary"
                                     type="object"
                                     string="Verify"
+                                    context="{'retry_existing': True}"
                                     help="Verify partner on Nilvera"/>
                         </div>
                     </div>

--- a/addons/l10n_tr_nilvera_base_vat/__init__.py
+++ b/addons/l10n_tr_nilvera_base_vat/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/l10n_tr_nilvera_base_vat/__manifest__.py
+++ b/addons/l10n_tr_nilvera_base_vat/__manifest__.py
@@ -1,0 +1,10 @@
+{
+    'name': 'Türkiye - Nilvera/Base VAT',
+    'version': '1.0',
+    'category': 'Accounting/Accounting',
+    'description': "Bridge module for Nilvera and Base VAT integration.",
+    'depends': ['l10n_tr_nilvera', 'base_vat'],
+    'auto_install': True,
+    'author': 'Odoo S.A.',
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_tr_nilvera_base_vat/models/__init__.py
+++ b/addons/l10n_tr_nilvera_base_vat/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_partner

--- a/addons/l10n_tr_nilvera_base_vat/models/res_partner.py
+++ b/addons/l10n_tr_nilvera_base_vat/models/res_partner.py
@@ -1,0 +1,12 @@
+from odoo import models
+
+NILVERA_TEST_VAT_NUMS = {'1234567801', '1234567802'}
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    def check_vat_tr(self, vat):
+        # EXTENDS 'base_vat'
+        company = self.env.company
+        return super().check_vat_tr(vat) or (company.l10n_tr_nilvera_use_test_env and vat in NILVERA_TEST_VAT_NUMS)

--- a/addons/l10n_tr_nilvera_einvoice/models/account_move.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_move.py
@@ -82,7 +82,7 @@ class AccountMove(models.Model):
 
     def button_draft(self):
         # EXTENDS account
-        for move in self.filtered('l10n_tr_nilvera_uuid'):
+        for move in self.filtered(lambda move: move.l10n_tr_nilvera_uuid and move.move_type == 'out_invoice'):
             if move.l10n_tr_nilvera_send_status == 'error':
                 move.message_post(body=_("To preserve accounting integrity and comply with legal requirements, invoices cannot be reused once an error occurs. Please create a new invoice to continue."))
             elif move.l10n_tr_nilvera_send_status != 'not_sent':

--- a/addons/l10n_tr_nilvera_einvoice/tests/test_tr_nilvera_mocked_requests.py
+++ b/addons/l10n_tr_nilvera_einvoice/tests/test_tr_nilvera_mocked_requests.py
@@ -135,8 +135,9 @@ class TestTRNilveraMockedRequests(TestUBLTRCommon):
     @patch_nilvera_request
     def setUpClass(cls):
         super().setUpClass()
-        cls.einvoice_partner._check_nilvera_customer()
-        cls.earchive_partner._check_nilvera_customer()
+        with patch.object(cls.env.cr, 'commit', autospec=True):
+            cls.einvoice_partner._check_nilvera_customer()
+            cls.earchive_partner._check_nilvera_customer()
         cls.env['account.journal'].create({
             'name': 'TR Journal',
             'code': 'TRJ',

--- a/addons/l10n_tr_nilvera_einvoice/views/account_move_views.xml
+++ b/addons/l10n_tr_nilvera_einvoice/views/account_move_views.xml
@@ -14,10 +14,10 @@
                 <attribute name="invisible" separator=" or " add="l10n_tr_nilvera_send_status == 'error' and l10n_tr_nilvera_uuid"/>
             </xpath>
             <xpath expr="//div[@name='journal_div']" position="after">
-                <label for="l10n_tr_nilvera_send_status" invisible="country_code != 'TR' or state == 'draft' or move_type not in ['out_invoice', 'in_invoice']"/>
+                <label for="l10n_tr_nilvera_send_status" invisible="country_code != 'TR' or state == 'draft' or move_type != 'out_invoice'"/>
                 <div name="nilvera_div"
                      class="d-flex"
-                     invisible="country_code != 'TR' or state == 'draft' or move_type not in ['out_invoice', 'in_invoice']">
+                     invisible="country_code != 'TR' or state == 'draft' or move_type != 'out_invoice'">
                     <field name="l10n_tr_nilvera_send_status" class="oe_inline"/>
                 </div>
             </xpath>

--- a/addons/l10n_tr_nilvera_einvoice_extended/views/account_move_views.xml
+++ b/addons/l10n_tr_nilvera_einvoice_extended/views/account_move_views.xml
@@ -19,10 +19,10 @@
                 <div class="d-flex" invisible="l10n_tr_is_export_invoice or country_code != 'TR' or move_type != 'out_invoice' or l10n_tr_nilvera_customer_status not in ['einvoice', 'earchive']">
                     <field name="l10n_tr_gib_invoice_scenario" invisible="l10n_tr_nilvera_customer_status != 'einvoice'" readonly="state in ['cancel', 'posted']"/>
                     <span class="o_form_label mx-3" invisible="l10n_tr_nilvera_customer_status != 'einvoice'">is</span>
-                    <field name="l10n_tr_gib_invoice_type" invisible="l10n_tr_nilvera_customer_status not in ['einvoice', 'earchive']" readonly="state in ['cancel', 'posted']"/>
+                    <field name="l10n_tr_gib_invoice_type" required="l10n_tr_nilvera_customer_status == 'einvoice' and l10n_tr_gib_invoice_scenario" invisible="l10n_tr_nilvera_customer_status not in ['einvoice', 'earchive']" readonly="state in ['cancel', 'posted']"/>
                 </div>
-                <field name="l10n_tr_exemption_code_id" domain="[('code_type', 'in', l10n_tr_exemption_code_domain_list or [])]" invisible="not l10n_tr_exemption_code_domain_list or l10n_tr_nilvera_customer_status not in ['einvoice', 'earchive']"  required="l10n_tr_is_export_invoice or l10n_tr_gib_invoice_type == 'IHRACKAYITLI'" readonly="state in ['cancel', 'posted']"/>
-                <field name="l10n_tr_shipping_type" invisible="not l10n_tr_exemption_code_domain_list or l10n_tr_nilvera_customer_status != 'earchive' or not l10n_tr_is_export_invoice" readonly="state in ['cancel', 'posted']"/>
+                <field name="l10n_tr_exemption_code_id" domain="[('code_type', 'in', l10n_tr_exemption_code_domain_list or [])]" invisible="not l10n_tr_exemption_code_domain_list or l10n_tr_nilvera_customer_status not in ['einvoice', 'earchive']"  required="l10n_tr_is_export_invoice or l10n_tr_gib_invoice_type in ('IHRACKAYITLI', 'ISTISNA')" readonly="state in ['cancel', 'posted']"/>
+                <field name="l10n_tr_shipping_type" required="l10n_tr_is_export_invoice" invisible="not l10n_tr_exemption_code_domain_list or l10n_tr_nilvera_customer_status != 'earchive' or not l10n_tr_is_export_invoice" readonly="state in ['cancel', 'posted']"/>
             </xpath>
 
             <xpath expr="//field[@name='invoice_line_ids']//list//field[@name='tax_ids']" position="after">


### PR DESCRIPTION
This commit adds the following improvements and bug fixes to the turkish localization:
- Make shipping method required for GiB export invoices
- Make Exemption Reason mandatory when Invoice Type is Tax Exempt
- Ensure Invoice Type is selected when Invoice Scenario is set
- Hide the nilvera send status for Vendor Bills
- Adjust the error message for missing CTSP numbers on invoice lines
- Allow resetting Vendor Bills to draft
- Give priority to the currency rate on the invoice when generating UBL
- Create a new bridge module to bypass the VAT validation for test VAT numbers
- Fix bug in bulk customer verification

task-5868201

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
