### PR TITLE
[FIX] point_of_sale: fix payment state for refund

### DIFF
--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -3110,6 +3110,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             return current_session
 
         self.bank_payment_method.outstanding_account_id = self.inbound_payment_method_line.payment_account_id.id
+        self.bank_payment_method.outstanding_account_id.account_type = "asset_cash"
         session_ids = [
             _do_pos_transaction(amount, split, idx).id
             for idx, (amount, split) in enumerate([(100, False), (-100, False), (100, True), (-100, True)])
@@ -3121,21 +3122,25 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
                     "payment_type": "inbound",
                     "outstanding_account_id": self.bank_payment_method.outstanding_account_id.id,
                     "destination_account_id": self.bank_payment_method.receivable_account_id.id,
+                    "state": "paid"
                 },
                 {
                     "payment_type": "outbound",
                     "outstanding_account_id": self.bank_payment_method.receivable_account_id.id,
                     "destination_account_id": self.bank_payment_method.outstanding_account_id.id,
+                    "state": "paid"
                 },
                 {
                     "payment_type": "inbound",
                     "outstanding_account_id": self.bank_payment_method.outstanding_account_id.id,
                     "destination_account_id": self.bank_payment_method.receivable_account_id.id,
+                    "state": "paid"
                 },
                 {
                     "payment_type": "outbound",
                     "outstanding_account_id": self.bank_payment_method.receivable_account_id.id,
                     "destination_account_id": self.bank_payment_method.outstanding_account_id.id,
+                    "state": "paid"
                 },
             ],
         )


### PR DESCRIPTION
Step to reproduce:
- go to "cards" payment method, check identify customer and set outstanding  account
- start pos and fulfill a order, refund it
- use card as payment method for both this transaction
- close session and goto "Customer Payments" menu in accounting module

Observation
- for refund payment, state is "in_process", but the related move is "posted"

Cause:
- we swap outstanding account with the destination account during refunds, 
https://github.com/odoo/odoo/blob/3ac8d967bedba8339661543d2cd19f099d9f7be0/addons/point_of_sale/models/pos_session.py#L1212
this causes issue when we do `action_post()` as it only marks payments as paid when
the outstanding account type is 'asset_cash', but here we swapped it
https://github.com/odoo/odoo/blob/3ac8d967bedba8339661543d2cd19f099d9f7be0/addons/account/models/account_payment.py#L1156-L1159

Fix:
- override `action_post` to mark such payment as "paid"
- override `_get_valid_liquidity_accounts` such that it return correct accounts
and not the swapped one when computing payment state.

~~Note, this pr will be updated after this is merged https://github.com/odoo/odoo/pull/247760~~

opw-5526716