### PR TITLE
[IMP] point_of_sale: QR code appearance consistency

### DIFF
--- a/addons/l10n_id_pos/static/tests/test_pos_qris_payment.tour.js
+++ b/addons/l10n_id_pos/static/tests/test_pos_qris_payment.tour.js
@@ -10,7 +10,7 @@ function isQRDisplayedinDialog() {
     return [
         {
             content: "Verify QR image is displayed",
-            trigger: ".modal-content img[src^='data:image/png;base64,']",
+            trigger: ".modal-content img[src^='data:image/svg+xml;base64,']",
             run: "click",
         },
     ].flat();

--- a/addons/l10n_in_pos/models/pos_payment_method.py
+++ b/addons/l10n_in_pos/models/pos_payment_method.py
@@ -1,10 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import base64
-
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.tools.image import image_data_uri
 from odoo.tools.urls import urljoin as url_join
 
 
@@ -40,12 +37,10 @@ class PosPaymentMethod(models.Model):
                 record['_qr_payment_icon_urls'] = [[icon.id, url_join(config.get_base_url(), icon.local_url)] for icon in payment_method.qr_payment_icon_ids]
         return read_records
 
-    def get_qr_code(self, amount, free_communication, structured_communication, currency, debtor_partner):
+    def get_qr_code_url(self, amount, free_communication, structured_communication, currency, debtor_partner):
         self.ensure_one()
         if self.payment_method_type == 'bank_qr_code' and self.qr_code_method == 'upi':
             if not self.upi_identifier:
                 raise UserError(_("Please set a UPI ID for the payment method '%s'.", self.name))
-            payment_url = f"upi://pay?pa={self.upi_identifier}&am={amount}&cu={self.journal_id.currency_id.name or self.env.company.currency_id.name}"
-            barcode = self.env['ir.actions.report'].barcode(barcode_type='QR', value=payment_url, width=120, height=120, barBorder=0)
-            return image_data_uri(base64.b64encode(barcode))
-        return super().get_qr_code(amount, free_communication, structured_communication, currency, debtor_partner)
+            return f"upi://pay?pa={self.upi_identifier}&am={amount}&cu={self.journal_id.currency_id.name or self.env.company.currency_id.name}"
+        return super().get_qr_code_url(amount, free_communication, structured_communication, currency, debtor_partner)

--- a/addons/l10n_test_pos_qr_payment/static/tests/test_pos_payment_tour.js
+++ b/addons/l10n_test_pos_qr_payment/static/tests/test_pos_payment_tour.js
@@ -14,7 +14,7 @@ function isQRDisplayedinDialog() {
     return [
         {
             content: "Verify QR image is displayed",
-            trigger: ".modal-content img[src^='data:image/png;base64,']",
+            trigger: ".modal-content img[src^='data:image/svg+xml;base64,']",
             run: "click",
         },
     ].flat();

--- a/addons/point_of_sale/models/pos_payment_method.py
+++ b/addons/point_of_sale/models/pos_payment_method.py
@@ -337,7 +337,7 @@ class PosPaymentMethod(models.Model):
                 continue
             try:
                 # Generate QR without amount that can then be used when the POS is offline
-                pm.default_qr = pm.get_qr_code(False, '', '', pm.company_id.currency_id.id, False)
+                pm.default_qr = pm.get_qr_code_url(False, '', '', pm.company_id.currency_id.id, False)
             except UserError:
                 pm.default_qr = False
 
@@ -349,8 +349,8 @@ class PosPaymentMethod(models.Model):
         # the payment terminal modules don't need to depend on it.
         return []
 
-    def get_qr_code(self, amount, free_communication, structured_communication, currency, debtor_partner):
-        """ Generates and returns a QR-code
+    def get_qr_code_url(self, amount, free_communication, structured_communication, currency, debtor_partner):
+        """ Generates and returns a QR-code Url
         """
         self.ensure_one()
         if self.payment_method_type != "bank_qr_code" or not self.qr_code_method:
@@ -359,5 +359,5 @@ class PosPaymentMethod(models.Model):
         debtor_partner = self.env['res.partner'].browse(debtor_partner)
         currency = self.env['res.currency'].browse(currency)
 
-        return payment_bank.with_context(is_online_qr=True).build_qr_code_base64(
+        return payment_bank.with_context(is_online_qr=True).build_qr_code_url(
             float(amount), free_communication, structured_communication, currency, debtor_partner, self.qr_code_method, silent_errors=False)

--- a/addons/point_of_sale/static/src/app/customer_display/customer_display_qr_code_popup.js
+++ b/addons/point_of_sale/static/src/app/customer_display/customer_display_qr_code_popup.js
@@ -17,7 +17,7 @@ export class QrCodeCustomerDisplay extends Component {
     }
 
     getQrCode() {
-        return generateQRCodeDataUrl(this.props.customerDisplayURL);
+        return generateQRCodeDataUrl(this.props.customerDisplayURL, { useThemeQr: true });
     }
 
     openOnThisDevice() {

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -8,6 +8,7 @@ import {
     Counter,
     orderUsageUTCtoLocalUtil,
     getTimeUtil,
+    generateQRCodeDataUrl,
 } from "@point_of_sale/utils";
 import { ConnectionLostError } from "@web/core/network/rpc";
 import { _t } from "@web/core/l10n/translation";
@@ -2394,9 +2395,9 @@ export class PosStore extends WithLazyGetterTrap {
             return false;
         }
         payment.setPaymentStatus("waiting");
-        let qr;
+        let qrCodeUrl;
         try {
-            qr = await this.data.call("pos.payment.method", "get_qr_code", [
+            qrCodeUrl = await this.data.call("pos.payment.method", "get_qr_code_url", [
                 [payment.payment_method_id.id],
                 payment.amount,
                 payment.pos_order_id.name + " " + payment.pos_order_id.tracking_number,
@@ -2405,8 +2406,8 @@ export class PosStore extends WithLazyGetterTrap {
                 payment.pos_order_id.partner_id?.id,
             ]);
         } catch (error) {
-            qr = payment.payment_method_id.default_qr;
-            if (!qr) {
+            qrCodeUrl = payment.payment_method_id.default_qr;
+            if (!qrCodeUrl) {
                 let message;
                 if (error instanceof ConnectionLostError) {
                     message = _t(
@@ -2422,8 +2423,8 @@ export class PosStore extends WithLazyGetterTrap {
                 return false;
             }
         }
-        payment.updateCustomerDisplayQrCode(qr);
-        payment.qr_code = qr;
+        payment.updateCustomerDisplayQrCode(generateQRCodeDataUrl(qrCodeUrl));
+        payment.qr_code = generateQRCodeDataUrl(qrCodeUrl, { useThemeQr: true });
         return await ask(this.env.services.dialog, payment.getQrPopupProps(), {}, QRPopup).then(
             (result) => {
                 payment.updateCustomerDisplayQrCode(null);

--- a/addons/point_of_sale/static/src/utils.js
+++ b/addons/point_of_sale/static/src/utils.js
@@ -1,6 +1,7 @@
 /* global QRCode */
 
 import { session } from "@web/session";
+import { cookie } from "@web/core/browser/cookie";
 import { getDataURLFromFile } from "@web/core/utils/urls";
 import { deserializeDateTime } from "@web/core/l10n/dates";
 import { Time } from "@web/core/l10n/time";
@@ -204,15 +205,32 @@ export function getTimeUtil(date) {
  * @param {number} [options.height=150] - The height of the QR code.
  * @param {number} [options.correctLevel=QRCode.CorrectLevel.L] - The error correction level for the QR code.
  * @param {boolean} [options.useSVG=true] - Whether to generate the QR code as SVG.
+ * @param {boolean} [options.useThemeQr=false] - Generates the QR code based on the active PoS theme.
+ *   DANGER: Do NOT use this option for receipt QR codes.
+ *   In dark mode, it generates a white QR code, which will become invisible on printed receipts.
  * @param {Object} [options.rest] - Additional options to pass to the QRCode constructor.
  * @returns {string} The QR code as a data URL in SVG format.
  */
 export function generateQRCodeDataUrl(
     url,
-    { width = 150, height = 150, correctLevel = QRCode.CorrectLevel.L, ...rest } = {}
+    {
+        width = 150,
+        height = 150,
+        correctLevel = QRCode.CorrectLevel.L,
+        useThemeQr = false,
+        ...rest
+    } = {}
 ) {
     const tempDiv = document.createElement("div");
-    const options = { width, height, correctLevel, ...rest };
+    let themeOptions = {};
+    if (useThemeQr) {
+        const colorScheme = cookie.get("pos_color_scheme") || "light";
+        themeOptions = {
+            colorDark: colorScheme === "light" ? "black" : "white",
+            colorLight: "transparent",
+        };
+    }
+    const options = { width, height, correctLevel, ...themeOptions, ...rest };
 
     new QRCode(tempDiv, { text: url, useSVG: true, ...options });
 

--- a/addons/pos_online_payment/static/src/app/utils/order_payment_validation.js
+++ b/addons/pos_online_payment/static/src/app/utils/order_payment_validation.js
@@ -3,7 +3,7 @@ import { patch } from "@web/core/utils/patch";
 import { _t } from "@web/core/l10n/translation";
 import { OnlinePaymentPopup } from "@pos_online_payment/app/components/popups/online_payment_popup/online_payment_popup";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
-import { qrCodeSrc } from "@point_of_sale/utils";
+import { generateQRCodeDataUrl } from "@point_of_sale/utils";
 import { ask } from "@point_of_sale/app/utils/make_awaitable_dialog";
 
 patch(OrderPaymentValidation.prototype, {
@@ -121,17 +121,19 @@ patch(OrderPaymentValidation.prototype, {
                     await this.pos.syncAllOrders({ orders: [this.order] });
                     onlinePaymentLine.setPaymentStatus("waiting");
                     this.order.selectPaymentline(onlinePaymentLine);
+                    const qrCodeUrl = `${this.pos.config._base_url}/pos/pay/${this.order.id}?access_token=${this.order.access_token}`;
                     const onlinePaymentData = {
                         formattedAmount: this.pos.env.utils.formatCurrency(onlinePaymentLineAmount),
-                        qrCode: qrCodeSrc(
-                            `${this.pos.config._base_url}/pos/pay/${this.order.id}?access_token=${this.order.access_token}`
-                        ),
+                        qrCode: generateQRCodeDataUrl(qrCodeUrl),
                         orderName: this.order.name,
                     };
                     this.order.onlinePaymentData = onlinePaymentData;
                     const qrCodePopupCloser = this.pos.dialog.add(
                         OnlinePaymentPopup,
-                        onlinePaymentData,
+                        {
+                            ...onlinePaymentData,
+                            qrCode: generateQRCodeDataUrl(qrCodeUrl, { useThemeQr: true }),
+                        },
                         {
                             onClose: () => {
                                 onlinePaymentLine.onlinePaymentResolver(false);


### PR DESCRIPTION
- Remove the white background from QR codes in POS to ensure consistent rendering across both light and dark modes.
- Additionally, in dark mode, the QR code color is now automatically set to white to maintain proper contrast and scannability.

Task-5945915
Related PR-https://github.com/odoo/enterprise/pull/107881

Before             |  After
:-------------------------:|:-------------------------:
<img width="458" height="524" alt="image" src="https://github.com/user-attachments/assets/0dd6e425-312f-4cb6-a4a7-d98cc4249f74" /> | <img width="458" height="519" alt="image" src="https://github.com/user-attachments/assets/736d6a0a-5c6a-4727-a667-ecbee56bdac2" />
