### PR TITLE
[IMP] web: show log-searchable timestamps in error dialog

### DIFF
--- a/addons/web/static/src/core/errors/error_dialogs.js
+++ b/addons/web/static/src/core/errors/error_dialogs.js
@@ -59,6 +59,12 @@ export class ErrorDialog extends Component {
         });
         this.copyButtonRef = useRef("copyButton");
         this.popover = usePopover(Tooltip);
+        let date = DateTime.now().setZone("UTC");
+        if (this.props.data?.timestamp) {
+            date = DateTime.fromSeconds(this.props.data.timestamp, { zone: "utc" });
+        }
+        this.logDate = date.toFormat("dd/MMM/yyyy HH:mm:ss", { locale: "en" });
+
         this.contextDetails = "Occured ";
         if (this.props.serverHost) {
             this.contextDetails += `on ${this.props.serverHost} `;
@@ -66,9 +72,7 @@ export class ErrorDialog extends Component {
         if (this.props.model) {
             this.contextDetails += `on model ${this.props.model} `;
         }
-        this.contextDetails += `on ${DateTime.now()
-            .setZone("UTC")
-            .toFormat("yyyy-MM-dd HH:mm:ss")} GMT`;
+        this.contextDetails += `on ${this.logDate}`;
     }
 
     showTooltip() {

--- a/addons/web/static/src/core/errors/error_dialogs.xml
+++ b/addons/web/static/src/core/errors/error_dialogs.xml
@@ -57,7 +57,7 @@
                     Something went wrong... If you really are stuck, share the report with your friendly support service
                 </p>
                 <details t-on-toggle="() => { this.state.showTraceback = !this.state.showTraceback }">
-                    <summary t-out="this.state.showTraceback ? this.constructor.hideTracebackButtonText : this.constructor.showTracebackButtonText" class="mb-1 link-info"/>
+                    <summary class="mb-1 link-info"><span t-out="this.state.showTraceback ? this.constructor.hideTracebackButtonText : this.constructor.showTracebackButtonText"/><span t-if="!this.state.showTraceback" t-out="`(${this.logDate})`" class="ms-1 text-400 small"/></summary>
                     <div class="text-bg-100 clearfix mt-2 position-relative o_error_detail pb-2">
                         <button class="btn position-absolute top-0 end-0 pt-2 btn-link link-body-emphasis" t-custom-ref="copyButton" t-on-click="this.onClickClipboard" data-available-offline="">
                             <span class="fa fa-clipboard"/>

--- a/addons/web/static/tests/core/errors/error_dialogs.test.js
+++ b/addons/web/static/tests/core/errors/error_dialogs.test.js
@@ -36,7 +36,7 @@ test("ErrorDialog with traceback", async () => {
     });
     expect(".o_dialog").toHaveCount(1);
     expect("header .modal-title").toHaveText("Oops!");
-    expect("main summary").toHaveText("See technical details");
+    expect("main summary").toHaveText("See technical details(11/Mar/2019 09:30:00)");
     expect(queryAllTexts("footer button")).toEqual(["Close"]);
     expect(queryFirst("main p")).toHaveText(
         "Something went wrong... If you really are stuck, share the report with your friendly support service"
@@ -46,14 +46,14 @@ test("ErrorDialog with traceback", async () => {
     await animationFrame();
     expect(queryAllTexts("main .clearfix div > *")).toEqual([
         "Odoo Error",
-        "Occured on 2019-03-11 09:30:00 GMT",
+        "Occured on 11/Mar/2019 09:30:00",
         "ERROR_NAME",
         "Something bad happened",
         "This is a traceback string",
     ]);
     expect(queryAllTexts("main .clearfix div > p")).toEqual([
         "Odoo Error",
-        "Occured on 2019-03-11 09:30:00 GMT",
+        "Occured on 11/Mar/2019 09:30:00",
     ]);
     expect(queryAllTexts("main .clearfix div > code")).toEqual([
         "ERROR_NAME",
@@ -78,7 +78,7 @@ test("Client ErrorDialog with traceback", async () => {
     });
     expect(".o_dialog").toHaveCount(1);
     expect("header .modal-title").toHaveText("Oops!");
-    expect("main summary").toHaveText("See technical details");
+    expect("main summary").toHaveText("See technical details(11/Mar/2019 09:30:00)");
     expect(queryAllTexts("footer button")).toEqual(["Close"]);
     expect(queryFirst("main p")).toHaveText(
         "Something went wrong... If you really are stuck, share the report with your friendly support service"
@@ -88,14 +88,14 @@ test("Client ErrorDialog with traceback", async () => {
     await animationFrame();
     expect(queryAllTexts("main .clearfix div > *")).toEqual([
         "Odoo Client Error",
-        "Occured on 2019-03-11 09:30:00 GMT",
+        "Occured on 11/Mar/2019 09:30:00",
         "ERROR_NAME",
         "Something bad happened",
         "This is a traceback string",
     ]);
     expect(queryAllTexts("main .clearfix div > p")).toEqual([
         "Odoo Client Error",
-        "Occured on 2019-03-11 09:30:00 GMT",
+        "Occured on 11/Mar/2019 09:30:00",
     ]);
     expect(queryAllTexts("main .clearfix div > code")).toEqual([
         "ERROR_NAME",
@@ -115,7 +115,7 @@ test("button clipboard copy error traceback", async () => {
     patchWithCleanup(navigator.clipboard, {
         writeText(value) {
             expect(value).toBe(
-                `${error.name}\n\n${error.message}\n\nOccured on 2019-03-11 09:30:00 GMT\n\n${error.traceback}`
+                `${error.name}\n\n${error.message}\n\nOccured on 11/Mar/2019 09:30:00\n\n${error.traceback}`
             );
         },
     });
@@ -246,4 +246,44 @@ test("SessionExpiredDialog", async () => {
     await click(".o_dialog footer button");
     await animationFrame();
     expect.verifySteps(["location reload"]);
+});
+
+test("ErrorDialog with timestamp provided", async () => {
+    freezeTime();
+    expect(".o_dialog").toHaveCount(0);
+    const env = await makeDialogMockEnv();
+    await mountWithCleanup(ErrorDialog, {
+        env,
+        props: {
+            message: "Something bad happened",
+            data: { debug: "Some strange unreadable stack", timestamp: 1700006000 },
+            name: "ERROR_NAME",
+            traceback: "This is a traceback string",
+            close() {},
+        },
+    });
+    expect(".o_dialog").toHaveCount(1);
+    expect("header .modal-title").toHaveText("Oops!");
+    expect("main summary").toHaveText("See technical details(14/Nov/2023 23:53:20)");
+    expect(queryFirst("main p")).toHaveText(
+        "Something went wrong... If you really are stuck, share the report with your friendly support service"
+    );
+    expect("div.o_error_detail").toHaveCount(1);
+    await click("main summary");
+    await animationFrame();
+    expect(queryAllTexts("main .clearfix div > *")).toEqual([
+        "Odoo Error",
+        "Occured on 14/Nov/2023 23:53:20",
+        "ERROR_NAME",
+        "Something bad happened",
+        "This is a traceback string",
+    ]);
+    expect(queryAllTexts("main .clearfix div > p")).toEqual([
+        "Odoo Error",
+        "Occured on 14/Nov/2023 23:53:20",
+    ]);
+    expect(queryAllTexts("main .clearfix div > code")).toEqual([
+        "ERROR_NAME",
+        "Something bad happened",
+    ]);
 });

--- a/addons/web/static/tests/webclient/clickbot.test.js
+++ b/addons/web/static/tests/webclient/clickbot.test.js
@@ -548,7 +548,7 @@ test("clickbot show rpc error when an error dialog is detected", async () => {
             <div role="alert">
                 <p> Something went wrong... If you really are stuck, share the report with your friendly support service </p>
                 <details>
-                    <summary class="mb-1 link-info">See technical details</summary>
+                    <summary class="mb-1 link-info"><span>See technical details</span><span class="ms-1 text-400 small">(10/Apr/2024 00:00:04)</span></summary>
                     <div class="text-bg-100 clearfix mt-2 position-relative o_error_detail pb-2">
                         <button class="btn position-absolute top-0 end-0 pt-2 btn-link link-body-emphasis" data-available-offline=""><span class="fa fa-clipboard"></span></button>
                         <div class="ps-1 pt-1 ps-md-3 pt-md-3">

--- a/odoo/addons/base/tests/test_ir_cron.py
+++ b/odoo/addons/base/tests/test_ir_cron.py
@@ -128,7 +128,7 @@ class TestIrCron(TransactionCase, CronMixinCase):
         action_params = action.pop('params')
         self.assertEqual(action, {'type': 'ir.actions.client', 'tag': 'display_exception'})
         self.assertEqual(list(action_params), ['code', 'message', 'data'])
-        self.assertEqual(list(action_params['data']), ['name', 'message', 'arguments', 'context', 'debug'])
+        self.assertEqual(list(action_params['data']), ['name', 'message', 'arguments', 'timestamp', 'context', 'debug'])
 
     def test_cron_no_job_ready(self):
         self.cron.nextcall = fields.Datetime.now() + timedelta(days=1)

--- a/odoo/addons/test_http/tests/test_error_http.py
+++ b/odoo/addons/test_http/tests/test_error_http.py
@@ -42,6 +42,7 @@ class TestHttpJsonError(TestHttpBase):
                 'debug': ...,
                 'message': ...,
                 'name': ...,
+                'timestamp': ...,
             },
             'message': ...,
         },

--- a/odoo/addons/test_http/tests/test_webjson2.py
+++ b/odoo/addons/test_http/tests/test_webjson2.py
@@ -36,7 +36,7 @@ class TestHttpWebJson_2(TestHttpBase):
             exc.add_note(response.text)
             raise
         self.assertIsInstance(body, dict, body)
-        self.assertEqual(list(body), ['name', 'message', 'arguments', 'context', 'debug'])
+        self.assertEqual(list(body), ['name', 'message', 'arguments', 'timestamp', 'context', 'debug'])
         self.assertEqual(submap(body, expected_error), expected_error)
 
     def test_webjson2_multi_db_no_header(self):

--- a/odoo/http/dispatcher.py
+++ b/odoo/http/dispatcher.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import logging
+import time
 import traceback
 import typing
 import weakref
 from abc import ABC, abstractmethod
 from http import HTTPStatus
+from wsgiref.handlers import format_date_time
 
 from werkzeug.exceptions import (
     BadRequest,
@@ -69,6 +71,7 @@ def serialize_exception(exception: Exception, *, message: str | None = None, arg
         'name': f'{module}.{name}' if module else name,
         'message': exception_to_unicode(exception) if message is None else message,
         'arguments': exception.args if arguments is None else arguments,
+        'timestamp': int(time.time()),
         'context': getattr(exception, 'context', {}),
         'debug': ''.join(traceback.format_exception(exception)),
     }
@@ -341,7 +344,11 @@ class JsonRPCDispatcher(Dispatcher):
         else:
             response['result'] = result
 
-        return self.request.make_json_response(response)
+        res = self.request.make_json_response(response)
+        if error is not None:
+            if timestamp := error.get('data', {}).get('timestamp'):
+                res.headers['Date'] = format_date_time(timestamp)
+        return res
 
 
 class Json2Dispatcher(Dispatcher):


### PR DESCRIPTION
This commit adds the exact date and time a problem occurred to the error dialog UI.

The timestamp is formatted and timezone-adjusted to match the server logs exactly. This ensures that even if a customer only shares a partial screenshot of an error, support teams can easily search the backend logs to find the specific request that failed.

task-5948597