### PR TITLE
[FIX] resource_mail: ResourceTag: do not crash in sample data

### DIFF
--- a/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.js
+++ b/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.js
@@ -51,7 +51,7 @@ class ResourceTag extends Component {
         onDelete: { type: Function, optional: true },
         text: { type: String, optional: true },
         tooltip: { type: String, optional: true },
-        type: { type: String },
+        type: { type: [String, { value: false }] }, // in sample data, the type is false
     };
 }
 


### PR DESCRIPTION
Go to the Planning calendar view and toggle filters such that there is no data displayed. Save the current filters as favorite. Then, reload and switch to the list view.

Before this commit, in **debug mode**, the props validation of the ResourceTag component crashed, because it received `false` as value for the `type` props, which expected a `string`.

The problem comes from the SampleServer, which only knows about the fields of the main model, but not those of co-models reachable from relational fields. In this case, there's a `resource_ids` many2many field on the main model whose relation is `resource.resource`, and there's a `type` selection field on that model. That field is required, so the code only expected `string` values, not `false`. But as the SampleModel doesn't know about that `type` field, it generates `false` as value.

Ideally, the SampleModel should know about the whole field specs (main model + relations). However, even though that would be quite easily doable for kanban and list views (unity specs), it wouldn't be the case for the other views (the SampleServer is shared between all views using sample data). So it would require non trivial architectural changes to make this work.

For that reasons, we went for the easy fix, which is to adapt the props definition to support `false`, as the value was actually already correctly handled by the Component itself.

runbot error~239951

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
