### PR TITLE
[FIX] stock: show correct quantities on delivery slip

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -882,7 +882,7 @@ class StockMoveLine(models.Model):
             aggregated_properties = self._get_aggregated_properties(move_line=move_line)
             line_key, uom = aggregated_properties['line_key'], aggregated_properties['product_uom']
             quantity = move_line.product_uom_id._compute_quantity(move_line.quantity, uom)
-            packaging_quantity = move_line.product_uom_id._compute_quantity(quantity, move_line.move_id.packaging_uom_id)
+            packaging_quantity = uom._compute_quantity(quantity, move_line.move_id.packaging_uom_id)
             if line_key not in aggregated_move_lines:
                 qty_ordered = None
                 packaging_qty_ordered = None

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -7160,3 +7160,50 @@ class StockMove(TransactionCase):
         tracked_move = picking.move_ids.filtered(lambda m: m.product_id == self.product_serial)
         self.assertEqual(tracked_move.lot_ids, sn_2)
         self.assertEqual(tracked_move.quantity, 1.00)
+
+    def test_delivery_slip_quantity_aggregation_with_pack_uom(self):
+        """
+        Test aggregated delivery slip quantities with respect to mixed uoms and packages.
+        """
+        pack_of_6 = self.env.ref('uom.product_uom_pack_6')
+        package1, package2 = self.env['stock.quant.package'].create([{'name': 'Pack 1'}, {'name': 'Pack 2'}])
+        receipt = self.env['stock.picking'].create({
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.stock_location.id,
+            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'move_ids': [Command.create({
+                'name': 'Receipt Picking',
+                'product_id': self.product.id,
+                'product_uom_qty': 10,
+                'product_uom': pack_of_6.id
+            })],
+        })
+        self.assertEqual(receipt.move_ids.packaging_uom_id, pack_of_6)
+        receipt.action_confirm()
+        receipt.write({
+            'move_line_ids': [
+                Command.update(receipt.move_ids.move_line_ids[0].id, {
+                    'product_id': self.product.id,
+                    'quantity': 30,
+                    'product_uom_id': self.uom_unit.id,
+                    'result_package_id': package1.id,
+                }),
+                Command.create({
+                    'product_id': self.product.id,
+                    'quantity': 30,
+                    'product_uom_id': self.uom_unit.id,
+                    'result_package_id': package2.id,
+                })]
+        })
+        aggregate_val = next(iter(receipt.move_line_ids._get_aggregated_product_quantities().values()))
+        self.assertDictEqual({
+            'qty_ordered': aggregate_val['qty_ordered'],
+            'quantity': aggregate_val['quantity'],
+            'packaging_quantity': aggregate_val['packaging_quantity'],
+            'packaging_qty_ordered': aggregate_val['packaging_qty_ordered'],
+        }, {
+            'qty_ordered': 10.0,
+            'quantity': 10.0,
+            'packaging_quantity': 10.0,
+            'packaging_qty_ordered': 10.0,
+        })


### PR DESCRIPTION
Currently, when a user prints a delivery slip for items with different packaging units, the report shows the wrong quantity.

## Steps to replicate:
- Install Purchase and Inventory with demo data
- Settings > Enable 'Units of Measure & Packagings' and 'Packages'
- Products > Desk Pad > Purchase > Add a line > Set unit to pack of 6 and set a vendor.
- Create new RFQ with the same vendor for 'Desk pad' having quantity 10
- Confirm RFQ > Go to receipt > Details
- Create and Set Destination Package to 
    - LOT A 5 pack of 6 
    - LOT B 5 pack of 6
- Validate Delivery Order and Print the Delivery Slip

## Observed Behavior:
Both the ordered and delivered quantities are showing 30.0 (Pack of 6), but this is incorrect.

The correct quantity ordered and delivered should be 5 (Pack of 6).

## Root cause:
This unintentional behavior occurs after commit [1].

When printing the delivery slip, function [2] is triggered. The packaging quantity is calculated using `move_line.product_uom_id`. In this case, the unit of measure is `pack of 6`, because the user selected a different UoM when setting the Destination Packaging.

As a result, when `_compute_quantity` is called, it reaches condition [3], where it checks whether the unit of measure provided as `self` matches `to_unit` Since both are `pack of 6`, no conversion is performed.

Because of this, the packaging quantity is not converted as expected, and the quantity is set to 30 instead of 5.
[2]-
https://github.com/odoo/odoo/blob/9c9ed6ef00b796d7428e4df6e5f96abb5b95287a/addons/stock/models/stock_move_line.py#L860-L945 
[3]-
https://github.com/odoo/odoo/blob/9c9ed6ef00b796d7428e4df6e5f96abb5b95287a/addons/uom/models/uom_uom.py#L87-L88
## Solution:
Use the uom variable instead, as it reflects the unit of measure for the product applied directly on the receipt. This ensures that the unit-of-measure conversion for packaging quantities is handled correctly.

**Before:**
<img width="824" height="244" alt="image" src="https://github.com/user-attachments/assets/ce0ae06b-7cba-46e0-929b-a51aadc0c199" />
**After:**
<img width="833" height="244" alt="image" src="https://github.com/user-attachments/assets/dff563ef-e05c-4b86-bd89-99e89378d152" />

[1]:
https://github.com/odoo/odoo/commit/fa606530235ac413d17dd3d58bdb0921bd811d28 

opw-5930343