### PR TITLE
[REF] account, *: run OWL3 rendering context migration script

### DIFF
--- a/addons/account/static/src/components/account_file_uploader/account_file_uploader.xml
+++ b/addons/account/static/src/components/account_file_uploader/account_file_uploader.xml
@@ -2,7 +2,7 @@
 
     <t t-name="account.AccountFileUploader" t-inherit="account.DocumentFileUploader" t-inherit-mode="primary">
         <xpath expr="//t[@t-slot='toggler']" position="replace">
-            <t t-if="props.togglerTemplate" t-call="{{ props.togglerTemplate }}"/>
+            <t t-if="this.props.togglerTemplate" t-call="{{ this.props.togglerTemplate }}"/>
             <t t-else="" t-slot="toggler"/>
          </xpath>
     </t>
@@ -18,12 +18,12 @@
     </t>
 
     <t t-name="account.JournalUploadLink">
-        <a t-att-class="props.btnClass" href="#" draggable="false">
+        <a t-att-class="this.props.btnClass" href="#" draggable="false">
             <div class="d-sm-none">
                 <i class="fa fa-upload"></i>
             </div>
             <div class="d-none d-sm-block">
-                <t t-out="props.linkText"/>
+                <t t-out="this.props.linkText"/>
             </div>
         </a>
     </t>

--- a/addons/account/static/src/components/account_payment_field/account_payment.xml
+++ b/addons/account/static/src/components/account_payment_field/account_payment.xml
@@ -24,7 +24,7 @@
                                    class="open_account_move oe_form_field btn btn-link w-100 text-start"
                                    t-on-click="() => this.openMove(line.move_id)"
                                    data-bs-toggle="tooltip"
-                                   t-att-payment-id="account_payment_id"
+                                   t-att-payment-id="this.account_payment_id"
                                    t-out="line.move_name"/>
                             </td>
                             <td class="ps-2">
@@ -76,48 +76,48 @@
 
     <t t-name="account.AccountPaymentPopOver">
         <div class="account_payment_popover">
-            <h3 t-if="props.title" class="popover-header"><t t-out="props.title"/></h3>
+            <h3 t-if="this.props.title" class="popover-header"><t t-out="this.props.title"/></h3>
             <div class="px-2">
                 <div>
                     <table>
                         <tr>
                             <td class="fw-bolder">Amount:</td>
                             <td class="ps-1">
-                                <t t-out="props.amount_company_currency"></t>
-                                <t t-if="props.amount_foreign_currency">
-                                    (<span class="fa fa-money"/> <t t-out="props.amount_foreign_currency"/>)
+                                <t t-out="this.props.amount_company_currency"></t>
+                                <t t-if="this.props.amount_foreign_currency">
+                                    (<span class="fa fa-money"/> <t t-out="this.props.amount_foreign_currency"/>)
                                 </t>
                             </td>
                         </tr>
                         <tr>
                             <td class="fw-bolder align-top">Memo:</td>
                             <td class="ps-1">
-                                <div class="o_memo_content" t-att-data-tooltip="props.ref" data-tooltip-position="left">
-                                    <t t-out="props.ref"/>
+                                <div class="o_memo_content" t-att-data-tooltip="this.props.ref" data-tooltip-position="left">
+                                    <t t-out="this.props.ref"/>
                                 </div>
                             </td>
                         </tr>
                         <tr>
                             <td class="fw-bolder">Date:</td>
-                            <td class="ps-1"><t t-out="props.date"/></td>
+                            <td class="ps-1"><t t-out="this.props.date"/></td>
                         </tr>
                         <tr>
                             <td class="fw-bolder">Journal:</td>
                             <td class="ps-1">
-                                <t t-out="props.journal_name"/>
-                                <span t-if="props.payment_method_name">
-                                    (<t t-out="props.payment_method_name"/>)
+                                <t t-out="this.props.journal_name"/>
+                                <span t-if="this.props.payment_method_name">
+                                    (<t t-out="this.props.payment_method_name"/>)
                                 </span>
                             </td>
                         </tr>
-                        <tr t-if="props.company_name">
+                        <tr t-if="this.props.company_name">
                             <td class="fw-bolder">Branch:</td>
-                            <td class="ps-1"><t t-out="props.company_name"/></td>
+                            <td class="ps-1"><t t-out="this.props.company_name"/></td>
                         </tr>
                     </table>
                 </div>
-                <button class="btn btn-sm btn-primary js_unreconcile_payment float-start" style="margin-top:5px; margin-bottom:5px;" t-on-click="() => props._onRemoveMoveReconcile(props.move_id, props.partial_id)">Unreconcile</button>
-                <button class="btn btn-sm btn-secondary js_open_payment float-end" style="margin-top:5px; margin-bottom:5px;" t-on-click="() => props._onOpenMove(props.move_id)">View</button>
+                <button class="btn btn-sm btn-primary js_unreconcile_payment float-start" style="margin-top:5px; margin-bottom:5px;" t-on-click="() => this.props._onRemoveMoveReconcile(this.props.move_id, this.props.partial_id)">Unreconcile</button>
+                <button class="btn btn-sm btn-secondary js_open_payment float-end" style="margin-top:5px; margin-bottom:5px;" t-on-click="() => this.props._onOpenMove(this.props.move_id)">View</button>
             </div>
         </div>
     </t>

--- a/addons/account/static/src/components/account_payment_register_html/account_payment_register_html.xml
+++ b/addons/account/static/src/components/account_payment_register_html/account_payment_register_html.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="account.AccountPaymentRegisterHtmlField">
-        <div t-out="value" t-on-click="switchInstallmentsAmount"/>
+        <div t-out="this.value" t-on-click="this.switchInstallmentsAmount"/>
     </t>
 </templates>

