### PR TITLE
[FIX] purchase_stock: conditionally skip picking update on POL creation

### DIFF
--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -94,7 +94,8 @@ class PurchaseOrderLine(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         lines = super().create(vals_list)
-        lines.filtered(lambda l: l.order_id.state == 'purchase')._create_or_update_picking()
+        if not self.env.context.get('picking_already_updated'):
+            lines.filtered(lambda l: l.order_id.state == 'purchase')._create_or_update_picking()
         return lines
 
     def write(self, vals):

--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -89,7 +89,7 @@ class StockMove(models.Model):
                 po_line_vals['price_unit'] = 0
             purchase_order_lines_vals.append(po_line_vals)
         if purchase_order_lines_vals:
-            self.env['purchase.order.line'].create(purchase_order_lines_vals)
+            self.env['purchase.order.line'].with_context(picking_already_updated=True).create(purchase_order_lines_vals)
         return super()._action_synch_order()
 
     def _should_ignore_pol_price(self):

--- a/addons/purchase_stock/tests/test_purchase_order.py
+++ b/addons/purchase_stock/tests/test_purchase_order.py
@@ -863,3 +863,26 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
                 'debit': 0.0,
             },
         ])
+
+    def test_additional_products_and_backorder(self):
+        '''
+        Test receiving part of the purchase's products + an additional product.
+        Expected behaviour:
+            - new picking for the backorder
+            - new POL for the added product
+        '''
+        po = self.env['purchase.order'].create(self.po_vals)
+        po.button_confirm()
+        reception = po.picking_ids
+        reception.move_ids = [Command.create({
+            'product_id': self.product_a.id,
+            'quantity': 2,
+        })]
+        self.assertEqual(len(reception.move_ids), 3)
+        reception.move_ids[0].move_line_ids.qty_done = 5
+        reception.move_ids[2].move_line_ids.qty_done = 2
+        self.assertEqual(reception.move_ids.mapped('picked'), [True, False, True])
+        res_dict = reception.button_validate()
+        self.env[res_dict['res_model']].with_context(res_dict['context']).process()
+        self.assertEqual(len(po.picking_ids), 2)
+        self.assertEqual(len(po.order_line), 3)


### PR DESCRIPTION
Issue
-----
Adding a new product to a PO's picking automatically creates a return when there is a backorder.

Steps to reproduce
-----
- Create 3 products: A, B & C
- Create a PO for A & B, confirm it
- Open the picking
- Set quantity for B to 0
- Add a line for 1 of C
- Validate the picking
- Create a backorder
- Go back to the PO, then its' linked pickings

> There are 3 pickings, 2 IN and 1 OUT

Cause
-----
`_action_synch_order` (introduced by 98fbff3) gets called when validating the picking to create a new POL for the added product. This in turn calls

https://github.com/odoo/odoo/blob/3670c83f1e59d79df439be7c23a679d4d988ec20/addons/purchase_stock/models/purchase_order_line.py#L95-L98

but there is no need to do `_create_or_update_picking` because the change comes from the picking already, so there is nothing to update in this case.

-----
Ticket:
opw-5351456
