### PR TITLE
[FIX] web_editor: show undo/redo buttons in mobile view

### DIFF
--- a/addons/web_editor/static/src/js/editor/toolbar.js
+++ b/addons/web_editor/static/src/js/editor/toolbar.js
@@ -52,7 +52,7 @@ export class Toolbar extends Component {
         showColors: true,
         showFontSize: true,
         useFontSizeInput: false,
-        showHistory: false,
+        showHistory: uiUtils.isSmall(),
 
         showStyle: true,
         showJustify: true,


### PR DESCRIPTION
Problem:
On mobile devices, the undo and redo buttons are not visible in the editor toolbar.

Cause:
`showHistory` is not enabled by default in mobile view, which hides the undo/redo controls.

Solution:
Pass `true` as the default value for `showHistory` when in mobile view, ensuring the undo/redo buttons are always visible.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