--- a/addons/account/static/src/components/account_resequence/account_resequence.xml
+++ b/addons/account/static/src/components/account_resequence/account_resequence.xml
@@ -19,10 +19,10 @@
 
     <t t-name="account.ResequenceChangeLine">
         <tr>
-            <td t-out="props.changeLine.date"/>
-            <td t-out="props.changeLine.current_name"/>
-            <td t-if="props.ordering == 'keep'" t-out="props.changeLine.new_by_name" t-attf-class="{{ props.changeLine.new_by_name != props.changeLine.new_by_date ? 'animate' : ''}}"/>
-            <td t-else="" t-out="props.changeLine.new_by_date" t-attf-class="{{ props.changeLine.new_by_name != props.changeLine.new_by_date ? 'animate' : ''}}"/>
+            <td t-out="this.props.changeLine.date"/>
+            <td t-out="this.props.changeLine.current_name"/>
+            <td t-if="this.props.ordering == 'keep'" t-out="this.props.changeLine.new_by_name" t-attf-class="{{ this.props.changeLine.new_by_name != this.props.changeLine.new_by_date ? 'animate' : ''}}"/>
+            <td t-else="" t-out="this.props.changeLine.new_by_date" t-attf-class="{{ this.props.changeLine.new_by_name != this.props.changeLine.new_by_date ? 'animate' : ''}}"/>
         </tr>
     </t>
 </templates>

--- a/addons/account/static/src/components/account_review_state_selection/account_review_state_selection_badge.xml
+++ b/addons/account/static/src/components/account_review_state_selection/account_review_state_selection_badge.xml
@@ -2,21 +2,21 @@
 <templates xml:space="preserve">
 
     <t t-name="account_reports.AccountReviewStateSelectionBadgeField">
-        <t t-if="this.editableOptions.includes(value)">
+        <t t-if="this.editableOptions.includes(this.value)">
             <Dropdown>
-                <button t-attf-class="btn {{ this.getDropdownButtonDecoration(value) }} d-flex justify-content-center align-items-center rounded-pill o_account_review_state_selection_badge_button {{ this.additionalClassName }}">
-                    <div t-out="display || '&#8203;'"/>
+                <button t-attf-class="btn {{ this.getDropdownButtonDecoration(this.value) }} d-flex justify-content-center align-items-center rounded-pill o_account_review_state_selection_badge_button {{ this.additionalClassName }}">
+                    <div t-out="this.display || '&#8203;'"/>
                 </button>
                 <t t-set-slot="content">
                     <t t-if="this.editableOptions.includes(false)">
                         <DropdownItem
                             class="'o_account_review_state_selection_badge_dropdown_item'"
-                            t-if="!required || !value"
+                            t-if="!this.required || !this.value"
                             t-out="this.props.placeholder || ''"
                             onSelected="() => this.onChange(false)"
                         />
                     </t>
-                    <t t-foreach="options" t-as="option" t-key="option[0]">
+                    <t t-foreach="this.options" t-as="option" t-key="option[0]">
                         <t t-if="this.editableOptions.includes(option[0])">
                             <DropdownItem
                                 class="'d-flex text-black align-items-center o_account_review_state_selection_badge_dropdown_item'"
@@ -36,10 +36,10 @@
                 t-on-click="(ev) => ev.stopPropagation()"
             >
                 <button
-                    t-attf-class="btn {{ this.getDropdownButtonDecoration(value) }} d-flex justify-content-center align-items-center rounded-pill o_account_review_state_selection_badge_button {{ this.additionalClassName }}"
+                    t-attf-class="btn {{ this.getDropdownButtonDecoration(this.value) }} d-flex justify-content-center align-items-center rounded-pill o_account_review_state_selection_badge_button {{ this.additionalClassName }}"
                     t-att-disabled="true"
                 >
-                    <div t-out="display || '&#8203;'"/>
+                    <div t-out="this.display || '&#8203;'"/>
                 </button>
             </div>
         </t>

--- a/addons/account/static/src/components/account_statusbar_secured/account_move_statusbar_secured.xml
+++ b/addons/account/static/src/components/account_statusbar_secured/account_move_statusbar_secured.xml
@@ -5,7 +5,7 @@
     <t t-name="account.MoveStatusBarSecuredField.ItemLabel">
         <span t-out="item.label" />
         <t t-if="item.value == 'posted'">
-            <i t-attf-class="fa fa-fw ms-1 #{isSecured ? 'fa-lock text-success' : 'fa-unlock text-warning'}"/>
+            <i t-attf-class="fa fa-fw ms-1 #{this.isSecured ? 'fa-lock text-success' : 'fa-unlock text-warning'}"/>
         </t>
     </t>
 

--- a/addons/account/static/src/components/bill_guide/bill_guide.xml
+++ b/addons/account/static/src/components/bill_guide/bill_guide.xml
@@ -1,18 +1,18 @@
 <templates>
 
     <t t-name="account.BillGuide">
-         <div class="d-flex flex-row bill_guide_container mb-3" t-att-class="{ 'mb-9': props.largeIcons }">
+         <div class="d-flex flex-row bill_guide_container mb-3" t-att-class="{ 'mb-9': this.props.largeIcons }">
             <div class="bill_guide_left d-flex align-items-center justify-content-center py-3">
                 <div>
                     <div class="text-center">
-                        <img t-att-class="{ 'bill-guide-img': props.largeIcons }" src="/web/static/img/folder.svg"/>
+                        <img t-att-class="{ 'bill-guide-img': this.props.largeIcons }" src="/web/static/img/folder.svg"/>
                     </div>
                     <div class="text-center mt-2">
