### PR TITLE
[FIX] point_of_sale: assign the correct value to `_base_url`

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -285,7 +285,7 @@ class PosConfig(models.Model):
 
         record = read_records[0]
         record['_server_version'] = exp_version()
-        record['_base_url'] = self.get_base_url()
+        record['_base_url'] = config.get_base_url()
         record['_data_server_date'] = self.env.context.get('pos_last_server_date') or self.env.cr.now()
         record['_has_cash_move_perm'] = self.env.user.has_group('account.group_account_invoice')
         record['_has_cash_delete_perm'] = self.env.user.has_group('account.group_account_basic')

--- a/addons/point_of_sale/tests/test_pos_basic_config.py
+++ b/addons/point_of_sale/tests/test_pos_basic_config.py
@@ -929,6 +929,19 @@ class TestPoSBasicConfig(TestPoSCommon):
         # calling load_data should not raise an error
         self.pos_session.load_data([])
 
+    def test_load_data_picks_the_company_website_domain(self):
+        if self.env['ir.module.module']._get('website').state != 'installed':
+            self.skipTest("website module is required for this test")
+
+        company_website = self.config.company_id.website_id
+
+        if company_website:
+            company_website.write({'domain': 'https://custom.test.domain.com'})
+            self.open_new_session()
+            response = self.pos_session.load_data([])
+
+            self.assertEqual(response['pos.config'][0]['_base_url'], company_website.domain)
+
     def test_invoice_past_refund(self):
         """ Test invoicing a past refund
 


### PR DESCRIPTION
Steps to reproduce
------------------
1. Make a website, associated with company 'A'
2. Add a `domain` on that website, e.g. 'test.domain.com'
3. Select company 'A', and create a PoS shop for it
4. Enable 'Self-service invoicing' for that PoS shop, select 'QR code'
5. Open the shop, select a client and make an order

-> The generated QR code point to the domain 'localhost:8069' and not to the company's website domain 'test.domain.com'.

Why the issue
-------------
In 1ee02f8a47d42d3ba3fd11ffcf8d9768ea17678e, we moved the `_base_url` from the session to the config. So now we call `self.get_base_url` on the config and not on the session anymore.

However, `self` is an empty config created on the fly, and it's not the `session.config_id` config object used by that shop.

The fix
-------
In `_load_pos_data_read` of the config model, we call `get_base_url` on the `config` instance, which is garanteed to be the valid config of that shop.

opw-5942057