### PR TITLE
[FIX] stock_account: no product move breaks AVCO compute on lots

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -316,8 +316,8 @@ class ProductProduct(models.Model):
         return std_price_by_product_id, value_by_product_id
 
     def _run_average_batch(self, at_date=None, lot=None, force_recompute=False):
-        std_price_by_product_id = {}
-        value_by_product_id = {}
+        std_price_by_product_id = {p.id: 0 for p in self}
+        value_by_product_id = {p.id: 0 for p in self}
         quantity_by_product_id = {}
 
         if not at_date and not force_recompute:


### PR DESCRIPTION
PR [247625](https://github.com/odoo/odoo/pull/247625) improved performance of the AVCO computation with `_run_average_batch()`.

However, it's currently possible that the method returns an empty dictionary if a product does not have any stock move associated with it. It then raises a traceback in `_run_avco()` because we expect the dictionary to always hold the product id keys.

Ticket: opw-5951133