### PR TITLE
[FIX] stock_account: no product move breaks AVCO compute on lots

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -549,7 +549,7 @@ class ProductProduct(models.Model):
     def _run_avco(self, at_date=None, lot=None, method="realtime"):
         self.ensure_one()
         price_unit, value = self._run_average_batch(at_date=at_date, lot=lot, force_recompute=True)
-        return price_unit[self.id], value[self.id]
+        return price_unit.get(self.id, 0), value.get(self.id, 0)
 
     def _get_value_from_lots(self):
         return 0


### PR DESCRIPTION
PR [247625](https://github.com/odoo/odoo/pull/247625) improved performance of the AVCO computation with `_run_average_batch()`.

However, it's currently possible that the method returns an empty dictionary if a product does not have any stock move associated with it. It then raises a traceback in `_run_avco()` because we expect the dictionary to always hold the product id keys.

Ticket: opw-5951133
