### PR TITLE
[FIX] l10n_ro_cpv_code: Fix CIUSRO ItemClassificationCode/listID

### DIFF
--- a/addons/l10n_ro_cpv_code/models/account_edi_xml_ubl_ciusro.py
+++ b/addons/l10n_ro_cpv_code/models/account_edi_xml_ubl_ciusro.py
@@ -8,6 +8,6 @@ class AccountEdiXmlUBLRO(models.AbstractModel):
         vals = super()._get_invoice_line_item_vals(line, taxes_vals)
         vals['commodity_classification_vals'] = [{
             'item_classification_code': line.product_id.cpv_code_id.code,
-            'item_classification_attrs': {'listID': 'CPV'},
+            'item_classification_attrs': {'listID': 'STI'},
         }]
         return vals

--- a/addons/l10n_ro_cpv_code/tests/__init__.py
+++ b/addons/l10n_ro_cpv_code/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_ubl_ro_cpv_code

--- a/addons/l10n_ro_cpv_code/tests/test_files/from_odoo/ciusro_out_invoice_cpv_code.xml
+++ b/addons/l10n_ro_cpv_code/tests/test_files/from_odoo/ciusro_out_invoice_cpv_code.xml
@@ -1,0 +1,179 @@
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+	<cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:efactura.mfinante.ro:CIUS-RO:1.0.1</cbc:CustomizationID>
+	<cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+	<cbc:ID>___ignore___</cbc:ID>
+	<cbc:IssueDate>2017-01-01</cbc:IssueDate>
+	<cbc:DueDate>2017-02-28</cbc:DueDate>
+	<cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+	<cbc:Note>test narration</cbc:Note>
+	<cbc:DocumentCurrencyCode>RON</cbc:DocumentCurrencyCode>
+	<cbc:TaxCurrencyCode>RON</cbc:TaxCurrencyCode>
+	<cbc:BuyerReference>ref_partner_a</cbc:BuyerReference>
+	<cac:OrderReference>
+		<cbc:ID>___ignore___</cbc:ID>
+	</cac:OrderReference>
+	<cac:AdditionalDocumentReference>
+		<cbc:ID>___ignore___</cbc:ID>
+		<cac:Attachment>
+			<cbc:EmbeddedDocumentBinaryObject filename="___ignore___" mimeCode="___ignore___">___ignore___</cbc:EmbeddedDocumentBinaryObject>
+		</cac:Attachment>
+	</cac:AdditionalDocumentReference>
+	<cac:AccountingSupplierParty>
+		<cac:Party>
+			<cbc:EndpointID schemeID="9947">RO1234567897</cbc:EndpointID>
+			<cac:PartyName>
+				<cbc:Name>Hudson Construction</cbc:Name>
+			</cac:PartyName>
+			<cac:PostalAddress>
+				<cbc:StreetName>Strada Kunst, 3</cbc:StreetName>
+				<cbc:CityName>SECTOR1</cbc:CityName>
+				<cbc:PostalZone>010101</cbc:PostalZone>
+				<cbc:CountrySubentity>RO-B</cbc:CountrySubentity>
+				<cac:Country>
+					<cbc:IdentificationCode>RO</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:PostalAddress>
+			<cac:PartyTaxScheme>
+				<cbc:CompanyID>RO1234567897</cbc:CompanyID>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:PartyTaxScheme>
+			<cac:PartyLegalEntity>
+				<cbc:RegistrationName>Hudson Construction</cbc:RegistrationName>
+				<cbc:CompanyID>RO1234567897</cbc:CompanyID>
+			</cac:PartyLegalEntity>
+			<cac:Contact>
+				<cbc:Name>Hudson Construction</cbc:Name>
+				<cbc:Telephone>+40 123 456 789</cbc:Telephone>
+			</cac:Contact>
+		</cac:Party>
+	</cac:AccountingSupplierParty>
+	<cac:AccountingCustomerParty>
+		<cac:Party>
+			<cbc:EndpointID schemeID="9947">RO1234567897</cbc:EndpointID>
+			<cac:PartyName>
+				<cbc:Name>Roasted Romanian Roller</cbc:Name>
+			</cac:PartyName>
+			<cac:PostalAddress>
+				<cbc:StreetName>Rolling Roast, 88</cbc:StreetName>
+				<cbc:CityName>SECTOR3</cbc:CityName>
+				<cbc:PostalZone>010101</cbc:PostalZone>
+				<cbc:CountrySubentity>RO-B</cbc:CountrySubentity>
+				<cac:Country>
+					<cbc:IdentificationCode>RO</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:PostalAddress>
+			<cac:PartyTaxScheme>
+				<cbc:CompanyID>RO1234567897</cbc:CompanyID>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:PartyTaxScheme>
+			<cac:PartyLegalEntity>
+				<cbc:RegistrationName>Roasted Romanian Roller</cbc:RegistrationName>
+				<cbc:CompanyID>RO1234567897</cbc:CompanyID>
+			</cac:PartyLegalEntity>
+			<cac:Contact>
+				<cbc:Name>Roasted Romanian Roller</cbc:Name>
+				<cbc:Telephone>+40 123 456 780</cbc:Telephone>
+			</cac:Contact>
+		</cac:Party>
+	</cac:AccountingCustomerParty>
+	<cac:Delivery>
+		<cac:DeliveryLocation>
+			<cac:Address>
+				<cbc:StreetName>Rolling Roast, 88</cbc:StreetName>
+				<cbc:CityName>SECTOR3</cbc:CityName>
+				<cbc:PostalZone>010101</cbc:PostalZone>
+				<cbc:CountrySubentity>RO-B</cbc:CountrySubentity>
+				<cac:Country>
+					<cbc:IdentificationCode>RO</cbc:IdentificationCode>
+				</cac:Country>
+			</cac:Address>
+		</cac:DeliveryLocation>
+		<cac:DeliveryParty>
+			<cac:PartyName>
+				<cbc:Name>Roasted Romanian Roller</cbc:Name>
+			</cac:PartyName>
+		</cac:DeliveryParty>
+	</cac:Delivery>
+	<cac:PaymentMeans>
+		<cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+		<cbc:PaymentID>___ignore___</cbc:PaymentID>
+		<cac:PayeeFinancialAccount>
+			<cbc:ID>RO98RNCB1234567890123456</cbc:ID>
+		</cac:PayeeFinancialAccount>
+	</cac:PaymentMeans>
+	<cac:PaymentTerms>
+		<cbc:Note>Payment terms: 30% Advance End of Following Month</cbc:Note>
+	</cac:PaymentTerms>
+	<cac:TaxTotal>
+		<cbc:TaxAmount currencyID="RON">285.00</cbc:TaxAmount>
+		<cac:TaxSubtotal>
+			<cbc:TaxableAmount currencyID="RON">1500.00</cbc:TaxableAmount>
+			<cbc:TaxAmount currencyID="RON">285.00</cbc:TaxAmount>
+			<cac:TaxCategory>
+				<cbc:ID>S</cbc:ID>
+				<cbc:Percent>19.0</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:TaxCategory>
+		</cac:TaxSubtotal>
+	</cac:TaxTotal>
+	<cac:TaxTotal>
+		<cbc:TaxAmount currencyID="EUR">285.00</cbc:TaxAmount>
+	</cac:TaxTotal>
+	<cac:LegalMonetaryTotal>
+		<cbc:LineExtensionAmount currencyID="RON">1500.00</cbc:LineExtensionAmount>
+		<cbc:TaxExclusiveAmount currencyID="RON">1500.00</cbc:TaxExclusiveAmount>
+		<cbc:TaxInclusiveAmount currencyID="RON">1785.00</cbc:TaxInclusiveAmount>
+		<cbc:PrepaidAmount currencyID="RON">0.00</cbc:PrepaidAmount>
+		<cbc:PayableAmount currencyID="RON">1785.00</cbc:PayableAmount>
+	</cac:LegalMonetaryTotal>
+	<cac:InvoiceLine>
+		<cbc:ID>___ignore___</cbc:ID>
+		<cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+		<cbc:LineExtensionAmount currencyID="RON">500.00</cbc:LineExtensionAmount>
+		<cac:Item>
+			<cbc:Description>product_a</cbc:Description>
+			<cbc:Name>product_a</cbc:Name>
+			<cac:CommodityClassification>
+				<cbc:ItemClassificationCode listID="STI">03000000-1</cbc:ItemClassificationCode>
+			</cac:CommodityClassification>
+			<cac:ClassifiedTaxCategory>
+				<cbc:ID>S</cbc:ID>
+				<cbc:Percent>19.0</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:ClassifiedTaxCategory>
+		</cac:Item>
+		<cac:Price>
+			<cbc:PriceAmount currencyID="RON">500.0</cbc:PriceAmount>
+		</cac:Price>
+	</cac:InvoiceLine>
+	<cac:InvoiceLine>
+		<cbc:ID>___ignore___</cbc:ID>
+		<cbc:InvoicedQuantity unitCode="DZN">1.0</cbc:InvoicedQuantity>
+		<cbc:LineExtensionAmount currencyID="RON">1000.00</cbc:LineExtensionAmount>
+		<cac:Item>
+			<cbc:Description>product_b</cbc:Description>
+			<cbc:Name>product_b</cbc:Name>
+			<cac:CommodityClassification>
+				<cbc:ItemClassificationCode listID="STI">03100000-2</cbc:ItemClassificationCode>
+			</cac:CommodityClassification>
+			<cac:ClassifiedTaxCategory>
+				<cbc:ID>S</cbc:ID>
+				<cbc:Percent>19.0</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:ClassifiedTaxCategory>
+		</cac:Item>
+		<cac:Price>
+			<cbc:PriceAmount currencyID="RON">1000.0</cbc:PriceAmount>
+		</cac:Price>
+	</cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_ro_cpv_code/tests/test_ubl_ro_cpv_code.py
+++ b/addons/l10n_ro_cpv_code/tests/test_ubl_ro_cpv_code.py
@@ -1,0 +1,13 @@
+from odoo.addons.l10n_ro_edi.tests.test_xml_ubl_ro import TestUBLROCommon
+from odoo.tests import tagged
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestUBLROCPVCode(TestUBLROCommon):
+
+    def test_export_invoice(self):
+        self.product_a.cpv_code_id = self.env.ref('l10n_ro_cpv_code.030000001')
+        self.product_b.cpv_code_id = self.env.ref('l10n_ro_cpv_code.031000002')
+        invoice = self.create_move("out_invoice")
+        attachment = self.get_attachment(invoice)
+        self._assert_invoice_attachment(attachment, xpaths=None, expected_file_path='from_odoo/ciusro_out_invoice_cpv_code.xml')

--- a/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
+++ b/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
@@ -70,6 +70,11 @@ class TestUBLROCommon(TestUBLCommon):
             ],
         )
 
+    def get_attachment(self, move):
+        self.assertTrue(move.ubl_cii_xml_id)
+        self.assertEqual(move.ubl_cii_xml_id.name[-11:], "cius_ro.xml")
+        return move.ubl_cii_xml_id
+
 
 @tagged('post_install_l10n', 'post_install', '-at_install')
 class TestUBLRO(TestUBLROCommon):
@@ -77,11 +82,6 @@ class TestUBLRO(TestUBLROCommon):
     ####################################################
     # Test export - import
     ####################################################
-
-    def get_attachment(self, move):
-        self.assertTrue(move.ubl_cii_xml_id)
-        self.assertEqual(move.ubl_cii_xml_id.name[-11:], "cius_ro.xml")
-        return move.ubl_cii_xml_id
 
     def test_export_invoice(self):
         invoice = self.create_move("out_invoice")


### PR DESCRIPTION
The value of `ItemClassificationCode/listID` that corresponds to `CPV` classification is `STI` not `CPV`.

See https://docs.peppol.eu/poacc/billing/3.0/codelist/UNCL7143/

task-5416833