### PR TITLE
[FIX] point_of_sale: support additional image formats for POS logo

### DIFF
--- a/addons/point_of_sale/receipt/pos_order_receipt.py
+++ b/addons/point_of_sale/receipt/pos_order_receipt.py
@@ -4,6 +4,7 @@ import qrcode
 from io import BytesIO
 from odoo import models, api, _
 from odoo.tools.misc import format_datetime, format_date
+from odoo.tools.image import image_data_uri
 
 
 class PosOrderReceipt(models.AbstractModel):
@@ -134,7 +135,7 @@ class PosOrderReceipt(models.AbstractModel):
 
         use_qr_code = self.company_id.point_of_sale_ticket_portal_url_display_mode != 'url'
         company = self.company_id
-        config_logo = 'data:image/png;base64,' + base64.b64encode(base64.b64decode(self.config_id.logo)).decode('utf-8')
+        config_logo = image_data_uri(self.config_id.logo) if self.config_id.logo else False
         qr_code_value = f"{self.env.company.get_base_url()}/pos/ticket?order_uuid={self.uuid}"
 
         return {

--- a/addons/point_of_sale/static/src/app/models/pos_config.js
+++ b/addons/point_of_sale/static/src/app/models/pos_config.js
@@ -2,6 +2,7 @@ import { registry } from "@web/core/registry";
 import { Base } from "./related_models";
 import { PosOrderlineAccounting } from "./accounting/pos_order_line_accounting";
 import { PosOrderAccounting } from "./accounting/pos_order_accounting";
+import { imageDataUri } from "@point_of_sale/utils";
 
 export class PosConfig extends Base {
     static pythonModel = "pos.config";
@@ -91,7 +92,7 @@ export class PosConfig extends Base {
     }
 
     get receiptLogoUrl() {
-        return this.logo ? `data:image/png;base64,${this.logo}` : false;
+        return this.logo ? imageDataUri(this.logo) : false;
     }
 
     get availablePricelists() {

--- a/addons/point_of_sale/static/src/utils.js
+++ b/addons/point_of_sale/static/src/utils.js
@@ -217,3 +217,19 @@ export function generateQRCodeDataUrl(
     const qr_code_svg = new XMLSerializer().serializeToString(svg);
     return "data:image/svg+xml;base64," + window.btoa(qr_code_svg);
 }
+
+const FILETYPE_BY_MAGIC_CHAR = {
+    "/": "jpeg",
+    R: "gif",
+    i: "png",
+    P: "svg+xml",
+    U: "webp",
+};
+// Equivalent to `image_data_uri` from odoo/tools/image.py
+export function imageDataUri(base64Source) {
+    if (!base64Source || typeof base64Source !== "string") {
+        return null;
+    }
+    const imageType = FILETYPE_BY_MAGIC_CHAR[base64Source.charAt(0)] || "png";
+    return `data:image/${imageType};base64,${base64Source}`;
+}


### PR DESCRIPTION
Fix the POS config logo URL computation to handle multiple image file formats.
This change enables support for SVG images as POS logos.

Task: 5951143
