### PR TITLE
[FW][FIX] core: stream Binary fields with non-b64 value

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -3,21 +3,24 @@ import io
 import json
 import logging
 import re
-import time
-import requests
-import werkzeug.exceptions
-import werkzeug.urls
-from PIL import Image, ImageFont, ImageDraw
-from lxml import etree
 from base64 import b64decode, b64encode
 from math import floor
 from os.path import join as opj
 
-from odoo.http import request, Response
-from odoo import http, tools, _
-from odoo.tools.misc import file_open
-from odoo.tools.image import image_data_uri, binary_to_image, get_webp_size
+import requests
+import werkzeug.exceptions
+from lxml import etree
+from PIL import Image, ImageDraw, ImageFont
 
+from odoo import http, tools
+from odoo.http import STATIC_CACHE, Response, request
+from odoo.tools.image import binary_to_image, get_webp_size, image_data_uri
+from odoo.tools.misc import file_open
+
+try:
+    from werkzeug.utils import send_file
+except ImportError:
+    from .tools._vendor.send_file import send_file
 
 logger = logging.getLogger(__name__)
 DEFAULT_LIBRARY_ENDPOINT = 'https://media-api.odoo.com'
@@ -147,16 +150,18 @@ class Web_Editor(http.Controller):
         # output image
         output = io.BytesIO()
         outimage.save(output, format="PNG")
-        response = Response()
-        response.mimetype = 'image/png'
-        response.data = output.getvalue()
-        response.headers['Cache-Control'] = 'public, max-age=604800'
+        output.seek(0)
+        response = send_file(
+            output,
+            request.httprequest.environ,
+            mimetype='image/png',
+            conditional=False,
+            etag=False,
+            max_age=STATIC_CACHE,
+            response_class=Response,
+        )
         response.headers['Access-Control-Allow-Origin'] = '*'
         response.headers['Access-Control-Allow-Methods'] = 'GET, POST'
-        response.headers['Connection'] = 'close'
-        response.headers['Date'] = time.strftime("%a, %d-%b-%Y %T GMT", time.gmtime())
-        response.headers['Expires'] = time.strftime("%a, %d-%b-%Y %T GMT", time.gmtime(time.time()+604800*60))
-
         return response
 
     #------------------------------------------------------

--- a/odoo/addons/test_http/tests/test_static.py
+++ b/odoo/addons/test_http/tests/test_static.py
@@ -456,6 +456,25 @@ class TestHttpStatic(TestHttpStaticCommon):
         self.assertEqual(res.headers['Date'].count(' GMT'), 1,
             "There must be only 1 Date header, not 2")
 
+    def test_static25_binary_non_base64(self):
+        self.authenticate('admin', 'admin')
+
+        # need a Binary(attachment=False) field
+        # TODO: master, add such a field on test_http.stargate
+        record = self.env['ir.mail_server'].create({
+            'name': 'dummy test_http test_static server',
+            'smtp_host': 'localhost',
+        })
+
+        record.smtp_ssl_certificate = b'non base64 value'
+        self.assertDownload(
+            f'/web/content/ir.mail_server/{record.id}/smtp_ssl_certificate',
+            headers={},
+            assert_status_code=200,
+            assert_headers={},
+            assert_content=b'non base64 value',
+        )
+
 
 @tagged('post_install', '-at_install')
 class TestHttpStaticLogo(TestHttpStaticCommon):

--- a/odoo/addons/test_http/tests/test_static.py
+++ b/odoo/addons/test_http/tests/test_static.py
@@ -449,6 +449,14 @@ class TestHttpStatic(TestHttpStaticCommon):
                     raise AssertionError(e) from exc
                 self.assertEqual(res.content, self.gizeh_data)
 
+    def test_static24_only_one_date_header(self):
+        res = self.assertDownloadPlaceholder('/web/image')
+        # requests merge multiple headers with a same key together, it
+        # concatenates the values, hence .count(' GMT')
+        self.assertEqual(res.headers['Date'].count(' GMT'), 1,
+            "There must be only 1 Date header, not 2")
+
+
 @tagged('post_install', '-at_install')
 class TestHttpStaticLogo(TestHttpStaticCommon):
     @staticmethod

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -514,8 +514,21 @@ class Stream:
     @classmethod
     def from_binary_field(cls, record, field_name):
         """ Create a :class:`~Stream`: from a binary field. """
