### PR TITLE
[IMP] hr_timesheet: allow multi edit of tasks

### DIFF
--- a/addons/hr_timesheet/static/src/views/timesheet_list/timesheet_list_renderer.js
+++ b/addons/hr_timesheet/static/src/views/timesheet_list/timesheet_list_renderer.js
@@ -1,0 +1,33 @@
+import { ListRenderer } from "@web/views/list/list_renderer";
+
+export class TimesheetListRenderer extends ListRenderer {
+    setup() {
+        super.setup();
+        this.multiEditLimitedFields = ["task_id"];
+        this.multiEditBlackList = ["project_id"];
+        this.lastLength = 0;
+    }
+
+    isCellReadonly(column, record) {
+        const isCellReadonly = super.isCellReadonly(column, record);
+        const selected = this.props.list.selection;
+        if (isCellReadonly) {
+            return isCellReadonly;
+        } else if (selected.length <= 1) {
+            // If only one element is selected multi-select readonly should not apply
+            this.lastLength = 1;
+            return false;
+        } else if (this.multiEditBlackList.includes(column.name)) {
+            return true;
+        } else if (this.multiEditLimitedFields.includes(column.name)) {
+            //If there is a difference between lastLength and selected.length, then there must be a change in the selection
+            if (this.lastLength !== selected.length) {
+                this.lastLength = selected.length;
+                this.allowTasks = selected.every(
+                    (line) => line.data.project_id.id === selected[0].data.project_id.id
+                );
+            }
+            return !this.allowTasks;
+        }
+    }
+}

--- a/addons/hr_timesheet/static/src/views/timesheet_list/timesheet_list_renderer.js
+++ b/addons/hr_timesheet/static/src/views/timesheet_list/timesheet_list_renderer.js
@@ -1,0 +1,37 @@
+
+import { ListRenderer } from "@web/views/list/list_renderer";
+
+export class TimesheetListRenderer extends ListRenderer {
+    setup() {
+        super.setup();
+        this.multiEditLimitedFields = ["task_id"]
+        this.multiEditBlackList = ["project_id"]
+        this.lastLength = 0;
+
+    }
+         
+    isCellReadonly(column, record) {
+        const selected = this.props.list.selection;
+        if(selected.length <= 1)
+        {
+            this.lastLength = 0;
+            return super.isCellReadonly(column,record)
+        }
+        if(this.multiEditBlackList.includes(column.name))
+        {
+            return true;
+        }
+        if(this.multiEditLimitedFields.includes(column.name))
+        {
+            if(this.lastLength != selected.length)
+            {
+                this.lastLength = selected.length;
+                this.allowTasks = selected.every(line => line.data.project_id.id === selected[0].data.project_id.id);
+            }
+            
+            return !this.allowTasks;
+        }
+        return false;
+    }
+
+}

--- a/addons/hr_timesheet/static/src/views/timesheet_list/timesheet_list_view.js
+++ b/addons/hr_timesheet/static/src/views/timesheet_list/timesheet_list_view.js
@@ -1,0 +1,9 @@
+import { registry } from "@web/core/registry";
+import { listView } from "@web/views/list/list_view";
+import { TimesheetListRenderer } from "./timesheet_list_renderer";
+
+export const timesheetListView = {
+    ...listView,
+    Renderer : TimesheetListRenderer
+}
+registry.category("views").add("timesheet_list_view",timesheetListView)

--- a/addons/hr_timesheet/static/src/views/timesheet_list/timesheet_list_view.js
+++ b/addons/hr_timesheet/static/src/views/timesheet_list/timesheet_list_view.js
@@ -1,0 +1,9 @@
+import { registry } from "@web/core/registry";
+import { listView } from "@web/views/list/list_view";
+import { TimesheetListRenderer } from "./timesheet_list_renderer";
+
+export const timesheetListView = {
+    ...listView,
+    Renderer: TimesheetListRenderer,
+};
+registry.category("views").add("timesheet_list_view", timesheetListView);

