### PR TITLE
[IMP] hr_expense: add manual correction to expenses

### DIFF
--- a/addons/hr_expense/static/src/scss/hr_expense.scss
+++ b/addons/hr_expense/static/src/scss/hr_expense.scss
@@ -66,7 +66,6 @@
 
     display: flex;
     justify-content: center;
-    z-index: -1;
     padding: 0 map-get($spacers, 3);
 
     img {


### PR DESCRIPTION
The commit aims to allow manual correction of the data extracted by OCR service for expense documents, both images and pdf. The z-index attribute of the scss was remove to allow the bbox to be shown on top of the documents when correcting the data.

related PR: https://github.com/odoo/enterprise/pull/108330
task: 5165853

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