-        data_b64 = record[field_name]
-        data = base64.b64decode(data_b64) if data_b64 else b''
+        data = record[field_name] or b''
+
+        # Image fields enforce base64 encoding. Binary fields don't
+        # enforce anything: raw bytes are fine, expected even.
+        # People nonetheless write base64 encoded bytes inside binary
+        # fields, and expect automatic decoding when read, crazy!
+        with contextlib.suppress(ValueError):
+            data = base64.b64decode(
+                # Some libs add linefeed every X (where X < 79) char in
+                # the base64, for email mime. validate=True would raise
+                # an error for those linefeeds so stip them.
+                data.replace(b'\r', b'').replace(b'\n', b''),
+                validate=True,
+            )
+
         return cls(
             type='data',
             data=data,

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -18,6 +18,7 @@ import threading
 import time
 from collections import deque
 import contextlib
+from email.utils import parsedate_to_datetime
 from io import BytesIO
 
 import psutil
@@ -169,6 +170,12 @@ class RequestHandler(werkzeug.serving.WSGIRequestHandler):
             elif self._sent_date_header == value:
                 return  # don't send the same header twice
             else:
+                sent_datetime = parsedate_to_datetime(self._sent_date_header)
+                new_datetime = parsedate_to_datetime(value)
+                if sent_datetime == new_datetime:
+                    return  # don't send the same date twice (differ in format)
+                if abs((sent_datetime - new_datetime).total_seconds()) <= 1:
+                    return  # don't send the same date twice (jitter of 1 second)
                 _logger.warning(
                     "sending two different Date response headers: %r vs %r",
                     self._sent_date_header, value)

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -129,6 +129,11 @@ class BaseWSGIServerNoBind(LoggingBaseWSGIServerMixIn, werkzeug.serving.BaseWSGI
 
 
 class RequestHandler(werkzeug.serving.WSGIRequestHandler):
+    def __init__(self, *args, **kwargs):
+        self._sent_date_header = None
+        self._sent_server_header = None
+        super().__init__(*args, **kwargs)
+
     def setup(self):
         # timeout to avoid chrome headless preconnect during tests
         if config['test_enable']:
@@ -157,6 +162,27 @@ class RequestHandler(werkzeug.serving.WSGIRequestHandler):
             # Do not keep processing requests.
             self.close_connection = True
             return
+
+        if keyword.casefold() == 'date':
+            if self._sent_date_header is None:
+                self._sent_date_header = value
+            elif self._sent_date_header == value:
+                return  # don't send the same header twice
+            else:
+                _logger.warning(
+                    "sending two different Date response headers: %r vs %r",
+                    self._sent_date_header, value)
+
+        if keyword.casefold() == 'server':
+            if self._sent_server_header is None:
+                self._sent_server_header = value
+            elif self._sent_server_header == value:
+                return  # don't send the same header twice
+            else:
+                _logger.warning(
+                    "sending two different Server response headers: %r vs %r",
+                    self._sent_server_header, value)
+
         super().send_header(keyword, value)
 
     def end_headers(self, *a, **kw):


### PR DESCRIPTION
Write some bytes in a `field.Binary(attachment=False)` field. The ORM doesn't encode the bytes in b64, and the value is stored as a binary blob in postgres.

Attempt to download the content via /web/content (actually any route that uses `http.Stream` is affected). It sometimes download something, sometimes fail with an "Incorrect padding" error.

The `http.Stream` class wrongly assumes that reading a binary/image field is always going to return the value base64-encoded, thus it always attemps to decode it. The `b64decode` function silently discard non-b64 characters and only complain if the final thing lacks the b64 `=` padding (to make the length a multiple of 4).

So when it downloaded something, it downloaded crap.

The thing actually is:

* Binary fields, accept raw bytes, store raw bytes in db.
* Image fields, reject raw bytes, want base64, store base64 in db.

When reading Image fields it is easy: always decode the base64.

For Binary fields it is complicated, because some crazy people encode their binary fields in base64, and expect automatic base64 decoding when read. Crazy! So *attempt* to decode the b64 and if the decoding fail just assume it was raw bytes from the beginning.

**Binary-field with non-b64 value** (original fix)

Forward-Port-Of: odoo/odoo#214412
Forward-Port-Of: odoo/odoo#213997

**binary can store raw bytes** (fix of *Binary-field with non-b64 value*)

Forward-Port-Of: odoo/odoo#214915
Forward-Port-Of: odoo/odoo#214758

This PR contains the squashed code of the above two PRs.