### PR TITLE
[IMP] html_editor: add table size selection for mobile

### DIFF
--- a/addons/html_editor/static/src/main/table/mobile_table_picker.js
+++ b/addons/html_editor/static/src/main/table/mobile_table_picker.js
@@ -1,0 +1,70 @@
+import { Component, useEffect, useExternalListener, useRef, useState } from "@odoo/owl";
+
+export class MobileTablePicker extends Component {
+    static template = "html_editor.MobileTablePicker";
+    static props = {
+        insertTable: Function,
+        close: Function,
+        editable: {
+            validate: (el) => el.nodeType === Node.ELEMENT_NODE,
+        },
+    };
+
+    setup() {
+        this.state = useState({
+            rowCount: 3,
+            columnCount: 3,
+        });
+        this.rowCountRef = useRef("rowCount");
+        this.columnCountRef = useRef("columnCount");
+        useEffect(
+            (el) => {
+                if (el) {
+                    el.focus();
+                }
+            },
+            () => [this.rowCountRef.el]
+        );
+        useExternalListener(
+            this.props.editable.ownerDocument,
+            "keydown",
+            (ev) => {
+                ev.stopPropagation();
+                if (!ev.target.matches(".o-we-tablesizepopover input")) {
+                    return;
+                }
+                switch (ev.key) {
+                    case "Enter":
+                        ev.preventDefault();
+                        this.insertTable();
+                        break;
+                    case "Escape":
+                        ev.preventDefault();
+                        this.props.close();
+                        break;
+                }
+            },
+            { capture: true }
+        );
+    }
+
+    updateSize() {
+        this.state.rowCount = parseInt(this.rowCountRef.el.value);
+        this.state.columnCount = parseInt(this.columnCountRef.el.value);
+    }
+
+    insertTable() {
+        if (this.state.columnCount > 0 && this.state.rowCount > 0) {
+            this.props.insertTable({ cols: this.state.columnCount, rows: this.state.rowCount });
+            this.props.close();
+        }
+    }
+
+    onApply() {
+        this.insertTable();
+    }
+
+    onDiscard() {
+        this.props.close();
+    }
+}

--- a/addons/html_editor/static/src/main/table/mobile_table_picker.scss
+++ b/addons/html_editor/static/src/main/table/mobile_table_picker.scss
@@ -1,0 +1,6 @@
+.o-we-tablesizepopover {
+    box-shadow: $box-shadow;
+    label {
+        padding: 10px;
+    }
+}

--- a/addons/html_editor/static/src/main/table/mobile_table_picker.xml
+++ b/addons/html_editor/static/src/main/table/mobile_table_picker.xml
@@ -1,0 +1,36 @@
+<templates xml:space="preserve">
+    <t t-name="html_editor.MobileTablePicker">
+        <div class="o-we-tablesizepopover d-flex bg-light overflow-auto shadow" t-on-keydown="onKeydown" role="dialog" aria-modal="true" aria-label="Table Size Popover">
+            <div class="container-fluid d-flex vertical-center p-2" t-ref="editing-wrapper">
+                <div class="d-flex">
+                    <div class="col p-2">
+                        <div class="input-group mb-2">
+                            <label for="rowCount">Row Count</label>
+                            <input id="rowCount" t-ref="rowCount"
+                                type="number" min="1" max="100"
+                                class="border-dark-subtle form-control form-control-sm"
+                                t-model="state.rowCount"
+                                title="Row count"
+                                placeholder="Number of rows"
+                                t-on-input="this.updateSize"/>
+                            <label for="rowCount">Column Count</label>
+                            <input id="columnCount" t-ref="columnCount"
+                                type="number" min="1" max="12"
+                                class="border-dark-subtle form-control form-control-sm"
+                                t-model="state.columnCount"
+                                title="Column count"
+                                placeholder="Number of columns"
+                                t-on-input="this.updateSize"/>
+                        </div>
+                        <div class="d-flex justify-content-between align-items-center mt-1">
+                            <div>
+                                <button class="btn btn-sm btn-primary" t-on-click="this.onApply">Apply</button>
+                                <button class="btn btn-sm btn-secondary ms-1" t-on-click="this.onDiscard">Discard</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/html_editor/static/src/main/table/table_ui_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_ui_plugin.js
@@ -2,6 +2,7 @@ import { reactive } from "@web/owl2/utils";
 import { Plugin } from "@html_editor/plugin";
 import { closestElement } from "@html_editor/utils/dom_traversal";
 import { _t } from "@web/core/l10n/translation";
