### PR TITLE
[IMP] pos_self_order: order reference on the order status screen

### DIFF
--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -177,14 +177,17 @@ class PosOrder(models.Model):
         existing_order = pos_config.env['pos.order']._get_open_order(order)
         if not existing_order.exists():
             pos_reference, tracking_number = pos_config._get_next_order_refs()
-            prefix = f"K{pos_config.id}-" if device_type == "kiosk" else "S"
+            prefix = "K" if device_type == "kiosk" else "S"
+            order_tracking_number = f"{prefix}{pos_config.id}-{tracking_number}"
 
-            if device_type == 'kiosk':
-                floating_order_name = f"Table tracker {order['table_stand_number']}" if order.get('table_stand_number') else tracking_number
-            elif not floating_order_name:
-                floating_order_name = f"Self-Order T {table.table_number}" if table else f"Self-Order {tracking_number}"
-
-            tracking_number = f"{prefix}{tracking_number}"
+            if not floating_order_name:
+                if device_type == 'kiosk':
+                    floating_order_name = f"Table tracker {order['table_stand_number']}" if order.get('table_stand_number') else order_tracking_number
+                else:
+                    floating_order_name = f"Self-Order T {table.table_number}" if table else f"Self-Order {order_tracking_number}"
+            else:
+                floating_order_name += f" ({order_tracking_number})"
+            tracking_number = order_tracking_number
         else:
             pos_reference = existing_order.pos_reference
             floating_order_name = existing_order.floating_order_name

--- a/addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.js
+++ b/addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.js
@@ -176,7 +176,7 @@ export class PresetInfoPopup extends Component {
 
     setPartnerAndOrderName(partner) {
         if (this.preset.needsPartner) {
-            this.selfOrder.currentOrder.floating_order_name = `${this.preset.name} - ${this.state.name}`;
+            this.selfOrder.currentOrder.floating_order_name = `${this.state.name} - ${this.preset.name}`;
         } else {
             this.selfOrder.currentOrder.floating_order_name = this.state.name;
         }

--- a/addons/pos_self_order/tests/test_self_order_mobile.py
+++ b/addons/pos_self_order/tests/test_self_order_mobile.py
@@ -310,7 +310,7 @@ class TestSelfOrderMobile(SelfOrderCommonTest):
 
         self.start_tour(self_route, "test_self_order_table_sharing-each_mode")
         last_order = self.pos_config.current_session_id.order_ids[0]
-        self.assertEqual(last_order.floating_order_name, f"Self-Order T {table.table_number}")
+        self.assertEqual(last_order.floating_order_name, f"Self-Order T {table.table_number} ({last_order.tracking_number})")
         self.assertFalse(last_order.table_id)
 
         self.pos_config.write({

--- a/addons/pos_self_order/tests/test_self_order_preset.py
+++ b/addons/pos_self_order/tests/test_self_order_preset.py
@@ -58,7 +58,8 @@ class TestSelfOrderPreset(SelfOrderCommonTest):
         self.pos_config.current_session_id.set_opening_control(0, "")
         self_route = self.pos_config._get_self_order_route()
         self.start_tour(self_route, "self_order_preset_takeaway_tour")
-        self.assertEqual("Dr Dre", self.env["pos.order"].search([], limit=1, order="id desc").floating_order_name)
+        order = self.env["pos.order"].search([], limit=1, order="id desc")
+        self.assertEqual(f"Dr Dre ({order.tracking_number})", order.floating_order_name)
 
     def test_preset_delivery_tour(self):
         self.pos_config.with_user(self.pos_user).open_ui()
@@ -125,7 +126,7 @@ class TestSelfOrderPreset(SelfOrderCommonTest):
         self_route = self.pos_config._get_self_order_route()
         self.start_tour(self_route, "self_order_preset_slot_tour")
         last_order = self.env["pos.order"].search([], limit=1, order="id desc")
-        self.assertEqual(last_order.floating_order_name, 'Dr Dre')
+        self.assertEqual(last_order.floating_order_name, f'Dr Dre ({last_order.tracking_number})')
         self.assertNotEqual(last_order.preset_time, False)
 
     def test_slot_limit_orders(self):


### PR DESCRIPTION
After this commit:
=
- The floating order name for Self Order/Kiosk will be formatted as: `partner_name - preset_name`
- Each self-order config have a unique tracking number.

task-5470833
related pr: https://github.com/odoo/enterprise/pull/104163