### PR TITLE
[FIX] account: fixes missing section on invoice when hiding price.

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -3426,22 +3426,50 @@ class AccountMoveLine(models.Model):
         Groups lines by their tax IDs and computes subtotal and total for each group.
         """
         self.ensure_one()
+        children_lines = self.move_id.invoice_line_ids.filtered(lambda l: self in {l.parent_id, l.parent_id.parent_id})
+        subsection_lines = children_lines.filtered(lambda l: l.display_type == 'line_subsection')
+        direct_children_lines = children_lines.filtered(lambda l: l.parent_id == self and l.display_type != 'line_subsection')
+        section_subtotal = sum(l.price_subtotal for l in children_lines)
+        section_total = sum(l.price_total for l in children_lines)
+        result = [{
+            'name': self.name,
+            'taxes': [tax.tax_label for tax in children_lines.tax_ids if tax.tax_label],
+            'price_subtotal': section_subtotal,
+            'price_total': section_total,
+            'display_type': self.display_type,
+            'quantity': 0,
+            'line_uom': False,
+            'product_uom': False,
+            'discount': 0.0,
+        }]
 
-        section_lines = self.move_id.invoice_line_ids.filtered(lambda l: (l.parent_id == self or l.parent_id.parent_id == self))
-        result = []
-        for taxes, lines_for_tax_group in groupby(section_lines, key=lambda l: l.tax_ids):
-            lines_for_tax_group = sum(lines_for_tax_group, start=self.env['account.move.line'])
-            tax_labels = [tax.tax_label for tax in taxes if tax.tax_label]
-            for section_line, move_lines in lines_for_tax_group.sorted('sequence').grouped('parent_id').items():
-                lines_to_sum = move_lines if section_line != self else lines_for_tax_group
-                subtotal = sum(l.price_subtotal for l in lines_to_sum)
-                total = sum(l.price_total for l in lines_to_sum)
+        if not self.collapse_composition:
+            for line in direct_children_lines:
+                result.append({
+                    'name': line.name,
+                    'taxes': [tax.tax_label for tax in line.tax_ids if tax.tax_label] if not self.collapse_prices else [],
+                    'price_subtotal': line.price_subtotal,
+                    'price_total': line.price_total,
+                    'display_type': line.display_type,
+                    'quantity': line.quantity,
+                    'line_uom': line.product_uom_id,
+                    'product_uom': line.product_id.uom_id,
+                    'discount': line.discount,
+                })
+
+        for subsection_line in subsection_lines:
+            lines_in_subsection = children_lines.filtered(lambda l: l.parent_id == subsection_line)
+            for taxes, lines_for_tax_group in groupby(lines_in_subsection, key=lambda l: l.tax_ids):
+                lines_for_tax_group = sum(lines_for_tax_group, start=self.env['account.move.line'])
+                tax_labels = [tax.tax_label for tax in taxes if tax.tax_label]
+                subtotal = sum(l.price_subtotal for l in lines_for_tax_group)
+                total = sum(l.price_total for l in lines_for_tax_group)
                 if not subtotal and not tax_labels:
                     continue
-                elif section_line.collapse_composition or section_line.parent_id.collapse_composition:
+                if subsection_line.collapse_composition or self.collapse_composition:
                     result.append({
-                        'name': section_line.name,
-                        'taxes': tax_labels if not section_line.parent_id.collapse_prices else [],
+                        'name': subsection_line.name,
+                        'taxes': tax_labels,
                         'price_subtotal': subtotal,
                         'price_total': total,
                         'display_type': 'product',
@@ -3451,19 +3479,18 @@ class AccountMoveLine(models.Model):
                         'discount': 0.0,
                     })
                 else:
-                    for line in (section_line | move_lines):
+                    for line in subsection_line | lines_for_tax_group:
                         result.append({
                             'name': line.name,
-                            'taxes': tax_labels if line == self else [],
-                            'price_subtotal': subtotal if line == section_line else line.price_subtotal,
-                            'price_total': total if line == section_line else line.price_total,
+                            'taxes': tax_labels if line == subsection_line else [],
+                            'price_subtotal': subtotal if line == subsection_line else line.price_subtotal,
+                            'price_total': total if line == subsection_line else line.price_total,
                             'display_type': line.display_type,
                             'quantity': line.quantity,
                             'line_uom': line.product_uom_id,
                             'product_uom': line.product_id.uom_id,
                             'discount': line.discount,
                         })
-
         return result or [{
             'name': self.name,
             'taxes': [],

--- a/addons/account/tests/test_account_section_and_subsection.py
+++ b/addons/account/tests/test_account_section_and_subsection.py
@@ -39,7 +39,7 @@ class TestAccountSectionAndSubsection(AccountTestInvoicingCommon):
         expected_values = [
             {'display_type': 'line_section', 'name': 'Section 1', 'price_subtotal': 400.0, 'taxes': ['15%']},
             {'display_type': 'product', 'name': 'product_a', 'price_subtotal': 100.0, 'taxes': []},
-            {'display_type': 'product', 'name': 'Subsection 1.1', 'price_subtotal': 300.0, 'taxes': []},
+            {'display_type': 'product', 'name': 'Subsection 1.1', 'price_subtotal': 300.0, 'taxes': ['15%']},
         ]
         for expected_value, line_value in zip(expected_values, section_lines):
             for key, value in expected_value.items():
@@ -81,12 +81,53 @@ class TestAccountSectionAndSubsection(AccountTestInvoicingCommon):
         ]
         section_lines = move.invoice_line_ids[0]._get_child_lines()
         expected_values = [
-            {'display_type': 'line_section', 'name': 'Section 1', 'price_subtotal': 300.0, 'taxes': ['15%']},
+            {'display_type': 'line_section', 'name': 'Section 1', 'price_subtotal': 600.0, 'taxes': ['15%', '15% (copy)']},
             {'display_type': 'product', 'name': 'product_a', 'price_subtotal': 100.0, 'taxes': []},
-            {'display_type': 'product', 'name': 'Subsection 1.1', 'price_subtotal': 200.0, 'taxes': []},
-            {'display_type': 'line_section', 'name': 'Section 1', 'price_subtotal': 300.0, 'taxes': ['15% (copy)']},
             {'display_type': 'product', 'name': 'product_a', 'price_subtotal': 100.0, 'taxes': []},
-            {'display_type': 'product', 'name': 'Subsection 1.1', 'price_subtotal': 200.0, 'taxes': []},
+            {'display_type': 'product', 'name': 'Subsection 1.1', 'price_subtotal': 200.0, 'taxes': ['15%']},
+            {'display_type': 'product', 'name': 'Subsection 1.1', 'price_subtotal': 200.0, 'taxes': ['15% (copy)']},
+        ]
+        for expected_value, line_value in zip(expected_values, section_lines):
+            for key, value in expected_value.items():
+                self.assertEqual(line_value[key], value)
+
+    def test_get_child_lines_with_products_in_subsections(self):
+        move = self._create_invoice(
+            invoice_line_ids=[Command.create(vals) for vals in [
+                {
+                    'name': "Section 1",
+                    'display_type': 'line_section',
+                    'collapse_prices': True,
+                },
+                {
+                    'name': "Subsection 1.1",
+                    'display_type': 'line_subsection',
+                    'collapse_composition': False,
+                },
+                {
+                    'product_id': self.product_a.id,
+                    'price_unit': 200,
+                    'tax_ids': self.tax_sale_a.ids,
+                },
+                {
+                    'name': "Subsection 1.2",
+                    'display_type': 'line_subsection',
+                    'collapse_composition': False,
+                },
+                {
+                    'product_id': self.product_b.id,
+                    'price_unit': 200,
+                    'tax_ids': self.tax_sale_b.ids,
+                },
+            ]]
+        )
+        section_lines = move.invoice_line_ids[0]._get_child_lines()
+        expected_values = [
+            {'display_type': 'line_section', 'name': 'Section 1', 'price_subtotal': 400.0, 'taxes': ['15%', '15% (copy)']},
+            {'display_type': 'line_subsection', 'name': 'Subsection 1.1', 'price_subtotal': 200.0, 'taxes': ['15%']},
+            {'display_type': 'product', 'name': 'product_a', 'price_subtotal': 200.0, 'taxes': []},
+            {'display_type': 'line_subsection', 'name': 'Subsection 1.2', 'price_subtotal': 200.0, 'taxes': ['15% (copy)']},
+            {'display_type': 'product', 'name': 'product_b', 'price_subtotal': 200.0, 'taxes': []},
         ]
         for expected_value, line_value in zip(expected_values, section_lines):
             for key, value in expected_value.items():

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -313,7 +313,7 @@
                                                 </td>
                                                 <td name="td_quantity_grouped"
                                                     colspan="1"
-                                                    t-if="hide_details or (hide_prices and grouped_line['display_type'] not in ('line_section', 'line_subsection'))"
+                                                    t-if="hide_details or (hide_prices and grouped_line['display_type'] not in ('line_section', 'line_subsection', 'line_note'))"
                                                     class="o_td_quantity text-end">
                                                     <!-- If line is hide composition, always show 1 unit -->
                                                     <div t-if="hide_details">


### PR DESCRIPTION
**STEP TO REPRODUCE**

1. Create an invoice, with:
- Section A
  - Subsection 1
   - product a, with tax Click on hide price on section A, and preview the invoice. Notice the Section A is missing from the preview/pdf. If you remove the tax on product a, there will also be a bug where Subsection 1 is duplicated, with one copy with no children lines below it.

opw-5927563