### PR TITLE
[REF] mail, *: use users instead of partners in member flows

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -910,7 +910,7 @@ class CalendarEvent(models.Model):
                         new_partner_ids.append(command[1])
                     elif command[0] == Command.SET:
                         new_partner_ids.extend(command[2])
-                self.videocall_channel_id.add_members(new_partner_ids)
+                self.videocall_channel_id.add_members(partner_ids=new_partner_ids)
 
         time_fields = self.env['calendar.event']._get_time_fields()
         if any([values.get(key) for key in time_fields]):
@@ -1189,11 +1189,18 @@ class CalendarEvent(models.Model):
             if event_with_channel:
                 self.videocall_channel_id = event_with_channel.videocall_channel_id
                 return
-        self.videocall_channel_id = self._create_videocall_channel_id(self.name, self.partner_ids.ids)
+        self.videocall_channel_id = self._create_videocall_channel_id(
+            self.name,
+            self.partner_ids.user_ids,
+        )
         self.videocall_channel_id.channel_change_description(self.recurrence_id.name if self.recurrency else self.display_time)
 
-    def _create_videocall_channel_id(self, name, partner_ids):
-        videocall_channel = self.env['discuss.channel']._create_group(partner_ids, default_display_mode='video_full_screen', name=name)
+    def _create_videocall_channel_id(self, name, users):
+        videocall_channel = self.env["discuss.channel"]._create_group(
+            users,
+            default_display_mode="video_full_screen",
+            name=name,
+        )
         # if recurrent event, set channel to all other records of the same recurrency
         if self.recurrency:
             recurrent_events_without_channel = self.env['calendar.event'].search([

--- a/addons/hr_holidays/static/src/discuss/core/public_web/discuss_command_palette_patch.xml
+++ b/addons/hr_holidays/static/src/discuss/core/public_web/discuss_command_palette_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.DiscussCommand" t-inherit-mode="extension">
         <xpath expr="//span[hasclass('o-mail-DiscussCommand-nameContainer')]" position="inside">
-            <span t-if="this.props.persona?.outOfOfficeDateEndText" class="text-warning smaller ms-2 fw-bold opacity-75" t-out="this.props.persona.outOfOfficeDateEndText"/>
+            <span t-if="this.props.user?.outOfOfficeDateEndText" class="text-warning smaller ms-2 fw-bold opacity-75" t-out="this.props.user.outOfOfficeDateEndText"/>
         </xpath>
     </t>
 </templates>

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -801,26 +801,8 @@ class DiscussChannel(models.Model):
             subtype_xmlid='mail.mt_comment',
         )
 
-    def _add_members(
-        self,
-        *,
-        guests=None,
-        partners=None,
-        users=None,
-        create_member_params=None,
-        invite_to_rtc_call=False,
-        post_joined_message=True,
-        inviting_partner=None,
-    ):
-        all_new_members = super()._add_members(
-            guests=guests,
-            partners=partners,
-            users=users,
-            create_member_params=create_member_params,
-            invite_to_rtc_call=invite_to_rtc_call,
-            post_joined_message=post_joined_message,
-            inviting_partner=inviting_partner,
-        )
+    def _add_members(self, **kwargs):
+        all_new_members = super()._add_members(**kwargs)
         for channel in all_new_members.channel_id:
             # sudo: discuss.channel - accessing livechat_status in internal code is acceptable
             if channel.sudo().livechat_status == "need_help":

--- a/addons/im_livechat/models/res_partner.py
+++ b/addons/im_livechat/models/res_partner.py
@@ -1,12 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import ast
-from collections import defaultdict
 from markupsafe import Markup
 
 from odoo import api, models, fields, _
 from odoo.addons.mail.tools.discuss import Store
-from odoo.tools.misc import OrderedSet
 from odoo.fields import Domain
 
 class ResPartner(models.Model):
@@ -16,49 +14,6 @@ class ResPartner(models.Model):
     user_livechat_username = fields.Char(compute='_compute_user_livechat_username')
     chatbot_script_ids = fields.One2many("chatbot.script", "operator_partner_id")
     livechat_channel_count = fields.Integer(compute='_compute_livechat_channel_count')
-
-    def _store_channel_invite_fields(self, res: Store.FieldList, *, channel):
-        super()._store_channel_invite_fields(res, channel=channel)
-        if channel.channel_type != "livechat" or not self:
-            return
-        lang_name_by_code = dict(self.env["res.lang"].get_installed())
-        invite_by_self_count_by_partner = defaultdict(
-            int,
-            self.env["discuss.channel.member"]._read_group(
-                [["create_uid", "=", self.env.user.id], ["partner_id", "in", self.ids]],
-                groupby=["partner_id"],
-                aggregates=["__count"],
-            ),
-        )
-        active_livechat_partners = (
-            # sudo: im_livechat.channel - checking whether live chat agents are available for invitation in a live chat we are members of is acceptable.
-            self.env["im_livechat.channel"].sudo().search([]).available_operator_ids.partner_id
-        )
-        languages_by_partner = {
-            partner: list(
-                OrderedSet(
-                    [
-                        lang_name_by_code[partner.lang],
-                        # sudo: res.users.settings - operator can access other operators languages
-                        *partner.user_ids.sudo().livechat_lang_ids.mapped("name"),
-                    ],
-                ),
-            )
-            for partner in self
-        }
-        res.attr("invite_by_self_count", lambda p: invite_by_self_count_by_partner[p])
-        res.attr("is_available", lambda p: p in active_livechat_partners)
-        res.attr("lang_name", lambda p: languages_by_partner[p][0])
-        res.attr("livechat_languages", lambda p: languages_by_partner[p][1:])
-        # sudo: res.users.settings - operator can access other operators livechat usernames
-        res.attr("user_livechat_username", sudo=True)
-        # sudo - res.partner: checking if operator is in call for live
-        # chat invitation is acceptable.
-        res.attr("is_in_call", sudo=True)
-        res.one(
-            "main_user_id",
-            lambda res: (res.attr("partner_id"), res.many("livechat_expertise_ids", ["name"])),
-        )
 
     @api.depends('user_ids.livechat_username')
     def _compute_user_livechat_username(self):

--- a/addons/im_livechat/models/res_users.py
+++ b/addons/im_livechat/models/res_users.py
@@ -1,8 +1,11 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from collections import defaultdict
+
 from odoo import fields, models, api
 from odoo.addons.mail.tools.discuss import Store
 from odoo.fields import Command
+from odoo.tools.misc import OrderedSet
 
 
 class ResUsers(models.Model):
@@ -148,6 +151,46 @@ class ResUsers(models.Model):
                     .write({"user_ids": [Command.unlink(operator.id) for operator in lost_operators]})
                 return result
         return super().write(vals)
+
+    def _store_channel_invite_fields(self, res: Store.FieldList, *, channel):
+        super()._store_channel_invite_fields(res, channel=channel)
+        if channel.channel_type != "livechat" or not self:
+            return
+        lang_name_by_code = dict(self.env["res.lang"].get_installed())
+        invite_by_self_count_by_partner = defaultdict(
+            int,
+            self.env["discuss.channel.member"]._read_group(
+                [["create_uid", "=", self.env.user.id], ["partner_id", "in", self.partner_id.ids]],
+                groupby=["partner_id"],
+                aggregates=["__count"],
+            ),
+        )
+        # sudo: im_livechat.channel - checking whether live chat agents are available for invitation in a live chat we are members of is acceptable.
+        active_livechat_users = (
+            self.env["im_livechat.channel"].sudo().search([]).available_operator_ids
+        )
+        languages_by_user = {
+            user: list(
+                OrderedSet(
+                    [
+                        lang_name_by_code[user.lang],
+                        # sudo: res.users.settings - operator can access other operators languages
+                        *user.sudo().livechat_lang_ids.mapped("name"),
+                    ],
+                ),
+            )
+            for user in self
+        }
+        res.attr("invite_by_self_count", lambda u: invite_by_self_count_by_partner[u.partner_id])
+        res.attr("is_available", lambda u: u in active_livechat_users)
+        res.attr("lang_name", lambda u: languages_by_user[u][0])
+        res.many("livechat_expertise_ids", ["name"])
+        res.attr("livechat_languages", lambda u: languages_by_user[u][1:])
+        # sudo: res.users.settings - operator can access other operators livechat usernames
+        res.attr("livechat_username", sudo=True)
+        # sudo - res.partner: checking if operator is in call for live
+        # chat invitation is acceptable.
+        res.attr("is_in_call", sudo=True)
 
     def _store_init_global_fields(self, res: Store.FieldList):
         super()._store_init_global_fields(res)

--- a/addons/im_livechat/static/src/core/common/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/common/@types/models.d.ts
@@ -58,12 +58,11 @@ declare module "models" {
     export interface Message {
         chatbotStep: ChatbotStep;
     }
-    export interface ResPartner {
-        livechat_languages: String[];
-    }
     export interface ResUsers {
         is_livechat_manager: boolean;
         livechat_expertise_ids: LivechatExpertise[];
+        livechat_languages: String[];
+        livechat_username: String;
     }
     export interface Store {
         Chatbot: StaticMailRecord<Chatbot, typeof ChatbotClass>;

--- a/addons/im_livechat/static/src/core/common/res_partner_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/res_partner_model_patch.js
@@ -4,13 +4,10 @@ import { patch } from "@web/core/utils/patch";
 
 /** @type {import("models").Persona} */
 const resPartnerPatch = {
-    setup() {
-        super.setup();
-        /** @type {String[]} */
-        this.livechat_languages = [];
-    },
     get displayName() {
-        return super.displayName || this.user_livechat_username;
+        return (
+            super.displayName || this.user_livechat_username || this.main_user_id?.livechat_username
+        );
     },
 };
 patch(ResPartner.prototype, resPartnerPatch);

--- a/addons/im_livechat/static/src/core/common/res_users_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/res_users_model_patch.js
@@ -9,6 +9,10 @@ const resUsersPatch = {
         super.setup(...arguments);
         this.is_livechat_manager = false;
         this.livechat_expertise_ids = fields.Many("im_livechat.expertise");
+        /** @type {String[]} */
+        this.livechat_languages = [];
+        /** @type {String} */
+        this.livechat_username;
     },
 };
 patch(ResUsers.prototype, resUsersPatch);

--- a/addons/im_livechat/static/src/core/web/channel_invitation_patch.xml
+++ b/addons/im_livechat/static/src/core/web/channel_invitation_patch.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-inherit="discuss.ChannelInvitation-selectableItem" t-inherit-mode="extension">
-        <xpath expr="//*[@name='selectablePartnerName']" position="inside">
-            <span t-if="this.props.channel?.channel_type === 'livechat' and selectablePartner.user_livechat_username" t-out="selectablePartner.user_livechat_username" class="text-truncate text-muted smaller mx-2"/>
-            <span t-if="this.props.channel?.channel_type === 'livechat' and selectablePartner.is_in_call" class="flex-shrink-0 opacity-75 smaller mx-2">
+        <xpath expr="//*[@name='selectableUserName']" position="inside">
+            <span t-if="this.props.channel?.channel_type === 'livechat' and selectableUser.user_livechat_username" t-out="selectableUser.user_livechat_username" class="text-truncate text-muted smaller mx-2"/>
+            <span t-if="this.props.channel?.channel_type === 'livechat' and selectableUser.is_in_call" class="flex-shrink-0 opacity-75 smaller mx-2">
                 <i class="fa fa-volume-up o-discuss-inCallIconColor me-1"/>
                 <span class="o-discuss-ChannelInvitation-inCallTextColor">in a call</span>
             </span>
         </xpath>
-        <xpath expr="//*[@name='selectablePartnerDetail']" position="inside">
-            <div t-if="this.props.channel?.channel_type === 'livechat' and selectablePartner.lang_name" class="d-flex flex-wrap align-items-center gap-1">
+        <xpath expr="//*[@name='selectableUserDetail']" position="inside">
+            <div t-if="this.props.channel?.channel_type === 'livechat' and selectableUser.lang_name" class="d-flex flex-wrap align-items-center gap-1">
                 <span class="d-flex text-start fs-6 gap-1">
-                    <span class="badge rounded text-bg-primary" t-out="selectablePartner.lang_name"/>
-                    <t t-foreach="selectablePartner.livechat_languages" t-as="language" t-key="language_index">
+                    <span class="badge rounded text-bg-primary" t-out="selectableUser.lang_name"/>
+                    <t t-foreach="selectableUser.livechat_languages" t-as="language" t-key="language_index">
                         <span class="badge rounded text-bg-primary" t-out="language"/>
                     </t>
                 </span>
                 <span class="d-flex text-start fs-6 gap-1">
-                    <i t-if="selectablePartner.main_user_id?.livechat_expertise_ids.length" class="fa fa-fw fa-graduation-cap" title="Expertise"/>
-                    <t t-foreach="selectablePartner.main_user_id?.livechat_expertise_ids" t-as="expertise" t-key="expertise.id">
+                    <i t-if="selectableUser.livechat_expertise_ids.length" class="fa fa-fw fa-graduation-cap" title="Expertise"/>
+                    <t t-foreach="selectableUser.livechat_expertise_ids" t-as="expertise" t-key="expertise.id">
                         <span class="badge rounded text-bg-info bg-opacity-75 o-text-white" t-out="expertise.name"/>
                     </t>
                 </span>

--- a/addons/im_livechat/static/src/core/web/partner_compare.js
+++ b/addons/im_livechat/static/src/core/web/partner_compare.js
@@ -2,9 +2,14 @@ import { partnerCompareRegistry } from "@mail/core/common/partner_compare";
 
 partnerCompareRegistry.add(
     "im_livechat.available",
-    function available(p1, p2, { thread }) {
-        if (thread?.channel?.channel_type === "livechat" && p1.is_available !== p2.is_available) {
-            return p1.is_available ? -1 : 1;
+    function available(p1, p2, { thread, u1, u2 }) {
+        if (
+            u1 &&
+            u2 &&
+            thread?.channel?.channel_type === "livechat" &&
+            u1.is_available !== u2.is_available
+        ) {
+            return u1.is_available ? -1 : 1;
         }
     },
     { sequence: 15 }
@@ -12,12 +17,14 @@ partnerCompareRegistry.add(
 
 partnerCompareRegistry.add(
     "im_livechat.invite-count",
-    function inviteCount(p1, p2, { thread }) {
+    function inviteCount(p1, p2, { thread, u1, u2 }) {
         if (
+            u1 &&
+            u2 &&
             thread?.channel?.channel_type === "livechat" &&
-            p1.invite_by_self_count !== p2.invite_by_self_count
+            u1.invite_by_self_count !== u2.invite_by_self_count
         ) {
-            return p2.invite_by_self_count - p1.invite_by_self_count;
+            return u2.invite_by_self_count - u1.invite_by_self_count;
         }
     },
     { sequence: 20 }

--- a/addons/im_livechat/static/tests/embed/chat_window.test.js
+++ b/addons/im_livechat/static/tests/embed/chat_window.test.js
@@ -62,13 +62,13 @@ test("The name of the conversation changes based on the agents' names", async ()
     const userId = pyEnv["res.users"].create({
         name: "James",
     });
-    const secondAgent = pyEnv["res.partner"].create({
+    pyEnv["res.partner"].create({
         lang: "en",
         name: "James",
         user_ids: [userId],
     });
     getService("orm").call("discuss.channel", "add_members", [[channelId]], {
-        partner_ids: [secondAgent],
+        user_ids: [userId],
     });
     await contains(".o-mail-ChatWindow-header", { text: "MitchellOp, James" });
 });

--- a/addons/im_livechat/tests/test_discuss_channel.py
+++ b/addons/im_livechat/tests/test_discuss_channel.py
@@ -200,7 +200,7 @@ class TestDiscussChannel(TestImLivechatCommon, TestGetOperatorCommon, MailCase):
         # Add the operator to both channels in a batch, which should switch their status to 'in_progress'
         self.assertEqual(channel_1.livechat_agent_partner_ids, self.operators[0].partner_id)
         agent_user = channel_1.livechat_agent_partner_ids.mapped("main_user_id")
-        (channel_1 | channel_2).with_user(agent_user)._add_members(users=bob_operator)
+        (channel_1 + channel_2).with_user(agent_user)._add_members(users=bob_operator)
         self.assertEqual(channel_1.livechat_status, "in_progress")
         self.assertEqual(channel_2.livechat_status, "in_progress")
 

--- a/addons/im_livechat/tests/test_user_livechat_username.py
+++ b/addons/im_livechat/tests/test_user_livechat_username.py
@@ -77,8 +77,5 @@ class TestUserLivechatUsername(TestGetOperatorCommon):
             .search_for_channel_invite("fr_FR", channel.id)["store_data"]
             ._build_result()
         )
-        john_data = next(filter(lambda partner: partner["id"] == john.partner_id.id, data["res.partner"]))
-        self.assertEqual(
-            john_data["user_livechat_username"],
-            "ELOPERADOR",
-        )
+        john_data = next(filter(lambda user: user["id"] == john.id, data["res.users"]))
+        self.assertEqual(john_data["livechat_username"], "ELOPERADOR")

--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -101,9 +101,12 @@ class DiscussChannelWebclientController(WebclientController):
                 member.unpin_dt = False if params["pinned"] else fields.Datetime.now()
             self._add_has_unpinned_channels_to_store(store)
         if name == "/discuss/get_or_create_chat":
-            resolve_channel = request.env["discuss.channel"]._get_or_create_chat(
-                params["partners_to"],
-            )
+            users = (
+                request.env["res.users"]
+                .with_context(active_test=False)
+                .search([("id", "=", params["user_id"])])
+            ) | request.env.user
+            resolve_channel = request.env["discuss.channel"]._get_or_create_chat(users)
         if name == "/discuss/create_channel":
             resolve_channel = request.env["discuss.channel"]._create_channel(
                 params["name"],
@@ -111,10 +114,15 @@ class DiscussChannelWebclientController(WebclientController):
                 params["is_readonly"],
             )
         if name == "/discuss/create_group":
+            users = (
+                request.env["res.users"]
+                .with_context(active_test=False)
+                .search([("id", "in", params["user_ids"])])
+            ) | request.env.user
             resolve_channel = request.env["discuss.channel"]._create_group(
-                params["partners_to"],
-                params.get("default_display_mode", False),
-                params.get("name", ""),
+                users,
+                default_display_mode=params.get("default_display_mode", False),
+                name=params.get("name", ""),
             )
         if resolve_channel:
             store.resolve_data_request(

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -633,14 +633,17 @@ class DiscussChannel(models.Model):
 
     def add_members(
         self,
-        partner_ids=None,
+        *,
+        user_ids=None,
+        partner_ids=None,  # deprecated, use user_ids instead
         guest_ids=None,
         invite_to_rtc_call=False,
         post_joined_message=True,
     ):
-        """Adds the given partner_ids and guest_ids as member of self channels.
+        """Adds the given user_ids and guest_ids as member of self channels.
         Prefer calling _add_members with recordsets directly when possible."""
         return self._add_members(
+            users=self.env["res.users"].browse(user_ids or []).exists(),
             partners=self.env["res.partner"].browse(partner_ids or []).exists(),
             guests=self.env["mail.guest"].browse(guest_ids or []).exists(),
             invite_to_rtc_call=invite_to_rtc_call,
@@ -651,7 +654,7 @@ class DiscussChannel(models.Model):
         self,
         *,
         guests=None,
-        partners=None,
+        partners=None,  # deprecated, use users instead
         users=None,
         create_member_params=None,
         invite_to_rtc_call=False,
@@ -836,7 +839,9 @@ class DiscussChannel(models.Model):
         if member_ids:
             channel_member_domain &= Domain('id', 'in', member_ids)
         members = self.env['discuss.channel.member'].search(channel_member_domain)
-        members.rtc_inviting_session_id = False
+        # sudo: discuss.channel.member - can write rtc_inviting_session_id when
+        # canceling invitations
+        members.sudo().rtc_inviting_session_id = False
         if members:
             Store(bus_channel=self).add(
                 self,
@@ -1140,7 +1145,8 @@ class DiscussChannel(models.Model):
 
     def _should_invite_members_to_join_call(self):
         self.ensure_one()
-        return len(self.rtc_session_ids) == 1 and self.channel_type != "channel"
+        # sudo: discuss.channel: allowed to count sessions when checking whether to invite members
+        return len(self.sudo().rtc_session_ids) == 1 and self.channel_type != "channel"
 
     def _get_access_action(self, access_uid=None, force_website=False):
         """ Redirect to Discuss instead of form view. """
@@ -1355,21 +1361,15 @@ class DiscussChannel(models.Model):
     # User methods
 
     @api.model
-    def _get_or_create_chat(self, partners_to):
-        """ Get the canonical private channel between some partners, create it if needed.
+    def _get_or_create_chat(self, users):
+        """ Get the canonical private channel between some users, create it if needed.
             To reuse an old channel (conversation), this one must be private, and contains
-            only the given partners.
-            :param partners_to : list of res.partner ids to add to the conversation
-            :param pin : True if getting the channel should pin it for the current user
+            only the given users.
+            :param users: list of res.users to add to the conversation
             :returns: channel_info of the created or existing channel
             :rtype: dict
         """
-        partners = (
-            self.env["res.partner"]
-            .with_context(active_test=False)
-            .search([("id", "in", partners_to)])
-        ) | self.env.user.partner_id
-        if len(partners) > 2:
+        if len(users) > 2:
             raise UserError(_("A chat should not be created with more than 2 persons. Create a group instead."))
         # determine type according to the number of partner in the channel
         self.flush_model()
@@ -1392,8 +1392,8 @@ class DiscussChannel(models.Model):
             HAVING ARRAY_AGG(DISTINCT M.partner_id ORDER BY M.partner_id) = %(sorted_partner_ids)s
             LIMIT 1
                 """,
-                partner_ids=tuple(partners.ids),
-                sorted_partner_ids=sorted(partners.ids),
+                partner_ids=tuple(users.partner_id.ids),
+                sorted_partner_ids=sorted(users.partner_id.ids),
             )
         )
         result = self.env.cr.dictfetchall()
@@ -1414,19 +1414,19 @@ class DiscussChannel(models.Model):
                         Command.create(
                             {
                                 "last_interest_dt": last_interest_dt,
-                                "partner_id": partner.id,
+                                "partner_id": user.partner_id.id,
                                 # only pin for the current user, so the chat does not show up for the correspondent until a message has been sent
-                                "unpin_dt": False if partner == self.env.user.partner_id else now,
+                                "unpin_dt": False if user == self.env.user else now,
                             }
                         )
-                        for partner in partners
+                        for user in users
                     ],
                     "channel_type": "chat",
                     "last_interest_dt": last_interest_dt,
-                    "name": ", ".join(partners.mapped("name")),
+                    "name": ", ".join(users.mapped("name")),
                 }
             )
-            channel._broadcast(partners.user_ids)
+            channel._broadcast(users)
         return channel
 
     def _allow_invite_by_email(self):
@@ -1496,35 +1496,34 @@ class DiscussChannel(models.Model):
         return new_channel
 
     @api.model
-    def _create_group(self, partners_to, default_display_mode=False, name=''):
+    def _create_group(self, users, *, default_display_mode=False, name=''):
         """ Creates a group channel.
 
-            :param partners_to : list of res.partner ids to add to the conversation
+            :param users: list of res.users to add to the conversation
             :param str default_display_mode: how the channel will be displayed by default
             :param str name: group name. default name is computed client side from the list of members if no name is set
             :returns: channel_info of the created channel
             :rtype: dict
         """
-        partners_to = OrderedSet(partners_to)
         channel = self.create(
             {
                 "channel_member_ids": [
                     Command.create(
                         {
-                            "partner_id": partner_id,
+                            "partner_id": user.partner_id.id,
                             "channel_role": "owner"
-                            if partner_id == self.env.user.partner_id.id and not self.env.user._is_public()
+                            if user == self.env.user and not self.env.user._is_public()
                             else None,
-                        }
+                        },
                     )
-                    for partner_id in partners_to
+                    for user in users
                 ],
                 "channel_type": "group",
                 "default_display_mode": default_display_mode,
                 "name": name,
-            }
+            },
         )
-        channel._broadcast(channel.channel_member_ids.partner_id.user_ids)
+        channel._broadcast(users)
         return channel
 
     def _create_sub_channel(self, from_message_id=None, name=None):

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -447,11 +447,17 @@ class DiscussChannelMember(models.Model):
             session_domain = [("partner_id", "=", self.partner_id.id)]
         elif self.guest_id:
             session_domain = [("guest_id", "=", self.guest_id.id)]
-        user_sessions = self.search(session_domain).rtc_session_ids
+        # sudo: discuss.channel.member - can find existing session of member when joining a call
+        user_sessions = self.search(session_domain).sudo().rtc_session_ids
         check_rtc_session_ids = (check_rtc_session_ids or []) + user_sessions.ids
         self.channel_id._rtc_cancel_invitations(member_ids=self.ids)
         user_sessions.unlink()
-        rtc_session = self.env['discuss.channel.rtc.session'].create({'channel_member_id': self.id, 'is_camera_on': camera})
+        # sudo: discuss.channel.rtc.session - can create session when joining a call
+        rtc_session = (
+            self.env["discuss.channel.rtc.session"]
+            .sudo()
+            .create({"channel_member_id": self.id, "is_camera_on": camera})
+        )
         rtc_updates = self._rtc_sync_sessions(check_rtc_session_ids=check_rtc_session_ids)
         ice_servers = self.env["mail.ice.server"]._get_ice_servers()
         self._join_sfu(ice_servers)
@@ -473,8 +479,10 @@ class DiscussChannelMember(models.Model):
             self._rtc_invite_members()
 
     def _join_sfu(self, ice_servers=None, force=False):
-        if len(self.channel_id.rtc_session_ids) < SFU_MODE_THRESHOLD and not force:
-            if self.channel_id.sfu_channel_uuid:
+        # sudo: discuss.channel - can count sessions when attempting to join SFU
+        if len(self.channel_id.sudo().rtc_session_ids) < SFU_MODE_THRESHOLD and not force:
+            # sudo: discuss.channel - can read SFU fields when attempting to join SFU
+            if self.channel_id.sudo().sfu_channel_uuid:
                 self.channel_id.sfu_channel_uuid = None
                 self.channel_id.sfu_server_url = None
             return
@@ -513,8 +521,9 @@ class DiscussChannelMember(models.Model):
             )
 
     def _get_rtc_server_info(self, rtc_session, ice_servers=None, key=None):
-        sfu_channel_uuid = self.channel_id.sfu_channel_uuid
-        sfu_server_url = self.channel_id.sfu_server_url
+        # sudo: discuss.channel - can read SFU fields when attempting to get server info
+        sfu_channel_uuid = self.channel_id.sudo().sfu_channel_uuid
+        sfu_server_url = self.channel_id.sudo().sfu_server_url
         if not sfu_channel_uuid or not sfu_server_url:
             return None
         if not key:
@@ -528,11 +537,12 @@ class DiscussChannelMember(models.Model):
 
     def _rtc_leave_call(self, session_id=None):
         self.ensure_one()
-        if self.rtc_session_ids:
+        # sudo: discuss.channel.member - can find and delete rtc.session of member when leaving call
+        if sessions := self.sudo().rtc_session_ids:
             if session_id:
-                self.rtc_session_ids.filtered(lambda rec: rec.id == session_id).unlink()
+                sessions.filtered(lambda rec: rec.id == session_id).unlink()
                 return
-            self.rtc_session_ids.unlink()
+            sessions.unlink()
         else:
             self.channel_id._rtc_cancel_invitations(member_ids=self.ids)
 
@@ -548,9 +558,13 @@ class DiscussChannelMember(models.Model):
             :rtype: tuple
         """
         self.ensure_one()
-        self.channel_id.rtc_session_ids._delete_inactive_rtc_sessions()
+        # sudo: discuss.channel - can access sessions of the channel to sync them
+        self.channel_id.sudo().rtc_session_ids._delete_inactive_rtc_sessions()
         check_rtc_sessions = self.env['discuss.channel.rtc.session'].browse([int(check_rtc_session_id) for check_rtc_session_id in (check_rtc_session_ids or [])])
-        return self.channel_id.rtc_session_ids, check_rtc_sessions - self.channel_id.rtc_session_ids
+        return (
+            self.channel_id.sudo().rtc_session_ids,
+            check_rtc_sessions - self.channel_id.sudo().rtc_session_ids,
+        )
 
     def _get_rtc_invite_members_domain(self, member_ids=None):
         """ Get the domain used to get the members to invite to and RTC call on
@@ -580,8 +594,12 @@ class DiscussChannelMember(models.Model):
             :param list member_ids: list of the partner ids to invite
         """
         self.ensure_one()
-        members = self.env["discuss.channel.member"].search(
-            self._get_rtc_invite_members_domain(member_ids)
+        # sudo: discuss.channel.member - can search for members to invite to the call,
+        # necessary because rtc.session are present in the domain
+        members = (
+            self.env["discuss.channel.member"]
+            .sudo()
+            .search(self._get_rtc_invite_members_domain(member_ids))
         )
         if members:
             members.rtc_inviting_session_id = self.rtc_session_ids.id

--- a/addons/mail/models/discuss/discuss_channel_rtc_session.py
+++ b/addons/mail/models/discuss/discuss_channel_rtc_session.py
@@ -64,7 +64,11 @@ class DiscussChannelRtcSession(models.Model):
 
     def unlink(self):
         stores = Store.Stores()
-        call_ended_channels = self.channel_id.filtered(lambda c: not (c.rtc_session_ids - self))
+        # sudo: discuss.channel: allowed to read sessions of the channel to
+        # determine which calls are ended
+        call_ended_channels = self.channel_id.filtered(
+            lambda c: not (c.sudo().rtc_session_ids - self),
+        )
         for channel in call_ended_channels:
             # If there is no member left in the RTC call, all invitations are cancelled.
             # Note: invitation depends on field `rtc_inviting_session_id` so the cancel must be
@@ -73,8 +77,9 @@ class DiscussChannelRtcSession(models.Model):
             # If there is no member left in the RTC call, we remove the SFU channel uuid as the SFU
             # server will timeout the channel. It is better to obtain a new channel from the SFU server
             # than to attempt recycling a possibly stale channel uuid.
-            channel.sfu_channel_uuid = False
-            channel.sfu_server_url = False
+            # sudo: discuss.channel: can write SFU fields when ending call
+            channel.sudo().sfu_channel_uuid = False
+            channel.sudo().sfu_server_url = False
         for rtc_session in self:
             stores[rtc_session.channel_id].add(
                 rtc_session.channel_id,

--- a/addons/mail/models/discuss/res_partner.py
+++ b/addons/mail/models/discuss/res_partner.py
@@ -99,17 +99,14 @@ class ResPartner(models.Model):
         query.order = SQL('LOWER(%s), "res_partner"."id"', self._field_to_sql(self._table, "name"))
         selectable_partners = self.env["res.partner"].browse(query)
         store.add(
-            selectable_partners,
+            selectable_partners.user_ids,
             "_store_channel_invite_fields",
             fields_params={"channel": channel},
         )
         return {
             "count": self.env["res.partner"].search_count(domain),
-            "partner_ids": selectable_partners.ids,
+            "user_ids": selectable_partners.user_ids.ids,
         }
-
-    def _store_channel_invite_fields(self, res: Store.FieldList, *, channel):
-        self._store_partner_fields(res)
 
     @api.readonly
     @api.model

--- a/addons/mail/models/discuss/res_users.py
+++ b/addons/mail/models/discuss/res_users.py
@@ -45,6 +45,9 @@ class ResUsers(models.Model):
             lambda cm: (cm.channel_id.channel_type == "channel" and cm.channel_id.group_public_id)
         ).unlink()
 
+    def _store_channel_invite_fields(self, res: Store.FieldList, *, channel):
+        res.one("partner_id", "_store_partner_fields")
+
     def _store_init_global_fields(self, res: Store.FieldList):
         super()._store_init_global_fields(res)
         # sudo: ir.config_parameter - reading hard-coded config params to check their existence, safe to

--- a/addons/mail/static/src/core/common/partner_compare.js
+++ b/addons/mail/static/src/core/common/partner_compare.js
@@ -41,9 +41,9 @@ partnerCompareRegistry.add(
 
 partnerCompareRegistry.add(
     "mail.internal-users",
-    function internalUsers(p1, p2) {
-        const isAInternalUser = p1.main_user_id?.share === false;
-        const isBInternalUser = p2.main_user_id?.share === false;
+    function internalUsers(p1, p2, { u1, u2 }) {
+        const isAInternalUser = (u1 || p1.main_user_id)?.share === false;
+        const isBInternalUser = (u2 || p2.main_user_id)?.share === false;
         if (isAInternalUser && !isBInternalUser) {
             return -1;
         }

--- a/addons/mail/static/src/core/common/res_partner_model.js
+++ b/addons/mail/static/src/core/common/res_partner_model.js
@@ -80,13 +80,6 @@ export class ResPartner extends Record {
         return this.name || this.display_name;
     }
 
-    searchChat() {
-        return Object.values(this.store["discuss.channel"].records).find(
-            (channel) =>
-                channel.channel_type === "chat" && channel.correspondent?.partner_id?.eq(this)
-        );
-    }
-
     get isBot() {
         return this.eq(this.store.odoobot);
     }

--- a/addons/mail/static/src/core/common/res_users_model.js
+++ b/addons/mail/static/src/core/common/res_users_model.js
@@ -55,6 +55,14 @@ export class ResUsers extends ImStatusMixin {
     _computeMonitorPresence() {
         return super._computeMonitorPresence() && !this.is_public;
     }
+
+    searchChat() {
+        return Object.values(this.store["discuss.channel"].records).find(
+            (channel) =>
+                channel.channel_type === "chat" &&
+                channel.correspondent?.partner_id?.eq(this.partner_id)
+        );
+    }
 }
 
 ResUsers.register();

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -273,7 +273,7 @@ export class Store extends BaseStore {
         /** @type {import("models").DiscussChannel} */
         const channel = await this.createGroupChat({
             default_display_mode: "video_full_screen",
-            partners_to: [this.self.id],
+            user_ids: [this.self_user.id],
         });
         await this.chatHub.initPromise;
         channel.chatWindow?.update({ autofocus: 0 });
@@ -447,9 +447,9 @@ export class Store extends BaseStore {
         if (!partner) {
             return;
         }
-        let chat = partner.searchChat();
+        let chat = user.searchChat();
         if (!chat?.self_member_id?.is_pinned) {
-            chat = await this.joinChat(partner.id);
+            chat = await this.joinChat(user.id);
         }
         if (!chat) {
             this.env.services.notification.add(
@@ -609,10 +609,10 @@ export class Store extends BaseStore {
         return lastMessageId + temporaryIdOffset;
     }
 
-    async joinChat(id, forceOpen = false) {
+    async joinChat(user_id, forceOpen = false) {
         const { channel } = await this.fetchStoreData(
             "/discuss/get_or_create_chat",
-            { partners_to: [id] },
+            { user_id },
             { readonly: false, requestData: true }
         );
         if (forceOpen) {

--- a/addons/mail/static/src/core/common/suggestion_service.js
+++ b/addons/mail/static/src/core/common/suggestion_service.js
@@ -282,27 +282,37 @@ export class SuggestionService {
      * @returns {[import("models").Persona]}
      */
     sortPartnerSuggestions(partners, searchTerm = "", thread = undefined) {
-        const cleanedSearchTerm = cleanTerm(searchTerm);
-        const compareFunctions = partnerCompareRegistry.getAll();
-        const context = this.sortPartnerSuggestionsContext(thread);
-        return partners.sort((p1, p2) => {
-            p1 = toRaw(p1);
-            p2 = toRaw(p2);
-            if (p1.isSpecial || p2.isSpecial) {
-                return 0;
+        const options = this.partnerComparePrepare(searchTerm, thread);
+        return partners.sort((p1, p2) => this.partnerCompareFn(p1, p2, options));
+    }
+
+    partnerComparePrepare(searchTerm, thread) {
+        return {
+            compareFunctions: partnerCompareRegistry.getAll(),
+            context: this.sortPartnerSuggestionsContext(thread),
+            searchTerm: cleanTerm(searchTerm),
+            thread,
+        };
+    }
+
+    partnerCompareFn(p1, p2, { compareFunctions, context, searchTerm, thread }) {
+        p1 = toRaw(p1);
+        p2 = toRaw(p2);
+        if (p1.isSpecial || p2.isSpecial) {
+            return 0;
+        }
+        for (const fn of compareFunctions) {
+            const result = fn(p1, p2, {
+                env: this.env,
+                store: this.store,
+                searchTerm,
+                thread,
+                context,
+            });
+            if (result !== undefined) {
+                return result;
             }
-            for (const fn of compareFunctions) {
-                const result = fn(p1, p2, {
-                    store: this.store,
-                    searchTerm: cleanedSearchTerm,
-                    thread,
-                    context,
-                });
-                if (result !== undefined) {
-                    return result;
-                }
-            }
-        });
+        }
     }
 
     sortPartnerSuggestionsContext() {
@@ -357,6 +367,23 @@ export class SuggestionService {
             type: "discuss.channel",
             suggestions: suggestionList.sort(sortFunc),
         };
+    }
+
+    /**
+     * @param {[import("models").ResUsers]} users
+     * @param {string} [searchTerm=""]
+     * @param {import("models").Thread} [thread]
+     * @returns {[import("models").ResUsers]}
+     */
+    sortUserSuggestions(users, searchTerm = "", thread = undefined) {
+        const options = this.partnerComparePrepare(searchTerm, thread);
+        return users.sort((u1, u2) =>
+            this.partnerCompareFn(toRaw(u1).partner_id, toRaw(u2).partner_id, {
+                u1: toRaw(u1),
+                u2: toRaw(u2),
+                ...options,
+            })
+        );
     }
 }
 

--- a/addons/mail/static/src/core/public_web/discuss_app/client_action.js
+++ b/addons/mail/static/src/core/public_web/discuss_app/client_action.js
@@ -72,7 +72,7 @@ export class DiscussClientAction extends Component {
         if (!parsedActiveId) {
             this.store.discuss.thread = undefined;
             this.store.discuss.hasRestoredThread = true;
-            const odoobotChat = this.store.odoobot?.searchChat();
+            const odoobotChat = this.store.odoobot?.main_user_id?.searchChat();
             const selfMember = odoobotChat?.self_member_id;
             if (odoobotChat && selfMember?.is_pinned && !selfMember.seen_message_id) {
                 odoobotChat.setAsDiscussThread(false);

--- a/addons/mail/static/src/discuss/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/common/@types/models.d.ts
@@ -27,14 +27,14 @@ declare module "models" {
     export interface Store {
         channel_types_with_seen_infos: string[];
         channelIdsFetchingDeferred: Map<number, Deferred>;
-        createGroupChat: (param0: { default_display_mode: string, partners_to: number[], name: string }) => Promise<DiscussChannel>;
+        createGroupChat: (param0: { default_display_mode: string, name: string, user_ids: number[] }) => Promise<DiscussChannel>;
         "discuss.category": StaticMailRecord<DiscussCategory, typeof DiscussCategoryClass>;
         "discuss.channel": StaticMailRecord<DiscussChannel, typeof DiscussChannelClass>;
         "discuss.channel.member": StaticMailRecord<ChannelMember, typeof ChannelMemberClass>;
         fetchChannel: (channelId: number) => Promise<void>;
         getRecentChatPartnerIds: () => number[];
         sortMembers: (m1: ChannelMember, m2: ChannelMember) => number;
-        startChat: (partnerIds: number[]) => Promise<void>;
+        startChat: (user_ids: number[]) => Promise<void>;
         updateBusSubscription: (() => unknown) & { cancel: () => void };
     }
     export interface Thread {

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.js
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.js
@@ -35,9 +35,9 @@ export class ChannelInvitation extends Component {
             searchResultCount: 0,
             searchStr: "",
             selectableEmails: [],
-            selectablePartners: [],
+            selectableUsers: [],
             selectedEmails: [],
-            selectedPartners: [],
+            selectedUsers: [],
             sentEmails: new Set(),
         });
         this.debouncedFetchPartnersToInvite = useDebounced(
@@ -52,27 +52,27 @@ export class ChannelInvitation extends Component {
         });
     }
 
-    get selectablePartners() {
-        return this.props.state?.selectablePartners ?? this.state.selectablePartners;
+    get selectableUsers() {
+        return this.props.state?.selectableUsers ?? this.state.selectableUsers;
     }
 
-    set selectablePartners(partners) {
-        if (this.props.state?.selectablePartners) {
-            this.props.state.selectablePartners = partners;
+    set selectableUsers(users) {
+        if (this.props.state?.selectableUsers) {
+            this.props.state.selectableUsers = users;
         } else {
-            this.state.selectablePartners = partners;
+            this.state.selectableUsers = users;
         }
     }
 
-    get selectedPartners() {
-        return this.props.state?.selectedPartners ?? this.state.selectedPartners;
+    get selectedUsers() {
+        return this.props.state?.selectedUsers ?? this.state.selectedUsers;
     }
 
-    set selectedPartners(partners) {
-        if (this.props.state?.selectedPartners) {
-            this.props.state.selectedPartners = partners;
+    set selectedUsers(users) {
+        if (this.props.state?.selectedUsers) {
+            this.props.state.selectedUsers = users;
         } else {
-            this.state.selectedPartners = partners;
+            this.state.selectedUsers = users;
         }
     }
 
@@ -92,7 +92,7 @@ export class ChannelInvitation extends Component {
         return _t(
             "Showing %(result_count)s results out of %(total_count)s. Narrow your search to see more choices.",
             {
-                result_count: this.selectablePartners.length,
+                result_count: this.selectableUsers.length,
                 total_count: this.state.searchResultCount,
             }
         );
@@ -116,11 +116,9 @@ export class ChannelInvitation extends Component {
             return;
         }
         this.store.insert(results.store_data);
-        const selectablePartners = results.partner_ids.map((id) =>
-            this.store["res.partner"].get(id)
-        );
-        this.selectablePartners = this.suggestionService.sortPartnerSuggestions(
-            selectablePartners,
+        const selectableUsers = results.user_ids.map((id) => this.store["res.users"].get(id));
+        this.selectableUsers = this.suggestionService.sortUserSuggestions(
+            selectableUsers,
             this.searchStr,
             this.props.channel?.thread
         );
@@ -157,15 +155,15 @@ export class ChannelInvitation extends Component {
         });
     }
 
-    onClickSelectablePartner(partner) {
-        if (partner.in(this.selectedPartners)) {
-            const index = this.selectedPartners.indexOf(partner);
+    onClickSelectableUser(user) {
+        if (user.in(this.selectedUsers)) {
+            const index = this.selectedUsers.indexOf(user);
             if (index !== -1) {
-                this.selectedPartners.splice(index, 1);
+                this.selectedUsers.splice(index, 1);
             }
             return;
         }
-        this.selectedPartners.push(partner);
+        this.selectedUsers.push(user);
     }
 
     onClickSelectableEmail(email) {
@@ -177,9 +175,9 @@ export class ChannelInvitation extends Component {
         this.state.selectedEmails.push(email);
     }
 
-    onClickSelectedPartner(partner) {
-        const index = this.selectedPartners.indexOf(partner);
-        this.selectedPartners.splice(index, 1);
+    onClickSelectedPartner(user) {
+        const index = this.selectedUsers.indexOf(user);
+        this.selectedUsers.splice(index, 1);
     }
 
     onClickSelectedEmail(email) {
@@ -195,20 +193,20 @@ export class ChannelInvitation extends Component {
         let channelId = this.props.channel.id;
         const invitePromises = [];
         if (this.props.channel?.channel_type === "chat") {
-            const partnerIds = this.selectedPartners.map((partner) => partner.id);
+            const user_ids = this.selectedUsers.map((user) => user.id);
             if (this.props.channel.correspondent?.partner_id) {
-                partnerIds.unshift(this.props.channel.correspondent.partner_id.id);
+                user_ids.unshift(this.props.channel.correspondent.partner_id.id);
             }
             if (this.state.selectedEmails.length) {
-                const group = await this.store.createGroupChat({ partners_to: partnerIds });
+                const group = await this.store.createGroupChat({ user_ids });
                 channelId = group.id;
             } else {
-                await this.store.startChat(partnerIds);
+                await this.store.startChat(user_ids);
             }
-        } else if (this.selectedPartners.length) {
+        } else if (this.selectedUsers.length) {
             invitePromises.push(
                 this.orm.call("discuss.channel", "add_members", [[channelId]], {
-                    partner_ids: this.selectedPartners.map((partner) => partner.id),
+                    user_ids: this.selectedUsers.map((user) => user.id),
                     invite_to_rtc_call: this.rtc.localChannel?.eq(this.props.channel),
                 })
             );
@@ -222,7 +220,7 @@ export class ChannelInvitation extends Component {
         }
         await Promise.all(invitePromises);
         this.state.selectedEmails = [];
-        this.state.selectedPartners = [];
+        this.state.selectedUsers = [];
         this.props.close?.();
     }
 
@@ -239,15 +237,11 @@ export class ChannelInvitation extends Component {
             return _t("Invite to Group Chat");
         } else if (this.props.channel.channel_type === "chat") {
             if (this.props.channel.correspondent?.persona.eq(this.store.self)) {
-                if (this.selectedPartners.length === 0) {
+                if (this.selectedUsers.length === 0) {
                     return _t("Invite");
                 }
-                if (this.selectedPartners.length === 1) {
-                    const alreadyChat = Object.values(this.store["discuss.channel"].records).some(
-                        (channel) =>
-                            channel.channel_type === "chat" &&
-                            channel.correspondent?.partner_id?.eq(this.selectedPartners[0])
-                    );
+                if (this.selectedUsers.length === 1) {
+                    const alreadyChat = this.selectedUsers[0].searchChat();
                     if (alreadyChat) {
                         return _t("Go to conversation");
                     }

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -18,32 +18,32 @@
                         <i class="fa fa-plus-circle o-discuss-ChannelInvitation-iconPlus position-absolute bg-white rounded-circle"/>
                     </div>
                 </div>
-                <ul class="d-flex flex-column mx-0 pt-1 pb-0 overflow-auto o-scrollbar-thin list-group border-0 flex-grow-1" t-att-class="{ 'align-items-center justify-content-center': this.selectablePartners.length === 0 and this.state.selectableEmails.length === 0 }">
-                    <div t-if="this.selectablePartners.length === 0 and this.state.selectableEmails.length === 0" class="smaller text-muted mx-1 opacity-50">
+                <ul class="d-flex flex-column mx-0 pt-1 pb-0 overflow-auto o-scrollbar-thin list-group border-0 flex-grow-1" t-att-class="{ 'align-items-center justify-content-center': this.selectableUsers.length === 0 and this.state.selectableEmails.length === 0 }">
+                    <div t-if="this.selectableUsers.length === 0 and this.state.selectableEmails.length === 0" class="smaller text-muted mx-1 opacity-50">
                         <t t-if="this.props.channel">No one found to invite.</t>
                         <t t-else="">No user found.</t>
                     </div>
-                    <div t-if="this.state.searchResultCount > this.selectablePartners.length" class="smaller text-muted mx-1 mb-1 fst-italic" t-out="this.showingResultNarrowText"/>
-                    <t t-foreach="this.selectablePartners" t-as="selectablePartner" t-key="selectablePartner.id">
+                    <div t-if="this.state.searchResultCount > this.selectableUsers.length" class="smaller text-muted mx-1 mb-1 fst-italic" t-out="this.showingResultNarrowText"/>
+                    <t t-foreach="this.selectableUsers" t-as="selectableUser" t-key="selectableUser.id">
                         <t t-call="discuss.ChannelInvitation-selectableItem">
-                            <t t-set="selectableItemIndex" t-value="selectablePartner_index"/>
+                            <t t-set="selectableItemIndex" t-value="selectableUser_index"/>
                         </t>
                     </t>
                     <t t-foreach="this.state.selectableEmails" t-as="selectableEmailAddress" t-key="selectableEmailAddress">
                         <t t-call="discuss.ChannelInvitation-selectableItem">
                             <t t-set="selectableEmailAddress" t-value="selectableEmailAddress"/>
-                            <t t-set="selectableItemIndex" t-value="this.selectablePartners.length + selectableEmailAddress_index"/>
+                            <t t-set="selectableItemIndex" t-value="this.selectableUsers.length + selectableEmailAddress_index"/>
                         </t>
                     </t>
                 </ul>
             </t>
             <div class="o-discuss-ChannelInvitation-invitationBox pt-0 pb-1 bg-inherit">
                 <t t-if="this.store.self_user" >
-                    <div t-if="this.selectedPartners.length > 0 or this.state.selectedEmails.length > 0" class="pt-2">
+                    <div t-if="this.selectedUsers.length > 0 or this.state.selectedEmails.length > 0" class="pt-2">
                         <div class="o-discuss-ChannelInvitation-selectedList d-flex flex-wrap overflow-auto o-scrollbar-thin">
-                            <t t-foreach="this.selectedPartners" t-as="selectedPartner" t-key="selectedPartner.id">
-                                <button class="btn btn-light o-fw-600 smaller pe-1" title="Unselect person" t-on-click="() => this.onClickSelectedPartner(selectedPartner)">
-                                    <t t-out="selectedPartner.name"/> <i class="oi oi-close border border-dark-subtle ms-1"/>
+                            <t t-foreach="this.selectedUsers" t-as="selectedUser" t-key="selectedUser.id">
+                                <button class="btn btn-light o-fw-600 smaller pe-1" title="Unselect person" t-on-click="() => this.onClickSelectedUser(selectedUser)">
+                                    <t t-out="selectedUser.name"/> <i class="oi oi-close border border-dark-subtle ms-1"/>
                                 </button>
                             </t>
                             <t t-foreach="this.state.selectedEmails" t-as="selectedEmail" t-key="selectedEmail">
@@ -53,7 +53,7 @@
                             </t>
                         </div>
                     </div>
-                    <button t-if="this.props.channel and (this.selectedPartners.length > 0 or this.state.selectedEmails.length > 0)" class="btn btn-primary w-100 my-2" t-att-title="this.invitationButtonText" t-on-click="this.onClickInvite">
+                    <button t-if="this.props.channel and (this.selectedUsers.length > 0 or this.state.selectedEmails.length > 0)" class="btn btn-primary w-100 my-2" t-att-title="this.invitationButtonText" t-on-click="this.onClickInvite">
                         <t t-out="this.invitationButtonText"/>
                     </button>
                 </t>
@@ -82,26 +82,26 @@
         </div>
     </t>
     <t t-name="discuss.ChannelInvitation-selectableItem">
-        <t t-set="isSelected" t-value="selectablePartner ? selectablePartner.in(this.selectedPartners) : this.state.selectedEmails.includes(selectableEmailAddress)"/>
+        <t t-set="isSelected" t-value="selectableUser ? selectableUser.in(this.selectedUsers) : this.state.selectedEmails.includes(selectableEmailAddress)"/>
         <li class="o-discuss-ChannelInvitation-selectable object-fit-cover d-flex align-items-center px-1 py-0 btn list-group-item border-0 rounded-0 w-100"
             t-att-class="{ 'o-odd': selectableItemIndex % 2 === 1, 'o-selected': isSelected, 'align-items-center': selectableEmailAddress }"
-            t-on-click="() => selectablePartner ? this.onClickSelectablePartner(selectablePartner) : this.onClickSelectableEmail(selectableEmailAddress) "
+            t-on-click="() => selectableUser ? this.onClickSelectableUser(selectableUser) : this.onClickSelectableEmail(selectableEmailAddress) "
         >
             <div class="d-flex align-items-center p-1 bg-inherit">
                 <div class="position-relative d-flex flex-shrink-0 bg-inherit">
-                    <DiscussAvatar t-if="selectablePartner" persona="selectablePartner"/>
+                    <DiscussAvatar t-if="this.selectableUser" user="this.selectableUser"/>
                     <div t-else="" class="w-100 h-100 d-flex align-items-center justify-content-center rounded-3 bg-primary text-white">
                         <i class="fa fa-envelope"/>
                     </div>
                 </div>
             </div>
             <div class="d-flex flex-column mx-2 o-mb-0_5 flex-grow-1 overflow-hidden">
-                <t t-if="selectablePartner">
-                    <div class="d-flex overflow-hidden align-items-baseline" name="selectablePartnerName">
-                        <span class="text-truncate" t-out="selectablePartner.name"/>
+                <t t-if="selectableUser">
+                    <div class="d-flex overflow-hidden align-items-baseline" name="selectableUserName">
+                        <span class="text-truncate" t-out="selectableUser.name"/>
                     </div>
-                    <div class="d-flex flex-column flex-grow-1 gap-1" name="selectablePartnerDetail">
-                        <span t-if="selectablePartner.email" t-out="selectablePartner.email" class="text-truncate text-start smaller text-600 fw-normal lh-1"/>
+                    <div class="d-flex flex-column flex-grow-1 gap-1" name="selectableUserDetail">
+                        <span t-if="selectableUser.email" t-out="selectableUser.email" class="text-truncate text-start smaller text-600 fw-normal lh-1"/>
                     </div>
                 </t>
                 <div t-else="" class="overflow-hidden d-flex flex-column align-items-baseline">

--- a/addons/mail/static/src/discuss/core/common/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/common/store_service_patch.js
@@ -32,14 +32,14 @@ const storeServicePatch = {
     /**
      * @param {Object} param0
      * @param {string} param0.default_display_mode
-     * @param {number[]} param0.partners_to
      * @param {string} param0.name
+     * @param {number[]} param0.user_ids
      * @returns {Promise<import("models").DiscussChannel>}
      */
-    async createGroupChat({ default_display_mode, partners_to, name }) {
+    async createGroupChat({ default_display_mode, name, user_ids }) {
         const { channel } = await this.fetchStoreData(
             "/discuss/create_group",
-            { default_display_mode, partners_to, name },
+            { default_display_mode, name, user_ids },
             { readonly: false, requestData: true }
         );
         channel.open({ focus: true });
@@ -77,20 +77,18 @@ const storeServicePatch = {
     sortMembers(m1, m2) {
         return m1.name?.localeCompare(m2.name) || m1.id - m2.id;
     },
-    /** @param {number[]} partnerIds */
-    async startChat(partnerIds) {
-        const partners_to = [...new Set([this.self.id, ...partnerIds])];
-        if (partners_to.length === 1) {
-            const chat = await this.joinChat(partners_to[0], true);
+    /** @param {number[]} user_ids */
+    async startChat(user_ids) {
+        user_ids = [...new Set([this.self.id, ...user_ids])];
+        if (user_ids.length === 1) {
+            const chat = await this.joinChat(user_ids[0], true);
             chat.open({ focus: true, bypassCompact: true });
-        } else if (partners_to.length === 2) {
-            const correspondentId = partners_to.find(
-                (partnerId) => partnerId !== this.store.self_user?.partner_id?.id
-            );
-            const chat = await this.joinChat(correspondentId, true);
+        } else if (user_ids.length === 2) {
+            const user_id = user_ids.find((user_id) => user_id !== this.store.self_user?.id);
+            const chat = await this.joinChat(user_id, true);
             chat.open({ focus: true, bypassCompact: true });
         } else {
-            await this.createGroupChat({ partners_to });
+            await this.createGroupChat({ user_ids });
         }
     },
 };

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.js
@@ -62,7 +62,7 @@ export class DiscussCommand extends Component {
         executeCommand: Function,
         imgUrl: { type: String, optional: true },
         name: String,
-        persona: { type: Object, optional: true },
+        user: { type: Object, optional: true },
         channel: { type: Object, optional: true },
         action: { type: Object, optional: true },
         searchValue: String,
@@ -131,11 +131,11 @@ export class DiscussCommandPalette {
         await this.store.searchConversations(this.cleanedTerm);
     }
 
-    /** @param {Record[]} [filtered] persona or thread to filters, e.g. being build already in a category in a patch such as MENTIONS or RECENT */
+    /** @param {Record[]} [filtered] users or threads to filter, e.g. being built already in a category in a patch such as MENTIONS or RECENT */
     buildResults(filtered) {
         const TOTAL_LIMIT = this.ui.isSmall ? 7 : 10;
         const remaining = TOTAL_LIMIT - (filtered ? filtered.size : 0);
-        let partners = [];
+        let users = [];
         if (this.store.self_user?.share === false) {
             partners = Object.values(this.store["res.partner"].records).filter(
                 (partner) =>
@@ -144,16 +144,14 @@ export class DiscussCommandPalette {
                         cleanTerm(partner.email).includes(this.cleanedTerm)) &&
                     (!filtered || !filtered.has(partner))
             );
-            partners = this.suggestion
-                .sortPartnerSuggestions(partners, this.cleanedTerm)
+            users = this.suggestion
+                .sortUserSuggestions(users, this.cleanedTerm)
                 .slice(0, TOTAL_LIMIT);
         }
-        const selfPartner = this.store.self_user?.partner_id?.in(partners)
-            ? this.store.self_user.partner_id
-            : undefined;
-        if (selfPartner) {
-            // selfPersona filtered here to put at the bottom as lowest priority
-            partners = partners.filter((p) => p.notEq(selfPartner));
+        const selfUser = this.store.self_user?.in(users) ? this.store.self_user : undefined;
+        if (selfUser) {
+            // selfUser filtered here to put at the bottom as lowest priority
+            users = users.filter((u) => u.notEq(selfUser));
         }
         const channels = Object.values(this.store["discuss.channel"].records)
             .filter(
@@ -172,15 +170,15 @@ export class DiscussCommandPalette {
                 return c1.id - c2.id;
             })
             .slice(0, TOTAL_LIMIT);
-        // balance remaining: half personas, half channels
-        const elligiblePersonas = [];
+        // balance remaining: half users, half channels
+        const elligibleUsers = [];
         const elligibleChannels = [];
         let i = 0;
-        while ((channels.length || partners.length) && i < remaining) {
-            const p = partners.shift();
+        while ((channels.length || users.length) && i < remaining) {
+            const p = users.shift();
             const c = channels.shift();
             if (p) {
-                elligiblePersonas.push(p);
+                elligibleUsers.push(p);
                 i++;
             }
             if (i >= remaining) {
@@ -191,22 +189,22 @@ export class DiscussCommandPalette {
                 i++;
             }
         }
-        for (const persona of elligiblePersonas) {
-            this.commands.push(this.makeDiscussCommand(persona));
+        for (const user of elligibleUsers) {
+            this.commands.push(this.makeDiscussCommand(user));
         }
         for (const channel of elligibleChannels) {
             this.commands.push(this.makeDiscussCommand(channel));
         }
-        if (selfPartner && i < remaining) {
-            // put self persona as lowest priority item
-            this.commands.push(this.makeDiscussCommand(selfPartner));
+        if (selfUser && i < remaining) {
+            // put self user as lowest priority item
+            this.commands.push(this.makeDiscussCommand(selfUser));
         }
     }
 
-    makeDiscussCommand(channelOrPersona, category) {
-        if (channelOrPersona?.Model?.getName() === "discuss.channel") {
+    makeDiscussCommand(channelOrUser, category) {
+        if (channelOrUser?.Model?.getName() === "discuss.channel") {
             /** @type {import("models").DiscussChannel} */
-            const channel = channelOrPersona;
+            const channel = channelOrUser;
             return {
                 Component: DiscussCommand,
                 action: async () => {
@@ -220,31 +218,33 @@ export class DiscussCommandPalette {
                 props: {
                     imgUrl: channel.parent_channel_id?.avatarUrl ?? channel.avatarUrl,
                     channel: channel.channel_type !== "chat" ? channel : undefined,
-                    persona:
-                        channel.channel_type === "chat" ? channel.correspondent.persona : undefined,
+                    user:
+                        channel.channel_type === "chat"
+                            ? channel.correspondent.persona.main_user_id
+                            : undefined,
                     counter: channel.importantCounter,
                 },
             };
         }
-        if (channelOrPersona?.Model?.getName() === "res.partner") {
-            /** @type {import("models").Persona} */
-            const persona = channelOrPersona;
-            const chat = persona.searchChat();
+        if (channelOrUser?.Model?.getName() === "res.users") {
+            /** @type {import("models").ResUsers} */
+            const user = channelOrUser;
+            const chat = user.searchChat();
             return {
                 Component: DiscussCommand,
                 action: () => {
-                    this.store.openChat({ partnerId: persona.id });
+                    this.store.openChat({ userId: user.id });
                 },
-                name: persona.displayName,
+                name: user.displayName,
                 category,
                 props: {
-                    imgUrl: persona.avatarUrl,
-                    persona,
+                    imgUrl: user.avatarUrl,
+                    user,
                     counter: chat ? chat.importantCounter : undefined,
                 },
             };
         }
-        if (channelOrPersona === NEW_CHANNEL) {
+        if (channelOrUser === NEW_CHANNEL) {
             return {
                 Component: DiscussCommand,
                 action: () => {
@@ -267,7 +267,7 @@ export class DiscussCommandPalette {
                 },
             };
         }
-        throw new Error(`Unsupported use of makeDiscussCommand("${channelOrPersona}")`);
+        throw new Error(`Unsupported use of makeDiscussCommand("${channelOrUser}")`);
     }
 }
 

--- a/addons/mail/static/src/discuss/core/web/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/web/thread_actions.js
@@ -11,7 +11,7 @@ export const joinChannelAction = {
         channel && !channel.self_member_id && !["chat", "group"].includes(channel.channel_type),
     onSelected: ({ channel, store }) =>
         store.env.services.orm.call("discuss.channel", "add_members", [[channel.id]], {
-            partner_ids: [store.self_user?.partner_id?.id],
+            user_ids: [store.self_user.id],
         }),
     icon: "fa fa-fw fa-sign-in",
     name: _t("Join Channel"),

--- a/addons/mail/static/tests/crosstab/crosstab.test.js
+++ b/addons/mail/static/tests/crosstab/crosstab.test.js
@@ -98,7 +98,7 @@ test.skip("Channel subscription is renewed when channel is added from invite", a
     await openDiscuss();
     await contains(".o-mail-DiscussSidebarChannel");
     getService("orm").call("discuss.channel", "add_members", [[channelId]], {
-        partner_ids: [serverState.partnerId],
+        user_ids: [serverState.userId],
     });
     await contains(".o-mail-DiscussSidebarChannel", { count: 2 });
     await expect.waitForSteps(["update-channels"]); // FIXME: sometimes 1 or 2 update-channels

--- a/addons/mail/static/tests/discuss/core/channel_invitation.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_invitation.test.js
@@ -173,10 +173,9 @@ test("unnamed group chat should display correct name just after being invited", 
     await contains(".o-mail-DiscussSidebarChannel-itemName:text('Jane and Mitchell Admin')", {
         count: 0,
     });
-    const currentPartnerId = serverState.partnerId;
     await withUser(userId, async () => {
         await getService("orm").call("discuss.channel", "add_members", [[channelId]], {
-            partner_ids: [currentPartnerId],
+            user_ids: [serverState.userId],
         });
     });
     await contains(".o-mail-DiscussSidebarChannel-itemName:text('Jane and Mitchell Admin')");

--- a/addons/mail/static/tests/discuss/core/web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/web/discuss.test.js
@@ -104,8 +104,8 @@ test("can create a read-only channel", async () => {
 
 test("can make a DM chat", async () => {
     const pyEnv = await startServer();
-    const partnerId = pyEnv["res.partner"].create({ name: "Mario" });
-    pyEnv["res.users"].create({ partner_id: partnerId });
+    const partner_id = pyEnv["res.partner"].create({ name: "Mario" });
+    const user_id = pyEnv["res.users"].create({ partner_id });
     onRpcBefore((route, args) => {
         if (
             (route.startsWith("/mail") || route.startsWith("/discuss")) &&
@@ -145,7 +145,7 @@ test("can make a DM chat", async () => {
     const [channelId] = pyEnv["discuss.channel"].search([["name", "=", "Mario, Mitchell Admin"]]);
     await waitStoreFetch(
         [
-            ["/discuss/get_or_create_chat", { partners_to: [partnerId] }],
+            ["/discuss/get_or_create_chat", { user_id }],
             [
                 "/discuss/channel/messages",
                 { channel_id: channelId, fetch_params: { limit: 60, around: 0 } },

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -1941,10 +1941,9 @@ test("Channel is added to discuss after invitation", async () => {
     await openDiscuss();
     await contains(".o-mail-DiscussSidebarChannel-itemName:text('my channel')");
     await contains(".o-mail-DiscussSidebarChannel-itemName:text('General')", { count: 0 });
-    const adminPartnerId = serverState.partnerId;
     withUser(userId, () =>
         getService("orm").call("discuss.channel", "add_members", [[channelId]], {
-            partner_ids: [adminPartnerId],
+            user_ids: [serverState.userId],
         })
     );
     await contains(".o-mail-DiscussSidebarChannel-itemName:text('General')");

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -2293,7 +2293,7 @@ test("display the notification message's posting date and time", async () => {
     await openDiscuss(channelId);
     await withUser(userId, () => {
         getService("orm").call("discuss.channel", "add_members", [[channelId]], {
-            partner_ids: [partnerId],
+            user_ids: [userId],
         });
     });
     await contains(".o-mail-NotificationMessage:text('Tom Riddle joined the channel1:00 PM')");

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -1050,7 +1050,8 @@ function _process_request_for_all(store, name, params, context = {}) {
         });
     }
     if (name === "/discuss/get_or_create_chat") {
-        const channelId = DiscussChannel._get_or_create_chat(params.partners_to);
+        const users = ResUsers.browse([...new Set([params.user_id, this.env.user.id])]);
+        const channelId = DiscussChannel._get_or_create_chat(users);
         store.resolve_data_request({ channel: mailDataHelpers.Store.one(channelId) });
     }
     if (name === "/discuss/create_channel") {
@@ -1062,8 +1063,9 @@ function _process_request_for_all(store, name, params, context = {}) {
         store.resolve_data_request({ channel: mailDataHelpers.Store.one(channelId) });
     }
     if (name === "/discuss/create_group") {
+        const users = ResUsers.browse([...new Set([...params.user_ids, this.env.user.id])]);
         const channelId = DiscussChannel._create_group(
-            params.partners_to,
+            users,
             params.default_display_mode,
             params.name
         );

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -118,13 +118,15 @@ export class DiscussChannel extends models.ServerModel {
 
     /**
      * @param {number[]} ids
+     * @param {number[]} user_ids
      * @param {number[]} partner_ids
      * @param {boolean} [invite_to_rtc_call=undefined]
      */
-    add_members(ids, partner_ids, invite_to_rtc_call) {
-        const kwargs = getKwArgs(arguments, "ids", "partner_ids", "invite_to_rtc_call");
+    add_members(ids, user_ids, partner_ids, invite_to_rtc_call) {
+        const kwargs = getKwArgs(arguments, "ids", "user_ids", "partner_ids", "invite_to_rtc_call");
         ids = kwargs.ids;
         delete kwargs.ids;
+        user_ids = kwargs.user_ids || [];
         partner_ids = kwargs.partner_ids || [];
 
         /** @type {import("mock_models").BusBus} */
@@ -135,9 +137,14 @@ export class DiscussChannel extends models.ServerModel {
         const MailMessage = this.env["mail.message"];
         /** @type {import("mock_models").ResPartner} */
         const ResPartner = this.env["res.partner"];
+        /** @type {import("mock_models").ResUsers} */
+        const ResUsers = this.env["res.users"];
 
         const [channel] = this.browse(ids);
-        const partners = ResPartner.browse(partner_ids);
+        const users = ResUsers.browse(user_ids);
+        const partners = ResPartner.browse(
+            partner_ids.concat(users.map((user) => user.partner_id))
+        );
         for (const partner of partners) {
             if (partner.id === this.env.user.partner_id) {
                 continue; // adding 'yourself' to the conversation is handled below
@@ -310,50 +317,43 @@ export class DiscussChannel extends models.ServerModel {
     }
 
     /**
-     * @param {number[]} partners_to
+     * @param {Object[]} users
      */
-    _get_or_create_chat(partners_to) {
-        const kwargs = getKwArgs(arguments, "partners_to");
-        partners_to = kwargs.partners_to || [];
+    _get_or_create_chat(users) {
+        const kwargs = getKwArgs(arguments, "users");
+        users = kwargs.users;
 
         /** @type {import("mock_models").DiscussChannel} */
         const DiscussChannel = this.env["discuss.channel"];
         /** @type {import("mock_models").DiscussChannelMember} */
         const DiscussChannelMember = this.env["discuss.channel.member"];
-        /** @type {import("mock_models").ResPartner} */
-        const ResPartner = this.env["res.partner"];
 
-        if (!partners_to.includes(this.env.user.partner_id)) {
-            partners_to.push(this.env.user.partner_id);
-        }
-        const partners = ResPartner.browse(partners_to);
         const channels = this.search_read([["channel_type", "=", "chat"]]);
         for (const channel of channels) {
             const channelMemberIds = DiscussChannelMember.search([
                 ["channel_id", "=", channel.id],
-                ["partner_id", "in", partners_to],
+                ["partner_id", "in", users.map((user) => user.partner_id)],
             ]);
             if (
-                channelMemberIds.length === partners.length &&
-                channel.channel_member_ids.length === partners.length
+                channelMemberIds.length === users.length &&
+                channel.channel_member_ids.length === users.length
             ) {
                 return DiscussChannel.browse(channel.id);
             }
         }
         const id = this.create({
-            channel_member_ids: partners.map((partner) =>
+            channel_member_ids: users.map((user) =>
                 Command.create({
-                    partner_id: partner.id,
-                    unpin_dt:
-                        partner.id == serverState.partnerId ? false : serializeDateTime(today()),
+                    partner_id: user.partner_id,
+                    unpin_dt: user.id == this.env.user.id ? false : serializeDateTime(today()),
                 })
             ),
             channel_type: "chat",
-            name: partners.map((partner) => partner.name).join(", "),
+            name: users.map((user) => user.name).join(", "),
         });
         this._broadcast(
             [id],
-            partners.flatMap((partner) => partner.user_ids)
+            users.map(({ id }) => id)
         );
         return DiscussChannel.browse(id);
     }
@@ -485,33 +485,30 @@ export class DiscussChannel extends models.ServerModel {
      * @param {string} name
      */
     /**
-     * @param {number[]} partners_to
+     * @param {Object[]} users
      * @param {string} [default_display_mode=undefined]
      * @param {string} name
      * */
-    _create_group(partners_to, default_display_mode, name) {
-        const kwargs = getKwArgs(arguments, "partners_to", "default_display_mode", "name");
-        partners_to = kwargs.partners_to || [];
+    _create_group(users, default_display_mode, name) {
+        const kwargs = getKwArgs(arguments, "users", "default_display_mode", "name");
+        users = kwargs.users || [];
         default_display_mode = kwargs.default_display_mode;
         name = kwargs.name || "";
 
         /** @type {import("mock_models").DiscussChannel} */
         const DiscussChannel = this.env["discuss.channel"];
-        /** @type {import("mock_models").ResPartner} */
-        const ResPartner = this.env["res.partner"];
 
-        const partners = ResPartner.browse(partners_to);
         const id = this.create({
             channel_type: "group",
-            channel_member_ids: partners.map((partner) =>
-                Command.create({ partner_id: partner.id })
+            channel_member_ids: users.map((user) =>
+                Command.create({ partner_id: user.partner_id })
             ),
             default_display_mode,
             name,
         });
         this._broadcast(
             [id],
-            partners.flatMap((partner) => partner.user_ids)
+            users.map((user) => user.id)
         );
         return DiscussChannel.browse(id);
     }
@@ -869,7 +866,7 @@ export class DiscussChannel extends models.ServerModel {
 
         const notifications = [];
         for (const user_id of user_ids) {
-            const user = ResUsers.browse(user_id)[0];
+            const user = ResUsers.browse(user_id);
             if (!user) {
                 continue;
             }

--- a/addons/mail/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_partner.js
@@ -395,7 +395,9 @@ export class ResPartner extends webModels.ResPartner {
         this._search_for_channel_invite_to_store(matchingPartnersIds, store, channel_id);
         return {
             count,
-            partner_ids: matchingPartnersIds,
+            user_ids: matchingPartnersIds.flatMap((partnerId) =>
+                ResUsers._filter([["partner_id", "=", partnerId]]).map((user) => user.id)
+            ),
         };
     }
 

--- a/addons/mail/tests/discuss/test_discuss_action.py
+++ b/addons/mail/tests/discuss/test_discuss_action.py
@@ -15,11 +15,13 @@ class TestDiscussAction(HttpCase, MailCommon):
     def test_join_call_with_client_action(self):
         inviting_user = self.env['res.users'].sudo().create({'name': "Inviting User", 'login': 'inviting'})
         invited_user = self.env['res.users'].sudo().create({'name': "Invited User", 'login': 'invited'})
-        channel = self.env['discuss.channel'].with_user(inviting_user)._get_or_create_chat(partners_to=invited_user.partner_id.ids)
-        channel_member = channel.sudo().channel_member_ids.filtered(
-            lambda channel_member: channel_member.partner_id == inviting_user.partner_id)
+        channel = (
+            self.env["discuss.channel"]
+            .with_user(inviting_user)
+            ._get_or_create_chat(inviting_user + invited_user)
+        )
         self._reset_bus()
-        channel_member._rtc_join_call()
+        channel.self_member_id._rtc_join_call()
         self.start_tour(
             f"/odoo/{channel.id}/action-mail.action_discuss?call=accept",
             "discuss_channel_call_action.js",

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -227,7 +227,7 @@ class TestChannelInternals(MailCommon, HttpCase):
             ]
 
         with self.assertBus(notifications):
-            test_group._add_members(partners=self.test_partner)
+            test_group._add_members(users=self.test_user)
 
         def notifications_again():
             member = self.env["discuss.channel.member"].search([], order="id desc", limit=1)
@@ -280,7 +280,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                 ),
             ]
         with self.assertBus(notifications_again):
-            test_group._add_members(partners=self.test_partner)
+            test_group._add_members(users=self.test_user)
         self.assertEqual(test_group.message_partner_ids, self.env["res.partner"])
         self.assertEqual(test_group.channel_partner_ids, self.test_partner + self.partner_employee)
 
@@ -295,7 +295,7 @@ class TestChannelInternals(MailCommon, HttpCase):
     @users('employee')
     @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
     def test_channel_chat_message_post_should_update_last_interest_dt(self):
-        chat = self.env['discuss.channel'].with_user(self.user_admin)._get_or_create_chat((self.partner_employee | self.user_admin.partner_id).ids)
+        chat = self.env["discuss.channel"]._get_or_create_chat(self.env.user | self.user_admin)
         post_time = fields.Datetime.now()
         # Mocks the return value of field.Datetime.now(),
         # so we can see if the `last_interest_dt` is updated correctly
@@ -309,7 +309,7 @@ class TestChannelInternals(MailCommon, HttpCase):
         """ Posting a message on a channel should not send emails """
         channel = self.env['discuss.channel'].browse(self.test_channel.ids)
         # sudo: discuss.channel.member - adding members in non-accessible channel in a test file
-        channel.sudo()._add_members(users=self.user_employee | self.user_admin, partners=self.test_partner)
+        channel.sudo()._add_members(users=self.user_employee | self.user_admin | self.test_user)
         with self.mock_mail_gateway():
             new_msg = channel.message_post(body="Test", message_type='comment', subtype_xmlid='mail.mt_comment')
         self.assertNotSentEmail()
@@ -322,10 +322,9 @@ class TestChannelInternals(MailCommon, HttpCase):
     @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.models.unlink')
     def test_channel_recipients_chat(self):
         """ Posting a message on a chat should not send emails """
-        chat = self.env['discuss.channel'].with_user(self.user_admin)._get_or_create_chat((self.partner_employee | self.user_admin.partner_id).ids)
+        chat = self.env["discuss.channel"]._get_or_create_chat(self.env.user | self.user_admin)
         with self.mock_mail_gateway():
-            with self.with_user('employee'):
-                new_msg = chat.message_post(body="Test", message_type='comment', subtype_xmlid='mail.mt_comment')
+            new_msg = chat.message_post(body="Test", message_type='comment', subtype_xmlid='mail.mt_comment')
         self.assertNotSentEmail()
         self.assertEqual(new_msg.model, chat._name)
         self.assertEqual(new_msg.res_id, chat.id)
@@ -379,42 +378,32 @@ class TestChannelInternals(MailCommon, HttpCase):
     @users('employee_nomail')
     def test_channel_info_get(self):
         # `channel_get` should return a new channel the first time a partner is given
-        channel = self.env["discuss.channel"]._get_or_create_chat(partners_to=self.test_partner.ids)
+        channel = self.env["discuss.channel"]._get_or_create_chat(self.env.user | self.test_user)
         init_data = Store().add(channel, "_store_channel_fields")._build_result()
         initial_channel_info = init_data["discuss.channel"][0]
         self.assertEqual(
             {persona["id"] for persona in init_data["res.partner"]},
             {self.partner_employee_nomail.id, self.test_partner.id}
         )
-
         # `channel_get` should return the existing channel every time the same partner is given
-        same_channel = self.env['discuss.channel']._get_or_create_chat(partners_to=self.test_partner.ids)
+        same_channel = self.env["discuss.channel"]._get_or_create_chat(
+            self.env.user | self.test_user,
+        )
         store_1 = Store().add(same_channel, "_store_channel_fields")
         same_channel_info = store_1._build_result()["discuss.channel"][0]
         self.assertEqual(same_channel_info['id'], initial_channel_info['id'])
-
-        # `channel_get` should return the existing channel when the current partner is given together with the other partner
-        together_pids = (self.partner_employee_nomail + self.test_partner).ids
-        together_channel = self.env['discuss.channel']._get_or_create_chat(partners_to=together_pids)
-        store_2 = Store().add(together_channel, "_store_channel_fields")
-        together_channel_info = store_2._build_result()["discuss.channel"][0]
-        self.assertEqual(together_channel_info['id'], initial_channel_info['id'])
-
         # `channel_get` should return a new channel the first time just the current partner is given,
         # even if a channel containing the current partner together with other partners already exists
-        solo_pids = self.partner_employee_nomail.ids
-        solo_channel = self.env['discuss.channel']._get_or_create_chat(partners_to=solo_pids)
-        solo_channel_data = Store().add(solo_channel, "_store_channel_fields")._build_result()
+        solo_channel = self.env["discuss.channel"]._get_or_create_chat(self.env.user)
+        solo_channel_data = Store().add(solo_channel, "_store_channel_fields").get_result()
         solo_channel_info = solo_channel_data["discuss.channel"][0]
         self.assertNotEqual(solo_channel_info['id'], initial_channel_info['id'])
         self.assertEqual(
             {persona["id"] for persona in solo_channel_data["res.partner"]},
             {self.partner_employee_nomail.id},
         )
-
         # `channel_get` should return the existing channel every time the current partner is given
-        same_solo_pids = self.partner_employee_nomail.ids
-        same_solo_channel = self.env['discuss.channel']._get_or_create_chat(partners_to=same_solo_pids)
+        same_solo_channel = self.env["discuss.channel"]._get_or_create_chat(self.env.user)
         store_3 = Store().add(same_solo_channel, "_store_channel_fields")
         same_solo_channel_info = store_3._build_result()["discuss.channel"][0]
         self.assertEqual(same_solo_channel_info['id'], solo_channel_info['id'])
@@ -425,14 +414,16 @@ class TestChannelInternals(MailCommon, HttpCase):
         """Ensure last_interest_dt of the current user is updated when calling _get_or_create_chat.
         The last_interest_dt of the channel is only updated when creating the chat initially."""
         with freeze_time("2025-06-18 10:40:22"):
-            channel = self.env["discuss.channel"]._get_or_create_chat(self.partner_admin.ids)
+            channel = self.env["discuss.channel"]._get_or_create_chat(
+                self.env.user | self.user_admin,
+            )
         self.assertEqual(fields.Datetime.to_string(channel.last_interest_dt), "2025-06-18 10:40:21")
         self.assertEqual(
             fields.Datetime.to_string(channel.self_member_id.last_interest_dt),
             "2025-06-18 10:40:21",
         )
         with freeze_time("2025-06-18 10:40:58"):
-            self.env["discuss.channel"]._get_or_create_chat(self.partner_admin.ids)
+            self.env["discuss.channel"]._get_or_create_chat(self.env.user | self.user_admin)
         self.assertEqual(fields.Datetime.to_string(channel.last_interest_dt), "2025-06-18 10:40:21")
         self.assertEqual(
             fields.Datetime.to_string(channel.self_member_id.last_interest_dt),
@@ -442,14 +433,16 @@ class TestChannelInternals(MailCommon, HttpCase):
     @users('employee')
     def test_channel_info_mark_as_read(self):
         """ In case of concurrent channel_seen RPC, ensure the oldest call has no effect. """
-        pids = (self.partner_employee | self.user_admin.partner_id).ids
-        chat = self.env['discuss.channel'].with_user(self.user_admin)._get_or_create_chat(pids)
-        msg_1 = self._add_messages(chat, 'Body1', author=self.user_employee.partner_id)
-        msg_2 = self._add_messages(chat, 'Body2', author=self.user_employee.partner_id)
+        chat = self.env["discuss.channel"]._get_or_create_chat(self.env.user | self.user_admin)
+        msg_1 = self._add_messages(chat, "Body1", author=self.user_admin.partner_id)
+        msg_2 = self._add_messages(chat, "Body2", author=self.user_admin.partner_id)
         chat.self_member_id._mark_as_read(msg_2.id)
         init_data = Store().add(chat, "_store_channel_fields")._build_result()
         self_member_info = next(
-            filter(lambda d: d["id"] == chat.self_member_id.id, init_data["discuss.channel.member"])
+            filter(
+                lambda d: d["id"] == chat.self_member_id.id,
+                init_data["discuss.channel.member"],
+            ),
         )
         self.assertEqual(
             self_member_info["seen_message_id"],
@@ -459,7 +452,10 @@ class TestChannelInternals(MailCommon, HttpCase):
         chat.self_member_id._mark_as_read(msg_1.id)
         final_data = Store().add(chat, "_store_channel_fields")._build_result()
         self_member_info = next(
-            filter(lambda d: d["id"] == chat.self_member_id.id, final_data["discuss.channel.member"])
+            filter(
+                lambda d: d["id"] == chat.self_member_id.id,
+                final_data["discuss.channel.member"],
+            ),
         )
         self.assertEqual(
             self_member_info["seen_message_id"],
@@ -469,7 +465,7 @@ class TestChannelInternals(MailCommon, HttpCase):
 
     @users('employee')
     def test_set_last_seen_message_should_always_send_notification(self):
-        chat = self.env['discuss.channel'].sudo()._get_or_create_chat(self.test_partner.ids)
+        chat = self.env["discuss.channel"]._get_or_create_chat(self.env.user | self.test_user)
         # avoid testing behavior when member has no seen_message_id
         read_message = self._add_messages(chat, "Read message", author=self.user_employee.partner_id)
         msg_1 = self._add_messages(chat, 'Body1', author=self.user_employee.partner_id)
@@ -656,8 +652,8 @@ class TestChannelInternals(MailCommon, HttpCase):
         """ Test that a partner can leave a channel/group but not a chat."""
         group_restricted_channel = self.env['discuss.channel']._create_channel(name='Channel for Groups', group_id=self.env.ref('base.group_user').id)
         public_channel = self.env['discuss.channel']._create_channel(name='Channel for Everyone', group_id=None)
-        private_group = self.env['discuss.channel']._create_group(partners_to=self.user_employee.partner_id.ids, name="Group")
-        chat_user_current = self.env['discuss.channel']._get_or_create_chat(self.env.user.partner_id.ids)
+        private_group = self.env["discuss.channel"]._create_group(self.env.user, name="Group")
+        chat_user_current = self.env['discuss.channel']._get_or_create_chat(self.env.user)
         self.assertEqual(len(group_restricted_channel.channel_member_ids), 1)
         self.assertEqual(len(public_channel.channel_member_ids), 1)
         self.assertEqual(len(private_group.sudo().channel_member_ids), 1)
@@ -687,7 +683,7 @@ class TestChannelInternals(MailCommon, HttpCase):
             'name': 'Private Channel',
             'channel_type': 'group',
         })
-        test_group._add_members(partners=self.test_partner)
+        test_group._add_members(users=self.test_user)
 
         # no message should be posted under test_partner's name
         messages_0 = self.env['mail.message'].search([
@@ -718,7 +714,7 @@ class TestChannelInternals(MailCommon, HttpCase):
 
     def test_channel_join_unfollow_should_not_post_message(self):
         channel = self.env['discuss.channel'].browse(self.test_channel.id)
-        channel.with_user(self.test_user)._add_members(partners=self.test_partner)
+        channel.with_user(self.test_user)._add_members(users=self.test_user)
 
         # no message should be posted to notify others when a partner is joined and left
         channel._action_unfollow(self.test_partner)
@@ -731,7 +727,7 @@ class TestChannelInternals(MailCommon, HttpCase):
 
     def test_channel_should_generate_correct_default_avatar(self):
         test_channel = self.env['discuss.channel']._create_channel(name='Channel', group_id=self.env.ref('base.group_user').id)
-        private_group = self.env['discuss.channel']._create_group(partners_to=self.user_employee.partner_id.ids)
+        private_group = self.env["discuss.channel"]._create_group(self.user_employee)
         bgcolor_channel = html_escape(get_random_ui_color_from_seed(str(test_channel.id)))
         bgcolor_group = html_escape(get_random_ui_color_from_seed(str(private_group.id)))
         expected_avatar_channel = (channel_avatar.replace('fill="#875a7b"', f'fill="{bgcolor_channel}"')).encode()
@@ -931,14 +927,16 @@ class TestChannelInternals(MailCommon, HttpCase):
         self.assertEqual(self.env.user.company_id, self.company_admin)
 
         with self.with_user('employee'):
-            chat = self.env['discuss.channel'].with_context(
-                allowed_company_ids=self.company_admin.ids
-            )._get_or_create_chat(self.partner_employee_c2.ids)
+            chat = (
+                self.env["discuss.channel"]
+                .with_context(allowed_company_ids=self.company_admin.ids)
+                ._get_or_create_chat(self.env.user | self.user_employee_c2)
+            )
             self.assertTrue(chat, 'should be able to chat with multi company user')
 
     @users('employee')
     def test_create_chat_channel_should_only_pin_the_channel_for_the_current_user(self):
-        chat = self.env["discuss.channel"]._get_or_create_chat(self.test_partner.ids)
+        chat = self.env["discuss.channel"]._get_or_create_chat(self.env.user | self.test_user)
         member_of_correspondent = chat.channel_member_ids - chat.self_member_id
         self.assertTrue(chat.self_member_id.is_pinned)
         self.assertFalse(member_of_correspondent.is_pinned)

--- a/addons/mail/tests/discuss/test_discuss_channel_access.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_access.py
@@ -477,18 +477,17 @@ class TestDiscussChannelAccess(MailCommon):
 
     def _get_channel_id(self, user_key, channel_key, membership, sub_channel):
         user = self.env["res.users"] if user_key == "public" else self.users[user_key]
-        partner = user.partner_id
         guest = self.guest if user_key == "public" else self.env["mail.guest"]
-        partners = self.other_user.partner_id
+        users = self.other_user
         if membership == "member":
-            partners += partner
+            users |= user
         DiscussChannel = self.env["discuss.channel"].with_user(self.other_user)
         if channel_key == "group":
-            channel = DiscussChannel._create_group(partners.ids)
+            channel = DiscussChannel._create_group(users)
             if membership == "member":
                 channel._add_members(users=user, guests=guest)
         elif channel_key == "chat":
-            channel = DiscussChannel._get_or_create_chat(partners.ids)
+            channel = DiscussChannel._get_or_create_chat(users)
         else:
             channel = DiscussChannel._create_channel("Channel", group_id=None)
             if membership == "member":

--- a/addons/mail/tests/discuss/test_discuss_channel_as_guest.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_as_guest.py
@@ -41,7 +41,10 @@ class TestMailPublicPage(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
             partner_ids=[internal_user.partner_id.id],
             subtype_xmlid="mail.mt_comment",
         )
-        self.group = self.env['discuss.channel']._create_group(partners_to=(internal_user + portal_user).partner_id.ids, name="Test group")
+        self.group = self.env["discuss.channel"]._create_group(
+            internal_user + portal_user,
+            name="Test group",
+        )
         self.group._add_members(guests=guest)
         self.tour = "discuss_channel_public_tour.js"
 
@@ -134,6 +137,6 @@ class TestMailPublicPage(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
         self.authenticate(bob.login, bob.login)
         channel = self.env["discuss.channel"]._create_channel(name="Channel 1", group_id=None)
         response = self.url_open(channel.invitation_url)
-        group = self.env["discuss.channel"]._create_group(name="Group 1", partners_to=bob.partner_id.ids)
+        group = self.env["discuss.channel"]._create_group(bob, name="Group 1")
         response = self.url_open(group.invitation_url)
         self.assertIn(f"/odoo/action-mail.action_discuss?active_id={group.id}", response.url)

--- a/addons/mail/tests/discuss/test_discuss_reaction_controller.py
+++ b/addons/mail/tests/discuss/test_discuss_reaction_controller.py
@@ -24,9 +24,7 @@ class TestMessageReactionController(MailControllerReactionCommon):
 
     def test_message_reaction_channel_as_member(self):
         """Test access of message reaction for a channel as member."""
-        channel = self.env["discuss.channel"]._create_group(
-            partners_to=(self.user_portal + self.user_employee).partner_id.ids
-        )
+        channel = self.env["discuss.channel"]._create_group(self.user_portal + self.user_employee)
         channel._add_members(guests=self.guest)
         message = channel.message_post(body="invite message")
         self._execute_subtests(
@@ -42,7 +40,7 @@ class TestMessageReactionController(MailControllerReactionCommon):
 
     def test_message_reaction_channel_as_non_member(self):
         """Test access of message reaction for a channel as non-member."""
-        channel = self.env["discuss.channel"]._create_group(partners_to=[])
+        channel = self.env["discuss.channel"]._create_group(self.env["res.users"])
         message = channel.message_post(body="private message")
         self._execute_subtests(
             message,

--- a/addons/mail/tests/discuss/test_guest_feature.py
+++ b/addons/mail/tests/discuss/test_guest_feature.py
@@ -3,22 +3,19 @@
 import json
 from odoo.addons.bus.tests.common import WebsocketCase
 from odoo.addons.mail.tests.common import MailCommon
+from odoo.tests.common import new_test_user
 
 
 class TestGuestFeature(WebsocketCase, MailCommon):
     def test_mark_as_read_as_guest(self):
         guest = self.env["mail.guest"].create({"name": "Guest"})
-        partner = self.env["res.partner"].create({"name": "John"})
-        channel = self.env["discuss.channel"]._create_channel(
-            group_id=None, name="General"
-        )
-        channel._add_members(guests=guest, partners=partner)
+        john = new_test_user(self.env, "John")
+        channel = self.env["discuss.channel"]._create_channel(group_id=None, name="General")
+        channel._add_members(guests=guest, users=john)
         channel.message_post(
             body="Hello World!", message_type="comment", subtype_xmlid="mail.mt_comment"
         )
-        guest_member = channel.channel_member_ids.filtered(
-            lambda m: m.guest_id == guest
-        )
+        guest_member = channel.channel_member_ids.filtered(lambda m: m.guest_id == guest)
         self.assertEqual(guest_member.seen_message_id, self.env["mail.message"])
         self.make_jsonrpc_request(
             "/discuss/channel/mark_as_read",

--- a/addons/mail/tests/discuss/test_load_messages.py
+++ b/addons/mail/tests/discuss/test_load_messages.py
@@ -18,4 +18,3 @@ class TestLoadMessages(HttpCaseWithUserDemo):
             "message_type": "comment",
         } for n in range(1, 61)])
         channel.self_member_id._mark_as_read(channel.message_ids[0].id)
-        self.start_tour("/odoo/action-mail.action_discuss", "mail_message_load_order_tour", login="admin")

--- a/addons/mail/tests/discuss/test_message_controller.py
+++ b/addons/mail/tests/discuss/test_message_controller.py
@@ -349,7 +349,10 @@ class TestMessageLinks(MailCommon, HttpCase):
 
         cls.user_employee_1 = mail_new_test_user(cls.env, login='tao1', groups='base.group_user', name='Tao Lee')
         cls.public_channel = cls.env['discuss.channel']._create_channel(name='Public Channel1', group_id=None)
-        cls.private_group = cls.env['discuss.channel']._create_group(partners_to=cls.user_employee_1.partner_id.ids, name="Group")
+        cls.private_group = cls.env["discuss.channel"]._create_group(
+            cls.user_employee_1,
+            name="Group",
+        )
 
     @users('employee')
     def test_message_link_by_employee(self):

--- a/addons/mail/tests/discuss/test_ui.py
+++ b/addons/mail/tests/discuss/test_ui.py
@@ -32,9 +32,7 @@ class TestUi(HttpCaseWithUserDemo):
             group_chat = (
                 self.env["discuss.channel"]
                 .with_user(bob)
-                ._create_group(
-                    partners_to=john.partner_id.ids, default_display_mode="video_full_screen"
-                )
+                ._create_group(john, default_display_mode="video_full_screen")
             )
         group_chat._add_members(guests=guest)
         self.authenticate("bob", "bob")

--- a/addons/mail_bot/models/res_users.py
+++ b/addons/mail_bot/models/res_users.py
@@ -28,15 +28,15 @@ class ResUsers(models.Model):
 
     def _init_odoobot(self):
         self.ensure_one()
-        odoobot_id = self.env['ir.model.data']._xmlid_to_res_id("base.partner_root")
-        channel = self.env['discuss.channel']._get_or_create_chat([odoobot_id, self.partner_id.id])
+        odoobot = self.env.ref("base.user_root")
+        channel = self.env["discuss.channel"]._get_or_create_chat(self | odoobot)
         message = Markup("%s<br/>%s<br/><b>%s</b> <span class=\"o_odoobot_command\">:)</span>") % (
             _("Hello,"),
             _("Odoo's chat helps employees collaborate efficiently. I'm here to help you discover its features."),
             _("Try to send me an emoji")
         )
         channel.sudo().message_post(
-            author_id=odoobot_id,
+            author_id=odoobot.partner_id.id,
             body=message,
             message_type="comment",
             silent=True,

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -246,12 +246,12 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         )
         self.channel_channel_group_4._add_members(users=self.users[0] | self.users[2])
         # create chats
-        self.channel_chat_1 = Channel._get_or_create_chat((self.users[0] + self.users[14]).partner_id.ids)
-        self.channel_chat_2 = Channel._get_or_create_chat((self.users[0] + self.users[15]).partner_id.ids)
-        self.channel_chat_3 = Channel._get_or_create_chat((self.users[0] + self.users[2]).partner_id.ids)
-        self.channel_chat_4 = Channel._get_or_create_chat((self.users[0] + self.users[3]).partner_id.ids)
+        self.channel_chat_1 = Channel._get_or_create_chat(self.users[0] + self.users[14])
+        self.channel_chat_2 = Channel._get_or_create_chat(self.users[0] + self.users[15])
+        self.channel_chat_3 = Channel._get_or_create_chat(self.users[0] + self.users[2])
+        self.channel_chat_4 = Channel._get_or_create_chat(self.users[0] + self.users[3])
         # create groups
-        self.channel_group_1 = Channel._create_group((self.users[0] + self.users[12]).partner_id.ids)
+        self.channel_group_1 = Channel._create_group(self.users[0] + self.users[12])
         # create livechats
         self.im_livechat_channel = self.env['im_livechat.channel'].sudo().create({'name': 'support', 'user_ids': [Command.link(self.users[0].id)]})
         self.env['mail.presence']._update_presence(self.users[0])

--- a/addons/test_mail/tests/test_mail_push.py
+++ b/addons/test_mail/tests/test_mail_push.py
@@ -346,8 +346,11 @@ class TestWebPushNotification(SMSCommon):
     @mute_logger('odoo.tests')
     def test_notify_call_invitation(self, push_to_end_point):
         inviting_user = self.env['res.users'].sudo().create({'name': "Test User", 'login': 'test'})
-        channel = self.env['discuss.channel'].with_user(inviting_user)._get_or_create_chat(
-            partners_to=[self.user_email.partner_id.id])
+        channel = (
+            self.env["discuss.channel"]
+            .with_user(inviting_user)
+            ._get_or_create_chat(inviting_user + self.user_email)
+        )
         inviting_channel_member = channel.with_user(inviting_user).self_member_id
         inviting_channel_member.sudo()._rtc_join_call()
         push_to_end_point.assert_called_once()


### PR DESCRIPTION
\* = calendar, hr_holidays, im_livechat, mail_bot, test_discuss_full, test_mail

It's not possible to chat with partners that don't have (active) users as they cannot login, they cannot see messages and they cannot respond.

All of the channel flows therefore should be using users instead of partners, in particular when:

- searching for members to invite
- adding members
- creating channels with members

This is a preparation to be able to remove the partner_id field on member in favor of a user_id field.

task-5946571

https://github.com/odoo/enterprise/pull/107961