-                        <span class="btn account_drag_drop_btn pe-none" t-att-class="{ 'btn-lg': props.largeIcons }">Drag &amp; drop</span>
-                        <div t-if="showSampleAction">
+                        <span class="btn account_drag_drop_btn pe-none" t-att-class="{ 'btn-lg': this.props.largeIcons }">Drag &amp; drop</span>
+                        <div t-if="this.showSampleAction">
                             <span class="btn pe-none px-1 fw-normal">or</span>
                             <a class="btn btn-link px-0 fw-normal"
-                                t-att-class="{ 'btn-lg': props.largeIcons }"
+                                t-att-class="{ 'btn-lg': this.props.largeIcons }"
                                 href="#"
                                 type="object"
                                 name="action_create_vendor_bill"
@@ -36,14 +36,14 @@
                 </div>
             </div>
             <div class="bill_guide_right d-flex align-items-center justify-content-center py-3">
-                <div t-if="alias">
+                <div t-if="this.alias">
                     <div class="text-center">
-                        <img t-att-class="{ 'bill-guide-img': props.largeIcons }" src="/account/static/src/img/bill.svg" alt="Email bills"/>
+                        <img t-att-class="{ 'bill-guide-img': this.props.largeIcons }" src="/account/static/src/img/bill.svg" alt="Email bills"/>
                     </div>
                     <div class="text-center mt-2">
                         <div class="">
                             <span class="btn pe-none px-1 fw-normal">Send a bill to</span>
-                            <a class="btn btn-link px-0 fw-normal" t-attf-href="mailto:{{alias}}" t-out="alias"></a>
+                            <a class="btn btn-link px-0 fw-normal" t-attf-href="mailto:{{this.alias}}" t-out="this.alias"></a>
                         </div>
                         <div>
                             <span class="btn pe-none px-1 fw-normal">or</span>
@@ -59,7 +59,7 @@
                 </div>
                 <div t-else="">
                     <div class="text-center">
-                        <img t-att-class="{ 'bill-guide-img': props.largeIcons }" src="/web/static/img/bill.svg" alt="Create bill manually"/>
+                        <img t-att-class="{ 'bill-guide-img': this.props.largeIcons }" src="/web/static/img/bill.svg" alt="Create bill manually"/>
                     </div>
                     <div class="text-center mt-2">
                         <div class="">

--- a/addons/account/static/src/components/document_file_uploader/document_file_uploader.xml
+++ b/addons/account/static/src/components/document_file_uploader/document_file_uploader.xml
@@ -2,11 +2,11 @@
 
     <t t-name="account.DocumentFileUploader">
         <FileUploader
-            acceptedFileExtensions="props.acceptedFileExtensions"
+            acceptedFileExtensions="this.props.acceptedFileExtensions"
             fileUploadClass="'document_file_uploader'"
             multiUpload="true"
-            onUploaded.bind="onFileUploaded"
-            onUploadComplete.bind="onUploadComplete">
+            onUploaded.bind="this.onFileUploaded"
+            onUploadComplete.bind="this.onUploadComplete">
             <t t-set-slot="toggler">
                 <t t-slot="toggler"/>
             </t>
@@ -15,9 +15,9 @@
     </t>
 
     <t t-name="account.DocumentViewUploadButton">
-        <DocumentFileUploader resModel="props.resModel">
+        <DocumentFileUploader resModel="this.props.resModel">
             <t t-set-slot="toggler">
-                <t t-if="!hideUploadButton">
+                <t t-if="!this.hideUploadButton">
                     <button type="button" class="btn btn-secondary" data-hotkey="shift+i">
                         Upload
                     </button>

--- a/addons/account/static/src/components/document_state/document_state_field.xml
+++ b/addons/account/static/src/components/document_state/document_state_field.xml
@@ -2,8 +2,8 @@
 <templates>
     <t t-name="account.DocumentStatePopover">
         <div class="row m-2 mt-4 justify-content-between account_document_state_popover">
-            <span class="col-10" t-out="props.message" style="white-space: pre-wrap;"/>
-            <button class="col-2 btn p-0 account_document_state_popover_clone" t-on-click="() => props.copyText()">
+            <span class="col-10" t-out="this.props.message" style="white-space: pre-wrap;"/>
+            <button class="col-2 btn p-0 account_document_state_popover_clone" t-on-click="() => this.props.copyText()">
                 <i class="fa fa-clipboard"/>
             </button>
         </div>

--- a/addons/account/static/src/components/fetch_einvoices/fetch_einvoices.xml
+++ b/addons/account/static/src/components/fetch_einvoices/fetch_einvoices.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <templates id="template" xml:space="preserve">
     <t t-name="account.FetchEInvoices">
-        <DropdownItem onSelected.bind="fetchEInvoices">
+        <DropdownItem onSelected.bind="this.fetchEInvoices">
             <i class="fa fa-fw fa-refresh me-1" aria-hidden="true"></i><t t-out="this.buttonLabel" />
         </DropdownItem>
     </t>

--- a/addons/account/static/src/components/grouped_view_widget/grouped_view_widget.xml
+++ b/addons/account/static/src/components/grouped_view_widget/grouped_view_widget.xml
@@ -19,23 +19,23 @@
 
     <tbody t-name="account.GroupedItemsTemplate">
         <tr style="background-color: #dee2e6;">
-            <td t-attf-colspan="{{props.options.columns.length}}">
-                <t t-out="props.group_vals.group_name"/>
+            <td t-attf-colspan="{{this.props.options.columns.length}}">
+                <t t-out="this.props.group_vals.group_name"/>
             </td>
         </tr>
