### PR TITLE
[IMP] website: improve the "Search Engine Optimization" form redirection

### DIFF
--- a/addons/website/static/src/components/dialog/seo.js
+++ b/addons/website/static/src/components/dialog/seo.js
@@ -1096,7 +1096,7 @@ export class OptimizeSEODialog extends Component {
         await Promise.all(rpcCalls);
 
         this.website.goToWebsite({
-            path: this.url.replace(this.previousSeoName || this.seoNameDefault, seoContext.seoName),
+            path: this.url.replace(this.previousSeoName || this.seoNameDefault, seoContext.seoName || this.seoNameDefault),
         });
     }
 }


### PR DESCRIPTION
This PR improves the redirection executed when the "Search Engine Optimization" is submitted. Previously, when the "Custom Url" field was left empty, the display name of the record was removed from the URL of the redirection, which can trigger a 404 error.

Those slugs, which only contain a dash fallowed by the id of the record, are correctly unslugged when they match a model in a route. However, if the route expect a string, IrHttp._unslug must be used to get the id of the record, and it does not unslugged correctly the slug as it considers the dash as part of the id. So, it is important to not remove any part of the slug and not keep only a dash fallowed by the id, when the "Custom Url" field is left empty but to use the default SEO name of the record.

Enterprise PR: https://github.com/odoo/enterprise/pull/102105

Task-5114394