### PR TITLE
[FIX] purchase_{mrp, stock}: fix kit valuation after vendor bill posting

### DIFF
--- a/addons/purchase_mrp/models/stock_move.py
+++ b/addons/purchase_mrp/models/stock_move.py
@@ -17,6 +17,18 @@ class StockMove(models.Model):
                 return (self.cost_share / 100) * quantity / uom_quantity
         return super()._get_cost_ratio(quantity)
 
+    def _get_value_from_bill(self, aml):
+        value = super()._get_value_from_bill(aml)
+        if self.bom_line_id.bom_id.type == "phantom":
+            value *= (self.cost_share / 100)
+        return value
+
+    def _get_quantity_from_bill(self, aml, quantity):
+        self.ensure_one()
+        if self.bom_line_id.bom_id.type == "phantom":
+            return aml.product_uom_id._compute_quantity(quantity, self.product_id.uom_id)
+        return super()._get_quantity_from_bill(aml, quantity)
+
     def _prepare_phantom_move_values(self, bom_line, product_qty, quantity_done):
         vals = super()._prepare_phantom_move_values(bom_line, product_qty, quantity_done)
         if self.purchase_line_id:

--- a/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
+++ b/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
@@ -499,7 +499,7 @@ class TestAngloSaxonValuationPurchaseMRP(TestStockValuationCommon):
         self.assertEqual(sum(purchase_order.order_line.move_ids.mapped('cost_share')), 100.0)
         receipt = purchase_order.picking_ids
         receipt.button_validate()
-        self.assertRecordValues(receipt.move_ids.sorted(lambda m: (m.product_id.id, m.cost_share)), [
+        expected_values = [
             {'product_id': component01.id, 'cost_share': 3.33, 'value': 33.3},
             {'product_id': component02.id, 'cost_share': 3.33, 'value': 33.3},
             {'product_id': component02.id, 'cost_share': 10.0, 'value': 100.0},
@@ -511,7 +511,15 @@ class TestAngloSaxonValuationPurchaseMRP(TestStockValuationCommon):
             {'product_id': component05.id, 'cost_share': 0.0, 'value': 0.0},
             {'product_id': component05.id, 'cost_share': 10.0, 'value': 100.0},
             {'product_id': component05.id, 'cost_share': 15.0, 'value': 150.0},
-        ])
+        ]
+        self.assertRecordValues(receipt.move_ids.sorted(lambda m: (m.product_id.id, m.cost_share)), expected_values)
+
+        move_form = Form(self.env['account.move'].with_context(default_move_type='in_invoice'))
+        move_form.purchase_vendor_bill_id = self.env['purchase.bill.union'].browse(-purchase_order.id)
+        move_form.invoice_date = Datetime.today()
+        move = move_form.save()
+        move.action_post()
+        self.assertRecordValues(receipt.move_ids.sorted(lambda m: (m.product_id.id, m.cost_share)), expected_values)
 
     def test_kit_bom_cost_share_constraint_with_variants(self):
         """

--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -169,11 +169,11 @@ class StockMove(models.Model):
                 continue
             aml_ids.add(aml.id)
             if aml.move_type == 'in_invoice':
-                aml_quantity += aml.product_uom_id._compute_quantity(aml.quantity, self.product_id.uom_id)
-                value += aml.company_id.currency_id.round(aml.price_subtotal / aml.currency_rate)
+                aml_quantity += self._get_quantity_from_bill(aml, quantity)
+                value += self._get_value_from_bill(aml)
             elif aml.move_type == 'in_refund':
-                aml_quantity -= aml.product_uom_id._compute_quantity(aml.quantity, self.product_id.uom_id)
-                value -= aml.company_id.currency_id.round(aml.price_subtotal / aml.currency_rate)
+                aml_quantity -= self._get_quantity_from_bill(aml, quantity)
+                value -= self._get_value_from_bill(aml)
 
         if aml_quantity <= 0:
             return valuation_data
@@ -209,6 +209,14 @@ class StockMove(models.Model):
             value=self.company_currency_id.format(value), quantity=aml_quantity, unit=self.product_id.uom_id.name,
             bills=account_moves.mapped('display_name'))
         return valuation_data
+
+    def _get_value_from_bill(self, aml):
+        self.ensure_one()
+        return aml.company_id.currency_id.round(aml.price_subtotal / aml.currency_rate)
+
+    def _get_quantity_from_bill(self, aml, quantity):
+        self.ensure_one()
+        return aml.product_uom_id._compute_quantity(aml.quantity, self.product_id.uom_id)
 
     def _get_cost_ratio(self, quantity):
         self.ensure_one()


### PR DESCRIPTION
**Issue**:
Billing a PO containing kit with several components can lead to incorrect
valuation of its components

**Steps to reproduce**:
- Create a kit product (by creating a BOM with 2 components) with AVCO valuation
- Create a PO for 1 unit at unit price 10
- Confirm PO and validate the receipt
- Go to the BOM of the kit product and check BOM overview
-> The cost of the two components are 5, which is correct
- Go to Accounting > Vendors > Bill
- Create a new bill by indicating the PO in "Auto-Complete" field and validate
- Go back to the BOM of the kit product and check BOM overview
-> The cost of the two components are 10, which is correct

This also occurs with FIFO valuation

**Cause**:
While computing the value of the move:
https://github.com/odoo/odoo/blob/2e4a4f2d063f9b09263e6c137e1c04358020c668/addons/stock_account/models/stock_move.py#L282
https://github.com/odoo/odoo/blob/2e4a4f2d063f9b09263e6c137e1c04358020c668/addons/stock_account/models/stock_move.py#L313-L314
It checks the value of the Bill:
https://github.com/odoo/odoo/blob/2e4a4f2d063f9b09263e6c137e1c04358020c668/addons/stock_account/models/stock_move.py#L357-L358
Which relies directly on the AML price of the kit:
https://github.com/odoo/odoo/blob/a2b3a10255dba290ea462b9193ae11c54d8dd5e0/addons/purchase_stock/models/stock_move.py#L170
This ignores the `cost_share` of each BOM component. As a result,
each component receives the full kit value instead of its proportional
share

This means that the value of the move is 10 instead of 10/2=5, which makes the valuation computation wrong:
https://github.com/odoo/odoo/blob/2e4a4f2d063f9b09263e6c137e1c04358020c668/addons/stock_account/models/product.py#L393

**Aditionnal note**
The computation of the quantity is also incorrect:
https://github.com/odoo/odoo/blob/a2b3a10255dba290ea462b9193ae11c54d8dd5e0/addons/purchase_stock/models/stock_move.py#L169
since it assumes the quantity of component of the kit is the same than the quantity of the kit itself,
which is not true in the general case.

opw-5924940