### PR TITLE
[IMP] mail: reduce font weight of important text in discuss app

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter.xml
+++ b/addons/mail/static/src/chatter/web/chatter.xml
@@ -116,7 +116,7 @@
 
 <t t-name="mail.ActivityList">
     <div class="o-mail-ActivityList">
-        <div class="d-flex pt-2 px-2 cursor-pointer fw-bolder" t-on-click="toggleActivities">
+        <div class="d-flex pt-2 px-2 cursor-pointer fw-bold" t-on-click="toggleActivities">
             <hr class="flex-grow-1 fs-3"/>
             <div class="d-flex align-items-center px-3">
                 <i class="fa fa-fw" t-att-class="state.showActivities ? 'fa-caret-down' : 'fa-caret-right'"/>
@@ -135,7 +135,7 @@
 
 <t t-name="mail.ScheduledMessagesList">
     <div class="o-mail-ScheduledMessagesList">
-        <div class="d-flex pt-2 cursor-pointer fw-bolder" t-on-click="toggleScheduledMessages">
+        <div class="d-flex pt-2 cursor-pointer fw-bold" t-on-click="toggleScheduledMessages">
             <hr class="flex-grow-1 fs-3"/>
             <div class="d-flex align-items-center px-3">
                 <i class="fa fa-fw" t-att-class="state.showScheduledMessages ? 'fa-caret-down' : 'fa-caret-right'"/>

--- a/addons/mail/static/src/core/common/action_list.xml
+++ b/addons/mail/static/src/core/common/action_list.xml
@@ -137,7 +137,7 @@
 </t>
 
 <t t-name="mail.Action.badge">
-    <span class="fw-bolder badge p-0 rounded-circle d-flex justify-content-center align-items-center" t-attf-class="{{ extraBadgeClass }}" t-att-class="{ 'bg-warning o-discuss-warningBadge': action.tags.includes('WARNING_BADGE'), 'o-discuss-badge': action.tags.includes('IMPORTANT_BADGE') }" style="aspect-ratio: 1; font-size: 0.6rem;">
+    <span class="o-fw-600 badge p-0 rounded-circle d-flex justify-content-center align-items-center" t-attf-class="{{ extraBadgeClass }}" t-att-class="{ 'bg-warning o-discuss-warningBadge': action.tags.includes('WARNING_BADGE'), 'o-discuss-badge': action.tags.includes('IMPORTANT_BADGE') }" style="aspect-ratio: 1; font-size: 0.6rem;">
         <i t-if="action.badgeIcon" t-att-class="action.badgeIcon"/><span t-elif="action.badgeText" t-esc="action.badgeText"/>
     </span>
 </t>

--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -14,7 +14,7 @@
 
     <t t-name="mail.ChatBubblePreview">
         <div t-if="props.chatWindow?.channel" class="o-mail-ChatBubble-preview o-mail-ChatBubble-menu px-0 py-1 shadow-sm border border-secondary bg-100 o-rounded-bubble">
-            <div class="text-truncate base-fs fw-bolder mb-0 mx-2 px-1" t-esc="props.chatWindow.channel.displayName"/>
+            <div class="text-truncate base-fs o-fw-600 mb-0 mx-2 px-1" t-esc="props.chatWindow.channel.displayName"/>
             <t t-set="message" t-value="channel.newestPersistentOfAllMessage" />
             <div t-if="previewText" class="text-truncate small mx-2 px-1 text-muted">
                 <MessageSeenIndicator t-if="message.showSeenIndicator(channel.thread)" message="message"/>

--- a/addons/mail/static/src/core/common/search_message_result.xml
+++ b/addons/mail/static/src/core/common/search_message_result.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="mail.SearchMessageResult">
         <div class="o-mail-SearchMessageResult">
