### PR TITLE
[FIX] iot_drivers: propagate session_id in scale and generic drivers

### DIFF
--- a/addons/iot_drivers/driver.py
+++ b/addons/iot_drivers/driver.py
@@ -56,7 +56,10 @@ class Driver(Thread):
                 return
             self._recent_action_ids[action_unique_id] = action_unique_id
 
-        self.data["owner"] = data.get('session_id')
+        session_id = data.get('session_id')
+        if session_id:
+            self.data["owner"] = session_id
+            self.data["session_id"] = session_id
 
         base_response = {'action_args': {**data}, 'session_id': data.get('session_id')}
         try:

--- a/addons/iot_drivers/iot_handlers/drivers/serial_scale_driver.py
+++ b/addons/iot_drivers/iot_handlers/drivers/serial_scale_driver.py
@@ -125,10 +125,10 @@ class ScaleDriver(SerialDriver):
         answer = self._get_raw_response(self._connection)
         match = re.search(self._protocol.measureRegexp, answer)
         if match:
-            self.data = {
+            self.data.update({
                 'result': float(match.group(1)),
                 'status': self._status
-            }
+            })
         else:
             self._read_status(answer)
 
@@ -215,8 +215,8 @@ class Toledo8217Driver(ScaleDriver):
             for index, bit in enumerate(binary_status_char[1:][::-1]):  # Read the bits in reverse order (LSB is at the last char) + ignore the first "parity" bit
                 if int(bit):
                     _logger.debug("Scale error: %s. Status string: %s. Scale answer: %s.", status_char_error_bits[index], binary_status_char, answer)
-                    self.data = {
+                    self.data.update({
                         'result': 0,
                         'status': self._status,
-                    }
+                    })
                     break


### PR DESCRIPTION
Before this commit, `session_id` was lost during scale operations because `ScaleDriver` overwrote `self.data` instead of updating it, erasing the context. Additionally, the generic Driver class stored the ID as "owner", causing a TypeError on the server which expects "session_id".

After this commit, `ScaleDriver` uses `.update()` to preserve the session context, and `Driver.action` correctly uses the key `session_id` in the response payload. This ensures requests are properly acknowledged by the Odoo server.

Backport of #245048

opw-5485278

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
