### PR TITLE
[FIX] iot_drivers: escpos print issues fixes

### DIFF
--- a/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py
+++ b/addons/iot_drivers/iot_handlers/drivers/printer_driver_base.py
@@ -119,7 +119,7 @@ class PrinterDriverBase(Driver, ABC):
         width = int((im.width + 7) / 8)
 
         raster_send = b'\x1d\x76\x30\x00'
-        max_slice_height = 255
+        max_slice_height = 100
 
         raster_data = b''
         dots = im.tobytes()
@@ -255,7 +255,7 @@ class PrinterDriverBase(Driver, ABC):
             with self.escpos_lock, EscposIO(self.escpos_device, autocut=False) as esc:
                 esc.printer.open()
                 if not self._check_status_escpos(esc.printer, action_unique_id):
-                    return False
+                    raise EscposNotAvailableError
                 esc.printer._raw(data)
             self.send_status(status='success')
             return True


### PR DESCRIPTION
This PR fixes a number of small issues we currently encounter with printing
1) The iot box not always printing the images correctly
2) Escpos printing not falling back to raw printing
3) USB timeout of 5 milliseconds instead of 5 seconds

Note: changing fragment_height to 100 based on https://github.com/python-escpos/python-escpos/issues/631
