### PR TITLE
[FIX] website_sale: updateVariantPreview, reduce forced reflow impact

### DIFF
--- a/addons/website_sale/static/src/scss/product_tile.scss
+++ b/addons/website_sale/static/src/scss/product_tile.scss
@@ -46,6 +46,8 @@
     margin-right: var(--o-wsale-card-margin-x);
     width: 100%;
     container: oe_product_cart / inline-size;
+    contain: layout style;
+    content-visibility: auto;
 
     &:before {
         $_y: var(--o-wsale-card-pseudobg-y, MIN(#{map-get($spacers, 3) * -0.5}, calc(var(--o-wsale-products-grid-gap-y) / 2)));


### PR DESCRIPTION
**Issue:**
Loading the shop page was slow due to excessive forced reflows. When a reflow occurs, the browser can't reuse the layout computed so far, and it's forced recalculate it again.

**Cause:**
In `updateVariantPreview`, the init loop wrote to the DOM (textContent, classList) then immediately read `offsetWidth` in the same iteration, forcing the browser to flush and recalculate layout once per product.
This PR tackles the 2 areas of improvement identified:
1. Reduce reflows **number**.
2. Reduce reflows performance **cost**.

[task-5177358](https://www.odoo.com/web#id=5177358&cids=1&menu_id=4720&action=333&active_id=1695&model=project.task&view_type=form)

---

###  1: Reduce reflows **number**.

**Before this PR:**
Phase 1 was a single loop mixing writes and reads, triggering N layout recalculations for N products on the page.

| Performance Tab:  CSS selectors & Advanced paint instr. active (slow) |
|--------|
| <img width="1847" height="650" alt="image" src="https://github.com/user-attachments/assets/91e86e91-1209-4865-bcbd-336f792664ed" /> | 
| Timing inflated by the debug environment | 

**After this PR**
Phase 1 is split into two sub-loops. All writes first (1a) and all reads after (1b). So the browser flushes layout only once, regardless of product count, matching the batching pattern already used in phases 2 and 3.

| Performance Tab:  CSS selectors & Advanced paint instr. active (slow) |
|--------|
| <img width="1380" height="555" alt="image" src="https://github.com/user-attachments/assets/c0fefe32-d309-4fc8-a945-1a5f5c12b86e" /> | 
| Timing inflated by the debug environment | 


**Performance results**
In a page with 21 products, 11 of which with variants, the number of reflows dropped from 12 to just 2, resulting on a 82% faster rendering, roughly a 5.5X speedup.

---

###  2: Reduce reflows performance **cost**.

Reflows cannot be entirely avoided, but side-effects can be mitigated in CSS by instructing the browser how to react when this circumstance occurs. This PR add two rules to the products card:

1. `contain`: Tells the browser each product card is a layout containment boundary and inner changes "should not" affect elements outside.
2. `content-visibility`: Tells the browser to try skipping cards outside the viewport. Their layout will be eventually evaluated when cards scroll into view.

**Performance result:**
In a page with 21 products, 11 of which with variants, the performance cost of a single reflow dropped by 22%.

_note: the browser is not obliged to honor these "suggestion" and may behave differently depending by the viewport size, the content and the browser itself._




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
