### PR TITLE
[FIX] crm: stop propagation of email to the company from contact partner

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1892,6 +1892,11 @@ class Lead(models.Model):
             'is_company': is_company,
             'type': 'contact'
         }
+        if is_company and self.contact_name:
+            # Email, phone and mobile belong to the contact person, not the company
+            for field in ('email', 'phone', 'mobile'):
+                res.pop(field, None)
+
         if self.lang_id.active:
             res['lang'] = self.lang_id.code
         return res

--- a/addons/crm/tests/test_crm_lead_convert.py
+++ b/addons/crm/tests/test_crm_lead_convert.py
@@ -416,6 +416,50 @@ class TestLeadConvert(crm_common.TestLeadConvertCommon):
         self.assertFalse(self.lead_1.lead_properties)
 
     @users('user_sales_manager')
+    def test_lead_convert_with_company_and_contact_email(self):
+        """ Test when a lead has both company name and contact names,
+        the resulting company partner has no phone, mobile and email while the contact partner has it. """
+        lead = self.env['crm.lead'].create({
+            'name': 'Test Lead',
+            'partner_name': 'Test Company',
+            'contact_name': 'Test Contact',
+            'email_from': 'test@example.com',
+            'phone': '123456789',
+            'mobile': '987654321',
+            'type': 'lead',
+        })
+        lead._handle_partner_assignment()
+        self.assertRecordValues(lead.partner_id, [{
+            'name': 'Test Contact',
+            'email': 'test@example.com',
+            'phone': "123456789",
+            'mobile': "987654321",
+        }])
+        self.assertRecordValues(lead.partner_id.parent_id, [{
+            'name': 'Test Company',
+            'email': False,
+            'phone': False,
+            'mobile': False,
+        }])
+        # IF only company name is provided and contact name is empty
+        # phone, mobile and email should belong to the company partner
+        lead = self.env['crm.lead'].create({
+            'name': 'Test Lead 2',
+            'partner_name': 'Test Company 2',
+            'type': 'lead',
+            'email_from': 'test2@example.com',
+            'phone': "1234567891",
+            'mobile': "9876543211",
+        })
+        lead._handle_partner_assignment()
+        self.assertRecordValues(lead.partner_id, [{
+            'name': 'Test Company 2',
+            'email': 'test2@example.com',
+            'phone': "1234567891",
+            'mobile': "9876543211",
+        }])
+
+    @users('user_sales_manager')
     def test_lead_merge(self):
         """ Test convert wizard working in merge mode """
         date = Datetime.from_string('2020-01-20 16:00:00')


### PR DESCRIPTION
Steps to reproduce:
1. Install `CRM`
2. Activate leads from the settings
3. Create a lead with `Contact Name`, `Company Name` and `Email`
4. Convert this lead to an opportunity with `action` and customer set to `convert to opportunity` and `Create a new contact`
5. Now look into contact and contacts's parent company

Issue:
- Both created contact partner and company partner have the same email

Solution:
- Remove `email` from the data based on `company name` availability while creating a customer

opw-5421940