### PR TITLE
[FIX] l10n_br: Make fiscal position company-specific

### DIFF
--- a/addons/l10n_br/tests/__init__.py
+++ b/addons/l10n_br/tests/__init__.py
@@ -1,2 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import test_l10n_br_fiscal_position
 from . import test_l10n_br_pix

--- a/addons/l10n_br/tests/test_l10n_br_fiscal_position.py
+++ b/addons/l10n_br/tests/test_l10n_br_fiscal_position.py
@@ -1,0 +1,46 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged("post_install_l10n", "post_install", "-at_install")
+class TestL10nBrFiscalPosition(AccountTestInvoicingCommon):
+    @classmethod
+    @AccountTestInvoicingCommon.setup_country('br')
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.br_company = cls.company_data['company']
+
+    def test_get_fiscal_position_multicompany(self):
+        """When a partner has a fiscal position on both a BR company and
+        another (non-BR) company, calling _get_fiscal_position from the BR company
+        should return the BR fiscal position, not the one from the other company."""
+
+        other_company = self.env['res.company'].create({
+            'name': 'Other Company',
+            'country_id': self.env.ref('base.us').id,
+        })
+        other_fp = self.env['account.fiscal.position'].create({
+            'name': 'Other Company FP',
+            'company_id': other_company.id,
+            'sequence': 1,
+        })
+        br_fp = self.env['account.fiscal.position'].create({
+            'name': 'BR Manual FP',
+            'company_id': self.br_company.id,
+            'sequence': 2,
+        })
+        partner = self.env['res.partner'].with_company(other_company).create({
+            'name': 'Test Partner',
+            'country_id': self.env.ref('base.br').id,
+            'property_account_position_id': other_fp.id,
+        })
+
+        partner.with_company(self.br_company).property_account_position_id = br_fp
+
+        fiscal_position = self.env['account.fiscal.position'].with_company(self.br_company)._get_fiscal_position(partner)
+
+        self.assertEqual(
+            fiscal_position, br_fp,
+            "Should return the  BR fiscal position, not the fiscal position from another company",
+        )


### PR DESCRIPTION
Issue
=====

The fiscal position defined on a partner was not properly isolated per company, leading to cross-company inconsistencies and errors.

Steps to Reproduce
==================

1. Install `industry_fsm_sale` and `l10n_br`.
2. In the US company:
   - Create a Brazilian customer.
   - Set a fiscal position on the customer.
3. Switch to the Brazilian company:
   - Open the same customer.
   - Set a fiscal position on the customer.
4. Still in the Brazilian company:
   - Create a task for that customer in the Field Service app.
   - Add a product to the task.

Result
======

An error is raised because the fiscal position from the US company is used, which is not valid for the Brazilian company.

Root Cause
==========

When reading the fiscal position from the partner, the value is fetched in the environment of the company in which the partner record was originally created (US company). If no company is explicitly specified, the fiscal position is read in that original environment, even when the user is operating under the Brazilian company.

Solution
========

Explicitly enforce the current company context when reading the fiscal position from the partner to ensure the correct company-specific value is used.

opw-5270522

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
