### PR TITLE
[FIX] html_editor, mass_mailing: properly name normalize resources

### DIFF
--- a/addons/html_editor/static/src/others/embedded_component_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_component_plugin.js
@@ -25,7 +25,6 @@ export class EmbeddedComponentPlugin extends Plugin {
     /** @type {import("plugins").EditorResources} */
     resources = {
         /** Handlers */
-        on_normalize_handlers: withSequence(0, this.normalize.bind(this)),
         on_attribute_changed_handlers: this.onChangeAttribute.bind(this),
         on_savepoint_restored_handlers: () => this.handleComponents(this.editable),
         on_history_reset_handlers: () => this.handleComponents(this.editable),

--- a/addons/mass_mailing/static/src/builder/plugins/empty_not_editable_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/empty_not_editable_plugin.js
@@ -7,7 +7,7 @@ export class EmptyNotEditableElementsPlugin extends Plugin {
     static id = "mass_mailing.EmptyNotEditableElements";
     static dependencies = ["selection"];
     resources = {
-        normalize_handlers: this.normalize.bind(this),
+        normalize_processors: this.normalize.bind(this),
     };
 
     /**


### PR DESCRIPTION
Commit [1] renamed `normalize_handlers` to `normalize_processors`. This fixes some forgotten references.

[1]: https://github.com/odoo/odoo/commit/8bc34275651bd63223d65b8d98e118b3725db8fd

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
