### PR TITLE
[FIX] l10n_tr_nilvera_edispatch: wrong mimetype with python-magic

### DIFF
--- a/addons/l10n_tr_nilvera_edispatch/tests/test_ereceipt_upload.py
+++ b/addons/l10n_tr_nilvera_edispatch/tests/test_ereceipt_upload.py
@@ -34,7 +34,7 @@ class TestTRNilveraEreceiptUpload(TestStockCommon):
     def test_ereceipt_xml_without_errors_upload(self):
         with file_open('l10n_tr_nilvera_edispatch/tests/test_files/test_ereceipt.xml', 'rb') as f:
             ereceipt_xml = self.env['ir.attachment'].create({
-                'name': 'E-Receipt Without Errors',
+                'name': 'test_ereceipt_upload.xml',
                 'type': 'binary',
                 'datas': base64.b64encode(f.read()),
             })


### PR DESCRIPTION
The test `test_ereceipt_xml_without_errors_upload` was broken on builds using python-magic for mimetype detection due to some behavior discrepancies with of without the libmagic bindings (detecting the `test_ereceipt.xml` file content as either plain text or proper xml).

This commit fixes it by simply renaming the attachment created for the test, as it was already done during the forward port of the original commit [^1] to 19.0.

runbot-238805

[^1]: https://github.com/odoo/odoo/pull/232848/changes#diff-764d87a2598c60c585bf203412013c9ac89acf74e083178120168031f78a64f1R37
