### PR TITLE
[FIX] sale_stock, stock_account: compute correct credit note cogs dif…

### DIFF
--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -165,7 +165,8 @@ class AccountMoveLine(models.Model):
         posted_cogs_qty = sum(self.sale_line_ids.order_id.invoice_ids.filtered(lambda m: m.move_type == 'out_invoice').line_ids.filtered(
             lambda line: line.product_id == self.product_id and line.display_type == 'cogs' and line.account_id == valuation_account
         ).mapped('quantity'))
-        return posted_cogs_qty + super()._get_cogs_qty()
+        posted_cogs_qty_prod_uom = self.product_uom_id._compute_quantity(posted_cogs_qty, self.product_id.uom_id)
+        return posted_cogs_qty_prod_uom + super()._get_cogs_qty()
 
     def _get_posted_cogs_value(self):
         self.ensure_one()

--- a/addons/sale_stock/tests/test_anglo_saxon_valuation.py
+++ b/addons/sale_stock/tests/test_anglo_saxon_valuation.py
@@ -1391,3 +1391,104 @@ class TestAngloSaxonValuation(TestStockValuationCommon, TestSaleStockCommon):
         self.assertEqual(self.lot1.standard_price, 10)
         self.assertEqual(self.lot2.standard_price, 16)
         self.assertEqual(self.product_avco_auto.standard_price, 14)
+
+    def test_credit_note_cogs_uom(self):
+        """
+        Check that when posting a credit note for a returned product, in a
+        different uom than the product's uom, the cogs are computed correctly.
+        """
+        self.product_standard_auto.invoice_policy = 'delivery'
+        self.product_standard_auto.standard_price = 10.0
+        self.env['stock.quant'].with_context(inventory_mode=True).create({
+            'product_id': self.product_standard_auto.id,
+            'inventory_quantity': 12,
+            'location_id': self.stock_location.id,
+        }).action_apply_inventory()
+
+        # confirm a sale order in other uom
+        so_1 = self.env['sale.order'].sudo().create({
+            'partner_id': self.owner.id,
+            'order_line': [Command.create({
+                'name': self.product_standard_auto.name,
+                'product_id': self.product_standard_auto.id,
+                'product_uom_qty': 2,
+                'product_uom_id': self.uom_pack_of_6.id,
+                'price_unit': 20,
+                'tax_ids': False,
+            })],
+        })
+        so_1.action_confirm()
+        so_1.picking_ids.move_ids.write({'quantity': 12, 'picked': True})
+        so_1.picking_ids.button_validate()
+
+        # invoice the picking
+        invoice_1 = so_1._create_invoices()
+        invoice_1.action_post()
+
+        # create the return in the products uom
+        ctx = {'active_id': so_1.picking_ids.id, 'active_model': 'stock.picking'}
+        return_wizard = Form(self.env['stock.return.picking'].with_context(ctx)).save()
+        return_wizard.product_return_moves.quantity = 9
+        return_picking = return_wizard._create_return()
+        return_picking.move_ids.write({'quantity': 9, 'picked': True})
+        return_picking.button_validate()
+
+        # invoice the credit note
+        credit_note = so_1._create_invoices(final=True)
+        credit_note.action_post()
+        cogs_aml = credit_note.line_ids.filtered(lambda l: l.display_type == 'cogs').sorted('credit')
+        self.assertRecordValues(cogs_aml, [
+            {'account_id': self.account_stock_valuation.id, 'debit': 90.0, 'credit': 0.0},
+            {'account_id': self.account_expense.id, 'debit': 0.0, 'credit': 90.0},
+        ])
+
+    def test_backorder_cogs_different_uom(self):
+        """
+        Check that when posting a credit note for a returned product, in a
+        different uom than the product's uom, the cogs are computed correctly.
+        """
+        self.product_standard_auto.invoice_policy = 'delivery'
+        self.product_standard_auto.standard_price = 10.0
+        self.env['stock.quant'].with_context(inventory_mode=True).create({
+            'product_id': self.product_standard_auto.id,
+            'inventory_quantity': 12,
+            'location_id': self.stock_location.id,
+        }).action_apply_inventory()
+
+        # confirm a sale order in other uom
+        so_1 = self.env['sale.order'].sudo().create({
+            'partner_id': self.owner.id,
+            'order_line': [Command.create({
+                'name': self.product_standard_auto.name,
+                'product_id': self.product_standard_auto.id,
+                'product_uom_qty': 2,
+                'product_uom_id': self.uom_pack_of_6.id,
+                'price_unit': 20,
+                'tax_ids': False,
+            })],
+        })
+        so_1.action_confirm()
+
+        # deliver and invoice first part
+        picking = so_1.picking_ids
+        picking.move_ids.write({'quantity': 6, 'picked': True})
+        Form.from_action(self.env, so_1.picking_ids.button_validate()).save().process()
+        invoice_1 = so_1._create_invoices()
+        invoice_1.action_post()
+
+        # deliver and validate barckorder
+        picking.backorder_ids.move_ids.write({'quantity': 6, 'picked': True})
+        picking.backorder_ids.button_validate()
+        invoice_2 = so_1._create_invoices()
+        invoice_2.action_post()
+
+        cogs_aml = invoice_1.line_ids.filtered(lambda l: l.display_type == 'cogs').sorted('debit')
+        self.assertRecordValues(cogs_aml, [
+            {'account_id': self.account_stock_valuation.id, 'debit': 0.0, 'credit': 60.0},
+            {'account_id': self.account_expense.id, 'debit': 60.0, 'credit': 0.0},
+        ])
+        backorder_cogs_aml = invoice_2.line_ids.filtered(lambda l: l.display_type == 'cogs').sorted('debit')
+        self.assertRecordValues(backorder_cogs_aml, [
+            {'account_id': self.account_stock_valuation.id, 'debit': 0.0, 'credit': 60.0},
+            {'account_id': self.account_expense.id, 'debit': 60.0, 'credit': 0.0},
+        ])

