### PR TITLE
[REF] iap, *: run rendering context migration script

### DIFF
--- a/addons/crm_livechat/static/src/core/web/livechat_channel_info_list_patch.xml
+++ b/addons/crm_livechat/static/src/core/web/livechat_channel_info_list_patch.xml
@@ -2,12 +2,12 @@
 <templates xml:space="preserve">
     <t t-name="website_livechat.LivechatChannelInfoList" t-inherit="im_livechat.LivechatChannelInfoList" t-inherit-mode="extension">
         <xpath expr="//t[@t-name='extra_infos']" position="inside">
-            <t t-if="props.thread.livechatVisitorMember?.partner_id?.opportunity_ids?.length" t-call="im_livechat.LivechatChannelInfoList.info_links">
+            <t t-if="this.props.thread.livechatVisitorMember?.partner_id?.opportunity_ids?.length" t-call="im_livechat.LivechatChannelInfoList.info_links">
                 <t t-set="title">Open leads</t>
                 <t t-set="templateParams"
                     t-value="{
                         title,
-                        'info_records': props.thread.livechatVisitorMember?.partner_id?.opportunity_ids,
+                        'info_records': this.props.thread.livechatVisitorMember?.partner_id?.opportunity_ids,
                         'model': 'crm.lead'
                     }"
                 />

--- a/addons/iap/static/src/action_buttons_widget/action_buttons_widget.xml
+++ b/addons/iap/static/src/action_buttons_widget/action_buttons_widget.xml
@@ -4,8 +4,8 @@
     <t t-name="iap.ActionButtonsWidget">
         <div class="row">
             <div class="col-sm">
-                <button t-on-click="onManageServiceLinkClicked" class="btn btn-link px-0 o-hidden-ios text-nowrap"><i class="oi oi-arrow-right"/> Manage Service &amp; Buy Credits</button><br/>
-                <button t-if="props.showServiceButtons" t-on-click="onViewServicesClicked" class="btn btn-link px-0 o-hidden-ios text-nowrap"><i class="oi oi-arrow-right"/> View My Services</button>
+                <button t-on-click="this.onManageServiceLinkClicked" class="btn btn-link px-0 o-hidden-ios text-nowrap"><i class="oi oi-arrow-right"/> Manage Service &amp; Buy Credits</button><br/>
+                <button t-if="this.props.showServiceButtons" t-on-click="this.onViewServicesClicked" class="btn btn-link px-0 o-hidden-ios text-nowrap"><i class="oi oi-arrow-right"/> View My Services</button>
             </div>
         </div>
     </t>

--- a/addons/im_livechat/static/src/core/common/close_confirmation.xml
+++ b/addons/im_livechat/static/src/core/common/close_confirmation.xml
@@ -7,8 +7,8 @@
                 <div class="position-absolute top-0 end-0 p-1 o-xsmaller">
                     <button class="o-livechat-CloseConfirmation-close btn-close" t-on-click.stop="() => this.props.onCloseConfirmationDialog()"/>
                 </div>
-                <span class="pt-2 pb-3" t-out="confirmationMessage"/>
-                <button class="o-livechat-CloseConfirmation-leave btn btn-danger p-2 gap-1" t-on-keydown.stop.prevent="onKeydown" t-on-click.stop="() => this.props.onClickLeaveConversation()" t-ref="confirm"><i class="fa fa-fw fa-sign-out"/>Yes, leave conversation</button>
+                <span class="pt-2 pb-3" t-out="this.confirmationMessage"/>
+                <button class="o-livechat-CloseConfirmation-leave btn btn-danger p-2 gap-1" t-on-keydown.stop.prevent="this.onKeydown" t-on-click.stop="() => this.props.onClickLeaveConversation()" t-ref="confirm"><i class="fa fa-fw fa-sign-out"/>Yes, leave conversation</button>
             </div>
         </div>
     </t>

--- a/addons/im_livechat/static/src/core/common/livechat_command_dialog.xml
+++ b/addons/im_livechat/static/src/core/common/livechat_command_dialog.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="im_livechat.LivechatCommandDialog">
-        <ActionPanel title="props.title" icon="props.icon" resizable="false">
+        <ActionPanel title="this.props.title" icon="this.props.icon" resizable="false">
             <div class="input-group my-2 shadow-sm">
                 <div class="o-livechat-LivechatCommandDialog-form form-control bg-view p-0" aria-autocomplete="list">
-                    <input type="text" class="border-0 h-100 rounded px-2 form-control" accesskey="Q" t-att-placeholder="props.placeholderText" t-on-keydown="onKeydown" t-ref="autofocus" t-model="state.inputText"/>
+                    <input type="text" class="border-0 h-100 rounded px-2 form-control" accesskey="Q" t-att-placeholder="this.props.placeholderText" t-on-keydown="this.onKeydown" t-ref="autofocus" t-model="this.state.inputText"/>
                 </div>
-                <button class="btn btn-primary" t-on-click="executeCommand" t-att-disabled="!state.inputText" t-out="props.title"/>
+                <button class="btn btn-primary" t-on-click="this.executeCommand" t-att-disabled="!this.state.inputText" t-out="this.props.title"/>
             </div>
         </ActionPanel>
     </t>

--- a/addons/im_livechat/static/src/core/common/transcript_sender.xml
+++ b/addons/im_livechat/static/src/core/common/transcript_sender.xml
@@ -3,19 +3,19 @@
     <t t-name="im_livechat.TranscriptSender">
         <div class="o-livechat-TranscriptSender">
             <div class="input-group">
-                <input t-ref="input" t-on-keydown="onKeydown" t-model="state.email" t-att-disabled="isInputDisabled" type="text" class="form-control" t-att-class="{'bg-view': !isInputDisabled}" placeholder="mail@example.com" />
-                <button class="btn btn-primary" type="button" data-action="sendTranscript" t-att-disabled="isButtonDisabled" t-on-click="onClickSend">
+                <input t-ref="input" t-on-keydown="this.onKeydown" t-model="this.state.email" t-att-disabled="this.isInputDisabled" type="text" class="form-control" t-att-class="{'bg-view': !this.isInputDisabled}" placeholder="mail@example.com" />
+                <button class="btn btn-primary" type="button" data-action="sendTranscript" t-att-disabled="this.isButtonDisabled" t-on-click="this.onClickSend">
                     <i class="fa" t-att-class="{
-                        'fa-circle-o-notch fa-spin': state.status === STATUS.SENDING,
-                        'fa-check': state.status === STATUS.SENT,
-                        'fa-paper-plane': state.status === STATUS.IDLE,
-                        'fa-repeat': state.status === STATUS.FAILED,
+                        'fa-circle-o-notch fa-spin': this.state.status === this.STATUS.SENDING,
+                        'fa-check': this.state.status === this.STATUS.SENT,
+                        'fa-paper-plane': this.state.status === this.STATUS.IDLE,
+                        'fa-repeat': this.state.status === this.STATUS.FAILED,
                     }" />
                 </button>
             </div>
             <div class="form-text ms-1">
