### PR TITLE
[FIX] account, purchase: catalog remove button not removing order line

### DIFF
--- a/addons/account/static/src/components/product_catalog/kanban_record.js
+++ b/addons/account/static/src/components/product_catalog/kanban_record.js
@@ -9,7 +9,7 @@ patch(ProductCatalogKanbanRecord.prototype, {
 
         useSubEnv({
             ...this.env,
-            selectedSectionId: this.env.searchModel.selectedSection?.sectionId,
+            selectedSectionId: this.env.searchModel.selectedSection.sectionId,
         });
     },
 
@@ -23,7 +23,7 @@ patch(ProductCatalogKanbanRecord.prototype, {
     _getUpdateQuantityAndGetPriceParams() {
         return {
             ...super._getUpdateQuantityAndGetPriceParams(),
-            section_id: this.env.searchModel.selectedSection.sectionId || false,
+            section_id: this.env.selectedSectionId,
         };
     },
 

--- a/addons/purchase/static/tests/tours/purchase_catalog.js
+++ b/addons/purchase/static/tests/tours/purchase_catalog.js
@@ -16,6 +16,11 @@ registry.category("web_tour.tours").add("test_catalog_vendor_uom", {
         { trigger: "td[data-tooltip='PO/TEST/00002']", run: "click" },
         ...purchaseForm.displayOptionalField("discount"),
         ...purchaseForm.openCatalog(),
+        {
+            content: "Check 'No section' is selected in the catalog",
+            trigger: ".o_search_panel_sections .o_selected_section:contains('No Section') span.o_section_name",
+            run: "click",
+        },
         ...productCatalog.checkProductPrice("Crab Juice", "$ 2.50"),
         // Add 6 units and check the price is correctly updated.
         ...productCatalog.addProduct("Crab Juice"),


### PR DESCRIPTION
Steps to reproduce:
1. Create a new SO/PO/Invoice and add a product.
2. Add a new section below the product.
3. Open the catalog and click the Remove button for the added product.

Issue:
- The product is not removed from the SO/PO/Invoice.

Cause:
- When removing the product, the 'No section' entry is also removed if it becomes empty.
- As a result, `this.env.searchModel.selectedSection.sectionId` point to the first remaining section in the order.
- Because of this incorrect reference, the wrong `section_id` is passed in the params, and `update_order_line_info` does not update the intended order line.

Fix:
- Use `this.env.selectedSectionId` instead of `searchModel.selectedSection.sectionId` to ensure the correct `section_id` is always passed.

After applying this fix, `test_catalog_vendor_uom` tour was failing because in tour execution the kanban records are mounted before the search panel finishes initializing the selected section. As a result, the initial section state is not yet stabilized when the price is asserted.

To address this:
- Update the tour to explicitly wait until the "No section" entry is marked as selected in the search panel before asserting      the product price, ensuring the catalog is fully initialized.

opw-5960140