-        <t t-foreach="props.group_vals.items_vals" t-as="item_vals" t-key="item_vals_index">
-            <ListItem item_vals="item_vals[2]" options="props.options"/>
+        <t t-foreach="this.props.group_vals.items_vals" t-as="item_vals" t-key="item_vals_index">
+            <ListItem item_vals="item_vals[2]" options="this.props.options"/>
         </t>
     </tbody>
 
     <tr t-name="account.GroupedItemTemplate">
-        <t t-foreach="props.options.columns" t-as="col" t-key="col_index">
-            <td t-out="props.item_vals[col['field']]" t-attf-class="{{col['class']}}"/>
+        <t t-foreach="this.props.options.columns" t-as="col" t-key="col_index">
+            <td t-out="this.props.item_vals[col['field']]" t-attf-class="{{col['class']}}"/>
         </t>
     </tr>
 
     <t t-name="account.OpenMoveTemplate">
-        <a href="#" t-out="widget.value"/>
+        <a href="#" t-out="this.widget.value"/>
     </t>
 
 </templates>

--- a/addons/account/static/src/components/m2o_cell_with_extra_m2o_fields/m2o_cell_with_extra_m2o_fields.xml
+++ b/addons/account/static/src/components/m2o_cell_with_extra_m2o_fields/m2o_cell_with_extra_m2o_fields.xml
@@ -1,5 +1,5 @@
 <t t-name="account.M2OCellWithExtraM2OFields">
     <div id="extra_m2o_fields">
-        <Many2One t-props="mainM2OProps"/>
+        <Many2One t-props="this.mainM2OProps"/>
     </div>
 </t>

--- a/addons/account/static/src/components/mail_attachments/mail_attachments.xml
+++ b/addons/account/static/src/components/mail_attachments/mail_attachments.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="account.mail_attachments">
         <ul class="list-unstyled m-0">
-            <t t-foreach="renderedAttachments" t-as="attachment" t-key="attachment.id">
+            <t t-foreach="this.renderedAttachments" t-as="attachment" t-key="attachment.id">
                 <t t-if="!attachment.skip">
                     <li class="d-flex align-items-center bg-200 p-1 ps-3 my-2">
                         <span t-out="attachment.name" class="flex-grow-1 text-truncate"/>

--- a/addons/account/static/src/components/many2x_tax_tags/tax_tag_popover.xml
+++ b/addons/account/static/src/components/many2x_tax_tags/tax_tag_popover.xml
@@ -6,23 +6,23 @@
 
             <div class="p-2 border-bottom bg-light d-flex justify-content-between align-items-center">
                 <span class="fw-bold">Tax Distribution</span>
-                <button type="button" class="btn-close" t-on-click="props.close" tabindex="-1"/>
+                <button type="button" class="btn-close" t-on-click="this.props.close" tabindex="-1"/>
             </div>
 
             <div class="p-3 o_invoice_tax_summary">
 
-                <t t-if="props.description">
+                <t t-if="this.props.description">
                     <span class="text-capitalize d-block mb-3 fs-6">
-                        <t t-out="props.description"/>
+                        <t t-out="this.props.description"/>
                     </span>
                 </t>
 
-                <div t-if="props.invoiceLines.length > 0" class="mb-2 fs-6">
+                <div t-if="this.props.invoiceLines.length > 0" class="mb-2 fs-6">
                     <div class="d-flex align-items-start">
                         <div class="fw-bold me-2">Invoice :</div>
 
                         <div class="d-flex flex-wrap align-items-center">
-                            <t t-foreach="props.invoiceLines" t-as="group" t-key="group.type">
+                            <t t-foreach="this.props.invoiceLines" t-as="group" t-key="group.type">
                                 <t t-if="group.lines.map(line => line.tag_names).flat().length">
                                     <div class="d-flex align-items-center me-2 mb-2">
                                         <span class="text-capitalize me-2">
@@ -46,12 +46,12 @@
                     </div>
                 </div>
 
-                <div t-if="props.refundLines.length" class="mb-2 fs-6">
+                <div t-if="this.props.refundLines.length" class="mb-2 fs-6">
                     <div class="d-flex align-items-start">
                         <div class="fw-bold me-2">Credit Note :</div>
 
                         <div class="d-flex flex-wrap align-items-center">
-                            <t t-foreach="props.refundLines" t-as="group" t-key="group.type">
+                            <t t-foreach="this.props.refundLines" t-as="group" t-key="group.type">
                                 <t t-if="group.lines.map(line => line.tag_names).flat().length">
                                     <div class="d-flex align-items-center me-2 mb-2">
                                         <span class="text-capitalize me-2">

--- a/addons/account/static/src/components/onboarding/onboarding.xml
+++ b/addons/account/static/src/components/onboarding/onboarding.xml
@@ -3,7 +3,7 @@
 
     <t t-name="account.Onboarding">
         <div class="">
-            <div class="col-auto my-1" t-foreach="recordOnboardingSteps" t-as="step" t-key="step.id">
+            <div class="col-auto my-1" t-foreach="this.recordOnboardingSteps" t-as="step" t-key="step.id">
                 <i class="fa me-2 fs-5" t-att-class="{
                     'fa-circle text-secondary': step.state == 'not_done',
                     'fa-check-circle text-success': step.state != 'not_done',

--- a/addons/account/static/src/components/open_move_line_move_widget/open_move_line_move_widget.xml
+++ b/addons/account/static/src/components/open_move_line_move_widget/open_move_line_move_widget.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="account.LineOpenMoveWidget">
-        <Many2One t-props="m2oProps"/>
+        <Many2One t-props="this.m2oProps"/>
     </t>
 
 </templates>

