### PR TITLE
[FIX] website: adjust color picker tabs for specific options

### DIFF
--- a/addons/website/static/src/builder/plugins/font_awesome_option.xml
+++ b/addons/website/static/src/builder/plugins/font_awesome_option.xml
@@ -3,11 +3,11 @@
 
 <t t-name="website.FontAwesomeOption">
     <BuilderRow label.translate="Color">
-        <BuilderColorPicker styleAction="'color'"/>
+        <BuilderColorPicker styleAction="'color'" enabledTabs="['solid', 'custom', 'gradient']"/>
     </BuilderRow>
 
     <BuilderRow label.translate="Background Color">
-        <BuilderColorPicker styleAction="'background-color'"/>
+        <BuilderColorPicker styleAction="'background-color'" enabledTabs="['solid', 'custom', 'gradient']"/>
     </BuilderRow>
 
     <BuilderRow label.translate="Size">

--- a/addons/website/static/src/builder/plugins/options/navtabs_style_option.xml
+++ b/addons/website/static/src/builder/plugins/options/navtabs_style_option.xml
@@ -14,7 +14,7 @@
             <BuilderColorPicker noTransparency="true" applyTo="'.s_tabs_nav'" styleAction="'--tabs-bg-color'" />
         </BuilderRow>
         <BuilderRow label.translate="Links Color" level="1">
-            <BuilderColorPicker noTransparency="true" applyTo="'.s_tabs_nav .nav-link'" styleAction="'--tabs-link-color'" />
+            <BuilderColorPicker noTransparency="true" applyTo="'.s_tabs_nav .nav-link'" styleAction="'--tabs-link-color'" enabledTabs="['solid', 'custom']"/>
         </BuilderRow>
     </t>
     <BuilderRow t-if="isActiveItem('pills_opt') or isActiveItem('underline_opt')"

--- a/addons/website/static/src/builder/plugins/options/scroll_button_option.xml
+++ b/addons/website/static/src/builder/plugins/options/scroll_button_option.xml
@@ -21,7 +21,7 @@
     <t t-if="this.isActiveItem('scroll_button_opt')">
         <BuilderRow label.translate="Colors" level="1" applyTo="':scope > .o_scroll_button'">
             <BuilderColorPicker styleAction="'background-color'"/>
-            <BuilderColorPicker styleAction="'color'"/>
+            <BuilderColorPicker styleAction="'color'" enabledTabs="['solid', 'custom', 'gradient']"/>
         </BuilderRow>
         <BuilderRow label.translate="Spacing" level="1" applyTo="':scope > .o_scroll_button'">
             <BuilderSelect>


### PR DESCRIPTION
This commit ensures the correct tabs are displayed in the color picker for Icon, Snippet Tabs and Scroll Button options.

The Theme tab was previously shown for these options, although it was not relevant in this context.

The color picker now only displays the tabs that make sense for each option.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
