### PR TITLE
[IMP] mail,*: update channel description to topic

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -1085,7 +1085,7 @@ class CalendarEvent(models.Model):
                 self.videocall_channel_id = event_with_channel.videocall_channel_id
                 return
         self.videocall_channel_id = self._create_videocall_channel_id(self.name, self.partner_ids.ids)
-        self.videocall_channel_id.channel_change_description(self.recurrence_id.name if self.recurrency else self.display_time)
+        self.videocall_channel_id.change_topic(self.recurrence_id.name if self.recurrency else self.display_time)
 
     def _create_videocall_channel_id(self, name, partner_ids):
         videocall_channel = self.env['discuss.channel']._create_group(partner_ids, default_display_mode='video_full_screen', name=name)

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_11.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_11.xml
@@ -6,7 +6,7 @@
             <field name="livechat_lang_id" ref="base.lang_en"/>
             <field name="livechat_status">need_help</field>
             <field name="livechat_looking_for_help_since_dt" eval="datetime.now()"/>
-            <field name="description">Customer needs more information on the Discuss application</field>
+            <field name="topic">Customer needs more information on the Discuss application</field>
             <field name="livechat_channel_id" ref="im_livechat.im_livechat_channel_data"/>
             <field name="livechat_failure">no_failure</field>
             <field name="channel_type">livechat</field>

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -411,7 +411,7 @@ class DiscussChannel(models.Model):
     def _sync_field_names(self, res):
         super()._sync_field_names(res)
         res[None].attr("livechat_end_dt", predicate=is_livechat_channel)
-        res["internal_users"].attr("description", predicate=is_livechat_channel)
+        res["internal_users"].attr("topic", predicate=is_livechat_channel)
         res["internal_users"].attr("livechat_note", predicate=is_livechat_channel)
         res["internal_users"].attr("livechat_status", predicate=is_livechat_channel)
         res["internal_users"].attr("livechat_looking_for_help_since_dt", predicate=is_livechat_channel)
@@ -435,7 +435,7 @@ class DiscussChannel(models.Model):
         )
         if res.is_for_internal_users():
             res.one("livechat_channel_id", ["name"], predicate=is_livechat_channel, sudo=True)
-            res.attr("description", predicate=is_livechat_channel)
+            res.attr("topic", predicate=is_livechat_channel)
             res.one("livechat_lang_id", ["name", "code"], predicate=is_livechat_channel)
             res.attr("livechat_note", predicate=is_livechat_channel)
             res.attr("livechat_outcome", predicate=is_livechat_channel)

--- a/addons/im_livechat/static/src/core/public_web/discuss_sidebar_channel_patch.xml
+++ b/addons/im_livechat/static/src/core/public_web/discuss_sidebar_channel_patch.xml
@@ -12,12 +12,12 @@
             </t>
         </xpath>
         <xpath expr="//*[hasclass('o-mail-DiscussSidebarChannel-itemName')]" position="inside">
-            <div t-if="channel.livechat_status === 'need_help' and channel.description" t-att-title="channel.description" class="text-muted text-truncate smaller" t-esc="channel.description"/>
+            <div t-if="channel.livechat_status === 'need_help' and channel.topic" t-att-title="channel.topic" class="text-muted text-truncate smaller" t-esc="channel.topic"/>
         </xpath>
     </t>
     <t t-inherit="mail.DiscussSidebarChannel" t-inherit-mode="extension">
         <xpath expr="//*[hasclass('o-mail-DiscussSidebarChannel-floatingName')]" position="after">
-            <div t-if="channel.livechat_status === 'need_help' and channel.description" t-att-title="channel.description" class="text-muted text-truncate smaller px-2 pb-1" t-esc="channel.description"/>
+            <div t-if="channel.livechat_status === 'need_help' and channel.topic" t-att-title="channel.topic" class="text-muted text-truncate smaller px-2 pb-1" t-esc="channel.topic"/>
             <div class="d-flex align-items-baseline gap-1 px-2 pb-2">
                 <CountryFlag t-if="channel.showCorrespondentCountry" country="channel.correspondentCountry" class="'o-mail-DiscussSidebarChannel-country my-auto'"/>
                 <span t-if="channel.livechat_lang_id" t-out="channel.livechat_lang_id.name" class="fw-normal small"/>

--- a/addons/im_livechat/static/src/core/web/discuss_content_patch.js
+++ b/addons/im_livechat/static/src/core/web/discuss_content_patch.js
@@ -10,11 +10,11 @@ patch(DiscussContent.prototype, {
             super.actionPanelAutoOpenFn();
         }
     },