-                <t t-if="state.status === STATUS.SENT">The conversation was sent.</t>
-                <t t-elif="state.status === STATUS.FAILED">An error occurred. Please try again.</t>
+                <t t-if="this.state.status === this.STATUS.SENT">The conversation was sent.</t>
+                <t t-elif="this.state.status === this.STATUS.FAILED">An error occurred. Please try again.</t>
             </div>
         </div>
     </t>

--- a/addons/im_livechat/static/src/core/web/command_palette.xml
+++ b/addons/im_livechat/static/src/core/web/command_palette.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="im_livechat.LivechatChannelCommand">
         <div class="o_command_default d-flex align-items-center justify-content-between px-4 py-2">
-            <i class="me-2" t-att-class="props.iconClass"/>
+            <i class="me-2" t-att-class="this.props.iconClass"/>
             <span class="flex-grow-1 text-ellipsis">
                 <t t-slot="name"/>
             </span>

--- a/addons/im_livechat/static/src/core/web/discuss_app/sidebar/category_patch.xml
+++ b/addons/im_livechat/static/src/core/web/discuss_app/sidebar/category_patch.xml
@@ -32,20 +32,20 @@
         <t t-set="livechatThread" t-value="templateParams.livechatThread"/>
         <t t-set="small" t-value="templateParams.small"/>
         <span t-if="livechatThread.channel?.channel_type === 'livechat' and (livechatThread.channel.livechat_status === 'need_help' or livechatThread.livechat_end_dt)" class="o-livechat-LivechatStatusLabel" t-att-title="livechatThread.channel.livechatStatusLabel" t-att-class="{
-            'position-absolute top-0 start-0': env.inDiscussSidebar or env.inChatBubble or env.inNotificationItem,
-            'o-livechat-LivechatStatusLabel-Sidebar end-0 bottom-0 rounded-2 border': env.inDiscussSidebar,
-            'd-flex z-1 bg-opacity-100': env.inChatBubble or env.inNotificationItem,
-            'mx-n1': env.inChatBubble,
-            'mx-n2 my-n1': env.inNotificationItem,
+            'position-absolute top-0 start-0': this.env.inDiscussSidebar or this.env.inChatBubble or this.env.inNotificationItem,
+            'o-livechat-LivechatStatusLabel-Sidebar end-0 bottom-0 rounded-2 border': this.env.inDiscussSidebar,
+            'd-flex z-1 bg-opacity-100': this.env.inChatBubble or this.env.inNotificationItem,
+            'mx-n1': this.env.inChatBubble,
+            'mx-n2 my-n1': this.env.inNotificationItem,
             'o-selfMember': livechatThread.channel.self_member_id,
             'o-help': livechatThread.channel.livechat_status === 'need_help',
-            'bg-info': env.inDiscussSidebar and livechatThread.channel.livechat_status === 'need_help' and !livechatThread.channel.self_member_id,
+            'bg-info': this.env.inDiscussSidebar and livechatThread.channel.livechat_status === 'need_help' and !livechatThread.channel.self_member_id,
         }">
-            <t t-set="livechatStatusButton" t-value="store.livechatStatusButtons.find(btn => btn.status === livechatThread.channel.livechat_status)"/>
+            <t t-set="livechatStatusButton" t-value="this.store.livechatStatusButtons.find(btn => btn.status === livechatThread.channel.livechat_status)"/>
             <i class="o-livechat-LivechatStatusLabel-icon" t-attf-class="{{ livechatThread.livechat_end_dt ? ('fa fa-flag-checkered' + (small ? ' o-xsmaller' : '')) : small ? livechatStatusButton?.iconSmall : livechatStatusButton?.icon }}" t-att-class="{
                 'o-white': livechatThread.livechat_end_dt,
-                'position-absolute start-0 top-0 z-1 o-inDiscussSidebar rounded-circle o-px-0_5': env.inDiscussSidebar,
-                'fa-fw': !env.inDiscussSidebar,
+                'position-absolute start-0 top-0 z-1 o-inDiscussSidebar rounded-circle o-px-0_5': this.env.inDiscussSidebar,
+                'fa-fw': !this.env.inDiscussSidebar,
             }"/>
         </span>
     </t>
@@ -53,7 +53,7 @@
     <t t-name="im_livechat.LivechatStatusSelection">
     <t t-set="livechatThread" t-value="templateParams.livechatThread"/>
         <div class="o-livechat-LivechatStatusSelection list-group" t-ref="livechat-status-selection">
-            <t t-foreach="store.livechatStatusButtons" t-as="btn" t-key="btn.status">
+            <t t-foreach="this.store.livechatStatusButtons" t-as="btn" t-key="btn.status">
                 <t t-set="isBtnActive" t-value="livechatThread.channel.livechat_status === btn.status"/>
                 <button
                     class="list-group-item list-group-item-action d-flex align-items-center gap-2"
@@ -63,7 +63,7 @@
                         'bg-view': isBtnActive and btn.status === 'in_progress',
                         'o-need-help': isBtnActive and btn.status === 'need_help',
                     }"
-                    t-att-disabled="!store.has_access_livechat"
+                    t-att-disabled="!this.store.has_access_livechat"
                     t-on-click="() => livechatThread.channel.updateLivechatStatus(btn.status)"
                 >
                     <input

--- a/addons/im_livechat/static/src/core/web/expertise_tags_autocomplete.xml
+++ b/addons/im_livechat/static/src/core/web/expertise_tags_autocomplete.xml
@@ -3,25 +3,25 @@
     <t t-name="im_livechat.ExpertiseTagsAutocomplete">
         <div
             class="o-livechat-ExpertiseTagsAutocomplete d-inline-flex o_tags_input flex-wrap gap-1 mb-3"
-            t-att-class="{'o_input': !props.disabled, 'o-disabled': props.disabled}"
+            t-att-class="{'o_input': !this.props.disabled, 'o-disabled': this.props.disabled}"
             t-ref="root"
         >
             <div class="d-flex flex-wrap gap-1">
-                <BadgeTag t-foreach="props.channel.livechat_expertise_ids" t-as="expertise" t-key="expertise.id" text="expertise.name" color="expertise.color" onDelete="props.disabled ? null : () => this.unlinkExpertise(expertise)"/>
+                <BadgeTag t-foreach="this.props.channel.livechat_expertise_ids" t-as="expertise" t-key="expertise.id" text="expertise.name" color="expertise.color" onDelete="this.props.disabled ? null : () => this.unlinkExpertise(expertise)"/>
             </div>
-            <div t-if="!props.disabled" class="flex-grow-1 d-inline-flex w-100" style="flex-basis: 0;">
+            <div t-if="!this.props.disabled" class="flex-grow-1 d-inline-flex w-100" style="flex-basis: 0;">
                 <Many2XAutocomplete
-                    placeholder="placeholder"
+                    placeholder="this.placeholder"
                     resModel="'im_livechat.expertise'"
                     activeActions="{'link': true}"
                     isToMany="true"
                     fieldString.translate="Expertise"
-                    update.bind="addExpertises"
-                    quickCreate="store.self_user?.is_livechat_manager ? (name) => this.createAndLinkExpertise(name) : null"
+                    update.bind="this.addExpertises"
+                    quickCreate="this.store.self_user?.is_livechat_manager ? (name) => this.createAndLinkExpertise(name) : null"
                     getDomain="() => []"
                 >
                     <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
