### PR TITLE
[FIX] warnings: ignore invalid escape sequence in docutils 0.17

### DIFF
--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -218,6 +218,9 @@ def init_logger():
     # This warning is triggered library only during the python precompilation which does not occur on readonly filesystem
     warnings.filterwarnings("ignore", r'invalid escape sequence', category=DeprecationWarning, module=".*vobject")
     warnings.filterwarnings("ignore", r'invalid escape sequence', category=SyntaxWarning, module=".*vobject")
+    # for docutils 0.17 (only when pyc are recomputed, discovered when using faketime)
+    warnings.filterwarnings("ignore", r'invalid escape sequence', category=DeprecationWarning, module=".*docutils.utils.smartquotes")
+    warnings.filterwarnings("ignore", r'invalid escape sequence', category=SyntaxWarning, module=".*docutils.utils.smartquotes")
 
     # jammy's pdfminer has a broken version (the distribution returns
     # `-VERSION-`, the code has a version of `__VERSION__`), which triggers


### PR DESCRIPTION
During the faketime builds, we discovered that docutils 0.17 triggers an invalid escape sequence warnings when the pyc files are regenerated.

After some investigations, it looks that in standard builds the pyc files are not regenerated, so the warning is not triggered. But in faketime builds, the pyc files are always regenerated, and the warning is triggered.

Playing in the docker 17 images, Those are the observations:

[1] python3 ./odoo-bin --stop
-> no warning

[2] faketime "2050-01-01 00:00 UTC" python3 ./odoo-bin --stop -> warning
[3] faketime "2050-01-01 00:00 UTC" python3 ./odoo-bin --stop -> warning (repetability)

[4] python3 ./odoo-bin --stop
-> warning (?)
[5] python3 ./odoo-bin --stop
-> no warning

The failure in 4 indicates that some kind of cached data causes the issue. This is only the case when staying in the docker image

Since the source filesystem is readonly, only the pyc files of system packages could cause this kind of behaviour
This was confirmed using the -B flag

[1] faketime "2050-01-01 00:00 UTC" python3 ./odoo-bin --stop -> warning

[2] python3 -B ./odoo-bin --stop
-> warning
[3] python3 -B ./odoo-bin --stop
-> warning

Since 2 is now executed with -B (not writing pyc files), the problem persists after the first execution

[1] faketime -B "2050-01-01 00:00 UTC" python3 ./odoo-bin --stop -> warning
[2] python3 -B ./odoo-bin --stop
-> no warning
[3] python3 -B ./odoo-bin --stop
-> no warning

Since 1 is executed without -B, no invalid .pyc file are generated and following executions uses the existing correct .pyc files

It looks like this problem only occurs since faketime was passed to the latest version (3062fb20041552727bdb810456d2f1b4001b341f) instead of 0.9.12