--- a/addons/hr_timesheet/static/tests/timesheet_list_multi_select.test.js
+++ b/addons/hr_timesheet/static/tests/timesheet_list_multi_select.test.js
@@ -1,0 +1,157 @@
+import { test, expect, beforeEach, animationFrame } from "@odoo/hoot";
+import { advanceTime } from "@odoo/hoot-mock";
+import { startServer } from "@mail/../tests/mail_test_helpers";
+import { mountView, contains } from "@web/../tests/web_test_helpers";
+import { defineTimesheetModels } from "./hr_timesheet_models";
+
+defineTimesheetModels();
+
+let pyEnv;
+beforeEach(async () => {
+    pyEnv = await startServer();
+    pyEnv["account.analytic.line"].unlink(pyEnv["account.analytic.line"].search([]));
+});
+
+test.tags("desktop");
+test("hr.timesheet (list): when timesheet's with different projects are selected task & project can't be modified ", async () => {
+    pyEnv["account.analytic.line"].create([
+        {
+            project_id: 1,
+            task_id: 3,
+            unit_amount: 1,
+        },
+        {
+            project_id: false,
+            task_id: false,
+            unit_amount: 2,
+        },
+    ]);
+
+    await mountView({
+        type: "list",
+        resModel: "account.analytic.line",
+        arch: `
+            <list multi_edit="1" js_class="timesheet_list_view">
+                <field name="project_id"/>
+                <field name="task_id"/>
+                <field name="name"/>
+            </list>
+        `,
+    });
+    // Select all rows
+    await contains(`.o_list_record_selector`).click();
+
+    // // Verify that bulk editing of timesheet names is permitted
+    await contains("tbody > tr:first-child > td[name='name']").click();
+    await contains("tbody > tr:first-child > td[name='name'] input").edit("Sample Text");
+    await advanceTime(200);
+    await animationFrame();
+    expect("main[role='alert'] > p").toHaveText(
+        "Among the 2 selected records, 1 are valid for this update.\nAre you sure you want to update 1 records?",
+        { message: "A dialog box should appear when editing multiple timesheet names" }
+    );
+    await contains("footer > button[class='btn btn-secondary']").click();
+
+    // Verify that bulk task editing is disabled when selected timesheets belong to different projects
+    await contains("tbody > tr:first-child > td[name='task_id']").click();
+    await contains("tbody > tr:first-child > td[name='task_id']").click();
+    expect("tbody > tr:first-child > td[name='task_id'] > div > div > div").toHaveCount(0, {
+        message: "Since task bulk‑editing is not allowed across different projects, no dropdown menu should appear",
+    });
+
+    // Verify that bulk project editing is disabled when selected timesheets belong to different projects
+    await contains("tbody > tr:first-child > td[name='project_id']").click();
+    await contains("tbody > tr:first-child > td[name='project_id']").click();
+    expect("tbody > tr:first-child > td[name='project_id'] > div > div > div").toHaveCount(0, {
+        message: "Since project bulk‑editing is disallowed, no dropdown menu should appear",
+    });
+});
+
+test.tags("desktop");
+test("hr.timesheet (list): when timesheet's with the same project are selected, task can be modified but project can't ", async () => {
+    pyEnv["account.analytic.line"].create([
+        {
+            project_id: 1,
+            task_id: 3,
+            unit_amount: 1,
+        },
+        {
+            project_id: 1,
+            task_id: false,
+            unit_amount: 2,
+        },
+    ]);
+    await mountView({
+        type: "list",
+        resModel: "account.analytic.line",
+        arch: `
+            <list multi_edit="1" js_class="timesheet_list_view">
+                <field name="project_id"/>
+                <field name="task_id"/>
+                <field name="name"/>
+            </list>
+        `,
+    });
+    // Select the rows with the same project
+    await contains(`.o_list_record_selector`).click();
+
+    // Verify that bulk task editing is permitted when all selected timesheets share the same project
+    await contains("tbody > tr:first-child > td[name='task_id']").click();
+    await contains("tbody > tr:first-child > td[name='task_id']").click();
+    expect("tbody > tr:first-child > td[name='task_id'] > div > div > div").toHaveCount(1, {
+        message: "Since task bulk‑editing is allowed, a dropdown menu should appear.",
+    });
+
+    await contains("tbody > tr:first-child > td[name='task_id'] input").edit("Task 1 AdditionalInfo");
+    await advanceTime(500);
+    await animationFrame();
+    expect("main[role='alert'] > p").toHaveText("Are you sure you want to update 2 records?", {
+        message: "A dialog box should open when editing multiple timesheet tasks at once, if all the timesheet share a project"
+    });
+    await contains("footer > button[class='btn btn-secondary']").click();
+
+    // Verify that bulk project editing is disabled when selected timesheets belong to the same project
+    await contains("tbody > tr:first-child > td[name='project_id']").click();
+    await contains("tbody > tr:first-child > td[name='project_id']").click();
+    expect("tbody > tr:first-child > td[name='project_id'] > div > div > div").toHaveCount(0, {
+        message: "Since project bulk‑editing is disallowed, no dropdown menu should appear",
+    });
+});
+
+test.tags("desktop");
+test("hr.timesheet (list): when only a single timesheet is selected, project can be modified  ", async () => {
+    pyEnv["account.analytic.line"].create([
+        {
+            project_id: 1,
+            task_id: 3,
+            unit_amount: 1,
+        },
+    ]);
+    await mountView({
+        type: "list",
+        resModel: "account.analytic.line",
+        arch: `
+            <list multi_edit="1" js_class="timesheet_list_view">
+                <field name="project_id"/>
+                <field name="task_id"/>
+                <field name="name"/>
+            </list>
+        `,
+    });
+
+    // Select the timesheet
+    await contains(`.o_list_record_selector`).click();
+
+    // Verify that single-timesheet project editing is allowed
+    await contains("tbody > tr:first-child > td[name='project_id']").click();
+    await contains("tbody > tr:first-child > td[name='project_id']").click();
+    expect("tbody > tr:first-child > td[name='project_id'] > div > div > div").toHaveCount(1, {
+        message: "Since project editing for a single timesheet is allowed, a dropdown menu should appear",
+    });
+    await contains("tbody > tr:first-child > td[name='project_id'] input").edit("Project 2");
+    await advanceTime(500);
+    await animationFrame();
+    expect("tbody > tr:first-child > td[name='project_id']").toHaveText("Project 2", {
+        message: "Updating the project should refresh the timesheet list",
+    });
+});