-                        <span t-att-class="{ 'fw-bold': isSelected(autoCompleteItemScope.record.id) }">
+                        <span t-att-class="{ 'fw-bold': this.isSelected(autoCompleteItemScope.record.id) }">
                             <span t-out="autoCompleteItemScope.label"/>
                         </span>
                     </t>

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="im_livechat.LivechatChannelInfoList">
-        <ActionPanel title.translate="Information" minWidth="200" initialWidth="env.inMeetingView ? 400 : 300" icon="'fa fa-info'">
-            <a t-if="visitorProfileURL" class="btn btn-primary mt-1 d-flex align-items-center justify-content-between" t-on-click.prevent="openVisitorProfile" t-att-href="visitorProfileURL" title="View Contact">
+        <ActionPanel title.translate="Information" minWidth="200" initialWidth="this.env.inMeetingView ? 400 : 300" icon="'fa fa-info'">
+            <a t-if="this.visitorProfileURL" class="btn btn-primary mt-1 d-flex align-items-center justify-content-between" t-on-click.prevent="this.openVisitorProfile" t-att-href="this.visitorProfileURL" title="View Contact">
                 <span class="flex-grow-1 text-center">
                     <i class="fa fa-address-book-o opacity-50 me-1"/>
                     View Contact
                 </span>
                 <i class="oi oi-chevron-right opacity-50 small"/>
             </a>
-            <div t-if="!props.thread.livechat_end_dt" class="o-livechat-LivechatChannelInfoList d-flex flex-column bg-inherit gap-1">
+            <div t-if="!this.props.thread.livechat_end_dt" class="o-livechat-LivechatChannelInfoList d-flex flex-column bg-inherit gap-1">
                 <h6 class="pt-3 mb-1">Status</h6>
                 <t t-call="im_livechat.LivechatStatusSelection">
-                    <t t-set="templateParams" t-value="{ livechatThread: props.thread }"/>
+                    <t t-set="templateParams" t-value="{ livechatThread: this.props.thread }"/>
                 </t>
             </div>
-            <div t-if="props.thread.livechat_end_dt" class="o-livechat-LivechatChannelInfoList d-flex flex-column bg-inherit gap-1">
+            <div t-if="this.props.thread.livechat_end_dt" class="o-livechat-LivechatChannelInfoList d-flex flex-column bg-inherit gap-1">
                 <h6 class="pt-3 mb-1">Outcome</h6>
                 <div class="d-flex text-truncate">
-                    <t t-if="props.thread.livechat_outcome === 'no_answer'">Never Answered</t>
-                    <t t-elif="props.thread.livechat_outcome === 'no_agent'">No one Available</t>
-                    <t t-elif="props.thread.livechat_outcome === 'no_failure'">Success</t>
-                    <t t-elif="props.thread.livechat_outcome === 'escalated'">Escalated</t>
+                    <t t-if="this.props.thread.livechat_outcome === 'no_answer'">Never Answered</t>
+                    <t t-elif="this.props.thread.livechat_outcome === 'no_agent'">No one Available</t>
+                    <t t-elif="this.props.thread.livechat_outcome === 'no_failure'">Success</t>
+                    <t t-elif="this.props.thread.livechat_outcome === 'escalated'">Escalated</t>
                 </div>
             </div>
             <div class="d-flex flex-column bg-inherit gap-1">
                 <h6 class="pt-3 mb-0">Notes</h6>
-                <textarea class="form-control" t-att-disabled="!store.has_access_livechat"  rows="3" placeholder="Add your notes here..." t-model="props.thread.livechatNoteText" t-on-blur="onBlurNote"></textarea>
+                <textarea class="form-control" t-att-disabled="!this.store.has_access_livechat"  rows="3" placeholder="Add your notes here..." t-model="this.props.thread.livechatNoteText" t-on-blur="this.onBlurNote"></textarea>
             </div>
-            <div t-if="expectAnswerSteps.length" class="d-flex flex-column bg-inherit gap-1">
+            <div t-if="this.expectAnswerSteps.length" class="d-flex flex-column bg-inherit gap-1">
                 <h6 class="pt-3 mb-0">Chatbot answers</h6>
-                <t t-foreach="expectAnswerSteps" t-as="step" t-key="step.id">
+                <t t-foreach="this.expectAnswerSteps" t-as="step" t-key="step.id">
                     <div class="d-flex align-items-center gap-1 bg-inherit rounded-3">
                         <i class="fa fa-comment-o me-1"/>
                         <span class="text-truncate" t-esc="step.answer"/>
@@ -39,20 +39,20 @@
             </div>
             <div class="d-flex flex-column bg-inherit gap-1">
                 <h6 class="pt-3 mb-1">Expertise</h6>
-                <ExpertiseTagsAutocomplete channel="props.thread.channel" disabled="!store.has_access_livechat"/>
+                <ExpertiseTagsAutocomplete channel="this.props.thread.channel" disabled="!this.store.has_access_livechat"/>
             </div>
-            <div t-if="props.thread.channel.correspondentCountry or props.thread.channel.livechat_lang_id">
+            <div t-if="this.props.thread.channel.correspondentCountry or this.props.thread.channel.livechat_lang_id">
                 <h6 class="pt-3">Country &amp; Language</h6>
                 <div class="d-flex bg-inherit align-items-center gap-1">
-                    <img t-if="props.thread.channel.correspondentCountry" class="o_country_flag" t-att-src="props.thread.channel.correspondentCountry.flagUrl" t-att-title="props.thread.channel.correspondentCountry.code or props.thread.channel.correspondentCountry.name" aria-label="Country"/>
-                    <span t-if="props.thread.channel.livechat_lang_id" title="Language" t-esc="props.thread.channel.livechat_lang_id.name"/>
+                    <img t-if="this.props.thread.channel.correspondentCountry" class="o_country_flag" t-att-src="this.props.thread.channel.correspondentCountry.flagUrl" t-att-title="this.props.thread.channel.correspondentCountry.code or this.props.thread.channel.correspondentCountry.name" aria-label="Country"/>
+                    <span t-if="this.props.thread.channel.livechat_lang_id" title="Language" t-esc="this.props.thread.channel.livechat_lang_id.name"/>
                 </div>
             </div>
             <t t-name="extra_infos"/>
-            <div t-if="props.thread.livechat_end_dt" class="d-flex flex-column bg-inherit gap-1">
+            <div t-if="this.props.thread.livechat_end_dt" class="d-flex flex-column bg-inherit gap-1">
                 <h6 class="pt-3 mb-0">Send conversation</h6>
-                <TranscriptSender thread="props.thread"/>
-                <a class="btn btn-outline-secondary" title="Download a copy of this conversation" target="_blank" t-att-href="props.thread.transcriptUrl"><i class="pe-2 fa fa-download"/>Download</a>
+                <TranscriptSender thread="this.props.thread"/>
+                <a class="btn btn-outline-secondary" title="Download a copy of this conversation" target="_blank" t-att-href="this.props.thread.transcriptUrl"><i class="pe-2 fa fa-download"/>Download</a>
             </div>
         </ActionPanel>
     </t>

