### PR TITLE
[IMP] gamification: no more ACLs for portal/public

### DIFF
--- a/addons/gamification/models/gamification_karma_rank.py
+++ b/addons/gamification/models/gamification_karma_rank.py
@@ -57,3 +57,16 @@ class GamificationKarmaRank(models.Model):
                 users = self.env['res.users'].sudo().search([('karma', '>=', max(low, 1)), ('karma', '<=', high)])
             users._recompute_rank()
         return res
+
+    def _can_return_content(self, field_name=None, access_token=None):
+        """Make public the rank images so they can be used in `t-field="rank_id.image_1920"`
+        without the need to grant the public/portal ACL to the `gamification.karma.rank` model.
+
+        `t-field="rank_id.image_1920` is converted to, for instance,
+        `<img src="/web/image/gamification.karma.rank/5/image_128/"`
+        The goal of this override is to allow the `/web/image` route to return the images related this model.
+        """
+        if isinstance(self.env['image.mixin']._fields.get(field_name), fields.Image):
+            # Allow to return the field for this model if it's an image coming from the `image.mixin` mixin
+            return True
+        return super()._can_return_content(field_name, access_token)

--- a/addons/gamification/security/gamification_security.xml
+++ b/addons/gamification/security/gamification_security.xml
@@ -3,7 +3,7 @@
         <record id="goal_user_visibility" model="ir.rule">
             <field name="name">User can only see his/her goals or goal from the same challenge in board visibility</field>
             <field name="model_id" ref="model_gamification_goal"/>
-            <field name="groups" eval="[(4, ref('base.group_user')), (4, ref('base.group_portal'))]"/>
+            <field name="groups" eval="[(4, ref('base.group_user'))]"/>
             <field name="perm_read" eval="True"/>
             <field name="perm_write" eval="True"/>
             <field name="perm_create" eval="False"/>

--- a/addons/gamification/security/ir.model.access.csv
+++ b/addons/gamification/security/ir.model.access.csv
@@ -2,32 +2,22 @@ id,name,model_id/id,group_id/id,perm_read,perm_write,perm_create,perm_unlink
 
 goal_employee,"Goal Employee",model_gamification_goal,base.group_user,1,1,0,0
 goal_manager,"Goal Manager",model_gamification_goal,base.group_erp_manager,1,1,1,1
-goal_portal,"Goal Portal",gamification.model_gamification_goal,base.group_portal,1,1,0,0
 
 goal_definition_employee,"Goal Definition Employee",model_gamification_goal_definition,base.group_user,1,0,0,0
 goal_definition_manager,"Goal Definition Manager",model_gamification_goal_definition,base.group_erp_manager,1,1,1,1
-goal_definition_portal,"Goal Definition Portal",gamification.model_gamification_goal_definition,base.group_portal,1,0,0,0
 
 challenge_employee,"Goal Challenge Employee",model_gamification_challenge,base.group_user,1,0,0,0
 challenge_manager,"Goal Challenge Manager",model_gamification_challenge,base.group_erp_manager,1,1,1,1
-challenge_portal,"Goal Challenge Portal",gamification.model_gamification_challenge,base.group_portal,1,0,0,0
 
 challenge_line_employee,"Challenge Line Employee",model_gamification_challenge_line,base.group_user,1,0,0,0
 challenge_line_manager,"Challenge Line Manager",model_gamification_challenge_line,base.group_erp_manager,1,1,1,1
-challenge_line_portal,"Challenge Line Portal",gamification.model_gamification_challenge_line,base.group_portal,1,0,0,0
 
 badge_employee,"Badge Employee",model_gamification_badge,base.group_user,1,0,0,0
 badge_manager,"Badge Manager",model_gamification_badge,base.group_erp_manager,1,1,1,1
-badge_portal,"Badge Portal",gamification.model_gamification_badge,base.group_portal,1,0,0,0
-badge_public,"Badge Public",gamification.model_gamification_badge,base.group_public,1,0,0,0
 
 badge_user_employee,"Badge-user Employee",model_gamification_badge_user,base.group_user,1,1,1,0
 badge_user_manager,"Badge-user Manager",model_gamification_badge_user,base.group_erp_manager,1,1,1,1
-badge_user_portal,"Badge-user Portal",gamification.model_gamification_badge_user,base.group_portal,1,1,1,0
-badge_user_public,"Badge-user Public",gamification.model_gamification_badge_user,base.group_public,1,0,0,0
 
-gamification_karma_rank_access_public,gamification.karma.rank.access.all,gamification.model_gamification_karma_rank,base.group_public,1,0,0,0
-gamification_karma_rank_access_portal,gamification.karma.rank.access.all,gamification.model_gamification_karma_rank,base.group_portal,1,0,0,0
 gamification_karma_rank_access_employee,gamification.karma.rank.access.all,gamification.model_gamification_karma_rank,base.group_user,1,0,0,0
 gamification_karma_rank_access_user_manager,gamification.karma.rank.access.user.manager,gamification.model_gamification_karma_rank,base.group_system,1,1,1,1
 gamification_karma_tracking_access_all,gamification.karma.tracking.access.all,gamification.model_gamification_karma_tracking,,0,0,0,0

--- a/addons/website_profile/static/tests/tours/tour_website_profile_description.js
+++ b/addons/website_profile/static/tests/tours/tour_website_profile_description.js
@@ -24,3 +24,59 @@ registry.category("web_tour.tours").add('website_profile_description', {
         trigger: "span[data-oe-field='website_description']:contains('content <p>code here</p>')",
     }]
 })
