### PR TITLE
[REF] account, sale_management: remove template variable in components

### DIFF
--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
@@ -109,20 +109,22 @@ export class SectionAndNoteListRenderer extends ListRenderer {
         return SHOW_ALL_ITEMS_TOOLTIP;
     }
 
-    get hidePrices() {
-        return this.record.data.collapse_prices;
+    hidePrices(record) {
+        return record.data.collapse_prices;
     }
 
-    get hideComposition() {
-        return this.record.data.collapse_composition;
+    hideComposition(record) {
+        return record.data.collapse_composition;
     }
 
-    get disablePricesButton() {
-        return this.shouldCollapse(this.record, 'collapse_prices') || this.disableCompositionButton;
+    disablePricesButton(record) {
+        return (
+            this.shouldCollapse(record, 'collapse_prices') || this.disableCompositionButton(record)
+        );
     }
 
-    get disableCompositionButton() {
-        return this.shouldCollapse(this.record, 'collapse_composition');
+    disableCompositionButton(record) {
+        return this.shouldCollapse(record, 'collapse_composition');
     }
 
     get sectionColumns() {
@@ -290,14 +292,12 @@ export class SectionAndNoteListRenderer extends ListRenderer {
     }
 
     isSectionOrNote(record = null) {
-        record = record || this.record;
         return [DISPLAY_TYPES.SECTION, DISPLAY_TYPES.SUBSECTION, DISPLAY_TYPES.NOTE].includes(
             record.data.display_type
         );
     }
 
     isSection(record = null) {
-        record = record || this.record;
         return [DISPLAY_TYPES.SECTION, DISPLAY_TYPES.SUBSECTION].includes(record.data.display_type);
     }
 

--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.xml
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.xml
@@ -30,20 +30,20 @@
                             <DropdownItem
                                 t-if="props.hidePrices"
                                 onSelected="() => this.toggleCollapse(record, 'collapse_prices')"
-                                attrs="{ 'class': disablePricesButton ? 'disabled' : '' }"
+                                attrs="{ 'class': this.disablePricesButton(record) ? 'disabled' : '' }"
                             >
-                                <i class="me-1 fa fa-fw" t-att-class="hidePrices ? 'fa-eye' : 'fa-eye-slash'"/>
-                                <span t-if="hidePrices">Show Prices</span>
+                                <i class="me-1 fa fa-fw" t-att-class="this.hidePrices(record) ? 'fa-eye' : 'fa-eye-slash'"/>
+                                <span t-if="this.hidePrices(record)">Show Prices</span>
                                 <span t-else="">Hide Prices</span>
                             </DropdownItem>
                             <t t-name="composition_button">
                                 <DropdownItem
                                     t-if="props.hideComposition"
                                     onSelected="() => this.toggleCollapse(record, 'collapse_composition')"
-                                    attrs="{ 'class': disableCompositionButton ? 'disabled' : '' }"
+                                    attrs="{ 'class': this.disableCompositionButton(record) ? 'disabled' : '' }"
                                 >
-                                    <i class="me-1 fa fa-fw" t-att-class="hideComposition ? 'fa-expand' : 'fa-compress'"/>
-                                    <span t-if="hideComposition">Show Composition</span>
+                                    <i class="me-1 fa fa-fw" t-att-class="this.hideComposition(record) ? 'fa-expand' : 'fa-compress'"/>
+                                    <span t-if="this.hideComposition(record)">Show Composition</span>
                                     <span t-else="">Hide Composition</span>
                                 </DropdownItem>
                             </t>

--- a/addons/sale_management/static/src/fields/sale_order_line_field/sale_order_line_field.js
+++ b/addons/sale_management/static/src/fields/sale_order_line_field/sale_order_line_field.js
@@ -15,17 +15,16 @@ patch(SaleOrderLineListRenderer.prototype, {
      * Disable "Hide Composition" and "Hide Prices" buttons for optional sections and their
      * subsections.
      */
-    get disableCompositionButton() {
+    disableCompositionButton(record) {
         return (
-            super.disableCompositionButton
-            || this.shouldCollapse(this.record, 'is_optional', true)
+            super.disableCompositionButton(record) ||
+            this.shouldCollapse(record, 'is_optional', true)
         );
     },
 
-    get disablePricesButton() {
+    disablePricesButton(record) {
         return (
-            super.disablePricesButton
-            || this.shouldCollapse(this.record, 'is_optional', true)
+            super.disablePricesButton(record) || this.shouldCollapse(record, 'is_optional', true)
         );
     },
 
@@ -35,11 +34,11 @@ patch(SaleOrderLineListRenderer.prototype, {
      *  - Parent section hides prices or composition
      *  - Section itself hides prices or composition
      */
-    get disableOptionalButton() {
+    disableOptionalButton(record) {
         return (
-            this.shouldCollapse(this.record, 'is_optional')
-            || this.shouldCollapse(this.record, 'collapse_prices', true)
-            || this.shouldCollapse(this.record, 'collapse_composition', true)
+            this.shouldCollapse(record, 'is_optional')
+            || this.shouldCollapse(record, 'collapse_prices', true)
+            || this.shouldCollapse(record, 'collapse_composition', true)
         );
     },
 

--- a/addons/sale_management/static/src/fields/sale_order_line_field/sale_order_line_field.xml
+++ b/addons/sale_management/static/src/fields/sale_order_line_field/sale_order_line_field.xml
@@ -5,7 +5,7 @@
         <t t-name="composition_button" position="after">
             <DropdownItem
                 onSelected="() => this.toggleIsOptional(record)"
-                attrs="{ 'class': disableOptionalButton ? 'disabled' : '' }"
+                attrs="{ 'class': this.disableOptionalButton(record) ? 'disabled' : '' }"
             >
                 <i class="me-1 fa fa-fw fa-dot-circle-o"/>
                 <span t-if="record.data.is_optional">Unset Optional</span>

--- a/addons/sale_management/static/src/fields/sale_order_template_line_field/sale_order_template_line_field.js
+++ b/addons/sale_management/static/src/fields/sale_order_template_line_field/sale_order_template_line_field.js
@@ -16,8 +16,8 @@ export class SaleOrderTemplateLineListRenderer extends SectionAndNoteListRendere
         this.copyFields.push('is_optional');
     }
 
-    get disableOptionalButton() {
-        return this.shouldCollapse(this.record, 'is_optional');
+    disableOptionalButton(record) {
+        return this.shouldCollapse(record, 'is_optional');
     }
 
     get isCurrentSectionOptional() {

--- a/addons/sale_management/static/src/fields/sale_order_template_line_field/sale_order_template_line_field.xml
+++ b/addons/sale_management/static/src/fields/sale_order_template_line_field/sale_order_template_line_field.xml
@@ -9,7 +9,7 @@
         <t t-name="composition_button" position="after">
             <DropdownItem
                 onSelected="() => this.toggleIsOptional(record)"
-                attrs="{ 'class': disableOptionalButton ? 'disabled' : '' }"
+                attrs="{ 'class': this.disableOptionalButton(record) ? 'disabled' : '' }"
             >
                 <i class="me-1 fa fa-fw fa-dot-circle-o"/>
                 <span t-if="record.data.is_optional">Unset Optional</span>


### PR DESCRIPTION
In preparation for owl3, where template variables will need to use `.this` to target component variables, there are manual changes we have to do as well as running a script.

In this case we had to refactor two methods to stop using a template variable with `this.` inside the template and instead pass them explicitly from the template as arguments.

task: OWL3 prep - add this. to template variables
