### PR TITLE
[FIX] hr_timesheet, sale_timesheet: allow project creation with partner from different company

### DIFF
--- a/addons/hr_timesheet/models/project_project.py
+++ b/addons/hr_timesheet/models/project_project.py
@@ -135,16 +135,7 @@ class ProjectProject(models.Model):
         """ Create an analytic account if project allow timesheet and don't provide one
             Note: create it before calling super() to avoid raising the ValidationError from _check_allow_timesheet
         """
-        defaults = self.default_get(['allow_timesheets', 'account_id', 'is_template'])
-        analytic_accounts_vals = [
-            vals for vals in vals_list
-            if (
-                vals.get('allow_timesheets', defaults.get('allow_timesheets')) and
-                not vals.get('account_id', defaults.get('account_id')) and not vals.get('is_template', defaults.get('is_template'))
-            )
-        ]
-
-        if analytic_accounts_vals:
+        if analytic_accounts_vals := self._get_processed_analytic_account_vals(vals_list):
             analytic_accounts = self.env['account.analytic.account'].create(self._get_values_analytic_account_batch(analytic_accounts_vals))
             for vals, analytic_account in zip(analytic_accounts_vals, analytic_accounts):
                 vals['account_id'] = analytic_account.id
@@ -205,6 +196,22 @@ class ProjectProject(models.Model):
         if not self.env.context.get('from_embedded_action'):
             action['display_name'] = _("%(name)s's Timesheets", name=self.name)
         return action
+
+    def _get_processed_analytic_account_vals(self, vals_list):
+        """
+        Filters the values list to return the values for analytic accounts creation.
+        Allows values modifications through overrides.
+        """
+        defaults = self.default_get(['allow_timesheets', 'account_id', 'is_template'])
+        analytic_accounts_vals = []
+        for vals in vals_list:
+            if (
+                vals.get('allow_timesheets', defaults.get('allow_timesheets'))
+                and not vals.get('account_id', defaults.get('account_id'))
+                and not vals.get('is_template', defaults.get('is_template'))
+            ):
+                analytic_accounts_vals.append(vals)
+        return analytic_accounts_vals
 
     # ----------------------------
     #  Project Updates

--- a/addons/sale_timesheet/models/project_project.py
+++ b/addons/sale_timesheet/models/project_project.py
@@ -530,3 +530,14 @@ class ProjectProject(models.Model):
             *super()._get_template_default_context_whitelist(),
             "allow_timesheets",
         ]
+
+    def _get_processed_analytic_account_vals(self, vals_list):
+        analytic_accounts_vals = super()._get_processed_analytic_account_vals(vals_list)
+        for vals in analytic_accounts_vals:
+            if (
+                (partner_id := self.env['res.partner'].browse(vals.get('partner_id')))
+                and partner_id.company_id
+                and vals.get('company_id') != partner_id.company_id.id
+            ):
+                vals['company_id'] = partner_id.company_id.id
+        return analytic_accounts_vals

--- a/addons/sale_timesheet/tests/test_project.py
+++ b/addons/sale_timesheet/tests/test_project.py
@@ -210,3 +210,23 @@ class TestProject(TestCommonSaleTimesheet):
     def test_duplicate_project_allocated_hours(self):
         self.project_global.allocated_hours = 10
         self.assertEqual(self.project_global.copy().allocated_hours, 10)
+
+    def test_project_creation_timesheet_account_companies(self):
+        project_template = self.env['project.project'].create({
+            'name': 'Project template',
+            'is_template': True,
+            'company_id': False,
+            'allow_timesheets': True,
+            'allow_billable': True,
+        })
+
+        self.partner_b.company_id = self.company
+
+        wizard = self.env['project.template.create.wizard'].create({
+            'template_id': project_template.id,
+            'name': 'New Project from Template',
+            'partner_id': self.partner_b.id,
+        })
+        new_project = wizard._create_project_from_template()
+
+        self.assertEqual(new_project.company_id, self.partner_b.company_id)


### PR DESCRIPTION
### Issue:
Creating a project from a template that has no company with a customer who has one results in a "company inconsistencies" error.

### Steps to reproduce:
- Install `hr_timesheet` and `project`
- Convert a project with no companies and the option "Timesheets" ticked, to a template
- Create a new project using the template
- In the wizard, input a name and select a customer with a company
- Click "Create Project"
- An error pops up

### Cause:
`hr_timesheet` overrides the `create()` of `project.project` to create an `account.analytic.account` if the project allows timesheet and none is given. During the creation of the analytic account, as the field `partner_id` is `check_company=True`, the error is raised in `_check_company()`.

### Solution:
We set the company of the customer on the generated project before building the `analytic_accounts_vals` list.

opw-5931994