### PR TITLE
[FIX] point_of_sale: fix silent error for pos invoice

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/invoice_button/invoice_button.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/invoice_button/invoice_button.js
@@ -97,7 +97,7 @@ export class InvoiceButton extends Component {
 
         // Part 2: Invoice the order.
         // FIXME POSREF timeout
-        await this.pos.data.silentCall("pos.order", "action_pos_order_invoice", [orderId]);
+        await this.pos.data.call("pos.order", "action_pos_order_invoice", [orderId]);
 
         // Part 3: Download invoice.
         await this._downloadInvoice(orderId);


### PR DESCRIPTION
Steps to reproduce:
- Add untrusted bank account to the database's selected company's contact
- Finalize an order in point of sale through register
- While in register, go to orders and click on the invoice button for the finalized order

Current behavior:
- There is no indication of why you can't generate an invoice

Expected behavior:
- There should be a popup to the user identifying the error (e.g. untrusted bank account)

This addresses a side effect of:
https://github.com/odoo/odoo/pull/248108

opw-5946239