### PR TITLE
[FIX] web: review `information_block` on bubble and lines layout

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -544,7 +544,7 @@
                 <table class="o_ignore_layout_styling table table-borderless mb-0">
                     <tbody>
                         <tr>
-                            <td t-attf-class="p-0 {{'pt-3' if information_block else ''}}">
+                            <td class="p-0">
                                 <t t-call="web.address_layout" custom_layout_address="True"/>
                             </td>
                             <td t-if="not information_block" class="align-bottom p-0 ps-2">

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -709,8 +709,8 @@
             </table>
         </div>
         <t t-call="web.external_layout_body" hide_recipient_address="True" hide_title="True">
-            <h2 class="text-center" t-out="layout_document_title"/>
-            <t t-call="web.address_layout" custom_layout_address="True" information_block="False"/>
+            <h2 t-attf-class="text-center {{'mb-4' if information_block else ''}}" t-out="layout_document_title"/>
+            <t t-call="web.address_layout" custom_layout_address="True"/>
             <t t-out="0"/>
         </t>
         <div t-attf-class="o_company_#{company.id}_layout footer position-relative {{report_type != 'pdf' and 'position-relative mt-auto mx-n5'}}">


### PR DESCRIPTION
The `information_block` is always false on the `external_layout_lines` this means that when a delivery address and invoicing address is specified they are not rendered.

Reviews the spacing of the bubble layout `information_block`

task-5951799
Part of task-5949213

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
