### PR TITLE
[FIX] lunch: fix traceback on lunch order with vendor until date set

### DIFF
--- a/addons/lunch/models/lunch_supplier.py
+++ b/addons/lunch/models/lunch_supplier.py
@@ -307,7 +307,8 @@ class LunchSupplier(models.Model):
         self.ensure_one()
 
         fieldname = WEEKDAY_TO_NAME[date.weekday()]
-        return not (self.recurrency_end_date and date.date() >= self.recurrency_end_date) and self[fieldname]
+        date = fields.Date.to_date(date)
+        return not (self.recurrency_end_date and date >= self.recurrency_end_date) and self[fieldname]
 
     @api.depends('available_today', 'automatic_email_time', 'send_by')
     def _compute_order_deadline_passed(self):

--- a/addons/lunch/tests/test_supplier.py
+++ b/addons/lunch/tests/test_supplier.py
@@ -259,3 +259,20 @@ env['lunch.supplier'].browse([{self.supplier_kothai.id}])._send_auto_email()""")
 
         order.action_order()
         self.assertEqual(order.state, "ordered")
+
+    def test_order_with_vendor_recurrency_end_date(self):
+        """ Test lunch order when vendor have recurrency_end_date field set """
+        self.supplier_pizza_inn.recurrency_end_date = self.monday_1pm.date() + timedelta(days=7)
+
+        # Test _compute_available_today flow (datetime.datetime object)
+        with patch.object(fields.Datetime, 'now', return_value=self.monday_1pm):
+            self.supplier_pizza_inn.invalidate_recordset(['available_today'])
+            self.assertTrue(self.supplier_pizza_inn.available_today)
+
+        # Test _compute_available_on_date flow (datetime.date object)
+        order = self.env['lunch.order'].create({
+            'product_id': self.product_pizza.id,
+            'date': self.monday_1pm.date(),
+            'supplier_id': self.supplier_pizza_inn.id,
+        })
+        self.assertTrue(order.available_on_date)


### PR DESCRIPTION
Steps to reproduce:
------------------------------
1. Install Lunch module
2. Lunch > configurations > Vendors
3. Open any vendor and set Until date to any near future date
4. Go to My Lunch > New Order
5. Click on Any product with above vendor > Add to Cart
6. Click on Order Now

Observation:
------------------------------
Traceback Occurs:
```
return not (self.recurrency_end_date and date.date() >= self.recurrency_end_date) and self[fieldname]
^^^^^^^^^
AttributeError: 'datetime.date' object has no attribute 'date'
```

Issue:
------------------------------
`_available_on_date` calls `date.date()` unconditionally, which fails when passed a `datetime.date` object (from `lunch.order`) since date objects lack the `date()` method.

Solution:
------------------------------
Check instance type before calling `date()` to handle both `datetime.datetime` and `datetime.date` objects correctly.

opw-5948688