### PR TITLE
[FIX] test_http: webjson2_url_params_vs_body_params

### DIFF
--- a/odoo/addons/test_http/tests/test_webjson2.py
+++ b/odoo/addons/test_http/tests/test_webjson2.py
@@ -237,8 +237,10 @@ class TestHttpWebJson_2(TestHttpBase):
         method = 'search'
 
         with (
-            patch.object(self.registry[url_model], method, autospec=True) as url_search,
-            patch.object(self.registry[body_model], method, autospec=True) as body_search,
+            patch.object(self.registry[url_model], method, autospec=True,
+                         side_effect=self.registry[url_model].search) as url_search,
+            patch.object(self.registry[body_model], method, autospec=True,
+                         side_effect=self.registry[body_model].search) as body_search,
         ):
             self.db_url_open(
                 f'/json/2/{url_model}/{method}',


### PR DESCRIPTION
The return value of the patched methods was a MagicMock and not a recordset, and make_json_response was doing funny stuff with that returned MagicMock

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
