### PR TITLE
[FIX] pos_event: display event ticket download button

### DIFF
--- a/addons/pos_event/models/pos_order.py
+++ b/addons/pos_event/models/pos_order.py
@@ -19,26 +19,32 @@ class PosOrder(models.Model):
 
     def read_pos_data(self, data, config_id):
         results = super().read_pos_data(data, config_id)
-        paid_orders = self.filtered_domain([('state', 'in', ['paid', 'done', 'invoiced'])])
-
-        if not paid_orders:
+        if not self:
             return results
 
-        lines_with_event = paid_orders.mapped('lines').filtered(lambda line: line.event_ticket_id)
-        event_event_fields = self.env['event.event']._load_pos_data_fields(paid_orders[0].config_id.id)
-        event_ticket_fields = self.env['event.event.ticket']._load_pos_data_fields(paid_orders[0].config_id.id)
-        event_registrations_fields = self.env['event.registration']._load_pos_data_fields(paid_orders[0].config_id.id)
-        event_registrations_answer_fields = self.env['event.registration.answer']._load_pos_data_fields(paid_orders[0].config_id.id)
+        lines_with_event = self.mapped('lines').filtered(lambda line: line.event_ticket_id)
+        event_event_fields = self.env['event.event']._load_pos_data_fields(self[0].config_id.id)
+        event_ticket_fields = self.env['event.event.ticket']._load_pos_data_fields(self[0].config_id.id)
+        event_registrations_fields = self.env['event.registration']._load_pos_data_fields(self[0].config_id.id)
+        event_registrations_answer_fields = self.env['event.registration.answer']._load_pos_data_fields(self[0].config_id.id)
         results['event.registration'] = lines_with_event.event_registration_ids.read(event_registrations_fields, load=False)
         results['event.event'] = lines_with_event.event_registration_ids.mapped('event_id').read(event_event_fields, load=False)
         results['event.event.ticket'] = lines_with_event.event_registration_ids.mapped('event_ticket_id').read(event_ticket_fields, load=False)
         results['event.registration.answer'] = lines_with_event.event_registration_ids.mapped('registration_answer_ids').read(event_registrations_answer_fields, load=False)
 
+        return results
+
+    def action_pos_order_paid(self):
+        res = super().action_pos_order_paid()
+        paid_orders = self.filtered_domain([('state', 'in', ['paid', 'done', 'invoiced'])])
+        lines_with_event = paid_orders.mapped('lines').filtered(lambda line: line.event_ticket_id)
+        self.send_paid_order_mail(lines_with_event)
+        return res
+
+    def send_paid_order_mail(self, lines_with_event):
         for registration in lines_with_event.event_registration_ids:
             if registration.email:
                 registration.action_send_badge_email()
-
-        return results
 
     @api.model
     def _process_order(self, order, existing_order):


### PR DESCRIPTION
**Steps to reproduce:**
- Set up an event, go put it's state to Annonced
- Set up any online payment method (Demo also triggers the bug)
- Go to a PoS that sells the event tickets
- Purchase one and pay with the online payment method
- Once on the ticket screen, the button to download the event tickets is not displayed

**Why the fix:**
The normal flow only works for offline payment methods, because we check if the ordered is either paid or invoiced before setting all the values needed by the frontend regarding the ticket registration.

The problem is that with an online payment method, once we enter the **read_pos_data** method that sets
the values for the frontend, the order is still in draft, so we just return without doing anything.

We now set the values regardless of the order's status and send the confirmation mail in the same way as if it was an online payment.
In the case of an online payment, the mail will be sent by the **action_pos_order_paid** function that is called once the payment is processed.

A test might be a bit weird to make as we don't have a bridge for pos_online_payment and pos_event, and that we would need to mock the server's answer to be able to pay for the online payment and check that we have the needed values. So the setup for pos_event would have to be copied into pos_online_payment to test it and it would only be ran if both modules are installed.

opw-5438432