### PR TITLE
[FIX] l10n_tr_nilvera_einvoice : allow non-admin user access to accou…

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/models/account_journal.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_journal.py
@@ -1,4 +1,5 @@
-from odoo import api, models
+from odoo import _, api, models
+from odoo.exceptions import RedirectWarning
 
 
 class AccountJournal(models.Model):
@@ -10,7 +11,6 @@ class AccountJournal(models.Model):
         super()._compute_show_fetch_in_einvoices_button()
         self.filtered(
             lambda j: j.is_nilvera_journal and
-                      j.l10n_tr_nilvera_api_key and
                       j.type == 'purchase'
         ).show_fetch_in_einvoices_button = True
 
@@ -19,17 +19,26 @@ class AccountJournal(models.Model):
         # EXTENDS 'account'
         super()._compute_show_refresh_out_einvoices_status_button()
         self.filtered(
-            lambda j: j.l10n_tr_nilvera_api_key and
-                      j.type == 'sale'
+            lambda j: j.type == 'sale'
         ).show_refresh_out_einvoices_status_button = True
 
     def button_fetch_in_einvoices(self):
         # EXTENDS 'account'
         """ Fetches bills from Nilvera."""
+        self._check_api_key()
         super().button_fetch_in_einvoices()
         self.env['account.move']._cron_nilvera_get_new_einvoice_purchase_documents()
 
     def button_refresh_out_einvoices_status(self):
         # EXTENDS 'account'
+        self._check_api_key()
         super().button_refresh_out_einvoices_status()
         self.env['account.move']._cron_nilvera_get_invoice_status()
+
+    def _check_api_key(self):
+        if self.sudo().filtered(lambda j: not j.l10n_tr_nilvera_api_key):
+            raise RedirectWarning(
+                _("Please configure your Nilvera API key"),
+                self.env.ref('account.action_account_config').id,
+                _("Go to the Accounting Settings")
+            )


### PR DESCRIPTION
…nting dashboard

# How to reproduce
- Add the l10n_tr_nilvera module
- Have at least one journal
- Connect with a non-admin user
- Go to the accounting dashboard

# The problem
An access right error message is displayed

# Why
When going to the accounting dashboard, both "_compute_show_fetch_in_einvoices_button" and "_compute_show_refresh_out_einvoices_status_button" are triggered. They both try to access the nilvera api key field of account.journal but only administrator users have access to that field.

opw-5928715

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
