### PR TITLE
[IMP] hr: clarify version edit log

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -1751,7 +1751,16 @@ class HrEmployee(models.Model):
             self.version_id.write(version_vals)
 
             for employee in self:
-                employee._track_set_log_message(Markup("<b>%s</b>") % self.env._("Modified on the Employee Record '%s'") % employee.version_id.display_name)
+                version_sudo = employee.version_id.sudo()
+                start = format_date_abbr(self.env, version_sudo.date_start) if version_sudo.date_start else False
+                end = format_date_abbr(self.env, version_sudo.date_end) if version_sudo.date_end else False
+                if start and end:
+                    msg = self.env._("Modified from %(start)s to %(end)s") % {'start': start, 'end': end}
+                elif start:
+                    msg = self.env._("Modified from %s") % (start)
+                else:
+                    msg = self.env._("Modified")
+                employee._track_set_log_message(Markup("<b>%s</b>") % msg)
         if res and ('resource_calendar_id' in vals or 'hours_per_week' in vals or 'hours_per_day' in vals):
             resources = self.env['resource.resource']
             for employee in self:


### PR DESCRIPTION
Make the employee-version edit log clearly indicate the exact period impacted by the change. If the version has no end date, the log shows only "Modified from <start>" (no "to <date>").

task-5946423

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
