### PR TITLE
[FIX] hr_expense: skip encrypted files from expenses report PDF (2)

### DIFF
--- a/addons/hr_expense/models/ir_actions_report.py
+++ b/addons/hr_expense/models/ir_actions_report.py
@@ -1,7 +1,7 @@
 import io
 from odoo import models, _
 from odoo.tools import pdf
-from odoo.tools.pdf import OdooPdfFileReader, OdooPdfFileWriter, PdfReadError
+from odoo.tools.pdf import OdooPdfFileReader, OdooPdfFileWriter, PdfReadError, DependencyError
 
 
 class IrActionsReport(models.Model):
@@ -37,7 +37,7 @@ class IrActionsReport(models.Model):
                     attachment_reader = OdooPdfFileReader(attachment_stream, strict=False)
                     try:
                         output_pdf.appendPagesFromReader(attachment_reader)
-                    except PdfReadError as e:
+                    except (PdfReadError, DependencyError) as e:
                         expense_sheet._message_log(body=_(
                             "The attachment (%s) has not been added to the report due to the following error: '%s'",
                             attachment.name,


### PR DESCRIPTION
**Issue:**
This is a complement to the previous commit:
https://github.com/odoo/odoo/commit/2eb12ba5e8055c5a0aa3ab86d0e173b3ca3ff2f0

When using version 2.12.1 of PyPDF2 as required if python version > 3.10, if PyCryptodome library is not installed, a DependencyError will be raised when trying to decrypt the file:
"PyCryptodome is required for AES algorithm".

opw-5194501



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
