### PR TITLE
[FIX] point_of_sale: ensure correct pricelist rule priority and stable tests

### DIFF
--- a/addons/point_of_sale/static/src/utils.js
+++ b/addons/point_of_sale/static/src/utils.js
@@ -168,7 +168,7 @@ export function computeProductPricelistCache(service, data = []) {
     // processServerData function when new products or pricelists are loaded into the PoS.
     // It caches the heavy pricelist calculation when there are many products and pricelists.
     const date = luxon.DateTime.now();
-    let pricelistItems = service.models["product.pricelist.item"].getAll();
+    const pricelistItems = service.models["product.pricelist.item"].getAll();
     let products = service.models["product.product"].getAll();
 
     if (data.length > 0) {
@@ -177,7 +177,6 @@ export function computeProductPricelistCache(service, data = []) {
         }
 
         if (data[0].model.modelName === "product.pricelist.item") {
-            pricelistItems = data;
             // it needs only to compute for the products that are affected by the pricelist items
             const productTmplIds = new Set(data.map((item) => item.raw.product_tmpl_id));
             const productIds = new Set(data.map((item) => item.raw.product_id));
@@ -236,20 +235,7 @@ export function computeProductPricelistCache(service, data = []) {
     for (const product of products) {
         const applicableRules = product.getApplicablePricelistRules(pricelistRules);
         for (const pricelistId in applicableRules) {
-            if (product.cachedPricelistRules[pricelistId]) {
-                const existingRuleIds = product.cachedPricelistRules[pricelistId].map(
-                    (rule) => rule.id
-                );
-                const newRules = applicableRules[pricelistId].filter(
-                    (rule) => !existingRuleIds.includes(rule.id)
-                );
-                product.cachedPricelistRules[pricelistId] = [
-                    ...newRules,
-                    ...product.cachedPricelistRules[pricelistId],
-                ];
-            } else {
-                product.cachedPricelistRules[pricelistId] = applicableRules[pricelistId];
-            }
+            product.cachedPricelistRules[pricelistId] = applicableRules[pricelistId];
         }
     }
     if (data.length > 0 && data[0].model.modelName === "product.product") {

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1290,8 +1290,12 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         # Check that two product variant are created
         self.assertEqual(product_2_template.product_variant_count, 2)
-        product_2_template.product_variant_ids[0].write({'barcode': '0100201'})
-        product_2_template.product_variant_ids[1].write({'barcode': '0100202'})
+        white_ptav = product_2_template.attribute_line_ids.product_template_value_ids.filtered(lambda v: v.name == 'White')
+        red_ptav = product_2_template.attribute_line_ids.product_template_value_ids.filtered(lambda v: v.name == 'Red')
+        variant_white = product_2_template.product_variant_ids.filtered(lambda v: white_ptav in v.product_template_variant_value_ids)
+        variant_red = product_2_template.product_variant_ids.filtered(lambda v: red_ptav in v.product_template_variant_value_ids)
+        variant_white.write({'barcode': '0100201'})
+        variant_red.write({'barcode': '0100202'})
 
         self.env['product.product'].create({
             'name': 'Test Product 3',
@@ -1314,7 +1318,7 @@ class TestUi(TestPointOfSaleHttpCommon):
             'fixed_price': 80,
         }, {
             'applied_on': '0_product_variant',
-            'product_id': product_2_template.product_variant_ids[1].id,
+            'product_id': variant_red.id,
             'fixed_price': 120,
         }])
         self.main_pos_config.pricelist_id.write({'item_ids': [(6, 0, pricelist_item.ids)]})


### PR DESCRIPTION
Prior to this commit, the frontend pricelist rule cache was updated by
prepending new rules to the existing cache during incremental data loads
(e.g., when scanning a product in "limited products" mode). This could
lead to incorrect price calculations if a more general rule was loaded
before a more specific one. The cache is now rebuilt from all loaded
pricelists items for the affected products, ensuring the correct
priority (Variant > Product > Category > Global) is always respected.

Additionally, fix the test setup to explicitly identify variants by
attribute value instead of relying on non-deterministic record ordering.

task-id: 5953802

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
