### PR TITLE
[FIX] account: Fixed addres info on invoice report 

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -63,62 +63,56 @@
                 </t>
                 <span t-if="o.name and o.name != '/'" t-field="o.name">INV/2023/0001</span>
             </t>
+            <t t-set="information_block" t-if="o.partner_shipping_id and (o.partner_shipping_id != o.partner_id)">
+                <div groups="account.group_delivery_invoice_address" name="shipping_address_block">
+                    <strong class="d-block mt-3">Shipping Address</strong>
+                    <div t-field="o.partner_shipping_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
+                </div>
+            </t>
+            <t t-set="address">
+                <t t-if="o.partner_shipping_id and (o.partner_shipping_id != o.partner_id)">
+                    <t name="address_not_same_as_shipping">
+                        <address class="mb-0" t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
+                        <div t-if="o.partner_id.vat" id="partner_vat_address_not_same_as_shipping">
+                            <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-out="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
+                            <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/>
+                        </div>
+                        <div t-if="o.partner_id.country_code == 'MA' and o.partner_id.company_registry">
+                            ICE: <a t-field="o.partner_id.company_registry"/>
+                        </div>
+                    </t>
+                </t>
+                <t t-elif="o.partner_shipping_id and (o.partner_shipping_id == o.partner_id)">
+                    <t name="address_same_as_shipping">
+                        <address class="mb-0" t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
+                        <div t-if="o.partner_id.vat" id="partner_vat_address_same_as_shipping">
+                            <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-out="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
+                            <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/>
+                        </div>
+                        <div t-if="o.partner_id.country_code == 'MA' and o.partner_id.company_registry">
+                            ICE: <a t-field="o.partner_id.company_registry"/>
+                        </div>
+                    </t>
+                </t>
+                <t t-else="">
+                    <t name="no_shipping">
+                        <address class="mb-0" t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
+                        <div t-if="o.partner_id.vat" id="partner_vat_no_shipping">
+                            <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-out="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
+                            <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/>
+                        </div>
+                        <div t-if="o.partner_id.country_code == 'MA' and o.partner_id.company_registry">
+                            ICE: <a t-field="o.partner_id.company_registry"/>
+                        </div>
+                    </t>
+                </t>
+            </t>
             <t t-call="web.external_layout"
                 forced_vat="o.fiscal_position_id.foreign_vat"
-                layout_document_title="layout_document_title">
+                layout_document_title="layout_document_title"
+                information_block="information_block"
+                address="address">
                 <t t-set="o" t-value="o.with_context(lang=lang)" /> <!-- So that it appears in the footer of the report instead of the company VAT if it's set -->
-                <div class="row">
-                    <t t-if="o.partner_shipping_id and (o.partner_shipping_id != o.partner_id)">
-                        <div class="col-6">
-                            <t t-set="information_block">
-                                <div groups="account.group_delivery_invoice_address" name="shipping_address_block">
-                                    <strong class="d-block mt-3">Shipping Address</strong>
-                                    <div t-field="o.partner_shipping_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
-                                </div>
-                            </t>
-                        </div>
-                        <div class="col-6" name="address_not_same_as_shipping">
-                            <t t-set="address">
-                                <address class="mb-0" t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
-                                <div t-if="o.partner_id.vat" id="partner_vat_address_not_same_as_shipping">
-                                    <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-out="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
-                                    <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/>
-                                </div>
-                                <div t-if="o.partner_id.country_code == 'MA' and o.partner_id.company_registry">
-                                    ICE: <a t-field="o.partner_id.company_registry"/>
-                                </div>
-                            </t>
-                        </div>
-                    </t>
-                    <t t-elif="o.partner_shipping_id and (o.partner_shipping_id == o.partner_id)">
-                        <div class="offset-col-6 col-6" name="address_same_as_shipping">
-                            <t t-set="address">
-                                <address class="mb-0" t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
-                                <div t-if="o.partner_id.vat" id="partner_vat_address_same_as_shipping">
-                                    <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-out="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
-                                    <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/>
-                                </div>
-                                <div t-if="o.partner_id.country_code == 'MA' and o.partner_id.company_registry">
-                                    ICE: <a t-field="o.partner_id.company_registry"/>
-                                </div>
-                            </t>
-                        </div>
-                    </t>
-                    <t t-else="">
-                        <div class="offset-col-6 col-6" name="no_shipping">
-                            <t t-set="address">
-                                <address class="mb-0" t-field="o.partner_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
-                                <div t-if="o.partner_id.vat" id="partner_vat_no_shipping">
-                                    <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-out="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
-                                    <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/>
-                                </div>
-                                <div t-if="o.partner_id.country_code == 'MA' and o.partner_id.company_registry">
-                                    ICE: <a t-field="o.partner_id.company_registry"/>
-                                </div>
-                            </t>
-                        </div>
-                    </t>
-                </div>
                 <div class="clearfix invoice_main">
                     <div class="page mb-4">
                         <div class="oe_structure"></div>

