### PR TITLE
[FIX] stock_account: prevent division by zero on MO unbuild while valuating move

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -453,8 +453,9 @@ class StockMove(models.Model):
     def _get_value_from_returns(self, quantity, at_date=None):
         if self.origin_returned_move_id and self.origin_returned_move_id.is_out:
             origin_move = self.origin_returned_move_id
+            origin_quantity = origin_move._get_valued_qty()
             return {
-                'value': origin_move.value * quantity / origin_move._get_valued_qty(),
+                'value': origin_move.value * quantity / origin_quantity if origin_quantity else 0,
                 'quantity': quantity,
                 'description': _('Value based on original move %(reference)s', reference=origin_move.reference),
             }

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -3102,6 +3102,15 @@ class TestStockValuation(TestStockValuationCommon):
         self.assertEqual(self.product_avco.total_value, 2000)
         self.assertEqual(self.product_avco.standard_price, 20)
 
+    def test_return_origin_value_zero(self):
+        self.product_avco.standard_price = 0.0
+        out_move = self._make_out_move(self.product_avco, 5, force_assign=True)
+        self.assertEqual(out_move._get_valued_qty(), 5)
+        self.assertEqual(out_move.value, 0)
+
+        out_move.quantity = 0
+        self._make_return(out_move, 5)
+
     def test_avco_report_multiple_page(self):
         # New prod to have clean avco report
         prod_avco = self.env['product.product'].create({


### PR DESCRIPTION
**Issue**:
Unbuilding a MO and setting its componentquantity to zero could lead to a division by 0.

**Steps to reproduce**:
- Create a manufacturing order for A with component B.
- Consume 2 units of the component
- Unbuild the order
- Update the quantity of the component on the original MO from 2 to 0.
- Go to Accounting > Review > Inventory > Inventory Valuation
- Check the valuation in the future. 
-> A traceback occurs

**Cause**:
While computing the value for the move `Production -> Stock` (the unbuild move): https://github.com/odoo/odoo/blob/c8e2175253d7cd15b7cbcf2559d1ae5283ab5896/addons/stock_account/models/product.py#L383 It needs to retrieve value for a quantity of 2 units: https://github.com/odoo/odoo/blob/c8e2175253d7cd15b7cbcf2559d1ae5283ab5896/addons/stock_account/models/stock_move.py#L339 Since there is no bill nor PO/SO, it tries to retrieve from returns (i.e: using the original move of the mo): https://github.com/odoo/odoo/blob/c8e2175253d7cd15b7cbcf2559d1ae5283ab5896/addons/stock_account/models/stock_move.py#L379 The original move now has a quantity of 0 (see step to reproduce) and there was no guard, so a traceback is raised: https://github.com/odoo/odoo/blob/c8e2175253d7cd15b7cbcf2559d1ae5283ab5896/addons/stock_account/models/stock_move.py#L446

opw-5945707