### PR TITLE
[FIX] web: some phones don't focus correctly

### DIFF
--- a/addons/web/static/src/core/barcode/barcode_video_scanner.js
+++ b/addons/web/static/src/core/barcode/barcode_video_scanner.js
@@ -98,6 +98,7 @@ export class BarcodeVideoScanner extends Component {
                 const [track] = tracks;
                 const settings = track.getSettings();
                 this.zoomRatio = Math.min(divWidth / settings.width, divHeight / settings.height);
+                this.addZoomSlider(track, settings);
             }
             this.detectorTimeout = setTimeout(this.detectCode.bind(this), 100);
         });
@@ -204,6 +205,23 @@ export class BarcodeVideoScanner extends Component {
             }
         }
         return newObject;
+    }
+
+    addZoomSlider(track, settings) {
+        const zoom = track.getCapabilities().zoom;
+        if (zoom?.min !== undefined && zoom?.max !== undefined) {
+            const inputElement = document.createElement("input");
+            inputElement.type = "range";
+            inputElement.min = zoom.min;
+            inputElement.max = zoom.max;
+            inputElement.step = zoom.step || 1;
+            inputElement.value = settings.zoom;
+            inputElement.classList.add("align-self-end", "m-5", "z-1");
+            inputElement.addEventListener("input", async (event) => {
+                await track?.applyConstraints({ advanced: [{ zoom: inputElement.value }] });
+            });
+            this.videoPreviewRef.el.parentElement.appendChild(inputElement);
+        }
     }
 }
 

--- a/addons/web/static/src/core/barcode/crop_overlay.js
+++ b/addons/web/static/src/core/barcode/crop_overlay.js
@@ -116,6 +116,9 @@ export class CropOverlay extends Component {
     }
 
     pointerDown(event) {
+        if (event.target.matches("input")) {
+            return;
+        }
         event.preventDefault();
         if (event.target.matches(".o_crop_icon")) {
             this.computeOverlayPosition();


### PR DESCRIPTION
This commit resolves an issue where certain mobile devices with multiple lenses (notably iPhone 13 Pro) failed to focus on barcodes at close range.
Since the Web API does not allow direct manual focus control in Safari iOS, a zoom slider has been added as a workaround to help the camera sharpen the image.

Note: While Chrome on Android supports direct focus adjustment, this zoom-based solution provides a consistent fix for all mobile users.

Steps to reproduce:
* Open Odoo on Mobile
* Go to Sale app
* Create a new SO
* Add a product
* Select the barcode icon to open the modal
* Try to scan a barcode (Object is near the phone) => Bug

opw-5870885

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
