### PR TITLE
[FIX] mrp, stock{_picking_batch}: disabled quick creation of picking types

### DIFF
--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -152,7 +152,7 @@
                                     <field name="allow_operation_dependencies" groups="mrp.group_mrp_workorder_dependencies"/>
                                 </group>
                                 <group>
-                                    <field name="picking_type_id" invisible="type == 'phantom'" string="Routing" groups="stock.group_adv_location"/>
+                                    <field name="picking_type_id" options="{'no_quick_create': True}" invisible="type == 'phantom'" string="Routing" groups="stock.group_adv_location"/>
                                     <label for="produce_delay" string="Manuf. Lead Time"/>
                                     <div>
                                         <field name="produce_delay" class="oe_inline"/> days

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -536,7 +536,7 @@
                         <page string="Miscellaneous" name="miscellaneous">
                             <group>
                                 <group>
-                                    <field name="picking_type_id" readonly="state not in ('draft', 'confirmed')"/>
+                                    <field name="picking_type_id" options="{'no_quick_create': True}" readonly="state not in ('draft', 'confirmed')"/>
                                     <field name="location_src_id" groups="stock.group_stock_multi_locations" options="{'no_create': True}" readonly="state != 'draft'"/>
                                     <field name="location_src_id" groups="!stock.group_stock_multi_locations" invisible="1"/>
                                     <field name="warehouse_id" invisible="1"/>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -93,7 +93,7 @@
                     <field name="date_done" string="Effective Date" optional="hide"/>
                     <field name="origin" optional="show" readonly="state in ['cancel', 'done']"/>
                     <field name="backorder_id" optional="hide"/>
-                    <field name="picking_type_id" optional="hide"/>
+                    <field name="picking_type_id" options="{'no_quick_create': True}" optional="hide"/>
                     <field name="company_id" groups="base.group_multi_company" optional="show"/>
                     <field name="state" optional="show" widget="badge"
                            decoration-danger="state=='cancel'"
@@ -209,7 +209,7 @@
                                        invisible="picking_type_code in ['incoming', 'outgoing']"/>
                             </div>
                             <field name="partner_id" nolabel="1" readonly="state in ['cancel', 'done']" placeholder="e.g. Lumber Inc"/>
-                            <field name="picking_type_id" options="{'no_open': True}"
+                            <field name="picking_type_id" options="{'no_open': True, 'no_quick_create': True}"
                                    readonly="state in ('done', 'cancel')"
                                    domain="[('code', 'in', ('incoming', 'outgoing', 'internal'))]" />
                             <field name="location_id" groups="!stock.group_stock_multi_locations" invisible="1" readonly="state == 'done'"/>

--- a/addons/stock/views/stock_rule_views.xml
+++ b/addons/stock/views/stock_rule_views.xml
@@ -74,7 +74,7 @@
                                 <field name="company_id" invisible="1"/>
                                 <field name="picking_type_code_domain" invisible="1"/>
                                 <field name="action"/>
-                                <field name="picking_type_id"/>
+                                <field name="picking_type_id" options="{'no_quick_create': True}"/>
                                 <field name="location_src_id" options="{'no_create': True}" required="action in ['pull', 'push', 'pull_push']"/>
                                 <field name="location_dest_id" options="{'no_create': True}"/>
                                 <field name="location_dest_from_rule" invisible="action not in ['pull', 'pull_push']" groups="base.group_no_one"/>

--- a/addons/stock_picking_batch/views/stock_picking_batch_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_batch_views.xml
@@ -102,7 +102,7 @@
                     <group>
                         <group id="batch_delivery_data">
                             <field name="user_id" readonly="state not in ['draft', 'in_progress']"/>
-                            <field name="picking_type_id" readonly="state != 'draft'"/>
+                            <field name="picking_type_id" options="{'no_quick_create': True}" readonly="state != 'draft'"/>
                             <field name="company_id" groups="base.group_multi_company" readonly="picking_ids" force_save="1"/>
                             <field name="scheduled_date" readonly="state in ['cancel', 'done']"/>
                             <field name="description"/>
@@ -139,7 +139,7 @@
                 <field name="description"/>
                 <field name="scheduled_date" readonly="state in ['cancel', 'done']"/>
                 <field name="user_id" widget="many2one_avatar_user" readonly="state not in ['draft', 'in_progress']"/>
-                <field name="picking_type_id" readonly="state != 'draft'"/>
+                <field name="picking_type_id" options="{'no_quick_create': True}" readonly="state != 'draft'"/>
                 <field name="company_id" optional="hide" groups="base.group_multi_company"/>
                 <field name="state" widget="badge" decoration-success="state == 'done'" decoration-info="state in ('draft', 'in_progress')" decoration-danger="state == 'cancel'"/>
                 <field name="activity_exception_decoration" widget="activity_exception"/>


### PR DESCRIPTION
Currently an error occurs when user quick creates a picking type and tries to create a  receipt with it.

**Steps to replicate (only in saas-19.1 and above):**
- Install stock.
- Go to Inventory > Receipts and create a new receipt > Save it.
- Clear the Operation Type field, type `test` and quick create it.
- Save and the error will occur.

**Error:**
```
UndefinedFunction: operator does not exist: integer = boolean
LINE 1: SELECT number_next FROM ir_sequence WHERE id=false FOR UPDAT...
```

**Cause:**
- As the user quick created the picking type, the `sequence_code` field was not set and when we try to get `next_number` to create the name for the current stock picking this error occurs.

- In the versions before `saas-19.1` trying to quick create picking type will lead to a `Not-Null Violation` as `sequence_code` is a required field and then stock picking type form view will open up.

- This error occurs only after `saas-19.1` and above versions because this [PR] made the `sequence_code` field into a related field so its required constraint was removed and hence quick create creates a new picking type.

**Solution:**
- Since Quick Create always opens the picking type form view (same behavior as `Create and edit` before saas-19.1), it should be disabled to avoid redundancy.
- This also prevents the error in versions `saas-19.1` and above.

[PR]: https://github.com/odoo/odoo/pull/190305/changes#diff-79cbc763115661182c02285c07320098510f5686700359ddee67443b4893dc30L32-R32

sentry-7203804886
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
