### PR TITLE
[IMP] hr_expense:  change the constraint of the expense

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -310,16 +310,16 @@ class HrExpense(models.Model):
     # --------------------------------------------
 
     @api.constrains('state', 'name', 'product_id', 'total_amount', 'total_amount_currency')
-    def _check_required_fields_if_not_draft(self):
+    def _check_required_fields(self):
         for expense in self.filtered(lambda expense: expense.state != 'draft'):
             errors = []
 
             # Check for required fields 'name' and 'product_id'
-            if not expense.name and not expense.product_id:
+            if not expense.name and not expense.product_id and expense.state != 'refused':
                 errors.append(self.env._("Enter a description and select a product to proceed."))
             elif not expense.name:
                 errors.append(self.env._("Enter a description to proceed."))
-            elif not expense.product_id:
+            elif not expense.product_id and expense.state != 'refused':
                 errors.append(self.env._("Select a product to proceed."))
 
             # Check for non-zero amounts

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -286,8 +286,8 @@ class HrExpense(models.Model):
     # --------------------------------------------
 
     @api.constrains('state', 'name', 'product_id', 'total_amount', 'total_amount_currency')
-    def _check_required_fields_if_not_draft(self):
-        for expense in self.filtered(lambda expense: expense.state != 'draft'):
+    def _check_required_fields(self):
+        for expense in self.filtered(lambda expense: expense.state not in ('draft', 'refused')):
             errors = []
 
             # Check for required fields 'name' and 'product_id'


### PR DESCRIPTION
Before this commit:
- the category (product_id) field could be empty only in
  the draft state.

After this commit:
- We change the constraint of the expense.
- Now it could be empty in the draft and refused state, because now when we
  create an expense using an unmapped MCC code, the expense should be created
  in the refused state without any category set.


task-5932712
