### PR TITLE
[FIX] mass_mailing: update Img option component to Image

### DIFF
--- a/addons/mass_mailing/static/src/builder/options/company_team_options.xml
+++ b/addons/mass_mailing/static/src/builder/options/company_team_options.xml
@@ -2,9 +2,9 @@
     <t t-name="mass_mailing.CompanyTeamShapesWidth">
         <BuilderRow label.translate="Content Width" applyTo="'div:is(.o_container_small, .container, .container-fluid)'">
             <BuilderButtonGroup action="'classAction'">
-                <BuilderButton actionParam="'o_container_small'"><Img src="'/mass_mailing/static/src/img/snippets_options/content_width_small.svg'" /></BuilderButton>
-                <BuilderButton actionParam="'container'"><Img src="'/mass_mailing/static/src/img/snippets_options/content_width_normal.svg'" /></BuilderButton>
-                <BuilderButton actionParam="'container-fluid'"><Img src="'/mass_mailing/static/src/img/snippets_options/content_width_full.svg'" /></BuilderButton>
+                <BuilderButton actionParam="'o_container_small'"><Image src="'/mass_mailing/static/src/img/snippets_options/content_width_small.svg'" /></BuilderButton>
+                <BuilderButton actionParam="'container'"><Image src="'/mass_mailing/static/src/img/snippets_options/content_width_normal.svg'" /></BuilderButton>
+                <BuilderButton actionParam="'container-fluid'"><Image src="'/mass_mailing/static/src/img/snippets_options/content_width_full.svg'" /></BuilderButton>
             </BuilderButtonGroup>
         </BuilderRow>
     </t>


### PR DESCRIPTION
The `Img` component was renamed `Image` in commit [1].

In the forward port [2], a template with usage of `Img` was not updated to use
`Image` instead, resulting in an issue when using the company teams snippet.

How to reproduce:
- create a new mailing using the builder
- add the s_company_team_shapes snippet
- click on an `<img>` element

Issue:
- crash (Img component is missing)

Solution:
- rename Img to Image

[1]: https://github.com/odoo/odoo/commit/a22e22acacc9d54f39d0f07acc3054cd2a33f61e

[2]: https://github.com/odoo/odoo/commit/d2b56435736e8d507434c1378cb68fae23e8511f

task-5963711