### PR TITLE
[IMP] website_sale: Improve extensibility to product_container

### DIFF
--- a/addons/website_sale/static/src/interactions/add_to_cart.js
+++ b/addons/website_sale/static/src/interactions/add_to_cart.js
@@ -24,7 +24,7 @@ export class AddToCart extends Interaction {
             noVariantAttributeValues: this._getSelectedNoVariantPtavs(productEl),
         } : {};
 
-        const productContainer = productEl ?? button.closest('#products_grid');
+        const productContainer = productEl ?? this._getProductContainer(button);
         const optionalParams = productContainer ? this._getOptionalParams(productContainer) : {};
 
         const quantity = await this.waitFor(this.services['cart'].add({
@@ -74,6 +74,17 @@ export class AddToCart extends Interaction {
             'input.js_variant_change:not(.no_variant):checked, select.js_variant_change:not(.no_variant)'
         );
         return Array.from(selectedPtavElements).map(el => parseInt(el.value));
+    }
+
+    /**
+     * Function to easily extend and customize the product details element.
+     *
+     * @param {HTMLElement} el
+     *
+     * @returns {HTMLElement} -- The element containing the product details.
+     */
+    _getProductContainer(el) {
+        return el.closest('#products_grid');
     }
 
     /**


### PR DESCRIPTION
The product_container element may vary across modules and cannot be hardcoded. Modifying it currently requires overriding the entire add_to_cart method, which reduces flexibility and maintainability.

This change extracts the product_container logic into a dedicated method, making it easier to extend and customize without duplicating the full add_to_cart implementation. This ensures better forward compatibility and modular extensibility.

Enterprise PR: https://github.com/odoo/enterprise/pull/107343



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
