### PR TITLE
[FIX] web: collect sub-field labels before search

### DIFF
--- a/addons/web/static/src/webclient/settings_form_view/settings/searchable_setting.js
+++ b/addons/web/static/src/webclient/settings_form_view/settings/searchable_setting.js
@@ -12,6 +12,7 @@ export class SearchableSetting extends Setting {
         this.state = useState({
             search: this.env.searchState,
             showAllContainer: this.env.showAllContainer,
+            labelsReady: false,
         });
         this.labels = [];
         this.labels.push(this.labelString, this.props.help);
@@ -23,6 +24,7 @@ export class SearchableSetting extends Setting {
                     this.labels.push(st.getAttribute("searchableText"));
                 });
             }
+            this.state.labelsReady = true;
         });
     }
 
@@ -37,6 +39,9 @@ export class SearchableSetting extends Setting {
             return true;
         }
         if (this.state.showAllContainer.showAllContainer) {
+            return true;
+        }
+        if (!this.state.labelsReady) {
             return true;
         }
         const regexp = new RegExp(escapeRegExp(this.state.search.value), "i");

--- a/addons/web/static/tests/webclient/settings_form_view/settings_form_view_tests.js
+++ b/addons/web/static/tests/webclient/settings_form_view/settings_form_view_tests.js
@@ -2130,4 +2130,44 @@ QUnit.module("SettingsFormView", (hooks) => {
             "the filename field should be empty since we removed the file"
         );
     });
+
+    QUnit.test("search finds settings by sub-field labels in non-selected app", async function (assert) {
+        await makeView({
+            type: "form",
+            resModel: "res.config.settings",
+            serverData,
+            arch: `
+                <form string="Settings" class="oe_form_configuration o_base_settings" js_class="base_settings">
+                    <app string="CRM" name="crm">
+                        <block title="CRM Settings">
+                            <setting help="this is foo">
+                                <field name="foo"/>
+                            </setting>
+                        </block>
+                    </app>
+                    <app string="Other" name="other">
+                        <block title="Other Settings">
+                            <setting string="Main Feature" help="enable the main feature">
+                                <field name="bar"/>
+                                <div class="text-muted">Add QR-code link on PDF</div>
+                            </setting>
+                        </block>
+                    </app>
+                </form>
+            `,
+        });
+        assert.strictEqual(
+            target.querySelector(".selected").dataset.key,
+            "crm",
+            "CRM app should be selected"
+        );
+
+        await editSearch(target, "QR-code");
+        await execTimeouts();
+        assert.deepEqual(
+            [...target.querySelectorAll(".o_setting_box .o_form_label")].map((x) => x.textContent),
+            ["Main Feature"],
+            "setting with sub-field label matching 'QR-code' should be found"
+        );
+    });
 });


### PR DESCRIPTION
**Problem:**
Searching for text that only exists in a setting's sub-field content (e.g., "qr" matching "Add QR-code link on PDF") fails to find the setting when searching from a different app tab in General Settings. The same search works when already on the correct app tab.

**Steps to reproduce:**
1. Open Settings (General tab is selected)
2. Search for "qr"
3. "Invoice Online Payment" setting is not found
4. Navigate to Accounting settings tab
5. Search for "qr" again
6. Now the setting appears

**Current behavior:**
Settings from non-selected apps are not found when the search term only matches sub-field content (text inside the setting body).

**Expected behavior:**
Search should find settings across all apps regardless of which tab is currently selected.

**Cause of the issue:**
SearchableSetting collects search labels in two phases: the setting's own label and help text during setup(), and sub-field text from span[searchableText] DOM elements during onMounted(). However, visible() is evaluated during render via t-if, which runs before onMounted. When an app first renders due to a search (it was previously unrendered because its tab wasn't selected), visible() only has the incomplete label set and returns false, preventing the setting div from rendering. This creates a chicken-and-egg problem: the DOM needed for label collection never exists because visibility check fails without those labels.

**Fix:**
A reactive labelsReady flag defers visibility filtering until onMounted has had a chance to collect all DOM-based labels. On the initial render, visible() returns true unconditionally so the DOM exists for label collection. The state change then triggers a proper re-render with the complete label set.

opw-5946625