### PR TITLE
[IMP] mail: rework the channel members list in the back-end form

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -9,7 +9,7 @@ from datetime import timedelta
 from odoo import _, api, fields, models, tools, Command
 from odoo.addons.base.models.avatar_mixin import get_random_ui_color_from_seed
 from odoo.addons.base.models.ir_mail_server import MailDeliveryException
-from odoo.addons.mail.tools.discuss import Store
+from odoo.addons.mail.tools.discuss import Store, get_member_ref_values
 from odoo.addons.mail.tools.web_push import PUSH_NOTIFICATION_TYPE
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.fields import Domain
@@ -428,6 +428,9 @@ class DiscussChannel(models.Model):
             for cmd in membership_ids_cmd:
                 if cmd[0] != 0:
                     raise ValidationError(_('Invalid value when creating a channel with memberships, only 0 is allowed.'))
+                # find partners and guests to add from member_refs
+                member_ref = cmd[2].pop("member_ref", False)
+                cmd[2].update(get_member_ref_values(member_ref))
                 for field_name in cmd[2]:
                     if field_name not in self._get_allowed_channel_member_create_params():
                         raise ValidationError(

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -918,6 +918,14 @@ class DiscussChannel(models.Model):
             for email in emails
         }
 
+    @api.readonly
+    def get_invite_partner_domain(self):
+        """Returns the domain of the partners that may still be invited to this channel."""
+        self.ensure_one()
+        if not self.env.user._is_internal() or not self.has_access("read"):
+            raise AccessError(self.env._("You don't have access to invite users to this channel."))
+        return list(self.env["res.partner"]._get_channel_invite_domain(self))
+
     def invite_by_email(self, emails):
         """
         Send channel invitation emails to a list of email addresses. Existing members'

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from markupsafe import Markup
 
 from odoo import api, fields, models, _
-from odoo.addons.mail.tools.discuss import Store
+from odoo.addons.mail.tools.discuss import Store, get_member_ref_values
 from odoo.addons.mail.tools.web_push import PUSH_NOTIFICATION_ACTION, PUSH_NOTIFICATION_TYPE
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.fields import Domain
@@ -29,6 +29,9 @@ class DiscussChannelMember(models.Model):
     # identity
     partner_id = fields.Many2one("res.partner", "Partner", ondelete="cascade", index=True)
     guest_id = fields.Many2one("mail.guest", "Guest", ondelete="cascade", index=True)
+    member_ref = fields.Reference(
+        [("res.partner", "Partner"), ("mail.guest", "Guest")], "Member", compute="_compute_member_ref", readonly=False
+    )
     is_self = fields.Boolean(compute="_compute_is_self", search="_search_is_self")
     # channel
     channel_id = fields.Many2one("discuss.channel", "Channel", ondelete="cascade", required=True, bypass_search_access=True)
@@ -193,6 +196,14 @@ class DiscussChannelMember(models.Model):
                 channel_name=member.channel_id.display_name,
             )
 
+    @api.depends("partner_id", "guest_id")
+    def _compute_member_ref(self):
+        for member in self:
+            if member.partner_id:
+                member.member_ref = f"res.partner,{member.partner_id.id}"
+            elif member.guest_id:
+                member.member_ref = f"mail.guest,{member.guest_id.id}"
+
     @api.depends("last_interest_dt", "unpin_dt", "channel_id.last_interest_dt")
     def _compute_is_pinned(self):
         for member in self:
@@ -232,6 +243,7 @@ class DiscussChannelMember(models.Model):
                 raise UserError(
                     _("Adding more members to this chat isn't possible; it's designed for just two people.")
                 )
+            vals.update(get_member_ref_values(vals.get("member_ref")))
         name_members_by_channel = {
             channel: channel.channel_name_member_ids
             for channel in self.env["discuss.channel"].browse(

--- a/addons/mail/models/discuss/mail_guest.py
+++ b/addons/mail/models/discuss/mail_guest.py
@@ -47,6 +47,25 @@ class MailGuest(models.Model):
                 else None
             )
 
+    @api.depends("name")
+    @api.depends_context("display_email", "formatted_display_name")
+    def _compute_display_name(self):
+        if not self.env.context.get("display_email"):
+            super()._compute_display_name()
+            return
+        for guest in self:
+            if self.env.context.get("formatted_display_name"):
+                guest.display_name = self.env._(
+                    "%(guest_name)s --%(guest_indicator)s--",
+                    guest_name=guest.name,
+                    guest_indicator="(External)",
+                )
+            else:
+                guest.display_name = self.env._(
+                    "%(guest_name)s (External)",
+                    guest_name=guest.name,
+                )
+
     def _get_guest_from_token(self, token=""):
         """Returns the guest record for the given token, if applicable."""
         guest = self.env["mail.guest"]

--- a/addons/mail/models/discuss/mail_guest.py
+++ b/addons/mail/models/discuss/mail_guest.py
@@ -58,6 +58,25 @@ class MailGuest(models.Model):
                 else None
             )
 
+    @api.depends("name")
+    @api.depends_context("display_email", "formatted_display_name")
+    def _compute_display_name(self):
+        if not self.env.context.get("display_email"):
+            super()._compute_display_name()
+            return
+        for guest in self:
+            if self.env.context.get("formatted_display_name"):
+                guest.display_name = self.env._(
+                    "%(guest_name)s --%(guest_indicator)s--",
+                    guest_name=guest.name,
+                    guest_indicator="(External)",
+                )
+            else:
+                guest.display_name = self.env._(
+                    "%(guest_name)s (External)",
+                    guest_name=guest.name,
+                )
+
     def _get_guest_from_token(self, token=""):
         """Returns the guest record for the given token, if applicable."""
         guest = self.env["mail.guest"]

--- a/addons/mail/models/discuss/res_partner.py
+++ b/addons/mail/models/discuss/res_partner.py
@@ -27,6 +27,18 @@ class ResPartner(models.Model):
         for partner in self:
             partner.is_in_call = bool(partner.rtc_session_ids)
 
+    @api.depends("name", "email")
+    @api.depends_context("display_email", "formatted_display_name")
+    def _compute_display_name(self):
+        if not self.env.context.get("display_email"):
+            super()._compute_display_name()
+            return
+        for partner in self:
+            if self.env.context.get("formatted_display_name"):
+                partner.display_name = f"{partner.name}" + (f" --({partner.email})--" if partner.email else "")
+            else:
+                partner.display_name = f"{partner.name}" + (f" ({partner.email})" if partner.email else "")
+
     @api.readonly
     @api.model
     def search_for_channel_invite(self, search_term, channel_id=None, limit=30):

--- a/addons/mail/models/discuss/res_partner.py
+++ b/addons/mail/models/discuss/res_partner.py
@@ -27,6 +27,18 @@ class ResPartner(models.Model):
         for partner in self:
             partner.is_in_call = bool(partner.rtc_session_ids)
 
+    @api.depends("name", "email")
+    @api.depends_context("display_email", "formatted_display_name")
+    def _compute_display_name(self):
+        if not self.env.context.get("display_email"):
+            super()._compute_display_name()
+            return
+        for partner in self:
+            if self.env.context.get("formatted_display_name"):
+                partner.display_name = f"{partner.name}" + (f" --({partner.email})--" if partner.email else "")
+            else:
+                partner.display_name = f"{partner.name}" + (f" ({partner.email})" if partner.email else "")
+
     @api.readonly
     @api.model
     def search_for_channel_invite(self, search_term, channel_id=None, limit=30):
@@ -76,24 +88,42 @@ class ResPartner(models.Model):
             "store_data": store,
         }
 
-    @api.readonly
     @api.model
-    def _search_for_channel_invite(self, store: Store, search_term, channel_id=None, limit=30):
+    def _get_channel_invite_domain(self, channel):
+        """Returns the domain of the partners that may be invited to ``channel``.
+
+        Shared by the Discuss invitation panel and the back-end channel form, so
+        that both propose the same candidates.
+
+        :param channel: channel to invite to, empty recordset to only apply the
+            channel independent conditions.
+        :type channel: discuss.channel
+        """
         domain = Domain.AND(
             [
-                Domain("name", "ilike", search_term) | Domain("email", "ilike", search_term),
-                [('id', '!=', self.env.user.partner_id.id)],
                 [("active", "=", True)],
                 [("user_ids", "!=", False)],
                 [("user_ids.active", "=", True)],
             ]
         )
-        channel = self.env["discuss.channel"]
-        if channel_id:
-            channel = self.env["discuss.channel"].search([("id", "=", int(channel_id))])
+        if channel:
             domain &= Domain("channel_ids", "not in", channel.id)
             if channel.group_public_id:
                 domain &= Domain("user_ids.all_group_ids", "in", channel.group_public_id.id)
+        return domain
+
+    @api.readonly
+    @api.model
+    def _search_for_channel_invite(self, store: Store, search_term, channel_id=None, limit=30):
+        channel = self.env["discuss.channel"]
+        if channel_id:
+            channel = self.env["discuss.channel"].search([("id", "=", int(channel_id))])
+        domain = self._get_channel_invite_domain(channel) & Domain.AND(
+            [
+                Domain("name", "ilike", search_term) | Domain("email", "ilike", search_term),
+                [('id', '!=', self.env.user.partner_id.id)],
+            ]
+        )
         selectable_partners = self.search(domain, limit=limit + 1, order="name, id")
         store.add(
             selectable_partners,

--- a/addons/mail/static/src/js/member_reference_field/member_reference_widget.js
+++ b/addons/mail/static/src/js/member_reference_field/member_reference_widget.js
@@ -1,0 +1,50 @@
+import { registry } from "@web/core/registry";
+import { ReferenceField, referenceField } from "@web/views/fields/reference/reference_field";
+
+export class MemberReferenceField extends ReferenceField {
+    static template = "mail.MemberReferenceField";
+
+    setup() {
+        const returnVal = super.setup();
+        // selection is [['res.partner', 'Partner'], ['mail.guest', 'Guest']]
+        // select partner by default
+        const defaultSelect = this.selection?.[0][0];
+        if (defaultSelect) {
+            this.state.currentRelation = defaultSelect;
+        }
+        return returnVal;
+    }
+
+    get m2oProps() {
+        const props = super.m2oProps;
+        props.cssClass = `${props.cssClass ?? ''} flex-grow-1`;
+        props.canCreate = false;
+        props.canCreateEdit = false;
+        props.canQuickCreate = false;
+        if (props.readonly) {
+            props.canOpen = false;
+        }
+        const memberPartnerIds = [];
+        this.props.record._parentRecord?.data.channel_member_ids?.records.forEach(
+            (record) => {
+                if (record.data.member_ref?.resModel == "res.partner") {
+                    memberPartnerIds.push(record.data.member_ref.resId);
+                }
+            }
+        ) || [];
+        const groupPublicId = this.props.record._parentRecord?.data.group_public_id?.id || [];
+        props.domain = () => [
+            ["partner_share", "=", false],
+            ["id", "not in", memberPartnerIds],
+            ["user_id.group_ids", "=", groupPublicId]
+        ];
+        return props;
+    }
+}
+
+export const memberReferenceField = {
+    ...referenceField,
+    component: MemberReferenceField,
+};
+
+registry.category("fields").add("member_reference", memberReferenceField);

--- a/addons/mail/static/src/js/member_reference_field/member_reference_widget.xml
+++ b/addons/mail/static/src/js/member_reference_field/member_reference_widget.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mail.MemberReferenceField">
+        <t t-set="model" t-value="m2oProps.relation"/>
+        <t t-set="id" t-value="m2oProps.value.id"/>
+        <div class="d-flex align-items-center gap-2">
+            <span t-if="id" class="o_avatar o_m2o_avatar">
+                <img class="rounded" t-attf-src="/web/image/{{model}}/{{id}}/avatar_128?unique={{m2oProps.value.write_date?.toMillis()}}"/>
+            </span>
+            <Many2One t-props="m2oProps">
+                <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
+                    <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
+                        <img class="rounded me-1" t-attf-src="/web/image/{{model}}/{{autoCompleteItemScope.record.id}}/avatar_128?unique={{autoCompleteItemScope.record.write_date?.toMillis()}}"/>
+                        <span t-out="autoCompleteItemScope.label"/>
+                    </span>
+                </t>
+            </Many2One>
+        </div>
+    </t>
+</templates>

--- a/addons/mail/static/src/views/fields/discuss_channel_member_list/discuss_channel_member_list_field.js
+++ b/addons/mail/static/src/views/fields/discuss_channel_member_list/discuss_channel_member_list_field.js
@@ -1,0 +1,53 @@
+import { makeContext } from "@web/core/context";
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { useSelectCreate } from "@web/views/fields/relational_utils";
+import { X2ManyField, x2ManyField } from "@web/views/fields/x2many/x2many_field";
+
+export class DiscussChannelMemberListField extends X2ManyField {
+    setup() {
+        super.setup();
+        this.orm = useService("orm");
+        this.selectPartners = useSelectCreate({
+            activeActions: { create: false, link: true },
+            onSelected: async (partnerIds) => {
+                for (const partnerId of partnerIds) {
+                    await this.list.addNewRecord({
+                        context: { default_partner_id: partnerId },
+                        mode: "readonly",
+                    });
+                }
+            },
+            resModel: "res.partner",
+        });
+    }
+
+    /**
+     * @param {Object} [params={}]
+     * @param {Object} [params.context]
+     */
+    async onAdd({ context } = {}) {
+        if (!makeContext([this.props.context, context]).add_members) {
+            return super.onAdd(...arguments);
+        }
+        if (!(await this.props.record.save())) {
+            return;
+        }
+        const domain = await this.orm.call(
+            this.props.record.resModel,
+            "get_invite_partner_domain",
+            [[this.props.record.resId]]
+        );
+        return this.selectPartners({ domain, title: _t("Add Members") });
+    }
+}
+
+export const discussChannelMemberListField = {
+    ...x2ManyField,
+    component: DiscussChannelMemberListField,
+    displayName: _t("Channel Members"),
+    supportedTypes: ["one2many"],
+};
+
+registry.category("fields").add("discuss_channel_member_list", discussChannelMemberListField);

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -155,6 +155,18 @@ def mail_route(*route_args, **route_kwargs):
     return decorator
 
 
+def get_member_ref_values(member_ref: str | None) -> dict:
+    if not member_ref:
+        return {}
+    model, id_str = member_ref.split(",")
+    record_id = int(id_str)
+    if model == "res.partner":
+        return {"partner_id": record_id, "guest_id": False}
+    if model == "mail.guest":
+        return {"guest_id": record_id, "partner_id": False}
+    return {}
+
+
 def get_twilio_credentials(env) -> tuple[str | None, str | None]:
     """
     To be overridable if we need to obtain credentials from another source.