-            <p t-if="MESSAGE_FOUND" class="o-mail-SearchMessagesPanel-title py-1 mb-0 fw-bolder text-center text-uppercase text-muted smaller">
+            <p t-if="MESSAGE_FOUND" class="o-mail-SearchMessagesPanel-title py-1 mb-0 o-fw-600 text-center text-uppercase text-muted smaller">
                 <t t-out="MESSAGE_FOUND" />
             </p>
             <MessageCardList 

--- a/addons/mail/static/src/core/public_web/discuss_content.xml
+++ b/addons/mail/static/src/core/public_web/discuss_content.xml
@@ -22,7 +22,7 @@
                 <div class="flex-grow-1 align-self-center align-items-center h-100 py-1" t-att-class="{ 'lh-sm': showsChatLocalDateTime }">
                     <div class="d-flex">
                         <div t-if="thread.channel?.parent_channel_id" class="d-flex align-items-center gap-1 ms-1">
-                            <span class="fw-bolder cursor-pointer opacity-75 opacity-100-hover o-hover-text-underline" t-esc="thread.channel.parent_channel_id.displayName" t-on-click="() => this.thread?.channel?.parent_channel_id?.open({ focus: true })"/>
+                            <span class="fw-bold cursor-pointer opacity-75 opacity-100-hover o-hover-text-underline" t-esc="thread.channel.parent_channel_id.displayName" t-on-click="() => this.thread?.channel?.parent_channel_id?.open({ focus: true })"/>
                             <i class="oi oi-chevron-right o-xsmaller mx-1"/>
                         </div>
                         <AutoresizeInput

--- a/addons/mail/static/src/core/web/thread_patch.xml
+++ b/addons/mail/static/src/core/web/thread_patch.xml
@@ -5,19 +5,19 @@
             <t t-if="props.thread.isEmpty and props.thread.model === 'mail.box'">
                 <t t-if="props.thread.id === 'inbox' and state.mountedAndLoaded">
                     <div class="align-items-center text-center">
-                        <h4 class="mb-3 fw-bolder">Congratulations, your inbox is empty</h4>
+                        <h4 class="mb-3 o-fw-600">Congratulations, your inbox is empty</h4>
                         New messages appear here.
                     </div>
                 </t>
                 <t t-if="props.thread.id === 'bookmark'">
                     <div class="d-flex flex-column align-items-center text-center">
-                        <h4 class="mb-3 fw-bolder">Bookmark important messages</h4>
+                        <h4 class="mb-3 o-fw-600">Bookmark important messages</h4>
                         Save messages here to easily keep track of them.
                     </div>
                 </t>
                 <t t-if="props.thread.id === 'history'">
                     <img src="/web/static/img/neutral_face.svg" alt="History"/>
-                    <h4 class="mb-3 fw-bolder">No history messages</h4>
+                    <h4 class="mb-3 o-fw-600">No history messages</h4>
                     Messages marked as read will appear in the history.
                 </t>
             </t>

--- a/addons/mail/static/src/discuss/call/common/call_menu.xml
+++ b/addons/mail/static/src/discuss/call/common/call_menu.xml
@@ -19,7 +19,7 @@
                         <button class="o-discuss-CallMenu-dropdownMore btn btn-group-item border-0 m-0 pe-1 o-ps-0_5 rounded-2 rounded-start-0 opacity-100-hover text-body" t-att-class="{ 'opacity-75 bg-transparent': !dropdownState.isOpen and !lastSelfAction?.tags.includes('WARNING_BADGE'), 'opacity-100': dropdownState.isOpen or lastSelfAction?.tags.includes('WARNING_BADGE') }" title="Select Actions">
                             <i class="fa fa-fw o-fs-small" t-attf-class="{{ icon }}" t-att-class="lastSelfActionAttClass"/>
                             <i class="oi oi-chevron-down o-xxsmaller opacity-75" t-att-class="{ 'mt-2': lastSelfAction?.tags.includes('WARNING_BADGE') }"/>
