### PR TITLE
[FIX] mail: channel member 'is typing' icon had incorrect dot color

### DIFF
--- a/addons/mail/static/src/core/common/im_status.js
+++ b/addons/mail/static/src/core/common/im_status.js
@@ -51,9 +51,9 @@ export class ImStatus extends Component {
 
     get class() {
         return attClassObjectToString({
-            [`o-mail-ImStatus d-flex ${this.icon} ${this.colorClass} ${this.props.className}`]: true,
+            [`o-mail-ImStatus d-flex ${this.colorClass} ${this.props.className}`]: true,
             "o-fs-small": this.persona?.im_status !== "bot",
-            "rounded-circle bg-transparent": !this.showTypingIndicator,
+            [`rounded-circle bg-transparent ${this.icon}`]: !this.showTypingIndicator,
             "rounded-pill": this.showTypingIndicator,
         });
     }

--- a/addons/mail/static/src/core/common/im_status.xml
+++ b/addons/mail/static/src/core/common/im_status.xml
@@ -5,7 +5,7 @@
         <t t-slot="pre_icon"/>
         <t name="icon">
             <i t-if="(!props.member or !showTypingIndicator) and persona" t-att-class="class" t-att-style="props.style" t-att-title="title" role="img" t-att-aria-label="title"/>
-            <div t-if="showTypingIndicator" class="o-mail-ImStatus-typingContainer rounded-pill" t-att="attr">
+            <div t-if="showTypingIndicator" class="o-mail-ImStatus-typingContainer rounded-pill" t-att-class="class">
                 <div class="o-mail-ImStatus-typingBg bg-success rounded-pill">
                     <Typing member="props.member" size="['sm', 'smaller'].includes(props.size) ? 'sm' : 'md'" displayText="false" />
                 </div>


### PR DESCRIPTION
Before this commit, the icon "is typing" had incorrect style.

Steps to reproduce:
- When in dark theme and in a conversation with "Members" panel open
- Current user is typing something in the composer => see the 'is typing' icon in member list have grey dot instead of white

This happens because the is typing is made with `ImStatus` component, and the icon lacked the `.o-mail-ImStatus` classname that is very important for knowing the style is the dot with filled background.

This was missing because it passed `t-att="attr"` like `ThreadIcon` but in `ImStatus` there's no such `attr` that combines all the properties. Instead it must make use of `class` getter.

This commit fixes the issue by replacing `t-att="attr"` by `t-att-class="class"` to get important classnames for style. The condition for classnames have also been adjusted because there was another typo with user icon being necessarily added regardless of "is typing", which is incorrect as the "is typing" is a temporarily replacement of the IM status icon.

Before / After
<img width="168" height="116" alt="Screenshot 2026-02-18 at 15 30 37" src="https://github.com/user-attachments/assets/cf5c8f2d-958a-4840-8c6a-075b3c62bcd7" /> <img width="192" height="126" alt="Screenshot 2026-02-18 at 15 29 43" src="https://github.com/user-attachments/assets/d82466da-3b21-41d4-b019-f7a843770f4c" />
