### PR TITLE
[FIX] mail: fix race-condition test auto-focus speaker in call

### DIFF
--- a/addons/mail/static/src/discuss/call/common/meeting.xml
+++ b/addons/mail/static/src/discuss/call/common/meeting.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.Meeting">
-        <div t-if="store.rtc.channel" class="o-mail-Meeting h-100 w-100 d-flex flex-column" t-att-class="{'o-fullscreen': store.rtc.isFullscreen, 'p-1': !ui.isSmall, 'pb-3': !ui.iSmall and !props.isPip}">
+        <div t-if="store.rtc.channel" class="o-mail-Meeting h-100 w-100 d-flex flex-column" t-att-class="{'o-fullscreen': store.rtc.isFullscreen, 'p-1': !ui.isSmall, 'pb-3': !ui.iSmall and !props.isPip}" t-att-data-active="store.meetingViewOpened">
             <div class="d-flex flex-grow-1 h-100 o-min-height-0 gap-1 position-relative">
                 <div class="o-mail-Meeting-callContainer h-100 flex-grow-1 o-min-width-0" t-att-class="{'d-none': ui.isSmall and threadActions.activeAction?.actionPanelComponentCondition, 'pb-0': ui.isSmall}">
                     <Call hasOverlay="false" isPip="props.isPip"/>

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -1225,7 +1225,7 @@ test("auto-focus participant video in one-to-one call in chat window", async () 
     await mockedRemote.updateUpload("camera", null);
     await click(".o-discuss-CallParticipantCard[aria-label='Batman']");
     await click("[title='Fullscreen']");
-    await contains(".o-mail-Meeting");
+    await contains(".o-mail-Meeting[data-active]");
     await mockedRemote.updateUpload("camera", createVideoStream().getVideoTracks()[0]);
     await contains(".o-discuss-CallParticipantCard[aria-label='Batman'] video");
     await contains(".o-discuss-CallParticipantCard", { count: 2 }); // card does not get focused in meeting view


### PR DESCRIPTION
Before this commit, the following discuss call test may fail non-deterministically:

```
@mail/discuss/call/call/auto-focus participant video in one-to-one call in chat window
```

This happens at the step where it checks that when inside the discuss meeting view, having another participant enable a video stream does not auto-focus the card.

The test was failing and auto-focusing the card because the simulated toggling of enabling the video stream happens before the side-effect of rendering to toggle the flag that meeting view is on. So the handling of event that video stream is toggled on was mistakenly considering outside of meeting view.

This commit fixes the issue by awaiting a `data-active` on the UI if meeting view, which ensures the rendering of meeting view is complete and store is aware of meeting view being open, before triggering the event that simulates toggling of video stream. This technique is borrowed from `DiscussApp` component that requires a similar technique to determine whether a chat window must auto-open or not, which also requires making sure the store knows precisely when `DiscussApp` is logically open.

Fixes runbot-error-240554