### PR TITLE
[FIX] html_editor: exclude non editable nodes from style detection

### DIFF
--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -202,7 +202,8 @@ export class FormatPlugin extends Plugin {
                 isTextNode(node) &&
                 !isZwnbsp(node) &&
                 !isEmptyTextNode(node) &&
-                (!/^\n+$/.test(node.nodeValue) || !isBlock(closestElement(node)))
+                (!/^\n+$/.test(node.nodeValue) || !isBlock(closestElement(node))) &&
+                this.dependencies.selection.isNodeEditable(node)
         );
         const isFormatted = formatsSpecs[format].isFormatted;
         return (

--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -197,15 +197,18 @@ export class FormatPlugin extends Plugin {
      * @returns {boolean}
      */
     isSelectionFormat(format, targetedNodes = this.dependencies.selection.getTargetedNodes()) {
+        const isFormatted = formatsSpecs[format].isFormatted;
+        const isNonFormattedWhiteSpaces = (node) =>
+            /^(\s|\n)+$/.test(node.nodeValue) && !isFormatted(node, { editable: this.editable });
         const targetedTextNodes = targetedNodes.filter(
             (node) =>
                 isTextNode(node) &&
                 !isZwnbsp(node) &&
                 !isEmptyTextNode(node) &&
+                !isNonFormattedWhiteSpaces(node) &&
                 (!/^\n+$/.test(node.nodeValue) || !isBlock(closestElement(node))) &&
                 this.dependencies.selection.isNodeEditable(node)
         );
-        const isFormatted = formatsSpecs[format].isFormatted;
         return (
             targetedTextNodes.length &&
             targetedTextNodes.every((node) => isFormatted(node, { editable: this.editable }))

--- a/addons/html_editor/static/tests/format/bold.test.js
+++ b/addons/html_editor/static/tests/format/bold.test.js
@@ -440,3 +440,13 @@ test("should not apply bold formatting for partial selection inside contentedita
     expect(getContent(el)).toBe(`<p contenteditable="false">T[e]st</p>`);
     expect(queryOne(`p[contenteditable="false"]`).childNodes.length).toBe(1);
 });
+
+test("should toggle bold around non editable", async () => {
+    const { el, editor } = await setupEditor(`<p>[a</p><p contenteditable="false">b</p><p>c]</p>`);
+    bold(editor);
+    expect(getContent(el)).toBe(
+        `<p><strong>[a</strong></p><p contenteditable="false">b</p><p><strong>c]</strong></p>`
+    );
+    bold(editor);
+    expect(getContent(el)).toBe(`<p>[a</p><p contenteditable="false">b</p><p>c]</p>`);
+});

--- a/addons/html_editor/static/tests/format/bold.test.js
+++ b/addons/html_editor/static/tests/format/bold.test.js
@@ -450,3 +450,30 @@ test("should toggle bold around non editable", async () => {
     bold(editor);
     expect(getContent(el)).toBe(`<p>[a</p><p contenteditable="false">b</p><p>c]</p>`);
 });
+
+test("should toggle bold across indented list items", async () => {
+    const { el, editor } = await setupEditor(`<ul>
+        <li><strong>A[B</strong></li>
+        <li>C]D</li>
+    </ul>`);
+    bold(editor);
+    expect(getContent(el)).toBe(`<ul>
+        <li><strong>A[B</strong></li>
+        <li><strong>C]</strong>D</li>
+    </ul>`);
+    bold(editor);
+    expect(getContent(el)).toBe(`<ul>
+        <li><strong>A</strong>[B</li>
+        <li>C]D</li>
+    </ul>`);
+});
+
+test("should toggle bold across nested spans", async () => {
+    const { el, editor } = await setupEditor(`<p><span><span>[A</span> </span></p><p>B]</p>`);
+    bold(editor);
+    expect(getContent(el)).toBe(
+        `<p><span><span><strong>[A</strong></span> </span></p><p><strong>B]</strong></p>`
+    );
+    bold(editor);
+    expect(getContent(el)).toBe(`<p><span><span>[A</span> </span></p><p>B]</p>`);
+});


### PR DESCRIPTION
When determining whether the "bold" action is about adding bold or removing bold, non-editable text nodes are also taken into account. Because of this, if the selection contains an embedded component such as `/file`, it always considers bold was not applied on all nodes, and should therefore be applied. The action thus never removes bold.

This commit fixes this by only taking into account the editable nodes.

Steps to reproduce:
- Go to a "To do" note
- Add a few lines of text
- Add a `/file` in the middle
- Select all
- Press Ctrl+B: bold is applied on the surrounding text
- Press Ctrl+B again

=> Bold was not removed from the surrounding text

task-5955977
