### PR TITLE
[FIX] mail: remove yellow color on message bookmarked icon

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -225,8 +225,8 @@
 </t>
 
 <t t-name="mail.Message.sidebarBookmark">
-    <small class="text-center lh-1 o-opacity-35" t-att-class="{ 'align-self-start ms-1': isAlignedRight, 'align-self-end me-1': !isAlignedRight, 'mt-2': props.squashed, 'mt-1': !props.squashed }" title="Bookmark">
-        <i class="fa fa-bookmark o-mail-favorite"/>
+    <small class="text-center lh-1 o-opacity-35" t-att-class="{ 'align-self-start ms-1': isAlignedRight, 'align-self-end me-1': !isAlignedRight, 'mt-2': props.squashed, 'mt-1': !props.squashed }" title="Bookmarked">
+        <i class="fa fa-bookmark"/>
     </small>
 </t>
 

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -111,7 +111,7 @@ registerMessageAction("add-bookmark", {
 });
 registerMessageAction("remove-bookmark", {
     condition: ({ message }) => message.canToggleBookmark && message.is_bookmarked,
-    icon: "fa fa-bookmark o-mail-favorite",
+    icon: "fa fa-bookmark",
     name: _t("Remove from bookmarks"),
     onSelected: ({ message, thread }) => message.removeBookmark(thread),
     sequence: 30,


### PR DESCRIPTION
Recently the feature to "star" a message was a star icon, and when a message was starred the star icon was filled with yellow.

The feature as renamed to "bookmark", i.e. a message is now bookmarked. Functionally this is equivalent, just a rename and icon change. The icon should just use a neutral color for bookmark and not preserve the yellow color from star, which is what this commit fixes.

Also rename "Bookmark" status to "Bookmarked" in the message sidebar.

Before / After
<img width="444" height="205" alt="Screenshot 2026-02-18 at 16 12 03" src="https://github.com/user-attachments/assets/06090f97-fbdb-4cd9-96f3-d884c853b82d" /> <img width="443" height="215" alt="Screenshot 2026-02-18 at 16 11 46" src="https://github.com/user-attachments/assets/49c034bd-039d-4147-ae82-388fde6b53af" />
