### PR TITLE
[IMP] orm: Model concat, union change

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -1108,7 +1108,7 @@ class AccountAccount(models.Model):
 
             records_list.append(new_accounts)
 
-        records = self.env['account.account'].union(*records_list)
+        records = self.env['account.account'].union(records_list)
         records._ensure_code_is_unique()
         return records
 
@@ -1337,7 +1337,7 @@ class AccountAccount(models.Model):
             })
             for company in companies_to_update
         }
-        new_accounts = self.env['account.account'].union(*new_account_by_company.values())
+        new_accounts = self.env['account.account'].union(new_account_by_company.values())
 
         # Step 3: Update foreign keys in DB.
 

--- a/addons/account/models/account_document_import_mixin.py
+++ b/addons/account/models/account_document_import_mixin.py
@@ -458,11 +458,11 @@ class AccountDocumentImportMixin(models.AbstractModel):
             This only returns those elements in `files_data` which correspond to an ir.attachment
             (thus, embedded files that were never turned into ir.attachments are omitted).
         """
-        return self.env['ir.attachment'].union(*(
+        return self.env['ir.attachment'].union(
             file_data['attachment']
             for file_data in files_data
             if file_data.get('attachment')
-        ))
+        )
 
     @api.model
     def _get_import_file_type(self, file_data):

--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -1163,7 +1163,7 @@ class AccountJournal(models.Model):
     def show_unhashed_entries(self):
         self.ensure_one()
         chains_to_hash = self._get_moves_to_hash(include_pre_last_hash=True, early_stop=False)
-        moves = self.env['account.move'].concat(*[chain_moves['moves'] for chain_moves in chains_to_hash])
+        moves = self.env['account.move'].concat(chain_moves['moves'] for chain_moves in chains_to_hash)
         action = {
             'type': 'ir.actions.act_window',
             'name': _('Journal Entries to Hash'),

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1948,9 +1948,9 @@ class AccountMove(models.Model):
         self.fetch(['fiscal_position_id', 'company_id'])
         foreign_vat_records = self.filtered(lambda r: r.fiscal_position_id.foreign_vat)
         for fiscal_position_id, record_group in groupby(foreign_vat_records, key=lambda r: r.fiscal_position_id):
-            self.env['account.move'].concat(*record_group).tax_country_id = fiscal_position_id.country_id
+            self.env['account.move'].concat(record_group).tax_country_id = fiscal_position_id.country_id
         for company_id, record_group in groupby((self-foreign_vat_records), key=lambda r: r.company_id):
-            self.env['account.move'].concat(*record_group).tax_country_id = company_id.account_fiscal_country_id
+            self.env['account.move'].concat(record_group).tax_country_id = company_id.account_fiscal_country_id
 
     @api.depends('tax_country_id')
     def _compute_tax_country_code(self):

--- a/addons/account/models/account_partial_reconcile.py
+++ b/addons/account/models/account_partial_reconcile.py
@@ -165,7 +165,7 @@ class AccountPartialReconcile(models.Model):
                 if not payment.currency_id.compare_amounts(payment.amount_signed, amount):
                     to_update.append(payment)
                     break
-        return self.env['account.payment'].union(*to_update)
+        return self.env['account.payment'].union(to_update)
 
     @api.model
     def _update_matching_number(self, amls):

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -459,7 +459,7 @@ class AccountPaymentRegister(models.TransientModel):
                 wizard.can_edit_wizard = True
             else:
                 # == Multiple batches: The wizard is not editable  ==
-                lines = self.env['account.move.line'].union(*(batch_result['lines'] for batch_result in batches))
+                lines = self.env['account.move.line'].union(batch_result['lines'] for batch_result in batches)
                 company = min(lines.company_id, key=lambda c: len(c.parent_ids)) if not self._from_sibling_companies(lines) else lines.company_id.root_id
                 wizard.update({
                     'company_id': company.id,
@@ -1342,7 +1342,7 @@ class AccountPaymentRegister(models.TransientModel):
                     'batch': batch_result,
                 } for batch_result in batches)
 
-        lines = self.env['account.move.line'].union(*(batch_result['lines'] for batch_result in batches))
+        lines = self.env['account.move.line'].union(batch_result['lines'] for batch_result in batches)
         from_sibling_companies = self._from_sibling_companies(lines)
         if from_sibling_companies and lines.company_id.root_id not in self.env.companies:
             # Payment made for sibling companies, we don't want to redirect to the payments

--- a/addons/account/wizard/account_secure_entries_wizard.py
+++ b/addons/account/wizard/account_secure_entries_wizard.py
@@ -68,8 +68,8 @@ class AccountSecureEntriesWizard(models.TransientModel):
         for wizard in self:
             chains_to_hash = wizard.with_context(chain_info_warnings=False)._get_chains_to_hash(wizard.company_id, today)
             moves = self.env['account.move'].concat(
-                *[chain['moves'] for chain in chains_to_hash],
-                *[chain['not_hashable_unlocked_moves'] for chain in chains_to_hash],
+                [chain['moves'] for chain in chains_to_hash]
+                + [chain['not_hashable_unlocked_moves'] for chain in chains_to_hash]
             )
             if moves:
                 min_date = self.env.execute_query(

--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -551,8 +551,7 @@ class CrmTeam(models.Model):
 
         # assign team to direct assign (leads_assigned) + dups keys (to ensure their team
         # if they are elected master of merge process)
-        dups_to_assign = [lead for lead in leads_dups_dict]
-        leads_assigned.union(*dups_to_assign)._handle_salesmen_assignment(user_ids=None, team_id=self.id)
+        leads_assigned.browse().union([leads_assigned, *leads_dups_dict])._handle_salesmen_assignment(user_ids=None, team_id=self.id)
 
         for lead in leads.filtered(lambda lead: lead in leads_dups_dict):
             lead_duplicates = leads_dups_dict[lead]
@@ -663,7 +662,7 @@ class CrmTeam(models.Model):
                     ])
                 ) for member in members_to_assign_wpref
             }
-            preferred_leads = self.env['crm.lead'].concat(*[lead for lead in preferred_leads_per_member.values()])
+            preferred_leads = self.env['crm.lead'].concat(preferred_leads_per_member.values())
             assigned_preferred_leads = self.env['crm.lead']
 
             # first assign loop: preferred leads, always priority

--- a/addons/hr_attendance/models/hr_version.py
+++ b/addons/hr_attendance/models/hr_version.py
@@ -27,7 +27,7 @@ class HrVersion(models.Model):
     def _get_versions_by_employee_and_date(self, employee_dates):
         # for `employee_dates` a dict[employee] -> dates
         # Generate a 2 level dict[employee][date] -> version
-        employees = self.env['hr.employee'].union(*employee_dates.keys())
+        employees = self.env['hr.employee'].union(employee_dates.keys())
         all_dates = [date for dates in employee_dates.values() for date in dates]
         if not all_dates:
             return {}

--- a/addons/hr_timesheet/controllers/portal.py
+++ b/addons/hr_timesheet/controllers/portal.py
@@ -139,7 +139,7 @@ class TimesheetCustomerPortal(CustomerPortal):
                 else:
                     time_data = Timesheet_sudo._read_group(domain, [field], ['unit_amount:sum'])
                     mapped_time = {field.id: unit_amount for field, unit_amount in time_data}
-                    grouped_timesheets = [(Timesheet_sudo.concat(*g), mapped_time[k.id]) for k, g in groupbyelem(timesheets, itemgetter(field))]
+                    grouped_timesheets = [(Timesheet_sudo.concat(g), mapped_time[k.id]) for k, g in groupbyelem(timesheets, itemgetter(field))]
                 return timesheets, grouped_timesheets
 
             grouped_timesheets = [(

--- a/addons/l10n_hu_edi/models/account_move.py
+++ b/addons/l10n_hu_edi/models/account_move.py
@@ -385,7 +385,7 @@ class AccountMove(models.Model):
                 'action_text': _('View invoice(s)'),
             },
             'invoice_chain_not_confirmed': {
-                'records': self.env['account.move'].union(*[
+                'records': self.env['account.move'].union(
                     move._l10n_hu_get_chain_base()._l10n_hu_get_chain_invoices().filtered(
                         lambda m: (
                             m.id < move.id
@@ -394,7 +394,7 @@ class AccountMove(models.Model):
                         )
                     )
                     for move in self
-                ]),
+                ),
                 'message': _('The following invoices appear to be earlier in the chain, but have not yet been sent. Please send them first.'),
                 'action_text': _('View invoice(s)'),
             },
@@ -490,7 +490,7 @@ class AccountMove(models.Model):
         # Batch by company, with max 100 invoices per batch.
         for __, batch_company in groupby(invoices_sorted, lambda m: m.company_id):
             for batch in split_every(100, batch_company):
-                self.env['account.move'].union(*batch)._l10n_hu_edi_upload_single_batch(connection)
+                self.env['account.move'].union(batch)._l10n_hu_edi_upload_single_batch(connection)
 
     def _l10n_hu_edi_get_operation_type(self):
         base_invoice = self._l10n_hu_get_chain_base()
@@ -580,7 +580,7 @@ class AccountMove(models.Model):
 
         # Querying status should be grouped by company and transaction code
         for __, invoices_grouped in groupby(invoices, lambda m: (m.company_id, m.l10n_hu_edi_transaction_code)):
-            self.env['account.move'].union(*invoices_grouped)._l10n_hu_edi_query_status_single_batch(connection)
+            self.env['account.move'].union(invoices_grouped)._l10n_hu_edi_query_status_single_batch(connection)
 
     def _l10n_hu_edi_query_status_single_batch(self, connection):
         """ Check the NAV status for invoices that share the same transaction code (uploaded in a single batch). """
@@ -736,7 +736,7 @@ class AccountMove(models.Model):
         # Batch by company, with max 100 annulment requests per batch.
         for __, batch_company in groupby(self, lambda m: m.company_id):
             for batch in split_every(100, batch_company):
-                self.env['account.move'].union(*batch)._l10n_hu_edi_request_cancel_single_batch(connection, code, reason)
+                self.env['account.move'].union(batch)._l10n_hu_edi_request_cancel_single_batch(connection, code, reason)
 
     def _l10n_hu_edi_request_cancel_single_batch(self, connection, code, reason):
         for i, invoice in enumerate(self, start=1):

--- a/addons/l10n_my_edi/models/account_move.py
+++ b/addons/l10n_my_edi/models/account_move.py
@@ -244,4 +244,4 @@ class AccountMove(models.Model):
 
     def _get_active_myinvois_document(self, including_in_progress=False):
         """ Shortcut to get the active document of all invoice in self. """
-        return self.env['myinvois.document'].union(*[invoice.l10n_my_edi_document_ids._get_active_myinvois_document(including_in_progress) for invoice in self])
+        return self.env['myinvois.document'].union(invoice.l10n_my_edi_document_ids._get_active_myinvois_document(including_in_progress) for invoice in self)

--- a/addons/l10n_my_edi/wizard/myinvois_consolidate_invoice_wizard.py
+++ b/addons/l10n_my_edi/wizard/myinvois_consolidate_invoice_wizard.py
@@ -119,7 +119,7 @@ class MyInvoisConsolidateInvoiceWizard(models.TransientModel):
             # We now know the amount of lines; we want to create one consolidated invoice per 100 lines.
             for (journal, prefix), lines in lines_per_journal_prefix.items():
                 for line_batch in split_every(MAX_LINE_COUNT_PER_INVOICE, lines, list):
-                    invoices = self.env["account.move"].union(*line_batch)
+                    invoices = self.env["account.move"].union(line_batch)
                     consolidated_invoice_vals.append({
                         "invoice_ids": [Command.set(invoices.ids)],
                         "company_id": journal.company_id.id,

--- a/addons/l10n_my_edi_pos/models/pos_order.py
+++ b/addons/l10n_my_edi_pos/models/pos_order.py
@@ -111,4 +111,4 @@ class PosOrder(models.Model):
 
     def _get_active_consolidated_invoice(self, including_in_progress=False):
         """ Small helper to get the currently active consolidated invoice if more that one is linked to an order. """
-        return self.env['myinvois.document'].union(*[order.consolidated_invoice_ids._get_active_myinvois_document(including_in_progress) for order in self])
+        return self.env['myinvois.document'].union(order.consolidated_invoice_ids._get_active_myinvois_document(including_in_progress) for order in self)

--- a/addons/l10n_my_edi_pos/wizard/myinvois_consolidate_invoice_wizard.py
+++ b/addons/l10n_my_edi_pos/wizard/myinvois_consolidate_invoice_wizard.py
@@ -50,7 +50,7 @@ class MyInvoisConsolidateInvoiceWizard(models.TransientModel):
             consolidated_invoice_vals = []
             for config, lines in lines_per_config.items():
                 for line_batch in split_every(MAX_LINE_COUNT_PER_INVOICE, lines, list):
-                    orders = self.env['pos.order'].union(*line_batch)
+                    orders = self.env['pos.order'].union(line_batch)
                     consolidated_invoice_vals.append({
                         'pos_order_ids': [Command.set(orders.ids)],
                         'company_id': config.company_id.id,

--- a/addons/l10n_pl_edi/models/account_move_send.py
+++ b/addons/l10n_pl_edi/models/account_move_send.py
@@ -49,7 +49,7 @@ class AccountMoveSend(models.AbstractModel):
         def is_ksef(move):
             return 'pl_ksef' in invoices_data[move].get('extra_edis', []) and not move.l10n_pl_edi_status
 
-        moves_by_company = self.env['account.move'].union(*invoices_data).filtered(is_ksef).grouped('company_id')
+        moves_by_company = self.env['account.move'].union(invoices_data).filtered(is_ksef).grouped('company_id')
         for company, moves in moves_by_company.items():
 
             service = KsefApiService(company)
@@ -112,7 +112,7 @@ class AccountMoveSend(models.AbstractModel):
                     attachment_ids=move.l10n_pl_edi_attachment_id.ids,
                 )
 
-        self.env['account.move'].union(*invoices_data).invalidate_recordset(fnames=[
+        self.env['account.move'].union(invoices_data).invalidate_recordset(fnames=[
             'l10n_pl_edi_attachment_id',
             'l10n_pl_edi_attachment_file',
         ])

--- a/addons/mail/models/ir_model_fields.py
+++ b/addons/mail/models/ir_model_fields.py
@@ -49,7 +49,7 @@ class IrModelFields(models.Model):
                 if field.model_id.model not in self.env:
                     # Model is already deleted
                     continue
-                self.env['mail.tracking.value'].concat(*trackings).write({
+                self.env['mail.tracking.value'].concat(trackings).write({
                     'field_info': {
                         'desc': field.field_description,
                         'name': field.name,

--- a/addons/mail/models/mail_message_reaction.py
+++ b/addons/mail/models/mail_message_reaction.py
@@ -28,7 +28,7 @@ class MailMessageReaction(models.Model):
         if res:
             raise NotImplementedError("Fields are not supported for reactions.")
         for (message, content), reactions in groupby(self, lambda r: (r.message_id, r.content)):
-            reactions = self.env["mail.message.reaction"].union(*reactions)
+            reactions = self.env["mail.message.reaction"].union(reactions)
             store.add_model_values(
                 "MessageReactions",
                 lambda res, content=content, message=message, reactions=reactions: (

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -1532,7 +1532,7 @@ class MailCase(common.TransactionCase, MockEmail, BusCase):
         :param mail_unlink_sent: mock parameter, tells if mails are unlinked
           and therefore we are able to check outgoing emails;
         """
