### PR TITLE
[FIX] sale: prevent downpayment price_unit to be rounded

### DIFF
--- a/addons/sale/tests/test_sale_order_down_payment.py
+++ b/addons/sale/tests/test_sale_order_down_payment.py
@@ -976,6 +976,36 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         ]
         self._assert_invoice_lines_values(invoice.line_ids, expected)
 
+    def test_so_downpayment_percentage_rounding(self):
+        self.sale_order.order_line = self.env["sale.order.line"].create({
+            "name": self.company_data["product_order_no"].name,
+            "product_id": self.company_data["product_order_no"].id,
+            "product_uom_qty": 1,
+            "price_unit": 145.05,
+            "order_id": self.sale_order.id,
+        })
+        self.sale_order.action_confirm()
+        so_context = {
+            "active_model": "sale.order",
+            "active_ids": [self.sale_order.id],
+            "active_id": self.sale_order.id,
+            "default_journal_id": self.company_data["default_journal_sale"].id,
+        }
+        payment_params = {"advance_payment_method": "percentage", "amount": 30.0}
+        downpayment = (
+            self.env["sale.advance.payment.inv"].with_context(so_context).create(payment_params)
+        )
+        invoices_ids = [downpayment.create_invoices()["res_id"]]
+        self.env["account.move"].browse(invoices_ids).action_post()
+        payment_params = {"advance_payment_method": "percentage", "amount": 70.0}
+        downpayment = (
+            self.env["sale.advance.payment.inv"].with_context(so_context).create(payment_params)
+        )
+        invoices_ids = []
+        invoices_ids.append(downpayment.create_invoices()["res_id"])
+        self.env["account.move"].browse(invoices_ids).action_post()
+        self.assertEqual(self.sale_order.amount_invoiced, self.sale_order.amount_total)
+
     def test_so_downpayment_invoice_credited_reinvoiced(self):
         """
         Test that, after a downpayment, if the rest has been invoiced, credited and re-invoiced

--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -315,8 +315,8 @@ class SaleAdvancePaymentInv(models.TransientModel):
                         line_analytic_distribution.setdefault(account, 0.0)
                         line_analytic_distribution[account] += price_subtotal / line_vals['price_unit'] * distribution
                 line_vals['analytic_distribution'] = line_analytic_distribution
-            # round price unit
-            line_vals['price_unit'] = order.currency_id.round(line_vals['price_unit'] * ratio)
+
+            line_vals['price_unit'] = line_vals['price_unit'] * ratio
 
             lines_values.append(line_vals)
             accounts.append(key['account_id'])


### PR DESCRIPTION
Issue:
The currency rounding on line_vals in downpayment cause discrepancies
in amount.

Steps to reproduce:
1- Create a SO with a line having unit_price = 145.05.
2- Create two downpayment invoices of 30% and 70%.
3- Create a final invoice which results in 1 cent difference.

Cause:
This is due to the currency rounding after applying the ratio on
price_unit because:
order.currency_id.round(line_vals['price_unit'] * .3) +
order.currency_id.round(line_vals['price_unit'] * .7) !=
order.currency_id.round(line_vals['price_unit'])
In our case:
currency_round(145.05 * .3) = 43.515 = 43.52
currency_round(145.05 * .7) = 101.535 = 101.54
Which the sum would be 145.06 != 145.05
commit adding round: #105177

Fix:
Removing the currency rounding on downpayment would fix the issue.

opw-5493781
opw-6005434
