### PR TITLE
[FIX] web, base_import: select menu fixes

### DIFF
--- a/addons/base_import/static/src/import_data_content/import_data_content.xml
+++ b/addons/base_import/static/src/import_data_content/import_data_content.xml
@@ -67,12 +67,12 @@
                                 >
                                     <t t-if="column.fieldInfo">
                                         <i
-                                            class="o_import_field_icon border-end"
+                                            class="o_import_field_icon"
                                             t-att-class="'position-absolute d-inline-block o_import_field_icon_' + column.fieldInfo.type"
                                             data-tooltip-template="web.FieldTooltip"
                                             t-att-data-tooltip-info="getTooltipDetails(column.fieldInfo)"
                                         ></i>
-                                        <span class="ps-5">
+                                        <span class="ps-4">
                                             <t t-esc="column.fieldInfo.label" />
                                         </span>
                                     </t>

--- a/addons/web/static/src/core/select_menu/select_menu.xml
+++ b/addons/web/static/src/core/select_menu/select_menu.xml
@@ -63,7 +63,7 @@
                 </t>
                 <t t-set-slot="content">
                     <button t-if="isBottomSheet and canDeselect" class="btn o_clear_button px-4 d-block ms-auto" t-on-click="onInputClear">Clear</button>
-                    <div class="o_select_menu_searchbox position-sticky start-0 d-empty-none" t-att-data-id="selectMenuId">
+                    <div class="o_select_menu_searchbox position-sticky start-0 d-empty-none z-1" t-att-data-id="selectMenuId">
                         <t t-if="displayInputInDropdown">
                             <t t-set="inputClass" t-value="'o_select_menu_input dropdown-item'"/>
                             <t t-call="web.SelectMenu.search" />


### PR DESCRIPTION
Before this commit, the select menu with its dropdown opened had a little style issue when scrolling

base_import's select menu had also a style which was a bit off.

After this commit, those are fixed

part-of-task-5935511

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
