### PR TITLE
[IMP] point_of_sale: make name and value mandatory for coins/bills

### DIFF
--- a/addons/point_of_sale/models/pos_bill.py
+++ b/addons/point_of_sale/models/pos_bill.py
@@ -1,5 +1,5 @@
 from odoo import api, fields, models, _
-from odoo.exceptions import UserError
+from odoo.exceptions import ValidationError
 
 
 class PosBill(models.Model):
@@ -8,18 +8,15 @@ class PosBill(models.Model):
     _description = "Coin/Bill"
     _inherit = ["pos.load.mixin"]
 
-    name = fields.Char("Name")
+    name = fields.Char("Name", required=True)
     value = fields.Float("Value", required=True, digits=(16, 4))
     pos_config_ids = fields.Many2many("pos.config", string="Point of Sales")
 
-    @api.model
-    def name_create(self, name):
-        try:
-            value = float(name)
-        except ValueError:
-            raise UserError(_("The name of the Coins/Bills must be a number."))
-        result = super().create({"name": name, "value": value})
-        return result.id, result.display_name
+    @api.constrains('value')
+    def _check_value_not_zero(self):
+        for bill in self:
+            if bill.value <= 0:
+                raise ValidationError(_("The value of a coin/bill must be greater than 0."))
 
     @api.model
     def _load_pos_data_domain(self, data, config):

--- a/addons/point_of_sale/views/pos_bill_view.xml
+++ b/addons/point_of_sale/views/pos_bill_view.xml
@@ -7,7 +7,7 @@
             <form string="Bills">
                 <sheet>
                     <group>
-                        <field name="name" />
+                        <field name="name" required="1"/>
                         <field name="value" />
                         <field name="pos_config_ids" widget="many2many_tags" />
                     </group>
@@ -21,7 +21,7 @@
         <field name="model">pos.bill</field>
         <field name="arch" type="xml">
             <list string="Bills" create="1" delete="1" editable="bottom" sample="1">
-                <field name="name" />
+                <field name="name" required="1"/>
                 <field name="value" />
                 <field name="pos_config_ids" widget="many2many_tags_placeholder_list_view" placeholder="For all point of sale."/>
             </list>


### PR DESCRIPTION
The name field is now required on the pos.bill model. A new constraint ensures that the value must be strictly greater than zero, raising a ValidationError otherwise.

task-id: 5901790

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
