### PR TITLE
[FIX] html_editor: prevent critical embedded attributes removal

### DIFF
--- a/addons/html_editor/static/src/core/sanitize_plugin.js
+++ b/addons/html_editor/static/src/core/sanitize_plugin.js
@@ -28,11 +28,18 @@ export class SanitizePlugin extends Plugin {
      * @returns {HTMLElement} the element itself
      */
     sanitize(elem) {
-        return this.DOMPurify.sanitize(elem, {
+        for (const cb of this.getResource("before_sanitize_processors")) {
+            elem = cb(elem);
+        }
+        elem = this.DOMPurify.sanitize(elem, {
             IN_PLACE: true,
             ADD_TAGS: ["#document-fragment", "fake-el"],
             ADD_ATTR: ["contenteditable"],
         });
+        for (const cb of this.getResource("after_sanitize_processors")) {
+            elem = cb(elem);
+        }
+        return elem;
     }
 
     normalize(element) {


### PR DESCRIPTION
Prior to this commit, since DOMPurify v3.1.2 (and more precisely since usage of v3.1.5
in Odoo), the JS sanitization process aggressively removes html attributes with
`-->`, `<style` and `<title` for security reasons (see [1]).

However `html_editor` embedded components use `data-attributes`
(`data-embedded-props` and `data-embedded-state`) to store various kind of data
as a JSON string. Obviously, such JSON strings easily match the DOMPurify regex
and these attributes are therefore removed, which results in an Editor crash.

There are multiple reasons why such values are acceptable as is for the
`html_editor` usage:
- only `HTMLElement` instances are sanitized, never a string, therefore there is
  no `DOMParser` to trick with invalid HTML.
- values in these attributes are always/exclusively parsed as JSON strings, and
  the editor will crash if the value is not a legit JSON.
- values in these attributes are HTML escaped by the python sanitizer when the
  serialized html is sent to the server.
- values in the JSON parsed object are at worst rendered as plain text (never as
  HTML or other parsed formats).
- values in the JSON parsed object are never executed as JS (only serializable
  primitives are stored).

Therefore, the suggested solution is to encode the values during sanitization,
and decode just after, to keep the rest of the codebase simple and explicit.

[1]: https://mizu.re/post/exploring-the-dompurify-library-hunting-for-misconfigurations#dompurify-gt-3.1.2-safe-for-xml

task-5960707