### PR TITLE
[FIX] mrp, stock: keep selected lots in MO consumption

### DIFF
--- a/addons/mrp/tests/test_consume_component.py
+++ b/addons/mrp/tests/test_consume_component.py
@@ -1,7 +1,7 @@
 import copy
 
 from odoo.exceptions import UserError
-from odoo.tests import common, tagged, Form
+from odoo.tests import common, Command, tagged, Form
 
 
 class TestConsumeComponentCommon(common.TransactionCase):
@@ -462,6 +462,38 @@ class TestConsumeComponent(TestConsumeComponentCommon):
         self.assertRecordValues(mo.move_raw_ids, [
             {'should_consume_qty': 1.0, 'quantity': 1.0, 'picked': True},
             {'should_consume_qty': 1.0, 'quantity': 1.0, 'picked': True},
+        ])
+
+    def test_multi_lot_component_consumption(self):
+        """
+        Check that indicated lot on raw move lines are conserved even if the first
+        lot has enough quantity on hand
+        """
+        quants = self.create_quant(self.raw_lot, 2)
+        quants |= self.create_quant(self.raw_lot, 2, offset=1)
+        quants |= self.create_quant(self.raw_serial, 2)
+        quants.action_apply_inventory()
+
+        mo = self.create_mo(self.mo_serial_tmpl, 1)
+        mo.action_confirm()
+        lot_move = mo.move_raw_ids.filtered(lambda m: m.product_id == self.raw_lot)
+        lot_move.quantity = 0
+        move_line_updates = [Command.clear()]
+        move_line_updates += [
+            Command.create({
+                'quantity': 1,
+                'product_id': self.raw_lot.id,
+                'product_uom_id': self.raw_lot.uom_id.id,
+                'lot_id': quants[i].lot_id.id
+            })
+            for i in range(2)
+        ]
+        lot_move.move_line_ids = move_line_updates
+
+        mo.button_mark_done()
+        self.assertRecordValues(mo.move_raw_line_ids.filtered(lambda m: m.product_id == self.raw_lot), [
+            {'quantity': 1.0},
+            {'quantity': 1.0},
         ])
 
     def test_no_component_consumption_on_lot_removal(self):

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2270,6 +2270,7 @@ Please change the quantity done or the rounding precision of your unit of measur
         qty = self.product_uom._compute_quantity(qty, self.product_id.uom_id, round=False)
         total_qty = qty
         consumed_quant = set()
+        quants = []
         for ml in self.move_line_ids:
             ml_qty = ml.quantity
             if float_compare(ml_qty, 0, precision_rounding=ml.product_uom_id.rounding) < 0:
@@ -2306,6 +2307,10 @@ Please change the quantity done or the rounding precision of your unit of measur
                                                                       package_id=ml.package_id,
                                                                       owner_id=ml.owner_id,
                                                                       strict=True)
+            quants.append(ml_quants)
+        for ml_quants in quants:
+            if float_is_zero(qty, precision_rounding=self.product_uom.rounding):
+                break
             avail_qty = sum(q[1] for q in ml_quants)
             # the quant did not add the quantity reserved on this specific move line
             consumed_quant |= {q[0].id for q in ml_quants}


### PR DESCRIPTION
**Issue**
Lots manually indicated on stock move lines can be overridden when producing a
Manufacturing Order.

**Steps to reproduce**
- Create a storable product P tracked by lot
- Create two lots for product P with 2 units each
- Create a MO for a product consuming two units P and confirm it
- On the raw move, manually set 1 unit for each lot
- Click on "Produce All"
- Check the move line associated to the product P
-> 2 units associated to the first lot consumed instead of 1 unit each

**Cause**
While producing:
https://github.com/odoo/odoo/blob/0fe2023dc57b6cc02bd399d3c8fc5d6c8ed6e833/addons/mrp/models/mrp_production.py#L2109-L2110
It sets the quantities:
https://github.com/odoo/odoo/blob/0fe2023dc57b6cc02bd399d3c8fc5d6c8ed6e833/addons/mrp/models/mrp_production.py#L2246
This calls `_set_quantity_done_prepare_vals` with a qty of 2:
https://github.com/odoo/odoo/blob/0fe2023dc57b6cc02bd399d3c8fc5d6c8ed6e833/addons/stock/models/stock_move.py#L2264
which will, for each move line:
- Take the quantity indicated by move line:
https://github.com/odoo/odoo/blob/0fe2023dc57b6cc02bd399d3c8fc5d6c8ed6e833/addons/stock/models/stock_move.py#L2274
https://github.com/odoo/odoo/blob/0fe2023dc57b6cc02bd399d3c8fc5d6c8ed6e833/addons/stock/models/stock_move.py#L2296-L2297
- Then take all the available quantity left for the lot associated to the move line:
https://github.com/odoo/odoo/blob/0fe2023dc57b6cc02bd399d3c8fc5d6c8ed6e833/addons/stock/models/stock_move.py#L2302-L2309
https://github.com/odoo/odoo/blob/0fe2023dc57b6cc02bd399d3c8fc5d6c8ed6e833/addons/stock/models/stock_move.py#L2326-L2327

Instead of first taking all the quantity indicated by the move line, before checking available quantity

opw-5946439