--- a/addons/account/static/src/components/open_move_widget/open_move_widget.xml
+++ b/addons/account/static/src/components/open_move_widget/open_move_widget.xml
@@ -2,7 +2,7 @@
 <templates>
 
     <t t-name="account.OpenMoveWidget">
-        <a href="#" t-out="props.record.data[props.name] || '/'" t-on-click.prevent.stop="(ev) => this.openMove()"/>
+        <a href="#" t-out="this.props.record.data[this.props.name] || '/'" t-on-click.prevent.stop="(ev) => this.openMove()"/>
     </t>
 
 </templates>

--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
@@ -3,34 +3,34 @@
 
     <t t-name="account.ProductLabelSectionAndNoteField">
         <div class="o_field_product_label_section_and_note_cell">
-            <t t-if="isNote()">
+            <t t-if="this.isNote()">
                 <textarea
                     class="o_input d-print-none border-0 fst-italic"
                     placeholder="Enter a description"
                     rows="1"
-                    t-att-class="sectionAndNoteClasses"
-                    t-att-readonly="sectionAndNoteIsReadonly"
-                    t-att-value="label"
+                    t-att-class="this.sectionAndNoteClasses"
+                    t-att-readonly="this.sectionAndNoteIsReadonly"
+                    t-att-value="this.label"
                     t-custom-ref="labelNodeRef"
-                    t-key="props.readonly"
+                    t-key="this.props.readonly"
                 />
             </t>
-            <t t-elif="isSectionOrSubSection">
+            <t t-elif="this.isSectionOrSubSection">
                 <input
                     type="text"
                     class="o_input text-wrap border-0 w-100"
                     placeholder="Enter a description"
-                    t-att-class="sectionAndNoteClasses"
-                    t-att-readonly="sectionAndNoteIsReadonly"
-                    t-att-value="label"
+                    t-att-class="this.sectionAndNoteClasses"
+                    t-att-readonly="this.sectionAndNoteIsReadonly"
+                    t-att-value="this.label"
                     t-custom-ref="labelNodeRef"
-                    t-key="props.readonly"
+                    t-key="this.props.readonly"
                 />
             </t>
             <t t-else="">
                 <div class="o_input_box">
-                    <Many2One t-props="this.m2oProps" t-on-keydown="onM2oInputKeydown"/>
-                    <t t-if="showLabelVisibilityToggler">
+                    <Many2One t-props="this.m2oProps" t-on-keydown="this.onM2oInputKeydown"/>
+                    <t t-if="this.showLabelVisibilityToggler">
                         <button
                             class="o_input_box_overlay_end btn btn-link fa fa-bars"
                             id="labelVisibilityButtonId"
@@ -40,10 +40,10 @@
                     </t>
                 </div>
                 <div
-                    t-if="props.readonly"
+                    t-if="this.props.readonly"
                     class="o_input d-print-none border-0 fst-italic"
-                    t-att-class="{ ...sectionAndNoteClasses, 'd-none': !(columnIsProductAndLabel.value and label) }"
-                    t-out="label"
+                    t-att-class="{ ...this.sectionAndNoteClasses, 'd-none': !(this.columnIsProductAndLabel.value and this.label) }"
+                    t-out="this.label"
                 />
                 <textarea
                     t-else=""
@@ -51,13 +51,13 @@
                     placeholder="Enter a description"
                     rows="1"
                     type="text"
-                    t-att-class="{ ...sectionAndNoteClasses, 'd-none': !(columnIsProductAndLabel.value and (label or labelVisibility.value)) }"
-                    t-att-value="label"
+                    t-att-class="{ ...this.sectionAndNoteClasses, 'd-none': !(this.columnIsProductAndLabel.value and (this.label or this.labelVisibility.value)) }"
+                    t-att-value="this.label"
                     t-custom-ref="labelNodeRef"
                 />
             </t>
-            <t t-if="isPrintMode.value">
-                <div class="d-none d-print-block text-wrap" t-out="label"/>
+            <t t-if="this.isPrintMode.value">
+                <div class="d-none d-print-block text-wrap" t-out="this.label"/>
             </t>
         </div>
     </t>

--- a/addons/account/static/src/components/receipt_selector/receipt_selector.xml
+++ b/addons/account/static/src/components/receipt_selector/receipt_selector.xml
@@ -3,8 +3,8 @@
 
     <t t-name="account.ReceiptSelector">
         <div>
-            <t t-if="props.readonly || ['in_refund', 'out_refund'].includes(value) || (!show_sale_receipts.value and ['out_invoice', 'out_receipt'].includes(value))">
-                <span t-out="string" t-att-raw-value="value" />
+            <t t-if="this.props.readonly || ['in_refund', 'out_refund'].includes(this.value) || (!this.show_sale_receipts.value and ['out_invoice', 'out_receipt'].includes(this.value))">
+                <span t-out="this.string" t-att-raw-value="this.value" />
             </t>
             <t t-else="">
                 <t t-call="web.RadioField"/>

--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.xml
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.xml
@@ -80,7 +80,7 @@
     </t>
 
     <t t-name="account.SectionAndNoteText">
-        <t t-component="componentToUse" t-props="props"/>
+        <t t-component="this.componentToUse" t-props="this.props"/>
     </t>
 
 </templates>

--- a/addons/account/static/src/components/section_state/section_state_icon.xml
+++ b/addons/account/static/src/components/section_state/section_state_icon.xml
@@ -2,10 +2,10 @@
 <templates>
 
     <t t-name="account.SectionStateIcon">
-        <t t-if="['line_section', 'line_subsection'].includes(props.record.data.display_type)">
+        <t t-if="['line_section', 'line_subsection'].includes(this.props.record.data.display_type)">
             <i
                 class="ms-1 mt-1 text-muted"
