### PR TITLE
[FIX] l10n_hr_edi: Improving credentials error handling, OIB/VAT handling

### DIFF
--- a/addons/l10n_hr_edi/models/res_company.py
+++ b/addons/l10n_hr_edi/models/res_company.py
@@ -191,14 +191,16 @@ class ResCompany(models.Model):
                     continue
                 elif any(not (item.get('ElectronicId') and item.get('StatusId')) for item in response):
                     # Case 2: a list with elements that appear to not be valid document dicts
-                    error = ("Incorrect multiple document response format while querying inbox for company: %s", company.name)
+                    error = ("Incorrect multiple document response format while querying inbox for company: %(company)s: %(response)s",
+                             company.name, response)
                 else:
                     # Case 3: a list of valid document dicts
                     pass
             elif isinstance(response, dict):
                 if not (response.get('ElectronicId') and response.get('StatusId')):
                     # Case 4: a single dict that doesn't appear to be a valid document
-                    error = ("Incorrect multiple document response format while querying inbox for company: %s", company.name)
+                    error = ("Incorrect single document response format while querying inbox for company: %(company)s: %(response)s",
+                             company.name, response)
                 else:
                     # Case 5: a single valid document dict
                     response = [response]

--- a/addons/l10n_hr_edi/tests/flows/in_invoice.xml
+++ b/addons/l10n_hr_edi/tests/flows/in_invoice.xml
@@ -208,7 +208,7 @@ PhFY/lSNktJsHzsRUaqzfVdRkHRFe/sBHG2YCnEuWSOO9wHWtky7Vc4=</xades:EncapsulatedTime
   </cac:AdditionalDocumentReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="9934">HR18724543544</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9934">18724543544</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>HR Company</cbc:Name>
       </cac:PartyName>

--- a/addons/l10n_hr_edi/tests/flows/out_invoice.xml
+++ b/addons/l10n_hr_edi/tests/flows/out_invoice.xml
@@ -45,7 +45,7 @@
   </cac:AdditionalDocumentReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="9934">HR68139364755</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9934">68139364755</cbc:EndpointID>
       <cac:PartyIdentification>
 				<cbc:ID>9934:68139364755</cbc:ID>
 			</cac:PartyIdentification>
@@ -82,7 +82,7 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="9934">HR08971065561</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9934">08971065561</cbc:EndpointID>
       <cac:PartyIdentification>
 				<cbc:ID>9934:08971065561</cbc:ID>
 			</cac:PartyIdentification>

--- a/addons/l10n_hr_edi/tests/test_files/test_invoice.xml
+++ b/addons/l10n_hr_edi/tests/test_files/test_invoice.xml
@@ -41,7 +41,7 @@
   </cac:OrderReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="9934">HR68139364755</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9934">68139364755</cbc:EndpointID>
       <cac:PartyIdentification>
 				<cbc:ID>9934:68139364755::HR99:12345</cbc:ID>
 			</cac:PartyIdentification>
@@ -78,7 +78,7 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="9934">HR08971065561</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9934">08971065561</cbc:EndpointID>
       <cac:PartyIdentification>
 				<cbc:ID>9934:08971065561</cbc:ID>
 			</cac:PartyIdentification>

--- a/addons/l10n_hr_edi/tests/test_files/test_invoice_cash_basis.xml
+++ b/addons/l10n_hr_edi/tests/test_files/test_invoice_cash_basis.xml
@@ -42,7 +42,7 @@
   </cac:OrderReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="9934">HR68139364755</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9934">68139364755</cbc:EndpointID>
       <cac:PartyIdentification>
 				<cbc:ID>9934:68139364755::HR99:12345</cbc:ID>
 			</cac:PartyIdentification>
@@ -79,7 +79,7 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="9934">HR08971065561</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9934">08971065561</cbc:EndpointID>
       <cac:PartyIdentification>
 				<cbc:ID>9934:08971065561</cbc:ID>
 			</cac:PartyIdentification>