--- a/addons/mail/views/discuss_channel_views.xml
+++ b/addons/mail/views/discuss_channel_views.xml
@@ -97,8 +97,8 @@
                                 <field name="channel_type" invisible="1"/>
                                 <field name="channel_member_ids" mode="list" context="{'active_test': False}" readonly="channel_type == 'chat'">
                                     <list string="Members" editable="bottom">
-                                        <field name="partner_id" readonly="id or guest_id" required="not guest_id"/>
-                                        <field name="guest_id" readonly="id or partner_id" required="not partner_id"/>
+                                        <field name="member_ref" widget="member_reference" string="Name" context="{'display_email': True}"/>
+                                        <field name="channel_role" readonly="guest_id" widget="selection"/>
                                     </list>
                                 </field>
                             </page>

--- a/addons/mail/views/discuss_channel_views.xml
+++ b/addons/mail/views/discuss_channel_views.xml
@@ -92,13 +92,16 @@
                         <notebook>
                             <page string="Members" name="members">
                                 <field name="channel_type" invisible="1"/>
-                                <field name="channel_member_ids" mode="list" context="{'active_test': False}" readonly="channel_type == 'chat'">
+                                <field name="channel_member_ids" widget="discuss_channel_member_list" mode="list" context="{'active_test': False}" readonly="channel_type == 'chat'">
                                     <list string="Members" editable="bottom">
                                         <control>
                                             <delete invisible="not can_unlink"/>
