### PR TITLE
[FIX] server: replace bare except clauses and shell=True subp…

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -816,7 +816,7 @@ class GeventServer(CommonServer):
         _logger.info('Evented Service (longpolling) running on %s:%s', self.interface, self.port)
         try:
             self.httpd.serve_forever()
-        except Exception:
+        except BaseException:
             _logger.exception("Evented Service (longpolling): uncaught error during main loop")
             raise
 
@@ -1306,7 +1306,7 @@ class Worker(object):
                 if not self.alive:
                     break
                 self.process_work()
-        except Exception:
+        except BaseException:
             _logger.exception("Worker %s (%s) Exception occurred, exiting...", self.__class__.__name__, self.pid)
             sys.exit(1)
 

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -816,7 +816,7 @@ class GeventServer(CommonServer):
         _logger.info('Evented Service (longpolling) running on %s:%s', self.interface, self.port)
         try:
             self.httpd.serve_forever()
-        except:
+        except Exception:
             _logger.exception("Evented Service (longpolling): uncaught error during main loop")
             raise
 
@@ -1306,7 +1306,7 @@ class Worker(object):
                 if not self.alive:
                     break
                 self.process_work()
-        except:
+        except Exception:
             _logger.exception("Worker %s (%s) Exception occurred, exiting...", self.__class__.__name__, self.pid)
             sys.exit(1)
 
@@ -1476,7 +1476,8 @@ def load_server_wide_modules():
 def _reexec(updated_modules=None):
     """reexecute openerp-server process with (nearly) the same arguments"""
     if osutil.is_running_as_nt_service():
-        subprocess.call('net stop {0} && net start {0}'.format(nt_service_name), shell=True)
+        if not subprocess.call(['net', 'stop', nt_service_name]):
+            subprocess.call(['net', 'start', nt_service_name])
     exe = os.path.basename(sys.executable)
     args = stripped_sys_argv()
     if updated_modules:


### PR DESCRIPTION
Two bare `except:` clauses swallow BaseException subclasses including
KeyboardInterrupt and SystemExit, interfering with clean process
termination. Changed to `except Exception:`.

The Windows NT service restart used subprocess.call() with shell=True
and string formatting. Replaced with list arguments to avoid shell
interpretation, preserving the original semantics: net start only
runs if net stop succeeds.

Current behavior before PR:
except:
subprocess.call('net stop {0} && net start {0}'.format(nt_service_name), shell=True)

Desired behavior after PR is merged:
except Exception:
if not subprocess.call(['net', 'stop', nt_service_name]):
    subprocess.call(['net', 'start', nt_service_name])