### PR TITLE
[FIX] mail: replace Tenor GIF API key to KLIPY GIF API key

### DIFF
--- a/addons/mail/controllers/discuss/gif.py
+++ b/addons/mail/controllers/discuss/gif.py
@@ -16,7 +16,7 @@ class DiscussGifController(Controller):
         response = None
         try:
             response = requests.get(
-                f"https://tenor.googleapis.com/v2/{endpoint}", timeout=3
+                f"https://api.klipy.com/v2/{endpoint}", timeout=3
             )
             response.raise_for_status()
         except (urllib3.exceptions.MaxRetryError, requests.exceptions.HTTPError):
@@ -33,7 +33,7 @@ class DiscussGifController(Controller):
         query_string = werkzeug.urls.url_encode(
             {
                 "q": search_term,
-                "key": ir_config.get_param("discuss.tenor_api_key"),
+                "key": ir_config.get_param("discuss.klipy_api_key"),
                 "client_key": request.env.cr.dbname,
                 "limit": ir_config.get_param("discuss.tenor_gif_limit"),
                 "contentfilter": ir_config.get_param("discuss.tenor_content_filter"),
@@ -53,7 +53,7 @@ class DiscussGifController(Controller):
         ir_config = request.env["ir.config_parameter"].sudo()
         query_string = werkzeug.urls.url_encode(
             {
-                "key": ir_config.get_param("discuss.tenor_api_key"),
+                "key": ir_config.get_param("discuss.klipy_api_key"),
                 "client_key": request.env.cr.dbname,
                 "limit": ir_config.get_param("discuss.tenor_gif_limit"),
                 "contentfilter": ir_config.get_param("discuss.tenor_content_filter"),
@@ -74,8 +74,8 @@ class DiscussGifController(Controller):
         ir_config = request.env["ir.config_parameter"].sudo()
         query_string = werkzeug.urls.url_encode(
             {
-                "ids": ",".join(ids),
-                "key": ir_config.get_param("discuss.tenor_api_key"),
+                "ids": ",".join(ids) or None,
+                "key": ir_config.get_param("discuss.klipy_api_key"),
                 "client_key": request.env.cr.dbname,
                 "media_filter": "tinygif",
             }
@@ -89,6 +89,8 @@ class DiscussGifController(Controller):
         tenor_gif_ids = request.env["discuss.gif.favorite"].search(
             [("create_uid", "=", request.env.user.id)], limit=20, offset=offset
         )
+        if not tenor_gif_ids.mapped("tenor_gif_id"):
+            return ([],)
         return (self._gif_posts(tenor_gif_ids.mapped("tenor_gif_id")) or [],)
 
     @route("/discuss/gif/remove_favorite", type="json", auth="user")

--- a/addons/mail/controllers/discuss/gif.py
+++ b/addons/mail/controllers/discuss/gif.py
@@ -16,7 +16,7 @@ class DiscussGifController(Controller):
         response = None
         try:
             response = requests.get(
-                f"https://tenor.googleapis.com/v2/{endpoint}", timeout=3
+                f"https://api.klipy.com/v2/{endpoint}", timeout=3
             )
             response.raise_for_status()
         except (urllib3.exceptions.MaxRetryError, requests.exceptions.HTTPError):
@@ -74,7 +74,7 @@ class DiscussGifController(Controller):
         ir_config = request.env["ir.config_parameter"].sudo()
         query_string = werkzeug.urls.url_encode(
             {
-                "ids": ",".join(ids),
+                "ids": ",".join(ids) or None,
                 "key": ir_config.get_param("discuss.tenor_api_key"),
                 "client_key": request.env.cr.dbname,
                 "media_filter": "tinygif",
@@ -89,6 +89,8 @@ class DiscussGifController(Controller):
         tenor_gif_ids = request.env["discuss.gif.favorite"].search(
             [("create_uid", "=", request.env.user.id)], limit=20, offset=offset
         )
+        if not tenor_gif_ids.mapped("tenor_gif_id"):
+            return ([[]])
         return (self._gif_posts(tenor_gif_ids.mapped("tenor_gif_id")) or [],)
 
     @route("/discuss/gif/remove_favorite", type="json", auth="user")

--- a/addons/mail/models/discuss/mail_guest.py
+++ b/addons/mail/models/discuss/mail_guest.py
@@ -136,8 +136,8 @@ class MailGuest(models.Model):
             'current_partner': False,
             'current_user_id': False,
             'current_user_settings': False,
-             # sudo: ir.config_parameter: safe to check for existence of tenor api key
-            'hasGifPickerFeature': bool(self.env["ir.config_parameter"].sudo().get_param("discuss.tenor_api_key")),
+             # sudo: ir.config_parameter: safe to check for existence of klipy api key
+            'hasGifPickerFeature': bool(self.env["ir.config_parameter"].sudo().get_param("discuss.klipy_api_key")),
             'hasLinkPreviewFeature': self.env['mail.link.preview']._is_link_preview_enabled(),
             'hasMessageTranslationFeature': False,
              # sudo: bus.bus: reading non-sensitive last id

--- a/addons/mail/models/discuss/res_users.py
+++ b/addons/mail/models/discuss/res_users.py
@@ -56,7 +56,7 @@ class ResUsers(models.Model):
         return {
             "channels": channels._channel_info(),
             # sudo: ir.config_parameter - reading hard-coded key to check its existence, safe to return if the feature is enabled
-            "hasGifPickerFeature": bool(self.env["ir.config_parameter"].sudo().get_param("discuss.tenor_api_key")),
+            "hasGifPickerFeature": bool(self.env["ir.config_parameter"].sudo().get_param("discuss.klipy_api_key")),
             # sudo: ir.config_parameter - reading hard-coded key to check its existence, safe to return if the feature is enabled
             'hasMessageTranslationFeature': bool(self.env["ir.config_parameter"].sudo().get_param("mail.google_translate_api_key")),
             **super()._init_messaging(),

--- a/addons/mail/models/ir_config_parameter.py
+++ b/addons/mail/models/ir_config_parameter.py
@@ -68,7 +68,7 @@ class IrConfigParameter(models.Model):
     #     configuration parameters when using web push notifications;
     #   * 'mail.use_twilio_rtc_servers', 'mail.sfu_server_url' and 'mail.
     #     sfu_server_key': rtc server usage and configuration;
-    #   * 'discuss.tenor_api_key', 'discuss.tenor_gif_limit' and 'discuss.
+    #   * 'discuss.klipy_api_key', 'discuss.tenor_gif_limit' and 'discuss.
     #     tenor_content_filter' used for gif fetch service;
     _inherit = 'ir.config_parameter'
 

--- a/addons/mail/models/res_config_settings.py
+++ b/addons/mail/models/res_config_settings.py
@@ -46,21 +46,23 @@ class ResConfigSettings(models.TransientModel):
     email_secondary_color = fields.Char(related='company_id.email_secondary_color', readonly=False)
 
     tenor_api_key = fields.Char(
-        'Tenor API key',
-        config_parameter='discuss.tenor_api_key',
-        help="Add a Tenor GIF API key to enable GIFs support. https://developers.google.com/tenor/guides/quickstart#setup",
+        'Klipy API key',
+        config_parameter='discuss.klipy_api_key',
+        help="Add a Klipy GIF API key to enable GIFs support. https://docs.klipy.com/getting-started\n"
+        "If you were using a Tenor GIF API key (service shutdown on June 30, 2026), please replace it here with a Klipy GIF API key",
     )
     tenor_content_filter = fields.Selection(
         [('high', 'High'),
         ('medium', 'Medium'),
         ('low', 'Low'),
         ('off', 'Off')],
-        string='Tenor content filter',
-        help="https://developers.google.com/tenor/guides/content-filtering",
+        string='Klipy content filter',
+        help="https://docs.klipy.com/migrate-from-tenor/content-filtering",
         config_parameter='discuss.tenor_content_filter',
         default='low',
     )
     tenor_gif_limit = fields.Integer(
+        string='Klipy GIF limits',
         default=8,
         config_parameter='discuss.tenor_gif_limit',
         help="Fetch up to the specified number of GIF.",

--- a/addons/mail/models/res_config_settings.py
+++ b/addons/mail/models/res_config_settings.py
@@ -46,9 +46,10 @@ class ResConfigSettings(models.TransientModel):
     email_secondary_color = fields.Char(related='company_id.email_secondary_color', readonly=False)
 
     tenor_api_key = fields.Char(
-        'Tenor API key',
+        'Klipy API key',
         config_parameter='discuss.tenor_api_key',
-        help="Add a Tenor GIF API key to enable GIFs support. https://developers.google.com/tenor/guides/quickstart#setup",
+        help="Add a Klipy GIF API key to enable GIFs support. https://docs.klipy.com/getting-started\n"
+        "If you were using a Tenor GIF API key (service shutdown on June 30, 2026), please replace it here with a Klipy GIF API",
     )
     tenor_content_filter = fields.Selection(
         [('high', 'High'),

--- a/addons/mail/static/src/discuss/gif_picker/common/composer_patch.js
+++ b/addons/mail/static/src/discuss/gif_picker/common/composer_patch.js
@@ -40,7 +40,7 @@ const composerPatch = {
         markEventHandled(ev, "Composer.onClickAddGif");
     },
     async sendGifMessage(gif) {
-        await this._sendMessage(gif.url, {
+        await this._sendMessage(gif.media_formats.tinygif.url, {
             parentId: this.props.messageToReplyTo?.message?.id,
         });
     },

--- a/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
+++ b/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
@@ -16,6 +16,7 @@
                 <div t-if="state.loadingError" class="text-center">
                     <span class="o-discuss-GifPicker-error d-block">😵‍💫</span>
                     <span class="fs-5 text-muted d-block">Failed to load gifs...</span>
+                    <span t-if="store.user?.isAdmin" class="small text-warning opacity-75 d-block mx-2"><i class="fa fa-warning me-1" role="img"/>If you were using a Tenor API key, please replace it with a Klipy API key in the General Settings.</span>
                 </div>
                 <div t-if="state.showCategories and !state.loadingError" class="row row-cols-2 gy-2 gx-2" aria-label="list">
                     <div t-if="!store.guest" class="col">

--- a/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
+++ b/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
@@ -16,6 +16,7 @@
                 <div t-if="state.loadingError" class="text-center">
                     <span class="o-discuss-GifPicker-error d-block">😵‍💫</span>
                     <span class="fs-5 text-muted d-block">Failed to load gifs...</span>
+                    <span t-if="store.user?.isAdmin" class="small text-muted text-warning opacity-75 d-block mx-2"><i class="fa fa-warning me-1"/>If you were using a Tenor API key, please replace it with a Klipy API key in the General Settings.</span>
                 </div>
                 <div t-if="state.showCategories and !state.loadingError" class="row row-cols-2 gy-2 gx-2" aria-label="list">
                     <div t-if="!store.guest" class="col">

--- a/addons/mail/views/res_config_settings_views.xml
+++ b/addons/mail/views/res_config_settings_views.xml
@@ -97,13 +97,13 @@
                         <setting id="restrict_template_rendering_setting" help="Restrict mail templates edition and QWEB placeholders usage.">
                             <field name="restrict_template_rendering"/>
                         </setting>
-                        <setting id="tenor_api_key" string="Tenor GIF API key" help="Add a Tenor GIF API key to enable GIFs support." documentation="https://developers.google.com/tenor/guides/quickstart#setup">
+                        <setting id="tenor_api_key" string="Klipy GIF API key" help="Add a Klipy GIF API key to enable GIFs support. If you were using a Tenor GIF API key (service shutdown on June 30, 2026), please replace it here with a Klipy GIF API key" documentation="https://docs.klipy.com/getting-started">
                             <field name="tenor_api_key" placeholder="Paste your API key"/>
                         </setting>
-                        <setting id="tenor_content_filter" string="Tenor GIF content filter" help="Select the content filter used for filtering GIFs" documentation="https://developers.google.com/tenor/guides/content-filtering">
+                        <setting id="tenor_content_filter" string="Klipy GIF content filter" help="Select the content filter used for filtering GIFs" documentation="https://docs.klipy.com/migrate-from-tenor/content-filtering">
                             <field name="tenor_content_filter"/>
                         </setting>
-                        <setting id="tenor_gif_limit" string="Tenor GIF limits" help="Fetch up to the specified number of GIF.">
+                        <setting id="tenor_gif_limit" string="Klipy GIF limits" help="Fetch up to the specified number of GIF.">
                             <field name="tenor_gif_limit"/>
                         </setting>
                         <setting string="Message Translation" help="Google Translate Integration" id="message_translation_setting" documentation="https://cloud.google.com/translate/docs/setup">

--- a/addons/mail/views/res_config_settings_views.xml
+++ b/addons/mail/views/res_config_settings_views.xml
@@ -97,7 +97,7 @@
                         <setting id="restrict_template_rendering_setting" help="Restrict mail templates edition and QWEB placeholders usage.">
                             <field name="restrict_template_rendering"/>
                         </setting>
-                        <setting id="tenor_api_key" string="Tenor GIF API key" help="Add a Tenor GIF API key to enable GIFs support." documentation="https://developers.google.com/tenor/guides/quickstart#setup">
+                        <setting id="tenor_api_key" string="Tenor GIF API key" help="Add a Klipy GIF API key to enable GIFs support. If you were using a Tenor GIF API key (service shutdown on June 30, 2026), please replace it here with a Klipy GIF API" documentation="https://docs.klipy.com/getting-started">
                             <field name="tenor_api_key" placeholder="Paste your API key"/>
                         </setting>
                         <setting id="tenor_content_filter" string="Tenor GIF content filter" help="Select the content filter used for filtering GIFs" documentation="https://developers.google.com/tenor/guides/content-filtering">


### PR DESCRIPTION
Tenor API will be terminated on June 30, 2026: https://developers.google.com/tenor/guides/quickstart

This commit makes the Tenor API key input settings use a Klipy GIF API key instead of a Tenor GIF API key. To keep GIF working after this commit, the API key must necessarily be changed to a Klipy GIF API key, as the old Tenor API key would be considered as an invalid Klipy API key.

Task-5491965

Upgrade: https://github.com/odoo/upgrade/pull/10516