### PR TITLE
[FIX] mrp : create MO with instructions on mobile

### DIFF
--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -353,6 +353,7 @@
             <kanban class="o_mrp_workorder_kanban" create="0" sample="1">
                 <field name="workcenter_id" invisible="True"/>
                 <field name="product_uom_id" invisible="True" force_save="True"/>
+                <field name="operation_id" invisible="True"/>
                 <field name="working_user_ids"/>
                 <field name="working_state"/>
                 <field name="date_start"/>


### PR DESCRIPTION
# How to reproduce
- Create a BOM for a product with a Work Order
- Add instructions to the WO
- Using mobile, create a new MO for the product

# The problem
The instructions are not linked to the MO. This can easily be seen via the shop floor application

# Why
This issue is identical to https://github.com/odoo/odoo/pull/197889. This commit https://github.com/odoo/odoo/commit/b1ceec4c616d8ad2fee5b0fa1ce76c85cacbb344 removed the operation_id field from the workorder kanban mobile view, which is used in the MO form on mobile. operation_id is then not passed to the server in vals_list when creating the MO but it is required to link the instructions from the BOM to the MO.

opw-5950983

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
