### PR TITLE
[FIX] *: Don't lose manual analytic distribution when project gets created

### DIFF
--- a/addons/project_purchase/models/purchase_order_line.py
+++ b/addons/project_purchase/models/purchase_order_line.py
@@ -8,13 +8,13 @@ class PurchaseOrderLine(models.Model):
 
     @api.depends('product_id', 'order_id.partner_id', 'order_id.project_id')
     def _compute_analytic_distribution(self):
-        super()._compute_analytic_distribution()
-        ProjectProject = self.env['project.project']
-        for line in self:
-            project_id = line._context.get('project_id')
-            project = ProjectProject.browse(project_id) if project_id else line.order_id.project_id
-            if line.display_type or not project:
-                continue
+        ctx_project = self.env['project.project'].browse(self.env.context.get('project_id'))
+        project_lines = self.filtered(lambda l: not l.display_type and (ctx_project or l.order_id.project_id))
+        empty_project_lines = project_lines.filtered(lambda l: not l.analytic_distribution)
+        super(PurchaseOrderLine, (self - project_lines) + empty_project_lines)._compute_analytic_distribution()
+
+        for line in project_lines:
+            project = ctx_project or line.order_id.project_id
             if line.analytic_distribution:
                 applied_root_plans = self.env['account.analytic.account'].browse(
                     list({int(account_id) for ids in line.analytic_distribution for account_id in ids.split(",")})


### PR DESCRIPTION
*: project_purchase, sale_project

---

Decription of the issue this commit addresses:

When confirming a sales order with a product-partner combination that has an Analytic Distribution Model assigned, any custom analytic distribution done on the line of the product will be lost, resetting the analytic distribution to the default value set on the Analytic Distribution Model.

---

Steps to reproduce:

1. Install sale_project,project_purchase.
2. Activate "Analytic Accounting" in the settings.
3. Create a new Product "test"; Type: Service, Create on Order: Project.
4. Create a new Analytic Distribution Models; Partner: Acme, Product: test, Analytic Distribution: anything but blank.
5. Create a new Quotation in the Sales apps; Partner: Acme.
6. Assign the Product test to the first order line. This will automatically set the analytic distrib of the Analytic Distribution Model.
7. In the Analytic Distribution cell, add a line with any non null distribution.
8. Confirm the Quotation.
9. The analytic distribution that was anually added has been removed. Only the default analytic distribution of the model remains.

---

Desired behavior after this commit is merged:

Any custom analytic distribution done on a line is never lost. The Analytic Distribution Model's distribution serves as a template but never overrides the values set by the user.

---

opw-4934291

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr