### PR TITLE
[FIX] html_builder, website: fix overlay not refreshing during resize

### DIFF
--- a/addons/html_builder/static/src/core/builder_overlay/builder_overlay_plugin.js
+++ b/addons/html_builder/static/src/core/builder_overlay/builder_overlay_plugin.js
@@ -195,6 +195,13 @@ export class BuilderOverlayPlugin extends Plugin {
             return;
         }
         this.removeHoverOverlay();
+        // Don't create a hover overlay for an element already tracked as an
+        // active overlay. When `removeHoverOverlay` is later called for this
+        // hover overlay, it would unobserve the element, breaking resize
+        // detection for the active overlay.
+        if (this.overlays.some((overlay) => overlay.overlayTarget === el)) {
+            return;
+        }
         const overlay = new BuilderOverlay(el, {
             iframe: this.iframe,
             overlayContainer: this.overlayContainer,

--- a/addons/website/static/tests/builder/builder_overlay.test.js
+++ b/addons/website/static/tests/builder/builder_overlay.test.js
@@ -31,6 +31,26 @@ test("Show an overlay when hovering an element with options", async () => {
     expect(".oe_overlay.o_hover_overlay").toHaveRect(":iframe .col-lg-3");
 });
 
+test("Do not show hover overlay on an already active element", async () => {
+    await setupWebsiteBuilder(`
+        <section>
+            <div class="container">
+                <div class="row">
+                    <div class="col-lg-3">
+                        <p>TEST</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+    `);
+    await contains(":iframe section").click();
+    expect(".oe_overlay.oe_active").toHaveCount(1);
+    expect(".oe_overlay.oe_active").toHaveRect(":iframe section");
+
+    await contains(":iframe section").hover();
+    expect(".oe_overlay.o_hover_overlay").toHaveCount(0);
+});
+
 test("Toggle the overlays when clicking on an option element", async () => {
     // TODO improve when more options will be defined.
     await setupWebsiteBuilder(`


### PR DESCRIPTION
**Issue:**
The builder overlay position was not reliably updating when resizing an
element via drag handles.

This happened because the hover overlay was also being created for
elements that already had an active builder overlay. When
`removeHoverOverlay()` ran, it unobserved the element from the
ResizeObserver.

Active builder overlays rely on that observer to refresh their position
and dimensions. Removing it prevented the overlay from updating while
resizing.

**Fix:**
Do not create a hover overlay for elements that already have an active
builder overlay.

This preserves the ResizeObserver for active overlays, and not showing
hover overlays for already active elements also makes functional sense.


task-[5955545](https://www.odoo.com/odoo/project/974/tasks/5955545)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
