### PR TITLE
[IMP] mrp: allow creating draft manufacturing orders from procurements

### DIFF
--- a/addons/mrp/models/stock_orderpoint.py
+++ b/addons/mrp/models/stock_orderpoint.py
@@ -186,26 +186,25 @@ class StockWarehouseOrderpoint(models.Model):
             product_qty = min(ratios_total or [0]) - min(ratios_qty_available or [0])
             res[orderpoint.id] = orderpoint.product_id.uom_id._compute_quantity(product_qty, orderpoint.uom_id, round=False)
 
-        bom_manufacture = self.env['mrp.bom']._bom_find(orderpoints_without_kit.product_id, bom_type='normal')
-        bom_manufacture = self.env['mrp.bom'].concat(bom_manufacture.values())
         # add quantities coming from draft MOs
         productions_group = self.env['mrp.production']._read_group(
             [
-                ('bom_id', 'in', bom_manufacture.ids),
                 ('state', '=', 'draft'),
-                ('orderpoint_id', 'in', orderpoints_without_kit.ids),
+                ('product_id', 'in', orderpoints_without_kit.product_id.ids),
+                ('forecasted_location_id', 'in', orderpoints_without_kit.location_id.ids),
                 ('id', 'not in', self.env.context.get('ignore_mo_ids', [])),
             ],
-            ['orderpoint_id', 'uom_id'],
-            ['product_qty:sum'])
-        for orderpoint, uom, product_qty_sum in productions_group:
-            res[orderpoint.id] += uom._compute_quantity(
-                product_qty_sum, orderpoint.uom_id, round=False)
+            ['product_id', 'forecasted_location_id'],
+            ['product_uom_qty:sum'],
+        )
+        orderpoint_map = {(op.product_id.id, op.location_id.id): op for op in orderpoints_without_kit}
+        for product, location, qty in productions_group:
+            if orderpoint := orderpoint_map.get((product.id, location.id)):
+                res[orderpoint.id] += qty
 
         # add quantities coming from confirmed MO to be started but not finished
         # by the end of the stock forecast
         in_progress_productions = self.env['mrp.production'].search([
-            ('bom_id', 'in', bom_manufacture.ids),
             ('state', '=', 'confirmed'),
             ('orderpoint_id', 'in', orderpoints_without_kit.ids),
             ('id', 'not in', self.env.context.get('ignore_mo_ids', [])),
@@ -225,11 +224,12 @@ class StockWarehouseOrderpoint(models.Model):
 
     def _post_process_scheduler(self):
         """ Confirm the productions only after all the orderpoints have run their
-        procurement to avoid the new procurement created from the production conflict
-        with them. """
+        procurement and when auto_confirm_production is enabled,
+        to avoid the new procurement created from the production conflict with them.
+        """
         self.env['mrp.production'].sudo().search([
             ('orderpoint_id', 'in', self.ids),
-            ('move_raw_ids', '!=', False),
+            ('picking_type_id.auto_confirm_production', '=', True),
             ('state', '=', 'draft'),
         ]).action_confirm()
         return super()._post_process_scheduler()

--- a/addons/mrp/models/stock_orderpoint.py
+++ b/addons/mrp/models/stock_orderpoint.py
@@ -181,26 +181,25 @@ class StockWarehouseOrderpoint(models.Model):
             product_qty = min(ratios_total or [0]) - min(ratios_qty_available or [0])
             res[orderpoint.id] = orderpoint.product_id.uom_id._compute_quantity(product_qty, orderpoint.uom_id, round=False)
 
-        bom_manufacture = self.env['mrp.bom']._bom_find(orderpoints_without_kit.product_id, bom_type='normal')
-        bom_manufacture = self.env['mrp.bom'].concat(bom_manufacture.values())
         # add quantities coming from draft MOs
         productions_group = self.env['mrp.production']._read_group(
             [
-                ('bom_id', 'in', bom_manufacture.ids),
                 ('state', '=', 'draft'),
-                ('orderpoint_id', 'in', orderpoints_without_kit.ids),
+                ('product_id', 'in', orderpoints_without_kit.product_id.ids),
+                ('location_final_id', 'in', orderpoints_without_kit.location_id.ids),
                 ('id', 'not in', self.env.context.get('ignore_mo_ids', [])),
             ],
-            ['orderpoint_id', 'uom_id'],
-            ['product_qty:sum'])
-        for orderpoint, uom, product_qty_sum in productions_group:
-            res[orderpoint.id] += uom._compute_quantity(
-                product_qty_sum, orderpoint.uom_id, round=False)
+            ['product_id', 'location_final_id'],
+            ['product_uom_qty:sum'],
+        )
+        orderpoint_map = {(op.product_id.id, op.location_id.id): op for op in orderpoints_without_kit}
+        for product, location, qty in productions_group:
+            if orderpoint := orderpoint_map.get((product.id, location.id)):
+                res[orderpoint.id] += qty
 
         # add quantities coming from confirmed MO to be started but not finished
         # by the end of the stock forecast
         in_progress_productions = self.env['mrp.production'].search([
-            ('bom_id', 'in', bom_manufacture.ids),
             ('state', '=', 'confirmed'),
             ('orderpoint_id', 'in', orderpoints_without_kit.ids),
             ('id', 'not in', self.env.context.get('ignore_mo_ids', [])),
@@ -220,11 +219,18 @@ class StockWarehouseOrderpoint(models.Model):
 
     def _post_process_scheduler(self):
         """ Confirm the productions only after all the orderpoints have run their
-        procurement to avoid the new procurement created from the production conflict
-        with them. """
-        self.env['mrp.production'].sudo().search([
-            ('orderpoint_id', 'in', self.ids),
-            ('move_raw_ids', '!=', False),
-            ('state', '=', 'draft'),
-        ]).action_confirm()
+        procurement and when Draft Production (allow_draft_production) is disabled,
+        to avoid the new procurement created from the production conflict with them.
+        """
+        orderpoints = self.filtered(
+            lambda op: any(
+                rule.action == 'manufacture' and not rule.allow_draft_production
+                for rule in op.rule_ids
+            ),
+        )
+        if orderpoints:
+            self.env['mrp.production'].sudo().search([
+                ('orderpoint_id', 'in', orderpoints.ids),
+                ('state', '=', 'draft'),
+            ]).action_confirm()
         return super()._post_process_scheduler()

--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -28,6 +28,9 @@ class StockPickingType(models.Model):
         help="Allow to create new lot/serial numbers for the components",
         default=False,
     )
+    auto_confirm_production = fields.Boolean(
+        "Auto Confirm Production", default=True,
+        help="Uncheck this option if you want to create a draft production order on replenishment, instead of a confirmed one.")
 
     auto_print_done_production_order = fields.Boolean(
         "Auto Print Done Production Order",

--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -33,6 +33,8 @@ class StockRule(models.Model):
                 rule.picking_type_code_domain = rule.picking_type_code_domain or [] + ['mrp_operation']
 
     def _should_auto_confirm_procurement_mo(self, p):
+        if not p.picking_type_id.auto_confirm_production:
+            return False
         if not p.move_raw_ids:
             return (not p.workorder_ids and (p.orderpoint_id or p.move_dest_ids.procure_method == 'make_to_stock'))
         return not p.orderpoint_id

--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -14,6 +14,10 @@ class StockRule(models.Model):
     action = fields.Selection(selection_add=[
         ('manufacture', 'Manufacture')
     ], ondelete={'manufacture': 'cascade'})
+    allow_draft_production = fields.Boolean(
+        "Draft Production",
+        help="Check this option if you want to create a draft production order on replenishment, instead of a confirmed one."
+    )
 
     def _get_message_dict(self):
         message_dict = super(StockRule, self)._get_message_dict()
@@ -95,6 +99,7 @@ class StockRule(models.Model):
                 procurement_qty = procurement.product_qty
                 batch_size = bom.uom_id._compute_quantity(bom.batch_size, procurement.uom_id) if is_batch_size else procurement_qty
                 vals = rule._prepare_mo_vals(*procurement, bom)
+                procurement.values['allow_draft_production'] = rule.allow_draft_production
                 while procurement.uom_id.compare(procurement_qty, 0) > 0:
                     new_productions_values_by_company[procurement.company_id.id]['values'].append({
                         **vals,
@@ -111,12 +116,13 @@ class StockRule(models.Model):
 
         for company_id in new_productions_values_by_company:
             productions_vals_list = new_productions_values_by_company[company_id]['values']
+            production_procurements = new_productions_values_by_company[company_id]['procurements']
             # create the MO as SUPERUSER because the current user may not have the rights to do it (mto product launched by a sale for example)
             productions = self.env['mrp.production'].with_user(SUPERUSER_ID).sudo().with_company(company_id).create(productions_vals_list)
-            for mo in productions:
-                if self._should_auto_confirm_procurement_mo(mo):
+            for mo, procurement in zip(productions, production_procurements):
+                if not procurement.values.get('allow_draft_production') and self._should_auto_confirm_procurement_mo(mo):
                     mo.action_confirm()
-            productions._post_run_manufacture(new_productions_values_by_company[company_id]['procurements'])
+            productions._post_run_manufacture(production_procurements)
         return True
 
     def _get_stock_move_values(self, product_id, product_qty, product_uom, location_id, name, origin, company_id, values):

--- a/addons/mrp/tests/test_procurement.py
+++ b/addons/mrp/tests/test_procurement.py
@@ -1450,3 +1450,38 @@ class TestProcurement(TestMrpCommon):
         self.assertRecordValues(target_moves, [
             {'quantity': 2.0}, {'quantity': 2.0}, {'quantity': 3.0}
         ])
+
+    def test_procurement_respects_auto_confirm_production(self):
+        """Ensure that manufacturing orders created from procurement remain in draft state
+        when auto_confirm_production boolean is disabled on the manufacturing operation type.
+        """
+        # Configure two BOMs with different auto_confirm_production settings on their manufacturing operation types.
+        warehouse = self.warehouse_1
+        self.bom_1.picking_type_id = warehouse.manu_type_id.copy({'auto_confirm_production': False})
+        self.bom_3.picking_type_id = warehouse.manu_type_id
+
+        # Trigger procurement for two products whose BOMs use operation types with different auto_confirm_production settings.
+        self.env['stock.rule'].run([
+            self.env['stock.rule'].Procurement(
+                product,
+                5.0,
+                product.uom_id,
+                warehouse.lot_stock_id,
+                product.name,
+                'MO State Test',
+                warehouse.company_id,
+                {
+                    'warehouse_id': warehouse,
+                },
+            )
+            for product in (self.product_4, self.product_6)
+        ])
+
+        # Verify that each MO has the correct state based on its operation type configuration
+        mo_draft = self.env['mrp.production'].search([('product_id', '=', self.product_4.id)], limit=1)
+        self.assertFalse(mo_draft.picking_type_id.auto_confirm_production)
+        self.assertEqual(mo_draft.state, 'draft', "MO should be in draft state because auto_confirm_production is disabled on the operation type.")
+
+        mo_confirm = self.env['mrp.production'].search([('product_id', '=', self.product_6.id)], limit=1)
+        self.assertTrue(mo_confirm.picking_type_id.auto_confirm_production)
+        self.assertEqual(mo_confirm.state, 'confirmed', "MO should be in confirmed state because auto_confirm_production is enabled on the operation type.")

--- a/addons/mrp/tests/test_procurement.py
+++ b/addons/mrp/tests/test_procurement.py
@@ -1183,3 +1183,40 @@ class TestProcurement(TestMrpCommon):
         update_quantity_wizard.change_prod_qty()
 
         self.assertEqual(mo_child.product_qty, 1.0)
+
+    def test_procurement_respects_draft_production(self):
+        """Ensure that manufacturing orders created from procurement remain in draft state
+        when Draft Production boolean(allow_draft_production) is enabled on the manufacturing rule.
+        """
+        # Configure two manufacture routes with different draft production settings
+        confirm_route = self.warehouse_1.manufacture_pull_id.route_id
+        draft_route = confirm_route.copy()
+        draft_route.rule_ids.allow_draft_production = True
+
+        # Trigger procurement for two products with different routes
+        self.env['stock.rule'].run([
+            self.env['stock.rule'].Procurement(
+                product,
+                5.0,
+                product.uom_id,
+                self.warehouse_1.lot_stock_id,
+                product.name,
+                'MO State Test',
+                self.warehouse_1.company_id,
+                {
+                    'warehouse_id': self.warehouse_1,
+                    'route_ids': route,
+                },
+            )
+            for product, route in [
+                (self.product_4, draft_route),
+                (self.product_6, confirm_route),
+            ]
+        ])
+
+        # Verify that each MO has the correct state based on its route configuration
+        mo_draft = self.env['mrp.production'].search([('product_id', '=', self.product_4.id)], limit=1)
+        self.assertEqual(mo_draft.state, 'draft', "MO should be draft when draft production is enabled on the rule.")
+
+        mo_confirm = self.env['mrp.production'].search([('product_id', '=', self.product_6.id)], limit=1)
+        self.assertEqual(mo_confirm.state, 'confirmed', "MO should be confirmed when draft production is disabled on the rule.")

--- a/addons/mrp/views/stock_picking_views.xml
+++ b/addons/mrp/views/stock_picking_views.xml
@@ -127,6 +127,9 @@
         <field name="model">stock.picking.type</field>
         <field name="inherit_id" ref="stock.view_picking_type_form"/>
         <field name="arch" type="xml">
+            <field name="create_backorder" position="after">
+                <field name="auto_confirm_production" invisible="code != 'mrp_operation'"/>
+            </field>
             <xpath expr="//group[@name='stock_picking_type_lot']" position="after">
                 <group invisible="code != 'mrp_operation'" string="Traceability" groups="stock.group_production_lot">
                     <field name="use_create_components_lots"/>

--- a/addons/mrp/views/stock_rule_views.xml
+++ b/addons/mrp/views/stock_rule_views.xml
@@ -9,6 +9,9 @@
                 <field name="location_dest_from_rule" position="attributes">
                     <attribute name="invisible">action not in ['pull', 'pull_push', 'manufacture']</attribute>
                 </field>
+                <field name="location_dest_from_rule" position="after">
+                    <field name="allow_draft_production" invisible="action != 'manufacture'"/>
+                </field>
             </field>
         </record>
     </data>


### PR DESCRIPTION
- Currently, manufacturing orders created from `replenishment, MPS, or SO confirmation (MTO procurements)` are automatically confirmed, except in some specific cases such as when the MO has no components or workorders `(when
_should_auto_confirm_procurement_mo method returns False)`. This reduces flexibility for users who may want to select a specific BOM when `multiple BOMs` exist for the same product or delay confirmation closer to the planned production date to better control production flow and reduce shopfloor noise.

- This change adds an option (checkbox) directly on the `manufacturing operation type` to control whether MOs created from procurements are automatically confirmed (except MOs without components and workorders) or remain in draft. When disabled, procurements using that operation type create MOs in draft state instead of confirming them immediately, giving users better control over when production should start based on their production planning needs.

- Along with this change, in the `_quantity_in_progress` method, draft MOs without a BOM were not considered, so the orderpoint's quantity to order did not reset even when replenishment existed. Also, in cases where a product lacks a reorder rule, demand may create a new orderpoint and check for in-progress quantities, but due to orderpoint check draft MOs were not included, leading to repeated replenishment suggestions even when a draft MO already existed. This change ensures draft MOs, including those without a BOM, are matched with orderpoints using product and location and counted as incoming allowing orderpoints to reset correctly and avoiding unnecessary replenishment.

Enterprise PR: odoo/enterprise#113803
TaskID-5877241