### PR TITLE
[REF] website_blog: remove url from js file tours

### DIFF
--- a/addons/website_blog/static/src/tours/website_blog.js
+++ b/addons/website_blog/static/src/tours/website_blog.js
@@ -3,119 +3,108 @@ import { clickOnSave, registerWebsitePreviewTour } from "@website/js/tours/tour_
 
 import { markup } from "@odoo/owl";
 
-registerWebsitePreviewTour(
-    "blog",
+registerWebsitePreviewTour("blog_tour", {}, () => [
     {
-        url: "/",
+        trigger: "body:not(:has(.o_new_content_menu_choices)) .o_new_content_container > button",
+        content: _t("Click here to add new content to your website."),
+        tooltipPosition: "bottom",
+        run: "click",
     },
-    () => [
-        {
-            trigger:
-                "body:not(:has(.o_new_content_menu_choices)) .o_new_content_container > button",
-            content: _t("Click here to add new content to your website."),
-            tooltipPosition: "bottom",
-            run: "click",
-        },
-        {
-            trigger: 'button[data-module-xml-id="base.module_website_blog"]',
-            content: _t("Select this menu item to create a new blog post."),
-            tooltipPosition: "bottom",
-            run: "click",
-        },
-        {
-            trigger: 'div[name="name"] input',
-            content: _t("Enter your post's title"),
-            tooltipPosition: "bottom",
-            run: "edit Test",
-        },
-        {
-            trigger: 'div.o_field_widget[name="blog_id"]',
-        },
-        {
-            trigger: "button.o_form_button_save",
-            content: _t("Select the blog you want to add the post to."),
-            // Without demo data (and probably in most user cases) there is only
-            // one blog so this step would not be needed and would block the
-            // tour. We keep the step with "auto: true", so that the main python
-            // test still works but never display this to the user anymore. We
-            // suppose the user does not need guidance once that modal is
-            // opened. Note: if you run the tour via your console without demo
-            // data, the tour will thus fail as this will be considered.
-            run: "click",
-        },
-        {
-            trigger: ".o_builder_sidebar_open .o-snippets-menu",
-            timeout: 15000,
-        },
-        {
-            trigger: ':iframe h1[data-oe-expression="blog_post.name"]',
-            content: _t("Edit your title, the subtitle is optional."),
-            tooltipPosition: "top",
-            run: "click",
-        },
-        {
-            trigger: `:iframe #wrap h1[data-oe-expression="blog_post.name"]:not(:contains(''))`,
-        },
-        {
-            trigger: "button[data-action-id='setCoverBackground'][title='Image']",
-            content: markup(_t("Set a blog post <b>cover</b>.")),
-            tooltipPosition: "top",
-            run: "click",
-        },
-        {
-            trigger: ".o_select_media_dialog .o_we_search",
-            content: _t('Search for an image. (eg: type "business")'),
-            tooltipPosition: "top",
-        },
-        {
-            trigger: ".o_select_media_dialog .o_existing_attachment_cell:first .o_button_area",
-            content: _t("Choose an image from the library."),
-            tooltipPosition: "top",
-            run: "click",
-        },
-        {
-            trigger: ":iframe #o_wblog_post_content p",
-            content: markup(
-                _t(
-                    "<b>Write your story here.</b> Use the top toolbar to style your text: add an image or table, set bold or italic, etc. Drag and drop building blocks for more graphical blogs."
-                )
-            ),
-            tooltipPosition: "top",
-            run: "editor Blog content",
-        },
-        ...clickOnSave(),
-        {
-            trigger: ".o_menu_systray_item.o_mobile_preview > a",
-            content: markup(
-                _t("Use this icon to preview your blog post on <b>mobile devices</b>.")
-            ),
-            tooltipPosition: "bottom",
-            run: "click",
-        },
-        {
-            trigger: ".o_website_preview.o_is_mobile",
-        },
-        {
-            trigger: ".o_menu_systray_item.o_mobile_preview > a",
-            content: _t(
-                "Once you have reviewed the content on mobile, you can switch back to the normal view by clicking here again"
-            ),
-            tooltipPosition: "right",
-            run: "click",
-        },
-        {
-            trigger: ":iframe body:not(.editor_enable)",
-        },
-        {
-            trigger: '.o_menu_systray_item a:contains("Unpublished")',
-            tooltipPosition: "bottom",
-            content: markup(
-                _t("<b>Publish your blog post</b> to make it visible to your visitors.")
-            ),
-            run: "click",
-        },
-        {
-            trigger: '.o_menu_systray_item a:contains("Published")',
-        },
-    ]
-);
+    {
+        trigger: 'button[data-module-xml-id="base.module_website_blog"]',
+        content: _t("Select this menu item to create a new blog post."),
+        tooltipPosition: "bottom",
+        run: "click",
+    },
+    {
+        trigger: 'div[name="name"] input',
+        content: _t("Enter your post's title"),
+        tooltipPosition: "bottom",
+        run: "edit Test",
+    },
+    {
+        trigger: 'div.o_field_widget[name="blog_id"]',
+    },
+    {
+        trigger: "button.o_form_button_save",
+        content: _t("Select the blog you want to add the post to."),
+        // Without demo data (and probably in most user cases) there is only
+        // one blog so this step would not be needed and would block the
+        // tour. We keep the step with "auto: true", so that the main python
+        // test still works but never display this to the user anymore. We
+        // suppose the user does not need guidance once that modal is
+        // opened. Note: if you run the tour via your console without demo
+        // data, the tour will thus fail as this will be considered.
+        run: "click",
+    },
+    {
+        trigger: ".o_builder_sidebar_open .o-snippets-menu",
+        timeout: 15000,
+    },
+    {
+        trigger: ':iframe h1[data-oe-expression="blog_post.name"]',
+        content: _t("Edit your title, the subtitle is optional."),
+        tooltipPosition: "top",
+        run: "click",
+    },
+    {
+        trigger: `:iframe #wrap h1[data-oe-expression="blog_post.name"]:not(:contains(''))`,
+    },
+    {
+        trigger: "button[data-action-id='setCoverBackground'][title='Image']",
+        content: markup(_t("Set a blog post <b>cover</b>.")),
+        tooltipPosition: "top",
+        run: "click",
+    },
+    {
+        trigger: ".o_select_media_dialog .o_we_search",
+        content: _t('Search for an image. (eg: type "business")'),
+        tooltipPosition: "top",
+    },
+    {
+        trigger: ".o_select_media_dialog .o_existing_attachment_cell:first .o_button_area",
+        content: _t("Choose an image from the library."),
+        tooltipPosition: "top",
+        run: "click",
+    },
+    {
+        trigger: ":iframe #o_wblog_post_content p",
+        content: markup(
+            _t(
+                "<b>Write your story here.</b> Use the top toolbar to style your text: add an image or table, set bold or italic, etc. Drag and drop building blocks for more graphical blogs."
+            )
+        ),
+        tooltipPosition: "top",
+        run: "editor Blog content",
+    },
+    ...clickOnSave(),
+    {
+        trigger: ".o_menu_systray_item.o_mobile_preview > a",
+        content: markup(_t("Use this icon to preview your blog post on <b>mobile devices</b>.")),
+        tooltipPosition: "bottom",
+        run: "click",
+    },
+    {
+        trigger: ".o_website_preview.o_is_mobile",
+    },
+    {
+        trigger: ".o_menu_systray_item.o_mobile_preview > a",
+        content: _t(
+            "Once you have reviewed the content on mobile, you can switch back to the normal view by clicking here again"
+        ),
+        tooltipPosition: "right",
+        run: "click",
+    },
+    {
+        trigger: ":iframe body:not(.editor_enable)",
+    },
+    {
+        trigger: '.o_menu_systray_item a:contains("Unpublished")',
+        tooltipPosition: "bottom",
+        content: markup(_t("<b>Publish your blog post</b> to make it visible to your visitors.")),
+        run: "click",
+    },
+    {
+        trigger: '.o_menu_systray_item a:contains("Published")',
+    },
+]);

