### PR TITLE
[FIX] account:  fix payment status for vendor bills

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -161,6 +161,7 @@ class AccountPayment(models.Model):
         compute='_compute_stat_buttons_from_reconciliation')
     reconciled_bill_ids = fields.Many2many('account.move', string="Reconciled Bills",
         compute='_compute_stat_buttons_from_reconciliation',
+        search='_search_reconciled_invoice_ids',
         help="Invoices whose journal items have been reconciled with these payments.")
     reconciled_bills_count = fields.Integer(string="# Reconciled Bills",
         compute="_compute_stat_buttons_from_reconciliation")
@@ -464,7 +465,7 @@ class AccountPayment(models.Model):
             if payment.journal_id.company_id not in payment.company_id.parent_ids:
                 payment.company_id = (payment.journal_id.company_id or self.env.company)._accessible_branches()[:1]
 
-    @api.depends('reconciled_invoice_ids.payment_state', 'move_id.line_ids.amount_residual')
+    @api.depends('reconciled_invoice_ids.payment_state', 'reconciled_bill_ids.payment_state', 'move_id.line_ids.amount_residual')
     def _compute_state(self):
         payments_is_matched_to_recompute = self.env['account.payment']
         for payment in self:
@@ -479,8 +480,9 @@ class AccountPayment(models.Model):
                     'in_process'
                 )
             if (
-                payment.state == 'in_process' and payment.reconciled_invoice_ids and
-                all(invoice.payment_state == 'paid' for invoice in payment.reconciled_invoice_ids)
+                payment.state == 'in_process'
+                and (payment.reconciled_invoice_ids or payment.reconciled_bill_ids) and
+                all(invoice.payment_state == 'paid' for invoice in payment.reconciled_invoice_ids | payment.reconciled_bill_ids)
             ):
                 # The access to invoice.payment_state will trigger a flush_model on account_payment.is_matched in its compute.
                 # This flush will then trigger _compute_reconciliation_status. However, the payment.state will then be changed by this next line of code.

--- a/addons/account/tests/test_account_payment.py
+++ b/addons/account/tests/test_account_payment.py
@@ -909,3 +909,24 @@ class TestAccountPayment(AccountTestInvoicingCommon, MailCommon):
         payment.action_draft()
         with self.assertRaises(UserError):
             payment.amount = 300.0
+
+    def test_vendor_bill_payment_status(self):
+        bill = self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': fields.Date.today(),
+            'invoice_line_ids': [Command.create({
+                'name': 'Test Product',
+                'quantity': 1,
+                'price_unit': 100.0,
+            })],
+        })
+        bill.action_post()
+
+        with patch.object(self.env.registry['account.move'], '_get_invoice_in_payment_state', lambda self: 'paid'):
+            payment = self.env['account.payment.register'].with_context(
+                active_model='account.move',
+                active_ids=bill.ids,
+            ).create({'journal_id': self.bank_journal_1.id})._create_payments()
+            self.assertTrue(payment.reconciled_bill_ids)
+            self.assertEqual(payment.state, 'paid')


### PR DESCRIPTION
**Steps to reproduce:**
1. Install `invoice` module.
2. Create a Vendor Bill, confirm it, and register payment.
3. Observe that Bill is marked `Paid`, but Payment status remains `In Process`.

**Issue:**
When paying a Vendor Bill, the payment remains in the `In Process` state even after the Bill is fully paid, unlike Customer Invoices where the payment correctly transitions to `Paid`.

**Cause:**
The discrepancy occurs because the system checks linked invoices to update the payment status but fails to check linked bills.

In `account.payment`, the `_compute_state` method only checks [reconciled_invoice_ids] to determine if the payment should transition from `In Process` to `Paid`. It ignores `reconciled_bill_ids` (Vendor Bills).

**Fix:**
Update code to check both `reconciled_invoice_ids` and `reconciled_bill_ids`. If all linked invoices or bills are paid, the
payment status is updated to `Paid`.

Related PR : [#231243](https://github.com/odoo/odoo/pull/231243/changes#diff-143d17de807d23650088a8c12f0a5b5cc2246b1b51e0bb7634e85247b6e535eaR392)


opw-5865798
