### PR TITLE
[FIX] point_of_sale: assign outstanding account to default payment method

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -1025,9 +1025,12 @@ class PosConfig(models.Model):
             bank_journal = self.env['account.journal'].search([('type', '=', 'bank'), ('company_id', 'in', self.env.company.parent_ids.ids)], limit=1)
             if not bank_journal:
                 raise UserError(_('Ensure that there is an existing bank journal. Check if chart of accounts is installed in your company.'))
+            chart_template = self.with_context(allowed_company_ids=self.env.company.root_id.ids).env['account.chart.template']
+            outstanding_account = chart_template.ref('account_journal_payment_debit_account_id', raise_if_not_found=False) or self.env.company.transfer_account_id
             bank_pm = self.env['pos.payment.method'].create({
                 'name': _('Card'),
                 'journal_id': bank_journal.id,
+                'outstanding_account_id': outstanding_account.id if outstanding_account else False,
                 'company_id': self.env.company.id,
                 'sequence': 1,
             })

--- a/addons/point_of_sale/tests/test_pos_setup.py
+++ b/addons/point_of_sale/tests/test_pos_setup.py
@@ -118,3 +118,11 @@ class TestPoSSetup(TestPoSCommon):
         )
         with self.assertRaises(ValidationError):
             journal.action_archive()
+
+    def test_card_payment_method_initialization(self):
+        """Test that the 'Card' payment method created by default has an outstanding account."""
+        card_pm = self.env['pos.payment.method'].search([
+            ('name', '=', 'Card'), ('company_id', '=', self.env.company.id),
+        ], limit=1)
+        self.assertTrue(card_pm)
+        self.assertTrue(card_pm.outstanding_account_id)


### PR DESCRIPTION
Steps to reproduce:
1. Initialize a new database with 'point_of_sale' and 'accountant' modules.
2. Go to Configuration > Payment Methods and open the 'Card' payment method.
3. Observe that the 'Outstanding Account' field is empty, despite being required in the view for bank journals.

The issue occurred because the '_create_journal_and_payment_methods' method created the default 'Card' payment method without specifying an 'outstanding_account_id'. While the ORM allows this (as the field is only required in the view), it creates an inconsistency between automated setup and manual configuration.

Solution:
Modify '_create_journal_and_payment_methods' to automatically assign the 'outstanding_account_id' during creation. It follows the pattern used in the payment method's onchange logic by fetching the default debit account from the chart template or falling back to the company's transfer account.

opw-5914536