### PR TITLE
[FIX] web: load Telugu in QWeb PDF reports

### DIFF
--- a/addons/web/static/fonts/fonts.scss
+++ b/addons/web/static/fonts/fonts.scss
@@ -34,7 +34,16 @@ $lato-font-path: './lato';
         font-style: $style;
         unicode-range: U+0600-06FF, U+0750-077F, U+08A0-08FF;
     }
-
+    // Telugu: U+0C00-0C7F
+    @font-face {
+        font-family: 'Odoo Unicode Support Noto';
+        src: url('https://fonts.odoocdn.com/fonts/noto/NotoSansTelugu-#{$type}.woff2') format('woff2'),
+             url('https://fonts.odoocdn.com/fonts/noto/NotoSansTelugu-#{$type}.woff') format('woff'),
+             url('https://fonts.odoocdn.com/fonts/noto/NotoSansTelugu-#{$type}.ttf') format('truetype');
+        font-weight: $weight;
+        font-style: $style;
+        unicode-range: U+0C00-0C7F;
+    }
     @font-face {
         font-family: 'Lato';
         src: url('#{$lato-font-path}/Lato-#{$type}-webfont.eot');


### PR DESCRIPTION
SaaS 19.0 QWeb PDF reports renders Telugu characters as black squares because the default font stack has no Telugu coverage on the server side. While some environments may display Telugu via locally installed fonts, wkhtmltopdf requires explicit webfont coverage to embed the glyphs in the PDF.

Add a Noto Sans Telugu @font-face rule with the Telugu unicode range so report rendering can fetch and embed a Telugu-capable font when needed. This mirrors the existing mechanism used for Arabic/Hebrew/Cyrillic.

opw-5886157 (related ticket)
https://github.com/odoo/odoo/pull/32312 (related PR)

I have attached the font files that needs to be uploaded to cdn in NotoSansTelugu.zip.
[NotoSansTelugu.zip](https://github.com/user-attachments/files/25395294/NotoSansTelugu.zip)

---