### PR TITLE
[IMP] core: add lru on `babel_locale_parse`

### DIFF
--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -9,6 +9,7 @@ import cProfile
 import collections
 import contextlib
 import datetime
+import functools
 import hmac as hmac_lib
 import hashlib
 import io
@@ -1371,6 +1372,8 @@ def get_lang(env, lang_code=False):
         lang = env.user.company_id.partner_id.lang
     return env['res.lang']._lang_get(lang)
 
+
+@functools.lru_cache
 def babel_locale_parse(lang_code):
     try:
         return babel.Locale.parse(lang_code)


### PR DESCRIPTION
`babel.Locale.parse` checks if a locale is valid by calling `os.path.exists` on the resolved filename for the locale (this is done in `babel.localedata.exists`).

Babel does have a locale cache which it checks, but currently that cache is only populated when the locale is actually loaded[^1], therefore in cases where we instantiate a significant number of locales but never actually need to load locale data (e.g. formatting a significant number of datetimes, in qweb, using only non-localised patterns) this results in severe FS traffic for no reason.

[^1]: python-babel/babel#1254 has been submitted to fix this issue