### PR TITLE
[FIX] sale_timesheet: (non-)billable timesheet filters

### DIFF
--- a/addons/hr_attendance/controllers/main.py
+++ b/addons/hr_attendance/controllers/main.py
@@ -27,7 +27,7 @@ class HrAttendance(http.Controller):
             response = {
                 'id': employee.id,
                 'name': employee.name,
-                'hours_today': float_round(employee.hours_today, precision_digits=2),
+                'hours_today': float_round(employee.hours_today, precision_digits=3),
                 'hours_previously_today': float_round(employee.hours_previously_today, precision_digits=2),
                 'today_attendance_ids': employee.today_attendance_ids.read(['check_in', 'check_out', 'worked_hours']),
                 'last_attendance_worked_hours': float_round(employee.last_attendance_worked_hours, precision_digits=2),

--- a/addons/sale_timesheet/data/sale_service_demo.xml
+++ b/addons/sale_timesheet/data/sale_service_demo.xml
@@ -700,7 +700,7 @@
             <field name="name">Improve</field>
             <field name="employee_id" ref="hr.employee_admin"/>
             <field name="date" eval="(DateTime.now() + relativedelta(days=0)).strftime('%Y-%m-%d')"/>
-            <field name="unit_amount">10.00</field>
+            <field name="unit_amount">5.00</field>
             <field name="task_id" search="[('sale_line_id', '=', ref('sale_line_12'))]"/>
             <field name="project_id" search="[('sale_line_id', '=', ref('sale_line_13'))]"/>
             <field name="so_line" ref="sale_line_12"/>
@@ -836,7 +836,7 @@
             <field name="name">Shifting</field>
             <field name="employee_id" ref="hr.employee_admin"/>
             <field name="date" eval="(DateTime.now() + relativedelta(days=0)).strftime('%Y-%m-%d')"/>
-            <field name="unit_amount">10.00</field>
+            <field name="unit_amount">4.00</field>
             <field name="task_id" search="[('sale_line_id', '=', ref('sale_line_18'))]"/>
             <field name="project_id" search="[('sale_line_id', '=', ref('sale_line_13'))]"/>
             <field name="so_line" ref="sale_line_18"/>

--- a/addons/sale_timesheet/views/hr_timesheet_views.xml
+++ b/addons/sale_timesheet/views/hr_timesheet_views.xml
@@ -10,12 +10,10 @@
                     <field name="order_id" string="Sales Order" filter_domain="['|', ('so_line', 'ilike', self), ('order_id', 'ilike', self)]"/>
                 </xpath>
                 <xpath expr="//filter[@name='month']" position="before">
-                    <filter name="billable" string="Billable" domain="[
-                        ('billable_type', 'in', ['02_billable_fixed', '04_billable_time', '06_billable_milestones', '08_billable_manual']),
-                    ]"
+                    <filter name="billable" string="Billable" domain="[('so_line', '!=', False)]"
                         context="{'show_target_left': True}"
                         groups="sales_team.group_sale_salesman"/>
-                    <filter name="non_billable" string="Non-Billable" domain="[('billable_type', '=', '09_non_billable')]"
+                    <filter name="non_billable" string="Non-Billable" domain="[('so_line', '=', False)]"
                         groups="sales_team.group_sale_salesman"/>
                     <separator/>
                 </xpath>


### PR DESCRIPTION
Due to a previous [commit](https://github.com/odoo/odoo/commit/8e8b273), the "Billable" and "Non-Billable" were incorrect for timesheets. This lead the billable timesheet KPI button not to filter the timesheets anymore.

This is fixed by filtering based on whether the analytic line has an SOL associated to it, which is more robust to
changes in the `billable_type` field, and improves clarity.

See odoo/enterprise#108347

task-5956027