### PR TITLE
[FIX] website: AI translation without timeout


### DIFF
--- a/addons/website/static/src/builder/plugins/translation_tab/customize_translation_tab_plugin.js
+++ b/addons/website/static/src/builder/plugins/translation_tab/customize_translation_tab_plugin.js
@@ -20,6 +20,10 @@ class TranslateToAction extends BuilderAction {
     static id = "translateWebpageAI";
     static dependencies = ["customizeTranslationTab"];
 
+    setup() {
+        this.canTimeout = false;
+    }
+
     async apply() {
         const translationState = this.dependencies.customizeTranslationTab.getTranslationState();
         try {


### PR DESCRIPTION

Scenario:

- have lot of untranslated text in a page
- in a secondary language, open translation editor
- click on "Translate to [current language]" in side panel

Result: the translation fails completely or partially, and there is a
notification saying "A technical issue occurred in the builder, you
should save or discard your changes.".

Reason: since 6df83abb35c95ab42e55d9a08cf6c411efa64b3e website builder
action have a default timeout of 10 seconds to prevent deadlocks. But
the /html_editor/generate_text can easily take more than 10 secondes
depending on latency and quantity of text to translate.

Fix: prevent the timeout when using the AI translation feature.

opw-5892402