-    get threadDescriptionAttClass() {
+    get threadTopicAttClass() {
         return {
-            ...super.threadDescriptionAttClass,
+            ...super.threadTopicAttClass,
             "text-muted":
-                this.thread.channel?.livechat_status === "need_help" && this.thread.description,
+                this.thread.channel?.livechat_status === "need_help" && this.thread.topic,
         };
     },
 });

--- a/addons/im_livechat/static/tests/discuss_app_patch.test.js
+++ b/addons/im_livechat/static/tests/discuss_app_patch.test.js
@@ -157,7 +157,7 @@ test("open visitor's partner profile if visitor has one", async () => {
     await contains("div.o_field_widget > input:value(Joel Willis)");
 });
 
-test("Conversation description works in livechat", async () => {
+test("Conversation topic works in livechat", async () => {
     const pyEnv = await startServer();
     const livechatPartner = pyEnv["res.partner"].create({ name: "Joel Willis" });
     const channelId = pyEnv["discuss.channel"].create({
@@ -166,12 +166,12 @@ test("Conversation description works in livechat", async () => {
             Command.create({ partner_id: livechatPartner, livechat_member_type: "visitor" }),
         ],
         channel_type: "livechat",
-        description: "Yup, that customer again...",
+        topic: "Yup, that customer again...",
     });
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Composer-input:focus");
     await contains(
-        "input.o-mail-DiscussContent-threadDescription:value(Yup, that customer again...)"
+        "input.o-mail-DiscussContent-threadTopic:value(Yup, that customer again...)"
     );
 });

--- a/addons/im_livechat/tests/test_discuss_channel.py
+++ b/addons/im_livechat/tests/test_discuss_channel.py
@@ -73,8 +73,8 @@ class TestDiscussChannel(TestImLivechatCommon, TestGetOperatorCommon, MailCase):
         )
         self.assertEqual(chat.livechat_failure, "no_failure")
 
-    def test_livechat_description_sync_to_internal_user_bus(self):
-        """Test the description of a livechat conversation is sent to the internal user bus."""
+    def test_livechat_topic_sync_to_internal_user_bus(self):
+        """Test the topic of a livechat conversation is sent to the internal user bus."""
         data = self.make_jsonrpc_request(
             "/im_livechat/get_session",
             {"channel_id": self.livechat_channel.id},
@@ -89,14 +89,14 @@ class TestDiscussChannel(TestImLivechatCommon, TestGetOperatorCommon, MailCase):
                         "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "description": "Description of the conversation",
+                                "topic": "Topic of the conversation",
                             }
                         ]
                     },
                 }
             ],
         ):
-            channel.description = "Description of the conversation"
+            channel.topic = "Topic of the conversation"
 
     def test_livechat_note_sync_to_internal_user_bus(self):
         """Test that a livechat note is sent to the internal user bus."""

--- a/addons/im_livechat/tests/test_session_views.py
+++ b/addons/im_livechat/tests/test_session_views.py
@@ -118,10 +118,10 @@ class TestImLivechatLookingForHelpViews(TestImLivechatSessionViews):
         agent.livechat_expertise_ids = sales_expertise
         accounting_chat = self.start_needhelp_session(guest_name="Visitor Accounting")
         accounting_chat.livechat_expertise_ids = accounting_expertise
-        accounting_chat.description = "Invoice SO0042 not received"
+        accounting_chat.topic = "Invoice SO0042 not received"
         sales_chat = self.start_needhelp_session(guest_name="Visitor Sales")
         sales_chat.livechat_expertise_ids = sales_expertise
-        sales_chat.description = "Delivery delayed for PO0099"
+        sales_chat.topic = "Delivery delayed for PO0099"
         self._reset_bus()
         self.start_tour(
             "/odoo/discuss",

--- a/addons/im_livechat/views/discuss_channel_views.xml
+++ b/addons/im_livechat/views/discuss_channel_views.xml
@@ -2,6 +2,18 @@
 <odoo>
     <data>
 
+        <record id="discuss_channel_view_form_im_livechat_inherited" model="ir.ui.view">
+            <field name="name">discuss.channel.form.im_livechat_inherited</field>
+            <field name="model">discuss.channel</field>
+            <field name="inherit_id" ref="mail.discuss_channel_view_form"/>
+            <field name="mode">extension</field>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='topic']" position='attributes'>
+                    <attribute name="invisible" add="channel_type != 'livechat'" separator=" and "/>
+                </xpath>
+            </field>
+        </record>
+
         <record id="discuss_channel_view_search" model="ir.ui.view">
             <field name="name">discuss.channel.search</field>
             <field name="model">discuss.channel</field>
