### PR TITLE
[IMP] mrp: do not subtract self

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1424,13 +1424,13 @@ class MrpProduction(models.Model):
         child_moves = procurement_moves.move_orig_ids
         return ((procurement_moves | child_moves).created_production_id.procurement_group_id.mrp_production_ids\
                 | child_moves.production_id)\
-                .filtered(lambda p: p.origin != self.origin) - self
+                .filtered(lambda p: p.origin != self.origin)
 
     def _get_sources(self):
         self.ensure_one()
         dest_moves = self.procurement_group_id.mrp_production_ids.move_dest_ids
         parent_moves = self.procurement_group_id.stock_move_ids.move_dest_ids
-        return (dest_moves | parent_moves).group_id.mrp_production_ids.filtered(lambda p: p.origin != self.origin) - self
+        return (dest_moves | parent_moves).group_id.mrp_production_ids.filtered(lambda p: p.origin != self.origin)
 
     def set_qty_producing(self):
         # This method is used to call `_set_lot_producing` when the onchange doesn't apply.


### PR DESCRIPTION
`- self` is redundant given there's already `.filtered(lambda p: p.origin !=self.origin)`.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
