### PR TITLE
[FIX] mrp{,_subcontracting}: prevent access error when generating serials

### DIFF
--- a/addons/mrp/wizard/mrp_production_serial_numbers.py
+++ b/addons/mrp/wizard/mrp_production_serial_numbers.py
@@ -63,7 +63,7 @@ class MrpProductionSerials(models.TransientModel):
             if lot_name in existing_lot_names:
                 continue
             if sequence and lot_name == sequence.get_next_char(sequence.number_next_actual):
-                sequence.number_next_actual += 1
+                sequence.sudo().number_next_actual += 1
             new_lots.append({
                 'name': lot_name,
                 'product_id': self.production_id.product_id.id

--- a/addons/mrp_subcontracting/wizard/mrp_production_serial_numbers.py
+++ b/addons/mrp_subcontracting/wizard/mrp_production_serial_numbers.py
@@ -25,7 +25,7 @@ class MrpProductionSerials(models.TransientModel):
             if lot_name in existing_lot_names:
                 continue
             if sequence and lot_name == sequence.get_next_char(sequence.number_next_actual):
-                sequence.number_next_actual += 1
+                sequence.sudo().number_next_actual += 1
             new_lots.append({
                 'name': lot_name,
                 'product_id': self.production_id.product_id.id


### PR DESCRIPTION
## Issue
When generating a batch of serial numbers, an AccessError is raised if the user does not have the *Write* access on the `ir.sequence` model.

## Steps to reproduce
1. Install *Manufacturing* (`mrp`)
2. In Settings, enable *Lots & Serial Numbers*
3. Create a Product P
    - Tracked *By Unique Serial Number*
    - Create a BoM for product P
5. As a user without *Write* access on the `ir.sequence` model:
    - Create and confirm a Manufacturing Order for product P - Quantity >= 2
    - Click *Generate Serial*, *Generate*, *Apply*
6. **An Access Error is displayed, stating that you are not allowed to modify 'Sequence' records.**

## Cause
Commit https://github.com/odoo/odoo/commit/3ff0f2e3ef4f (and https://github.com/odoo/odoo/commit/9cd0c4affeb1) changed the way the serial sequence was updated by replacing `IrSequence.next_by_id()` with manual incrementation (`IrSequence.number_next_actual += 1`). The former method requires read access but does not require write access, whereas the latter does.

https://github.com/odoo/odoo/blob/8f0a5d31d62ea6fc2a1c94be8501735a01323954/odoo/addons/base/models/ir_sequence.py#L272-L275

Since the write access should not be required to generate serial numbers, the sequence is incremented using `sudo()`.

(related to)
opw-5882578