+                                            <create name="add_members" string="Add Members" context="{'add_members': True}"/>
                                         </control>
-                                        <field name="partner_id" readonly="id or guest_id" required="not guest_id"/>
-                                        <field name="guest_id" readonly="id or partner_id" required="not partner_id"/>
+                                        <column string="Name">
+                                            <field name="partner_id" context="{'display_email': True}" readonly="id or guest_id" required="not guest_id" invisible="guest_id"/>
+                                            <field name="guest_id" context="{'display_email': True}" readonly="id or partner_id" required="not partner_id" invisible="partner_id"/>
+                                        </column>
                                     </list>
                                 </field>
                             </page>


### PR DESCRIPTION
`partner_id` and `guest_id` were listed in two separate columns. A member
is either one or the other, so every row left one column empty and the
list read as half blank. Stack both fields in a single cell with the
`<column>` element: each sub-field is hidden when the other one is set, so
a row always shows exactly one identity. Both are rendered with
`display_email` to tell a member apart from a homonym, which requires
`_compute_display_name` overrides on `res.partner` and `mail.guest`.

Members could also only be added one row at a time, which is tedious for a
channel with many participants. Add an "Add Multiple Members" control
opening a partner selection dialog, handled by the new
`discuss_channel_member_list` widget. `<control>` only accepts `<create>`
and `<button>`, and `SelectCreateDialog` cannot be reached from an action,
so the control is flagged through its context and `X2ManyField.onAdd` is
overridden client-side.

Candidates must follow the same rules as the Discuss invitation panel:
active partners having an active user, not already a member, and part of
the channel authorized group. That domain only existed inline in
`_search_for_channel_invite`, so extract it into
`res.partner._get_channel_invite_domain` and expose it through
`discuss.channel.get_invite_partner_domain`, which re-checks the invite
access the same way `invite_by_email` does. Creating the members
themselves is already covered by the `discuss.channel.member` create
rules.

task-6069191

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
