### PR TITLE
[FIX] account: fix click handling in showProductColumn helper

### DIFF
--- a/addons/account/static/src/js/tours/tour_utils.js
+++ b/addons/account/static/src/js/tours/tour_utils.js
@@ -9,9 +9,9 @@ export function showProductColumn() {
         {
             content: "Show product column",
             trigger: '.o-dropdown-item input[name="product_id"], .o-dropdown-item input[name="product_template_id"]',
-            run: function (actions) {
-                if (!this.anchor.checked) {
-                    actions.click();
+            run: function ({ anchor }) {
+                if (!anchor.checked) {
+                    anchor.click();
                 }
             },
         },


### PR DESCRIPTION
- Destructure `{ anchor }` from the `run` method arguments instead of using the `this` context.
- Swap `actions.click()` for native `anchor.click()` to ensure the checkbox state is toggled correctly.

runbot-234872

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