-                            <span t-if="lastSelfAction?.tags.includes('WARNING_BADGE')" class="o-discuss-CallMenu-warningBadge fw-bolder badge p-0 rounded-circle d-flex justify-content-center align-items-center o-discuss-warningBadge position-absolute bg-warning" style="aspect-ratio: 1; font-size: 0.6rem;">
+                            <span t-if="lastSelfAction?.tags.includes('WARNING_BADGE')" class="o-discuss-CallMenu-warningBadge o-fw-600 badge p-0 rounded-circle d-flex justify-content-center align-items-center o-discuss-warningBadge position-absolute bg-warning" style="aspect-ratio: 1; font-size: 0.6rem;">
                                 <i t-if="lastSelfAction?.badgeIcon" t-att-class="lastSelfAction.badgeIcon"/><span t-elif="lastSelfAction.badgeText" t-esc="lastSelfAction.badgeText"/>
                             </span>
                         </button>

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.xml
@@ -44,12 +44,12 @@
                 <!-- overlay -->
                 <span class="o-discuss-CallParticipantCard-overlay o-discuss-CallParticipantCard-overlayBottom z-1 position-absolute bottom-0 start-0 d-flex overflow-hidden rounded-3" t-att-class="{ 'o-proportional-container w-50': isSmall }" t-att-data-connection-state="rtcSession.connectionState">
                     <span t-if="!props.minimized" class="rounded-3 text-truncate o-proportional-text o-discuss-CallParticipantCard-overlayBottomName" t-att-class="{'o-minimized px-1 small': isSmall, 'o-px-1_5 py-1': !isSmall }" t-esc="name"/>
-                    <small t-if="rtcSession.is_screen_sharing_on and props.minimized and !isOfActiveCall" class="user-select-none o-proportional-text o-minimized rounded text-bg-danger d-flex align-items-center fw-bolder p-1" title="live" aria-label="live">
+                    <small t-if="rtcSession.is_screen_sharing_on and props.minimized and !isOfActiveCall" class="user-select-none o-proportional-text o-minimized rounded text-bg-danger d-flex align-items-center o-fw-600 p-1" title="live" aria-label="live">
                         LIVE
                     </small>
                 </span>
                 <span t-if="showRemoteWarning" class="o-discuss-CallParticipantCard-overlay o-proportional-container z-1 w-50 position-absolute d-flex align-items-center justify-content-center overflow-hidden">
-                    <span class="fw-bolder p-1 rounded-3 o-video-text o-proportional-text">Video visible in the call tab</span>
+                    <span class="o-fw-600 p-1 rounded-3 o-video-text o-proportional-text">Video visible in the call tab</span>
                 </span>
                 <div t-if="!props.inset and !props.minimized" class="o-discuss-CallParticipantCard-overlay position-absolute top-0 end-0 d-flex w-50 flex-row-reverse" t-att-class="{ 'o-proportional-container': isSmall, 'mw-25': props.isSidebarItem or props.inset }">
                     <span t-if="rtcSession.is_deaf" class="o-proportional-text d-flex flex-column justify-content-center me-1 rounded-circle o-discuss-CallParticipantCard-iconBlackBg" t-att-class="{'o-minimized p-1': isSmall, 'p-2': !isSmall }" title="deaf" aria-label="deaf">
@@ -84,7 +84,7 @@
                     <span t-if="showConnectionState" class="o-proportional-text d-flex flex-column justify-content-center me-1 rounded-circle o-discuss-CallParticipantCard-iconBlackBg" t-att-class="{'o-minimized p-1': isSmall, 'p-2': !isSmall }" t-att-title="rtcSession.connectionState">
                         <i class="fa fa-exclamation-triangle text-warning"/>
                     </span>