--- a/addons/im_livechat/static/src/embed/common/feedback_panel/feedback_panel.xml
+++ b/addons/im_livechat/static/src/embed/common/feedback_panel/feedback_panel.xml
@@ -5,30 +5,30 @@
 <div class="d-flex flex-column bg-view flex-grow-1 p-3">
     <div class="p-2">
         <div class="mb-5">
-            <t t-if="state.step === STEP.RATING">
+            <t t-if="this.state.step === this.STEP.RATING">
                 <p class="text-center fs-6 mb-4">Did we correctly answer your question?</p>
                 <div class="d-flex justify-content-center">
-                    <img role="button" class="mx-3 opacity-50 opacity-100-hover" t-att-class="{ 'opacity-100': state.rating === RATING.GOOD }" t-att-src="url(`/rating/static/src/img/rating_${RATING.GOOD}.png`)" t-att-alt="RATING.GOOD" t-on-click="() => this.select(RATING.GOOD)"/>
-                    <img role="button" class="mx-3 opacity-50 opacity-100-hover" t-att-class="{ 'opacity-100': state.rating === RATING.OK }" t-att-src="url(`/rating/static/src/img/rating_${RATING.OK}.png`)" t-att-alt="RATING.OK"  t-on-click="() => this.select(RATING.OK)"/>
-                    <img role="button" class="mx-3 opacity-50 opacity-100-hover" t-att-class="{ 'opacity-100': state.rating === RATING.BAD }" t-att-src="url(`/rating/static/src/img/rating_${RATING.BAD}.png`)" t-att-alt="RATING.BAD" t-on-click="() => this.select(RATING.BAD)"/>
+                    <img role="button" class="mx-3 opacity-50 opacity-100-hover" t-att-class="{ 'opacity-100': this.state.rating === this.RATING.GOOD }" t-att-src="this.url(`/rating/static/src/img/rating_${this.RATING.GOOD}.png`)" t-att-alt="this.RATING.GOOD" t-on-click="() => this.select(this.RATING.GOOD)"/>
+                    <img role="button" class="mx-3 opacity-50 opacity-100-hover" t-att-class="{ 'opacity-100': this.state.rating === this.RATING.OK }" t-att-src="this.url(`/rating/static/src/img/rating_${this.RATING.OK}.png`)" t-att-alt="this.RATING.OK"  t-on-click="() => this.select(this.RATING.OK)"/>
+                    <img role="button" class="mx-3 opacity-50 opacity-100-hover" t-att-class="{ 'opacity-100': this.state.rating === this.RATING.BAD }" t-att-src="this.url(`/rating/static/src/img/rating_${this.RATING.BAD}.png`)" t-att-alt="this.RATING.BAD" t-on-click="() => this.select(this.RATING.BAD)"/>
                 </div>
             </t>
             <t t-else="">
                 <p class="text-center fs-5 fw-bold mb-4">Thank you for your feedback</p>
             </t>
         </div>
-        <div t-if="state.rating and state.step === STEP.RATING" class="d-flex flex-column mb-5">
-            <textarea t-model="state.feedback" class="form-control my-2" placeholder="Explain your note"/>
-            <button class="btn btn-primary align-self-end" t-on-click="onClickSendFeedback">Send</button>
+        <div t-if="this.state.rating and this.state.step === this.STEP.RATING" class="d-flex flex-column mb-5">
+            <textarea t-model="this.state.feedback" class="form-control my-2" placeholder="Explain your note"/>
+            <button class="btn btn-primary align-self-end" t-on-click="this.onClickSendFeedback">Send</button>
         </div>
-        <label class="mb-5 w-100" t-if="store.self_user?.share === false">
+        <label class="mb-5 w-100" t-if="this.store.self_user?.share === false">
             Receive a copy of this conversation
-            <TranscriptSender thread="props.thread" disableOnSend="true"/>
+            <TranscriptSender thread="this.props.thread" disableOnSend="true"/>
         </label>
         <div class="d-flex gap-2 justify-content-center">
-            <button class="btn btn-outline-secondary" t-on-click="props.onClickClose">Close</button>
-            <button t-if="allowNewSession" class="btn btn-outline-secondary" t-on-click="props.onClickNewSession">New Session</button>
-            <a t-if="store.can_download_transcript" class="btn btn-outline-secondary" title="Download a copy of this conversation" target="_blank" t-att-href="props.thread.transcriptUrl"><i class="fa fa-download"/></a>
+            <button class="btn btn-outline-secondary" t-on-click="this.props.onClickClose">Close</button>
+            <button t-if="this.allowNewSession" class="btn btn-outline-secondary" t-on-click="this.props.onClickNewSession">New Session</button>
+            <a t-if="this.store.can_download_transcript" class="btn btn-outline-secondary" title="Download a copy of this conversation" target="_blank" t-att-href="this.props.thread.transcriptUrl"><i class="fa fa-download"/></a>
         </div>
     </div>
 </div>

--- a/addons/im_livechat/static/src/embed/common/livechat_button.xml
+++ b/addons/im_livechat/static/src/embed/common/livechat_button.xml
@@ -4,16 +4,16 @@
 <t t-name="im_livechat.LivechatButton">
     <button
         part="openChatButton"
-        t-if="isShown"
+        t-if="this.isShown"
         class="btn o-livechat-LivechatButton p-3 d-flex justify-content-center align-items-center shadow rounded-circle "
-        t-attf-style="color: {{livechatService.options.button_text_color}}; background-color: {{livechatService.options.button_background_color}};"
+        t-attf-style="color: {{this.livechatService.options.button_text_color}}; background-color: {{this.livechatService.options.button_background_color}};"
         t-ref="button"
-        t-on-click="onClick"
+        t-on-click="this.onClick"
         title="Chat with us"
     >
         <i class="fa fa-commenting" style="font-size: 22px;"/>
-        <div t-if="store.livechat_rule?.action === 'display_button_and_text'" class="o-livechat-LivechatButton-notification text-nowrap position-absolute bg-100 py-2 px-3 rounded" style="max-width: 75vw;" t-att-class="{'o-livechat-LivechatButton-animate': state.animateNotification}">
-            <p class="m-0 text-dark text-truncate" t-esc="livechatService.options.button_text"/>
+        <div t-if="this.store.livechat_rule?.action === 'display_button_and_text'" class="o-livechat-LivechatButton-notification text-nowrap position-absolute bg-100 py-2 px-3 rounded" style="max-width: 75vw;" t-att-class="{'o-livechat-LivechatButton-animate': this.state.animateNotification}">
+            <p class="m-0 text-dark text-truncate" t-esc="this.livechatService.options.button_text"/>
         </div>
     </button>
 </t>

--- a/addons/im_livechat/static/src/js/colors_reset_button/colors_reset_button.xml
+++ b/addons/im_livechat/static/src/js/colors_reset_button/colors_reset_button.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="im_livechat.ColorsResetButton">
-        <button class="btn btn-link oe_edit_only" t-on-click="onColorsResetButtonClick" aria-label="Reset to default colors" title="Reset to default colors">
+        <button class="btn btn-link oe_edit_only" t-on-click="this.onColorsResetButtonClick" aria-label="Reset to default colors" title="Reset to default colors">
             <span class="fa fa-refresh mb-4"/>
         </button>
     </t>

