### PR TITLE
[FIX] mass_mailing: hide content of folded group of options

### DIFF
--- a/addons/mass_mailing/static/src/builder/options/options_container.xml
+++ b/addons/mass_mailing/static/src/builder/options/options_container.xml
@@ -1,17 +1,9 @@
 <templates xml:space="preserve">
     <t t-name="mass_mailing.OptionsContainer" t-inherit="html_builder.OptionsContainer">
         <xpath expr="//div[@t-ref='content']" position="replace">
-            <t t-if="versionState.isUpToDate">
-                <div class="we-bg-options-container pb-3" t-ref="content">
-                    <t t-foreach="props.options" t-as="OptionClass" t-key="OptionClass.name + '-' + OptionClass.template">
-                        <BuilderContext applyTo="OptionClass.applyTo" t-if="hasAccess(OptionClass.groups)">
-                            <t t-component="OptionClass"></t>
-                        </BuilderContext>
-                    </t>
-                </div>
-            </t>
+            <t t-if="versionState.isUpToDate">$0</t>
             <t t-else="">
-                <div class="o_we_version_control d-flex flex-column p-3 pt-4 align-items-center text-center text-white">
+                <div t-if="!this.props.folded" class="o_we_version_control d-flex flex-column p-3 pt-4 align-items-center text-center text-white">
                     <div class="title">This block is outdated.</div>
                     <div>You might not be able to customize it anymore.</div>
                     <button type="button" class="btn btn-primary py-2 my-4 border-0" t-on-click="() => this.replaceElementWithNewVersion()">REPLACE BY NEW VERSION</button>


### PR DESCRIPTION
Commit 64d35ccd6fade9e0473686b8484f561b5f4215ce added folding of groups of options, but the customization to the options container made in `mass_mailing` removed the condition to hide the group if folded.

This commit fixes the replacing content to take into account the whether the groupd is currently folded.

Steps to reproduce:
- Open the mail editor for a html mail
- Click on an element with option, that has an ancestor with option
- Bug: the group of options for the ancestor appears, but has the "folded" indicator

task-5959568