--- a/addons/hr_timesheet/views/account_analytic_line_views.xml
+++ b/addons/hr_timesheet/views/account_analytic_line_views.xml
@@ -5,7 +5,7 @@
             <field name="name">account.analytic.line.list.hr_timesheet</field>
             <field name="model">account.analytic.line</field>
             <field name="arch" type="xml">
-                <list editable="top" string="Timesheet Activities" sample="1" decoration-muted="readonly_timesheet == True">
+                <list editable="top" string="Timesheet Activities" sample="1" decoration-muted="readonly_timesheet == True" multi_edit="1" js_class="timesheet_list_view">
                     <field name="readonly_timesheet" column_invisible="True"/>
                     <field name="date" readonly="readonly_timesheet"/>
                     <field name="employee_id" column_invisible="True" readonly="readonly_timesheet"/>
@@ -49,6 +49,9 @@
             <field name="mode">primary</field>
             <field name="priority">10</field>
             <field name="arch" type="xml">
+                <xpath expr="//list" position="attributes">
+                    <attribute name="js_class">timesheet_list_view</attribute>
+                </xpath>
                 <xpath expr="//field[@name='employee_id']" position="attributes">
                     <attribute name="column_invisible">0</attribute>
                     <attribute name="required">1</attribute>

--- a/addons/hr_timesheet/views/account_analytic_line_views.xml
+++ b/addons/hr_timesheet/views/account_analytic_line_views.xml
@@ -5,7 +5,7 @@
             <field name="name">account.analytic.line.list.hr_timesheet</field>
             <field name="model">account.analytic.line</field>
             <field name="arch" type="xml">
-                <list editable="top" string="Timesheet Activities" sample="1" decoration-muted="readonly_timesheet == True">
+                <list editable="top" string="Timesheet Activities" sample="1" decoration-muted="readonly_timesheet == True" multi_edit="1" js_class="timesheet_list_view">
                     <field name="readonly_timesheet" column_invisible="True"/>
                     <field name="date" readonly="readonly_timesheet"/>
                     <field name="employee_id" column_invisible="True" readonly="readonly_timesheet"/>

--- a/addons/sale_timesheet/__manifest__.py
+++ b/addons/sale_timesheet/__manifest__.py
@@ -42,6 +42,7 @@ have real delivered quantities in sales orders.
         ],
         'web.assets_backend': [
             'sale_timesheet/static/src/components/**/*',
+            'sale_timesheet/static/src/views/**/*'
         ],
         'web.assets_tests': [
             'sale_timesheet/static/tests/tours/**/*',

--- a/addons/sale_timesheet/__manifest__.py
+++ b/addons/sale_timesheet/__manifest__.py
@@ -42,6 +42,7 @@ have real delivered quantities in sales orders.
         ],
         'web.assets_backend': [
             'sale_timesheet/static/src/components/**/*',
+            'sale_timesheet/static/src/views/**/*',
         ],
         'web.assets_tests': [
             'sale_timesheet/static/tests/tours/**/*',

--- a/addons/sale_timesheet/static/src/views/timesheet_list/timesheet_list_renderer.js
+++ b/addons/sale_timesheet/static/src/views/timesheet_list/timesheet_list_renderer.js
@@ -1,0 +1,10 @@
+import { TimesheetListRenderer} from "@hr_timesheet/views/timesheet_list/timesheet_list_renderer";
+import { patch } from "@web/core/utils/patch";
+
+patch(TimesheetListRenderer.prototype, {
+    setup()
+    {
+        super.setup();
+        this.multiEditBlackList.push("so_line");
+    }
+});

--- a/addons/sale_timesheet/static/src/views/timesheet_list/timesheet_list_renderer.js
+++ b/addons/sale_timesheet/static/src/views/timesheet_list/timesheet_list_renderer.js
@@ -1,0 +1,9 @@
+import { TimesheetListRenderer } from "@hr_timesheet/views/timesheet_list/timesheet_list_renderer";
+import { patch } from "@web/core/utils/patch";
+
+patch(TimesheetListRenderer.prototype, {
+    setup() {
+        super.setup();
+        this.multiEditBlackList.push("so_line");
+    },
+});


### PR DESCRIPTION
## Behavior Before Commit :
The Timesheet list view did not allow users to modify multiple rows at once.

## Excpted Behavior After Commit :
Users can now multi‑edit Timesheet entries, but only the task field and only when all selected lines belong to the same project.

## Additions
- The standard list view '''multi_edit''' attribute only supports enabling multi‑edit for all fields or none. To support conditional multi‑edit, a custom ListRenderer was implemented.

- The '''isCellReadonly''' method is triggered on every change for every record/column pair. Evaluating the task‑edit condition repeatedly would be unnecessarily expensive, so the result is cached in '''this.allowTask''' and recalculated only when the selection changes.

## Task:
task-[5320301](https://www.odoo.com/odoo/project/4105/tasks/5320301)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
