### PR TITLE
[REF] website: remove url from js file tours

### DIFF
--- a/addons/portal/static/tests/tours/skip_to_content.js
+++ b/addons/portal/static/tests/tours/skip_to_content.js
@@ -1,12 +1,12 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("skip_to_content", {
-    url: "/",
     steps: () => [
         {
-            content: "Make sure that Skip to Content button is on top of all the links present in header",
+            content:
+                "Make sure that Skip to Content button is on top of all the links present in header",
             trigger: "a:first-child[class~='o_skip_to_content']",
-            run: "click"
+            run: "click",
         },
         {
             content: "Check if we have been redirected to #wrap",
@@ -15,7 +15,7 @@ registry.category("web_tour.tours").add("skip_to_content", {
                 if (!window.location.href.endsWith("#wrap")) {
                     console.error("We should be on #wrap.");
                 }
-            }
-        }
-    ]
+            },
+        },
+    ],
 });

--- a/addons/test_website/static/tests/tours/custom_snippets.js
+++ b/addons/test_website/static/tests/tours/custom_snippets.js
@@ -22,7 +22,6 @@ import { insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tou
 registerWebsitePreviewTour(
     "test_custom_snippet",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/test_website/static/tests/tours/form.js
+++ b/addons/test_website/static/tests/tours/form.js
@@ -8,7 +8,6 @@ import {
 registerWebsitePreviewTour(
     "test_form_conditional_visibility_record_field",
     {
-        url: "/test_website/model_item/1",
         edition: true,
     },
     () => [

--- a/addons/test_website/static/tests/tours/image_link.js
+++ b/addons/test_website/static/tests/tours/image_link.js
@@ -30,7 +30,6 @@ const selectImageSteps = [
 registerWebsitePreviewTour(
     "test_image_link",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/test_website/static/tests/tours/image_upload_progress.js
+++ b/addons/test_website/static/tests/tours/image_upload_progress.js
@@ -86,7 +86,6 @@ registerWebsitePreviewTour(
     "test_image_upload_progress",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/test_image_progress",
         edition: true,
     },
     () => [
@@ -231,7 +230,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "test_image_upload_progress_unsplash",
     {
-        url: "/test_image_progress",
         edition: true,
     },
     () => [

--- a/addons/test_website/static/tests/tours/replace_media.js
+++ b/addons/test_website/static/tests/tours/replace_media.js
@@ -15,7 +15,6 @@ registerWebsitePreviewTour(
     "test_replace_media",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/test_website/static/tests/tours/reset_views.js
+++ b/addons/test_website/static/tests/tours/reset_views.js
@@ -13,7 +13,6 @@ var BROKEN_STEP = {
 registerWebsitePreviewTour(
     "test_reset_page_view_complete_flow_part1",
     {
-        url: "/test_page_view",
         // 1. Edit the page through Edit Mode, it will COW the view
         edition: true,
     },
@@ -63,55 +62,49 @@ registerWebsitePreviewTour(
     ]
 );
 
-registerWebsitePreviewTour(
-    "test_reset_page_view_complete_flow_part2",
+registerWebsitePreviewTour("test_reset_page_view_complete_flow_part2", {}, () => [
     {
-        url: "/test_page_view",
+        content: "check that the view got fixed",
+        trigger: ":iframe p:text(Test Page View)",
     },
-    () => [
-        {
-            content: "check that the view got fixed",
-            trigger: ":iframe p:text(Test Page View)",
+    {
+        content: "check that the inherited COW view is still there (created during edit mode)",
+        trigger: ":iframe #oe_structure_test_website_page .s_cover",
+    },
+    //4. Now break the inherited view created when dropping a snippet
+    {
+        content: "open site menu",
+        trigger: 'button[data-menu-xmlid="website.menu_site"]',
+        run: "click",
+    },
+    {
+        content: "open html editor",
+        trigger: 'a[data-menu-xmlid="website.menu_ace_editor"]',
+        run: "click",
+    },
+    {
+        content: "select oe_structure view",
+        trigger: ".o_resource_editor_title .o_select_menu_toggler",
+        run: "click",
+    },
+    {
+        content: "select oe_structure view",
+        trigger: ".o_select_menu_menu .o_select_menu_item:contains(Test Page View)",
+        run: "click",
+    },
+    {
+        content: "add a broken t-field in page DOM",
+        trigger: 'div.ace_line .ace_xml:contains("oe_structure_test_website_page")',
+        run() {
+            ace.edit(document.querySelector("#resource-editor div"))
+                .getSession()
+                .insert({ row: 4, column: 1 }, '<t t-field="not.exist"/>\n');
         },
-        {
-            content: "check that the inherited COW view is still there (created during edit mode)",
-            trigger: ":iframe #oe_structure_test_website_page .s_cover",
-        },
-        //4. Now break the inherited view created when dropping a snippet
-        {
-            content: "open site menu",
-            trigger: 'button[data-menu-xmlid="website.menu_site"]',
-            run: "click",
-        },
-        {
-            content: "open html editor",
-            trigger: 'a[data-menu-xmlid="website.menu_ace_editor"]',
-            run: "click",
-        },
-        {
-            content: "select oe_structure view",
-            trigger: ".o_resource_editor_title .o_select_menu_toggler",
-            run: "click",
-        },
-        {
-            content: "select oe_structure view",
-            trigger: ".o_select_menu_menu .o_select_menu_item:contains(Test Page View)",
-            run: "click",
-        },
-        {
-            content: "add a broken t-field in page DOM",
-            trigger: 'div.ace_line .ace_xml:contains("oe_structure_test_website_page")',
-            run() {
-                ace.edit(document.querySelector("#resource-editor div"))
-                    .getSession()
-                    .insert({ row: 4, column: 1 }, '<t t-field="not.exist"/>\n');
-            },
-        },
-        {
-            content: "save the html editor",
-            trigger: ".o_resource_editor button:contains(Save)",
-            run: "click",
-        },
-        BROKEN_STEP,
-    ]
-);
+    },
+    {
+        content: "save the html editor",
+        trigger: ".o_resource_editor button:contains(Save)",
+        run: "click",
+    },
+    BROKEN_STEP,
+]);

--- a/addons/test_website/static/tests/tours/restricted_editor.js
+++ b/addons/test_website/static/tests/tours/restricted_editor.js
@@ -70,7 +70,6 @@ registerWebsitePreviewTour(
     "test_restricted_editor_only",
     {
         undeterministicTour_doNotCopy: true,
-        url: "/",
     },
     () => [
         // Home
@@ -123,7 +122,6 @@ registerWebsitePreviewTour(
         // Remove this key to make the tour fail with error:
         // "Element has not been found." at step "Open Edit menu"
         undeterministicTour_doNotCopy: true,
-        url: "/",
     },
     () => [
         // Home
@@ -183,17 +181,11 @@ registerWebsitePreviewTour(
     ]
 );
 
-registerWebsitePreviewTour(
-    "test_restricted_editor_tester",
+registerWebsitePreviewTour("test_restricted_editor_tester", {}, () => [
+    ...clickOnEditAndWaitEditMode(),
     {
-        url: "/test_model/1",
+        content: "Footer should not be be editable for restricted user",
+        trigger: ":iframe :has(.o_savable) footer:not(.o_savable):not(:has(.o_savable))",
     },
-    () => [
-        ...clickOnEditAndWaitEditMode(),
-        {
-            content: "Footer should not be be editable for restricted user",
-            trigger: ":iframe :has(.o_savable) footer:not(.o_savable):not(:has(.o_savable))",
-        },
-        ...clickOnSave(),
-    ]
-);
+    ...clickOnSave(),
+]);

--- a/addons/test_website/static/tests/tours/snippet_background_video.js
+++ b/addons/test_website/static/tests/tours/snippet_background_video.js
@@ -7,7 +7,6 @@ import { insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tou
 registerWebsitePreviewTour(
     "snippet_background_video",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/test_website/static/tests/tours/systray.js
+++ b/addons/test_website/static/tests/tours/systray.js
@@ -2,7 +2,7 @@
 import {
     clickOnEditAndWaitEditMode,
     clickOnSave,
-    registerWebsitePreviewTour,
+    registerWebsitePreviewTourLegacy,
 } from "@website/js/tours/tour_utils";
 import { stepUtils } from "@web_tour/tour_utils";
 
@@ -209,7 +209,7 @@ const ensureWebsiteSwitcherIsVisible = [
 ];
 
 const register = (title, steps, undeterministicTour_doNotCopy) => {
-    registerWebsitePreviewTour(
+    registerWebsitePreviewTourLegacy(
         title,
         {
             url: "/test_model/1",

--- a/addons/test_website/static/tests/tours/translation.js
+++ b/addons/test_website/static/tests/tours/translation.js
@@ -188,29 +188,23 @@ const ensureEnSite = {
     trigger: ":iframe .o_main_nav:contains(Home)",
 };
 
-registerWebsitePreviewTour(
-    "translation_single_language_fr_user_fr_site",
-    {
-        url: "/",
-    },
-    () => [ensureFrUser, ensureFrSite, ...singleLanguage()]
-);
+registerWebsitePreviewTour("translation_single_language_fr_user_fr_site", {}, () => [
+    ensureFrUser,
+    ensureFrSite,
+    ...singleLanguage(),
+]);
 
-registerWebsitePreviewTour(
-    "translation_single_language_en_user_fr_site",
-    {
-        url: "/",
-    },
-    () => [ensureEnUser, ensureFrSite, ...singleLanguage()]
-);
+registerWebsitePreviewTour("translation_single_language_en_user_fr_site", {}, () => [
+    ensureEnUser,
+    ensureFrSite,
+    ...singleLanguage(),
+]);
 
-registerWebsitePreviewTour(
-    "translation_single_language_fr_user_en_site",
-    {
-        url: "/",
-    },
-    () => [ensureFrUser, ensureEnSite, ...singleLanguage()]
-);
+registerWebsitePreviewTour("translation_single_language_fr_user_en_site", {}, () => [
+    ensureFrUser,
+    ensureEnSite,
+    ...singleLanguage(),
+]);
 
 function switchLanguage(lang, timeout = 50000) {
     return [
@@ -458,7 +452,6 @@ function multiLanguage(mainLanguage, secondLanguage) {
 registerWebsitePreviewTour(
     "translation_multi_language_fr_user_fr_en_site",
     {
-        url: "/fr",
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     },
     () => [ensureFrUser, ensureFrSite, ...multiLanguage("fr", "en")]
@@ -467,7 +460,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "translation_multi_language_fr_user_en_fr_site",
     {
-        url: "/en",
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     },
     () => [ensureFrUser, ensureEnSite, ...multiLanguage("en", "fr")]
@@ -476,7 +468,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "translation_multi_language_en_user_fr_en_site",
     {
-        url: "/fr",
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     },
     () => [ensureEnUser, ensureFrSite, ...multiLanguage("fr", "en")]
@@ -485,7 +476,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "translation_multi_language_en_user_en_fr_site",
     {
-        url: "/en",
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     },
     () => [ensureEnUser, ensureEnSite, ...multiLanguage("en", "fr")]

--- a/addons/test_website/static/tests/tours/website_controller_page.js
+++ b/addons/test_website/static/tests/tours/website_controller_page.js
@@ -13,7 +13,6 @@ function assertEqual(actual, expected) {
 registerWebsitePreviewTour(
     "website_controller_page_listing_layout",
     {
-        url: "/model/exposed-model",
         edition: true,
     },
     () => [
@@ -66,27 +65,21 @@ registerWebsitePreviewTour(
     ]
 );
 
-registerWebsitePreviewTour(
-    "website_controller_page_default_page_check",
+registerWebsitePreviewTour("website_controller_page_default_page_check", {}, () => [
     {
-        url: "/model/exposed-model",
-    },
-    () => [
-        {
-            content: "records are listed in list mode by default",
-            trigger: ":iframe [is-ready=true] .o_website_list",
-            run() {
-                const iframeDocument = document.querySelector(
-                    ".o_website_preview iframe"
-                ).contentDocument;
-                // list option is selected by default in the switch
-                assertEqual(
-                    iframeDocument.querySelector(".listing_layout_switcher #o_wstudio_apply_list")
-                        .checked,
-                    true
-                );
-                assertEqual([...iframeDocument.querySelectorAll(".test_record_listing")].length, 2);
-            },
+        content: "records are listed in list mode by default",
+        trigger: ":iframe [is-ready=true] .o_website_list",
+        run() {
+            const iframeDocument = document.querySelector(
+                ".o_website_preview iframe"
+            ).contentDocument;
+            // list option is selected by default in the switch
+            assertEqual(
+                iframeDocument.querySelector(".listing_layout_switcher #o_wstudio_apply_list")
+                    .checked,
+                true
+            );
+            assertEqual([...iframeDocument.querySelectorAll(".test_record_listing")].length, 2);
         },
-    ]
-);
+    },
+]);

--- a/addons/test_website/static/tests/tours/website_field_sanitize.js
+++ b/addons/test_website/static/tests/tours/website_field_sanitize.js
@@ -1,9 +1,9 @@
 import { clickOnSave, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
 
 // As admin, add a YouTube video iframe in a `sanitize_overridable` HTML field.
-registerWebsitePreviewTour("website_designer_iframe_video",
+registerWebsitePreviewTour(
+    "website_designer_iframe_video",
     {
-        url: "/test_website/model_item/1",
         edition: true,
     },
     () => [
@@ -26,15 +26,15 @@ registerWebsitePreviewTour("website_designer_iframe_video",
         {
             content: "Check that the video was correctly saved",
             trigger: ":iframe .media_iframe_video[data-oe-expression*='G8b4UZIcTfg']",
-            run: () => {},
         },
     ]
 );
 
 // Check that a restricted editor can edit the field content (even with
 // a video iframe).
-registerWebsitePreviewTour("website_restricted_editor_iframe_video", {
-        url: "/test_website/model_item/1",
+registerWebsitePreviewTour(
+    "website_restricted_editor_iframe_video",
+    {
         edition: true,
     },
     () => [
@@ -42,7 +42,6 @@ registerWebsitePreviewTour("website_restricted_editor_iframe_video", {
             content: "Check that the video iframe was correctly restored after saving the changes",
             trigger:
                 ":iframe [data-oe-field]:not([data-oe-sanitize-prevent-edition]) .media_iframe_video[data-oe-expression*='G8b4UZIcTfg']",
-            run: () => {},
         },
         {
             content: "As a restricted editor, edit the HTML field content",
@@ -54,7 +53,6 @@ registerWebsitePreviewTour("website_restricted_editor_iframe_video", {
             content: "Check that the HTML content (with a video iframe) was correctly updated",
             trigger:
                 ":iframe .o_test_website_description:contains('I can still edit the HTML field')",
-            run: () => {},
         },
     ]
 );

--- a/addons/test_website/static/tests/tours/website_page_properties.js
+++ b/addons/test_website/static/tests/tours/website_page_properties.js
@@ -308,55 +308,41 @@ function testWebsitePageProperties() {
     return steps;
 }
 
-registerWebsitePreviewTour(
-    "website_page_properties_common",
-    {
-        url: "/test_view",
-    },
-    () => [...testCommonProperties("/test_view", false).finalize()]
-);
+registerWebsitePreviewTour("website_page_properties_common", {}, () => [
+    ...testCommonProperties("/test_view", false).finalize(),
+]);
 
-registerWebsitePreviewTour(
-    "website_page_properties_can_publish",
-    {
-        url: "/test_website/model_item/1",
-    },
-    () => [...testCommonProperties("/test_website/model_item/1", true).finalize()]
-);
+registerWebsitePreviewTour("website_page_properties_can_publish", {}, () => [
+    ...testCommonProperties("/test_website/model_item/1", true).finalize(),
+]);
 
-registerWebsitePreviewTour(
-    "website_page_properties_website_page",
+registerWebsitePreviewTour("website_page_properties_website_page", {}, () => [
+    ...openCreatePageDialog,
     {
-        url: "/",
+        content: "Use blank template",
+        trigger: ".o_page_template .o_button_area:hidden",
+        run: "click",
     },
-    () => [
-        ...openCreatePageDialog,
-        {
-            content: "Use blank template",
-            trigger: ".o_page_template .o_button_area:hidden",
-            run: "click",
-        },
-        {
-            content: "Name page",
-            trigger: ".modal-body input",
-            run: "edit New Page",
-        },
-        {
-            content: "Don't add to menu",
-            trigger: ".modal-body .o_switch",
-            run: "click",
-        },
-        {
-            content: "Click on Create button",
-            trigger: ".modal-footer .btn-primary",
-            run: "click",
-        },
-        {
-            content: "Wait for editor to open",
-            trigger: ":iframe body.editor_enable",
-            timeout: 30000,
-        },
-        ...clickOnSave(),
-        ...testWebsitePageProperties().finalize(),
-    ]
-);
+    {
+        content: "Name page",
+        trigger: ".modal-body input",
+        run: "edit New Page",
+    },
+    {
+        content: "Don't add to menu",
+        trigger: ".modal-body .o_switch",
+        run: "click",
+    },
+    {
+        content: "Click on Create button",
+        trigger: ".modal-footer .btn-primary",
+        run: "click",
+    },
+    {
+        content: "Wait for editor to open",
+        trigger: ":iframe body.editor_enable",
+        timeout: 30000,
+    },
+    ...clickOnSave(),
+    ...testWebsitePageProperties().finalize(),
+]);

--- a/addons/test_website/tests/test_custom_snippet.py
+++ b/addons/test_website/tests/test_custom_snippet.py
@@ -10,4 +10,4 @@ class TestCustomSnippet(odoo.tests.HttpCase):
 
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
     def test_01_run_tour(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'test_custom_snippet', login="admin")
+        self.start_tour(self.env['website'].get_client_action_url("/", True), 'test_custom_snippet', login="admin")

--- a/addons/test_website/tests/test_form.py
+++ b/addons/test_website/tests/test_form.py
@@ -8,7 +8,7 @@ class TestForm(HttpCase):
 
     def test_form_conditional_visibility_record_field(self):
         self.start_tour(
-            self.env['website'].get_client_action_url('/test_website/model_item/1'),
+            self.env['website'].get_client_action_url('/test_website/model_item/1', True),
             'test_form_conditional_visibility_record_field',
             login='admin',
         )

--- a/addons/test_website/tests/test_image_upload_progress.py
+++ b/addons/test_website/tests/test_image_upload_progress.py
@@ -13,7 +13,7 @@ from odoo import http
 class TestImageUploadProgress(odoo.tests.HttpCase):
 
     def test_01_image_upload_progress(self):
-        self.start_tour(self.env['website'].get_client_action_url('/test_image_progress'), 'test_image_upload_progress', login="admin")
+        self.start_tour(self.env['website'].get_client_action_url('/test_image_progress', True), 'test_image_upload_progress', login="admin")
 
     def test_02_image_upload_progress_unsplash(self):
         BASE_URL = self.base_url()
@@ -55,4 +55,4 @@ class TestImageUploadProgress(odoo.tests.HttpCase):
         # disable undraw, no third party should be called in tests
         self.patch(Web_Unsplash, 'fetch_unsplash_images', fetch_unsplash_images)
 
-        self.start_tour(self.env['website'].get_client_action_url('/test_image_progress'), 'test_image_upload_progress_unsplash', login="admin")
+        self.start_tour(self.env['website'].get_client_action_url('/test_image_progress', True), 'test_image_upload_progress_unsplash', login="admin")

--- a/addons/test_website/tests/test_media.py
+++ b/addons/test_website/tests/test_media.py
@@ -16,7 +16,7 @@ class TestMedia(odoo.tests.HttpCase):
             'mimetype': 'image/svg+xml',
             'raw': SVG,
         })
-        self.start_tour("/", 'test_replace_media', login="admin")
+        self.start_tour(self.env['website'].get_client_action_url("/", True), 'test_replace_media', login="admin")
 
     def test_02_image_link(self):
-        self.start_tour("/", 'test_image_link', login="admin")
+        self.start_tour(self.env['website'].get_client_action_url("/", True), 'test_image_link', login="admin")

--- a/addons/test_website/tests/test_reset_views.py
+++ b/addons/test_website/tests/test_reset_views.py
@@ -95,9 +95,9 @@ class TestWebsiteResetViews(odoo.tests.HttpCase):
 
     @mute_logger('odoo.http')
     def test_07_reset_page_view_complete_flow(self):
-        self.start_tour(self.env['website'].get_client_action_url('/test_page_view'), 'test_reset_page_view_complete_flow_part1', login="admin")
+        self.start_tour(self.env['website'].get_client_action_url('/test_page_view', True), 'test_reset_page_view_complete_flow_part1', login="admin")
         self.fix_it('/test_page_view')
-        self.start_tour(self.env['website'].get_client_action_url('/test_page_view'), 'test_reset_page_view_complete_flow_part2', login="admin")
+        self.start_tour(self.env['website'].get_client_action_url('/test_page_view', False), 'test_reset_page_view_complete_flow_part2', login="admin")
         self.fix_it('/test_page_view')
 
     @mute_logger('odoo.http')

--- a/addons/test_website/tests/test_snippet_background_video.py
+++ b/addons/test_website/tests/test_snippet_background_video.py
@@ -7,4 +7,4 @@ import odoo.tests
 class TestSnippetBackgroundVideo(odoo.tests.HttpCase):
 
     def test_snippet_background_video(self):
-        self.start_tour("/", "snippet_background_video", login="admin")
+        self.start_tour(self.env["website"].get_client_action_url("/", True), "snippet_background_video", login="admin")

--- a/addons/test_website/tests/test_translation.py
+++ b/addons/test_website/tests/test_translation.py
@@ -16,16 +16,16 @@ class TestTranslation(HttpCase):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'translation_single_language_fr_user_en_site', login='admin')
 
     def _multi_language_fr_user_fr_en_site(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'translation_multi_language_fr_user_fr_en_site', login='admin', timeout=250)
+        self.start_tour(self.env['website'].get_client_action_url('/fr'), 'translation_multi_language_fr_user_fr_en_site', login='admin', timeout=250)
 
     def _multi_language_fr_user_en_fr_site(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'translation_multi_language_fr_user_en_fr_site', login='admin', timeout=250)
+        self.start_tour(self.env['website'].get_client_action_url('/en'), 'translation_multi_language_fr_user_en_fr_site', login='admin', timeout=250)
 
     def _multi_language_en_user_fr_en_site(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'translation_multi_language_en_user_fr_en_site', login='admin', timeout=250)
+        self.start_tour(self.env['website'].get_client_action_url('/fr'), 'translation_multi_language_en_user_fr_en_site', login='admin', timeout=250)
 
     def _multi_language_en_user_en_fr_site(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'translation_multi_language_en_user_en_fr_site', login='admin', timeout=250)
+        self.start_tour(self.env['website'].get_client_action_url('/en'), 'translation_multi_language_en_user_en_fr_site', login='admin', timeout=250)
 
     def _fr_db(self):
         self._fr_en_db()

--- a/addons/test_website/tests/test_website_controller_page.py
+++ b/addons/test_website/tests/test_website_controller_page.py
@@ -161,10 +161,10 @@ class TestWebsiteControllerPage(HttpCase):
 
     def test_default_layout(self):
         self.assertEqual(self.listing_controller_page.default_layout, 'grid')
-        self.start_tour('/model/exposed-model', 'website_controller_page_listing_layout', login='admin')
+        self.start_tour(self.env["website"].get_client_action_url('/model/exposed-model', True), 'website_controller_page_listing_layout', login='admin')
         self.assertEqual(self.listing_controller_page.default_layout, 'list')
         #check that the user that has not previously interacted with the layout switcher will prompt on the default layout
-        self.start_tour('/model/exposed-model', 'website_controller_page_default_page_check', login='admin')
+        self.start_tour(self.env["website"].get_client_action_url('/model/exposed-model', False), 'website_controller_page_default_page_check', login='admin')
 
     def test_model_constrains(self):
         def get_model_meta_params(model_name):

--- a/addons/test_website/tests/test_website_field_sanitize.py
+++ b/addons/test_website/tests/test_website_field_sanitize.py
@@ -20,13 +20,13 @@ class TestWebsiteFieldSanitize(odoo.tests.HttpCase):
 
         # Add a video to an HTML field (admin).
         self.start_tour(
-            self.env['website'].get_client_action_url('/test_website/model_item/1'),
+            self.env['website'].get_client_action_url('/test_website/model_item/1', True),
             'website_designer_iframe_video',
             login='admin'
         )
         # Make sure a user can still edit the content (restricted editor).
         self.start_tour(
-            self.env['website'].get_client_action_url('/test_website/model_item/1'),
+            self.env['website'].get_client_action_url('/test_website/model_item/1', True),
             'website_restricted_editor_iframe_video',
             login='restricted'
         )

--- a/addons/test_website/tests/test_website_page_properties.py
+++ b/addons/test_website/tests/test_website_page_properties.py
@@ -7,10 +7,10 @@ from odoo.tests import HttpCase, tagged
 class TestWebsitePageProperties(HttpCase):
 
     def test_website_page_properties_common(self):
-        self.start_tour('/test_view', 'website_page_properties_common', login='admin')
+        self.start_tour(self.env["website"].get_client_action_url('/test_view'), 'website_page_properties_common', login='admin')
 
     def test_website_page_properties_can_publish(self):
-        self.start_tour('/test_website/model_item/1', 'website_page_properties_can_publish', login='admin')
+        self.start_tour(self.env["website"].get_client_action_url('/test_website/model_item/1'), 'website_page_properties_can_publish', login='admin')
 
     def test_website_page_properties_website_page(self):
         # Create a website page with a different URL to be tested for dependency
@@ -24,4 +24,4 @@ class TestWebsitePageProperties(HttpCase):
             'website_id': self.env['website'].search([], limit=1).id,
         })
 
-        self.start_tour('/', 'website_page_properties_website_page', login='admin')
+        self.start_tour(self.env["website"].get_client_action_url('/'), 'website_page_properties_website_page', login='admin')

--- a/addons/website/static/tests/tours/add_snippet_dialog.js
+++ b/addons/website/static/tests/tours/add_snippet_dialog.js
@@ -4,7 +4,6 @@ registerWebsitePreviewTour(
     "website_add_snippet_dialog",
     {
         edition: true,
-        url: "/",
     },
     () => [
         {

--- a/addons/website/static/tests/tours/alt_a.js
+++ b/addons/website/static/tests/tours/alt_a.js
@@ -25,7 +25,6 @@ function searchParamsCheck() {
 }
 
 registry.category("web_tour.tours").add("alt_a_edit", {
-    url: "/",
     steps: () => [
         pressAltA(),
         {

--- a/addons/website/static/tests/tours/anchor_on_accordion_tour.js
+++ b/addons/website/static/tests/tours/anchor_on_accordion_tour.js
@@ -12,7 +12,6 @@ registerWebsitePreviewTour(
     "anchor_behaviour_on_accordion_same_tab",
     {
         edition: true,
-        url: "/",
     },
     () => [
         ...insertSnippet({
@@ -77,7 +76,6 @@ registerWebsitePreviewTour(
 );
 
 registry.category("web_tour.tours").add("anchor_behaviour_on_accordion_new_tab", {
-    url: "/#What-services-does-your-company-offer-%3F",
     steps: () => [
         {
             content: "Check that the accordion item's content is visible",

--- a/addons/website/static/tests/tours/auto_hide_menu.js
+++ b/addons/website/static/tests/tours/auto_hide_menu.js
@@ -41,69 +41,63 @@ const checkThatLayoutChanged = {
     },
 };
 
-registerWebsitePreviewTour(
-    "website_auto_hide_menu",
+registerWebsitePreviewTour("website_auto_hide_menu", {}, () => [
     {
-        url: "/",
+        content: "Click on Site",
+        trigger: ".o_main_navbar .o_menu_sections :contains('Site')",
+        run: "click",
     },
-    () => [
-        {
-            content: "Click on Site",
-            trigger: ".o_main_navbar .o_menu_sections :contains('Site')",
-            run: "click",
-        },
-        {
-            content: "Click on Menu Editor",
-            trigger: ".o_popover .o-dropdown-item:contains('Menu Editor')",
-            run: "click",
-        },
-        ...Array(5).fill(addNavItem).flat(),
-        {
-            content: "Save",
-            trigger: ".modal-footer .btn:contains('Save')",
-            run: "click",
-        },
-        {
-            content: "Check that modal has disappeared",
-            trigger: "body:not(:has(.modal))",
-        },
-        {
-            trigger: `:iframe .o_homepage_editor_welcome_message:contains(welcome to your homepage)`,
-        },
-        ...clickOnEditAndWaitEditMode(),
-        getTheLayoutChildren,
-        {
-            content: "Click on the navbar",
-            trigger: ":iframe nav",
-            run: "click",
-        },
-        {
-            content: "Change content width",
-            trigger: ".hb-row[data-label='Content Width'] .o-hb-btn[title='Small']",
-            run: "click",
-        },
-        checkThatLayoutChanged,
-        {
-            content: "Make content width large",
-            trigger: ".hb-row[data-label='Content Width'] .o-hb-btn[title='Full']",
-            run: "click",
-        },
-        getTheLayoutChildren,
-        {
-            content: "Go to the Theme Tab",
-            trigger: ".o-website-builder_sidebar .o-snippets-tabs [data-name='theme']",
-            run: "click",
-        },
-        {
-            content: "Change the page layout",
-            trigger: ".hb-row[data-label='Page Layout'] .o-dropdown",
-            run: "click",
-        },
-        {
-            content: "Set the page layout to 'boxed'",
-            trigger: ".o-hb-select-dropdown-item[data-action-value='boxed']",
-            run: "click",
-        },
-        checkThatLayoutChanged,
-    ]
-);
+    {
+        content: "Click on Menu Editor",
+        trigger: ".o_popover .o-dropdown-item:contains('Menu Editor')",
+        run: "click",
+    },
+    ...Array(5).fill(addNavItem).flat(),
+    {
+        content: "Save",
+        trigger: ".modal-footer .btn:contains('Save')",
+        run: "click",
+    },
+    {
+        content: "Check that modal has disappeared",
+        trigger: "body:not(:has(.modal))",
+    },
+    {
+        trigger: `:iframe .o_homepage_editor_welcome_message:contains(welcome to your homepage)`,
+    },
+    ...clickOnEditAndWaitEditMode(),
+    getTheLayoutChildren,
+    {
+        content: "Click on the navbar",
+        trigger: ":iframe nav",
+        run: "click",
+    },
+    {
+        content: "Change content width",
+        trigger: ".hb-row[data-label='Content Width'] .o-hb-btn[title='Small']",
+        run: "click",
+    },
+    checkThatLayoutChanged,
+    {
+        content: "Make content width large",
+        trigger: ".hb-row[data-label='Content Width'] .o-hb-btn[title='Full']",
+        run: "click",
+    },
+    getTheLayoutChildren,
+    {
+        content: "Go to the Theme Tab",
+        trigger: ".o-website-builder_sidebar .o-snippets-tabs [data-name='theme']",
+        run: "click",
+    },
+    {
+        content: "Change the page layout",
+        trigger: ".hb-row[data-label='Page Layout'] .o-dropdown",
+        run: "click",
+    },
+    {
+        content: "Set the page layout to 'boxed'",
+        trigger: ".o-hb-select-dropdown-item[data-action-value='boxed']",
+        run: "click",
+    },
+    checkThatLayoutChanged,
+]);

--- a/addons/website/static/tests/tours/background_color_gradient_precedence.js
+++ b/addons/website/static/tests/tours/background_color_gradient_precedence.js
@@ -7,7 +7,6 @@ import {
 registerWebsitePreviewTour(
     "background_color_gradient_precedence",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/carousel.js
+++ b/addons/website/static/tests/tours/carousel.js
@@ -17,7 +17,6 @@ const carouselInnerSelector = ":iframe .carousel-inner";
 registerWebsitePreviewTour(
     "carousel_content_removal",
     {
-        url: "/",
         edition: true,
     },
     () => [
@@ -83,7 +82,6 @@ const checkSlides = (number, position) => {
 registerWebsitePreviewTour(
     "snippet_carousel",
     {
-        url: "/",
         edition: true,
     },
     () => [
@@ -176,7 +174,6 @@ registerWebsitePreviewTour(
     "snippet_carousel_clickable_slides",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/client_action_iframe_fallback.js
+++ b/addons/website/static/tests/tours/client_action_iframe_fallback.js
@@ -1,23 +1,12 @@
 import { registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
 
-registerWebsitePreviewTour(
-    "client_action_iframe_fallback",
+registerWebsitePreviewTour("client_action_iframe_fallback", {}, () => [
     {
-        url: "/",
+        content: "Ensure we are on the expected page",
+        trigger: ':iframe html[data-view-xmlid="website.homepage"]',
     },
-    () => [
-        {
-            content: "Ensure we are on the expected page",
-            trigger: ':iframe html[data-view-xmlid="website.homepage"]',
-        },
-        {
-            content: "Ensure the iframe fallback is not loaded in test mode",
-            trigger: "body",
-            run() {
-                if (document.querySelector('iframe[src="/website/iframefallback"]')) {
-                    throw new Error("The iframe fallback shouldn't be inside the DOM.");
-                }
-            },
-        },
-    ]
-);
+    {
+        content: "Ensure the iframe fallback is not loaded in test mode",
+        trigger: `body:not(:has(iframe[src="/website/iframefallback"]))`,
+    },
+]);

--- a/addons/website/static/tests/tours/colorpicker.js
+++ b/addons/website/static/tests/tours/colorpicker.js
@@ -44,7 +44,6 @@ registerWebsitePreviewTour(
     "website_background_colorpicker",
     {
         edition: true,
-        url: "/",
     },
     () => [
         ...insertSnippet({

--- a/addons/website/static/tests/tours/conditional_visibility.js
+++ b/addons/website/static/tests/tours/conditional_visibility.js
@@ -57,7 +57,6 @@ registerWebsitePreviewTour(
     "conditional_visibility_1",
     {
         edition: true,
-        url: "/",
     },
     () => [
         ...insertSnippet(snippets[0]),
@@ -117,7 +116,6 @@ registerWebsitePreviewTour(
     "conditional_visibility_3",
     {
         edition: true,
-        url: "/",
     },
     () => [
         checkEyeIcon("Text - Image", true),
@@ -177,7 +175,6 @@ registerWebsitePreviewTour(
     "conditional_visibility_4",
     {
         edition: true,
-        url: "/",
     },
     () => [
         // Click on the "Text-Image" snippet.
@@ -221,7 +218,6 @@ registerWebsitePreviewTour(
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
         edition: true,
-        url: "/",
     },
     () => [
         {

--- a/addons/website/static/tests/tours/cookies_consent.js
+++ b/addons/website/static/tests/tours/cookies_consent.js
@@ -22,7 +22,6 @@ function assertGtagConsent(expectedState) {
 }
 
 registry.category("web_tour.tours").add("cookie_bar_updates_gtag_consent", {
-    url: "/",
     steps: () => [
         {
             content: "Accept all cookies",

--- a/addons/website/static/tests/tours/create_missing_page.js
+++ b/addons/website/static/tests/tours/create_missing_page.js
@@ -8,7 +8,6 @@ import {
 registerWebsitePreviewTour(
     "create_missing_page",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/default_shape_gets_palette_colors.js
+++ b/addons/website/static/tests/tours/default_shape_gets_palette_colors.js
@@ -8,7 +8,6 @@ import {
 registerWebsitePreviewTour(
     "default_shape_gets_palette_colors",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/drag_and_drop_on_non_editable.js
+++ b/addons/website/static/tests/tours/drag_and_drop_on_non_editable.js
@@ -8,7 +8,6 @@ registerWebsitePreviewTour(
     "test_drag_and_drop_on_non_editable",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/drop_404_ir_attachment_url.js
+++ b/addons/website/static/tests/tours/drop_404_ir_attachment_url.js
@@ -8,7 +8,6 @@ import { onceAllImagesLoaded } from "@website/utils/images";
 registerWebsitePreviewTour(
     "drop_404_ir_attachment_url",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/dropdowns_and_header_hide_on_scroll.js
+++ b/addons/website/static/tests/tours/dropdowns_and_header_hide_on_scroll.js
@@ -35,7 +35,6 @@ registerWebsitePreviewTour(
     "dropdowns_and_header_hide_on_scroll",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/dynamic_svg_theme_colors.js
+++ b/addons/website/static/tests/tours/dynamic_svg_theme_colors.js
@@ -27,7 +27,6 @@ async function assertSvgColors(img, color1, color2, errorMessage) {
 registerWebsitePreviewTour(
     "website_dynamic_svg_theme_colors",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/edit_link_popover.js
+++ b/addons/website/static/tests/tours/edit_link_popover.js
@@ -33,7 +33,6 @@ registerWebsitePreviewTour(
     "edit_link_popover",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/edit_megamenu.js
+++ b/addons/website/static/tests/tours/edit_megamenu.js
@@ -30,7 +30,6 @@ const toggleMegaMenu = (stepOptions) =>
 registerWebsitePreviewTour(
     "edit_megamenu",
     {
-        url: "/",
         edition: true,
     },
     () => [
@@ -138,7 +137,6 @@ registerWebsitePreviewTour(
     "megamenu_active_nav_link",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [
@@ -212,7 +210,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "edit_megamenu_big_icons_subtitles",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -76,7 +76,6 @@ registerWebsitePreviewTour(
     "edit_menus",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
     },
     () => [
         // Add a megamenu item from the menu.
@@ -565,34 +564,28 @@ registerWebsitePreviewTour(
     ]
 );
 
-registerWebsitePreviewTour(
-    "edit_menus_delete_parent",
+registerWebsitePreviewTour("edit_menus_delete_parent", {}, () => [
     {
-        url: "/",
+        trigger: ":iframe #wrapwrap",
     },
-    () => [
-        {
-            trigger: ":iframe #wrapwrap",
-        },
-        {
-            content: "Open site menu",
-            trigger: 'button[data-menu-xmlid="website.menu_site"]',
-            run: "click",
-        },
-        {
-            content: "Click on Edit Menu",
-            trigger: 'a[data-menu-xmlid="website.menu_edit_menu"]',
-            run: "click",
-        },
-        {
-            content: "Delete Home menu",
-            trigger: ".modal-body ul li:nth-child(1) button.js_delete_menu",
-            run: "click",
-        },
-        {
-            content: "Save",
-            trigger: ".modal-footer button:first-child",
-            run: "click",
-        },
-    ]
-);
+    {
+        content: "Open site menu",
+        trigger: 'button[data-menu-xmlid="website.menu_site"]',
+        run: "click",
+    },
+    {
+        content: "Click on Edit Menu",
+        trigger: 'a[data-menu-xmlid="website.menu_edit_menu"]',
+        run: "click",
+    },
+    {
+        content: "Delete Home menu",
+        trigger: ".modal-body ul li:nth-child(1) button.js_delete_menu",
+        run: "click",
+    },
+    {
+        content: "Save",
+        trigger: ".modal-footer button:first-child",
+        run: "click",
+    },
+]);

--- a/addons/website/static/tests/tours/editable_root_as_custom_snippet.js
+++ b/addons/website/static/tests/tours/editable_root_as_custom_snippet.js
@@ -12,7 +12,6 @@ registerWebsitePreviewTour(
     "editable_root_as_custom_snippet",
     {
         edition: true,
-        url: "/custom-page",
     },
     () => [
         ...clickOnSnippet(

--- a/addons/website/static/tests/tours/font_family.js
+++ b/addons/website/static/tests/tours/font_family.js
@@ -4,7 +4,6 @@ import { patch } from "@web/core/utils/patch";
 registerWebsitePreviewTour(
     "website_font_family",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/gray_color_palette.js
+++ b/addons/website/static/tests/tours/gray_color_palette.js
@@ -12,7 +12,6 @@ function waitForCSSReload() {
 registerWebsitePreviewTour(
     "website_gray_color_palette",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/grid_layout.js
+++ b/addons/website/static/tests/tours/grid_layout.js
@@ -75,7 +75,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "scroll_to_new_grid_item",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/hide_sidebar_header.js
+++ b/addons/website/static/tests/tours/hide_sidebar_header.js
@@ -5,7 +5,6 @@ registerWebsitePreviewTour(
     "hide_sidebar_header",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/html_editor.js
+++ b/addons/website/static/tests/tours/html_editor.js
@@ -5,61 +5,54 @@ import { clickOnSave, registerWebsitePreviewTour } from "@website/js/tours/tour_
 const adminCssModif = "#wrap {display: none;}";
 const demoCssModif = "// demo_edition";
 
-registerWebsitePreviewTour(
-    "html_editor_language",
+registerWebsitePreviewTour("html_editor_language", {}, () => [
     {
-        url: "/test_page",
+        content:
+            "Wait the content is loaded and html/css editor is in menu before clicking on open site menu",
+        trigger: ":iframe main:contains(rommelpot)",
     },
-    () => [
-        {
-            content:
-                "Wait the content is loaded and html/css editor is in menu before clicking on open site menu",
-            trigger: ":iframe main:contains(rommelpot)",
+    {
+        content: "open site menu",
+        trigger: 'button[data-menu-xmlid="website.menu_site"]',
+        run: "click",
+    },
+    {
+        content: "open html editor",
+        trigger: 'a[data-menu-xmlid="website.menu_ace_editor"]',
+        run: "click",
+    },
+    {
+        content: "add something in the page's default language version",
+        trigger: 'div.ace_line .ace_xml:contains("rommelpot")',
+        run: () => {
+            ace.edit(document.querySelector("#resource-editor div")).getSession().insert(
+                {
+                    row: 1,
+                    column: 1,
+                },
+                '<div class="test_language"/>\n'
+            );
         },
-        {
-            content: "open site menu",
-            trigger: 'button[data-menu-xmlid="website.menu_site"]',
-            run: "click",
-        },
-        {
-            content: "open html editor",
-            trigger: 'a[data-menu-xmlid="website.menu_ace_editor"]',
-            run: "click",
-        },
-        {
-            content: "add something in the page's default language version",
-            trigger: 'div.ace_line .ace_xml:contains("rommelpot")',
-            run: () => {
-                ace.edit(document.querySelector("#resource-editor div")).getSession().insert(
-                    {
-                        row: 1,
-                        column: 1,
-                    },
-                    '<div class="test_language"/>\n'
-                );
-            },
-        },
-        {
-            content: "save the html editor",
-            trigger:
-                'body:has(div.ace_line .ace_xml:contains("test_language")) .o_resource_editor .btn-primary',
-            run: "click",
-        },
-        {
-            content: "check that the page has the modification",
-            trigger: ":iframe #wrapwrap:has(.test_language)",
-        },
-        {
-            content: "check that the page has not lost the original text",
-            trigger: ':iframe #wrapwrap:contains("rommelpot")',
-        },
-    ]
-);
+    },
+    {
+        content: "save the html editor",
+        trigger:
+            'body:has(div.ace_line .ace_xml:contains("test_language")) .o_resource_editor .btn-primary',
+        run: "click",
+    },
+    {
+        content: "check that the page has the modification",
+        trigger: ":iframe #wrapwrap:has(.test_language)",
+    },
+    {
+        content: "check that the page has not lost the original text",
+        trigger: ':iframe #wrapwrap:contains("rommelpot")',
+    },
+]);
 
 registerWebsitePreviewTour(
     "html_editor_multiple_templates",
     {
-        url: "/generic",
         edition: true,
     },
     () => [
@@ -141,321 +134,294 @@ registerWebsitePreviewTour(
     ]
 );
 
-registerWebsitePreviewTour(
-    "test_html_editor_scss",
+registerWebsitePreviewTour("test_html_editor_scss", {}, () => [
+    // 1. Open Html Editor and select a scss file
     {
-        url: "/contactus",
+        trigger: ":iframe #wrap:visible", // ensure state for later
     },
-    () => [
-        // 1. Open Html Editor and select a scss file
+    {
+        trigger: ":iframe h1:contains(contact us)",
+    },
+    {
+        trigger: ":iframe input[name=company]",
+    },
+    {
+        content: "open site menu",
+        trigger: 'nav button[data-menu-xmlid="website.menu_site"]:contains(site)',
+        run: "click",
+    },
+    {
+        content: "open html editor",
+        trigger: '.o_popover a[data-menu-xmlid="website.menu_ace_editor"]:contains(/^HTML/)',
+        run: "click",
+    },
+    {
+        content: "open type switcher",
+        trigger: ".o_resource_editor_type_switcher button",
+        run: "click",
+    },
+    {
+        content: "select scss files",
+        trigger: '.o-dropdown--menu .dropdown-item:contains("SCSS")',
+        run: "click",
+    },
+    {
+        content: "select 'user_custom_rules'",
+        trigger: '.o_resource_editor .o_select_menu_toggler:contains("user_custom_rules")',
+    },
+    // 2. Edit that file and ensure it was saved then reset it
+    {
+        content: "add some scss content in the file",
+        trigger: 'div.ace_line .ace_comment:contains("footer {")',
+        run() {
+            ace.edit(document.querySelector("#resource-editor div"))
+                .getSession()
+                .insert({ row: 2, column: 0 }, `${adminCssModif}\n`);
+        },
+    },
+    {
+        trigger: `div.ace_line:contains("${adminCssModif}")`,
+    },
+    {
+        content: "save the html editor",
+        trigger: ".o_resource_editor_title button:contains(Save)",
+        run: "click",
+    },
+    {
+        content: "check that the scss modification got applied",
+        trigger: ":iframe body:has(#wrap:hidden)",
+        timeout: 30000, // SCSS compilation might take some time
+    },
+    {
+        content: "reset view (after reload, html editor should have been reopened where it was)",
+        trigger: "#resource-editor-id button:contains(Reset)",
+        run: "click",
+    },
+    {
+        content: "confirm reset warning",
+        trigger: ".modal-footer .btn-primary",
+        run: "click",
+    },
+    {
+        content:
+            "check that the scss file was reset correctly, wrap content should now be visible again",
+        trigger: ":iframe #wrap:visible",
+        timeout: 30000, // SCSS compilation might take some time
+    },
+    // 3. Customize again that file (will be used in second part of the test
+    //    to ensure restricted user can still use the HTML Editor)
+    {
+        content: "add some scss content in the file",
+        trigger: 'div.ace_line .ace_comment:contains("footer {")',
+        run() {
+            ace.edit(document.querySelector("#resource-editor div"))
+                .getSession()
+                .insert({ row: 2, column: 0 }, `${adminCssModif}\n`);
+        },
+    },
+    {
+        trigger: `div.ace_line:contains("${adminCssModif}")`,
+    },
+    {
+        content: "save the html editor",
+        trigger: ".o_resource_editor_title button:contains(Save)",
+        run: "click",
+    },
+    {
+        content: "check that the scss modification got applied",
+        trigger: ":iframe body:has(#wrap:hidden)",
+    },
+    {
+        trigger: "nav img[src]:not([src=''])",
+    },
+]);
+
+registerWebsitePreviewTour("test_html_editor_scss_2", {}, () => [
+    // This part of the test ensures that a restricted user can still use
+    // the HTML Editor if someone else made a customization previously.
+
+    // 4. Open Html Editor and select a scss file
+    {
+        trigger: ":iframe [is-ready=true] #wrapwrap",
+    },
+    {
+        content: "open site menu",
+        trigger: 'button[data-menu-xmlid="website.menu_site"]',
+        run: "click",
+    },
+    {
+        content: "open html editor",
+        trigger: '.o_popover a[data-menu-xmlid="website.menu_ace_editor"]:contains(/^HTML/)',
+        run: "click",
+    },
+    {
+        content: "open type switcher",
+        trigger: ".o_resource_editor_type_switcher button",
+        run: "click",
+    },
+    {
+        content: "select scss files",
+        trigger: '.o-dropdown--menu .dropdown-item:contains("SCSS")',
+        run: "click",
+    },
+    {
+        content: "select 'user_custom_rules'",
+        trigger: '.o_resource_editor .o_select_menu_toggler:contains("user_custom_rules")',
+    },
+    // 5. Edit that file and ensure it was saved then reset it
+    {
+        content: "add some scss content in the file",
+        trigger: `div.ace_line:contains("${adminCssModif}")`,
+        // ensure the admin modification is here
+        run() {
+            ace.edit(document.querySelector("#resource-editor div"))
+                .getSession()
+                .insert({ row: 2, column: 0 }, `${demoCssModif}\n`);
+        },
+    },
+    {
+        trigger: `div.ace_line:contains("${demoCssModif}")`,
+    },
+    {
+        content: "save the html editor",
+        trigger: ".o_resource_editor button:contains(Save)",
+        run: "click",
+    },
+    {
+        content: "reset view (after reload, html editor should have been reopened where it was)",
+        trigger: "#resource-editor-id button:contains(Reset)",
+        timeout: 30000, // SCSS compilation might take some time
+        run: "click",
+    },
+    {
+        content: "confirm reset warning",
+        trigger: ".modal:contains(Reset to default?) .modal-footer .btn-primary",
+        run: "click",
+    },
+    {
+        trigger: `body:not(:has(div.ace_line:contains("${adminCssModif}")))`,
+    },
+    {
+        content: "check that the scss file was reset correctly",
+        trigger: `body:not(:has(div.ace_line:contains("${demoCssModif}")))`,
+        timeout: 30000, // SCSS compilation might take some time
+    },
+]);
+
+registerWebsitePreviewTour("website_code_editor_usable", {}, () => [
+    {
+        trigger: ":iframe #wrapwrap",
+    },
+    {
+        content: "Open Site menu",
+        trigger: 'button[data-menu-xmlid="website.menu_site"]',
+        run: "click",
+    },
+    {
+        content: "Open HTML / CSS Editor",
+        trigger: '.o_popover a[data-menu-xmlid="website.menu_ace_editor"]:contains(/^HTML/)',
+        run: "click",
+    },
+    {
+        content: "Bypass warning",
+        trigger: ".o_resource_editor_wrapper div:nth-child(2) > button",
+        run: "click",
+    },
+    // Test all 3 file type options
+    ...[
         {
-            trigger: ":iframe #wrap:visible", // ensure state for later
+            menuItemIndex: 1,
+            editorMode: "qweb",
         },
         {
-            trigger: ":iframe h1:contains(contact us)",
+            menuItemIndex: 2,
+            editorMode: "scss",
         },
         {
-            trigger: ":iframe input[name=company]",
-        },
-        {
-            content: "open site menu",
-            trigger: 'nav button[data-menu-xmlid="website.menu_site"]:contains(site)',
-            run: "click",
-        },
-        {
-            content: "open html editor",
-            trigger: '.o_popover a[data-menu-xmlid="website.menu_ace_editor"]:contains(/^HTML/)',
-            run: "click",
-        },
-        {
-            content: "open type switcher",
-            trigger: ".o_resource_editor_type_switcher button",
-            run: "click",
-        },
-        {
-            content: "select scss files",
-            trigger: '.o-dropdown--menu .dropdown-item:contains("SCSS")',
-            run: "click",
-        },
-        {
-            content: "select 'user_custom_rules'",
-            trigger: '.o_resource_editor .o_select_menu_toggler:contains("user_custom_rules")',
-        },
-        // 2. Edit that file and ensure it was saved then reset it
-        {
-            content: "add some scss content in the file",
-            trigger: 'div.ace_line .ace_comment:contains("footer {")',
-            run() {
-                ace.edit(document.querySelector("#resource-editor div"))
-                    .getSession()
-                    .insert({ row: 2, column: 0 }, `${adminCssModif}\n`);
-            },
-        },
-        {
-            trigger: `div.ace_line:contains("${adminCssModif}")`,
-        },
-        {
-            content: "save the html editor",
-            trigger: ".o_resource_editor_title button:contains(Save)",
-            run: "click",
-        },
-        {
-            content: "check that the scss modification got applied",
-            trigger: ":iframe body:has(#wrap:hidden)",
-            timeout: 30000, // SCSS compilation might take some time
-        },
-        {
-            content:
-                "reset view (after reload, html editor should have been reopened where it was)",
-            trigger: "#resource-editor-id button:contains(Reset)",
-            run: "click",
-        },
-        {
-            content: "confirm reset warning",
-            trigger: ".modal-footer .btn-primary",
-            run: "click",
-        },
-        {
-            content:
-                "check that the scss file was reset correctly, wrap content should now be visible again",
-            trigger: ":iframe #wrap:visible",
-            timeout: 30000, // SCSS compilation might take some time
-        },
-        // 3. Customize again that file (will be used in second part of the test
-        //    to ensure restricted user can still use the HTML Editor)
-        {
-            content: "add some scss content in the file",
-            trigger: 'div.ace_line .ace_comment:contains("footer {")',
-            run() {
-                ace.edit(document.querySelector("#resource-editor div"))
-                    .getSession()
-                    .insert({ row: 2, column: 0 }, `${adminCssModif}\n`);
-            },
-        },
-        {
-            trigger: `div.ace_line:contains("${adminCssModif}")`,
-        },
-        {
-            content: "save the html editor",
-            trigger: ".o_resource_editor_title button:contains(Save)",
-            run: "click",
-        },
-        {
-            content: "check that the scss modification got applied",
-            trigger: ":iframe body:has(#wrap:hidden)",
-        },
-        {
-            trigger: "nav img[src]:not([src=''])",
+            menuItemIndex: 3,
+            editorMode: "javascript",
         },
     ]
-);
-
-registerWebsitePreviewTour(
-    "test_html_editor_scss_2",
-    {
-        url: "/",
-    },
-    () => [
-        // This part of the test ensures that a restricted user can still use
-        // the HTML Editor if someone else made a customization previously.
-
-        // 4. Open Html Editor and select a scss file
-        {
-            trigger: ":iframe [is-ready=true] #wrapwrap",
-        },
-        {
-            content: "open site menu",
-            trigger: 'button[data-menu-xmlid="website.menu_site"]',
-            run: "click",
-        },
-        {
-            content: "open html editor",
-            trigger: '.o_popover a[data-menu-xmlid="website.menu_ace_editor"]:contains(/^HTML/)',
-            run: "click",
-        },
-        {
-            content: "open type switcher",
-            trigger: ".o_resource_editor_type_switcher button",
-            run: "click",
-        },
-        {
-            content: "select scss files",
-            trigger: '.o-dropdown--menu .dropdown-item:contains("SCSS")',
-            run: "click",
-        },
-        {
-            content: "select 'user_custom_rules'",
-            trigger: '.o_resource_editor .o_select_menu_toggler:contains("user_custom_rules")',
-        },
-        // 5. Edit that file and ensure it was saved then reset it
-        {
-            content: "add some scss content in the file",
-            trigger: `div.ace_line:contains("${adminCssModif}")`,
-            // ensure the admin modification is here
-            run() {
-                ace.edit(document.querySelector("#resource-editor div"))
-                    .getSession()
-                    .insert({ row: 2, column: 0 }, `${demoCssModif}\n`);
-            },
-        },
-        {
-            trigger: `div.ace_line:contains("${demoCssModif}")`,
-        },
-        {
-            content: "save the html editor",
-            trigger: ".o_resource_editor button:contains(Save)",
-            run: "click",
-        },
-        {
-            content:
-                "reset view (after reload, html editor should have been reopened where it was)",
-            trigger: "#resource-editor-id button:contains(Reset)",
-            timeout: 30000, // SCSS compilation might take some time
-            run: "click",
-        },
-        {
-            content: "confirm reset warning",
-            trigger: ".modal:contains(Reset to default?) .modal-footer .btn-primary",
-            run: "click",
-        },
-        {
-            trigger: `body:not(:has(div.ace_line:contains("${adminCssModif}")))`,
-        },
-        {
-            content: "check that the scss file was reset correctly",
-            trigger: `body:not(:has(div.ace_line:contains("${demoCssModif}")))`,
-            timeout: 30000, // SCSS compilation might take some time
-        },
-    ]
-);
-
-registerWebsitePreviewTour(
-    "website_code_editor_usable",
-    {
-        // TODO: enable debug mode when failing tests have been fixed (props validation)
-        url: "/",
-    },
-    () => [
-        {
-            trigger: ":iframe #wrapwrap",
-        },
-        {
-            content: "Open Site menu",
-            trigger: 'button[data-menu-xmlid="website.menu_site"]',
-            run: "click",
-        },
-        {
-            content: "Open HTML / CSS Editor",
-            trigger: '.o_popover a[data-menu-xmlid="website.menu_ace_editor"]:contains(/^HTML/)',
-            run: "click",
-        },
-        {
-            content: "Bypass warning",
-            trigger: ".o_resource_editor_wrapper div:nth-child(2) > button",
-            run: "click",
-        },
-        // Test all 3 file type options
-        ...[
+        .map(({ menuItemIndex, editorMode }) => [
             {
-                menuItemIndex: 1,
-                editorMode: "qweb",
+                content: "Open file type dropdown",
+                trigger: ".o_resource_editor_type_switcher .dropdown-toggle",
+                run: "click",
             },
             {
-                menuItemIndex: 2,
-                editorMode: "scss",
+                content: `Select type ${menuItemIndex}`,
+                trigger: `.o-overlay-container .o-dropdown--menu .dropdown-item:nth-child(${menuItemIndex})`,
+                run: "click",
             },
             {
-                menuItemIndex: 3,
-                editorMode: "javascript",
+                content: "Wait for editor mode to change",
+                trigger: `.ace_editor[data-mode="${editorMode}"]`,
             },
-        ]
-            .map(({ menuItemIndex, editorMode }) => [
-                {
-                    content: "Open file type dropdown",
-                    trigger: ".o_resource_editor_type_switcher .dropdown-toggle",
-                    run: "click",
-                },
-                {
-                    content: `Select type ${menuItemIndex}`,
-                    trigger: `.o-overlay-container .o-dropdown--menu .dropdown-item:nth-child(${menuItemIndex})`,
-                    run: "click",
-                },
-                {
-                    content: "Wait for editor mode to change",
-                    trigger: `.ace_editor[data-mode="${editorMode}"]`,
-                },
-                {
-                    content: "Make sure text is being highlighted",
-                    trigger: ".ace_content .ace_text-layer .ace_line:first-child span",
-                },
-            ])
-            .flat(),
-    ]
-);
+            {
+                content: "Make sure text is being highlighted",
+                trigger: ".ace_content .ace_text-layer .ace_line:first-child span",
+            },
+        ])
+        .flat(),
+]);
 
-registerWebsitePreviewTour(
-    "test_ace_editor_is_hidden",
+registerWebsitePreviewTour("test_ace_editor_is_hidden", {}, () => [
     {
-        url: "/",
+        trigger: ":iframe #wrapwrap",
     },
-    () => [
-        {
-            trigger: ":iframe #wrapwrap",
-        },
-        {
-            content: "Open Site menu",
-            trigger: "button[data-menu-xmlid='website.menu_site']",
-            run: "click",
-        },
-        {
-            content: "Open HTML / CSS Editor",
-            trigger: ".o_popover a[data-menu-xmlid='website.menu_ace_editor']:contains(/^HTML/)",
-            run: "click",
-        },
-        {
-            content: "Make sure the editor is open",
-            trigger: ".o_resource_editor",
-        },
-        {
-            content: "Click on edit",
-            trigger: ".o_menu_systray_item.o_edit_website_container > button",
-            run: "click",
-        },
-        {
-            content: "Wait for it to open",
-            trigger: ".o-website-builder_sidebar",
-        },
-        {
-            content: "Make sure the editor has been hidden after starting editing",
-            trigger: ":not(.o_resource_editor)",
-        },
-        {
-            content: "Discard edit mode",
-            trigger: ".o-website-builder_sidebar .o-snippets-top-actions button:contains(Discard)",
-            run: "click",
-        },
-        {
-            content: "Open Site menu",
-            trigger: "button[data-menu-xmlid='website.menu_site']",
-            run: "click",
-        },
-        {
-            content: "Open HTML / CSS Editor",
-            trigger: ".o_popover a[data-menu-xmlid='website.menu_ace_editor']:contains(/^HTML/)",
-            run: "click",
-        },
-        {
-            content: "Make sure the editor is open",
-            trigger: ".o_resource_editor",
-        },
-        {
-            content: "Navigate to contact us page",
-            trigger: ":iframe a[href='/contactus']",
-            run: "click",
-        },
-        {
-            content: "Make sure the editor has been hidden after navigating to other page",
-            trigger: ":not(.o_resource_editor)",
-        },
-    ]
-);
+    {
+        content: "Open Site menu",
+        trigger: "button[data-menu-xmlid='website.menu_site']",
+        run: "click",
+    },
+    {
+        content: "Open HTML / CSS Editor",
+        trigger: ".o_popover a[data-menu-xmlid='website.menu_ace_editor']:contains(/^HTML/)",
+        run: "click",
+    },
+    {
+        content: "Make sure the editor is open",
+        trigger: ".o_resource_editor",
+    },
+    {
+        content: "Click on edit",
+        trigger: ".o_menu_systray_item.o_edit_website_container > button",
+        run: "click",
+    },
+    {
+        content: "Wait for it to open",
+        trigger: ".o-website-builder_sidebar",
+    },
+    {
+        content: "Make sure the editor has been hidden after starting editing",
+        trigger: ":not(.o_resource_editor)",
+    },
+    {
+        content: "Discard edit mode",
+        trigger: ".o-website-builder_sidebar .o-snippets-top-actions button:contains(Discard)",
+        run: "click",
+    },
+    {
+        content: "Open Site menu",
+        trigger: "button[data-menu-xmlid='website.menu_site']",
+        run: "click",
+    },
+    {
+        content: "Open HTML / CSS Editor",
+        trigger: ".o_popover a[data-menu-xmlid='website.menu_ace_editor']:contains(/^HTML/)",
+        run: "click",
+    },
+    {
+        content: "Make sure the editor is open",
+        trigger: ".o_resource_editor",
+    },
+    {
+        content: "Navigate to contact us page",
+        trigger: ":iframe a[href='/contactus']",
+        run: "click",
+    },
+    {
+        content: "Make sure the editor has been hidden after navigating to other page",
+        trigger: ":not(.o_resource_editor)",
+    },
+]);

--- a/addons/website/static/tests/tours/interaction_lifecycle.js
+++ b/addons/website/static/tests/tours/interaction_lifecycle.js
@@ -14,7 +14,6 @@ const localStorageKey = "interactionAndWysiwygLifecycle";
 registerWebsitePreviewTour(
     "interaction_lifecycle",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/link_to_document.js
+++ b/addons/website/static/tests/tours/link_to_document.js
@@ -50,7 +50,6 @@ registerWebsitePreviewTour(
     "test_link_to_document",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/media_dialog.js
+++ b/addons/website/static/tests/tours/media_dialog.js
@@ -9,7 +9,6 @@ registerWebsitePreviewTour(
     "website_media_dialog_undraw",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [
@@ -44,7 +43,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "website_media_dialog_external_library",
     {
-        url: "/",
         edition: true,
     },
     () => [
@@ -167,7 +165,6 @@ registerWebsitePreviewTour(
     "website_media_dialog_image_shape",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [
@@ -209,7 +206,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "website_media_dialog_insert_media",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/media_iframe_video.js
+++ b/addons/website/static/tests/tours/media_iframe_video.js
@@ -4,7 +4,6 @@ registerWebsitePreviewTour(
     "website_media_iframe_video",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/mega_footer.js
+++ b/addons/website/static/tests/tours/mega_footer.js
@@ -10,7 +10,6 @@ import {
 registerWebsitePreviewTour(
     "mega_footer",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/multi_edition.js
+++ b/addons/website/static/tests/tours/multi_edition.js
@@ -7,7 +7,6 @@ import {
 registerWebsitePreviewTour(
     "website_multi_edition",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/navigation.js
+++ b/addons/website/static/tests/tours/navigation.js
@@ -1,30 +1,24 @@
 import { stepUtils } from "@web_tour/tour_utils";
 import { insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
 
-registerWebsitePreviewTour(
-    "website_editing_awaits_navigation",
+registerWebsitePreviewTour("website_editing_awaits_navigation", {}, () => [
     {
-        url: "/",
+        content: "Click on Edit right after that",
+        trigger: ".o_menu_systray_item.o_edit_website_container > button",
+        run: "click",
     },
-    () => [
-        {
-            content: "Click on Edit right after that",
-            trigger: ".o_menu_systray_item.o_edit_website_container > button",
-            run: "click",
-        },
-        stepUtils.waitIframeIsReady(),
-        {
-            content: "Can insert a snippet",
-            trigger: ".o-website-builder_sidebar",
-        },
-        ...insertSnippet({
-            id: "s_banner",
-            name: "Banner",
-            groupName: "Intro",
-        }),
-        {
-            content: "",
-            trigger: ":iframe section.s_banner",
-        },
-    ]
-);
+    stepUtils.waitIframeIsReady(),
+    {
+        content: "Can insert a snippet",
+        trigger: ".o-website-builder_sidebar",
+    },
+    ...insertSnippet({
+        id: "s_banner",
+        name: "Banner",
+        groupName: "Intro",
+    }),
+    {
+        content: "",
+        trigger: ":iframe section.s_banner",
+    },
+]);

--- a/addons/website/static/tests/tours/page_manager.js
+++ b/addons/website/static/tests/tours/page_manager.js
@@ -222,7 +222,6 @@ registerWebsitePreviewTour(
     "website_page_manager",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
     },
     () => [
         {
@@ -274,7 +273,6 @@ registerWebsitePreviewTour(
     "website_page_manager_session_forced",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
     },
     () => [
         ...testSwitchWebsite("Test Website"),
@@ -316,7 +314,6 @@ registerWebsitePreviewTour(
     "website_clone_pages",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
     },
     () => [
         {

--- a/addons/website/static/tests/tours/parallax.js
+++ b/addons/website/static/tests/tours/parallax.js
@@ -12,7 +12,6 @@ const coverSnippet = { id: "s_cover", name: "Cover", groupName: "Intro" };
 registerWebsitePreviewTour(
     "test_parallax",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/popup_visibility_option.js
+++ b/addons/website/static/tests/tours/popup_visibility_option.js
@@ -3,7 +3,6 @@ import { insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tou
 registerWebsitePreviewTour(
     "website_popup_visibility_option",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/restricted_editor.js
+++ b/addons/website/static/tests/tours/restricted_editor.js
@@ -3,10 +3,4 @@ import {
     registerWebsitePreviewTour,
 } from "@website/js/tours/tour_utils";
 
-registerWebsitePreviewTour(
-    "restricted_editor",
-    {
-        url: "/",
-    },
-    () => [...clickOnEditAndWaitEditMode()]
-);
+registerWebsitePreviewTour("restricted_editor", {}, () => [...clickOnEditAndWaitEditMode()]);

--- a/addons/website/static/tests/tours/rte.js
+++ b/addons/website/static/tests/tours/rte.js
@@ -55,7 +55,6 @@ function installParseltongueAndOpenLangDropdown() {
 registerWebsitePreviewTour(
     "rte_translator",
     {
-        url: "/",
         edition: true,
     },
     () => [
@@ -173,7 +172,7 @@ registerWebsitePreviewTour(
             trigger: ':iframe html[lang*="en"]',
         },
         {
-            trigger: ':iframe .js_language_selector > button:contains(English)',
+            trigger: ":iframe .js_language_selector > button:contains(English)",
         },
         {
             content: "click on Parseltongue version",
@@ -181,7 +180,7 @@ registerWebsitePreviewTour(
             run: "click",
         },
         {
-            trigger: ':iframe .js_language_selector > button:contains(Parseltongue)',
+            trigger: ":iframe .js_language_selector > button:contains(Parseltongue)",
         },
         {
             content: "edit",
@@ -213,7 +212,7 @@ registerWebsitePreviewTour(
             trigger: ".o_customize_tab .options-container [data-label='Translate to']",
         },
         {
-            trigger: ':iframe .js_language_selector > button:contains(Parseltongue)',
+            trigger: ":iframe .js_language_selector > button:contains(Parseltongue)",
         },
         {
             content: "translate text",
@@ -299,7 +298,7 @@ registerWebsitePreviewTour(
             run: "click",
         },
         {
-            trigger: ':iframe .js_language_selector > button:contains(English)',
+            trigger: ":iframe .js_language_selector > button:contains(English)",
         },
         {
             content: "check: default value translation",
@@ -320,7 +319,7 @@ registerWebsitePreviewTour(
             trigger: ':iframe input[placeholder="test Parseltongue placeholder"]',
         },
         {
-            trigger: ':iframe .js_language_selector > button:contains(Parseltongue)',
+            trigger: ":iframe .js_language_selector > button:contains(Parseltongue)",
         },
         ...clickOnEditAndWaitEditModeInTranslatedPage(),
         {
@@ -447,7 +446,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "multiple_websites_add_language",
     {
-        url: "/",
         edition: true,
     },
     () => [...installParseltongueAndOpenLangDropdown()]

--- a/addons/website/static/tests/tours/snippet_background_edition.js
+++ b/addons/website/static/tests/tours/snippet_background_edition.js
@@ -125,7 +125,6 @@ registerWebsitePreviewTour(
     "snippet_background_edition",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/snippet_cache_across_websites.js
+++ b/addons/website/static/tests/tours/snippet_cache_across_websites.js
@@ -9,7 +9,6 @@ registerWebsitePreviewTour(
     "snippet_cache_across_websites",
     {
         edition: true,
-        url: "/@/",
     },
     () => [
         {

--- a/addons/website/static/tests/tours/snippet_countdown.js
+++ b/addons/website/static/tests/tours/snippet_countdown.js
@@ -9,7 +9,6 @@ import {
 registerWebsitePreviewTour(
     "snippet_countdown",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/snippet_editor_panel_options.js
+++ b/addons/website/static/tests/tours/snippet_editor_panel_options.js
@@ -33,7 +33,6 @@ const oldWriteText = browser.navigator.clipboard.writeText;
 registerWebsitePreviewTour(
     "snippet_editor_panel_options",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/snippet_empty_parent_autoremove.js
+++ b/addons/website/static/tests/tours/snippet_empty_parent_autoremove.js
@@ -17,7 +17,6 @@ function removeSelectedBlock() {
 registerWebsitePreviewTour(
     "snippet_empty_parent_autoremove",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/snippet_image.js
+++ b/addons/website/static/tests/tours/snippet_image.js
@@ -3,7 +3,6 @@ import { insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tou
 registerWebsitePreviewTour(
     "snippet_image",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/snippet_image_gallery.js
+++ b/addons/website/static/tests/tours/snippet_image_gallery.js
@@ -15,7 +15,6 @@ import {
 registerWebsitePreviewTour(
     "snippet_image_gallery",
     {
-        url: "/",
         edition: true,
     },
     () => [
@@ -36,7 +35,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "snippet_image_gallery_remove",
     {
-        url: "/",
         edition: true,
     },
     () => [
@@ -97,7 +95,6 @@ registerWebsitePreviewTour(
     "snippet_image_gallery_reorder",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [
@@ -180,7 +177,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "snippet_image_gallery_thumbnail_update",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/snippet_image_quality.js
+++ b/addons/website/static/tests/tours/snippet_image_quality.js
@@ -4,7 +4,6 @@ registerWebsitePreviewTour(
     "website_image_quality",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/snippet_image_srcset.js
+++ b/addons/website/static/tests/tours/snippet_image_srcset.js
@@ -8,7 +8,6 @@ registerWebsitePreviewTour(
     "website_image_srcset",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/snippet_images_wall.js
+++ b/addons/website/static/tests/tours/snippet_images_wall.js
@@ -57,7 +57,6 @@ const reselectSignImageSteps = [
 registerWebsitePreviewTour(
     "snippet_images_wall",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/snippet_popup_and_animations.js
+++ b/addons/website/static/tests/tours/snippet_popup_and_animations.js
@@ -52,7 +52,6 @@ registerWebsitePreviewTour(
         // Remove this key to make the tour fail with error:
         // "The scroll animation in the modal did not start properly"
         undeterministicTour_doNotCopy: true,
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/snippet_popup_and_scrollbar.js
+++ b/addons/website/static/tests/tours/snippet_popup_and_scrollbar.js
@@ -58,7 +58,6 @@ registerWebsitePreviewTour(
     "snippet_popup_and_scrollbar",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/snippet_popup_display_on_click.js
+++ b/addons/website/static/tests/tours/snippet_popup_display_on_click.js
@@ -15,7 +15,6 @@ registerWebsitePreviewTour(
     "snippet_popup_display_on_click",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/snippet_popup_open_on_top.js
+++ b/addons/website/static/tests/tours/snippet_popup_open_on_top.js
@@ -11,7 +11,6 @@ registerWebsitePreviewTour(
     "snippet_popup_open_on_top",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/snippet_rating.js
+++ b/addons/website/static/tests/tours/snippet_rating.js
@@ -8,7 +8,6 @@ import {
 registerWebsitePreviewTour(
     "snippet_rating",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/snippet_shape_image.js
+++ b/addons/website/static/tests/tours/snippet_shape_image.js
@@ -3,7 +3,6 @@ import { insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tou
 registerWebsitePreviewTour(
     "snippet_shape_image",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/snippet_social_media.js
+++ b/addons/website/static/tests/tours/snippet_social_media.js
@@ -45,7 +45,8 @@ const replaceIconByImage = function (url) {
         },
         {
             content: "Go to the Images tab in the media dialog",
-            trigger: ".o_select_media_dialog .o_notebook_headers .nav-item button:contains('Images')",
+            trigger:
+                ".o_select_media_dialog .o_notebook_headers .nav-item button:contains('Images')",
             run: "click",
         },
         {
@@ -95,7 +96,6 @@ registerWebsitePreviewTour(
     "snippet_social_media",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/snippet_table_of_content.js
+++ b/addons/website/static/tests/tours/snippet_table_of_content.js
@@ -27,7 +27,6 @@ registerWebsitePreviewTour(
     "snippet_table_of_content",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/snippet_tabs.js
+++ b/addons/website/static/tests/tours/snippet_tabs.js
@@ -9,7 +9,6 @@ registerWebsitePreviewTour(
     "snippet_tabs",
     {
         edition: true,
-        url: "/",
     },
     () => [
         ...insertSnippet({

--- a/addons/website/static/tests/tours/snippet_translation.js
+++ b/addons/website/static/tests/tours/snippet_translation.js
@@ -5,46 +5,38 @@ import {
     clickOnEditAndWaitEditModeInTranslatedPage,
     clickOnSave,
     insertSnippet,
-    registerWebsitePreviewTour,
+    registerWebsitePreviewTourLegacy,
     testSwitchWebsite,
 } from "@website/js/tours/tour_utils";
 import { stepUtils } from "@web_tour/tour_utils";
 
-registerWebsitePreviewTour(
-    "snippet_translation",
+registerWebsitePreviewTourLegacy("snippet_translation", {}, () => [
     {
-        url: "/",
+        content: "Wait for website preview and check language",
+        trigger: ":iframe html:has(body:contains(welcome to your)):has(.o_top_fixed_element)",
+        run: () => {
+            if (localization.code !== "fu_GB") {
+                console.error("the user language is not properly set");
+            } else {
+                translatedTermsGlobal["Save"] = "Save in fu_GB";
+            }
+        },
     },
-    () => [
-        {
-            content: "Wait for website preview and check language",
-            trigger: ":iframe html:has(body:contains(welcome to your)):has(.o_top_fixed_element)",
-            run: () => {
-                if (localization.code !== "fu_GB") {
-                    console.error("the user language is not properly set");
-                } else {
-                    translatedTermsGlobal["Save"] = "Save in fu_GB";
-                }
-            },
-        },
-        ...clickOnEditAndWaitEditMode(),
-        ...insertSnippet({ id: "s_cover", name: "Cover", groupName: "Intro" }),
-        {
-            content: "Check that contact us contain Parseltongue",
-            trigger:
-                ':iframe .s_cover .btn-outline-secondary:contains("Contact us in Parseltongue")',
-        },
-        {
-            content: "Check that the save button contains 'in fu_GB'",
-            trigger: '.btn[data-action="save"]:contains("Save in fu_GB")',
-        },
-    ]
-);
-registerWebsitePreviewTour(
+    ...clickOnEditAndWaitEditMode(),
+    ...insertSnippet({ id: "s_cover", name: "Cover", groupName: "Intro" }),
+    {
+        content: "Check that contact us contain Parseltongue",
+        trigger: ':iframe .s_cover .btn-outline-secondary:contains("Contact us in Parseltongue")',
+    },
+    {
+        content: "Check that the save button contains 'in fu_GB'",
+        trigger: '.btn[data-action="save"]:contains("Save in fu_GB")',
+    },
+]);
+registerWebsitePreviewTourLegacy(
     "snippet_translation_changing_lang",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
     },
     () => [
         stepUtils.waitIframeIsReady(),
@@ -101,52 +93,38 @@ registerWebsitePreviewTour(
         },
     ]
 );
-registerWebsitePreviewTour(
-    "snippet_translation_switching_website",
+registerWebsitePreviewTourLegacy("snippet_translation_switching_website", {}, () => [
+    ...clickOnEditAndWaitEditModeInTranslatedPage(),
+    ...insertSnippet({ id: "s_cover", name: "Cover", groupName: "Intro" }),
     {
-        url: "/",
+        content: "Check that contact us contain Parseltongue",
+        trigger: ":iframe .s_cover .btn-outline-secondary:contains('Contact us in Parseltongue')",
     },
-    () => [
-        ...clickOnEditAndWaitEditModeInTranslatedPage(),
-        ...insertSnippet({ id: "s_cover", name: "Cover", groupName: "Intro" }),
-        {
-            content: "Check that contact us contain Parseltongue",
-            trigger:
-                ":iframe .s_cover .btn-outline-secondary:contains('Contact us in Parseltongue')",
-        },
-        ...clickOnSave(),
-        ...testSwitchWebsite("website fu_GB"),
-        ...clickOnEditAndWaitEditMode(),
-        ...insertSnippet({ id: "s_cover", name: "Cover", groupName: "Intro" }),
-        {
-            content: "Check that contact us contain Fake User Lang",
-            trigger: ":iframe .s_cover .btn-outline-secondary:contains('Fake User Lang')",
-        },
-    ]
-);
-registerWebsitePreviewTour(
-    "snippet_dialog_rtl",
+    ...clickOnSave(),
+    ...testSwitchWebsite("website fu_GB"),
+    ...clickOnEditAndWaitEditMode(),
+    ...insertSnippet({ id: "s_cover", name: "Cover", groupName: "Intro" }),
     {
-        url: "/",
+        content: "Check that contact us contain Fake User Lang",
+        trigger: ":iframe .s_cover .btn-outline-secondary:contains('Fake User Lang')",
     },
-    () => [
-        ...clickOnEditAndWaitEditMode(),
-        {
-            trigger: ".o_builder_sidebar_open",
-        },
-        {
-            content: "Select a category snippet to show the snippet dialog",
-            trigger: `.o_block_tab:not(.o_we_ongoing_insertion) #snippet_groups .o_snippet[name="Intro"].o_draggable .o_snippet_thumbnail_area`,
-            run: "click",
-        },
-        {
-            content: "Check that the snippets preview is in rtl",
-            trigger: ":iframe .o_snippets_preview_row[dir=rtl]",
-        },
-        {
-            content: "Check that web.assets_frontend CSS bundle is in rtl",
-            trigger:
-                ":iframe link[type='text/css'][href*='/web.assets_frontend.rtl']:not(:visible)",
-        },
-    ]
-);
+]);
+registerWebsitePreviewTourLegacy("snippet_dialog_rtl", {}, () => [
+    ...clickOnEditAndWaitEditMode(),
+    {
+        trigger: ".o_builder_sidebar_open",
+    },
+    {
+        content: "Select a category snippet to show the snippet dialog",
+        trigger: `.o_block_tab:not(.o_we_ongoing_insertion) #snippet_groups .o_snippet[name="Intro"].o_draggable .o_snippet_thumbnail_area`,
+        run: "click",
+    },
+    {
+        content: "Check that the snippets preview is in rtl",
+        trigger: ":iframe .o_snippets_preview_row[dir=rtl]",
+    },
+    {
+        content: "Check that web.assets_frontend CSS bundle is in rtl",
+        trigger: ":iframe link[type='text/css'][href*='/web.assets_frontend.rtl']:not(:visible)",
+    },
+]);

--- a/addons/website/static/tests/tours/snippet_version.js
+++ b/addons/website/static/tests/tours/snippet_version.js
@@ -8,7 +8,6 @@ registerWebsitePreviewTour(
     "snippet_version_1",
     {
         edition: true,
-        url: "/",
     },
     () => [
         ...insertSnippet({

--- a/addons/website/static/tests/tours/snippet_visibility_option.js
+++ b/addons/website/static/tests/tours/snippet_visibility_option.js
@@ -9,7 +9,6 @@ registerWebsitePreviewTour(
     "snippet_visibility_option",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/specific_website_editor.js
+++ b/addons/website/static/tests/tours/specific_website_editor.js
@@ -1,10 +1,10 @@
 import { registry } from "@web/core/registry";
 import {
     clickOnEditAndWaitEditMode,
-    registerWebsitePreviewTour,
+    registerWebsitePreviewTourLegacy,
 } from "@website/js/tours/tour_utils";
 
-registerWebsitePreviewTour(
+registerWebsitePreviewTourLegacy(
     "generic_website_editor",
     {
         edition: true,

--- a/addons/website/static/tests/tours/start_cloned_snippet.js
+++ b/addons/website/static/tests/tours/start_cloned_snippet.js
@@ -8,7 +8,6 @@ registerWebsitePreviewTour(
     "website_start_cloned_snippet",
     {
         edition: true,
-        url: "/",
     },
     () => {
         const countdownSnippet = {

--- a/addons/website/static/tests/tours/text_animations.js
+++ b/addons/website/static/tests/tours/text_animations.js
@@ -28,7 +28,6 @@ function setTextAnimation(trigger, value) {
 registerWebsitePreviewTour(
     "text_animations",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/text_highlights.js
+++ b/addons/website/static/tests/tours/text_highlights.js
@@ -34,7 +34,6 @@ registerWebsitePreviewTour(
         // Remove this key to make the tour fail with error:
         // "The highlight svgs are not correctly applied to text lines"
         undeterministicTour_doNotCopy: true,
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/translate_menu_name.js
+++ b/addons/website/static/tests/tours/translate_menu_name.js
@@ -10,7 +10,6 @@ registerWebsitePreviewTour(
     "translate_menu_name",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/pa_GB",
         edition: false,
     },
     () => [

--- a/addons/website/static/tests/tours/translate_text_options.js
+++ b/addons/website/static/tests/tours/translate_text_options.js
@@ -9,7 +9,6 @@ import {
 registerWebsitePreviewTour(
     "translate_text_options",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/unsplash_beacon.js
+++ b/addons/website/static/tests/tours/unsplash_beacon.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("test_unsplash_beacon", {
-    url: "/",
     steps: () => [
         {
             content: "Verify whether beacon was sent.",

--- a/addons/website/static/tests/tours/website_backend_menus_redirect.js
+++ b/addons/website/static/tests/tours/website_backend_menus_redirect.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_backend_menus_redirect", {
-    url: "/",
     steps: () => [
         {
             isActive: ["enterprise"],

--- a/addons/website/static/tests/tours/website_click_tests.js
+++ b/addons/website/static/tests/tours/website_click_tests.js
@@ -14,42 +14,36 @@ const cover = {
     groupName: "Intro",
 };
 
-registerWebsitePreviewTour(
-    "website_click_tour",
+registerWebsitePreviewTour("website_click_tour", {}, () => [
+    stepUtils.waitIframeIsReady(),
     {
-        url: "/",
+        content: "trigger a page navigation",
+        trigger: ':iframe a[href="/contactus"]',
+        run: "click",
     },
-    () => [
-        stepUtils.waitIframeIsReady(),
-        {
-            content: "trigger a page navigation",
-            trigger: ':iframe a[href="/contactus"]',
-            run: "click",
-        },
-        {
-            content: "wait for the page to be loaded",
-            trigger: ".o_website_preview :iframe [data-view-xmlid='website.contactus']",
-        },
-        ...clickOnEditAndWaitEditMode(),
-        {
-            content: "click on a link that would trigger navigation",
-            trigger: ':iframe a[href="/"]',
-            run: "click",
-        },
-        {
-            content: "click the User dropdown to show Log out button",
-            trigger: ":iframe .dropdown:has(#o_logout) > a",
-            run: "click",
-        },
-        {
-            content:
-                "click the Log out button and expect not to be logged out during the following steps",
-            trigger: ":iframe .editor_enable #o_logout",
-            run: "click",
-        },
-        goBackToBlocks(),
-        ...insertSnippet(cover),
-        ...clickOnSnippet(cover),
-        ...clickOnSave(),
-    ]
-);
+    {
+        content: "wait for the page to be loaded",
+        trigger: ".o_website_preview :iframe [data-view-xmlid='website.contactus']",
+    },
+    ...clickOnEditAndWaitEditMode(),
+    {
+        content: "click on a link that would trigger navigation",
+        trigger: ':iframe a[href="/"]',
+        run: "click",
+    },
+    {
+        content: "click the User dropdown to show Log out button",
+        trigger: ":iframe .dropdown:has(#o_logout) > a",
+        run: "click",
+    },
+    {
+        content:
+            "click the Log out button and expect not to be logged out during the following steps",
+        trigger: ":iframe .editor_enable #o_logout",
+        run: "click",
+    },
+    goBackToBlocks(),
+    ...insertSnippet(cover),
+    ...clickOnSnippet(cover),
+    ...clickOnSave(),
+]);

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -171,7 +171,6 @@ registerWebsitePreviewTour(
     "website_form_editor_tour",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [
@@ -921,7 +920,6 @@ function editContactUs(steps) {
 registerWebsitePreviewTour(
     "website_form_contactus_edition_with_email",
     {
-        url: "/contactus",
         edition: true,
     },
     () =>
@@ -937,7 +935,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "website_form_contactus_edition_no_email",
     {
-        url: "/contactus",
         edition: true,
     },
     () =>
@@ -960,7 +957,6 @@ registerWebsitePreviewTour(
     "website_form_conditional_required_checkboxes",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [
@@ -1116,7 +1112,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "website_form_contactus_change_random_option",
     {
-        url: "/contactus",
         edition: true,
     },
     () =>
@@ -1133,7 +1128,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "website_form_nested_forms",
     {
-        url: "/my/account",
         edition: true,
     },
     () => [
@@ -1160,7 +1154,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "website_form_editable_content",
     {
-        url: "/",
         edition: true,
     },
     () => [
@@ -1229,7 +1222,6 @@ registerWebsitePreviewTour(
     "website_form_special_characters",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [
@@ -1272,7 +1264,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "website_form_duplicate_field_ids",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/website_navbar_menu.js
+++ b/addons/website/static/tests/tours/website_navbar_menu.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add("website_navbar_menu", {
-    url: "/",
     steps: () => [
         {
             content: "Ensure menus are in DOM",
@@ -23,7 +22,7 @@ registry.category("web_tour.tours").add("website_navbar_menu", {
     ],
 });
 
-registerWebsitePreviewTour("website_systray_items_disappear", { url: "/" }, () => [
+registerWebsitePreviewTour("website_systray_items_disappear", {}, () => [
     {
         content: "Ensure frontend systray items have been added to the navbar",
         trigger: ".o_main_navbar .o_menu_systray:has(.o_edit_website_container)",

--- a/addons/website/static/tests/tours/website_no_dirty_page.js
+++ b/addons/website/static/tests/tours/website_no_dirty_page.js
@@ -63,7 +63,6 @@ const makeSteps = (steps = []) => [
 registerWebsitePreviewTour(
     "website_no_action_no_dirty_page",
     {
-        url: "/",
         edition: true,
     },
     () => makeSteps()
@@ -72,7 +71,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "website_no_dirty_page",
     {
-        url: "/",
         edition: true,
     },
     () =>
@@ -119,7 +117,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     "website_no_dirty_lazy_image",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/website_page_options.js
+++ b/addons/website/static/tests/tours/website_page_options.js
@@ -9,7 +9,6 @@ import {
 registerWebsitePreviewTour(
     "website_page_options",
     {
-        url: "/",
         edition: true,
     },
     () => [
@@ -139,8 +138,6 @@ registerWebsitePreviewTour(
     "website_page_breadcrumb",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/contactus",
-        edition: false,
     },
     () => [
         {

--- a/addons/website/static/tests/tours/website_seo_notification.js
+++ b/addons/website/static/tests/tours/website_seo_notification.js
@@ -6,88 +6,80 @@ import {
     registerWebsitePreviewTour,
 } from "@website/js/tours/tour_utils";
 
-registerWebsitePreviewTour(
-    "website_seo_notification",
+registerWebsitePreviewTour("website_seo_notification", {}, () => [
+    // Part one checks that the SEO notification is displayed when the page title is not set.
     {
-        url: "/",
+        content: "Open new page menu",
+        trigger: ".o_menu_systray .o_new_content_container > button",
+        run: "click",
     },
-    () => [
-        // Part one checks that the SEO notification is displayed when the page title is not set.
-        {
-            content: "Open new page menu",
-            trigger: ".o_menu_systray .o_new_content_container > button",
-            run: "click",
-        },
-        {
-            content: "Click on new page",
-            trigger: "button.o_new_content_element",
-            run: "click",
-        },
-        {
-            content: "Click on Use this template",
-            trigger: ".o_page_template .o_button_area:not(:visible)",
-            run: "click",
-        },
-        {
-            content: "Insert page name",
-            trigger:
-                ".modal:not(.o_inactive_modal):contains(new page) .modal-body input[type=text]",
-            run: "edit Test Page",
-        },
-        {
-            trigger: "input[type='text']:value(Test Page)",
-        },
-        {
-            content: "Create page",
-            trigger:
-                ".modal:not(.o_inactive_modal):contains(new page) button.btn-primary:contains(create)",
-            run: "click",
-        },
-        ...insertSnippet({
-            id: "s_text_image",
-            name: "Text - Image",
-            groupName: "Content",
-        }),
-        ...clickOnSave(),
-        {
-            content: "Publish your website",
-            trigger: ".o_menu_systray_item.o_website_publish_container a",
-            run: "click",
-        },
-        {
-            content: "Check the SEO notification is displayed",
-            trigger: ".o_notification_manager .o_notification:contains('Page title not set.')",
-        },
-        {
-            trigger: "body:not(:has(.o_notification_manager .o_notification))",
-        },
+    {
+        content: "Click on new page",
+        trigger: "button.o_new_content_element",
+        run: "click",
+    },
+    {
+        content: "Click on Use this template",
+        trigger: ".o_page_template .o_button_area:not(:visible)",
+        run: "click",
+    },
+    {
+        content: "Insert page name",
+        trigger: ".modal:not(.o_inactive_modal):contains(new page) .modal-body input[type=text]",
+        run: "edit Test Page",
+    },
+    {
+        trigger: "input[type='text']:value(Test Page)",
+    },
+    {
+        content: "Create page",
+        trigger:
+            ".modal:not(.o_inactive_modal):contains(new page) button.btn-primary:contains(create)",
+        run: "click",
+    },
+    ...insertSnippet({
+        id: "s_text_image",
+        name: "Text - Image",
+        groupName: "Content",
+    }),
+    ...clickOnSave(),
+    {
+        content: "Publish your website",
+        trigger: ".o_menu_systray_item.o_website_publish_container a",
+        run: "click",
+    },
+    {
+        content: "Check the SEO notification is displayed",
+        trigger: ".o_notification_manager .o_notification:contains('Page title not set.')",
+    },
+    {
+        trigger: "body:not(:has(.o_notification_manager .o_notification))",
+    },
 
-        // Part 2 checks that the SEO notification is not displayed when we are in any page like /my or /shop etc.
-        {
-            content: "Open the dropdown menu",
-            trigger:
-                ":iframe #o_main_nav .navbar-nav .dropdown.o_no_autohide_item > a.dropdown-toggle",
-            run: "click",
-        },
-        {
-            content: "Click on My Account",
-            trigger: ":iframe #o_main_nav .js_usermenu a.dropdown-item.ps-3:contains('My Account')",
-            run: "click",
-        },
-        {
-            content: "Let the page get loaded",
-            trigger: ":iframe .o_portal",
-        },
-        ...clickOnEditAndWaitEditMode(),
-        ...insertSnippet({
-            id: "s_text_image",
-            name: "Text - Image",
-            groupName: "Content",
-        }),
-        ...clickOnSave(),
-        {
-            content: "Check the SEO notification should not be displayed",
-            trigger: "body:not(:has(.o_notification_manager .o_notification))",
-        },
-    ]
-);
+    // Part 2 checks that the SEO notification is not displayed when we are in any page like /my or /shop etc.
+    {
+        content: "Open the dropdown menu",
+        trigger: ":iframe #o_main_nav .navbar-nav .dropdown.o_no_autohide_item > a.dropdown-toggle",
+        run: "click",
+    },
+    {
+        content: "Click on My Account",
+        trigger: ":iframe #o_main_nav .js_usermenu a.dropdown-item.ps-3:contains('My Account')",
+        run: "click",
+    },
+    {
+        content: "Let the page get loaded",
+        trigger: ":iframe .o_portal",
+    },
+    ...clickOnEditAndWaitEditMode(),
+    ...insertSnippet({
+        id: "s_text_image",
+        name: "Text - Image",
+        groupName: "Content",
+    }),
+    ...clickOnSave(),
+    {
+        content: "Check the SEO notification should not be displayed",
+        trigger: "body:not(:has(.o_notification_manager .o_notification))",
+    },
+]);

--- a/addons/website/static/tests/tours/website_snippets_menu_tabs.js
+++ b/addons/website/static/tests/tours/website_snippets_menu_tabs.js
@@ -3,7 +3,6 @@ import { goToTheme, registerWebsitePreviewTour } from "@website/js/tours/tour_ut
 registerWebsitePreviewTour(
     "website_snippets_menu_tabs",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/website_style_edition.js
+++ b/addons/website/static/tests/tours/website_style_edition.js
@@ -48,7 +48,6 @@ const checkBodyColor = function () {
 registerWebsitePreviewTour(
     "website_style_edition",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/website_text_edition.js
+++ b/addons/website/static/tests/tours/website_text_edition.js
@@ -12,7 +12,6 @@ const WEBSITE_MAIN_COLOR = "#ABCDEF";
 registerWebsitePreviewTour(
     "website_text_edition",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/website_text_font_size.js
+++ b/addons/website/static/tests/tours/website_text_font_size.js
@@ -212,7 +212,6 @@ function getAllFontSizesTestSteps() {
 registerWebsitePreviewTour(
     "website_text_font_size",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/static/tests/tours/website_update_column_count.js
+++ b/addons/website/static/tests/tours/website_update_column_count.js
@@ -48,7 +48,6 @@ const checkIfNoMobileOrder = (snippetRowSelector) => ({
 registerWebsitePreviewTour(
     "website_update_column_count",
     {
-        url: "/",
         edition: true,
     },
     () => [
@@ -199,7 +198,6 @@ registerWebsitePreviewTour(
     "website_mobile_order_with_drag_and_drop",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website/tests/test_attachment.py
+++ b/addons/website/tests/test_attachment.py
@@ -37,7 +37,7 @@ class TestWebsiteAttachment(odoo.tests.HttpCase):
         self.assertEqual(req.status_code, 200)
 
     def test_02_image_quality(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'website_image_quality', login="admin")
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'website_image_quality', login="admin")
 
     def test_03_link_to_document(self):
         text = b'Lorem Ipsum'
@@ -47,7 +47,7 @@ class TestWebsiteAttachment(odoo.tests.HttpCase):
             'mimetype': 'text/plain',
             'raw': text,
         })
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'test_link_to_document', login="admin")
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'test_link_to_document', login="admin")
 
     def test_04_image_srcset(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'website_image_srcset', login="admin")
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'website_image_srcset', login="admin")

--- a/addons/website/tests/test_client_action.py
+++ b/addons/website/tests/test_client_action.py
@@ -24,4 +24,4 @@ class TestClientAction(HttpCaseWithWebsiteUser):
         self.start_tour(page.url, 'client_action_redirect', login='website_user', timeout=180)
 
     def test_02_client_action_iframe_fallback(self):
-        self.start_tour('/@/', 'client_action_iframe_fallback', login='admin')
+        self.start_tour(self.env["website"].get_client_action_url('/'), 'client_action_iframe_fallback', login='admin')

--- a/addons/website/tests/test_custom_snippets.py
+++ b/addons/website/tests/test_custom_snippets.py
@@ -214,9 +214,9 @@ class TestHttpCustomSnippet(HttpCase):
                 </t>
             """,
         })
-        custom_page = Page.create({
+        Page.create({
             'view_id': custom_page_view.id,
             'url': '/custom-page',
         })
 
-        self.start_tour(f'{custom_page.url}', 'editable_root_as_custom_snippet', login='admin')
+        self.start_tour(self.env["website"].get_client_action_url("/custom-page", True), 'editable_root_as_custom_snippet', login='admin')

--- a/addons/website/tests/test_grid_layout.py
+++ b/addons/website/tests/test_grid_layout.py
@@ -10,8 +10,8 @@ class TestWebsiteGridLayout(odoo.tests.HttpCase):
     def test_01_replace_grid_image(self):
         create_image_attachment(self.env, '/web/image/website.s_banner_default_image', 's_banner_default_image.jpg')
         create_image_attachment(self.env, '/web/image/website.s_banner_default_image', 's_banner_default_image2.webp')
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'website_replace_grid_image', login="admin")
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'website_replace_grid_image', login="admin")
 
     def test_02_scroll_to_new_grid_item(self):
         create_image_attachment(self.env, '/web/image/website.s_banner_default_image', 's_banner_default_image.jpg')
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'scroll_to_new_grid_item', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'scroll_to_new_grid_item', login='admin')

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -21,10 +21,10 @@ class TestSnippets(HttpCase):
         return super().fetch_proxy(url)
 
     def test_01_empty_parents_autoremove(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_empty_parent_autoremove', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'snippet_empty_parent_autoremove', login='admin')
 
     def test_02_default_shape_gets_palette_colors(self):
-        self.start_tour('/@/', 'default_shape_gets_palette_colors', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'default_shape_gets_palette_colors', login='admin')
 
     def test_03_snippets_all_drag_and_drop(self):
         with MockRequest(self.env, website=self.env['website'].browse(1)):
@@ -60,7 +60,7 @@ class TestSnippets(HttpCase):
         self.start_tour(f"/odoo/action-website.website_preview?{path}", "snippets_all_drag_and_drop", login='admin', timeout=600)
 
     def test_04_countdown_preview(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_countdown', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'snippet_countdown', login='admin')
 
     def test_05_social_media(self):
         self.env.ref('website.default_website').write({
@@ -74,7 +74,7 @@ class TestSnippets(HttpCase):
             'social_discord': 'https://discord.com/servers/discord-town-hall-169256939211980800',
         })
         create_image_attachment(self.env, '/web/image/website.s_banner_default_image', 's_banner_default_image.jpg')
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_social_media', login="admin")
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'snippet_social_media', login="admin")
         self.assertEqual(
             self.env['website'].browse(1).social_instagram,
             'https://instagram.com/odoo.official/',
@@ -82,21 +82,21 @@ class TestSnippets(HttpCase):
         )
 
     def test_06_snippet_popup_add_remove(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_popup_add_remove', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'snippet_popup_add_remove', login='admin')
 
     def test_07_image_gallery(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_image_gallery', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'snippet_image_gallery', login='admin')
 
     def test_08_table_of_content(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_table_of_content', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'snippet_table_of_content', login='admin')
 
     def test_09_snippet_image_gallery(self):
         create_image_attachment(self.env, '/web/image/website.s_banner_default_image', 's_default_image.jpg')
         create_image_attachment(self.env, '/web/image/website.s_banner_default_image_2', 's_default_image2.webp')
-        self.start_tour("/", "snippet_image_gallery_remove", login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), "snippet_image_gallery_remove", login='admin')
 
     def test_10_parallax(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'test_parallax', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'test_parallax', login='admin')
 
     def test_11_snippet_popup_display_on_click(self):
         # To make the tour reliable we need to wait a field using data-fill-with
@@ -109,50 +109,50 @@ class TestSnippets(HttpCase):
                 'vat': 'BE0477472701',
             }).id
         })
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_popup_display_on_click', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'snippet_popup_display_on_click', login='admin')
 
     def test_12_snippet_images_wall(self):
-        self.start_tour('/', 'snippet_images_wall', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'snippet_images_wall', login='admin')
 
     def test_snippet_popup_with_scrollbar_and_animations(self):
         website = self.env.ref('website.default_website')
         website.cookies_bar = True
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_popup_and_scrollbar', login='admin')
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_popup_and_animations', login='admin', timeout=90)
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'snippet_popup_and_scrollbar', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'snippet_popup_and_animations', login='admin', timeout=90)
 
     def test_drag_and_drop_on_non_editable(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'test_drag_and_drop_on_non_editable', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'test_drag_and_drop_on_non_editable', login='admin')
 
     def test_snippet_image_gallery_reorder(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), "snippet_image_gallery_reorder", login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), "snippet_image_gallery_reorder", login='admin')
 
     def test_snippet_image_gallery_thumbnail_update(self):
         create_image_attachment(self.env, '/web/image/website.s_banner_default_image', 's_default_image.jpg')
         create_image_attachment(self.env, '/web/image/website.s_banner_default_image_2', 's_default_image_2.jpg')
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_image_gallery_thumbnail_update', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'snippet_image_gallery_thumbnail_update', login='admin')
 
     def test_dropdowns_and_header_hide_on_scroll(self):
         self.env.ref('base.user_admin').write({
             'name': 'mitchell admin',
             'email': 'mitchell.admin@example.com',
         })
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'dropdowns_and_header_hide_on_scroll', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'dropdowns_and_header_hide_on_scroll', login='admin')
 
     def test_snippet_image(self):
         create_image_attachment(self.env, '/web/image/website.s_banner_default_image', 's_default_image.jpg')
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_image', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'snippet_image', login='admin')
 
     def test_rating_snippet(self):
-        self.start_tour(self.env["website"].get_client_action_url("/"), "snippet_rating", login="admin")
+        self.start_tour(self.env["website"].get_client_action_url("/", True), "snippet_rating", login="admin")
 
     def test_custom_popup_snippet(self):
-        self.start_tour(self.env["website"].get_client_action_url("/"), "custom_popup_snippet", login="admin")
+        self.start_tour(self.env["website"].get_client_action_url("/", True), "custom_popup_snippet", login="admin")
 
     def test_snippet_popup_open_on_top(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_popup_open_on_top', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'snippet_popup_open_on_top', login='admin')
 
     def test_tabs_snippet(self):
-        self.start_tour(self.env["website"].get_client_action_url("/"), "snippet_tabs", login="admin")
+        self.start_tour(self.env["website"].get_client_action_url("/", True), "snippet_tabs", login="admin")
 
     def test_cookie_bar_updates_gtag_consent(self):
         website = self.env.ref('website.default_website')
@@ -161,7 +161,7 @@ class TestSnippets(HttpCase):
         self.start_tour(website.get_client_action_url('/'), 'cookie_bar_updates_gtag_consent')
 
     def test_shape_image_snippet(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_shape_image', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'snippet_shape_image', login='admin')
 
     def test_snippet_pill_shape(self):
         res = self.url_open('/html_editor/image_shape/website.s_intro_pill_default_image/html_builder/geometric_round/geo_round_pill.svg')

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -137,7 +137,7 @@ class TestUiHtmlEditor(HttpCaseWithUserDemo):
         '''
         generic_page.arch = oe_structure_layout
         oe_structure_layout = generic_page.arch
-        self.start_tour(self.env['website'].get_client_action_url('/generic'), 'html_editor_multiple_templates', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/generic', True), 'html_editor_multiple_templates', login='admin')
         self.assertEqual(View.search_count([('key', '=', 'test.generic_view')]), 2, "homepage view should have been COW'd")
         self.assertTrue(generic_page.arch == oe_structure_layout, "Generic homepage view should be untouched")
         self.assertEqual(len(generic_page.inherit_children_ids.filtered(lambda v: 'oe_structure' in v.name)), 0, "oe_structure view should have been deleted when aboutus was COW")
@@ -180,7 +180,7 @@ class TestUiHtmlEditor(HttpCaseWithUserDemo):
         mock_media_library_search.routing_type = 'json'
         HTML_Editor.media_library_search = http.route(['/html_editor/media_library_search'], type='jsonrpc', auth='user', website=True)(mock_media_library_search)
 
-        self.start_tour("/", 'website_media_dialog_undraw', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'website_media_dialog_undraw', login='admin')
 
     def test_dynamic_svg_theme_colors(self):
         svg = (
@@ -198,18 +198,17 @@ class TestUiHtmlEditor(HttpCaseWithUserDemo):
             'public': True,
             'url': '/html_editor/shape/illustration/dynamic-svg-test',
         })
-        self.start_tour("/", 'website_dynamic_svg_theme_colors', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'website_dynamic_svg_theme_colors', login='admin')
 
     def test_code_editor_usable(self):
         # TODO: enable debug mode when failing tests have been fixed (props validation)
-        url = '/odoo/action-website.website_preview'
-        self.start_tour(url, 'website_code_editor_usable', login='admin')
+        self.start_tour(self.env["website"].get_client_action_url("/", False), 'website_code_editor_usable', login='admin')
 
 
 @odoo.tests.tagged('external', '-standard', '-at_install', 'post_install')
 class TestUiHtmlEditorWithExternal(HttpCaseWithUserDemo):
     def test_media_dialog_external_library(self):
-        self.start_tour("/", 'website_media_dialog_external_library', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'website_media_dialog_external_library', login='admin')
 
 
 @odoo.tests.tagged('-at_install', 'post_install')
@@ -221,7 +220,7 @@ class TestUiTranslate(odoo.tests.HttpCase):
             'iso_code': 'pa_GB',
             'url_code': 'pa_GB',
         })
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'rte_translator', login='admin', timeout=120)
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'rte_translator', login='admin', timeout=120)
 
     def test_translate_menu_name(self):
         lang_en = self.env.ref('base.lang_en')
@@ -244,7 +243,7 @@ class TestUiTranslate(odoo.tests.HttpCase):
             'url': '/englishURL',
         })
 
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'translate_menu_name', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/pa_GB'), 'translate_menu_name', login='admin')
 
         self.assertNotEqual(new_menu.name, 'value pa-GB', msg="The new menu should not have its value edited, only its translation")
         self.assertEqual(new_menu.with_context(lang=parseltongue.code).name, 'value pa-GB', msg="The new translation should be set")
@@ -259,7 +258,7 @@ class TestUiTranslate(odoo.tests.HttpCase):
             'language_ids': [(6, 0, (lang_en + lang_fr).ids)],
         })
 
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'translate_text_options', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'translate_text_options', login='admin')
 
     def test_snippet_translation(self):
         ResLang = self.env['res.lang']
@@ -319,7 +318,7 @@ class TestUiTranslate(odoo.tests.HttpCase):
         })
         Website = self.env['website']
         Website.create({'name': 'Website Test'})
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'multiple_websites_add_language', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'multiple_websites_add_language', login='admin')
 
     def test_translate_select_element(self):
         lang_en = self.env.ref('base.lang_en')
@@ -331,7 +330,7 @@ class TestUiTranslate(odoo.tests.HttpCase):
             'language_ids': [(6, 0, (lang_en + lang_fr).ids)],
         })
 
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'translate_select_element', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'translate_select_element', login='admin')
 
 
 @odoo.tests.common.tagged('post_install', '-at_install')
@@ -410,7 +409,7 @@ class TestUi(HttpCaseWithWebsiteUser):
                 </xpath>
             """,
         }])
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_version_1', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'snippet_version_1', login='admin')
 
     def test_08_website_style_custo(self):
         self.env['ir.attachment'].create({
@@ -420,17 +419,17 @@ class TestUi(HttpCaseWithWebsiteUser):
             'name': 'bg_test.png',
             'mimetype': 'image/png',
         })
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'website_style_edition', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'website_style_edition', login='admin')
 
     def test_09_website_edit_link_popover(self):
-        self.start_tour('/@/', 'edit_link_popover', login='admin', timeout=180)
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'edit_link_popover', login='admin', timeout=180)
 
     def test_10_website_conditional_visibility(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'conditional_visibility_1', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'conditional_visibility_1', login='admin')
         self.start_tour('/odoo', 'conditional_visibility_2', login='website_user')
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'conditional_visibility_3', login='admin', timeout=180)
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'conditional_visibility_4', login='admin')
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'conditional_visibility_5', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'conditional_visibility_3', login='admin', timeout=180)
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'conditional_visibility_4', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'conditional_visibility_5', login='admin')
 
     def test_11_website_snippet_background_edition(self):
         self.env['ir.attachment'].create({
@@ -440,7 +439,7 @@ class TestUi(HttpCaseWithWebsiteUser):
             'name': 'test.png',
             'mimetype': 'image/png',
         })
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_background_edition', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'snippet_background_edition', login='admin')
 
     def test_12_edit_translated_page_redirect(self):
         lang = self.env['res.lang']._activate_lang('nl_NL')
@@ -448,34 +447,34 @@ class TestUi(HttpCaseWithWebsiteUser):
         self.start_tour("/nl/contactus", 'edit_translated_page_redirect', login='admin')
 
     def test_14_carousel_snippet_content_removal(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'carousel_content_removal', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'carousel_content_removal', login='admin')
 
     def test_16_website_edit_megamenu(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'edit_megamenu', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'edit_megamenu', login='admin')
 
     def test_website_megamenu_active_nav_link(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'megamenu_active_nav_link', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'megamenu_active_nav_link', login='admin')
 
     def test_17_website_edit_menus(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'edit_menus', login='admin')
 
     def test_18_website_snippets_menu_tabs(self):
-        self.start_tour('/', 'website_snippets_menu_tabs', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'website_snippets_menu_tabs', login='admin')
 
     def test_19_website_page_options(self):
-        self.start_tour("/odoo", "website_page_options", login="admin")
+        self.start_tour(self.env['website'].get_client_action_url('/', True), "website_page_options", login="admin")
 
     def test_20_snippet_editor_panel_options(self):
-        self.start_tour('/@/', 'snippet_editor_panel_options', login='admin')
+        self.start_tour(self.env["website"].get_client_action_url('/', True), 'snippet_editor_panel_options', login='admin')
 
     def test_21_website_start_cloned_snippet(self):
-        self.start_tour('/odoo', 'website_start_cloned_snippet', login='admin')
+        self.start_tour(self.env["website"].get_client_action_url('', True), 'website_start_cloned_snippet', login='admin')
 
     def test_22_website_gray_color_palette(self):
-        self.start_tour('/odoo', 'website_gray_color_palette', login='admin')
+        self.start_tour(self.env["website"].get_client_action_url('/', True), 'website_gray_color_palette', login='admin')
 
     def test_23_website_multi_edition(self):
-        self.start_tour('/@/', 'website_multi_edition', login='admin')
+        self.start_tour(self.env["website"].get_client_action_url('/', True), 'website_multi_edition', login='admin')
 
     def test_24_snippet_cache_across_websites(self):
         default_website = self.env.ref('website.default_website')
@@ -494,7 +493,7 @@ class TestUi(HttpCaseWithWebsiteUser):
             thumbnail_url='/website/static/src/img/snippets_thumbs/s_text_block.svg',
             snippet_key='s_text_block',
             template_key='website.snippets')
-        self.start_tour('/@/', 'snippet_cache_across_websites', login='admin', cookies={
+        self.start_tour(self.env["website"].get_client_action_url('/@/', True), 'snippet_cache_across_websites', login='admin', cookies={
             'websiteIdMapping': json.dumps({'Test Website': website.id})
         })
 
@@ -509,13 +508,13 @@ class TestUi(HttpCaseWithWebsiteUser):
             'social_tiktok': 'https://www.tiktok.com/@odoo',
             'social_discord': 'https://discord.com/servers/discord-town-hall-169256939211980800',
         })
-        self.start_tour("/", 'website_media_dialog_icons', login='admin')
+        self.start_tour(self.env["website"].get_client_action_url('/', True), 'website_media_dialog_icons', login='admin')
 
     def test_27_website_clicks(self):
-        self.start_tour('/odoo', 'website_click_tour', login='admin')
+        self.start_tour(self.env["website"].get_client_action_url('/', False), 'website_click_tour', login='admin')
 
     def test_29_website_text_edition(self):
-        self.start_tour('/@/', 'website_text_edition', login='admin')
+        self.start_tour(self.env["website"].get_client_action_url('/', True), 'website_text_edition', login='admin')
 
     def test_29_website_backend_menus_redirect(self):
         Menu = self.env['ir.ui.menu']
@@ -530,13 +529,13 @@ class TestUi(HttpCaseWithWebsiteUser):
         self.start_tour('/', 'website_backend_menus_redirect', login='admin')
 
     def test_30_website_text_animations(self):
-        self.start_tour("/", 'text_animations', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'text_animations', login='admin')
 
     def test_31_website_edit_megamenu_big_icons_subtitles(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'edit_megamenu_big_icons_subtitles', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'edit_megamenu_big_icons_subtitles', login='admin')
 
     def test_32_website_background_colorpicker(self):
-        self.start_tour(self.env['website'].get_client_action_url("/"), "website_background_colorpicker", login="admin")
+        self.start_tour(self.env['website'].get_client_action_url("/", True), "website_background_colorpicker", login="admin")
 
     def test_33_website_menus(self):
         # Create a website to prevent auto-assignment of the default parent menu.
@@ -546,22 +545,22 @@ class TestUi(HttpCaseWithWebsiteUser):
         self.start_tour("/odoo/action-website.action_website_menu", "parent_child_menu", login="admin")
 
     def test_34_website_page_breadcrumb(self):
-        self.start_tour('/contactus', 'website_page_breadcrumb', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url("/contactus", False), 'website_page_breadcrumb', login='admin')
 
     def test_website_media_dialog_image_shape(self):
-        self.start_tour("/", 'website_media_dialog_image_shape', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url("/", True), 'website_media_dialog_image_shape', login='admin')
 
     def test_website_media_dialog_insert_media(self):
-        self.start_tour("/", "website_media_dialog_insert_media", login="admin")
+        self.start_tour(self.env['website'].get_client_action_url("/", True), "website_media_dialog_insert_media", login="admin")
 
     def test_website_text_font_size(self):
-        self.start_tour('/@/', 'website_text_font_size', login='admin', timeout=300)
+        self.start_tour(self.env['website'].get_client_action_url("/", True), 'website_text_font_size', login='admin', timeout=300)
 
     def test_update_column_count(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'website_update_column_count', login="admin")
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'website_update_column_count', login="admin")
 
     def test_website_text_highlights(self):
-        self.start_tour("/", 'text_highlights', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'text_highlights', login='admin')
 
     def test_website_extra_items_no_dirty_page(self):
         """
@@ -595,7 +594,7 @@ class TestUi(HttpCaseWithWebsiteUser):
             'parent_id': website.menu_id.id,
         })
 
-        self.start_tour('/', 'website_no_action_no_dirty_page', login='admin')
+        self.start_tour(self.env["website"].get_client_action_url('/', True), 'website_no_action_no_dirty_page', login='admin')
 
     def test_website_no_dirty_page(self):
         # Previous tests are testing the dirty behavior when the extra items
@@ -604,7 +603,7 @@ class TestUi(HttpCaseWithWebsiteUser):
         website = self.env['website'].get_current_website()
         website.menu_id.child_id[1:].unlink()
 
-        self.start_tour('/', 'website_no_dirty_page', login='admin')
+        self.start_tour(self.env["website"].get_client_action_url('/', True), 'website_no_dirty_page', login='admin')
 
     def test_interaction_lifecycle(self):
         self.env['ir.asset'].create({
@@ -612,7 +611,7 @@ class TestUi(HttpCaseWithWebsiteUser):
             'bundle': 'website.assets_wysiwyg',
             'path': 'website/static/tests/tour_utils/lifecycle_patch_wysiwyg.js',
         })
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'interaction_lifecycle', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'interaction_lifecycle', login='admin')
 
     def test_drop_404_ir_attachment_url(self):
         website_snippets = self.env.ref('website.snippets')
@@ -648,14 +647,14 @@ class TestUi(HttpCaseWithWebsiteUser):
             'model': 'ir.attachment',
             'res_id': attachment.id,
         })
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'drop_404_ir_attachment_url', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'drop_404_ir_attachment_url', login='admin')
 
     def test_mobile_order_with_drag_and_drop(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'website_mobile_order_with_drag_and_drop', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'website_mobile_order_with_drag_and_drop', login='admin')
 
     def test_powerbox_snippet(self):
-        self.start_tour('/', 'website_powerbox_snippet', login='admin')
-        self.start_tour('/', 'website_powerbox_keyword', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'website_powerbox_snippet', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'website_powerbox_keyword', login='admin')
 
     def test_website_no_dirty_lazy_image(self):
         website = self.env['website'].browse(1)
@@ -688,7 +687,7 @@ class TestUi(HttpCaseWithWebsiteUser):
         ]:
             self.env['website'].with_context(website_id=website.id).viewref(key).active = active
 
-        self.start_tour('/', 'website_no_dirty_lazy_image', login='admin')
+        self.start_tour(self.env["website"].get_client_action_url("/", True), 'website_no_dirty_lazy_image', login='admin')
 
     def test_website_edit_menus_delete_parent(self):
         website = self.env['website'].browse(1)
@@ -708,46 +707,46 @@ class TestUi(HttpCaseWithWebsiteUser):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'edit_menus_delete_parent', login='admin')
 
     def test_snippet_carousel(self):
-        self.start_tour('/', 'snippet_carousel', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'snippet_carousel', login='admin')
 
     def test_snippet_carousel_clickable_slides(self):
-        self.start_tour("/", "snippet_carousel_clickable_slides", login="admin")
+        self.start_tour(self.env['website'].get_client_action_url('/', True), "snippet_carousel_clickable_slides", login="admin")
 
     def test_media_iframe_video(self):
-        self.start_tour("/", "website_media_iframe_video", login="admin")
+        self.start_tour(self.env['website'].get_client_action_url('/', True), "website_media_iframe_video", login="admin")
 
     def test_snippet_visibility_option(self):
-        self.start_tour("/", "snippet_visibility_option", login="admin")
+        self.start_tour(self.env['website'].get_client_action_url('/', True), "snippet_visibility_option", login="admin")
 
     def test_website_font_family(self):
-        self.start_tour("/", "website_font_family", login="admin")
+        self.start_tour(self.env['website'].get_client_action_url('/', True), "website_font_family", login="admin")
 
     def test_website_seo_notification(self):
-        self.start_tour(self.env['website'].get_client_action_url("/"), "website_seo_notification", login="admin")
+        self.start_tour(self.env['website'].get_client_action_url("/", False), "website_seo_notification", login="admin")
 
     def test_website_add_snippet_dialog(self):
-        self.start_tour("/", "website_add_snippet_dialog", login="admin")
+        self.start_tour(self.env['website'].get_client_action_url("/", True), "website_add_snippet_dialog", login="admin")
 
     def test_popup_visibility_option(self):
-        self.start_tour("/", "website_popup_visibility_option", login="admin")
+        self.start_tour(self.env['website'].get_client_action_url("/", True), "website_popup_visibility_option", login="admin")
 
     def test_systray_items_disappear(self):
-        self.start_tour("/", "website_systray_items_disappear", login="admin")
+        self.start_tour(self.env['website'].get_client_action_url("/", False), "website_systray_items_disappear", login="admin")
 
     def test_auto_hide_menu(self):
-        self.start_tour("/", "website_auto_hide_menu", login="admin")
+        self.start_tour(self.env['website'].get_client_action_url("/", False), "website_auto_hide_menu", login="admin")
 
     def test_editing_awaits_navigation(self):
-        self.start_tour("/", "website_editing_awaits_navigation", login="admin")
+        self.start_tour(self.env['website'].get_client_action_url("/", False), "website_editing_awaits_navigation", login="admin")
 
     def test_create_missing_page(self):
-        self.start_tour("/", "create_missing_page", login="admin")
+        self.start_tour(self.env['website'].get_client_action_url("/", True), "create_missing_page", login="admin")
 
     def test_hiding_sidebar_header(self):
-        self.start_tour("/", "hide_sidebar_header", login="admin")
+        self.start_tour(self.env['website'].get_client_action_url("/", True), "hide_sidebar_header", login="admin")
 
     def test_website_edit_megamenu_visibility(self):
-        self.start_tour("/", 'edit_megamenu_visibility', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url("/", True), 'edit_megamenu_visibility', login='admin')
 
     def test_alt_a_edit(self):
         lang_en = self.env.ref('base.lang_en')
@@ -777,10 +776,10 @@ class TestUi(HttpCaseWithWebsiteUser):
         self.start_tour('/', 'alt_a_edit', login='admin')
 
     def test_mega_footer(self):
-        self.start_tour('/', 'mega_footer', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url("/", True), 'mega_footer', login='admin')
 
     def test_anchor_on_accordion_item(self):
-        self.start_tour("/", "anchor_behaviour_on_accordion_same_tab", login="admin")
+        self.start_tour(self.env['website'].get_client_action_url("/", True), "anchor_behaviour_on_accordion_same_tab", login="admin")
         self.start_tour("/#What-services-does-your-company-offer-%3F", "anchor_behaviour_on_accordion_new_tab", login="admin")
 
     def test_background_color_gradient_precedence(self):
@@ -795,4 +794,4 @@ class TestUi(HttpCaseWithWebsiteUser):
                 'menu-gradient': 'linear-gradient(rgb(2, 2, 2), rgb(3, 3, 3))',
             },
         )
-        self.start_tour('/', 'background_color_gradient_precedence', login='admin')
+        self.start_tour(self.env["website"].get_client_action_url('/', True), 'background_color_gradient_precedence', login='admin')

--- a/addons/website/tests/test_website_form_editor.py
+++ b/addons/website/tests/test_website_form_editor.py
@@ -21,12 +21,12 @@ class TestWebsiteFormEditor(HttpCaseWithUserPortal):
         })
 
     def test_tour(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'website_form_editor_tour', login='admin', timeout=240)
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'website_form_editor_tour', login='admin', timeout=240)
         self.start_tour('/', 'website_form_editor_tour_submit')
         self.start_tour('/', 'website_form_editor_tour_results', login="admin")
 
     def test_website_form_contact_us_edition_with_email(self):
-        self.start_tour('/odoo', 'website_form_contactus_edition_with_email', login="admin")
+        self.start_tour(self.env['website'].get_client_action_url('/contactus', True), 'website_form_contactus_edition_with_email', login="admin")
         self.start_tour('/contactus', 'website_form_contactus_submit', login="portal")
         mail = self.env['mail.mail'].search([], order='id desc', limit=1)
         self.assertEqual(
@@ -36,7 +36,7 @@ class TestWebsiteFormEditor(HttpCaseWithUserPortal):
 
     def test_website_form_contact_us_edition_no_email(self):
         self.env.company.email = 'website_form_contactus_edition_no_email@mail.com'
-        self.start_tour('/odoo', 'website_form_contactus_edition_no_email', login="admin")
+        self.start_tour(self.env['website'].get_client_action_url('/contactus', True), 'website_form_contactus_edition_no_email', login="admin")
         self.start_tour('/contactus', 'website_form_contactus_submit', login="portal")
         mail = self.env['mail.mail'].search([], order='id desc', limit=1)
         self.assertEqual(
@@ -45,29 +45,29 @@ class TestWebsiteFormEditor(HttpCaseWithUserPortal):
             'The email was not edited, the form should still have been sent to the company email')
 
     def test_website_form_conditional_required_checkboxes(self):
-        self.start_tour('/', 'website_form_conditional_required_checkboxes', login="admin")
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'website_form_conditional_required_checkboxes', login="admin")
 
     def test_contactus_form_email_stay_dynamic(self):
         # The contactus form should always be sent to the company email except
         # if the user explicitly changed it in the options.
         self.env.company.email = 'before.change@mail.com'
-        self.start_tour('/contactus', 'website_form_contactus_change_random_option', login="admin")
+        self.start_tour(self.env['website'].get_client_action_url('/contactus', True), 'website_form_contactus_change_random_option', login="admin")
         self.env.company.email = 'after.change@mail.com'
         self.start_tour('/contactus', 'website_form_contactus_check_changed_email', login="portal")
 
     def test_website_form_editable_content(self):
-        self.start_tour('/', 'website_form_editable_content', login="admin")
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'website_form_editable_content', login="admin")
 
     def test_website_form_special_characters(self):
-        self.start_tour('/', 'website_form_special_characters', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'website_form_special_characters', login='admin')
         mail = self.env['mail.mail'].search([], order='id desc', limit=1)
         self.assertIn('Test1&#34;&#39;', mail.body_html, 'The single quotes and double quotes characters should be visible on the received mail')
 
     def test_website_form_nested_forms(self):
-        self.start_tour('/my/account', 'website_form_nested_forms', login='admin')
+        self.start_tour(self.env["website"].get_client_action_url('/my/account', True), 'website_form_nested_forms', login='admin')
 
     def test_website_form_duplicate_field_ids(self):
-        self.start_tour('/', 'website_form_duplicate_field_ids', login='admin')
+        self.start_tour(self.env["website"].get_client_action_url('/', True), 'website_form_duplicate_field_ids', login='admin')
 
 
 @tagged('post_install', '-at_install')

--- a/addons/website_blog/static/src/tours/website_blog.js
+++ b/addons/website_blog/static/src/tours/website_blog.js
@@ -3,119 +3,108 @@ import { clickOnSave, registerWebsitePreviewTour } from "@website/js/tours/tour_
 
 import { markup } from "@odoo/owl";
 
-registerWebsitePreviewTour(
-    "blog",
+registerWebsitePreviewTour("blog", {}, () => [
     {
-        url: "/",
+        trigger: "body:not(:has(.o_new_content_menu_choices)) .o_new_content_container > button",
+        content: _t("Click here to add new content to your website."),
+        tooltipPosition: "bottom",
+        run: "click",
     },
-    () => [
-        {
-            trigger:
-                "body:not(:has(.o_new_content_menu_choices)) .o_new_content_container > button",
-            content: _t("Click here to add new content to your website."),
-            tooltipPosition: "bottom",
-            run: "click",
-        },
-        {
-            trigger: 'button[data-module-xml-id="base.module_website_blog"]',
-            content: _t("Select this menu item to create a new blog post."),
-            tooltipPosition: "bottom",
-            run: "click",
-        },
-        {
-            trigger: 'div[name="name"] input',
-            content: _t("Enter your post's title"),
-            tooltipPosition: "bottom",
-            run: "edit Test",
-        },
-        {
-            trigger: 'div.o_field_widget[name="blog_id"]',
-        },
-        {
-            trigger: "button.o_form_button_save",
-            content: _t("Select the blog you want to add the post to."),
-            // Without demo data (and probably in most user cases) there is only
-            // one blog so this step would not be needed and would block the
-            // tour. We keep the step with "auto: true", so that the main python
-            // test still works but never display this to the user anymore. We
-            // suppose the user does not need guidance once that modal is
-            // opened. Note: if you run the tour via your console without demo
-            // data, the tour will thus fail as this will be considered.
-            run: "click",
-        },
-        {
-            trigger: ".o_builder_sidebar_open .o-snippets-menu",
-            timeout: 15000,
-        },
-        {
-            trigger: ':iframe h1[data-oe-expression="blog_post.name"]',
-            content: _t("Edit your title, the subtitle is optional."),
-            tooltipPosition: "top",
-            run: "click",
-        },
-        {
-            trigger: `:iframe #wrap h1[data-oe-expression="blog_post.name"]:not(:contains(''))`,
-        },
-        {
-            trigger: "button[data-action-id='setCoverBackground'][title='Image']",
-            content: markup(_t("Set a blog post <b>cover</b>.")),
-            tooltipPosition: "top",
-            run: "click",
-        },
-        {
-            trigger: ".o_select_media_dialog .o_we_search",
-            content: _t('Search for an image. (eg: type "business")'),
-            tooltipPosition: "top",
-        },
-        {
-            trigger: ".o_select_media_dialog .o_existing_attachment_cell:first .o_button_area",
-            content: _t("Choose an image from the library."),
-            tooltipPosition: "top",
-            run: "click",
-        },
-        {
-            trigger: ":iframe #o_wblog_post_content p",
-            content: markup(
-                _t(
-                    "<b>Write your story here.</b> Use the top toolbar to style your text: add an image or table, set bold or italic, etc. Drag and drop building blocks for more graphical blogs."
-                )
-            ),
-            tooltipPosition: "top",
-            run: "editor Blog content",
-        },
-        ...clickOnSave(),
-        {
-            trigger: ".o_menu_systray_item.o_mobile_preview > a",
-            content: markup(
-                _t("Use this icon to preview your blog post on <b>mobile devices</b>.")
-            ),
-            tooltipPosition: "bottom",
-            run: "click",
-        },
-        {
-            trigger: ".o_website_preview.o_is_mobile",
-        },
-        {
-            trigger: ".o_menu_systray_item.o_mobile_preview > a",
-            content: _t(
-                "Once you have reviewed the content on mobile, you can switch back to the normal view by clicking here again"
-            ),
-            tooltipPosition: "right",
-            run: "click",
-        },
-        {
-            trigger: ":iframe body:not(.editor_enable)",
-        },
-        {
-            trigger: '.o_menu_systray_item a:contains("Unpublished")',
-            tooltipPosition: "bottom",
-            content: markup(
-                _t("<b>Publish your blog post</b> to make it visible to your visitors.")
-            ),
-            run: "click",
-        },
-        {
-            trigger: '.o_menu_systray_item a:contains("Published")',
-        },
-    ]
-);
+    {
+        trigger: 'button[data-module-xml-id="base.module_website_blog"]',
+        content: _t("Select this menu item to create a new blog post."),
+        tooltipPosition: "bottom",
+        run: "click",
+    },
+    {
+        trigger: 'div[name="name"] input',
+        content: _t("Enter your post's title"),
+        tooltipPosition: "bottom",
+        run: "edit Test",
+    },
+    {
+        trigger: 'div.o_field_widget[name="blog_id"]',
+    },
+    {
+        trigger: "button.o_form_button_save",
+        content: _t("Select the blog you want to add the post to."),
+        // Without demo data (and probably in most user cases) there is only
+        // one blog so this step would not be needed and would block the
+        // tour. We keep the step with "auto: true", so that the main python
+        // test still works but never display this to the user anymore. We
+        // suppose the user does not need guidance once that modal is
+        // opened. Note: if you run the tour via your console without demo
+        // data, the tour will thus fail as this will be considered.
+        run: "click",
+    },
+    {
+        trigger: ".o_builder_sidebar_open .o-snippets-menu",
+        timeout: 15000,
+    },
+    {
+        trigger: ':iframe h1[data-oe-expression="blog_post.name"]',
+        content: _t("Edit your title, the subtitle is optional."),
+        tooltipPosition: "top",
+        run: "click",
+    },
+    {
+        trigger: `:iframe #wrap h1[data-oe-expression="blog_post.name"]:not(:contains(''))`,
+    },
+    {
+        trigger: "button[data-action-id='setCoverBackground'][title='Image']",
+        content: markup(_t("Set a blog post <b>cover</b>.")),
+        tooltipPosition: "top",
+        run: "click",
+    },
+    {
+        trigger: ".o_select_media_dialog .o_we_search",
+        content: _t('Search for an image. (eg: type "business")'),
+        tooltipPosition: "top",
+    },
+    {
+        trigger: ".o_select_media_dialog .o_existing_attachment_cell:first .o_button_area",
+        content: _t("Choose an image from the library."),
+        tooltipPosition: "top",
+        run: "click",
+    },
+    {
+        trigger: ":iframe #o_wblog_post_content p",
+        content: markup(
+            _t(
+                "<b>Write your story here.</b> Use the top toolbar to style your text: add an image or table, set bold or italic, etc. Drag and drop building blocks for more graphical blogs."
+            )
+        ),
+        tooltipPosition: "top",
+        run: "editor Blog content",
+    },
+    ...clickOnSave(),
+    {
+        trigger: ".o_menu_systray_item.o_mobile_preview > a",
+        content: markup(_t("Use this icon to preview your blog post on <b>mobile devices</b>.")),
+        tooltipPosition: "bottom",
+        run: "click",
+    },
+    {
+        trigger: ".o_website_preview.o_is_mobile",
+    },
+    {
+        trigger: ".o_menu_systray_item.o_mobile_preview > a",
+        content: _t(
+            "Once you have reviewed the content on mobile, you can switch back to the normal view by clicking here again"
+        ),
+        tooltipPosition: "right",
+        run: "click",
+    },
+    {
+        trigger: ":iframe body:not(.editor_enable)",
+    },
+    {
+        trigger: '.o_menu_systray_item a:contains("Unpublished")',
+        tooltipPosition: "bottom",
+        content: markup(_t("<b>Publish your blog post</b> to make it visible to your visitors.")),
+        run: "click",
+    },
+    {
+        trigger: '.o_menu_systray_item a:contains("Published")',
+    },
+]);

--- a/addons/website_blog/static/tests/tours/blog_context.js
+++ b/addons/website_blog/static/tests/tours/blog_context.js
@@ -8,7 +8,6 @@ registerWebsitePreviewTour(
     "blog_context_and_social_media",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/blog",
     },
     () => [
         {

--- a/addons/website_blog/static/tests/tours/blog_manager_tour.js
+++ b/addons/website_blog/static/tests/tours/blog_manager_tour.js
@@ -7,85 +7,73 @@ import {
 /**
  * Makes sure that blog are only managable by Blog Manager Group.
  */
-registerWebsitePreviewTour(
-    "blog_manager",
+registerWebsitePreviewTour("blog_manager", {}, () => [
     {
-        url: "/blog",
+        content: "Open create content menu.",
+        trigger: ".o_menu_systray .o_new_content_container button",
+        run: "click",
     },
-    () => [
-        {
-            content: "Open create content menu.",
-            trigger: ".o_menu_systray .o_new_content_container button",
-            run: "click",
-        },
-        {
-            content: "Select option to create a new blog post.",
-            trigger: "button[data-module-xml-id='base.module_website_blog']",
-            run: "click",
-        },
-        {
-            content: "Enter your post's title",
-            trigger: "div[name='name'] input",
-            run: "edit Manager Blog",
-        },
-        {
-            content: "Click on save button to create the blog post.",
-            trigger: "button.o_form_button_save",
-            run: "click",
-        },
-        ...clickOnEditAndWaitEditMode(),
-        {
-            content: "Edit blog title",
-            trigger: ":iframe [data-oe-expression='blog_post.name']",
-            run: "editor Manager Blog Test Title",
-        },
-        {
-            content: "Edit blog content.",
-            trigger: ":iframe #o_wblog_post_content p",
-            run: "editor Manager Blog Test Content",
-        },
-        ...clickOnSave(),
-        {
-            content: "Check if blog get edited!",
-            trigger: ":iframe #o_wblog_post_content p:contains('Manager Blog Test Content')",
-        },
-    ]
-);
+    {
+        content: "Select option to create a new blog post.",
+        trigger: "button[data-module-xml-id='base.module_website_blog']",
+        run: "click",
+    },
+    {
+        content: "Enter your post's title",
+        trigger: "div[name='name'] input",
+        run: "edit Manager Blog",
+    },
+    {
+        content: "Click on save button to create the blog post.",
+        trigger: "button.o_form_button_save",
+        run: "click",
+    },
+    ...clickOnEditAndWaitEditMode(),
+    {
+        content: "Edit blog title",
+        trigger: ":iframe [data-oe-expression='blog_post.name']",
+        run: "editor Manager Blog Test Title",
+    },
+    {
+        content: "Edit blog content.",
+        trigger: ":iframe #o_wblog_post_content p",
+        run: "editor Manager Blog Test Content",
+    },
+    ...clickOnSave(),
+    {
+        content: "Check if blog get edited!",
+        trigger: ":iframe #o_wblog_post_content p:contains('Manager Blog Test Content')",
+    },
+]);
 
-registerWebsitePreviewTour(
-    "blog_no_manager",
+registerWebsitePreviewTour("blog_no_manager", {}, () => [
     {
-        url: "/blog",
+        content: "Open create content menu.",
+        trigger: ".o_menu_systray .o_new_content_container button",
+        run: "click",
     },
-    () => [
-        {
-            content: "Open create content menu.",
-            trigger: ".o_menu_systray .o_new_content_container button",
-            run: "click",
-        },
-        {
-            content: "Check if Blog Option is not present.",
-            trigger:
-                ".o_new_content_menu_choices:not(:has([data-module-xml-id='base.module_website_blog']))",
-        },
-        {
-            content: "Click on the first article",
-            trigger: ":iframe article[name='blog_post'] a",
-            run: "click",
-        },
-        {
-            content: "Open Post Form in Backend",
-            trigger: ".o_website_edit_in_backend a",
-            run: "click",
-        },
-        {
-            content: "Click on gear Icon",
-            trigger: ".o_action_manager button[data-tooltip='Actions']",
-            run: "click",
-        },
-        {
-            content: "Check if delete action is available or not",
-            trigger: ".o_popover:not(:has(i.fa-trash-o))",
-        },
-    ]
-);
+    {
+        content: "Check if Blog Option is not present.",
+        trigger:
+            ".o_new_content_menu_choices:not(:has([data-module-xml-id='base.module_website_blog']))",
+    },
+    {
+        content: "Click on the first article",
+        trigger: ":iframe article[name='blog_post'] a",
+        run: "click",
+    },
+    {
+        content: "Open Post Form in Backend",
+        trigger: ".o_website_edit_in_backend a",
+        run: "click",
+    },
+    {
+        content: "Click on gear Icon",
+        trigger: ".o_action_manager button[data-tooltip='Actions']",
+        run: "click",
+    },
+    {
+        content: "Check if delete action is available or not",
+        trigger: ".o_popover:not(:has(i.fa-trash-o))",
+    },
+]);

--- a/addons/website_blog/static/tests/tours/blog_posts_dynamic_snippet.js
+++ b/addons/website_blog/static/tests/tours/blog_posts_dynamic_snippet.js
@@ -21,7 +21,6 @@ registerWebsitePreviewTour(
     "blog_posts_dynamic_snippet_options",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/?debug=1",
         edition: true,
     },
     () => [

--- a/addons/website_blog/static/tests/tours/blog_posts_dynamic_snippet_visibility.js
+++ b/addons/website_blog/static/tests/tours/blog_posts_dynamic_snippet_visibility.js
@@ -39,7 +39,6 @@ const isSnippetHidden = () => [
 registerWebsitePreviewTour(
     "blog_posts_dynamic_snippet_edit",
     {
-        url: "/",
         edition: true,
     },
     () => [
@@ -57,24 +56,12 @@ registerWebsitePreviewTour(
     ]
 );
 
-registerWebsitePreviewTour(
-    "blog_posts_dynamic_snippet_empty",
-    {
-        url: "/",
-    },
-    isSnippetHidden
-);
+registerWebsitePreviewTour("blog_posts_dynamic_snippet_empty", {}, isSnippetHidden);
 
-registerWebsitePreviewTour(
-    "blog_posts_dynamic_snippet_misconfigured",
+registerWebsitePreviewTour("blog_posts_dynamic_snippet_misconfigured", {}, () => [
+    ...isSnippetHidden(),
     {
-        url: "/",
+        content: "Check that the snippet 'missing option' warning is visible",
+        trigger: ":iframe .s_dynamic_snippet_blog_posts .missing_option_warning",
     },
-    () => [
-        ...isSnippetHidden(),
-        {
-            content: "Check that the snippet 'missing option' warning is visible",
-            trigger: ":iframe .s_dynamic_snippet_blog_posts .missing_option_warning",
-        },
-    ]
-);
+]);

--- a/addons/website_blog/static/tests/tours/blog_sidebar_with_date_and_tag.js
+++ b/addons/website_blog/static/tests/tours/blog_sidebar_with_date_and_tag.js
@@ -1,62 +1,55 @@
 import { registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
 
-registerWebsitePreviewTour(
-    "blog_sidebar_with_date_and_tag",
+registerWebsitePreviewTour("blog_sidebar_with_date_and_tag", {}, () => [
     {
-        url: "/blog",
+        content: "Click on the 'Nature' blog category to filter blog posts.",
+        trigger: ":iframe b:contains('Nature')",
+        run: "click",
     },
-    () => [
-        {
-            content: "Click on the 'Nature' blog category to filter blog posts.",
-            trigger: ":iframe b:contains('Nature')",
-            run: "click",
+    {
+        content: "Verify that the blog post list shows only posts from the 'Nature' category.",
+        trigger: ":iframe .o_wblog_post_name:contains('Nature')",
+    },
+    {
+        content: "Check if the archive dropdown contains exactly 1 option: February.",
+        trigger: ":iframe select[name=archive]",
+        run: function () {
+            const optionEls = this.anchor.querySelectorAll("optgroup option");
+            const length = optionEls.length;
+            const monthName = optionEls[0].textContent;
+            if (length !== 1 || !monthName.includes("February")) {
+                throw new Error("Expected 1 option in the select with February");
+            }
         },
-        {
-            content: "Verify that the blog post list shows only posts from the 'Nature' category.",
-            trigger: ":iframe .o_wblog_post_name:contains('Nature')",
+    },
+    {
+        content: "Click on the 'Space' blog category to switch filters.",
+        trigger: ":iframe b:contains('Space')",
+        run: "click",
+    },
+    {
+        content: "Verify that the blog post list shows only posts from the 'Space' category.",
+        trigger: ":iframe .o_wblog_post_name:contains('Space')",
+    },
+    {
+        content: "Verify that the archive dropdown now contains only 1 option: January.",
+        trigger: ":iframe select[name=archive]",
+        run: function () {
+            const optionEls = this.anchor.querySelectorAll("optgroup option");
+            const length = optionEls.length;
+            const monthName = optionEls[0].textContent;
+            if (length !== 1 || !monthName.includes("January")) {
+                throw new Error("Expected 1 option in the select with January");
+            }
         },
-        {
-            content: "Check if the archive dropdown contains exactly 1 option: February.",
-            trigger: ":iframe select[name=archive]",
-            run: function () {
-                const optionEls = this.anchor.querySelectorAll("optgroup option");
-                const length = optionEls.length;
-                const monthName = optionEls[0].textContent;
-                if (length !== 1 || !monthName.includes("February")) {
-                    throw new Error("Expected 1 option in the select with February");
-                }
-            },
-        },
-        {
-            content: "Click on the 'Space' blog category to switch filters.",
-            trigger: ":iframe b:contains('Space')",
-            run: "click",
-        },
-        {
-            content: "Verify that the blog post list shows only posts from the 'Space' category.",
-            trigger: ":iframe .o_wblog_post_name:contains('Space')",
-        },
-        {
-            content: "Verify that the archive dropdown now contains only 1 option: January.",
-            trigger: ":iframe select[name=archive]",
-            run: function () {
-                const optionEls = this.anchor.querySelectorAll("optgroup option");
-                const length = optionEls.length;
-                const monthName = optionEls[0].textContent;
-                if (length !== 1 || !monthName.includes("January")) {
-                    throw new Error("Expected 1 option in the select with January");
-                }
-            },
-        },
-        {
-            content: "Click on the 'Second Blog Post' to view its details.",
-            trigger: ":iframe article a:contains('Second Blog Post')",
-            run: "click",
-        },
-        {
-            content:
-                "Verify that 'Add some' button has the correct URL for navigating to the backend.",
-            trigger: ":iframe #edit-in-backend[href*='/odoo/website/blog.post/']",
-        },
-    ]
-);
+    },
+    {
+        content: "Click on the 'Second Blog Post' to view its details.",
+        trigger: ":iframe article a:contains('Second Blog Post')",
+        run: "click",
+    },
+    {
+        content: "Verify that 'Add some' button has the correct URL for navigating to the backend.",
+        trigger: ":iframe #edit-in-backend[href*='/odoo/website/blog.post/']",
+    },
+]);

--- a/addons/website_blog/static/tests/tours/blog_tags_tour.js
+++ b/addons/website_blog/static/tests/tours/blog_tags_tour.js
@@ -13,7 +13,6 @@ registerWebsitePreviewTour(
     "blog_tags",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/blog",
     },
     () => [
         stepUtils.waitIframeIsReady(),

--- a/addons/website_blog/static/tests/tours/blog_tags_with_date.js
+++ b/addons/website_blog/static/tests/tours/blog_tags_with_date.js
@@ -8,7 +8,6 @@ registerWebsitePreviewTour(
     "blog_tags_with_date",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: "/blog",
     },
     () => [
         {

--- a/addons/website_blog/static/tests/tours/snippet_blog_post.js
+++ b/addons/website_blog/static/tests/tours/snippet_blog_post.js
@@ -9,7 +9,6 @@ import {
 registerWebsitePreviewTour(
     "snippet_blog_bost",
     {
-        url: "/",
         edition: true,
     },
     () => [

--- a/addons/website_blog/tests/test_ui.py
+++ b/addons/website_blog/tests/test_ui.py
@@ -69,7 +69,7 @@ class TestWebsiteBlogUi(odoo.tests.HttpCase, TestWebsiteBlogCommon):
             'social_discord': 'https://discord.com/servers/discord-town-hall-169256939211980800',
         })
         self.env.ref('website_blog.opt_blog_sidebar_show').active = True
-        self.start_tour("/blog", "blog_context_and_social_media", login="admin")
+        self.start_tour(self.env["website"].get_client_action_url("/blog"), "blog_context_and_social_media", login="admin")
 
     def test_avatar_comment(self):
         mail_message = self.env['mail.message'].create({
@@ -114,7 +114,7 @@ class TestWebsiteBlogUi(odoo.tests.HttpCase, TestWebsiteBlogCommon):
 
         self.env.ref("website_blog.opt_blog_sidebar_show").active = True
         self.env.ref("website_blog.opt_blog_post_sidebar").active = True
-        self.start_tour("/blog", "blog_sidebar_with_date_and_tag", login="admin")
+        self.start_tour(self.env["website"].get_client_action_url("/blog"), "blog_sidebar_with_date_and_tag", login="admin")
 
         blog_tag = self.env.ref('website_blog.blog_tag_5', raise_if_not_found=False)
         if not blog_tag:
@@ -122,7 +122,7 @@ class TestWebsiteBlogUi(odoo.tests.HttpCase, TestWebsiteBlogCommon):
         blog_post_1.write({'tag_ids': [(4, blog_tag.id)]})
         blog_post_2.write({'tag_ids': [(4, blog_tag.id)]})
 
-        self.start_tour("/blog", "blog_tags_with_date", login="admin")
+        self.start_tour(self.env["website"].get_client_action_url("/blog"), "blog_tags_with_date", login="admin")
 
     def test_blog_access_rights(self):
         group_website_blog_manager_id = self.ref("website_blog.group_website_blog_manager")
@@ -144,10 +144,10 @@ class TestWebsiteBlogUi(odoo.tests.HttpCase, TestWebsiteBlogCommon):
         self.start_tour(self.env["website"].get_client_action_url("/blog"), "blog_no_manager", login="eve")
 
     def test_blog_posts_dynamic_snippet_options(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'blog_posts_dynamic_snippet_options', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True, True), 'blog_posts_dynamic_snippet_options', login='admin')
 
     def test_blog_posts_dynamic_snippet_visibility(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'blog_posts_dynamic_snippet_edit', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/', True), 'blog_posts_dynamic_snippet_edit', login='admin')
         homepage_view = self.env['ir.ui.view'].search([
             ('website_id', '=', self.env.ref('website.default_website').id),
             ('key', '=', 'website.homepage'),

--- a/addons/website_crm/static/tests/tours/website_crm.js
+++ b/addons/website_crm/static/tests/tours/website_crm.js
@@ -31,7 +31,6 @@ function setFormActionToCreateOpportunity() {
 registerWebsitePreviewTour(
     "website_crm_pre_tour",
     {
-        url: "/contactus",
         edition: true,
     },
     () => [
@@ -112,7 +111,6 @@ registry.category("web_tour.tours").add('website_crm_catch_logged_partner_info_t
 registerWebsitePreviewTour(
     "website_crm_form_properties",
     {
-        url: "/contactus",
         edition: true,
     },
     () => [

--- a/addons/website_crm/tests/test_website_crm.py
+++ b/addons/website_crm/tests/test_website_crm.py
@@ -13,7 +13,7 @@ class TestWebsiteCrm(odoo.tests.HttpCase, TestCrmCommon):
         utm_medium = self.env['utm.medium'].create({'name': 'Medium'})
         utm_source = self.env['utm.source'].create({'name': 'Source'})
         # change action to create opportunity
-        self.start_tour(self.env['website'].get_client_action_url('/contactus'), 'website_crm_pre_tour', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/contactus', True), 'website_crm_pre_tour', login='admin')
         self.start_tour("/?utm_source=Source&utm_medium=Medium&utm_campaign=New campaign", 'website_crm_tour')
 
         # check result
@@ -40,7 +40,7 @@ class TestWebsiteCrm(odoo.tests.HttpCase, TestCrmCommon):
         partner_phone = user_partner.phone
 
         # no edit on prefilled data from logged partner : propagate partner_id on created lead
-        self.start_tour(self.env['website'].get_client_action_url('/contactus'), 'website_crm_pre_tour', login=user_login)
+        self.start_tour(self.env['website'].get_client_action_url('/contactus', True), 'website_crm_pre_tour', login=user_login)
 
         with odoo.tests.RecordCapturer(self.env['crm.lead']) as capt:
             self.start_tour("/", "website_crm_catch_logged_partner_info_tour", login=user_login)
@@ -62,4 +62,4 @@ class TestWebsiteCrm(odoo.tests.HttpCase, TestCrmCommon):
             'string': 'test property',
             'type': 'char',
         }]
-        self.start_tour(self.env['website'].get_client_action_url('/contactus'), 'website_crm_form_properties', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/contactus', True), 'website_crm_form_properties', login='admin')

--- a/addons/website_event/static/tests/tours/website_event.js
+++ b/addons/website_event/static/tests/tours/website_event.js
@@ -112,10 +112,7 @@ function websiteEditEventTourSteps() {
     ];
 }
 
-registerWebsitePreviewTour(
-    "website_event_tour",
-    {
-        url: "/",
-    },
-    () => [...websiteCreateEventTourSteps(), ...websiteEditEventTourSteps()]
-);
+registerWebsitePreviewTour("website_event_tour", {}, () => [
+    ...websiteCreateEventTourSteps(),
+    ...websiteEditEventTourSteps(),
+]);

--- a/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
+++ b/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
@@ -73,9 +73,7 @@ registry.category("web_tour.tours").add('website_hr_recruitment_tour', {
     }),
 ]});
 
-registerWebsitePreviewTour('website_hr_recruitment_tour_edit_form', {
-    url: '/jobs',
-}, () => [
+registerWebsitePreviewTour('website_hr_recruitment_tour_edit_form', {}, () => [
     stepUtils.waitIframeIsReady(),
 {
     content: 'Go to the Guru job page',

--- a/addons/website_livechat/static/tests/tours/lazy_frontend_bus_tour.js
+++ b/addons/website_livechat/static/tests/tours/lazy_frontend_bus_tour.js
@@ -6,7 +6,6 @@ import { patchWithCleanup } from "@web/../tests/helpers/utils";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_livechat.lazy_frontend_bus", {
-    url: "/",
     steps: () => [
         {
             trigger: "body",

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_forward.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_forward.js
@@ -3,7 +3,6 @@ import { registry } from "@web/core/registry";
 const messagesContain = (text) => `.o-livechat-root:shadow .o-mail-Message:contains("${text}")`;
 
 registry.category("web_tour.tours").add("website_livechat.chatbot_forward", {
-    url: "/",
     steps: () => [
         {
             trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",

--- a/addons/website_livechat/static/tests/tours/website_livechat_rating.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_rating.js
@@ -13,38 +13,31 @@ import {
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_livechat_complete_flow_tour", {
-    url: "/",
     steps: () =>
         [].concat(start, closeChat, confirmnClose, okRating, feedback, downloadTranscript, close),
 });
 
 registry.category("web_tour.tours").add("website_livechat_complete_flow_tour_logged_in", {
-    url: "/",
     steps: () =>
         [].concat(start, closeChat, confirmnClose, okRating, feedback, emailTranscript, close),
 });
 
 registry.category("web_tour.tours").add("website_livechat_happy_rating_tour", {
-    url: "/",
     steps: () => [].concat(start, closeChat, confirmnClose, goodRating, feedback),
 });
 
 registry.category("web_tour.tours").add("website_livechat_ok_rating_tour", {
-    url: "/",
     steps: () => [].concat(start, closeChat, confirmnClose, okRating, feedback),
 });
 
 registry.category("web_tour.tours").add("website_livechat_sad_rating_tour", {
-    url: "/",
     steps: () => [].concat(start, closeChat, confirmnClose, sadRating, feedback),
 });
 
 registry.category("web_tour.tours").add("website_livechat_no_rating_tour", {
-    url: "/",
     steps: () => [].concat(start, closeChat, confirmnClose, downloadTranscript, close),
 });
 
 registry.category("web_tour.tours").add("website_livechat_no_rating_no_close_tour", {
-    url: "/",
     steps: () => [].concat(start),
 });

--- a/addons/website_livechat/static/tests/tours/website_livechat_request.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_request.js
@@ -45,7 +45,6 @@ const chatRequest = [
 ];
 
 registry.category("web_tour.tours").add("website_livechat_chat_request", {
-    url: "/",
     steps: () =>
         [].concat(chatRequest, closeChat, confirmnClose, okRating, feedback, downloadTranscript),
 });

--- a/addons/website_livechat/static/tests/tours/website_livechat_session_user_changes.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_session_user_changes.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_livechat_logout_after_chat_start", {
-    url: "/",
     steps: () => [
         {
             trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",

--- a/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_block_with_edit.js
+++ b/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_block_with_edit.js
@@ -7,7 +7,6 @@ import {
 } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour('snippet_newsletter_block_with_edit', {
-    url: '/',
     edition: true,
 }, () => [
     // Put a Newsletter block.

--- a/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_popup_edition.js
+++ b/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_popup_edition.js
@@ -2,24 +2,27 @@ import {
     clickOnSave,
     insertSnippet,
     registerWebsitePreviewTour,
-} from '@website/js/tours/tour_utils';
+} from "@website/js/tours/tour_utils";
 
-registerWebsitePreviewTour("snippet_newsletter_popup_edition", {
-    url: "/",
-    edition: true,
-}, () => [
-    ...insertSnippet({
-        id: 's_newsletter_subscribe_popup',
-        name: 'Newsletter Popup',
-        groupName: "Contact & Forms",
-    }),
+registerWebsitePreviewTour(
+    "snippet_newsletter_popup_edition",
     {
-        content: "Check the modal is opened for edition",
-        trigger: ':iframe .o_newsletter_popup .modal:visible',
+        edition: true,
     },
-    ...clickOnSave(),
-    {
-        content: "Check the modal has been saved, closed",
-        trigger: ':iframe body:has(.o_newsletter_popup:not(:visible) .modal)',
-    }
-]);
+    () => [
+        ...insertSnippet({
+            id: "s_newsletter_subscribe_popup",
+            name: "Newsletter Popup",
+            groupName: "Contact & Forms",
+        }),
+        {
+            content: "Check the modal is opened for edition",
+            trigger: ":iframe .o_newsletter_popup .modal:visible",
+        },
+        ...clickOnSave(),
+        {
+            content: "Check the modal has been saved, closed",
+            trigger: ":iframe body:has(.o_newsletter_popup:not(:visible) .modal)",
+        },
+    ]
+);

--- a/addons/website_mass_mailing/tests/test_snippets.py
+++ b/addons/website_mass_mailing/tests/test_snippets.py
@@ -8,7 +8,7 @@ from odoo.tests import HttpCase, tagged
 class TestSnippets(HttpCase):
 
     def test_snippet_newsletter_popup(self):
-        self.start_tour("/", "snippet_newsletter_popup_edition", login='admin')
+        self.start_tour(self.env["website"].get_client_action_url("/", True), "snippet_newsletter_popup_edition", login='admin')
         self.start_tour("/", "snippet_newsletter_popup_use", login=None)
 
         mailing_list = self.env['mailing.list'].search([], limit=1)
@@ -27,7 +27,7 @@ class TestSnippets(HttpCase):
             'contact_ids': [(3, contact_id) for contact_id in mass_mailing_contacts.ids],
         })
         self.start_tour(
-            self.env['website'].get_client_action_url('/'),
+            self.env['website'].get_client_action_url('/', True),
             "snippet_newsletter_block_with_edit",
             login='admin'
         )

--- a/addons/website_partnership/static/tests/tours/publish.js
+++ b/addons/website_partnership/static/tests/tours/publish.js
@@ -10,7 +10,6 @@ import { stepUtils } from "@web_tour/tour_utils";
 
 registerWebsitePreviewTour('test_can_publish_partner', {
     edition: false,
-    url: '/partners',
 }, () => [
     stepUtils.waitIframeIsReady(),
 {
@@ -43,7 +42,6 @@ registerWebsitePreviewTour('test_can_publish_partner', {
 
 registerWebsitePreviewTour('test_cannot_publish_partner', {
     edition: false,
-    url: '/partners',
 }, () => [
     stepUtils.waitIframeIsReady(),
 {

--- a/addons/website_payment/static/tests/tours/donation.js
+++ b/addons/website_payment/static/tests/tours/donation.js
@@ -10,7 +10,6 @@ import {
 registerWebsitePreviewTour(
     "donation_snippet_edition",
     {
-        url: "/",
         edition: true,
     },
     () => [
@@ -24,7 +23,6 @@ registerWebsitePreviewTour(
 );
 
 registry.category("web_tour.tours").add("donation_snippet_use", {
-    url: "/",
     steps: () => [
         // -- Testing the minimum amount --
         {
@@ -120,7 +118,6 @@ registry.category("web_tour.tours").add("donation_snippet_use", {
 registerWebsitePreviewTour(
     "donation_snippet_edition_2",
     {
-        url: "/",
         edition: true,
     },
     () => [
@@ -136,7 +133,6 @@ registerWebsitePreviewTour(
 );
 
 registry.category("web_tour.tours").add("donation_snippet_use_2", {
-    url: "/",
     steps: () => [
         {
             content: "Click on $10 button",

--- a/addons/website_payment/static/tests/tours/donation_form_custom_fields.js
+++ b/addons/website_payment/static/tests/tours/donation_form_custom_fields.js
@@ -32,7 +32,6 @@ function fillInputField(selector, value) {
 registerWebsitePreviewTour(
     "donation_form_custom_field_create",
     {
-        url: "/donation/pay",
         edition: true,
     },
     () => [

--- a/addons/website_payment/tests/test_snippets.py
+++ b/addons/website_payment/tests/test_snippets.py
@@ -28,11 +28,11 @@ class TestSnippets(HttpCaseWithUserPortal):
         self.user_portal.country_id = belgium.id
 
     def test_01_donation(self):
-        self.start_tour("/?enable_editor=1", "donation_snippet_edition", login='admin')
+        self.start_tour(self.env["website"].get_client_action_url("/", True), "donation_snippet_edition", login='admin')
         self.start_tour("/", "donation_snippet_use", login="portal")
-        self.start_tour("/?enable_editor=1", "donation_snippet_edition_2", login='admin')
+        self.start_tour(self.env["website"].get_client_action_url("/", True), "donation_snippet_edition_2", login='admin')
         self.start_tour("/", "donation_snippet_use_2", login="portal")
 
     def test_02_donation_form_custom_field(self):
-        self.start_tour("/donation/pay", "donation_form_custom_field_create", login="admin")
+        self.start_tour(self.env["website"].get_client_action_url("/donation/pay", True), "donation_form_custom_field_create", login="admin")
         self.start_tour("/donation/pay", "donation_form_custom_field_submit", login="portal")

--- a/addons/website_sale/data/tour.xml
+++ b/addons/website_sale/data/tour.xml
@@ -3,5 +3,6 @@
     <record id="test_01_admin_shop_tour" model="web_tour.tour">
         <field name="name">website_sale.onboarding_tour</field>
         <field name="sequence">130</field>
+        <field name="url">/shop</field>
     </record>
 </odoo>

--- a/addons/website_sale/static/src/js/tours/website_sale_shop.js
+++ b/addons/website_sale/static/src/js/tours/website_sale_shop.js
@@ -3,109 +3,110 @@ import {
     goBackToBlocks,
     insertSnippet,
     registerWebsitePreviewTour,
-} from '@website/js/tours/tour_utils';
+} from "@website/js/tours/tour_utils";
 
 import { markup } from "@odoo/owl";
 
-registerWebsitePreviewTour(
-    "website_sale.onboarding_tour",
+registerWebsitePreviewTour("website_sale.onboarding_tour", {}, () => [
     {
-        url: '/shop',
+        trigger: ":iframe .o_wsale_products_page",
     },
-    () => [
-        {
-            trigger: ":iframe .o_wsale_products_page",
-        },
-        {
-            trigger: ".o_menu_systray .o_new_content_container > button",
-            content: _t("Let's create your first product."),
-            tooltipPosition: "bottom",
-            run: "click",
-        },
-        {
-            trigger: "button[data-module-xml-id='base.module_website_sale']",
-            content: markup(_t("Select <b>New Product</b> to create it and manage its properties to boost your sales.")),
-            tooltipPosition: "bottom",
-            run: "click",
-        },
-        {
-            trigger: ".modal-dialog input[type=text]",
-            content: _t("Enter a name for your new product"),
-            tooltipPosition: "left",
-            run: "edit Test",
-        },
-        {
-            trigger: ".modal-footer button.btn-primary",
-            content: markup(_t("Click on <em>Save</em> to create the product.")),
-            tooltipPosition: "right",
-            run: "click",
-        },
-        {
-            trigger: ".o_builder_sidebar_open",
-        },
-        {
-            trigger: ":iframe .product_price .oe_currency_value:visible",
-            content: _t("Edit the price of this product by clicking on the amount."),
-            tooltipPosition: "bottom",
-            run: "editor 1.99",
-            timeout: 30000,
-        },
-        {
-            trigger: ":iframe .product_price .o_dirty .oe_currency_value:not(:text(1.00))",
-        },
-        {
-            trigger: ":iframe #wrap img.product_detail_img",
-            content: _t("Double click here to set an image describing your product."),
-            tooltipPosition: "top",
-            run: "dblclick",
-        },
-        {
-            isActive: ["auto"],
-            trigger: ".o_select_media_dialog .o_upload_media_button",
-            content: _t("Upload a file from your local library."),
-            tooltipPosition: "bottom",
-            run: "click .modal-footer .btn-secondary",
-        },
-        goBackToBlocks(),
-        {
-            trigger: "body:not(.modal-open)",
-        },
-        ...insertSnippet({
-            id: "s_text_image",
-            name: "Text - Image",
-            groupName: "Content",
-        }),
-        {
-            // Wait until the drag and drop is resolved (causing a history step)
-            // before clicking save.
-            trigger: ".o-snippets-top-actions button.fa-undo:not([disabled])",
-        },
-        {
-            trigger: "button[data-action=save]",
-            content: markup(_t("Once you click on <b>Save</b>, your product is updated.")),
-            tooltipPosition: "bottom",
-            run: "click",
-        },
-        {
-            trigger: ":iframe body:not(.editor_enable)",
-        },
-        {
-            trigger: ".o_menu_systray_item.o_website_publish_container a",
-            content: _t("Click on this button so your customers can see it."),
-            tooltipPosition: "bottom",
-            run: "click",
-        },
-        {
-            trigger: "button[data-menu-xmlid='website.menu_reporting']",
-            content: _t("Click here to open the reporting menu"),
-            tooltipPosition: "bottom",
-            run: "click",
-        },
-        {
-            trigger: "a[data-menu-xmlid='website.menu_website_dashboard'], a[data-menu-xmlid='website.menu_website_analytics']",
-            content: _t("Let's now take a look at your eCommerce dashboard to get your eCommerce website ready in no time."),
-            tooltipPosition: "bottom",
-            // Just check during test mode. Otherwise, clicking it will result to random error on loading the Chart.js script.
-        }
-    ]
-);
+    {
+        trigger: ".o_menu_systray .o_new_content_container > button",
+        content: _t("Let's create your first product."),
+        tooltipPosition: "bottom",
+        run: "click",
+    },
+    {
+        trigger: "button[data-module-xml-id='base.module_website_sale']",
+        content: markup(
+            _t(
+                "Select <b>New Product</b> to create it and manage its properties to boost your sales."
+            )
+        ),
+        tooltipPosition: "bottom",
+        run: "click",
+    },
+    {
+        trigger: ".modal-dialog input[type=text]",
+        content: _t("Enter a name for your new product"),
+        tooltipPosition: "left",
+        run: "edit Test",
+    },
+    {
+        trigger: ".modal-footer button.btn-primary",
+        content: markup(_t("Click on <em>Save</em> to create the product.")),
+        tooltipPosition: "right",
+        run: "click",
+    },
+    {
+        trigger: ".o_builder_sidebar_open",
+    },
+    {
+        trigger: ":iframe .product_price .oe_currency_value:visible",
+        content: _t("Edit the price of this product by clicking on the amount."),
+        tooltipPosition: "bottom",
+        run: "editor 1.99",
+        timeout: 30000,
+    },
+    {
+        trigger: ":iframe .product_price .o_dirty .oe_currency_value:not(:text(1.00))",
+    },
+    {
+        trigger: ":iframe #wrap img.product_detail_img",
+        content: _t("Double click here to set an image describing your product."),
+        tooltipPosition: "top",
+        run: "dblclick",
+    },
+    {
+        isActive: ["auto"],
+        trigger: ".o_select_media_dialog .o_upload_media_button",
+        content: _t("Upload a file from your local library."),
+        tooltipPosition: "bottom",
+        run: "click .modal-footer .btn-secondary",
+    },
+    goBackToBlocks(),
+    {
+        trigger: "body:not(.modal-open)",
+    },
+    ...insertSnippet({
+        id: "s_text_image",
+        name: "Text - Image",
+        groupName: "Content",
+    }),
+    {
+        // Wait until the drag and drop is resolved (causing a history step)
+        // before clicking save.
+        trigger: ".o-snippets-top-actions button.fa-undo:not([disabled])",
+    },
+    {
+        trigger: "button[data-action=save]",
+        content: markup(_t("Once you click on <b>Save</b>, your product is updated.")),
+        tooltipPosition: "bottom",
+        run: "click",
+    },
+    {
+        trigger: ":iframe body:not(.editor_enable)",
+    },
+    {
+        trigger: ".o_menu_systray_item.o_website_publish_container a",
+        content: _t("Click on this button so your customers can see it."),
+        tooltipPosition: "bottom",
+        run: "click",
+    },
+    {
+        trigger: "button[data-menu-xmlid='website.menu_reporting']",
+        content: _t("Click here to open the reporting menu"),
+        tooltipPosition: "bottom",
+        run: "click",
+    },
+    {
+        trigger:
+            "a[data-menu-xmlid='website.menu_website_dashboard'], a[data-menu-xmlid='website.menu_website_analytics']",
+        content: _t(
+            "Let's now take a look at your eCommerce dashboard to get your eCommerce website ready in no time."
+        ),
+        tooltipPosition: "bottom",
+        // Just check during test mode. Otherwise, clicking it will result to random error on loading the Chart.js script.
+    },
+]);

--- a/addons/website_sale/static/tests/tours/add_to_cart_snippet_tour.js
+++ b/addons/website_sale/static/tests/tours/add_to_cart_snippet_tour.js
@@ -35,7 +35,6 @@ registerWebsitePreviewTour(
     'website_sale.add_to_cart_snippet',
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: '/',
         edition: true,
     },
     () => [

--- a/addons/website_sale/static/tests/tours/category_page_and_products_snippet.js
+++ b/addons/website_sale/static/tests/tours/category_page_and_products_snippet.js
@@ -5,13 +5,8 @@ import {
     registerWebsitePreviewTour,
 } from "@website/js/tours/tour_utils";
 
-registerWebsitePreviewTour(
-    'website_sale.category_page_and_products_snippet_edition',
+registerWebsitePreviewTour("website_sale.category_page_and_products_snippet_edition", {}, () => [
     {
-        url: '/shop',
-    },
-    () => [
-        {
         content: "Navigate to category",
         trigger: ':iframe .o_wsale_filmstrip > li:contains("Test Category") > a',
         run: "click",

--- a/addons/website_sale/static/tests/tours/complete_flow_backend.js
+++ b/addons/website_sale/static/tests/tours/complete_flow_backend.js
@@ -1,8 +1,8 @@
-import { clickOnSave, registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
+import { clickOnSave, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
 
-registerWebsitePreviewTour('website_sale.enable_extra_info',
+registerWebsitePreviewTour(
+    "website_sale.enable_extra_info",
     {
-        url: '/shop/cart',
         edition: true,
     },
     () => [
@@ -16,12 +16,13 @@ registerWebsitePreviewTour('website_sale.enable_extra_info',
         },
         {
             content: "Enable Extra step",
-            trigger: "[data-action-param='{\"views\":[\"website_sale.extra_info\"]}'] input[type='checkbox']",
+            trigger:
+                "[data-action-param='{\"views\":[\"website_sale.extra_info\"]}'] input[type='checkbox']",
             run: "click",
         },
         {
             trigger: ":iframe .o_wizard [name=step_name]:contains(extra)",
         },
         ...clickOnSave(),
-    ],
+    ]
 );

--- a/addons/website_sale/static/tests/tours/remove_product_image.js
+++ b/addons/website_sale/static/tests/tours/remove_product_image.js
@@ -3,7 +3,7 @@ import {
     clickOnEditAndWaitEditMode,
     clickOnSave,
     registerWebsitePreviewTour,
-} from '@website/js/tours/tour_utils';
+} from "@website/js/tours/tour_utils";
 
 const clickOnImgAndWaitForLoad = [
     {
@@ -30,69 +30,58 @@ const enterEditModeOfTestProduct = () => [
     ...clickOnEditAndWaitEditMode(),
 ];
 
-
-registerWebsitePreviewTour(
-    "website_sale.add_and_remove_main_product_image_no_variant",
+registerWebsitePreviewTour("website_sale.add_and_remove_main_product_image_no_variant", {}, () => [
+    ...enterEditModeOfTestProduct(),
     {
-        url: "/shop?search=Test Remove Image",
+        content: "Double click on the product image",
+        trigger: ":iframe #o-carousel-product img[alt='Test Remove Image']",
+        run: "dblclick",
     },
-    () => [
-        ...enterEditModeOfTestProduct(),
-        {
-            content: "Double click on the product image",
-            trigger: ":iframe #o-carousel-product img[alt='Test Remove Image']",
-            run: "dblclick",
-        },
-        {
-            content: "Click on the new image",
-            trigger: ".o_select_media_dialog .o_existing_attachment_cell .o_button_area",
-            run: "click",
-        },
-        {
-            content: "Check that the snippet editor of the clicked image has been loaded",
-            trigger: ".o_customize_tab [data-container-title='Image']",
-        },
-        {
-            content: "Ensure the new image is really loaded in DOM before click on remove",
-            trigger: `:iframe .o_product_detail_img_wrapper img:not([alt='Test Remove Image'])`,
-        },
-        // Double check not placeholder image is loaded with :not(:contains(5.9 kB)
-        {
-            content: "Click on Remove",
-            trigger: ".o_customize_tab [data-container-title='Image']:has(.o-hb-image-size-info:not(:contains(5.9 kB))) button[data-action-id='removeMedia']",
-            run: "click",
-        },
-        // If the snippet editor is not visible, the remove process is considered as finished.
-        {
-            content: "Check that the snippet editor is not visible",
-            trigger: ".o_customize_tab:not(:has([data-container-title='Image']))",
-        },
-    ]
-);
-registerWebsitePreviewTour(
-    "website_sale.remove_main_product_image_with_variant",
     {
-        url: "/shop?search=Test Remove Image",
+        content: "Click on the new image",
+        trigger: ".o_select_media_dialog .o_existing_attachment_cell .o_button_area",
+        run: "click",
     },
-    () => [
-        ...enterEditModeOfTestProduct(),
-        ...clickOnImgAndWaitForLoad,
-        ...clickOnSave(),
-        ...clickOnEditAndWaitEditMode(),
-        ...clickOnImgAndWaitForLoad,
-        {
-            content: "Ensure the image is really loaded in DOM before click on remove",
-            trigger: `:iframe .o_product_detail_img_wrapper img`,
-        },
-        {
-            content: "Click on Remove",
-            trigger: ".o_customize_tab [data-container-title='Image']:has(.o-hb-image-size-info) button[data-action-id='removeMedia']",
-            run: "click",
-        },
-        // If the snippet editor is not visible, the remove process is considered as finished.
-        {
-            content: "Check that the snippet editor is not visible",
-            trigger: ".o_customize_tab:not(:has([data-container-title='Image']))",
-        },
-    ]
-);
+    {
+        content: "Check that the snippet editor of the clicked image has been loaded",
+        trigger: ".o_customize_tab [data-container-title='Image']",
+    },
+    {
+        content: "Ensure the new image is really loaded in DOM before click on remove",
+        trigger: `:iframe .o_product_detail_img_wrapper img:not([alt='Test Remove Image'])`,
+    },
+    // Double check not placeholder image is loaded with :not(:contains(5.9 kB)
+    {
+        content: "Click on Remove",
+        trigger:
+            ".o_customize_tab [data-container-title='Image']:has(.o-hb-image-size-info:not(:contains(5.9 kB))) button[data-action-id='removeMedia']",
+        run: "click",
+    },
+    // If the snippet editor is not visible, the remove process is considered as finished.
+    {
+        content: "Check that the snippet editor is not visible",
+        trigger: ".o_customize_tab:not(:has([data-container-title='Image']))",
+    },
+]);
+registerWebsitePreviewTour("website_sale.remove_main_product_image_with_variant", {}, () => [
+    ...enterEditModeOfTestProduct(),
+    ...clickOnImgAndWaitForLoad,
+    ...clickOnSave(),
+    ...clickOnEditAndWaitEditMode(),
+    ...clickOnImgAndWaitForLoad,
+    {
+        content: "Ensure the image is really loaded in DOM before click on remove",
+        trigger: `:iframe .o_product_detail_img_wrapper img`,
+    },
+    {
+        content: "Click on Remove",
+        trigger:
+            ".o_customize_tab [data-container-title='Image']:has(.o-hb-image-size-info) button[data-action-id='removeMedia']",
+        run: "click",
+    },
+    // If the snippet editor is not visible, the remove process is considered as finished.
+    {
+        content: "Check that the snippet editor is not visible",
+        trigger: ".o_customize_tab:not(:has([data-container-title='Image']))",
+    },
+]);

--- a/addons/website_sale/static/tests/tours/restricted_editor_ui.js
+++ b/addons/website_sale/static/tests/tours/restricted_editor_ui.js
@@ -1,55 +1,50 @@
 import { stepUtils } from "@web_tour/tour_utils";
-import { registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
+import { registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
 
-registerWebsitePreviewTour(
-    'website_sale.restricted_editor_ui',
+registerWebsitePreviewTour("website_sale.restricted_editor_ui", {}, () => [
     {
-        url: `/shop`,
+        content: "Open the site menu to check what is inside",
+        trigger: '[data-menu-xmlid="website.menu_site"]',
+        run: "click",
     },
-    () => [
-        {
-            content: "Open the site menu to check what is inside",
-            trigger: '[data-menu-xmlid="website.menu_site"]',
-            run: "click",
-        },
-        {
-            // Not very robust but still nice to have an extra check as this is the
-            // main purpose of this tour
-            content: "First check the user is not a designer",
-            trigger: '.dropdown-menu:not(:has([data-menu-xmlid="website.menu_edit_menu"]))',
-            run: "click",
-        },
-        {
-            // Wait for the possibility to edit to appear
-            trigger: ".o_menu_systray button:contains('Edit')",
-        },
-        {
-            content: "Ensure the publish and 'edit-in-backend' buttons are not shown",
-            trigger: '.o_menu_systray:not(:has(.form-switch)):not(:has(.o_website_edit_in_backend))',
-            run: "click",
-        },
-        stepUtils.waitIframeIsReady(),
-        {
-            content: "Navigate to the first product",
-            trigger: ':iframe .oe_product_image_link',
-            run: "click",
-        },
-        {
-            content: "Click on publish/unpublish",
-            trigger: '.o_website_publish_container a:has(input:checked)',
-            run: "click",
-        },
-        {
-            trigger:
-                ".o_menu_systray_item:not([data-processing]) .form-switch:has(input:not(:checked))",
-        },
-        {
-            content: "Click on edit-in-backend",
-            trigger: '.o_menu_systray .o_website_edit_in_backend a',
-            run: "click",
-        },
-        {
-            content: "Check that you landed on a form view and that the record was unpublished",
-            trigger: '.o-form-buttonbox [name="is_published"] .fa-globe.text-danger',
-        },
-    ]);
+    {
+        // Not very robust but still nice to have an extra check as this is the
+        // main purpose of this tour
+        content: "First check the user is not a designer",
+        trigger: '.dropdown-menu:not(:has([data-menu-xmlid="website.menu_edit_menu"]))',
+        run: "click",
+    },
+    {
+        // Wait for the possibility to edit to appear
+        trigger: ".o_menu_systray button:contains('Edit')",
+    },
+    {
+        content: "Ensure the publish and 'edit-in-backend' buttons are not shown",
+        trigger: ".o_menu_systray:not(:has(.form-switch)):not(:has(.o_website_edit_in_backend))",
+        run: "click",
+    },
+    stepUtils.waitIframeIsReady(),
+    {
+        content: "Navigate to the first product",
+        trigger: ":iframe .oe_product_image_link",
+        run: "click",
+    },
+    {
+        content: "Click on publish/unpublish",
+        trigger: ".o_website_publish_container a:has(input:checked)",
+        run: "click",
+    },
+    {
+        trigger:
+            ".o_menu_systray_item:not([data-processing]) .form-switch:has(input:not(:checked))",
+    },
+    {
+        content: "Click on edit-in-backend",
+        trigger: ".o_menu_systray .o_website_edit_in_backend a",
+        run: "click",
+    },
+    {
+        content: "Check that you landed on a form view and that the record was unpublished",
+        trigger: '.o-form-buttonbox [name="is_published"] .fa-globe.text-danger',
+    },
+]);

--- a/addons/website_sale/static/tests/tours/shop_editor_tours.js
+++ b/addons/website_sale/static/tests/tours/shop_editor_tours.js
@@ -2,12 +2,11 @@ import {
     clickOnEditAndWaitEditMode,
     clickOnSave,
     registerWebsitePreviewTour,
-} from '@website/js/tours/tour_utils';
+} from "@website/js/tours/tour_utils";
 
 registerWebsitePreviewTour(
     "website_sale.shop_editor",
     {
-        url: "/shop",
         edition: true,
     },
     () => [
@@ -17,7 +16,8 @@ registerWebsitePreviewTour(
             run: "click",
         },
         {
-            trigger: ":iframe div.o_pricelist_dropdown a[data-bs-toggle=dropdown][aria-expanded=true]",
+            trigger:
+                ":iframe div.o_pricelist_dropdown a[data-bs-toggle=dropdown][aria-expanded=true]",
         },
         {
             trigger: ":iframe input[name=search]",
@@ -25,23 +25,25 @@ registerWebsitePreviewTour(
             run: "click",
         },
         {
-            trigger: ":iframe div.o_pricelist_dropdown a[data-bs-toggle=dropdown][aria-expanded=false]",
+            trigger:
+                ":iframe div.o_pricelist_dropdown a[data-bs-toggle=dropdown][aria-expanded=false]",
         },
         {
             trigger: ":iframe div.o_pricelist_dropdown a[data-bs-toggle=dropdown]",
             content: "Click on the pricelist again.",
             run: "click",
-        }, {
-            trigger: ":iframe div.o_pricelist_dropdown a[data-bs-toggle=dropdown][aria-expanded=true]",
+        },
+        {
+            trigger:
+                ":iframe div.o_pricelist_dropdown a[data-bs-toggle=dropdown][aria-expanded=true]",
             content: "Check pricelist dropdown opened",
-        }
+        },
     ]
 );
 
 registerWebsitePreviewTour(
     "website_sale.shop_editor_set_product_ribbon",
     {
-        url: "/shop",
         edition: true,
     },
     () => [
@@ -49,11 +51,13 @@ registerWebsitePreviewTour(
             content: "Click on first product",
             trigger: ":iframe .oe_product:first",
             run: "click",
-        }, {
+        },
+        {
             content: "Open the ribbon selector",
             trigger: ".o_wsale_ribbon_select + button:contains('None')",
             run: "click",
-        }, {
+        },
+        {
             content: "Select a ribbon",
             trigger: ".o_popover div.o-dropdown-item:contains('Sale')",
             run: "click",
@@ -62,14 +66,13 @@ registerWebsitePreviewTour(
         {
             content: "Check that the ribbon was properly saved",
             trigger: ':iframe .oe_product:first .o_ribbons:contains("Sale")',
-        }
+        },
     ]
 );
 
 registerWebsitePreviewTour(
-    "shop_editor_no_alternative_products_visibility_tour", 
+    "shop_editor_no_alternative_products_visibility_tour",
     {
-        url: "/shop",
         edition: false,
     },
     () => [
@@ -80,25 +83,25 @@ registerWebsitePreviewTour(
         },
         {
             content: "Ensure product page is loaded before clicking on Edit",
-            trigger: ':iframe #product_details',
+            trigger: ":iframe #product_details",
         },
         ...clickOnEditAndWaitEditMode(),
         {
-            trigger: ':iframe .s_dynamic_snippet_title h4',
+            trigger: ":iframe .s_dynamic_snippet_title h4",
             run: "click",
         },
         {
             content: "Edit the alternative products section header",
             trigger: `:iframe .container[contenteditable="true"] h4`,
             run: function () {
-                this.anchor.textContent = "Edited Alternative"
+                this.anchor.textContent = "Edited Alternative";
                 this.anchor.dispatchEvent(new Event("input", { bubbles: true }));
             },
         },
         ...clickOnSave(),
         {
             content: "Navigate back to shop page",
-            trigger: ':iframe .breadcrumb-item a',
+            trigger: ":iframe .breadcrumb-item a",
             run: "click",
         },
         {
@@ -108,7 +111,7 @@ registerWebsitePreviewTour(
         },
         {
             content: "Ensure alternative products section is hidden",
-            trigger: ':iframe .s_dynamic_snippet_products:not(:visible)',
-        }
+            trigger: ":iframe .s_dynamic_snippet_products:not(:visible)",
+        },
     ]
 );

--- a/addons/website_sale/static/tests/tours/snippet_products.js
+++ b/addons/website_sale/static/tests/tours/snippet_products.js
@@ -12,7 +12,6 @@ const productsSnippet = { id: "s_dynamic_snippet_products", name: "Products", gr
 registerWebsitePreviewTour(
     'website_sale.snippet_products',
     {
-        url: '/',
         edition: true,
     },
     () => {
@@ -32,7 +31,6 @@ registerWebsitePreviewTour(
 registerWebsitePreviewTour(
     'website_sale.products_snippet_recently_viewed',
     {
-        url: '/',
         edition: true,
     },
     () => [

--- a/addons/website_sale/static/tests/tours/website_sale_product_publish.js
+++ b/addons/website_sale/static/tests/tours/website_sale_product_publish.js
@@ -1,73 +1,61 @@
 /** @odoo-module **/
 
-import { registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
+import { registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
 
-registerWebsitePreviewTour(
-    'product_unpublished_without_category',
+registerWebsitePreviewTour("product_unpublished_without_category", {}, () => [
     {
-        url: '/',
+        trigger: "body:not(:has(.o_new_content_menu_choices)) .o_new_content_container > button",
+        run: "click",
     },
-    () => [
-        {
-            trigger:'body:not(:has(.o_new_content_menu_choices)) .o_new_content_container > button',
-            run: 'click',
-        },
-        {
-            trigger: 'button[data-module-xml-id="base.module_website_sale"]',
-            run: 'click',
-        },
-        {
-            trigger: '.modal-dialog .o_field_widget[name="name"] input',
-            run: 'edit Product Without Category',
-        },
-        {
-            trigger: '.modal-footer button.btn-primary',
-            run: 'click',
-        },
-        {
-            trigger: 'body:not(:has(.modal))',
-        },
-        {
-            trigger: ':iframe body:has(h1:contains("Product Without Category"))',
-        },
-    ]
-);
+    {
+        trigger: 'button[data-module-xml-id="base.module_website_sale"]',
+        run: "click",
+    },
+    {
+        trigger: '.modal-dialog .o_field_widget[name="name"] input',
+        run: "edit Product Without Category",
+    },
+    {
+        trigger: ".modal-footer button.btn-primary",
+        run: "click",
+    },
+    {
+        trigger: "body:not(:has(.modal))",
+    },
+    {
+        trigger: ':iframe body:has(h1:contains("Product Without Category"))',
+    },
+]);
 
-registerWebsitePreviewTour(
-    'product_published_with_category',
+registerWebsitePreviewTour("product_published_with_category", {}, () => [
     {
-        url: '/',
+        trigger: "body:not(:has(.o_new_content_menu_choices)) .o_new_content_container > button",
+        run: "click",
     },
-    () => [
-        {
-            trigger:'body:not(:has(.o_new_content_menu_choices)) .o_new_content_container > button',
-            run: 'click',
-        },
-        {
-            trigger: 'button[data-module-xml-id="base.module_website_sale"]',
-            run: 'click',
-        },
-        {
-            trigger: '.modal-dialog .o_field_widget[name="name"] input',
-            run: 'edit Product With Category',
-        },
-        {
-            trigger: '.modal-dialog .o_field_widget[name="public_categ_ids"] input',
-            run: 'edit Test',
-        },
-        {
-            trigger: '.ui-autocomplete a:contains("Test Category")',
-            run: 'click',
-        },
-        {
-            trigger: '.modal-footer button.btn-primary',
-            run: 'click',
-        },
-        {
-            trigger: 'body:not(:has(.modal))',
-        },
-        {
-            trigger: ':iframe body:has(h1:contains("Product With Category"))',
-        },
-    ]
-);
+    {
+        trigger: 'button[data-module-xml-id="base.module_website_sale"]',
+        run: "click",
+    },
+    {
+        trigger: '.modal-dialog .o_field_widget[name="name"] input',
+        run: "edit Product With Category",
+    },
+    {
+        trigger: '.modal-dialog .o_field_widget[name="public_categ_ids"] input',
+        run: "edit Test",
+    },
+    {
+        trigger: '.ui-autocomplete a:contains("Test Category")',
+        run: "click",
+    },
+    {
+        trigger: ".modal-footer button.btn-primary",
+        run: "click",
+    },
+    {
+        trigger: "body:not(:has(.modal))",
+    },
+    {
+        trigger: ':iframe body:has(h1:contains("Product With Category"))',
+    },
+]);

--- a/addons/website_sale/tests/test_add_to_cart_snippet.py
+++ b/addons/website_sale/tests/test_add_to_cart_snippet.py
@@ -81,4 +81,4 @@ class TestAddToCartSnippet(HttpCase):
             'phone': "+32 123456789"
         })
         self.env.ref('base.user_admin').country_id = self.env.ref('base.be')
-        self.start_tour('/', 'website_sale.add_to_cart_snippet', login='admin')
+        self.start_tour(self.env["website"].get_client_action_url("/", True), 'website_sale.add_to_cart_snippet', login='admin')

--- a/addons/website_sale/tests/test_customize.py
+++ b/addons/website_sale/tests/test_customize.py
@@ -240,7 +240,7 @@ class TestCustomize(HttpCaseWithUserDemo, HttpCaseWithUserPortal, TestProductCon
             {'name': 'Base Pricelist', 'selectable': True},
             {'name': 'Other Pricelist', 'selectable': True}
         ])
-        self.start_tour('/shop', 'website_sale.shop_editor', login='website_user')
+        self.start_tour(self.env["website"].get_client_action_url("/shop", True), 'website_sale.shop_editor', login='website_user')
 
     def test_08_portal_tour_archived_variant_multiple_attributes(self):
         """The goal of this test is to make sure that an archived variant with multiple
@@ -392,7 +392,7 @@ class TestCustomize(HttpCaseWithUserDemo, HttpCaseWithUserPortal, TestProductCon
         )
 
     def test_11_shop_editor_set_product_ribbon(self):
-        self.start_tour('/shop', 'website_sale.shop_editor_set_product_ribbon', login='admin')
+        self.start_tour(self.env["website"].get_client_action_url("/shop", True), 'website_sale.shop_editor_set_product_ribbon', login='admin')
 
     def test_12_multi_checkbox_attribute_single_value(self):
         attribute = self.env['product.attribute'].create([
@@ -433,4 +433,4 @@ class TestCustomize(HttpCaseWithUserDemo, HttpCaseWithUserPortal, TestProductCon
         })
         product_no_alternative.set_sequence_top()
         product_with_alternative.set_sequence_top()
-        self.start_tour('/shop', 'shop_editor_no_alternative_products_visibility_tour', login="admin")
+        self.start_tour(self.env["website"].get_client_action_url("/shop", False), 'shop_editor_no_alternative_products_visibility_tour', login="admin")

--- a/addons/website_sale/tests/test_product_page.py
+++ b/addons/website_sale/tests/test_product_page.py
@@ -85,7 +85,7 @@ class TestWebsiteSaleProductPage(HttpCase, ProductVariantsCommon, WebsiteSaleCom
 
     def test_product_unpublished_without_category(self):
         """Test that products created from frontend are unpublished without category"""
-        self.start_tour("/", 'product_unpublished_without_category', login="admin")
+        self.start_tour(self.env["website"].get_client_action_url("/"), 'product_unpublished_without_category', login="admin")
         product = self.env['product.product'].search(
             [('name', '=', 'Product Without Category')],
             limit=1,
@@ -96,7 +96,7 @@ class TestWebsiteSaleProductPage(HttpCase, ProductVariantsCommon, WebsiteSaleCom
     def test_product_published_with_category(self):
         """Test that products with category are published"""
         self.env['product.public.category'].create({'name': 'Test Category'})
-        self.start_tour("/", 'product_published_with_category', login="admin")
+        self.start_tour(self.env["website"].get_client_action_url("/"), 'product_published_with_category', login="admin")
         product = self.env['product.product'].search(
             [('name', '=', 'Product With Category')],
             limit=1,

--- a/addons/website_sale/tests/test_sale_process.py
+++ b/addons/website_sale/tests/test_sale_process.py
@@ -130,7 +130,7 @@ class TestSaleProcess(HttpCaseWithUserDemo, WebsiteSaleCommon, HttpCaseWithWebsi
 
         self.start_tour('/shop?search=Storage Box Test', 'website_sale.complete_flow_1')
         self.start_tour(
-            self.env['website'].get_client_action_url('/shop/cart'),
+            self.env['website'].get_client_action_url('/shop/cart', True),
             'website_sale.enable_extra_info',
             login='admin'
         )

--- a/addons/website_sale/tests/test_snippets.py
+++ b/addons/website_sale/tests/test_snippets.py
@@ -37,7 +37,7 @@ class TestSnippets(HttpCase):
             'sale_ok': True,
             'list_price': 500,
         })
-        self.start_tour('/', 'website_sale.snippet_products', login='admin')
+        self.start_tour(self.env["website"].get_client_action_url("/", True), 'website_sale.snippet_products', login='admin')
 
     def test_02_snippet_products_remove(self):
         Visitor = self.env['website.visitor']
@@ -57,7 +57,7 @@ class TestSnippets(HttpCase):
         before_tour_product_ids = website_visitor.product_ids.ids
         website_visitor._add_viewed_product(self.product.id)
 
-        self.start_tour('/', 'website_sale.products_snippet_recently_viewed', login='admin')
+        self.start_tour(self.env["website"].get_client_action_url("/", True), 'website_sale.products_snippet_recently_viewed', login='admin')
         self.assertEqual(before_tour_product_ids, website_visitor.product_ids.ids, "There shouldn't be any new product in recently viewed after this tour")
 
     def test_website_category_url(self):

--- a/addons/website_slides/data/slides_tour.xml
+++ b/addons/website_slides/data/slides_tour.xml
@@ -2,6 +2,6 @@
 <odoo>
     <record id="slides_tour" model="web_tour.tour">
         <field name="name">slides_tour</field>
-        <field name="url"></field>
+        <field name="url">/slides</field>
     </record>
 </odoo>

--- a/addons/website_slides/static/src/js/tours/slides_tour.js
+++ b/addons/website_slides/static/src/js/tours/slides_tour.js
@@ -1,128 +1,192 @@
 import { _t } from "@web/core/l10n/translation";
-import { registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
+import { registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
 
 import { markup } from "@odoo/owl";
 
-registerWebsitePreviewTour('slides_tour', {
-    url: '/slides',
-}, () => [{
-    trigger: "body:not(.editor_has_snippets) .o_new_content_container > a",
-    content: markup(_t("Welcome on your course's home page. It's still empty for now. Click on \"<b>New</b>\" to write your first course.")),
-    tooltipPosition: 'bottom',
-    run: "click",
-}, {
-    trigger: 'a[data-module-xml-id="base.module_website_slides"]',
-    content: markup(_t("Select <b>Course</b> to create it and manage it.")),
-    tooltipPosition: 'bottom',
-    run: "click",
-}, {
-    trigger: 'input#name_0',
-    content: markup(_t("Give your course an engaging <b>Title</b>.")),
-    tooltipPosition: 'bottom',
-    run: "edit My New Course",
-}, {
-    trigger: 'div[name="description"] div[contenteditable=true]',
-    content: markup(_t("Give your course a helpful <b>Description</b>.")),
-    tooltipPosition: 'bottom',
-    run: "edit This course is for advanced users.",
-}, {
-    trigger: 'button.btn-primary',
-    content: markup(_t("Click on the <b>Save</b> button to create your first course.")),
-    run: "click",
-}, {
-    trigger: ':iframe .o_wslides_js_slide_section_add',
-    content: markup(_t("Congratulations, your course has been created, but there isn't any content yet. First, let's add a <b>Section</b> to give your course a structure.")),
-    tooltipPosition: 'bottom',
-    run: "click",
-}, {
-    trigger: ':iframe #section_name',
-    content: markup(_t("A good course has a structure. Pick a name for your first <b>Section</b>.")),
-    tooltipPosition: 'bottom',
-    run: "click",
-}, {
-    trigger: ':iframe button.btn-primary:contains("Save")',
-    content: markup(_t("Click <b>Save</b> to create it.")),
-    tooltipPosition: 'bottom',
-    run: "click",
-}, {
-    trigger: '.o_iframe:iframe a.btn-primary.o_wslides_js_slide_upload',
-    content: markup(_t("Your first section is created, now it's time to add lessons to your course. Click on <b>Add Content</b> to upload a document, create an article or link a video.")),
-    tooltipPosition: 'bottom',
-    run: "click",
-}, {
-    trigger: ':iframe a[data-slide-category="document"]',
-    content: markup(_t("First, let's add a <b>Document</b>. It has to be a .pdf file.")),
-    tooltipPosition: 'bottom',
-    run: "click",
-}, {
-    trigger: ':iframe input#upload',
-    content: markup(_t("Choose a <b>File</b> on your computer.")),
-    run: "click",
-}, {
-    trigger: ':iframe input#name',
-    content: markup(_t("The <b>Title</b> of your lesson is autocompleted but you can change it if you want.</br>A <b>Preview</b> of your file is available on the right side of the screen.")),
-    run: "click",
-}, {
-    trigger: ':iframe input#duration',
-    content: markup(_t("The <b>Duration</b> of the lesson is based on the number of pages of your document. You can change this number if your attendees will need more time to assimilate the content.")),
-    run: "click",
-}, {
-    trigger: ':iframe button.o_w_slide_upload_published',
-    content: markup(_t("<b>Save & Publish</b> your lesson to make it available to your attendees.")),
-    tooltipPosition: 'bottom',
-    run: "click",
-}, {
-    trigger: '.o_iframe:iframe span.badge:contains("New")',
-    content: markup(_t("Congratulations! Your first lesson is available. Let's see the options available here. The tag \"<b>New</b>\" indicates that this lesson was created less than 7 days ago.")),
-    tooltipPosition: 'bottom',
-    run: "click",
-}, {
-    trigger: ':iframe a[name="o_wslides_list_slide_add_quizz"]',
-    content: markup(_t("If you want to be sure that attendees have understood and memorized the content, you can add a Quiz on the lesson. Click on <b>Add Quiz</b>.")),
-    run: "click",
-}, {
-    trigger: ':iframe input[name="question-name"]',
-    content: markup(_t("Enter your <b>Question</b>. Be clear and concise.")),
-    tooltipPosition: 'left',
-    run: "click",
-}, {
-    trigger: ':iframe input.o_wslides_js_quiz_answer_value',
-    content: markup(_t("Enter at least two possible <b>Answers</b>.")),
-    tooltipPosition: 'left',
-    run: "click",
-}, {
-    trigger: ':iframe a.o_wslides_js_quiz_is_correct',
-    content: markup(_t("Mark the correct answer by checking the <b>correct</b> mark.")),
-    tooltipPosition: 'right',
-    run: "click",
-}, {
-    trigger: ':iframe i.o_wslides_js_quiz_comment_answer:last',
-    content: markup(_t("You can add <b>comments</b> on answers. This will be visible with the results if the user select this answer.")),
-    tooltipPosition: 'right',
-    run: "click",
-}, {
-    trigger: ':iframe a.o_wslides_js_quiz_validate_question',
-    content: markup(_t("<b>Save</b> your question.")),
-    tooltipPosition: 'left',
-    run: "click",
-}, {
-    trigger: '.o_iframe:iframe li.breadcrumb-item:nth-child(2)',
-    content: markup(_t("Click on your <b>Course</b> to go back to the table of content.")),
-    tooltipPosition: 'top',
-    run: "click",
-}, {
-    trigger: '.o_menu_systray_item.o_website_publish_container a',
-    content: markup(_t("Once you're done, don't forget to <b>Publish</b> your course.")),
-    tooltipPosition: 'bottom',
-    run: "click",
-}, {
-    trigger: ':iframe a.o_wslides_js_slides_list_slide_link',
-    content: markup(_t("Congratulations, you've created your first course.<br/>Click on the title of this content to see it in fullscreen mode.")),
-    tooltipPosition: 'bottom',
-    run: "click",
-}, {
-    trigger: ':iframe .o_wslides_fs_toggle_sidebar',
-    content: markup(_t("Finally you can click here to enjoy your content in fullscreen")),
-    tooltipPosition: 'bottom',
-    run: "click",
-}]);
+registerWebsitePreviewTour("slides_tour", {}, () => [
+    {
+        trigger: "body:not(.editor_has_snippets) .o_new_content_container > a",
+        content: markup(
+            _t(
+                "Welcome on your course's home page. It's still empty for now. Click on \"<b>New</b>\" to write your first course."
+            )
+        ),
+        tooltipPosition: "bottom",
+        run: "click",
+    },
+    {
+        trigger: 'a[data-module-xml-id="base.module_website_slides"]',
+        content: markup(_t("Select <b>Course</b> to create it and manage it.")),
+        tooltipPosition: "bottom",
+        run: "click",
+    },
+    {
+        trigger: "input#name_0",
+        content: markup(_t("Give your course an engaging <b>Title</b>.")),
+        tooltipPosition: "bottom",
+        run: "edit My New Course",
+    },
+    {
+        trigger: 'div[name="description"] div[contenteditable=true]',
+        content: markup(_t("Give your course a helpful <b>Description</b>.")),
+        tooltipPosition: "bottom",
+        run: "edit This course is for advanced users.",
+    },
+    {
+        trigger: "button.btn-primary",
+        content: markup(_t("Click on the <b>Save</b> button to create your first course.")),
+        run: "click",
+    },
+    {
+        trigger: ":iframe .o_wslides_js_slide_section_add",
+        content: markup(
+            _t(
+                "Congratulations, your course has been created, but there isn't any content yet. First, let's add a <b>Section</b> to give your course a structure."
+            )
+        ),
+        tooltipPosition: "bottom",
+        run: "click",
+    },
+    {
+        trigger: ":iframe #section_name",
+        content: markup(
+            _t("A good course has a structure. Pick a name for your first <b>Section</b>.")
+        ),
+        tooltipPosition: "bottom",
+        run: "click",
+    },
+    {
+        trigger: ':iframe button.btn-primary:contains("Save")',
+        content: markup(_t("Click <b>Save</b> to create it.")),
+        tooltipPosition: "bottom",
+        run: "click",
+    },
+    {
+        trigger: ".o_iframe:iframe a.btn-primary.o_wslides_js_slide_upload",
+        content: markup(
+            _t(
+                "Your first section is created, now it's time to add lessons to your course. Click on <b>Add Content</b> to upload a document, create an article or link a video."
+            )
+        ),
+        tooltipPosition: "bottom",
+        run: "click",
+    },
+    {
+        trigger: ':iframe a[data-slide-category="document"]',
+        content: markup(_t("First, let's add a <b>Document</b>. It has to be a .pdf file.")),
+        tooltipPosition: "bottom",
+        run: "click",
+    },
+    {
+        trigger: ":iframe input#upload",
+        content: markup(_t("Choose a <b>File</b> on your computer.")),
+        run: "click",
+    },
+    {
+        trigger: ":iframe input#name",
+        content: markup(
+            _t(
+                "The <b>Title</b> of your lesson is autocompleted but you can change it if you want.</br>A <b>Preview</b> of your file is available on the right side of the screen."
+            )
+        ),
+        run: "click",
+    },
+    {
+        trigger: ":iframe input#duration",
+        content: markup(
+            _t(
+                "The <b>Duration</b> of the lesson is based on the number of pages of your document. You can change this number if your attendees will need more time to assimilate the content."
+            )
+        ),
+        run: "click",
+    },
+    {
+        trigger: ":iframe button.o_w_slide_upload_published",
+        content: markup(
+            _t("<b>Save & Publish</b> your lesson to make it available to your attendees.")
+        ),
+        tooltipPosition: "bottom",
+        run: "click",
+    },
+    {
+        trigger: '.o_iframe:iframe span.badge:contains("New")',
+        content: markup(
+            _t(
+                'Congratulations! Your first lesson is available. Let\'s see the options available here. The tag "<b>New</b>" indicates that this lesson was created less than 7 days ago.'
+            )
+        ),
+        tooltipPosition: "bottom",
+        run: "click",
+    },
+    {
+        trigger: ':iframe a[name="o_wslides_list_slide_add_quizz"]',
+        content: markup(
+            _t(
+                "If you want to be sure that attendees have understood and memorized the content, you can add a Quiz on the lesson. Click on <b>Add Quiz</b>."
+            )
+        ),
+        run: "click",
+    },
+    {
+        trigger: ':iframe input[name="question-name"]',
+        content: markup(_t("Enter your <b>Question</b>. Be clear and concise.")),
+        tooltipPosition: "left",
+        run: "click",
+    },
+    {
+        trigger: ":iframe input.o_wslides_js_quiz_answer_value",
+        content: markup(_t("Enter at least two possible <b>Answers</b>.")),
+        tooltipPosition: "left",
+        run: "click",
+    },
+    {
+        trigger: ":iframe a.o_wslides_js_quiz_is_correct",
+        content: markup(_t("Mark the correct answer by checking the <b>correct</b> mark.")),
+        tooltipPosition: "right",
+        run: "click",
+    },
+    {
+        trigger: ":iframe i.o_wslides_js_quiz_comment_answer:last",
+        content: markup(
+            _t(
+                "You can add <b>comments</b> on answers. This will be visible with the results if the user select this answer."
+            )
+        ),
+        tooltipPosition: "right",
+        run: "click",
+    },
+    {
+        trigger: ":iframe a.o_wslides_js_quiz_validate_question",
+        content: markup(_t("<b>Save</b> your question.")),
+        tooltipPosition: "left",
+        run: "click",
+    },
+    {
+        trigger: ".o_iframe:iframe li.breadcrumb-item:nth-child(2)",
+        content: markup(_t("Click on your <b>Course</b> to go back to the table of content.")),
+        tooltipPosition: "top",
+        run: "click",
+    },
+    {
+        trigger: ".o_menu_systray_item.o_website_publish_container a",
+        content: markup(_t("Once you're done, don't forget to <b>Publish</b> your course.")),
+        tooltipPosition: "bottom",
+        run: "click",
+    },
+    {
+        trigger: ":iframe a.o_wslides_js_slides_list_slide_link",
+        content: markup(
+            _t(
+                "Congratulations, you've created your first course.<br/>Click on the title of this content to see it in fullscreen mode."
+            )
+        ),
+        tooltipPosition: "bottom",
+        run: "click",
+    },
+    {
+        trigger: ":iframe .o_wslides_fs_toggle_sidebar",
+        content: markup(_t("Finally you can click here to enjoy your content in fullscreen")),
+        tooltipPosition: "bottom",
+        run: "click",
+    },
+]);

--- a/addons/website_slides/static/tests/tours/slides_course_member_yt.js
+++ b/addons/website_slides/static/tests/tours/slides_course_member_yt.js
@@ -9,58 +9,51 @@ import { registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
  * they use fullscreen player to complete the course;
  * they rate the course;
  */
-registerWebsitePreviewTour(
-    "course_member_youtube",
+registerWebsitePreviewTour("course_member_youtube", {}, () => [
+    // eLearning: go on /all, find free course and join it
     {
-        url: "/slides",
-        edition: false,
+        trigger: ":iframe a.o_wslides_home_all_slides",
+        run: "click",
     },
-    () => [
-        // eLearning: go on /all, find free course and join it
-        {
-            trigger: ":iframe a.o_wslides_home_all_slides",
-            run: "click",
-        },
-        {
-            trigger: ':iframe a:contains("Choose your wood")',
-            run: "click",
-        },
-        {
-            trigger: ':iframe a:contains("Join this Course")',
-            run: "click",
-        },
-        {
-            // check membership
-            trigger: ':iframe .o_wslides_js_course_join:contains("You\'re enrolled")',
-        },
-        {
-            trigger: ':iframe a:contains("Comparing Hardness of Wood Species")',
-            run: "click",
-        },
-        {
-            // check progression
-            trigger: ':iframe .o_wslides_progress_percentage:contains("50")',
-        },
-        {
-            trigger: ':iframe .o_wslides_fs_slide_name:contains("Wood Bending With Steam Box")',
-            run: "click",
-        },
-        {
-            // check player loading
-            trigger: ":iframe .player",
-        },
-        {
-            // check that video slide is marked as 'done'
-            trigger:
-                ':iframe .o_wslides_fs_sidebar_section_slides li:contains("Wood Bending With Steam Box") .o_wslides_slide_completed',
-        },
-        {
-            // check progression
-            trigger: ":iframe .o_wslides_channel_completion_completed:contains(Completed)",
-        },
-        {
-            trigger: ':iframe a:contains("Back to course")',
-            run: "click",
-        },
-    ]
-);
+    {
+        trigger: ':iframe a:contains("Choose your wood")',
+        run: "click",
+    },
+    {
+        trigger: ':iframe a:contains("Join this Course")',
+        run: "click",
+    },
+    {
+        // check membership
+        trigger: ':iframe .o_wslides_js_course_join:contains("You\'re enrolled")',
+    },
+    {
+        trigger: ':iframe a:contains("Comparing Hardness of Wood Species")',
+        run: "click",
+    },
+    {
+        // check progression
+        trigger: ':iframe .o_wslides_progress_percentage:contains("50")',
+    },
+    {
+        trigger: ':iframe .o_wslides_fs_slide_name:contains("Wood Bending With Steam Box")',
+        run: "click",
+    },
+    {
+        // check player loading
+        trigger: ":iframe .player",
+    },
+    {
+        // check that video slide is marked as 'done'
+        trigger:
+            ':iframe .o_wslides_fs_sidebar_section_slides li:contains("Wood Bending With Steam Box") .o_wslides_slide_completed',
+    },
+    {
+        // check progression
+        trigger: ":iframe .o_wslides_channel_completion_completed:contains(Completed)",
+    },
+    {
+        trigger: ':iframe a:contains("Back to course")',
+        run: "click",
+    },
+]);

--- a/addons/website_slides/static/tests/tours/slides_course_publisher.js
+++ b/addons/website_slides/static/tests/tours/slides_course_publisher.js
@@ -15,8 +15,6 @@ registerWebsitePreviewTour(
     "course_publisher",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps ) #245680
-        // TODO: replace by getClientActionURL when it's added
-        url: "/slides",
     },
     () =>
         [

--- a/addons/website_slides/static/tests/tours/slides_full_screen_web_editor.js
+++ b/addons/website_slides/static/tests/tours/slides_full_screen_web_editor.js
@@ -1,4 +1,7 @@
-import { clickOnEditAndWaitEditMode, registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
+import {
+    clickOnEditAndWaitEditMode,
+    registerWebsitePreviewTour,
+} from "@website/js/tours/tour_utils";
 import { stepUtils } from "@web_tour/tour_utils";
 
 /**
@@ -11,24 +14,26 @@ import { stepUtils } from "@web_tour/tour_utils";
  * See "Fullscreen#_onWebEditorClick" for more information.
  *
  */
-registerWebsitePreviewTour('full_screen_web_editor', {
-    url: '/slides',
-}, () => [
+registerWebsitePreviewTour("full_screen_web_editor", {}, () => [
     stepUtils.waitIframeIsReady(),
     {
-    // open to the course
-    trigger: ':iframe a:contains("Basics of Gardening")',
-    run: "click",
-}, {
-    // click on a slide to open the fullscreen view
-    trigger: ':iframe a.o_wslides_js_slides_list_slide_link:contains("Home Gardening")[href*="fullscreen=1"]',
-    run: "click",
-}, {
-    // check we land on the fullscreen view
-    trigger: ':iframe .o_wslides_fs_main',
-},
-...clickOnEditAndWaitEditMode()
-, {
-    // check we are redirected on the detailed view
-    trigger: ':iframe .o_wslides_lesson_main',
-}]);
+        // open to the course
+        trigger: ':iframe a:contains("Basics of Gardening")',
+        run: "click",
+    },
+    {
+        // click on a slide to open the fullscreen view
+        trigger:
+            ':iframe a.o_wslides_js_slides_list_slide_link:contains("Home Gardening")[href*="fullscreen=1"]',
+        run: "click",
+    },
+    {
+        // check we land on the fullscreen view
+        trigger: ":iframe .o_wslides_fs_main",
+    },
+    ...clickOnEditAndWaitEditMode(),
+    {
+        // check we are redirected on the detailed view
+        trigger: ":iframe .o_wslides_lesson_main",
+    },
+]);

--- a/addons/website_slides/static/tests/tours/slides_text_highlights.js
+++ b/addons/website_slides/static/tests/tours/slides_text_highlights.js
@@ -4,73 +4,71 @@ import {
     clickOnEditAndWaitEditMode,
     clickOnSave,
     registerWebsitePreviewTour,
-} from '@website/js/tours/tour_utils';
+} from "@website/js/tours/tour_utils";
 
-const selectText = (selector) => {
-    return {
-        content: "Select some text content",
-        trigger: "iframe",
-        run() {
-            const iframeWindow = this.anchor.contentWindow;
-            const iframeDocument = iframeWindow.document;
-            const p = iframeDocument.querySelector(selector);
-            p.click();
-            const selection = iframeWindow.getSelection();
-            const range = iframeDocument.createRange();
-            range.selectNodeContents(p);
-            selection.removeAllRanges();
-            selection.addRange(range);
-        },
-    };
-};
+const selectText = (selector) => ({
+    content: "Select some text content",
+    trigger: "iframe",
+    run() {
+        const iframeWindow = this.anchor.contentWindow;
+        const iframeDocument = iframeWindow.document;
+        const p = iframeDocument.querySelector(selector);
+        p.click();
+        const selection = iframeWindow.getSelection();
+        const range = iframeDocument.createRange();
+        range.selectNodeContents(p);
+        selection.removeAllRanges();
+        selection.addRange(range);
+    },
+});
 
-registerWebsitePreviewTour('fullscreen_slide_text_highlights', {
-    url: "/slides",
-}, () => [
-        {
-            trigger: ':iframe a:contains("Basics of Gardening - Test")',
-            run: "click",
-        },
-        {
-            trigger: ':iframe a:contains("Article test")',
-            run: "click",
-        },
-        ...clickOnEditAndWaitEditMode(),
-        selectText(".s_text_block > p"),
-        {
-            content: "Expand the text editor toolbar",
-            trigger: 'button[name="expand_toolbar"]',
-            run: "click",
-        },
-        {
-            content: "Click on the 'Highlight Effects' button to show the listing",
-            trigger: 'button.o-select-highlight',
-            run: "click",
-        },
-        {
-            content: "Click on the first highlight effect proposed to activate it",
-            trigger: 'span.o_text_highlight',
-            run: "click",
-        },
-        {
-            content: "Check that the highlight was applied",
-            trigger: ":iframe .o_wslides_lesson_content_type p span.o_text_highlight > svg",
-        },
-        {
-            content: "Check that the highlight was applied",
-            trigger: ":iframe .o_wslides_lesson_content_type p span.o_text_highlight > svg.o_text_highlight_svg",
-        },
-        ...clickOnSave(),
-        {
-            content: "Click on the fullscreen button",
-            trigger: ':iframe #wrapwrap a[aria-label="Fullscreen"]',
-            run: "click",
-        }, {
-            content: "Wait for fullscreen",
-            trigger: ':iframe #wrapwrap a[title="Exit Fullscreen"]',
-        }, {
-            content: "Check that the highlight was applied in fullscreen",
-            trigger: ":iframe .o_wslides_fs_content p span.o_text_highlight > svg.o_text_highlight_svg",
-        },
-    ],
-);
+registerWebsitePreviewTour("fullscreen_slide_text_highlights", {}, () => [
+    {
+        trigger: ':iframe a:contains("Basics of Gardening - Test")',
+        run: "click",
+    },
+    {
+        trigger: ':iframe a:contains("Article test")',
+        run: "click",
+    },
+    ...clickOnEditAndWaitEditMode(),
+    selectText(".s_text_block > p"),
+    {
+        content: "Expand the text editor toolbar",
+        trigger: 'button[name="expand_toolbar"]',
+        run: "click",
+    },
+    {
+        content: "Click on the 'Highlight Effects' button to show the listing",
+        trigger: "button.o-select-highlight",
+        run: "click",
+    },
+    {
+        content: "Click on the first highlight effect proposed to activate it",
+        trigger: "span.o_text_highlight",
+        run: "click",
+    },
+    {
+        content: "Check that the highlight was applied",
+        trigger: ":iframe .o_wslides_lesson_content_type p span.o_text_highlight > svg",
+    },
+    {
+        content: "Check that the highlight was applied",
+        trigger:
+            ":iframe .o_wslides_lesson_content_type p span.o_text_highlight > svg.o_text_highlight_svg",
+    },
+    ...clickOnSave(),
+    {
+        content: "Click on the fullscreen button",
+        trigger: ':iframe #wrapwrap a[aria-label="Fullscreen"]',
+        run: "click",
+    },
+    {
+        content: "Wait for fullscreen",
+        trigger: ':iframe #wrapwrap a[title="Exit Fullscreen"]',
+    },
+    {
+        content: "Check that the highlight was applied in fullscreen",
+        trigger: ":iframe .o_wslides_fs_content p span.o_text_highlight > svg.o_text_highlight_svg",
+    },
+]);

--- a/addons/website_slides/tests/test_ui_wslides.py
+++ b/addons/website_slides/tests/test_ui_wslides.py
@@ -271,7 +271,7 @@ class TestUi(TestUICommon):
             'html_content': "<section class=\"s_text_block\" data-snippet=\"s_text_block\"><p>Hello World!</p></section>"
         })
 
-        self.start_tour("/slides", 'fullscreen_slide_text_highlights', login='admin')
+        self.start_tour(self.env["website"].get_client_action_url("/slides"), 'fullscreen_slide_text_highlights', login='admin')
 
 
 @tests.common.tagged('post_install', '-at_install')
@@ -351,7 +351,7 @@ class TestUiPublisherYoutube(HttpCaseGamification):
         self.env.ref('website_slides.slide_channel_demo_3_furn0')._remove_membership(self.env.ref('base.partner_demo').ids)
         self.env.ref('website_slides.slide_slide_demo_3_1').url += '&start=260'
 
-        self.start_tour('/slides', 'course_member_youtube', login=user_demo.login)
+        self.start_tour(self.env['website'].get_client_action_url('/slides'), 'course_member_youtube', login=user_demo.login)
 
     def test_course_publisher_elearning_manager(self):
         user_demo = self.user_demo


### PR DESCRIPTION
The URL key in a tour's JavaScript file implies a redirect to that URL once the browser opens. If this URL is the same as the one used in `start_tour()` (Python), then it serves no purpose. It's even detrimental because it implies a redirect (and therefore a waste of time). The URL key in the JS file is (for now) only used for onboarding tours. This key will be defined later in the .xml file for onboarding tours.

That's why we're removing the URL keys from the registries here.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
