### PR TITLE
[FIX] pos_loyalty: change popup redemption message

### DIFF
--- a/addons/pos_loyalty/models/loyalty_card.py
+++ b/addons/pos_loyalty/models/loyalty_card.py
@@ -20,7 +20,7 @@ class LoyaltyCard(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config):
-        return ['partner_id', 'code', 'points', 'program_id', 'expiration_date', 'write_date']
+        return ['partner_id', 'code', 'points', 'points_display', 'program_id', 'expiration_date', 'write_date']
 
     def _has_source_order(self):
         return super()._has_source_order() or bool(self.source_pos_order_id)

--- a/addons/pos_loyalty/models/pos_config.py
+++ b/addons/pos_loyalty/models/pos_config.py
@@ -122,6 +122,7 @@ class PosConfig(models.Model):
                 'coupon_id': coupon.id,
                 'coupon_partner_id': coupon.partner_id.id,
                 'points': coupon.points,
+                'points_display': coupon.points_display,
                 'has_source_order': coupon._has_source_order(),
             },
         }

--- a/addons/pos_loyalty/static/src/app/services/pos_store.js
+++ b/addons/pos_loyalty/static/src/app/services/pos_store.js
@@ -322,6 +322,7 @@ patch(PosStore.prototype, {
                     program_id: this.models["loyalty.program"].get(payload.program_id),
                     partner_id: this.models["res.partner"].get(payload.partner_id),
                     points: payload.points,
+                    points_display: payload.points_display,
                     // TODO JCB: make the expiration_date work.
                     // expiration_date: payload.expiration_date,
                 });
@@ -342,11 +343,7 @@ patch(PosStore.prototype, {
             }
         }
         if (!rule && order.lines.length === 0 && coupon) {
-            return _t(
-                "Gift Card: %s\nBalance: %s",
-                code,
-                this.env.utils.formatCurrency(coupon.points)
-            );
+            return _t("%s: %s\nBalance: %s", coupon.program_id.name, code, coupon.points_display);
         }
         return true;
     },


### PR DESCRIPTION
Currently, the popup message shown when redeeming a code is the same for all programs but is always displayed as if it was a giftcard.

Steps to reproduce:
-------------------
* Create a program of type coupon, points unit: Coupon points, currency: USD
* Create x coupons with 5 points
* Copy a coupon code
* Open shop
* Enter code
> Popup message says: Gift card: *code*, Balance: $ 5.00

Why the fix:
------------
Since this popup is used for multiple program we try to make it as generic as possible. Now we'll use the prgram name instead of the generic "Gift Card" string.

Instead of formatting the points with the currency we can use `points_display` as it reflects the currency symbol or point unit name accordingly.

<img width="416" height="82" alt="image" src="https://github.com/user-attachments/assets/a4c3c1ef-e02f-4618-809f-4bff5d99c948" />


opw-5220834