### PR TITLE
[FIX] web: search_bar: `isComposing` on Safari during IME input

### DIFF
--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -9,7 +9,7 @@ import { _t } from "@web/core/l10n/translation";
 import { SearchBarMenu } from "../search_bar_menu/search_bar_menu";
 import { Component, status, useRef, useState } from "@odoo/owl";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
-import { hasTouch } from "@web/core/browser/feature_detection";
+import { hasTouch, isIOS } from "@web/core/browser/feature_detection";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { useNavigation } from "@web/core/navigation/navigation";
@@ -669,6 +669,9 @@ export class SearchBar extends Component {
     onSearchInput(ev) {
         if (!hasTouch()) {
             this.searchBarDropdownState.close();
+        }
+        if (isIOS() && !ev.key) {
+            return;
         }
         const query = ev.target.value;
         if (query.trim()) {


### PR DESCRIPTION
Safari does not reliably set `KeyboardEvent.isComposing` during IME
composition (e.g. Korean). As a result, the search value was processed
too early and got cleared while composition was still in progress.

Interestingly, the issue could not be reproduced with the Japanese
keyboard, which appeared to behave correctly. See [1].

This commit adds an early return while composing to prevent
interpreting the value prematurely.
Since this is a targeted fix, it is applied only on iOS.

Steps to reproduce:
- Configure a Korean keyboard on an iPhone
- Open a Sale Order
- Focus the search bar
- Type a character, then type a second one to combine them
- The search input value gets reset

[1] https://github.com/odoo/odoo/pull/222151

opw-5448385

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