-                t-att-class="iconClass"
+                t-att-class="this.iconClass"
                 aria-hidden="true"
             />
         </t>

--- a/addons/account/static/src/components/tax_totals/tax_totals.xml
+++ b/addons/account/static/src/components/tax_totals/tax_totals.xml
@@ -4,34 +4,34 @@
     <t t-name="account.TaxGroupComponent">
         <tr>
             <td class="o_td_label">
-                <label class="o_form_label o_tax_total_label" t-out="props.taxGroup.group_name"/>
+                <label class="o_form_label o_tax_total_label" t-out="this.props.taxGroup.group_name"/>
             </td>
 
             <td  class="o_tax_group">
-                <t t-if="!props.isReadonly">
-                    <t t-if="['edit', 'disable'].includes(state.value)">
+                <t t-if="!this.props.isReadonly">
+                    <t t-if="['edit', 'disable'].includes(this.state.value)">
                         <span class="o_tax_group_edit_input" t-custom-ref="numpadDecimal">
                             <input
                                 type="text"
                                 t-custom-ref="taxValueInput"
                                 class="o_field_float
                                 o_field_number o_input"
-                                t-att-disabled="state.value === 'disable'"
-                                t-on-change.prevent="_onChangeTaxValue"
-                                t-on-blur="_onChangeTaxValue"/>
+                                t-att-disabled="this.state.value === 'disable'"
+                                t-on-change.prevent="this._onChangeTaxValue"
+                                t-on-blur="this._onChangeTaxValue"/>
                         </span>
                     </t>
                     <t t-else="">
                         <span class="o_tax_group_edit" t-on-click.prevent="() => this.setState('edit')">
                             <span class="o_tax_group_amount_value o_list_monetary">
-                                <i class="fa fa-pencil me-2"/> <t t-out="formatMonetary(props.taxGroup.tax_amount_currency)"/>
+                                <i class="fa fa-pencil me-2"/> <t t-out="this.formatMonetary(this.props.taxGroup.tax_amount_currency)"/>
                             </span>
                         </span>
                     </t>
                 </t>
                 <t t-else="">
                     <span class="o_tax_group_amount_value o_list_monetary">
-                        <t t-out="formatMonetary(props.taxGroup.tax_amount_currency)" style="white-space: nowrap;"/>
+                        <t t-out="this.formatMonetary(this.props.taxGroup.tax_amount_currency)" style="white-space: nowrap;"/>
                     </span>
                 </t>
             </td>
@@ -39,9 +39,9 @@
     </t>
 
     <t t-name="account.TaxTotalsField">
-        <table t-if="totals" class="float-end">
+        <table t-if="this.totals" class="float-end">
             <tbody>
-                <t t-foreach="totals.subtotals" t-as="subtotal" t-key="subtotal_index">
+                <t t-foreach="this.totals.subtotals" t-as="subtotal" t-key="subtotal_index">
                     <tr>
                         <td class="o_td_label">
                             <label class="o_form_label o_tax_total_label" t-out="subtotal.name"/>
@@ -50,29 +50,29 @@
                         <td class="o_list_monetary">
                             <span t-att-name="subtotal.name"
                                   style="white-space: nowrap; font-weight: bold;"
-                                  t-out="formatMonetary(subtotal.base_amount_currency)"/>
+                                  t-out="this.formatMonetary(subtotal.base_amount_currency)"/>
                         </td>
                     </tr>
 
                     <t t-foreach="subtotal.tax_groups" t-as="taxGroup" t-key="taxGroup_index">
                         <TaxGroupComponent
-                            totals="totals"
+                            totals="this.totals"
                             subtotal="subtotal"
                             taxGroup="taxGroup"
-                            isReadonly="readonly"
-                            onChangeTaxGroup.bind="_onChangeTaxValueByTaxGroup"
-                            invalidate.bind="invalidate"
+                            isReadonly="this.readonly"
+                            onChangeTaxGroup.bind="this._onChangeTaxValueByTaxGroup"
+                            invalidate.bind="this.invalidate"
                         />
                     </t>
                 </t>
 
-                <tr t-if="'cash_rounding_base_amount_currency' in totals">
+                <tr t-if="'cash_rounding_base_amount_currency' in this.totals">
                     <td class="o_td_label">
                         <label class="o_form_label o_tax_total_label">Rounding</label>
                     </td>
                     <td class="o_list_monetary">
                         <span
-                            t-out="formatMonetary(totals.cash_rounding_base_amount_currency)"
+                            t-out="this.formatMonetary(this.totals.cash_rounding_base_amount_currency)"
                         />
                     </td>
                 </tr>
@@ -86,8 +86,8 @@
                     <td class="o_list_monetary">
                         <span
                             name="amount_total"
-                            t-att-class="{'oe_subtotal_footer_separator': totals.has_tax_groups}"
-                            t-out="formatMonetary(totals.total_amount_currency)"
+                            t-att-class="{'oe_subtotal_footer_separator': this.totals.has_tax_groups}"
+                            t-out="this.formatMonetary(this.totals.total_amount_currency)"
                             style="font-size: 1.3em; font-weight: bold; white-space: nowrap;"
                         />
                     </td>

--- a/addons/account/static/src/components/tests_shared_js_python/test_shared_js_python.xml
+++ b/addons/account/static/src/components/tests_shared_js_python/test_shared_js_python.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <templates>
 <t t-name="account.TestsSharedJsPython">
-    <button t-attf-class="#{state.done ? 'text-success' : ''}" t-on-click="processTests">Test</button>
+    <button t-attf-class="#{this.state.done ? 'text-success' : ''}" t-on-click="this.processTests">Test</button>
 </t>
 </templates>

