### PR TITLE
[FIX] sale: fix product creation from Services and Materials view

### DIFF
--- a/addons/sale/views/account_analytic_line_views.xml
+++ b/addons/sale/views/account_analytic_line_views.xml
@@ -40,6 +40,7 @@
                 <field
                     name="product_id"
                     domain="[('expense_policy', '!=', 'no')]"
+                    context="{'default_expense_policy' : 'sales_price'}"
                     required="True"
                     width="350px"
                 />


### PR DESCRIPTION
This commit fixes an issue where products created from the `Services and Materials` view were assigned the default `no` expense policy. They should instead default to `sales_price`

task-5490517

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
