### PR TITLE
[FIX] website: preserve vertical video alignment after save

### DIFF
--- a/addons/website/static/src/js/content/generate_video_iframe.js
+++ b/addons/website/static/src/js/content/generate_video_iframe.js
@@ -46,7 +46,9 @@ export function generateVideoIframe(parentEl, manageIframeSrcFct) {
     const extraEditionEl = document.createElement("div");
     extraEditionEl.className = "css_editable_mode_display";
     const extraSizeEl = document.createElement("div");
-    extraSizeEl.className = "media_iframe_video_size";
+    extraSizeEl.className = parentEl.dataset.isVertical
+        ? "media_iframe_video_size_for_vertical"
+        : "media_iframe_video_size";
     parentEl.append(extraEditionEl, extraSizeEl);
 
     // Rebuild the iframe. Depending on version / compatibility / instance, the


### PR DESCRIPTION
Problem:
When setting a video to vertical and saving the page, the alignment is not preserved after reload.

Cause:
`generateVideoIframe` always sets the `media_iframe_video_size` class, even for vertical videos. As a result, the vertical configuration is lost after saving.

Solution:
Apply `media_iframe_video_size_for_vertical` when the video is marked as vertical, so the correct layout is preserved after saving.

Steps to reproduce:
- Drop a Video snippet on a page.
- In the selector, enable the vertical option.
- Add the video.
- Save the page.
- Observe that the video is no longer vertical.

opw-5941900

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
