### PR TITLE
[FIX] website_mass_mailing: prevent newsletter snippets from appearing in unrelated searches

### DIFF
--- a/addons/website_mass_mailing/views/snippets_templates.xml
+++ b/addons/website_mass_mailing/views/snippets_templates.xml
@@ -7,22 +7,22 @@
 <template id="snippets" inherit_id="website.snippets">
     <xpath expr="//t[@id='mass_mailing_newsletter_block_hook']" position="replace">
         <t t-snippet="website_mass_mailing.s_newsletter_block" string="Newsletter Block" t-forbid-sanitize="form" group="contact_and_forms" label="Newsletter">
-            <keywords>form, updates, digest, bulletin, announcements, notifications, communication, email, modal, alert, dialog, prompt, pop-up, subscription</keywords>
+            <keywords>form, updates, digest, bulletin, announcements, notifications, communication, email, prompt, subscription</keywords>
         </t>
     </xpath>
     <xpath expr="//t[@id='mass_mailing_newsletter_box_hook']" position="replace">
         <t t-snippet="website_mass_mailing.s_newsletter_box" string="Newsletter Box" t-forbid-sanitize="form" group="contact_and_forms" label="Newsletter">
-            <keywords>updates, digest, bulletin, announcements, notifications, communication, promotional, email, alert, dialog, prompt, subscription, subscribe, mailing-list, news, box, image, picture</keywords>
+            <keywords>updates, digest, bulletin, announcements, notifications, communication, promotional, email, prompt, subscription, subscribe, mailing-list, news, box, image, picture</keywords>
         </t>
     </xpath>
     <xpath expr="//t[@id='mass_mailing_newsletter_centered_hook']" position="replace">
         <t t-snippet="website_mass_mailing.s_newsletter_centered" string="Newsletter Centered" t-forbid-sanitize="form" group="contact_and_forms" label="Newsletter">
-            <keywords>updates, digest, bulletin, announcements, notifications, communication, promotional, email, alert, dialog, prompt, subscription, subscribe, mailing-list, news</keywords>
+            <keywords>updates, digest, bulletin, announcements, notifications, communication, promotional, email, prompt, subscription, subscribe, mailing-list, news</keywords>
         </t>
     </xpath>
     <xpath expr="//t[@id='mass_mailing_newsletter_grid_hook']" position="replace">
         <t t-snippet="website_mass_mailing.s_newsletter_grid" string="Newsletter Grid" t-forbid-sanitize="form" group="contact_and_forms">
-            <keywords>updates, digest, bulletin, announcements, notifications, communication, promotional, email, alert, dialog, prompt, subscription, subscribe, mailing-list, news, grid, image, picture</keywords>
+            <keywords>updates, digest, bulletin, announcements, notifications, communication, promotional, email, prompt, subscription, subscribe, mailing-list, news, grid, image, picture</keywords>
         </t>
     </xpath>
     <xpath expr="//t[@id='mass_mailing_newsletter_aside_hook']" position="replace">


### PR DESCRIPTION
## Behavior before this fix

- Newsletter snippets had irrelevant keyword settings causing those snippets being caught by mistake during fuzzy search and appearing in unrelated searches

## Behavior after this fix

- Keywords are removed and only relevant
newsletter snippets should appear when using keywords for searching.

## How to reproduce:
- Open the website builder
- Insert a Block
- Search for "popup" in the search bar
- The "Newsletter" block `s_newsletter_block` would
   incorrectly appear alongside the actual popup snippets

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
