### PR TITLE
[FIX] account_edi_ubl_cii: 'NoneType' object has no attribute 'invoic…

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -508,7 +508,10 @@ class AccountEdiXmlUbl_Bis3(models.AbstractModel):
         # EXTENDS account.edi.ubl
         node = super()._ubl_get_delivery_node_from_delivery_address(vals)
         invoice = vals.get('invoice')
-        if invoice and invoice.delivery_date:
+        if not invoice:
+            return node
+
+        if invoice.delivery_date:
             node['cbc:ActualDeliveryDate']['_text'] = invoice.delivery_date
 
         # Intracom delivery inside European area.


### PR DESCRIPTION
…e_date'

When exporting an SO, we got a traceback when the goods are traveling inside Europe in 2 differents countries because that part of the code was not checking an invoice was involved or not.

opw-5959874

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
