### PR TITLE
[FIX] point_of_sale: ensure test partner is loaded in tour

### DIFF
--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -3114,6 +3114,8 @@ class TestUi(TestPointOfSaleHttpCommon):
             'name': 'Delivery',
             'identification': 'address',
         })
+        # Ensure Test partner is loaded.
+        self.env['ir.config_parameter'].set_param('point_of_sale.limited_customer_count', 9999)
         self.env['res.partner'].create({
             'name': 'Test Partner',
             'street': '123 Test Street',


### PR DESCRIPTION
Increase limited partner loading count in Point of Sale to ensure test partner is loaded in tour.

runbot error: 233397
