### PR TITLE
[FIX] hr_holidays: fix group time off duration computation

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -801,9 +801,11 @@ Attempting to double-book your time off won't magically make your vacation 2x be
             if any(leave.state == 'cancel' for leave in self):
                 raise UserError(_('Only a manager can modify a canceled leave.'))
 
-        # Unlink existing resource.calendar.leaves for validated time off
-        if 'state' in values and values['state'] != 'validate':
-            validated_leaves = self.filtered(lambda l: l.state == 'validate')
+        # If a leave changes state from validated or if the dates of a validated leave change
+        # unlink the corresponding resource calendar leave
+        date_fields = {'date_from', 'date_to', 'request_date_from', 'request_date_to'}
+        validated_leaves = self.filtered(lambda l: l.state == 'validate')
+        if validated_leaves and (('state' in values and values['state'] != 'validate') or date_fields.intersection(values)):
             validated_leaves._remove_resource_leave()
 
         employee_id = values.get('employee_id', False)

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -1698,3 +1698,137 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         })
 
         self.assertEqual(leave.number_of_hours, 13.0)
+
+    def test_group_leave_conflicting_days_computation(self):
+        """Test that a group leave that overrides existing approved time off days
+        correctly computes the duration of each leave.
+        """
+        LeaveType = self.env['hr.leave.type'].with_user(self.user_hrmanager_id)
+        self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).create({
+            'name': 'Annual Time Off',
+            'employee_id': self.employee_emp_id,
+            'holiday_status_id': self.holidays_type_4.id,
+            'number_of_days': 20,
+            'date_from': '2026-01-01',
+        }).action_approve()
+
+        # Create existing approved time off: Feb 23 - Feb 24 (2 days) and Feb 26 - Feb 27
+        leave1, leave2 = self.env['hr.leave'].with_user(self.user_employee_id).create([
+            {
+                'name': 'Approved Leave 1',
+                'employee_id': self.employee_emp_id,
+                'holiday_status_id': self.holidays_type_4.id,
+                'request_date_from': '2026-02-23',
+                'request_date_to': '2026-02-24',
+            },
+            {
+                'name': 'Approved Leave 2',
+                'employee_id': self.employee_emp_id,
+                'holiday_status_id': self.holidays_type_1.id,
+                'request_date_from': '2026-02-26',
+                'request_date_to': '2026-02-27',
+            }])
+
+        leave1.with_user(self.user_hrmanager_id).action_validate()
+        self.assertEqual(leave1.number_of_days, 2, "Approved Leave 1 should be 2 days")
+
+        leave2.with_user(self.user_hrmanager_id).action_validate()
+        self.assertEqual(leave2.number_of_days, 2, "Approved Leave 2 should be 2 days")
+
+        # Create Training Leave Type
+        training_type = LeaveType.create({
+            'name': 'Training',
+            'requires_allocation': 'no',
+            'leave_validation_type': 'no_validation',
+        })
+
+        # Use the Wizard to create a Training for the whole company: Feb 24 - Feb 26
+        # This overlaps with two days of approved allocated leaves
+        # Last day of leave 1 and first day of leave 2
+        leave_wizard_form = Form(self.env['hr.leave.generate.multi.wizard'].with_user(self.user_hrmanager_id))
+        leave_wizard_form.allocation_mode = 'company'
+        leave_wizard_form.company_id = self.env.company
+        leave_wizard_form.holiday_status_id = training_type
+        leave_wizard_form.date_from = date(2026, 2, 24)
+        leave_wizard_form.date_to = date(2026, 2, 26)
+        leave_wizard = leave_wizard_form.save()
+        leave_wizard.action_generate_time_off()
+
+        generated_training = self.env['hr.leave'].search([
+            ('employee_id', '=', self.employee_emp_id),
+            ('holiday_status_id', '=', training_type.id),
+            ('request_date_from', '=', '2026-02-24')
+        ])
+
+        # ASSERTS
+        # Assert correct duration calculation for the training leave
+        self.assertEqual(generated_training.number_of_days, 3.0,
+            "The training (Feb 25-27) should be 3 days, since it overrides other leaves.")
+
+        # Assert the original time off was split correctly
+        # It should now only cover Feb 23 (1 day) and Feb 27 (1 day)
+        leave1.invalidate_recordset(['number_of_days', 'request_date_to'])
+        self.assertEqual(leave1.request_date_to, date(2026, 2, 23),
+            "Leave 1 should have been shortened to end before the training.")
+        self.assertEqual(leave1.number_of_days, 1.0,
+            "Leave 1 duration should have been updated to 1 day.")
+
+        leave2.invalidate_recordset(['number_of_days', 'request_date_to'])
+        self.assertEqual(leave2.request_date_from, date(2026, 2, 27),
+            "Leave 2 should have been shortened to start after the training.")
+        self.assertEqual(leave2.number_of_days, 1.0,
+            "Leave 2 duration should have been updated to 1 day.")
+
+    def test_group_leave_hourly_conflict(self):
+        """Ensure batch generation fails if overlapping hourly time off exists
+        and does not unlink the related calendar leaves."""
+
+        # Create an hourly leave and validate it
+        LeaveType = self.env['hr.leave.type'].with_user(self.user_hrmanager_id)
+        hourly_type = LeaveType.create({
+            'name': 'Hourly Leave',
+            'request_unit': 'hour',
+            'requires_allocation': 'no',
+            'leave_validation_type': 'no_validation',
+        })
+        hourly_leave = self.env['hr.leave'].with_user(self.user_employee_id).create({
+            'name': 'Hourly Leave',
+            'employee_id': self.employee_emp_id,
+            'holiday_status_id': hourly_type.id,
+            'request_unit_hours': True,
+            'request_date_from': '2026-02-24',
+            'request_date_to': '2026-02-24',
+            'request_hour_from': 8,
+            'request_hour_to': 12,
+        })
+        hourly_leave.with_user(self.user_hrmanager_id).action_validate()
+
+        # Check that the leave exists and is linked to a calendar leave
+        calendar_leave = self.env['resource.calendar.leaves'].search([
+            ('holiday_id', '=', hourly_leave.id)
+        ])
+        self.assertTrue(calendar_leave)
+
+        # Create a group leave that overlaps with the hourly leave
+        training_type = LeaveType.create({
+                    'name': 'Training',
+                    'requires_allocation': 'no',
+                    'leave_validation_type': 'no_validation',
+                })
+        leave_wizard_form = Form(self.env['hr.leave.generate.multi.wizard'].with_user(self.user_hrmanager_id))
+        leave_wizard_form.allocation_mode = 'company'
+        leave_wizard_form.company_id = self.env.company
+        leave_wizard_form.holiday_status_id = training_type
+        leave_wizard_form.date_from = date(2026, 2, 24)
+        leave_wizard_form.date_to = date(2026, 2, 24)
+        leave_wizard = leave_wizard_form.save()
+
+        # ASSERTIONS
+        # Should raise an error and the approved leave should not be changed or removed
+        with self.assertRaises(UserError):
+            leave_wizard.action_generate_time_off()
+
+        self.assertTrue(calendar_leave.exists(), "Calendar leaves should not be unlinked on error")
+
+        hourly_leave.invalidate_recordset()
+        self.assertEqual(hourly_leave.state, 'validate')


### PR DESCRIPTION
Problem
------------------------
When an employee has approved leaves, and a group leave is created that overlaps with the approved leave and overrides it, the duration of the new group leave is not computed correctly. The duration does not include the overridden days. To reproduce:
1. Create allocated leave for employee and approve and validate it.
2. Go to Management > Time Off and create a group leave for the employee that includes the approved time off dates. The dates of all leaves are updated correctly, but the duration of the group leave is incorrect.

Objective
---------------------------
Even though conflicting leaves were correctly split in the multi leave generation wizard, the resource.calendar.leaves table was not synchronized within the same transaction. Because the leave types required allocation, the duration was computed by subtracting the old time off days from the new leave's duration, since they were treated as unavailable.

Solution
--------------------------
Manually unlink the resource.calendar.leaves records associated with the conflicting leaves before calculating the new duration. The clears the employee's schedule in the database so that the dates are correctly processed as available. The calendar blocks for the remaining days of the approved time off and the new group leave are generated when the leaves are created.

Task: 5911074





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