--- a/addons/website_blog/static/tests/tours/blog_context.js
+++ b/addons/website_blog/static/tests/tours/blog_context.js
@@ -8,7 +8,6 @@ registerWebsitePreviewTour(
     "blog_context_and_social_media",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/blog",
     },
     () => [
         {

--- a/addons/website_blog/static/tests/tours/blog_manager_tour.js
+++ b/addons/website_blog/static/tests/tours/blog_manager_tour.js
@@ -7,85 +7,73 @@ import {
 /**
  * Makes sure that blog are only managable by Blog Manager Group.
  */
-registerWebsitePreviewTour(
-    "blog_manager",
+registerWebsitePreviewTour("blog_manager_tour", {}, () => [
     {
-        url: "/blog",
+        content: "Open create content menu.",
+        trigger: ".o_menu_systray .o_new_content_container button",
+        run: "click",
     },
-    () => [
-        {
-            content: "Open create content menu.",
-            trigger: ".o_menu_systray .o_new_content_container button",
-            run: "click",
-        },
-        {
-            content: "Select option to create a new blog post.",
-            trigger: "button[data-module-xml-id='base.module_website_blog']",
-            run: "click",
-        },
-        {
-            content: "Enter your post's title",
-            trigger: "div[name='name'] input",
-            run: "edit Manager Blog",
-        },
-        {
-            content: "Click on save button to create the blog post.",
-            trigger: "button.o_form_button_save",
-            run: "click",
-        },
-        ...clickOnEditAndWaitEditMode(),
-        {
-            content: "Edit blog title",
-            trigger: ":iframe [data-oe-expression='blog_post.name']",
-            run: "editor Manager Blog Test Title",
-        },
-        {
-            content: "Edit blog content.",
-            trigger: ":iframe #o_wblog_post_content p",
-            run: "editor Manager Blog Test Content",
-        },
-        ...clickOnSave(),
-        {
-            content: "Check if blog get edited!",
-            trigger: ":iframe #o_wblog_post_content p:contains('Manager Blog Test Content')",
-        },
-    ]
-);
+    {
+        content: "Select option to create a new blog post.",
+        trigger: "button[data-module-xml-id='base.module_website_blog']",
+        run: "click",
+    },
+    {
+        content: "Enter your post's title",
+        trigger: "div[name='name'] input",
+        run: "edit Manager Blog",
+    },
+    {
+        content: "Click on save button to create the blog post.",
+        trigger: "button.o_form_button_save",
+        run: "click",
+    },
+    ...clickOnEditAndWaitEditMode(),
+    {
+        content: "Edit blog title",
+        trigger: ":iframe [data-oe-expression='blog_post.name']",
+        run: "editor Manager Blog Test Title",
+    },
+    {
+        content: "Edit blog content.",
+        trigger: ":iframe #o_wblog_post_content p",
+        run: "editor Manager Blog Test Content",
+    },
+    ...clickOnSave(),
+    {
+        content: "Check if blog get edited!",
+        trigger: ":iframe #o_wblog_post_content p:contains('Manager Blog Test Content')",
+    },
+]);
 
-registerWebsitePreviewTour(
-    "blog_no_manager",
+registerWebsitePreviewTour("blog_no_manager", {}, () => [
     {
-        url: "/blog",
+        content: "Open create content menu.",
+        trigger: ".o_menu_systray .o_new_content_container button",
+        run: "click",
     },
-    () => [
-        {
-            content: "Open create content menu.",
-            trigger: ".o_menu_systray .o_new_content_container button",
-            run: "click",
-        },
-        {
-            content: "Check if Blog Option is not present.",
-            trigger:
-                ".o_new_content_menu_choices:not(:has([data-module-xml-id='base.module_website_blog']))",
-        },
-        {
-            content: "Click on the first article",
-            trigger: ":iframe article[name='blog_post'] a",
-            run: "click",
-        },
-        {
-            content: "Open Post Form in Backend",
-            trigger: ".o_website_edit_in_backend a",
-            run: "click",
-        },
-        {
-            content: "Click on gear Icon",
-            trigger: ".o_action_manager button[data-tooltip='Actions']",
-            run: "click",
-        },
-        {
-            content: "Check if delete action is available or not",
-            trigger: ".o_popover:not(:has(i.fa-trash-o))",
-        },
-    ]
-);
+    {
+        content: "Check if Blog Option is not present.",
+        trigger:
+            ".o_new_content_menu_choices:not(:has([data-module-xml-id='base.module_website_blog']))",
+    },
+    {
+        content: "Click on the first article",
+        trigger: ":iframe article[name='blog_post'] a",
+        run: "click",
+    },
+    {
+        content: "Open Post Form in Backend",
+        trigger: ".o_website_edit_in_backend a",
+        run: "click",
+    },
+    {
+        content: "Click on gear Icon",
+        trigger: ".o_action_manager button[data-tooltip='Actions']",
+        run: "click",
+    },
+    {
+        content: "Check if delete action is available or not",
+        trigger: ".o_popover:not(:has(i.fa-trash-o))",
+    },
+]);

--- a/addons/website_blog/static/tests/tours/blog_posts_dynamic_snippet.js
+++ b/addons/website_blog/static/tests/tours/blog_posts_dynamic_snippet.js
@@ -21,7 +21,6 @@ registerWebsitePreviewTour(
     "blog_posts_dynamic_snippet_options",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/?debug=1",
         edition: true,
     },
     () => [

--- a/addons/website_blog/static/tests/tours/blog_posts_dynamic_snippet_visibility.js
+++ b/addons/website_blog/static/tests/tours/blog_posts_dynamic_snippet_visibility.js
@@ -39,7 +39,6 @@ const isSnippetHidden = () => [
 registerWebsitePreviewTour(
     "blog_posts_dynamic_snippet_edit",
     {
-        url: "/",
         edition: true,
     },
     () => [
@@ -57,24 +56,12 @@ registerWebsitePreviewTour(
     ]
 );
 
-registerWebsitePreviewTour(
-    "blog_posts_dynamic_snippet_empty",
-    {
-        url: "/",
-    },
-    isSnippetHidden
-);
+registerWebsitePreviewTour("blog_posts_dynamic_snippet_empty", {}, isSnippetHidden);
 
-registerWebsitePreviewTour(
-    "blog_posts_dynamic_snippet_misconfigured",
+registerWebsitePreviewTour("blog_posts_dynamic_snippet_misconfigured", {}, () => [
+    ...isSnippetHidden(),
     {
-        url: "/",
+        content: "Check that the snippet 'missing option' warning is visible",
+        trigger: ":iframe .s_dynamic_snippet_blog_posts .missing_option_warning",
     },
-    () => [
-        ...isSnippetHidden(),
-        {
-            content: "Check that the snippet 'missing option' warning is visible",
-            trigger: ":iframe .s_dynamic_snippet_blog_posts .missing_option_warning",
-        },
-    ]
-);
+]);

--- a/addons/website_blog/static/tests/tours/blog_search_with_date.js
+++ b/addons/website_blog/static/tests/tours/blog_search_with_date.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
  * Makes sure that blog search can be used with the date filtering.
  */
 registry.category("web_tour.tours").add("blog_autocomplete_with_date", {
-    url: "/blog",
     steps: () => [
         {
             content: "Select first month",

--- a/addons/website_blog/static/tests/tours/blog_sidebar_with_date_and_tag.js
+++ b/addons/website_blog/static/tests/tours/blog_sidebar_with_date_and_tag.js
@@ -1,62 +1,55 @@
 import { registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
 
-registerWebsitePreviewTour(
-    "blog_sidebar_with_date_and_tag",
+registerWebsitePreviewTour("blog_sidebar_with_date_and_tag", () => [
     {
-        url: "/blog",
+        content: "Click on the 'Nature' blog category to filter blog posts.",
+        trigger: ":iframe b:contains('Nature')",
+        run: "click",
     },
-    () => [
-        {
-            content: "Click on the 'Nature' blog category to filter blog posts.",
-            trigger: ":iframe b:contains('Nature')",
-            run: "click",
+    {
+        content: "Verify that the blog post list shows only posts from the 'Nature' category.",
+        trigger: ":iframe .o_wblog_post_name:contains('Nature')",
+    },
+    {
+        content: "Check if the archive dropdown contains exactly 1 option: February.",
+        trigger: ":iframe select[name=archive]",
+        run: function () {
+            const optionEls = this.anchor.querySelectorAll("optgroup option");
+            const length = optionEls.length;
+            const monthName = optionEls[0].textContent;
+            if (length !== 1 || !monthName.includes("February")) {
+                throw new Error("Expected 1 option in the select with February");
+            }
         },
-        {
-            content: "Verify that the blog post list shows only posts from the 'Nature' category.",
-            trigger: ":iframe .o_wblog_post_name:contains('Nature')",
+    },
+    {
+        content: "Click on the 'Space' blog category to switch filters.",
+        trigger: ":iframe b:contains('Space')",
+        run: "click",
+    },
+    {
+        content: "Verify that the blog post list shows only posts from the 'Space' category.",
+        trigger: ":iframe .o_wblog_post_name:contains('Space')",
+    },
+    {
+        content: "Verify that the archive dropdown now contains only 1 option: January.",
+        trigger: ":iframe select[name=archive]",
+        run: function () {
+            const optionEls = this.anchor.querySelectorAll("optgroup option");
+            const length = optionEls.length;
+            const monthName = optionEls[0].textContent;
+            if (length !== 1 || !monthName.includes("January")) {
+                throw new Error("Expected 1 option in the select with January");
+            }
         },
-        {
-            content: "Check if the archive dropdown contains exactly 1 option: February.",
-            trigger: ":iframe select[name=archive]",
-            run: function () {
-                const optionEls = this.anchor.querySelectorAll("optgroup option");
-                const length = optionEls.length;
-                const monthName = optionEls[0].textContent;
-                if (length !== 1 || !monthName.includes("February")) {
-                    throw new Error("Expected 1 option in the select with February");
-                }
-            },
-        },
-        {
-            content: "Click on the 'Space' blog category to switch filters.",
-            trigger: ":iframe b:contains('Space')",
-            run: "click",
-        },
-        {
-            content: "Verify that the blog post list shows only posts from the 'Space' category.",
-            trigger: ":iframe .o_wblog_post_name:contains('Space')",
-        },
-        {
-            content: "Verify that the archive dropdown now contains only 1 option: January.",
-            trigger: ":iframe select[name=archive]",
-            run: function () {
-                const optionEls = this.anchor.querySelectorAll("optgroup option");
-                const length = optionEls.length;
-                const monthName = optionEls[0].textContent;
-                if (length !== 1 || !monthName.includes("January")) {
-                    throw new Error("Expected 1 option in the select with January");
-                }
-            },
-        },
-        {
-            content: "Click on the 'Second Blog Post' to view its details.",
-            trigger: ":iframe article a:contains('Second Blog Post')",
-            run: "click",
-        },
-        {
-            content:
-                "Verify that 'Add some' button has the correct URL for navigating to the backend.",
-            trigger: ":iframe #edit-in-backend[href*='/odoo/website/blog.post/']",
-        },
-    ]
-);
+    },
+    {
+        content: "Click on the 'Second Blog Post' to view its details.",
+        trigger: ":iframe article a:contains('Second Blog Post')",
+        run: "click",
+    },
+    {
+        content: "Verify that 'Add some' button has the correct URL for navigating to the backend.",
+        trigger: ":iframe #edit-in-backend[href*='/odoo/website/blog.post/']",
+    },
+]);

--- a/addons/website_blog/static/tests/tours/blog_tags_tour.js
+++ b/addons/website_blog/static/tests/tours/blog_tags_tour.js
@@ -13,7 +13,6 @@ registerWebsitePreviewTour(
     "blog_tags",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/blog",
     },
     () => [
         stepUtils.waitIframeIsReady(),

--- a/addons/website_blog/static/tests/tours/blog_tags_with_date.js
+++ b/addons/website_blog/static/tests/tours/blog_tags_with_date.js
@@ -8,7 +8,6 @@ registerWebsitePreviewTour(
     "blog_tags_with_date",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/blog",
     },
     () => [
         {

--- a/addons/website_blog/static/tests/tours/snippet_blog_post.js
+++ b/addons/website_blog/static/tests/tours/snippet_blog_post.js
@@ -9,7 +9,6 @@ import {
 registerWebsitePreviewTour(
     "snippet_blog_bost",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website_blog/tests/test_ui.py
+++ b/addons/website_blog/tests/test_ui.py
@@ -47,7 +47,7 @@ class TestWebsiteBlogUi(odoo.tests.HttpCase, TestWebsiteBlogCommon):
             'mimetype': 'image/png',
         })
 
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'blog', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'blog_tour', login='admin')
 
     def test_blog_post_tags(self):
         self.start_tour(self.env['website'].get_client_action_url('/blog'), 'blog_tags', login='admin')
@@ -134,7 +134,7 @@ class TestWebsiteBlogUi(odoo.tests.HttpCase, TestWebsiteBlogCommon):
             "email": "adam.manager@example.com",
             "group_ids": [(6, 0, [group_website_blog_manager_id, group_employee_id])],
         })
-        self.start_tour(self.env["website"].get_client_action_url("/blog"), "blog_manager", login="adam")
+        self.start_tour(self.env["website"].get_client_action_url("/blog"), "blog_manager_tour", login="adam")
         self.env["res.users"].with_context({"no_reset_password": True}).create({
             "name": "Eve Employee",
             "login": "eve",


### PR DESCRIPTION
The URL key in a tour's JavaScript file implies a redirect to that URL once the browser opens. If this URL is the same as the one used in `start_tour()` (Python), then it serves no purpose. It's even detrimental because it implies a redirect (and therefore a waste of time). The URL key in the JS file is (for now) only used for onboarding tours. This key will be defined later in the .xml file for onboarding tours.

That's why we're removing the URL keys from the registries here.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
