### PR TITLE
[FIX] crm_sale_project: whitelist company_id in template default context

### DIFF
--- a/addons/crm_sale_project/models/project_project.py
+++ b/addons/crm_sale_project/models/project_project.py
@@ -17,6 +17,7 @@ class ProjectProject(models.Model):
     def _get_template_default_context_whitelist(self):
         return [
             *super()._get_template_default_context_whitelist(),
+            'company_id',
             'lead_id',
         ]
 

--- a/addons/crm_sale_project/tests/__init__.py
+++ b/addons/crm_sale_project/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_crm_project_multicompany

--- a/addons/crm_sale_project/tests/test_crm_project_multicompany.py
+++ b/addons/crm_sale_project/tests/test_crm_project_multicompany.py
@@ -1,0 +1,35 @@
+from odoo.addons.crm.tests.common import TestCrmCommon
+from odoo.tests import tagged, users
+
+
+@tagged('-at_install', 'post_install')
+class TestCrmProjectMultiCompany(TestCrmCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._activate_multi_company()
+        cls.user_sales_manager_mc.group_ids += cls.env.ref('project.group_project_manager')
+        cls.project_template = cls.env['project.project'].with_context(no_create_folder=True).create({
+            'name': 'Test Project Template',
+            'is_template': True,
+            'allow_billable': True,
+            'company_id': cls.company_main.id,
+        })
+
+    @users('user_sales_manager_mc')
+    def test_create_project_from_lead_template(self):
+        lead = self.env['crm.lead'].create({
+            'name': 'Test Lead',
+            'partner_name': 'Test Partner Company',
+            'team_id': self.team_company2.id,
+        })
+
+        ctx = lead._get_project_create_from_lead_context()
+        wizard = self.env['project.template.create.wizard'].with_context(**ctx).create({
+            'name': 'New Project from Lead',
+            'template_id': self.project_template.id,
+        })
+        wizard.action_create_project_from_lead()
+        project = lead.project_ids
+        self.assertEqual(project.company_id, lead.company_id)


### PR DESCRIPTION
When creating a project from a CRM lead using a template, the `default_company_id` set by `_get_project_create_from_lead_context` is ignored because `company_id` is not in the template default context whitelist. This causes the new project to inherit the template's company instead of the lead's company, resulting in a company mismatch with the partner and a UserError.

https://github.com/odoo/odoo/blob/2b89db4af2265e5cec8feb11853364e293de203e/addons/crm_sale_project/models/crm_lead.py#L37-L45

https://github.com/odoo/odoo/blob/2b89db4af2265e5cec8feb11853364e293de203e/addons/project/models/project_project.py#L1413-L1419

Steps To Reproduce:
1. Go to CRM, create or open a lead.
2. Clear the contact field and save.
3. Click the gear icon → Create Project.
4. Select any project template (not empty) and submit.

Ticket [link](https://www.odoo.com/odoo/project.task/5933253)
opw-5933253

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
