### PR TITLE
[FIX] mail: standardize `<DeviceSelect>` button states

### DIFF
--- a/addons/mail/static/src/discuss/call/common/device_select.dark.scss
+++ b/addons/mail/static/src/discuss/call/common/device_select.dark.scss
@@ -1,3 +1,0 @@
-.o-mail-DeviceSelect-button {
-  --o-mail-device-select-button-color: $gray-300;
-}

--- a/addons/mail/static/src/discuss/call/common/device_select.scss
+++ b/addons/mail/static/src/discuss/call/common/device_select.scss
@@ -1,3 +1,28 @@
 .o-mail-DeviceSelect-button {
-  color: var(--o-mail-device-select-button-color, $gray-600);
+  --box-shadow-sm: none;
+
+  // Ugly hack to override border-secondary utility
+  --o-mail-DeviceSelect-button-border-color: var(--btn-border-color);
+
+  border-color: var(--o-mail-DeviceSelect-button-border-color) !important;
+
+  &:hover,
+  &:focus-visible {
+    --o-mail-DeviceSelect-button-border-color: var(--btn-hover-border-color);
+  }
+
+  &:focus-visible {
+    --box-shadow-sm: var(--btn-focus-box-shadow);
+  }
+
+  &:active,
+  &.active,
+  &.show {
+    --o-mail-DeviceSelect-button-border-color: var(--btn-active-border-color);
+  }
+
+  &:disabled,
+  &.disabled {
+    --o-mail-DeviceSelect-button-border-color: var(--btn-disabled-border-color);
+  }
 }

--- a/addons/mail/static/src/discuss/call/common/device_select.xml
+++ b/addons/mail/static/src/discuss/call/common/device_select.xml
@@ -9,7 +9,7 @@
         >
             <button
                 t-if="isPermissionGranted(props.kind)"
-                class="o-mail-DeviceSelect-button btn cursor-pointer border-1 border-secondary align-items-center d-flex w-100 mw-100 shadow-sm o-dropdown--no-caret overflow-hidden"
+                class="o-mail-DeviceSelect-button btn btn-secondary cursor-pointer border-1 border-secondary align-items-center d-flex w-100 mw-100 shadow-sm o-dropdown--no-caret overflow-hidden text-reset"
                 t-att-data-kind="props.kind"
                 t-attf-class="{{ props.roundedType === 'pill' ? 'rounded-pill' : 'rounded' }}"
              >
@@ -22,7 +22,7 @@
             </button>
             <button
                 t-else=""
-                class="o-mail-DeviceSelect-button btn cursor-pointer border-1 border-secondary align-items-center d-flex w-100 mw-100 shadow-sm o-dropdown--no-caret"
+                class="o-mail-DeviceSelect-button btn btn-secondary cursor-pointer border-1 border-secondary align-items-center d-flex w-100 mw-100 shadow-sm o-dropdown--no-caret text-reset"
                 t-att-data-kind="props.kind"
                 t-attf-class="{{ props.roundedType === 'pill' ? 'rounded-pill' : 'rounded' }}"
                 t-on-pointerdown.prevent="() => this.showPermissionDialog(props.kind)"


### PR DESCRIPTION
This PR fixes an issue related to a custom border applied on the `<DeviceSelect>` button. Prior to this commit, the buttons used a custom border handled via `border border-secondary` which will prevent the default border that comes with our buttons to be applied.

The visual result is a default button but with a custom border which won't change according to the state.

While fixing this, we also add a `.btn-secondary` class on these buttons to improve consistency and ensure they get styled correctly.

task-5921830

X-original-commit: [256de110fc73ce9dec640db8b6e73a9d519ee5ec](https://github.com/odoo/odoo/commit/256de110fc73ce9dec640db8b6e73a9d519ee5ec)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