-        partners = self.env['res.partner'].sudo().concat(*list(p['partner'] for i in recipients_info for p in i['notif'] if p.get('partner')))
+        partners = self.env['res.partner'].sudo().concat(p['partner'] for i in recipients_info for p in i['notif'] if p.get('partner'))
         email_addrs = [email for i in recipients_info for p in i['notif'] for email in p.get('email_to', []) if not p.get('partner')]
         base_domain = ['|', ('res_partner_id', 'in', partners.ids), ('mail_email_address', 'in', email_addrs)]
         if messages is not None:

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1909,7 +1909,7 @@ class MrpProduction(models.Model):
         moves_to_do = self.move_raw_ids.filtered(lambda x: x.state == 'done') - self.env['stock.move'].browse(moves_not_to_do)
         # Create a dict to avoid calling filtered inside for loops.
         moves_to_do_by_order = defaultdict(lambda: self.env['stock.move'], [
-            (key, self.env['stock.move'].concat(*values))
+            (key, self.env['stock.move'].concat(values))
             for key, values in tools_groupby(moves_to_do, key=lambda m: m.raw_material_production_id.id)
         ])
         for order in self:
@@ -2479,7 +2479,7 @@ class MrpProduction(models.Model):
             visited_objects = [sm for sm in visited_objects if sm._name == 'stock.move']
             impacted_object = []
             if visited_objects:
