### PR TITLE
[FIX] mrp: ensure components pick transfer linked to all relevant MOs

### DIFF
--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -134,7 +134,8 @@ class StockPicking(models.Model):
 
     production_ids = fields.One2many(
         'mrp.production',
-        related='move_ids.production_group_id.production_ids',
+        compute='_compute_production_ids',
+        string="Manufacturing Orders",
         groups='mrp.group_mrp_user')
     production_group_id = fields.Many2one(
         'mrp.production.group',
@@ -146,6 +147,11 @@ class StockPicking(models.Model):
     def _compute_has_kits(self):
         for picking in self:
             picking.has_kits = any(picking.move_ids.mapped('bom_line_id'))
+
+    @api.depends('reference_ids.production_ids')
+    def _compute_production_ids(self):
+        for picking in self:
+            picking.production_ids = picking.move_ids.production_group_id.production_ids
 
     @api.depends('production_ids')
     def _compute_mrp_production_ids(self):

--- a/addons/sale_mrp/tests/test_multistep_manufacturing.py
+++ b/addons/sale_mrp/tests/test_multistep_manufacturing.py
@@ -3,6 +3,7 @@
 
 from odoo.tests import Form
 from odoo.addons.mrp.tests.common import TestMrpCommon
+from odoo import Command
 
 
 class TestMultistepManufacturing(TestMrpCommon):
@@ -206,3 +207,74 @@ class TestMultistepManufacturing(TestMrpCommon):
         self.assertFalse(self.sale_order.picking_ids.move_ids.move_orig_ids)
         self.sale_order.picking_ids.action_assign()
         self.assertEqual(self.sale_order.picking_ids.move_ids.quantity, 1.0)
+
+    def test_rr_triggered_mos_shared_pick(self):
+        """Test that a single PBM picking is created for multiple MOs triggered by reordering rules
+        from the same SO and that its properly linked to these MOs.
+        """
+        self.warehouse.manufacture_steps = "pbm"
+        self.warehouse.mto_pull_id.route_id.rule_ids.procure_method = "make_to_stock"
+
+        product_1, product_2, raw_1, raw_2 = self.env["product.product"].create([
+            {"name": "product 1", "uom_id": self.uom_unit.id, "is_storable": True},
+            {"name": "product 2", "uom_id": self.uom_unit.id, "is_storable": True},
+            {"name": "raw 1", "uom_id": self.uom_unit.id, "is_storable": True},
+            {"name": "raw 2", "uom_id": self.uom_unit.id, "is_storable": True},
+        ])
+        bom_1, bom_2 = self.env["mrp.bom"].create([{
+                "product_tmpl_id": product_1.product_tmpl_id.id,
+                "product_qty": 1.0,
+                "type": "normal",
+                "bom_line_ids": [
+                    Command.create({"product_id": raw_1.id, "product_qty": 2}),
+                ],
+            }, {
+                "product_tmpl_id": product_2.product_tmpl_id.id,
+                "product_qty": 1.0,
+                "type": "normal",
+                "bom_line_ids": [
+                    Command.create({"product_id": raw_2.id, "product_qty": 2}),
+                ],
+        }])
+        self.env["stock.warehouse.orderpoint"].create([{
+                "name": "Orderpoint for P1",
+                "product_id": product_1.id,
+                "product_min_qty": 0,
+                "product_max_qty": 0,
+                "route_id": self.warehouse.manufacture_pull_id.route_id.id,
+                "bom_id": bom_1.id,
+                "warehouse_id": self.warehouse.id,
+            }, {
+                "name": "Orderpoint for P2",
+                "product_id": product_2.id,
+                "product_min_qty": 0,
+                "product_max_qty": 0,
+                "route_id": self.warehouse.manufacture_pull_id.route_id.id,
+                "bom_id": bom_2.id,
+                "warehouse_id": self.warehouse.id,
+        }])
+
+        partner = self.env["res.partner"].create({"name": "My Picking Production Test Partner"})
+        so = self.env["sale.order"].create({
+            "partner_id": partner.id,
+            "picking_policy": "direct",
+            "warehouse_id": self.warehouse.id,
+            "order_line": [
+                Command.create({
+                    "name": product_1.name,
+                    "product_id": product_1.id,
+                    "product_uom_qty": 1.0,
+                    "price_unit": 10.0,
+                }),
+                Command.create({
+                    "name": product_2.name,
+                    "product_id": product_2.id,
+                    "product_uom_qty": 1.0,
+                    "price_unit": 10.0,
+                }),
+            ],
+        })
+        so.action_confirm()
+        self.assertEqual(so.mrp_production_count, 2, "There should be 2 manufactured orders linked to this sale order.")
+        self.assertEqual(len(so.mrp_production_ids.picking_ids), 1, "There should only be 1 pick components transfer for the 2 manufacturing orders.")
+        self.assertEqual(len(so.mrp_production_ids.picking_ids.production_ids), 2, "There should be 2 manufacture orders linked to the pick components transfer.")


### PR DESCRIPTION
Current behavior
---
When confirming 1 SO with 2 products with 1 BoM and 1 Rerouting Rule with 0 min/max, with warehouse rule pbm (2 steps: Pick then manufacture), it creates a picking transfer with only 1 MO attached.

Expected behavior
---
The picking transfer should have 2 MO's.

Steps to reproduce
---
1. Create 2 Products with different BoM's, keep per-product routes empty. 
2. Set reordering rules for both to route: Manufacture.
3. Go to warehouses config and set manufacture rule to 2 step (pick -> manufacture)
4. Confirm a SO with those 2 products.

Cause of the issue
---
If we don't have any Make-to-Order routes for a product, the Make-to-Stock default rule of the warehouse would be used. 
In such case, all MO's related to such OP (orderpoint/warehouse) would be linked into one picking. The stock.picking model uses related fields to compute product_ids, which calculates relation using next(...) in the ORM. This takes only the first MO's stock move and ignores the second, hence ignoring other production groups.

Fix
---
Instead of using related fields, use compute to access every relavent production ids.

---
opw-5442012
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
