### PR TITLE
[FIX] stock: auto-fill destination package  when selecting quant manually

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -52,7 +52,7 @@ class StockMoveLine(models.Model):
     result_package_id = fields.Many2one(
         'stock.package', 'Destination Package',
         ondelete='restrict', required=False, check_company=True,
-        domain="['|', '|', ('location_id', '=', location_dest_id), ('id', '=', package_id), '&', ('location_id', '=', False), '|', ('move_line_ids', '=', False), ('move_line_ids.location_dest_id', '=', location_dest_id)]",
+        domain="['|', '|', '|', ('location_id', '=', location_dest_id), ('id', '=', package_id), ('id', '=', quant_package_id), '&', ('location_id', '=', False), '|', ('move_line_ids', '=', False), ('move_line_ids.location_dest_id', '=', location_dest_id)]",
         help="If set, the operations are packed into this package")
     result_package_dest_name = fields.Char('Destination Package Name', related='result_package_id.dest_complete_name')
     package_history_id = fields.Many2one('stock.package.history', string="Package History", index='btree_not_null')
@@ -93,9 +93,15 @@ class StockMoveLine(models.Model):
     quant_id = fields.Many2one('stock.quant', "Pick From", store=False)  # Dummy field for the detailed operation view
     picking_location_id = fields.Many2one(related='picking_id.location_id')
     picking_location_dest_id = fields.Many2one(related='picking_id.location_dest_id')
+    quant_package_id = fields.Many2one('stock.package', compute='_compute_quant_package_id')  # Dummy field for the detailed operation view
 
     _free_reservation_index = models.Index("""(id, company_id, product_id, lot_id, location_id, owner_id, package_id)
         WHERE (state IS NULL OR state NOT IN ('cancel', 'done')) AND quantity_product_uom > 0 AND picked IS NOT TRUE""")
+
+    @api.depends('quant_id')
+    def _compute_quant_package_id(self):
+        for record in self:
+            record.quant_package_id = record.quant_id.package_id if record.quant_id else False
 
     @api.depends('product_id', 'product_id.uom_id', 'product_id.uom_ids', 'product_id.seller_ids', 'product_id.seller_ids.product_uom_id')
     def _compute_allowed_uom_ids(self):

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -420,6 +420,9 @@ class StockMoveLine(models.Model):
         move_done = mls.filtered(lambda m: m.state == "done").move_id
         if move_done:
             move_done._check_quantity()
+        mls_to_check = mls.filtered(lambda m: m.package_id and not m.result_package_id and m.picking_id and m.state not in ('done', 'cancel') and not m.picked)
+        for picking in mls_to_check.mapped('picking_id'):
+            picking._check_entire_pack()
         return mls
 
     def write(self, vals):

--- a/addons/stock/tests/test_move_lines.py
+++ b/addons/stock/tests/test_move_lines.py
@@ -185,3 +185,46 @@ class StockMoveLine(TestStockCommon):
             (move_line1 | move_line2).lot_id = self.lot
         with self.assertRaises(UserError):
             (move_line1 | move_line2).quant_id = quant_productA
+
+    def test_manually_readded_move_line_sets_result_package(self):
+        """Test When a move reserves multiple packaged quants, unlinking one move line
+        and re-adding it via quant should be auto-filled result_package_id."""
+        self.shelf1.quant_ids.unlink()
+        package_1, package_2 = self.env['stock.quant.package'].create([
+            {'name': 'Pack A'},
+            {'name': 'Pack B'},
+        ])
+        quants = self.env['stock.quant'].create([
+            {
+                'product_id': self.product.id,
+                'location_id': self.shelf1.id,
+                'quantity': 1,
+                'lot_id': self.lot.id,
+                'owner_id': self.partner.id,
+                'package_id': package.id,
+            }
+            for package in (package_1, package_2)
+        ])
+        move = self.env['stock.move'].create({
+            'name': 'Test Move',
+            'product_id': self.product.id,
+            'product_uom_qty': 2,
+            'location_id': self.shelf1.id,
+            'location_dest_id': self.stock_location,
+            'picking_type_id': self.picking_type_internal,
+        })
+        move._action_confirm()
+        move._action_assign()
+        self.assertRecordValues(move.move_line_ids, [
+            {'package_id': package_1.id, 'result_package_id': package_1.id},
+            {'package_id': package_2.id, 'result_package_id': package_2.id},
+        ])
+        move.move_line_ids[1].unlink()
+        move_form = Form(move, view='stock.view_stock_move_operations')
+        with move_form.move_line_ids.new() as ml:
+            ml.quant_id = quants[1]
+        move = move_form.save()
+        self.assertRecordValues(move.move_line_ids, [
+            {'package_id': package_2.id, 'result_package_id': package_2.id},
+            {'package_id': package_1.id, 'result_package_id': package_1.id},
+        ])


### PR DESCRIPTION
**Steps to reproduce:**
* Install the *Inventory* (`stock`) module.
* Go to *Inventory → Configuration → Settings* and enable *Packages*.
* Create a storable product with on-hand stock stored in packages:
  * e.g. PACK-1 (qty: 1)
  * e.g. PACK-2 (qty: 1)
* Go to *Inventory → Delivery Orders → Create*.
* Add the created product with a demand of *2* and click *Mark as To Do*.
* Open the generated stock move lines.
* Remove the move line corresponding to *PACK-2* and save.
* Add the same line again manually by selecting the quant  save.
* Check the *Destination Package* column.

**Observed behavior:**
* The *Destination Package* (`result_package_id`) remains empty 
after manually re-adding the quant.

**Cause:**
* During the initial reservation, `_action_confirm` triggers `action_assing` and it trigger

https://github.com/odoo/odoo/blob/80375b295098cedc1c7af8c08addf96114fd7a33/addons/stock/models/stock_move.py#L1811

  `_check_entire_pack`, which correctly sets `result_package_id`:
So when Click *Mark as To Do* is properly set Value. 
 https://github.com/odoo/odoo/blob/80375b295098cedc1c7af8c08addf96114fd7a33/addons/stock/models/stock_picking.py#L1043-L1044

* When selected manually on a move line, the quant_id is set on the
move line, which triggers create().

* In create(), the presence of `quant_id` in `vals` trigger  `_copy_quant_info(vals)`
https://github.com/odoo/odoo/blob/80375b295098cedc1c7af8c08addf96114fd7a33/addons/stock/models/stock_move_line.py#L350-L351
This method copies product_id, lot_id, package_id (source
package), and other related fields from the quant.

* However, `result_package_id` (destination package) is not included in the
returned values. As a result, only the source package is copied from the
quant, while the destination package is lost.

---

opw-5895370

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