@@ -11,7 +23,7 @@
                     <field name="livechat_agent_requesting_help_history"/>
                     <field name="livechat_agent_providing_help_history"/>
                     <field name="country_id" string="Country"/>
-                    <field name="description"/>
+                    <field name="topic"/>
                     <field name="livechat_customer_partner_ids" string="Customer"/>
                     <filter name="filter_my_sessions" domain="[('livechat_agent_partner_ids.user_ids', 'in', uid)]" string="My Sessions"/>
                     <separator/>
@@ -58,7 +70,7 @@
                     <field name="livechat_agent_requesting_help_history" widget="many2one_avatar" optional="hide"/>
                     <field name="livechat_agent_providing_help_history" widget="many2one_avatar" optional="hide"/>
                     <field name="livechat_bot_history_ids" string="Chatbot" widget="many2many_tags_avatar" optional="hide"/>
-                    <field name="description" optional="hide"/>
+                    <field name="topic" optional="hide"/>
                     <field name="country_id" optional="show"/>
                     <field name="livechat_lang_id" optional="show"/>
                     <field name="livechat_expertise_ids" string="Expertise" widget="many2many_tags" optional="show"/>

--- a/addons/mail/data/discuss_channel_data.xml
+++ b/addons/mail/data/discuss_channel_data.xml
@@ -4,12 +4,12 @@
 
         <record model="discuss.channel" id="mail.channel_all_employees">
             <field name="name">general</field>
-            <field name="description">General announcements for all employees.</field>
+            <field name="topic">General announcements for all employees.</field>
         </record>
 
         <record model="discuss.channel" id="mail.channel_admin">
             <field name="name">Administrators</field>
-            <field name="description">General channel for administrators.</field>
+            <field name="topic">General channel for administrators.</field>
             <field name="group_public_id" ref="base.group_system"/>
         </record>
 

--- a/addons/mail/demo/discuss/public_channel_demo.xml
+++ b/addons/mail/demo/discuss/public_channel_demo.xml
@@ -6,7 +6,7 @@
         </record>
         <record model="discuss.channel" id="mail.channel_public_community_demo">
             <field name="name">Public Community</field>
-            <field name="description">A space for engaging discussions among employees, partners, and the public.</field>
+            <field name="topic">A space for engaging discussions among employees, partners, and the public.</field>
             <field name="group_public_id" eval="False"/>
         </record>
         <record model="mail.message" id="mail.channel_public_community_message_0_demo">

--- a/addons/mail/demo/discuss/readonly_channel_demo.xml
+++ b/addons/mail/demo/discuss/readonly_channel_demo.xml
@@ -2,7 +2,7 @@
     <data noupdate="1">
         <record model="discuss.channel" id="mail.illusorium">
             <field name="name">Illusorium</field>
-            <field name="description">A channel that you can watch but not interact.</field>
+            <field name="topic">A channel that you can watch but not interact.</field>
             <field name="is_readonly" eval="True"/>
         </record>
         <record model="mail.message" id="mail.illusorium_message_0">

--- a/addons/mail/demo/discuss_channel_demo.xml
+++ b/addons/mail/demo/discuss_channel_demo.xml
@@ -5,15 +5,15 @@
         <!-- Discussion groups, done in 2 steps to remove creator from followers -->
         <record model="discuss.channel" id="mail.channel_1">
             <field name="name">sales</field>
-            <field name="description">Discussion about best sales practices and deals.</field>
+            <field name="topic">Discussion about best sales practices and deals.</field>
         </record>
         <record model="discuss.channel" id="mail.channel_2">
             <field name="name">board-meetings</field>
-            <field name="description">Board meetings, budgets, strategic plans</field>
+            <field name="topic">Board meetings, budgets, strategic plans</field>
         </record>
         <record model="discuss.channel" id="mail.channel_3">
             <field name="name">rd</field>
-            <field name="description">Research and development discussion group</field>
+            <field name="topic">Research and development discussion group</field>
         </record>
 
         <!-- Best sales practices messages -->

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -78,7 +78,7 @@ class DiscussChannel(models.Model):
     is_editable = fields.Boolean('Is Editable', compute='_compute_is_editable')
     is_readonly = fields.Boolean('Read-only', help="Only admins are allowed to post messages in a read-only channel.")
     default_display_mode = fields.Selection(string="Default Display Mode", selection=[('video_full_screen', "Full screen video")], help="Determines how the channel will be displayed by default when opening it from its invitation link. No value means display text (no voice/video).")
