### PR TITLE
[FIX] account: align to-check payment query with _where_calc behavior

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -754,7 +754,7 @@ class AccountJournal(models.Model):
             ('journal_id', 'in', self.ids),
             ('checked', '=', False),
             ('state', '=', 'posted'),
-        ])
+        ], bypass_access=True)
         selects = [
             SQL("journal_id"),
             SQL("company_id"),


### PR DESCRIPTION
In v19 `_where_calc` was merged[^1] into `_search`, where `bypass_access=True` replicates the previous behavior.

The dashboard query for payments to check was executed with the default `bypass_access=False`, causing record rules to be applied. This introduced extra joins (e.g. on `res_company`) and resulted in ambiguous column errors during aggregation.

```py
File "/home/odoo/src/odoo/19.0/addons/account/models/account_journal_dashboard.py", line 414, in _get_journal_dashboard_data_batched
    self._fill_sale_purchase_dashboard_data(dashboard_data)
   File "/home/odoo/src/odoo/19.0/addons/account/models/account_journal_dashboard.py", line 600, in _fill_sale_purchase_dashboard_data
    self.env.cr.execute(sql)
   File "/home/odoo/src/odoo/19.0/odoo/tests/test_cursor.py", line 79, in execute
    return self._cursor.execute(*args, **kwargs)
   File "/home/odoo/src/odoo/19.0/odoo/sql_db.py", line 433, in execute
    self._obj.execute(query, params)
 psycopg2.errors.AmbiguousColumn: column reference "currency_id" is ambiguous
LINE 1: SELECT journal_id, company_id, currency_id AS currency, invo...
                                       ^
```

Set `bypass_access=True` to match the original `_where_calc` behavior and avoid unnecessary joins.

opw-5951694
upg-3902613

[^1]: https://github.com/odoo/odoo/commit/6f95152b00df75f503f445e3b77b891b5f83c055





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
