### PR TITLE
[FIX] orm: avoid generating SQL for custom access tables

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -29,6 +29,7 @@ class MailActivity(models.Model):
     _description = 'Activity'
     _order = 'date_deadline ASC, id ASC'
     _rec_name = 'summary'
+    _access_domain_heavy = True
 
     @api.model
     def default_get(self, fields):

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -389,8 +389,8 @@ class MailActivity(models.Model):
         # Rules do not apply to administrator
         if self.env.is_superuser() or bypass_access:
             return super()._search(domain, offset, limit, order, bypass_access=True, **kwargs)
-        if self.env.context.get('_read_groupby'):
-            raise ValueError("Cannot group by mail.activity")
+        if self.env.context.get('_generating_sql_for_fields'):
+            raise ValueError("Cannot generate SQL for whole mail.activity")
 
         # retrieve activities and their corresponding res_model, res_id
         # Don't use the ORM to avoid cache pollution

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -344,8 +344,8 @@ class MailMessage(models.Model):
         # Rules do not apply to administrator
         if self.env.is_superuser() or bypass_access:
             return super()._search(domain, offset, limit, order, bypass_access=True, **kwargs)
-        if self.env.context.get('_read_groupby'):
-            raise ValueError("Cannot group by mail.message")
+        if self.env.context.get('_generating_sql_for_fields'):
+            raise ValueError("Cannot generate SQL for whole mail.message")
 
         # Non-employee see only messages with a subtype and not internal
         if not self.env.user._is_internal():

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -73,6 +73,7 @@ class MailMessage(models.Model):
     _description = 'Message'
     _order = 'id desc'
     _rec_name = 'subject'
+    _access_domain_heavy = True
 
     @api.model
     def default_get(self, fields):

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -75,6 +75,7 @@ class IrAttachment(models.Model):
     _name = 'ir.attachment'
     _description = 'Attachment'
     _order = 'id desc'
+    _access_domain_heavy = True
 
     def _compute_res_name(self):
         for attachment in self:

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -613,8 +613,8 @@ class IrAttachment(models.Model):
         domain = domain.optimize(self)
         if self.env.su or bypass_access or domain.is_false():
             return super()._search(domain, offset, limit, order, active_test=active_test, bypass_access=bypass_access)
-        if self.env.context.get('_read_groupby'):
-            raise ValueError("Cannot group by ir.attachment")
+        if self.env.context.get('_generating_sql_for_fields'):
+            raise ValueError("Cannot generate SQL for whole ir.attachment")
 
         # General access rules
         # - public == True are always accessible

--- a/odoo/addons/test_orm/models/test_orm.py
+++ b/odoo/addons/test_orm/models/test_orm.py
@@ -1206,6 +1206,7 @@ class TestOrmTransient_Model(models.TransientModel):
 class TestOrmAttachment(models.Model):
     _name = 'test_orm.attachment'
     _description = 'Attachment'
+    _access_domain_heavy = True
 
     res_model = fields.Char(required=True)
     res_id = fields.Integer(required=True)
@@ -1215,13 +1216,6 @@ class TestOrmAttachment(models.Model):
     def _compute_name(self):
         for rec in self:
             rec.name = self.env[rec.res_model].browse(rec.res_id).display_name
-
-    # override those methods for many2many search
-    def _search(self, domain, offset=0, limit=None, order=None, *, active_test=True, bypass_access=False):
-        return super()._search(domain, offset, limit, order, active_test=active_test, bypass_access=bypass_access)
-
-    def _check_access(self, operation):
-        return super()._check_access(operation)
 
     # DLE P55: `test_cache_invalidation`
     def modified(self, fnames, *args, **kwargs):

--- a/odoo/addons/test_orm/tests/test_read_group_private.py
+++ b/odoo/addons/test_orm/tests/test_read_group_private.py
@@ -1207,6 +1207,9 @@ class TestPrivateReadGroup(common.TransactionCase):
                 [('a', 1 + 1 + 2), ('b', 3), (False, 4)],
             )
 
+        # warmup
+        RelatedInherits._read_group([], ['foo_id_name'], ['__count'])
+        RelatedInherits._read_group([], ['foo_id_name_sudo'], ['__count'])
         expected_query = """
             SELECT "test_read_group_related_inherits__base_id__foo_id"."name",
                     COUNT(*)

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -644,8 +644,15 @@ class Field(typing.Generic[T]):
             self.inverse = self._inverse_related
         if (
             not self.store
-            and (self.compute_sudo or self.inherited)
-            and all(f.column_type and (f.store or f.compute_sql) for f in field_seq)
+            and all(
+                # representable in SQL
+                f.column_type
+                # and we know how to represent it
+                and (f.store or f.compute_sql)
+                # but we don't traverse a model with heavy permission checks (such as ir.attachment)
+                and (f is field_seq[-1] or not getattr(model.pool[f.model_name], '_access_domain_heavy', False))
+                for f in field_seq
+            )
         ):
             self.compute_sql = self._compute_sql_related
         if not self.store and all(f._description_searchable for f in field_seq):

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -1423,7 +1423,7 @@ class Many2many(_RelationalMulti):
 
         # bypass the access during search if method is overwriten to avoid
         # possibly filtering all records of the comodel before joining
-        bypass_access = self.bypass_search_access and type(comodel)._search is not BaseModel._search
+        bypass_access = self.bypass_search_access and getattr(comodel, '_access_domain_heavy', False)
 
         # make the query for the lines
         domain = self.get_comodel_domain(records)

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -552,7 +552,7 @@ class Many2one(_Relational):
         if self.compute_sudo or self.delegate or model.env.su:
             coquery = None
         else:
-            coquery = comodel._search(Domain.TRUE, active_test=False)
+            coquery = comodel.with_context(_generating_sql_for_fields=True)._search(Domain.TRUE, active_test=False)
             if not coquery.where_clause:
                 coquery = None
         if coquery is None:

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -1997,7 +1997,7 @@ class BaseModel(metaclass=MetaModel):
         if not func:
             raise ValueError(f"Aggregate method is mandatory for {fname!r}")
 
-        table = table._with_model(table._model.with_context(_read_groupby=True))
+        table = table._with_model(table._model.with_context(_generating_sql_for_fields=True))
         field = self._fields[fname]
         if func == 'sum_currency':
             if field.type != 'monetary':
@@ -2038,7 +2038,7 @@ class BaseModel(metaclass=MetaModel):
         if fname not in self._fields:
             raise ValueError(f"Invalid field {fname!r} on model {self._name!r}")
         field = self._fields[fname]
-        table = table._with_model(table._model.with_context(_read_groupby=True))
+        table = table._with_model(table._model.with_context(_generating_sql_for_fields=True))
 
         if field.type == 'properties':
             sql_expr = table[fname][seq_fnames]


### PR DESCRIPTION
## [FIX] orm: stop generating slow SQL
Update the context variable to cover the case where we have a related
field such as "mail_message_id.body" which is not ran un sudo. In that
case, we don't want to generate the SQL.

## [FIX] orm: _access_domain_heavy
Mark some models that have heavy access checks so that they can be
handled in a special way for performance reasons.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
