### PR TITLE
[IMP] point_of_sale: add unselect button on partner list

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_line/partner_line.scss
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_line/partner_line.scss
@@ -45,13 +45,4 @@
         background-color: $o-component-active-bg;
         color: $o-action;
     }
-
-    &.selected .btn.btn-link:hover .fa-check {
-        display: none;
-    }
-
-    &.selected .btn.btn-link:hover::after {
-        content: "\e852";
-        font-family: 'odoo_ui_icons';
-    }
 }

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_line/partner_line.xml
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_line/partner_line.xml
@@ -60,8 +60,9 @@
                 <!-- FIXME: this should be in pos_settle_due, not here -->
                 <td class="partner-line-balance" t-if="props.isBalanceDisplayed"></td>
                 <td class="edit-partner-button-cell align-middle pe-0">
-                    <button t-if="props.isSelected" t-on-click.stop="props.onClickUnselect" class="unselect-tag d-lg-inline-block d-none btn btn-link btn-lg mt-1 float-end">
-                        <i class="fa fa-check"/>
+                    <button t-if="props.isSelected" t-on-click.stop="props.onClickUnselect" class="unselect-tag fs-5 btn btn-light lh-lg border d-inline-flex align-items-center">
+                        <i class="fa fa-times me-1"></i>
+                        <span>UNSELECT</span>
                     </button>
                 </td>
                 <td class="edit-partner-button-cell align-middle">


### PR DESCRIPTION
Before this commit:
====
- Initially if partner is selected then hovering over partner shows option to remove the partner, until user won't be able to get how to remove the customer if selected.
- Not good from user perspective.

Following this commit:
====
- Unselect button will be shown everytime instead of hovering if partner is selected so that when user open the partner list, user can easily unselect the partner.

task-5945904
