### PR TITLE
[FIX] project: perserve dates while converting project to template

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -1229,7 +1229,7 @@ class ProjectProject(models.Model):
 
     def action_create_template_from_project(self):
         self.ensure_one()
-        template = self.copy(default={"is_template": True, "partner_id": False})
+        template = self.copy(default={"is_template": True, "partner_id": False, "date_start": self.date_start, "date": self.date})
         template._toggle_template_mode(True)
         template.message_post(body=self.env._("Template created from %s.", self.name))
         config = {

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -1234,7 +1234,9 @@ class ProjectProject(models.Model):
 
     def action_create_template_from_project(self):
         self.ensure_one()
-        template = self.copy(default={"is_template": True, "partner_id": False})
+        template = self.with_context(convert_to_template=True).copy(
+            default={"is_template": True, "partner_id": False, "date_start": self.date_start, "date": self.date,
+        })
         template._toggle_template_mode(True)
         template.message_post(body=self.env._("Template created from %s.", self.name))
         config = {

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -846,6 +846,8 @@ class ProjectTask(models.Model):
             active_users = self.user_ids.filtered('active')
         milestone_mapping = self.env.context.get('milestone_mapping', {})
         for task, vals in zip(self, vals_list):
+            if self.env.context.get('convert_to_template'):
+                vals['date_deadline'] = task.date_deadline
 
             if not default.get('stage_id'):
                 vals['stage_id'] = task.stage_id.id

--- a/addons/project/tests/test_project_template.py
+++ b/addons/project/tests/test_project_template.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from odoo.exceptions import UserError
 from odoo import Command
 from odoo.addons.project.tests.test_project_base import TestProjectCommon
@@ -15,6 +17,62 @@ class TestProjectTemplates(TestProjectCommon):
             "name": "Task in Project Template",
             "project_id": cls.project_template.id,
         })
+
+    def test_convert_project_to_project_template_preserves_planned_dates(self):
+        """
+        Test that converting a project into a project template preserves the planned start and end dates.
+        """
+        project = self.env["project.project"].create({
+            "name": "Project",
+            "date_start": date(2025, 6, 1),
+            "date": date(2025, 6, 11),
+        })
+        task_1, task_2 = self.env["project.task"].create([{
+            "name": "Task 1",
+            "project_id": project.id,
+            "date_deadline": date(2025, 6, 10),
+        }, {
+            "name": "Task 2",
+            "project_id": project.id,
+            "date_deadline": date(2025, 6, 11),
+        }])
+
+        data = project.action_create_template_from_project()
+        project_template = self.env["project.project"].browse(
+            data["params"]["project_id"]
+        )
+
+        self.assertTrue(project_template.is_template,
+            "The generated project should be marked as a template."
+        )
+        self.assertEqual(project_template.date_start, project.date_start,
+            "The start date should be preserved when converting a project to a template."
+        )
+        self.assertEqual(project_template.date, project.date,
+            "The expiration date should be preserved when converting a project to a template."
+        )
+        self.assertEqual(task_1.date_deadline, project_template.task_ids[0].date_deadline,
+            "The task 1 deadline date should be preserved when converting a project to a template."
+        )
+        self.assertEqual(task_2.date_deadline, project_template.task_ids[1].date_deadline,
+            "The task 2 deadline date should be preserved when converting a project to a template."
+        )
+
+        # Create project without passing planned dates
+        project_a = project_template.action_create_from_template({"name": "Project A"})
+
+        self.assertFalse(project_a.date_start, "Project should not have a start date by default.")
+        self.assertFalse(project_a.date, "Project should not have an expiration date by default.")
+
+        # Create project with planned new dates
+        project_b = project_template.action_create_from_template({
+            "name": "Project B",
+            "date_start": date(2025, 6, 1),
+            "date": date(2025, 6, 10),
+        })
+
+        self.assertEqual(project_b.date_start, date(2025, 6, 1), "Project should have the new start date.")
+        self.assertEqual(project_b.date, date(2025, 6, 10), "Project should have the new expiration date.")
 
     def test_create_from_template(self):
         """


### PR DESCRIPTION
****Steps** to reproduce:**
 - Open a project with a planned date set.
 - Create Template of that project.
 - Observe the created project template.

**Issue:**
  The planned dates of the project are lost when converting the project into a
  template.

**Cause:**
 When we create a project template from a project, the project gets archived. Because a new project template record is created, and the start and expiration fields have copy=False, those dates are not being copied.

**Fix:**
  Explicitly pass the planned date when copying the project, so the project template keeps the original planned date.

task-5872500