--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -102,15 +102,6 @@
 
         <!-- remove default partner address -->
         <t t-set="address" position="replace"/>
-        <xpath expr="//div[@name='address_not_same_as_shipping']" position="replace">
-            <div name="address_not_same_as_shipping"/>
-        </xpath>
-        <xpath expr="//div[@name='address_same_as_shipping']" position="replace">
-            <div name="address_same_as_shipping"/>
-        </xpath>
-        <xpath expr="//div[@name='no_shipping']" position="replace">
-            <div name="no_shipping"/>
-        </xpath>
 
         <!-- remove default document title -->
         <xpath expr="//t[@t-set='layout_document_title']" position="replace"/>

--- a/addons/l10n_ca/views/report_invoice.xml
+++ b/addons/l10n_ca/views/report_invoice.xml
@@ -1,12 +1,12 @@
 <odoo>
     <template id="l10n_ca_report_invoice_document_inherit" inherit_id="account.report_invoice_document">
-        <xpath expr="//div[hasclass('row')]//div[@name='address_not_same_as_shipping']//t[@t-set='address']" position="inside">
+        <xpath expr="//t[@name='address_not_same_as_shipping']" position="inside">
             <div t-if="o.partner_id.l10n_ca_pst">PST: <span t-field="o.partner_id.l10n_ca_pst"/></div>
         </xpath>
-        <xpath expr="//div[hasclass('row')]//div[@name='address_same_as_shipping']//t[@t-set='address']" position="inside">
+        <xpath expr="//t[@name='address_same_as_shipping']" position="inside">
             <div t-if="o.partner_id.l10n_ca_pst">PST: <span t-field="o.partner_id.l10n_ca_pst"/></div>
         </xpath>
-        <xpath expr="//div[hasclass('row')]//div[@name='no_shipping']//t[@t-set='address']" position="inside">
+        <xpath expr="//t[@name='no_shipping']" position="inside">
             <div t-if="o.partner_id.l10n_ca_pst">PST: <span t-field="o.partner_id.l10n_ca_pst"/></div>
         </xpath>
     </template>

--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -136,15 +136,7 @@
         </t>
 
         <!-- remove default partner address -->
-        <xpath expr="//div[@name='address_not_same_as_shipping']" position="replace">
-            <div name="address_not_same_as_shipping"/>
-        </xpath>
-        <xpath expr="//div[@name='address_same_as_shipping']" position="replace">
-            <div name="address_same_as_shipping"/>
-        </xpath>
-        <xpath expr="//div[@name='no_shipping']" position="replace">
-            <div name="no_shipping"/>
-        </xpath>
+        <t t-set="address" position="replace" />
 
         <xpath expr="//t[@t-set='layout_document_title']" position="replace"/>
 

--- a/addons/l10n_fr_facturx_chorus_pro/views/report_invoice.xml
+++ b/addons/l10n_fr_facturx_chorus_pro/views/report_invoice.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="report_invoice_document" inherit_id="account.report_invoice_document">
-        <xpath expr="//div[@name='address_not_same_as_shipping']//t[@t-set='address']" position="inside">
+        <xpath expr="//t[@name='address_not_same_as_shipping']" position="inside">
             <div t-if="o.buyer_reference">
                 Buyer Reference: <span t-field="o.buyer_reference"/>
             </div>
