### PR TITLE
[IMP] website, html_builder: share snippet enhancement

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_list.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.js
@@ -42,6 +42,7 @@ export class BuilderList extends Component {
         forbidLastItemRemoval: { type: Boolean, optional: true },
         isEditable: { type: Boolean, optional: true },
         limit: { type: Number, optional: true },
+        disableLastCheckedCheckbox: { type: Boolean, optional: true },
     };
     static defaultProps = {
         addItemTitle: _t("Add"),
@@ -54,6 +55,7 @@ export class BuilderList extends Component {
         forbidLastItemRemoval: false,
         isEditable: true,
         limit: 50,
+        disableLastCheckedCheckbox: false,
     };
     static components = { BuilderComponent, SelectMenu };
 
@@ -268,5 +270,31 @@ export class BuilderList extends Component {
         } else {
             this.preview(items);
         }
+    }
+
+    /**
+     * Checks if the checkbox for the given item is the only one
+     * still checked for the given property, and should be disabled
+     * to prevent unchecking all options.
+     *
+     * @param {Array} items - List of all items
+     * @param {Object} currentItem - Item to check
+     * @param {string} propertyName - Property name to check against
+     * @returns {boolean} True if this is the last checked checkbox
+     */
+    isLastCheckboxChecked(items, currentItem, propertyName) {
+        if (!this.props.disableLastCheckedCheckbox || !currentItem[propertyName]) {
+            return false;
+        }
+        let activeCount = 0;
+        for (const item of items) {
+            if (item[propertyName]) {
+                activeCount++;
+            }
+            if (activeCount > 1) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/addons/html_builder/static/src/core/building_blocks/builder_list.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_list.xml
@@ -26,6 +26,7 @@
                                                     t-att-checked="item[entry[0]]"
                                                     t-att-data-id="item._id"
                                                     t-on-click="this.onChange"
+                                                    t-att-disabled="isLastCheckboxChecked(items, item, entry[0])"
                                                 />
                                             </div>
                                         </t>

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_list.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_list.test.js
@@ -491,3 +491,20 @@ test("loads more items when the last row intersects", async () => {
     await contains(".we-bg-options-container .o_we_table_wrapper").scroll({ top: 9999 });
     expect(".we-bg-options-container .o_row_draggable").toHaveCount(150);
 });
+
+test("should disable last checked checkbox", async () => {
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderList
+                dataAttributeAction="'list'"
+                itemShape="{ value: 'boolean' }"
+                default="{'value':'true'}"
+                disableLastCheckedCheckbox="true"
+            />`,
+    });
+    await setupHTMLBuilder(`<div class="test-options-target">a</div>`);
+    await contains(":iframe .test-options-target").click();
+    await contains(".we-bg-options-container .builder_list_add_item").click();
+    expect(".we-bg-options-container tr .o-checkbox input").toHaveAttribute("disabled");
+});

--- a/addons/website/static/src/builder/plugins/options/social_media_links.xml
+++ b/addons/website/static/src/builder/plugins/options/social_media_links.xml
@@ -42,9 +42,26 @@
 </t>
 
 
+<t t-name="website.ShareMediaLinksOption">
+    <BuilderList
+        action="'shareMediaLinks'"
+        itemShape="{ name : 'text', status: 'boolean' }"
+        isEditable="false"
+        disableLastCheckedCheckbox="true"
+    />
+</t>
+
 <t t-inherit="website.BuilderOptions" t-inherit-mode="extension">
     <xpath expr="//t[@id='snippet_specific_options']" position="after">
         <social_media_links selector=".s_social_media"/>
+    </xpath>
+</t>
+
+<t t-inherit="website.BuilderOptions" t-inherit-mode="extension">
+    <xpath expr="//t[@id='snippet_specific_options']" position="after">
+        <share_media_links
+            template="website.ShareMediaLinksOption"
+            selector=".s_share"/>
     </xpath>
 </t>
 

--- a/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
@@ -131,6 +131,7 @@ export class SocialMediaOptionPlugin extends Plugin {
             DeleteSocialMediaLinkAction,
             EditSocialMediaLinkAction,
             AddSocialMediaLinkAction,
+            ShareMediaLinksAction,
         },
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
         normalize_processors: this.normalize.bind(this),
@@ -151,6 +152,7 @@ export class SocialMediaOptionPlugin extends Plugin {
                 return false;
             }
         },
+        immutable_link_selectors: [".s_share a"],
     };
 
     async onSnippetDropped({ snippetEl }) {
@@ -222,7 +224,7 @@ export class SocialMediaOptionPlugin extends Plugin {
         }
 
         // ensure one '\n' between each element + before and after
-        for (const element of selectElements(root, ".s_social_media > *")) {
+        for (const element of selectElements(root, ".s_social_media > *, .s_share > *")) {
             if (element.nextSibling?.nodeType === Node.TEXT_NODE) {
                 while (element.nextSibling.nextSibling?.nodeType === Node.TEXT_NODE) {
                     element.parentNode.removeChild(element.nextSibling);
@@ -405,6 +407,32 @@ export class AddSocialMediaLinkAction extends BuilderAction {
                 editingElement.querySelector(":scope > a")
             )
         );
+    }
+}
+export class ShareMediaLinksAction extends BuilderAction {
+    static id = "shareMediaLinks";
+    getValue({ editingElement }) {
+        return JSON.stringify(
+            Array.from(editingElement.querySelectorAll(":scope > a"), (mediaEl) => ({
+                name: mediaEl.ariaLabel,
+                status: !mediaEl.classList.contains("d-none"),
+            }))
+        );
+    }
+    apply({ editingElement, value }) {
+        const mediaNameElMap = new Map();
+        const fragment = document.createDocumentFragment();
+        editingElement.querySelectorAll(":scope > a").forEach((mediaEl) => {
+            mediaNameElMap.set(mediaEl.ariaLabel, mediaEl);
+        });
+        JSON.parse(value).forEach((mediaInfo) => {
+            const shareMediaEl = mediaNameElMap.get(mediaInfo.name);
+            if (shareMediaEl) {
+                shareMediaEl.classList.toggle("d-none", !mediaInfo.status);
+                fragment.appendChild(shareMediaEl);
+            }
+        });
+        editingElement.appendChild(fragment);
     }
 }
 

--- a/addons/website/static/tests/builder/website_builder/social_media.test.js
+++ b/addons/website/static/tests/builder/website_builder/social_media.test.js
@@ -9,7 +9,7 @@ import {
     unfoldAllOptionsGroups,
     waitForEndOfOperation,
 } from "@html_builder/../tests/helpers";
-import { click, queryOne, animationFrame, edit, waitFor } from "@odoo/hoot-dom";
+import { click, queryOne, animationFrame, edit, waitFor, press } from "@odoo/hoot-dom";
 
 defineWebsiteModels();
 
@@ -259,6 +259,10 @@ test("Edit share icon", async () => {
     await dragAndDropSnippet("s_share");
     await contains(":iframe .s_share a i").dblclick();
     expect(".modal-content").toBeDisplayed();
+    await press("Escape");
+    await contains(":iframe .s_share a").dblclick();
+    await animationFrame();
+    expect(".o-we-linkpopover").toHaveCount(0);
 });
 
 test("Social Media snippet options are correct", async () => {
@@ -266,5 +270,11 @@ test("Social Media snippet options are correct", async () => {
 });
 
 test("Share snippet options are correct", async () => {
+    const rowSelector = (id) => `.we-bg-options-container .o_row_draggable[data-id="${id}"]`;
     await testSocialSnippetOptions("s_share", "Share", "facebook");
+    expect(":iframe .s_share.o_not_editable").toHaveCount(1);
+    await contains(`${rowSelector(0)} .o_handle_cell`).dragAndDrop(rowSelector(1));
+    expect(":iframe .s_share a:first-of-type").toHaveClass("s_share_twitter");
+    await contains(".o_we_table_wrapper tr:nth-of-type(1) .o-checkbox input").click();
+    expect(":iframe .s_share .s_share_twitter.d-none").toHaveCount(1);
 });

--- a/addons/website/views/snippets/s_share.xml
+++ b/addons/website/views/snippets/s_share.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template id="s_share" name="Share">
-    <div t-attf-class="s_share text-start o_no_link_popover #{_classes}" t-ignore="#{_ignore}">   
+    <div t-attf-class="s_share text-start o_no_link_popover #{_classes} o_not_editable" t-ignore="#{_ignore}">   
         <h4 t-if="not _no_title" class="s_share_title d-none">Share</h4>
         <a t-if="not _exclude_share_links or not 'facebook' in _exclude_share_links" href="https://www.facebook.com/sharer/sharer.php?u={url}" t-attf-class="s_share_facebook #{_link_classes}" target="_blank" aria-label="Facebook">
             <i t-attf-class="fa fa-facebook #{not _link_classes and 'rounded shadow-sm'} small_social_icon"/>


### PR DESCRIPTION
This PR includes improvements to the `Share` snippet and enhancements to the `BuilderList` component.

---
1. Add support for disabling last checked checkbox in `BuilderList`

  Before this PR:
  - There was no way to prevent users from unchecking the last checked checkbox in `BuilderList` component.
  
  After this PR:
  - Added support of disabling the **last checked checkbox**.

---

2. Improve the Share Snippet

  Before this PR:
  - Users could duplicate or delete individual share icons.
  - The UI displayed unnecessary drop zones between icons.
  - There was no way to reorder or control visibility of share icons.
  - Although the links were not editable, double-clicking an icon would still open the link popover.
  
  After this PR:
  - Removed the "duplicate" and "delete" actions from individual share icons.
  - Removed unnecessary drop zones between icons.
  - Enhanced snippet options to allow users to reorder or control visibility of share icons.
  - Prevents the link popover from opening on double-click.

task: 5245453