--- a/addons/im_livechat/static/src/views/boolean_phone/boolean_phone.xml
+++ b/addons/im_livechat/static/src/views/boolean_phone/boolean_phone.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="im_livechat.BooleanPhoneField">
-        <i t-if="state.value" class="fa fa-fw fa-phone" role="img" title="In a Call"/>
+        <i t-if="this.state.value" class="fa fa-fw fa-phone" role="img" title="In a Call"/>
     </t>
 </templates>

--- a/addons/im_livechat/static/src/views/discuss_template.xml
+++ b/addons/im_livechat/static/src/views/discuss_template.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="im_livechat.LivechatDiscuss">
-        <t t-if="thread">
-            <Discuss hasSidebar="false" thread="thread"/>
+        <t t-if="this.thread">
+            <Discuss hasSidebar="false" thread="this.thread"/>
         </t>
         <t t-else="">
             <div class="d-flex h-100 flex-column justify-content-center align-items-center">
                 <span class="fs-1">No conversation found</span>
-                <button type="button" class="btn btn-primary" t-on-click="redirectToSessions">
+                <button type="button" class="btn btn-primary" t-on-click="this.redirectToSessions">
                     Go to Sessions
                 </button>
             </div>

--- a/addons/loyalty/static/src/js/portal/loyalty_card_dialog/loyalty_card_dialog.xml
+++ b/addons/loyalty/static/src/js/portal/loyalty_card_dialog/loyalty_card_dialog.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="loyalty.portal_loyalty_card_dialog">
-        <Dialog size="'md'" header="false" footer="false" t-on-click="props.close">
+        <Dialog size="'md'" header="false" footer="false" t-on-click="this.props.close">
             <div class="d-flex align-items-center" t-on-click.stop="">
                 <div class="d-flex justify-content-between w-100 align-items-center">
                     <div class="d-flex align-items-center gap-2">
                         <img
                             class="img-fluid"
-                            t-att-src="props.img_path"
+                            t-att-src="this.props.img_path"
                             width="40"
                         />
-                        <div class="fs-5"><t t-out="props.program.program_name"/></div>
+                        <div class="fs-5"><t t-out="this.props.program.program_name"/></div>
                     </div>
                     <div class="d-flex flex-column align-items-end">
-                        <span class="fs-5" t-out="props.card.points_display"/>
-                        <i class="text-secondary fs-6" t-if="props.card.expiration_date">
-                            Valid until <t t-out="props.card.expiration_date"/>
+                        <span class="fs-5" t-out="this.props.card.points_display"/>
+                        <i class="text-secondary fs-6" t-if="this.props.card.expiration_date">
+                            Valid until <t t-out="this.props.card.expiration_date"/>
                         </i>
                     </div>
                 </div>
                 <div
                     type="button"
                     class="d-sm-block btn-close p-0 p-md-2"
-                    t-on-click="props.close"
+                    t-on-click="this.props.close"
                 />
             </div>
             <hr/>
             <div class="mt-0 pt-0" t-on-click.stop="">
                 <div name="history_lines">
-                    <t t-if="props.history_lines.length">
+                    <t t-if="this.props.history_lines.length">
                         <strong>Last Transactions</strong>
                         <div
-                            t-foreach="props.history_lines"
+                            t-foreach="this.props.history_lines"
                             t-as="line"
                             t-key="line_index"
                             class="row px-2"
@@ -49,8 +49,8 @@
                             <div t-out="line.points" class="text-end col-5"/>
                         </div>
                         <div class="mt-1 mb-1">
-                            <a t-attf-href="/my/loyalty_card/{{props.card.id}}/history/">
-                                -> View History
+                            <a t-attf-href="/my/loyalty_card/{{this.props.card.id}}/history/">
+                                -&gt; View History
                             </a>
                         </div>
                     </t>

--- a/addons/loyalty/static/src/xml/loyalty_templates.xml
+++ b/addons/loyalty/static/src/xml/loyalty_templates.xml
@@ -11,9 +11,9 @@
     <t t-name="loyalty.LoyaltyActionHelper">
         <div class="o_view_nocontent">
             <div class="o_nocontent_help container mt-5 my-lg-auto">
-                <t t-out="props.noContentHelp"/>
+                <t t-out="this.props.noContentHelp"/>
                 <div class="row g-2 g-md-3 mx-auto mt-2 justify-content-center">
-                    <div class="col-12 col-md-4 col-xl-3" t-foreach="Object.entries(loyaltyTemplateData)" t-as="data" t-key="data[0]">
+                    <div class="col-12 col-md-4 col-xl-3" t-foreach="Object.entries(this.loyaltyTemplateData)" t-as="data" t-key="data[0]">
                         <t t-set="loyalty_el_icon" t-value="data[1].icon"/>
                         <t t-set="loyalty_el_title" t-value="data[1].title"/>
                         <button type="button" class="loyalty-template card flex-row flex-md-column align-items-center w-100 h-100 gap-4 gap-md-3 p-3 border rounded" t-on-click.stop.prevent="() => this.onTemplateClick(data[0])" t-attf-aria-label="Select {{loyalty_el_title}} template">

--- a/addons/lunch/static/src/components/lunch_dashboard.xml
+++ b/addons/lunch/static/src/components/lunch_dashboard.xml
@@ -2,9 +2,9 @@
 <templates id="template" xml:space="preserve">
     <t t-name="lunch.LunchCurrency">
         <span>
-            <t t-if="props.currency.position == 'before'" t-esc="props.currency.symbol"/>
-            <t t-esc="amount"/>
-            <t t-if="props.currency.position == 'after'" t-esc="props.currency.symbol"/>
+            <t t-if="this.props.currency.position == 'before'" t-esc="this.props.currency.symbol"/>
+            <t t-esc="this.amount"/>
+            <t t-if="this.props.currency.position == 'after'" t-esc="this.props.currency.symbol"/>
         </span>
     </t>
 
@@ -12,36 +12,36 @@
         <li
             class="d-flex flex-column gap-2 border rounded p-2 w-100 mb-2"
             name="o_lunch_order_line"
-            t-attf-aria-label="{{line.quantity}} {{line.product[1]}} - {{line.state}}"
+            t-attf-aria-label="{{this.line.quantity}} {{this.line.product[1]}} - {{this.line.state}}"
             tabindex="0"
         >
             <div class="d-flex justify-content-between align-items-start gap-2">
                 <h6 class="mb-0">
-                    <span t-if="!props.isToOrder"><t t-out="line.quantity"/> x </span>
-                    <t t-out="line.product[1]"/>
-                    <span t-if="!props.isToOrder"> &#8226; <LunchCurrency currency="props.currency" amount="line.product[2]"/></span>
+                    <span t-if="!this.props.isToOrder"><t t-out="this.line.quantity"/> x </span>
+                    <t t-out="this.line.product[1]"/>
+                    <span t-if="!this.props.isToOrder"> • <LunchCurrency currency="this.props.currency" amount="this.line.product[2]"/></span>
                 </h6>
