### PR TITLE
[IMP] point_of_sale: Global discount exclude from gift receipt

### DIFF
--- a/addons/pos_discount/__manifest__.py
+++ b/addons/pos_discount/__manifest__.py
@@ -18,6 +18,7 @@ discount to a customer.
         'views/res_config_settings_views.xml',
         'views/pos_config_views.xml',
         'views/pos_session_sales_details.xml',
+        'receipt/pos_order_receipt.xml',
         ],
     'assets': {
         'point_of_sale._assets_pos': [

--- a/addons/pos_discount/receipt/pos_order_receipt.xml
+++ b/addons/pos_discount/receipt/pos_order_receipt.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data>
+        <template id="pos_discount.pos_order_receipt" inherit_id="point_of_sale.pos_order_receipt">
+            <xpath expr="//t[@t-call='point_of_sale.pos_orderline_receipt']" position="attributes">
+                <attribute name="t-if">not (line['product_id'] == config['discount_product_id'] and conditions['basic_receipt'])</attribute>
+            </xpath>
+        </template>
+    </data>
+</odoo>


### PR DESCRIPTION
Global discount line applied to an order was visible in the basic receipt. We souldn't see these lines.

task-id: 5944518

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
