### PR TITLE
[FIX] website: prevent random link_tools tour failure

### DIFF
--- a/addons/website/static/tests/tours/link_tools.js
+++ b/addons/website/static/tests/tours/link_tools.js
@@ -151,6 +151,13 @@ wTourUtils.registerWebsitePreviewTour('link_tools', {
     {
         content: "Re-select image.",
         trigger: 'iframe .s_three_columns .row > :nth-child(1) img',
+        run: function (actions) {
+            actions.click();
+            const el = this.$anchor[0];
+            const sel = el.ownerDocument.getSelection();
+            sel.collapse(el, 0);
+            el.focus();
+        },
     },
     {
         content: "Check that the second image is not within a link.",
@@ -178,6 +185,13 @@ wTourUtils.registerWebsitePreviewTour('link_tools', {
     {
         content: "Reselect the first image.",
         trigger: 'iframe .s_three_columns .row > :nth-child(1) div > a > img',
+        run: function (actions) {
+            actions.click();
+            const el = this.$anchor[0];
+            const sel = el.ownerDocument.getSelection();
+            sel.collapse(el, 0);
+            el.focus();
+        },
     },
     {
         content: "Check that link tools appear.",


### PR DESCRIPTION
Steps to reproduce
==================

Run the test test_15_website_link_tools a bunch of times. It will eventually fail.

It happens every time if we add the following step after the "Reselect the first image" or the "Re-select image." step:

```js
{
    trigger: "body",
    run: async function() {
        const { promise, resolve } = Promise.withResolvers()
        setTimeout(resolve, 500)
        return promise
    }
},
```

It will fail when checking if the link toolbar is present

Cause of the issue
==================

In 17.0, the tour service doesn't trigger exactly the same events as a real user.

In this case, a selectionchange event is trigger causing the linkpopover to disappear

https://github.com/odoo/odoo/blob/6f7baa97db91f9a447257c3762febf4bd8a04800/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js#L2963-L2977

Solution
========

We can set and focus the selection on the after clicking on it.

runbot-237703