### PR TITLE
[REF] pos_mercado_pago: migrate from Payment Intents to Orders API

### DIFF
--- a/addons/pos_mercado_pago/controllers/main.py
+++ b/addons/pos_mercado_pago/controllers/main.py
@@ -11,21 +11,21 @@ _logger = logging.getLogger(__name__)
 
 
 class PosMercadoPagoWebhook(http.Controller):
-    @http.route('/pos_mercado_pago/notification', methods=['POST'], type="http", auth="none", csrf=False)
+    @http.route("/pos_mercado_pago/notification", methods=["POST"], type="jsonrpc", auth="none", csrf=False)
     def notification(self):
-        """ Process the notification sent by Mercado Pago
+        """Process the notification sent by Mercado Pago
 
         Notification format is always json
         """
         # Check for mandatory keys in header
-        x_request_id = request.httprequest.headers.get('X-Request-Id')
+        x_request_id = request.httprequest.headers.get("X-Request-Id")
         if not x_request_id:
-            _logger.warning('POST message received with no X-Request-Id in header')
+            _logger.warning("POST message received with no X-Request-Id in header")
             return http.Response(status=400)
 
-        x_signature = request.httprequest.headers.get('X-Signature')
+        x_signature = request.httprequest.headers.get("X-Signature")
         if not x_signature:
-            _logger.warning('POST message received with no X-Signature in header')
+            _logger.warning("POST message received with no X-Signature in header")
             return http.Response(status=400)
 
         ts_m = re.search(r"ts=(\d+)", x_signature)
@@ -33,57 +33,59 @@ class PosMercadoPagoWebhook(http.Controller):
         ts = ts_m.group(1) if ts_m else None
         v1 = v1_m.group(1) if v1_m else None
         if not ts or not v1:
-            _logger.warning('Webhook bad X-Signature, ts: %s, v1: %s', ts, v1)
+            _logger.warning("Webhook bad X-Signature, ts: %s, v1: %s", ts, v1)
             return http.Response(status=400)
 
         # Check for payload
         data = request.httprequest.get_json(silent=True)
         if not data:
-            _logger.warning('POST message received with no data')
+            _logger.warning("POST message received with no data")
             return http.Response(status=400)
 
         # If and only if this webhook is related with a payment intend (see payment_mercado_pago.js)
-        # then the field data['additional_info']['external_reference'] contains a string
+        # then the field data['data']['external_reference'] contains a string
         # formated like `XXX_YYY_ZZZ` where:
         # - `XXX` is the session_id
         # - `YYY` is the payment_method_id
         # - `ZZZ` is the pos order uuid for customer identification (Format xxxx-xxxx-xxx) where x is a hexadecimal digit
-        external_reference = data.get('additional_info', {}).get('external_reference')
+        external_reference = data.get("data", {}).get("external_reference")
 
-        mercado_pago_pattern = r'(\d+)_(\d+)_([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})'
+        mercado_pago_pattern = r"(\d+)_(\d+)_([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"
 
         if not external_reference or not (match := re.fullmatch(mercado_pago_pattern, external_reference)):
-            _logger.warning('POST message received with no or malformed "external_reference" key: %s', external_reference)
+            _logger.warning(
+                'POST message received with no or malformed "external_reference" key: %s', external_reference
+            )
             return http.Response(status=400)
 
         session_id, payment_method_id, _ = match.groups()
 
-        pos_session_sudo = request.env['pos.session'].sudo().browse(int(session_id))
-        if not pos_session_sudo or pos_session_sudo.state != 'opened':
+        pos_session_sudo = request.env["pos.session"].sudo().browse(int(session_id))
+        if not pos_session_sudo or pos_session_sudo.state != "opened":
             _logger.error("Invalid session id: %s", session_id)
             # This error is not related with Mercado Pago, simply acknowledge Mercado Pago message
-            return http.Response('OK', status=200)
+            return http.Response("OK", status=200)
 
-        payment_method_sudo = pos_session_sudo.config_id.payment_method_ids.filtered(lambda p: p.id == int(payment_method_id))
-        if not payment_method_sudo or payment_method_sudo.use_payment_terminal != 'mercado_pago':
+        payment_method_sudo = pos_session_sudo.config_id.payment_method_ids.filtered(
+            lambda p: p.id == int(payment_method_id)
+        )
+        if not payment_method_sudo or payment_method_sudo.use_payment_terminal != "mercado_pago":
             _logger.error("Invalid payment method id: %s", payment_method_id)
             # This error is not related with Mercado Pago, simply acknowledge Mercado Pago message
-            return http.Response('OK', status=200)
+            return http.Response("OK", status=200)
 
         # We have to check if this comes from Mercado Pago with the secret key
         secret_key = payment_method_sudo.mp_webhook_secret_key
         signed_template = f"id:{data['id']};request-id:{x_request_id};ts:{ts};"
         cyphed_signature = hmac.new(secret_key.encode(), signed_template.encode(), hashlib.sha256).hexdigest()
         if not hmac.compare_digest(cyphed_signature, v1):
-            _logger.error('Webhook authenticating failure, ts: %s, v1: %s', ts, v1)
+            _logger.error("Webhook authenticating failure, ts: %s, v1: %s", ts, v1)
             return http.Response(status=401)
 
-        _logger.debug('Webhook authenticated, POST message: %s', data)
+        _logger.debug("Webhook authenticated, POST message: %s", data)
 
         # Notify the frontend that we received a message from Mercado Pago
-        pos_session_sudo.config_id._notify('MERCADO_PAGO_LATEST_MESSAGE', {
-            'config_id': pos_session_sudo.config_id.id
-        })
+        pos_session_sudo.config_id._notify("MERCADO_PAGO_LATEST_MESSAGE", {"config_id": pos_session_sudo.config_id.id})
 
         # Acknowledge Mercado Pago message
-        return http.Response('OK', status=200)
+        return http.Response("OK", status=200)

--- a/addons/pos_mercado_pago/models/mercado_pago_pos_request.py
+++ b/addons/pos_mercado_pago/models/mercado_pago_pos_request.py
@@ -12,12 +12,13 @@ class MercadoPagoPosRequest:
     def __init__(self, mp_bearer_token):
         self.mercado_pago_bearer_token = mp_bearer_token
 
-    def call_mercado_pago(self, method, endpoint, payload):
+    def call_mercado_pago(self, method, endpoint, payload, idempotency_key=None):
         """ Make a request to Mercado Pago POS API.
 
         :param method: "GET", "POST", ...
         :param endpoint: The endpoint to be reached by the request.
         :param payload: The payload of the request.
