### PR TITLE
[IMP] hr: changing display name from gender to sex in employee form view

### DIFF
--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -72,7 +72,7 @@ class HrVersion(models.Model):
         ('male', 'Male'),
         ('female', 'Female'),
         ('other', 'Other'),
-    ], groups="hr.group_hr_user", tracking=1, help="This is the legal sex as recognized by the state, used for official and statutory purposes.", string='Gender')
+    ], groups="hr.group_hr_user", tracking=1, help="This is the legal sex as recognized by the state, used for official and statutory purposes.")
 
     private_street = fields.Char(string="Private Street", groups="hr.group_hr_user", tracking=1)
     private_street2 = fields.Char(string="Private Street2", groups="hr.group_hr_user", tracking=1)

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -282,7 +282,7 @@
                                             <div class="mx-3 flex-grow-0">─</div>
                                             <field name="country_of_birth" class="oe_inline o_hr_narrow_field" nolabel="1" placeholder="Country"/>
                                         </div>
-                                        <field name="sex" string="Gender"/>
+                                        <field name="sex"/>
                                     </group>
                                     <group name="citizenship" string="Citizenship">
                                         <field name="country_id" options='{"no_open": True, "no_create": True}'/>


### PR DESCRIPTION
In warnings we will decide to go with Sex
    - it should be consistent with form view
    - that's why we also change this

task - 5917840

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
