### PR TITLE
[FIX] account_edi_ubl_cii: use TST code for UNSPSC in Peppol XML

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_ubl.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_ubl.py
@@ -919,7 +919,7 @@ class AccountEdiUBL(models.AbstractModel):
         return {
             'cbc:ItemClassificationCode': {
                 '_text': unspsc_code.code,
-                'listID': 'UNSPSC',
+                'listID': 'TST',
                 'listVersionID': None,
             }
         }
@@ -928,7 +928,7 @@ class AccountEdiUBL(models.AbstractModel):
         return {
             'cbc:ItemClassificationCode': {
                 '_text': cpv_code.code,
-                'listID': 'CPV',
+                'listID': 'STI',
                 'listVersionID': None,
             }
         }

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_product_commodity_code_cpv.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_product_commodity_code_cpv.xml
@@ -132,7 +132,7 @@
 			<cbc:Description>Test Product</cbc:Description>
 			<cbc:Name>Test Product</cbc:Name>
 			<cac:CommodityClassification>
-				<cbc:ItemClassificationCode listID="CPV">35113110-0</cbc:ItemClassificationCode>
+				<cbc:ItemClassificationCode listID="STI">35113110-0</cbc:ItemClassificationCode>
 			</cac:CommodityClassification>
 			<cac:ClassifiedTaxCategory>
 				<cbc:ID>S</cbc:ID>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_product_commodity_code_unspsc.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_product_commodity_code_unspsc.xml
@@ -132,7 +132,7 @@
 			<cbc:Description>Test Product</cbc:Description>
 			<cbc:Name>Test Product</cbc:Name>
 			<cac:CommodityClassification>
-				<cbc:ItemClassificationCode listID="UNSPSC">12141906</cbc:ItemClassificationCode>
+				<cbc:ItemClassificationCode listID="TST">12141906</cbc:ItemClassificationCode>
 			</cac:CommodityClassification>
 			<cac:ClassifiedTaxCategory>
 				<cbc:ID>S</cbc:ID>


### PR DESCRIPTION
**Steps to reproduce:**
* Install the **product_unspsc** module.
* Create a product with a **UNSPSC category**.
* Create and post an invoice for this product.
* Send the invoice via **Peppol**.

**Observed behavior:**
* Peppol validation fails with error **[BR-CL-13]**: *“Item classification identifier identification scheme identifier MUST be coded using one of the UNTDID 7143 list.”*
* The XML uses `listID='UNSPSC'` in `cbc:ItemClassificationCode`.

**Cause:**
* The `listID` attribute was set to the literal string **'UNSPSC'**.
* According to the **UNCL7143** code list, the correct scheme identifier for UNSPSC is **'TST'**, not 'UNSPSC'.

**Fix:**
* Replace `listID='UNSPSC'` with `listID='TST'` when generating the commodity classification node.
* Update and extend tests to validate the correct scheme identifier.
* Same for CPV code from the documentation i's code is also changed to 'STI'.

ref: https://docs.peppol.eu/poacc/billing/3.0/codelist/UNCL7143/

opw-5948723
