### PR TITLE
[FIX] stock: stock in transit from sublocation

### DIFF
--- a/addons/stock/report/stock_forecasted.py
+++ b/addons/stock/report/stock_forecasted.py
@@ -349,6 +349,15 @@ class StockForecasted(models.AbstractModel):
             for out in out_moves:
                 data = _get_out_move_taken_from_stock_data(out, currents, moves_data[out])
                 moves_data[out].update(data)
+
+        # The out reserved moves may have removed quantities on a sublocation;
+        # any sublocation qties will be added to the main stock location qty
+        for product_id, location_id in currents:
+            qties = currents[product_id, location_id]
+            if location_id in wh_stock_sub_location_ids and location_id != wh_stock_location.id:
+                currents[product_id, location_id] -= qties
+                currents[product_id, wh_stock_location.id] += qties
+
         product_sum = defaultdict(float)
         for product_loc, quantity in currents.items():
             product_sum[product_loc[0]] += quantity

--- a/addons/stock/tests/test_report.py
+++ b/addons/stock/tests/test_report.py
@@ -1342,6 +1342,12 @@ class TestReports(TestReportsCommon):
             }
         ])
 
+        # Ensure that a move from a sublocation doesn't create a negative 'in_transit' line.
+        delivery.action_assign()
+        _, _, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
+        self.assertFalse(any(line['in_transit'] for line in lines))
+        self.assertEqual(len(lines), 2)
+
     def test_report_reception_1_one_receipt(self):
         """ Create 2 deliveries and 1 receipt where some of the products being received
         can be reserved for the deliveries. Check that the reception report correctly


### PR DESCRIPTION
If you create & reserve a move from a sublocation of the main stock location, the forecast report would put this reserved quantity as a negative line in "Free Stock in Transit" instead of removing it from the "Free Stock".

## Steps to reproduce:
- Create sub location WH/Stock/A
- Put 20 unit of a storable product P in WH/Stock/A
- Create Delivery todo in future of 5 units of P, from WH/Stock/A
=> Check Forecasted report, Free Stock = 20 | Free Stock in Transit = -5 

OPW-5953172

---

<img width="1827" height="784" alt="image" src="https://github.com/user-attachments/assets/57c0b130-3916-4b35-9dad-e642f5319591" />

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
