### PR TITLE
[IMP] Resource: Copying work entr types for new work calendars

### DIFF
--- a/addons/hr_work_entry/tests/test_work_entry_type_data.py
+++ b/addons/hr_work_entry/tests/test_work_entry_type_data.py
@@ -5,6 +5,7 @@ from odoo.release import version_info
 from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
 
+
 @tagged('-at_install', 'post_install', 'post_install_l10n')
 class TestWorkEntryTypeData(TransactionCase):
 
@@ -42,3 +43,36 @@ class TestWorkEntryTypeData(TransactionCase):
             for code in generic_codes:
                 if not self.env['hr.work.entry.type'].search_count([('code', '=', code), ('country_id', '=', country.id)], limit=1):
                     raise ValidationError("Missing generic work entry redefinition with code %s for %s" % (code, country.name))
+
+    def test_work_entry_type_calendar_creation(self):
+        """
+        This is to test the implemention of automatically populating newly created
+        work calendar with the default work calendar.
+        """
+        default_calendar = self.env['resource.calendar'].create({
+            'name': '40 hours/week',
+            'hours_per_day': 8,
+            'full_time_required_hours': 40,
+            'attendance_ids': [
+                (0, 0, {'dayofweek': '0', 'duration_hours': 8, 'hour_from': 0, 'hour_to': 0, 'work_entry_type_id': 9}),
+                (0, 0, {'dayofweek': '1', 'duration_hours': 8, 'hour_from': 0, 'hour_to': 0, 'work_entry_type_id': 2}),
+                (0, 0, {'dayofweek': '2', 'duration_hours': 8, 'hour_from': 0, 'hour_to': 0, 'work_entry_type_id': 3}),
+                (0, 0, {'dayofweek': '3', 'duration_hours': 8, 'hour_from': 0, 'hour_to': 0, 'work_entry_type_id': 1}),
+                (0, 0, {'dayofweek': '4', 'duration_hours': 8, 'hour_from': 0, 'hour_to': 0, 'work_entry_type_id': 5}),
+            ],
+        })
+        # Assigning the created calendar to the company resource calendar
+        self.env.company.resource_calendar_id = default_calendar
+
+        cloned_calendar = self.env['resource.calendar'].create({
+            'name': 'Cloned 40hr/week',
+        })
+        self.assertEqual(
+            len(default_calendar.attendance_ids),
+            len(cloned_calendar.attendance_ids),
+            f"Expected {len(default_calendar.attendance_ids)} days to be copied from the resource calendar but the duplicated calendar contains {len(cloned_calendar.attendance_ids)} days.")
+        for day in range(len(cloned_calendar.attendance_ids)):
+            self.assertEqual(
+                cloned_calendar.attendance_ids[day].work_entry_type_id,
+                default_calendar.attendance_ids[day].work_entry_type_id,
+                f"{day} of copied calendar contains work entry '{cloned_calendar.attendance_ids[day].work_entry_type_id.name}' while it should contain work entry '{default_calendar.attendance_ids[day].work_entry_type_id.name}'")

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -678,14 +678,7 @@ class ResourceCalendar(models.Model):
         """ return a copy of the company's calendar attendance or default 40 hours/week """
         if company_id and (attendances := company_id.resource_calendar_id.attendance_ids):
             return [
-                Command.create({
-                    'dayofweek': attendance.dayofweek,
-                    'week_type': attendance.week_type,
-                    'duration_hours': attendance.duration_hours,
-                    'hour_from': attendance.hour_from,
-                    'hour_to': attendance.hour_to,
-                })
-                for attendance in attendances
+                Command.create(attendance._copy_attendance_vals()) for attendance in attendances
             ]
         return [
             Command.create({'dayofweek': '0', 'duration_hours': 8, 'hour_from': 0, 'hour_to': 0}),


### PR DESCRIPTION
In order to maintain consistency for the user and streamline his activities while creating and maintaing different work calendars, upon creating a new work calendar, all the fields of the default work calendar will be automatically populated (including the work entry type id).

Task: 5949961

Description of the issue/feature this PR addresses: https://www.odoo.com/odoo/project/1251/tasks/5949961

Current behavior before PR: Work entries in newly created work schedules were defaulted to 'attendance' work entry type

Desired behavior after PR is merged: Each newly created work schedules are automatically populated with the resource calendar of the company




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
