### PR TITLE
[FIX] website: Close modal with escape

### DIFF
--- a/addons/website/static/src/snippets/s_popup/000.js
+++ b/addons/website/static/src/snippets/s_popup/000.js
@@ -222,7 +222,7 @@ const PopupWidget = publicWidget.Widget.extend(ObservingCookieWidgetMixin, {
             tabableEls[0].focus();
             this.el.querySelector(".modal").scrollTop = 0;
         } else {
-            this.el.focus();
+            this.el.querySelector(".modal").focus();
         }
         // The focus should stay free for no backdrop popups.
         if (this.el.querySelector(".s_popup_no_backdrop")) {

--- a/addons/website/static/tests/tours/snippet_popup_esc.js
+++ b/addons/website/static/tests/tours/snippet_popup_esc.js
@@ -1,0 +1,49 @@
+/** @odoo-module **/
+
+import {
+    clickOnSave,
+    insertSnippet,
+    registerWebsitePreviewTour,
+} from "@website/js/tours/tour_utils";
+
+registerWebsitePreviewTour("snippet_popup_esc", {
+    url: "/",
+    edition: true,
+}, () => [
+    ...insertSnippet({
+        name: "Popup",
+        id: "s_popup",
+        groupName: "Content",
+    }),
+    {
+        content: "Remove the 'New customer' button so the popup has no focusable elements",
+        trigger: ":iframe .s_popup .btn-primary",
+        run: function() {
+            this.anchor.remove();
+        },
+    },
+    {
+        content: "Click inside the popup to access its options",
+        trigger: ":iframe .s_popup .modal-content",
+        run: "click",
+    },
+    {
+        content: "Set delay to 0 so the popup appears immediately after save",
+        trigger: '[data-attribute-name="showAfter"] input',
+        run: "edit 0",
+    },
+    ...clickOnSave(),
+    {
+        content: "Wait for the popup to be displayed after save",
+        trigger: ":iframe .s_popup .modal.show",
+    },
+    {
+        content: "Press ESC to close the popup",
+        trigger: ":iframe",
+        run: "press Escape",
+    },
+    {
+        content: "Verify the popup is closed",
+        trigger: ":iframe .s_popup .modal:not(.show)",
+    },
+]);

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -146,6 +146,9 @@ class TestSnippets(HttpCase):
     def test_snippet_popup_open_on_top(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_popup_open_on_top', login='admin')
 
+    def test_snippet_popup_esc(self):
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_popup_esc', login='admin')
+
     def test_footer_slideout_and_animation(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'footer_slideout_and_animation', login='admin')
 


### PR DESCRIPTION
Steps to reproduce:
===================
- Add a Popup snippet to a page
- Remove all links/buttons inside the popup
- Save and wait for the popup to appear
- Press ESC

-> Nothing happens.

Cause:
======
https://github.com/odoo/odoo/blob/a922c31fa7ccd1107b31287ab1f75697fae874f8/addons/website/static/src/snippets/s_popup/000.js#L219-L226 when the popup contains  no tabbable elements, `this.el.focus()` was called. `this.el` refers to the `.s_popup` div, not the `.modal` element that Bootstrap monitors for keyboard events. As a result, the ESC keydown event never reached Bootstrap's handler and the modal stayed open.

When focusable elements (links, buttons) were present, `tabableEls[0].focus()` correctly focused an element inside `.modal`, so ESC worked fine in that case.

Solution:
=========
Replace `this.el.focus()` with `this.el.querySelector(".modal").focus()` so focus lands on the `.modal` element allowing Bootstrap's built-in ESC handler to fire correctly in all cases

opw-5891054

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
