### PR TITLE
[PERF] point_of_sale: reduce memory usage

### DIFF
--- a/addons/barcodes/static/src/barcode_service.js
+++ b/addons/barcodes/static/src/barcode_service.js
@@ -92,6 +92,7 @@ export const barcodeService = {
             if (currentTarget !== barcodeInput && isEditable(currentTarget) &&
                 !currentTarget.dataset.enableBarcode &&
                 currentTarget.getAttribute("barcode_events") !== "true") {
+                currentTarget = null;
                 return;
             }
 

--- a/addons/point_of_sale/static/src/app/models/pos_config.js
+++ b/addons/point_of_sale/static/src/app/models/pos_config.js
@@ -10,6 +10,14 @@ const CONSOLE_COLOR = "#F5B427";
 
 export class PosConfig extends Base {
     static pythonModel = "pos.config";
+    static excludedLazyGetters = [
+        "hasCashRounding",
+        "hasGlobalRounding",
+        "displayBigTrackingNumber",
+        "displayTrackingNumber",
+        "receiptLogoUrl",
+        "receiptCompanyLogoUrl",
+    ];
 
     initState() {
         super.initState();

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -9,6 +9,18 @@ const { DateTime } = luxon;
 
 export class PosOrder extends PosOrderAccounting {
     static pythonModel = "pos.order";
+    static excludedLazyGetters = [
+        "user",
+        "company",
+        "currency",
+        "pickingType",
+        "session",
+        "finalized",
+        "isUnsyncedPaid",
+        "originalSplittedOrder",
+        "isRefund",
+        "floatingOrderName",
+    ];
 
     setup(vals) {
         super.setup(vals);

--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -1,6 +1,7 @@
 import { registry } from "@web/core/registry";
 import { Base } from "./related_models";
 import { normalize } from "@web/core/l10n/utils";
+import { ProductTemplate } from "./product_template";
 
 // When adding a method to this class, please pay attention to naming.
 // As in the backend, when trying to access taxes_id on product.product,
@@ -10,38 +11,77 @@ import { normalize } from "@web/core/l10n/utils";
 // class, it will override this path.
 export class ProductProduct extends Base {
     static pythonModel = "product.product";
+    static enableLazyGetters = false;
+    static setupFn = enhanceProductTemplate;
+
+    setup(_vals) {
+        super.setup(_vals);
+        this._searchString = null;
+        this.product_tmpl_id?.onUpdate(); // To invalidate the searchString of the template
+    }
 
     getImageUrl() {
         return `/web/image?model=product.product&field=image_128&id=${this.id}&unique=${this.write_date}`;
     }
 
     get searchString() {
+        if (this._searchString) {
+            return this._searchString;
+        }
         const fields = ["display_name", "barcode", "default_code"];
         const raw = fields
             .map((field) => this[field] || "")
             .filter(Boolean)
             .join(" ");
-        return normalize(raw);
+        this._searchString = normalize(raw);
+        return this._searchString;
     }
 }
 
-const ProductProductTemplateProxy = new Proxy(ProductProduct, {
-    construct(target, args) {
-        const instance = new target(...args);
-        return new Proxy(instance, {
-            get(target, prop) {
-                const val = Reflect.get(target, prop);
+export function enhanceProductTemplate() {
+    // This mimics the Odoo delegation inheritance between product.product and product.template,
+    // where accessing an undefined field/method on a product transparently falls through to its template.
 
-                if (val !== undefined || target.model.fields[prop] || typeof prop === "symbol") {
-                    return val;
+    let proto = ProductTemplate.prototype;
+    while (proto && proto !== Object.prototype) {
+        for (const name of Object.getOwnPropertyNames(proto)) {
+            if (name === "constructor") {
+                continue;
+            }
+            if (name in ProductProduct.prototype) {
+                continue;
+            }
+
+            const desc = Object.getOwnPropertyDescriptor(proto, name);
+            if (!desc) {
+                continue;
+            }
+            if (typeof desc.value === "function") {
+                Object.defineProperty(ProductProduct.prototype, name, {
+                    value: function (...args) {
+                        return this.product_tmpl_id?.[name]?.call(this, ...args);
+                    },
+                    configurable: true,
+                });
+            } else if (typeof desc.get === "function") {
+                const propertyDescriptor = {
+                    get: function () {
+                        return this.product_tmpl_id?.[name];
+                    },
+                    configurable: true,
+                };
+                if (typeof desc.set === "function") {
+                    propertyDescriptor.set = function (value) {
+                        if (this.product_tmpl_id) {
+                            this.product_tmpl_id[name] = value;
+                        }
+                    };
                 }
+                Object.defineProperty(ProductProduct.prototype, name, propertyDescriptor);
+            }
+        }
+        proto = Object.getPrototypeOf(proto);
+    }
+}
 
-                return target?.product_tmpl_id?.[prop];
-            },
-        });
-    },
-});
-
-registry
-    .category("pos_available_models")
-    .add(ProductProduct.pythonModel, ProductProductTemplateProxy);
+registry.category("pos_available_models").add(ProductProduct.pythonModel, ProductProduct);

--- a/addons/point_of_sale/static/src/app/models/product_tag.js
+++ b/addons/point_of_sale/static/src/app/models/product_tag.js
@@ -4,6 +4,7 @@ import { registry } from "@web/core/registry";
 
 export class ProductTag extends Base {
     static pythonModel = "product.tag";
+    static enableLazyGetters = false;
 
     get posDescriptionMarkup() {
         return this.pos_description ? markup(this.pos_description) : "";

--- a/addons/point_of_sale/static/src/app/models/product_template_attribute_line.js
+++ b/addons/point_of_sale/static/src/app/models/product_template_attribute_line.js
@@ -3,7 +3,7 @@ import { Base } from "./related_models";
 
 export class ProductTemplateAttributeLine extends Base {
     static pythonModel = "product.template.attribute.line";
-
+    static enableLazyGetters = false;
     values() {
         return this.product_template_value_ids;
     }

--- a/addons/point_of_sale/static/src/app/models/product_template_attribute_value.js
+++ b/addons/point_of_sale/static/src/app/models/product_template_attribute_value.js
@@ -3,6 +3,7 @@ import { Base } from "./related_models";
 
 export class ProductTemplateAttributeValue extends Base {
     static pythonModel = "product.template.attribute.value";
+    static enableLazyGetters = false;
 }
 
 registry

--- a/addons/point_of_sale/static/src/app/models/related_models/base.js
+++ b/addons/point_of_sale/static/src/app/models/related_models/base.js
@@ -1,10 +1,18 @@
 import { WithLazyGetterTrap } from "@point_of_sale/lazy_getter";
-import { deepImmutable, clone, RAW_SYMBOL } from "./utils";
+import { deepImmutable, RAW_SYMBOL } from "./utils";
 import { toRaw } from "@odoo/owl";
 const { DateTime } = luxon;
 
+function rawValueConverter(value) {
+    if (value instanceof Set) {
+        return Array.from(value);
+    }
+    return value;
+}
+
 export class Base extends WithLazyGetterTrap {
     static excludedLazyGetters = ["id", "models"];
+    static enableLazyGetters = true;
 
     constructor({ model, raw }) {
         super({});
@@ -25,7 +33,7 @@ export class Base extends WithLazyGetterTrap {
     }
 
     get raw() {
-        return deepImmutable(clone(this[RAW_SYMBOL]), "Raw data cannot be modified");
+        return deepImmutable(this[RAW_SYMBOL], "Raw data cannot be modified", rawValueConverter);
     }
 
     /**

--- a/addons/point_of_sale/static/src/app/models/related_models/record_store.js
+++ b/addons/point_of_sale/static/src/app/models/related_models/record_store.js
@@ -1,6 +1,5 @@
 import { Base } from "./base";
 import { RAW_SYMBOL } from "./utils";
-import { reactive } from "@odoo/owl";
 
 export class RecordStore {
     /**
@@ -20,7 +19,6 @@ export class RecordStore {
                 modelMap.set(key, new Map());
             }
         });
-        return reactive(this);
     }
 
     /**
@@ -109,7 +107,20 @@ export class RecordStore {
      * @param {Array<Base>} - Map of records by ids.
      */
     getOrderedRecords(model) {
-        return Array.from(this.getRecordsMap(model, "id").values());
+        return Array.from(this.getRecordIterator(model));
+    }
+
+    /**
+     * Retrieves an iterator over the records in insertion order.
+     * @param model
+     * @returns {*}
+     */
+    getRecordIterator(model) {
+        return this.getRecordsMap(model, "id").values();
+    }
+
+    getFirstRecord(model) {
+        return this.getRecordsMap(model, "id").values().next().value;
     }
 
     /**

--- a/addons/point_of_sale/static/src/app/models/related_models/utils.js
+++ b/addons/point_of_sale/static/src/app/models/related_models/utils.js
@@ -91,16 +91,19 @@ export function convertDateToRaw(value) {
  *
  * @param {Object|Array} obj - The object or array to make immutable.
  * @param {string} errorMsg - The error message to throw on modification attempts.
+ * @param valueConverter
  * @returns {Proxy} A Proxy that enforces deep immutability.
  */
-export function deepImmutable(obj, errorMsg) {
+export function deepImmutable(obj, errorMsg, valueConverter = (value) => value) {
     return new Proxy(obj, {
         get(target, prop, receiver) {
             if ("__deepImmutable" === prop) {
                 return true;
             }
-            const value = Reflect.get(target, prop, receiver);
-            return value && typeof value === "object" ? deepImmutable(value, errorMsg) : value;
+            const value = valueConverter(Reflect.get(target, prop, receiver));
+            return value && typeof value === "object"
+                ? deepImmutable(value, errorMsg, valueConverter)
+                : value;
         },
         set() {
             throw new Error(errorMsg);

--- a/addons/point_of_sale/static/src/app/models/res_partner.js
+++ b/addons/point_of_sale/static/src/app/models/res_partner.js
@@ -3,8 +3,18 @@ import { Base } from "./related_models";
 
 export class ResPartner extends Base {
     static pythonModel = "res.partner";
+    static enableLazyGetters = false;
+
+    setup(_vals) {
+        super.setup(_vals);
+        this._searchString = null;
+    }
 
     get searchString() {
+        if (this._searchString) {
+            return this._searchString;
+        }
+
         const fields = [
             "name",
             "barcode",
@@ -14,7 +24,7 @@ export class ResPartner extends Base {
             "parent_name",
             "pos_contact_address",
         ];
-        return fields
+        this._searchString = fields
             .map((field) => {
                 if (field === "phone" && this[field]) {
                     return this[field].replace(/[+\s()-]/g, "");
@@ -23,6 +33,7 @@ export class ResPartner extends Base {
             })
             .filter(Boolean)
             .join(" ");
+        return this._searchString;
     }
 
     exactMatch(searchWord) {

--- a/addons/point_of_sale/static/src/app/models/utils/indexed_db.js
+++ b/addons/point_of_sale/static/src/app/models/utils/indexed_db.js
@@ -233,6 +233,14 @@ export default class IndexedDB {
         }
         return this.promises(storeName, arrData, "put");
     }
+    async readAllExceptStores(storeToIgnores = [], options) {
+        const allStoreNames = this.dbStores.map((store) => store[1]);
+        const storeNames =
+            storeToIgnores.length > 0
+                ? allStoreNames.filter((s) => !storeToIgnores.includes(s))
+                : allStoreNames;
+        return this.readAll(storeNames, options);
+    }
 
     readAll(store = [], retry = 0) {
         const storeNames = store.length > 0 ? store : this.dbStores.map((store) => store[1]);

--- a/addons/point_of_sale/static/src/app/pos_app.js
+++ b/addons/point_of_sale/static/src/app/pos_app.js
@@ -2,7 +2,7 @@ import { Transition } from "@web/core/transition";
 import { MainComponentsContainer } from "@web/core/main_components_container";
 import { Navbar } from "@point_of_sale/app/components/navbar/navbar";
 import { usePos } from "@point_of_sale/app/hooks/pos_hook";
-import { reactive, Component, onMounted, onWillStart } from "@odoo/owl";
+import { Component, onMounted, onWillStart } from "@odoo/owl";
 import { effect } from "@web/core/utils/reactive";
 import { batched } from "@web/core/utils/timing";
 import { useOwnDebugContext } from "@web/core/debug/debug_context";
@@ -32,8 +32,7 @@ export class Chrome extends Component {
             this.pos.navigateToFirstPage();
         }
 
-        const reactivePos = reactive(this.pos);
-        window.posmodel = reactivePos;
+        window.posmodel = this.pos;
         useOwnDebugContext();
         if (this.env.debug) {
             initDebugFormatters();

--- a/addons/point_of_sale/static/src/app/utils/numbers.js
+++ b/addons/point_of_sale/static/src/app/utils/numbers.js
@@ -28,6 +28,8 @@ function invertMethod(method) {
 }
 
 export class AbstractNumbers extends Base {
+    static enableLazyGetters = false;
+
     get precision() {
         return Math.pow(10, -2);
     }

--- a/addons/point_of_sale/static/src/lazy_getter.js
+++ b/addons/point_of_sale/static/src/lazy_getter.js
@@ -121,6 +121,9 @@ function lazyComputed(obj, propName, compute) {
 export class WithLazyGetterTrap {
     constructor({ traps = {} }) {
         const Class = this.constructor;
+        if (Class.enableLazyGetters === false) {
+            return;
+        }
         const instance = new Proxy(this, { get: defineLazyGetterTrap(Class), ...traps });
         for (const [lazyName, func] of getLazyGetters(Class).values()) {
             lazyComputed(instance, lazyName, func);

--- a/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
+++ b/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
@@ -287,8 +287,8 @@ describe("pos_store.js", () => {
 
         const productA = store.models["product.product"].get(5);
         const productB = store.models["product.product"].get(6);
-        productA.parentPosCategIds = [1];
-        productB.parentPosCategIds = [2];
+        productA.pos_categ_ids = [1];
+        productB.pos_categ_ids = [2];
 
         const currentOrderChange = {
             new: [

--- a/addons/pos_event/static/src/app/models/product_template.js
+++ b/addons/pos_event/static/src/app/models/product_template.js
@@ -9,6 +9,9 @@ patch(ProductTemplate.prototype, {
 
         return this.models["event.event"].get(this._event_id);
     },
+    set event_id(event) {
+        this._event_id = event ? event.id : undefined;
+    },
     get canBeDisplayed() {
         if (this.event_id) {
             return true;

--- a/addons/pos_loyalty/static/src/app/services/pos_store.js
+++ b/addons/pos_loyalty/static/src/app/services/pos_store.js
@@ -565,9 +565,7 @@ patch(PosStore.prototype, {
 
         this.partnerId2CouponIds = {};
 
-        this.computeDiscountProductIdsForAllRewards({
-            ids: this.data.models["product.product"].getAllIds(),
-        });
+        this.computeDiscountProductIdsForAllRewards();
 
         this.models["product.product"].addEventListener(
             "create",
@@ -586,7 +584,8 @@ patch(PosStore.prototype, {
     },
 
     computeDiscountProductIdsForAllRewards(data) {
-        const products = this.models["product.product"].readMany(data.ids);
+        const productModel = this.models["product.product"].toRaw(); // Limit the number of reactivity proxy instances
+        const products = data ? productModel.readMany(data.ids) : productModel.getAll();
         for (const reward of this.models["loyalty.reward"].getAll()) {
             this.computeDiscountProductIds(reward, products);
         }


### PR DESCRIPTION
This commit reduces memory consumption in the POS, especially when loading a large number of products.

Reactivity usage has been optimized, particularly for product data. Additional optimizations were implemented to handle large product sets more efficiently.

Metrics

5,000 products
	•	Chrome: 440 MB → 75 MB
	•	Safari / Firefox: 1 GB → 250 MB

20,000 products
	•	Chrome: 1.5 GB → 135 MB
	•	Safari / Firefox: 4 GB → 300 MB

Enterprise PR: https://github.com/odoo/enterprise/pull/107978