### PR TITLE
[FIX] hr_skills: random runbot tour failure

### DIFF
--- a/addons/hr_skills/static/tests/tours/skills_tour.js
+++ b/addons/hr_skills/static/tests/tours/skills_tour.js
@@ -173,7 +173,7 @@ registry.category("web_tour.tours").add('hr_skills_tour', {
     },
     {
         content: "Close validation error popup",
-        trigger: ".modal-footer .btn-primary",
+        trigger: ".o_error_dialog .modal-footer .btn-primary",
         run: "click",
     },
     {


### PR DESCRIPTION
When looking for this selector `.modal-footer .btn-primary` multiple popup are opened and the tour could select the wrong one. It would then not close the correct popup and fail the tour.

runbot-238877