### PR TITLE
[IMP] web: Highlight Missing Settings

### DIFF
--- a/addons/web/static/src/webclient/settings_form_view/settings/settings_page.js
+++ b/addons/web/static/src/webclient/settings_form_view/settings/settings_page.js
@@ -55,6 +55,18 @@ export class SettingsPage extends Component {
         );
     }
 
+    get invalidApps() {
+        const invalidApps = [];
+        for (const anchor of this.props.anchors) {
+            if (
+                anchor.fieldNames.some((fieldName) => this.env.model.root.isFieldInvalid(fieldName))
+            ) {
+                invalidApps.push(anchor.app);
+            }
+        }
+        return invalidApps;
+    }
+
     getCurrentIndex() {
         return this.props.modules.findIndex((object) => object.key === this.state.selectedTab);
     }

--- a/addons/web/static/src/webclient/settings_form_view/settings/settings_page.xml
+++ b/addons/web/static/src/webclient/settings_form_view/settings/settings_page.xml
@@ -7,7 +7,7 @@
                     <t t-foreach="props.modules" t-as="module" t-key="module.key">
                         <a class="tab" t-if="!module.isVisible"
                              t-att-class="{
-                                'selected': state.selectedTab === module.key and state.search.value.length === 0, 'text-bg-primary shadow-none': state.selectedTab === module.key and state.search.value.length === 0 and env.isSmall
+                                'o_page_invalid': invalidApps.includes(module.key), 'selected': state.selectedTab === module.key and state.search.value.length === 0, 'text-bg-primary shadow-none': state.selectedTab === module.key and state.search.value.length === 0 and env.isSmall
                              }" t-att-data-key="module.key" role="tab" t-attf-href="#${ctx.module.key}" t-on-click="() => this.onSettingTabClick(module.key)">
                             <span class="icon d-none d-md-block" t-attf-style="background : url('{{module.imgurl}}') no-repeat center;background-size:contain;"/> <span class="app_name"><t t-esc="module.string"/></span>
                         </a>

--- a/addons/web/static/src/webclient/settings_form_view/settings_form_compiler.js
+++ b/addons/web/static/src/webclient/settings_form_view/settings_form_compiler.js
@@ -73,11 +73,20 @@ export class SettingsFormCompiler extends FormCompiler {
         for (const child of el.children) {
             append(settingsApp, this.compileNode(child, params));
         }
-
         params.anchors.push(
-            ...[...settingsApp.querySelectorAll("SearchableSetting")]
-                .filter((s) => s.id)
-                .map((s) => ({ app: module.key, settingId: s.id.replaceAll("`", "") }))
+            ...[...settingsApp.querySelectorAll("SearchableSetting")].flatMap((s) => {
+                if (!s.id) {
+                    return [];
+                }
+                return {
+                    app: module.key,
+                    settingId: s.id.replaceAll("`", ""),
+                    fieldNames: [...s.querySelectorAll("Field")].flatMap((el) => {
+                        const name = el.getAttribute("name");
+                        return name ? [name.replaceAll("'", "")] : [];
+                    }),
+                };
+            })
         );
         return settingsApp;
     }

--- a/addons/web/static/src/webclient/settings_form_view/settings_form_view.scss
+++ b/addons/web/static/src/webclient/settings_form_view/settings_form_view.scss
@@ -104,6 +104,10 @@ body:not(.o_touch_device) .o_settings_container .o_field_selection {
                    color: $black;
                }
            }
+            .o_page_invalid {
+                color: o-text-color('danger') !important;
+                background-color: #{$o-input-invalid-bg} !important;
+            }
        }
 
        .settings {

--- a/addons/web/static/tests/webclient/settings_form_view/settings_form_view.test.js
+++ b/addons/web/static/tests/webclient/settings_form_view/settings_form_view.test.js
@@ -493,6 +493,43 @@ test("edit header field", async () => {
     expect("[name='foo_text'] input").toHaveValue("Hello again");
 });
 
+test("Warn when unset required field", async () => {
+    ResConfigSettings._fields.woof = fields.Char();
+    await mountView({
+        type: "form",
+        resModel: "res.config.settings",
+        arch: /* xml */ `
+            <form js_class="base_settings">
+                <app string="Some App" name="someApp">
+                    <setting id="setting_id">
+                        <field name="woof" required="1"/>
+                    </setting>
+                </app>
+                <app string="Some Other App" name="someOtherApp">
+                    <setting id="setting_id"/>
+                </app>
+            </form>
+        `,
+    });
+    expect(".o_field_char[name=woof]").toHaveCount(1);
+    expect(".settings_tab a").toHaveCount(2);
+
+    // Change page
+    await contains(".settings_tab a:eq(1)").click();
+    await animationFrame();
+    expect(".settings_tab a:eq(0)").not.toHaveClass("o_page_invalid");
+
+    // Save
+    await clickSave();
+    await animationFrame();
+    expect(".settings_tab a:eq(0)").toHaveClass("o_page_invalid");
+
+    // Discard
+    await click(".o_form_button_cancel");
+    await animationFrame();
+    expect(".settings_tab a:eq(0)").not.toHaveClass("o_page_invalid");
+});
+
 test("don't show noContentHelper if no search is done", async () => {
     await mountView({
         type: "form",
@@ -1861,7 +1898,7 @@ test("standalone field labels with string inside a settings page", async () => {
 
     expect("label.highhopes").toHaveText(`My" little ' Label`);
     const expectedCompiled = /* xml */ `
-            <SettingsPage slots="{NoContentHelper:__comp__.props.slots.NoContentHelper}" initialTab="__comp__.props.initialApp" t-slot-scope="settings" modules="[{&quot;key&quot;:&quot;crm&quot;,&quot;string&quot;:&quot;CRM&quot;,&quot;imgurl&quot;:&quot;${MOCK_IMAGE}&quot;}]" anchors="[{&quot;app&quot;:&quot;crm&quot;,&quot;settingId&quot;:&quot;setting_id&quot;}]">
+            <SettingsPage slots="{NoContentHelper:__comp__.props.slots.NoContentHelper}" initialTab="__comp__.props.initialApp" t-slot-scope="settings" modules="[{&quot;key&quot;:&quot;crm&quot;,&quot;string&quot;:&quot;CRM&quot;,&quot;imgurl&quot;:&quot;${MOCK_IMAGE}&quot;}]" anchors="[{&quot;app&quot;:&quot;crm&quot;,&quot;settingId&quot;:&quot;setting_id&quot;,&quot;fieldNames&quot;:[&quot;display_name&quot;]}]">
                 <SettingsApp key="\`crm\`" string="\`CRM\`" imgurl="\`${MOCK_IMAGE}\`" selectedTab="settings.selectedTab">
                     <SearchableSetting info="\`\`" title="\`\`"  help="\`\`" companyDependent="false" documentation="\`\`" record="__comp__.props.record" id="\`setting_id\`" string="\`\`" addLabel="true">
                         <FormLabel id="'display_name_0'" fieldName="'display_name'" record="__comp__.props.record" fieldInfo="__comp__.props.archInfo.fieldNodes['display_name_0']" className="&quot;highhopes&quot;" string="\`My&quot; little '  Label\`"/>


### PR DESCRIPTION
When a mandatory setting is missing (eg: Employee - Company Timezone) and settings are saved; a notification appear with the text: "Missing required fields".

This commit adds a visual warning on the app sidebar so the user can know which app(s) have missing required fields instead of manually checking all setting pages.

task-5936477
