### PR TITLE
[IMP] point_of_sale: improved ui in combo configurator

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/combo_configurator_popup/combo_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/combo_configurator_popup/combo_configurator_popup.js
@@ -1,6 +1,7 @@
 import { useState } from "@web/owl2/utils";
 import { Dialog } from "@web/core/dialog/dialog";
 import { Component, onWillStart } from "@odoo/owl";
+import { formatCurrency } from "@web/core/currency";
 import { usePos } from "@point_of_sale/app/hooks/pos_hook";
 import { ProductCard } from "@point_of_sale/app/components/product_card/product_card";
 import { QuantityButtons } from "@point_of_sale/app/components/buttons/quantity_buttons/quantity_buttons";
@@ -162,7 +163,11 @@ export class ComboConfiguratorPopup extends Component {
             return "";
         }
         const priceSign = comboItem.extra_price > 0 ? "+" : "-";
-        return priceSign + " " + this.env.utils.formatCurrency(comboItem.extra_price);
+        return (
+            priceSign +
+            " " +
+            formatCurrency(comboItem.extra_price, this.pos.currency.id, { trailingZeros: false })
+        );
     }
 
     getSelectedComboItems() {

--- a/addons/point_of_sale/static/src/app/components/popups/combo_configurator_popup/combo_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/combo_configurator_popup/combo_configurator_popup.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.ComboConfiguratorPopup">
         <Dialog t-if="this.hasMultipleChoices()" title="this.title" contentClass="'combo-configurator-popup'">
-            <div t-foreach="props.productTemplate.combo_ids" t-as="combo" t-key="combo.id" class="d-flex flex-column m-3 mb-4">
+            <div t-foreach="props.productTemplate.combo_ids" t-as="combo" t-key="combo.id" class="d-flex flex-column my-3 mb-4">
                 <div class="d-flex align-items-center mb-3">
                     <h3 class="mb-0" t-out="combo.name"></h3>
                     <t t-if="combo.qty_free > 0">

--- a/addons/point_of_sale/static/src/app/components/product_card/product_card.xml
+++ b/addons/point_of_sale/static/src/app/components/product_card/product_card.xml
@@ -25,7 +25,7 @@
                     class="product-cart-qty position-absolute bottom-0 end-0 m-1 px-2 rounded bg-black text-white fs-5 fw-bolder"
                     t-att-class="{'text-danger': this.productQty lt 0}"/>
             </div>
-            <span t-if="props.comboExtraPrice" style="font-size: 0.75rem;" class="price-extra px-2 py-0 rounded-1 text-bg-info position-absolute top-0 end-0 mt-1 me-1">
+            <span t-if="props.comboExtraPrice" style="font-size: 0.65rem;" class="price-extra px-1 py-0 rounded-1 text-bg-info position-absolute top-0 end-0">
                 <t t-out="props.comboExtraPrice"/>
             </span>
             <t t-slot="quantityButtons" />

--- a/addons/point_of_sale/static/tests/unit/components/popup/combo_configurator_popup.test.js
+++ b/addons/point_of_sale/static/tests/unit/components/popup/combo_configurator_popup.test.js
@@ -1,0 +1,22 @@
+import { test, expect } from "@odoo/hoot";
+import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { setupPosEnv } from "@point_of_sale/../tests/unit/utils";
+import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
+import { ComboConfiguratorPopup } from "@point_of_sale/app/components/popups/combo_configurator_popup/combo_configurator_popup";
+
+definePosModels();
+
+test("formattedComboPrice_contains_no_trailing_zeros", async () => {
+    const store = await setupPosEnv();
+    const productTemplate = store.models["product.template"].get(7);
+    const comboConfigurator = await mountWithCleanup(ComboConfiguratorPopup, {
+        props: { productTemplate: productTemplate, getPayload: () => {}, close: () => {} },
+    });
+    // check if no additional trailing zeros added from formatCurrency when the extra_price has decimals or not
+    expect(
+        comboConfigurator.formattedComboPrice(productTemplate.combo_ids[0].combo_item_ids[1])
+    ).toEqual("+ $ 35");
+    expect(
+        comboConfigurator.formattedComboPrice(productTemplate.combo_ids[1].combo_item_ids[1])
+    ).toEqual("+ $ 50");
+});


### PR DESCRIPTION
In this commit:
---------------
- Modified extra_price formatting to strip trailing zeros (e.g., `2.00` → `2`) for better visual
consistency in compact UI.
- Adjusted modal spacing by removing unnecessary margins to ensure proper alignment
with the header and footer.

task: 5946300
