### PR TITLE
[FIX] purchase: prevent price computation for downpayment lines

### DIFF
--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -158,7 +158,7 @@ class PurchaseOrderLine(models.Model):
     @api.depends('product_uom_id', 'price_unit')
     def _compute_price_unit_product_uom(self):
         for line in self:
-            line.price_unit_product_uom = not line.display_type and line.product_uom_id._compute_price(line.price_unit, line.product_id.uom_id)
+            line.price_unit_product_uom = not line.display_type and not line.is_downpayment and line.product_uom_id._compute_price(line.price_unit, line.product_id.uom_id)
 
     @api.depends('invoice_lines.move_id.state', 'invoice_lines.quantity', 'qty_received', 'product_uom_qty', 'order_id.state')
     def _compute_qty_invoiced(self):


### PR DESCRIPTION
## Issue:
When viewing purchase order lines, the system attempts to compute the unit
price for downpayment lines. This results in unintended behavior.

## Cause:
PR https://github.com/odoo/odoo/pull/236669 introduced the `price_unit_product_uom` field 
along with its compute method `_compute_price_unit_product_uom` to manage PO comparison.
Although the compute method correctly skips section and note lines, it does
not exclude downpayment lines. Downpayment lines are identified by the
`is_downpayment` field, which was introduced earlier in PR https://github.com/odoo/odoo/pull/176137.
As a result, the computation is incorrectly applied to downpayment lines.

## With this commit:
The UoM price computation is prevented for purchase order lines where
is_downpayment is set to True. Downpayment lines are now treated
similarly to section and note lines to prevent unintended price recalculations.

Steps to reproduce : [Video](https://drive.google.com/file/d/1JrMN8x-i86QjRfMnaeYu-Jac03iFoJs3/view?usp=drive_link)

OPW - 5930652