### PR TITLE
[FIX] barcodes_gs1_nomenclature: prevent traceback on barcode rule form

### DIFF
--- a/addons/barcodes_gs1_nomenclature/views/barcodes_view.xml
+++ b/addons/barcodes_gs1_nomenclature/views/barcodes_view.xml
@@ -23,6 +23,7 @@
                     <attribute name="column_invisible">parent.is_gs1_nomenclature</attribute>
                 </xpath>
                 <xpath expr="//field[@name='pattern']" position="after">
+                    <field name="is_gs1_nomenclature" invisible="1"/> <!-- Needed to toggle fields in the barcode rule form without saving this field -->
                     <field name="gs1_content_type" column_invisible="not parent.is_gs1_nomenclature"/>
                     <field name="gs1_decimal_usage" column_invisible="not parent.is_gs1_nomenclature" invisible="gs1_content_type != 'measure'"/>
                     <field name="associated_uom_id" column_invisible="not parent.is_gs1_nomenclature" invisible="gs1_content_type != 'measure'"/>
@@ -47,12 +48,12 @@
             <field name="inherit_id" ref="barcodes.view_barcode_rule_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='encoding']" position="attributes">
-                    <attribute name="invisible">parent.is_gs1_nomenclature or type == 'alias'</attribute>
+                    <attribute name="invisible">is_gs1_nomenclature or type == 'alias'</attribute>
                 </xpath>
                 <xpath expr="//field[@name='alias']" position="after">
-                    <field name="gs1_content_type" invisible="not parent.is_gs1_nomenclature"/>
-                    <field name="gs1_decimal_usage" invisible="not parent.is_gs1_nomenclature or gs1_content_type != 'measure'"/>
-                    <field name="associated_uom_id" invisible="not parent.is_gs1_nomenclature or gs1_content_type != 'measure'"/>
+                    <field name="gs1_content_type" invisible="not is_gs1_nomenclature"/>
+                    <field name="gs1_decimal_usage" invisible="not is_gs1_nomenclature or gs1_content_type != 'measure'"/>
+                    <field name="associated_uom_id" invisible="not is_gs1_nomenclature or gs1_content_type != 'measure'"/>
                     <field name="is_gs1_nomenclature" invisible="1"/>
                 </xpath>
             </field>


### PR DESCRIPTION
Issue before this commit:
=========================
When opening a Barcode Rule form view, a traceback was raised due to the following
python expression: bool(parent.is_gs1_nomenclature or type == 'alias')

Steps to Reproduce:
=========================
- Install the stock module.
- Go to Configuration → Barcode Nomenclatures in the Stock app.
- Open any Barcode Nomenclature form.
- Go to the Rules tab and open a rule (pop-up form view).
- Click on the Expand button.
- A traceback is raised.

Cause of the issue:
=========================
The form view tries to evaluate `parent.is_gs1_nomenclature`, but the `parent` record
is not defined when the rule form view is opened directly (via expand), leading to a traceback.

This happens because the form view is not defined as a child of any parent view,
so no parent context is available, which leads to a traceback.

With This Commit:
=========================
Removed the usage of `parent.is_gs1_nomenclature` and use `is_gs1_nomenclature`
directly instead. The `is_gs1_nomenclature` field on `barcode.rule` is already a
related field to `barcode.nomenclature`, so it can be safely used without relying on the parent.

opw-5949083