### PR TITLE
[FIX] iot_drivers: fix tim paths

### DIFF
--- a/addons/iot_drivers/iot_handlers/interfaces/tim_interface.py
+++ b/addons/iot_drivers/iot_handlers/interfaces/tim_interface.py
@@ -26,7 +26,7 @@ def _configure_tim_lib(lib_name: str) -> bool:
         return True
     zip_path = drivers_path / "ctep.zip"
     helpers.download_from_url(f"https://download.odoo.com/master/posbox/iotbox/{source_zip_name}", zip_path)
-    helpers.unzip_file(zip_path, drivers_path)
+    helpers.unzip_file(zip_path, drivers_path / "tim")
 
     # Make TIM SDK dependency libraries visible for the linker
     if IS_WINDOWS:


### PR DESCRIPTION
Currently in saas-19.2 on start of Odoo tim_interface throws an exception and Odoo doesn't start:

```
2026-02-20 14:15:31,683 10276 CRITICAL ? odoo.modules.module: Couldn't load module iot_drivers  2026-02-20 14:15:31,684 10276 ERROR ? odoo.service.server: Failed to load server-wide module `iot_drivers`.  Traceback (most recent call last):
  File "/home/pi/odoo/odoo/service/server.py", line 1554, in load_server_wide_modules     load_openerp_module(m)
    ~~~~~~~~~~~~~~~~~~~^^^
  File "/home/pi/odoo/odoo/modules/module.py", line 488, in load_openerp_module     __import__(qualname)
    ~~~~~~~~~~^^^^^^^^^^
  File "/home/pi/odoo/addons/iot_drivers/__init__.py", line 18, in <module>     interface_thread().start()
    ~~~~~~~~~~~~~~~~^^
  File "/home/pi/odoo/addons/iot_drivers/iot_handlers/interfaces/tim_interface.py", line 61, in __init__     self.tim_api.six_initialize_manager.argtypes = [ctypes.c_int]     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'six_initialize_manager'
```

This is due to a missing 'tim' directory:
```
/home/pi/odoo/addons/iot_drivers/iot_handlers/drivers cp: cannot stat '/home/pi/odoo/addons/iot_drivers/iot_handlers/drivers/tim/libtimapi.so.3.38.0-5308': No such file or directory
```

This PR adds 'tim' directory in unzipping fixing the path


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