--- a/addons/stock_account/models/account_move_line.py
+++ b/addons/stock_account/models/account_move_line.py
@@ -71,14 +71,15 @@ class AccountMoveLine(models.Model):
                 price_unit = self.product_id.standard_price
             else:
                 price_unit = self.product_id._run_fifo(cogs_qty) / cogs_qty if cogs_qty else 0
-        return (price_unit * cogs_qty - self._get_posted_cogs_value()) / self.quantity
+        line_quantity_uom = self.product_uom_id._compute_quantity(self.quantity, self.product_id.uom_id)
+        return (price_unit * cogs_qty - self._get_posted_cogs_value()) / line_quantity_uom
 
     def _get_stock_moves(self):
         return self.env['stock.move']
 
     def _get_cogs_qty(self):
         self.ensure_one()
-        return self.quantity
+        return self.product_uom_id._compute_quantity(self.quantity, self.product_id.uom_id)
 
     def _get_posted_cogs_value(self):
         self.ensure_one()


### PR DESCRIPTION
…f uom

**Problem:**
partial cogs are computed incorrectly when 
the uom of the invoice is different than the one 
of the product

**Steps to reproduce:**
-1) created a stored product with category std price perpetual
-2) set a cost of 1 and an on hand quantity of 12
-3) for the invoicing policy select 'delivered quantities'
-4) in the sales tab add the packaging 'pack of 6'
-5) confirm a sale order for 2 packs of 6

Problem A: 
-6a) validate the delivery
-7a) create and confirm an invoice for all the quanity 
-8b) on the delivery create a return for a quantity of 6 and validate
-9b) select 'create invoice' on the sale order
-10b) confirm the credit note

Problem B: 
-6b) change the quantity to 6 units on the delivery
-7b) validate with backorder
-8b) create and confirm an invoice for the delivered quantity
(1 pack of 6)
-9b) validate the back order
-10b) create and confirm an invoice for the remaining (1 pack of 6)

**Current behavior:**
Problem A : 
the cogs lines are : 
- crediting stock valuation of 54$
- debiting expenses of 54$

Problem B: 
the cogs lines are: 
- debiting stock valuation of 24
- crediting expenses of 24

**Expected behavior:**
Problem A:
the cogs lines should be: 
- debiting stock valuation of 6
- crediting expenses of 6

Problem B: 
the cogs lines should be: 
- crediting stock valuation of 6
- debiting expenses of 6

**Cause of the issue:**
Both problems have the same cause.
To compute the price unit for the cogs we call _get_cogs_value()
https://github.com/odoo/odoo/blob/b071bc3cb9e1d91d9d0fbce7961c3c75f28ef874/addons/stock_account/models/account_move.py#L122
Inside _get_cogs_value, in the computation of the return value:
https://github.com/odoo/odoo/blob/b071bc3cb9e1d91d9d0fbce7961c3c75f28ef874/addons/stock_account/models/account_move_line.py#L74
- price_unit is computed (in both use cases) using _get_cogs_price_unit
https://github.com/odoo/odoo/blob/b071bc3cb9e1d91d9d0fbce7961c3c75f28ef874/addons/stock_account/models/account_move_line.py#L68
and is expressed in the uom of the product 
https://github.com/odoo/odoo/blob/b071bc3cb9e1d91d9d0fbce7961c3c75f28ef874/addons/stock_account/models/stock_move.py#L238-L240
- self.quantity is expressed in the uom of the invoice (pack of 6)
- cogs_qty is computed using _get_cogs_qty()
https://github.com/odoo/odoo/blob/b071bc3cb9e1d91d9d0fbce7961c3c75f28ef874/addons/stock_account/models/account_move_line.py#L66
and is expressed in the uom of the invoices (pack of 6)

Because of this, in both use cases, the computation is incorrect.

**fix:**
we use the uom of the product everywhere because _get_cogs_value()
should return the price unit in the products uom
https://github.com/odoo/odoo/blob/b071bc3cb9e1d91d9d0fbce7961c3c75f28ef874/addons/stock_account/models/account_move_line.py#L51-L52

opw-5901706