### PR TITLE
[FIX] *_picking_batch: display only one Validate button

### DIFF
--- a/addons/stock_picking_batch/views/stock_picking_batch_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_batch_views.xml
@@ -77,11 +77,11 @@
                 <header>
                     <button name="action_confirm" invisible="state != 'draft'" string="Confirm" type="object" class="oe_highlight"/>
                     <button name="action_done" string="Validate" type="object" class="oe_highlight"
-                        invisible="state != 'in_progress' or show_check_availability"/>
+                        invisible="not picking_ids or state != 'in_progress' or show_check_availability"/>
                     <button name="action_assign" string="Check Availability" type="object" class="oe_highlight"
                         invisible="state != 'in_progress' or not show_check_availability"/>
                     <button name="action_done" string="Validate" type="object"
-                        invisible="state != 'in_progress' or not show_check_availability"/>
+                        invisible="not picking_ids or state != 'in_progress' or not show_check_availability"/>
                     <button name="action_assign" string="Check Availability" type="object"
                         invisible="state != 'draft' or not show_check_availability"/>
                     <button name="action_print" invisible="state not in ('in_progress', 'done')" string="Print" type="object"/>


### PR DESCRIPTION
Steps to reproduce:
- Create two storable products: “P1” and “P2”
- Create two pickings, one with P1 and another with P2
- Create a quality check for P1
- From the picking list view:
  - Select both pickings and create a batch
- Open the batch

Problem:
Two “Validate” buttons are displayed instead of one.

The inherited view was overriding the original `invisible` attributes of the two existing `action_done` buttons and also adding an extra `action_done` button. Because the original visibility logic was replaced (instead of extended), the conditions were no longer mutually exclusive, causing multiple Validate buttons to be visible at the same time.

Solution:
- Remove the extra `action_done` button added in the inherited view
- Extend the existing `invisible` conditions using `separator=" or "` so the original logic is preserved and the buttons remain mutually exclusive

opw-5508871
