### PR TITLE
[FIX] mail: prevent missing cache assignment in is_bookmarked compute

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -366,8 +366,8 @@ class MailMessage(models.Model):
             .filtered(lambda msg: self.env.user.partner_id in msg.bookmarked_partner_ids)
             .sudo(False)
         )
-        bookmarked.is_bookmarked = True
-        (self - bookmarked).is_bookmarked = False
+        for message in self:
+            message.is_bookmarked = message in bookmarked
 
     @api.model
     def _search_is_bookmarked(self, operator, operand):


### PR DESCRIPTION
**Description of the issue this PR addresses:**
The compute method of `is_bookmarked` did not reliably assign
a value to all records in self when invoked in batched or partial contexts.

During discuss store loading, the field could be computed multiple times
on subsets of mail.message records. Assignments did not cover all records
in self, causing a cache miss

triggering:
`ValueError: Compute method failed to assign mail.message(...).is_bookmarked`

**Current behavior before PR:**
- assignments did not cover all records in self, resulting in a cache miss
- some records were left without a value in the field cache
- crashed in partial or repeated compute calls

**Desired behavior after PR is merged:**
- all records in the compute batch are guaranteed a value
- no cache miss occurs during field assignment
- field remains safe under partial or repeated compute calls
- no longer crashes due to missing field assignments

task-[5947784](https://www.odoo.com/odoo/project/1519/tasks/5947784)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
