### PR TITLE
[IMP] web: add no_symbol option to percentage widget

### DIFF
--- a/addons/web/static/src/views/fields/formatters.js
+++ b/addons/web/static/src/views/fields/formatters.js
@@ -449,7 +449,10 @@ export function formatPercentage(value, options = {}) {
     const formatted = formatFloatNumber(value * 100, options);
     return `${formatted}${options.noSymbol ? "" : "%"}`;
 }
-formatPercentage.extractOptions = formatFloat.extractOptions;
+formatPercentage.extractOptions = ({ attrs, options }) => ({
+    ...formatFloat.extractOptions({ attrs, options }),
+    noSymbol: options.no_symbol,
+});
 
 /**
  * Returns a string representing the value of the python properties field

--- a/addons/web/static/src/views/fields/percentage/percentage_field.js
+++ b/addons/web/static/src/views/fields/percentage/percentage_field.js
@@ -13,6 +13,7 @@ export class PercentageField extends Component {
     static props = {
         ...standardFieldProps,
         digits: { type: Array, optional: true },
+        noSymbol: { type: Boolean, optional: true },
     };
 
     setup() {
@@ -32,6 +33,7 @@ export class PercentageField extends Component {
     get formattedValue() {
         return formatPercentage(this.props.record.data[this.props.name], {
             digits: this.props.digits,
+            noSymbol: this.props.noSymbol,
             field: this.props.record.fields[this.props.name],
         });
     }
@@ -51,8 +53,11 @@ export const percentageField = {
             digits = options.digits;
         }
 
+        const noSymbol = options.no_symbol || false;
+
         return {
             digits,
+            noSymbol,
         };
     },
 };

--- a/addons/web/static/src/views/fields/percentage/percentage_field.xml
+++ b/addons/web/static/src/views/fields/percentage/percentage_field.xml
@@ -14,7 +14,7 @@
                     inputmode="decimal"
                     autocomplete="off"
                 />
-                <span>%</span>
+                <span t-if="!props.noSymbol">%</span>
             </div>
         </t>
     </t>

--- a/addons/web/static/tests/views/fields/percentage_field.test.js
+++ b/addons/web/static/tests/views/fields/percentage_field.test.js
@@ -59,3 +59,30 @@ test("PercentageField in form view without rounding error", async () => {
 
     expect("[name='float_field'] input").toHaveValue("28");
 });
+
+test("PercentageField with no_symbol option", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: /* xml */ `<form><field name="float_field" widget="percentage" options="{'no_symbol': true}"/></form>`,
+        resId: 1,
+    });
+
+    expect(".o_field_widget[name=float_field] input").toHaveValue("44.4");
+    expect(".o_field_widget[name=float_field] span").toHaveCount(0, {
+        message: "The percentage symbol should not be displayed when no_symbol is true.",
+    });
+});
+
+test("PercentageField without no_symbol option shows percentage symbol", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: /* xml */ `<form><field name="float_field" widget="percentage"/></form>`,
+        resId: 1,
+    });
+
+    expect(".o_field_widget[name=float_field] input").toHaveValue("44.4");
+    expect(".o_field_widget[name=float_field] span").toHaveCount(1);
+    expect(".o_field_widget[name=float_field] span").toHaveText("%");
+});


### PR DESCRIPTION
Allow hiding the "%" symbol in percentage fields when using the percentage widget with options="{'no_symbol': true}". This is useful when the field already has a visible unit selector or when the symbol is redundant in the UI context.

The option affects both edit and readonly modes, giving developers flexibility in how percentage values are displayed.

Task Id: 5470141