### PR TITLE
[FIX] product: fix product_variant pricelist rule without product_tmpl_id

### DIFF
--- a/addons/product/models/product_pricelist_item.py
+++ b/addons/product/models/product_pricelist_item.py
@@ -408,7 +408,9 @@ class PricelistItem(models.Model):
     def _onchange_rule_content(self):
         if not self.env.context.get('default_applied_on', False):
             # If we aren't coming from a specific product template/variant.
-            variants_rules = self.filtered('product_id')
+            variants_rules = self.filtered(
+                lambda r: bool(r.product_id) and bool(r.product_tmpl_id)
+            )
             template_rules = (self-variants_rules).filtered('product_tmpl_id')
             category_rules = self.filtered(lambda cat: cat.categ_id and cat.categ_id.name != 'All')
             variants_rules.update({'applied_on': '0_product_variant'})

--- a/addons/product/tests/test_product_pricelist.py
+++ b/addons/product/tests/test_product_pricelist.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import time
 
 from odoo.fields import Command, first
+from odoo.tests import Form
 from odoo.tools import float_compare
 
 from odoo.addons.product.tests.common import ProductCommon
@@ -309,6 +310,26 @@ class TestProductPricelist(ProductCommon):
 
         # Assert: The set value is kept
         self.assertEqual(pricelist_item.min_quantity, precise_value)
+
+    def test_remove_product_on_0_product_variant_applied_on_rule(self):
+        """Test generation of applied on based on rule data"""
+        self.pricelist_item = self.env['product.pricelist.item'].create({
+             'pricelist_id': self.pricelist.id,
+             'applied_on': '0_product_variant',
+             'product_tmpl_id': self.product.product_tmpl_id.id,
+             'product_id': self.product.id,
+             'compute_price': 'fixed',
+             'fixed_price': 50,
+             'base': 'list_price',
+        })
+
+        self.assertEqual(self.pricelist_item.applied_on, '0_product_variant')
+        with Form(self.pricelist_item) as form:
+            form.product_tmpl_id = self.env['product.template']
+        # Test values after on change
+        self.assertFalse(self.pricelist_item.product_tmpl_id)
+        self.assertFalse(self.pricelist_item.product_id)
+        self.assertEqual(self.pricelist_item.applied_on, '3_global')
 
     def test_pricelist_sync_on_partners(self):
         ResPartner = self.env['res.partner']


### PR DESCRIPTION
Steps:
- Create a price list (or existing one)
- Create (or find) a product with only one variant
- Add price list rule for that variant (Should show as Variant:... in Pricelist listing)
- Go to pricelist listing, select the pricelist
- Edit price list rule - Remove the product
- Save and check the data (applied_on, product_id, product_tmpl_id) (applied_on still 0_product_variant, product_id, and NO product_tmpl_id)

Related ticket:
opw-5411034

(Video: https://drive.google.com/file/d/1xmg9A9NgavFQkIFkUZrzuAxVF-PNqdnL/view)

Description of the issue/feature this PR addresses:
Fix corrupted data
<img width="583" height="108" alt="image" src="https://github.com/user-attachments/assets/961e75f8-b2a6-4812-a0b4-d73e02d52b08" />

Current behavior before PR:
product_tmpl_id set to None
product_id / applied_on data stays the same

Desired behavior after PR is merged:
When product_tmpl_id is removed, reset the applied_on type back to 3_global

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
