### PR TITLE
[IMP] mail, hr: be sure to prepare all tracking values

### DIFF
--- a/addons/hr/tests/test_hr_org_chart.py
+++ b/addons/hr/tests/test_hr_org_chart.py
@@ -29,6 +29,7 @@ class TestHrOrgChart(TestHrCommon, HttpCase):
         ])
 
     def test_employee_deletion(self):
+        self.cr.flush()  # detect tracking issues
         # Tests an issue with the form view where the employee could be deleted
         self.employee_georges.write({
             'parent_id': self.employee_georges.id,

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -543,7 +543,7 @@ class MailThread(models.AbstractModel):
             return
         self.env.cr.precommit.add(self._track_finalize)
         initial_values = self.env.cr.precommit.data.setdefault(f'mail.tracking.{self._name}', {})
-        for record in self:
+        for record in self.sudo():  # be sure to compute initial values whatever current user ACLs
             if not record.id:
                 continue
             values = initial_values.setdefault(record.id, {})
@@ -581,7 +581,7 @@ class MailThread(models.AbstractModel):
         ids = [id_ for id_, vals in initial_values.items() if vals]
         if not ids:
             return
-        records = self.browse(ids).sudo()
+        records = self.browse(ids).sudo()  # be sure to compute end values whatever current user ACLs
         fnames = self._track_get_fields()
         context = clean_context(self.env.context)
         tracking = records.with_context(context)._message_track(fnames, initial_values)


### PR DESCRIPTION
When prepating initial value to track value changes, do it as sudo. Indeed user access rights should not prevent from checking tracking.

Use case: hr employee update triggers an update on version records. On version model sign requests are tracked, but their access is limited to sign members. Tracking should not crash at that point.

When finalizing, "new" value of tracking is also computed as sudo. We hence ensure that all values (pre and post) are computed the same way and independently from implemented ACLs.

Reproduce steps: run 'test_employee_deletion'. It was not visible before adding a manual flush, as cr was still in "no tracking" mode (precommit data kept from creation in setupclass).

Task-5935695 ([mail, various] Cleanup and test tracking usage) Prepares Task-3645865 ([mail] In-body tracking)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
