### PR TITLE
[FIX] account: show journal items for archived account

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -315,7 +315,7 @@
                     <field name="date_maturity" string="Due Date"/>
                     <field name="discount_date" string="Discount Date"/>
                     <field name="balance" string="Amount" filter_domain="['|', ('credit', '=', raw_value), ('debit', '=', raw_value)]"/>
-                    <field name="account_id"/>
+                    <field name="account_id" context="{'active_test': False}"/>
                     <field name="account_type"/>
                     <field name="partner_id"/>
                     <field name="journal_id"/>


### PR DESCRIPTION
This commit makes it possible to see the journal items for archived account when searching for the account. Previously, when searching for an account that is archived, its journal items weren't shown.

task-5905559

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
