### PR TITLE
[IMP] mail: add KLIPY support for GIFs

### DIFF
--- a/addons/mail/controllers/discuss/gif.py
+++ b/addons/mail/controllers/discuss/gif.py
@@ -15,12 +15,17 @@ _logger = logging.getLogger(__name__)
 
 
 class DiscussGifController(Controller):
-    def _request_gifs(self, endpoint):
+    def _request_gifs(self, endpoint, klipy=False):
         response = None
         try:
-            response = requests.get(
-                f"https://tenor.googleapis.com/v2/{endpoint}", timeout=3
-            )
+            if klipy:
+                response = requests.get(
+                    f"https://api.klipy.com/v2/{endpoint}", timeout=3
+                )
+            else:
+                response = requests.get(
+                    f"https://tenor.googleapis.com/v2/{endpoint}", timeout=3
+                )
             response.raise_for_status()
         except (urllib3.exceptions.MaxRetryError, requests.exceptions.HTTPError):
             _logger.error("Exceeded the request's maximum size for a searching term.")
@@ -38,7 +43,7 @@ class DiscussGifController(Controller):
         query_string = werkzeug.urls.url_encode(
             {
                 "q": search_term,
-                "key": ir_config.get_str("discuss.tenor_api_key"),
+                "key": self._get_key(ir_config),
                 "client_key": request.env.cr.dbname,
                 "limit": TENOR_GIF_LIMIT,
                 "contentfilter": TENOR_CONTENT_FILTER,
@@ -48,7 +53,7 @@ class DiscussGifController(Controller):
                 "pos": position,
             }
         )
-        response = self._request_gifs(f"search?{query_string}")
+        response = self._request_gifs(f"search?{query_string}", klipy=self._is_klipy(ir_config))
         if response:
             return response.json()
 
@@ -60,7 +65,7 @@ class DiscussGifController(Controller):
             return
         query_string = werkzeug.urls.url_encode(
             {
-                "key": ir_config.get_str("discuss.tenor_api_key"),
+                "key": self._get_key(ir_config),
                 "client_key": request.env.cr.dbname,
                 "limit": TENOR_GIF_LIMIT,
                 "contentfilter": TENOR_CONTENT_FILTER,
@@ -68,7 +73,7 @@ class DiscussGifController(Controller):
                 "country": country,
             }
         )
-        response = self._request_gifs(f"categories?{query_string}")
+        response = self._request_gifs(f"categories?{query_string}", klipy=self._is_klipy(ir_config))
         if response:
             return response.json()
 
@@ -80,18 +85,27 @@ class DiscussGifController(Controller):
             return
         request.env["discuss.gif.favorite"].create({"tenor_gif_id": tenor_gif_id})
 
+    def _is_klipy(self, ir_config):
+        return ir_config.get_str("discuss.tenor_api_key").startswith("KLIPY:")
+
+    def _get_key(self, ir_config):
+        key = ir_config.get_str("discuss.tenor_api_key")
+        if key.startswith("KLIPY:"):
+            key = key[len("KLIPY:"):]
+        return key
+
     def _gif_posts(self, ids):
         # sudo: ir.config_parameter - read keys are hard-coded and values are only used for server requests
         ir_config = request.env["ir.config_parameter"].sudo()
         query_string = werkzeug.urls.url_encode(
             {
-                "ids": ",".join(ids),
-                "key": ir_config.get_str("discuss.tenor_api_key"),
+                "ids": ",".join(ids) or None,
+                "key": self._get_key(ir_config),
                 "client_key": request.env.cr.dbname,
                 "media_filter": "tinygif",
             }
         )
-        response = self._request_gifs(f"posts?{query_string}")
+        response = self._request_gifs(f"posts?{query_string}", klipy=self._is_klipy(ir_config))
         if response:
             return response.json()["results"]
 
@@ -104,6 +118,8 @@ class DiscussGifController(Controller):
         tenor_gif_ids = request.env["discuss.gif.favorite"].search(
             [("create_uid", "=", request.env.user.id)], limit=20, offset=offset
         )
+        if not tenor_gif_ids.mapped("tenor_gif_id"):
+            return ([[]])
         return (self._gif_posts(tenor_gif_ids.mapped("tenor_gif_id")) or [],)
 
     @route("/discuss/gif/remove_favorite", type="jsonrpc", auth="user")

--- a/addons/mail/models/res_config_settings.py
+++ b/addons/mail/models/res_config_settings.py
@@ -63,7 +63,8 @@ class ResConfigSettings(models.TransientModel):
     tenor_api_key = fields.Char(
         'Tenor API key',
         config_parameter='discuss.tenor_api_key',
-        help="Add a Tenor GIF API key to enable GIFs support. https://developers.google.com/tenor/guides/quickstart#setup",
+        help="Add a Tenor GIF API key to enable GIFs support. https://developers.google.com/tenor/guides/quickstart#setup\n"
+        "/!\\ Tenor shuts down June 30, please provide Klipy API instead https://klipy.com/migrate with prefix 'KLIPY:' (without quotes)",
     )
     use_google_translate_api = fields.Boolean(
         "Use Google Translate API",

--- a/addons/mail/static/src/discuss/gif_picker/common/composer_actions_patch.js
+++ b/addons/mail/static/src/discuss/gif_picker/common/composer_actions_patch.js
@@ -27,9 +27,9 @@ registerComposerAction("add-gif", {
                 undefined,
                 {
                     onSelect: async (gif) => {
-                        const href = encodeURI(gif.url);
+                        const href = encodeURI(gif.media_formats.tinygif.url);
                         await owner._sendMessage(
-                            markup`<a href="${href}" target="_blank" rel="noreferrer noopener">${gif.url}</a>`,
+                            markup`<a href="${href}" target="_blank" rel="noreferrer noopener">${gif.media_formats.tinygif.url}</a>`,
                             {
                                 parentId: owner.props.composer.replyToMessage?.id,
                             }

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -486,10 +486,10 @@ async function mail_link_preview(request) {
     const { message_id } = await parseRequestParams(request);
     const [message] = MailMessage.search_read([["id", "=", message_id]]);
     const link = createDocumentFragmentFromContent(markup(message.body)).querySelector(
-        "a[href^='https://tenor.com'], a[href='https://make-link-preview.com']"
+        "a[href^='https://media.tenor.com'], a[href='https://make-link-preview.com']"
     );
     if (link) {
-        const isGifPreview = link.href.startsWith("https://tenor.com");
+        const isGifPreview = link.href.startsWith("https://media.tenor.com");
         const linkPreviewId = MailLinkPreview.create({
             og_description: isGifPreview ? "Click to view the GIF" : "test description",
             og_image: isGifPreview ? link.href : undefined,


### PR DESCRIPTION
Tenor API will be terminated on June 30, 2026:
https://developers.google.com/tenor/guides/quickstart

This commit adds support for Klipy API as a replacement: instead of providing the Tenor API key, you can pass the Klipy API key with the prefix "KLIPY:" (without quotes). For example:

```
Tenor API: 1234567890
Klipy API: abcdefghij

1234567890 -> Tenor API key with value 1234567890
KLIPY:abcdefghij -> Klipy API key with value abcdefghij
```

Task-5491965