### PR TITLE
[IMP] mail: improved Discuss demo and non-demo data

### DIFF
--- a/addons/mail/__init__.py
+++ b/addons/mail/__init__.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from markupsafe import Markup
+
 from . import models
 from . import tools
 from . import wizard
@@ -8,3 +10,19 @@ from . import controllers
 
 def _mail_post_init(env):
     env['mail.alias.domain']._migrate_icp_to_domain()
+    admin_lang = env.ref("base.partner_admin").lang
+    translate_env = env(context=dict(env.context, lang=admin_lang))
+    env.ref("mail.channel_all_employees").write({
+        "name": translate_env._("General"),
+        "description": translate_env._(
+            "A place to connect and exchange news with colleagues across the company.",
+        ),
+    })
+    env.ref("mail.channel_admin").write({
+        "name": translate_env._("Administrators"),
+        "description": translate_env._("General channel for administrators."),
+    })
+    env.ref("mail.module_install_notification").body = Markup("%s<br/>%s") % (
+        translate_env._("Welcome to the #General channel 🎉"),
+        translate_env._("This is a space for the whole team to connect and share updates."),
+    )

--- a/addons/mail/data/discuss_channel_data.xml
+++ b/addons/mail/data/discuss_channel_data.xml
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data noupdate="1">
+        <!-- missing string values are populated in _mail_post_init for translation reasons -->
 
         <record model="discuss.channel" id="mail.channel_all_employees">
-            <field name="name">general</field>
-            <field name="description">General announcements for all employees.</field>
+            <field name="name"/>
         </record>
 
         <record model="discuss.channel" id="mail.channel_admin">
-            <field name="name">Administrators</field>
-            <field name="description">General channel for administrators.</field>
+            <field name="name"/>
             <field name="group_public_id" ref="base.group_system"/>
         </record>
 
@@ -17,18 +16,13 @@
         <record model="mail.message" id="mail.module_install_notification">
             <field name="model">discuss.channel</field>
             <field name="res_id" ref="mail.channel_all_employees"/>
-            <field name="message_type">email</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
-            <field name="subject">Welcome to Odoo!</field>
-            <field name="body"><![CDATA[<p>Welcome to the #general channel.</p>
-            <p>This channel is accessible to all users to <b>easily share company information</b>.</p>]]></field>
         </record>
 
         <record model="discuss.channel.member" id="channel_member_general_channel_for_admin">
             <field name="partner_id" ref="base.partner_admin"/>
             <field name="channel_id" ref="mail.channel_all_employees"/>
             <field name="channel_role" eval="'owner'"/>
-            <field name="is_favorite" eval="True"/>
             <field name="seen_message_id" ref="mail.module_install_notification"/>
         </record>
 
@@ -40,7 +34,6 @@
         <record model="discuss.channel.member" id="channel_member_channel_admin_partner_admin">
             <field name="partner_id" ref="base.partner_admin"/>
             <field name="channel_id" ref="mail.channel_admin"/>
-            <field name="is_favorite" eval="True"/>
         </record>
 
         <!-- link group after creating the members to avoid autosubscribe too early -->

--- a/addons/mail/demo/discuss_channel_demo.xml
+++ b/addons/mail/demo/discuss_channel_demo.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data noupdate="1">
+        <record model="discuss.channel.member" id="channel_member_general_channel_for_admin">
+            <field name="is_favorite" eval="True"/>
+        </record>
+        <record model="discuss.channel.member" id="channel_member_channel_admin_partner_admin">
+            <field name="is_favorite" eval="True"/>
+        </record>
 
         <!-- Discussion groups, done in 2 steps to remove creator from followers -->
         <record model="discuss.channel" id="mail.channel_1">
@@ -159,7 +165,7 @@
         <record model="discuss.channel" id="mail.from_notification_message">
             <field name="parent_channel_id" ref="mail.channel_all_employees"/>
             <field name="from_message_id" ref="mail.module_install_notification"/>
-            <field name="name">Welcome to the #general channel</field>
+            <field name="name">Welcome to the #General channel</field>
         </record>
         <record model="discuss.channel.member" id="mail.admin_member_from_notification">
             <field name="partner_id" ref="base.partner_admin"/>

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -671,7 +671,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "channel_type": "channel",
                 "create_uid": self.user_root.id,
                 "default_display_mode": False,
-                "description": "General announcements for all employees.",
+                "description": "A place to connect and exchange news with colleagues across the company.",
                 "discuss_category_id": False,
                 "fetchChannelInfoState": "fetched",
                 "from_message_id": False,
@@ -684,7 +684,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "member_count": len(self.group_user.all_user_ids),
                 "message_needaction_counter_bus_id": bus_last_id,
                 "message_needaction_counter": 0,
-                "name": "general",
+                "name": "General",
                 "parent_channel_id": False,
                 "uuid": channel.uuid,
             }
@@ -1332,7 +1332,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "body": ["markup", "<p>test</p>"],
                 "create_date": create_date,
                 "date": date,
-                "default_subject": "general",
+                "default_subject": "General",
                 "email_from": '"Ernest Employee" <e.e@example.com>',
                 "id": last_message.id,
                 "incoming_email_cc": False,
@@ -1351,7 +1351,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                     {"content": "😁", "message": last_message.id},
                     {"content": "😊", "message": last_message.id},
                 ],
-                "record_name": "general",
+                "record_name": "General",
                 "reply_to": '"Ernest Employee" <catchall.test@test.mycompany.com>',
                 "res_id": 1,
                 "scheduledDatetime": False,
@@ -1846,7 +1846,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             "rating_count": 0,
         }
         if channel == self.channel_general:
-            return {**common_data, "display_name": "general"}
+            return {**common_data, "display_name": "General"}
         if channel == self.channel_channel_public_1:
             return {**common_data, "display_name": "public channel 1"}
         if channel == self.channel_channel_public_2:


### PR DESCRIPTION
This commit improves the demo and non-demo data of Discuss by:
1. Moving favorites to demo data.
2. Refining the #general's description and first message.
3. Moving non-demo data strings to the post init hook in order to translate them (the regular field translation does not work since those fields are not marked as translate).

task-5955751