### PR TITLE
[FIX] website_slides: fix course card layout issue

### DIFF
--- a/addons/website_slides/static/src/scss/website_slides.scss
+++ b/addons/website_slides/static/src/scss/website_slides.scss
@@ -175,11 +175,72 @@ $line-height-truncate: 1.5em;
         margin-left: auto;
         margin-right: auto;
     }
+
+    // Temporary workaround addresses a scenario where the user might add a link
+    // in the description. Since a card is enclosed within an `<a>` tag, inserting
+    // another `<a>` tag inside would disrupt the HTML   structure, leading to a
+    // broken layout. The following rules adapt that said broken layout to visually
+    // resemble a card.
+
+    // TODO: Address the issue on master by wrapping in `<a>` tag only the image
+    div:has(> .card + .card-body) {
+        --card-cap-padding-x: #{$card-cap-padding-x};
+        --card-cap-padding-y: #{$card-cap-padding-y};
+        --card-spacer-x: #{$card-spacer-x};
+        --card-spacer-y: #{$card-spacer-y};
+        --card-cap-bg: #{$card-cap-bg};
+        --card-border-width: #{$card-border-width};
+        --card-border-color: #{$card-border-color};
+        --card-inner-border-radius: #{$card-inner-border-radius};
+
+        flex-direction: column;
+
+        // Link wrapping the course cover
+        > .o_wslides_course_card {
+            --card-border-radius: #{$card-border-radius} #{$card-border-radius} 0 0;
+
+            height: auto !important;
+            border-bottom: 0;
+        }
+
+        // Links in the description field
+        .card-text .o_wslides_course_card {
+            display: inline;
+            border: 0;
+        }
+
+        .card-body {
+            border-width: 0 var(--card-border-width) 0 var(--card-border-width) !important;
+
+            // Link wrapping the course title + unpublished badge
+            & > .o_wslides_course_card {
+                display: inline;
+                border: 0;
+                height: auto !important;
+            }
+
+            // Restore card-body/card-footer properties as they're not in a .card anymore
+            &, & + .card-footer {
+                border: var(--card-border-width) solid var(--card-border-color);
+            }
+
+            // Hide empty links rendered above/inside the description field
+            // except those wrapped in a <p> tag
+            .card-text {
+                > .o_wslides_course_card, .o_wslides_course_card:empty {
+                    display: none;
+                }
+            }
+        }
+    }
 }
 
 // Courses Card
 // **************************************************
-.o_wslides_course_card.o_wslides_course_unpublished {
+// Move the opacity to the container to ensure opacity is applied even if the card
+// is not wrapped in a <a> tag
+
+div:has(> .card + .card-body, > .o_wslides_course_unpublished > .card-body) {
     opacity: 0.5;
 }
 


### PR DESCRIPTION
This PR fixes an issue introduced by Commit[^1]. In Commit[^1], we decided to review the course card layout by removing the individual links that were wrapping the title, the cover image, and the description.

| 19.0 and above | This PR |
|--------|--------|
| <img width="333" height="392" alt="image" src="https://github.com/user-attachments/assets/3dce73b3-0ce9-486e-b1de-f88a74e52e05" /> | <img width="313" height="381" alt="image" src="https://github.com/user-attachments/assets/25d75970-7f55-4967-87ba-3ecf5710835d" /> |

#### Steps to reproduce:
1. Go to `website_slides`
2. Create a new course
3. Go to the description tab
4. Insert a link in the description and save
5. Go to the frontend to see the courses list
6. Course cards with a description containing a link are visually broken.

While this looked like an improvement because it simplified the DOM, it was done with the assumption that the course card could not contain another link. This is, of course, not the case, as the description field
is editable by the user and can therefore contain a link. Because this is not valid HTML, the layout removes all nested links and renders them separately. Since all the classes related to the card design
are applied to that `<a>` tag, all links are rendered with a border and other styling.

This PR fixes the issue by reassigning all the card styles to the card container. We then reassign each property to the corresponding element, adapt the styles to mimic the original card design, and hide extra links
that are rendered empty. This should at least fix the layout for users.

[^1]: https://github.com/odoo/odoo/commit/f632b8a9e74a050288e3ec75a4f49ae3ecb551d6

task-5957910

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
