### PR TITLE
[FIX] web_editor: fix error when loading undefined base snippet

### DIFF
--- a/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
+++ b/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
@@ -220,6 +220,9 @@ export class AddSnippetDialog extends Component {
                     originalSnippet = [...this.props.snippets.values()].filter(snip =>
                         !snip.isCustom && snip.name === snippet.name
                     )[0];
+                    if (!originalSnippet) {
+                        return;
+                    }
                     if (originalSnippet.baseBody.querySelector(".s_dialog_preview")
                         || originalSnippet.imagePreview
                         // Specific case for "s_countdown" because it's hybrid (also
@@ -339,6 +342,9 @@ export class AddSnippetDialog extends Component {
             const leftColElements = [];
             const rightColElements = [];
             for (const itemEl of itemEls) {
+                if (!itemEl) {
+                    continue;
+                }
                 const size = itemEl.getBoundingClientRect().height;
                 if (leftColSize <= rightColSize) {
                     leftColElements.push(itemEl);

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -355,7 +355,7 @@
                 <t t-if="debug or not google_maps_api_key" t-snippet="website.s_map" string="Map"
                     t-thumbnail="/website/static/src/img/snippets_thumbs/s_map.svg" group="social"
                     t-image-preview="/website/static/src/img/snippets_previews/s_map_preview.png"/>
-                <t t-if="debug or google_maps_api_key" t-snippet="website.s_google_map" string="Map"
+                <t t-if="debug or google_maps_api_key" t-snippet="website.s_google_map" string="Google Map"
                     t-thumbnail="/website/static/src/img/snippets_thumbs/s_google_map.svg" group="social"
                     t-image-preview="/website/static/src/img/snippets_previews/s_map_preview.png"/>
 


### PR DESCRIPTION
Steps to reproduce:

1. Go to the website editor (ensure developer mode is off)
2. Drag and drop a Map snippet onto the page
3. Click on the newly placed snippet and save it as a custom snippet
4. Enable developer mode and refresh the website editor
5. Add a new Google Map snippet to the page a. The Google Map snippet is the one where the icon shows a map with a pin on the **left side**.
6. In the wizard, enter your valid API key and click Save a. Alternatively, you can use Odoo inspector to write any string into the `google_maps_api_key` field of the `website` model to simulate the above
7. Disable developer mode and refresh the website editor
8. Click one of the categories in the editor side panel to open the snippets browser
9. Click into the 'Custom' snippets category
10. Observe the error

Depending on whether or not you have a Google Maps API key configured on your website, either the `s_map` or `s_google_map` base snippet will be disabled/hidden. When a user has created custom snippets out of the disabled base snippet, you will recieve the error mentioned above when the snippet browser attempts to load in these custom snippets, as it will be unable to load the base snippet. To fix this, we check if an original snippet was found when loading in a custom snippet. If not, we will not load in the custom snippet to avoid confusion. This error does not occur in Developer Mode, as both base snippets are always enabled in this case.

Aditionally, we also clarify which snippet is the Google Map snippet to avoid confusion for the user when creating custom snippets.

opw-5933787