### PR TITLE
[FIX] website_sale_{collect,stock}: consider rental period in click and collect

### DIFF
--- a/addons/website_sale_collect/models/product_template.py
+++ b/addons/website_sale_collect/models/product_template.py
@@ -27,7 +27,7 @@ class ProductTemplate(models.Model):
                 and order_sudo.pickup_location_data
             ):  # Get stock values for the product variant in the selected store.
                 res['in_store_stock'] = utils.format_product_stock_values(
-                    product_or_template.sudo(), wh_id=order_sudo.pickup_location_data['id']
+                    product_or_template.sudo(), wh_id=order_sudo.pickup_location_data['id'], free_qty=website._get_free_qty(product_or_template)
                 )
             else:
                 res['in_store_stock'] = utils.format_product_stock_values(

--- a/addons/website_sale_collect/models/website.py
+++ b/addons/website_sale_collect/models/website.py
@@ -39,3 +39,6 @@ class Website(models.Model):
             product.with_context(warehouse_id=wh.id).free_qty
             for wh in self.sudo().in_store_dm_id.warehouse_ids
         ], default=0)
+
+    def _get_free_qty(self, product, **kwargs):
+        return super()._get_free_qty(product)

--- a/addons/website_sale_stock/models/website.py
+++ b/addons/website_sale_stock/models/website.py
@@ -19,3 +19,6 @@ class Website(models.Model):
 
     def _get_product_available_qty(self, product, **kwargs):
         return product.with_context(warehouse_id=self.warehouse_id.id).free_qty
+
+    def _get_free_qty(self, product, **kwargs):
+        return product.with_context(warehouse_id=self.warehouse_id.id).free_qty


### PR DESCRIPTION
Click and collect widget is not supported for rental products

Steps to reproduce:
-------------------
* Enable "Click and collect" in setting and set up warehouses
* Create a rental product
* Add a unit of the product in one of the warehouses
* Rent that product for a period
* Go on the website>shop>the product
* The available quantity for the warehouse does not account for the in start/end dates in the eCommerce product page

Observation:
-------------
The issue is that click and collect and openLocationSelector has no information about he rental periode https://github.com/odoo/odoo/blob/20e54e37670ffa569f47663a7e4b8d7de3a4c33c/addons/website_sale_collect/views/templates.xml#L28-L36 https://github.com/odoo/odoo/blob/20e54e37670ffa569f47663a7e4b8d7de3a4c33c/addons/website_sale_collect/static/src/js/click_and_collect_availability/click_and_collect_availability.js#L54 the rental period is set in the xml file:
https://github.com/odoo/enterprise/blob/1bf7dbcfef2186ee5a08382367fe195efca033dc/website_sale_renting/views/templates.xml#L90

opw-5365564