### PR TITLE
[FIX] account_edi_ubl_cii,account_peppol: R010/R020 checks only when …

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -777,21 +777,6 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
                     "The VAT number of the supplier does not seem to be valid. It should be of the form: NO179728982MVA."
                 ) if not mva.is_valid(vat) or len(vat) != 14 or vat[:2] != 'NO' or vat[-3:] != 'MVA' else "",
             })
-
-        # [PEPPOL-EN16931-R010]
-        if not vals['document_node']['cac:AccountingCustomerParty']['cac:Party']['cbc:EndpointID']['_text']:
-            constraints['ubl_peppol_en16931-r010'] = _(
-                "[PEPPOL-EN16931-R010] An electronic address (EAS) must be provided on the customer '%s'.",
-                vals['customer'].display_name,
-            )
-
-        # [PEPPOL-EN16931-R020]
-        if not vals['document_node']['cac:AccountingSupplierParty']['cac:Party']['cbc:EndpointID']['_text']:
-            constraints['ubl_peppol_en16931-r020'] = _(
-                "[PEPPOL-EN16931-R020] An electronic address (EAS) must be provided on the company '%s'.",
-                vals['supplier'].display_name,
-            )
-
         return constraints
 
     # -------------------------------------------------------------------------

--- a/addons/account_edi_ubl_cii/models/account_move_send.py
+++ b/addons/account_edi_ubl_cii/models/account_move_send.py
@@ -117,7 +117,11 @@ class AccountMoveSend(models.AbstractModel):
 
         if invoice._need_ubl_cii_xml(invoice_data['invoice_edi_format']):
             builder = invoice.partner_id.commercial_partner_id._get_edi_builder(invoice_data['invoice_edi_format'])
-            xml_content, errors = builder._export_invoice(invoice)
+            xml_content, errors = (
+                builder
+                .with_context(from_peppol='peppol' in invoice_data['sending_methods'])
+                ._export_invoice(invoice)
+            )
             filename = builder._export_invoice_filename(invoice)
 
             # Failed.

--- a/addons/account_edi_ubl_cii/tests/common.py
+++ b/addons/account_edi_ubl_cii/tests/common.py
@@ -134,8 +134,8 @@ class TestUblCiiCommon(AccountTestInvoicingCommon):
         return 'export'
 
     @classmethod
-    def _generate_invoice_ubl_file(cls, invoice):
-        cls.env['account.move.send']._generate_and_send_invoices(invoice, sending_methods=['manual'])
+    def _generate_invoice_ubl_file(cls, invoice, **kwargs):
+        cls.env['account.move.send']._generate_and_send_invoices(invoice, **{'sending_methods': ['manual'], **kwargs})
 
     def _assert_invoice_ubl_file(self, invoice, filename):
         self.assertTrue(invoice.ubl_cii_xml_id)

--- a/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
@@ -1,6 +1,5 @@
 from odoo import Command
 from odoo.addons.account_edi_ubl_cii.tests.common import TestUblBis3Common, TestUblCiiBECommon
-from odoo.exceptions import UserError
 try:
     from odoo.addons.test_mimetypes.tests.test_guess_mimetypes import contents
 except ImportError:
@@ -623,38 +622,6 @@ class TestUblExportBis3BE(TestUblBis3Common, TestUblCiiBECommon):
 
         self._generate_invoice_ubl_file(invoice)
         self._assert_invoice_ubl_file(invoice, 'test_invoice_product_commodity_code_cpv')
-
-    def test_invoice_PEPPOL_EN16931_R010_R020_ensure_customer_supplier_endpoint_id(self):
-        """
-        [PEPPOL-EN16931-R010] Buyer electronic address MUST be provided.
-        [PEPPOL-EN16931-R020] Seller electronic address MUST be provided.
-        """
-        partner = self.env['res.partner'].create({
-            **self._create_partner_default_values(),
-            'name': "partner",
-            'country_id': self.env.ref('base.be').id,
-        })
-        tax_21 = self.percent_tax(21.0)
-        product = self._create_product(lst_price=10.0, taxes_id=tax_21)
-        invoice = self._create_invoice_one_line(
-            product_id=product,
-            partner_id=partner,
-            post=True,
-        )
-
-        # Check customer's endpoint.
-        with self.assertRaisesRegex(UserError, r".*\[PEPPOL\-EN16931\-R010\].*"):
-            self._generate_invoice_ubl_file(invoice)
-
-        # Check supplier's endpoint.
-        partner.peppol_eas = '0208'
-        partner.peppol_endpoint = '0477472701'
-        self.env.company.partner_id.vat = None
-        self.env.company.partner_id.company_registry = None
-        self.env.company.partner_id.peppol_eas = None
-        self.env.company.partner_id.peppol_endpoint = None
-        with self.assertRaisesRegex(UserError, r".*\[PEPPOL\-EN16931\-R020\].*"):
-            self._generate_invoice_ubl_file(invoice)
 
     def _assert_invoice_partner_party_identifiers(self, partner, test_file):
         tax_21 = self.percent_tax(21.0)