-                    <span t-if="showLiveLabel" class="user-select-none rounded o-proportional-text text-bg-danger d-flex align-items-center py-1 px-2 fw-bolder" title="live" aria-label="live">
+                    <span t-if="showLiveLabel" class="user-select-none rounded o-proportional-text text-bg-danger d-flex align-items-center p-1 o-fw-600" title="live" aria-label="live">
                         LIVE
                     </span>
                 </div>

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -42,12 +42,12 @@
                     <div t-if="selectedPartners.length > 0 or state.selectedEmails.length > 0" class="pt-2">
                         <div class="o-discuss-ChannelInvitation-selectedList d-flex flex-wrap overflow-auto o-scrollbar-thin">
                             <t t-foreach="selectedPartners" t-as="selectedPartner" t-key="selectedPartner.id">
-                                <button class="btn btn-light fw-bolder smaller pe-1" title="Unselect person" t-on-click="() => this.onClickSelectedPartner(selectedPartner)">
+                                <button class="btn btn-light o-fw-600 smaller pe-1" title="Unselect person" t-on-click="() => this.onClickSelectedPartner(selectedPartner)">
                                     <t t-esc="selectedPartner.name"/> <i class="oi oi-close border border-dark-subtle ms-1"/>
                                 </button>
                             </t>
                             <t t-foreach="state.selectedEmails" t-as="selectedEmail" t-key="selectedEmail">
-                                <button class="btn btn-light fw-bolder smaller pe-1" title="Unselect person" t-on-click="() => this.onClickSelectedEmail(selectedEmail)">
+                                <button class="btn btn-light o-fw-600 smaller pe-1" title="Unselect person" t-on-click="() => this.onClickSelectedEmail(selectedEmail)">
                                     <t t-esc="selectedEmail"/> <i class="oi oi-close border border-dark-subtle ms-1"/>
                                 </button>
                             </t>

--- a/addons/mail/static/src/discuss/core/common/notification_settings.xml
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.xml
@@ -34,7 +34,7 @@
                         <div class="d-flex flex-grow-1 align-items-center px-2 rounded">
                             <div class="d-flex flex-column align-items-start">
                                 <span class="fs-6 text-wrap text-start text-break">Use Default</span>
-                                <span class="fw-bolder o-xsmaller ps-2 o-discuss-NotificationSettings-defaultValue"><t t-out="store.settings.NOTIFICATIONS.find((n) => n.label === store.settings.channel_notifications).name"/></span>
+                                <span class="o-fw-600 o-xsmaller ps-2 o-discuss-NotificationSettings-defaultValue"><t t-out="store.settings.NOTIFICATIONS.find((n) => n.label === store.settings.channel_notifications).name"/></span>
                             </div>
                             <div class="o-discuss-NotificationSettings-separator flex-grow-1"/>
                             <input class="form-check-input shadow-sm" type="radio" t-att-checked="!props.channel.self_member_id?.custom_notifications"/>

--- a/addons/mail/static/src/discuss/core/common/thread_patch.xml
+++ b/addons/mail/static/src/discuss/core/common/thread_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.Thread" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('o-mail-Thread')]" position="before">
-            <span t-if="!env.inChatter and channel?.showUnreadBanner" class="o-mail-Thread-banner d-flex cursor-pointer shadow-sm smaller fw-bolder border border-warning">
+            <span t-if="!env.inChatter and channel?.showUnreadBanner" class="o-mail-Thread-banner d-flex cursor-pointer shadow-sm smaller o-fw-600 border border-warning">
                 <t t-set="alertClass" t-value="'alert alert-warning m-0 border-start-0 o-mail-Thread-bannerHover py-1 rounded-0'"/>
                 <span t-attf-class="{{ alertClass }} flex-grow-1" t-on-click="onClickUnreadMessagesBanner" t-esc="newMessageBannerText"/>
                 <span t-attf-class="{{ alertClass }}" t-on-click="() => props.thread.markAsRead()">Mark as Read<i class="ms-2 fa fa-check-square"/></span>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.js
