### PR TITLE
[IMP] tests: explicit at_install in tagged

### DIFF
--- a/odoo/addons/base/tests/test_tests_tags.py
+++ b/odoo/addons/base/tests/test_tests_tags.py
@@ -21,6 +21,16 @@ class TestSetTags(TransactionCase):
         self.assertEqual(fc.test_tags, {'post_install', 'standard'})
         self.assertEqual(fc.test_module, 'base')
 
+    def test_set_tags_at_install_explicitly(self):
+        @tagged('at_install')
+        class FakeClass(TransactionCase):
+            pass
+
+        fc = FakeClass()
+
+        self.assertEqual(fc.test_tags, {'at_install', 'standard'})
+        self.assertEqual(fc.test_module, 'base')
+
     def test_set_tags_not_decorated(self):
         """Test that a TransactionCase has some test_tags by default"""
 

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2786,6 +2786,8 @@ def tagged(*tags):
     exclude = {t[1:] for t in tags if t.startswith('-')}
 
     def tags_decorator(obj):
+        if 'at_install' in include and 'post_install' not in include:
+            exclude.add('post_install')
         obj.test_tags = (getattr(obj, 'test_tags', set()) | include) - exclude
         at_install = 'at_install' in obj.test_tags
         post_install = 'post_install' in obj.test_tags


### PR DESCRIPTION
Explicitly setting `at_install` in `tagged()` will remove the default `post_install`

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
