### PR TITLE
[FIX] mrp: prevent traceback when scrapping from shopfloor

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -987,6 +987,10 @@ class MrpWorkorder(models.Model):
             'date_finished': False,
         })
 
+    def action_scrap(self):
+        self.ensure_one()
+        return self.production_id.action_scrap()
+
     def _compute_expected_operation_cost(self, without_employee_cost=False):
         return (self.duration_expected / 60.0) * (self.costs_hour or self.workcenter_id.costs_hour)
 

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -340,7 +340,7 @@
                                     <field name="quantity" string="Quantity" readonly="state in ('done', 'cancel')"/>
                                     <field name="uom_id" widget="many2one_uom" options="{'no_open': True, 'no_create': True}" groups="uom.group_uom" readonly="state in ('done', 'cancel')"/>
                                 </div>
-                                <field name="lot_ids" widget="many2many_tags" string="Lot/Serial Numbers" invisible="not product_id or has_tracking == 'none'" readonly="state in ('done', 'cancel')" domain="[('product_id', '=', product_id), ('id', 'in', context.get('lot_ids'))] if context.get('lot_ids') else [('product_id', '=', product_id)]"/>
+                                <field name="lot_ids" widget="many2many_tags" string="Lot/Serial Numbers" invisible="not product_id or has_tracking not in ['lot', 'serial']" readonly="state in ('done', 'cancel')" domain="[('product_id', '=', product_id), ('id', 'in', context.get('lot_ids'))] if context.get('lot_ids') else [('product_id', '=', product_id)]"/>
                                 <field name="scrap_reason_tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" readonly="state == 'cancel'"/>
                             </group>
                             <group>


### PR DESCRIPTION
Issue before this commit:
=========================
Creating a scrap order from a specific workorder in the shopfloor
view raises a traceback: `The method 'mrp.workorder.action_scrap' does not exist.`

Additionally, in the scrap form view, the `Lot/Serial Numbers field is displayed for 
non-tracked(e.g. consumables such as screw) products`, incorrectly prompting the 
user to add a lot/serial number.

Steps to Reproduce:
=========================
- Install the mrp module.
- Create a Manufacturing Order for a product with at least 
   one operation (e.g. Desk Combination).
- Open the shopfloor view.
- Enter a specific workcenter (e.g. Assembly 1).
- Open the three-dot menu and create a scrap order.
- Confirm the scrap order.
- A traceback is raised.

Cause of the issue:
=========================
The method action_scrap was removed from mrp.workorder 
in [this PR](https://github.com/odoo/odoo/pull/210299), However,  from the JavaScript side, 
the scrap option still triggers a call on the mrp.workorder model 
when the user clicks Scrap in the shopfloor view.

With This Commit:
=========================
Reintroduce the action_scrap method on mrp.workorder so 
users can correctly create scrap orders from a specific workcenter in the 
shopfloor view without triggering a traceback.

Fix the visibility condition of lot_ids so the Lot/Serial Numbers field is hidden
for non-tracked (consumable) products and is shown only for trackable products (lot/serial).

Enterprise PR: https://github.com/odoo/enterprise/pull/108259

Task: 5958933