### PR TITLE
[FIX][v18] crm: Changing customer on Lead keeps old values when new customer values

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -430,7 +430,7 @@ class Lead(models.Model):
     @api.depends('partner_id.email')
     def _compute_email_from(self):
         for lead in self:
-            if lead.partner_id.email and lead._get_partner_email_update():
+            if lead._get_partner_email_update():
                 lead.email_from = lead.partner_id.email
 
     def _inverse_email_from(self):
@@ -449,7 +449,7 @@ class Lead(models.Model):
     @api.depends('partner_id.phone')
     def _compute_phone(self):
         for lead in self:
-            if lead.partner_id.phone and lead._get_partner_phone_update():
+            if lead._get_partner_phone_update():
                 lead.phone = lead.partner_id.phone
 
     def _inverse_phone(self):
@@ -659,11 +659,10 @@ class Lead(models.Model):
 
     def _prepare_address_values_from_partner(self, partner):
         # Sync all address fields from partner, or none, to avoid mixing them.
-        if any(partner[f] for f in PARTNER_ADDRESS_FIELDS_TO_SYNC):
-            values = {f: partner[f] for f in PARTNER_ADDRESS_FIELDS_TO_SYNC}
-        else:
-            values = {f: self[f] for f in PARTNER_ADDRESS_FIELDS_TO_SYNC}
-        return values
+        return {
+            f: partner[f] or False
+            for f in PARTNER_ADDRESS_FIELDS_TO_SYNC
+        }
 
     def _prepare_contact_name_from_partner(self, partner):
         contact_name = False if partner.is_company else partner.name


### PR DESCRIPTION
When changing the customer (partner_id) on a CRM lead, contact and address fields (phone, email, street, city, etc.) may retain values from the previously selected partner if the newly selected partner has empty fields.

This leads to stale and incorrect information being displayed and potentially propagated to the new partner.

Current behavior before PR:

Create a lead and select Partner A (with phone/email/address).
Lead fields are populated correctly.
Change the customer to Partner B with empty contact/address fields.
Lead keeps old values from Partner A instead of clearing them.
Saving the lead may propagate these outdated values to Partner B.

Result: outdated data leaks between partners.

Desired behavior after PR is merged:

When changing the customer, lead fields must always reflect the selected partner.
If the new partner has empty values, corresponding lead fields should be cleared.
No previous partner data should remain or be propagated.
This ensures the partner is always the single source of truth and prevents stale data.


Task : https://github.com/odoo/odoo/issues/245215

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
