### PR TITLE
[FIX] website_blog, *: prevent editing next post cover title/subtitle

### DIFF
--- a/addons/html_builder/static/src/@types/plugins.d.ts
+++ b/addons/html_builder/static/src/@types/plugins.d.ts
@@ -1,7 +1,7 @@
 declare module "plugins" {
     import { AnchorShared } from "@html_builder/core/anchor/anchor_plugin";
     import { builder_components, BuilderComponentShared } from "@html_builder/core/builder_component_plugin";
-    import { builder_header_middle_buttons, builder_options, BuilderOptionsShared, change_current_options_containers_listeners, clone_disabled_reason_providers, container_title, elements_to_options_title_components, get_options_container_top_buttons, has_overlay_options, keep_overlay_options, no_parent_containers, on_restore_containers_handlers, remove_disabled_reason_providers } from "@html_builder/core/builder_options_plugin";
+    import { builder_header_middle_buttons, builder_options, BuilderOptionsShared, change_current_options_containers_listeners, clone_disabled_reason_providers, container_title, elements_to_options_title_components, get_options_container_top_buttons, has_overlay_options, keep_overlay_options, no_parent_containers, not_activable_element_selectors, on_restore_containers_handlers, remove_disabled_reason_providers } from "@html_builder/core/builder_options_plugin";
     import { BuilderOverlayShared } from "@html_builder/core/builder_overlay/builder_overlay_plugin";
     import { CachedModelShared } from "@html_builder/core/cached_model_plugin";
     import { CloneShared, on_cloned_handlers, on_will_clone_handlers } from "@html_builder/core/clone_plugin";
@@ -142,6 +142,7 @@ declare module "plugins" {
         is_unremovable_selector: is_unremovable_selector;
         lower_panel_entries: lower_panel_entries;
         mark_color_level_selector_params: mark_color_level_selector_params;
+        not_activable_element_selectors: not_activable_element_selectors;
         no_parent_containers: no_parent_containers;
         o_editable_selectors: o_editable_selectors;
         /** @deprecated */

--- a/addons/html_builder/static/src/@types/plugins.d.ts
+++ b/addons/html_builder/static/src/@types/plugins.d.ts
@@ -1,7 +1,7 @@
 declare module "plugins" {
     import { AnchorShared } from "@html_builder/core/anchor/anchor_plugin";
     import { builder_components, BuilderComponentShared } from "@html_builder/core/builder_component_plugin";
-    import { builder_header_middle_buttons, builder_options, BuilderOptionsShared, change_current_options_containers_listeners, clone_disabled_reason_providers, container_title, elements_to_options_title_components, get_options_container_top_buttons, has_overlay_options, keep_overlay_options, no_parent_containers, on_restore_containers_handlers, remove_disabled_reason_providers } from "@html_builder/core/builder_options_plugin";
+    import { builder_header_middle_buttons, builder_options, BuilderOptionsShared, change_current_options_containers_listeners, clone_disabled_reason_providers, container_title, elements_to_options_title_components, get_options_container_top_buttons, has_overlay_options, keep_overlay_options, no_parent_containers, not_activable_element_selectors, on_restore_containers_handlers, remove_disabled_reason_providers } from "@html_builder/core/builder_options_plugin";
     import { BuilderOverlayShared } from "@html_builder/core/builder_overlay/builder_overlay_plugin";
     import { CachedModelShared } from "@html_builder/core/cached_model_plugin";
     import { CloneShared, on_cloned_handlers, on_will_clone_handlers } from "@html_builder/core/clone_plugin";
@@ -141,6 +141,7 @@ declare module "plugins" {
         is_unremovable_selector: is_unremovable_selector;
         lower_panel_entries: lower_panel_entries;
         mark_color_level_selector_params: mark_color_level_selector_params;
+        not_activable_element_selectors: not_activable_element_selectors;
         no_parent_containers: no_parent_containers;
         o_editable_selectors: o_editable_selectors;
         /** @deprecated */

--- a/addons/html_builder/static/src/core/builder_options_plugin.js
+++ b/addons/html_builder/static/src/core/builder_options_plugin.js
@@ -78,6 +78,7 @@ import { OptionsContainer } from "@html_builder/sidebar/option_container";
  *      editableOnly?: boolean;
  * }[]} has_overlay_options
  * @typedef {CSSSelector[]} no_parent_containers
+ * @typedef {CSSSelector[]} not_activable_element_selectors
  * @typedef {((el: HTMLElement) => boolean)[]} keep_overlay_options
  */
 /**
@@ -141,6 +142,19 @@ export class BuilderOptionsPlugin extends Plugin {
                 this.updateContainers(el);
             }
         },
+        // Selector of elements that should not update/have containers when they
+        // are clicked.
+        not_activable_element_selectors: [
+            "#web_editor-top-edit",
+            "#oe_manipulators",
+            ".oe_drop_zone",
+            ".o_notification_manager",
+            ".o_we_no_overlay",
+            ".ui-autocomplete",
+            ".modal .btn-close",
+            ".transfo-container",
+            ".o_datetime_picker",
+        ],
     };
 
     setup() {
@@ -176,19 +190,9 @@ export class BuilderOptionsPlugin extends Plugin {
 
         this.lastContainers = [];
 
-        // Selector of elements that should not update/have containers when they
-        // are clicked.
-        this.notActivableElementsSelector = [
-            "#web_editor-top-edit",
-            "#oe_manipulators",
-            ".oe_drop_zone",
-            ".o_notification_manager",
-            ".o_we_no_overlay",
-            ".ui-autocomplete",
-            ".modal .btn-close",
-            ".transfo-container",
-            ".o_datetime_picker",
-        ].join(", ");
+        this.notActivableElementsSelector = this.getResource(
+            "not_activable_element_selectors"
+        ).join(", ");
         const unclonableButtonSelector = [
             ".oe_unremovable",
             ...this.getResource("submit_button_selectors"),

--- a/addons/html_builder/static/src/core/builder_options_plugin.js
+++ b/addons/html_builder/static/src/core/builder_options_plugin.js
@@ -78,6 +78,7 @@ import { OptionsContainer } from "@html_builder/sidebar/option_container";
  *      editableOnly?: boolean;
  * }[]} has_overlay_options
  * @typedef {CSSSelector[]} no_parent_containers
+ * @typedef {CSSSelector[]} not_activable_element_selectors
  * @typedef {((el: HTMLElement) => boolean)[]} keep_overlay_options
  */
 /**
@@ -140,6 +141,19 @@ export class BuilderOptionsPlugin extends Plugin {
                 this.updateContainers(el);
             }
         },
+        // Selector of elements that should not update/have containers when they
+        // are clicked.
+        not_activable_element_selectors: [
+            "#web_editor-top-edit",
+            "#oe_manipulators",
+            ".oe_drop_zone",
+            ".o_notification_manager",
+            ".o_we_no_overlay",
+            ".ui-autocomplete",
+            ".modal .btn-close",
+            ".transfo-container",
+            ".o_datetime_picker",
+        ],
     };
 
     setup() {
@@ -175,19 +189,9 @@ export class BuilderOptionsPlugin extends Plugin {
 
         this.lastContainers = [];
 
-        // Selector of elements that should not update/have containers when they
-        // are clicked.
-        this.notActivableElementsSelector = [
-            "#web_editor-top-edit",
-            "#oe_manipulators",
-            ".oe_drop_zone",
-            ".o_notification_manager",
-            ".o_we_no_overlay",
-            ".ui-autocomplete",
-            ".modal .btn-close",
-            ".transfo-container",
-            ".o_datetime_picker",
-        ].join(", ");
+        this.notActivableElementsSelector = this.getResource(
+            "not_activable_element_selectors"
+        ).join(", ");
     }
 
     destroy() {

--- a/addons/website_blog/static/src/website_builder/blog_page_option_plugin.js
+++ b/addons/website_blog/static/src/website_builder/blog_page_option_plugin.js
@@ -16,6 +16,10 @@ export class BlogPageOptionPlugin extends Plugin {
     /** @type {import("plugins").WebsiteResources} */
     resources = {
         builder_options: [BlogPageOption],
+        content_not_editable_selectors: [
+            "#o_wblog_post_footer .o_wblog_post_name, #o_wblog_post_footer .o_wblog_post_subtitle",
+        ],
+        not_activable_element_selectors: ["#o_wblog_post_footer .o_record_cover_image"],
     };
 }
 

--- a/addons/website_blog/static/tests/website_builder/blog_page_option.test.js
+++ b/addons/website_blog/static/tests/website_builder/blog_page_option.test.js
@@ -1,0 +1,37 @@
+import { expect, test } from "@odoo/hoot";
+import { contains } from "@web/../tests/web_test_helpers";
+import {
+    addPlugin,
+    defineWebsiteModels,
+    setupWebsiteBuilder,
+} from "@website/../tests/builder/website_helpers";
+import { BlogPageOptionPlugin } from "@website_blog/website_builder/blog_page_option_plugin";
+
+defineWebsiteModels();
+
+const testImgSrc = "/website_blog/static/src/img/cover_2.jpg";
+test("Clicking on next post cover image does not activate the builder overlay", async () => {
+    addPlugin(BlogPageOptionPlugin);
+    await setupWebsiteBuilder(` 
+        <main>
+            <div id="o_wblog_post_main">Blog post content</div>
+            <section id="o_wblog_post_footer">
+                <div class="o_wblog_post_name">Post Name</div>
+                <div class="o_wblog_post_subtitle">Post Subtitle</div>
+                <div class="o_record_cover_image" style="background-image: url(${testImgSrc});">Cover</div>
+            </section>
+        </main>
+    `);
+
+    await contains(":iframe #o_wblog_post_footer .o_record_cover_image").click();
+    expect(".oe_overlay").toHaveCount(0);
+    expect(".options-container").toHaveCount(0);
+    expect(":iframe #o_wblog_post_footer .o_wblog_post_name").toHaveAttribute(
+        "contenteditable",
+        "false"
+    );
+    expect(":iframe #o_wblog_post_footer .o_wblog_post_subtitle").toHaveAttribute(
+        "contenteditable",
+        "false"
+    );
+});


### PR DESCRIPTION
[*]: html_builder

Issue:
When viewing a blog post, the "Next Post" section allows editing the cover image, title, and subtitle of another post. Editing content that belongs to a different post from within the current one is incorrect.

Steps to reproduce:
  * Open a blog post that has a "Next Post" section visible.
  * Enter edit mode.
  * Try to edit the cover image, title, or subtitle of the next post.
  * These elements can be interacted with even though they should not be
    editable.

Fix:
Make the "Next Post" section fully non-editable. The title and subtitle were already handled via content_not_editable_selectors, but the cover image could still activate builder options, allowing it to be replaced.

Introduce a new `not_activable_element_selectors` resource in the `BuilderOptionsPlugin` so that plugins can declare elements that should not trigger the builder overlay when clicked. Updated the builder to retrieve this selector list from plugin resources instead of using a hardcoded value.

task-5435878