### PR TITLE
[FIX] stock_account: use accounting date for stock valuation closing validation

### DIFF
--- a/addons/stock_account/models/res_company.py
+++ b/addons/stock_account/models/res_company.py
@@ -340,7 +340,10 @@ class ResCompany(models.Model):
             return False
         am_state_field = self.env['ir.model.fields'].search([('model', '=', 'account.move'), ('name', '=', 'state')], limit=1)
         state_tracking = closing.message_ids.sudo().tracking_value_ids.filtered(lambda t: t.field_id == am_state_field).sorted('id')
-        return state_tracking[-1:].create_date or fields.Datetime.to_datetime(closing.date)
+        create_date = state_tracking[-1:].create_date
+        if create_date and create_date.date() == closing.date:
+            return create_date
+        return fields.Datetime.to_datetime(closing.date)
 
     def _save_closing_id(self, move_id):
         self.ensure_one()

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -764,6 +764,43 @@ class TestStockValuation(TestStockValuationCommon):
         self._make_in_move(product, 1, unit_cost=77)
         self.assertEqual(product.standard_price, 77)
 
+    def test_post_multiple_stock_valuation_closings_in_past(self):
+        """
+        Ensure multiple stock valuation closings with different accounting dates in the past
+        can be posted.
+
+        Example scenario:
+        - Move 1: Accounting date = today - 4 days
+        - Move 2: Accounting date = today - 2 days
+        - First closing: at_date = today - 3 days
+        - Second closing: at_date = today - 1 day
+        Both closings should post successfully and calculate the correct valuation amounts.
+        """
+        self.env = self.env['base'].with_context(
+            tracking_disable=False,
+            mail_create_nolog=False,
+            mail_notrack=False,
+        ).env
+
+        product = self.product_fifo
+        today = Datetime.now()
+        with freeze_time(today - timedelta(days=4)):
+            move = self._make_in_move(product, 1, 10, create_picking=True, owner=self.env.company.partner_id)
+        with freeze_time(today - timedelta(days=2)):
+            move_2 = self._make_in_move(product, 1, 10, create_picking=True, owner=self.env.company.partner_id)
+
+        closing_move = self.env['account.move'].browse(move.company_id.action_close_stock_valuation(at_date=Date.to_date(today - timedelta(days=3)))['res_id'])
+        self.env.cr.flush()
+        closing_move._post()
+        self.env.cr.flush()
+        closing_move_2 = self.env['account.move'].browse(move_2.company_id.action_close_stock_valuation(at_date=Date.to_date(today - timedelta(days=1)))['res_id'])
+        closing_move_2._post()
+
+        self.assertEqual(move.value, 10)
+        self.assertEqual(closing_move.amount_total, 10)
+        self.assertEqual(move_2.value, 10)
+        self.assertEqual(closing_move_2.amount_total, 10)
+
     def test_create_done_move(self):
         """Stock Move created directly in Done state must impact de valuation."""
         product = self.product_avco


### PR DESCRIPTION
**Issue**:
Making two stock valuation closings with different accounting dates in the past,
on the same day, leads to an "Invalid Operation" error.

**Steps to reproduce**:
- In settings, set inventory valuation at invoicing
- Create 2 bills of a storable product::
	- `Accounting date` = `bill date` = today - 2 days
	- `Accounting date` = `bill date` = today - 4 days
- Go to Accounting > Review > Inventory > Inventory Valuation
- Set the day to today - 3 days, generate and post the entry
- Go back the Inventory Valuation
- Set the day to today - 1 day, generate the entry
-> Invalid Operation error: the system thinks it exists a closing entry after the selected date.

**Cause**:
The regression was introduced by commit https://github.com/odoo-dev/odoo/commit/594654deb84ba45e9a6a765b89de79e4ce4e4b50
Indeed, `_get_last_closing_date` was modified to prioritize the creation date
of the closing instead of its accounting date:
https://github.com/odoo/odoo/blob/594654deb84ba45e9a6a765b89de79e4ce4e4b50/addons/stock_account/models/res_company.py#L336

As a consequence, the second closing with at_date = today - 1 day
was compared against last_closing_date = today (creation date):
https://github.com/odoo/odoo/blob/b3559145febc16271c78ca516af9d7e99bf3452f/addons/stock_account/models/res_company.py#L53-L55

**Solution**
To avoid to revert this commit https://github.com/odoo-dev/odoo/commit/594654deb84ba45e9a6a765b89de79e4ce4e4b50 fix, both creation and accounting date are used.

opw-5559264