### PR TITLE
[FIX] l10n_de: ensure pdf rendering in audit trail test

### DIFF
--- a/addons/l10n_de/tests/test_audit_trail.py
+++ b/addons/l10n_de/tests/test_audit_trail.py
@@ -26,6 +26,7 @@ class TestAuditTrailDE(AccountTestInvoicingCommon):
         self.env['account.move.send'].with_context(
             active_model='account.move',
             active_ids=invoice.ids,
+            force_report_rendering=True,
         ).create({
             'checkbox_download': False,
             'checkbox_send_mail': False,


### PR DESCRIPTION
This commit fixes the invoice's pdf generation being skipped during tests (generating HTML instead), raising an error while pypdf tries to read the actual pdf (during multipage recomputation).

Note: forcing report rendering was already set during forward-porting of the original commit [^1].

runbot-238807

[^1]: https://github.com/odoo/odoo/commit/aa67d2833514c10acb49bc3f8896c6f59910d3c2
