### PR TITLE
[IMP] website_slides: redirect internal users to backend view for message links

### DIFF
--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -1142,9 +1142,10 @@ class Channel(models.Model):
         return activities
 
     def _get_access_action(self, access_uid=None, force_website=False):
-        """ Instead of the classic form view, redirect to website if it is published. """
+        """ Instead of the classic form view, redirect non-internal users to website
+        if it is published. """
         self.ensure_one()
-        if force_website or self.website_published:
+        if force_website or (self.website_published and self.env.user.share):
             return {
                 "type": "ir.actions.act_url",
                 "url": self.website_url,


### PR DESCRIPTION
Since #202555, a message link in slides redirects internal users to the website
page if it's published.
To ensure consistency with other documents in the portal, this commit
redirects internal users to the backend form view of the slides.
Portal and public users continue to be redirected to the published website page.