### PR TITLE
[FIX] web: mobile horizontal scroll on listView with search panel

### DIFF
--- a/addons/web/static/src/search/search_panel/search_panel.scss
+++ b/addons/web/static/src/search/search_panel/search_panel.scss
@@ -2,20 +2,14 @@
 
 .o_component_with_search_panel,
 .o_controller_with_searchpanel {
-    display: flex;
-    align-items: flex-start;
+    @include media-breakpoint-up(md) {
+        display: flex;
 
-    .o_renderer,
-    .o_renderer_with_searchpanel {
-        flex: 1 1 100%;
-        overflow: auto; // make the renderer and search panel scroll individually
-        max-height: 100%;
-        position: relative;
-        height: 100%;
-
-        @include media-breakpoint-down(md) {
-            overflow: visible;
-        }    
+        .o_renderer,
+        .o_renderer_with_searchpanel {
+            overflow: auto;
+            width: 100%;
+        }
     }
 }
 


### PR DESCRIPTION
This PR aims to fix the horizontal scroll overflow which only affects list views with a search panel (e.g. Rental, Employees, etc.).

task-5888678

| Before | After |
|--------|--------|
| <img width="1125" height="2436" alt="Screen Shot 2026-02-19 at 15 29 15" src="https://github.com/user-attachments/assets/b89d2979-78a8-4c58-8f7f-7dedb6fc8fff" /> | <img width="1125" height="2436" alt="Screen Shot 2026-02-19 at 15 30 10" src="https://github.com/user-attachments/assets/0989b6e7-ef91-43b5-8df5-c27696d43f65" /> | 



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
