### PR TITLE
[IMP] point_of_sale, **: recenter odoo logo and floor plan buttons

### DIFF
--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.xml
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.xml
@@ -24,7 +24,7 @@
                     </button>
                 </div>
             </div>
-            <div t-if="!this.pos.getOrder()" class="pos-centerheader d-none d-xl-flex justify-content-center overflow-hidden">
+            <div t-if="!this.pos.getOrder()" class="pos-centerheader d-none d-xl-flex position-absolute start-50 translate-middle-x">
                 <div class="pos-logo mw-100" />
             </div>
             <div class="pos-rightheader flex-shrink-0">

--- a/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.xml
+++ b/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.xml
@@ -17,7 +17,7 @@
                     </button>
 
                     <!-- Center Side Div -->
-                    <div class="floor-selector d-flex gap-1 overflow-auto">
+                    <div class="floor-selector d-flex gap-1 overflow-auto position-absolute start-50 translate-middle-x">
                         <t t-if="floorPlanStore.floors.length > 1" t-foreach="floorPlanStore.floors" t-as="floor" t-key="floor.uuid">
                             <button class="button button-floor btn btn-outline-secondary btn-lg px-3 lh-lg text-nowrap text-body"
                                     t-att-class="{'active': floor === floorPlanStore.selectedFloor}"


### PR DESCRIPTION
** = pos_restaurant

In this commit:
- Recentered the Odoo logo and floor plan button based on the viewport size for better alignment and responsiveness.
- Applied a shadow on the Odoo logo for a better user experience.

Before: 
<img width="1920" height="852" alt="image" src="https://github.com/user-attachments/assets/e8b05b7a-11be-4652-90dc-2b89236fc190" />

After:
<img width="1920" height="852" alt="image" src="https://github.com/user-attachments/assets/b32c4b46-3e66-4948-8bd6-ae7dc935e037" />



Task-5946199


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
