### PR TITLE
[IMP] auth_oauth: move `fragment_to_query_string` in tools

### DIFF
--- a/addons/auth_oauth/controllers/main.py
+++ b/addons/auth_oauth/controllers/main.py
@@ -1,5 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-import functools
 import json
 import logging
 
@@ -8,41 +7,17 @@ from werkzeug.exceptions import BadRequest
 
 from odoo import SUPERUSER_ID, _, api
 from odoo.exceptions import AccessDenied
-from odoo.http import Controller, Response, request, route
+from odoo.http import Controller, request, route
 from odoo.http.router import db_filter
 from odoo.http.session import authenticate
 from odoo.modules.registry import Registry
 from odoo.tools.misc import clean_context
+from odoo.tools.http import fragment_to_query_string
 
 from odoo.addons.auth_signup.controllers.main import AuthSignupHome as Home
 from odoo.addons.web.controllers.utils import _get_login_redirect_url, ensure_db
 
 _logger = logging.getLogger(__name__)
-
-
-# ----------------------------------------------------------
-# helpers
-# ----------------------------------------------------------
-def fragment_to_query_string(func):
-    @functools.wraps(func)
-    def wrapper(self, *a, **kw):
-        kw.pop('debug', False)
-        if not kw:
-            return Response("""<html><head><script>
-                var l = window.location;
-                var q = l.hash.substring(1);
-                var r = l.pathname + l.search;
-                if(q.length !== 0) {
-                    var s = l.search ? (l.search === '?' ? '' : '&') : '?';
-                    r = l.pathname + l.search + s + q;
-                }
-                if (r == l.pathname) {
-                    r = '/';
-                }
-                window.location = r;
-            </script></head><body></body></html>""")
-        return func(self, *a, **kw)
-    return wrapper
 
 
 # ----------------------------------------------------------