+        :param idempotency_key: Optional idempotency key for request deduplication.
         :return The JSON-formatted content of the response.
 
         Note: The platform id below is not secret, and is just used to
@@ -28,6 +29,11 @@ class MercadoPagoPosRequest:
             'Authorization': f"Bearer {self.mercado_pago_bearer_token}",
             'X-platform-id': "dev_cdf1cfac242111ef9fdebe8d845d0987"
         }
+        
+        # Add idempotency key header if provided
+        if idempotency_key:
+            header['X-Idempotency-Key'] = idempotency_key
+        
         try:
             response = requests.request(method, endpoint, headers=header, json=payload, timeout=REQUEST_TIMEOUT)
             return response.json()

--- a/addons/pos_mercado_pago/models/pos_payment_method.py
+++ b/addons/pos_mercado_pago/models/pos_payment_method.py
@@ -1,4 +1,5 @@
 import logging
+import hashlib
 
 from odoo import api, fields, models, _
 from odoo.exceptions import AccessError, UserError
@@ -35,41 +36,94 @@ class PosPaymentMethod(models.Model):
         """
         Triggered in debug mode when the user wants to force the "PDV" mode.
         It calls the Mercado Pago API to set the terminal mode to "PDV".
+        Uses the terminals API: PATCH /terminals/v1/setup
+        Reference: https://www.mercadopago.com.ar/developers/es/reference/in-person-payments/point/terminals/update-operation-mode/patch
         """
         self._check_special_access()
 
         mercado_pago = MercadoPagoPosRequest(self.sudo().mp_bearer_token)
         _logger.info('Calling Mercado Pago to force the terminal mode to "PDV"')
 
-        mode = {"operating_mode": "PDV"}
-        resp = mercado_pago.call_mercado_pago("patch", f"/point/integration-api/devices/{self.mp_id_point_smart_complet}", mode)
-        if resp.get("operating_mode") != "PDV":
+        payload = {
+            "terminals": [
+                {
+                    "id": self.mp_id_point_smart_complet,
+                    "operating_mode": "PDV"
+                }
+            ]
+        }
+        
+        # Use the terminals API endpoint
+        resp = mercado_pago.call_mercado_pago("patch", "/terminals/v1/setup", payload)
+        
+        # Check if the response contains the updated terminals
+        if 'terminals' in resp and len(resp['terminals']) > 0:
+            if resp['terminals'][0].get("operating_mode") != "PDV":
+                raise UserError(_("Unexpected Mercado Pago response: %s", resp))
+            _logger.debug("Successfully set the terminal mode to 'PDV'.")
+        else:
             raise UserError(_("Unexpected Mercado Pago response: %s", resp))
