### PR TITLE
[FIX] website_sale: fix off-screen filters

### DIFF
--- a/addons/website_sale/templates/shop_page_templates.xml
+++ b/addons/website_sale/templates/shop_page_templates.xml
@@ -401,7 +401,11 @@
                                                 <i class="oi oi-search" role="img"/>
                                             </a>
                                         </t>
-                                        <div t-attf-class="{{'d-lg-none' if not hasPricelistDropdown and not is_view_active('website_sale.sort') else ''}} o_wsale_products_header_dropdown_wrap d-flex gap-3">
+                                        <t
+                                            t-set="show_product_controls_header"
+                                            t-value="hasPricelistDropdown or is_view_active('website_sale.sort') or wsale_has_filters_btn"
+                                        />
+                                        <div t-attf-class="{{'d-lg-none' if not show_product_controls_header else ''}} o_wsale_products_header_dropdown_wrap d-flex gap-3">
                                             <t
                                                 t-if="hasPricelistDropdown"
                                                 t-call="website_sale.pricelist_list"


### PR DESCRIPTION
Versions
--------
- 19.1+

Steps
-----
1. Disable all pricelists to hide pricelist filter
2. Go to shop page
3. Change Filters style to "Off-screen Menu"
  - Note that a "Filters" button appears next to the sort by dropdown
4. Remove the sort by from the toolbar by untoggling it

Issue
-----
When the filters are set to off-screen and there is no sort by dropdown or pricelist dropdown, the filters button disappears.

Cause
-----
The div containing the filters button, sort by dropdown, and pricelist dropdown, is set to `d-lg-none` when there is no pricelist dropdown and no sort by dropdown, causing it do disappear.

Solution
--------
Only allow the div to disappear when the filter button shouldn't appear (`wsale_has_filters_btn` set to False)

opw-5933858