### PR TITLE
[FIX] l10n_it_edi: prevent error when downloading xml fatturapa

### DIFF
--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -396,11 +396,11 @@ class AccountMove(models.Model):
         self.ensure_one()
         if filetype == 'fatturapa':
             if fatturapa_attachment := self.l10n_it_edi_attachment_file:
-                return {
+                return [{
                     'filename': self.l10n_it_edi_attachment_name,
                     'filetype': 'xml',
                     'content': b64decode(fatturapa_attachment),
-                }
+                }]
         return super()._get_invoice_legal_documents(filetype, allow_fallback=allow_fallback)
 
     def get_extra_print_items(self):

--- a/addons/l10n_it_edi/tests/__init__.py
+++ b/addons/l10n_it_edi/tests/__init__.py
@@ -4,6 +4,7 @@ from . import common
 from . import test_account_move_document_type
 from . import test_account_move_payment_method
 from . import test_account_move_send
+from . import test_download_docs
 from . import test_edi_address
 from . import test_edi_export
 from . import test_edi_import

--- a/addons/l10n_it_edi/tests/test_download_docs.py
+++ b/addons/l10n_it_edi/tests/test_download_docs.py
@@ -1,0 +1,26 @@
+import base64
+from unittest.mock import patch
+
+from odoo.fields import Command
+from odoo.tests.common import HttpCase, tagged
+
+from odoo.addons.l10n_it_edi.tests.common import TestItEdi
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestDownloadDocs(HttpCase, TestItEdi):
+
+    def test_download_invoice_documents_fatturapa(self):
+        invoice = self._create_invoice(
+            partner_id=self.italian_partner_a.id,
+            company_id=self.company.id,
+            invoice_line_ids=[Command.create({'price_unit': 100, 'tax_ids': [Command.set(self.default_tax.ids)]})],
+            post=True,
+        )
+        with patch('odoo.addons.account.models.account_move_send.AccountMoveSend._get_default_extra_edis', return_value=[]):
+            self.env['account.move.send']._generate_and_send_invoices(invoice)
+        url = f'/account/download_invoice_documents/{invoice.id}/fatturapa'
+        self.authenticate(self.env.user.login, self.env.user.login)
+        res = self.url_open(url)
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.content, base64.b64decode(invoice.l10n_it_edi_attachment_file))


### PR DESCRIPTION
When downloading the XML FatturaPA of an invoice in an Italian company, A traceback will generate.

Steps to reproduce the error:
- Install ``l10n_it_edi`` module with demo data
- Switch to IT Company
- Create a new invoice > Customer: IT Company > Add a product > Confirm >
  Send > Send
- Actions > Print > XML FatturaPA

Traceback:
```py
TypeError: string indices must be integers, not 'str'
```

In commit [1], ``_get_invoice_legal_documents`` was updated to return a list instead of a dictionary.
However, the ``l10n_it_edi`` module was not adapted accordingly and still returns a dictionary at [2].
If ``_get_invoice_legal_documents`` returns a dictionary instead of a list,
the following logic incorrectly iterates over dictionary key which leads to the above traceback.
https://github.com/odoo/odoo/blob/a74e7e2fa96a56737e9105f3b54d5db2d9c2dba3/addons/account/controllers/download_docs.py#L24-L26

[1]: https://github.com/odoo/odoo/commit/90dcd6cfe904974dfa077c2d8d9e168a09eeecf9
[2]: https://github.com/odoo/odoo/blob/a74e7e2fa96a56737e9105f3b54d5db2d9c2dba3/addons/l10n_it_edi/models/account_move.py#L399-L403

sentry-7272542156

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
