### PR TITLE
[FIX] mail: reduce wasted space of message actions in meeting chat

### DIFF
--- a/addons/mail/static/src/core/common/action_list.xml
+++ b/addons/mail/static/src/core/common/action_list.xml
@@ -89,7 +89,7 @@
         'o-p-1_5':       props.inline   and  !env.inMeetingView and hasBtnBg and isInlineCircleButton and !env.inChatWindow,
         'o-px-0_5':      props.inline   and  !env.inMeetingView and !hasBtnBg and !action.icon,
         'p-1':           props.inline   and  hasBtnBg and isInlineCircleButton and env.inChatWindow,
-        'o-p-0_5':       props.inline   and  !env.inMeetingView and !hasBtnBg and !env.inComposer,
+        'o-p-0_5':       props.inline   and  (!env.inMeetingView and !hasBtnBg and !env.inComposer) or env.inMessage,
         'px-3 py-2':     props.dropdown and   ui.isSmall,
         'px-2 py-1':     props.dropdown and  !ui.isSmall,
     })"/>


### PR DESCRIPTION
Before this commit, message actions in meeting chat were taking too much space, reducing the size of message bubbles.

This happens because the "..." button had no explicit padding and thus fall-backed to the default padding of a button, which is way too much.

This commit fixes the issue by providing the proper padding to message actions in the inline presentation, which is necessarily with a tiny padding.

Before / After
<img width="297" height="565" alt="Screenshot 2026-02-20 at 18 38 05" src="https://github.com/user-attachments/assets/580bd0ff-ff3a-4830-bac4-6764e78863e2" /> <img width="296" height="562" alt="Screenshot 2026-02-20 at 18 37 41" src="https://github.com/user-attachments/assets/2f3eda5e-4016-402f-9450-157fe7be69bc" />
