### PR TITLE
[FIX] web: formatFloatTime + use extractOptions in list/graph

### DIFF
--- a/addons/hr_holidays/static/src/leave_stats/leave_stats.xml
+++ b/addons/hr_holidays/static/src/leave_stats/leave_stats.xml
@@ -31,7 +31,7 @@
                     </div>
                     <div class="col-3 flex-wrap">
                     (
-                        <span t-if="leave.work_entry_type_request_unit == 'hour'"><t t-esc="leave.number_of_hours"/> hours</span>
+                        <span t-if="leave.work_entry_type_request_unit == 'hour'"><t t-esc="leave.number_of_hours"/></span>
                         <span t-else=""><t t-esc="leave.number_of_days"/> days</span>
                     )
                     </div>
@@ -69,7 +69,7 @@
                         </div>
                         <div class="col-3 flex-wrap">
                             (
-                            <span t-if="leave.work_entry_type_request_unit == 'hour'"><t t-esc="leave.number_of_hours"/> hours</span>
+                            <span t-if="leave.work_entry_type_request_unit == 'hour'"><t t-esc="leave.number_of_hours"/></span>
                             <span t-else=""><t t-esc="leave.number_of_days"/> days</span>
                             )
                         </div>

--- a/addons/hr_holidays/static/tests/leave_stats.test.js
+++ b/addons/hr_holidays/static/tests/leave_stats.test.js
@@ -107,12 +107,12 @@ test("leave stats render correctly", async () => {
     expect(queryAll("span:contains(Legal Leave)", { root: individualLeaves })).toHaveCount(1);
     expect(queryAll("span:contains(2 days)", { root: individualLeaves })).toHaveCount(1);
     expect(queryAll("span:contains(Unpaid Leave)", { root: individualLeaves })).toHaveCount(1);
-    expect(queryAll("span:contains(01:00 hours)", { root: individualLeaves })).toHaveCount(1);
+    expect(queryAll("span:contains(1h)", { root: individualLeaves })).toHaveCount(1);
 
     // Displays all leaves for that department
     expect(queryAll("span:contains(Richard)", { root: DepartmentLeaves })).toHaveCount(2);
     expect(queryAll("span:contains(10/16/2016)", { root: DepartmentLeaves })).toHaveCount(1);
-    expect(queryAll("span:contains(02:00 hours)", { root: DepartmentLeaves })).toHaveCount(1);
+    expect(queryAll("span:contains(2h)", { root: DepartmentLeaves })).toHaveCount(1);
     expect(queryAll("span:contains(10/20/2016)", { root: DepartmentLeaves })).toHaveCount(1);
     expect(queryAll("span:contains(10/25/2016)", { root: DepartmentLeaves })).toHaveCount(1);
 

--- a/addons/im_livechat/report/im_livechat_report_channel_views.xml
+++ b/addons/im_livechat/report/im_livechat_report_channel_views.xml
@@ -8,10 +8,10 @@
             <field name="arch" type="xml">
                 <pivot js_class="im_livechat.report_channel_pivot" string="Live Chat Support Statistics" sample="1" display_quantity="1">
                     <field name="has_call" type="measure" invisible="1"/>
-                    <field name="call_duration_hour" type="measure" widget="float_time"/>
+                    <field name="call_duration_hour" type="measure" widget="float_time" options="{'show_seconds': true}"/>
                     <field name="partner_id" type="row"/>
                     <field name="percentage_of_calls" type="measure" widget="percentage"/>
-                    <field name="time_to_answer" string="Response Time" type="measure" widget="float_time"/>
+                    <field name="time_to_answer" string="Response Time" type="measure" widget="float_time" options="{'show_seconds': true}"/>
                     <field name="duration" type="measure"/>
                     <field name="rating" string="Rating (%)" type="measure" widget="im_livechat.rating_percentage"/>
                     <field name="number_of_calls" string="# of calls" type="measure" widget="integer"/>

--- a/addons/im_livechat/views/discuss_channel_views.xml
+++ b/addons/im_livechat/views/discuss_channel_views.xml
@@ -63,7 +63,7 @@
                     <field name="livechat_lang_id" optional="show"/>
                     <field name="livechat_expertise_ids" string="Expertise" widget="many2many_tags" optional="show"/>
                     <field name="livechat_channel_id" optional="hide"/>
-                    <field name="duration" widget="float_time" optional="show"/>
+                    <field name="duration" widget="float_time" optional="show" options="{'show_seconds': true}"/>
                     <field name="message_count" string="Messages" optional="show"/>
                     <field name="rating_last_text" string="Rating" decoration-danger="rating_last_text == 'ko'"
                         decoration-warning="rating_last_text == 'ok'" decoration-success="rating_last_text == 'top'"
@@ -84,7 +84,7 @@
                                 <div class="d-flex flex-column">
                                     <field class="fw-bolder" name="livechat_customer_history_ids" widget="im_livechat.one2many_names"/>
                                     <span class="fw-bold">Date: <field name="create_date" class="fw-normal"/></span>
-                                    <span class="fw-bold">Duration: <field class="d-inline fw-normal" name="duration" widget="float_time"/></span>
+                                    <span class="fw-bold">Duration: <field class="d-inline fw-normal" name="duration" widget="float_time" options="{'show_seconds': true}"/></span>
                                     <span class="fw-bold">Messages: <field name="message_count" class="fw-normal"/></span>
                                     <field name="livechat_failure" invisible="1"/>
                                     <field name="livechat_is_escalated" invisible="1"/>

--- a/addons/im_livechat/views/im_livechat_channel_member_history_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_member_history_views.xml
@@ -24,7 +24,7 @@
                     <field name="partner_id"/>
                     <field name="chatbot_script_id"/>
                     <field name="guest_id"/>
-                    <field name="session_duration_hour" widget="float_time"/>
+                    <field name="session_duration_hour" widget="float_time" options="{'show_seconds': true}"/>
                     <field name="livechat_member_type" string="Member Type"/>
                 </list>
             </field>
@@ -110,10 +110,10 @@
                     <field name="session_start_hour" invisible="1"/>
                     <field name="session_week_day" invisible="1"/>
                     <field name="partner_id" type="row"/>
-                    <field name="call_duration_hour" type="measure" widget="float_time"/>
+                    <field name="call_duration_hour" type="measure" widget="float_time" options="{'show_seconds': true}"/>
                     <field name="call_percentage" type="measure" widget="percentage"/>
-                    <field name="response_time_hour" string="Response Time" type="measure" widget="float_time" />
-                    <field name="session_duration_hour" type="measure" widget="float_time"/>
+                    <field name="response_time_hour" string="Response Time" type="measure" widget="float_time" options="{'show_seconds': true}"/>
+                    <field name="session_duration_hour" type="measure" widget="float_time" options="{'show_seconds': true}"/>
                     <field name="rating" string="Rating (%)" type="measure" widget="im_livechat.rating_percentage"/>
                     <field name="call_count" type="measure" widget="integer"/>
                 </pivot>

--- a/addons/mail/views/discuss/discuss_call_history_views.xml
+++ b/addons/mail/views/discuss/discuss_call_history_views.xml
@@ -8,7 +8,7 @@
                 <list string="Call History" sample="1">
                     <field name="channel_id" string="Conversation"/>
                     <field name="start_dt" string="Date" widget="daterange" options="{'end_date_field': 'end_dt'}"/>
-                    <field name="duration_hour" string="Duration" widget="float_time" options="{'show_seconds': false}"/>
+                    <field name="duration_hour" string="Duration" widget="float_time" options="{'show_seconds': true}"/>
                 </list>
             </field>
         </record>
@@ -21,7 +21,7 @@
                         <field name="channel_id"/>
                         <field name="start_dt"/>
                         <field name="end_dt"/>
-                        <field name="duration_hour" widget="float_time"/>
+                        <field name="duration_hour" widget="float_time" options="{'show_seconds': true}"/>
                     </group>
                 </form>
             </field>

--- a/addons/mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.js
+++ b/addons/mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.js
@@ -1,6 +1,6 @@
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
-import { formatFloat, formatDuration, formatMonetary } from "@web/views/fields/formatters";
+import { formatFloat, formatFloatTime, formatMonetary } from "@web/views/fields/formatters";
 import { Component } from "@odoo/owl";
 
 export class BomOverviewLine extends Component {
@@ -29,7 +29,7 @@ export class BomOverviewLine extends Component {
         this.actionService = useService("action");
         this.ormService = useService("orm");
         this.formatFloat = formatFloat;
-        this.formatDuration = formatDuration;
+        this.formatFloatTime = formatFloatTime;
         this.formatMonetary = (val) => formatMonetary(val, { currencyId: this.data.currency_id });
     }
 

--- a/addons/mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.xml
+++ b/addons/mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.xml
@@ -18,7 +18,7 @@
             </div>
         </td>
         <td class="text-end" name="quantity">
-            <t t-if="data.type == 'operation'" t-esc="formatDuration(data.quantity, {'unit': 'minutes'})"/>
+            <t t-if="data.type == 'operation'" t-esc="formatFloatTime(data.quantity, {'unit': 'minutes'})"/>
             <t t-else="" t-esc="formatFloat(data.quantity, {'digits': [false, precision]})"/>
         </td>
          <td t-if="showUom" class="text-start" t-esc="data.uom_name"/>

--- a/addons/mrp/static/src/components/bom_overview_special_line/mrp_bom_overview_special_line.js
+++ b/addons/mrp/static/src/components/bom_overview_special_line/mrp_bom_overview_special_line.js
@@ -1,4 +1,4 @@
-import { formatFloat, formatDuration, formatMonetary } from "@web/views/fields/formatters";
+import { formatFloat, formatFloatTime, formatMonetary } from "@web/views/fields/formatters";
 import { Component } from "@odoo/owl";
 
 export class BomOverviewSpecialLine extends Component {
@@ -25,7 +25,7 @@ export class BomOverviewSpecialLine extends Component {
 
     setup() {
         this.formatFloat = formatFloat;
-        this.formatDuration = formatDuration;
+        this.formatFloatTime = formatFloatTime;
         this.formatMonetary = (val) => formatMonetary(val, { currencyId: this.data.currency_id });
     }
 

--- a/addons/mrp/static/src/components/bom_overview_special_line/mrp_bom_overview_special_line.xml
+++ b/addons/mrp/static/src/components/bom_overview_special_line/mrp_bom_overview_special_line.xml
@@ -13,7 +13,7 @@
             </span>
         </td>
         <td name="quantity" class="text-end">
-            <span t-if="props.type == 'operations'" t-esc="formatDuration(data.operations_time, {'unit': 'minutes'})"/>
+            <span t-if="props.type == 'operations'" t-esc="formatFloatTime(data.operations_time, {'unit': 'minutes'})"/>
             <span t-elif="props.type == 'byproducts'" t-esc="formatFloat(data.byproducts_total, {'digits': [false, precision]})"/>
         </td>
         <td name="uom" t-if="showUom" class="text-start"/>

--- a/addons/mrp/static/src/components/mo_overview_line/mrp_mo_overview_line.js
+++ b/addons/mrp/static/src/components/mo_overview_line/mrp_mo_overview_line.js
@@ -1,7 +1,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { Component } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
-import { formatFloat, formatDuration, formatMonetary } from "@web/views/fields/formatters";
+import { formatFloat, formatFloatTime, formatMonetary } from "@web/views/fields/formatters";
 import { getStateDecorator } from "./mo_overview_colors";
 import { SHOW_OPTIONS } from "../mo_overview_display_filter/mrp_mo_overview_display_filter";
 
@@ -62,7 +62,7 @@ export class MoOverviewLine extends Component {
         this.actionService = useService("action");
         this.ormService = useService("orm");
         this.formatFloat = (val) => formatFloat(val, { digits: [false, this.data.uom_precision || undefined] });
-        this.formatDuration = formatDuration;
+        this.formatFloatTime = formatFloatTime;
         this.formatMonetary = (val) => formatMonetary(val, { currencyId: this.data.currency_id });
     }
 
@@ -147,7 +147,7 @@ export class MoOverviewLine extends Component {
 
     get formattedQuantity() {
         if (this.data.model === "mrp.workorder" || !this.data.model) {
-            return this.formatDuration(this.data.quantity, { unit: this.data.state ? "minutes" : "hours" });
+            return this.formatFloatTime(this.data.quantity, { unit: this.data.state ? "minutes" : "hours" });
         }
         return this.formatFloat(this.data.quantity);
     }

--- a/addons/mrp/static/src/components/mo_overview_operations_block/mrp_mo_overview_operations_block.js
+++ b/addons/mrp/static/src/components/mo_overview_operations_block/mrp_mo_overview_operations_block.js
@@ -1,6 +1,6 @@
 import { Component, useState } from "@odoo/owl";
 import { useBus } from "@web/core/utils/hooks";
-import { formatDuration, formatMonetary } from "@web/views/fields/formatters";
+import { formatFloatTime, formatMonetary } from "@web/views/fields/formatters";
 import { MoOverviewLine } from "../mo_overview_line/mrp_mo_overview_line";
 import { SHOW_OPTIONS } from "../mo_overview_display_filter/mrp_mo_overview_display_filter";
 
@@ -36,7 +36,7 @@ export class MoOverviewOperationsBlock extends Component {
     };
 
     setup() {
-        this.formatDuration = formatDuration;
+        this.formatFloatTime = formatFloatTime;
         this.state = useState({
             // Unfold the main MO's operations by default
             isFolded: this.level > 0 && !this.props.unfoldAll,
@@ -87,7 +87,7 @@ export class MoOverviewOperationsBlock extends Component {
     get totalQuantity() {
         // Float for Hours when displaying done productions, FloatTime for Minutes otherwise.
         return this.props.summary?.done ?
-            formatDuration(this.props.summary.quantity, { unit: "hours" }) :
-            formatDuration(this.props.summary.quantity, { unit: "minutes" })
+            formatFloatTime(this.props.summary.quantity, { unit: "hours" }) :
+            formatFloatTime(this.props.summary.quantity, { unit: "minutes" })
     }
 }

--- a/addons/web/static/src/views/fields/float_time/float_time_field.js
+++ b/addons/web/static/src/views/fields/float_time/float_time_field.js
@@ -1,10 +1,10 @@
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
-import { formatDuration } from "../formatters";
+import { formatFloatTime } from "../formatters";
 import { useInputField } from "../input_field_hook";
 import { standardFieldProps } from "../standard_field_props";
 import { useNumpadDecimal } from "../numpad_decimal_hook";
-import { parseDuration, parseFloatDuration } from "../parsers";
+import { parseFloatTime } from "../parsers";
 
 import { Component, useState } from "@odoo/owl";
 import { usePopover } from "@web/core/popover/popover_hook";
@@ -18,7 +18,6 @@ export class FloatTimeField extends Component {
         unit: { type: ["hours", "minutes", "seconds"], optional: true },
     };
     static defaultProps = {
-        showSeconds: true,
         numeric: false,
         unit: "hours",
     };
@@ -27,7 +26,7 @@ export class FloatTimeField extends Component {
         this.inputFloatTimeRef = useInputField({
             getValue: () => this.formattedValue,
             refName: "numpadDecimal",
-            parse: (v) => parseFloatDuration(v, this.props.unit),
+            parse: (v) => parseFloatTime(v, this.props.unit),
         });
 
         this.state = useState({
@@ -41,16 +40,23 @@ export class FloatTimeField extends Component {
 
     onValueChange(ev) {
         const currentInput = ev.target.value;
-        this.state.formattedResult = formatDuration(parseDuration(currentInput, this.props.unit), {
+        this.state.formattedResult = formatFloatTime(parseFloatTime(currentInput, this.props.unit), {
             showSeconds: this.props.showSeconds,
             numeric: this.props.numeric,
             unit: this.props.unit,
         });
+        if (currentInput === this.state.formattedResult && this.resultPopover.isOpen) {
+            this.resultPopover.close();
+        } else if (currentInput !== this.state.formattedResult && !this.resultPopover.isOpen) {
+            this.resultPopover.open(this.inputFloatTimeRef.el, {
+                state: this.state,
+            });
+        }
     }
 
     openPopover() {
-        const duration = parseDuration(this.inputFloatTimeRef.el.value, this.props.unit);
-        this.state.formattedResult = formatDuration(duration, {
+        const duration = parseFloatTime(this.inputFloatTimeRef.el.value, this.props.unit);
+        this.state.formattedResult = formatFloatTime(duration, {
             showSeconds: this.props.showSeconds,
             numeric: this.props.numeric,
             unit: this.props.unit,
@@ -65,13 +71,14 @@ export class FloatTimeField extends Component {
     }
 
     get formattedValue() {
-        const value = {};
-        value[this.props.unit] = this.props.record.data[this.props.name];
-        return formatDuration(value, {
-            showSeconds: this.props.showSeconds,
-            numeric: this.props.numeric,
-            unit: this.props.unit,
-        });
+        const value = this.props.record.data[this.props.name];
+        return formatFloatTime(value,
+            {
+                showSeconds: this.props.showSeconds,
+                numeric: this.props.numeric,
+                unit: this.props.unit,
+            },
+        );
     }
 }
 
@@ -91,7 +98,6 @@ export const floatTimeField = {
             label: _t("Show seconds"),
             name: "show_seconds",
             type: "boolean",
-            default: true,
         },
         {
             label: _t("Type"),
@@ -119,8 +125,8 @@ export const floatTimeField = {
     supportedTypes: ["float"],
     isEmpty: () => false,
     extractProps: ({ options }) => ({
-        showSeconds: options.show_seconds,
-        numeric: options.numeric,
+        showSeconds: Boolean(options.show_seconds),
+        numeric: Boolean(options.numeric),
         unit: options.unit,
     }),
 };

--- a/addons/web/static/src/views/fields/formatters.js
+++ b/addons/web/static/src/views/fields/formatters.js
@@ -186,9 +186,9 @@ formatFloatFactor.extractOptions = ({ attrs, options }) => ({
 });
 
 /**
- * Returns a string representing a time value, from a float.  The idea is that
- * we sometimes want to display something like 1:45 instead of 1.75, or 0:15
- * instead of 0.25.
+ * Returns a string representing a time value, from a float or a Duration object.
+ * The idea is that we sometimes want to display something like 1h 45m instead of 1.75,
+ * or 0:15 instead of 0.25.
  *
  * @param {import("./parsers").Duration} value
  * @param {Object} [options]
@@ -197,13 +197,13 @@ formatFloatFactor.extractOptions = ({ attrs, options }) => ({
  * @param {import("./parsers").UnitOfTime} [options.unit="hours"] The unit of mesure for the duration
  * @returns {string}
  */
-export function formatDuration(value, options = {}) {
+function formatDuration(value, options = {}) {
     if (value === false) {
         return "";
     }
 
-    options.unit = options.unit || "hours";
-
+    const showSeconds = options.showSeconds || options.unit === "seconds";
+    const unit = options.unit || "hours";
     let seconds = (value.hours || 0) * 3600 + (value.minutes || 0) * 60 + (value.seconds || 0);
     let isNegative;
 
@@ -213,19 +213,20 @@ export function formatDuration(value, options = {}) {
     }
 
     const duration = {
-        hours: parseInt(seconds / 3600, 10),
-        minutes: parseInt((seconds % 3600) / 60, 10),
-        seconds: parseInt(seconds % 60, 10),
+        hours: Math.floor(seconds / 3600),
+        minutes: showSeconds
+            ? Math.floor((seconds % 3600) / 60)
+            : Math.round((seconds % 3600) / 60),
+        seconds: showSeconds ? Math.round(seconds % 60) : 0,
     };
 
     let durationParts = new Intl.DurationFormat(l10n.locale, {
         style: options.numeric ? "digital" : "narrow",
-        hoursDisplay: options.unit === "hours" || options.numeric ? "always" : "auto",
+        hoursDisplay: unit === "hours" || options.numeric ? "always" : "auto",
         minutesDisplay: "always",
-        secondsDisplay: options.unit === "seconds" || options.numeric ? "always" : "auto",
+        secondsDisplay: showSeconds ? "always" : "auto",
     })
         .formatToParts(duration)
-        .filter((d) => d.unit !== "second" || options.showSeconds !== false)
         .filter((d) => d.type !== "literal");
 
     let formattedValue = "";
@@ -237,9 +238,9 @@ export function formatDuration(value, options = {}) {
     } else {
         if (
             duration.minutes === 0 &&
-            options.unit !== "minutes" &&
-            ((duration.hours === 0 && options.unit !== "hours") ||
-                (duration.seconds === 0 && options.unit !== "seconds"))
+            unit !== "minutes" &&
+            (!durationParts.some((d) => d.unit === "hour") ||
+                !durationParts.some((d) => d.unit === "second"))
         ) {
             durationParts = durationParts.filter((d) => d.unit !== "minute");
         }
@@ -254,55 +255,37 @@ export function formatDuration(value, options = {}) {
 
     return `${isNegative ? "-" : ""}${formattedValue}`;
 }
-formatDuration.extractOptions = ({ options }) => ({
-    showSeconds: options.show_seconds,
-    numeric: options.numeric,
-});
 
 /**
+ *
  * Returns a string representing a time value, from a float.  The idea is that
- * we sometimes want to display something like 1:45 instead of 1.75, or 0:15
+ * we sometimes want to display something like 1h 45m instead of 1.75, or 0:15
  * instead of 0.25.
  *
- * @param {number | false} value
+ * @param {number} value
  * @param {Object} [options]
- * @param {boolean} [options.noLeadingZeroHour] if true, format like 1:30 otherwise, format like 01:30
- * @param {boolean} [options.showSeconds] if true, format like ?1:30:00 otherwise, format like ?1:30
+ * @param {boolean} [options.showSeconds] if true, format like 1:30:00 otherwise, format like 1:30
+ * @param {boolean} [options.numeric] if true, show the duration in the format set on the language
+ * @param {import("./parsers").UnitOfTime} [options.unit="hours"] The unit of mesure for the duration
  * @returns {string}
  */
 export function formatFloatTime(value, options = {}) {
     if (value === false) {
         return "";
     }
-    const isNegative = value < 0;
-    value = Math.abs(value);
 
-    let hour = Math.floor(value);
-    const milliSecLeft = Math.round(value * 3600000) - hour * 3600000;
-    // Although looking quite overkill, the following lines ensures that we do
-    // not have float issues while still considering that 59s is 00:00.
-    let min = milliSecLeft / 60000;
-    if (options.showSeconds) {
-        min = Math.floor(min);
-    } else {
-        min = Math.round(min);
-    }
-    if (min === 60) {
-        min = 0;
-        hour = hour + 1;
-    }
-    min = String(min).padStart(2, "0");
-    if (!options.noLeadingZeroHour) {
-        hour = String(hour).padStart(2, "0");
-    }
-    let sec = "";
-    if (options.showSeconds) {
-        sec = ":" + String(Math.floor((milliSecLeft % 60000) / 1000)).padStart(2, "0");
-    }
-    return `${isNegative ? "-" : ""}${hour}:${min}${sec}`;
+    options.unit = options.unit || "hours";
+
+    return formatDuration(
+        {
+            [options.unit]: value,
+        },
+        options,
+    );
 }
 formatFloatTime.extractOptions = ({ options }) => ({
-    showSeconds: options.show_seconds,
+    showSeconds: Boolean(options.show_seconds),
+    numeric: Boolean(options.numeric),
 });
 
 /**

--- a/addons/web/static/src/views/fields/parsers.js
+++ b/addons/web/static/src/views/fields/parsers.js
@@ -108,35 +108,10 @@ export function parseFloat(value, { allowOperation = false } = {}) {
  * The float time can have two formats: float or integer:integer.
  *
  * @param {string} value
+ * @param {UnitOfTime} [unit="hours"]
  * @returns {number} a float
  */
-export function parseFloatTime(value) {
-    let sign = 1;
-    if (value[0] === "-") {
-        value = value.slice(1);
-        sign = -1;
-    }
-    const values = value.split(":");
-    if (values.length > 2) {
-        throw new InvalidNumberError(`"${value}" is not a correct number`);
-    }
-    if (values.length === 1) {
-        return sign * parseFloat(value);
-    }
-    const hours = parseInteger(values[0]);
-    const minutes = parseInteger(values[1]);
-    return sign * (hours + minutes / 60);
-}
-
-/**
- *
- * Parse a string of a duration to float value based on unit
- * e.g.: 1h 30m in hours would be 1.5 
- * 
- * @param {string} value
- * @param {UnitOfTime} unit
- */
-export function parseFloatDuration(value, unit) {
+export function parseFloatTime(value, unit = "hours") {
     const duration = parseDuration(value, unit);
 
     if (unit === "hours") {
@@ -156,10 +131,10 @@ export function parseFloatDuration(value, unit) {
  * - Human format as 12h 30m 45s (depends of the local)
  *
  * @param {string} value
- * @param {UnitOfTime} unit
+ * @param {UnitOfTime} [unit="hours"]
  * @return {Duration}
  */
-export function parseDuration(value, unit = "hours") {
+function parseDuration(value, unit = "hours") {
     let isNegative;
     const duration = {
         hours: 0,
@@ -188,7 +163,7 @@ export function parseDuration(value, unit = "hours") {
     }
 
     // 12:30:45 format
-    else if (value.match(/\d+:\d*(:\d*)?/)) {
+    else if (value.match(/(\d+)?:\d*(:\d*)?/)) {
         const result = value.split(":");
         let unitFound = result.length === 3;
         let i = 0;

--- a/addons/web/static/src/views/graph/graph_arch_parser.js
+++ b/addons/web/static/src/views/graph/graph_arch_parser.js
@@ -1,4 +1,5 @@
 import { exprToBoolean } from "@web/core/utils/strings";
+import { evaluateExpr } from "@web/core/py_js/py";
 import { visitXML } from "@web/core/utils/xml";
 import { GROUPABLE_TYPES } from "@web/search/utils/misc";
 
@@ -46,27 +47,22 @@ export class GraphArchParser {
                     if (fieldName === "id") {
                         break;
                     }
+                    if (!archInfo.fieldAttrs[fieldName]) {
+                        archInfo.fieldAttrs[fieldName] = {};
+                    }
+
+                    const options = node.getAttribute("options");
+                    archInfo.fieldAttrs[fieldName].options = options ? evaluateExpr(options): {};
+                    
                     const string = node.getAttribute("string");
                     if (string) {
-                        if (!archInfo.fieldAttrs[fieldName]) {
-                            archInfo.fieldAttrs[fieldName] = {};
-                        }
                         archInfo.fieldAttrs[fieldName].string = string;
                     }
                     const widget = node.getAttribute("widget");
                     if (widget) {
-                        if (!archInfo.fieldAttrs[fieldName]) {
-                            archInfo.fieldAttrs[fieldName] = {};
-                        }
                         archInfo.fieldAttrs[fieldName].widget = widget;
                     }
-                    if (
-                        node.getAttribute("invisible") === "True" ||
-                        node.getAttribute("invisible") === "1"
-                    ) {
-                        if (!archInfo.fieldAttrs[fieldName]) {
-                            archInfo.fieldAttrs[fieldName] = {};
-                        }
+                    if (exprToBoolean(node.getAttribute("invisible"))) {
                         archInfo.fieldAttrs[fieldName].isInvisible = true;
                         break;
                     }

--- a/addons/web/static/src/views/graph/graph_renderer.js
+++ b/addons/web/static/src/views/graph/graph_renderer.js
@@ -267,10 +267,14 @@ export class GraphRenderer extends Component {
      * @param {boolean} [allIntegers=true]
      * @returns {string}
      */
-    formatValue(value, allIntegers = true, formatType = "") {
+    formatValue(value, measure, allIntegers = true) {
         const largeNumber = Math.abs(value) >= 1000;
-        if (formatType) {
-            return formatters.get(formatType)(value);
+        const widget = this.model.metaData.fieldAttrs[measure]?.widget
+        let options = this.model.metaData.fieldAttrs[measure]?.options
+        if (widget) {
+            const formatter = formatters.get(widget);
+            options = formatter.extractOptions ? formatter.extractOptions({ options }) : {};
+            return formatter(value, options);
         }
         if (allIntegers && !largeNumber) {
             return String(value);
@@ -554,7 +558,7 @@ export class GraphRenderer extends Component {
      */
     getScaleOptions() {
         const { labels } = this.model.data;
-        const { fieldAttrs, measure, measures, mode, stacked } = this.model.metaData;
+        const { measure, measures, mode, stacked } = this.model.metaData;
         if (mode === "pie") {
             return {};
         }
@@ -585,7 +589,7 @@ export class GraphRenderer extends Component {
                         : null,
             },
             ticks: {
-                callback: (value) => this.formatValue(value, false, fieldAttrs[measure]?.widget),
+                callback: (value) => this.formatValue(value, measure, false),
                 color: GRAPH_LABEL_COLOR,
             },
             stacked: mode === "line" && stacked ? stacked : undefined,
@@ -622,19 +626,18 @@ export class GraphRenderer extends Component {
             const dataset = data.datasets[item.datasetIndex] || this.model.lineOverlayDataset;
             let label = dataset.trueLabels[index];
             let value = dataset.data[index];
-            const measureWidget = metaData.fieldAttrs[measure]?.widget;
             if (dataset.currencyIds?.[index]) {
                 value = formatMonetary(value, { currencyId: dataset.currencyIds[index] });
             } else if (dataset.currencyIds?.[index] === false) {
                 value = markup`${formatMonetary(value)}<sup class="ms-1 fw-bolder">?</sup>`;
             } else {
-                value = this.formatValue(value, allIntegers, measureWidget);
+                value = this.formatValue(value, measure, allIntegers);
             }
             let boxColor;
             let percentage;
             if (mode === "pie") {
                 if (label === NO_DATA) {
-                    value = this.formatValue(0, allIntegers, measureWidget);
+                    value = this.formatValue(0, measure, allIntegers);
                 }
                 boxColor = dataset.backgroundColor[index];
                 const totalData = dataset.data.reduce((a, b) => a + b, 0);

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -763,7 +763,9 @@ export class ListRenderer extends Component {
             if (func) {
                 const aggregatedValue = computeAggregatedValue(fieldValues, func);
                 const formatter = formatters.get(widget, false) || formatters.get(type, false);
+                const options = formatter.extractOptions && formatter.extractOptions(column);
                 const formatOptions = {
+                    ...options,
                     digits: attrs.digits ? JSON.parse(attrs.digits) : undefined,
                     escape: true,
                 };

--- a/addons/web/static/tests/views/fields/float_time_field.test.js
+++ b/addons/web/static/tests/views/fields/float_time_field.test.js
@@ -7,19 +7,22 @@ import {
     models,
     mountView,
     onRpc,
+    webModels,
 } from "@web/../tests/web_test_helpers";
 
-class Partner extends models.Model {
+const { ResCompany, ResUsers, ResPartner } = webModels;
+
+class Foo extends models.Model {
     qux = fields.Float();
 
     _records = [{ id: 5, qux: 9.1 }];
 }
 
-defineModels([Partner]);
+defineModels([Foo, ResPartner, ResCompany, ResUsers]);
 
 test("FloatTimeField in form view", async () => {
-    expect.assertions(5);
-    onRpc("partner", "web_save", ({ args }) => {
+    expect.assertions(4);
+    onRpc("foo", "web_save", ({ args }) => {
         // 48 / 60 = 0.8
         expect(args[1].qux).toBe(-11.8, {
             message: "the correct float value should be saved",
@@ -28,11 +31,11 @@ test("FloatTimeField in form view", async () => {
 
     await mountView({
         type: "form",
-        resModel: "partner",
+        resModel: "foo",
         arch: `
             <form>
                 <sheet>
-                    <field name="qux" widget="float_time" options="{ 'numeric': true, 'show_seconds': false }"/>
+                    <field name="qux" widget="float_time" options="{ 'numeric': true }"/>
                 </sheet>
             </form>`,
         resId: 5,
@@ -44,7 +47,6 @@ test("FloatTimeField in form view", async () => {
     });
 
     await contains(".o_field_float_time[name=qux] input").edit("-11:48");
-    expect(".o_duration_popover").toHaveText("-11:48");
     expect(".o_field_float_time[name=qux] input").toHaveValue("-11:48", {
         message: "The new value should be displayed properly in the input.",
     });
@@ -56,15 +58,15 @@ test("FloatTimeField in form view", async () => {
 });
 
 test("FloatTimeField value formatted on blur", async () => {
-    expect.assertions(4);
-    onRpc("partner", "web_save", ({ args }) => {
+    expect.assertions(5);
+    onRpc("foo", "web_save", ({ args }) => {
         expect(args[1].qux).toBe(9.5, {
             message: "the correct float value should be saved",
         });
     });
     await mountView({
         type: "form",
-        resModel: "partner",
+        resModel: "foo",
         arch: `
             <form>
                 <field name="qux" widget="float_time"/>
@@ -77,6 +79,7 @@ test("FloatTimeField value formatted on blur", async () => {
     });
 
     await contains(".o_field_float_time[name=qux] input").edit("9.5");
+    expect(".o_duration_popover").toHaveText("9h 30m");
     expect(".o_field_float_time[name=qux] input").toHaveValue("9h 30m", {
         message: "The new value should be displayed properly in the input.",
     });
@@ -90,7 +93,7 @@ test("FloatTimeField value formatted on blur", async () => {
 test("FloatTimeField with invalid value", async () => {
     await mountView({
         type: "form",
-        resModel: "partner",
+        resModel: "foo",
         arch: `
             <form>
                 <field name="qux" widget="float_time"/>
@@ -110,7 +113,7 @@ test("FloatTimeField with invalid value", async () => {
 test("float_time field does not have an inputmode attribute", async () => {
     await mountView({
         type: "form",
-        resModel: "partner",
+        resModel: "foo",
         arch: `
             <form>
                 <field name="qux" widget="float_time"/>
@@ -118,4 +121,32 @@ test("float_time field does not have an inputmode attribute", async () => {
     });
 
     expect(".o_field_widget[name='qux'] input").not.toHaveAttribute("inputmode");
+});
+
+test("float_time apply beautiful duration on sum", async () => {
+    await mountView({
+        type: "list",
+        resModel: "foo",
+        arch: `
+            <list>
+                <field name="qux" sum="Sum" widget="float_time"/>
+            </list>`,
+    });
+
+    expect(".o_field_widget[name='qux'] time").toHaveText("9h 6m");
+    expect(".o_list_footer .o_list_number").toHaveText("9h 6m");
+});
+
+test("float_time apply options duration on sum", async () => {
+    await mountView({
+        type: "list",
+        resModel: "foo",
+        arch: `
+            <list>
+                <field name="qux" sum="Sum" widget="float_time" options="{'numeric': 1}"/>
+            </list>`,
+    });
+
+    expect(".o_field_widget[name='qux'] time").toHaveText("9:06");
+    expect(".o_list_footer .o_list_number").toHaveText("9:06");
 });

--- a/addons/web/static/tests/views/fields/formatters.test.js
+++ b/addons/web/static/tests/views/fields/formatters.test.js
@@ -19,7 +19,6 @@ import {
     formatX2many,
     formatDate,
     formatDateTime,
-    formatDuration,
 } from "@web/views/fields/formatters";
 
 const { DateTime } = luxon;
@@ -52,21 +51,21 @@ test("formatFloatFactor", () => {
 });
 
 test("formatFloatTime", () => {
-    expect(formatFloatTime(2)).toBe("02:00");
-    expect(formatFloatTime(3.5)).toBe("03:30");
-    expect(formatFloatTime(0.25)).toBe("00:15");
-    expect(formatFloatTime(0.58)).toBe("00:35");
-    expect(formatFloatTime(2 / 60, { showSeconds: true })).toBe("00:02:00");
-    expect(formatFloatTime(2 / 60 + 1 / 3600, { showSeconds: true })).toBe("00:02:01");
-    expect(formatFloatTime(2 / 60 + 2 / 3600, { showSeconds: true })).toBe("00:02:02");
-    expect(formatFloatTime(2 / 60 + 3 / 3600, { showSeconds: true })).toBe("00:02:03");
-    expect(formatFloatTime(0.25, { showSeconds: true })).toBe("00:15:00");
-    expect(formatFloatTime(0.25 + 15 / 3600, { showSeconds: true })).toBe("00:15:15");
-    expect(formatFloatTime(0.25 + 45 / 3600, { showSeconds: true })).toBe("00:15:45");
-    expect(formatFloatTime(56 / 3600, { showSeconds: true })).toBe("00:00:56");
-    expect(formatFloatTime(-0.5)).toBe("-00:30");
+    expect(formatFloatTime(2)).toBe("2h");
+    expect(formatFloatTime(3.5)).toBe("3h 30m");
+    expect(formatFloatTime(0.25)).toBe("0h 15m");
+    expect(formatFloatTime(0.58)).toBe("0h 35m");
+    expect(formatFloatTime(2 / 60, { showSeconds: true })).toBe("0h 2m 0s");
+    expect(formatFloatTime(2 / 60 + 1 / 3600, { showSeconds: true })).toBe("0h 2m 1s");
+    expect(formatFloatTime(2 / 60 + 2 / 3600, { showSeconds: true })).toBe("0h 2m 2s");
+    expect(formatFloatTime(2 / 60 + 3 / 3600, { showSeconds: true })).toBe("0h 2m 3s");
+    expect(formatFloatTime(0.25, { showSeconds: true })).toBe("0h 15m 0s");
+    expect(formatFloatTime(0.25 + 15 / 3600, { showSeconds: true })).toBe("0h 15m 15s");
+    expect(formatFloatTime(0.25 + 45 / 3600, { showSeconds: true })).toBe("0h 15m 45s");
+    expect(formatFloatTime(56 / 3600, { showSeconds: true })).toBe("0h 0m 56s");
+    expect(formatFloatTime(-0.5)).toBe("-0h 30m");
 
-    const options = { noLeadingZeroHour: true };
+    const options = { numeric: true };
     expect(formatFloatTime(2, options)).toBe("2:00");
     expect(formatFloatTime(3.5, options)).toBe("3:30");
     expect(formatFloatTime(3.5, { ...options, showSeconds: true })).toBe("3:30:00");
@@ -236,57 +235,26 @@ test("formatDateTime", () => {
     );
 });
 
-test("formatDuration", () => {
-    expect(formatDuration({ hours: 2 })).toBe("2h");
-    expect(formatDuration({ hours: 3.5 })).toBe("3h 30m");
-    expect(formatDuration({ hours: 0.25 })).toBe("0h 15m");
-    expect(formatDuration({ minutes: 35 })).toBe("0h 35m");
-    expect(formatDuration({ minutes: 35 }, { unit: "minutes" })).toBe("35m");
-    expect(formatDuration({ hours: 2, seconds: 15 })).toBe("2h 0m 15s");
-    expect(formatDuration({ seconds: 15 })).toBe("0h 0m 15s");
-    expect(formatDuration({ hours: 2 }, { unit: "seconds" })).toBe("2h 0m 0s");
-    expect(formatDuration({ minutes: 2, seconds: 15 })).toBe("0h 2m 15s");
-    expect(formatDuration({ seconds: 135 }, { showSeconds: false })).toBe("0h 2m");
-    expect(formatDuration({ minutes: 2, seconds: 15 }, { showSeconds: false, unit: "minutes" })).toBe("2m");
-    expect(formatDuration({ minutes: -30 })).toBe("-0h 30m");
-    expect(formatDuration({ minutes: -30 }, { unit: "minutes" })).toBe("-30m");
-
-    const options = { numeric: true };
-    expect(formatDuration({ hours: 3.5 }, options)).toBe("3:30:00");
-    expect(formatDuration({ hours: 3, seconds: 30 }, options)).toBe("3:00:30");
-    expect(formatDuration({ minutes: 3, seconds: 30 }, {...options, unit: "minutes"})).toBe("0:03:30");
-    expect(formatDuration({ hours: 0.25 }, options)).toBe("0:15:00");
-    expect(formatDuration({ minutes: 35 }, options)).toBe("0:35:00");
-    expect(formatDuration({ minutes: 2, seconds: 15 }, options)).toBe("0:02:15");
-    expect(formatDuration({ seconds: 135 }, { ...options, showSeconds: false })).toBe("0:02");
-    expect(formatDuration({ minutes: -30 }, options)).toBe("-0:30:00");
-    expect(formatDuration({ hours: -0.5 }, { ...options, showSeconds: false })).toBe("-0:30");
-});
-
-test("formatDuration special cases", () => {
-    expect(formatDuration({ hours: 2, minutes: 5, seconds: 30 })).toBe("2h 5m 30s");
+test("formatFloatTime special cases", () => {
+    const options = { showSeconds: true };
+    expect(formatFloatTime(1.25 + 45 / 3600, options)).toBe("1h 15m 45s");
 
     localization.locale = "fr-FR";
-    expect(formatDuration({ hours: 2, minutes: 5, seconds: 30 })).toBe("2h 5min 30s");
+    expect(formatFloatTime(1.25 + 45 / 3600, options)).toBe("1h 15min 45s");
 
     localization.locale = "zh-CN";
-    expect(formatDuration({ hours: 2, minutes: 5, seconds: 30 })).toBe("2小时 5分钟 30秒");
-    expect(formatDuration({ minutes: 120 })).toBe("2小时");
+    expect(formatFloatTime(1.25 + 45 / 3600, options)).toBe("1小时 15分钟 45秒");
+    expect(formatFloatTime(2)).toBe("2小时");
 
     localization.locale = "ar-SY";
-    expect(formatDuration({ hours: 2, minutes: 5, seconds: 30 })).toBe("٢س ٥د ٣٠ث");
-    expect(formatDuration({ hours: 2, minutes: 5, seconds: 30 }, { numeric: true })).toBe(
-        "2:05:30"
+    expect(formatFloatTime(1.25 + 45 / 3600, options)).toBe("١س ١٥د ٤٥ث");
+    expect(formatFloatTime(1.25 + 45 / 3600, { ...options, numeric: true })).toBe(
+        "1:15:45"
     );
-    expect(formatDuration({ minutes: 120 })).toBe("٢س");
 
     localization.locale = "th-TH";
-    expect(formatDuration({ hours: 2, minutes: 5, seconds: 30 })).toBe("2ชม. 5นาที 30วิ");
-    expect(formatDuration({ minutes: 120 })).toBe("2ชม.");
-    expect(formatDuration({ seconds: 30 }, { unit: "seconds" })).toBe("30วิ");
+    expect(formatFloatTime(1.25 + 45 / 3600, options)).toBe("1ชม. 15นาที 45วิ");
 
     localization.locale = "hi-IN";
-    expect(formatDuration({ hours: 2, minutes: 5, seconds: 30 })).toBe("2घं 5मि 30से");
-    expect(formatDuration({ minutes: 120 })).toBe("2घं");
-    expect(formatDuration({ seconds: 30 }, { unit: "seconds" })).toBe("30से");
+    expect(formatFloatTime(1.25 + 45 / 3600, options)).toBe("1घं 15मि 45से");
 });

--- a/addons/web/static/tests/views/fields/parsers.test.js
+++ b/addons/web/static/tests/views/fields/parsers.test.js
@@ -11,7 +11,6 @@ import {
     parseMonetary,
     parsePercentage,
 } from "@web/views/fields/parsers";
-import { parseDuration } from "../../../src/views/fields/parsers";
 
 beforeEach(makeMockEnv);
 
@@ -53,10 +52,32 @@ test("parseFloatTime", () => {
     expect(parseFloatTime("1:")).toBe(1);
     expect(parseFloatTime(":12")).toBe(0.2);
 
-    expect(() => parseFloatTime("a:1")).toThrow();
-    expect(() => parseFloatTime("1:a")).toThrow();
-    expect(() => parseFloatTime("1:1:")).toThrow();
-    expect(() => parseFloatTime(":1:1")).toThrow();
+    expect(parseFloatTime("a:12")).toBe(0.2);
+    expect(parseFloatTime("1:a")).toBe(1);
+    expect(parseFloatTime("1:12:")).toBe(1.2);
+    expect(parseFloatTime(":30:45")).toBe(0.5125);
+
+    expect(parseFloatTime("1h 30m 45s")).toBe(1.5125);
+    expect(parseFloatTime("1h 45s")).toBe(1.0125);
+    expect(parseFloatTime("45s 30m 1h")).toBe(1.5125);
+    expect(parseFloatTime("45s 20s 55s")).toBe(0.0125);
+    expect(parseFloatTime("1h30")).toBe(1.5);
+    expect(parseFloatTime("-1h 30m 45s")).toBe(-1.5125);
+
+    expect(parseFloatTime("qwerwqer")).toBe(0);
+
+    clearMemoizeCaches();
+    localization.locale = "fr-FR";
+    expect(parseFloatTime("2h 30m 45s")).toBe(2.5125);
+    expect(parseFloatTime("2h 30min 45s")).toBe(2.5125);
+
+    clearMemoizeCaches();
+    localization.locale = "zh-CN";
+    expect(parseFloatTime("2小时 30分钟 45秒")).toBe(2.5125);
+
+    clearMemoizeCaches();
+    localization.locale = "ar-SY";
+    expect(parseFloatTime("٢س ٣٠د ٤٥ث")).toBe(2.5125);
 });
 
 test("parseInteger", () => {
@@ -176,35 +197,4 @@ test("parseMonetary", () => {
     expect(parseMonetary("=1.000,00 + 11.121,00")).toBe(12121);
     expect(parseMonetary("=1000,00 + 11122,00")).toBe(12122);
     expect(parseMonetary("=1000 + 11123")).toBe(12123);
-});
-
-test("parseDuration", () => {
-    expect(parseDuration("1")).toEqual({ hours: 1, minutes: 0, seconds: 0 });
-    expect(parseDuration("1:")).toEqual({ hours: 1, minutes: 0, seconds: 0 });
-    expect(parseDuration("1:25")).toEqual({ hours: 1, minutes: 25, seconds: 0 });
-    expect(parseDuration("1:25", "minutes")).toEqual({ hours: 0, minutes: 1, seconds: 25 });
-    expect(parseDuration("1:25:30")).toEqual({ hours: 1, minutes: 25, seconds: 30 });
-    expect(parseDuration("-1:30:20")).toEqual({ hours: -1, minutes: -30, seconds: -20 });
-
-    expect(parseDuration("1h 30m 45s")).toEqual({ hours: 1, minutes: 30, seconds: 45 });
-    expect(parseDuration("1h 45s")).toEqual({ hours: 1, minutes: 0, seconds: 45 });
-    expect(parseDuration("25s 30m 1h")).toEqual({ hours: 1, minutes: 30, seconds: 25 });
-    expect(parseDuration("25s 40s 55s")).toEqual({ hours: 0, minutes: 0, seconds: 25 });
-    expect(parseDuration("1h30")).toEqual({ hours: 1, minutes: 30, seconds: 0 });
-    expect(parseDuration("-1h 30m 20s")).toEqual({ hours: -1, minutes: -30, seconds: -20 });
-
-    expect(parseDuration("qwerwqer")).toEqual({ hours: 0, minutes: 0, seconds: 0 });
-
-    clearMemoizeCaches();
-    localization.locale = "fr-FR";
-    expect(parseDuration("2h 5m 30s")).toEqual({ hours: 2, minutes: 5, seconds: 30 });
-    expect(parseDuration("2h 5min 30s")).toEqual({ hours: 2, minutes: 5, seconds: 30 });
-
-    clearMemoizeCaches();
-    localization.locale = "zh-CN";
-    expect(parseDuration("2小时 5分钟 30秒")).toEqual({ hours: 2, minutes: 5, seconds: 30 });
-
-    clearMemoizeCaches();
-    localization.locale = "ar-SY";
-    expect(parseDuration("٢ س ٥ د ٣٠ ث")).toEqual({ hours: 2, minutes: 5, seconds: 30 });
 });

--- a/addons/web/static/tests/views/graph/graph_view.test.js
+++ b/addons/web/static/tests/views/graph/graph_view.test.js
@@ -563,7 +563,7 @@ test("format total in hh:mm when measure is unit_amount", async () => {
         resModel: "foo",
         arch: /* xml */ `
             <graph>
-                <field name="unit_amount" type="measure" widget="float_time" />
+                <field name="unit_amount" type="measure" widget="float_time" options="{'numeric': 1}" />
             </graph>
         `,
     });
@@ -579,18 +579,8 @@ test("format total in hh:mm when measure is unit_amount", async () => {
     expect(fieldAttrs[measure].widget).toBe("float_time", {
         message: "should be a float_time widget",
     });
-    checkYTicks(view, [
-        "00:00",
-        "01:00",
-        "02:00",
-        "03:00",
-        "04:00",
-        "05:00",
-        "06:00",
-        "07:00",
-        "08:00",
-    ]);
-    checkTooltip(view, { title: "Unit Amount", lines: [{ label: "Total", value: "08:00" }] }, 0);
+    checkYTicks(view, ["0:00", "1:00", "2:00", "3:00", "4:00", "5:00", "6:00", "7:00", "8:00"]);
+    checkTooltip(view, { title: "Unit Amount", lines: [{ label: "Total", value: "8:00" }] }, 0);
 });
 
 test("Stacked button visible in the line chart", async () => {
@@ -1146,8 +1136,24 @@ test("process arch with field tags", async () => {
     expect(new GraphArchParser().parse(arch, fooFields)).toEqual({
         fields: fooFields,
         fieldAttrs: {
-            bar: { isInvisible: true, string: "My invisible field" },
-            fighters: { string: "FooFighters" },
+            bar: {
+                isInvisible: true,
+                options: {},
+                string: "My invisible field",
+            },
+            date: {
+                options: {},
+            },
+            fighters: {
+                options: {},
+                string: "FooFighters",
+            },
+            foo: {
+                options: {},
+            },
+            revenue: {
+                options: {},
+            },
         },
         measure: "revenue",
         measures: ["revenue"],
@@ -1170,7 +1176,17 @@ test("process arch with non stored field tags of type measure", async () => {
     `;
     expect(new GraphArchParser().parse(arch, fooFields)).toEqual({
         fields: fooFields,
-        fieldAttrs: {},
+        fieldAttrs: {
+            foo: {
+                options: {},
+            },
+            product_id: {
+                options: {},
+            },
+            revenue: {
+                options: {},
+            },
+        },
         measure: "foo",
         measures: ["revenue", "foo"],
         groupBy: ["product_id"],

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -4991,7 +4991,7 @@ test(`aggregates are formatted according to field widget`, async () => {
             </list>
         `,
     });
-    expect(`tfoot`).toHaveText("19:24", {
+    expect(`tfoot`).toHaveText("19h 24m", {
         message: "total should be formatted as a float_time",
     });
 });

--- a/addons/web/static/tests/views/pivot_view.test.js
+++ b/addons/web/static/tests/views/pivot_view.test.js
@@ -295,7 +295,7 @@ test("pivot rendering with widget", async () => {
 			</pivot>
 		`,
     });
-    expect("td.o_pivot_cell_value:contains(32:00)").toHaveCount(1);
+    expect("td.o_pivot_cell_value:contains(32h)").toHaveCount(1);
 });
 
 test("pivot rendering with widget and options", async () => {
@@ -304,7 +304,7 @@ test("pivot rendering with widget and options", async () => {
         resModel: "partner",
         arch: `
 			<pivot string="Partners">
-                <field name="foo" type="measure" widget="float_time"/>
+                <field name="foo" type="measure" widget="float_time" options="{'numeric': 1}"/>
 			</pivot>
 		`,
     });


### PR DESCRIPTION
The rounding of time was not correct. I was always flooring, but before
the new duration the rounding was depending of the precision of the
duration. The rounding has been restored as before and put in
formatDuration.
formatFloatTime has been modified to use formatDuration and now take
the same options (specify the unit of time of the value).

The graph view and list view didn't extract the otpions from the fields
with widget. Now, they get the options and give them to the formatter.

The widget was showing the seconds by default, but it doesn't match with
the behavior of the DateTime widget. It has been changed and now the seconds
are shown only if the options 'showSeconds' is true and it's false by default.
The impacted views has been restored as before the original commit.

The options of float_time widget couldn't take falsy values, now it can.

an improvment has also been done: the popover on the float_time widget
doesn't show up if the input value and the formattedValue are the same.

followup of TASK-5347051

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
