### PR TITLE
[FIX] product: serialize product catalog qty update requests

### DIFF
--- a/addons/product/static/src/product_catalog/kanban_record.js
+++ b/addons/product/static/src/product_catalog/kanban_record.js
@@ -16,6 +16,7 @@ export class ProductCatalogKanbanRecord extends KanbanRecord {
         this.debouncedUpdateQuantity = useDebounced(this._updateQuantity, 500, {
             execBeforeUnmount: true,
         });
+        this._pendingUpdate = Promise.resolve();
 
         useSubEnv({
             currencyId: this.props.record.context.product_catalog_currency_id,
@@ -64,7 +65,13 @@ export class ProductCatalogKanbanRecord extends KanbanRecord {
     }
 
     _updateQuantityAndGetPrice() {
-        return rpc("/product/catalog/update_order_line_info", this._getUpdateQuantityAndGetPriceParams());
+        // Chain RPC calls to ensure that each request is completed before starting the next one.
+        // This prevents race conditions and ensures the server processes updates sequentially.
+        this._pendingUpdate = this._pendingUpdate.then(() => rpc(
+            "/product/catalog/update_order_line_info",
+            this._getUpdateQuantityAndGetPriceParams(),
+        ));
+        return this._pendingUpdate;
     }
 
     _getUpdateQuantityAndGetPriceParams() {


### PR DESCRIPTION
Issue:
---
Concurrent qty update might cause issue.

Steps to reproduce:
---
1- We need a DB with too many products. Also it might not be easy to reproduce the issue locally. Try runbot.
2- Create a SO.
3- On SOL creation, click on Catalog.
4- Copy the number 100 and click on catalog records fast and paste the number rapidly. Repeat this for all records of the page.
5- Go back to SO. You might find some lines with qty = 1.

Cause:
---
This is a concurrency issue. In the faulty cases, `update_order_line_info` setting quantity to 1, takes a few seconds to resolve, while the update setting quantity to 100 resolves faster (around 200ms). This cause the SOL final quantity set to 1.

As an example you could see two `update_order_line_info` requests for the same `product_id`, first one setting quantity to 1 and second one to 100, in which first one resolves faster.

<img width="912" height="316" alt="image" src="https://github.com/user-attachments/assets/219d2d10-32bf-490f-9f2c-a6229d60b991" />

<img width="927" height="328" alt="image" src="https://github.com/user-attachments/assets/1f0bddaf-e7d0-4311-b458-4416d77562c6" />

Fix:
---
We can chain RPC calls to ensure that each request is completed before starting the next one.

opw-5861412
