### PR TITLE
[FIX] l10n_in: prevent duplicate invoice rendering in Folder layout

### DIFF
--- a/addons/l10n_in/views/report_invoice.xml
+++ b/addons/l10n_in/views/report_invoice.xml
@@ -79,7 +79,7 @@
                 <t t-set="hsn_summary" t-value="o._l10n_in_get_hsn_summary_table()"/>
                 <t t-if="hsn_summary">
                     <div name="l10n_in_hsn_summary" class="mt-3" style="page-break-inside: avoid;">
-                        <h3>HSN Summary</h3>
+                        <h4>HSN Summary</h4>
                         <table class="table table-sm table-borderless col-6">
                             <thead>
                                 <th>HSN/SAC</th>


### PR DESCRIPTION
**Steps to reproduce:**
1. Install l10n_in module
2. Switch to india
3. Go to Settings → Configure Document Layout and select Folder layout.
4. Create two Invoices: Select a customer.
Add at least 6–7 invoice lines.
Confirm the invoices then duplicate and again confirm.
5. Go back to the Invoice list view.
6. Select both newly created invoices.
7. Click Print

**Issue:**
When using Folder layout, invoices were rendered twice in PDF while printing.

**Cause:**
The `HSN Summary` title used an `<h3>` tag.
Its larger default margins increased the document height, triggering a pagination reflow issue in wkhtmltopdf specific to Folder layout (due to floats and dynamic header spacing). This caused the invoice to be rendered twice.

**Fix:**
Replaced `<h3>` with `<h4>` to reduce vertical spacing and avoid pagination overflow.

opw-5452609