### PR TITLE
[FIX] point_of_sale: Warning when cancelling a paid order

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1125,6 +1125,8 @@ class PosOrder(models.Model):
             draft_orders.write({'state': 'cancel'})
             for config in draft_orders.mapped('config_id'):
                 config.notify_synchronisation(config.current_session_id.id, self.env.context.get('login_number', 0))
+        else:
+            raise UserError(_('This order has already been paid. You cannot set it back to draft or edit it.'))
         return {
             'pos.order': draft_orders.read(self._load_pos_data_fields(self.config_id.ids[0]), load=False)
         }


### PR DESCRIPTION
From 18.2, the warning to prevent users to cancel paid or posted orders from backend was no longer displayed.

It's caused because it was handled in the write() method from pos.order model. But, since a recent change, we call write() method only on draft orders. So, if there is no draft orders selected, the warning doesn't appear.

task: 5959917

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
