### PR TITLE
[FIX] website: do not prefix `#top` and `#bottom` menu URLs

### DIFF
--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -186,7 +186,7 @@ class Menu(models.Model):
             url = self.page_id.sudo().url
         else:
             url = self.url
-            if url and not self.url.startswith('/'):
+            if url and not url.startswith('/') and url not in ('#top', '#bottom'):
                 if '@' in self.url:
                     if not self.url.startswith('mailto'):
                         url = 'mailto:%s' % self.url
@@ -305,13 +305,15 @@ class Menu(models.Model):
             if not menu['url'] or '#' in menu['url']:
                 # Multiple case possible
                 # 1. `#` => menu container (dropdown, ..)
-                # 2. `#anchor` => anchor on current page
-                # 3. `/url#something` => valid internal URL
-                # 4. https://google.com#smth => valid external URL
+                # 2. `#top` or `#bottom` => special anchors valid for any page
+                # 3. `#anchor` => anchor on current page
+                # 4. `/url#something` => valid internal URL
+                # 5. https://google.com#smth => valid external URL
                 if menu_id.page_id:
                     menu_id.page_id = None
-                if request and menu['url'] and menu['url'].startswith('#') and len(menu['url']) > 1:
-                    # Working on case 2.: prefix anchor with referer URL
+                if request and menu['url'] and menu['url'].startswith('#') and \
+                        len(menu['url']) > 1 and menu['url'] not in ['#top', '#bottom']:
+                    # Working on case 3.: prefix anchor with referer URL
                     referer_url = werkzeug.urls.url_parse(request.httprequest.headers.get('Referer', '')).path
                     menu['url'] = referer_url + menu['url']
             else:

--- a/addons/website/tests/test_menu.py
+++ b/addons/website/tests/test_menu.py
@@ -370,6 +370,23 @@ class TestMenuHttp(common.HttpCase):
         self.assertEqual(self.menu.url, self.page_url + '#anchor', "Page URL should have been properly prefixed with the referer url")
         self.assertEqual(self.page.url, self.page_url, "Page URL should not have changed")
 
+    def test_menu_special_anchors(self):
+        data = {
+            'id': self.menu.id,
+            'parent_id': self.menu.parent_id.id,
+            'name': self.menu.name,
+        }
+
+        data['url'] = '#top'
+        self.simulate_rpc_save_menu(data)
+        self.assertEqual(self.menu.url, '#top', "Menu #top anchor without a page prefix")
+        self.assertEqual(self.menu._clean_url(), '#top', "Clean URL should not have a prefix for #top anchor")
+
+        data['url'] = '#bottom'
+        self.simulate_rpc_save_menu(data)
+        self.assertEqual(self.menu.url, '#bottom', "Menu #bottom anchor without a page prefix")
+        self.assertEqual(self.menu._clean_url(), '#bottom', "Clean URL should not have a prefix for #bottom anchor")
+
     def test_03_mega_menu_translate(self):
         # Setup
         fr = self.env['res.lang']._activate_lang('fr_FR')


### PR DESCRIPTION
__Before commit:__
Menu items with anchor URLs (e.g., `#my-anchor`) are prefixed with the
current page's path. This is correct for page-specific anchors but
breaks generic ones like `#top` and `#bottom`. A menu with the URL
`#top` becomes `/current-page#top`, preventing it from functioning
as a universal "scroll to top" link.

__Cause:__
The server-side logic for processing menu URLs does not differentiate
between page-specific anchors and generic anchors like `#top` or
`#bottom`, treating all anchor links as belonging to the current page.

__Fix:__
In the `save` method, exclude `#top` and `#bottom` from the logic that
prefixes anchors with the current page's URL. This ensures these
special anchors, typically set on the header and footer, work
consistently across the entire website.

A new unit test verifies that `#top` and `#bottom` menu URLs are saved
correctly without being prefixed.

task-5941115