-                <span t-esc="line.state" t-attf-class="badge flex-shrink-0 rounded-pill text-bg-#{badgeClass}"/>
+                <span t-esc="this.line.state" t-attf-class="badge flex-shrink-0 rounded-pill text-bg-#{this.badgeClass}"/>
             </div>
-            <div t-if="line.note" class="p-2 rounded bg-100 text-muted">
+            <div t-if="this.line.note" class="p-2 rounded bg-100 text-muted">
                 <i class="fa fa-fw fa-sticky-note pe-2"/>
-                <t t-out="line.note"/>
+                <t t-out="this.line.note"/>
             </div>
             <div class="d-flex justify-content-between">
-                <span class="text-nowrap" t-esc="line.location"/>
-                <span class="text-nowrap" t-esc="line.date"/>
+                <span class="text-nowrap" t-esc="this.line.location"/>
+                <span class="text-nowrap" t-esc="this.line.date"/>
             </div>
-            <ul t-if="hasToppings" class="list-group list-group-flush" t-foreach="line.toppings" t-as="topping" t-key="topping">
+            <ul t-if="this.hasToppings" class="list-group list-group-flush" t-foreach="this.line.toppings" t-as="topping" t-key="topping">
                 <li class="list-group-item d-flex justify-content-between ps-2 pe-0 py-1">
                     <span>+ <t t-esc="topping[0]"/></span>
-                    <LunchCurrency currency="props.currency" amount="topping[1]"/>
+                    <LunchCurrency currency="this.props.currency" amount="topping[1]"/>
                 </li>
             </ul>
-            <div t-if="props.isToOrder" class="d-flex justify-content-between">
+            <div t-if="this.props.isToOrder" class="d-flex justify-content-between">
                 <div class="o_lunch_order_line_quantity input-group">
                     <button
                         type="button"
-                        t-attf-class="o_lunch_qty_btn btn btn-sm btn-outline-secondary border-end-0 {{canEdit ? '' : 'opacity-100 disabled'}}"
+                        t-attf-class="o_lunch_qty_btn btn btn-sm btn-outline-secondary border-end-0 {{this.canEdit ? '' : 'opacity-100 disabled'}}"
                         t-on-click="() => this.updateQuantity(-1)"
                         aria-label="Decrease quantity"
                     >
@@ -49,13 +49,13 @@
                     </button>
                     <input
                         type="text"
-                        t-attf-class="form-control border border-start-0 border-end-0 text-center bg-view {{canAdd or canEdit ? '' : 'o_lunch_order_line_input_disabled'}}"
-                        t-att-value="line.quantity"
+                        t-attf-class="form-control border border-start-0 border-end-0 text-center bg-view {{this.canAdd or this.canEdit ? '' : 'o_lunch_order_line_input_disabled'}}"
+                        t-att-value="this.line.quantity"
                         disabled="true"
                     />
                     <button
                         type="button"
-                        t-attf-class="o_lunch_qty_btn btn btn-sm btn-outline-secondary border-start-0 {{canAdd ? '' : 'opacity-100 disabled'}}"
+                        t-attf-class="o_lunch_qty_btn btn btn-sm btn-outline-secondary border-start-0 {{this.canAdd ? '' : 'opacity-100 disabled'}}"
                         t-on-click="() => this.updateQuantity(1)"
                         aria-label="Increase quantity"
                     >
@@ -63,15 +63,15 @@
                     </button>
                 </div>
                 <span class="align-content-end fs-3">
-                    <LunchCurrency currency="props.currency" amount="line.product[2]"/>
+                    <LunchCurrency currency="this.props.currency" amount="this.line.product[2]"/>
                 </span>
             </div>
         </li>
     </t>
 
     <t t-name="lunch.LunchAlerts">
-        <div class="alert alert-warning mb-0" t-if="props.alerts.length !== 0" role="alert">
-            <t t-foreach="props.alerts" t-as="alert" t-key="alert.id">
+        <div class="alert alert-warning mb-0" t-if="this.props.alerts.length !== 0" role="alert">
+            <t t-foreach="this.props.alerts" t-as="alert" t-key="alert.id">
                 <LunchAlert message="alert.message" />
             </t>
         </div>
@@ -79,15 +79,15 @@
 
     <t t-name="lunch.LunchUser">
         <div class="lunch_user flex-grow-1">
-            <span t-if="!props.isManager" t-esc="props.username"/>
+            <span t-if="!this.props.isManager" t-esc="this.props.username"/>
             <div t-else="" class="o_field_widget w-100">
                 <Many2XAutocomplete
-                    value="props.username"
+                    value="this.props.username"
                     resModel="'res.users'"
-                    getDomain="getDomain"
-                    fieldString="props.username"
+                    getDomain="this.getDomain"
+                    fieldString="this.props.username"
                     activeActions="{}"
-                    update.bind="props.onUpdateUser"
+                    update.bind="this.props.onUpdateUser"
                 />
             </div>
         </div>
@@ -95,15 +95,15 @@
 
     <t t-name="lunch.LunchLocation">
         <div class="lunch_location">
-            <t t-if="props.location">
+            <t t-if="this.props.location">
                 <div class="o_field_widget w-100">
                     <Many2XAutocomplete
-                        value="props.location"
+                        value="this.props.location"
                         resModel="'lunch.location'"
-                        fieldString="props.location"
-                        getDomain="getDomain"
+                        fieldString="this.props.location"
+                        getDomain="this.getDomain"
                         activeActions="{}"
-                        update.bind="props.onUpdateLunchLocation"
+                        update.bind="this.props.onUpdateLunchLocation"
                     />
                 </div>
             </t>
@@ -118,29 +118,29 @@
         <div class="o_lunch_banner d-flex flex-column border-start h-100 bg-view">
             <div class="p-3 overflow-y-auto w-100">
                 <div class="d-flex flex-column w-100 gap-2">
-                    <LunchAlerts alerts="state.infos.alerts"/>
+                    <LunchAlerts alerts="this.state.infos.alerts"/>
                     <div class="d-flex gap-2 align-content-center">
-                        <img class="o_image_24_cover rounded" t-att-src="state.infos.userimage"/>
+                        <img class="o_image_24_cover rounded" t-att-src="this.state.infos.userimage"/>
                         <LunchUser
-                            isManager="state.infos.is_manager"
-                            username="state.infos.username"
-                            onUpdateUser.bind="onUpdateUser"/>
+                            isManager="this.state.infos.is_manager"
+                            username="this.state.infos.username"
+                            onUpdateUser.bind="this.onUpdateUser"/>
                     </div>
                     <LunchLocation
-                        location="location"
-                        onUpdateLunchLocation.bind="onUpdateLunchLocation"/>
+                        location="this.location"
+                        onUpdateLunchLocation.bind="this.onUpdateLunchLocation"/>
 
                     <div id="lunch_order_date">
                         <DateTimeInput
                             type="'date'"
                             value="this.state.date"
-                            onChange.bind="onUpdateLunchTime"/>
+                            onChange.bind="this.onUpdateLunchTime"/>
                     </div>
                 </div>
                 <div id="o_lunch_orders" class="o_lunch_widget_line">
-                    <div t-if="hasLines" class="accordion">
+                    <div t-if="this.hasLines" class="accordion">
                         <button