+import { MobileTablePicker } from "./mobile_table_picker";
 import { TableMenu } from "./table_menu";
 import { TablePicker } from "./table_picker";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
@@ -13,7 +14,7 @@ import { TableDragDrop } from "./table_drag_drop";
  */
 export class TableUIPlugin extends Plugin {
     static id = "tableUi";
-    static dependencies = ["history", "overlay", "table"];
+    static dependencies = ["history", "overlay", "selection", "table"];
     /** @type {import("plugins").EditorResources} */
     resources = {
         user_commands: [
@@ -48,6 +49,18 @@ export class TableUIPlugin extends Plugin {
                         picker.style.right = `${window.innerWidth - left - popperRect.width}px`;
                         picker.style.removeProperty("left");
                     }
+                },
+            },
+        });
+
+        /** @type {import("@html_editor/core/overlay_plugin").Overlay} */
+        this.mobilePicker = this.dependencies.overlay.createOverlay(MobileTablePicker, {
+            positionOptions: {
+                updatePositionOnResize: false,
+                onPositioned: (picker) => {
+                    picker.style.bottom = 0;
+                    picker.style.width = "100%";
+                    picker.style.removeProperty("top");
                 },
             },
         });
@@ -91,9 +104,22 @@ export class TableUIPlugin extends Plugin {
         });
     }
 
