### PR TITLE
[FIX] website_sale_stock : use website email when sending availibity …

### DIFF
--- a/addons/website_sale_stock/tests/test_website_sale_stock_stock_notification.py
+++ b/addons/website_sale_stock/tests/test_website_sale_stock_stock_notification.py
@@ -54,7 +54,10 @@ class TestStockNotificationProduct(HttpCase):
         })
         quants.action_apply_inventory()
 
+        website = self.env['website'].get_current_website()
+
         ProductProduct._send_availability_email()
         emails = self.env['mail.mail'].search([('email_to', '=', partner.email_formatted)])
         self.assertEqual(emails[0].subject, "The product 'Macbook Pro' is now available")
+        self.assertEqual(emails[0].email_from, website.company_id.partner_id.email_formatted)
         self.assertFalse(product._has_stock_notification(partner))


### PR DESCRIPTION
…notification

# The problem
The mail sent to notify a customer that a product is back in stock used the e-mail of the company associated with the product. We would rather use the e-mail of the company associated with the website the notification request was done in.

This commit aligns versions 18.0+ with what is done on master (https://github.com/odoo/odoo/commit/8ec57b1115a55e8b59db9b8c1e843c6a1c888db3)

opw-5868889

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
