### PR TITLE
[FIX] l10n_in: prevent error when trying to merge multiple contacts

### DIFF
--- a/addons/l10n_in/models/res_partner.py
+++ b/addons/l10n_in/models/res_partner.py
@@ -55,7 +55,8 @@ class ResPartner(models.Model):
 
     @api.depends('l10n_in_pan')
     def _compute_display_pan_warning(self):
-        self.display_pan_warning = self.vat and self.l10n_in_pan and self.l10n_in_pan != self.vat[2:12]
+        for partner in self:
+            partner.display_pan_warning = partner.vat and partner.l10n_in_pan and partner.l10n_in_pan != partner.vat[2:12]
 
     @api.onchange('company_type')
     def onchange_company_type(self):


### PR DESCRIPTION
When we select multiple customers and attempt to merge their contacts by removing one of the customers, this error occurs.

Steps to reproduce:
- Install the 'l10n_in' module
- Switch to 'IN company'
- Invoicing > Customers >Customers
- Go to list view > Select all Customers > Actions > Merge
- Click on 'Deco Addict', now come back and remove it
- Click on 'Merge Contacts'

Traceback:ValueError
Expected singleton: res.partner(50, 46, 43, 36)

This error occurred at [1] because multiple values are getting in self.

This commit will fix the above error by adding it to the loop.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