-        _logger.debug("Successfully set the terminal mode to 'PDV'.")
+        
         return None
 
-    def mp_payment_intent_create(self, infos):
+    def _prepare_mp_order_payload(self, infos):
         """
-        Called from frontend for creating a payment intent in Mercado Pago
+        Prepare the order payload for Mercado Pago Point API.
+        This method can be inherited to customize the payload structure.
+        
+        :param infos: Dictionary containing order information from frontend
+        :return: Dictionary with the order payload
+        """
+        return {
+            "type": "point",
+            "external_reference": infos.get("external_reference"),
+            "expiration_time": "PT16M", 
+            "transactions": {
+                "payments": [
+                    {
+                        "amount": f"{infos.get('amount', 0) / 100.0:.2f}"
+                    }
+                ]
+            },
+            "config": {
+                "point": {
+                    "terminal_id": self.mp_id_point_smart_complet,
+                    "print_on_terminal": "seller_ticket",
+                    "ticket_number": infos.get("ticket_number")
+                },
+                "payment_method": {
+                    "default_type": infos.get("card_type")
+                }
+            },
+            "description": f"Point of Sale payment - {infos.get('external_reference')}",
+        }
+
+    def mp_order_create(self, infos):
+        """
+        Called from frontend for creating an order in Mercado Pago Point
         """
         self._check_special_access()
 
         mercado_pago = MercadoPagoPosRequest(self.sudo().mp_bearer_token)
-        # Call Mercado Pago for payment intend creation
-        resp = mercado_pago.call_mercado_pago("post", f"/point/integration-api/devices/{self.mp_id_point_smart_complet}/payment-intents", infos)
-        _logger.debug("mp_payment_intent_create(), response from Mercado Pago: %s", resp)
+        
+        order_payload = self._prepare_mp_order_payload(infos)        
+        idempotency_key = hashlib.sha256(str(order_payload).encode()).hexdigest()
+        resp = mercado_pago.call_mercado_pago("post", "/v1/orders", order_payload, idempotency_key=idempotency_key)
+        _logger.debug("mp_order_create(), response from Mercado Pago: %s", resp)
         return resp
 
-    def mp_payment_intent_get(self, payment_intent_id):
+    def mp_order_get(self, order_id):
         """
-        Called from frontend to get the last payment intend from Mercado Pago
+        Called from frontend to get the order status from Mercado Pago Point
+        Uses the Orders API: GET /v1/orders/{id}
+        Reference: https://www.mercadopago.com.ar/developers/es/reference/in-person-payments/point/orders/get-order/get
         """
         self._check_special_access()
 
         mercado_pago = MercadoPagoPosRequest(self.sudo().mp_bearer_token)
-        # Call Mercado Pago for payment intend status
-        resp = mercado_pago.call_mercado_pago("get", f"/point/integration-api/payment-intents/{payment_intent_id}", {})
-        _logger.debug("mp_payment_intent_get(), response from Mercado Pago: %s", resp)
+        # Call Mercado Pago for order status using Orders API
+        resp = mercado_pago.call_mercado_pago("get", f"/v1/orders/{order_id}", {})
+        _logger.debug("mp_order_get(), response from Mercado Pago: %s", resp)
         return resp
 
     def mp_get_payment_status(self, payment_id):
@@ -84,29 +138,31 @@ class PosPaymentMethod(models.Model):
         _logger.debug("mp_get_payment_status(), response from Mercado Pago: %s", resp)
         return resp
 
-    def mp_payment_intent_cancel(self, payment_intent_id):
+    def mp_order_cancel(self, order_id):
         """
-        Called from frontend to cancel a payment intent in Mercado Pago
+        Called from frontend to cancel an order in Mercado Pago Point
+        Uses the Orders API: /v1/orders/{order_id}/cancel
         """
         self._check_special_access()
 
         mercado_pago = MercadoPagoPosRequest(self.sudo().mp_bearer_token)
