### PR TITLE
[FIX] project: Enable auto-delete for task assignment emails

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1558,7 +1558,7 @@ class ProjectTask(models.Model):
                     partner_ids=user.partner_id.ids,
                     email_layout_xmlid='mail.mail_notification_layout',
                     model_description=task_model_description,
-                    mail_auto_delete=False,
+                    mail_auto_delete=True,
                 )
 
     def _message_auto_subscribe_followers(self, updated_values, default_subtype_ids):


### PR DESCRIPTION
Task assignment notification emails are kept permanently (mail_auto_delete=False), creating unnecessary clutter in mail.mail records.

This is inconsistent with 'You have been invited to follow' notifications which use mail_auto_delete=True. Assignment is already tracked in user_ids and chatter, so these emails serve no purpose after being sent.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
