### PR TITLE
[FIX] mrp_account: avoid duplicate labour entry on backorder

### DIFF
--- a/addons/mrp_account/models/mrp_production.py
+++ b/addons/mrp_account/models/mrp_production.py
@@ -74,6 +74,9 @@ class MrpProduction(models.Model):
             if mo.with_company(mo.company_id).product_id.valuation != 'real_time':
                 continue
 
+            if mo.workorder_ids.time_ids.account_move_line_id:
+                continue
+
             product_accounts = mo.product_id.product_tmpl_id.get_product_accounts()
             labour_amounts = defaultdict(float)
             workorders = defaultdict(self.env['mrp.workorder'].browse)

--- a/addons/mrp_account/tests/test_mrp_account.py
+++ b/addons/mrp_account/tests/test_mrp_account.py
@@ -821,3 +821,54 @@ class TestMrpAccountMove(TestAccountMoveStockCommon):
             {'credit': 0.01, 'debit': 0.00},
             {'credit': 0.00, 'debit': 0.01},
         ])
+
+    def test_labor_move_not_duplicated_when_backorder_always(self):
+        """ Ensure labor accounting entry is not duplicated when create backorder is set to always. """
+        # Setup
+        self.env.ref('base.group_user').implied_ids += (
+            self.env.ref('mrp.group_mrp_routings')
+        )
+
+        picking_type = self.env['stock.picking.type'].search([
+            ('code', '=', 'mrp_operation'),
+            ('company_id', '=', self.env.company.id),
+        ], limit=1)
+        self.assertTrue(picking_type, "Manufacturing operation type not found")
+        picking_type.create_backorder = 'always'
+
+        self.workcenter.write({'costs_hour': 20})
+        self.bom.write({
+            'operation_ids': [
+                Command.create({
+                    'name': 'work',
+                    'workcenter_id': self.workcenter.id,
+                    'time_cycle': 60,
+                    'sequence': 1,
+                }),
+            ],
+        })
+
+        # Build
+        production_form = Form(self.env['mrp.production'])
+        production_form.product_id = self.product_A
+        production_form.bom_id = self.bom
+        production_form.product_qty = 100
+        production = production_form.save()
+        production.action_confirm()
+
+        workorder = production.workorder_ids
+        workorder.duration = 1.0
+        workorder.time_ids.write({'duration': 1.0})
+
+        mo_form = Form(production)
+        mo_form.qty_producing = 50
+        production = mo_form.save()
+        production._post_inventory()
+        production.button_mark_done()
+
+        labour_moves = self.env['account.move'].search([
+            ('ref', '=', production.name + ' - Labour'),
+            ('state', '=', 'posted'),
+            ('company_id', '=', production.company_id.id),
+        ])
+        self.assertEqual(len(labour_moves), 1, "Labor entry should not be duplicated when backorder=always")


### PR DESCRIPTION
When the Manufacturing operation type is configured with Create Backorder = Always, `mrp.production.pre_button_mark_done()` re-enters `button_mark_done()` in the same server execution path. This can trigger `_post_labour()` twice, causing two posted “<MO> - Labour” journal entries and doubling labour costs in Accounting.

Labour costs should be posted only once per workorder time entry. Ensure labour is only posted once by skipping workorder times that were already linked to an accounting entry. This prevents a second execution from creating a duplicate labour journal entry.

A test was added to cover the partial production flow when backorder is set to “Always.”

Related ticket: opw-5931754

---