### PR TITLE
[FIX] sale_mrp: show MO reference instead of SO in forecasted report

### DIFF
--- a/addons/sale_mrp/models/stock_move.py
+++ b/addons/sale_mrp/models/stock_move.py
@@ -14,3 +14,6 @@ class StockMove(models.Model):
             if bom:
                 return self._get_kit_price_unit(product, bom, order_line.qty_delivered)
         return super()._get_price_unit()
+
+    def _get_source_document(self):
+        return self.production_id or self.raw_material_production_id or super()._get_source_document()

--- a/addons/sale_mrp/tests/test_sale_mrp_report.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_report.py
@@ -1,10 +1,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.fields import Command
-from odoo.tests import tagged
+from odoo.tests import Form, tagged
 from odoo.tools import html2plaintext
 
+
 from odoo.addons.sale.tests.common import TestSaleCommon
+from odoo.addons.stock.tests.test_report import TestReportsCommon
 
 
 @tagged('post_install', '-at_install')
@@ -132,3 +134,33 @@ class TestSaleMrpInvoices(TestSaleCommon):
             [replenisment_line['document_in'], replenisment_line['document_out'], replenisment_line['quantity'], replenisment_line['move_out'], replenisment_line['replenishment_filled']],
             [False, False, 10.0, None, True]
         )
+
+
+class TestSaleMrpReports(TestReportsCommon):
+
+    def test_forecast_report_shows_mo_for_mto_manufacture(self):
+        """Ensure forecast report shows Manufacturing Order as source
+        for MTO manufactured products."""
+        # Enable MTO route
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        mto_route = warehouse.mto_pull_id.route_id
+        mto_route.active = True
+        self.product.route_ids = [Command.link(mto_route.id)]
+        # Create component and BOM
+        component = self.env['product.product'].create({'name': 'Component'})
+        self.env['mrp.bom'].create({
+            'product_tmpl_id': self.product_template.id,
+            'bom_line_ids': [Command.create({'product_id': component.id})],
+        })
+        # Create and confirm SO
+        so_form = Form(self.env['sale.order'])
+        so_form.partner_id = self.partner
+        with so_form.order_line.new() as line:
+            line.product_id = self.product
+        so = so_form.save()
+        so.action_confirm()
+        # Get forecast report
+        _, _, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(lines[0]['document_in']['id'], so.mrp_production_ids.id)
+        self.assertEqual(lines[0]['document_out']['id'], so.id)


### PR DESCRIPTION
Issue:
------------------------------------------------
When a Manufacturing Order is created via an MTO flow from a Sales Order,
the Forecast Report was displaying the Sales Order in the "Available" section
instead of the Manufacturing Order.

Steps to Reproduce:
------------------------------------------------
1. Install `sale_mrp` and `sale_management`.
2. Create a storable product with BOM and MTO route
3. Confirm a Sales Order for the product
4. Open the Forecast Report
5. Observe incorrect reference in "Available" section

Cause:
------------------------------------------------
Before v19.0, finished moves of an MO created via MTO did not carry a
`sale_line_id`, but now it will propagate to the MO finished moves.
Because `_get_source_document()` is overridden in multiple modules,
the `sale_stock` implementation now matches first and returns the
Sales Order, preventing the MRP logic from returning the Manufacturing Order.

With this commit:
------------------------------------------------
This fix ensures that the Manufacturing Order is shown as the
source document providing correct traceability and aligning the behaviour
with the purchase MTO flows.

task-5941986