-                visited_objects = self.env[visited_objects[0]._name].concat(*visited_objects)
+                visited_objects = self.env[visited_objects[0]._name].concat(visited_objects)
                 visited_objects |= visited_objects.mapped('move_orig_ids')
                 impacted_object = visited_objects.filtered(lambda m: m.state not in ('done', 'cancel')).mapped('picking_id')
             values = {

--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -378,10 +378,10 @@ class ProductProduct(models.Model):
 
     def action_open_quants(self):
         bom_kits = self.env['mrp.bom']._bom_find(self, bom_type='phantom')
-        components = self - self.env['product.product'].concat(*list(bom_kits.keys()))
+        components = self - self.env['product.product'].concat(bom_kits)
         for product in bom_kits:
-            boms, bom_sub_lines = bom_kits[product].explode(product, 1)
-            components |= self.env['product.product'].concat(*[l[0].product_id for l in bom_sub_lines])
+            _boms, bom_sub_lines = bom_kits[product].explode(product, 1)
+            components |= self.env['product.product'].concat(l[0].product_id for l in bom_sub_lines)
         res = super(ProductProduct, components).action_open_quants()
         if bom_kits:
             res['context'].pop('default_product_tmpl_id', None)

--- a/addons/mrp/models/stock_orderpoint.py
+++ b/addons/mrp/models/stock_orderpoint.py
@@ -156,7 +156,7 @@ class StockWarehouseOrderpoint(models.Model):
             for orderpoint in self
             if orderpoint.product_id in bom_kits
         }
-        orderpoints_without_kit = self - self.env['stock.warehouse.orderpoint'].concat(*bom_kit_orderpoints.keys())
+        orderpoints_without_kit = self - self.env['stock.warehouse.orderpoint'].concat(bom_kit_orderpoints.keys())
         res = super(StockWarehouseOrderpoint, orderpoints_without_kit)._quantity_in_progress()
         for orderpoint in bom_kit_orderpoints:
             dummy, bom_sub_lines = bom_kit_orderpoints[orderpoint].explode(orderpoint.product_id, 1)
@@ -182,7 +182,7 @@ class StockWarehouseOrderpoint(models.Model):
             res[orderpoint.id] = orderpoint.product_id.uom_id._compute_quantity(product_qty, orderpoint.uom_id, round=False)
 
         bom_manufacture = self.env['mrp.bom']._bom_find(orderpoints_without_kit.product_id, bom_type='normal')
