### PR TITLE
[FIX] core: use --db_port when --db_replica_port is not set

### DIFF
--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -841,7 +841,7 @@ def connection_info_for(db_or_uri, readonly=False):
     for p in ('host', 'port', 'user', 'password', 'sslmode'):
         cfg = tools.config['db_' + p]
         if readonly:
-            cfg = tools.config.get('db_replica_' + p, cfg)
+            cfg = tools.config.get('db_replica_' + p) or cfg
         if cfg:
             connection_info[p] = cfg
 


### PR DESCRIPTION
Start postgres on an alternative port (e.g. 5434), start odoo with `--db_port 5434 --db_replica_host=''`, access /web/database/manager, there's a warning in the logs that says it is not possible to connect to the replica database.

The empty string for the replica host is Odoo 18 way to tell Odoo to simulate a replica database by connecting to the same db as the primary one. It should use `--db_replica_port` and when not set fallback on the same port as `--db_port`. The problem is that in case no `--db_replica_port` is set, the option is set `None` in the config, i.e. `get('db_replica_port', cfg)` was retuning `None` as was not using the fallback.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
