### PR TITLE
[FIX] mrp(workorder): Fix Gantt view

### DIFF
--- a/addons/mrp/data/mrp_data.xml
+++ b/addons/mrp/data/mrp_data.xml
@@ -74,6 +74,23 @@
             <field name="sequence">0</field>
         </record>
 
+        <record id="mrp_workcenter_calendar" model="resource.calendar">
+            <field name="name">Work Center 40 hours/week</field>
+            <field name="company_id" eval="False"/>
+            <field name="hours_per_day">8</field>
+            <field name="attendance_ids"
+                eval="[
+                    Command.clear(),
+                    Command.create({'dayofweek': '0', 'duration_hours': 8, 'hour_from': 8, 'hour_to': 16}),
+                    Command.create({'dayofweek': '1', 'duration_hours': 8, 'hour_from': 8, 'hour_to': 16}),
+                    Command.create({'dayofweek': '2', 'duration_hours': 8, 'hour_from': 8, 'hour_to': 16}),
+                    Command.create({'dayofweek': '3', 'duration_hours': 8, 'hour_from': 8, 'hour_to': 16}),
+                    Command.create({'dayofweek': '4', 'duration_hours': 8, 'hour_from': 8, 'hour_to': 16}),
+                ]"
+            />
+            <field name="full_time_required_hours">40</field>
+        </record>
+
     </data>
 
 </odoo>

--- a/addons/mrp/data/mrp_demo.xml
+++ b/addons/mrp/data/mrp_demo.xml
@@ -19,17 +19,17 @@
 
         <record id="mrp_workcenter_3" model="mrp.workcenter">
             <field name="name">Assembly 1</field>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std"/>
+            <field name="resource_calendar_id" ref="mrp.mrp_workcenter_calendar"/>
         </record>
 
         <record id="mrp_workcenter_1" model="mrp.workcenter">
             <field name="name">Drill 1</field>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std"/>
+            <field name="resource_calendar_id" ref="mrp.mrp_workcenter_calendar"/>
         </record>
 
         <record id="mrp_workcenter_2" model="mrp.workcenter">
             <field name="name">Assembly 2</field>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std"/>
+            <field name="resource_calendar_id" ref="mrp.mrp_workcenter_calendar"/>
         </record>
 
         <!-- Resource: mrp.bom -->

--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -78,7 +78,7 @@ class MrpWorkcenter(models.Model):
     capacity_ids = fields.One2many('mrp.workcenter.capacity', 'workcenter_id', string='Product Capacities',
         help="Specific number of pieces that can be produced in parallel per product.", copy=True)
     kanban_dashboard_graph = fields.Text(compute='_compute_kanban_dashboard_graph')
-    resource_calendar_id = fields.Many2one(check_company=True)
+    resource_calendar_id = fields.Many2one(check_company=True, default=lambda self: self.env.ref('mrp.mrp_workcenter_calendar', raise_if_not_found=False))
 
     def _compute_display_name(self):
         super()._compute_display_name()

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -317,7 +317,10 @@ class MrpWorkorder(models.Model):
         for wo in self:
             wo.display_name = f"{wo.production_id.name} - {wo.name}"
             if self.env.context.get('prefix_product'):
-                wo.display_name = f"{wo.product_id.name} - {wo.production_id.name} - {wo.name}"
+                product_name = wo.product_id.name
+                if variant := wo.product_id.product_template_attribute_value_ids._get_combination_name():
+                    product_name = f"{product_name}({variant})"
+                wo.display_name = f"{product_name} - {wo.production_id.name} - {wo.name}"
 
     @api.depends('duration_expected', 'duration', 'state')
     def _compute_remaining_time(self):
@@ -612,7 +615,8 @@ class MrpWorkorder(models.Model):
             if wo.id in done_wo:
                 continue
             date_start = max(from_date or datetime.now(), datetime.now())
-            wo.blocked_by_workorder_ids.filtered(lambda wo: wo.id not in done_wo)._plan_workorders(from_date=from_date)
+            if self.env.context.get('consider_blocked_by', True):
+                wo.blocked_by_workorder_ids.filtered(lambda wo: wo.id not in done_wo)._plan_workorders(from_date=from_date, alternative=alternative)
             done_wo.update(wo.blocked_by_workorder_ids.ids)
             if wo.blocked_by_workorder_ids and wo.blocked_by_workorder_ids[-1].date_finished:
                 date_start = wo.blocked_by_workorder_ids[-1].date_finished
@@ -978,7 +982,7 @@ class MrpWorkorder(models.Model):
         date_to_plan_on = max((wo.leave_id.date_to for wo in self.blocked_by_workorder_ids if wo.leave_id), default=datetime.now())
         if self.env.context.get('date_to_plan_on'):
             date_to_plan_on = fields.Datetime.from_string(self.env.context.get('date_to_plan_on'))
-        self._plan_workorders(from_date=date_to_plan_on, alternative=False)
+        self.with_context(consider_blocked_by=False)._plan_workorders(from_date=date_to_plan_on, alternative=False)
 
     def action_unplan(self):
         self.leave_id.unlink()

--- a/addons/mrp/tests/common.py
+++ b/addons/mrp/tests/common.py
@@ -132,18 +132,21 @@ class TestMrpCommon(TestStockCommon):
                 'time_stop': 5,
                 'time_efficiency': 80,
                 'tz': 'UTC',
+                'resource_calendar_id': cls.env.company.resource_calendar_id.id,
             }, {
                 'name': 'Simple Workcenter',
                 'time_start': 0,
                 'time_stop': 0,
                 'time_efficiency': 100,
                 'tz': 'UTC',
+                'resource_calendar_id': cls.env.company.resource_calendar_id.id,
             }, {
                 'name': 'Double Workcenter',
                 'time_start': 0,
                 'time_stop': 0,
                 'time_efficiency': 100,
                 'tz': 'UTC',
+                'resource_calendar_id': cls.env.company.resource_calendar_id.id,
             }
         ])
         for (workcenter, default_capacity) in [(cls.workcenter_1, 2), (cls.workcenter_2, 1), (cls.workcenter_3, 2)]:


### PR DESCRIPTION
- Use the old 'workcenter' gantt view rather than the 'production' (and remove it)
- Create a new Work Center calendar
- Add variant name in workorder display name
- Add the falsy label to employee_assigned_ids (for Gantt view mainly)
- Restore the possibility of not planning the 'blocked by' workorders
- Reload after Plan in Gantt view

task: 5946267
