### PR TITLE
[FIX] account_peppol: prevent duplicate invoices

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -231,11 +231,14 @@ class Account_Edi_Proxy_ClientUser(models.Model):
                     "type": "binary",
                     "mimetype": "application/xml",
                 })
-                vals_to_ack = edi_user._peppol_import_invoice(attachment, content["state"], uuid, journal=journal)
-                if move_to_ack := vals_to_ack.get('move'):
-                    created_moves |= move_to_ack
-                if uuid_to_ack := vals_to_ack.get('uuid'):
-                    uuids_to_ack.append(uuid_to_ack)
+                try:
+                    vals_to_ack = edi_user._peppol_import_invoice(attachment, content["state"], uuid, journal=journal)
+                    if move_to_ack := vals_to_ack.get('move'):
+                        created_moves |= move_to_ack
+                    if uuid_to_ack := vals_to_ack.get('uuid'):
+                        uuids_to_ack.append(uuid_to_ack)
+                except Exception as e:  # noqa: BLE001
+                    _logger.error('Error while processing the Peppol document with uuid %s: %s', uuid, e)
 
             if not (modules.module.current_test or tools.config['test_enable']):
                 self.env.cr.commit()


### PR DESCRIPTION
When importing invoices, if an error occurs in `_peppol_import_invoice`, Odoo crashes before acknowledging the already created bills.

But, since `rollbackable_transaction` is used in
`_extend_with_attachments`, the invoice is already committed. Since the acknowledgement is not sent while the invoice is committed, the next `_peppol_get_new_documents` attempt duplicates the invoice.

opw-5937044