### PR TITLE
[FIX] spreadsheet: Fix chart link to datasources

### DIFF
--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_chart_helpers.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_chart_helpers.js
@@ -3,6 +3,12 @@ import { Domain } from "@web/core/domain";
 import { _t } from "@web/core/l10n/translation";
 import { globalFieldMatchingRegistry } from "@spreadsheet/global_filters/helpers";
 
+const DataSourceViewTypeMap = {
+    list: "list",
+    pivot: "pivot",
+    chart: "graph",
+};
+
 export function onOdooChartItemClick(getters, chart) {
     return navigateInOdooMenuOnClick(getters, chart, (chartJsItem, chartData) => {
         const { datasets, labels } = chartData;
@@ -199,7 +205,7 @@ export async function navigateToOdooDatasourceFromChart(
             domain,
             context,
         },
-        { newWindow }
+        { viewType: DataSourceViewTypeMap[dataSourceType], newWindow }
     );
 }
 


### PR DESCRIPTION
Currently, if the user clicks on a datasource link (inside a chart) they will be directed to the default view of the action realted to the datasource model but it will not go to the corresponding type of view (e.g. a list datasource should direct to a list view).

Task-5957004

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
