### PR TITLE
[IMP] web: offline searchbar: avoid displaying "Custom filter"

### DIFF
--- a/addons/web/static/src/core/offline/offline_service.js
+++ b/addons/web/static/src/core/offline/offline_service.js
@@ -196,6 +196,7 @@ class OfflineManager extends Reactive {
             } else {
                 value = (await this._idb.read(this._idbTable, key)) || {};
                 let count = value[search.key]?.count || 0;
+                search = value[search.key]?.search || search; // keep original search (no "Custom Filter")
                 delete value[search.key]; // delete and re-add to mark it as "last visited"
                 value[search.key] = { count: ++count, search };
             }

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -530,10 +530,30 @@ export class SearchModel extends EventBus {
         this._appliedSearch = search;
         const { domain, groupBys } = search;
         if (domain !== "[]") {
-            const description = _t("Custom filter");
-            this.createNewFilters([
-                { description, domain, name: "custom filter", invisible: "True" },
-            ]);
+            search.facets.forEach((facet) => {
+                if (!["field", "filter", "favorite"].includes(facet.type)) {
+                    return;
+                }
+                let description = facet.values.join(` ${facet.separator} `);
+                if (facet.type === "field") {
+                    description = `${facet.title} ${description}`;
+                }
+                this.searchItems[this.nextId] = {
+                    id: this.nextId,
+                    groupId: this.nextGroupId,
+                    groupNumber: this.nextGroupNumber,
+                    type: facet.type === "favorite" ? "favorite" : "filter",
+                    description,
+                    domain: facet.domain,
+                    orderBy: [],
+                    name: `offline filter ${this.nextId}`,
+                    invisible: "True",
+                };
+                this.query.push({ searchItemId: this.nextId });
+                this.nextId++;
+                this.nextGroupId++;
+                this.nextGroupNumber++;
+            });
         }
         this._toggleGroupBys(groupBys);
         this._notify();


### PR DESCRIPTION
Enter a list or kanban view, enable some filters/groupbys and/or favorite items. Switch offline, and select one of the available search in the offline search menu (pick a search that has at least a "filter" facet). Switch back online.

Before this commit, the search was displayed in the (online) searchbar with a single "Custom filter" facet. This wasn't ideal, as the user had no clue about what actually was the filter. Moreover, if he kept modifying the search (e.g. add new filters) such that there were other facets alongside the "Custom filter" facet in the searchbar, and then switched offline, new searches were available in the offline search menu, but they all displayed the "Custom filter" facet, instead of the original, real, facet label.

With this commit, we stop generating a single "Custom filter" facet. Instead, we generate one facet for each filter/field/favorite facet of the offline search.

Moreover, when a search (identified by the stringification of its domain and groupby) is already available offline, and we visit it again, we keep the original facet representation. This ensures that we always keep original facets to display in the offline search menu, and not "fake" facets that have been created when searching offline.

Task~5913149

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