--- a/addons/account_peppol/models/__init__.py
+++ b/addons/account_peppol/models/__init__.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import account_edi_proxy_user
+from . import account_edi_xml_ubl_bis3
 from . import account_journal
 from . import account_move
 from . import account_move_send

--- a/addons/account_peppol/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_peppol/models/account_edi_xml_ubl_bis3.py
@@ -1,0 +1,29 @@
+from odoo import _, models
+
+
+class AccountEdiXmlUBLBIS3(models.AbstractModel):
+    _inherit = 'account.edi.xml.ubl_bis3'
+
+    def _invoice_constraints_peppol_en16931_ubl_new(self, invoice, vals):
+        # EXTENDS account.edi.xml.ubl_bis3
+        # Some constraints are specific to Peppol because the xml file might be used in B2C operations
+        # without Peppol but to be given to the accountant to import the invoice in another accounting
+        # software.
+        constraints = super()._invoice_constraints_peppol_en16931_ubl_new(invoice, vals)
+
+        if self.env.context.get('from_peppol'):
+            # [PEPPOL-EN16931-R010]
+            if not vals['document_node']['cac:AccountingCustomerParty']['cac:Party']['cbc:EndpointID']['_text']:
+                constraints['ubl_peppol_en16931-r010'] = _(
+                    "[PEPPOL-EN16931-R010] An electronic address (EAS) must be provided on the customer '%s'.",
+                    vals['customer'].display_name,
+                )
+
+            # [PEPPOL-EN16931-R020]
+            if not vals['document_node']['cac:AccountingSupplierParty']['cac:Party']['cbc:EndpointID']['_text']:
+                constraints['ubl_peppol_en16931-r020'] = _(
+                    "[PEPPOL-EN16931-R020] An electronic address (EAS) must be provided on the company '%s'.",
+                    vals['supplier'].display_name,
+                )
+
+        return constraints

--- a/addons/account_peppol/tests/__init__.py
+++ b/addons/account_peppol/tests/__init__.py
@@ -3,3 +3,4 @@
 
 from . import test_peppol_messages
 from . import test_peppol_participant
+from . import test_ubl_export_bis3_be

--- a/addons/account_peppol/tests/test_ubl_export_bis3_be.py
+++ b/addons/account_peppol/tests/test_ubl_export_bis3_be.py
@@ -1,0 +1,51 @@
+from odoo.addons.account_edi_ubl_cii.tests.test_ubl_export_bis3_be import TestUblExportBis3BE
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install', *TestUblExportBis3BE.extra_tags)
+class TestUblExportBis3BEPeppol(TestUblExportBis3BE):
+
+    def test_invoice_PEPPOL_EN16931_R010_R020_ensure_customer_supplier_endpoint_id(self):
+        """
+        [PEPPOL-EN16931-R010] Buyer electronic address MUST be provided.
+        [PEPPOL-EN16931-R020] Seller electronic address MUST be provided.
+        """
+        partner = self.env['res.partner'].create({
+            **self._create_partner_default_values(),
+            'name': "partner",
+            'country_id': self.env.ref('base.be').id,
+        })
+        tax_21 = self.percent_tax(21.0)
+        product = self._create_product(lst_price=10.0, taxes_id=tax_21)
+
+        # Check customer's endpoint with Peppol.
+        invoice = self._create_invoice_one_line(
+            product_id=product,
+            partner_id=partner,
+            post=True,
+        )
+        with self.assertRaisesRegex(UserError, r".*\[PEPPOL\-EN16931\-R010\].*"):
+            self._generate_invoice_ubl_file(invoice, sending_methods=['peppol'])
+
+        # Check customer's endpoint without Peppol.
+        self._generate_invoice_ubl_file(invoice)
+
+        # Check supplier's endpoint with Peppol.
+        invoice = self._create_invoice_one_line(
+            product_id=product,
+            partner_id=partner,
+            post=True,
+        )
+
+        partner.peppol_eas = '0208'
+        partner.peppol_endpoint = '0477472701'
+        self.env.company.partner_id.vat = None
+        self.env.company.partner_id.company_registry = None
+        self.env.company.partner_id.peppol_eas = None
+        self.env.company.partner_id.peppol_endpoint = None
+        with self.assertRaisesRegex(UserError, r".*\[PEPPOL\-EN16931\-R020\].*"):
+            self._generate_invoice_ubl_file(invoice, sending_methods=['peppol'])
+
+        # Check supplier's endpoint without Peppol.
+        self._generate_invoice_ubl_file(invoice)


### PR DESCRIPTION
…peppol checked

Some people are using BIS3 files even for B2C. They give the xml files to the accountant for him/her to import the file and generate the invoice in the accounting software. In that case, since it's a B2C transaction, the EndpointId might not be set but that's ok since it's only used to generate the invoice.

opw-5952109

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
