### PR TITLE
[FIX] html_editor: prevent button removal when typing in empty link

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -642,7 +642,10 @@ export class FormatPlugin extends Plugin {
             if (!selection.isCollapsed) {
                 return;
             }
-            const element = closestElement(selection.anchorNode);
+            // Links are a special case here. When typing, link
+            // element gets removed automatically whereas
+            // other inline tags would be preserved.
+            const element = closestElement(selection.anchorNode, ":not(a)");
             if (element.hasAttribute("data-oe-zws-empty-inline")) {
                 // Select its ZWS content to make sure the text will be
                 // inserted inside the element, and not before (outside) it.

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -1362,11 +1362,15 @@ export class LinkPlugin extends Plugin {
             ? findInSelection(selection, "a.btn")
             : closestElement(selection.anchorNode, "a.btn");
         if (buttonElement) {
+            // We need to ignore the feffs the boundaries otherwise the browser will
+            // add the character outside of the button in case we triple click and
+            // we type something.
+            const buttonDescendants = descendants(buttonElement).filter((node) => !isZwnbsp(node));
             this.dependencies.selection.setSelection({
-                anchorNode: buttonElement,
+                anchorNode: buttonDescendants[0],
                 anchorOffset: 0,
-                focusNode: buttonElement,
-                focusOffset: nodeSize(buttonElement),
+                focusNode: buttonDescendants.at(-1),
+                focusOffset: nodeSize(buttonDescendants.at(-1)),
             });
             ev.preventDefault();
             return true;

--- a/addons/html_editor/static/tests/link/button.test.js
+++ b/addons/html_editor/static/tests/link/button.test.js
@@ -323,7 +323,7 @@ describe("button edit", () => {
         manuallyDispatchProgrammaticEvent(button, "mousedown", { detail: 3 });
         await animationFrame();
         expect(getContent(el)).toBe(
-            '<p>this is a \ufeff<a href="http://test.test/" class="btn btn-fill-primary">[\ufefftest btn\ufeff]</a>\ufeff</p>'
+            '<p>this is a \ufeff<a href="http://test.test/" class="btn btn-fill-primary">\ufeff[test btn]\ufeff</a>\ufeff</p>'
         );
         expect(cleanLinkArtifacts(getContent(el))).toBe(
             '<p>this is a <a href="http://test.test/" class="btn btn-fill-primary">[test btn]</a></p>'
@@ -332,6 +332,17 @@ describe("button edit", () => {
         expect(cleanLinkArtifacts(getContent(el))).toBe(
             '<p>this is a <a href="http://test.test/" class="btn btn-fill-primary">X[]</a></p>'
         );
+    });
+
+    test("triple and type inside button should not remove the button", async () => {
+        const { el, editor } = await setupEditor(
+            '<p><a href="http://test.test/" class="btn btn-fill-primary">b[]</a></p>'
+        );
+        const button = el.querySelector("a");
+        manuallyDispatchProgrammaticEvent(button, "mousedown", { detail: 3 });
+        await animationFrame();
+        await editor.document.execCommand("insertText", false, "a");
+        expect(button.isConnected).toBe(true);
     });
 
     test("Should not remove invisible button", async () => {


### PR DESCRIPTION
Problem:
On the website, typing inside an empty button removes the button element entirely.

Cause:
In `beforeinput` (when `ev.inputType === "insertText"`), we set the selection to `boundariesIn` of a link. When the browser then inserts the character, it replaces the link node, causing the button to be removed.

Solution:
In `FormatPlugin.onBeforeInput`, avoid setting the selection to `boundariesIn` of a link for `insertText` events. This prevents the browser from replacing the link element when typing.

Steps to reproduce:
- Open Website.
- Drop a snippet containing a button.
- Triple-click on the button content.
- Press Backspace to empty it.
- Type any character.
- Observe that the button is removed.

task-5949409

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
