### PR TITLE
[FIX] pos_event: ensure registration records answers

### DIFF
--- a/addons/pos_event/tests/test_frontend.py
+++ b/addons/pos_event/tests/test_frontend.py
@@ -240,6 +240,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.assertEqual(len(no_partner_registration), 1)
         self.assertEqual(no_partner_registration.name, "Name 1")
         self.assertEqual(no_partner_registration.email, "1@test.com")
+        self.assertEqual(len(no_partner_registration.registration_answer_ids), 2)
 
         partner_registrations = registrations.filtered(lambda r: r.partner_id == event_partner)
         self.assertEqual(len(partner_registrations), 3)
@@ -248,13 +249,16 @@ class TestUi(TestPointOfSaleHttpCommon):
         r2 = partner_registrations.filtered(lambda r: r.name == "Name 2")
         self.assertEqual(len(r2), 1)
         self.assertEqual(r2.email, "2@test.com")
+        self.assertEqual(len(r2.registration_answer_ids), 2)
 
         # Customer during order, partial registration information
         r3 = partner_registrations.filtered(lambda r: r.name == "Name 3")
         self.assertEqual(len(r3), 1)
         self.assertEqual(r3.email, "event@partner.com")
+        self.assertEqual(len(r3.registration_answer_ids), 1)
 
         # Customer during order, no registration information
         r_empty = partner_registrations.filtered(lambda r: r.name == "Event Parter")
         self.assertEqual(len(r_empty), 1)
         self.assertEqual(r_empty.email, "event@partner.com")
+        self.assertEqual(len(r_empty.registration_answer_ids), 0)


### PR DESCRIPTION
Currently when event only have questions of type text, the field `registration_answer_ids` is empty after the order is synced to the backend.

Steps to reproduce:
-------------------
* Create an event for which you anloy have questions of type text: name, phone, email
* Open a shop
* Sell a ticket for the event and answer all 3 questions
* Validate order
* Check event registrations
> Observe that although attendee's corresponding fields have been populated,
the question' list is empty.

Why is the issue happening:
---------------------------
In the model EventRegistration there are two fields `registration_answer_ids` and `registration_answer_choice_ids`. Those two fields share the same relation table.
https://github.com/odoo/odoo/blob/7c93b869a97f30a5b75d603b5973bf37b91bd63e/addons/event/models/event_registration.py#L83-L84

The registration is created here:
https://github.com/odoo/odoo/blob/ef92cf5b33a3e55e801feea71bdbdd212da59adb/addons/pos_event/static/src/app/screens/product_screen/product_screen.js#L246 For context, when calling the create method `registration_answer_ids` has 3 values and `registration_answer_choice_ids` is empty (since no selection question).

During the creation process we call the `_update` function. We first see what's happening with `registration_answer_ids`. Since there are some values we'll use the `create` part.
https://github.com/odoo/odoo/blob/ef92cf5b33a3e55e801feea71bdbdd212da59adb/addons/point_of_sale/static/src/app/models/related_models/index.js#L394-L398

The `_connect` method will call itself on the inverse of the field. https://github.com/odoo/odoo/blob/ef92cf5b33a3e55e801feea71bdbdd212da59adb/addons/point_of_sale/static/src/app/models/related_models/index.js#L684

We'll finally try to get the inverse of this inverse. The first problem can be seen here because the inverse of the inverse points toward `registration_answer_choice_ids`.

When we look at the field `registration_answer_choice_ids` since it is empty it will use the `clear` method. This also end up calling the `_connect` method on its inverse. Since the inverse of the inverse of `registration_answer_choice_ids` also points out to `registration_answer_choice_ids` thus it deletes the records that were added with `registration_answer_ids`

This all happens because in the inversMap bot fields point toward the same value but the inverse of this value can only point to one value. In this case, ´registration_answer_choice_ids`.

Why the fix:
------------
Touching the inverseMap or the related model is too risky at this point. So instead we focus on avoiding to clear all records. This can be achieved by creating the record empty of the two fields and creating the records for `registration_answer_ids` and `registration_answer_choice_ids` separately to link them later.

opw-58966712