### PR TITLE
[REF] google_*: run rendering context migration script

### DIFF
--- a/addons/google_address_autocomplete/static/src/address_autocomplete/google_address_autocomplete.xml
+++ b/addons/google_address_autocomplete/static/src/address_autocomplete/google_address_autocomplete.xml
@@ -3,12 +3,12 @@
 <templates>
     <t t-name="google_address_autocomplete.AddressAutoCompleteTemplate">
         <AutoComplete
-            value="props.record.data[props.name] || ''"
-            sources="sources"
-            placeholder="props.placeholder"
+            value="this.props.record.data[this.props.name] || ''"
+            sources="this.sources"
+            placeholder="this.props.placeholder"
             searchOnInputClick="false"
             inputDebounceDelay="350"
-            input="input"
+            input="this.input"
         >
             <t t-set-slot="option" t-slot-scope="optionScope">
                 <strong t-esc="optionScope.label"/>

--- a/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_api_key_dialog.xml
+++ b/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_api_key_dialog.xml
@@ -1,5 +1,5 @@
 <t t-name="website.GoogleMapsApiKeyDialog">
-    <Dialog title="props.title" size="'md'" modalRef="modalRef">
+    <Dialog title="this.props.title" size="'md'" modalRef="this.modalRef">
         <p>Use Google Map on your website (Contact Us page, snippets, etc).</p>
         <div class="row mb-0">
             <label class="col-sm-2 col-form-label" for="pin_address">API Key</label>
@@ -7,12 +7,12 @@
                 <div class="input-group">
                     <div class="input-group-text"><i class="fa fa-key"/></div>
                     <input type="text" class="form-control" id="api_key_input"
-                            t-att-class="{ 'is-invalid': state.apiKeyValidation and !state.apiKeyValidation.isValid and state.apiKeyValidation.message }"
-                            t-model="state.apiKey"
+                            t-att-class="{ 'is-invalid': this.state.apiKeyValidation and !this.state.apiKeyValidation.isValid and this.state.apiKeyValidation.message }"
+                            t-model="this.state.apiKey"
                             placeholder="BSgzTvR5L1GB9jriT451iTN4huVPxHmltG6T6eo"/>
                 </div>
-                <small t-if="state.apiKeyValidation and !state.apiKeyValidation.isValid and state.apiKeyValidation.message" id="api_key_help" class="text-danger">
-                    <t t-esc="state.apiKeyValidation.message"/>
+                <small t-if="this.state.apiKeyValidation and !this.state.apiKeyValidation.isValid and this.state.apiKeyValidation.message" id="api_key_help" class="text-danger">
+                    <t t-esc="this.state.apiKeyValidation.message"/>
                 </small>
                 <div class="small form-text text-muted">
                     Hint: How to use Google Map on your website (Contact Us page and as a snippet)
@@ -49,7 +49,7 @@
             </div>
         </div>
         <t t-set-slot="footer">
-            <button t-on-click="onClickSave" class="btn btn-primary" data-hotkey="q">Save</button>
+            <button t-on-click="this.onClickSave" class="btn btn-primary" data-hotkey="q">Save</button>
             <button class="btn" t-on-click="() => this.props.close()" data-hotkey="x">Discard</button>
         </t>
     </Dialog>

--- a/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option.xml
+++ b/addons/website/static/src/builder/plugins/options/google_maps_option/google_maps_option.xml
@@ -6,7 +6,7 @@
         <input
             type="text"
             class="o_we_large"
-            t-att-value="state.formattedAddress"
+            t-att-value="this.state.formattedAddress"
             placeholder.translate="e.g. De Brouckere, Brussels, Belgium"
             t-ref="inputRef"
         />
@@ -25,7 +25,7 @@
             <BuilderSelectItem dataAttributeActionValue="'HYBRID'">Hybrid</BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>
-    <BuilderRow label.translate="&#8985; Style" preview="false" t-if="this.isActiveItem('roadmap_opt')">
+    <BuilderRow label.translate="⌙ Style" preview="false" t-if="this.isActiveItem('roadmap_opt')">
         <BuilderSelect dataAttributeAction="'mapColor'">
             <BuilderSelectItem dataAttributeActionValue="">
                 <Image src="'/website/static/src/snippets/s_google_map/img/thumbs/map-default.jpg'"/>


### PR DESCRIPTION
In preparation for OWL3, where template variables will need to use `.this` to target component variables, we add `.this` to template variables that are targetting the component.

Script PR: odoo/odoo#247965

task: OWL3 prep - add this. to template variables

THIS_TARGETS = ["fleet", "frontdesk", "gamification", "google", "helpdesk"]