### PR TITLE
[IMP] core: typo check_python_external_dependency

### DIFF
--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -579,7 +579,7 @@ def check_python_external_dependency(pydep: str) -> None:
         try:
             # keep compatibility with module name but log a warning instead of info
             importlib.import_module(pydep)
-            _logger.warning("python external dependency on '%s' does not appear o be a valid PyPI package. Using a PyPI package name is recommended.", pydep)
+            _logger.warning("python external dependency on '%s' does not appear to be a valid PyPI package. Using a PyPI package name is recommended.", pydep)
             return
         except ImportError:
             pass


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Fixes typo "o" should be "to"

Current behavior before PR:
Warning text is shown as `python external dependency on 'jwt' does not appear o be a valid PyPI package. Using a PyPI package name is recommended.` when having in `__manifest__.py` : `  "external_dependencies": {"python": ["jwt"]},` 

Desired behavior after PR is merged:
Warning text without typo : `python external dependency on 'jwt' does not appear `**to**` be a valid PyPI package. Using a PyPI package name is recommended`



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
