### PR TITLE
[FIX] point_of_sale: load html editor in POS partner notes

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -187,6 +187,9 @@
             ('remove', 'web/static/src/webclient/actions/reports/layout_assets/**/*'),
             ('remove', 'web/static/src/webclient/actions/**/*css'),
             'web/static/src/webclient/company_service.js',
+            "web/static/lib/dompurify/DOMpurify.js",
+            'html_editor/static/src/**/*',
+            ('include', 'html_editor.assets_media_dialog'),
         ],
         'point_of_sale.base_tests': [
             "web/static/lib/hoot-dom/**/*",


### PR DESCRIPTION
Ensure the POS asset bundle includes the html editor runtime (and DOMPurify) so partner Internal Notes are rendered/edited correctly in the Edit Details dialog.

Steps to reproduce:
-------------------
* Install only Point of Sale on a fresh DB (community setup).
* Add a formatted note in a customer Internal Notes field.
* Open POS -> Customer -> Edit Details -> Internal Notes.
> Observation: note is shown as raw HTML / fallback textarea instead of rendered HTML.

Why the fix:
------------
`point_of_sale.assets_prod` did not include the html editor runtime. Adding html editor to that bundle restores proper HTML rendering/editing.

Test note:
----------
No automated test added: the issue depends on runtime asset loading  and it differs in POS vs backend/test environment

opw-5938168