### PR TITLE
[FIX] core: update delayed constraints

### DIFF
--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -701,6 +701,8 @@ class Registry(Mapping[str, type["BaseModel"]]):
                 # not already marked as "to be applied".
                 with cr.savepoint(flush=False):
                     func(cr)
+            else:
+                self._constraint_queue[key] = func
         except Exception as e:
             if self._is_install:
                 _schema.error(*e.args)


### PR DESCRIPTION
Current issue:
Module A fails to add constraint X with definition D1 -> (X,D1) is delayed
Module B loaded after A, overrides constraint X to D2 and also fails to add
the constraint -> still (X,D1) are in the delayed queue, instead of
(X,D2)

In this patch we ensure the delayed constraint gets the latest
definition (D2)

This issue affects upgrades.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
