### PR TITLE
[FIX] hr_attendance: duplicate field name in attendance view

### DIFF
--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -28,10 +28,10 @@
                 <field name="out_mode" string="Input Mode (Out)" optional="hidden"/>
                 <field name="in_latitude" string="Latitude (In)" optional="hidden"/>
                 <field name="in_longitude" string="Longitude (In)" optional="hidden"/>
-                <field name="in_location" string="Longitude (In)" optional="hidden"/>
+                <field name="in_location" string="Location (In)" optional="hidden"/>
                 <field name="out_latitude" string="Latitude (Out)" optional="hidden"/>
                 <field name="out_longitude" string="Longitude (Out)" optional="hidden"/>
-                <field name="out_location" string="Location" optional="hidden"/>
+                <field name="out_location" string="Location (Out)" optional="hidden"/>
                 <field name="create_uid" optional="hidden"/>
                 <field name="write_uid" optional="hidden"/>
                 <field name="write_date" optional="hidden"/>


### PR DESCRIPTION
Steps to reproduce:
--------------------------------------
1. Install the Attendance module
2. Go to the attendance list view
3. Click on the optional fields tray

Observation:
--------------------------------------
Duplicate field name Longitude (In)

Issue:
--------------------------------------
For the `in_location` field, a duplicate string was added in the list view

Solution:
--------------------------------------
Changed string to `Location (In)` for `in_location` field and changed string to `Location (Out)` for `out_location` field

Before:
<img width="348" height="511" alt="image" src="https://github.com/user-attachments/assets/109ff380-df4f-4dc6-ad01-a955d85436c7" />

After:
<img width="330" height="503" alt="image" src="https://github.com/user-attachments/assets/894e6045-ec34-4296-8aff-f0e7bee32d9f" />

opw-5909500