### PR TITLE
[FIX] mail: more intuitive UI with 'generate a new link'

### DIFF
--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -58,21 +58,26 @@
                     </button>
                 </t>
                 <hr t-if="props.channel?.invitationLink" class="border-dark-subtle"/>
-                <div t-if="props.channel?.invitationLink" class="input-group">
-                    <input class="border border-secondary form-control lh-1 rounded-start border-0 smaller" type="text" t-att-value="props.channel.invitationLink" readonly="" disabled="" t-on-focus="onFocusInvitationLinkInput"/>
-                    <button class="btn btn-primary px-2 o-py-0_5" t-on-click="() => this.props.channel.copyInvitationLink()">
-                        <i class="fa fa-copy"/>
-                    </button>
+                <t t-if="props.channel?.invitationLink">
+                    <div class="input-group">
+                        <input class="border border-secondary form-control lh-1 rounded-start border-0 smaller" type="text" t-att-value="props.channel.invitationLink" readonly="" disabled="" t-on-focus="onFocusInvitationLinkInput"/>
+                        <button class="btn btn-primary px-2 o-py-0_5" t-on-click="() => this.props.channel.copyInvitationLink()">
+                            <i class="fa fa-copy"/>
+                        </button>
+                    </div>
+                </t>
+                <div t-if="props.channel?.accessRestrictedToGroupText or props.channel?.invitationLink" class="mt-2 smaller ms-1 gap-1 d-flex align-items-center">
+                    <span class="text-muted me-1" t-esc="props.channel.accessRestrictedToGroupText"/>
+                    <span class="flex-grow-1"/>
                     <button
-                        t-if= "['owner', 'admin'].includes(props.channel.self_member_id?.channel_role)"
-                        class="btn btn-secondary px-2 o-py-0_5"
+                        t-if="['owner', 'admin'].includes(props.channel.self_member_id?.channel_role)"
+                        class="btn btn-link btn-sm px-2 o-py-0_5 opacity-75 opacity-100-hover me-n2 d-flex align-items-center gap-1 align-self-start flex-shrink-0"
                         t-on-click="onClickGenerateNewLink"
-                        title="Generate new invite link"
                     >
-                        <i class="fa fa-refresh"/>
+                        <i class="fa fa-refresh opacity-75"/>
+                        Generate new invite link
                     </button>
                 </div>
-                <div t-if="props.channel?.accessRestrictedToGroupText" class="mt-2 text-muted smaller mx-1" t-esc="props.channel.accessRestrictedToGroupText"/>
             </div>
         </div>
     </t>


### PR DESCRIPTION
The channel invitation has a new feature to generate a new link.

Before this commit, this was placed as an icon button next to the copy clipboard. While this looks like a good placement at first, there is some UX issues: this doesn't feel as natural as before to copy link in clipboard.

This happens because the save to clipboard was the last item, therefore it felt extremely easy to just click on it. With the new button, the generate new link is at the end, and so we are more prone to click on the renew link button than the save to clipboard. Even with the primary button, the placement of save to clipboard requires more precision than we'd expect from such a heavily used button.

This commit fixes the issue by moving the "Generate a new link" below, with the "Access restricted to" text. Justifications are:
- Other positions next to input felt off, whether swap order with save to clipboard or renew button as prefix of input.
- This button is niche, so being below matches more the niche usage of the feature.
- Overall UI of channel invitation feels more balanced.
- Moving to bottom allows to put plain text on button, making it clearer what this button means.

Before / After
<img width="626" height="243" alt="Screenshot 2026-02-23 at 15 42 46" src="https://github.com/user-attachments/assets/01bbf9b6-6fda-4981-8191-a09598e98af8" /> <img width="618" height="251" alt="Screenshot 2026-02-23 at 15 42 25" src="https://github.com/user-attachments/assets/21a797c7-c61e-404f-afe0-fcb4eefe177e" />