@@ -12,7 +12,7 @@
                 Purchase Order Reference: <span t-field="o.purchase_order_reference"/>
             </div>
         </xpath>
-        <xpath expr="//div[@name='address_same_as_shipping']//t[@t-set='address']" position="inside">
+        <xpath expr="//t[@name='address_same_as_shipping']" position="inside">
             <div t-if="o.buyer_reference">
                 Buyer Reference: <span t-field="o.buyer_reference"/>
             </div>
@@ -23,7 +23,7 @@
                 Purchase Order Reference: <span t-field="o.purchase_order_reference"/>
             </div>
         </xpath>
-        <xpath expr="//div[@name='no_shipping']//t[@t-set='address']" position="inside">
+        <xpath expr="//t[@name='no_shipping']" position="inside">
             <div t-if="o.buyer_reference">
                 Buyer Reference: <span t-field="o.buyer_reference"/>
             </div>

--- a/addons/l10n_hu_edi/views/report_invoice.xml
+++ b/addons/l10n_hu_edi/views/report_invoice.xml
@@ -43,11 +43,11 @@
         <xpath expr="//div[@name='invoice_date']/t[1]" position="attributes">
             <attribute name="t-if">o.move_type == 'out_invoice' or (o.move_type == 'out_refund' and not o.reversed_entry_id)</attribute>
         </xpath>
-        <xpath expr="//div[@name='address_not_same_as_shipping']//address" position="before">
+        <xpath expr="//t[@name='address_not_same_as_shipping']//address" position="before">
             <strong>Customer:</strong>
         </xpath>
-        <xpath expr="//div[@name='shipping_address_block']/../.." position="replace"/>
-        <xpath expr="//div[@name='address_not_same_as_shipping']//span[@t-field='o.partner_id.vat']/.." position="after">
+        <t t-set="information_block" position="replace"/>
+        <xpath expr="//t[@name='address_not_same_as_shipping']//span[@t-field='o.partner_id.vat']/.." position="after">
             <div t-if="o.partner_id.l10n_hu_group_vat">Group Member Tax ID: <span t-field="o.partner_id.l10n_hu_group_vat"/></div>
             <div groups="account.group_delivery_invoice_address" name="shipping_address_block">
                 <div/>
@@ -55,17 +55,17 @@
                 <div t-field="o.partner_shipping_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
             </div>
         </xpath>
-        <xpath expr="//div[@name='address_same_as_shipping']//address" position="before">
+        <xpath expr="//t[@name='address_same_as_shipping']//address" position="before">
             <strong>Customer:</strong>
         </xpath>
-        <xpath expr="//div[@name='address_same_as_shipping']//span[@t-field='o.partner_id.vat']/.." position="after">
+        <xpath expr="//t[@name='address_same_as_shipping']//span[@t-field='o.partner_id.vat']/.." position="after">
             <div t-if="o.partner_id.l10n_hu_group_vat">Group Member Tax ID: <span t-field="o.partner_id.l10n_hu_group_vat"/></div>
             <div t-if="o.move_type == 'out_refund' and o.partner_bank_id">Bank Account: <span t-field="o.partner_bank_id.account_number"/></div>
         </xpath>
-        <xpath expr="//div[@name='no_shipping']//address" position="before">
+        <xpath expr="//t[@name='no_shipping']//address" position="before">
             <strong>Customer:</strong>
         </xpath>
-        <xpath expr="//div[@name='no_shipping']//span[@t-field='o.partner_id.vat']/.." position="after">
+        <xpath expr="//t[@name='no_shipping']//span[@t-field='o.partner_id.vat']/.." position="after">
             <div t-if="o.partner_id.l10n_hu_group_vat">Group Member Tax ID: <span t-field="o.partner_id.l10n_hu_group_vat"/></div>
         </xpath>
         <xpath expr="//div[@name='due_date']" position="after">

--- a/addons/l10n_in/views/report_invoice.xml
+++ b/addons/l10n_in/views/report_invoice.xml
@@ -15,13 +15,13 @@
         <xpath expr="//div[@id='partner_vat_no_shipping']" position="attributes">
             <attribute name="t-if" add="o.company_id.l10n_in_is_gst_registered" separator="and"/>
         </xpath>
