### PR TITLE
[IMP] hr_timesheet: add confirmation dialog for timesheet deletion

### DIFF
--- a/addons/hr_timesheet/static/src/components/task_timesheet_one2many/task_timesheet_list_renderer.xml
+++ b/addons/hr_timesheet/static/src/components/task_timesheet_one2many/task_timesheet_list_renderer.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="hr_timesheet.TaskTimesheetListRenderer.RecordRow"
+       t-inherit="web.ListRenderer.RecordRow"
+       t-inherit-mode="primary">
+        <xpath expr="//td[contains(@class, 'o_list_record_remove')]/button" position="attributes">
+            <attribute name="data-tooltip">Delete</attribute>
+            <attribute name="class" add="o_task_timesheet_delete" separator=" "/>
+        </xpath>
+    </t>
+</templates>

--- a/addons/hr_timesheet/static/src/components/task_timesheet_one2many/task_timesheet_one2many.js
+++ b/addons/hr_timesheet/static/src/components/task_timesheet_one2many/task_timesheet_one2many.js
@@ -1,0 +1,72 @@
+/** @odoo-module **/
+
+import { _t } from "@web/core/l10n/translation";
+import {
+    ConfirmationDialog,
+    deleteConfirmationMessage,
+} from "@web/core/confirmation_dialog/confirmation_dialog";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { ListRenderer } from "@web/views/list/list_renderer";
+import { X2ManyField, x2ManyField } from "@web/views/fields/x2many/x2many_field";
+
+async function confirmDeleteRecord(dialog, record, onDelete) {
+    if (record.isNew) {
+        return onDelete();
+    }
+    const confirmed = await new Promise((resolve) => {
+        dialog.add(ConfirmationDialog, {
+            body: deleteConfirmationMessage,
+            confirmLabel: _t("Delete"),
+            confirmClass: "btn-danger",
+            confirm: () => resolve(true),
+            cancel: () => resolve(false),
+        });
+    });
+    if (confirmed) {
+        return onDelete();
+    }
+}
+
+class TaskTimesheetListRenderer extends ListRenderer {
+    static recordRowTemplate = "hr_timesheet.TaskTimesheetListRenderer.RecordRow";
+
+    setup() {
+        super.setup();
+        this.dialog = useService("dialog");
+    }
+
+    async onDeleteRecord(record) {
+        return confirmDeleteRecord(this.dialog, record, () => super.onDeleteRecord(record));
+    }
+}
+
+class TaskTimesheetOne2ManyField extends X2ManyField {
+    static components = {
+        ...X2ManyField.components,
+        ListRenderer: TaskTimesheetListRenderer,
+    };
+
+    setup() {
+        super.setup();
+        this.dialog = useService("dialog");
+        this._baseOnDelete = this.activeActions.onDelete;
+    }
+
+    get rendererProps() {
+        const rendererProps = super.rendererProps;
+        if (this.props.viewMode !== "kanban" || !this._baseOnDelete) {
+            return rendererProps;
+        }
+        this.activeActions.onDelete = (record) =>
+            confirmDeleteRecord(this.dialog, record, () => this._baseOnDelete(record));
+        return rendererProps;
+    }
+}
+
+const taskTimesheetOne2ManyField = {
+    ...x2ManyField,
+    component: TaskTimesheetOne2ManyField,
+};
+
+registry.category("fields").add("task_timesheet_one2many", taskTimesheetOne2ManyField);

--- a/addons/hr_timesheet/static/src/scss/timesheets_task_form.scss
+++ b/addons/hr_timesheet/static/src/scss/timesheets_task_form.scss
@@ -1,3 +1,7 @@
 .o_web_studio_form_view_editor .o_field_widget.o_web_studio_widget_empty.o_task_planned_hours {
     max-width: 70ch;
 }
+
+.o_list_record_remove button.o_task_timesheet_delete:hover {
+    color: $o-danger;
+}

--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -41,7 +41,7 @@
                         <field name="analytic_account_active" invisible="1"/>
                     </t>
                     <page string="Timesheets" name="page_timesheets" id="timesheets_tab" invisible="not allow_timesheets or has_template_ancestor or has_project_template or (not id and context.get('hide_timesheet_ids'))" groups="hr_timesheet.group_hr_timesheet_user">
-                    <field name="timesheet_ids" mode="list,kanban" readonly="not analytic_account_active" context="{'default_project_id': project_id, 'default_name': '', 'form_view_ref': 'hr_timesheet.timesheet_view_form_user'}">
+                    <field name="timesheet_ids" mode="list,kanban" readonly="not analytic_account_active" context="{'default_project_id': project_id, 'default_name': '', 'form_view_ref': 'hr_timesheet.timesheet_view_form_user'}" widget="task_timesheet_one2many">
                         <list editable="bottom" string="Timesheet Activities" decoration-muted="readonly_timesheet == True">
                             <field name="readonly_timesheet" column_invisible="True"/>
                             <field name="date" readonly="readonly_timesheet"/>


### PR DESCRIPTION
Prevent accidental deletion of timesheet entries in related lists by adding a confirmation dialog. The delete button now turns red on hover and displays a tooltip to improve visibility of this destructive action.

Users must confirm before any timesheet record is permanently removed, reducing unintended data loss.

task-5149854

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
