### PR TITLE
[IMP] mail: align unread indicators with notification settings

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -912,8 +912,11 @@ class DiscussChannel(models.Model):
             [("channel_id", "=", self.id)],
             [("partner_id", "!=", author_id)],
             [("partner_id.active", "=", True)],
-            [("mute_until_dt", "=", False)],
             [("partner_id.user_ids.manual_im_status", "!=", "busy")],
+            Domain.OR([
+                [("mute_until_dt", "=", False)],
+                [("partner_id", "in", pids)],
+            ]),
             Domain.OR([
                 [("channel_id.channel_type", "!=", "channel")],
                 Domain.AND([

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -37,10 +37,10 @@
                 <t t-set="message" t-value="thread.channel?.isChatChannel or (thread.channel?.channel_type === 'channel' and thread.needactionMessages.length === 0) ? thread.newestPersistentOfAllMessage : thread.needactionMessages.at(-1)"/>
                 <NotificationItem
                     isActive="state.activeIndex === itemIndex"
-                    counter="thread.needactionCounter"
+                    counter="thread.channel?.importantCounter ?? thread.needactionCounter"
                     datetime="message?.datetime"
                     iconSrc="thread.avatarUrl"
-                    important="thread.needactionCounter"
+                    important="thread.channel?.importantCounter ?? thread.needactionCounter"
                     hasMarkAsReadButton="thread.isUnread"
                     muted="thread.channel?.self_member_id?.mute_until_dt ? 2 : !thread.isUnread ? 1 : 0"
                     onClick="(isMarkAsRead) => this.onClickThread(isMarkAsRead, thread, message)"

--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -44,7 +44,12 @@
                                 <span class="o-mail-NotificationItem-badge o-discuss-badgeShape d-flex align-items-center justify-content-center mx-1 my-0 rounded fw-bold o-mail-NotificationItem-markAsRead text-600 cursor-pointer shadow-sm position-absolute top-0 end-0 z-1" title="Mark As Read" t-ref="markAsRead"><i class="fa fa-check text-success"/></span>
                             </span>
                         </span>
-                        <span t-if="!props.muted" t-attf-class="o-mail-NotificationItem-badge o-discuss-badge {{ props.counter > 0 and props.muted === 2 ? 'o-muted' : '' }} {{ props.important ? 'o-important' : '' }} {{ props.counter === 0 ? 'o-empty me-1' : '' }} d-flex align-items-center justify-content-center m-0 o-mx-0_5 badge rounded-pill fw-bold o-mail-NotificationItem-counter shadow-sm"><t t-if="props.counter" t-esc="props.counter"/></span>
+                        <span t-if="!props.muted or props.counter > 0" class="o-mail-NotificationItem-badge o-discuss-badge d-flex align-items-center justify-content-center m-0 o-mx-0_5 badge rounded-pill fw-bold o-mail-NotificationItem-counter shadow-sm" t-att-class="{
+                            'o-important': props.important,
+                            'o-empty me-1': props.counter === 0,
+                        }">
+                            <t t-if="props.counter" t-esc="props.counter"/>
+                        </span>
                     </div>
                 </div>
             </div>

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -167,6 +167,11 @@ export class DiscussChannel extends Record {
             this._onDeleteChatWindow();
         },
     });
+    get channelNotifications() {
+        return (
+            this.self_member_id?.custom_notifications || this.store.settings.channel_notifications
+        );
+    }
     get chatChannelTypes() {
         return ["chat", "group"];
     }
@@ -329,18 +334,19 @@ export class DiscussChannel extends Record {
         },
     });
     get importantCounter() {
-        if (this.isChatChannel && this.self_member_id?.message_unread_counter_ui) {
+        if (
+            this.isChatChannel &&
+            this.self_member_id?.message_unread_counter_ui &&
+            (this.channel_type !== "group" || !this.self_member_id?.mute_until_dt)
+        ) {
             return this.self_member_id.message_unread_counter_ui;
         }
-        if (this.discussAppCategory?.id === "channels") {
-            if (this.store.settings.channel_notifications === "no_notif") {
+        if (this.channel_type === "channel") {
+            if (this.channelNotifications === "no_notif") {
                 return 0;
             }
-            if (
-                this.store.settings.channel_notifications === "all" &&
-                !this.self_member_id?.mute_until_dt
-            ) {
-                return this.self_member_id?.message_unread_counter_ui;
+            if (this.channelNotifications === "all" && !this.self_member_id?.mute_until_dt) {
+                return this.self_member_id.message_unread_counter_ui;
             }
         }
         return this.message_needaction_counter;

--- a/addons/mail/static/src/discuss/core/public_web/discuss_channel_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_channel_model_patch.js
@@ -145,8 +145,8 @@ const discussChannelPatch = {
     /**
      * Handle the notification of a new message based on the notification setting of the user.
      * Thread on mute:
-     * 1. No longer see the unread status: the bold text disappears and the channel name fades out.
-     * 2. Without sound + need action counter.
+     * 1. The bold text disappears and the channel name fades out.
+     * 2. Only mention sounds + need action counter.
      * Thread Notification Type:
      * All messages:All messages sound + need action counter
      * Mentions:Only mention sounds + need action counter
@@ -155,15 +155,14 @@ const discussChannelPatch = {
      * @param {import("models").Message} message
      */
     async notifyMessageToUser(message) {
-        const channel_notifications =
-            this.self_member_id?.custom_notifications || this.store.settings.channel_notifications;
         if (
-            !this.self_member_id?.mute_until_dt &&
+            (!this.self_member_id?.mute_until_dt ||
+                message.partner_ids?.includes(this.store.self)) &&
             this.store.self.im_status !== "busy" &&
             (this.channel_type !== "channel" ||
                 (this.channel_type === "channel" &&
-                    (channel_notifications === "all" ||
-                        (channel_notifications === "mentions" &&
+                    (this.channelNotifications === "all" ||
+                        (this.channelNotifications === "mentions" &&
                             message.partner_ids?.includes(this.store.self)))))
         ) {
             if (this.inChathubOnNewMessage) {


### PR DESCRIPTION
Backport of https://github.com/odoo/odoo/pull/243218

This commit aligns the red counter and unread badge (bold) with notification settings.

- All Messages: Red counter for mentions, unread badge (bold) for all messages
- Mentions Only: Red counter and unread badge (bold) for mentions only
- Nothing: No red counter, unread badge (bold) for all messages
- Mute: Channels and groups are downgraded to "Mentions Only", with push notifications for mentions

This ensures consistent and clear unread indicators across conversations.

Task-5418490