### PR TITLE
[FIX] web_editor, html_editor, *: fix checkbox hint position

### DIFF
--- a/addons/html_editor/static/src/main/list/list.scss
+++ b/addons/html_editor/static/src/main/list/list.scss
@@ -15,16 +15,19 @@ ul.o_checklist {
             display: block;
             height: 14px;
             width: 14px;
-            top: 1px;
+            top: calc(50% - 7px);
             border: 1px solid;
             cursor: pointer;
         }
-        &.o_checked:after {
+        &.o_checked:before {
             content: "✓";
+            font-size: 14px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding-left: 1px #{"/*rtl:ignore*/"};
+            padding-top: 1px;
             transition: opacity .5s;
-            position: absolute;
-            left: -18px;
-            top: -1px;
             opacity: 1;
         }
     }

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/checklist.scss
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/checklist.scss
@@ -10,16 +10,19 @@ ul.o_checklist {
             display: block;
             height: 14px;
             width: 14px;
-            top: 1px;
+            top: calc(50% - 7px);
             border: 1px solid;
             cursor: pointer;
         }
-        &.o_checked:after {
+        &.o_checked:before {
             content: "✓";
+            font-size: 14px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding-left: 1px #{"/*rtl:ignore*/"};
+            padding-top: 1px;
             transition: opacity .5s;
-            position: absolute;
-            left: -18px;
-            top: -1px;
             opacity: 1;
         }
     }

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/list.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/list.test.js
@@ -9,6 +9,7 @@ import {
     insertParagraphBreak,
     insertText,
     indentList,
+    nextTickFrame,
     outdentList,
     testEditor,
     toggleCheckList,
@@ -18,6 +19,16 @@ import {
     unformat,
     switchDirection
 } from '../utils.js';
+
+async function clickCheckbox(li) {
+    li.scrollIntoView();
+    await nextTickFrame();
+    const rect = li.getBoundingClientRect();
+    await click(li, {
+        clientX: rect.left - 10,
+        clientY: rect.top + rect.height / 2,
+    });
+}
 
 describe('List', () => {
     describe('toggleList', () => {
@@ -1734,7 +1745,7 @@ describe('List', () => {
                         '.o_checklist > li:not([class^="oe-nested"])',
                     );
                     const li = lis[0];
-                    await click(li, { clientX: li.getBoundingClientRect().left - 10 });
+                    await clickCheckbox(li);
                 },
                 contentAfter: unformat(`
                     <ul class="o_checklist">
@@ -1754,7 +1765,7 @@ describe('List', () => {
                         '.o_checklist > li:not([class^="oe-nested"])',
                     );
                     const li = lis[0];
-                    await click(li, { clientX: li.getBoundingClientRect().left - 10 });
+                    await clickCheckbox(li);
                 },
                 contentAfter: unformat(`
                     <ul class="o_checklist">
@@ -1774,7 +1785,7 @@ describe('List', () => {
                         '.o_checklist > li:not([class^="oe-nested"])',
                     );
                     const li = lis[0];
-                    await click(li, { clientX: li.getBoundingClientRect().left - 10 });
+                    await clickCheckbox(li);
                 },
                 contentAfter: unformat(`
                     <ul class="o_checklist">
@@ -1794,7 +1805,7 @@ describe('List', () => {
                         '.o_checklist > li:not([class^="oe-nested"])',
                     );
                     const li = lis[0];
-                    await click(li, { clientX: li.getBoundingClientRect().left - 10 });
+                    await clickCheckbox(li);
                 },
                 contentAfter: unformat(`
                     <ul class="o_checklist">
@@ -1820,7 +1831,7 @@ describe('List', () => {
                         '.o_checklist > li:not([class^="oe-nested"])',
                     );
                     const li = lis[2];
-                    await click(li, { clientX: li.getBoundingClientRect().left - 10 });
+                    await clickCheckbox(li);
                 },
                 contentAfter: unformat(`
                 <ul class="o_checklist">
@@ -1852,7 +1863,7 @@ describe('List', () => {
                         '.o_checklist > li:not([class^="oe-nested"])',
                     );
                     const li = lis[2];
-                    await click(li, { clientX: li.getBoundingClientRect().left - 10 });
+                    await clickCheckbox(li);
                 },
                 contentAfter: unformat(`
                 <ul class="o_checklist">
@@ -1889,7 +1900,7 @@ describe('List', () => {
                         '.o_checklist > li:not([class^="oe-nested"])',
                     );
                     const li = lis[3];
-                    await click(li, { clientX: li.getBoundingClientRect().left - 10 });
+                    await clickCheckbox(li);
                 },
                 contentAfter: unformat(`
                     <ul class="o_checklist">
@@ -1931,7 +1942,7 @@ describe('List', () => {
                         '.o_checklist > li:not([class^="oe-nested"])',
                     );
                     const li = lis[3];
-                    await click(li, { clientX: li.getBoundingClientRect().left - 10 });
+                    await clickCheckbox(li);
                 },
                 contentAfter: unformat(`
                     <ul class="o_checklist">
@@ -1980,7 +1991,7 @@ describe('List', () => {
                         '.o_checklist > li:not([class^="oe-nested"])',
                     );
                     const li = lis[0];
-                    await click(li, { clientX: li.getBoundingClientRect().left - 10 });
+                    await clickCheckbox(li);
                 },
                 contentAfter: unformat(`
                     <ul class="o_checklist">
@@ -2032,7 +2043,7 @@ describe('List', () => {
                         '.o_checklist > li:not([class^="oe-nested"])',
                     );
                     const li = lis[0];
-                    await click(li, { clientX: li.getBoundingClientRect().left - 10 });
+                    await clickCheckbox(li);
                 },
                 contentAfter: unformat(`
                     <ul class="o_checklist">
@@ -2077,7 +2088,7 @@ describe('List', () => {
                         '.o_checklist > li:not([class^="oe-nested"])',
                     );
                     const li = lis[1];
-                    await click(li, { clientX: li.getBoundingClientRect().left - 10 });
+                    await clickCheckbox(li);
                 },
                 contentAfter: unformat(`
                     <ul class="o_checklist">
@@ -2119,7 +2130,7 @@ describe('List', () => {
                         '.o_checklist > li:not([class^="oe-nested"])',
                     );
                     const li = lis[1];
-                    await click(li, { clientX: li.getBoundingClientRect().left - 10 });
+                    await clickCheckbox(li);
                 },
                 contentAfter: unformat(`
                     <ul class="o_checklist">

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -100,7 +100,7 @@ html, body {
     height: 100%;
 }
 
-pre {    
+pre {
     padding: map-get($spacers, 2) map-get($spacers, 3);
     border: $border-width solid $border-color;
     border-radius: $border-radius;
@@ -156,7 +156,7 @@ ul.o_checklist {
             display: block;
             height: $o-checklist-before-size;
             width: $o-checklist-before-size;
-            top: 4px;
+            top: calc(50% - #{$o-checklist-before-size / 2});
             border: 1px solid;
             text-align: center;
             cursor: pointer;
@@ -170,6 +170,10 @@ ul.o_checklist {
                 justify-content: center;
                 padding-left: 1px #{"/*rtl:ignore*/"};
                 padding-top: 1px;
+                font-size: $o-checklist-before-size;
+            }
+            &::after {
+                text-decoration: line-through;
             }
         }
     }
@@ -1012,7 +1016,8 @@ section, .oe_img_bg, [data-oe-shape-data] {
         margin-bottom: 0;
     }
     ul.o_checklist>li:not(.oe-nested)::before {
-        top: 0px!important;
+        top: 0 !important;
+        transform: none !important;
     }
 }
 

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -2086,11 +2086,6 @@ $ribbon-padding: 100px;
     flex: 1;
 }
 
-ul.o_checklist > li.o_checked::after {
-    left: - ($o-checklist-margin-left - $o-checklist-checkmark-width) - 1;
-    top: 0;
-}
-
 // Bottom fixed element (e.g. livechat button)
 .modal-open .o_bottom_fixed_element, .o_bottom_fixed_element_hidden {
     // Prevent bottom fixed elements from hidding buttons and


### PR DESCRIPTION
*: website

Before this commit, checkboxes would have issues when checked:
- Outside of website, the hint disappears and there are two checkmarks
- In website, the hint is shifted to the left

The checkmark element is created with ::after
The hint element is created with ::before

These issues happen because the selectors were sometime switched.

This commit also center the checkbox to the text and add the strike to the hint for checked list item.

task-5909172