### PR TITLE
[FIX] point_of_sale: missing order-level customer note on preparation ticket

### DIFF
--- a/addons/point_of_sale/static/src/app/utils/printer/generate_printer_data.js
+++ b/addons/point_of_sale/static/src/app/utils/printer/generate_printer_data.js
@@ -321,7 +321,11 @@ export class GeneratePrinterData {
             );
         }
 
-        if (orderChange.internal_note || orderChange.general_customer_note) {
+        // Print a separate order note ticket only if no other tickets exist
+        if (
+            !receiptsData.length &&
+            (orderChange.internal_note || orderChange.general_customer_note)
+        ) {
             receiptsData.push(this.preparePreparationGroupedData({ title: "", data: [] }));
         }
         return receiptsData;
@@ -370,7 +374,7 @@ export class GeneratePrinterData {
                         reprint: Boolean(reprint),
                         time: DateTime.now().toFormat("HH:mm"),
                         internal_note: getStrNotes(change.internal_note) || false,
-                        general_customer_note: orderChange.general_customer_note || false,
+                        general_customer_note: change.general_customer_note || false,
                         employee_name: order.employee_id?.name || order.user_id?.name || false,
                         preset_time: order.presetDateTime || false,
                     },

--- a/addons/point_of_sale/static/src/app/utils/printer/generate_printer_data.js
+++ b/addons/point_of_sale/static/src/app/utils/printer/generate_printer_data.js
@@ -323,7 +323,11 @@ export class GeneratePrinterData {
             );
         }
 
-        if (orderChange.internal_note || orderChange.general_customer_note) {
+        // Print a separate order note ticket only if no other tickets exist
+        if (
+            !receiptsData.length &&
+            (orderChange.internal_note || orderChange.general_customer_note)
+        ) {
             receiptsData.push(this.preparePreparationGroupedData({ title: "", data: [] }));
         }
         return receiptsData;
@@ -372,7 +376,7 @@ export class GeneratePrinterData {
                         reprint: Boolean(reprint),
                         time: DateTime.now().toFormat("HH:mm"),
                         internal_note: getStrNotes(change.internal_note) || false,
-                        general_customer_note: orderChange.general_customer_note || false,
+                        general_customer_note: change.general_customer_note || false,
                         employee_name: order.employee_id?.name || order.user_id?.name || false,
                         preset_time: order.presetDateTime || false,
                     },

--- a/addons/point_of_sale/static/tests/unit/services/printer.test.js
+++ b/addons/point_of_sale/static/tests/unit/services/printer.test.js
@@ -1,0 +1,49 @@
+import { test, expect } from "@odoo/hoot";
+import { getFilledOrder, setupPosEnv } from "../utils";
+import { definePosModels } from "../data/generate_model_definitions";
+
+definePosModels();
+
+test("Preparation ticket: order note behavior and change detection", async () => {
+    const store = await setupPosEnv();
+    const order = await getFilledOrder(store);
+    const categoryIds = new Set(store.models["pos.category"].map((category) => category.id));
+
+    const generatePreparationChanges = (currentOrder) => {
+        const generator = store.ticketPrinter.getGenerator({
+            models: store.models,
+            order: currentOrder,
+        });
+        return generator.generatePreparationData(categoryIds, {});
+    };
+    // Case 1: Adding a general customer note with line changes
+    {
+        order.general_customer_note = "Order Customer Note";
+        const changes = generatePreparationChanges(order);
+        expect(changes).toHaveLength(1);
+        expect(changes[0].extra_data.general_customer_note).toBe("Order Customer Note");
+        expect(changes[0].changes.title).toBe("NEW");
+    }
+    // Case 2: Updating the general customer note alone
+    {
+        order.updateLastOrderChange();
+        order.general_customer_note = "Updated Order Customer Note";
+        const changes = generatePreparationChanges(order);
+        expect(changes).toHaveLength(1);
+        expect(changes[0].extra_data.general_customer_note).toBe("Updated Order Customer Note");
+        expect(changes[0].changes).toMatchObject({
+            data: [],
+            title: "",
+        });
+    }
+    // Case 3: Updating internal note should trigger with order Note Change
+    {
+        order.updateLastOrderChange();
+        order.internal_note = "Order Internal Note";
+        order.lines[0].customer_note = "Orderline customer note";
+        const changes = generatePreparationChanges(order);
+        expect(changes).toHaveLength(1);
+        expect(changes[0].extra_data.internal_note).toBe("Order Internal Note");
+        expect(changes[0].changes.title).toBe("NOTE UPDATE");
+    }
+});


### PR DESCRIPTION
Steps to Reproduce:
- Open Restaurant POS configured with a preparation printer.
- Create a new order and add a customer note at the order level.
- Send the order for preparation.

Issue:
- The order-level customer note is not printed on the preparation ticket.

Fix:
- Ensure the customer note is included in the preparation ticket.
- Prevent additional preparation tickets from being printed when the customer note (or internal note) is modified alongside order lines.

Task-5960046