-                            t-if="state.infos.lines.some(line => ['sent', 'confirmed'].includes(line.raw_state))"
+                            t-if="this.state.infos.lines.some(line => ['sent', 'confirmed'].includes(line.raw_state))"
                             class="accordion-button collapsed py-2 px-0 bg-view shadow-none"
                             data-bs-toggle="collapse"
                             href="#o_lunch_passed_orders"
@@ -150,7 +150,7 @@
                             Passed orders
                             <span
                                 class="badge rounded-pill ms-2 text-bg-secondary"
-                                t-out="state.infos.lines.filter(line => ['sent', 'confirmed'].includes(line.raw_state)).length"
+                                t-out="this.state.infos.lines.filter(line => ['sent', 'confirmed'].includes(line.raw_state)).length"
                             />
                         </button>
                         <div
@@ -162,16 +162,16 @@
                             <div class="accordion-body px-0 pt-0">
                                 <ul class="list-unstyled">
                                     <t
-                                        t-foreach="state.infos.lines"
+                                        t-foreach="this.state.infos.lines"
                                         t-as="line" t-key="line.id"
                                         t-if="line.raw_state != 'new' &amp;&amp; line.raw_state != 'ordered'"
                                     >
                                         <LunchOrderLine
                                             line="line"
                                             currency="currency"
-                                            onUpdateQuantity.bind="onUpdateQuantity"
-                                            openOrderLine.bind="props.openOrderLine"
-                                            infos="state.infos"
+                                            onUpdateQuantity.bind="this.onUpdateQuantity"
+                                            openOrderLine.bind="this.props.openOrderLine"
+                                            infos="this.state.infos"
                                             isToOrder="false"
                                         />
                                     </t>
@@ -181,29 +181,29 @@
                     </div>
                     <span
                         class="d-flex justify-content-between p-2 bg-100 rounded"
-                        t-attf-class="{{hasLines and state.infos.lines.some(line => ['sent', 'confirmed'].includes(line.raw_state)) ? '' : 'mt-2'}}"
-                        name="o_lunch_balance" role="status" tabindex="0" t-attf-aria-label="Available Balance {{state.infos.wallet}} {{currency.symbol}}"
+                        t-attf-class="{{this.hasLines and this.state.infos.lines.some(line => ['sent', 'confirmed'].includes(line.raw_state)) ? '' : 'mt-2'}}"
+                        name="o_lunch_balance" role="status" tabindex="0" t-attf-aria-label="Available Balance {{this.state.infos.wallet}} {{currency.symbol}}"
                     >
                         <span><i class="fa fa-money me-2"/>Available Balance</span>
-                        <LunchCurrency currency="currency" amount="state.infos.wallet"/>
+                        <LunchCurrency currency="currency" amount="this.state.infos.wallet"/>
                     </span>
                     <h4 class="mt-3 pt-3 border-top">Your Order</h4>
-                    <p t-if="!(['new', 'ordered'].includes(state.infos.raw_state))" class="text-muted">
+                    <p t-if="!(['new', 'ordered'].includes(this.state.infos.raw_state))" class="text-muted">
                         Nothing to order, add some meals to begin.
                     </p>
-                    <t t-if="hasLines">
+                    <t t-if="this.hasLines">
                         <ul class="list-unstyled">
                             <t
-                                t-foreach="state.infos.lines"
+                                t-foreach="this.state.infos.lines"
                                 t-as="line" t-key="line.id"
                                 t-if="line.raw_state == 'new' || line.raw_state == 'ordered'"
                             >
                                 <LunchOrderLine
                                     line="line"
                                     currency="currency"
-                                    onUpdateQuantity.bind="onUpdateQuantity"
-                                    openOrderLine.bind="props.openOrderLine"
-                                    infos="state.infos"
+                                    onUpdateQuantity.bind="this.onUpdateQuantity"
+                                    openOrderLine.bind="this.props.openOrderLine"
+                                    infos="this.state.infos"
                                     isToOrder="true"
                                 />
                             </t>
@@ -211,34 +211,34 @@
                     </t>
                 </div>
             </div>
-            <div t-if="hasLines" class="mt-auto p-3 border-top">
+            <div t-if="this.hasLines" class="mt-auto p-3 border-top">
                 <span class="d-flex justify-content-between text-muted">
                     Total
-                    <LunchCurrency currency="currency" amount="state.infos.total"/>
+                    <LunchCurrency currency="currency" amount="this.state.infos.total"/>
                 </span>
                 <span class="d-flex justify-content-between text-muted">
                     Already Paid
-                    <LunchCurrency currency="currency" amount="state.infos.paid_subtotal"/>
+                    <LunchCurrency currency="currency" amount="this.state.infos.paid_subtotal"/>
                 </span>
                 <h4 class="d-flex justify-content-between">
                     To Pay
-                    <LunchCurrency currency="currency" amount="state.infos.unpaid_subtotal"/>
+                    <LunchCurrency currency="currency" amount="this.state.infos.unpaid_subtotal"/>
                 </h4>
                 <div class="d-flex flex-column gap-2" name="o_lunch_order_buttons">
                     <button
-                        t-if="canOrder"
+                        t-if="this.canOrder"
                         type="button"
                         class="btn btn-primary"
-                        t-on-click="orderNow"
-                        t-attf-aria-label="Order Now {{state.infos.unpaid_subtotal}}{{currency.symbol}}"
+                        t-on-click="this.orderNow"
+                        t-attf-aria-label="Order Now {{this.state.infos.unpaid_subtotal}}{{currency.symbol}}"
                     >
                         Order Now
                     </button>
                     <button
                         type="button"
-                        t-if="(['new', 'ordered'].includes(state.infos.raw_state))"
+                        t-if="(['new', 'ordered'].includes(this.state.infos.raw_state))"
                         class="btn btn-secondary"
-                        t-on-click.prevent="emptyCart">
+                        t-on-click.prevent="this.emptyCart">
                         Clear Order
                     </button>
                 </div>
@@ -247,8 +247,8 @@
     </t>
 
     <t t-name="lunch.LunchDashboard">
-        <t t-set="currency" t-value="state.infos.currency"/>
-        <t t-if="!env.isSmall">
+        <t t-set="currency" t-value="this.state.infos.currency"/>
+        <t t-if="!this.env.isSmall">
             <t t-call="lunch.LunchDashboardOrder"/>
         </t>
         <t t-else="">
@@ -260,7 +260,7 @@
                     data-bs-target="#lunch_order_mobile"
                     aria-controls="lunch_order_mobile"
                 >
-                    Your Cart (<LunchCurrency currency="currency" amount="state.infos.total || 0"/>)
+                    Your Cart (<LunchCurrency currency="currency" amount="this.state.infos.total || 0"/>)
                 </button>
             </div>
             <div

--- a/addons/lunch/static/src/views/kanban.xml
+++ b/addons/lunch/static/src/views/kanban.xml
@@ -5,7 +5,7 @@
             <div class="o_lunch_content_container flex-grow-1">
                 <t t-call="lunch.WebKanbanRenderer"/>
             </div>
-            <LunchDashboard openOrderLine.bind="openOrderLine"/>
+            <LunchDashboard openOrderLine.bind="this.openOrderLine"/>
         </div>
     </t>
 