+
+registry.category("web_tour.tours").add("website_profile_portal_access", {
+    steps: () => [
+        {
+            content: "Ensure portal can see 2 badges for Bob",
+            trigger: 'tr:contains("Bob"):contains("2 Badges")',
+        },
+        {
+            content: "Ensure portal can see 1 badge for Alice",
+            trigger: 'tr:contains("Alice"):contains("1 Badges")',
+        },
+        {
+            content: `Ensure portal can't see John as he is not published.
+                      There must be only 2 rows in the table`,
+            trigger: 'table:contains("Bob") tr:nth-of-type(2):last-child',
+        },
+        {
+            content: "Click on one user profile card",
+            trigger: 'tr:contains("Bob")',
+            run: "click",
+            expectUnloadPage: true,
+        },
+        {
+            content: "Ensure portal can see 2 badges for Bob",
+            trigger: 'tr:contains("Badges") td:contains("2")',
+        },
+        {
+            content: "Ensure portal can see the name of badges",
+            trigger: 'div:has(div:contains("Good Job")):has(div:contains("Problem Solver"))',
+        },
+        {
+            content: "Ensure the image of the badge is displayed",
+            trigger: 'img[src^="/web/image/gamification.badge/"][alt="Good Job"]',
+            run: async function () {
+                if (
+                    (await fetch(this.anchor.src)).headers.get("Content-Disposition") !==
+                    'inline; filename="Good Job.png"'
+                ) {
+                    throw new Error("The image of the badge is not displayed as expected");
+                }
+            },
+        },
+        {
+            content: "Ensure the image of the rank is displayed",
+            trigger: 'img[src^="/web/image/gamification.karma.rank/"][alt="Bachelor"]',
+            run: async function () {
+                if (
+                    (await fetch(this.anchor.src)).headers.get("Content-Disposition") !==
+                    "inline; filename=Bachelor.svg"
+                ) {
+                    throw new Error("The image of the rank is not displayed as expected");
+                }
+            },
+        },
+    ],
+});

--- a/addons/website_profile/tests/test_website_profile.py
+++ b/addons/website_profile/tests/test_website_profile.py
@@ -42,3 +42,32 @@ class TestWebsiteProfile(HttpCaseGamification):
             'email': 'mitchell.admin@example.com',
         })
         self.start_tour("/profile/users", 'website_profile_description', login="admin")
+
+    def test_portal_access(self):
+        bob = odoo.tests.new_test_user(self.env, 'Bob', karma=100, website_published=True)
+        alice = odoo.tests.new_test_user(self.env, 'Alice', karma=100, website_published=True)
+        john = odoo.tests.new_test_user(self.env, 'John', karma=100)
+        odoo.tests.new_test_user(self.env, 'test_portal', groups='base.group_portal', karma=1000)
+
+        badge_good_job = self.env.ref("gamification.badge_good_job")
+        badge_problem_solver = self.env.ref("gamification.badge_problem_solver")
+        # Publish the badges otherwise they do not appear on the user profile page
+        # https://github.com/odoo/odoo/blob/a5f053932a73932866e04b05ecbd2c82b84c2c62/addons/website_profile/views/website_profile.xml#L170
+        (badge_good_job + badge_problem_solver).website_published = True
+
+        for wizard in self.env["gamification.badge.user.wizard"].create([{
+            "badge_id": badge_good_job.id,
+            "user_id": bob.id,
+        }, {
+            "badge_id": badge_problem_solver.id,
+            "user_id": bob.id,
+        }, {
+            "badge_id": badge_good_job.id,
+            "user_id": alice.id,
+        }, {
+            "badge_id": badge_good_job.id,
+            "user_id": john.id,
+        }]):
+            wizard.action_grant_badge()
+
+        self.start_tour("/profile/users", 'website_profile_portal_access', login="test_portal")


### PR DESCRIPTION
Most of the data displayed to the portal/public user regarding gamification, goals, badges, etc,
for instance, in the user profile in the forum and in the elearning/slides,
is fetched using `sudo`.

For instance in the user profile:
- https://github.com/odoo/odoo/blob/4c586eea30e8ae02b4e467b7ac7fcf948af8f716/addons/website_profile/controllers/main.py#L172-L173 In the Qweb templates for the user profile, it uses `user.badge_ids`:
- https://github.com/odoo/odoo/blob/4c586eea30e8ae02b4e467b7ac7fcf948af8f716/addons/website_profile/views/website_profile.xml#L168-L171 the `user` passed to the QWeb rendering is passed as `sudo`:
- https://github.com/odoo/odoo/blob/4c586eea30e8ae02b4e467b7ac7fcf948af8f716/addons/website_profile/controllers/main.py#L120-L125
- https://github.com/odoo/odoo/blob/4c586eea30e8ae02b4e467b7ac7fcf948af8f716/addons/website_profile/controllers/main.py#L78

The user profile is shared between slides / forum.

Hence, applying the least privileges principle, it's better to not grant access rights to the portal / public if there is no need of it, to reduce the data surface he can access to,
using the RPC api for instance. Especially that most of the access rights (ACLs) were given without record rules along (`ir.rule`), therefore granting the portal user read access to the whole model /table, not just a subset.

It's a bit hard to find all the places where gamification stuff is shown to the portal / public, and it looks like there are not really unit tests regarding this, at least not a single unit test failed when simply removing all ACL regarding gamification for portal / public.

This revision adds a test to cover one bug found during testing, regarding the images of `gamification.karma.rank` which were not shown in the user profile with the ACL removed.

I will take care to correct bugs as they are discovered following the removal of these ACls regarding gamification
