### PR TITLE
[ADD] base: basic coalescing to cron triggers

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -4,6 +4,7 @@ import contextvars
 import copy
 import enum
 import logging
+import math
 import os
 import threading
 import time
@@ -734,7 +735,7 @@ class IrCron(models.Model):
             return True
         return self.write({'active': active})
 
-    def _trigger(self, at: datetime | Iterable[datetime] | None = None):
+    def _trigger(self, at: datetime | Iterable[datetime] | None = None, *, coalesce: int = 0):
         """
         Schedule a cron job to be executed soon independently of its
         ``nextcall`` field value.
@@ -751,6 +752,9 @@ class IrCron(models.Model):
         :param at:
             When to execute the cron, at one or several moments in time
             instead of as soon as possible.
+        :param coalesce: coalescing window, in minutes, every trigger
+            is shifted to the end of the window, this allows limiting
+            the number or frequency of wakeups for less pressing triggers
         :return: the created triggers records
         """
         if at is None:
@@ -761,6 +765,14 @@ class IrCron(models.Model):
             at_list = list(at)
             assert all(isinstance(at, datetime) for at in at_list)
 
+        if coalesce:
+            factor = coalesce * 60
+            at_list = [
+                datetime.fromtimestamp(
+                    math.ceil(dt.timestamp() / factor) * factor,
+                )
+                for dt in at_list
+            ]
         return self._trigger_list(at_list)
 
     def _trigger_list(self, at_list: list[datetime]):

--- a/odoo/addons/base/tests/test_ir_cron.py
+++ b/odoo/addons/base/tests/test_ir_cron.py
@@ -7,13 +7,13 @@ import secrets
 import textwrap
 import time
 from contextlib import closing
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest.mock import patch
 
-from freezegun import freeze_time
+import freezegun
 
 from odoo import fields
-from odoo.tests.common import RecordCapturer, TransactionCase, tagged
+from odoo.tests.common import RecordCapturer, TransactionCase, tagged, freeze_time
 from odoo.tools import mute_logger
 
 from odoo.addons.base.models.ir_cron import (
@@ -78,7 +78,7 @@ class TestIrCron(TransactionCase, CronMixinCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        freezer = freeze_time(cls.cr.now())
+        freezer = freezegun.freeze_time(cls.cr.now())
         cls.frozen_datetime = freezer.start()
         cls.addClassCleanup(freezer.stop)
 
@@ -684,3 +684,67 @@ class TestIrCron(TransactionCase, CronMixinCase):
 
         self.env.invalidate_all()
         self.assertFalse(self.cron.active)
+
+
+COALESCE_WINDOW_MINS = 5
+COALESCE_WINDOW_SECS = COALESCE_WINDOW_MINS * 60
+
+
+@tagged('-at_install', 'post_install')
+@freeze_time("1999-09-30 10:32:00")
+class TestIrCronTriggerCoalescing(TransactionCase, CronMixinCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.cron = cls.env['ir.cron'].create(cls._get_cron_data(cls.env))
+
+    def test_cron_trigger_coalesce_instant(self):
+        with self.capture_triggers(self.cron.id) as capture:
+            self.cron._trigger(coalesce=COALESCE_WINDOW_MINS)
+
+        self.assertEqual(len(capture.records), 1)
+        self.assertEqual(
+            capture.records[0].call_at,
+            datetime(1999, 9, 30, 10, 35),
+        )
+
+    def test_cron_trigger_coalesce_explicit(self):
+        at = datetime.now() + timedelta(minutes=11)
+
+        with self.capture_triggers(self.cron.id) as capture:
+            self.cron._trigger(at=at, coalesce=COALESCE_WINDOW_MINS)
+
+        self.assertEqual(len(capture.records), 1)
+        self.assertEqual(
+            capture.records[0].call_at,
+            datetime(1999, 9, 30, 10, 45),
+        )
+
+    def test_cron_trigger_coalesce_same_window(self):
+        now = datetime.now()
+        t1 = now + timedelta(minutes=1)
+        t2 = now + timedelta(minutes=2)
+
+        with self.capture_triggers(self.cron.id) as capture:
+            self.cron._trigger(at=[t1, t2], coalesce=COALESCE_WINDOW_MINS)
+
+        self.assertEqual(len(capture.records), 2)
+        call_ats = {r.call_at for r in capture.records}
+        self.assertEqual(len(call_ats), 1)
+        self.assertEqual(
+            call_ats.pop(),
+            datetime(1999, 9, 30, 10, 35)
+        )
+
+    def test_cron_trigger_coalesce_different_windows(self):
+        now = datetime.now()
+        t1 = now + timedelta(minutes=2)
+        t2 = now + timedelta(minutes=4)
+
+        with self.capture_triggers(self.cron.id) as capture:
+            self.cron._trigger(at=[t1, t2], coalesce=COALESCE_WINDOW_MINS)
+
+        call_ats = sorted(r.call_at for r in capture.records)
+        self.assertEqual(len(call_ats), 2)
+        self.assertEqual(call_ats[0], datetime(1999, 9, 30, 10, 35))
+        self.assertEqual(call_ats[1], datetime(1999, 9, 30, 10, 40))


### PR DESCRIPTION
Cron triggers are convenient, but that convenience can come at a cost: while very rare `_trigger()` greatly limit wakeups compared to a normal cron, very frequent (but non urgent) `_trigger()` can cause a lot of extra work compared to a more sedate cron executing every few minutes or hours.

Timer coalescing can provide the best of both worlds: if a job is not very urgent, and has high variability in terms of job throughput (e.g. a lot of work items are created some times and almost none at others), coalescing triggers to X provides the same efficiency as a cron with a X interval when "loaded", but if there is no work to do it stops executing entirely per trigger semantics whereas the corresponding cron will spuriously wake up every X only to go back to sleep having found no work to do.
