### PR TITLE
[IMP] tests: cr.flush and single savepoint in TransactionCase

### DIFF
--- a/addons/l10n_in/tests/test_l10n_in_company.py
+++ b/addons/l10n_in/tests/test_l10n_in_company.py
@@ -6,25 +6,20 @@ from odoo.tests import tagged
 @tagged('post_install', '-at_install', 'post_install_l10n')
 class TestL10nInCompany(L10nInTestInvoicingCommon):
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-
-        # Create a branch company under the default company
-        cls.company_data['company'].write({
-            'child_ids': [Command.create({
-                'name': 'IN Branch',
-                'country_id': cls.country_in.id,
-                'vat': '24FANCY1234AAZA',
-            })],
-        })
-        cls.in_branch = cls.company_data['company'].child_ids
-
     def test_l10n_in_journal_priority(self):
         """
         Ensure that when a branch company has its own journals,
         it is selected instead of falling back to the parent company's journal.
         """
+        # Create a branch company under the default company
+        self.company_data['company'].write({
+            'child_ids': [Command.create({
+                'name': 'IN Branch',
+                'country_id': self.country_in.id,
+                'vat': '24FANCY1234AAZA',
+            })],
+        })
+        self.in_branch = self.company_data['company'].child_ids
 
         # Check: branch has no journal initially
         branch_sale_journal = self.env['account.journal'].search([

--- a/odoo/addons/base/tests/test_db_cursor.py
+++ b/odoo/addons/base/tests/test_db_cursor.py
@@ -366,6 +366,10 @@ class TestCursorHooksTransactionCaseCleanup(common.TransactionCase):
 
     def assertHookData(self):
         for callback, name in zip(self.callbacks, self.callback_names):
+            if name == 'precommit':
+                self.assertFalse(callback._funcs, "precommit is flushed for savepoint between tests")
+                self.assertFalse(callback.data)
+                continue
             self.assertEqual(
                 callback.data[f'test_cursor_hooks_{name}'],
                 ['keep'],
@@ -377,6 +381,8 @@ class TestCursorHooksTransactionCaseCleanup(common.TransactionCase):
     def test_1_isolation(self):
         self.assertHookData()
         for callback, name in zip(self.callbacks, self.callback_names):
+            if name == 'precommit':
+                callback.data['test_cursor_hooks_precommit'] = []
             callback.data[f'test_cursor_hooks_{name}'].append("don't keep")
             callback.add(self.other_callback)
 

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -34,7 +34,7 @@ import odoo
 from . import tools
 from .release import MIN_PG_VERSION
 from .tools import SQL, config
-from .tools.func import frame_codeinfo, locked
+from .tools.func import frame_codeinfo, locked, reset_cached_properties
 from .tools.misc import Callbacks, real_time
 
 if typing.TYPE_CHECKING:
@@ -137,12 +137,16 @@ class _FlushingSavepoint(Savepoint):
     def __init__(self, cr: BaseCursor):
         cr.flush()
         super().__init__(cr)
+        self._default_env = cr.transaction.default_env if cr.transaction is not None else None
 
     def rollback(self):
         cr = self._cr
         assert isinstance(cr, BaseCursor)
         if cr.transaction is not None:
+            cr.transaction.default_env = self._default_env
             cr.transaction.clear()
+            for env in cr.transaction.envs:
+                reset_cached_properties(env)
         super().rollback()
 
     def _close(self, rollback: bool):

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -70,7 +70,7 @@ from odoo.http.session import (
 )
 from odoo.http.session import Session as OdooHttpSession
 from odoo.modules.registry import Registry
-from odoo.sql_db import Cursor, Savepoint
+from odoo.sql_db import Cursor
 from odoo.tools import SQL, DotDict, config, float_compare, mute_logger, profiler
 from odoo.tools.mail import single_email_re
 from odoo.tools.misc import diff_zip, find_in_path, lower_logging
@@ -1073,6 +1073,7 @@ class TransactionCase(BaseCase):
     """
     muted_registry_logger = mute_logger(odoo.orm.registry._logger.name)
     freeze_time = None
+    savepoint = None
 
     @classmethod
     def _gc_filestore(cls):
@@ -1170,24 +1171,14 @@ class TransactionCase(BaseCase):
                 )
 
         self.addCleanup(_check_registry_lock)
-        # restore environments after the test to avoid invoking flush() with an
-        # invalid environment (inexistent user id) from another test
-        for env in self.env.transaction.envs:
-            self.addCleanup(env.clear)
-
-        # restore the set of known environments as it was at setUp
-        def reset_env(transaction, envs):
-            transaction._recent_envs.clear()
-            transaction._weak_envs.clear()
-            transaction._weak_envs.extend(envs)
-
-        self.addCleanup(reset_env, self.env.transaction, list(self.env.transaction._weak_envs))
 
         self.addCleanup(self.muted_registry_logger(self.registry.clear_all_caches))
 
         # flush everything in setUpClass before introducing a savepoint
         cr = self.cr
-        cr.flush()
+        if self.savepoint is None:
+            self.savepoint = self.cr.savepoint(flush=True)
+            self.addClassCleanup(self.savepoint.close)
 
         # This prevents precommit functions and data from piling up
         # until cr.flush is called in 'assertRaises' clauses
@@ -1198,8 +1189,7 @@ class TransactionCase(BaseCase):
         for callback in [cr.precommit, cr.postcommit, cr.prerollback, cr.postrollback]:
             self.addCleanup(_reset, callback, deque(callback._funcs), deepcopy(callback.data))
 
-        savepoint = Savepoint(cr)
-        self.addCleanup(savepoint.close)
+        self.addCleanup(self.savepoint.rollback)
 
     @contextmanager
     def enter_registry_test_mode(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Instead of flushing the environment, flush the cursor which includes running precommit hooks.

We can reuse a single save point for all tests thus avoiding recreating one for each test. After each test, rollback to the savepoint and after the class, release it.

A *flushing* savepoint is used which should contain already some logic to reset properly the transaction and environments. We add resetting the default environment and all environment properties when rollbacking such a savepoint as modifications inside that context should be ignored.

Current behavior before PR:
- We flush only data, not precommit hooks.
- We create the savepoint at each test and release it after.
- We restore previous environments.

Desired behavior after PR is merged:
- Use a flushing savepoint.
- Create a single savepoint for a class and rollback to it after each test. Release the savepoint after the class.
- Just reset environments. We have the default environment so that flushing is not random.

https://github.com/odoo/enterprise/pull/107826

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
