### PR TITLE
[FIX] resource: show correct hours per week for flexible resources

### DIFF
--- a/addons/resource/models/resource_resource.py
+++ b/addons/resource/models/resource_resource.py
@@ -337,7 +337,11 @@ class ResourceResource(models.Model):
                 year_week = weeknumber(babel_locale_parse(locale), day)
                 year, week = year_week
                 if (year < end_year) or (year == end_year and week <= end_week):
-                    resource_hours_per_week[resource.id][year_week] = min(resource.calendar_id.full_time_required_hours, day_working_hours + resource_hours_per_week[resource.id][year_week])
+                    # cap weekly hours to the calendar's configured hours_per_week (not the
+                    # company default full_time_required_hours which does not respect
+                    # part-time schedules).
+                    cap = resource.calendar_id.hours_per_week or resource.calendar_id.full_time_required_hours
+                    resource_hours_per_week[resource.id][year_week] = min(cap, day_working_hours + resource_hours_per_week[resource.id][year_week])
 
         for calendar, resources in calendar_resources.items():
             domain = [('calendar_id', '=', False)] if not calendar else None

--- a/addons/resource/tests/test_flexible_resource_calendar.py
+++ b/addons/resource/tests/test_flexible_resource_calendar.py
@@ -64,6 +64,28 @@ class TestFlexibleResourceCalendar(TransactionCase):
 
         cls.resources = cls.flex_resource | cls.fully_flex_resource
 
+    def test_flexible_resource_hours_per_week(self):
+        cal = self.env['resource.calendar'].create({
+            'name': 'Flexible 38h',
+            'tz': 'UTC',
+            'hours_per_day': 7.6,
+            'flexible_hours': True,
+            'hours_per_week': 38.0,
+            'full_time_required_hours': 40.0,
+        })
+        self.assertAlmostEqual(cal.work_time_rate, 95.0, 2)
+        resource = self.env['resource.resource'].create({
+            'name': 'flexpt',
+            'tz': 'UTC',
+            'calendar_id': cal.id,
+        })
+        start_dt = datetime(2025, 7, 28).astimezone(UTC)
+        end_dt = datetime(2025, 8, 3).astimezone(UTC)
+        work_intervals, hours_per_day, hours_per_week = resource._get_flexible_resource_valid_work_intervals(start_dt, end_dt)
+        hours = resource._get_flexible_resource_work_hours(work_intervals[resource.id], hours_per_day[resource.id], hours_per_week[resource.id])
+        self.assertAlmostEqual(hours, 38.0, 2)
+        self.assertAlmostEqual(hours_per_week[resource.id][2025, 31], 38.0, 2)
+
     def test_flexible_resource_work_intervals(self):
         start_dt = datetime(2025, 7, 28).astimezone(UTC)
         end_dt = datetime(2025, 8, 3, 17, 0).astimezone(UTC)


### PR DESCRIPTION
### Steps to reproduce:
- Download Planning app
- From the employees app, create an employee
- Assign that employee a new schedule that is 'Flexible', has 07:36 hours/day 'Avg', and has 'Total' 38 hours/week
- Search for that employee in the planning app and hover over their name

### Cause of Issue:
The total available hours for that employee show as 40h. This is because when calculating the hours per week for the resource, the resource's schedule is not taken into account but the company's.

### Fix:
Add the hours per week for the resource's calendar (if available) in the calculation

opw-5954982