### PR TITLE
[IMP] mail: inbox read/unread improvements

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -873,6 +873,7 @@ class MailMessage(models.Model):
                 "needaction_inbox_counter": self.env.user.partner_id._get_needaction_count(),
             },
         )
+        return notifications.mail_message_id.ids
 
     def set_message_done(self):
         """ Remove the needaction from messages for the current partner. """
@@ -1143,7 +1144,7 @@ class MailMessage(models.Model):
             res.many(
                 "notification_ids",
                 "_store_notification_fields",
-                value=lambda m: m.sudo().notification_ids._filtered_for_web_client(),
+                sudo=True,
             )
 
         # fetch scheduled notifications once, only if msg_vals is not given to

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -40,7 +40,7 @@
                     <span t-if="props.composer.replyToMessage.thread?.notEq(props.composer.thread)">
                         on: <b><t t-esc="props.composer.replyToMessage.thread.displayName"/></b>
                     </span>
-                    <i class="fa fa-lg fa-times-circle rounded-circle p-0 ms-1 cursor-pointer" title="Stop replying" t-on-click="() => (props.composer.replyToMessage = undefined)"/>
+                    <i class="fa fa-lg fa-times-circle rounded-circle p-0 ms-1 cursor-pointer" title="Discard" t-on-click="() => (props.composer.replyToMessage = undefined)"/>
                 </div>
                 <span t-if="props.composer.message and ui.isSmall" class="px-1" t-on-click="onClickCancelOrSaveEditText">
                     <button class="btn btn-sm btn-secondary rounded-pill border border-secondary ps-1 pe-2 py-0 mb-1" t-att-data-type="EDIT_CLICK_TYPE.CANCEL">

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -540,6 +540,14 @@ export class Message extends Component {
             { context: this }
         );
     }
+
+    get showSubject() {
+        return (
+            this.props.message.subject &&
+            !this.message.isSubjectSimilarToThreadName &&
+            !this.message.isSubjectDefault
+        );
+    }
 }
 
 discussComponentRegistry.add("Message", Message);

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -66,7 +66,7 @@
                             <t t-if="!isAlignedRight and !message.bubbleColor and !(props.asCard and isMobileOS)" t-call="mail.Message.actions"/>
                         </div>
                         <div class="o-mail-Message-contentContainer position-relative d-flex" t-att-class="{ 'flex-row-reverse': isAlignedRight }">
-                            <div class="o-mail-Message-content o-min-width-0" t-att-class="{ 'w-100': isEditing, 'opacity-50': message.isPending, 'pt-1': message.isNote, 'o-mail-Message-pollContent flex-grow-1': message.poll }">
+                            <div class="o-mail-Message-content o-min-width-0" t-att-class="{ 'w-100': isEditing, 'opacity-50': message.isPending, 'pt-1': message.isNote and (!showSubject and !message.bubbleColor), 'o-mail-Message-pollContent flex-grow-1': message.poll }">
                                 <div class="o-mail-Message-textContent position-relative d-flex" t-att-class="{ 'w-100': isEditing }">
                                     <t t-set="showTextVisually" t-value="!message.linkPreviewSquash and (message.hasTextContent or message.subtype_id?.description or message.isEmpty)"/>
                                     <t t-if="message.message_type === 'notification' and message.richBody" t-call="mail.Message.bodyAsNotification" name="bodyAsNotification"/>
@@ -114,7 +114,7 @@
                                                     <i t-if="message.isEmpty" class="text-muted opacity-75" t-out="message.inlineBody"/>
                                                     <Composer t-elif="isEditing" autofocus="true" composer="message.composer" onDiscardCallback.bind="exitEditMode" onPostCallback.bind="exitEditMode" mode="'compact'" sidebar="false"/>
                                                     <t t-else="">
-                                                        <em t-if="message.subject and !message.isSubjectSimilarToThreadName and !message.isSubjectDefault" class="d-block text-muted smaller">Subject: <t t-out="props.messageSearch?.highlight(message.subject) ?? message.subject"/></em>
+                                                        <em t-if="showSubject" class="d-block text-muted smaller" t-att-class="{ 'mb-2': !message.bubbleColor }">Subject: <t t-out="props.messageSearch?.highlight(message.subject) ?? message.subject"/></em>
                                                         <div class="overflow-x-auto" t-if="message.message_type and message.message_type.includes('email')" t-ref="shadowBody"/>
                                                         <t t-elif="message.showTranslation" t-out="message.richTranslationValue"/>
                                                         <div class="o-mail-Message-richBody overflow-x-auto" t-elif="message.hasTextContent and message.richBody and !message.linkPreviewSquash" t-out="props.messageSearch?.highlight(message.richBody) ?? message.richBody"/>