-        <xpath expr="//div[@name='address_not_same_as_shipping']//t[@t-set='address']" position="inside">
+        <xpath expr="//t[@name='address_not_same_as_shipping']" position="inside">
             <t t-call="l10n_in.place_of_supply"/>
         </xpath>
-        <xpath expr="//div[@name='address_same_as_shipping']//t[@t-set='address']" position="inside">
+        <xpath expr="//t[@name='address_same_as_shipping']" position="inside">
             <t t-call="l10n_in.place_of_supply"/>
         </xpath>
-        <xpath expr="//div[@name='no_shipping']//t[@t-set='address']" position="inside">
+        <xpath expr="//t[@name='no_shipping']" position="inside">
             <t t-call="l10n_in.place_of_supply"/>
         </xpath>
 

--- a/addons/l10n_mu_account/views/report_invoice.xml
+++ b/addons/l10n_mu_account/views/report_invoice.xml
@@ -24,13 +24,13 @@
             <t name="cancelled_proforma_invoice_title">Cancelled Proforma VAT Invoice</t>
         </t>
 
-        <xpath expr="//div[@name='address_not_same_as_shipping']//t[@t-set='address']" position="inside">
+        <xpath expr="//t[@name='address_not_same_as_shipping']" position="inside">
             <span t-field="o.partner_id.company_registry"/>
         </xpath>
-        <xpath expr="//div[@name='address_same_as_shipping']//t[@t-set='address']" position="inside">
+        <xpath expr="//t[@name='address_same_as_shipping']" position="inside">
             <span t-field="o.partner_id.company_registry"/>
         </xpath>
-        <xpath expr="//div[@name='no_shipping']//t[@t-set='address']" position="inside">
+        <xpath expr="//t[@name='no_shipping']" position="inside">
             <span t-field="o.partner_id.company_registry"/>
         </xpath>
 

--- a/addons/l10n_sa_edi/views/report_invoice.xml
+++ b/addons/l10n_sa_edi/views/report_invoice.xml
@@ -3,7 +3,7 @@
     <data>
         <template id="l10n_sa_edi_report_invoice_document" inherit_id="l10n_sa.l10n_sa_report_invoice_document">
             <!-- Address format -->
-            <xpath expr="//div[hasclass('invoice_main')]" position="before">
+            <xpath expr="//t[@t-set='address']" position="after">
                 <t t-set="address">
                     <t t-out="address"/>
                     <t t-if="o.partner_id.l10n_sa_edi_additional_identification_scheme and o.partner_id.l10n_sa_edi_additional_identification_number">

--- a/addons/l10n_th/views/report_invoice.xml
+++ b/addons/l10n_th/views/report_invoice.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <template id="report_invoice_document" inherit_id="account.report_invoice_document" primary="True">
-        <xpath expr="//div[@name='address_not_same_as_shipping']//span[@t-field='o.partner_id.vat']" position="after">
+        <xpath expr="//t[@name='address_not_same_as_shipping']//span[@t-field='o.partner_id.vat']" position="after">
             <span t-out="o.partner_id.l10n_th_branch_name"/>
         </xpath>
 
-        <xpath expr="//div[@name='address_same_as_shipping']//span[@t-field='o.partner_id.vat']" position="after">
+        <xpath expr="//t[@name='address_same_as_shipping']//span[@t-field='o.partner_id.vat']" position="after">
             <span t-out="o.partner_id.l10n_th_branch_name"/>
         </xpath>
-        <xpath expr="//div[@name='no_shipping']//span[@t-field='o.partner_id.vat']" position="after">
+        <xpath expr="//t[@name='no_shipping']//span[@t-field='o.partner_id.vat']" position="after">
             <span t-out="o.partner_id.l10n_th_branch_name"/>
         </xpath>
         <t name="invoice_title" position="replace">


### PR DESCRIPTION
After the refactoring of the t-set syntax on qweb templates and
application of the script, the contact address info stopped rendering due
to how now a template level variables are now used.

This commit targets to fix the invoice pdf report t-set for 'information_block'
and 'address' so that the elements are rendered when the 'external_layout'
is rendered.

task-5955062
target: saas-19.2 -> master



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
