### PR TITLE
[FIX] website: snippet popup & animations tour

### DIFF
--- a/addons/website/static/tests/tours/snippet_popup_and_animations.js
+++ b/addons/website/static/tests/tours/snippet_popup_and_animations.js
@@ -35,6 +35,18 @@ const setOnScrollAnim = function () {
     ];
 };
 
+function scrollToSnippet(snippetId) {
+    return [
+        {
+            trigger: `:iframe .${snippetId}`,
+            content: `Scroll to the ${snippetId} snippet`,
+            run() {
+                this.anchor.scrollIntoView();
+            },
+        },
+    ];
+}
+
 registerWebsitePreviewTour("snippet_popup_and_animations", {
     url: "/",
     edition: true,
@@ -140,6 +152,7 @@ registerWebsitePreviewTour("snippet_popup_and_animations", {
         content: "Check that the popup has been closed",
         trigger: ".o_we_invisible_el_panel .o_we_invisible_entry:contains('Popup') i.fa-eye-slash",
     },
+    ...scrollToSnippet("s_three_columns"),
     clickOnElement("Last image of the 'Columns' snippet", ":iframe .s_three_columns .o_animate_on_scroll img"),
     ...changeOptionInPopover("Image", "Animation", "On Hover"),
     {
@@ -148,19 +161,20 @@ registerWebsitePreviewTour("snippet_popup_and_animations", {
     },
     ...clickOnSave(),
     ...clickOnEditAndWaitEditMode(),
-    clickOnElement("Image of the 'Columns' snippet with the overlay effect", ":iframe .s_three_columns .o_animate_on_scroll img[data-hover-effect='overlay']:not(:visible)"),
+    ...scrollToSnippet("s_three_columns"),
+    clickOnElement("Image of the 'Columns' snippet with the overlay effect", ":iframe .s_three_columns .o_animate_on_scroll img[data-hover-effect='overlay']"),
     ...changeOptionInPopover("Image", "Effect", "Outline"),
     {
         trigger: ".o_customize_tab .options-container[data-container-title='Image'] [data-label='Effect'] button:contains('Outline')",
     },
     {
         content: "Check that the outline effect has been applied on the image",
-        trigger: ":iframe .s_three_columns .o_animate_on_scroll img[data-hover-effect='outline']:not(:visible)",
+        trigger: ":iframe .s_three_columns .o_animate_on_scroll img[data-hover-effect='outline']",
     },
     ...clickOnSave(),
     {
         content: "Check that the image src is not the raw data",
-        trigger: ":iframe .s_three_columns .o_animate_on_scroll img[data-hover-effect='outline']:not(:visible)",
+        trigger: ":iframe .s_three_columns .o_animate_on_scroll img[data-hover-effect='outline']",
         run() {
             const imgEl = document.querySelector("iframe").contentDocument.querySelector(".s_three_columns .o_animate_on_scroll img[data-hover-effect='outline']");
             const src = imgEl.getAttribute("src");
@@ -170,13 +184,8 @@ registerWebsitePreviewTour("snippet_popup_and_animations", {
         },
     },
     ...clickOnEditAndWaitEditMode(),
-    {
-        trigger: ":iframe .s_three_columns .o_animate_on_scroll img[data-hover-effect='outline']:not(:visible)",
-        run() {
-            this.anchor.scrollIntoView();
-            this.anchor.click();
-        },
-    },
+    ...scrollToSnippet("s_three_columns"),
+    clickOnElement("Image of the 'Columns' snippet with the outline effect", ":iframe .s_three_columns .o_animate_on_scroll img[data-hover-effect='outline']"),
     ...changeOptionInPopover("Image", "Filter", "Blur"),
     {
         trigger: ".o_customize_tab .options-container[data-container-title='Image'] [data-label='Filter'] button:contains('Blur')",


### PR DESCRIPTION
The snippet_popup_and_animations tour relied on the visibility of the s_three_columns snippet, which depends on scroll position to trigger its animation logic.

Since no explicit scroll was performed in some steps, the snippet could already be in the viewport, introducing indeterminism in animation timing and visibility checks. This caused flaky behavior in the tour, especially around assertions using :not(:visible).

This PR introduces a dedicated scrollToSnippet helper and explicitly scrolls to the s_three_columns snippet before interacting with it. Visibility checks are simplified accordingly.

By ensuring the snippet is properly scrolled into view before each interaction, the tour becomes deterministic and more reliable.

The commit in PR is backport of: https://github.com/odoo/odoo/commit/9adee50e

runbot-238402