-    description = fields.Text('Description')
+    topic = fields.Text("Topic")
     image_128 = fields.Image("Image", max_width=128, max_height=128)
     avatar_128 = fields.Image("Avatar", max_width=128, max_height=128, compute='_compute_avatar_128')
     avatar_cache_key = fields.Char(compute="_compute_avatar_cache_key")
@@ -557,7 +557,7 @@ class DiscussChannel(models.Model):
         # sudo: discuss.category - guests can read categories of accessible channels
         res[None].one("discuss_category_id", "_store_category_fields", sudo=True)
         res[None].extend(["channel_type", "create_uid", "default_display_mode"])
-        res[None].attr("description", predicate=is_channel_or_group)
+        res[None].attr("topic", predicate=is_channel_or_group)
         res[None].many("group_ids", [], predicate=is_channel)
         res[None].one("group_public_id", ["full_name"], predicate=is_channel)
         res[None].attr("is_readonly", predicate=is_channel)
@@ -1296,7 +1296,7 @@ class DiscussChannel(models.Model):
             predicate=lambda channel: channel in channels_with_all_members,
         )
         res.attr("default_display_mode")
-        res.attr("description", predicate=is_channel_or_group)
+        res.attr("topic", predicate=is_channel_or_group)
         res.one("from_message_id", "_store_message_fields", predicate=is_channel_or_group)
         # sudo: we are reading only the ids (comodel is inaccessible)
         res.many("group_ids", [], predicate=is_channel, sudo=True)
@@ -1448,9 +1448,9 @@ class DiscussChannel(models.Model):
         body = Markup('<div data-oe-type="channel_rename" class="o_mail_notification">%s</div>') % name
         self.message_post(body=body, message_type="notification", subtype_xmlid="mail.mt_comment")
 
-    def channel_change_description(self, description):
+    def change_topic(self, topic):
         self.ensure_one()
