### PR TITLE
[FIX] pos_restaurant: fix failing SplitBillScreenTour2 tour

### DIFF
--- a/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
@@ -100,6 +100,7 @@ registry.category("web_tour.tours").add("SplitBillScreenTour2", {
             SplitBillScreen.clickOrderline("Coca-Cola"),
             SplitBillScreen.orderlineHas("Coca-Cola", "1", "1"),
             SplitBillScreen.clickPay(),
+            Chrome.waitRequest(),
             PaymentScreen.clickBack(),
             Chrome.clickMenuOption("Orders"),
             Chrome.waitRequest(),


### PR DESCRIPTION
This commit fixes the failing `SplitBillScreenTour2` tour by properly waiting for the split order request to complete before proceeding to the next steps.

Runbot error [233594](https://runbot.odoo.com/odoo/runbot.build.error/233594)
Task [5953808](https://www.odoo.com/odoo/project.task/5953808)

