### PR TITLE
[FIX] project: prevent crash on 'Search More' in task relational fields

### DIFF
--- a/addons/project/static/src/views/project_task_model_mixin.js
+++ b/addons/project/static/src/views/project_task_model_mixin.js
@@ -5,7 +5,7 @@ export const ProjectTaskModelMixin = (T) => class ProjectTaskModelMixin extends 
     _processSearchDomain(domain) {
         const { my_tasks, subtask_action } = this.env.searchModel.globalContext;
         const showSubtasks = my_tasks || subtask_action || JSON.parse(browser.localStorage.getItem("showSubtasks"));
-        if (!showSubtasks) {
+        if (['project.task', 'report.project.task.user'].includes(this.env.searchModel.resModel) && !showSubtasks) {
             return Domain.and([
                 domain,
                 [['display_in_project', '=', true]],


### PR DESCRIPTION
Steps to reproduce:
--------------------------
1. Install Project and create a portal user.
2. Create a project and a task with tags added to it.
3. Share the project with the portal user (Edit access).
4. Log in as the portal user and open the task.
5. Click on the 'Tags' field and select 'Search More'

Issue:
----------
A traceback occurs:
```ValueError: Invalid field project.tags.display_in_project in condition ('display_in_project', '=', True)```

Cause:
----------
The [ProjectTaskRelationalModel](https://github.com/odoo/odoo/blob/75fd7b05766c6789bf311f6a8257b89ecf4f86de/addons/project/static/src/views/project_task_relational_model.js#L4-L7) calls `_processSearchDomain.`
This method automatically appends a domain when 'showSubtasks' is not enabled.
https://github.com/odoo/odoo/blob/75fd7b05766c6789bf311f6a8257b89ecf4f86de/addons/project/static/src/views/project_task_model_mixin.js#L5-L12

When clicking 'Search More' on the 'Tags' field, the same domain is
applied to the **project.tags** model. However, since **project.tags**
does not have the `display_in_project` field, the ORM raises a ValueError.

In portal, only `project.webclient` assets are loaded, causing
ProjectTaskRelationalModel to be used for all relational fields.
In contrast, internal users use the standard RelationalModel, so the
issue does not occur.

Solution:
-------------
Restrict the domain modification in _processSearchDomain to apply only
when the current model is `project.task` and `report.project.task.user`.

**NOTE:**
Alternatively, we could guard this specifically for portal usage by
skipping the domain when the action is project_sharing and the model
is project.tags, e.g.:
```python
if (router.current.action === 'project_sharing' && this.env.searchModel.resModel === 'project.tags') {
    return domain;
}
```

opw-5930427



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
