### PR TITLE
[IMP] im_livechat: improve leave action wording

### DIFF
--- a/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
@@ -113,10 +113,10 @@ const discussChannelPatch = {
         ) {
             return false;
         }
-        return (
-            this.self_member_id.livechat_member_type === "visitor" ||
-            this.channel_member_ids.length <= 2
+        const hasOtherAgent = this.channel_member_ids.some(
+            (m) => m.livechat_member_type === "agent" && m.notEq(this.self_member_id)
         );
+        return this.self_member_id.livechat_member_type === "visitor" || !hasOtherAgent;
     },
     get typesAllowingCalls() {
         return [...super.typesAllowingCalls, "livechat"];

--- a/addons/im_livechat/static/src/core/common/thread_actions_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_actions_patch.js
@@ -1,4 +1,6 @@
 import { ThreadAction, threadActionsRegistry } from "@mail/core/common/thread_actions";
+
+import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
 patch(ThreadAction.prototype, {
@@ -56,5 +58,14 @@ patch(threadActionsRegistry.get("call"), {
             return super.condition(...arguments) && !channel.livechat_end_dt;
         }
         return super.condition(...arguments);
+    },
+});
+
+patch(threadActionsRegistry.get("leave"), {
+    name({ channel }) {
+        if (channel?.livechatShouldAskLeaveConfirmation) {
+            return _t("Close Conversation");
+        }
+        return _t("Leave Channel");
     },
 });

--- a/addons/im_livechat/static/src/core/public_web/livechat_leave_dialog.js
+++ b/addons/im_livechat/static/src/core/public_web/livechat_leave_dialog.js
@@ -19,7 +19,7 @@ export class LivechatLeaveDialog extends Component {
 
     get title() {
         return _t(
-            "Leaving will end the live chat with %(channel_name)s. Are you sure you want to continue?",
+            "Closing this will end the live chat with %(channel_name)s. Are you sure you want to proceed?",
             { channel_name: this.props.channel.displayName }
         );
     }

--- a/addons/im_livechat/static/src/core/public_web/livechat_leave_dialog.xml
+++ b/addons/im_livechat/static/src/core/public_web/livechat_leave_dialog.xml
@@ -10,7 +10,7 @@
         <t t-set-slot="footer">
             <button class="btn btn-danger me-2" t-on-click="this.onClickConfirm">
                 <i class="fa fa-sign-out me-1 opacity-50"/>
-                Leave Conversation
+                Close Conversation
             </button>
             <button class="btn btn-secondary me-2" t-on-click="this.props.close">
                 <i class="oi oi-close me-1 opacity-50"/>

--- a/addons/im_livechat/static/tests/channel_join_leave.test.js
+++ b/addons/im_livechat/static/tests/channel_join_leave.test.js
@@ -89,12 +89,12 @@ test("from the discuss app", async () => {
     await click("[title='Chat Actions']", {
         parent: [".o-mail-DiscussSidebarChannel", { text: "guest_1" }],
     });
-    await click(".o-dropdown-item:contains('Leave Channel')");
+    await click(".o-dropdown-item:contains('Close Conversation')");
     await contains(
-        ".modal-header:has(:text('Leaving will end the live chat with guest_1. Are you sure you want to continue?'))"
+        ".modal-header:has(:text('Closing this will end the live chat with guest_1. Are you sure you want to proceed?'))"
     );
     await contains(".modal-body .o-mail-Message-body:has(:text('Last message from guest_1'))");
-    await click("button:contains(Leave Conversation)");
+    await click("button:contains(Close Conversation)");
     await contains(".o-mail-DiscussSidebarChannel", { text: "guest_1", count: 0 });
     await click("[title='Chat Actions']", {
         parent: [".o-mail-DiscussSidebarChannel", { text: "guest_2" }],

--- a/addons/im_livechat/static/tests/sidebar_patch.test.js
+++ b/addons/im_livechat/static/tests/sidebar_patch.test.js
@@ -289,12 +289,12 @@ test("Clicking on leave button leaves the channel", async () => {
     await openDiscuss();
     await contains(".o-mail-DiscussSidebarChannel", { text: "Visitor 11" });
     await click("[title='Chat Actions']");
-    await click(".o-dropdown-item:contains('Leave Channel')");
+    await click(".o-dropdown-item:contains('Close Conversation')");
     await contains(
-        ".modal-header:has(:text('Leaving will end the live chat with Visitor 11. Are you sure you want to continue?'))"
+        ".modal-header:has(:text('Closing this will end the live chat with Visitor 11. Are you sure you want to proceed?'))"
     );
     await contains(".modal-body .o-mail-Message-body:has(:text('Last message from Visitor'))");
-    await click("button:contains(Leave Conversation)");
+    await click("button:contains(Close Conversation)");
     await contains(".o-mail-DiscussSidebarChannel", { count: 0, text: "Visitor 11" });
 });
 


### PR DESCRIPTION
**Purpose of this PR:**

Before this commit, the leave action always displayed `“Leave conversation”`. 
However, when no other agent was present, the action actually closed the conversation.

This resulted in inconsistent behavior between the label and action. 
The wording suggested that the agent would simply leave the chat, while the conversation was ended.

Therefore, this commit updates the action text to `“Close conversation”` when no other agent is present. 
The same wording is also applied to the confirmation dialog to keep the UI consistent.

Task-[5873788](https://www.odoo.com/odoo/project/1519/tasks/5873788)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
