### PR TITLE
[IMP] hr_{holidays,work_entry}: Adjusted combined work entry type form view

### DIFF
--- a/addons/hr_holidays/data/hr_work_entry_type_data.xml
+++ b/addons/hr_holidays/data/hr_work_entry_type_data.xml
@@ -56,7 +56,6 @@
             'requires_allocation': False,
             'leave_validation_type': 'both',
             'allocation_validation_type': 'hr',
-            'request_unit': 'hour',
             'unit_of_measure': 'hour',
             'hide_on_dashboard': True,
             'unpaid': True,
@@ -757,5 +756,15 @@
         <field name="request_unit">day</field>
         <field name="country_id" ref="base.tr"/>
     </record>
+
+    <function model="hr.work.entry.type" name="write">
+        <value model="hr.work.entry.type" eval="obj().sudo().search([('code', 'in', ['LEAVE100', 'LEAVE105', 'WORK110', 'LEAVE90', 'LEAVE110', 'LEAVE120', 'OUT'])]).ids"/>
+        <value eval="{'request_unit': 'half_day'}"/>
+    </function>
+
+    <function model="hr.work.entry.type" name="write">
+        <value model="hr.work.entry.type" eval="obj().sudo().search([('code', 'in', ['WORK100'])]).ids"/>
+        <value eval="{'request_unit': 'hour'}"/>
+    </function>
 
 </data></odoo>

--- a/addons/hr_holidays/models/hr_work_entry_type.py
+++ b/addons/hr_holidays/models/hr_work_entry_type.py
@@ -62,7 +62,7 @@ class HrWorkEntryType(models.Model):
                                  domain=lambda self: [('id', 'in', self.env.companies.country_id.ids)])
     country_code = fields.Char(related='country_id.code', depends=['country_id'], readonly=True)
     leave_validation_type = fields.Selection([
-        ('no_validation', 'None needed'),
+        ('no_validation', 'None'),
         ('hr', 'By Time Off Officer'),
         ('manager', "By Employee's Approver"),
         ('both', "By Employee's Approver and Time Off Officer")], default='hr', string='Time Off Validation')
@@ -71,7 +71,7 @@ class HrWorkEntryType(models.Model):
         help="""Extra Days Requests Allowed: User can request an allocation for himself.\n
         Not Allowed: User cannot request an allocation.""")
     allocation_validation_type = fields.Selection([
-        ('no_validation', 'None needed'),
+        ('no_validation', 'None'),
         ('hr', 'By Time Off Officer'),
         ('manager', "By Employee's Approver"),
         ('both', "By Employee's Approver and Time Off Officer")], default='hr', string='Approval',
@@ -85,7 +85,7 @@ class HrWorkEntryType(models.Model):
         ('day', 'Full Day'),
         ('half_day', 'Half-Day'),
         ('hour', 'Custom Hours')], default='day', string='Duration Type', required=True,
-        help="Define the minimum time off duration in which an employee can take when requesting a leave")
+        help="""Define the minimum time off duration in which an employee can take when requesting a leave""")
     unit_of_measure = fields.Selection([('hour', 'Hours'), ('day', 'Days')], default="hour", string="Unit of measure", required=True,
                                        help="Define if the time off type will be allocated/accrued in hours or days")
     unpaid = fields.Boolean('Is Unpaid', default=False)
@@ -98,7 +98,7 @@ class HrWorkEntryType(models.Model):
     elligible_for_accrual_rate = fields.Boolean(string='Eligible for Accrual Rate', compute="_compute_eligible_for_accrual_rate", store=True, readonly=False,
         help="If checked, this time off type will be taken into account for accruals computation.")
     # negative time off
-    allows_negative = fields.Boolean(string='Allow Negative Cap',
+    allows_negative = fields.Boolean(string='Allow Negative',
         help="If checked, users request can exceed the allocated days and balance can go in negative.")
     max_allowed_negative = fields.Integer(string="Maximum Excess Amount",
         help="Define the maximum level of negative days this kind of time off can reach. Value must be at least 1.")
@@ -107,6 +107,7 @@ class HrWorkEntryType(models.Model):
         'CHECK(NOT allows_negative OR max_allowed_negative > 0)',
         'The maximum excess amount should be greater than 0. If you want to set 0, disable the negative cap instead.'
     )
+    time_off_selectable = fields.Boolean(string="Selectable in Time Off", default=True)
 
     @api.model
     def _search_valid(self, operator, value):

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -2646,6 +2646,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             'code': 'Training',
             'requires_allocation': False,
             'leave_validation_type': 'no_validation',
+            'request_unit': 'day',
         })
 
         # Use the Wizard to create a Training for the whole company: Feb 24 - Feb 26
@@ -2719,6 +2720,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
                     'code': 'Training',
                     'requires_allocation': False,
                     'leave_validation_type': 'no_validation',
