### PR TITLE
[REF] website_sale: remove url from js file tours

### DIFF
--- a/addons/website_sale/static/tests/tours/basic_shop_flow.js
+++ b/addons/website_sale/static/tests/tours/basic_shop_flow.js
@@ -1,8 +1,7 @@
 import { registry } from "@web/core/registry";
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
-registry.category("web_tour.tours").add('website_sale.basic_shop_flow', {
-    url: '/shop',
+registry.category("web_tour.tours").add("website_sale.basic_shop_flow", {
     steps: () => [
         ...tourUtils.searchProduct("Storage Box", { select: true }),
         ...tourUtils.addToCartFromProductPage(),
@@ -14,14 +13,13 @@ registry.category("web_tour.tours").add('website_sale.basic_shop_flow', {
             expectUnloadPage: true,
             waitFinalizeYourPayment: true,
         }),
-    ]
+    ],
 });
 
-registry.category("web_tour.tours").add('shop_repair_product', {
-    url: '/shop',
+registry.category("web_tour.tours").add("shop_repair_product", {
     steps: () => [
         ...tourUtils.searchProduct("Test Repair Service", { select: true }),
         ...tourUtils.addToCartFromProductPage(),
         tourUtils.goToCart(),
-    ]
+    ],
 });

--- a/addons/website_sale/static/tests/tours/cart_notification.js
+++ b/addons/website_sale/static/tests/tours/cart_notification.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add("website_sale.cart_notification_tax_included", {
-    url: "/shop",
     steps: () => [
         ...tourUtils.addToCart({
             productName: "website_sale_cart_notification_product_1",
@@ -26,7 +25,7 @@ registry.category("web_tour.tours").add("website_sale.cart_notification_tax_incl
         },
         {
             content: "change quantity",
-            trigger: '.js_product input[name=add_qty]',
+            trigger: ".js_product input[name=add_qty]",
             run: "edit 3",
         },
         ...tourUtils.addToCartFromProductPage(),
@@ -63,9 +62,7 @@ registry.category("web_tour.tours").add("website_sale.cart_notification_tax_incl
     ],
 });
 
-
 registry.category("web_tour.tours").add("website_sale.cart_notification_tax_excluded", {
-    url: "/shop",
     steps: () => [
         ...tourUtils.addToCart({
             productName: "website_sale_cart_notification_product_1",
@@ -89,7 +86,7 @@ registry.category("web_tour.tours").add("website_sale.cart_notification_tax_excl
         },
         {
             content: "change quantity",
-            trigger: '.js_product input[name=add_qty]',
+            trigger: ".js_product input[name=add_qty]",
             run: "edit 3",
         },
         ...tourUtils.addToCartFromProductPage(),
@@ -126,9 +123,7 @@ registry.category("web_tour.tours").add("website_sale.cart_notification_tax_excl
     ],
 });
 
-
 registry.category("web_tour.tours").add("website_sale.cart_notification_qty_and_total", {
-    url: "/shop",
     steps: () => [
         ...tourUtils.addToCart({
             productName: "website_sale_cart_notification_product_1",
@@ -149,7 +144,7 @@ registry.category("web_tour.tours").add("website_sale.cart_notification_qty_and_
         // Again add same product
         {
             content: "change quantity",
-            trigger: '.js_product input[name=add_qty]',
+            trigger: ".js_product input[name=add_qty]",
             run: "edit 3",
         },
         ...tourUtils.addToCartFromProductPage(),

--- a/addons/website_sale/static/tests/tours/cart_recovery.js
+++ b/addons/website_sale/static/tests/tours/cart_recovery.js
@@ -4,12 +4,11 @@ import { redirect } from "@web/core/utils/urls";
 import { post } from "@web/core/network/http_service";
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
-var orderIdKey = 'website_sale.tour_shop_cart_recovery.orderId';
-var recoveryLinkKey = 'website_sale.tour_shop_cart_recovery.recoveryLink';
+var orderIdKey = "website_sale.tour_shop_cart_recovery.orderId";
+var recoveryLinkKey = "website_sale.tour_shop_cart_recovery.recoveryLink";
 
-registry.category("web_tour.tours").add('website_sale.cart_recovery', {
+registry.category("web_tour.tours").add("website_sale.cart_recovery", {
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: '/shop',
     steps: () => [
         ...tourUtils.addToCart({ productName: "Acoustic Bloc Screens", expectUnloadPage: true }),
         tourUtils.goToCart(),
@@ -20,7 +19,11 @@ registry.category("web_tour.tours").add('website_sale.cart_recovery', {
                 const orderId = document.querySelector(".my_cart_quantity").dataset["orderId"];
                 browser.localStorage.setItem(orderIdKey, orderId);
 
-                const url = await post('/web/session/logout?redirect=/web/login', { csrf_token: odoo.csrf_token }, "url");
+                const url = await post(
+                    "/web/session/logout?redirect=/web/login",
+                    { csrf_token: odoo.csrf_token },
+                    "url"
+                );
                 redirect(url);
             },
             expectUnloadPage: true,
@@ -42,7 +45,7 @@ registry.category("web_tour.tours").add('website_sale.cart_recovery', {
                 const orderId = browser.localStorage.getItem(orderIdKey);
                 const url = "/odoo/action-sale.action_orders/" + orderId;
                 this.anchor.value = url;
-            }
+            },
         },
         {
             content: "login as admin and go to the SO (backend)",
@@ -52,7 +55,7 @@ registry.category("web_tour.tours").add('website_sale.cart_recovery', {
         },
         {
             content: "click action",
-            trigger: '.o_cp_action_menus .dropdown-toggle',
+            trigger: ".o_cp_action_menus .dropdown-toggle",
             run: "click",
         },
         {
@@ -71,22 +74,29 @@ registry.category("web_tour.tours").add('website_sale.cart_recovery', {
         },
         {
             content: 'Select the "Ecommerce: Cart Recovery" template from the list.',
-            trigger: '.mail-composer-template-dropdown.popover .o-dropdown-item:contains("Ecommerce: Cart Recovery")',
-            run: 'click'
+            trigger:
+                '.mail-composer-template-dropdown.popover .o-dropdown-item:contains("Ecommerce: Cart Recovery")',
+            run: "click",
         },
         {
             content: "click Send email",
-            trigger: '.btn.o_mail_send',
+            trigger: ".btn.o_mail_send",
             run: "click",
         },
         {
             content: "check the mail is sent, grab the recovery link, and logout",
             trigger: ".o-mail-Message-body a:text(Resume order)",
             async run({ queryOne }) {
-                var link = queryOne('.o-mail-Message-body a:contains("Resume order")').getAttribute('href');
+                var link = queryOne('.o-mail-Message-body a:contains("Resume order")').getAttribute(
+                    "href"
+                );
                 browser.localStorage.setItem(recoveryLinkKey, link);
 
-                const url = await post('/web/session/logout?redirect=/', { csrf_token: odoo.csrf_token }, "url");
+                const url = await post(
+                    "/web/session/logout?redirect=/",
+                    { csrf_token: odoo.csrf_token },
+                    "url"
+                );
                 redirect(url);
             },
             expectUnloadPage: true,
@@ -113,5 +123,5 @@ registry.category("web_tour.tours").add('website_sale.cart_recovery', {
             content: "check product is in restored cart",
             trigger: 'div>a>h6:contains("Acoustic Bloc Screens")',
         },
-    ]
+    ],
 });

--- a/addons/website_sale/static/tests/tours/category_page_and_products_snippet.js
+++ b/addons/website_sale/static/tests/tours/category_page_and_products_snippet.js
@@ -1,6 +1,9 @@
 import { registry } from "@web/core/registry";
-import { clickOnSave, clickOnEditAndWaitEditMode, registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
-
+import {
+    clickOnSave,
+    clickOnEditAndWaitEditMode,
+    registerWebsitePreviewTour,
+} from "@website/js/tours/tour_utils";
 
 registerWebsitePreviewTour(
     'website_sale.category_page_and_products_snippet_edition',
@@ -9,51 +12,51 @@ registerWebsitePreviewTour(
     },
     () => [
         {
-            content: "Navigate to category",
-            trigger: ':iframe .o_wsale_filmstrip > li:contains("Test Category") > a',
-            run: "click",
-        },
-        {
-            content: "Wait for page to load",
-            trigger: ":iframe h1:contains('Test Category'):not(:visible)",
-        },
-        ...clickOnEditAndWaitEditMode(),
-        {
-            trigger: ".o-website-builder_sidebar .o_snippets_container .o_snippet",
-        },
-        {
-            content: "Drag and drop the Products snippet group inside the category area.",
-            trigger: ".o_block_tab:not(.o_we_ongoing_insertion) .o_snippet[name='Catalog'] .o_snippet_thumbnail",
-            run: "drag_and_drop :iframe #category_header",
-        },
-        {
-            content: "Click on the s_dynamic_snippet_products snippet.",
-            trigger: ':iframe .o_snippet_preview_wrap[data-snippet-id="s_dynamic_snippet_products"]',
-            run: "click",
-        },
-        {
-            trigger: ".o_website_preview :iframe:not(:has(.o_loading_screen))",
-        },
-        {
-            content: "Click on the product snippet to show its options",
-            trigger: ':iframe #category_header .s_dynamic_snippet_products',
-            run: "click",
-        },
-        {
-            content: "Open category option dropdown",
-            trigger: "button[id='product_category_opt']",
-            run: "click",
-        },
-        {
-            content: "Choose the option to use the current page's category",
-            trigger: "div.o-dropdown-item:contains('Current Category or All')",
-            run: "click",
-        },
-        ...clickOnSave(),
-    ]);
+        content: "Navigate to category",
+        trigger: ':iframe .o_wsale_filmstrip > li:contains("Test Category") > a',
+        run: "click",
+    },
+    {
+        content: "Wait for page to load",
+        trigger: ":iframe h1:contains('Test Category'):not(:visible)",
+    },
+    ...clickOnEditAndWaitEditMode(),
+    {
+        trigger: ".o-website-builder_sidebar .o_snippets_container .o_snippet",
+    },
+    {
+        content: "Drag and drop the Products snippet group inside the category area.",
+        trigger:
+            ".o_block_tab:not(.o_we_ongoing_insertion) .o_snippet[name='Catalog'] .o_snippet_thumbnail",
+        run: "drag_and_drop :iframe #category_header",
+    },
+    {
+        content: "Click on the s_dynamic_snippet_products snippet.",
+        trigger: ':iframe .o_snippet_preview_wrap[data-snippet-id="s_dynamic_snippet_products"]',
+        run: "click",
+    },
+    {
+        trigger: ".o_website_preview :iframe:not(:has(.o_loading_screen))",
+    },
+    {
+        content: "Click on the product snippet to show its options",
+        trigger: ":iframe #category_header .s_dynamic_snippet_products",
+        run: "click",
+    },
+    {
+        content: "Open category option dropdown",
+        trigger: "button[id='product_category_opt']",
+        run: "click",
+    },
+    {
+        content: "Choose the option to use the current page's category",
+        trigger: "div.o-dropdown-item:contains('Current Category or All')",
+        run: "click",
+    },
+    ...clickOnSave(),
+]);
 
-registry.category("web_tour.tours").add('website_sale.category_page_and_products_snippet_use', {
-    url: '/shop',
+registry.category("web_tour.tours").add("website_sale.category_page_and_products_snippet_use", {
     steps: () => [
         {
             content: "Navigate to category",
@@ -64,24 +67,33 @@ registry.category("web_tour.tours").add('website_sale.category_page_and_products
         {
             content: "Check that the snippet displays the right products",
             // Wait for at least one shown product
-            trigger: '#category_header .s_dynamic_snippet_products:has(.oe_product_image_link)',
+            trigger: "#category_header .s_dynamic_snippet_products:has(.oe_product_image_link)",
             run() {
                 // Fetch the category's id from the url.
-                const productCategoryId = window.location.href.match('/shop/category/test-category-(\\d+)')[1];
-                const productGridEl = document.getElementById('o_wsale_products_grid');
-                const regex = new RegExp(`^/shop/test-category-${productCategoryId}/[\\w-/]+-(\\d+)$`);
-                const allPageProductIDs = [...productGridEl.querySelectorAll('.oe_product_image_link')]
-                    .map(el => el.getAttribute('href').match(regex)[1]);
+                const productCategoryId = window.location.href.match(
+                    "/shop/category/test-category-(\\d+)"
+                )[1];
+                const productGridEl = document.getElementById("o_wsale_products_grid");
+                const regex = new RegExp(
+                    `^/shop/test-category-${productCategoryId}/[\\w-/]+-(\\d+)$`
+                );
+                const allPageProductIDs = [
+                    ...productGridEl.querySelectorAll(".oe_product_image_link"),
+                ].map((el) => el.getAttribute("href").match(regex)[1]);
 
-                const $shownProductLinks = this.anchor.querySelectorAll(".s_dynamic_snippet_products .oe_product_image_link");
+                const $shownProductLinks = this.anchor.querySelectorAll(
+                    ".s_dynamic_snippet_products .oe_product_image_link"
+                );
                 const regex2 = new RegExp(`^/shop/[\\w-/]+-(\\d+)(?:#attribute_values=\\d*)?$`);
                 for (const shownProductLinkEl of $shownProductLinks) {
-                    const productID = shownProductLinkEl.getAttribute('href').match(regex2)[1];
+                    const productID = shownProductLinkEl.getAttribute("href").match(regex2)[1];
                     if (!allPageProductIDs.includes(productID)) {
-                        console.error(`The snippet displays a product (${productID}) which does not belong to the current category (${allPageProductIDs})`);
+                        console.error(
+                            `The snippet displays a product (${productID}) which does not belong to the current category (${allPageProductIDs})`
+                        );
                     }
                 }
             },
         },
-    ]
+    ],
 });

--- a/addons/website_sale/static/tests/tours/compare_list_price_pricelist.js
+++ b/addons/website_sale/static/tests/tours/compare_list_price_pricelist.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import * as tourUtils from '@website_sale/js/tours/tour_utils';
 
 registry.category("web_tour.tours").add('website_sale.compare_list_price_price_list_display', {
-        url: '/shop?search=test_product',
         steps: () => [
         tourUtils.assertProductPrice("price_reduce", "1,000", "test_product_default"),
         tourUtils.assertProductPrice("price_reduce", "2,000", "test_product_with_compare_list_price"),

--- a/addons/website_sale/static/tests/tours/complete_flow.js
+++ b/addons/website_sale/static/tests/tours/complete_flow.js
@@ -5,7 +5,6 @@ import { post } from "@web/core/network/http_service";
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('website_sale.complete_flow_1', {
-    url: '/shop?search=Storage Box Test',
     steps: () => [
         // Testing b2c with Tax-Excluded Prices
         {
@@ -315,7 +314,6 @@ registry.category("web_tour.tours").add('website_sale.complete_flow_1', {
 });
 
 registry.category("web_tour.tours").add('website_sale.complete_flow_2', {
-    url: '/shop/cart',
     steps: () => [
         {
             trigger: '.o_wizard:contains("Extra Info")',

--- a/addons/website_sale/static/tests/tours/deleted_archived_variants.js
+++ b/addons/website_sale/static/tests/tours/deleted_archived_variants.js
@@ -1,8 +1,7 @@
 import { registry } from "@web/core/registry";
 
 // This tour relies on a data created from the python test.
-registry.category("web_tour.tours").add('website_sale.deleted_archived_variants', {
-    url: '/shop?search=Test Product 2',
+registry.category("web_tour.tours").add("website_sale.deleted_archived_variants", {
     steps: () => [
         {
             content: "check price on /shop (template price)",
@@ -43,6 +42,6 @@ registry.category("web_tour.tours").add('website_sale.deleted_archived_variants'
         {
             content: "check add to cart not possible",
             trigger: '.js_product button[name="add_to_cart"]:disabled',
-        }
-    ]
+        },
+    ],
 });

--- a/addons/website_sale/static/tests/tours/google_analytics.js
+++ b/addons/website_sale/static/tests/tours/google_analytics.js
@@ -32,7 +32,6 @@ let itemId;
 
 
 registry.category("web_tour.tours").add('website_sale.google_analytics_view_item', {
-    url: '/shop?search=Colored T-Shirt',
     steps: () => [
         {
             content: "select Colored T-Shirt",
@@ -64,7 +63,6 @@ registry.category("web_tour.tours").add('website_sale.google_analytics_view_item
 });
 
 registry.category("web_tour.tours").add('website_sale.google_analytics_add_to_cart', {
-    url: '/shop?search=Basic Shirt',
     steps: () => [
         ...tourUtils.addToCart({ productName: 'Basic Shirt', search: false, expectUnloadPage: true }),
         {

--- a/addons/website_sale/static/tests/tours/pricelist_tour.js
+++ b/addons/website_sale/static/tests/tours/pricelist_tour.js
@@ -1,30 +1,26 @@
 import { registry } from "@web/core/registry";
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
-registry.category("web_tour.tours").add(
-    "website_sale.pricelist_on_login",
-    {
-        url: '/shop',
-        steps: () => [
-            {
-                content: "Check pricelist",
-                trigger: ".o_pricelist_dropdown .dropdown-toggle:not(:contains('User Pricelist'))",
-            },
-            {
-                content: "Go to login page",
-                trigger: "a:contains('Sign in')",
-                run: "click",
-                expectUnloadPage: true,
-            },
-            ...tourUtils.login({
-                login: 'toto',
-                password: 'long_enough_password',
-                redirectUrl: '/shop',
-            }),
-            {
-                content: "Check pricelist",
-                trigger: ".o_pricelist_dropdown .dropdown-toggle:contains('User Pricelist')",
-            },
-        ]
-    }
-);
+registry.category("web_tour.tours").add("website_sale.pricelist_on_login", {
+    steps: () => [
+        {
+            content: "Check pricelist",
+            trigger: ".o_pricelist_dropdown .dropdown-toggle:not(:contains('User Pricelist'))",
+        },
+        {
+            content: "Go to login page",
+            trigger: "a:contains('Sign in')",
+            run: "click",
+            expectUnloadPage: true,
+        },
+        ...tourUtils.login({
+            login: "toto",
+            password: "long_enough_password",
+            redirectUrl: "/shop",
+        }),
+        {
+            content: "Check pricelist",
+            trigger: ".o_pricelist_dropdown .dropdown-toggle:contains('User Pricelist')",
+        },
+    ],
+});

--- a/addons/website_sale/static/tests/tours/product_page_zoom.js
+++ b/addons/website_sale/static/tests/tours/product_page_zoom.js
@@ -1,16 +1,14 @@
 import { registry } from "@web/core/registry";
 
 var imageSelector = '#o-carousel-product .carousel-item.active img';
-var imageName = "A Colorful Image";
 var nameGreen = "Forest Green";
 
 // This tour relies on a data created from the python test.
 registry.category("web_tour.tours").add('website_sale.product_page_zoom', {
-    url: '/shop?debug=1&search=' + imageName,
     steps: () => [
         {
-            content: "select " + imageName,
-            trigger: `.oe_product_cart a:text(${imageName})`,
+            content: "select A Colorful Image",
+            trigger: `.oe_product_cart a:text(A Colorful Image)`,
             run: "click",
             expectUnloadPage: true,
         },

--- a/addons/website_sale/static/tests/tours/reorder_from_portal.js
+++ b/addons/website_sale/static/tests/tours/reorder_from_portal.js
@@ -1,27 +1,26 @@
 import { registry } from "@web/core/registry";
-import { assertCartContains } from '@website_sale/js/tours/tour_utils';
+import { assertCartContains } from "@website_sale/js/tours/tour_utils";
 
-registry.category("web_tour.tours").add('website_sale.reorder_from_portal', {
-    url: '/my/orders',
+registry.category("web_tour.tours").add("website_sale.reorder_from_portal", {
     steps: () => [
         {
-            content: 'Select first order',
-            trigger: '.o_portal_my_doc_table a:first',
+            content: "Select first order",
+            trigger: ".o_portal_my_doc_table a:first",
             run: "click",
             expectUnloadPage: true,
         },
         {
-            content: 'Reorder Again',
-            trigger: '.o_wsale_reorder_button',
+            content: "Reorder Again",
+            trigger: ".o_wsale_reorder_button",
             run: "click",
             expectUnloadPage: true,
         },
-        ...assertCartContains({ productName: 'Reorder Product 1' }),
-        ...assertCartContains({ productName: 'Reorder Product 2' }),
+        ...assertCartContains({ productName: "Reorder Product 1" }),
+        ...assertCartContains({ productName: "Reorder Product 2" }),
         {
             content: "Check that quantity is 1",
             trigger: ".js_quantity[value='1']",
             run: "edit Test",
         },
-    ]
+    ],
 });

--- a/addons/website_sale/static/tests/tours/update_address.js
+++ b/addons/website_sale/static/tests/tours/update_address.js
@@ -1,8 +1,7 @@
 import { registry } from "@web/core/registry";
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
-registry.category("web_tour.tours").add('website_sale.update_billing_shipping_address', {
-    url: '/shop',
+registry.category("web_tour.tours").add("website_sale.update_billing_shipping_address", {
     steps: () => [
         ...tourUtils.addToCart({ productName: "Office Chair Black TEST", expectUnloadPage: true }),
         tourUtils.goToCart(),
@@ -16,7 +15,7 @@ registry.category("web_tour.tours").add('website_sale.update_billing_shipping_ad
         },
         {
             content: "Edit  billing address which is shipping address too",
-            trigger: 'a.js_edit_address',
+            trigger: "a.js_edit_address",
             run: "click",
             expectUnloadPage: true,
         },
@@ -32,7 +31,7 @@ registry.category("web_tour.tours").add('website_sale.update_billing_shipping_ad
         },
         {
             content: "Check there is a warning for required field.",
-            trigger: ':invalid',
+            trigger: ":invalid",
         },
     ],
 });

--- a/addons/website_sale/static/tests/tours/update_cart.js
+++ b/addons/website_sale/static/tests/tours/update_cart.js
@@ -1,8 +1,7 @@
-import { registry } from '@web/core/registry';
-import * as tourUtils from '@website_sale/js/tours/tour_utils';
+import { registry } from "@web/core/registry";
+import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
-registry.category('web_tour.tours').add('website_sale.update_cart', {
-    url: '/shop',
+registry.category("web_tour.tours").add("website_sale.update_cart", {
     steps: () => [
         ...tourUtils.searchProduct("conference chair", { select: true }),
         {
@@ -10,7 +9,7 @@ registry.category('web_tour.tours').add('website_sale.update_cart', {
         },
         {
             content: "select Conference Chair Aluminium",
-            trigger: 'label:contains(Aluminium) input',
+            trigger: "label:contains(Aluminium) input",
             run: "click",
         },
         {
@@ -18,7 +17,7 @@ registry.category('web_tour.tours').add('website_sale.update_cart', {
         },
         {
             content: "select Conference Chair Steel",
-            trigger: 'label:contains(Steel) input',
+            trigger: "label:contains(Steel) input",
             run: "click",
         },
         {
@@ -31,7 +30,10 @@ registry.category('web_tour.tours').add('website_sale.update_cart', {
             run: "click",
             expectUnloadPage: true,
         },
-        ...tourUtils.assertCartContains({ productName: 'Conference Chair', combinationName: 'Steel' }),
+        ...tourUtils.assertCartContains({
+            productName: "Conference Chair",
+            combinationName: "Steel",
+        }),
         {
             content: "add suggested",
             trigger: '.js_cart_lines:has(a:contains("Storage Box")) button:contains("Add to cart")',
@@ -43,23 +45,27 @@ registry.category('web_tour.tours').add('website_sale.update_cart', {
         },
         {
             content: "remove Storage Box",
-            trigger: '#cart_products div:has(a[name="o_cart_line_product_link"]>h6:contains("Storage Box")) a:has(i.oi-minus)',
+            trigger:
+                '#cart_products div:has(a[name="o_cart_line_product_link"]>h6:contains("Storage Box")) a:has(i.oi-minus)',
             run: "click",
         },
         {
-            trigger: '#wrap:not(:has(#cart_products a[name="o_cart_line_product_link"]>h6:contains("Storage Box")))',
+            trigger:
+                '#wrap:not(:has(#cart_products a[name="o_cart_line_product_link"]>h6:contains("Storage Box")))',
         },
         {
             content: "add one more",
-            trigger: '#cart_products div:has(a[name="o_cart_line_product_link"]>h6:contains("Conference Chair")) a:has(i.oi-plus)',
+            trigger:
+                '#cart_products div:has(a[name="o_cart_line_product_link"]>h6:contains("Conference Chair")) a:has(i.oi-plus)',
             run: "click",
         },
         {
-            trigger: '#cart_products div:has(div>a>h6:contains("Conference Chair")) input.js_quantity:value(2)',
+            trigger:
+                '#cart_products div:has(div>a>h6:contains("Conference Chair")) input.js_quantity:value(2)',
         },
         {
             content: "set one",
-            trigger: '#cart_products input.js_quantity',
+            trigger: "#cart_products input.js_quantity",
             run: "edit 1",
         },
     ],

--- a/addons/website_sale/static/tests/tours/website_sale_comparison.js
+++ b/addons/website_sale/static/tests/tours/website_sale_comparison.js
@@ -4,7 +4,6 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('website_sale.product_comparison', {
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: "/shop",
     steps: () => [
         // test from shop page
         {

--- a/addons/website_sale/static/tests/tours/website_sale_shop_filters.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_filters.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("shop_attribute_filters_remain_when_changing_page", {
-    url: "/shop",
     steps: () => [
         {
             content: "Select first attribute value",

--- a/addons/website_sale/static/tests/tours/website_sale_wishlist.js
+++ b/addons/website_sale/static/tests/tours/website_sale_wishlist.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import * as tourUtils from "@website_sale/js/tours/wishlist_tour_utils";
 
 registry.category("web_tour.tours").add('website_sale.wishlist_updates', {
-    url: '/shop?search=Customizable Desk',
     steps: () => [
         ...tourUtils.addToWishlistFromShopPage(),
         tourUtils.goToWishlist({ quantity: 1 }),
@@ -169,7 +168,6 @@ registry.category("web_tour.tours").add('website_sale.wishlist_updates', {
 
 
 registry.category("web_tour.tours").add('website_sale.dynamic_variants_wishlist', {
-    url: '/shop?search=Bottle',
     steps: () => [
         {
             trigger: '.oe_product_cart:contains("Bottle")',
@@ -219,7 +217,6 @@ registry.category("web_tour.tours").add('website_sale.dynamic_variants_wishlist'
 });
 
 registry.category("web_tour.tours").add('website_sale.archived_variant', {
-    url: '/shop?search=Bottle',
     steps: () => [
         {
             trigger: ".o_wsale_products_page",

--- a/addons/website_sale/tests/test_cart_notification.py
+++ b/addons/website_sale/tests/test_cart_notification.py
@@ -38,16 +38,16 @@ class TestWebsiteSaleCartNotification(HttpCase, ProductVariantsCommon):
     def test_website_sale_cart_notification_tax_included(self):
         self.env.ref('website_sale.product_search').active = True
         self.website.show_line_subtotals_tax_selection = 'tax_included'
-        self.start_tour("/", 'website_sale.cart_notification_tax_included')
+        self.start_tour("/shop", 'website_sale.cart_notification_tax_included')
 
     def test_website_sale_cart_notification_tax_excluded(self):
         self.env.ref('website_sale.product_search').active = True
         self.website.show_line_subtotals_tax_selection = 'tax_excluded'
-        self.start_tour("/", 'website_sale.cart_notification_tax_excluded')
+        self.start_tour("/shop", 'website_sale.cart_notification_tax_excluded')
 
     def test_website_sale_cart_notification_qty_and_total(self):
         """Check that adding product into cart which is already in the cart only display newly
         added qty count and total.
         """
         self.env.ref('website_sale.product_search').active = True
-        self.start_tour('/', 'website_sale.cart_notification_qty_and_total')
+        self.start_tour('/shop', 'website_sale.cart_notification_qty_and_total')

--- a/addons/website_sale/tests/test_cart_recovery.py
+++ b/addons/website_sale/tests/test_cart_recovery.py
@@ -19,7 +19,7 @@ class TestWebsiteSaleCartRecovery(HttpCaseWithUserPortal):
             'website_published': True,
         })
 
-        self.start_tour('/', 'website_sale.cart_recovery', login='portal')
+        self.start_tour('/shop', 'website_sale.cart_recovery', login='portal')
 
 
 @tagged('post_install', '-at_install')

--- a/addons/website_sale/tests/test_customize.py
+++ b/addons/website_sale/tests/test_customize.py
@@ -188,7 +188,7 @@ class TestCustomize(HttpCaseWithUserDemo, HttpCaseWithUserPortal, TestProductCon
         # delete second combination (which is now first variant since cache has been cleared)
         product_template.product_variant_ids[0].unlink()
 
-        self.start_tour('/', 'website_sale.deleted_archived_variants', login='portal')
+        self.start_tour('/shop?search=Test Product 2', 'website_sale.deleted_archived_variants', login='portal')
 
     def test_05_demo_tour_no_variant_attribute(self):
         """The goal of this test is to make sure attributes no_variant are
@@ -240,7 +240,7 @@ class TestCustomize(HttpCaseWithUserDemo, HttpCaseWithUserPortal, TestProductCon
             {'name': 'Base Pricelist', 'selectable': True},
             {'name': 'Other Pricelist', 'selectable': True}
         ])
-        self.start_tour('/', 'website_sale.shop_editor', login='website_user')
+        self.start_tour('/shop', 'website_sale.shop_editor', login='website_user')
 
     def test_08_portal_tour_archived_variant_multiple_attributes(self):
         """The goal of this test is to make sure that an archived variant with multiple
@@ -392,7 +392,7 @@ class TestCustomize(HttpCaseWithUserDemo, HttpCaseWithUserPortal, TestProductCon
         )
 
     def test_11_shop_editor_set_product_ribbon(self):
-        self.start_tour('/', 'website_sale.shop_editor_set_product_ribbon', login='admin')
+        self.start_tour('/shop', 'website_sale.shop_editor_set_product_ribbon', login='admin')
 
     def test_12_multi_checkbox_attribute_single_value(self):
         attribute = self.env['product.attribute'].create([
@@ -433,4 +433,4 @@ class TestCustomize(HttpCaseWithUserDemo, HttpCaseWithUserPortal, TestProductCon
         })
         product_no_alternative.set_sequence_top()
         product_with_alternative.set_sequence_top()
-        self.start_tour('/', 'shop_editor_no_alternative_products_visibility_tour', login="admin")
+        self.start_tour('/shop', 'shop_editor_no_alternative_products_visibility_tour', login="admin")

--- a/addons/website_sale/tests/test_product_image.py
+++ b/addons/website_sale/tests/test_product_image.py
@@ -208,7 +208,7 @@ class TestWebsiteSaleImage(HttpCaseWithWebsiteUser):
         # This ensures that tours with triggers on the amounts will run properly.
         self.env['product.pricelist'].search([]).action_archive()
 
-        self.start_tour('/', 'website_sale.product_page_zoom', login='website_user')
+        self.start_tour('/shop?debug=1&search=A Colorful Image', 'website_sale.product_page_zoom', login='website_user')
 
         # CASE: unlink move image to fallback if fallback image empty
         template.image_1920 = False
@@ -376,7 +376,7 @@ class TestWebsiteSaleRemoveImage(HttpCase):
         })
 
         self.start_tour(
-            self.env['website'].get_client_action_url('/'),
+            self.env['website'].get_client_action_url('/shop?search=Test Remove Image'),
             'website_sale.add_and_remove_main_product_image_no_variant',
             login='admin',
         )
@@ -394,7 +394,7 @@ class TestWebsiteSaleRemoveImage(HttpCase):
             'product_tmpl_id': self.template.id,
         })
         self.start_tour(
-            self.env['website'].get_client_action_url('/'),
+            self.env['website'].get_client_action_url('/shop?search=Test Remove Image'),
             'website_sale.remove_main_product_image_with_variant',
             login='admin',
         )

--- a/addons/website_sale/tests/test_reorder_from_portal.py
+++ b/addons/website_sale/tests/test_reorder_from_portal.py
@@ -83,7 +83,7 @@ class TestWebsiteSaleReorderFromPortal(HttpCaseWithUserPortal):
         order.action_confirm()
         order.message_subscribe(user_admin.partner_id.ids)
 
-        self.start_tour("/", 'website_sale.reorder_from_portal', login='admin')
+        self.start_tour("/my/orders", 'website_sale.reorder_from_portal', login='admin')
 
         reorder_cart = self.env['sale.order'].search([('website_id', '!=', False)], limit=1)
         previous_lines = order.order_line

--- a/addons/website_sale/tests/test_sale_process.py
+++ b/addons/website_sale/tests/test_sale_process.py
@@ -87,20 +87,20 @@ class TestSaleProcess(HttpCaseWithUserDemo, WebsiteSaleCommon, HttpCaseWithWebsi
         )
 
     def test_01_cart_update_check(self):
-        self.start_tour('/', 'website_sale.update_cart', login='admin')
+        self.start_tour('/shop', 'website_sale.update_cart', login='admin')
 
     def test_02_admin_checkout(self):
         if self.env['ir.module.module']._get('payment_custom').state != 'installed':
             self.skipTest("Transfer provider is not installed")
 
-        self.start_tour('/', 'website_sale.basic_shop_flow', login='admin')
+        self.start_tour('/shop', 'website_sale.basic_shop_flow', login='admin')
 
     def test_03_demo_checkout(self):
         self.partner_demo.write(self.dummy_partner_address_values)
         if self.env['ir.module.module']._get('payment_custom').state != 'installed':
             self.skipTest("Transfer provider is not installed")
 
-        self.start_tour('/', 'website_sale.basic_shop_flow', login='demo')
+        self.start_tour('/shop', 'website_sale.basic_shop_flow', login='demo')
 
     def test_04_admin_website_sale_tour(self):
         if self.env['ir.module.module']._get('payment_custom').state != 'installed':
@@ -128,13 +128,13 @@ class TestSaleProcess(HttpCaseWithUserDemo, WebsiteSaleCommon, HttpCaseWithWebsi
             'show_line_subtotals_tax_selection': 'tax_excluded',
         }).execute()
 
-        self.start_tour('/', 'website_sale.complete_flow_1')
+        self.start_tour('/shop?search=Storage Box Test', 'website_sale.complete_flow_1')
         self.start_tour(
             self.env['website'].get_client_action_url('/shop/cart'),
             'website_sale.enable_extra_info',
             login='admin'
         )
-        self.start_tour('/', 'website_sale.complete_flow_2', login='admin')
+        self.start_tour('/shop/cart', 'website_sale.complete_flow_2', login='admin')
 
     def test_05_google_analytics_tracking(self):
         # Data for google_analytics_view_item
@@ -165,7 +165,7 @@ class TestSaleProcess(HttpCaseWithUserDemo, WebsiteSaleCommon, HttpCaseWithWebsi
             ]
         })
         self.env['website'].browse(1).write({'google_analytics_key': 'G-XXXXXXXXXXX'})
-        self.start_tour('/shop', 'website_sale.google_analytics_view_item')
+        self.start_tour('/shop?search=Colored T-Shirt', 'website_sale.google_analytics_view_item')
         # Data for google_analytics_add_to_cart
         self.env['product.template'].create({
             'name': 'Basic Shirt',
@@ -173,7 +173,7 @@ class TestSaleProcess(HttpCaseWithUserDemo, WebsiteSaleCommon, HttpCaseWithWebsi
             'type': 'consu',
             'website_published': True
         })
-        self.start_tour('/shop', 'website_sale.google_analytics_add_to_cart')
+        self.start_tour('/shop?search=Basic Shirt', 'website_sale.google_analytics_add_to_cart')
 
     def test_06_public_user_shop_repair(self):
         """ Public user purchasing repair service products in website shop. """
@@ -187,7 +187,7 @@ class TestSaleProcess(HttpCaseWithUserDemo, WebsiteSaleCommon, HttpCaseWithWebsi
             'sale_ok': True,
             'is_published': True,
         })
-        self.start_tour("/", 'shop_repair_product', login=None)
+        self.start_tour("/shop", 'shop_repair_product', login=None)
 
     def test_checkout_with_rewrite(self):
         # check that checkout page can be open with step rewritten

--- a/addons/website_sale/tests/test_show_compare_list_price.py
+++ b/addons/website_sale/tests/test_show_compare_list_price.py
@@ -108,7 +108,7 @@ class WebsiteSaleShopPriceListCompareListPriceDispayTests(AccountTestInvoicingHt
             'group_product_price_comparison': True,
         }).execute()
         self.start_tour(
-            '/',
+            '/shop?search=test_product',
             'website_sale.compare_list_price_price_list_display',
             login=self.env.user.login,
         )

--- a/addons/website_sale/tests/test_website_sale_comparison.py
+++ b/addons/website_sale/tests/test_website_sale_comparison.py
@@ -119,7 +119,7 @@ class TestWebsiteSaleComparisonUi(HttpCase):
                 })
             ]
         }])
-        self.start_tour("/", 'website_sale.product_comparison', login='admin')
+        self.start_tour("/shop", 'website_sale.product_comparison', login='admin')
 
     def test_02_attribute_multiple_lines(self):
         # Case product page with "Product attributes table" disabled (website_sale standard case)

--- a/addons/website_sale/tests/test_wishlist_ui.py
+++ b/addons/website_sale/tests/test_wishlist_ui.py
@@ -61,7 +61,7 @@ class TestWishlistProcess(HttpCase):
 
         self.env.ref('base.user_admin').name = 'Mitchell Admin'
 
-        self.start_tour('/', 'website_sale.wishlist_updates', timeout=120)
+        self.start_tour('/shop?search=Customizable Desk', 'website_sale.wishlist_updates', timeout=120)
 
     def test_wishlist_dynamic_attributes(self):
 
@@ -85,9 +85,9 @@ class TestWishlistProcess(HttpCase):
             ],
             'website_published': True,
         })
-        self.start_tour("/", 'website_sale.dynamic_variants_wishlist')
+        self.start_tour("/shop?search=Bottle", 'website_sale.dynamic_variants_wishlist')
         bottle.product_variant_ids[:1].action_archive()
-        self.start_tour("/", 'website_sale.archived_variant')
+        self.start_tour("/shop?search=Bottle", 'website_sale.archived_variant')
         bottle.product_variant_ids.action_archive()
         # Republish the template after archiving all variants so the product
         # page stays reachable.


### PR DESCRIPTION
The URL key in a tour's JavaScript file implies a redirect to that URL once the browser opens. If this URL is the same as the one used in `start_tour()` (Python), then it serves no purpose. It's even detrimental because it implies a redirect (and therefore a waste of time). The URL key in the JS file is (for now) only used for onboarding tours. This key will be defined later in the .xml file for onboarding tours.

That's why we're removing the URL keys from the registries here.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