--- a/addons/account/static/src/components/upload_drop_zone/upload_drop_zone.xml
+++ b/addons/account/static/src/components/upload_drop_zone/upload_drop_zone.xml
@@ -1,42 +1,42 @@
 <templates>
 
     <t t-name="account.UploadDropZone">
-        <t t-if="dashboardState.isDragging or props.visible">
+        <t t-if="this.dashboardState.isDragging or this.props.visible">
             <div
                 class="o_drop_area d-flex align-items-center justify-content-center flex-column"
                 t-att-class="{
-                    'drag_to_card': props.visible,
+                    'drag_to_card': this.props.visible,
                 }"
                 t-on-click="() => this.env.setDragging(false)"
                 t-on-dragover.prevent="()=>{}"
-                t-on-dragleave="props.hideZone"
-                t-on-drop.prevent="onDrop"
+                t-on-dragleave="this.props.hideZone"
+                t-on-drop.prevent="this.onDrop"
             >
-                <t t-if="props.dragIcon and props.dragText">
+                <t t-if="this.props.dragIcon and this.props.dragText">
                     <div class="text-align-center pe-none">
-                        <img class="img-fluid" t-att-src="props.dragIcon"/>
+                        <img class="img-fluid" t-att-src="this.props.dragIcon"/>
                     </div>
-                    <t t-if="props.visible">
+                    <t t-if="this.props.visible">
                         <div class="position-absolute upload_badge pe-none">
                             <i class="fa fa-circle fa-stack-2x text-primary"/>
                             <i class="fa fa-upload fa-stack-1x fa-inverse"/>
                         </div>
                    </t>
-                    <div class="h3 pe-none" t-att-class="{'text-primary': props.visible}">
-                        <t t-out="props.dragTitle"/>
+                    <div class="h3 pe-none" t-att-class="{'text-primary': this.props.visible}">
+                        <t t-out="this.props.dragTitle"/>
                     </div>
-                    <t t-if="props.dragShowCompany">
-                        <div t-att-class="{'text-primary': props.visible}">
-                            <span class="small fw-bold">(<t t-out="props.dragCompany"/>)</span>
+                    <t t-if="this.props.dragShowCompany">
+                        <div t-att-class="{'text-primary': this.props.visible}">
+                            <span class="small fw-bold">(<t t-out="this.props.dragCompany"/>)</span>
                         </div>
                     </t>
                   <div class="pe-none">
-                      <span t-att-class="{'invisible': !props.visible, 'text-primary': props.visible}">
-                          <t t-out="props.dragText"/>
+                      <span t-att-class="{'invisible': !this.props.visible, 'text-primary': this.props.visible}">
+                          <t t-out="this.props.dragText"/>
                       </span>
                   </div>
                 </t>
-                <t t-elif="props.visible">
+                <t t-elif="this.props.visible">
                     <img
                         class="img-fluid"
                         src="/account/static/src/img/bill.svg"
@@ -47,10 +47,10 @@
                         <i class="fa fa-upload fa-stack-1x fa-inverse"></i>
                     </span>
                     <h2 class="mt-5 fw-bold text-primary text-center">
-                        <t t-out="props.dropZoneTitle"/>
+                        <t t-out="this.props.dropZoneTitle"/>
                     </h2>
                     <span class="mt-2 text-primary text-center">
-                        <t t-out="props.dropZoneDescription"/>
+                        <t t-out="this.props.dropZoneDescription"/>
                     </span>
                 </t>
             </div>

--- a/addons/account/static/src/components/x2many_buttons/x2many_buttons.xml
+++ b/addons/account/static/src/components/x2many_buttons/x2many_buttons.xml
@@ -2,14 +2,14 @@
 <templates>
     <t t-name="account.X2ManyButtons">
         <div class="d-flex align-items-center">
-            <t t-foreach="this.currentField.records.slice(0, props.nbRecordsShown)" t-as="record" t-key="record.id">
+            <t t-foreach="this.currentField.records.slice(0, this.props.nbRecordsShown)" t-as="record" t-key="record.id">
                 <button class="btn btn-link p-0"
                         t-on-click="() => this.openFormAndDiscard(record.resId)"
                         t-att-data-hotkey="`shift+${record_index + 1}`"
                         t-out="record.data.display_name"/>
                 <span t-if="!record_last" class="pe-1">,</span>
             </t>
-            <t t-if="this.currentField.count gt props.nbRecordsShown">
+            <t t-if="this.currentField.count gt this.props.nbRecordsShown">
                 <button class="btn btn-link p-0" t-on-click="() => this.openTreeAndDiscard()" data-hotkey="shift+4">... (View all)</button>
             </t>
         </div>

--- a/addons/account/static/src/views/account_dashboard_kanban/account_dashboard_kanban_record.xml
+++ b/addons/account/static/src/views/account_dashboard_kanban/account_dashboard_kanban_record.xml
@@ -2,21 +2,21 @@
 
     <t t-name="account.DashboardKanbanRecord">
         <article
-            t-att-class="getRecordClasses()"
-            t-att-data-id="props.canResequence and props.record.id"
-            t-att-tabindex="props.record.model.useSampleModel ? -1 : 0"
-            t-on-click="onGlobalClick"
-            t-on-dragenter.stop.prevent="() => dropzoneState.visible = true"
+            t-att-class="this.getRecordClasses()"
+            t-att-data-id="this.props.canResequence and this.props.record.id"
+            t-att-tabindex="this.props.record.model.useSampleModel ? -1 : 0"
+            t-on-click="this.onGlobalClick"
+            t-on-dragenter.stop.prevent="() => this.dropzoneState.visible = true"
             t-custom-ref="root">
