### PR TITLE
[IMP] core: make optparse resilient to prefix collision

### DIFF
--- a/odoo/addons/base/tests/test_configmanager.py
+++ b/odoo/addons/base/tests/test_configmanager.py
@@ -764,3 +764,8 @@ class TestConfigManager(TransactionCase):
             _, options = self.parse_reset(['--db_replica_host', '', '--dev', 'replica'])
         self.assertIsNone(options['db_replica_host'])
         self.assertEqual(options['dev_mode'], ['replica'])
+
+    def test_14_st_for_stop(self):
+        # Remove this test once there's a new option that also start with --st
+        _, options = self.parse_reset(['--st'])
+        self.assertTrue(options['stop_after_init'])

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -37,6 +37,23 @@ class _Empty:
 EMPTY = _Empty()
 
 
+class OdooOptionParser(optparse.OptionParser):
+    def _match_long_opt(self, opt):
+        # --st is an "ambigous" prefix for --stop and --stop-after-init
+        # which actually are the same option, make it return that single
+        # option.
+        possibilities = [
+            (long_opt, option)
+            for long_opt, option
+            in self._long_opt.items()
+            if long_opt.startswith(opt)
+        ]
+        possible_targets = set(p[1] for p in possibilities)
+        if len(possible_targets) == 1:
+            return possibilities[0][0]
+        return super()._match_long_opt(opt)
+
+
 class _OdooOption(optparse.Option):
     config = None  # must be overriden
 
@@ -192,7 +209,7 @@ class configmanager:
         PosixOnlyOption = type('PosixOnlyOption', (_PosixOnlyOption, OdooOption), {})
 
         version = "%s %s" % (release.description, release.version)
-        parser = optparse.OptionParser(version=version, option_class=OdooOption)
+        parser = OdooOptionParser(version=version, option_class=OdooOption)
 
         parser.add_option(FileOnlyOption(dest='admin_passwd', my_default='admin'))
         parser.add_option(FileOnlyOption(dest='bin_path', type='path', my_default='', file_exportable=False))


### PR DESCRIPTION
Start Odoo with "odoo-bin --st", it crashes with the following error:

> error: ambiguous option: --st (--stop, --stop-after-init?)

There are no "--st" option, and optparse makes a best-effort to match a corresponding option. If there is only a single long-option that starts with that prefix, optparse will use the option. Sadly it doesn't work when there is a single option with multiple long-options that all start with the same prefix, like --st for --stop and --stop-after-init.

It is a silly limitation of optparse, in this work we add support for that specific case.