--- a/addons/lunch/static/src/views/list.xml
+++ b/addons/lunch/static/src/views/list.xml
@@ -4,7 +4,7 @@
         <div class="o_lunch_content d-flex flex-column flex-md-row h-100 overflow-auto">
             <t t-call="lunch.WebListRenderer"/>
         </div>
-        <LunchDashboard openOrderLine.bind="openOrderLine"/>
+        <LunchDashboard openOrderLine.bind="this.openOrderLine"/>
     </t>
 
     <t t-name="lunch.WebListRenderer" t-inherit="web.ListRenderer" t-inherit-mode="primary" owl="1">

--- a/addons/lunch/static/src/views/no_content_helper.xml
+++ b/addons/lunch/static/src/views/no_content_helper.xml
@@ -4,7 +4,7 @@
     <t t-name="lunch.NoContentHelper" owl="1">
         <t t-set="showNoLocationHelper" t-value="!this.env.searchModel.lunchState.locationId"/>
 
-        <div t-if="showNoLocationHelper and !showNoContentHelper" class="o_view_nocontent" style="pointer-events: all">
+        <div t-if="showNoLocationHelper and !this.showNoContentHelper" class="o_view_nocontent" style="pointer-events: all">
             <div class="o_nocontent_help">
                 <p class="o_view_nocontent_smiling_face">
                     No location found

--- a/addons/pos_loyalty/static/src/portal/loyalty_card_dialog.xml
+++ b/addons/pos_loyalty/static/src/portal/loyalty_card_dialog.xml
@@ -2,14 +2,14 @@
     <t t-inherit="loyalty.portal_loyalty_card_dialog" t-inherit-mode="extension">
         <div name="history_lines" position="before">
             <div
-                t-if="props.program.program_type == 'loyalty'"
+                t-if="this.props.program.program_type == 'loyalty'"
                 class="d-flex align-items-center flex-column"
             >
                 <img
-                    t-att-src="`/report/barcode/Code128/${props.card.code}?&amp;width=350&amp;height=100`"
+                    t-att-src="`/report/barcode/Code128/${this.props.card.code}?&amp;width=350&amp;height=100`"
                     style="width:400px;height:100px"
                 />
-                <span t-out="props.card.code" class="fs-5"/>
+                <span t-out="this.props.card.code" class="fs-5"/>
             </div>
         </div>
     </t>

--- a/addons/website_livechat/static/src/core/web/livechat_channel_info_list_patch.xml
+++ b/addons/website_livechat/static/src/core/web/livechat_channel_info_list_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="website_livechat.LivechatChannelInfoList" t-inherit="im_livechat.LivechatChannelInfoList" t-inherit-mode="extension">
         <xpath expr="//t[@t-name='extra_infos']" position="inside">
-            <t t-set="visitor" t-value="props.thread.livechat_visitor_id"/>
+            <t t-set="visitor" t-value="this.props.thread.livechat_visitor_id"/>
             <div t-if="visitor?.pageVisitHistoryText" class="d-flex flex-column bg-inherit gap-1">
                 <h6 class="pt-3">Recent page views</h6>
                 <div t-if="visitor.website_id">
@@ -11,11 +11,11 @@
                 </div>
                 <span t-esc="visitor.pageVisitHistoryText"/>
             </div>
-            <div t-if="!props.thread.livechat_end_dt and recentConversations.length" class="d-flex flex-column bg-inherit gap-1">
+            <div t-if="!this.props.thread.livechat_end_dt and this.recentConversations.length" class="d-flex flex-column bg-inherit gap-1">
                 <h6 class="pt-3">Recent conversations</h6>
                 <div class="btn btn-group o-rounded-bubble d-flex flex-column w-100 p-0 m-0" style="gap: 1px;">
                     <a
-                        t-foreach="recentConversations" t-as="channel" t-key="channel.localId"
+                        t-foreach="this.recentConversations" t-as="channel" t-key="channel.localId"
                         class="o-livechat-LivechatChannelInfoList-recentConversation btn btn-sm btn-secondary btn-group-item d-flex flex-column w-100 m-0 px-3 py-1"
                         t-attf-href="/odoo/discuss?active_id=discuss.channel_{{channel.id}}"
                         target="_blank"
@@ -29,7 +29,7 @@
                         <div class="d-flex align-items-center">
                             <i class="fa fa-external-link me-2 o-mt-0_5 opacity-75"/>
                             <span>
-                                <t t-if="channel.livechat_end_dt" t-out="CLOSED_ON_TEXT(channel)"/>
+                                <t t-if="channel.livechat_end_dt" t-out="this.CLOSED_ON_TEXT(channel)"/>
                                 <t t-else="">Conversation ongoing</t>
                             </span>
                         </div>

--- a/addons/website_sale_loyalty/static/src/js/portal_loyalty_card.xml
+++ b/addons/website_sale_loyalty/static/src/js/portal_loyalty_card.xml
@@ -3,8 +3,8 @@
     <t t-inherit="loyalty.portal_loyalty_card_dialog" t-inherit-mode="extension">
         <div name="history_lines" position="after">
             <div
-                t-if="props.program.program_type == 'loyalty'"
-                t-foreach="props.rewards"
+                t-if="this.props.program.program_type == 'loyalty'"
+                t-foreach="this.props.rewards"
                 t-as="reward"
                 t-key="reward_index"
                 class="mb-2 mt-2"
@@ -16,9 +16,9 @@
                     <span class="text-primary" t-out="reward.points"/>
                 </div>
             </div>
-            <div t-if="props.rewards.length > 0" class="d-flex justify-content-center">
+            <div t-if="this.props.rewards.length > 0" class="d-flex justify-content-center">
                 <a
-                    t-if="props.program.program_type == 'loyalty'"
+                    t-if="this.props.program.program_type == 'loyalty'"
                     type="button"
                     href="/shop"
                     class="btn btn-primary"
@@ -27,18 +27,18 @@
                 </a>
             </div>
             <div
-                t-if="props.program.program_type == 'ewallet'
-                and props.program.trigger_products.length"
+                t-if="this.props.program.program_type == 'ewallet'
+                and this.props.program.trigger_products.length"
             >
                 <form
                     method="post"
                     action="/wallet/top_up"
                     class="d-flex w-75 w-md-50 m-auto gap-1"
                 >
-                    <input type="hidden" name="csrf_token" t-att-value="csrf_token"/>
+                    <input type="hidden" name="csrf_token" t-att-value="this.csrf_token"/>
                     <select name="trigger_product_id" class="form-select">
                         <t
-                            t-foreach="props.program.trigger_products"
+                            t-foreach="this.props.program.trigger_products"
                             t-as="product"
                             t-key="product_index"
                         >


### PR DESCRIPTION
In preparation for OWL3, where template variables will need to use `.this` to target component variables, we add `.this` to template variables that are targetting the component.

Enterprise PR: https://github.com/odoo/enterprise/pull/108322
Script PR: odoo/odoo#247965

task: OWL3 prep - add this. to template variables

THIS_TARGETS = ["iap", "im_livechat", "iot", "knowledge", "link_tracker", "loyalty", "lunch"]