+                    'request_unit': 'day',
                 })
         leave_wizard = self.env['hr.leave.generate.multi.wizard'].create({
             'work_entry_type_id': training_type.id,

--- a/addons/hr_holidays/tests/test_work_entry_holidays.py
+++ b/addons/hr_holidays/tests/test_work_entry_holidays.py
@@ -426,6 +426,7 @@ class TestWorkeEntryHolidays(TestWorkEntryBase, TestHolidayContract):
         self.assertEqual(resource_leave.work_entry_type_id, self.work_entry_type, "it should have the corresponding work_entry type")
 
     def test_multi_contract_holiday(self):
+        self.work_entry_type.request_unit = 'day'
         # Leave during second contract
         leave = self.create_leave(datetime(2015, 11, 17), datetime(2015, 11, 20), name="Doctor Appointment", employee_id=self.jules_emp.id)
         start = datetime(2015, 11, 1, 0, 0, 0)
@@ -451,6 +452,7 @@ class TestWorkeEntryHolidays(TestWorkEntryBase, TestHolidayContract):
             ],
         })
         self.work_entry_type_leave.requires_allocation = False
+        self.work_entry_type_leave.request_unit = 'day'
         self.contract_cdi.resource_calendar_id = calendar_20h
         leave = self.env['hr.leave'].create({
             'name': 'Holiday!!',

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -406,17 +406,17 @@
                             </div>
                             <field name="work_entry_type_id" force_save="1"
                                 domain="[
-                                    '&amp;',
-                                        ('id', 'in', work_entry_type_filter_domain or []),
-                                        '|',
-                                            ('requires_allocation', '=', False),
-                                            '&amp;',
-                                                ('has_valid_allocation', '=', True),
-                                                '|',
-                                                    ('allows_negative', '=', True),
-                                                    '&amp;',
-                                                        ('virtual_remaining_leaves', '>', 0),
-                                                        ('allows_negative', '=', False),
+                                    ('time_off_selectable', '=', True),
+                                    ('id', 'in', work_entry_type_filter_domain or []),
+                                    '|',
+                                        ('requires_allocation', '=', False),
+                                        '&amp;',
+                                            ('has_valid_allocation', '=', True),
+                                            '|',
+                                                ('allows_negative', '=', True),
+                                                '&amp;',
+                                                    ('virtual_remaining_leaves', '>', 0),
+                                                    ('allows_negative', '=', False),
                                 ]"
                                 context="{'employee_id': employee_id, 'default_date_from': date_from, 'default_date_to': date_to}"
                                 options="{'no_create': True, 'request_type': 'leave'}"
@@ -568,6 +568,19 @@
                 <field name="employee_id" groups="hr_holidays.group_hr_holidays_responsible" readonly="state in ['cancel', 'refuse', 'validate', 'validate1']" widget="many2one_avatar_employee"/>
                 <field name="company_id" groups="base.group_multi_company"/>
                 <field name="department_id" groups="hr_holidays.group_hr_holidays_responsible" readonly="1"/>
+            </xpath>
+            <xpath expr="//field[@name='work_entry_type_id']" position="attributes">
+                <attribute name="domain">[
+                    '|',
+                        ('requires_allocation', '=', False),
+                        '&amp;',
+                            ('has_valid_allocation', '=', True),
+                            '|',
+                                ('allows_negative', '=', True),
+                                '&amp;',
+                                    ('virtual_remaining_leaves', '&gt;', 0),
+                                    ('allows_negative', '=', False),
+                ]</attribute>
             </xpath>
         </field>
     </record>

--- a/addons/hr_holidays/views/hr_work_entry_type_views.xml
+++ b/addons/hr_holidays/views/hr_work_entry_type_views.xml
@@ -44,29 +44,31 @@
                     </div>
                 </button>
             </div>
+            <group name="identification" class="o_form_fw_labels" position="inside">
+                <field name="time_off_selectable"/>
+            </group>
+            <xpath expr="//field[@name='count_as']" position="after">
+                <field name="unit_of_measure" widget="radio" options="{'horizontal': True}"/>
+                <field name="request_unit" widget="radio" options="{'horizontal': True}"/>
+            </xpath>
             <notebook position="inside">
-                <page string="Time Off">
-                    <group>
-                        <group>
-                                <field name="unit_of_measure" widget="radio" options="{'horizontal': True}"/>
-                                <field name="request_unit" widget="radio" options="{'horizontal': True}"/>
-                        </group>
-                    </group>
+                <page string="Time Off" invisible="not time_off_selectable">
                     <group>
                         <group name="leave_validation" id="time_off_requests" string="Time Off Requests">
                             <field name="active" invisible="1"/>
                             <field name="leave_validation_type" string="Approval" widget="radio"/>
                         </group>
-                        <group name="allocation_validation" id="allocation_requests" string="Allocation Requests">
-                            <field name="requires_allocation"/>
+                        <group name="allocation_validation" id="allocation_requests" string="Allocation">
+                            <field name="requires_allocation" string="Limited Days"/>
                             <field name="employee_requests" invisible="not requires_allocation"/>
-                            <field name="allocation_validation_type" string="Approval" widget="radio" invisible="not requires_allocation"/>
+                            <field name="allocation_validation_type" string="Approval" widget="radio" invisible="not requires_allocation or not employee_requests"/>
                         </group>
                     </group>
                     <group style="justify-content: unset;">
                         <group name="configuration" id="configuration" string="Configuration">
                             <div class="o_cell o_wrap_label text-break text-900 d-flex flex-row" colspan="2">
                                 <div class="d-flex flex-column gap-2">
+                                    <label for="allows_negative" class="me-4" readonly="0" invisible="not requires_allocation"/>
                                     <label for="include_public_holidays_in_duration" class="me-4"/>
                                     <label for="hide_on_dashboard" class="me-4"/>
                                     <label for="support_document" class="me-4" string="Require Supporting Document"/>
@@ -74,6 +76,15 @@
                                     <label for="allow_request_on_top" class="me-4" invisible="count_as == 'absence'"/>
                                 </div>
                                 <div class="d-flex flex-column gap-1">
+                                    <div class="o_row o_cell o_wrap_label text-break text-900" invisible="not requires_allocation">
+                                        <field name="allows_negative" nolabel="1"/>
+                                        <div invisible="not allows_negative">
+                                            <span class="mx-2">up to</span>
+                                            <field name="max_allowed_negative" class="oe_inline"/>
+                                            <span class="mx-2" invisible="unit_of_measure == 'hour'">days</span>
+                                            <span class="mx-2" invisible="unit_of_measure != 'hour'">hours</span>
+                                        </div>
+                                    </div>
                                     <field name="include_public_holidays_in_duration" class="mb-2" nolabel="1"/>
                                     <field name="hide_on_dashboard" class="mb-2" nolabel="1"/>
                                     <field name="support_document" nolabel="1"/>
@@ -82,24 +93,6 @@
                                 </div>
                             </div>
                         </group>
-                        <group>
-                            <group name="negative_cap" id="negative_cap" string="Negative Cap"
-                                invisible="not requires_allocation" colspan="2">
-                                <div class="o_row o_cell o_wrap_label text-break text-900" colspan="2">
-                                    <label for="allows_negative" class="me-4" readonly="0"/>
-                                    <field name="allows_negative" nolabel="1"/>
-                                    <div invisible="not allows_negative">
-                                        <span class="mx-2">up to</span>
-                                        <field name="max_allowed_negative" class="oe_inline"/>
-                                        <span class="mx-2" invisible="unit_of_measure == 'hour'">days</span>
-                                        <span class="mx-2" invisible="unit_of_measure != 'hour'">hours</span>
-                                    </div>
-                                </div>
-                            </group>
-                        </group>
-                    </group>
-                    <group name="visual" id="visual" string="Display Option" class="mw-100 col-lg-12">
-                        <field name="color" widget="color_picker" />
                     </group>
                 </page>
             </notebook>

--- a/addons/hr_work_entry/views/hr_work_entry_type_views.xml
+++ b/addons/hr_work_entry/views/hr_work_entry_type_views.xml
@@ -63,27 +63,26 @@
                     <group name="main_group">
                         <group name="identification" class="o_form_fw_labels">
                             <field name="active" invisible="1"/>
-                            <field name="code" placeholder="e.g. WORK100, LEAVE210, OUT, ..."/>
+                            <field name="code" string="Code" placeholder="e.g. WORK100, LEAVE210, OUT, ..."/>
+                            <field string="Considered as" name="count_as" widget="radio" options="{'horizontal': True}" />
                         </group>
                         <group>
                             <field name="country_id" options="{'no_create': True, 'no_open': True}" placeholder="All Countries"/>
+                            <separator string="Display" />
+                            <field name="display_code" placeholder="e.g. ATT, PTO, STO, OT, RW, ..."/>
+                            <field name="color" widget="color_picker"/>
                         </group>
                     </group>
 
                     <notebook>
                         <page string="Payroll">
-                            <group>
-                                <group name='computation' string="Computation">
+                            <group string="Computation">
+                                <group name='computation'>
                                     <label for="amount_rate"/>
                                     <div name="amount_rate">
                                         <field style='width: 4em;' name="amount_rate" widget="percentage"/>
                                     </div>
                                     <field name="is_extra_hours"/>
-                                    <field string="Considered as" name="count_as" widget="radio" options="{'horizontal': True}" />
-                                </group>
-                                <group string="Display">
-                                    <field name="display_code" placeholder="e.g. ATT, PTO, STO, OT, RW, ..."/>
-                                    <field name="color" widget="color_picker"/>
                                 </group>
                             </group>
 


### PR DESCRIPTION
After the merge of work entry type and time off type in https://www.odoo.com/odoo/project/1251/tasks/5407736, the form view needed some fixes and tweaks. Fields were moved around the sections of the form view, and some redundant fields were removed/altered to have both old functionalities working.

task-5942695

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
