### PR TITLE
[FIX] crm_iap_mine: move extra steps to the end of the tour

### DIFF
--- a/addons/crm_iap_mine/static/src/js/tours/crm_iap_lead.js
+++ b/addons/crm_iap_mine/static/src/js/tours/crm_iap_lead.js
@@ -7,21 +7,12 @@ import { markup } from "@odoo/owl";
 
 patch(registry.category("web_tour.tours").get("crm_tour"), {
     steps() {
-        const originalSteps = super.steps();
-        const DragOppToWonStepIndex = originalSteps.findIndex(
-            (step) => step.id === "drag_opportunity_to_won_step"
-        );
-        originalSteps.splice(
-            DragOppToWonStepIndex + 1,
-            0,
+        /**
+        * Add some steps related to the lead generation (crm_iap_mine).
+        * This eases the on boarding for the Lead Generation process.
+        */
+        const newSteps = [
             {
-                /**
-                 * Add some steps between "Drag your opportunity to <b>Won</b> when you get
-                 * the deal. Congrats!" and "Let’s have a look at an Opportunity." to
-                 * include the steps related to the lead generation (crm_iap_mine).
-                 * This eases the on boarding for the Lead Generation process.
-                 *
-                 */
                 trigger: ".o_button_generate_leads",
                 content: markup(_t("Looking for more opportunities?<br>Try the <b>Lead Generation</b> tool.")),
                 tooltipPosition: "bottom",
@@ -47,7 +38,7 @@ patch(registry.category("web_tour.tours").get("crm_tour"), {
                 tooltipPosition: "bottom",
                 run: "click",
             }
-        );
-        return originalSteps;
+        ];
+        return [...super.steps(), ...newSteps];
     },
 });


### PR DESCRIPTION
The crm_iap_mine module extended the crm tour, by adding steps to introduce the lead generation feature. These steps were inserted in the middle of the tour, which caused the tour to backtrack and loop on itself.

Why?
For the tour to wait for the next step, we specify the selectors it should look for. In this case, because the modal redirects to the same page (with an updated domain), we cannot specify a selector that would be unique to the new page -> the target is found before the redirect -> after the redirect happens, the tour backtracks to try and recover, causing the loop.

Moving the steps to the end of the tour fixes the issue.

The disadvantage of this is that no the last step of the tour is not deterministic - it can fail if the user selects a combination of countries and industries which have no valid leads (Antarctica...) or if the user doesn't have enough IAP credits. In this case, the 'Congrats' rainbowman is shown even if the generation failed.

Task-5386684