### PR TITLE
[IMP] web: Support M2M in searchpanel

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -1610,7 +1610,7 @@ class Base(models.AbstractModel):
             or an object with an error message when limit is defined and is reached.
         """
         field = self._fields[field_name]
-        supported_types = ['many2one', 'selection']
+        supported_types = ['many2one', 'selection', 'many2many']
         if field.type not in supported_types:
             types = dict(self.env["ir.model.fields"]._fields["ttype"]._description_selection(self.env))
             raise UserError(self.env._(

--- a/addons/web/static/tests/_framework/mock_server/mock_model.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_model.js
@@ -961,7 +961,7 @@ function parseView(model, params) {
 function searchPanelDomainImage(model, fieldName, domain, setCount = false, limit = false) {
     const field = model._fields[fieldName];
     let groupIdName;
-    if (isM2OField(field)) {
+    if (isM2OField(field) || field.type === "many2many") {
         groupIdName = (value) => value || [false, undefined];
         // formatted_read_group does not take care of the condition [fieldName, '!=', false]
         // in the domain defined below!!!
@@ -2311,7 +2311,7 @@ export class Model extends Array {
 
         const field = this._fields[fieldName];
         const coModel = getRelation(field);
-        const supportedTypes = ["many2one", "selection"];
+        const supportedTypes = ["many2one", "selection", "many2many"];
         if (!supportedTypes.includes(field.type)) {
             throw new MockServerError(
                 `Only category types ${supportedTypes.join(" and ")} are supported, got "${

--- a/addons/web/static/tests/search/search_panel_desktop.test.js
+++ b/addons/web/static/tests/search/search_panel_desktop.test.js
@@ -763,6 +763,65 @@ test("use category (on selection) to refine search", async () => {
     expect(component.domain).toEqual([]);
 });
 
+test("use category (on many2many) to refine search", async () => {
+    Partner._records.push({
+        id: 5,
+        bar: true,
+        foo: "woof",
+        int_field: 8,
+        company_ids: [5, 3],
+        company_id: 5,
+        state: "def",
+        category_id: 7,
+    });
+    Partner._views = {
+        search: /* xml */ `
+            <search>
+                <searchpanel>
+                    <field name="company_ids" enable_counters="1"/>
+                </searchpanel>
+            </search>
+        `,
+    };
+    const component = await mountWithSearch(TestComponent, {
+        resModel: "partner",
+        searchViewId: false,
+        domain: [["bar", "=", true]],
+        context: {
+            searchpanel_default_company_id: false,
+            searchpanel_default_state: "ghi",
+        },
+    });
+    expect(component.domain).toEqual([["bar", "=", true]]);
+
+    // select "asustek"
+    await contains(queryAll`.o_search_panel_category_value header`[1]).click();
+    expect(`.o_search_panel_category_value .active`).toHaveCount(1);
+    expect(`.o_search_panel_category_value:eq(1) .active`).toHaveCount(1);
+    // Since #3641f23, all domains `[(x, '=', value)]` become `[(x, 'in', [value])]`.
+    expect(component.env.searchModel.domain).toEqual([
+        "&",
+        ["bar", "=", true],
+        ["company_ids", "=", 3],
+    ]);
+
+    // select "agrolait"
+    await contains(queryAll`.o_search_panel_category_value header`[2]).click();
+    expect(`.o_search_panel_category_value .active`).toHaveCount(1);
+    expect(`.o_search_panel_category_value:eq(2) .active`).toHaveCount(1);
+    expect(component.env.searchModel.domain).toEqual([
+        "&",
+        ["bar", "=", true],
+        ["company_ids", "=", 5],
+    ]);
+
+    // select "All"
+    await contains(queryAll`.o_search_panel_category_value header`[0]).click();
+    expect(`.o_search_panel_category_value .active`).toHaveCount(1);
+    expect(`.o_search_panel_category_value:first .active`).toHaveCount(1);
+    expect(component.env.searchModel.domain).toEqual([["bar", "=", true]]);
+});
+
 test("category has been archived", async () => {
     Company._fields.active = fields.Boolean({ string: "Archived" });
     Company._records = [

--- a/odoo/addons/test_web/models/models.py
+++ b/odoo/addons/test_web/models/models.py
@@ -8,6 +8,11 @@ class Test_Search_PanelSource_Model(models.Model):
     name = fields.Char('Name', required=True)
     state = fields.Selection([('a', "A"), ('b', "B")])
     folder_id = fields.Many2one('test_search_panel.category_target_model')
+    folder_ids = fields.Many2many(
+        comodel_name='test_search_panel.category_target_model',
+        relation='test_sp_source_categ_m2m_rel',
+        string="Folders M2M"
+    )
     categ_id = fields.Many2one(
         'test_search_panel.category_target_model_no_parent_name')
     tag_ids = fields.Many2many(

--- a/odoo/addons/test_web/tests/test_search_panel_select_range.py
+++ b/odoo/addons/test_web/tests/test_search_panel_select_range.py
@@ -1,4 +1,5 @@
 import odoo.tests
+from odoo import Command
 
 SEARCH_PANEL_ERROR = {'error_msg': "Too many items to display."}
 
@@ -702,4 +703,365 @@ class TestSelectRange(odoo.tests.TransactionCase):
             [
                 {'display_name': 'A', 'id': 'a'},
             ],
+        )
+
+    # Many2many case
+
+    def test_many2many_empty(self):
+        result = self.SourceModel.search_panel_select_range('folder_ids')
+        self.assertEqual(
+            result,
+            {
+                'parent_field': 'parent_name_id',
+                'values': [],
+            },
+        )
+
+    def test_many2many(self):
+        self.maxDiff = None
+        parent_folders = self.TargetModel.create([
+            {'name': 'Folder 1'},
+            {'name': 'Folder 2'},
+        ])
+
+        f1_id, f2_id = parent_folders.ids
+
+        children_folders = self.TargetModel.create([
+            {'name': 'Folder 3', 'parent_name_id': f1_id},
+            {'name': 'Folder 4', 'parent_name_id': f2_id},
+        ])
+
+        f3_id, f4_id = children_folders.ids
+
+        records = self.SourceModel.create([
+            {'name': 'Rec 1', 'folder_ids': [Command.set([f1_id, f2_id])]},
+            {'name': 'Rec 2', 'folder_ids': [Command.set([f3_id])]},
+            {'name': 'Rec 3', 'folder_ids': [Command.set([f4_id, f1_id])]},
+            {'name': 'Rec 4'},
+        ])
+
+        # counters, expand, and hierarchization
+        result = self.SourceModel.search_panel_select_range(
+            'folder_ids',
+            enable_counters=True,
+            expand=True,
+        )
+
+        # Folder1 ( rec1, rec3 ) + Folder3 ( rec2 ) -> 3
+        # Folder2 ( rec1 )       + Folder4 ( rec3 ) -> 2
+        # Folder3 ( rec2 ) -> 1
+        # Folder4 ( rec3 ) -> 1
+        self.assertEqual(
+            result['values'],
+            [
+                {'__count': 3, 'display_name': 'Folder 1', 'id': f1_id, 'parent_name_id': False},
+                {'__count': 2, 'display_name': 'Folder 2', 'id': f2_id, 'parent_name_id': False},
+                {'__count': 1, 'display_name': 'Folder 3', 'id': f3_id, 'parent_name_id': f1_id},
+                {'__count': 1, 'display_name': 'Folder 4', 'id': f4_id, 'parent_name_id': f2_id},
+            ],
+        )
+
+        r1_id, _, r3_id, _ = records.ids
+
+        # counters, expand, hierarchization, and search domain
+        result = self.SourceModel.search_panel_select_range(
+            'folder_ids',
+            enable_counters=True,
+            expand=True,
+            search_domain=[['id', 'in', [r1_id, r3_id]]],  # impact expected
+        )
+
+        # Folder1 ( rec1, rec3 ) + Folder3 ( \rec2 ) -> 2
+        # Folder2 ( rec1 )       + Folder4 ( rec3 )  -> 2
+        # Folder3 ( \rec2 ) -> 0
+        # Folder4 ( rec3 )  -> 1
+        self.assertEqual(
+            result['values'],
+            [
+                {'__count': 2, 'display_name': 'Folder 1',
+                    'id': f1_id, 'parent_name_id': False},
+                {'__count': 2, 'display_name': 'Folder 2',
+                    'id': f2_id, 'parent_name_id': False},
+                {'__count': 0, 'display_name': 'Folder 3',
+                    'id': f3_id, 'parent_name_id': f1_id},
+                {'__count': 1, 'display_name': 'Folder 4',
+                    'id': f4_id, 'parent_name_id': f2_id},
+            ],
+        )
+
+        # counters, expand, hierarchization, and reached limit
+        result = self.SourceModel.search_panel_select_range(
+            'folder_ids',
+            enable_counters=True,
+            expand=True,
+            limit=2,
+        )
+        self.assertEqual(result, SEARCH_PANEL_ERROR)
+
+        # counters, expand, hierarchization, and unreached limit
+        result = self.SourceModel.search_panel_select_range(
+            'folder_ids',
+            enable_counters=True,
+            expand=True,
+            limit=200,
+        )
+        self.assertEqual(
+            result,
+            {
+                'parent_field': 'parent_name_id',
+                'values': [
+                    {'__count': 3, 'display_name': 'Folder 1',
+                        'id': f1_id, 'parent_name_id': False},
+                    {'__count': 2, 'display_name': 'Folder 2',
+                        'id': f2_id, 'parent_name_id': False},
+                    {'__count': 1, 'display_name': 'Folder 3',
+                        'id': f3_id, 'parent_name_id': f1_id},
+                    {'__count': 1, 'display_name': 'Folder 4',
+                        'id': f4_id, 'parent_name_id': f2_id},
+                ],
+            },
+        )
+
+        # counters, expand, and no hierarchization
+        result = self.SourceModel.search_panel_select_range(
+            'folder_ids',
+            enable_counters=True,
+            expand=True,
+            hierarchize=False,
+        )
+        self.assertEqual(
+            result['values'],
+            [
+                {'__count': 2, 'display_name': 'Folder 1', 'id': f1_id},
+                {'__count': 1, 'display_name': 'Folder 2', 'id': f2_id},
+                {'__count': 1, 'display_name': 'Folder 3', 'id': f3_id},
+                {'__count': 1, 'display_name': 'Folder 4', 'id': f4_id},
+            ],
+        )
+        self.assertEqual(
+            result['parent_field'],
+            False,
+        )
+
+        # no counters, expand, and hierarchization
+        result = self.SourceModel.search_panel_select_range(
+            'folder_ids',
+            expand=True,
+        )
+        self.assertEqual(
+            result['values'],
+            [
+                {'display_name': 'Folder 1',
+                    'id': f1_id, 'parent_name_id': False},
+                {'display_name': 'Folder 2',
+                    'id': f2_id, 'parent_name_id': False},
+                {'display_name': 'Folder 3',
+                    'id': f3_id, 'parent_name_id': f1_id},
+                {'display_name': 'Folder 4',
+                    'id': f4_id, 'parent_name_id': f2_id},
+            ],
+        )
+
+        # no counters, expand, hierarchization, and search domain
+        result = self.SourceModel.search_panel_select_range(
+            'folder_ids',
+            expand=True,
+            search_domain=[['id', 'in', [r1_id, r3_id]]],  # no impact expected
+        )
+        self.assertEqual(
+            result['values'],
+            [
+                {'display_name': 'Folder 1',
+                    'id': f1_id, 'parent_name_id': False},
+                {'display_name': 'Folder 2',
+                    'id': f2_id, 'parent_name_id': False},
+                {'display_name': 'Folder 3',
+                    'id': f3_id, 'parent_name_id': f1_id},
+                {'display_name': 'Folder 4',
+                    'id': f4_id, 'parent_name_id': f2_id},
+            ],
+        )
+
+        # no counters, expand, and no hierarchization
+        result = self.SourceModel.search_panel_select_range(
+            'folder_ids',
+            expand=True,
+            hierarchize=False,
+        )
+        self.assertEqual(
+            result['values'],
+            [
+                {'display_name': 'Folder 1',
+                    'id': f1_id},
+                {'display_name': 'Folder 2',
+                    'id': f2_id},
+                {'display_name': 'Folder 3',
+                    'id': f3_id},
+                {'display_name': 'Folder 4',
+                    'id': f4_id},
+            ],
+        )
+
+        # counters, no expand, and hierarchization
+        result = self.SourceModel.search_panel_select_range(
+            'folder_ids',
+            enable_counters=True,
+        )
+        self.assertEqual(
+            result['values'],
+            [
+                {'__count': 3, 'display_name': 'Folder 1',
+                    'id': f1_id, 'parent_name_id': False},
+                {'__count': 2, 'display_name': 'Folder 2',
+                    'id': f2_id, 'parent_name_id': False},
+                {'__count': 1, 'display_name': 'Folder 3',
+                    'id': f3_id, 'parent_name_id': f1_id},
+                {'__count': 1, 'display_name': 'Folder 4',
+                    'id': f4_id, 'parent_name_id': f2_id},
+            ],
+        )
+        self.assertEqual(
+            result['parent_field'],
+            'parent_name_id',
+        )
+
+        # counters, no expand, and no hierarchization
+        result = self.SourceModel.search_panel_select_range(
+            'folder_ids',
+            enable_counters=True,
+            hierarchize=False,
+        )
+        self.assertEqual(
+            result['values'],
+            [
+                {'__count': 2, 'display_name': 'Folder 1', 'id': f1_id},
+                {'__count': 1, 'display_name': 'Folder 2', 'id': f2_id},
+                {'__count': 1, 'display_name': 'Folder 3', 'id': f3_id},
+                {'__count': 1, 'display_name': 'Folder 4', 'id': f4_id},
+            ],
+        )
+        self.assertEqual(
+            result['parent_field'],
+            False,
+        )
+
+        # counters, no expand, no hierarchization, and category_domain
+        result = self.SourceModel.search_panel_select_range(
+            'folder_ids',
+            enable_counters=True,
+            hierarchize=False,
+            category_domain=[['id', 'in', [r1_id, r3_id]]],  # impact expected
+        )
+        self.assertEqual(
+            result['values'],
+            [
+                {'__count': 2, 'display_name': 'Folder 1', 'id': f1_id},
+                {'__count': 1, 'display_name': 'Folder 2', 'id': f2_id},
+                {'__count': 0, 'display_name': 'Folder 3', 'id': f3_id},
+                {'__count': 1, 'display_name': 'Folder 4', 'id': f4_id},
+            ],
+        )
+        self.assertEqual(
+            result['parent_field'],
+            False,
+        )
+
+        # counters, no expand, no hierarchization, and limit
+        result = self.SourceModel.search_panel_select_range(
+            'folder_ids',
+            enable_counters=True,
+            hierarchize=False,
+            limit=2,
+        )
+        self.assertEqual(result, SEARCH_PANEL_ERROR)
+
+        # no counters, no expand, and hierarchization
+        result = self.SourceModel.search_panel_select_range(
+            'folder_ids',
+            hierarchize=True,
+        )
+        self.assertEqual(
+            result['values'],
+            [
+                {'display_name': 'Folder 1',
+                    'id': f1_id, 'parent_name_id': False},
+                {'display_name': 'Folder 2',
+                    'id': f2_id, 'parent_name_id': False},
+                {'display_name': 'Folder 3',
+                    'id': f3_id, 'parent_name_id': f1_id},
+                {'display_name': 'Folder 4',
+                    'id': f4_id, 'parent_name_id': f2_id},
+            ],
+        )
+        self.assertEqual(
+            result['parent_field'],
+            'parent_name_id',
+        )
+
+        # no counters, no expand, and hierarchization
+        result = self.SourceModel.search_panel_select_range(
+            'folder_ids',
+            search_domain=[(0, '=', 1)],
+        )
+        self.assertEqual(
+            result,
+            {'parent_field': 'parent_name_id', 'values': []},  # should not be a SEARCH_PANEL_ERROR
+        )
+
+        # no counters, no expand, and no hierarchization
+        result = self.SourceModel.search_panel_select_range(
+            'folder_ids',
+            hierarchize=False,
+        )
+        self.assertEqual(
+            result['values'],
+            [
+                {'display_name': 'Folder 1', 'id': f1_id},
+                {'display_name': 'Folder 2', 'id': f2_id},
+                {'display_name': 'Folder 3', 'id': f3_id},
+                {'display_name': 'Folder 4', 'id': f4_id},
+            ],
+        )
+        self.assertEqual(
+            result['parent_field'],
+            False,
+        )
+
+        # no counters, no expand, no hierarchization, and category_domain
+        result = self.SourceModel.search_panel_select_range(
+            'folder_ids',
+            hierarchize=False,
+            category_domain=[['id', 'in', [r1_id, r3_id]]],  # no impact expected
+
+        )
+        self.assertEqual(
+            result['values'],
+            [
+                {'display_name': 'Folder 1', 'id': f1_id},
+                {'display_name': 'Folder 2', 'id': f2_id},
+                {'display_name': 'Folder 3', 'id': f3_id},
+                {'display_name': 'Folder 4', 'id': f4_id},
+            ],
+        )
+        self.assertEqual(
+            result['parent_field'],
+            False,
+        )
+
+        # no counters, no expand, no hierarchization, and comodel_domain
+        result = self.SourceModel.search_panel_select_range(
+            'folder_ids',
+            hierarchize=False,
+            comodel_domain=[['id', 'in', [f1_id, f4_id]]],
+        )
+        self.assertEqual(
+            result['values'],
+            [
+                {'display_name': 'Folder 1', 'id': f1_id},
+                {'display_name': 'Folder 4', 'id': f4_id},
+            ],
+        )
+        self.assertEqual(
+            result['parent_field'],
+            False,
         )


### PR DESCRIPTION
This commits adds support for m2m fields in the searchpanel. 

For example:
```xml
<search>
    <searchpanel>
        <field name="company_ids"/>
    </searchpanel>
</search>
```

task-5153761