### PR TITLE
[FIX] purchase_stock: prevent missing MO link to Purchase Order

### DIFF
--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -233,9 +233,6 @@ class PurchaseOrder(models.Model):
             pikings_to_cancel = self.env['stock.picking'].browse(pickings_to_cancel_ids)
             pikings_to_cancel.action_cancel()
 
-        if order_lines:
-            order_lines.write({'move_dest_ids': [(5, 0, 0)]})
-
         return super().button_cancel()
 
     def action_view_picking(self):


### PR DESCRIPTION
* Currently when a PO generated from MO, after that we cancel that PO, the MO statsbutton disappear,

* Reason: because we remove move_dest_ids out of po line so the link is missing

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
