### PR TITLE
[FIX] mail: prevent lost cursor with mention

### DIFF
--- a/addons/mail/static/src/core/common/plugin/mention_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mention_plugin.js
@@ -14,6 +14,8 @@ export class MentionPlugin extends Plugin {
                 }
             }
         },
+        selectors_for_feff_providers: () =>
+            this.MENTION_SELECTORS.map(({ selector }) => selector).join(", "),
         select_all_overrides: this.selectAll.bind(this),
     };
 


### PR DESCRIPTION
In chatter, using "Reply" in HTML composer could focus the composer without giving a usable caret. The inserted partner mention is a non-editable link (`contenteditable="false"`), and selection could end up inside that node, so typing would not insert text.

This also fix the related firefox issue:
mentions are rendered as `a[contenteditable=false]`. Firefox is stricter than Chrome for carret
positions around non-editable inline nodes, so clicking before a mention
or moving left from its right edge could make stuck.

so we register mention selectors as FEFF providers in the mention plugin.
(a feature of html_editor FEFF plugin to add invisible boundary
characters around mentions, which gives firefox what it need to move carret around.

[task-5262368](https://www.odoo.com/odoo/project/1519/tasks/5262368)
