### PR TITLE
[FIX] web: handle typeerror during domain validation

### DIFF
--- a/addons/web/controllers/domain.py
+++ b/addons/web/controllers/domain.py
@@ -20,5 +20,5 @@ class DomainController(Controller):
         try:
             Domain(domain).validate(Model.sudo())
             return True
-        except ValueError:  # noqa: BLE001
+        except (ValueError, TypeError):  # noqa: BLE001
             return False

--- a/addons/web/tests/test_domain.py
+++ b/addons/web/tests/test_domain.py
@@ -42,3 +42,10 @@ class DomainTest(HttpCaseWithUserDemo):
             data=json.dumps({'params': {'model':'res.users', 'domain':[('hop')]}}),
         )
         self.assertEqual(resp.json()['result'], False)
+
+        resp = self.url_open(
+            '/web/domain/validate',
+            headers={'Content-Type': 'application/json'},
+            data=json.dumps({'params': {'model': 'res.users', 'domain': [('', '=', 1)]}}),
+        )
+        self.assertEqual(resp.json()['result'], False)


### PR DESCRIPTION
Currently, an error occurs when user tries to validate a domain with no field name.

Steps to install:
- Install `sale_management` > Open sale order list view > Turn on debug mode.
- Click on search bar > Custom filter > Click on field and remove its field name written below the list of fields.
- Click validate.

Error:
```
TypeError: Empty field name in condition ('', '=', 1)
```

Cause:
- As the field name was emptied by the user the [line] will raise a TypeError during the domain validation.
- Till `19.0` any error during domain validation was handled  through [here] which was later changed to handle only ValueErrors through this [commit].

Solution:
- Handled TypeErrors during domain validation.

[line]: https://github.com/odoo/odoo/blob/260b9c0417ed2278429fcdd7f50d61786d4e9beb/odoo/orm/domains.py#L841

[here]: https://github.com/odoo/odoo/blob/a220fb71c036c93fa1e75d4d37127e5eda0118f9/addons/web/controllers/domain.py#L34

[commit]: https://github.com/odoo/odoo/commit/a1434c32e9f4dd226d512677fd96e3051b908d8b#diff-e5da86414a8020b2843fb359453238e4977027d30f73f1fa792ca63ddd8fa2a7L34-R23

sentry-7278978488
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
