### PR TITLE
[IMP] html_editor, mail: make responses beautiful again paky

### DIFF
--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -126,6 +126,7 @@ export class TablePlugin extends Plugin {
         clean_for_save_handlers: ({ root }) => this.deselectTable(root),
         before_line_break_handlers: this.resetTableSelection.bind(this),
         before_split_block_handlers: this.resetTableSelection.bind(this),
+        before_insert_processors: this.handleTableInsert.bind(this),
 
         /** Overrides */
         tab_overrides: withSequence(20, this.handleTab.bind(this)),
@@ -1330,6 +1331,27 @@ export class TablePlugin extends Plugin {
             focusNode: anchorTD.lastChild,
             focusOffset: nodeSize(anchorTD.lastChild),
         });
+    }
+
+    handleTableInsert(insertContainer) {
+        const thead = insertContainer.querySelector("THEAD");
+        if (thead) {
+            const tbody = thead.nextElementSibling;
+            if (tbody) {
+                const thChildren = thead.querySelectorAll("TH");
+                thChildren.forEach((element) => {
+                    element.classList.add("o_table_header");
+                });
+                // If a <tbody> already exists, move all rows from
+                // <thead> into the start of <tbody>.
+                tbody.prepend(...thead.children);
+                thead.remove();
+            } else {
+                // Otherwise, replace the <thead> with <tbody>
+                this.dependencies.dom.setTagName(thead, "TBODY");
+            }
+        }
+        return insertContainer;
     }
 
     /**

--- a/addons/mail/static/src/discuss/core/web/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/web/thread_actions.js
@@ -3,6 +3,9 @@ import { registerThreadAction } from "@mail/core/common/thread_actions";
 
 import { _t } from "@web/core/l10n/translation";
 
+export const expandDiscussSequenceGroup = 5;
+export const expandDiscussSequenceQuick = 0;
+
 export const joinChannelAction = {
     condition: ({ channel }) =>
         channel && !channel.self_member_id && !["chat", "group"].includes(channel.channel_type),
@@ -38,7 +41,8 @@ registerThreadAction("expand-discuss", {
         );
     },
     sequence: 10,
-    sequenceGroup: 5,
+    sequenceGroup: expandDiscussSequenceGroup,
+    sequenceQuick: expandDiscussSequenceQuick,
 });
 registerThreadAction("advanced-settings", {
     condition: ({ channel, owner }) => channel && owner.isDiscussSidebarChannelActions,


### PR DESCRIPTION
Prior to this commit, when inserting a table in an html_field, it would
use tags such as `thead` which are not supposed by the table plugin when
doing table manipulations.

With this commit, we create an insertion handler which changes any thead
to tbody and applies the `o_table_header` class to the rows so it
visually resembles a thead.

Exported some variables for the expand-discuss thread action since we are
modifying the thread action registry in the AI module.

Specifically we export the sequencegroup and the sequencequick variables
since we are changing those for AI chats.

Task-5164382