-        # Call Mercado Pago for payment intend cancelation
-        resp = mercado_pago.call_mercado_pago("delete", f"/point/integration-api/devices/{self.mp_id_point_smart_complet}/payment-intents/{payment_intent_id}", {})
-        _logger.debug("mp_payment_intent_cancel(), response from Mercado Pago: %s", resp)
+        
+        idempotency_key = hashlib.sha256(str(order_id).encode()).hexdigest()        
+        resp = mercado_pago.call_mercado_pago("post", f"/v1/orders/{order_id}/cancel", {}, idempotency_key=idempotency_key)
+        _logger.debug("mp_order_cancel(), response from Mercado Pago: %s", resp)
         return resp
 
     def _find_terminal(self, token, point_smart):
         mercado_pago = MercadoPagoPosRequest(token)
-        data = mercado_pago.call_mercado_pago("get", "/point/integration-api/devices", {})
-        if 'devices' in data:
-            # Search for a device id that contains the serial number entered by the user
-            found_device = next((device for device in data['devices'] if point_smart in device['id']), None)
+        data = mercado_pago.call_mercado_pago("get", "/terminals/v1/list", {})
+        if 'data' in data and 'terminals' in data['data']:
+            # Search for a terminal id that contains the serial number entered by the user
+            found_terminal = next((terminal for terminal in data['data']['terminals'] if point_smart in terminal['id']), None)
 
-            if not found_device:
+            if not found_terminal:
                 raise UserError(_("The terminal serial number is not registered on Mercado Pago"))
 
-            return found_device.get('id', '')
+            return found_terminal.get('id', '')
         else:
             raise UserError(_("Please verify your production user token as it was rejected"))
 

--- a/addons/pos_mercado_pago/static/src/app/utils/payment/payment_mercado_pago.js
+++ b/addons/pos_mercado_pago/static/src/app/utils/payment/payment_mercado_pago.js
@@ -2,44 +2,50 @@ import { _t } from "@web/core/l10n/translation";
 import { PaymentInterface } from "@point_of_sale/app/utils/payment/payment_interface";
 import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { register_payment_method } from "@point_of_sale/app/services/pos_store";
