### PR TITLE
[FIX] html_builder: block builder on reloadable action

### DIFF
--- a/addons/html_builder/static/src/core/utils.js
+++ b/addons/html_builder/static/src/core/utils.js
@@ -617,12 +617,14 @@ function useOperationWithReload(callApply, reload) {
     const env = useEnv();
     return async (...args) => {
         const { editingElement } = args[0][0];
+        env.services.ui.block();
         await callApply(...args);
         env.editor.shared.history.addStep();
         await env.editor.shared.savePlugin.save();
         const target = env.editor.shared.builderOptions.getReloadSelector(editingElement);
         const url = reload.getReloadUrl?.();
         await env.editor.config.reloadEditor({ target, url });
+        env.services.ui.unblock();
     };
 }
 

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -70,6 +70,7 @@ export class WebsiteBuilderClientAction extends Component {
         this.iframefallback = useRef("iframefallback");
 
         this.websiteContent = useRef("iframe");
+        this.builderSidebarRef = useRef("builder_sidebar");
         this.cleanups = [];
 
         this.snippetsTemplate = "website.snippets";
@@ -525,7 +526,9 @@ export class WebsiteBuilderClientAction extends Component {
         this.initialTab = param.initialTab;
         this.target = param.target || null;
         await this.reloadIframe(this.state.isEditing, param.url);
-        // trigger an new instance of the builder menu
+        // Disable the current instance of the builder and trigger a new
+        // instance of it with `t-key`
+        this.builderSidebarRef.el.firstElementChild.classList.add("o_builder_disabled");
         this.state.key++;
 
         this.notification.add(_t("Your modifications were saved to apply this option."), {

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.scss
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.scss
@@ -91,6 +91,15 @@
     }
 }
 
+.o_builder_disabled {
+    opacity: 0.5;
+    cursor: wait;
+}
+
+.o_builder_disabled  > *{
+    pointer-events: none;
+}
+
 body:has(.o_builder_sidebar_open) .o_notification_manager {
     @include o-position-absolute($top: map-get($spacers, 2), $right: calc(#{$o-we-sidebar-width} + 0.5rem));
 }

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.xml
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.xml
@@ -19,7 +19,7 @@
         </ResizablePanel>
         <LocalOverlayContainer localOverlay="overlayRef" identifier="env.localOverlayContainerKey"/>
         <div t-att-class="{'o_builder_sidebar_open': state.isEditing and state.showSidebar, 'o_is_microsoft_edge': isMicrosoftEdge}"
-            class="o-website-builder_sidebar border-start border-dark">
+            class="o-website-builder_sidebar border-start border-dark" t-ref="builder_sidebar">
             <LazyComponent  t-if="state.isEditing" Component="'website.WebsiteBuilder'" props="() => this.websiteBuilderProps" bundle="'website.website_builder_assets'" t-key="state.key"/>
         </div>
     </div>

--- a/addons/website/static/tests/builder/builder_action.test.js
+++ b/addons/website/static/tests/builder/builder_action.test.js
@@ -1,9 +1,14 @@
+import { onWillStart, xml } from "@odoo/owl";
 import { beforeEach, expect, test } from "@odoo/hoot";
 import { advanceTime, animationFrame, click, Deferred, queryOne, waitFor } from "@odoo/hoot-dom";
+import { Builder } from "@html_builder/builder";
+import { addBuilderAction, addBuilderOption } from "@html_builder/../tests/helpers";
+import { BuilderAction } from "@html_builder/core/builder_action";
+import { BaseOptionComponent } from "@html_builder/core/utils";
 import { Plugin } from "@html_editor/plugin";
 import { setSelection } from "@html_editor/../tests/_helpers/selection";
 import { expandToolbar } from "@html_editor/../tests/_helpers/toolbar";
-import { contains, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { contains, onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { addPlugin, defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
 import { WebsiteBuilderClientAction } from "@website/client_actions/website_preview/website_builder_action";
 
@@ -103,4 +108,58 @@ test("elements within iframe can't be clicked while the builder is being set up"
     await contains(":iframe .test-section button").click();
     await animationFrame();
     expect.verifySteps(["button clicked"]);
+});
+
+test("Builder is disabled when reloading", async () => {
+    onRpc("ir.ui.view", "save", () => true);
+    addBuilderAction({
+        TestReloadAction: class extends BuilderAction {
+            static id = "testReload";
+            setup() {
+                this.reload = {};
+            }
+            isApplied({ editingElement }) {
+                return editingElement.dataset.applied === "true";
+            }
+            async apply({ editingElement }) {
+                editingElement.dataset.applied = "true";
+            }
+            clean({ editingElement }) {
+                editingElement.dataset.applied = "false";
+            }
+        },
+    });
+
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static selector = ".target";
+            static template = xml`<BuilderButton action="'testReload'">Reload editor</BuilderButton>`;
+        }
+    );
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(
+        `<section class="target">Section</section>`
+    );
+    const def = new Deferred();
+    patchWithCleanup(Builder.prototype, {
+        setup() {
+            super.setup();
+            onWillStart(async () => {
+                await def;
+            });
+        },
+    });
+    await contains(":iframe .target").click();
+    await waitSidebarUpdated();
+    await contains(".options-container [data-action-id='testReload']").click();
+    expect(".o-website-builder_sidebar .o_builder_disabled").toHaveCount(1);
+    // when builder is disabled we can't go to another tab, or do anything else
+    // in the builder
+    await contains(".o-snippets-tabs [data-name='blocks']").click();
+    expect(".o-snippets-tabs [data-name='customize']").toHaveClass("active");
+    // new instance of the builder shouldn't be disabled
+    def.resolve();
+    await waitSidebarUpdated();
+    expect(".o-website-builder_sidebar .o_builder_disabled").toHaveCount(0);
+    await contains(".o-snippets-tabs [data-name='blocks']").click();
+    expect(".o-snippets-tabs [data-name='blocks']").toHaveClass("active");
 });

--- a/addons/website/static/tests/tours/hide_sidebar_header.js
+++ b/addons/website/static/tests/tours/hide_sidebar_header.js
@@ -24,14 +24,6 @@ registerWebsitePreviewTour(
             run: "click",
         },
         {
-            content: "Check that the loading screen has appeared",
-            trigger: ":iframe .o_loading_screen",
-        },
-        {
-            content: "Wait for the loading screen to disappear",
-            trigger: ":iframe :not(.o_loading_screen)",
-        },
-        {
             content: "Wait for the builder to mount after iframe reload",
             trigger: ":iframe body.editor_enable",
         },


### PR DESCRIPTION
When we perform a reloadable action in the builder, the builder's UI is not blocked, unlike in previous versions before the html_builder [refactoring]

Steps to reproduce the issue:
 - Open website, and click on the header
 - In the dev tools, set the network throttling to 3G or slow 4G 
 - Change the header's template
=> Notice that the sidebar is not blocked, while it should be.

[refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

task-5952793

