### PR TITLE
[FIX] core: missing type check

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -2519,7 +2519,7 @@ class Image(Binary):
         if self.readonly and (
             (not self.max_width and not self.max_height)
             or (
-                self.related_field
+                isinstance(self.related_field, Image)
                 and self.max_width == self.related_field.max_width
                 and self.max_height == self.related_field.max_height
             )


### PR DESCRIPTION
This fixes an oversight of 4840a6639deb171c28ae14b0269d420aa1503860 that `Image` and `Binary` objects have the same `self.type` value and thus an `Image` can relate to a `Binary`, after all.