### PR TITLE
[FIX] resource: recompute `hours_per_week`/`hours_per_day` when based on duration

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -692,7 +692,7 @@ class ResourceCalendar(models.Model):
         self.ensure_one()
         hour_count = 0.0
         for attendance in self._get_global_attendances():
-            hour_count += attendance.hour_to - attendance.hour_from
+            hour_count += attendance.duration_hours
         return hour_count / 2 if self.two_weeks_calendar else hour_count
 
     def _get_hours_per_day(self):


### PR DESCRIPTION
### Issue:
When creating a Working Schedule, and choosing the option "Define Amount of Hours per day" then the fields `hours_per_day` and `hours_per_week` are not recomputed correctly.

### Steps to reproduce:
- Create a new Working Schedule
- Tick the option "Define Amount of Hours per day"
- Change the duration on a line
- Hours per day and hours per week are not updated

### Cause:
This [commit](https://github.com/odoo/odoo/commit/77f860f5d3757e5a56861ac1de95b9ad29ea0dff) introduced the possibility of defining `resource.calendar.attendance` with `duration_hours` instead of `hour_from`/`hour_to`.

The fields `hours_per_week`/`hours_per_day` are recomputed when changing `hour_from`, `hour_to` or `duration_hours`. This recompute is done because an onchange is triggered and will recompute all compute fields displayed in the form view.

As the fields `hour_from`/`hour_to` are not computed, they are not changed when changing `duration_hours` on the form view but they are when saving because of `_inverse_duration_hours()`.

The compute method of `hours_per_week` only takes into account `hour_from`/`hour_to`. So if `duration_based` is False, then changing `hour_from` will recompute `hours_per_week` but changing `duration_hours` will not as `hour_from`/`hour_to` still have the previous values.

### Solution:
We need the recomputation to be made on `duration_hours` when `duration_based` is True.

As `duration_hours` is recomputed via `_compute_duration_hours()` when `hour_from`/`hour_to` change, we only use `duration_hours`.

opw-5942240