--- a/addons/html_editor/static/src/fields/x2many_field/custom_media_dialog.js
+++ b/addons/html_editor/static/src/fields/x2many_field/custom_media_dialog.js
@@ -9,6 +9,8 @@ export class CustomMediaDialog extends MediaDialog {
         extraTabs: t
             .array(t.object())
             .optional([{ id: "VIDEOS", title: _t("Videos"), Component: VideoSelector }]),
+        imageSave: t.function(),
+        videoSave: t.function().optional(),
     });
     async save() {
         if (this.errorMessages[this.activeTab()]) {

--- a/addons/html_editor/static/src/fields/x2many_field/x2many_image_field.js
+++ b/addons/html_editor/static/src/fields/x2many_field/x2many_image_field.js
@@ -7,6 +7,12 @@ import { saveSingleAttachment } from "@web/core/utils/image_library";
 
 export class X2ManyImageField extends ImageField {
     static template = "html_editor.ImageField";
+    static props = {
+        ...ImageField.props,
+        setAttachmentId: { type: Boolean, optional: true },
+        onlyImage: { type: Boolean, optional: true },
+    };
+
     setup() {
         super.setup();
         this.orm = useService("orm");
@@ -29,7 +35,7 @@ export class X2ManyImageField extends ImageField {
             mediaEl.dataset.src = this.props.record.data.video_url;
         }
         return {
-            visibleTabs: ["IMAGES", "VIDEOS"],
+            visibleTabs: this.props.onlyImage ? ["IMAGES"] : ["IMAGES", "VIDEOS"],
             media: mediaEl,
             activeTab: isVideo ? "VIDEOS" : "IMAGES",
             save: (el) => {}, // Simple rebound to fake its execution
@@ -37,11 +43,13 @@ export class X2ManyImageField extends ImageField {
             videoSave: this.onVideoSave.bind(this),
         };
     }
+
     async onImageSave(attachments) {
         await saveSingleAttachment(this.env, {
             attachment: attachments[0],
             targetRecord: this.props.record,
             targetFieldName: this.props.name,
+            setAttachmentId: this.props.setAttachmentId,
             changeRecordName: true,
         });
     }
@@ -63,6 +71,20 @@ export class X2ManyImageField extends ImageField {
 export const x2ManyImageField = {
     ...imageField,
     component: X2ManyImageField,
+    extractProps: (
+        { attrs, relatedFields, viewMode, views, widget, options, string },
+        dynamicInfo
+    ) => {
+        const x2ManyFieldProps = imageField.extractProps(
+            { attrs, relatedFields, viewMode, views, widget, options, string },
+            dynamicInfo
+        );
+        return {
+            ...x2ManyFieldProps,
+            setAttachmentId: options.set_attachment_id,
+            onlyImage: options.only_image,
+        };
+    },
 };
 
 registry.category("fields").add("x2_many_image", x2ManyImageField);

--- a/addons/html_editor/static/src/fields/x2many_field/x2many_media_viewer.js
+++ b/addons/html_editor/static/src/fields/x2many_field/x2many_media_viewer.js
@@ -11,6 +11,9 @@ export class X2ManyMediaViewer extends X2ManyField {
     static props = {
         ...X2ManyField.props,
         convertToWebp: { type: Boolean, optional: true },
+        forceCreate: { type: Boolean, optional: true },
+        setAttachmentId: { type: Boolean, optional: true },
+        onlyImage: { type: Boolean, optional: true },
     };
 
     setup() {
@@ -32,7 +35,7 @@ export class X2ManyMediaViewer extends X2ManyField {
         return {
             save: (el) => {}, // Simple rebound to fake its execution
             multiImages: true,
-            visibleTabs: ["IMAGES", "VIDEOS"],
+            visibleTabs: this.props.onlyImage ? ["IMAGES"] : ["IMAGES", "VIDEOS"],
             imageSave: this.onImageSave.bind(this),
             videoSave: this.onVideoSave.bind(this),
         };
@@ -52,6 +55,8 @@ export class X2ManyMediaViewer extends X2ManyField {
             targetRecord: this.props.record,
             targetFieldName: this.props.name,
             convertToWebp: this.props.convertToWebp,
+            forceCreate: this.props.forceCreate,
+            setAttachmentId: this.props.setAttachmentId,
         });
     }
 
@@ -74,6 +79,9 @@ export const x2ManyMediaViewer = {
         return {
             ...x2ManyFieldProps,
             convertToWebp: options.convert_to_webp,
+            forceCreate: options.force_create,
+            setAttachmentId: options.set_attachment_id,
+            onlyImage: options.only_image,
         };
     },
 };

--- a/addons/mass_mailing/wizard/mailing_mailing_schedule_date_views.xml
+++ b/addons/mass_mailing/wizard/mailing_mailing_schedule_date_views.xml
@@ -7,7 +7,8 @@
             <form string="Take Future Schedule Date">
                 <group>
                     <group>
-                        <field name="schedule_date" string="Send on" placeholder="Choose a date" required="1"/>
+                        <field name="schedule_date" string="Send on" placeholder="Choose a date" required="1"
+                            options="{'auto_open': True}"/>
                     </group>
                 </group>
                 <footer>

--- a/addons/web/static/src/core/utils/image_library.js
+++ b/addons/web/static/src/core/utils/image_library.js
@@ -1,6 +1,6 @@
 export async function saveSingleAttachment(
     env,
-    { attachment, targetRecord, targetFieldName, changeRecordName }
+    { attachment, targetRecord, targetFieldName, changeRecordName, setAttachmentId }
 ) {
     const attachmentRecord = (
         await retrieveAttachmentRecords(env, { attachmentIds: [attachment.id] })
@@ -8,18 +8,22 @@ export async function saveSingleAttachment(
     if (!attachmentRecord.raw) {
         return notifyURLAttachmentUploadFailed(env, { attachmentName: attachmentRecord.name });
     }
-    const update_data = {
-        [targetFieldName]: attachmentRecord.raw,
-    };
-    if (changeRecordName) {
-        update_data["name"] = attachmentRecord.name;
+
+    const update_data = {};
+    if (setAttachmentId) {
+        update_data[targetFieldName] = attachmentRecord;
+    } else {
+        update_data[targetFieldName] = attachmentRecord.raw;
+        if (changeRecordName) {
+            update_data["name"] = attachmentRecord.name;
+        }
     }
     await targetRecord.update(update_data);
 }
 
 export async function saveMultipleAttachments(
     env,
-    { attachments, targetRecord, targetFieldName, convertToWebp }
+    { attachments, targetRecord, targetFieldName, convertToWebp, setAttachmentId, forceCreate }
 ) {
     const imageList = targetRecord.data[targetFieldName];
     const supportedFields = ["image_1920", "image_1024", "image_512", "image_256", "image_128"];
@@ -34,16 +38,26 @@ export async function saveMultipleAttachments(
             await convertToWebpFormat(env, { attachmentRecord });
         }
         const activeFields = imageList.activeFields;
-        imageList.addNewRecord({ position: "bottom" }).then((record) => {
-            const updateData = {};
+        const updateData = {};
+        if (setAttachmentId) {
+            updateData["attachment_id"] = attachmentRecord.id;
+        } else {
             for (const field in activeFields) {
                 if (attachmentRecord.raw && supportedFields.includes(field)) {
                     updateData[field] = attachmentRecord.raw;
                     updateData["name"] = attachmentRecord.name;
                 }
             }
+        }
+
+        if (forceCreate) {
+            imageList.linkTo(
+                await env.services.orm.call(imageList._config.resModel, "create", [updateData])
+            );
+        } else {
+            const record = await imageList.addNewRecord({ position: "bottom" });
             record.update(updateData);
-        });
+        }
     }
 }
 

--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -1,5 +1,5 @@
 import { onWillRender, useLayoutEffect, useRef, useState } from "@web/owl2/utils";
-import { Component } from "@odoo/owl";
+import { Component, onMounted } from "@odoo/owl";
 import { useDateTimePicker } from "@web/core/datetime/datetime_picker_hook";
 import { areDatesEqual, deserializeDate, deserializeDateTime, today } from "@web/core/l10n/dates";
 import { localization } from "@web/core/l10n/localization";
@@ -52,6 +52,7 @@ export class DateTimeField extends Component {
         warnFuture: { type: Boolean, optional: true },
         showSeconds: { type: Boolean, optional: true },
         showTime: { type: Boolean, optional: true },
+        autoOpen: { type: Boolean, optional: true },
         minPrecision: {
             type: String,
             optional: true,
@@ -176,6 +177,12 @@ export class DateTimeField extends Component {
         );
 
         onWillRender(() => this.triggerIsDirty());
+
+        onMounted(() => {
+            if (this.props.autoOpen) {
+                this.openPicker();
+            }
+        })
 
         this.futureWarningMsg = _t("This date is in the future");
     }
@@ -485,6 +492,7 @@ export const dateField = {
         warnFuture: Boolean(options.warn_future),
         minPrecision: options.min_precision,
         maxPrecision: options.max_precision,
+        autoOpen: options.auto_open,
     }),
     listViewWidth: ({ options }) =>
         options.numeric ? FIELD_WIDTHS.numeric_date : FIELD_WIDTHS.date,

--- a/addons/web/static/src/views/fields/many2many_checkboxes/many2many_checkboxes_field.js
+++ b/addons/web/static/src/views/fields/many2many_checkboxes/many2many_checkboxes_field.js
@@ -23,19 +23,7 @@ export class Many2ManyCheckboxesField extends Component {
         this.specialData = useSpecialData((orm, props) => {
             const { relation } = props.record.fields[props.name];
             const domain = getFieldDomain(props.record, props.name, props.domain);
-            return orm
-                .call(relation, "name_search", ["", domain], {
-                    context: this.props.context || {},
-                })
-                .catch((error) => {
-                    if (error instanceof ConnectionLostError) {
-                        return this.props.record.data[this.props.name].records.map((r) => [
-                            r.resId,
-                            r.data.display_name,
-                        ]);
-                    }
-                    throw error;
-                });
+            return this.fetchSpecialData(orm, relation, domain);
         });
         // these two sets track pending changes in the relation, and allow us to
         // batch consecutive changes into a single replaceWith, thus saving
@@ -45,6 +33,26 @@ export class Many2ManyCheckboxesField extends Component {
         this.debouncedCommitChanges = debounce(this.commitChanges.bind(this), 500);
         useBus(this.props.record.model.bus, "NEED_LOCAL_CHANGES", this.commitChanges.bind(this));
         onWillUnmount(this.commitChanges.bind(this));
+    }
+
+    /**
+     * Fetch the special data for the field
+     * (by default perform a name search).
+     */
+    async fetchSpecialData(orm, relation, domain) {
+        return orm
+            .call(relation, "name_search", ["", domain], {
+                context: this.props.context || {},
+            })
+            .catch((error) => {
+                if (error instanceof ConnectionLostError) {
+                    return this.props.record.data[this.props.name].records.map((r) => [
+                        r.resId,
+                        r.data.display_name,
+                    ]);
+                }
+                throw error;
+            });
     }
 
     get items() {

--- a/odoo/tools/http.py
+++ b/odoo/tools/http.py
@@ -1,0 +1,24 @@
+import functools
+from odoo.http import Response
+
+
+def fragment_to_query_string(func):
+    @functools.wraps(func)
+    def wrapper(self, *a, **kw):
+        kw.pop('debug', False)
+        if not kw:
+            return Response("""<html><head><script>
+                var l = window.location;
+                var q = l.hash.substring(1);
+                var r = l.pathname + l.search;
+                if(q.length !== 0) {
+                    var s = l.search ? (l.search === '?' ? '' : '&') : '?';
+                    r = l.pathname + l.search + s + q;
+                }
+                if (r == l.pathname) {
+                    r = '/';
+                }
+                window.location = r;
+            </script></head><body></body></html>""")
+        return func(self, *a, **kw)
+    return wrapper


### PR DESCRIPTION
Move `fragment_to_query_string` in tools
========================================
`fragment_to_query_string` is used in the social module but now show
a warning because it does not depend on `auth_oauth`, so we move the
function to the "tools" folder.

Allow to force the creation of the record
=========================================
In social, the same record can be used on many image fields (one for
each medias). Because of that, we need to have the same behavior as
the "many2many binary" widget, and the file record needs to be created
before updating the field (see `/web/binary/upload_attachment`).

Allow writing on `attachment_id` to not duplicate the `ir.attachment`
when using the same image on different fields.

Allow changing which field are fetched for `many2many_checkboxes`
=================================================================
In social, we would like to show an icon corresponding to the media of
the `social.account`. For that, we need to be able to change which
fields are read when fetching the records.

Fix the image dialog
====================
Since https://github.com/odoo/odoo/commit/55fd748ada717df5b27376c81a8eba53d9b8ddac , we added the `props`
function, and so now `this.props.xxx` crash if `xxx` is not listed in
the `props` function.

Task-5491124