### PR TITLE
[FIX] point_of_sale: fix test printer button

### DIFF
--- a/addons/point_of_sale/static/src/backend/test_epos/test_epos.js
+++ b/addons/point_of_sale/static/src/backend/test_epos/test_epos.js
@@ -111,7 +111,7 @@ export class TestEPos extends Component {
         if (printer.printer_type === "epson_epos") {
             try {
                 const protocol = printer.use_lna ? "http:" : window.location.protocol;
-                const url = protocol + "//" + printer.epson_printer_ip;
+                const url = protocol + "//" + printer.printer_ip;
                 const address = url + "/cgi-bin/epos/service.cgi?devid=local_printer";
                 const params = {
                     method: "POST",


### PR DESCRIPTION
When creating a new printer and test it with the test printer button, it will cause an error because the field of the ip address in pos.printer has changed and it was not changed into the test button.