### PR TITLE
[FIX] portal, test_mail_full: show edited message in portal chatter

### DIFF
--- a/addons/portal/controllers/thread.py
+++ b/addons/portal/controllers/thread.py
@@ -140,7 +140,7 @@ class PortalWebClientController(WebclientController):
             Domain("body", "!=", False)
             & Domain(
                 "body",
-                "not like",
+                "not =like",
                 '<span class="o-mail-Message-edited" data-o-datetime="%"></span>',
             )
         ) | Domain("attachment_ids", "!=", False)

--- a/addons/test_mail_full/static/tests/tours/message_actions_tour.js
+++ b/addons/test_mail_full/static/tests/tours/message_actions_tour.js
@@ -54,6 +54,14 @@ registry.category("web_tour.tours").add("message_actions_tour", {
             trigger: "#chatterRoot:shadow .o-mail-Message button:contains(save)",
             run: "click",
         },
+        // If it fails here, it means the edited message has not been fetched correctly.
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message:contains(Message content changed)",
+            run: function () {
+                window.location.reload();
+            },
+            expectUnloadPage: true,
+        },
         {
             trigger: "#chatterRoot:shadow .o-mail-Message:contains(Message content changed)",
             run: "hover && click #chatterRoot:shadow button[title='Expand']",


### PR DESCRIPTION
PR #247795 uses `not like` operator to filter messages with an empty body containing only the `edited` tag which actually filters all edited messages in portal. This change fixes the incorrect filtering by using `not =like` operator to be more explicit about the body content.

