### PR TITLE
[FIX] sale_loyalty: use order currency for loyalty programs

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -250,6 +250,7 @@ class SaleOrder(models.Model):
                 continue
             tax_data = line.tax_id.compute_all(
                 line.price_unit,
+                currency=line.currency_id,
                 quantity=line.product_uom_qty,
                 product=line.product_id,
                 partner=line.order_partner_id,

--- a/addons/sale_loyalty/tests/test_program_numbers.py
+++ b/addons/sale_loyalty/tests/test_program_numbers.py
@@ -1901,6 +1901,65 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         used_points = coupon.history_ids[0].used
         self.assertEqual(used_points, coupon.currency_id.round(used_points))
 
+    def test_rounding_program_application(self):
+        """Check that the loyalty program is applied with the currency settings of the order."""
+        self.env.company = self.env['res.company'].create({
+            'name': 'Test',
+            'currency_id': self.env.ref('base.JPY').id
+        })
+        product_a = self._create_product(
+            name='product_a',
+            lst_price=0.4,
+            taxes_id=[Command.set([])],
+        )
+        loyalty_program = self.env['loyalty.program'].create({
+            'name': '10% promotion',
+            'program_type': 'promotion',
+            'trigger': 'auto',
+            'applies_on': 'current',
+            'rule_ids': [Command.create({})],
+            'reward_ids': [Command.create({
+                'reward_type': 'discount',
+                'discount_mode': 'percent',
+                'discount': 10,
+                'discount_applicability': 'order',
+                'required_points': 1,
+            })],
+        })
+        loyalty_card = self.env['loyalty.card'].create({
+            'program_id': loyalty_program.id,
+            'partner_id': self.partner.id,
+            'points': 10,
+        })
+
+        self.partner.property_product_pricelist.currency_id = self.env.ref('base.USD').id
+        order = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [
+                Command.create({
+                    'product_id': product_a.id,
+                }),
+            ]
+        })
+
+        self.assertEqual(len(order.order_line), 1, 'Promotion line should not be present')
+
+        order._update_programs_and_rewards()
+        rewards = order._get_claimable_rewards(loyalty_card)
+        applicable_reward = rewards.get(loyalty_card)
+
+        self.assertTrue(applicable_reward.program_id, 'Promotion should be applicable')
+        self.assertEqual(applicable_reward.program_id.id, loyalty_program.id, '10% promotion should be applicable')
+
+        self._claim_reward(order, loyalty_program, loyalty_card)
+
+        self.assertEqual(len(order.order_line), 2, 'Promotion should add 1 line')
+        reward_line = order.order_line.filtered(lambda x: x.is_reward_line)
+        self.assertTrue(reward_line, 'Promotion should add 1 line')
+        self.assertEqual(reward_line.reward_id.program_id.id, loyalty_program.id, 'Reward line should be 10% promotion')
+        self.assertEqual(order.reward_amount, -0.04, '10% promotion should be applied')
+        self.assertEqual(order.amount_total, 0.36, '10% promotion should be applied')
+
     def test_apply_order_and_specific_discounts(self):
         """Ensure you can apply a full-order discount, and then a product-specific discount."""
         order_program, specific_program = self.env['loyalty.program'].create([


### PR DESCRIPTION
When the company currency rounds on unit and we try to apply a reward on a sale order that uses another currency and that has a total of less than 0.5, no reward is applied

Steps to reproduce:
1. Install Sales app and l10n_cl and loyalty module
2. Switch to CL Company
3. Go to Sales > Products > Discount & Loyalty
4. Create a new program and change the rule's minimum purchase to 0.00
5. Go to Sales and create a new quotation for customer Acme Corporation and add any product
6. Change the sale order line unit price to 0.4 and click on Reward
7. No discount is applied

Problem:
The company currency is used to compute the discountable amount but when this currency rounds on unit, any amount that is less than 0.5 will be considered as zero so no discount will be applied. This is because the `compute_all` method is called without specifying the currency, so we fallback on the company currency.

Solution:
Pass the order currency when computing the discountable amount

opw-5946975