### PR TITLE
[FIX] html_editor: set cursor after zws for ios safari collapsed bold

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -395,7 +395,14 @@ export class FormatPlugin extends Plugin {
             selectedTextNodes[0] &&
             selectedTextNodes[0].textContent === "\u200B"
         ) {
-            this.dependencies.selection.setCursorStart(selectedTextNodes[0]);
+            // We set the cursor at the end of the selected ZWS text node, to
+            // avoid an issue on ios safari where the selection is collapsed,
+            // and set the format as bold/italic, the cursor is not properly
+            // updated. Even though the selection is properly set, safari seems
+            // to force the cursor to stay at the old position at rendering
+            // if there's no node between the old and new cursor position,
+            // e.g. <div>[]<p>\u200B</p></div> -> <div><p>[]\u200B</p></div>.
+            this.dependencies.selection.setCursorEnd(selectedTextNodes[0]);
         } else if (selectedTextNodes.length) {
             const firstNode = selectedTextNodes[0];
             const lastNode = selectedTextNodes[selectedTextNodes.length - 1];

--- a/addons/html_editor/static/tests/format/bold.test.js
+++ b/addons/html_editor/static/tests/format/bold.test.js
@@ -115,7 +115,7 @@ test("should get ready to type in bold", async () => {
     await testEditor({
         contentBefore: "<p>ab[]cd</p>",
         stepFunction: bold,
-        contentAfterEdit: `<p>ab<strong data-oe-zws-empty-inline="">[]\u200B</strong>cd</p>`,
+        contentAfterEdit: `<p>ab<strong data-oe-zws-empty-inline="">\u200B[]</strong>cd</p>`,
         contentAfter: `<p>ab[]cd</p>`,
     });
 });
@@ -124,7 +124,7 @@ test("should get ready to type in not bold", async () => {
     await testEditor({
         contentBefore: `<p><strong>ab[]cd</strong></p>`,
         stepFunction: bold,
-        contentAfterEdit: `<p><strong>ab</strong><span data-oe-zws-empty-inline="">[]\u200B</span><strong>cd</strong></p>`,
+        contentAfterEdit: `<p><strong>ab</strong><span data-oe-zws-empty-inline="">\u200B[]</span><strong>cd</strong></p>`,
         contentAfter: `<p><strong>ab[]cd</strong></p>`,
     });
 });
@@ -250,7 +250,7 @@ test("should insert a span zws when toggling a formatting command twice", () =>
         // todo: It would be better to remove the zws entirely so that
         // the P could have the "/" hint but that behavior might be
         // complex with the current implementation.
-        contentAfterEdit: `<p placeholder='Type "/" for commands' class="o-we-hint"><span data-oe-zws-empty-inline="">[]\u200B</span></p>`,
+        contentAfterEdit: `<p placeholder='Type "/" for commands' class="o-we-hint"><span data-oe-zws-empty-inline="">\u200B[]</span></p>`,
     }));
 
 // This test uses execCommand to reproduce as closely as possible the browser's
