### PR TITLE
[FIX] account: prevent invoice content overlapping header on second page

### DIFF
--- a/addons/account/static/src/css/report_invoice.css
+++ b/addons/account/static/src/css/report_invoice.css
@@ -6,6 +6,10 @@
     page-break-inside: avoid;
 }
 
+.invoice_main .table-responsive-sm {
+    overflow: visible;
+}
+
 .justify-text {
     text-align:justify;
     text-justify:inter-word;


### PR DESCRIPTION
**Steps to reproduce:**
* Install `Accounting` module.
* Create an invoice with enough lines to span multiple pages.
* Print the invoice to PDF (or use the 'Print' action).

**Observed behavior:**
* On the second page (and subsequent pages), the invoice table rows overlap with the company header (logo, address).
* This regression was introduced in saas-19.1 after the flexible document layout refactoring (commit).

**Cause:**
* The invoice's main table (`o_main_table`) is wrapped in a `<div class='table-responsive-sm'>`.
* `table-responsive-sm` applies `overflow-x: auto` at narrow viewports, which creates a Block Formatting Context (BFC).
* In wkhtmltopdf's WebKit engine, a BFC container does not participate in normal page fragmentation. When the table spans multiple pages, the content bleeds into the next page without respecting the header spacing defined by `--margin-top` and `--header-spacing`.
* This causes the continued table rows (and any repeated `<thead>`) to render at the very top of the content area, overlapping with the page header.

**ref:**
https://github.com/odoo/odoo/commit/15697add5751181544fb61302ddb745a354a2935#diff-c85e75bc27fc841662ca0598c09a22670e0a0b4e5120815934c0a50999ff02bfR172
with this commit `table-responsive-sm` added to invoice pdf layout.

**Fix:**
* Add `overflow: visible` on the `table-responsive-sm` wrapper div to prevent the creation of a scroll container / BFC.
* This ensures wkhtmltopdf can properly fragment the table across pages and respect the header spacing on all pages.

**Before:**
<img width="874" height="250" alt="image" src="https://github.com/user-attachments/assets/2da0a82a-abc9-49d6-9788-c8e89283e4b2" />

**After:**
<img width="872" height="256" alt="image" src="https://github.com/user-attachments/assets/cd38b7e3-b2b6-4c03-a1d8-5ac31cad0925" />


opw-5949713