-        self.write({'description': description})
+        self.topic = topic
 
     def channel_join(self):
         """Shortcut to add the current user as member of self channels.

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -102,7 +102,7 @@ export class Thread extends Record {
     /** @type {string} */
     defaultSubject;
     /** @type {string} */
-    description;
+    topic;
     /** @type {string} */
     display_name;
     followers = fields.Many("mail.followers", {

--- a/addons/mail/static/src/core/public_web/discuss_content.js
+++ b/addons/mail/static/src/core/public_web/discuss_content.js
@@ -86,9 +86,9 @@ export class DiscussContent extends Component {
         );
     }
 
-    get threadDescriptionAttClass() {
+    get threadTopicAttClass() {
         return {
-            "o-mail-DiscussContent-threadDescription flex-shrink-1 small pt-1": true,
+            "o-mail-DiscussContent-threadTopic flex-shrink-1 small pt-1": true,
         };
     }
 
@@ -107,13 +107,19 @@ export class DiscussContent extends Component {
         await this.thread.channel.rename(name);
     }
 
-    async updateThreadDescription(description) {
-        const newDescription = description.trim();
-        if (!newDescription && !this.thread.channel.description) {
+    async updateTopic(topic) {
+        const newTopic = topic.trim();
+        if (!newTopic && !this.thread.channel.topic) {
             return;
         }
-        if (newDescription !== this.thread.channel.description) {
-            await this.thread.channel.notifyDescriptionToServer(newDescription);
+        if (newTopic !== this.thread.channel.topic) {
+            this.thread.channel.topic = newTopic;
+            await this.store.env.services.orm.call(
+                "discuss.channel",
+                "change_topic",
+                [[this.thread.channel.id]],
+                { topic: newTopic }
+            );
         }
     }
 }

--- a/addons/mail/static/src/core/public_web/discuss_content.xml
+++ b/addons/mail/static/src/core/public_web/discuss_content.xml
@@ -31,15 +31,15 @@
                             onValidate.bind="renameThread"
                             value="thread.displayName || ''"
                         />
-                        <t t-if="thread.channel?.allowDescription and (thread.is_editable or (!thread.is_editable and thread.description))">
+                        <t t-if="thread.channel?.allowTopic and (thread.is_editable or (!thread.is_editable and thread.topic))">
                             <div class="flex-shrink-0 mx-1 py-2 border-start"/>
-                            <t t-set="autogrowDescriptionPlaceholder">Add a description</t>
+                            <t t-set="autogrowDescriptionPlaceholder">Add a topic</t>
                             <AutoresizeInput
-                                className="attClassObjectToString(threadDescriptionAttClass)"
+                                className="attClassObjectToString(threadTopicAttClass)"
                                 enabled="thread.is_editable"
-                                onValidate.bind="updateThreadDescription"
+                                onValidate.bind="updateTopic"
                                 placeholder="thread.is_editable ? autogrowDescriptionPlaceholder : ''"
-                                value="thread.description or ''"
+                                value="thread.topic or ''"
                             />
                         </t>
                     </div>

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -98,7 +98,7 @@ export class DiscussChannel extends Record {
     get allowDescriptionTypes() {
         return ["channel", "group"];
     }
-    get allowDescription() {
+    get allowTopic() {
         return this.allowDescriptionTypes.includes(this.channel_type);
     }
     get allowedToLeaveChannelTypes() {

--- a/addons/mail/static/src/discuss/core/public_web/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/public_web/@types/models.d.ts
@@ -16,7 +16,6 @@ declare module "models" {
         lastSubChannelLoaded: DiscussChannel;
         loadMoreSubChannels: (param0: { searchTerm: string }) => Promise<void>;
         loadSubChannelsDone: boolean;
-        notifyDescriptionToServer: (description: string) => Promise<unknown>;
         notifyMessageToUser: (message: Message) => Promise<void>;
         subChannelsInSidebar: DiscussChannel[];
     }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_channel_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_channel_model_patch.js
@@ -82,16 +82,6 @@ const discussChannelPatch = {
     get autoOpenChatWindowOnNewMessage() {
         return false;
     },
-    /** @param {string} description */
-    async notifyDescriptionToServer(description) {
-        this.description = description;
-        return this.store.env.services.orm.call(
-            "discuss.channel",
-            "channel_change_description",
-            [[this.id]],
-            { description }
-        );
-    },
     /**
      * @param {Object} [param0={}]
      * @param {import("models").Message} [param0.initialMessage]

--- a/addons/mail/static/tests/crosstab/crosstab.test.js
+++ b/addons/mail/static/tests/crosstab/crosstab.test.js
@@ -52,7 +52,7 @@ test("Thread rename", async () => {
 });
 
 test.tags("focus required");
-test("Thread description update", async () => {
+test("Thread topic update", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
         create_uid: serverState.userId,
@@ -63,7 +63,7 @@ test("Thread description update", async () => {
     await openDiscuss(channelId, { target: env1 });
     await openDiscuss(channelId, { target: env2 });
     await insertText(
-        `${env1.selector} .o-mail-DiscussContent-threadDescription`,
+        `${env1.selector} .o-mail-DiscussContent-threadTopic`,
         "The very best channel",
         {
             replace: true,
@@ -71,7 +71,7 @@ test("Thread description update", async () => {
     );
     triggerHotkey("Enter");
     await contains(
-        `${env2.selector} .o-mail-DiscussContent-threadDescription[title='The very best channel']`
+        `${env2.selector} .o-mail-DiscussContent-threadTopic[title='The very best channel']`
     );
 });
 

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -167,24 +167,24 @@ test("can change the thread description of #general", async () => {
     const channelId = pyEnv["discuss.channel"].create({
         name: "general",
         channel_type: "channel",
-        description: "General announcements...",
+        topic: "General announcements...",
         create_uid: serverState.userId,
     });
 
-    onRpc("discuss.channel", "channel_change_description", ({ route }) => expect.step(route));
+    onRpc("discuss.channel", "change_topic", ({ route }) => expect.step(route));
 
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Composer-input:focus");
-    await contains("input.o-mail-DiscussContent-threadDescription:value(General announcements...)");
+    await contains("input.o-mail-DiscussContent-threadTopic:value(General announcements...)");
     await insertText(
-        "input.o-mail-DiscussContent-threadDescription:enabled",
+        "input.o-mail-DiscussContent-threadTopic:enabled",
         "I want a burger today!",
         { replace: true }
     );
     triggerHotkey("Enter");
-    await expect.waitForSteps(["/web/dataset/call_kw/discuss.channel/channel_change_description"]);
-    await contains("input.o-mail-DiscussContent-threadDescription:value(I want a burger today!)");
+    await expect.waitForSteps(["/web/dataset/call_kw/discuss.channel/change_topic"]);
+    await contains("input.o-mail-DiscussContent-threadTopic:value(I want a burger today!)");
 });
 
 test("Message following a notification should not be squashed", async () => {
@@ -1882,11 +1882,11 @@ test("Do not trigger channel description server update when channel has no descr
         name: "General",
     });
 
-    onRpc("discuss.channel", "channel_change_description", ({ method }) => expect.step(method));
+    onRpc("discuss.channel", "change_topic", ({ method }) => expect.step(method));
 
     await start();
     await openDiscuss(channelId);
-    await insertText("input.o-mail-DiscussContent-threadDescription", "");
+    await insertText("input.o-mail-DiscussContent-threadTopic", "");
     triggerHotkey("Enter");
     await expect.waitForSteps([]);
 });

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -199,16 +199,16 @@ export class DiscussChannel extends models.ServerModel {
 
     /**
      * @param {number[]} ids
-     * @param {string} description
+     * @param {string} topic
      */
-    channel_change_description(ids, description) {
-        const kwargs = getKwArgs(arguments, "ids", "description");
+    change_topic(ids, topic) {
+        const kwargs = getKwArgs(arguments, "ids", "topic");
         ids = kwargs.ids;
         delete kwargs.ids;
-        description = kwargs.description || "";
+        topic = kwargs.topic || "";
 
         const [channel] = this.browse(ids);
-        this.write([channel.id], { description });
+        this.write([channel.id], { topic });
     }
 
     unlink(ids) {
@@ -264,11 +264,11 @@ export class DiscussChannel extends models.ServerModel {
             "create_date",
             "create_uid",
             "default_display_mode",
-            "description",
             "group_public_id",
             "is_readonly",
             "last_interest_dt",
             "name",
+            "topic",
             "uuid",
         ];
     }

--- a/addons/mail/static/tests/web/fields/onchange_on_keydown.test.js
+++ b/addons/mail/static/tests/web/fields/onchange_on_keydown.test.js
@@ -16,23 +16,23 @@ defineMailModels();
 describe.current.tags("desktop");
 
 test("onchange_on_keydown option triggers onchange properly", async () => {
-    DiscussChannel._onChanges.description = () => {};
+    DiscussChannel._onChanges.topic = () => {};
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     await start();
     onRpc("discuss.channel", "onchange", (params) => {
-        expect(params.args[1].description).toBe("testing the keydown event");
+        expect(params.args[1].topic).toBe("testing the keydown event");
         expect.step("onchange");
     });
     await openFormView("discuss.channel", channelId, {
-        arch: "<form><field name='description' onchange_on_keydown='True'/></form>",
+        arch: "<form><field name='topic' onchange_on_keydown='True'/></form>",
     });
-    await insertText("textarea#description_0", "testing the keydown event");
+    await insertText("textarea#topic_0", "testing the keydown event");
     await expect.waitForSteps(["onchange"]);
 });
 
 test("editing a text field with the onchange_on_keydown option disappearing shouldn't trigger a crash", async () => {
-    DiscussChannel._onChanges.description = () => {};
+    DiscussChannel._onChanges.topic = () => {};
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     onRpc("discuss.channel", "onchange", () => expect.step("onchange"));
@@ -40,15 +40,15 @@ test("editing a text field with the onchange_on_keydown option disappearing shou
     await openFormView("discuss.channel", channelId, {
         arch: `
             <form>
-                <field name="description" onchange_on_keydown="True" invisible="name == 'yop'"/>
+                <field name="topic" onchange_on_keydown="True" invisible="name == 'yop'"/>
                 <field name="name"/>
             </form>
         `,
     });
-    await click("textarea#description_0");
+    await click("textarea#topic_0");
     await keyDown("a");
     await insertText("[name=name] input", "yop", { replace: true });
-    await contains("textarea#description_0", { count: 0 });
+    await contains("textarea#topic_0", { count: 0 });
     await runAllTimers();
     await expect.waitForSteps([]);
 });

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -647,7 +647,7 @@ class TestChannelInternals(MailCommon, HttpCase):
         self.assertEqual(test_channel.avatar_128, test_channel.image_128)
 
     def test_channel_write_should_send_notification(self):
-        channel = self.env['discuss.channel'].create({"name": "test", "description": "test"})
+        channel = self.env["discuss.channel"].create({"name": "test", "topic": "test"})
         with self.assertBus(
             [(self.cr.dbname, "discuss.channel", channel.id)],
             [

--- a/addons/mail/views/discuss_channel_views.xml
+++ b/addons/mail/views/discuss_channel_views.xml
@@ -23,7 +23,7 @@
                                     <span class="fw-bold fs-5">#<field name="display_name"/></span>
                                 </div>
                                 <field name="channel_type" groups="base.group_no_one"/>
-                                <field name="description" class="small text-muted"/>
+                                <field name="topic" widget="char_emojis" placeholder="Let everyone know what's being discussed here" readonly="not is_editable"  invisible="channel_type not in ('channel', 'group')"/>
                             </main>
                             <footer>
                                 <button type="object" invisible="not can_leave" class="btn btn-secondary ms-auto mt-auto" name="action_unfollow">
@@ -47,7 +47,7 @@
                 <list default_order="last_interest_dt desc" action="open_chat_window_action" type="object">
                     <field name="avatar_128" invisible="parent_channel_id" widget="image" options="{'size': [24, 24]}" width="30" string=""/>
                     <field name="display_name"/>
-                    <field name="description"/>
+                    <field name="topic" widget="char_emojis" placeholder="Let everyone know what's being discussed here" readonly="not is_editable"  invisible="channel_type not in ('channel', 'group')"/>
                     <field name="last_interest_dt" optional="hide"/>
                     <button type="object" invisible="not can_leave" class="btn btn-secondary" name="action_unfollow" string="Leave"/>
                     <button type="object" invisible="not can_join" class="btn btn-primary" name="channel_join" string="Join"/>
@@ -87,7 +87,7 @@
                         <group class="o_label_nowrap">
                             <field name="active" invisible="1"/>
                             <field name="discuss_category_id"/>
-                            <field name="description" placeholder="Topics discussed in this group..." readonly="not is_editable"/>
+                            <field name="topic" widget="char_emojis" placeholder="Let everyone know what's being discussed here" readonly="not is_editable"  invisible="channel_type not in ('channel', 'group')"/>
                             <field name="is_readonly" invisible="channel_type != 'channel'" readonly="id and not can_self_edit_readonly_channel"/>
                         </group>
                         <notebook>
@@ -144,7 +144,7 @@
             <field name="priority" eval="10"/>
             <field name="arch" type="xml">
                 <search>
-                    <field name="display_name"/>
+                    <field name="topic"/>
                     <filter string="Joined" name="filter_joined" domain="[('is_member', '=', True)]"/>
                     <filter string="Not Joined" name="filter_not_joined" domain="[('is_member', '=', False)]"/>
                     <separator/>

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -667,7 +667,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "channel_type": "channel",
                 "create_uid": self.user_root.id,
                 "default_display_mode": False,
-                "description": "General announcements for all employees.",
                 "discuss_category_id": False,
                 "fetchChannelInfoState": "fetched",
                 "from_message_id": False,
@@ -682,6 +681,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "message_needaction_counter": 0,
                 "name": "general",
                 "parent_channel_id": False,
+                "topic": "General announcements for all employees.",
                 "uuid": channel.uuid,
             }
         if channel == self.channel_channel_public_1:
@@ -690,7 +690,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "channel_type": "channel",
                 "create_uid": self.env.user.id,
                 "default_display_mode": False,
-                "description": False,
                 "discuss_category_id": False,
                 "fetchChannelInfoState": "fetched",
                 "from_message_id": False,
@@ -705,6 +704,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "message_needaction_counter": 1,
                 "name": "public channel 1",
                 "parent_channel_id": False,
+                "topic": False,
                 "uuid": channel.uuid,
             }
         if channel == self.channel_channel_public_2:
@@ -713,7 +713,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "channel_type": "channel",
                 "create_uid": self.env.user.id,
                 "default_display_mode": False,
-                "description": False,
                 "discuss_category_id": False,
                 "fetchChannelInfoState": "fetched",
                 "from_message_id": False,
@@ -728,6 +727,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "message_needaction_counter": 0,
                 "name": "public channel 2",
                 "parent_channel_id": False,
+                "topic": False,
                 "uuid": channel.uuid,
             }
         if channel == self.channel_channel_group_1:
@@ -736,7 +736,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "channel_type": "channel",
                 "create_uid": self.env.user.id,
                 "default_display_mode": False,
-                "description": False,
                 "discuss_category_id": False,
                 "fetchChannelInfoState": "fetched",
                 "from_message_id": False,
@@ -754,6 +753,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "parent_channel_id": False,
                 # sudo: discuss.channel.rtc.session - reading a session in a test file
                 "rtc_session_ids": [["ADD", [member_2.sudo().rtc_session_ids.id]]],
+                "topic": False,
                 "uuid": channel.uuid,
             }
         if channel == self.channel_channel_group_2:
@@ -762,7 +762,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "channel_type": "channel",
                 "create_uid": self.env.user.id,
                 "default_display_mode": False,
-                "description": False,
                 "discuss_category_id": False,
                 "fetchChannelInfoState": "fetched",
                 "from_message_id": False,
@@ -777,6 +776,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "message_needaction_counter": 0,
                 "name": "group restricted channel 2",
                 "parent_channel_id": False,
+                "topic": False,
                 "uuid": channel.uuid,
             }
         if channel == self.channel_group_1:
@@ -786,7 +786,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "channel_type": "group",
                 "create_uid": self.env.user.id,
                 "default_display_mode": False,
-                "description": False,
                 "discuss_category_id": False,
                 "fetchChannelInfoState": "fetched",
                 "from_message_id": False,
@@ -798,6 +797,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "message_needaction_counter": 0,
                 "name": "",
                 "parent_channel_id": False,
+                "topic": False,
                 "uuid": channel.uuid,
             }
         if channel == self.channel_chat_1:
@@ -871,7 +871,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "country_id": self.env.ref("base.in").id,
                 "create_uid": self.users[1].id,
                 "default_display_mode": False,
-                "description": False,
                 "discuss_category_id": False,
                 "fetchChannelInfoState": "fetched",
                 "id": channel.id,
@@ -892,6 +891,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "message_needaction_counter": 0,
                 "name": "test1 Ernest Employee",
                 "requested_by_operator": False,
+                "topic": False,
                 "uuid": channel.uuid,
             }
         if channel == self.channel_livechat_2:
@@ -901,7 +901,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "country_id": self.env.ref("base.be").id,
                 "create_uid": self.env.ref("base.public_user").id,
                 "default_display_mode": False,
-                "description": False,
                 "discuss_category_id": False,
                 "fetchChannelInfoState": "fetched",
                 "id": channel.id,
@@ -922,6 +921,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "message_needaction_counter": 0,
                 "name": "Visitor Ernest Employee",
                 "requested_by_operator": False,
+                "topic": False,
                 "uuid": channel.uuid,
             }
         return {}

--- a/addons/website_livechat/static/src/core/web/livechat_channel_info_list_patch.xml
+++ b/addons/website_livechat/static/src/core/web/livechat_channel_info_list_patch.xml
@@ -33,7 +33,7 @@
                                 <t t-else="">Conversation ongoing</t>
                             </span>
                         </div>
-                        <span t-if="channel.description" class="text-start text-muted smaller text-truncate" t-out="channel.description"/>
+                        <span t-if="channel.topic" class="text-start text-muted smaller text-truncate" t-out="channel.topic"/>
                     </a>
                 </div>
             </div>

--- a/addons/website_livechat/static/tests/livechat_channel_info_list_patch.test.js
+++ b/addons/website_livechat/static/tests/livechat_channel_info_list_patch.test.js
@@ -54,14 +54,14 @@ test("Show recent conversations in channel info list", async () => {
         {
             channel_member_ids: [],
             channel_type: "livechat",
-            description: "question about the live chat app",
+            topic: "question about the live chat app",
             livechat_status: "in_progress",
             livechat_visitor_id: visitorId,
         },
         {
             channel_member_ids: [],
             channel_type: "livechat",
-            description: "question about the discuss app",
+            topic: "question about the discuss app",
             livechat_status: "in_progress",
             livechat_visitor_id: visitorId,
         },

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -172,7 +172,6 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                         "country_id": False,
                         "create_uid": self.user_public.id,
                         "default_display_mode": False,
-                        "description": False,
                         "discuss_category_id": False,
                         "fetchChannelInfoState": "fetched",
                         "id": channel.id,
@@ -193,6 +192,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                         "message_needaction_counter_bus_id": 0,
                         "name": f"Visitor #{self.visitor.id} El Deboulonnator",
                         "requested_by_operator": False,
+                        "topic": False,
                         "uuid": channel.uuid,
                     }
                 ),


### PR DESCRIPTION
This commit updates the channel description field to be called topic and be displayed in a more visible way in the UI.
The field is also updated to support emojis with the char_emojis widget.

task-5475249

https://github.com/odoo/upgrade/pull/9518


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
