### PR TITLE
[FIX] hr_attendance, base: fix 'departement' typo

### DIFF
--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -247,7 +247,7 @@
                     )]"/>
                 <group expand="0" string="Group By">
                     <filter string="Employee" name="employee" context="{'group_by': 'employee_id'}"/>
-                    <filter string="Department" name="departement" context="{'group_by': 'department_id'}"/>
+                    <filter string="Department" name="department" context="{'group_by': 'department_id'}"/>
                     <filter string="Manager" name="manager" context="{'group_by': 'manager_id'}"/>
                     <filter string="Method" name="groupby_mode_in" context="{'group_by': 'in_mode'}"/>
                     <filter string="Date" name="groupby_name" context="{'group_by': 'check_in:month'}"/>

--- a/doc/cla/individual/vedantmadane.md
+++ b/doc/cla/individual/vedantmadane.md
@@ -1,0 +1,1 @@
+India, 2026-02-21 I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0. I declare that I am authorized and able to make this agreement and sign this declaration. Signed, Vedant Madane 6527493+VedantMadane@users.noreply.github.com https://github.com/VedantMadane

--- a/odoo/addons/base/models/res_country.py
+++ b/odoo/addons/base/models/res_country.py
@@ -167,7 +167,7 @@ class CountryState(models.Model):
 
     country_id = fields.Many2one('res.country', string='Country', required=True)
     name = fields.Char(string='State Name', required=True,
-               help='Administrative divisions of a country. E.g. Fed. State, Departement, Canton')
+               help='Administrative divisions of a country. E.g. Fed. State, Department, Canton')
     code = fields.Char(string='State Code', help='The state code.', required=True)
 
     _sql_constraints = [


### PR DESCRIPTION
This PR fixes two occurrences of the typo 'departement' (French spelling) in English contexts. One in the search filter name of hr_attendance and another in a help string in the base module. Fixes #202198.