### PR TITLE
[FIX] mail: capitalize 'Remove from Bookmarks' label

### DIFF
--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -112,7 +112,7 @@ registerMessageAction("add-bookmark", {
 registerMessageAction("remove-bookmark", {
     condition: ({ message }) => message.canToggleBookmark && message.is_bookmarked,
     icon: "fa fa-bookmark",
-    name: _t("Remove from bookmarks"),
+    name: _t("Remove from Bookmarks"),
     onSelected: ({ message, thread }) => message.removeBookmark(thread),
     sequence: 30,
 });

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1146,8 +1146,8 @@ test("add and remove bookmark from message", async () => {
     await contains("button:has(:text('Bookmarks'))", { contains: [".badge:text('1')"] });
     await waitStoreFetch([["add_bookmark", { message_id: messageId }]]);
     await contains(".o-mail-Message");
-    await contains(".o-mail-Message [title='Remove from bookmarks']" + " i.fa-bookmark");
-    await click(".o-mail-Message [title='Remove from bookmarks']");
+    await contains(".o-mail-Message [title='Remove from Bookmarks']" + " i.fa-bookmark");
+    await click(".o-mail-Message [title='Remove from Bookmarks']");
     await contains("button:has(:text('Bookmarks'))", { contains: [".badge", { count: 0 }] });
     await waitStoreFetch([["remove_bookmark", { message_id: messageId }]]);
     await contains(".o-mail-Message");


### PR DESCRIPTION
Use capital letter for "Bookmarks" in this label, for consistency with labels of other actions but also to make it clearer this is related to the "Bookmarks" item in Discuss app.

Before / After
<img width="212" height="226" alt="Screenshot 2026-02-19 at 12 40 06" src="https://github.com/user-attachments/assets/28f8777e-521f-4ce5-ac07-2c8ff19539d2" /> <img width="211" height="230" alt="Screenshot 2026-02-19 at 12 40 24" src="https://github.com/user-attachments/assets/fa6168ef-7128-42a0-a2eb-d94bf381db5f" />
