### PR TITLE
[FIX] Add active test False into method _search_new_account_code to avoid duplicate code creation

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -518,7 +518,7 @@ class AccountAccount(models.Model):
             """
             return (
                 new_code not in cache
-                and not self.sudo().search_count([
+                and not self.with_context(active_test=False).sudo().search_count([
                     ('code', '=', new_code),
                     '|',
                     ('company_ids', 'parent_of', self.env.company.id),


### PR DESCRIPTION
**Description**
This PR addresses a critical validation issue in the accounting module where the system blocks the creation of new journals if a default account linked to an existing journal has been archived.

**Current Behavior**
Currently, when a user creates a new journal (e.g., a "Bank" type journal), the system automatically generates or assigns a default account. If the user subsequently archives that default account, any future attempt to create a new journal of the same type results in a Validation Error:

"Account codes must be unique. You can't create accounts with these duplicate codes: [XXXXXX]"

This happens because the system's uniqueness check for account codes includes archived accounts, but the automated journal setup logic fails to account for this  state, effectively locking the user out from creating new journals until the archived account is manually renamed or unarchived.

**Desired Behavior**
After this PR is merged, users should be able to create new journals seamlessly, even if previous journals have archived default accounts.

**video**
https://drive.google.com/file/d/1VzAskdTwF7lNc1y8PIpvN0T2zzKTMtdJ/view



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
