### PR TITLE
[FIX] spreadsheet_dashboard: forbidden data responses

### DIFF
--- a/addons/spreadsheet_dashboard/controllers/dashboards_controllers.py
+++ b/addons/spreadsheet_dashboard/controllers/dashboards_controllers.py
@@ -18,7 +18,7 @@ class DashboardDataRoute(http.Controller):
         cids_str = request.cookies.get('cids', str(request.env.user.company_id.id))
         cids = [int(cid) for cid in cids_str.split('-')]
         dashboard = dashboard.with_context(allowed_company_ids=cids)
-        if dashboard._dashboard_is_empty() and dashboard.sample_dashboard_file_path:
+        if dashboard.sample_dashboard_file_path and dashboard._dashboard_is_empty():
             sample_data = dashboard._get_sample_dashboard()
             if sample_data:
                 return request.make_json_response({

--- a/addons/spreadsheet_dashboard/models/spreadsheet_dashboard.py
+++ b/addons/spreadsheet_dashboard/models/spreadsheet_dashboard.py
@@ -63,7 +63,13 @@ class SpreadsheetDashboard(models.Model):
             return
 
     def _dashboard_is_empty(self):
-        return any(self.env[model].search_count([], limit=1) == 0 for model in self.main_data_model_ids.sudo().mapped("model"))
+        for model_name in self.main_data_model_ids.sudo().mapped("model"):
+            model = self.env[model_name]
+            if not model.has_access("read"):
+                model = model.sudo()
+            if model.search_count([], limit=1) == 0:
+                return True
+        return False
 
     def copy_data(self, default=None):
         default = dict(default or {})

--- a/addons/spreadsheet_dashboard/tests/test_dashboard_controllers.py
+++ b/addons/spreadsheet_dashboard/tests/test_dashboard_controllers.py
@@ -47,3 +47,17 @@ class TestDashboardController(DashboardTestCommon, HttpCase):
             'is_sample': True,
             'snapshot': {'sheets': []},
         })
+
+    def test_load_dashboard_with_unreadable_main_model(self):
+        self.authenticate(self.user.login, self.user.password)
+        sample_dashboard_path = 'spreadsheet_dashboard/tests/data/sample_dashboard.json'
+        dashboard = self.create_dashboard()
+        dashboard.sample_dashboard_file_path = sample_dashboard_path
+        dashboard.main_data_model_ids = [(4, self.env.ref('base.model_ir_model').id)]
+        self.assertFalse(self.env['ir.model'].with_user(self.user).has_access('read'))
+
+        response = self.url_open(f'/spreadsheet/dashboard/data/{dashboard.id}')
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertNotIn('is_sample', data)
+        self.assertEqual(data['revisions'], [])


### PR DESCRIPTION
## Description

When opening a dashboard, `_dashboard_is_empty()` may call `search_count()`
on one of the dashboard's main data models to decide whether sample data
should be loaded.

If the current user does not have read access to one of these models,
`search_count()` raises an access error and the dashboard loading can fail,
even though the user has access to the dashboard itself.

To avoid this, only unreadable models are checked with `sudo()`, while
readable models are still evaluated with the current user rights.

This prevents the access error in `_dashboard_is_empty()` and allows the
dashboard to open instead of failing early.

Task: [5905166](https://www.odoo.com/odoo/project/2328/tasks/5905166)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