-            <AccountFileUploader t-if="allowDrop" record="props.record">
+            <AccountFileUploader t-if="this.allowDrop" record="this.props.record">
                 <t t-set-slot="default">
-                    <UploadDropZone t-props="dropzoneProps"/>
-                    <t t-call="{{ templates[this.constructor.KANBAN_CARD_ATTRIBUTE] }}"
-                        t-call-context="renderingContext"/>
+                    <UploadDropZone t-props="this.dropzoneProps"/>
+                    <t t-call="{{ this.templates[this.constructor.KANBAN_CARD_ATTRIBUTE] }}"
+                        t-call-context="this.renderingContext"/>
                 </t>
             </AccountFileUploader>
-            <t t-else="" t-call="{{ templates[this.constructor.KANBAN_CARD_ATTRIBUTE] }}"
-                t-call-context="renderingContext"/>
+            <t t-else="" t-call="{{ this.templates[this.constructor.KANBAN_CARD_ATTRIBUTE] }}"
+                t-call-context="this.renderingContext"/>
             <t t-call="{{ this.constructor.menuTemplate }}"/>
         </article>
     </t>

--- a/addons/account_peppol/static/src/components/peppol_info/peppol_info.xml
+++ b/addons/account_peppol/static/src/components/peppol_info/peppol_info.xml
@@ -31,7 +31,7 @@
                         </div>
                     </li>
                 </ul>
-                <button class="btn btn-lg btn-primary mt-3 w-100" t-on-click="activate" t-out="closeButtonLabel()"/>
+                <button class="btn btn-lg btn-primary mt-3 w-100" t-on-click="this.activate" t-out="this.closeButtonLabel()"/>
             </div>
         </div>
     </t>

--- a/addons/purchase/static/src/components/tax_totals/tax_totals.xml
+++ b/addons/purchase/static/src/components/tax_totals/tax_totals.xml
@@ -2,9 +2,9 @@
 <templates>
     <t t-inherit="account.TaxTotalsField" t-inherit-mode="extension" owl="1">
         <xpath expr="//tr[2]" position="after">
-            <tr t-if="totals.amount_total_cc">
+            <tr t-if="this.totals.amount_total_cc">
                 <td colspan="2">
-                    <span t-out="totals.amount_total_cc" style="font-size: 1.1em;"/>
+                    <span t-out="this.totals.amount_total_cc" style="font-size: 1.1em;"/>
                 </td>
             </tr>
         </xpath>

--- a/addons/purchase_product_matrix/static/src/js/purchase_product_field.xml
+++ b/addons/purchase_product_matrix/static/src/js/purchase_product_field.xml
@@ -5,14 +5,14 @@
     <t t-name="purchase.PurchaseProductField" t-inherit="account.ProductLabelSectionAndNoteField" t-inherit-mode="primary">
         <xpath expr="//Many2One" position="after">
             <button
-                t-if="!props.readonly and isConfigurableTemplate"
+                t-if="!this.props.readonly and this.isConfigurableTemplate"
                 type="button"
                 class="btn btn-link fa fa-pencil px-2"
                 tabindex="-1"
                 draggable="false"
-                t-att-aria-label="configurationButtonHelp"
-                t-att-data-tooltip="configurationButtonHelp"
-                t-on-click="onEditConfiguration"/>
+                t-att-aria-label="this.configurationButtonHelp"
+                t-att-data-tooltip="this.configurationButtonHelp"
+                t-on-click="this.onEditConfiguration"/>
         </xpath>
     </t>
 

--- a/addons/sale/static/src/xml/sale_product_field.xml
+++ b/addons/sale/static/src/xml/sale_product_field.xml
@@ -6,14 +6,14 @@
         <xpath expr="//Many2One" position="after">
             <!-- Show configuration button for custom lines/products -->
             <button
-                t-if="!props.readonly and hasConfigurationButton"
+                t-if="!this.props.readonly and this.hasConfigurationButton"
                 type="button"
                 class="btn btn-secondary fa fa-pencil px-2"
                 tabindex="-1"
                 draggable="false"
-                t-att-aria-label="configurationButtonHelp"
-                t-att-data-tooltip="configurationButtonHelp"
-                t-on-click="onEditConfiguration"
+                t-att-aria-label="this.configurationButtonHelp"
+                t-att-data-tooltip="this.configurationButtonHelp"
+                t-on-click="this.onEditConfiguration"
             />
         </xpath>
     </t>

--- a/addons/sale_management/static/src/fields/sale_order_template_line_field/sale_order_template_line_field.xml
+++ b/addons/sale_management/static/src/fields/sale_order_template_line_field/sale_order_template_line_field.xml
@@ -8,11 +8,11 @@
     >
         <t t-name="composition_button" position="after">
             <DropdownItem
-                onSelected="() => this.toggleIsOptional(record)"
-                attrs="{ 'class': this.disableOptionalButton(record) ? 'disabled' : '' }"
+                onSelected="() => this.toggleIsOptional(this.record)"
+                attrs="{ 'class': this.disableOptionalButton(this.record) ? 'disabled' : '' }"
             >
                 <i class="me-1 fa fa-fw fa-dot-circle-o"/>
-                <span t-if="record.data.is_optional">Unset Optional</span>
+                <span t-if="this.record.data.is_optional">Unset Optional</span>
                 <span t-else="">Set Optional</span>
             </DropdownItem>
         </t>


### PR DESCRIPTION
In preparation for OWL3, where template variables will need to use .this to target component variables, we add .this to template variables that are targetting the component.

Enterprise PR: https://github.com/odoo/enterprise/pull/108138
Script PR: https://github.com/odoo/odoo/pull/247965

task: OWL3 prep - add this. to template variables

THIS_TARGETS = ["account", "accountant"]

I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)