### PR TITLE
[FIX] web: accomodate one extra address line report bubble

### DIFF
--- a/addons/web/static/src/webclient/actions/reports/report.scss
+++ b/addons/web/static/src/webclient/actions/reports/report.scss
@@ -122,6 +122,12 @@ li.oe-nested {
     }
 }
 
+.o_shape_bubble_1 ~ table .o_company_logo {
+    margin-bottom: map-get($spacers, 1) !important;
+    max-height: 3rem;
+    max-width: 9rem;
+}
+
 .o_company_tagline p {
     margin-bottom: 0;
 }


### PR DESCRIPTION
The bubble layout was changed in commit[1] but the logo size is too big to accomodate a sufficient amount of address lines.

task-5951770
[1]: odoo/odoo@8eb61a245cd3b650e309fdb55d24654c34d785cd

Enterprise PR: https://github.com/odoo/enterprise/pull/110858

| Before | After |
|--------|--------|
| <img width="566" height="182" alt="image" src="https://github.com/user-attachments/assets/bb2671c3-62c8-45df-8039-4a9455d21982" /> | <img width="566" height="182" alt="image" src="https://github.com/user-attachments/assets/d36ca5fe-24b3-4a74-8323-2c587d11495e" />|
| <img width="566" height="182" alt="image" src="https://github.com/user-attachments/assets/2b1c7ce9-2d14-47ab-9fc0-b4bca33e412f" /> | <img width="566" height="182" alt="image" src="https://github.com/user-attachments/assets/df189280-b274-4dea-9ec1-9482c47b00e5" /> |  


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
