### PR TITLE
[FIX] sale_loyalty: raise error on multi-quote confirm if loyalty points insufficient

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -164,6 +164,13 @@ class SaleOrder(models.Model):
         ).coupon_id.sudo().unlink()
         # Add/remove the points to our coupons
         for coupon, change in self.filtered(lambda s: s.state != 'sale')._get_point_changes().items():
+            if change < 0 and abs(change) > coupon.points:
+                raise ValidationError(
+                    _(
+                        "You don't have enough coupon points to proceed. Please check your applied"
+                        " rewards and coupon balance. "
+                    )
+                )
             coupon.points += change
         res = super().action_confirm()
         # Prioritize any action from super()

--- a/addons/sale_loyalty/tests/test_loyalty.py
+++ b/addons/sale_loyalty/tests/test_loyalty.py
@@ -166,6 +166,78 @@ class TestLoyalty(TestSaleCouponCommon):
         order._action_cancel()
         self.assertFalse(order.coupon_point_ids)
 
+    def test_prevent_using_same_points_on_batch_confirmation(self):
+        """
+        Check that confirming multiple quotations at once raises a ValidationError
+        when they each claim the same reward but the loyalty card doesn't have enough points.
+        """
+        # disable the generic ewallet program created in setUpClass so it doesn't interfere
+        if hasattr(self, 'ewallet_program'):
+            self.ewallet_program.active = False
+
+        program = self.env['loyalty.program'].create({
+            'name': '10% discount for 100 pts',
+            'program_type': 'loyalty',
+            'applies_on': 'both',
+            'trigger': 'auto',
+            'rule_ids': [Command.create({
+                'reward_point_amount': 1,
+                'reward_point_mode': 'money',
+                'minimum_amount': 200,
+            })],
+            'reward_ids': [Command.create({
+                'reward_type': 'discount',
+                'discount_mode': 'percent',
+                'discount': 10.0,
+                'discount_applicability': 'order',
+                'required_points': 100,
+            })],
+        })
+        card = self.env['loyalty.card'].create({
+            'program_id': program.id,
+            'partner_id': self.partner.id,
+            'points': 100,
+        })
+        # Two draft quotations and claim the reward on each quotation
+        order_1, order_2 = self.env['sale.order'].create([
+            {
+                'partner_id': self.partner.id,
+                'order_line': [
+                    Command.create({
+                        'product_id': self.product_B.id,
+                        'product_uom_qty': 1,
+                    }),
+                ],
+            },
+            {
+                'partner_id': self.partner.id,
+                'order_line': [
+                    Command.create({
+                        'product_id': self.product_B.id,
+                        'product_uom_qty': 2,
+                    }),
+                ],
+            },
+        ])
+        order_1._update_programs_and_rewards()
+        self.assertTrue(
+            self._claim_reward(order_1, program, coupon=card),
+            'Reward must be claimable on the quotation',
+        )
+        order_2._update_programs_and_rewards()
+        self.assertTrue(
+            self._claim_reward(order_2, program, coupon=card),
+            'Reward must be claimable on the quotation',
+        )
+
+        # Confirming both quotations at once (mimics "Confirm Orders" smart button) raises an error
+        orders = order_1 | order_2
+        with self.assertRaises(ValidationError):
+            orders.action_confirm()
+
+        # Confirmation should fail and the loyalty card balance must remain unchanged
+        self.assertEqual(card.points, 100)
+
     def test_distribution_amount_payment_programs(self):
         """
         Check how the amount of a payment reward is distributed.


### PR DESCRIPTION
### Steps to reproduce:
- Download Sales app
- Then, tick Configuration -> Settings -> Promotions, Loyalty & Gift Card
- From the sales app top bar, Products -> Discount and Loyalty -> New
- Rule = Default & Reward = any discount for 100 points
- From the 'Loyalty Cards' smart button, create a new loyalty card for a test customer and set its balance to 100 points
- Create 2 "Quotations" with product below 50$ and claim reward. Don't confirm the quotes
- Select the previous quotes and click "Confirm Orders" smart button
- Verify that the created loyalty card has a balance of -100

### Cause of Issue:
When multiple quotations are confirmed in bulk, the system processes their eligibility for rewards one by one. https://github.com/odoo/odoo/blob/3656171994450d11151565efdb4b9dd0468cefa8/addons/sale_loyalty/models/sale_order.py#L150-L153 Hence, each quote will pass the check because the check since they individually require a number of points less than or equal the current loyalty card balance. Then https://github.com/odoo/odoo/blob/3656171994450d11151565efdb4b9dd0468cefa8/addons/sale_loyalty/models/sale_order.py#L166-L167 The change is caluclated collectively, which lowers the balance to a negative amount.

### Fix:
Since the `change` is calculated before any change is done in the database, it is suitable to raise an error to the user at this point if the change is going to turn the balance negative.

opw-5929187