### PR TITLE
[FIX] account_edi_ubl_cii: guard invoice in intracom delivery date logic

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -514,7 +514,9 @@ class AccountEdiXmlUbl_Bis3(models.AbstractModel):
         customer = vals['customer']
         supplier = vals['supplier']
         if (
-            customer.country_id.code in EUROPEAN_ECONOMIC_AREA_COUNTRY_CODES
+            invoice
+            and invoice.invoice_date
+            and customer.country_id.code in EUROPEAN_ECONOMIC_AREA_COUNTRY_CODES
             and supplier.country_id.code in EUROPEAN_ECONOMIC_AREA_COUNTRY_CODES
             and supplier.country_id != customer.country_id
         ):


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:
A regression in account_edi_xml_ubl_bis (_ubl_get_delivery_node_from_delivery_address) references invoice.invoice_date in the intracom delivery branch even when invoice is not set.
This method is also used in sale-order UBL export flows (for example during quotation PDF generation from mail.compose.message), where vals.get('invoice') can be None.
Blame points to regression introduction in commit 0bf8df7d0a096cf8fe984c42d331404d473eeb71 (FP from f6c5aed52e00e807c4879e4139b116f1bea8282e).

### Current behavior before PR:
When the flow reaches sale-order BIS3 export without an invoice in vals, Odoo crashes with:

AttributeError: 'NoneType' object has no attribute 'invoice_date'

This raises an RPC_ERROR and breaks the mail composer / send flow

### Desired behavior after PR is merged:
The intracom delivery-date override is only applied when invoice exists and has invoice_date.
If invoice is missing (sale-order export context), no crash occurs, the delivery node is still generated safely, and mail composer/report generation completes normally.
Invoice export behavior remains unchanged for valid invoice contexts.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
