### PR TITLE
[FIX] pos_self_order: remove undeterministicTour

### DIFF
--- a/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
@@ -6,7 +6,6 @@ import * as LandingPage from "@pos_self_order/../tests/tours/utils/landing_page_
 import { negateStep } from "@point_of_sale/../tests/generic_helpers/utils";
 
 registry.category("web_tour.tours").add("self_attribute_selector", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         Utils.clickBtn("Order Now"),
         ProductPage.clickProduct("Desk Organizer"),
@@ -14,6 +13,7 @@ registry.category("web_tour.tours").add("self_attribute_selector", {
             { name: "Size", value: "M" },
             { name: "Fabric", value: "Leather" },
         ]),
+        Utils.clickBtn("Add to cart"),
         Utils.clickBtn("Checkout"),
         CartPage.checkAttribute("Desk Organizer", [
             { name: "Size", value: "M" },
@@ -26,6 +26,7 @@ registry.category("web_tour.tours").add("self_attribute_selector", {
             { name: "Size", value: "L" },
             { name: "Fabric", value: "Leather" },
         ]),
+        Utils.clickBtn("Add to cart"),
         Utils.clickBtn("Checkout"),
         CartPage.checkAttribute("Desk Organizer", [
             { name: "Size", value: "L" },
@@ -42,18 +43,25 @@ registry.category("web_tour.tours").add("self_attribute_selector", {
 });
 
 registry.category("web_tour.tours").add("self_multi_attribute_selector", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         Utils.clickBtn("Order Now"),
         ProductPage.clickProduct("Multi Check Attribute Product"),
-        ...ProductPage.setupAttribute(
-            [
-                { name: "Attribute 1", value: "Attribute Val 1" },
-                { name: "Attribute 1", value: "Attribute Val 2" },
-            ],
-            false
-        ),
-        ProductPage.verifyIsCheckedAttribute("Attribute 1", ["Attribute Val 1", "Attribute Val 2"]),
+        ...ProductPage.setupAttribute([
+            { name: "Attribute 1", value: "Attribute Val 1" },
+            { name: "Attribute 1", value: "Attribute Val 2" },
+        ]),
+        {
+            content: `Select value for attribute Attribute 1`,
+            trigger: `div h2:contains(Attribute 1)`,
+        },
+        {
+            content: "Check that there are 2 and only 2 attribute buttons",
+            trigger: `.self_order_attribute_selection:has(button:count(2))`,
+        },
+        {
+            content: "Check content attribute buttons",
+            trigger: `.self_order_attribute_selection:has(button:contains(Attribute val 1)):has(button:contains(Attribute val 2))`,
+        },
     ],
 });
 
@@ -63,12 +71,14 @@ registry.category("web_tour.tours").add("selfAlwaysAttributeVariants", {
         ProductPage.waitProduct("Chair"),
         ProductPage.clickProduct("Chair"),
         ...ProductPage.setupAttribute([{ name: "Color", value: "White" }]),
+        Utils.clickBtn("Add to cart"),
         Utils.clickBtn("Checkout"),
         CartPage.checkProduct("Chair", "10", "1"),
         CartPage.checkAttribute("Chair", [{ name: "Color", value: "White" }]),
         CartPage.clickBack(),
         ProductPage.clickProduct("Chair"),
         ...ProductPage.setupAttribute([{ name: "Color", value: "Red" }]),
+        Utils.clickBtn("Add to cart"),
         Utils.clickBtn("Checkout"),
         CartPage.checkProduct("Chair", "15", "1"),
         CartPage.checkAttribute("Chair", [{ name: "Color", value: "Red" }]),
@@ -118,22 +128,19 @@ registry.category("web_tour.tours").add("test_self_order_multi_check_attribute_w
                 content: "Check no required badge for Add-ons attribute",
                 trigger: "h2:contains('Add-ons'):not(:has(.badge))",
             },
-            ProductPage.setupAttribute(
-                [
-                    { name: "Fabric", value: "Leather" },
-                    { name: "Add-ons", value: "Pen Holder" },
-                    { name: "Add-ons", value: "Mini Drawer" },
-                    { name: "Colour", value: "Blue" },
-                ],
-                false
-            ),
+            ProductPage.setupAttribute([
+                { name: "Fabric", value: "Leather" },
+                { name: "Add-ons", value: "Pen Holder" },
+                { name: "Add-ons", value: "Mini Drawer" },
+                { name: "Colour", value: "Blue" },
+            ]),
             Utils.checkMissingRequiredsExists(),
             Utils.clickMissingRequireds(),
             {
                 content: "Size attribute selection is visible",
                 trigger: "h2:contains('Size'):visible",
             },
-            ProductPage.setupAttribute([{ name: "Size", value: "M" }], false),
+            ProductPage.setupAttribute([{ name: "Size", value: "M" }]),
             negateStep(Utils.checkMissingRequiredsExists()),
             Utils.clickBtn("Add to Cart"),
             Utils.clickBtn("Checkout"),

--- a/addons/pos_self_order/static/tests/tours/self_order_combo_prices_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_combo_prices_tour.js
@@ -59,14 +59,17 @@ registry.category("web_tour.tours").add("test_combo_prices", {
             { product: "Green 1", attributes: [] },
             { product: "Green 2", attributes: [] },
         ]),
+        Utils.clickBtn("Next"),
         ...ProductPage.setupCombo([
             { product: "Red 1", attributes: [] },
             { product: "Red 2", attributes: [] },
         ]),
+        Utils.clickBtn("Next"),
         ...ProductPage.setupCombo([
             { product: "Purple 1", attributes: [] },
             { product: "Purple 2", attributes: [] },
         ]),
+        Utils.clickBtn("Next"),
         ...commonSteps,
         Utils.clickBtn("Order Now"),
         ProductPage.clickProduct("Big Combo"),
@@ -74,6 +77,7 @@ registry.category("web_tour.tours").add("test_combo_prices", {
             { product: "Green 1", attributes: [] },
             { product: "Green 2", attributes: [] },
         ]),
+        Utils.clickBtn("Next"),
         ...ProductPage.setupCombo([
             { product: "Red 1", attributes: [] },
             { product: "Red 1", attributes: [] },
@@ -81,6 +85,7 @@ registry.category("web_tour.tours").add("test_combo_prices", {
             { product: "Red 2", attributes: [] },
             { product: "Red 2", attributes: [] },
         ]),
+        Utils.clickBtn("Next"),
         ...ProductPage.setupCombo([
             { product: "Purple 1", attributes: [] },
             { product: "Purple 1", attributes: [] },
@@ -93,6 +98,7 @@ registry.category("web_tour.tours").add("test_combo_prices", {
             { product: "Purple 2", attributes: [] },
             { product: "Purple 2", attributes: [] },
         ]),
+        Utils.clickBtn("Next"),
         ...commonSteps,
         Utils.clickBtn("Order Now"),
         ProductPage.clickProduct("Big Combo"),
@@ -111,17 +117,22 @@ registry.category("web_tour.tours").add("test_combo_prices", {
         ...ProductPage.setupCombo([
             { product: "Red 1", attributes: [] },
             { product: "Red 1", attributes: [] },
+        ]),
+        ...ProductPage.setupCombo([
             {
                 product: "Red 3",
                 attributes: [
                     { name: "Size", value: "Big" },
                     { name: "Color", value: "Blue" },
                 ],
-                extraSteps: [Utils.clickBtn("Next")],
             },
+        ]),
+        Utils.clickBtn("Next"),
+        ...ProductPage.setupCombo([
             { product: "Red 3", attributes: [] },
             { product: "Red 3", attributes: [] },
         ]),
+        Utils.clickBtn("Next"),
         ...ProductPage.setupCombo([
             { product: "Purple 1", attributes: [] },
             { product: "Purple 1", attributes: [] },
@@ -131,16 +142,19 @@ registry.category("web_tour.tours").add("test_combo_prices", {
             { product: "Purple 2", attributes: [] },
             { product: "Purple 2", attributes: [] },
             { product: "Purple 2", attributes: [] },
+        ]),
+        ...ProductPage.setupCombo([
             {
                 product: "Purple 3",
-                extraSteps: [Utils.clickBtn("Next")],
                 attributes: [
                     { name: "Size", value: "Small" },
                     { name: "Color", value: "Red" },
                 ],
             },
-            { product: "Purple 3", attributes: [] },
         ]),
+        Utils.clickBtn("Next"),
+        ...ProductPage.setupCombo([{ product: "Purple 3", attributes: [] }]),
+        Utils.clickBtn("Next"),
         ...commonSteps,
     ],
 });

--- a/addons/pos_self_order/static/tests/tours/self_order_combo_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_combo_tour.js
@@ -6,7 +6,6 @@ import * as ConfirmationPage from "@pos_self_order/../tests/tours/utils/confirma
 import * as LandingPage from "@pos_self_order/../tests/tours/utils/landing_page_util";
 
 registry.category("web_tour.tours").add("self_combo_selector", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         Utils.clickBtn("Order Now"),
         ProductPage.clickProduct("Office Combo"),
@@ -18,6 +17,9 @@ registry.category("web_tour.tours").add("self_combo_selector", {
                     { name: "Fabric", value: "Leather" },
                 ],
             },
+        ]),
+        Utils.clickBtn("Next"),
+        ...ProductPage.setupCombo([
             {
                 product: "Combo Product 5",
                 attributes: [],
@@ -27,6 +29,7 @@ registry.category("web_tour.tours").add("self_combo_selector", {
                 attributes: [],
             },
         ]),
+        Utils.clickBtn("Add to cart"),
         Utils.clickBtn("Checkout"),
         {
             trigger: ".btn .oi-plus",
@@ -67,6 +70,7 @@ registry.category("web_tour.tours").add("self_combo_selector_category", {
                 attributes: [],
             },
         ]),
+        Utils.clickBtn("Add to cart"),
         Utils.clickBtn("Checkout"),
         Utils.clickBtn("Order"),
         Utils.clickBtn("Ok"),

--- a/addons/pos_self_order/static/tests/tours/self_order_common_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_common_tour.js
@@ -27,7 +27,6 @@ registry.category("web_tour.tours").add("self_order_landing_page_carousel", {
 });
 
 registry.category("web_tour.tours").add("self_order_pos_closed", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         LandingPage.isClosed(),
         // Normal product
@@ -37,43 +36,39 @@ registry.category("web_tour.tours").add("self_order_pos_closed", {
         Utils.checkIsNoBtn("Checkout"),
         // Product with attributes
         ProductPage.clickProduct("Desk Organizer"),
-        ...ProductPage.setupAttribute(
-            [
-                { name: "Size", value: "M" },
-                { name: "Fabric", value: "Leather" },
-            ],
-            false
-        ),
+        ...ProductPage.setupAttribute([
+            { name: "Size", value: "M" },
+            { name: "Fabric", value: "Leather" },
+        ]),
         Utils.checkIsNoBtn("Add to cart"),
         ProductPage.clickDiscard(),
         // Combo product
         ProductPage.clickProduct("Office Combo"),
-        ...ProductPage.setupCombo(
-            [
-                {
-                    product: "Desk Organizer",
-                    attributes: [
-                        { name: "Size", value: "M" },
-                        { name: "Fabric", value: "Leather" },
-                    ],
-                },
-                {
-                    product: "Combo Product 5",
-                    attributes: [],
-                },
-                {
-                    product: "Combo Product 8",
-                    attributes: [],
-                },
-            ],
-            false
-        ),
+        ...ProductPage.setupCombo([
+            {
+                product: "Desk Organizer",
+                attributes: [
+                    { name: "Size", value: "M" },
+                    { name: "Fabric", value: "Leather" },
+                ],
+            },
+        ]),
+        Utils.clickBtn("Next"),
+        ...ProductPage.setupCombo([
+            {
+                product: "Combo Product 5",
+                attributes: [],
+            },
+            {
+                product: "Combo Product 8",
+                attributes: [],
+            },
+        ]),
         Utils.checkIsNoBtn("Add to cart"),
     ],
 });
 
 registry.category("web_tour.tours").add("kiosk_order_pos_closed", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         LandingPage.isClosed(),
         Utils.clickBtn("Order Now"),
@@ -85,38 +80,35 @@ registry.category("web_tour.tours").add("kiosk_order_pos_closed", {
 
         // Product with attributes
         ProductPage.clickProduct("Desk Organizer"),
-        ...ProductPage.setupAttribute(
-            [
-                { name: "Size", value: "M" },
-                { name: "Fabric", value: "Leather" },
-            ],
-            false
-        ),
+        ...ProductPage.setupAttribute([
+            { name: "Size", value: "M" },
+            { name: "Fabric", value: "Leather" },
+        ]),
         Utils.checkIsNoBtn("Add to cart"),
         ProductPage.clickDiscard(),
         // Combo product
         ProductPage.clickCategory("Category 2"),
         ProductPage.clickProduct("Office Combo"),
-        ...ProductPage.setupCombo(
-            [
-                {
-                    product: "Desk Organizer",
-                    attributes: [
-                        { name: "Size", value: "M" },
-                        { name: "Fabric", value: "Leather" },
-                    ],
-                },
-                {
-                    product: "Combo Product 5",
-                    attributes: [],
-                },
-                {
-                    product: "Combo Product 8",
-                    attributes: [],
-                },
-            ],
-            false
-        ),
+        ...ProductPage.setupCombo([
+            {
+                product: "Desk Organizer",
+                attributes: [
+                    { name: "Size", value: "M" },
+                    { name: "Fabric", value: "Leather" },
+                ],
+            },
+        ]),
+        Utils.clickBtn("Next"),
+        ...ProductPage.setupCombo([
+            {
+                product: "Combo Product 5",
+                attributes: [],
+            },
+            {
+                product: "Combo Product 8",
+                attributes: [],
+            },
+        ]),
         Utils.checkIsNoBtn("Add to cart"),
     ],
 });

--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -160,7 +160,6 @@ registry.category("web_tour.tours").add("self_order_language_changes", {
 });
 
 registry.category("web_tour.tours").add("test_self_order_kiosk_combo_sides", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         Utils.clickBtn("Order Now"),
         LandingPage.selectLocation("Test-In"),
@@ -174,6 +173,7 @@ registry.category("web_tour.tours").add("test_self_order_kiosk_combo_sides", {
             { name: "Size", value: "M" },
             { name: "Fabric", value: "Leather" },
         ]),
+        Utils.clickBtn("Next"),
         Utils.clickBtn("Add to cart"),
     ],
 });

--- a/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
@@ -83,25 +83,12 @@ export function clickDiscard() {
     };
 }
 
-export function setupAttribute(attributes, addToCart = true) {
-    const steps = [];
-    if (addToCart) {
-        steps.push({
-            content: `Click on 'Add to cart' button`,
-            trigger: `.btn.btn-primary`,
-            run: "click",
-        });
-    }
-
-    for (const attr of attributes) {
-        steps.unshift({
-            content: `Select value ${attr.value} for attribute ${attr.name}`,
-            trigger: `h2:contains("${attr.name}") + div.row button:contains("${attr.value}")`,
-            run: "click",
-        });
-    }
-
-    return steps;
+export function setupAttribute(attributes) {
+    return attributes.map((attr) => ({
+        content: `Select value ${attr.value} for attribute ${attr.name}`,
+        trigger: `h2:contains("${attr.name}") + div.row button:contains("${attr.value}")`,
+        run: "click",
+    }));
 }
 
 export function attributeHasColorDot(attribute) {
@@ -118,49 +105,6 @@ export function attributeHasImage(attribute) {
     };
 }
 
-export function verifyIsCheckedAttribute(attribute, values = []) {
-    return {
-        content: `Select value for attribute ${attribute}`,
-        trigger: `div h2:contains("${attribute}")`,
-        run: () => {
-            const attributesValues = Array.from(document.querySelectorAll("div h2")).find((el) =>
-                el.textContent.includes(attribute)
-            );
-            if (!attributesValues) {
-                throw Error(`${attribute} not found.`);
-            }
-            const rowDiv = attributesValues.nextElementSibling;
-            if (!rowDiv || !rowDiv.matches("div.row")) {
-                throw Error("Sibling div.row not found or is incorrect.");
-            }
-
-            const selectedButtons = rowDiv.querySelectorAll(".border-primary");
-            // Extract text content of selected buttons
-            const selectedValues = Array.from(selectedButtons).map((btn) =>
-                btn.querySelector("span")?.textContent.trim()
-            );
-
-            // Check if all expected values are selected
-            for (const val of values) {
-                if (!selectedValues.includes(val)) {
-                    throw new Error(
-                        `Expected value "${val}" for attribute "${attribute}" is not selected.`
-                    );
-                }
-            }
-
-            // Optionally, verify that no unexpected values are selected
-            if (selectedValues.length !== values.length) {
-                throw new Error(
-                    `Mismatch in selected values for attribute "${attribute}". Expected: ${values.join(
-                        ", "
-                    )}, Found: ${selectedValues.join(", ")}`
-                );
-            }
-        },
-    };
-}
-
 export function clickComboProduct(productName) {
     return {
         content: `Click on combo product '${productName}'`,
@@ -169,7 +113,7 @@ export function clickComboProduct(productName) {
     };
 }
 
-export function setupCombo(products, addToCart = true) {
+export function setupCombo(products) {
     const steps = [];
 
     for (const product of products) {
@@ -180,18 +124,6 @@ export function setupCombo(products, addToCart = true) {
             steps.push(...setupAttribute(product.attributes));
             negateStep(Utils.checkMissingRequiredsExists());
         }
-
-        if (product.extraSteps?.length) {
-            steps.push(...product.extraSteps);
-        }
-    }
-
-    if (addToCart) {
-        steps.push({
-            content: `Click on 'Add to cart' button`,
-            trigger: `.btn.btn-primary`,
-            run: "click",
-        });
     }
 
     return steps;


### PR DESCRIPTION
With this commit, we remove undeterministicTour key that allows delay
between steps.
The problem stems from the fact that the step
Click on 'Add to cart' in setupAttribute and setupCombo helper is too
generic.
To simplify these two helpers, we remove the click button steps and add
its directly in tours.
We also remove verifyIsCheckedAttribute helper that is used only once
and that can be easily replaced by steps with trigger.