### PR TITLE
[FIX] mail: add missing kpi_provider_visibility to mail.activity.type form view

### DIFF
--- a/addons/mail/models/mail_activity_type.py
+++ b/addons/mail/models/mail_activity_type.py
@@ -82,7 +82,7 @@ class MailActivityType(models.Model):
         help="Whether this type of activity should be displayed in the KPI Provider API.\n"
              "None: never display this type of activity\n"
              "Own Activities: the synchronization user will only count their own activities of this type\n"
-             "All Activities: the synchronization user will count the all the activities of this type, whatever their owner")
+             "All Activities: the synchronization user will count all the activities of this type, whatever their owner")
 
     #Fields for display purpose only
     initial_res_model = fields.Selection(selection=_get_model_selection, string='Initial model', compute="_compute_initial_res_model", store=False,

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -28,6 +28,7 @@
                                 <field class="oe_inline ps-1 pe-2" name="delay_unit"/>
                                 <field class="oe_inline" name="delay_from"/>
                             </div>
+                            <field name="kpi_provider_visibility" groups="base.group_no_one"/>
                         </group>
                         <group name="activity_planning" string="Next Activity">
                             <field name="chaining_type" invisible="category == 'upload_file'"/>


### PR DESCRIPTION
Introduced in ff941e6555c12918803db4a72511c9381cc58c31, the field `kpi_provider_visibility` was not added to the form view.

With this commit, we add the field to the form view, so that the value can be changed by the administrator of the database.

Task-id: [5167740](https://www.odoo.com/odoo/project.task/5167740)