@@ -275,7 +275,7 @@ test("should type in bold", async () => {
 
     // Toggle bold on.
     bold(editor);
-    expect(getContent(el)).toBe(`<p>ab<strong data-oe-zws-empty-inline="">[]\u200B</strong>cd</p>`);
+    expect(getContent(el)).toBe(`<p>ab<strong data-oe-zws-empty-inline="">\u200B[]</strong>cd</p>`);
 
     // Simulate text insertion as done by the contenteditable.
     await typeChar(editor, "x");
@@ -289,7 +289,7 @@ test("should type in bold", async () => {
     // Toggle bold off and type more.
     bold(editor);
     expect(getContent(el)).toBe(
-        `<p>ab<strong>xy</strong><span data-oe-zws-empty-inline="">[]\u200B</span>cd</p>`
+        `<p>ab<strong>xy</strong><span data-oe-zws-empty-inline="">\u200B[]</span>cd</p>`
     );
     await typeChar(editor, "z");
     expect(getContent(el)).toBe(`<p>ab<strong>xy</strong>z[]cd</p>`);
@@ -299,19 +299,19 @@ test.tags("desktop");
 test("create bold with shortcut + selected with arrow", async () => {
     const { editor, el } = await setupEditor("<p>ab[]cd</p>");
     await press(["control", "b"]);
-    expect(getContent(el)).toBe(`<p>ab<strong data-oe-zws-empty-inline="">[]\u200B</strong>cd</p>`);
+    expect(getContent(el)).toBe(`<p>ab<strong data-oe-zws-empty-inline="">\u200B[]</strong>cd</p>`);
 
     await simulateArrowKeyPress(editor, ["Shift", "ArrowRight"]);
     await tick(); // await selectionchange
     await animationFrame();
     await expectElementCount(".o-we-toolbar", 1);
-    expect(getContent(el)).toBe(`<p>ab<strong data-oe-zws-empty-inline="">[\u200B</strong>c]d</p>`);
+    expect(getContent(el)).toBe(`<p>ab<strong data-oe-zws-empty-inline="">\u200B</strong>[c]d</p>`);
 
     await simulateArrowKeyPress(editor, ["Shift", "ArrowLeft"]);
     await tick(); // await selectionchange
     await animationFrame();
     await expectElementCount(".o-we-toolbar", 0);
-    expect(getContent(el)).toBe(`<p>ab<strong data-oe-zws-empty-inline="">[\u200B]</strong>cd</p>`);
+    expect(getContent(el)).toBe(`<p>ab<strong data-oe-zws-empty-inline="">\u200B[]</strong>cd</p>`);
 });
 
 const styleContentBold = `.boldClass { font-weight: bold; }`;
@@ -378,7 +378,7 @@ test("should remove empty bold tag when changing selection", async () => {
 
     bold(editor);
     await tick();
-    expect(getContent(el)).toBe(`<p>ab<strong data-oe-zws-empty-inline="">[]\u200B</strong>cd</p>`);
+    expect(getContent(el)).toBe(`<p>ab<strong data-oe-zws-empty-inline="">\u200B[]</strong>cd</p>`);
 
     await simulateArrowKeyPress(editor, "ArrowLeft");
     await tick(); // await selectionchange
@@ -392,7 +392,7 @@ test("should remove multiple formatted empty bold tag when changing selection", 
     italic(editor);
     await tick();
     expect(getContent(el)).toBe(
-        `<p>ab<strong data-oe-zws-empty-inline=""><em data-oe-zws-empty-inline="">[]\u200B</em></strong>cd</p>`
+        `<p>ab<strong data-oe-zws-empty-inline=""><em data-oe-zws-empty-inline="">\u200B[]</em></strong>cd</p>`
     );
 
     await simulateArrowKeyPress(editor, "ArrowLeft");
@@ -406,7 +406,7 @@ test("should not remove empty bold tag in an empty block when changing selection
     bold(editor);
     await tick();
     expect(getContent(el)).toBe(
-        `<p>abcd</p><p placeholder='Type "/" for commands' class="o-we-hint"><strong data-oe-zws-empty-inline="">[]\u200B</strong></p>`
+        `<p>abcd</p><p placeholder='Type "/" for commands' class="o-we-hint"><strong data-oe-zws-empty-inline="">\u200B[]</strong></p>`
     );
 
     await simulateArrowKeyPress(editor, "ArrowUp");
@@ -425,7 +425,7 @@ test("should not add history step for bold on collapsed selection", async () => 
     // step. The empty inline tag is temporary: auto-cleaned if unused. We want
     // to avoid having a phantom step in the history.
     await press(["ctrl", "b"]);
-    expect(getContent(el)).toBe(`<p>abcd<strong data-oe-zws-empty-inline="">[]\u200B</strong></p>`);
+    expect(getContent(el)).toBe(`<p>abcd<strong data-oe-zws-empty-inline="">\u200B[]</strong></p>`);
 
     await insertText(editor, "A");
     expect(getContent(el)).toBe(`<p>abcd<strong>A[]</strong></p>`);

--- a/addons/html_editor/static/tests/format/italic.test.js
+++ b/addons/html_editor/static/tests/format/italic.test.js
@@ -103,7 +103,7 @@ test("should get ready to type in italic", async () => {
     await testEditor({
         contentBefore: `<p>ab[]cd</p>`,
         stepFunction: italic,
-        contentAfterEdit: `<p>ab<em data-oe-zws-empty-inline="">[]\u200B</em>cd</p>`,
+        contentAfterEdit: `<p>ab<em data-oe-zws-empty-inline="">\u200B[]</em>cd</p>`,
         contentAfter: `<p>ab[]cd</p>`,
     });
 });
@@ -112,7 +112,7 @@ test("should get ready to type in not italic", async () => {
     await testEditor({
         contentBefore: `<p><em>ab[]cd</em></p>`,
         stepFunction: italic,
-        contentAfterEdit: `<p><em>ab</em><span data-oe-zws-empty-inline="">[]\u200B</span><em>cd</em></p>`,
+        contentAfterEdit: `<p><em>ab</em><span data-oe-zws-empty-inline="">\u200B[]</span><em>cd</em></p>`,
         contentAfter: `<p><em>ab[]cd</em></p>`,
     });
 });
@@ -130,7 +130,7 @@ test("should remove empty italic tag when changing selection", async () => {
 
     italic(editor);
     await tick();
-    expect(getContent(el)).toBe(`<p>ab<em data-oe-zws-empty-inline="">[]\u200B</em>cd</p>`);
+    expect(getContent(el)).toBe(`<p>ab<em data-oe-zws-empty-inline="">\u200B[]</em>cd</p>`);
 
     await simulateArrowKeyPress(editor, "ArrowLeft");
     await tick(); // await selectionchange
@@ -192,7 +192,7 @@ test("should not add history step for italic on collapsed selection", async () =
     // step. The empty inline tag is temporary: auto-cleaned if unused. We want
     // to avoid having a phantom step in the history.
     await press(["ctrl", "i"]);
-    expect(getContent(el)).toBe(`<p>abcd<em data-oe-zws-empty-inline="">[]\u200B</em></p>`);
+    expect(getContent(el)).toBe(`<p>abcd<em data-oe-zws-empty-inline="">\u200B[]</em></p>`);
 
     await insertText(editor, "A");
     expect(getContent(el)).toBe(`<p>abcd<em>A[]</em></p>`);

--- a/addons/html_editor/static/tests/format/strike_through.test.js
+++ b/addons/html_editor/static/tests/format/strike_through.test.js
@@ -158,7 +158,7 @@ test("should get ready to type in strikeThrough", async () => {
     await testEditor({
         contentBefore: `<p>ab[]cd</p>`,
         stepFunction: strikeThrough,
-        contentAfterEdit: `<p>ab<s data-oe-zws-empty-inline="">[]\u200B</s>cd</p>`,
+        contentAfterEdit: `<p>ab<s data-oe-zws-empty-inline="">\u200B[]</s>cd</p>`,
         contentAfter: `<p>ab[]cd</p>`,
     });
 });
@@ -167,7 +167,7 @@ test("should get ready to type in not underline", async () => {
     await testEditor({
         contentBefore: `<p><s>ab[]cd</s></p>`,
         stepFunction: strikeThrough,
-        contentAfterEdit: `<p><s>ab</s><span data-oe-zws-empty-inline="">[]\u200B</span><s>cd</s></p>`,
+        contentAfterEdit: `<p><s>ab</s><span data-oe-zws-empty-inline="">\u200B[]</span><s>cd</s></p>`,
         contentAfter: `<p><s>ab[]cd</s></p>`,
     });
 });
@@ -258,7 +258,7 @@ test("should remove empty strikeThrough when changing selection", async () => {
 
     strikeThrough(editor);
     await tick();
-    expect(getContent(el)).toBe(`<p>ab<s data-oe-zws-empty-inline="">[]\u200B</s>cd</p>`);
+    expect(getContent(el)).toBe(`<p>ab<s data-oe-zws-empty-inline="">\u200B[]</s>cd</p>`);
 
     await simulateArrowKeyPress(editor, "ArrowLeft");
     await tick(); // await selectionchange
@@ -274,7 +274,7 @@ test("should not add history step for strikethrough on collapsed selection", asy
     // step. The empty inline tag is temporary: auto-cleaned if unused. We want
     // to avoid having a phantom step in the history.
     await press(["ctrl", "5"]);
-    expect(getContent(el)).toBe(`<p>abcd<s data-oe-zws-empty-inline="">[]\u200B</s></p>`);
+    expect(getContent(el)).toBe(`<p>abcd<s data-oe-zws-empty-inline="">\u200B[]</s></p>`);
 
     await insertText(editor, "A");
     expect(getContent(el)).toBe(`<p>abcd<s>A[]</s></p>`);

--- a/addons/html_editor/static/tests/format/underline.test.js
+++ b/addons/html_editor/static/tests/format/underline.test.js
@@ -101,7 +101,7 @@ test("should get ready to type in underline", async () => {
     await testEditor({
         contentBefore: `<p>ab[]cd</p>`,
         stepFunction: underline,
-        contentAfterEdit: `<p>ab<u data-oe-zws-empty-inline="">[]\u200B</u>cd</p>`,
+        contentAfterEdit: `<p>ab<u data-oe-zws-empty-inline="">\u200B[]</u>cd</p>`,
         contentAfter: `<p>ab[]cd</p>`,
     });
 });
@@ -110,7 +110,7 @@ test("should get ready to type in not underline", async () => {
     await testEditor({
         contentBefore: `<p><u>ab[]cd</u></p>`,
         stepFunction: underline,
-        contentAfterEdit: `<p><u>ab</u><span data-oe-zws-empty-inline="">[]\u200B</span><u>cd</u></p>`,
+        contentAfterEdit: `<p><u>ab</u><span data-oe-zws-empty-inline="">\u200B[]</span><u>cd</u></p>`,
         contentAfter: `<p><u>ab[]cd</u></p>`,
     });
 });
@@ -174,7 +174,7 @@ describe("with strikeThrough", () => {
         await testEditor({
             contentBefore: `<p>ab<u><s>cd[]ef</s></u></p>`,
             stepFunction: underline,
-            contentAfterEdit: `<p>ab<u><s>cd</s></u><s data-oe-zws-empty-inline="">[]\u200b</s><u><s>ef</s></u></p>`,
+            contentAfterEdit: `<p>ab<u><s>cd</s></u><s data-oe-zws-empty-inline="">\u200B[]</s><u><s>ef</s></u></p>`,
             contentAfter: `<p>ab<u><s>cd[]ef</s></u></p>`,
         });
     });
@@ -183,16 +183,16 @@ describe("with strikeThrough", () => {
         await testEditor({
             contentBefore: `<p>ab<u><s>cd</s></u><s data-oe-zws-empty-inline="">\u200b[]</s><u><s>ef</s></u></p>`,
             stepFunction: underline,
-            contentAfterEdit: `<p>ab<u><s>cd</s></u><s data-oe-zws-empty-inline=""><u data-oe-zws-empty-inline="">[]\u200b</u></s><u><s>ef</s></u></p>`,
+            contentAfterEdit: `<p>ab<u><s>cd</s></u><s data-oe-zws-empty-inline=""><u data-oe-zws-empty-inline="">\u200B[]</u></s><u><s>ef</s></u></p>`,
             contentAfter: `<p>ab<u><s>cd[]ef</s></u></p>`,
         });
     });
 
     test("should remove underline after restoring it after removing it (collapsed, strikeThrough)", async () => {
         await testEditor({
-            contentBefore: `<p>ab<u><s>cd</s></u><s><u>[]\u200b</u></s><u><s>ef</s></u></p>`,
+            contentBefore: `<p>ab<u><s>cd</s></u><s><u>\u200B[]</u></s><u><s>ef</s></u></p>`,
             stepFunction: underline,
-            contentAfterEdit: `<p>ab<u><s>cd</s></u><s data-oe-zws-empty-inline="">[]\u200b</s><u><s>ef</s></u></p>`,
+            contentAfterEdit: `<p>ab<u><s>cd</s></u><s data-oe-zws-empty-inline="">\u200B[]</s><u><s>ef</s></u></p>`,
             contentAfter: `<p>ab<u><s>cd[]ef</s></u></p>`,
         });
     });
@@ -201,7 +201,7 @@ describe("with strikeThrough", () => {
         await testEditor({
             contentBefore: `<p>ab<u><s>cd</s></u><s><u>ghi[]</u></s><u><s>ef</s></u></p>`,
             stepFunction: underline,
-            contentAfterEdit: `<p>ab<u><s>cd</s></u><s><u>ghi</u></s><s data-oe-zws-empty-inline="">[]\u200b</s><u><s>ef</s></u></p>`,
+            contentAfterEdit: `<p>ab<u><s>cd</s></u><s><u>ghi</u></s><s data-oe-zws-empty-inline="">\u200B[]</s><u><s>ef</s></u></p>`,
             // The reason the cursor is after the tag <s> is because when the editor get's cleaned, the zws tag gets deleted.
             contentAfter: `<p>ab<u><s>cd</s></u><s><u>ghi</u></s>[]<u><s>ef</s></u></p>`,
         });
@@ -242,7 +242,7 @@ describe("with italic", () => {
                 italic(editor);
                 underline(editor);
             },
-            contentAfterEdit: `<p>ab<em data-oe-zws-empty-inline=""><u data-oe-zws-empty-inline="">[]\u200b</u></em>cd</p>`,
+            contentAfterEdit: `<p>ab<em data-oe-zws-empty-inline=""><u data-oe-zws-empty-inline="">\u200B[]</u></em>cd</p>`,
             contentAfter: `<p>ab[]cd</p>`,
         });
     });
@@ -255,7 +255,7 @@ describe("with italic", () => {
                 underline(editor);
                 underline(editor);
             },
-            contentAfterEdit: `<p>ab<em data-oe-zws-empty-inline="">[]\u200B</em>cd</p>`,
+            contentAfterEdit: `<p>ab<em data-oe-zws-empty-inline="">\u200B[]</em>cd</p>`,
             contentAfter: `<p>ab[]cd</p>`,
         });
     });
@@ -268,7 +268,7 @@ describe("with italic", () => {
                 italic(editor);
                 underline(editor);
             },
-            contentAfterEdit: `<p>ab<em data-oe-zws-empty-inline="">[]\u200B</em>cd</p>`,
+            contentAfterEdit: `<p>ab<em data-oe-zws-empty-inline="">\u200B[]</em>cd</p>`,
             contentAfter: `<p>ab[]cd</p>`,
         });
     });
@@ -281,7 +281,7 @@ describe("with italic", () => {
                 underline(editor);
                 italic(editor);
             },
-            contentAfterEdit: `<p>ab<em data-oe-zws-empty-inline="">[]\u200B</em>cd</p>`,
+            contentAfterEdit: `<p>ab<em data-oe-zws-empty-inline="">\u200B[]</em>cd</p>`,
             contentAfter: `<p>ab[]cd</p>`,
         });
     });
@@ -290,25 +290,25 @@ describe("with italic", () => {
         await testEditor({
             contentBefore: `<p>ab<u><em>cd[]ef</em></u></p>`,
             stepFunction: underline,
-            contentAfterEdit: `<p>ab<u><em>cd</em></u><em data-oe-zws-empty-inline="">[]\u200b</em><u><em>ef</em></u></p>`,
+            contentAfterEdit: `<p>ab<u><em>cd</em></u><em data-oe-zws-empty-inline="">\u200B[]</em><u><em>ef</em></u></p>`,
             contentAfter: `<p>ab<u><em>cd[]ef</em></u></p>`,
         });
     });
 
     test("should restore underline after removing it (collapsed, italic)", async () => {
         await testEditor({
-            contentBefore: `<p>ab<u><em>cd</em></u><em>[]\u200b</em><u><em>ef</em></u></p>`,
+            contentBefore: `<p>ab<u><em>cd</em></u><em>\u200B[]</em><u><em>ef</em></u></p>`,
             stepFunction: underline,
-            contentAfterEdit: `<p>ab<u><em>cd</em></u><em><u data-oe-zws-empty-inline="">[]\u200b</u></em><u><em>ef</em></u></p>`,
+            contentAfterEdit: `<p>ab<u><em>cd</em></u><em><u data-oe-zws-empty-inline="">\u200B[]</u></em><u><em>ef</em></u></p>`,
             contentAfter: `<p>ab<u><em>cd</em></u><em>[]</em><u><em>ef</em></u></p>`,
         });
     });
 
     test("should remove underline after restoring it after removing it (collapsed, italic)", async () => {
         await testEditor({
-            contentBefore: `<p>ab<u><em>cd</em></u><em><u>[]\u200b</u></em><u><em>ef</em></u></p>`,
+            contentBefore: `<p>ab<u><em>cd</em></u><em><u>\u200B[]</u></em><u><em>ef</em></u></p>`,
             stepFunction: underline,
-            contentAfterEdit: `<p>ab<u><em>cd</em></u><em data-oe-zws-empty-inline="">[]\u200b</em><u><em>ef</em></u></p>`,
+            contentAfterEdit: `<p>ab<u><em>cd</em></u><em data-oe-zws-empty-inline="">\u200B[]</em><u><em>ef</em></u></p>`,
             contentAfter: `<p>ab<u><em>cd[]ef</em></u></p>`,
         });
     });
@@ -317,7 +317,7 @@ describe("with italic", () => {
         await testEditor({
             contentBefore: `<p>ab<u><em>cd</em></u><em><u>ghi[]</u></em><u><em>ef</em></u></p>`,
             stepFunction: underline,
-            contentAfterEdit: `<p>ab<u><em>cd</em></u><em><u>ghi</u></em><em data-oe-zws-empty-inline="">[]\u200b</em><u><em>ef</em></u></p>`,
+            contentAfterEdit: `<p>ab<u><em>cd</em></u><em><u>ghi</u></em><em data-oe-zws-empty-inline="">\u200B[]</em><u><em>ef</em></u></p>`,
             // The reason the cursor is after the tag <s> is because when the editor get's cleaned, the zws tag gets deleted.
             contentAfter: `<p>ab<u><em>cd</em></u><em><u>ghi</u></em>[]<u><em>ef</em></u></p>`,
         });
@@ -346,7 +346,7 @@ describe("with italic", () => {
 
         underline(editor);
         await tick();
-        expect(getContent(el)).toBe(`<p>ab<u data-oe-zws-empty-inline="">[]\u200B</u>cd</p>`);
+        expect(getContent(el)).toBe(`<p>ab<u data-oe-zws-empty-inline="">\u200B[]</u>cd</p>`);
 
         await simulateArrowKeyPress(editor, "ArrowLeft");
         await tick(); // await selectionchange
@@ -363,7 +363,7 @@ test("should not add history step for underline on collapsed selection", async (
     // step. The empty inline tag is temporary: auto-cleaned if unused. We want
     // to avoid having a phantom step in the history.
     await press(["ctrl", "u"]);
-    expect(getContent(el)).toBe(`<p>abcd<u data-oe-zws-empty-inline="">[]\u200B</u></p>`);
+    expect(getContent(el)).toBe(`<p>abcd<u data-oe-zws-empty-inline="">\u200B[]</u></p>`);
 
     await insertText(editor, "A");
     expect(getContent(el)).toBe(`<p>abcd<u>A[]</u></p>`);

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -85,7 +85,7 @@ test("should show bold button highlighted after applying format when selection i
     await contains(".btn[name='bold']").click();
 
     expect(".btn[name='bold']").toHaveClass("active");
-    expect(getContent(el)).toBe(`<p>te<strong data-oe-zws-empty-inline="">[]\u200B</strong>st</p>`);
+    expect(getContent(el)).toBe(`<p>te<strong data-oe-zws-empty-inline="">\u200B[]</strong>st</p>`);
 });
 
 test("toolbar closes when selection leaves editor", async () => {


### PR DESCRIPTION
Before this commit: when we applying format on collapsed cursor, we create a formatted element with ZWS, and set the cursor before the ZWS

After this commit: we set the cursor after the ZWS, cause otherwise safari doesn't update the cursor properly leading to unformatted input

task-4243977


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