-        bom_manufacture = self.env['mrp.bom'].concat(*bom_manufacture.values())
+        bom_manufacture = self.env['mrp.bom'].concat(bom_manufacture.values())
         # add quantities coming from draft MOs
         productions_group = self.env['mrp.production']._read_group(
             [

--- a/addons/mrp/tests/test_traceability.py
+++ b/addons/mrp/tests/test_traceability.py
@@ -495,7 +495,7 @@ class TestTraceability(TestMrpCommon):
         pickingA_out._action_done()
 
         # Use concat so that delivery_ids is computed in batch.
-        for lot in lot_subcomponentA.concat(lot_componentA, lot_endProductA):
+        for lot in (lot_subcomponentA + lot_componentA + lot_endProductA):
             self.assertEqual(lot.delivery_ids.ids, pickingA_out.ids)
 
     def test_unbuild_scrap_and_unscrap_tracked_component(self):

--- a/addons/mrp_account/models/account_move.py
+++ b/addons/mrp_account/models/account_move.py
@@ -52,7 +52,7 @@ class AccountMoveLine(models.Model):
         # Replace the kit-type products with their components
         qties = defaultdict(float)
         res = super()._get_invoiced_qty_per_product()
-        invoiced_products = self.env['product.product'].concat(*res.keys())
+        invoiced_products = self.env['product.product'].concat(res.keys())
         bom_kits = self.env['mrp.bom']._bom_find(invoiced_products, company_id=self.company_id[:1].id, bom_type='phantom')
         for product, qty in res.items():
             bom_kit = bom_kits[product]

--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -167,7 +167,7 @@ class StockMove(models.Model):
             picking._subcontracted_produce(subcontract_details)
 
         if subcontract_details_per_picking:
-            self.env['stock.picking'].concat(*list(subcontract_details_per_picking.keys())).action_assign()
+            self.env['stock.picking'].concat(subcontract_details_per_picking).action_assign()
         return res
 
     def _get_subcontract_bom(self):

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -817,7 +817,7 @@ class PosConfig(models.Model):
                 field = pos_config._fields[field_name]
                 if field.type in ('boolean', 'selection') and hasattr(field, 'implied_group'):
                     field_group_xmlids = getattr(field, 'group', 'base.group_user').split(',')
-                    field_groups = self.env['res.groups'].concat(*(self.env.ref(it) for it in field_group_xmlids))
+                    field_groups = self.env['res.groups'].concat(self.env.ref(it) for it in field_group_xmlids)
                     field_groups.write({'implied_ids': [(4, self.env.ref(field.implied_group).id)]})
 
 

--- a/addons/portal/models/mail_message.py
+++ b/addons/portal/models/mail_message.py
@@ -125,7 +125,7 @@ class MailMessage(models.Model):
                 values['published_date_str'] = format_datetime(self.env, values['date']) if values.get('date') else ''
             reaction_groups = []
             for content, reactions in groupby(message.sudo().reaction_ids, lambda r: r.content):
-                reactions = self.env["mail.message.reaction"].union(*reactions)
+                reactions = self.env["mail.message.reaction"].union(reactions)
                 reaction_groups.append(
                     {
                         "content": content,

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -654,7 +654,7 @@ class ProductProduct(models.Model):
             ptal = template_attribute_to_ptal.get((template_id, attribute_id))
             if ptal:
                 # add the new value ids
-                ptal.value_ids = ptal.value_ids.union(*pavs)
+                ptal.value_ids |= ptal.value_ids.browse().union(pavs)
             else:
                 ptals_to_create.append({
                     'product_tmpl_id': template_id,
@@ -827,7 +827,7 @@ class ProductProduct(models.Model):
 
         # Use tmp recordset in case we copy several variants from the same template
         templates = [product.product_tmpl_id for product in self]
-        templates_to_copy = self.env['product.template'].concat(*templates)
+        templates_to_copy = self.env['product.template'].concat(templates)
         new_templates = templates_to_copy.copy(default=default)
         new_products = self.env['product.product']
         for new_template in new_templates:

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -969,9 +969,10 @@ class ProductTemplate(models.Model):
 
             elif existing_variants:
                 variants_combinations = [variant.product_template_attribute_value_ids for variant in existing_variants.values()]
-                current_variants_to_activate += Product.concat(*[existing_variants[possible_combination]
+                current_variants_to_activate += Product.concat(
+                    existing_variants[possible_combination]
                     for possible_combination in tmpl_id._filter_combinations_impossible_by_config(variants_combinations, ignore_no_variant=True)
-                ])
+                )
                 variants_to_activate += current_variants_to_activate
 
             variants_to_unlink += all_variants - current_variants_to_activate
@@ -1163,7 +1164,7 @@ class ProductTemplate(models.Model):
             lambda l: l.attribute_id.display_type != 'multi')
         exclusions = self._get_own_attribute_exclusions()
         for combination_tuple in combination_tuples:
-            combination = self.env['product.template.attribute.value'].concat(*combination_tuple)
+            combination = self.env['product.template.attribute.value'].concat(combination_tuple)
             combination_without_multi = combination.filtered(
                 lambda l: l.attribute_line_id.attribute_id.display_type != 'multi')
             if len(combination_without_multi) != len(attribute_lines_without_multi):

--- a/addons/product_margin/models/product_product.py
+++ b/addons/product_margin/models/product_product.py
@@ -73,7 +73,7 @@ class ProductProduct(models.Model):
         base_result = super()._read_group(domain, groupby, base_aggregates, having, offset, limit, order)
 
         # Force the compute of all records to bypass the limit compute batching (PREFETCH_MAX)
-        all_records = self.browse().union(*(item[-1] for item in base_result))
+        all_records = self.browse().union(item[-1] for item in base_result)
         # This line will compute all fields having _compute_product_margin_fields_values
         # as compute method.
         self._fields['turnover'].compute_value(all_records)
@@ -97,7 +97,7 @@ class ProductProduct(models.Model):
         base_result = super()._read_grouping_sets(domain, grouping_sets, base_aggregates, order)
 
         # Force the compute of all records to bypass the limit compute batching (PREFETCH_MAX)
-        all_records = self.concat(*(item[-1] for row in base_result for item in row))
+        all_records = self + self.browse().concat(item[-1] for row in base_result for item in row)
         # This line will compute all fields having _compute_product_margin_fields_values
         # as compute method.
         all_records._compute_product_margin_fields_values()

--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -429,7 +429,7 @@ class ProjectCustomerPortal(CustomerPortal):
 
             if groupby != 'none':
                 if groupby == 'milestone_id':
-                    grouped_tasks = [Task_sudo.concat(*g) for k, g in groupbyelem(tasks_project_allow_milestone, itemgetter(groupby))]
+                    grouped_tasks = [Task_sudo.concat(g) for k, g in groupbyelem(tasks_project_allow_milestone, itemgetter(groupby))]
 
                     if not grouped_tasks:
                         if tasks_no_milestone:
@@ -441,7 +441,7 @@ class ProjectCustomerPortal(CustomerPortal):
                             grouped_tasks[len(grouped_tasks) - 1] |= tasks_no_milestone
 
                 else:
-                    grouped_tasks = [Task_sudo.concat(*g) for k, g in groupbyelem(tasks, itemgetter(groupby))]
+                    grouped_tasks = [Task_sudo.concat(g) for k, g in groupbyelem(tasks, itemgetter(groupby))]
             else:
                 grouped_tasks = [tasks] if tasks else []
 

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -238,7 +238,7 @@ class ProjectProject(models.Model):
                 ['id:recordset'],
             )
         }
-        milestones = self.env['project.milestone'].concat(*milestones_per_project_id.values())
+        milestones = self.env['project.milestone'].concat(milestones_per_project_id.values())
         task_read_group = self.env['project.task']._read_group(
             [('milestone_id', 'in', milestones.ids)],
             ['milestone_id', 'state'],

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1631,7 +1631,7 @@ class ProjectTask(models.Model):
             sanitized_email_dict.keys(),
             no_create=True
         )
-        users = self.env['res.partner'].concat(*matched_partners).user_ids
+        users = self.env['res.partner'].concat(matched_partners).user_ids
         return users.filtered(lambda u: not u.share).ids
 
     @api.model

--- a/addons/project/models/project_task_recurrence.py
+++ b/addons/project/models/project_task_recurrence.py
@@ -89,7 +89,7 @@ class ProjectTaskRecurrence(models.Model):
 
     @api.model
     def _create_next_occurrences_values(self, recurrence_by_task):
-        tasks = self.env['project.task'].concat(*recurrence_by_task.keys())
+        tasks = self.env['project.task'].concat(recurrence_by_task.keys())
         list_create_values = []
         list_copy_data = tasks.with_context(copy_project=True, active_test=False).sudo().copy_data()
         list_fields_to_copy = tasks._read_format(self._get_recurring_fields_to_copy())

--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -411,7 +411,7 @@ class AccountMove(models.Model):
                     matching_po_lines = self._find_matching_subset_po_lines(
                         po_lines_with_amount, amount_total, timeout)
                     if matching_po_lines:
-                        return 'subset_total_match', self.env['purchase.order.line'].union(*matching_po_lines), None
+                        return 'subset_total_match', self.env['purchase.order.line'].union(matching_po_lines), None
                     else:
                         # We did not find a match for the invoice total.
                         # We return all purchase order lines based only on the purchase order reference(s) in the
@@ -428,7 +428,7 @@ class AccountMove(models.Model):
                         # We found a subset of purchase order lines that match a subset of the vendor bill lines.
                         # We return the matching purchase order lines and vendor bill lines.
                         return ('subset_match',
-                                self.env['purchase.order.line'].union(*matching_po_lines),
+                                self.env['purchase.order.line'].union(matching_po_lines),
                                 matching_inv_lines)
 
         # As a last resort we try matching a purchase order by vendor and total amount.

--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -333,7 +333,7 @@ class PurchaseOrder(models.Model):
         def _render_note_exception_quantity_po(order_exceptions):
             order_line_ids = self.env['purchase.order.line'].browse([order_line.id for order in order_exceptions.values() for order_line in order[0]])
             purchase_order_ids = order_line_ids.mapped('order_id')
-            move_ids = self.env['stock.move'].concat(*rendering_context.keys())
+            move_ids = self.env['stock.move'].concat(rendering_context.keys())
             impacted_pickings = move_ids.mapped('picking_id')._get_impacted_pickings(move_ids) - move_ids.mapped('picking_id')
             values = {
                 'purchase_order_ids': purchase_order_ids,

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -130,7 +130,7 @@ class StockRule(models.Model):
             po_lines_by_product = {}
             grouped_po_lines = groupby(po.order_line.filtered(lambda l: not l.display_type), key=lambda l: l.product_id.id)
             for product, po_lines in grouped_po_lines:
-                po_lines_by_product[product] = self.env['purchase.order.line'].concat(*po_lines)
+                po_lines_by_product[product] = self.env['purchase.order.line'].concat(po_lines)
             po_line_values = []
             for procurement in procurements:
                 po_lines = po_lines_by_product.get(procurement.product_id.id, self.env['purchase.order.line'])

--- a/addons/resource/models/resource_mixin.py
+++ b/addons/resource/models/resource_mixin.py
@@ -73,8 +73,7 @@ class ResourceMixin(models.AbstractModel):
             resource_default['company_id'] = default['company_id']
         if 'resource_calendar_id' in default:
             resource_default['calendar_id'] = default['resource_calendar_id']
-        resources = [record.resource_id for record in self]
-        resources_to_copy = self.env['resource.resource'].concat(*resources)
+        resources_to_copy = self.resource_id.browse().concat(r.resource_id for r in self)
         new_resources = resources_to_copy.copy(resource_default)
         for resource, vals in zip(new_resources, vals_list):
             vals['resource_id'] = resource.id

--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -48,7 +48,7 @@ class AccountMove(models.Model):
         for (user_id, company_id), moves in groupby(
             sale_moves, key=lambda m: (m.invoice_user_id.id, m.company_id.id)
         ):
-            self.env["account.move"].concat(*moves).team_id = (
+            self.env["account.move"].concat(moves).team_id = (
                 self
                 .env["crm.team"]
                 .with_context(allowed_company_ids=[company_id])

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -300,7 +300,7 @@ class SaleOrder(models.Model):
         def _render_note_exception_quantity_so(rendering_context):
             order_exceptions, visited_moves = rendering_context
             visited_moves = list(visited_moves)
-            visited_moves = self.env[visited_moves[0]._name].concat(*visited_moves)
+            visited_moves = self.env[visited_moves[0]._name].concat(visited_moves)
             order_line_ids = self.env['sale.order.line'].browse([order_line.id for order in order_exceptions.values() for order_line in order[0]])
             sale_order_ids = order_line_ids.mapped('order_id')
             impacted_pickings = visited_moves.filtered(lambda m: m.state not in ('done', 'cancel')).mapped('picking_id')

--- a/addons/sms/tests/common.py
+++ b/addons/sms/tests/common.py
@@ -250,7 +250,7 @@ class SMSCase(MockSMS):
           :param content: SMS content
           :param mail_message_values: dictionary of expected mail message fields values
         """
-        partners = self.env['res.partner'].concat(*list(p['partner'] for p in recipients_info if p.get('partner')))
+        partners = self.env['res.partner'].concat(p['partner'] for p in recipients_info if p.get('partner'))
         numbers = [p['number'] for p in recipients_info if p.get('number')]
         # special case of void notifications: check for False / False notifications
         if not partners and not numbers:

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -499,7 +499,7 @@ class StockLocation(models.Model):
             groupby=['location_dest_id', 'product_id'], aggregates=['quantity_product_uom:sum']
         )
 
-        products = Product.union(*(product for __, product, __ in quants + outgoing_move_lines + incoming_move_lines))
+        products = Product.union(product for __, product, __ in quants + outgoing_move_lines + incoming_move_lines)
         products.fetch(['weight'])
 
         result = defaultdict(lambda: defaultdict(float))

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1246,7 +1246,7 @@ Please change the quantity done or the rounding precision in your settings.""",
         else:
             candidate_moves_set.add(merge_into | self)
 
-        distinct_fields = (self | self.env['stock.move'].concat(*candidate_moves_set))._prepare_merge_moves_distinct_fields()
+        distinct_fields = (self | self.env['stock.move'].concat(candidate_moves_set))._prepare_merge_moves_distinct_fields()
 
         # Move removed after merge
         moves_to_unlink = self.env['stock.move']
@@ -1268,7 +1268,7 @@ Please change the quantity done or the rounding precision in your settings.""",
             # First step find move to merge.
             candidate_moves = candidate_moves.filtered(lambda m: m.state not in ('done', 'cancel', 'draft')) - neg_qty_moves
             for __, g in groupby(candidate_moves, key=self._merge_move_itemgetter(distinct_fields)):
-                moves = self.env['stock.move'].concat(*g)
+                moves = self.env['stock.move'].concat(g)
                 # Merge all positive moves together
                 if len(moves) > 1:
                     # link all move lines to record 0 (the one we will keep).
@@ -1413,7 +1413,7 @@ Please change the quantity done or the rounding precision in your settings.""",
         Picking = self.env['stock.picking']
         grouped_moves = groupby(self, key=lambda m: m._key_assign_picking())
         for _group, moves in grouped_moves:
-            moves = self.env['stock.move'].concat(*moves)
+            moves = self.env['stock.move'].concat(moves)
             new_picking = False
             # Could pass the arguments contained in group but they are the same
             # for each move that why moves[0] is acceptable
@@ -1882,7 +1882,7 @@ Please change the quantity done or the rounding precision in your settings.""",
                 quantity += ml.uom_id._compute_quantity(ml.quantity, ml.product_id.uom_id)
             grouped_move_lines_out[k] = quantity
         for k, g in groupby(move_lines_out_reserved, key=_keys_out_groupby):
-            grouped_move_lines_out[k] = sum(self.env['stock.move.line'].concat(*list(g)).mapped('quantity_product_uom'))
+            grouped_move_lines_out[k] = sum(self.env['stock.move.line'].concat(g).mapped('quantity_product_uom'))
 
         return grouped_move_lines_out
 

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -259,7 +259,7 @@ class StockMoveLine(models.Model):
             return
         self = self.with_context(do_not_unreserve=True)
         for (package), smls in groupby(self, lambda sml: (sml.result_package_id.outermost_package_id)):
-            smls = self.env['stock.move.line'].concat(*smls)
+            smls = self.env['stock.move.line'].concat(smls)
             locations = smls.move_id.location_dest_id.child_internal_location_ids
             excluded_smls = set(smls.ids)
             if package.package_type_id:

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -752,7 +752,7 @@ class StockWarehouseOrderpoint(models.Model):
                         for procurement, error_msg in errors.procurement_exceptions:
                             orderpoints_exceptions += [(procurement.values.get('orderpoint_id'), error_msg)]
                         all_orderpoints_exceptions += orderpoints_exceptions
-                        failed_orderpoints = self.env['stock.warehouse.orderpoint'].concat(*[o[0] for o in orderpoints_exceptions])
+                        failed_orderpoints = self.env['stock.warehouse.orderpoint'].concat(o[0] for o in orderpoints_exceptions)
                         if not failed_orderpoints:
                             _logger.error('Unable to process orderpoints')
                             break

--- a/addons/stock/models/stock_package.py
+++ b/addons/stock/models/stock_package.py
@@ -423,11 +423,11 @@ class StockPackage(models.Model):
 
         grouped_quants = {}
         for k, g in groupby(self.contained_quant_ids, key=_keys_groupby):
-            grouped_quants[k] = sum(self.env['stock.quant'].concat(*g).mapped('quantity'))
+            grouped_quants[k] = sum(self.env['stock.quant'].concat(g).mapped('quantity'))
 
         grouped_ops = {}
         for k, g in groupby(move_lines, key=_keys_groupby):
-            grouped_ops[k] = sum(self.env['stock.move.line'].concat(*g).mapped('quantity_product_uom'))
+            grouped_ops[k] = sum(self.env['stock.move.line'].concat(g).mapped('quantity_product_uom'))
 
         return all(float_is_zero(grouped_quants.get(key, 0) - grouped_ops.get(key, 0), precision_digits=precision_digits) for key in grouped_quants) \
            and all(float_is_zero(grouped_ops.get(key, 0) - grouped_quants.get(key, 0), precision_digits=precision_digits) for key in grouped_ops)

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1643,8 +1643,8 @@ class StockPicking(models.Model):
         """
         if self.env.context.get('skip_activity'):
             return {}
-        move_to_orig_object_rel = {co: ooc for ooc in orig_obj_changes.keys() for co in ooc[stream_field]}
-        origin_objects = self.env[list(orig_obj_changes.keys())[0]._name].concat(*list(orig_obj_changes.keys()))
+        move_to_orig_object_rel = {co: ooc for ooc in orig_obj_changes for co in ooc[stream_field]}
+        origin_objects = self.env[next(iter(orig_obj_changes.keys()))._name].concat(orig_obj_changes.keys())
         # The purpose here is to group each destination object by
         # (document to log, responsible) no matter the stream direction.
         # example:
@@ -1677,7 +1677,7 @@ class StockPicking(models.Model):
         for (parent, responsible), moves in grouped_moves:
             if not parent:
                 continue
-            moves = self.env[moves[0]._name].concat(*moves)
+            moves = self.env[moves[0]._name].concat(moves)
             # Get the note
             rendering_context = {move: (orig_object, orig_obj_changes[orig_object]) for move in moves for orig_object in move_to_orig_object_rel[move]}
             if visited_documents:
@@ -1733,7 +1733,7 @@ class StockPicking(models.Model):
             """
             origin_moves = self.env['stock.move'].browse([move.id for move_orig in rendering_context.values() for move in move_orig[0]])
             origin_picking = origin_moves.mapped('picking_id')
-            move_dest_ids = self.env['stock.move'].concat(*rendering_context.keys())
+            move_dest_ids = self.env['stock.move'].concat(rendering_context.keys())
             impacted_pickings = origin_picking._get_impacted_pickings(move_dest_ids) - move_dest_ids.mapped('picking_id')
             values = {
                 'origin_picking': origin_picking,

--- a/addons/stock/report/report_stock_rule.py
+++ b/addons/stock/report/report_stock_rule.py
@@ -94,8 +94,8 @@ class ReportStockReport_Stock_Rule(models.AbstractModel):
             then we add the locations grouped by warehouse and we finish by the locations of type
             customer and the ones that were not added by the sort.
         """
-        all_src = self.env['stock.location'].concat(*([r['source'] for r in rules_and_loc]))
-        all_dest = self.env['stock.location'].concat(*([r['destination'] for r in rules_and_loc]))
+        all_src = self.env['stock.location'].concat(r['source'] for r in rules_and_loc)
+        all_dest = self.env['stock.location'].concat(r['destination'] for r in rules_and_loc)
         all_locations = all_src | all_dest
         ordered_locations = self.env['stock.location']
         locations = all_locations.filtered(lambda l: l.usage in ('supplier', 'production'))
@@ -103,14 +103,14 @@ class ReportStockReport_Stock_Rule(models.AbstractModel):
             all_warehouse_locations = all_locations.filtered(lambda l: l.warehouse_id == warehouse_id)
             starting_rules = [d for d in rules_and_loc if d['source'] not in all_warehouse_locations]
             if starting_rules:
-                start_locations = self.env['stock.location'].concat(*([r['destination'] for r in starting_rules]))
+                start_locations = self.env['stock.location'].concat(r['destination'] for r in starting_rules)
             else:
                 starting_rules = [d for d in rules_and_loc if d['source'] not in all_dest]
-                start_locations = self.env['stock.location'].concat(*([r['source'] for r in starting_rules]))
+                start_locations = self.env['stock.location'].concat(r['source'] for r in starting_rules)
             used_rules = self.env['stock.rule']
             locations |= self._sort_locations_by_warehouse(rules_and_loc, used_rules, start_locations, ordered_locations, warehouse_id)
             if any(location not in locations for location in all_warehouse_locations):
-                remaining_locations = self.env['stock.location'].concat(*([r['source'] for r in rules_and_loc])).filtered(lambda l: l not in locations)
+                remaining_locations = self.env['stock.location'].concat(r['source'] for r in rules_and_loc).filtered(lambda l: l not in locations)
                 locations |= self._sort_locations_by_warehouse(rules_and_loc, used_rules, remaining_locations, ordered_locations, warehouse_id)
         locations |= all_locations.filtered(lambda l: l.usage in ('customer'))
         locations |= all_locations.filtered(lambda l: l not in locations)
@@ -128,8 +128,8 @@ class ReportStockReport_Stock_Rule(models.AbstractModel):
                 rules_start.append(rule)
                 used_rules |= rule['rule']
         if rules_start:
-            rules_start_dest_locations = self.env['stock.location'].concat(*([r['destination'] for r in rules_start]))
-            remaining_rules = self.env['stock.rule'].concat(*([r['rule'] for r in rules_and_loc])) - used_rules
+            rules_start_dest_locations = self.env['stock.location'].concat(r['destination'] for r in rules_start)
+            remaining_rules = self.env['stock.rule'].concat(r['rule'] for r in rules_and_loc) - used_rules
             remaining_rules_location = self.env['stock.location']
             for r in rules_and_loc:
                 if r['rule'] in remaining_rules:

--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -263,7 +263,7 @@ class ProductProduct(models.Model):
         moves_qty_by_product = {}
         for product in self:
             moves, remaining_qty = product._run_fifo_get_stack()
-            moves = self.env['stock.move'].concat(*moves)
+            moves = self.env['stock.move'].concat(moves)
             if not moves:
                 continue
             qty_by_move = {m: m.quantity for m in moves[1:]}

--- a/addons/stock_account/models/product_value.py
+++ b/addons/stock_account/models/product_value.py
@@ -88,7 +88,7 @@ class ProductValue(models.Model):
         if products:
             moves_by_product = products._get_remaining_moves()
             for qty_by_move in moves_by_product.values():
-                move_ids.update(self.env['stock.move'].concat(*qty_by_move.keys()).ids)
+                move_ids.update(self.env['stock.move'].concat(qty_by_move.keys()).ids)
 
         res = super().create(vals_list)
         if move_ids:

--- a/addons/stock_account/models/stock_quant.py
+++ b/addons/stock_account/models/stock_quant.py
@@ -79,7 +79,7 @@ class StockQuant(models.Model):
 
     def _apply_inventory(self, date=None):
         for accounting_date, inventory_ids in groupby(self, key=lambda q: q.accounting_date):
-            inventories = self.env['stock.quant'].concat(*inventory_ids)
+            inventories = self.env['stock.quant'].concat(inventory_ids)
             if accounting_date:
                 super(StockQuant, inventories.with_context(force_period_date=accounting_date))._apply_inventory(date)
                 inventories.accounting_date = False

--- a/addons/survey/models/survey_question.py
+++ b/addons/survey/models/survey_question.py
@@ -780,7 +780,7 @@ class SurveyQuestion(models.Model):
         right_answers = self.suggested_answer_ids.filtered(lambda label: label.is_correct)
         if self.question_type == 'multiple_choice':
             for user_input, lines in tools.groupby(user_input_lines, operator.itemgetter('user_input_id')):
-                user_input_answers = self.env['survey.user_input.line'].concat(*lines).filtered(lambda l: l.answer_is_correct).mapped('suggested_answer_id')
+                user_input_answers = self.env['survey.user_input.line'].concat(lines).filtered(lambda l: l.answer_is_correct).mapped('suggested_answer_id')
                 if user_input_answers and user_input_answers < right_answers:
                     partial_inputs += user_input
                 elif user_input_answers:

--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -646,7 +646,7 @@ class SurveySurvey(models.Model):
                 questions |= page.question_ids
             else:
                 if 0 < page.random_questions_count < len(page.question_ids):
-                    questions = questions.concat(*random.sample(page.question_ids, page.random_questions_count))
+                    questions += questions.browse().concat(random.sample(page.question_ids, page.random_questions_count))
                 else:
                     questions |= page.question_ids
 

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -220,7 +220,7 @@ class TestComposerForm(TestMailComposer):
         self.assertEqual(len(composer_form.attachment_ids), 4)
         report_attachments = [att for att in composer_form.attachment_ids if att not in template_1_attachments]
         self.assertEqual(len(report_attachments), 2)
-        tpl_attachments = composer_form.attachment_ids[:] - self.env['ir.attachment'].concat(*report_attachments)
+        tpl_attachments = composer_form.attachment_ids[:] - self.env['ir.attachment'].concat(report_attachments)
         self.assertEqual(tpl_attachments, template_1_attachments)
 
         # change template: 0 static (attachment_ids) and 1 dynamic (report)
@@ -228,7 +228,7 @@ class TestComposerForm(TestMailComposer):
         self.assertEqual(len(composer_form.attachment_ids), 1)
         report_attachments = [att for att in composer_form.attachment_ids if att not in template_1_attachments]
         self.assertEqual(len(report_attachments), 1)
-        tpl_attachments = composer_form.attachment_ids[:] - self.env['ir.attachment'].concat(*report_attachments)
+        tpl_attachments = composer_form.attachment_ids[:] - self.env['ir.attachment'].concat(report_attachments)
         self.assertFalse(tpl_attachments)
 
         # change back to template 1
@@ -236,7 +236,7 @@ class TestComposerForm(TestMailComposer):
         self.assertEqual(len(composer_form.attachment_ids), 4)
         report_attachments = [att for att in composer_form.attachment_ids if att not in template_1_attachments]
         self.assertEqual(len(report_attachments), 2)
-        tpl_attachments = composer_form.attachment_ids[:] - self.env['ir.attachment'].concat(*report_attachments)
+        tpl_attachments = composer_form.attachment_ids[:] - self.env['ir.attachment'].concat(report_attachments)
         self.assertEqual(tpl_attachments, template_1_attachments)
 
         # reset template

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -439,7 +439,7 @@ class Base(models.AbstractModel):
                 for sub_search in records_opening_info
             ]
 
-            all_records = self.browse().union(*recordset_groups)
+            all_records = self.browse().union(recordset_groups)
             record_mapped = dict(zip(
                 all_records._ids,
                 all_records.web_read(unfold_read_specification or {}),

--- a/addons/website/models/ir_asset.py
+++ b/addons/website/models/ir_asset.py
@@ -72,7 +72,7 @@ class IrAsset(models.Model):
                 # specific asset for this asset (based on the same `key` attribute)
                 most_specific_assets.append(asset)
 
-        return self.browse().union(*most_specific_assets)
+        return self.browse().union(most_specific_assets)
 
     def write(self, vals):
         """COW for ir.asset. This way editing websites does not impact other

--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -311,7 +311,7 @@ class IrUiView(models.Model):
             elif not view.website_id and view.key not in specific_views_keys:
                 most_specific_views.append(view)
 
-        return self.browse().union(*most_specific_views)
+        return self.browse().union(most_specific_views)
 
     @api.model
     def _view_get_inherited_children(self, view):

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -348,7 +348,7 @@ class Website(models.CachedModel):
 
         if not self.env.user.has_group('website.group_multi_website') and self.search_count([]) > 1:
             all_user_groups = 'base.group_portal,base.group_user,base.group_public'
-            groups = self.env['res.groups'].concat(*(self.env.ref(it) for it in all_user_groups.split(',')))
+            groups = self.env['res.groups'].concat(self.env.ref(it) for it in all_user_groups.split(','))
             groups.write({'implied_ids': [(4, self.env.ref('website.group_multi_website').id)]})
 
         return websites

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -905,7 +905,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
                 )
             )
             combination_info = product._get_combination_info(
-                combination=request.env["product.template.attribute.value"].concat(combination)
+                combination=combination.with_env(self.env)
             )
         else:
             combination_info = product._get_combination_info()

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -955,10 +955,10 @@ class IrModelFields(models.Model):
                     field=field, other_field=dep,
                 ))
             else:
-                self = self.union(*[
+                self |= self.browse().union(
                     self._get(dep.model_name, dep.name)
                     for field, dep in failed_dependencies
-                ])
+                )
 
         records = self.filtered(lambda record: record.state == 'manual')
         if not records:

--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -1253,7 +1253,7 @@ class IrQweb(models.AbstractModel):
 
         xmlids = list(missing_refs)
         missing_refs_values = list(missing_refs.values())
-        views = self.env['ir.ui.view'].sudo().union(*[data['view'] for data in missing_refs_values])
+        views = self.env['ir.ui.view'].sudo().union(data['view'] for data in missing_refs_values)
 
         trees = views._get_view_etrees()
 

--- a/odoo/addons/base/models/res_config.py
+++ b/odoo/addons/base/models/res_config.py
@@ -211,7 +211,7 @@ class ResConfigSettings(models.TransientModel):
                 if not hasattr(field, 'implied_group'):
                     raise Exception("Field %s without attribute 'implied_group'" % field)
                 field_group_xmlids = getattr(field, 'group', 'base.group_user').split(',')
-                field_groups = Groups.concat(*(ref(it) for it in field_group_xmlids))
+                field_groups = Groups.concat(ref(it) for it in field_group_xmlids)
                 groups.append((name, field_groups, ref(field.implied_group)))
             elif name.startswith('module_'):
                 if field.type not in ('boolean', 'selection'):

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -352,7 +352,7 @@ class ResPartner(models.Model):
         super(ResPartner, partners_with_internal_user)._compute_avatar(avatar_field, image_field)
         partners_without_image = (self - partners_with_internal_user).filtered(lambda p: not p[image_field])
         for _, group in tools.groupby(partners_without_image, key=lambda p: p._avatar_get_placeholder_path()):
-            group_partners = self.env['res.partner'].concat(*group)
+            group_partners = self.env['res.partner'].concat(group)
             group_partners[avatar_field] = group_partners[0]._avatar_get_placeholder()
 
         for partner in self - partners_with_internal_user - partners_without_image:

--- a/odoo/addons/base/tests/test_ir_ui_view.py
+++ b/odoo/addons/base/tests/test_ir_ui_view.py
@@ -223,7 +223,7 @@ class TestViewInheritance(ViewCase):
         return view
 
     def get_views(self, names):
-        return self.View.concat(*(self.view_ids[name] for name in names))
+        return self.View.concat(self.view_ids[name] for name in names)
 
     def setUp(self):
         super(TestViewInheritance, self).setUp()

--- a/odoo/addons/test_orm/models/test_orm.py
+++ b/odoo/addons/test_orm/models/test_orm.py
@@ -706,7 +706,7 @@ class TestOrmOrderLine(models.Model):
             for other_line in line.order_id.line_ids
             if other_line.reward and other_line.product == line.product
         ]
-        self = self.union(*reward_lines)  # noqa: PLW0642
+        self |= self.browse().union(reward_lines)  # noqa: PLW0642
         return super().unlink()
 
 

--- a/odoo/addons/test_orm/models/test_performance.py
+++ b/odoo/addons/test_orm/models/test_performance.py
@@ -113,7 +113,7 @@ class Test_PerformanceSimpleMinded(models.Model):
 
     def union_once(self):
         """ Union all first children at once. """
-        return self.browse().union(*[record.child_ids[:1] for record in self])
+        return self.browse().union(record.child_ids[:1] for record in self)
 
     def union_loop(self):
         """ Union all first children in a loop. """

--- a/odoo/addons/test_orm/tests/test_api.py
+++ b/odoo/addons/test_orm/tests/test_api.py
@@ -439,8 +439,8 @@ class TestAPI(SavepointCaseWithUserDemo):
         for child in children:
             self.assertEqual(set(prefetch_ids), set(child._prefetch_ids))
 
-        self.assertEqual(set(prefetch_ids), set(partners.browse().concat(*children)._prefetch_ids))
-        self.assertEqual(set(prefetch_ids), set(partners.browse().union(*children)._prefetch_ids))
+        self.assertEqual(set(prefetch_ids), set(partners.browse().concat(children)._prefetch_ids))
+        self.assertEqual(set(prefetch_ids), set(partners.browse().union(children)._prefetch_ids))
 
     def test_60_prefetch_model_performance(self):
         # number of records, and number of children per record
@@ -510,7 +510,7 @@ class TestAPI(SavepointCaseWithUserDemo):
             fetched_ids = records._fields['name']._get_all_cache_ids(records.env)
             self.assertEqual(set(fetched_ids), set(records._ids))
 
-            records = self.env['res.partner'].concat(*[partner.child_ids[0] for partner in partners])
+            records = self.env['res.partner'].concat(partner.child_ids[0] for partner in partners)
             records.invalidate_model(['name'])
             records.mapped('name')
             fetched_ids = records._fields['name']._get_all_cache_ids(records.env)

--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -3943,8 +3943,10 @@ class TestParentStore(TransactionCaseWithUserDemo):
         cat7 = Cat.create({'name': '7', 'parent': cat6.id})
         cat8 = Cat.create({'name': '8', 'parent': cat6.id})
         cat9 = Cat.create({'name': '9', 'parent': cat6.id})
-        cls._cats = Cat.concat(cat0, cat1, cat2, cat3, cat4,
-                               cat5, cat6, cat7, cat8, cat9)
+        cls._cats = Cat.concat((
+            cat0, cat1, cat2, cat3, cat4,
+            cat5, cat6, cat7, cat8, cat9,
+        ))
 
     def cats(self, *indexes):
         """ Return the given categories. """

--- a/odoo/addons/test_orm/tests/test_sort.py
+++ b/odoo/addons/test_orm/tests/test_sort.py
@@ -160,14 +160,14 @@ class TestSort(TransactionCase):
         self.assertGreater(NewId(5), NewId(4))
 
     def test_sorted_new_id(self):
-        new_countries = self.env['test_orm.country'].concat(*[
+        new_countries = self.env['test_orm.country'].concat(
             self.env['test_orm.country'].new(vals)
             for vals in [
                 {'name': 'B'},
                 {'name': 'A'},
                 {'name': 'C'},
             ]
-        ])
+        )
 
         order = 'id'  # new id after existing ones
         self.assertEqual(

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -786,7 +786,7 @@ class BaseModel(metaclass=MetaModel):
                         if property_type not in ('many2one', 'many2many') or not property_cache:
                             continue
                         model = next(iter(property_cache.values())).browse()
-                        subrecords = model.union(*[property_cache[rec_id] for rec_id in records.ids if rec_id in property_cache])
+                        subrecords = model.union(property_cache[rec_id] for rec_id in records.ids if rec_id in property_cache)
                     else:  # Normal field
                         field = records._fields[fname]
                         if not field.relational:
@@ -2691,7 +2691,7 @@ class BaseModel(metaclass=MetaModel):
                 allowed_groups_msg = _("custom field access rules")
             else:
                 groups_list = [self.env.ref(g) for g in field.groups.split(',')]
-                groups = self.env['res.groups'].union(*groups_list).sorted('id')
+                groups = self.env['res.groups'].union(groups_list).sorted('id')
                 allowed_groups_msg = _(
                     "allowed for groups %s",
                     ', '.join(repr(g.display_name) for g in groups),
@@ -4140,7 +4140,7 @@ class BaseModel(metaclass=MetaModel):
             return
 
         # create new records for the vals that must be completed
-        records = self.browse().concat(*(self.new(vals) for vals in vals_list_todo))
+        records = self.browse().concat(self.new(vals) for vals in vals_list_todo)
 
         for record, vals in zip(records, vals_list_todo):
             vals['__precomputed__'] = precomputed = set()
@@ -4522,7 +4522,7 @@ class BaseModel(metaclass=MetaModel):
         # create or update XMLIDs
         imd._update_xmlids(imd_data_list, update)
 
-        return original_self.concat(*(data['record'] for data in data_list))
+        return original_self + self.browse().concat(data['record'] for data in data_list)
 
     def _check_qorder(self, word: str) -> None:
         if not regex_order.match(word):
@@ -5470,7 +5470,7 @@ class BaseModel(metaclass=MetaModel):
         if self:
             vals = [func(rec) for rec in self]
             if isinstance(vals[0], BaseModel):
-                return vals[0].union(*vals)
+                return vals[0].browse().union(vals)
             return vals
         else:
             # we want to follow-up the comodel from the function
@@ -5845,25 +5845,43 @@ class BaseModel(metaclass=MetaModel):
 
     def __add__(self, other) -> Self:
         """ Return the concatenation of two recordsets. """
-        return self.concat(other)
+        try:
+            if other._name != self._name:
+                raise TypeError(f"inconsistent models in: {self} + {other}")
+            if other:
+                ids = self._ids + other._ids
+                return self.__class__(self.env, ids, Prefetch.union(ids, self._prefetch_ids, other._prefetch_ids))
+        except AttributeError:
+            raise TypeError(f"unsupported operand types in: {self} + {other!r}")
+        return self
 
     @api.private
-    def concat(self, *args: Self) -> Self:
+    def concat(self, it: Iterable[Self] = (), /, *args: Self) -> Self:
         """ Return the concatenation of ``self`` with all the arguments (in
             linear time complexity).
         """
-        ids = list(self._ids)
-        prefetch_ids_list = [self._prefetch_ids]
-        for arg in args:
+        if args:
+            warnings.warn("Since 20.0, use concat() with only one iterable")
+        if self:
+            warnings.warn("Since 20.0, use concat() on an empty recordset")
+        ids = []
+        prefetch_ids_list = []
+        for arg in (self, *it, *args):
             try:
                 if arg._name != self._name:
                     raise TypeError(f"inconsistent models in: {self} + {arg}")
+                if not arg._ids:
+                    continue
                 ids.extend(arg._ids)
                 prefetch_ids_list.append(arg._prefetch_ids)
             except AttributeError:
                 raise TypeError(f"unsupported operand types in: {self} + {arg!r}")
         ids = tuple(ids)
-        return self.__class__(self.env, ids, Prefetch.union(ids, *prefetch_ids_list))
+        if len(prefetch_ids_list) == 1:
+            prefetch_ids = prefetch_ids_list[0]
+        else:
+            prefetch_ids = Prefetch.union(ids, *prefetch_ids_list)
+        return self.__class__(self.env, ids, prefetch_ids)
 
     def __sub__(self, other) -> Self:
         """ Return the recordset of all the records in ``self`` that are not in
@@ -5895,25 +5913,43 @@ class BaseModel(metaclass=MetaModel):
         """ Return the union of two recordsets.
             Note that first occurrence order is preserved.
         """
-        return self.union(other)
+        try:
+            if other._name != self._name:
+                raise TypeError(f"inconsistent models in: {self} | {other}")
+            if other:
+                ids = tuple(dict.fromkeys(self._ids + other._ids))
+                return self.__class__(self.env, ids, Prefetch.union(ids, self._prefetch_ids, other._prefetch_ids))
+        except AttributeError:
+            raise TypeError(f"unsupported operand types in: {self} | {other!r}")
+        return self
 
     @api.private
-    def union(self, *args: Self) -> Self:
+    def union(self, it: Iterable[Self] = (), /, *args: Self) -> Self:
         """ Return the union of ``self`` with all the arguments (in linear time
             complexity, with first occurrence order preserved).
         """
-        ids = list(self._ids)
-        prefetch_ids_list = [self._prefetch_ids]
-        for arg in args:
+        if args:
+            warnings.warn("Since 20.0, use union() with only one iterable")
+        if self:
+            warnings.warn("Since 20.0, use union() on an empty recordset")
+        ids = []
+        prefetch_ids_list = []
+        for arg in (self, *it, *args):
             try:
                 if arg._name != self._name:
                     raise TypeError(f"inconsistent models in: {self} | {arg}")
+                if not arg._ids:
+                    continue
                 ids.extend(arg._ids)
                 prefetch_ids_list.append(arg._prefetch_ids)
             except AttributeError:
                 raise TypeError(f"unsupported operand types in: {self} | {arg!r}")
         ids = tuple(dict.fromkeys(ids))
-        return self.__class__(self.env, ids, Prefetch.union(ids, *prefetch_ids_list))
+        if len(prefetch_ids_list) == 1:
+            prefetch_ids = prefetch_ids_list[0]
+        else:
+            prefetch_ids = Prefetch.union(ids, *prefetch_ids_list)
+        return self.__class__(self.env, ids, prefetch_ids)
 
     def __eq__(self, other):
         """ Test whether two recordsets are equivalent (up to reordering). """

--- a/odoo/tools/intervals.py
+++ b/odoo/tools/intervals.py
@@ -44,8 +44,9 @@ class Intervals[T]:
                     starts.append(value)
                     if items is None:
                         items = value_items
-                    else:
-                        items = items.union(value_items)
+                    elif value_items:
+                        # make sure we have a copy of items
+                        items = items | value_items
                 else:
                     start = starts.pop()
                     if not starts:


### PR DESCRIPTION
Change the API of these functions to accept iterables. Deprecate the inclusion of `self.ids` and other arguments.
```py
records.browse().concat(*list(...))  # old
model.concat(...)  # new
```

In `odoo.tools.intervals`, we use `union`, but this is not defined on `collections.abc.Set`, just use the __or__ operator instead.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