@@ -91,7 +91,7 @@ export class DiscussSidebarChannel extends Component {
 
     get itemNameAttClass() {
         return {
-            "o-unread fw-bolder":
+            "o-unread o-fw-600":
                 this.channel.self_member_id?.message_unread_counter > 0 &&
                 !this.channel.self_member_id?.mute_until_dt,
             "opacity-75 opacity-100-hover":

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.xml
@@ -8,7 +8,7 @@
                     <t t-set-slot="content">
                         <UseHoverOverlay hover="hover">
                             <div class="overflow-hidden d-flex flex-column" t-ref="floating">
-                                <span class="o-mail-DiscussSidebarChannel-floatingName fw-bolder user-select-none text-truncate d-inline-block p-2 pb-0" t-esc="channel.displayName"/>
+                                <span class="o-mail-DiscussSidebarChannel-floatingName o-fw-600 user-select-none text-truncate d-inline-block p-2 pb-0" t-esc="channel.displayName"/>
                                 <DiscussSidebarChannelActions channel="channel"/>
                             </div>
                         </UseHoverOverlay>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/subchannel.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/subchannel.xml
@@ -6,7 +6,7 @@
             <t t-set-slot="content">
                 <UseHoverOverlay hover="hover">
                     <div class="overflow-hidden d-flex flex-column" t-ref="floating">
-                        <span class="fw-bolder user-select-none text-truncate d-inline-block p-2 pb-0" t-esc="channel.displayName"/>
+                        <span class="o-fw-600 user-select-none text-truncate d-inline-block p-2 pb-0" t-esc="channel.displayName"/>
                         <DiscussSidebarChannelActions channel="channel"/>
                     </div>
                 </UseHoverOverlay>
@@ -35,7 +35,7 @@
                 'opacity-50': channel.self_member_id?.mute_until_dt,
             }">
                 <span class="text-truncate" t-esc="channel.displayName" t-att-class="{
-                    'fw-bolder': channel.self_member_id?.message_unread_counter > 0,
+                    'o-fw-600': channel.self_member_id?.message_unread_counter > 0,
                     'opacity-75 opacity-100-hover': !(channel.self_member_id?.message_unread_counter > 0 and !channel.self_member_id?.mute_until_dt),
                 }" t-att-style="store.discuss.isSidebarCompact ? 'text-overflow: clip;' : ''"/>
                 <span class="flex-grow-1"/>


### PR DESCRIPTION
Many texts on Discuss have `.fw-bolder`, like unread conversations. While `.fw-bolder` helps to see the difference between other items, like read conversations, `.fw-bolder` is very strong and makes the text fatiguing to read. `.fw-bold` is a softer version, but this is too similar from the normal font.

This commit replaces most occurrences of `fw-bolder` to `o-fw-600`, which is an intermediate weight that is not as heavy as `.fw-bolder` but definitely visible compared to `fw-bold`.

Some occurrences of `.fw-bolder` were inconsistent with other similar items and have been downgraded to `.fw-bold` to match the other items. For example, "Planned Activities" had `.fw-bolder` when other Chatter categories like "Files" has `.fw-bold`. `.fw-bold` is more than enough.

Before / After
<img width="300" height="590" alt="Screenshot 2026-02-20 at 18 07 33" src="https://github.com/user-attachments/assets/31e55703-8e15-4eec-8265-ba2e4b26f71f" /> <img width="301" height="589" alt="Screenshot 2026-02-20 at 18 07 19" src="https://github.com/user-attachments/assets/d15e6b47-644d-4f5f-b903-c8fa0932f09a" />

<img width="302" height="590" alt="Screenshot 2026-02-20 at 18 09 25" src="https://github.com/user-attachments/assets/5adfcc84-865c-4f0b-8aea-c715bf4a41d8" /> <img width="302" height="589" alt="Screenshot 2026-02-20 at 18 09 49" src="https://github.com/user-attachments/assets/45265057-4e3d-4c39-b1cf-777ceae08491" />
