### PR TITLE
[IMP] {project_}mrp: hide unnecessarily fields in kit bom form view

### DIFF
--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -169,8 +169,8 @@
                        </page>
                         <page string="Miscellaneous" name="miscellaneous">
                             <group>
-                                <group>
-                                    <field name="picking_type_id" invisible="type == 'phantom'" groups="stock.group_adv_location"/>
+                                <group invisible="type == 'phantom'">
+                                    <field name="picking_type_id" groups="stock.group_adv_location"/>
                                     <label for="produce_delay" string="Manuf. Lead Time"/>
                                     <div class="o_input_box">
                                         <field name="produce_delay"/>

--- a/addons/project_mrp/views/mrp_bom_views.xml
+++ b/addons/project_mrp/views/mrp_bom_views.xml
@@ -5,7 +5,7 @@
         <field name="model">mrp.bom</field>
         <field name="inherit_id" ref="mrp.mrp_bom_form_view"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='picking_type_id']" position="after">
+            <xpath expr="//field[@name='ready_to_produce']" position="before">
                 <field name="project_id" groups="project.group_project_user"/>
             </xpath>
         </field>


### PR DESCRIPTION
Hide fields (Manufacturing Lead Time and Days to Prepare) that are not
relevant to kits in the BoM form view. Rearranged the Project field to
another group where it is still relevant to kits and remains visible.

TaskID - 5917731