--- a/addons/mail/static/src/core/web/discuss_app/discuss_app_patch.js
+++ b/addons/mail/static/src/core/web/discuss_app/discuss_app_patch.js
@@ -4,7 +4,6 @@ import { Discuss } from "@mail/core/public_web/discuss_app/discuss_app";
 import { MessagingMenu } from "@mail/core/public_web/messaging_menu";
 
 import { ControlPanel } from "@web/search/control_panel/control_panel";
-import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
 Object.assign(Discuss.components, { ControlPanel, MessagingMenu });
@@ -12,7 +11,6 @@ Object.assign(Discuss.components, { ControlPanel, MessagingMenu });
 patch(Discuss.prototype, {
     setup() {
         super.setup();
-        this.prevInboxCounter = this.store.inbox.counter;
         useLayoutEffect(
             (threadName) => {
                 if (threadName) {
@@ -20,23 +18,6 @@ patch(Discuss.prototype, {
                 }
             },
             () => [this.thread?.displayName]
-        );
-        useLayoutEffect(
-            () => {
-                if (
-                    this.thread?.id === "inbox" &&
-                    this.prevInboxCounter !== this.store.inbox.counter &&
-                    this.store.inbox.counter === 0
-                ) {
-                    this.effect.add({
-                        message: _t("Congratulations, your inbox is empty!"),
-                        type: "rainbow_man",
-                        fadeout: "fast",
-                    });
-                }
-                this.prevInboxCounter = this.store.inbox.counter;
-            },
-            () => [this.store.inbox.counter]
         );
     },
 });

--- a/addons/mail/static/src/core/web/thread_patch.xml
+++ b/addons/mail/static/src/core/web/thread_patch.xml
@@ -4,9 +4,9 @@
         <xpath expr="//*[@name='empty-message']" position="replace">
             <t t-if="props.thread.isEmpty and props.thread.model === 'mail.box'">
                 <t t-if="props.thread.id === 'inbox' and state.mountedAndLoaded">
-                    <div class="align-items-center text-center">
-                        <h4 class="mb-3 fw-bolder">Congratulations, your inbox is empty</h4>
-                        New messages appear here.
+                    <div class="o-mail-EmptyInbox align-items-center text-center">
+                        <h4 class="mb-3 fw-bolder">You're all caught up!</h4>
+                        New messages will appear here.
                     </div>
                 </t>
                 <t t-if="props.thread.id === 'bookmark'">

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -77,7 +77,7 @@ test("sanity check", async () => {
     await openDiscuss("mail.box_inbox");
     await waitStoreFetch(["channels_as_member", "/mail/inbox/messages"]);
     await contains(".o-mail-DiscussSidebar");
-    await contains("h4:contains('Congratulations, your inbox is empty')");
+    await contains(".o-mail-EmptyInbox");
 });
 
 test.tags("focus required");
@@ -1012,11 +1012,11 @@ test('messages marked as read move to "History" mailbox', async () => {
     await contains(".o-mail-Thread h4:text('No history messages')");
     await click("button:has(:text('Inbox'))");
     await contains("button.o-active:has(:text('Inbox'))");
-    await contains(".o-mail-Thread h4:text('Congratulations, your inbox is empty')", { count: 0 });
+    await contains(".o-mail-Thread .o-mail-EmptyInbox", { count: 0 });
     await contains(".o-mail-Thread .o-mail-Message", { count: 2 });
     await click("button:text('Mark all read')");
     await contains("button.o-active:has(:text('Inbox'))");
-    await contains(".o-mail-Thread h4:text('Congratulations, your inbox is empty')");
+    await contains(".o-mail-Thread .o-mail-EmptyInbox");
     await click("button:text('History')");
     await contains("button.o-active:text('History')");
     await contains(".o-mail-Thread h4:text('No history messages')", { count: 0 });
@@ -1958,7 +1958,7 @@ test('auto-select "Inbox nav bar" when discuss had inbox as active thread', asyn
     await contains(".o-mail-DiscussContent-threadName", { value: "Inbox" });
     await contains(".o-mail-MessagingMenu-navbar button.active:text('Inbox')");
     await contains("button.active.o-active:text('Inbox')");
-    await contains("h4:text('Congratulations, your inbox is empty')");
+    await contains(".o-mail-EmptyInbox");
 });
 
 test("composer should be focused automatically after clicking on the send button", async () => {

--- a/addons/mail/static/tests/discuss_app/inbox.test.js
+++ b/addons/mail/static/tests/discuss_app/inbox.test.js
@@ -549,8 +549,8 @@ test("reply: stop replying button click", async () => {
     await click("[title='Expand']");
     await click(".o-dropdown-item:contains('Reply')");
     await contains(".o-mail-Composer");
-    await contains("i[title='Stop replying']");
-    await click("i[title='Stop replying']");
+    await contains("i[title='Discard']");
+    await click("i[title='Discard']");
     await contains(".o-mail-Composer", { count: 0 });
 });
 
@@ -577,60 +577,6 @@ test("error notifications should not be shown in Inbox", async () => {
         `.o-mail-Message-header a[href*='/odoo/res.partner/${partnerId}']:text('Demo User')`
     );
     await contains(".o-mail-Message-notification", { count: 0 });
-});
-
-test("emptying inbox displays rainbow man in inbox", async () => {
-    const pyEnv = await startServer();
-    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
-    const messageId1 = pyEnv["mail.message"].create({
-        body: "not empty",
-        model: "discuss.channel",
-        needaction: true,
-        res_id: channelId,
-    });
-    pyEnv["mail.notification"].create([
-        {
-            mail_message_id: messageId1,
-            notification_type: "inbox",
-            res_partner_id: serverState.partnerId,
-        },
-    ]);
-    await start();
-    await openDiscuss("mail.box_inbox");
-    await contains(".o-mail-Message");
-    await click("button:enabled:text('Mark all read')");
-    await contains(".o_reward_rainbow");
-});
-
-test("emptying inbox doesn't display rainbow man in another thread", async () => {
-    const pyEnv = await startServer();
-    pyEnv["res.users"].write(serverState.userId, { notification_type: "inbox" });
-    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
-    const partnerId = pyEnv["res.partner"].create({});
-    const messageId = pyEnv["mail.message"].create({
-        body: "not empty",
-        model: "res.partner",
-        needaction: true,
-        res_id: partnerId,
-    });
-    pyEnv["mail.notification"].create([
-        {
-            mail_message_id: messageId,
-            notification_type: "inbox",
-            res_partner_id: serverState.partnerId,
-        },
-    ]);
-    await start();
-    await openDiscuss(channelId);
-    await contains("button:has(:text('Inbox'))", { contains: [".badge:text('1')"] });
-    const [partner] = pyEnv["res.partner"].read(serverState.partnerId);
-    pyEnv["bus.bus"]._sendone(partner, "mail.message/mark_as_read", {
-        message_ids: [messageId],
-        needaction_inbox_counter: 0,
-    });
-    await contains("button:has(:text('Inbox'))", { contains: [".badge", { count: 0 }] });
-    // weak test, no guarantee that we waited long enough for the potential rainbow man to show
-    await contains(".o_reward_rainbow", { count: 0 });
 });
 
 test("Counter should be incremented by 1 when receiving a message with a mention in a channel", async () => {

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -263,9 +263,7 @@ test("default thread rendering", async () => {
     await contains("button:text('History')");
     await contains(".o-mail-DiscussSidebar-item:has(:text('General'))");
     await contains("button.o-active:text('Inbox')");
-    await contains(
-        ".o-mail-Thread:text('Congratulations, your inbox is empty New messages appear here.')"
-    );
+    await contains(".o-mail-Thread .o-mail-EmptyInbox");
     await click("button:text('Bookmarks')");
     await contains("button.o-active:text('Bookmarks')");
     await contains(

--- a/addons/mail/static/tests/thread/thread.test.js
+++ b/addons/mail/static/tests/thread/thread.test.js
@@ -650,7 +650,7 @@ test("[text composer] Opening thread with needaction messages should mark all me
     await contains(".o-mail-Composer-input");
     await triggerEvents(".o-mail-Composer-input", ["blur", "focusout"]);
     await click("button:text('Inbox')");
-    await contains("h4:text('Congratulations, your inbox is empty')");
+    await contains(".o-mail-EmptyInbox");
     const messageId = pyEnv["mail.message"].create({
         author_id: partnerId,
         body: "@Mitchel Admin",
@@ -708,7 +708,7 @@ test("Opening thread with needaction messages should mark all messages of thread
     await contains(".o-mail-Composer-html.odoo-editor-editable");
     await triggerEvents(".o-mail-Composer-html.odoo-editor-editable", ["blur", "focusout"]);
     await click("button:text('Inbox')");
-    await contains("h4:text('Congratulations, your inbox is empty')");
+    await contains(".o-mail-EmptyInbox");
     const messageId = pyEnv["mail.message"].create({
         author_id: partnerId,
         body: "@Mitchel Admin",


### PR DESCRIPTION
This commit improves the UX of the inbox by:
1. Improving the copywrite of the empty inbox.
2. Removing the rainbow man animation.
3. Showing a toast notification upon marking all read giving the possibility to undo.
4. Allowing any message that got notified to the inbox to be marked as unread.
5. Adapted the spacing of messages with subject.


| Before  | After |
| ------------- | ------------- |
| <img width="564" height="235" alt="image" src="https://github.com/user-attachments/assets/fc937a48-9947-42ed-8f5c-77455a203702" />  | <img width="554" height="232" alt="image" src="https://github.com/user-attachments/assets/dc295e3e-57d3-4007-9aad-05f555943cba" />|

task-5952525