+    openMobilePicker() {
+        this.mobilePicker.open({
+            props: {
+                editable: this.editable,
+                close: () => {
+                    this.mobilePicker.close();
+                    this.dependencies.selection.focusEditable();
+                },
+                insertTable: (params) => this.dependencies.table.insertTable(params),
+            },
+        });
+    }
+
     openPickerOrInsertTable() {
         if (this.services.ui.isSmall) {
-            this.dependencies.table.insertTable({ cols: 3, rows: 3 });
+            this.openMobilePicker();
         } else {
             this.openPicker();
         }

--- a/addons/html_editor/static/tests/powerbox.test.js
+++ b/addons/html_editor/static/tests/powerbox.test.js
@@ -532,6 +532,9 @@ test("should insert a 3x3 table on type `/table` in mobile view", async () => {
     await insertText(editor, "/table");
     await waitFor(".o-we-powerbox ");
     await press("Enter");
+    await animationFrame();
+
+    await press("Enter");
     await tick();
     expect(getContent(el)).toBe(
         `<p data-selection-placeholder=""><br></p><table class="table table-bordered o_table"><tbody><tr><td><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td><td><p><br></p></td></tr></tbody></table><p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`

--- a/addons/html_editor/static/tests/table/adding_table.test.js
+++ b/addons/html_editor/static/tests/table/adding_table.test.js
@@ -4,7 +4,7 @@ import { setupEditor } from "../_helpers/editor";
 import { getContent } from "../_helpers/selection";
 import { insertText } from "../_helpers/user_actions";
 import { unformat } from "../_helpers/format";
-import { press, waitFor, queryOne } from "@odoo/hoot-dom";
+import { click, press, waitFor, queryOne } from "@odoo/hoot-dom";
 import { expectElementCount } from "../_helpers/ui_expectations";
 import { findInSelection } from "@html_editor/utils/selection";
 
@@ -63,6 +63,108 @@ test("can add a table using the powerbox and keyboard", async () => {
     );
 });
 
+test.tags("mobile");
+test("can add a table using the powerbox and keyboard (mobile)", async () => {
+    const { el, editor } = await setupEditor("<p>a[]</p>");
+    await expectElementCount(".o-we-powerbox", 0);
+    expectContentToBe(el, `<p>a[]</p>`);
+
+    // open powerbox
+    await insertText(editor, "/");
+    await waitFor(".o-we-powerbox");
+    await expectElementCount(".o-we-tablesizepopover", 0);
+
+    // filter to get table command in first position
+    await insertText(editor, "table");
+    await animationFrame();
+
+    // press enter to open tablepicker
+    await press("Enter");
+    await waitFor(".o-we-tablesizepopover");
+    await expectElementCount(".o-we-powerbox", 0);
+
+    // press enter to validate current dimension (3x3)
+    await press("Enter");
+    await animationFrame();
+    await expectElementCount(".o-we-powerbox", 0);
+    await expectElementCount(".o-we-tablesizepopover", 0);
+    expectContentToBe(
+        el,
+        `<p>a</p>
+        <table class="table table-bordered o_table">
+            <tbody>
+                <tr>
+                    <td><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td>
+                    <td><p><br></p></td>
+                    <td><p><br></p></td>
+                </tr>
+                <tr>
+                    <td><p><br></p></td>
+                    <td><p><br></p></td>
+                    <td><p><br></p></td>
+                </tr>
+                <tr>
+                    <td><p><br></p></td>
+                    <td><p><br></p></td>
+                    <td><p><br></p></td>
+                </tr>
+            </tbody>
+        </table>
+        <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+    );
+});
+
+test.tags("mobile");
+test("can add a table using the powerbox and apply (mobile)", async () => {
+    const { el, editor } = await setupEditor("<p>a[]</p>");
+    await expectElementCount(".o-we-powerbox", 0);
+    expectContentToBe(el, `<p>a[]</p>`);
+
+    // open powerbox
+    await insertText(editor, "/");
+    await waitFor(".o-we-powerbox");
+    await expectElementCount(".o-we-tablesizepopover", 0);
+
+    // filter to get table command in first position
+    await insertText(editor, "table");
+    await animationFrame();
+
+    // press enter to open tablepicker
+    await press("Enter");
+    await waitFor(".o-we-tablesizepopover");
+    await expectElementCount(".o-we-powerbox", 0);
+
+    // click apply to validate current dimension (3x3)
+    await click(".o-we-tablesizepopover .btn-primary");
+    await animationFrame();
+    await expectElementCount(".o-we-powerbox", 0);
+    await expectElementCount(".o-we-tablesizepopover", 0);
+    expectContentToBe(
+        el,
+        `<p>a</p>
+        <table class="table table-bordered o_table">
+            <tbody>
+                <tr>
+                    <td><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td>
+                    <td><p><br></p></td>
+                    <td><p><br></p></td>
+                </tr>
+                <tr>
+                    <td><p><br></p></td>
+                    <td><p><br></p></td>
+                    <td><p><br></p></td>
+                </tr>
+                <tr>
+                    <td><p><br></p></td>
+                    <td><p><br></p></td>
+                    <td><p><br></p></td>
+                </tr>
+            </tbody>
+        </table>
+        <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+    );
+});
+
 test.tags("desktop");
 test("can close table picker with escape", async () => {
     const { el, editor } = await setupEditor("<p>a[]</p>");
@@ -77,6 +179,38 @@ test("can close table picker with escape", async () => {
     await press("escape");
     await animationFrame();
     await expectElementCount(".o-we-tablepicker", 0);
+});
+
+test.tags("mobile");
+test("can close table picker with escape (mobile)", async () => {
+    const { el, editor } = await setupEditor("<p>a[]</p>");
+    await insertText(editor, "/");
+    await waitFor(".o-we-powerbox");
+    await insertText(editor, "table");
+    expectContentToBe(el, "<p>a/table[]</p>");
+    await animationFrame();
+    await press("Enter");
+    await expectElementCount(".o-we-tablesizepopover", 1);
+    await press("escape");
+    await animationFrame();
+    expectContentToBe(el, "<p>a[]</p>");
+    await expectElementCount(".o-we-tablesizepopover", 0);
+});
+
+test.tags("mobile");
+test("can close table picker with discard (mobile)", async () => {
+    const { el, editor } = await setupEditor("<p>a[]</p>");
+    await insertText(editor, "/");
+    await waitFor(".o-we-powerbox");
+    await insertText(editor, "table");
+    expectContentToBe(el, "<p>a/table[]</p>");
+    await animationFrame();
+    await press("Enter");
+    await expectElementCount(".o-we-tablesizepopover", 1);
+    await click(".o-we-tablesizepopover .btn-secondary");
+    await animationFrame();
+    expectContentToBe(el, "<p>a[]</p>");
+    await expectElementCount(".o-we-tablesizepopover", 0);
 });
 
 test.tags("iframe", "desktop");


### PR DESCRIPTION
When adding a table on mobile, it is always created as 3x3 without asking for the size to the user.

This commit adds a popover where the user can specify the number of rows and the number of columns.

task-5951362
