### PR TITLE
[FIX] stock_delivery: compute shipping weight on multiple pickings

### DIFF
--- a/addons/stock_delivery/models/stock_quant_package.py
+++ b/addons/stock_delivery/models/stock_quant_package.py
@@ -9,6 +9,7 @@ class StockQuantPackage(models.Model):
     _inherit = "stock.quant.package"
 
     @api.depends('quant_ids', 'package_type_id')
+    @api.depends_context('picking_id')
     def _compute_weight(self):
         if self.env.context.get('picking_id'):
             package_weights = defaultdict(float)

--- a/addons/stock_delivery/tests/test_packing_delivery.py
+++ b/addons/stock_delivery/tests/test_packing_delivery.py
@@ -294,9 +294,14 @@ class TestPacking(TestPackingCommon):
     def test_delivery_shipping_weight_with_package_before_validation(self):
         """Check that package and picking shipping weights are correctly computed
         on delivery pickings when products are put into a package.
+
+        The test performs the same operations twice on two pickings to ensure
+        package weights are recomputed per picking and are not cached from the
+        context of the first picking, which would affect the shipping weight of
+        the following pickings.
         """
         self.env['stock.quant']._update_available_quantity(self.product_aw, self.stock_location, 1)
-        picking_ship = self.env['stock.picking'].create({
+        picking_ships = self.env['stock.picking'].create([{
             'picking_type_id': self.warehouse.out_type_id.id,
             'location_id': self.stock_location.id,
             'location_dest_id': self.customer_location.id,
@@ -305,19 +310,23 @@ class TestPacking(TestPackingCommon):
                 'product_id': self.product_aw.id,
                 'quantity': 1,
                 'location_id': self.stock_location.id,
-                'location_dest_id': self.customer_location.id
+                'location_dest_id': self.customer_location.id,
             })],
-        })
-        picking_ship.action_confirm()
-        self.assertEqual(picking_ship.shipping_weight, self.product_aw.weight)
-        picking_ship.action_put_in_pack()
-        package = picking_ship.package_ids
-        self.assertEqual(picking_ship.shipping_weight, self.product_aw.weight)
-        self.assertEqual(package.weight, self.product_aw.weight, "The package weight is correctly computed using the picking context "
-                                                                    "and cached during the picking shipping weight computation.")
-        self.assertFalse(package.quant_ids, "No quant should be linked to the package yet.")
-        picking_ship.button_validate()
-        self.assertEqual(picking_ship.state, 'done')
-        self.assertTrue(package.quant_ids)
-        self.assertEqual(package.weight, self.product_aw.weight, "As the package contains quants, its weight is correctly computed from them.")
-        self.assertEqual(picking_ship.shipping_weight, self.product_aw.weight)
+        } for _ in range(2)])
+        picking_ships.action_confirm()
+        self.assertListEqual(picking_ships.mapped('shipping_weight'), [self.product_aw.weight, self.product_aw.weight])
+        for picking in picking_ships:
+            picking.action_put_in_pack()
+        packages = picking_ships.package_ids
+        self.assertListEqual(picking_ships.mapped('shipping_weight'), [self.product_aw.weight, self.product_aw.weight])
+        self.assertListEqual(
+            [picking.package_ids.with_context(picking_id=picking.id).weight for picking in picking_ships],
+            [self.product_aw.weight, self.product_aw.weight],
+            "The package weight is correctly computed using the picking context and cached during the picking shipping weight computation."
+        )
+        self.assertFalse(packages.quant_ids, "No quant should be linked to the package yet.")
+        picking_ships.button_validate()
+        self.assertListEqual(picking_ships.mapped('state'), ['done', 'done'])
+        self.assertTrue(packages.quant_ids)
+        self.assertListEqual(packages.mapped('weight'), [self.product_aw.weight, self.product_aw.weight], "As the package contains quants, its weight is correctly computed from them.")
+        self.assertListEqual(picking_ships.mapped('shipping_weight'), [self.product_aw.weight, self.product_aw.weight])


### PR DESCRIPTION
Problem: When computing the `shipping_weight` for pickings with packages,
we use package weights. If a picking is passed via the context, the
package weight is computed using the contained product weights. Otherwise,
it just uses the `package.package_type_id.base_weight` or 0.

This issue occurs when computing the `shipping_weight` for multiple
pickings at one time. Odoo prefetches the packages and their weights are
computed using the context of the first picking. If a package does not
belong to the first picking, their weight is not computed using its
`stock.move.line` product weights and the incorrect value is cached. When
the loop reaches the next picking, it uses the incorrect weight that was cached.

Purpose: Add `@api.depends_context('picking_id')` to `_compute_weight` so that
package weights are cached per picking.

I have updated this assert
https://github.com/odoo/odoo/blob/338fc201cc0ed0f2fd8349fab4f538817e69a295/addons/stock_delivery/tests/test_packing_delivery.py#L316-L317
to explicitly pass the `picking_id` in the context when checking the cached package weights.

Steps to Reproduce on Runbot:
Navigate to Inventory > Configuration > Settings and enable Packages.
Create a new storable product with a weight of 1 kg and add 2 units on-hand.
Create a delivery for 1 unit of our newly created product, mark as todo and put in a pack.
Create a second delivery for 1 unit of our newly created product, mark as todo, and put in a pack.
Observe on the second delivery the weight for shipping is 1 kg.
Navigate to the list view of deliveries and add the weight for shipping field to the view.
Search for both deliveries we created and observe the first one has a weight for shipping of 1 kg,
but the second one has a weight for shipping of 0 kg.

opw-5902814