+import { SelectionPopup } from "@point_of_sale/app/components/popups/selection_popup/selection_popup";
+import { makeAwaitable } from "@point_of_sale/app/utils/make_awaitable_dialog";
 
 export class PaymentMercadoPago extends PaymentInterface {
-    async createPaymentIntent() {
+    async createOrder(cardType) {
         const order = this.pos.getOrder();
         const line = order.getSelectedPaymentline();
-        // Build informations for creating a payment intend on Mercado Pago.
+        // Build informations for creating an order on Mercado Pago.
         // Data in "external_reference" are send back with the webhook notification
+        
+        // Generate ticket_number (max 20 characters)
+        const ticketNumber = `${this.pos.config.current_session_id.id}_${line.payment_method_id.id}`.substring(0, 20);
+        
         const infos = {
             amount: parseInt(line.amount * 100, 10),
-            additional_info: {
-                external_reference: `${this.pos.config.current_session_id.id}_${line.payment_method_id.id}_${order.uuid}`,
-                print_on_terminal: true,
-            },
+            external_reference: `${this.pos.config.current_session_id.id}_${line.payment_method_id.id}_${order.uuid}`,
+            ticket_number: ticketNumber,
+            card_type: cardType,
         };
-        // mp_payment_intent_create will call the Mercado Pago api
+        
+        // mp_order_create will call the Mercado Pago api
         return await this.env.services.orm.silent.call(
             "pos.payment.method",
-            "mp_payment_intent_create",
+            "mp_order_create",
             [[line.payment_method_id.id], infos]
         );
     }
-    async getLastStatusPaymentIntent() {
+    async getLastStatusOrder() {
         const line = this.pos.getOrder().getSelectedPaymentline();
-        // mp_payment_intent_get will call the Mercado Pago api
+        // mp_order_get will call the Mercado Pago api
         return await this.env.services.orm.silent.call(
             "pos.payment.method",
-            "mp_payment_intent_get",
-            [[line.payment_method_id.id], this.payment_intent.id]
+            "mp_order_get",
+            [[line.payment_method_id.id], this.order.id]
         );
     }
 
-    async cancelPaymentIntent() {
+    async cancelOrder() {
         const line = this.pos.getOrder().getSelectedPaymentline();
-        // mp_payment_intent_cancel will call the Mercado Pago api
+        // mp_order_cancel will call the Mercado Pago api
         return await this.env.services.orm.silent.call(
             "pos.payment.method",
-            "mp_payment_intent_cancel",
-            [[line.payment_method_id.id], this.payment_intent.id]
+            "mp_order_cancel",
+            [[line.payment_method_id.id], this.order.id]
         );
     }
 
@@ -56,26 +62,64 @@ export class PaymentMercadoPago extends PaymentInterface {
     setup() {
         super.setup(...arguments);
         this.webhook_resolver = null;
-        this.payment_intent = {};
+        this.order = {};
+    }
+
+    async selectPaymentMethod() {
+        // Show selection dialog for card type
+        const selectionList = [
+            {
+                id: 1,
+                label: _t("Credit Card"),
+                isSelected: false,
+                item: 'credit_card',
+            },
+            {
+                id: 2,
+                label: _t("Debit Card"),
+                isSelected: false,
+                item: 'debit_card',
+            },
+            {
+                id: 3,
+                label: _t("QR Code"),
+                isSelected: false,
+                item: 'qr',
+            },
+        ];
+        
+        return await makeAwaitable(this.env.services.dialog, SelectionPopup, {
+            title: _t("Select Payment Method"),
+            list: selectionList,
+        });
     }
 
     async sendPaymentRequest(cid) {
         await super.sendPaymentRequest(...arguments);
         const line = this.pos.getOrder().getSelectedPaymentline();
+        
         try {
-            // During payment creation, user can't cancel the payment intent
-            line.setPaymentStatus("waitingCapture");
-            // Call Mercado Pago to create a payment intent
-            const payment_intent = await this.createPaymentIntent();
-            if (!("id" in payment_intent)) {
-                this._showMsg(payment_intent.message, "error");
+            // Get payment method (from config or user selection)
+            const paymentMethod = await this.selectPaymentMethod();
+            
+            // If user cancels the selection, abort payment
+            if (!paymentMethod) {
                 return false;
             }
-            // Payment intent creation successfull, save it
-            this.payment_intent = payment_intent;
-            // After payment creation, make the payment intent canceling possible
+            
+            // During payment creation, user can't cancel the order
+            line.setPaymentStatus("waitingCapture");
+            // Call Mercado Pago to create an order
+            const order = await this.createOrder(paymentMethod);
+            if (!("id" in order)) {
+                this._showMsg(order.errors[0].message, "error");
+                return false;
+            }
+            // Order creation successful, save it
+            this.order = order;
+            // After order creation, make the order canceling possible
             line.setPaymentStatus("waitingCard");
-            // Wait for payment intent status change and return status result
+            // Wait for order status change and return status result
             return await new Promise((resolve) => {
                 this.webhook_resolver = resolve;
             });
@@ -87,10 +131,10 @@ export class PaymentMercadoPago extends PaymentInterface {
 
     async sendPaymentCancel(order, cid) {
         await super.sendPaymentCancel(order, cid);
-        if (!("id" in this.payment_intent)) {
+        if (!("id" in this.order)) {
             return true;
         }
-        const canceling_status = await this.cancelPaymentIntent();
+        const canceling_status = await this.cancelOrder();
         if ("error" in canceling_status) {
             const message =
                 canceling_status.status === 409
@@ -116,12 +160,12 @@ export class PaymentMercadoPago extends PaymentInterface {
             return resolverValue;
         };
 
-        const handleFinishedPayment = async (paymentIntent) => {
-            if (paymentIntent.state === "CANCELED") {
+        const handleFinishedPayment = async (order) => {
+            if (order.state === "CANCELED") {
                 return showMessageAndResolve(_t("Payment has been canceled"), "info", false);
             }
-            if (["FINISHED", "PROCESSED"].includes(paymentIntent.state)) {
-                const payment = await this.getPayment(paymentIntent.payment.id);
+            if (["FINISHED", "PROCESSED"].includes(order.state)) {
+                const payment = await this.getPayment(order.payment.id);
                 if (payment.status === "approved") {
                     return showMessageAndResolve(_t("Payment has been processed"), "info", true);
                 }
@@ -129,38 +173,38 @@ export class PaymentMercadoPago extends PaymentInterface {
             }
         };
 
-        // No payment intent id means either that the user reload the page or
+        // No order id means either that the user reload the page or
         // it is an old webhook -> trash
-        if ("id" in this.payment_intent) {
-            // Call Mercado Pago to get the payment intent status
-            let last_status_payment_intent = await this.getLastStatusPaymentIntent();
-            // Bad payment intent id, then it's an old webhook not related with the
-            // current payment intent -> trash
-            if (this.payment_intent.id == last_status_payment_intent.id) {
+        if ("id" in this.order) {
+            // Call Mercado Pago to get the order status
+            let last_status_order = await this.getLastStatusOrder();
+            // Bad order id, then it's an old webhook not related with the
+            // current order -> trash
+            if (this.order.id == last_status_order.id) {
                 if (
-                    ["FINISHED", "PROCESSED", "CANCELED"].includes(last_status_payment_intent.state)
+                    ["FINISHED", "PROCESSED", "CANCELED"].includes(last_status_order.state)
                 ) {
-                    return await handleFinishedPayment(last_status_payment_intent);
+                    return await handleFinishedPayment(last_status_order);
                 }
                 // BUG Sometimes the Mercado Pago webhook return ON_TERMINAL
-                // instead of CANCELED/FINISHED when we requested a payment status
+                // instead of CANCELED/FINISHED when we requested an order status
                 // that was actually canceled/finished by the user on the terminal.
                 // Then the strategy here is to ask Mercado Pago MAX_RETRY times the
-                // payment intent status, hoping going out of this status
+                // order status, hoping going out of this status
                 if (
-                    ["OPEN", "ON_TERMINAL", "PROCESSING"].includes(last_status_payment_intent.state)
+                    ["OPEN", "ON_TERMINAL", "PROCESSING"].includes(last_status_order.state)
                 ) {
                     return await new Promise((resolve) => {
                         let retry_cnt = 0;
                         const s = setInterval(async () => {
-                            last_status_payment_intent = await this.getLastStatusPaymentIntent();
+                            last_status_order = await this.getLastStatusOrder();
                             if (
                                 ["FINISHED", "PROCESSED", "CANCELED"].includes(
-                                    last_status_payment_intent.state
+                                    last_status_order.state
                                 )
                             ) {
                                 clearInterval(s);
-                                resolve(await handleFinishedPayment(last_status_payment_intent));
+                                resolve(await handleFinishedPayment(last_status_order));
                             }
                             retry_cnt += 1;
                             if (retry_cnt >= MAX_RETRY) {


### PR DESCRIPTION
Migration from deprecated Payment Intents API to modern Orders API

This commit migrates the Mercado Pago Point integration from the legacy Payment Intents API (/point/integration-api) to the new Orders API (/v1/orders). Although the old API still works, it has been deprecated by Mercado Pago and lacks support for modern payment methods.

Main improvements:

* API Endpoints Migration:
  - Changed payment intent creation from POST /point/integration-api/devices/{device_id}/payment-intents to POST /v1/orders (with idempotency support)
  - Changed status retrieval from GET /point/integration-api/payment-intents/{id} to GET /v1/orders/{id}
  - Changed cancellation from DELETE /point/integration-api/devices/{device_id}/payment-intents/{id} to POST /v1/orders/{order_id}/cancel (with idempotency support)
  - Changed terminal configuration from PATCH /point/integration-api/devices/{device_id} to PATCH /terminals/v1/setup
  - Changed terminal listing from GET /point/integration-api/devices to GET /terminals/v1/list

* Payment Method Selection:
  - Added dynamic payment method selection dialog (Credit Card, Debit Card, QR)
  - Enables support for PIX and QR code payments through Point Smart terminals

* Payload Structure Improvements:
  - Simplified payload structure according to official documentation
  - Added _prepare_mp_order_payload() method for easy customization via inheritance

* Code Quality Enhancements:
  - Implemented idempotency headers (X-Idempotency-Key) for create and cancel operations
  - Dynamic ticket number generation with 20-character limit
  - Removed mp_print_on_terminal field (always uses "seller_ticket")
  - Better error handling and response validation
  - Improved logging and debugging messages

* Technical Changes:
  - Renamed mp_payment_intent_* methods to mp_order_* throughout codebase
  - Updated JavaScript from payment_intent to order terminology
  - Added SHA-256 hash-based idempotency key generation

References:
- Orders API: https://www.mercadopago.com.ar/developers/es/reference/in-person-payments/point/orders
- Terminals API: https://www.mercadopago.com.ar/developers/es/reference/in-person-payments/point/terminals

The new Orders API provides better support for modern payment methods including PIX (Brazil) and QR codes, making the integration future-proof and compliant with Mercado Pago's latest standards.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
