### PR TITLE
[FIX] l10n_ro_edi: allow to resend E-Factura to SPV if error

### DIFF
--- a/addons/l10n_ro_edi/models/account_move.py
+++ b/addons/l10n_ro_edi/models/account_move.py
@@ -45,7 +45,9 @@ class AccountMove(models.Model):
         # EXTENDS 'account'
         super()._compute_show_reset_to_draft_button()
         for move in self:
-            if move.move_type in ('out_invoice', 'out_refund') and move.l10n_ro_edi_state in ('invoice_sent', 'invoice_validated'):
+            if move.move_type in ('out_invoice', 'out_refund') and move.l10n_ro_edi_state in ('invoice_sent', 'invoice_validated') and not (
+                move.l10n_ro_edi_document_ids and all(doc.state == 'invoice_sending_failed' for doc in move.l10n_ro_edi_document_ids)
+            ):
                 move.show_reset_to_draft_button = False
 
     ################################################################################


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting and l10n_ro_edi
- Switch to a Romanian company (e.g. RO Company)
- In Accounting settings, configure Romanian E-Factura

- Create an invoice for a Romanian customer
- Confirm the invoice
- Send E-Factura to SPV

**Issue:**
If the document is rejected by SPV due to a validation error, it is not possible to:

1) reset the invoice to draft in order to fix the error in the invoice because the button is hidden
2) resend the new E-Factura to SPV  because the option is disabled

**Solution:**
Check if there are Romanian E-Factura documents linked to the invoice and if they are all rejected.
If it is the case, then allow to reset the invoice to draft and to resend E-Factura to SPV.

opw-5936668




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
