### PR TITLE
[FIX] sale,website_sale_collect: disable click and collect for renting

### DIFF
--- a/addons/sale/models/product_product.py
+++ b/addons/sale/models/product_product.py
@@ -98,6 +98,9 @@ class ProductProduct(models.Model):
         linked_product_ids = [product.id for [product] in lines]
         return super(ProductProduct, self - self.browse(linked_product_ids))._filter_to_unlink()
 
+    def get_show_click_and_collect_availability(self):
+        return self.product_tmpl_id.get_show_click_and_collect_availability()
+
 
 class ProductAttributeCustomValue(models.Model):
     _inherit = "product.attribute.custom.value"

--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -235,6 +235,9 @@ class ProductTemplate(models.Model):
             }
         return res
 
+    def get_show_click_and_collect_availability(self):
+        return True
+
     @api.model
     def _get_saleable_tracking_types(self):
         """Return list of salealbe service_tracking types.

--- a/addons/website_sale_collect/models/product_template.py
+++ b/addons/website_sale_collect/models/product_template.py
@@ -21,7 +21,7 @@ class ProductTemplate(models.Model):
             and product_or_template.is_storable
             and not (in_store_dm.excluded_tag_ids & product_or_template.all_product_tag_ids)
         ):
-            res['show_click_and_collect_availability'] = True
+            res['show_click_and_collect_availability'] = product_or_template.get_show_click_and_collect_availability()
             order_sudo = website.sale_get_order()
             if (
                 order_sudo

--- a/addons/website_sale_collect/tests/test_click_and_collect_flow.py
+++ b/addons/website_sale_collect/tests/test_click_and_collect_flow.py
@@ -26,3 +26,12 @@ class TestClickAndCollectFlow(HttpCase, ClickAndCollectCommon):
             }
         )
         self.start_tour('/', 'website_sale_collect_widget')
+
+    def test_click_and_collect_visibility(self):
+        """ Check that the click and collect website buttons are invisible for rental products since the feature is currently unsupported.
+        """
+        if self.env['ir.module.module']._get('sale_renting').state != 'installed':
+            self.skipTest("If the 'sale_renting' module isn't installed, we can't test rent_ok!")
+        self.assertTrue(self.storable_product.get_show_click_and_collect_availability())
+        self.storable_product.rent_ok = True
+        self.assertFalse(self.storable_product.get_show_click_and_collect_availability())


### PR DESCRIPTION
Click and collect widget is not supported for rental products

Steps to reproduce:
-------------------
* Enable "Click and collect" in setting and set up warehouses
* Create a rental product
* Add a unit of the product in one of the warehouses
* Rent that product for a period
* Go on the website>shop>the product
-> The available quantity for the warehouse does not account for the in start/end dates in the eCommerce product page

Observation:
---------------
The implementation of click and collect does not include a sale_renting module, this entails that click and collect and openLocationSelector has no information about the rental period.
https://github.com/odoo/odoo/blob/20e54e37670ffa569f47663a7e4b8d7de3a4c33c/addons/website_sale_collect/views/templates.xml#L28-L36 

https://github.com/odoo/odoo/blob/20e54e37670ffa569f47663a7e4b8d7de3a4c33c/addons/website_sale_collect/static/src/js/click_and_collect_availability/click_and_collect_availability.js#L54-L61
The rental date range is shown when the product is possible to rent and the rental period is only set in the [xml](https://github.com/odoo/enterprise/blob/1bf7dbcfef2186ee5a08382367fe195efca033dc/website_sale_renting/views/templates.xml#L90) 

Since openLocationSelector don't have access to the rental period, it can't update the necessary information to work with rental products.
For example, the free_qty should change depending on the rental period.


opw-5365564