### PR TITLE
[FIX] mail: prevent stale typing indicators

### DIFF
--- a/addons/mail/static/src/discuss/core/common/channel_member_model.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_model.js
@@ -60,7 +60,14 @@ export class ChannelMember extends Record {
         },
     });
     new_message_separator_ui = null;
-    isTyping = false;
+    isTyping = fields.Attr(false, {
+        onUpdate() {
+            browser.clearTimeout(this.typingTimeoutId);
+            if (this.isTyping) {
+                this.registerTypingTimeout();
+            }
+        },
+    });
     is_typing_dt = fields.Datetime({
         onUpdate() {
             browser.clearTimeout(this.typingTimeoutId);
@@ -71,13 +78,16 @@ export class ChannelMember extends Record {
                 this.isTyping = false;
             }
             if (this.isTyping) {
-                this.typingTimeoutId = browser.setTimeout(
-                    () => (this.isTyping = false),
-                    Store.OTHER_LONG_TYPING
-                );
+                this.registerTypingTimeout();
             }
         },
     });
+    registerTypingTimeout() {
+        this.typingTimeoutId = browser.setTimeout(
+            () => (this.isTyping = false),
+            Store.OTHER_LONG_TYPING
+        );
+    }
     threadAsTyping = fields.One("Thread", {
         compute() {
             return this.isTyping ? this.channel_id : undefined;


### PR DESCRIPTION
Typing expiration was indirectly tied to typing timestamp updates. Typing timestamps are second-precision, so two consecutive typing events can carry the same timestamp value.

In that case, the timestamp field may not be considered updated on the client. The expiration timeout is then not re-armed even though typing is set to true.

When that happens, the typing indicator can remain visible indefinitely unless an explicit "stop typing" event is received.

This change makes timeout registration depend on typing state updates directly. Expiration is always scheduled when typing becomes active, regardless of timestamp equality.

[task-4922630](https://www.odoo.com/odoo/project/1519/tasks/4922630)