--- a/addons/l10n_hr_edi/tests/test_files/test_invoice_exemption_e.xml
+++ b/addons/l10n_hr_edi/tests/test_files/test_invoice_exemption_e.xml
@@ -43,7 +43,7 @@
   </cac:OrderReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="9934">HR68139364755</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9934">68139364755</cbc:EndpointID>
       <cac:PartyIdentification>
 				<cbc:ID>9934:68139364755::HR99:12345</cbc:ID>
 			</cac:PartyIdentification>
@@ -80,7 +80,7 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="9934">HR08971065561</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9934">08971065561</cbc:EndpointID>
       <cac:PartyIdentification>
 				<cbc:ID>9934:08971065561</cbc:ID>
 			</cac:PartyIdentification>

--- a/addons/l10n_hr_edi/tests/test_files/test_invoice_exemption_k.xml
+++ b/addons/l10n_hr_edi/tests/test_files/test_invoice_exemption_k.xml
@@ -42,7 +42,7 @@
   </cac:OrderReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="9934">HR68139364755</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9934">68139364755</cbc:EndpointID>
       <cac:PartyIdentification>
 				<cbc:ID>9934:68139364755::HR99:12345</cbc:ID>
 			</cac:PartyIdentification>
@@ -79,7 +79,7 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="9934">HR08971065561</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9934">08971065561</cbc:EndpointID>
       <cac:PartyIdentification>
 				<cbc:ID>9934:08971065561</cbc:ID>
 			</cac:PartyIdentification>

--- a/addons/l10n_hr_edi/tests/test_files/test_invoice_multiple.xml
+++ b/addons/l10n_hr_edi/tests/test_files/test_invoice_multiple.xml
@@ -66,7 +66,7 @@
   </cac:OrderReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="9934">HR68139364755</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9934">68139364755</cbc:EndpointID>
       <cac:PartyIdentification>
 				<cbc:ID>9934:68139364755::HR99:12345</cbc:ID>
 			</cac:PartyIdentification>
@@ -103,7 +103,7 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="9934">HR08971065561</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9934">08971065561</cbc:EndpointID>
       <cac:PartyIdentification>
 				<cbc:ID>9934:08971065561</cbc:ID>
 			</cac:PartyIdentification>

--- a/addons/l10n_hr_edi/tests/test_files/test_invoice_refund.xml
+++ b/addons/l10n_hr_edi/tests/test_files/test_invoice_refund.xml
@@ -40,7 +40,7 @@
   </cac:OrderReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="9934">HR68139364755</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9934">68139364755</cbc:EndpointID>
       <cac:PartyIdentification>
 				<cbc:ID>9934:68139364755::HR99:12345</cbc:ID>
 			</cac:PartyIdentification>
@@ -77,7 +77,7 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="9934">HR08971065561</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9934">08971065561</cbc:EndpointID>
       <cac:PartyIdentification>
 				<cbc:ID>9934:08971065561</cbc:ID>
 			</cac:PartyIdentification>

--- a/addons/l10n_hr_edi/tools.py
+++ b/addons/l10n_hr_edi/tools.py
@@ -96,6 +96,9 @@ def _make_request(company, endpoint_type, params=False):
             if response_json['error']['code'] == 404:
                 message = company.env._('The url that this service tried to contact does not exist. The url was “%s”', url)
             raise MojEracunServiceError('connection_error', message)
+        elif 'Username' in response_json:  # No valid response contains this, it is a credentials error format
+            message = company.env._("MER service returned an error: Username '%(name)s': %(desc)s", name=response_json['Username'].get('Value'), desc=response_json['Username'].get('Messages'))
+            raise MojEracunServiceError('credentials_error', message)
         return response_json
     else:
         return response.content


### PR DESCRIPTION
- Credentials errors have a separate format in MER, they should now be displayed in a more user-fiendly manner
- Correcting XML generation for partners with no explicit OIB provided
- Adding tests for both changes
task-none

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
