### PR TITLE
[FIX] tools: fix traceback related to `clone_reader_root_document`

### DIFF
--- a/addons/account_edi/models/ir_actions_report.py
+++ b/addons/account_edi/models/ir_actions_report.py
@@ -31,7 +31,7 @@ class IrActionsReport(models.Model):
 
                     # Post-process and embed the additional files.
                     writer = OdooPdfFileWriter()
-                    writer.clone_reader_root_document(reader)
+                    writer.clone_reader_document_root(reader)
                     for edi_document in to_embed:
                         # The attachements on the edi documents are only system readable
                         # because they don't have res_id and res_model, here we are sure that

--- a/addons/sale/models/ir_actions_report.py
+++ b/addons/sale/models/ir_actions_report.py
@@ -28,7 +28,7 @@ class IrActionsReport(models.Model):
             reader_buffer = io.BytesIO(pdf_content)
             reader = OdooPdfFileReader(reader_buffer, strict=False)
             writer = OdooPdfFileWriter()
-            writer.clone_reader_root_document(reader)
+            writer.clone_reader_document_root(reader)
 
             # Generate and attach EDI documents from each builder
             for builder in builders:

--- a/odoo/tools/pdf/__init__.py
+++ b/odoo/tools/pdf/__init__.py
@@ -408,8 +408,8 @@ class OdooPdfFileWriter(PdfFileWriter):
         assert attachment, "embed_odoo_attachment cannot be called without attachment."
         self.add_attachment(attachment.name, attachment.raw, subtype=subtype or attachment.mimetype)
 
-    def clone_reader_root_document(self, reader):
-        super().clone_reader_root_document(reader)
+    def clone_reader_document_root(self, reader):
+        super().clone_reader_document_root(reader)
         self._reader = reader
         # Try to read the header coming in, and reuse it in our new PDF
         # This is done in order to allows modifying PDF/A files after creating them (as PyPDF does not read it)


### PR DESCRIPTION
Update the method calls and definition `clone_reader_root_document` to  `clone_reader_document_root` for correct usage.

Causing PR: https://github.com/odoo/odoo/pull/248197
