### PR TITLE
[FIX] account_edi_proxy_client: allow child company parent proxy

### DIFF
--- a/addons/account_edi_proxy_client/security/account_edi_proxy_client_security.xml
+++ b/addons/account_edi_proxy_client/security/account_edi_proxy_client_security.xml
@@ -4,7 +4,7 @@
     <record id="account_edi_proxy_client_user_comp_rule" model="ir.rule">
         <field name="name">Account EDI Proxy Client User</field>
         <field name="model_id" ref="model_account_edi_proxy_client_user"/>
-        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'parent_of', company_ids)]</field>
     </record>
 </data>
 </odoo>


### PR DESCRIPTION
This fix implements the same change made in PR #209120 to allow a child company to use the parent proxy user. It seems the record rules modification was missed during the FW, causing issues for clients using this feature in 18.2+

Steps to reproduce:
- Create company A and a child company B sharing the same fiscal and VAT information
- Register company A in the SDI (creating a proxy user)
- Go to company B and try to send an invoice. You will get an error because Odoo will try to create a new proxy user as the parent proxy is currently inaccessible due to record rule constraints.

Ticket [link](https://www.odoo.com/odoo/project.task/5927104)
opw-5927104