### PR TITLE
[FIX] hr_attendance: regenerate overtimes with multiple versions

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -296,24 +296,17 @@ class HrAttendance(models.Model):
         attendances_by_ruleset = defaultdict(lambda: self.env['hr.attendance'])
         for employee, emp_attendance in attendances_by_employee.items():
             for attendance in emp_attendance:
-                attendance_intervals = Intervals([(
-                    utc.localize(attendance.check_in),
-                    utc.localize(attendance.check_out),
-                    self.env['hr.version'])])
-                inter = Intervals(version_periods_by_employee[employee]) & attendance_intervals
-                if not inter:
-                    continue
-                version = inter._items[0][2]
-                ruleset = version.ruleset_id
-                if ruleset:
-                    attendances_by_ruleset[ruleset] += attendance
+                version_sudo = employee.sudo()._get_version(attendance._get_localized_times()[0])
+                ruleset_sudo = version_sudo.ruleset_id
+                if ruleset_sudo:
+                    attendances_by_ruleset[ruleset_sudo] += attendance
         employees = all_attendances.employee_id
         schedules_intervals_by_employee = employees._get_schedules_by_employee_by_work_type(min_check_in, max_check_out, version_periods_by_employee)
         overtime_vals_list = []
-        for ruleset, ruleset_attendances in attendances_by_ruleset.items():
+        for ruleset_sudo, ruleset_attendances in attendances_by_ruleset.items():
             attendances_dates = list(chain(*ruleset_attendances._get_dates().values()))
             overtime_vals_list.extend(
-                ruleset.rule_ids._generate_overtime_vals_v2(min(attendances_dates), max(attendances_dates), ruleset_attendances, schedules_intervals_by_employee)
+                ruleset_sudo.rule_ids._generate_overtime_vals_v2(min(attendances_dates), max(attendances_dates), ruleset_attendances, schedules_intervals_by_employee)
             )
         self.env['hr.attendance.overtime.line'].create(overtime_vals_list)
         self.env.add_to_compute(self._fields['overtime_hours'], all_attendances)

--- a/addons/hr_attendance/models/hr_attendance_overtime_rule.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime_rule.py
@@ -696,7 +696,7 @@ class HrAttendanceOvertimeRule(models.Model):
 
         overtimes, undertimes = self._get_overtime_undertime_intervals_by_employee_by_attendance(min_check_in, max_check_out, attendances, schedules_intervals_by_employee)
         for employee, intervals_by_attendance in overtimes.items():
-            tz = timezone(employee._get_tz())
+            tz = timezone(employee.sudo()._get_tz())
             for attendance, intervals in intervals_by_attendance.items():
                 duration_by_day_by_rules = defaultdict(lambda: defaultdict(float))
                 record_overlap_intervals = _record_overlap_intervals(intervals)
@@ -706,7 +706,7 @@ class HrAttendanceOvertimeRule(models.Model):
                 _add_overtime_val(attendance, duration_by_day_by_rules)
 
         for employee, intervals_by_attendance in undertimes.items():
-            tz = timezone(employee._get_tz())
+            tz = timezone(employee.sudo()._get_tz())
             for attendance, intervals in intervals_by_attendance.items():
                 date = attendance.check_in.astimezone(tz).date()
                 duration_by_day_by_rules = defaultdict(lambda: defaultdict(float))


### PR DESCRIPTION
_
## Short functional explanation of the error
When we generate overtime for an employee who has 2 different versions. If each version has a different overtime ruleset and an attendance exists during the time frame of each version.
When trying to generate overtime for the ruleset of the first version, a traceback occurs.

## Reproduction Steps
1. Create an employee. Create 2 different versions for this employee. On each version, set a different overtime ruleset.
2. Create 2 attendances: one during the time frame on which the first version applies, and one during the time frame on which the second version applies.
3. Go to overtime rulesets. Click on the ruleset you applied on the first version and click Reenerate Overtimes.

### Expected behavior
The overtimes are regenerated correctly.

### Unexpected behavior
A traceback occurs:
`ValueError: Expected singleton: hr.attendance.overtime.ruleset(7, 6) `

## Origin of the issue
In the code, we retrieve the version applying to the attendance for which we want to compute overtimes, to get the ruleset with which we will compute the compensation for overtimes: https://github.com/odoo/odoo/blob/347c46f8ecff7ae97c2a686bf5750374b6c3e2d3/addons/hr_attendance/models/hr_attendance.py#L303-L306 However, `version = inter._items[0][2]` returns both versions, thus obtaining both rulesets and creating the error when trying to accss the field `self.ruleset_id.rate_combination_mode` later, as self.ruleset_id will contain both rulesets.

__
opw-5443700

