### PR TITLE
[FIX] Traceback when printing sale order report

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -514,7 +514,9 @@ class AccountEdiXmlUbl_Bis3(models.AbstractModel):
         customer = vals['customer']
         supplier = vals['supplier']
         if (
-            customer.country_id.code in EUROPEAN_ECONOMIC_AREA_COUNTRY_CODES
+            invoice
+            and invoice.invoice_date
+            and customer.country_id.code in EUROPEAN_ECONOMIC_AREA_COUNTRY_CODES
             and supplier.country_id.code in EUROPEAN_ECONOMIC_AREA_COUNTRY_CODES
             and supplier.country_id != customer.country_id
         ):


### PR DESCRIPTION
If there is no invoice there is no invoice_date

Description of the issue/feature this PR addresses:

Current behavior before PR:

Traceback when printing sale_order report

RPC_ERROR

Odoo Server Error

Occured on picto.odoo.com on 2026-02-23 15:04:53 GMT

Traceback (most recent call last):
  File "/home/odoo/src/odoo/19.0/addons/web/controllers/report.py", line 120, in report_download
    response = self.report_routes(reportname, docids=docids, converter=converter, context=context)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/19.0/odoo/http.py", line 788, in route_wrapper
    result = endpoint(self, *args, **params_ok)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/19.0/addons/web/controllers/report.py", line 42, in report_routes
    pdf = report.with_context(context)._render_qweb_pdf(reportname, docids, data=data)[0]
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/19.0/odoo/addons/base/models/ir_actions_report.py", line 1037, in _render_qweb_pdf
    collected_streams, report_type = self._pre_render_qweb_pdf(report_ref, res_ids=res_ids, data=data)
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/19.0/addons/account/models/ir_actions_report.py", line 74, in _pre_render_qweb_pdf
    return super()._pre_render_qweb_pdf(report_ref, res_ids=res_ids, data=data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/19.0/odoo/addons/base/models/ir_actions_report.py", line 1028, in _pre_render_qweb_pdf
    return self._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids), 'pdf'
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/19.0/addons/sale_pdf_quote_builder/models/ir_actions_report.py", line 23, in _render_qweb_pdf_prepare_streams
    result = super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/enterprise/19.0/account_followup/models/ir_actions_report.py", line 13, in _render_qweb_pdf_prepare_streams
    res = super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/19.0/addons/sale/models/ir_actions_report.py", line 35, in _render_qweb_pdf_prepare_streams
    xml_content = builder._export_order(sale_order)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/19.0/addons/sale_edi_ubl/models/sale_edi_xml_ubl_bis3.py", line 21, in _export_order
    document_node = self._get_sale_order_node(vals)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/19.0/addons/sale_edi_ubl/models/sale_edi_xml_ubl_bis3.py", line 37, in _get_sale_order_node
    self._add_sale_order_delivery_nodes(document_node, vals)
  File "/home/odoo/src/odoo/19.0/addons/sale_edi_ubl/models/sale_edi_xml_ubl_bis3.py", line 138, in _add_sale_order_delivery_nodes
    self._ubl_add_delivery_nodes(sub_vals)
  File "/home/odoo/src/odoo/19.0/addons/account_edi_ubl_cii/models/account_edi_ubl.py", line 1456, in _ubl_add_delivery_nodes
    nodes.append(self._ubl_get_delivery_node_from_delivery_address(vals))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/19.0/addons/sale_edi_ubl/models/sale_edi_xml_ubl_bis3.py", line 126, in _ubl_get_delivery_node_from_delivery_address
    node = super()._ubl_get_delivery_node_from_delivery_address(vals)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/19.0/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py", line 521, in _ubl_get_delivery_node_from_delivery_address
    node['cbc:ActualDeliveryDate']['_text'] = invoice.invoice_date
                                              ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'invoice_date'

The above server error caused the following client error:
RPC_ERROR: Odoo Server Error
    RPCError@https://picto.odoo.com/web/assets/19d4fdc/web.assets_web.min.js:3191:78
    makeErrorFromResponse@https://picto.odoo.com/web/assets/19d4fdc/web.assets_web.min.js:3194:165
    configureBlobDownloadXHR/xhr.onload/decoder.onload@https://picto.odoo.com/web/assets/19d4fdc/web.assets_web.min.js:3177:7
    

Desired behavior after PR is merged:

No more traceback 
