### PR TITLE
[IMP] *: replace lru_cache by cache on 0-argument functions

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -89,7 +89,7 @@ class WkhtmlInfo(typing.NamedTuple):
     wkhtmltoimage_version: tuple[str, ...] | None
 
 
-@functools.lru_cache(1)
+@functools.cache
 def _wkhtml() -> WkhtmlInfo:
     state = 'install'
     bin_path = 'wkhtmltopdf'

--- a/odoo/http/geoip.py
+++ b/odoo/http/geoip.py
@@ -31,7 +31,7 @@ class EmptyGeoDB:
         raise geoip2.errors.AddressNotFoundError(ip)
 
 
-@functools.lru_cache(1)
+@functools.cache
 def _geoip_city_db():
     try:
         return geoip2.database.Reader(config['geoip_city_db'])
@@ -43,7 +43,7 @@ def _geoip_city_db():
         return EmptyGeoDB()
 
 
-@functools.lru_cache(1)
+@functools.cache
 def _geoip_country_db():
     try:
         return geoip2.database.Reader(config['geoip_country_db'])

--- a/odoo/http/session.py
+++ b/odoo/http/session.py
@@ -595,7 +595,7 @@ class SessionStore:
                 self.save(session)
 
 
-@functools.lru_cache(1)
+@functools.cache
 def session_store():
     _logger.debug('HTTP sessions stored in: %s', config.session_dir)
     return SessionStore(path=config.session_dir)

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -36,7 +36,7 @@ from concurrent.futures import CancelledError, Future, InvalidStateError, wait
 from contextlib import ExitStack, contextmanager
 from copy import deepcopy
 from datetime import datetime
-from functools import lru_cache, partial, wraps
+from functools import cache, partial, wraps
 from itertools import islice, zip_longest
 from textwrap import shorten
 from typing import TYPE_CHECKING
@@ -2124,7 +2124,7 @@ class Screencaster:
             self._logger.runbot('Screencast in: %s', outfile)
 
 
-@lru_cache(1)
+@cache
 def _find_executable():
     system = platform.system()
     if system == 'Linux':

--- a/odoo/tools/barcode.py
+++ b/odoo/tools/barcode.py
@@ -12,7 +12,7 @@ _barcode_init_lock = RLock()
 # before rendering a barcode (done in a C extension) and this part is not thread safe.
 # This cached functions allows to lazily initialize the T1 fonts cache need for rendering of
 # barcodes in a thread-safe way.
-@functools.lru_cache(1)
+@functools.cache
 def _init_barcode():
     with _barcode_init_lock:
         try:


### PR DESCRIPTION
A 0-argument function can definitionally only have one cache entry (at `()`). Not only is a bound entirely useless (`lru_cache` does not do any presizing), using `lru_cache` incurs the full cost of maintaining an LRU's doubly-linked list.

Using `cache` (~ `lru_cache(None)`) still allocates and interacts with a dict, but it at least skips the whole LRU.
