### PR TITLE
[FIX] html_builder, website: drop empty text input in BuilderList

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_list.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.js
@@ -200,9 +200,11 @@ export class BuilderList extends Component {
         const id = targetInputEl.dataset.id;
         const propertyName = targetInputEl.name;
         const isCheckbox = targetInputEl.type === "checkbox";
+        const isText = targetInputEl.type === "text";
         const value = isCheckbox ? targetInputEl.checked : targetInputEl.value;
 
-        const items = this.formatRawValue(this.state.value);
+        let items = this.formatRawValue(this.state.value);
+
         if (value === true && this.props.itemShape[propertyName] === "exclusive_boolean") {
             for (const item of items) {
                 item[propertyName] = false;
@@ -212,6 +214,14 @@ export class BuilderList extends Component {
         item[propertyName] = value;
         if (!isCheckbox) {
             item.id = isSmallInteger(value) ? parseInt(value) : value;
+        }
+
+        // Empty text inputs are not allowed, so we remove them, unless removing
+        // them would violate `props.forbidLastItemRemoval`.
+        const inputIsEmptyText = isText && value === "";
+        const canDeleteItem = items.length > 1 || !this.props.forbidLastItemRemoval;
+        if (inputIsEmptyText && canDeleteItem) {
+            items = items.filter((item) => item._id !== id);
         }
 
         if (commitToHistory) {

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_list.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_list.test.js
@@ -4,6 +4,7 @@ import { BaseOptionComponent } from "@html_builder/core/utils";
 import { expect, test, describe } from "@odoo/hoot";
 import { onError, xml } from "@odoo/owl";
 import { contains } from "@web/../tests/web_test_helpers";
+import { press } from "@odoo/hoot-dom";
 
 describe.current.tags("desktop");
 
@@ -381,4 +382,55 @@ test("can add item with string and integer ids", async () => {
         await contains(".o_select_menu_menu .o-dropdown-item").click();
     }
     expect(".we-bg-options-container .o-hb-selectMany2X-toggle").toHaveProperty("disabled");
+});
+
+test("drops blank textual entries", async () => {
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static template = xml`
+            <BuilderList
+                dataAttributeAction="'list'"
+                addItemTitle="'Add'"
+                itemShape="{ display_name: 'text' }"
+                default="{ display_name: 'default' }"/>`;
+            static components = { BuilderList };
+            static props = ["*"];
+            static selector = ".test-options-target-a";
+        }
+    );
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static template = xml`
+            <BuilderList
+                dataAttributeAction="'list'"
+                addItemTitle="'Add'"
+                itemShape="{ display_name: 'text' }"
+                default="{ display_name: 'default' }"
+                forbidLastItemRemoval="true"/>`;
+            static components = { BuilderList };
+            static props = ["*"];
+            static selector = ".test-options-target-b";
+        }
+    );
+    await setupHTMLBuilder(`
+        <div class="test-options-target-a">a</div>
+        <div class="test-options-target-b">b</div>`);
+
+    // forbidLastItemRemoval="false"
+    await contains(":iframe .test-options-target-a").click();
+    await contains(".we-bg-options-container .builder_list_add_item").click();
+    expect(".we-bg-options-container input").toHaveCount(1);
+
+    await contains(".we-bg-options-container input").clear();
+    await press("enter");
+    expect(".we-bg-options-container input").toHaveCount(0);
+
+    // forbidLastItemRemoval="true"
+    await contains(":iframe .test-options-target-b").click();
+    await contains(".we-bg-options-container .builder_list_add_item").click();
+    expect(".we-bg-options-container input").toHaveCount(1);
+
+    await contains(".we-bg-options-container input").clear();
+    await press("enter");
+    expect(".we-bg-options-container input").toHaveCount(1);
 });

--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -1437,7 +1437,7 @@ export class SetFormCustomFieldValueListAction extends BuilderAction {
         const fields = [];
         const field = getActiveField(fieldEl, { fields });
         if (
-            field.records.length &&
+            field.records.length > 1 &&
             field.records[0].display_name === "" &&
             field.records[0].selected === true
         ) {

--- a/addons/website/static/tests/builder/website_builder/form_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/form_option.test.js
@@ -187,6 +187,44 @@ test("empty placeholder selection input for selection field", async () => {
     expect(":iframe select option:eq(0)").toHaveText("");
 });
 
+test("selection field discards empty entries", async () => {
+    onRpc("get_authorized_fields", () => ({}));
+    const { getEditor } = await setupWebsiteBuilder(
+        `<section class="s_website_form"><form data-model_name="mail.mail">
+            <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_custom" data-type="many2one">
+                <div class="row s_col_no_resize s_col_no_bgcolor">
+                    <label class="col-form-label col-sm-auto s_website_form_label" for="ozp7022vqhe">
+                        <span class="s_website_form_label_content">Selection Field</span>
+                    </label>
+                    <div class="col-sm">
+                        <select class="form-select s_website_form_input" name="Phone Number" id="ozp7022vqhe">
+                            <option id="ozp7022vqhe0" value="Option 1">Option 1</option>
+                            <option id="ozp7022vqhe1" value="Option 2">Option 2</option>
+                        </select>
+                    </div>
+                </div>
+            </div>
+            <div class="s_website_form_submit">
+                <div class="s_website_form_label"/>
+                <a>Submit</a>
+            </div>
+        </form></section>`
+    );
+    getEditor();
+    await contains(":iframe .s_website_form_field[data-type='many2one']").click();
+    expect(".o_row_draggable").toHaveCount(2);
+
+    // If the entry is empty, it is dropped
+    await contains(".o_we_table_wrapper input[type='text']").clear();
+    await press("enter");
+    expect(".o_row_draggable").toHaveCount(1);
+
+    // If the entry is empty, but it is the last one, it is not dropped
+    await contains(".o_we_table_wrapper input[type='text']").clear();
+    await press("enter");
+    expect(".o_row_draggable").toHaveCount(1);
+});
+
 test("Set 'Message' as form success action and show/hide the message preview", async () => {
     await setupWebsiteBuilderWithSnippet("s_website_form");
     await contains(":iframe section.s_website_form").click();


### PR DESCRIPTION
**Description of the problem**
Before this commit, the user could entry empty many2one options in a form, and these would
be saved and displayed in the website as empty entries in a dropdown selector.

**How to reproduce the problem**
1. Drop a form
2. Add a "Selection" field (many2one)
3. Clear the text in one of the options in "Option List"
4. Save
5. The empty option is not removed, and shows up in the dropdown selector

**Why the problem happens**
Commit [1] introduced some changes to the action `SetFormCustomFieldValueListAction`, as a
result, empty many2one options are not dropped anymore on apply.

**Solution**
The solution is applied on `BuilderList` (not only forms), as required by the task.
`BuilderList.handleValueChange` now drops empty text fields before commiting changes, unless
this violates `props.forbidLastItemRemoval`.
The form action `setFormCustomFieldValueList` is changed such that the last entry is never
removed even if its text is empty (unless `props.forbidLastItemRemoval` is false).

task-5925171

[1]: https://github.com/odoo/odoo/commit/cb8469e9fe73f5c10b4e49d3462e0b23df2a047d