### PR TITLE
[FIX] purchase_stock,mrp: prevent traceback on replenishment

### DIFF
--- a/addons/mrp/wizard/product_replenish.py
+++ b/addons/mrp/wizard/product_replenish.py
@@ -46,7 +46,7 @@ class ProductReplenish(models.TransientModel):
     def _get_route_domain(self, product_tmpl_id):
         domain = super()._get_route_domain(product_tmpl_id)
         company = product_tmpl_id.company_id or self.env.company
-        manufacture_route = self.env['stock.rule'].search([('action', '=', 'manufacture'), ('company_id', '=', company.id)]).route_id
+        manufacture_route = self.env['stock.rule'].search([('action', '=', 'manufacture'), ('company_id', '=', company.id)], limit=1).route_id
         if manufacture_route and product_tmpl_id.bom_ids:
             domain = Domain.OR([domain, Domain('id', '=', manufacture_route.id)])
         return domain

--- a/addons/purchase_stock/wizard/product_replenish.py
+++ b/addons/purchase_stock/wizard/product_replenish.py
@@ -91,7 +91,7 @@ class ProductReplenish(models.TransientModel):
     def _get_route_domain(self, product_tmpl_id):
         domain = super()._get_route_domain(product_tmpl_id)
         company = product_tmpl_id.company_id or self.env.company
-        buy_route = self.env['stock.rule'].search([('action', '=', 'buy'), ('company_id', '=', company.id)]).route_id
+        buy_route = self.env['stock.rule'].search([('action', '=', 'buy'), ('company_id', '=', company.id), ('picking_type_id.code', '=', 'incoming')], limit=1).route_id
         if buy_route and product_tmpl_id.seller_ids:
             domain = Domain.OR([domain, Domain('id', '=', buy_route.id)])
         return domain


### PR DESCRIPTION
## Issue Before This PR:
While replenishing a product from the replenishment wizard,
a traceback is raised:
`ValueError("Expected singleton: %s" % record) from None`

## Steps to Reproduce:
- Install Inventory and Purchase modules
- Enable Dropshipping
- Create a storable product with a vendor set
- Open the Forecast view
- Click on Replenish
- Observe the traceback

## Cause of the Issue:
During `default_get`, `_get_route_domain()` builds a domain
including the Buy route using: `Domain('id', '=', buy_route.id)`
However, the search for the Buy route could return multiple
stock.route records for the same company.
Accessing `.id` on a multi-recordset triggers an
`Expected singleton` error, causing the replenishment
wizard to crash.

## With This PR:
The Buy route search is refined to ensure it returns a single
record before accessing `.id`. This prevents the singleton
error and allows the replenishment wizard to open correctly.
