### PR TITLE
[FIX] html_editor: clear caption on media replace

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
@@ -263,12 +263,18 @@ export class CaptionPlugin extends Plugin {
 
     onImageReplaced(media) {
         const figure = closestElement(media, "figure");
-        if (media.nodeName === "IMG" && figure) {
-            const [anchorNode, anchorOffset] = rightPos(figure);
-            const caption = figure.querySelector("[data-embedded='caption'] input")?.value;
-            figure.before(media);
-            figure.remove();
-            this.addImageCaption(media, caption, false);
+        let anchorNode, anchorOffset;
+        if (figure) {
+            if (media.nodeName === "IMG") {
+                [anchorNode, anchorOffset] = rightPos(figure);
+                const caption = figure.querySelector("[data-embedded='caption'] input")?.value;
+                figure.before(media);
+                figure.remove();
+                this.addImageCaption(media, caption, false);
+            } else {
+                this.removeImageCaption(media);
+                [anchorNode, anchorOffset] = rightPos(media);
+            }
             this.dependencies.selection.setSelection({ anchorNode, anchorOffset });
         }
     }

--- a/addons/html_editor/static/tests/caption.test.js
+++ b/addons/html_editor/static/tests/caption.test.js
@@ -603,6 +603,39 @@ test("replace an image with a caption", async () => {
     });
 });
 
+test("remove caption when replacing an image with other media", async () => {
+    onRpc("ir.attachment", "search_read", () => [
+        {
+            id: 1,
+            name: "logo",
+            mimetype: "image/png",
+            image_src: "/web/static/img/logo2.png",
+            access_token: false,
+            public: true,
+        },
+    ]);
+    const { el } = await setupEditorWithEmbeddedCaption(
+        unformat(
+            `<figure>
+                <img src="/web/static/img/logo.png">
+                <figcaption>Hello</figcaption>
+            </figure>
+            <p>abc</p>`
+        )
+    );
+    await click("img");
+    await waitFor(".o-we-toolbar button[name='replace_image']");
+    await click("button[name='replace_image']");
+    await waitFor(".o_select_media_dialog");
+    await click(".modal .modal-body .nav-item:nth-child(3) a"); // Icons
+    await waitFor(".modal .modal-body .fa-heart");
+    await click(".modal .modal-body .fa-heart");
+    expect("img[src='/web/static/img/logo.png']").toHaveCount(0);
+    expect(getContent(el)).toBe(
+        '<p><br></p><p>\ufeff<span class="fa fa-heart" contenteditable="false">\u200b</span>[]\ufeff</p><p>abc</p>'
+    );
+});
+
 test("edit caption after replacing image", async () => {
     onRpc("/web/dataset/call_kw/ir.attachment/search_read", () => [
         {


### PR DESCRIPTION
**Current behavior before PR:**

Steps to reproduce:

- Add a caption on an image
- Click on image
- Replace image by an icon using replace option from Toolbar
- Putting cursor on caption input and clicking anywhere outside editable leads to traceback.

This happens because after replacing image with an icon, caption is still there but there is no image inside caption. As result, in `cleanForSave` accessing image leads to traceback.

**Desired behavior after PR is merged:**

Now, if image is replaced by any other media than image, caption is removed.

task-5950977






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
