### PR TITLE
[IMP] web,mail: add icon_selector widget

### DIFF
--- a/addons/fleet/data/mail_activity_type_data.xml
+++ b/addons/fleet/data/mail_activity_type_data.xml
@@ -4,7 +4,7 @@
         <record id="mail_act_fleet_contract_to_renew" model="mail.activity.type">
             <field name="name">Contract to Renew</field>
             <field name="summary">Contract to Renew</field>
-            <field name="icon">fa-car</field>
+            <field name="icon">fa fa-car</field>
             <field name="res_model">fleet.vehicle.log.contract</field>
         </record>
     </data>

--- a/addons/hr_expense/data/mail_activity_type_data.xml
+++ b/addons/hr_expense/data/mail_activity_type_data.xml
@@ -4,7 +4,7 @@
         <record id="mail_act_expense_approval" model="mail.activity.type">
             <field name="name">Expense Approval</field>
             <field name="summary">Expense Approval</field>
-            <field name="icon">fa-dollar</field>
+            <field name="icon">fa fa-dollar</field>
             <field name="res_model">hr.expense</field>
         </record>
     </data>

--- a/addons/hr_holidays/data/mail_activity_type_data.xml
+++ b/addons/hr_holidays/data/mail_activity_type_data.xml
@@ -5,14 +5,14 @@
         <record id="mail_act_leave_approval" model="mail.activity.type">
             <field name="name">Time Off Approval</field>
             <field name="summary">Time Off Approval</field>
-            <field name="icon">fa-sun-o</field>
+            <field name="icon">fa fa-sun-o</field>
             <field name="res_model">hr.leave</field>
             <field name="delay_count">15</field>
         </record>
         <record id="mail_act_leave_second_approval" model="mail.activity.type">
             <field name="name">Time Off Second Approve</field>
             <field name="summary">Time Off Second Approve</field>
-            <field name="icon">fa-sun-o</field>
+            <field name="icon">fa fa-sun-o</field>
             <field name="res_model">hr.leave</field>
         </record>
 
@@ -20,14 +20,14 @@
         <record id="mail_act_leave_allocation_approval" model="mail.activity.type">
             <field name="name">Allocation Approval</field>
             <field name="summary">Allocation Approval</field>
-            <field name="icon">fa-sun-o</field>
+            <field name="icon">fa fa-sun-o</field>
             <field name="res_model">hr.leave.allocation</field>
         </record>
 
         <record id="mail_act_leave_allocation_second_approval" model="mail.activity.type">
             <field name="name">Allocation Second Approval</field>
             <field name="summary">Allocation Second Approval</field>
-            <field name="icon">fa-sun-o</field>
+            <field name="icon">fa fa-sun-o</field>
             <field name="res_model">hr.leave.allocation</field>
         </record>
     </data>

--- a/addons/mail/data/mail_activity_type_data.xml
+++ b/addons/mail/data/mail_activity_type_data.xml
@@ -4,13 +4,13 @@
         <record id="mail_activity_data_email" model="mail.activity.type">
             <field name="name">Email</field>
             <field name="summary">Email</field>
-            <field name="icon">fa-envelope</field>
+            <field name="icon">fa fa-envelope</field>
             <field name="sequence">3</field>
         </record>
         <record id="mail_activity_data_call" model="mail.activity.type">
             <field name="name">Call</field>
             <field name="summary">Call</field>
-            <field name="icon">fa-phone</field>
+            <field name="icon">fa fa-phone</field>
             <field name="category">phonecall</field>
             <field name="delay_count">2</field>
             <field name="sequence">6</field>
@@ -18,27 +18,27 @@
         <record id="mail_activity_data_meeting" model="mail.activity.type">
             <field name="name">Meeting</field>
             <field name="summary">Meeting</field>
-            <field name="icon">fa-users</field>
+            <field name="icon">fa fa-group</field>
             <field name="sequence">9</field>
         </record>
         <record id="mail_activity_data_todo" model="mail.activity.type">
             <field name="name">To-Do</field>
             <field name="summary">To-Do</field>
-            <field name="icon">fa-check</field>
+            <field name="icon">fa fa-check</field>
             <field name="delay_count">5</field>
             <field name="sequence">2</field>
         </record>
         <record id="mail_activity_data_upload_document" model="mail.activity.type">
             <field name="name">Document</field>
             <field name="summary">Document</field>
-            <field name="icon">fa-upload</field>
+            <field name="icon">fa fa-upload</field>
             <field name="delay_count">5</field>
             <field name="sequence">25</field>
             <field name="category">upload_file</field>
         </record>
         <record id="mail_activity_data_warning" model="mail.activity.type">
             <field name="name">Exception</field>
-            <field name="icon">fa-warning</field>
+            <field name="icon">fa fa-warning</field>
             <field name="delay_count">0</field>
             <field name="sequence">99</field>
             <field name="decoration_type">warning</field>

--- a/addons/mail/data/mail_templates_chatter.xml
+++ b/addons/mail/data/mail_templates_chatter.xml
@@ -12,7 +12,7 @@
         <template id="message_activity_done">
 <div>
     <p>
-        <span t-attf-class="fa #{activity.activity_type_id.icon} fa-fw"/><span t-field="activity.activity_type_id.name"/> done
+        <span t-attf-class="#{activity.activity_type_id.icon} fa-fw"/><span t-field="activity.activity_type_id.name"/> done
         <t t-if="display_assignee"> (originally assigned to <span t-field="activity.user_id.name"/>)</t>
         <span t-if="activity.summary">: </span><span t-if="activity.summary" t-field="activity.summary"/>
     </p>

--- a/addons/mail/static/src/core/web/activity.xml
+++ b/addons/mail/static/src/core/web/activity.xml
@@ -16,7 +16,7 @@
                         }"
                     t-attf-style="{{!this.props.activity.user_id ? 'height:80%; width:80%;' : ''}}"
                 >
-                    <i class="fa small" t-attf-class="{{ this.props.activity.icon }} {{this.props.activity.user_id ? 'small' : 'fs-2'}}"/>
+                    <i t-attf-class="{{ this.props.activity.icon }} {{this.props.activity.user_id ? 'small' : 'fs-2'}}"/>
                 </div>
             </div>
         </div>

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -20,7 +20,7 @@
                             <field name="res_model" invisible="context.get('default_res_model')"
                                 placeholder="Available everywhere"/>
                             <field name="summary" placeholder="e.g. &quot;Discuss proposal&quot;"/>
-                            <field name="icon" groups="base.group_no_one"/>
+                            <field name="icon" groups="base.group_no_one" widget="fa_icon"/>
                             <field name="decoration_type" groups="base.group_no_one"/>
                             <label for="delay_count"/>
                             <div>

--- a/addons/maintenance/data/mail_activity_type_data.xml
+++ b/addons/maintenance/data/mail_activity_type_data.xml
@@ -5,7 +5,7 @@
     <record id="mail_act_maintenance_request" model="mail.activity.type">
         <field name="name">Maintenance Request</field>
         <field name="summary">Maintenance Request</field>
-        <field name="icon">fa-wrench</field>
+        <field name="icon">fa fa-wrench</field>
         <field name="res_model">maintenance.request</field>
     </record>
 </data>

--- a/addons/web/static/src/core/select_menu/select_menu.js
+++ b/addons/web/static/src/core/select_menu/select_menu.js
@@ -285,6 +285,10 @@ export class SelectMenu extends Component {
         if (this.displayInputInToggler) {
             this.state.isFocused = false;
         }
+        const nextFocus = ev.relatedTarget;
+        if (this.menuRef.el?.contains(nextFocus)) {
+            return;
+        }
         if (ev.target.value === "" && this.canDeselect && !this.props.multiSelect) {
             this.onInputClear();
         }

--- a/addons/web/static/src/views/fields/font_awesome_icon/font_awesome_icon_field.js
+++ b/addons/web/static/src/views/fields/font_awesome_icon/font_awesome_icon_field.js
@@ -1,0 +1,49 @@
+import { Component } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { SelectMenu } from "@web/core/select_menu/select_menu";
+import { hasTouch } from "@web/core/browser/feature_detection";
+import { getFontAwesomeIcons } from "@web/views/utils"
+import { standardFieldProps } from "../standard_field_props";
+
+export class FontAwesomeIconField extends Component {
+    static template = "web.FontAwesomeIconField";
+    static components = { SelectMenu };
+    static props = {
+        ...standardFieldProps,
+    };
+
+    setup() {
+        this.ICONS = getFontAwesomeIcons();
+    }
+
+    get choices() {
+        return this.ICONS.map(icon => ({
+            value: icon.className,
+            label: icon.className,
+        }));
+    }
+
+    get iconValue() {
+        return this.props.record.data[this.props.name] || "";
+    }
+
+    get isBottomSheet() {
+        return this.env.isSmall && hasTouch();
+    }
+
+    getIconTooltip(value) {
+        const icon = this.ICONS.find(i => i.className === value);
+        return icon?.tooltip || "";
+    }
+
+    onSelect(value) {
+        this.props.record.update({
+            [this.props.name]: value,
+        });
+    }
+}
+
+registry.category("fields").add("fa_icon", {
+    component: FontAwesomeIconField,
+    supportedTypes: ["char"],
+});

--- a/addons/web/static/src/views/fields/font_awesome_icon/font_awesome_icon_field.scss
+++ b/addons/web/static/src/views/fields/font_awesome_icon/font_awesome_icon_field.scss
@@ -1,0 +1,17 @@
+.o_fa_icon_field_selector_menu {
+    min-width: 0;
+    max-height: 350px;
+    overflow-y: auto;
+
+    .o_select_menu_item {
+        display: inline-block !important;
+        padding: .5em;
+        width: auto;
+        line-height: 1;
+    }
+
+    .o_font_awesome_icon_selector_value {
+        width: 22px;
+        height: 22px;
+    }
+}

--- a/addons/web/static/src/views/fields/font_awesome_icon/font_awesome_icon_field.xml
+++ b/addons/web/static/src/views/fields/font_awesome_icon/font_awesome_icon_field.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="web.FontAwesomeIconField">
+        <t t-if="props.readonly" t-out="iconValue" />
+        <t t-else="">
+            <SelectMenu
+                autoSort="false"
+                class="'border-0'"
+                menuClass="'o_fa_icon_field_selector_menu'"
+                value="this.iconValue"
+                choices="this.choices"
+                onSelect.bind="this.onSelect"
+                placeholder.translate="Select icon"
+                searchable="!this.isBottomSheet">
+
+                <t t-set-slot="choice" t-slot-scope="choice">
+                    <i t-att-class="'o_font_awesome_icon_selector_value  d-inline-flex justify-content-center align-items-center fs-3 ' + choice.data.value" t-att-data-tooltip="this.getIconTooltip(choice.data.value)" />
+                </t>
+            </SelectMenu>
+        </t>
+    </t>
+</templates>

--- a/addons/web/static/src/views/utils.js
+++ b/addons/web/static/src/views/utils.js
@@ -312,3 +312,28 @@ export function computeAggregatedValue(values, aggregator) {
     }
     throw new Error(`Invalid aggregator '${aggregator}'`);
 }
+
+/**
+ * This allows to list Font Awesome icon, independently of the library version
+ * Some icons use the same glyph for multiple classes. Those are filtered to only
+ * list the icon once
+ */
+export function getFontAwesomeIcons() {
+    const styleSheet = [...document.styleSheets].find(
+        (s) => s && s.href && s.href.includes("/web/")
+    );
+    const fontAwesomeStyles = [...styleSheet.cssRules]
+        .filter((e) => /^\.fa-.*:before/.test(e.selectorText))
+        .filter((e) => e && e.style && e.style.length === 1 && e.style[0] === "content");
+    return fontAwesomeStyles.map((rule) => {
+        const classNames = rule.selectorText.split(/:?:before|,/).filter((e) => e.length > 1);
+        const searchTerms = classNames.map((selector) =>
+            selector.replace(".fa-", "").replace(/-o$/g, " (Outline)").replaceAll("-", " ")
+        );
+        return {
+            className: "fa " + classNames[0].slice(1),
+            searchTerms,
+            tooltip: searchTerms[0].charAt(0).toUpperCase() + searchTerms[0].slice(1),
+        };
+    });
+}

--- a/addons/web/static/tests/core/select_menu.test.js
+++ b/addons/web/static/tests/core/select_menu.test.js
@@ -1415,3 +1415,48 @@ test("prevent glitch on open or focusout", async () => {
     expect(queryOne(".o_select_menu_searchbox input")).toBe(searchInput);
     expect(searchInput.placeholder).toBe("searchPlaceholder");
 });
+
+test.tags("desktop");
+test("Input blur only clears value when focus leaves SelectMenu", async () => {
+    expect.assertions(3);
+
+    class Parent extends Component {
+        static props = ["*"];
+        static components = { SelectMenu };
+        static template = xml`
+            <SelectMenu
+                choices="this.choices"
+                value="this.state.value"
+                onSelect.bind="this.onSelect"
+            />
+        `;
+
+        setup() {
+            this.state = useState({ value: "hello" });
+            this.choices = [
+                { label: "Hello", value: "hello" },
+                { label: "World", value: "world" },
+            ];
+        }
+
+        onSelect(value) {
+            expect.step("Cleared");
+            this.state.value = value;
+        }
+    }
+
+    await mountSingleApp(Parent);
+
+    await click(".o_select_menu_toggler");
+    await animationFrame();
+    await press("Backspace");
+    await animationFrame();
+    expect(".o_select_menu_toggler").toHaveValue("");
+
+    await click(".o_select_menu_item");
+    await animationFrame();
+    expect(".o_select_menu_toggler").toHaveValue("Hello");
+
+    // Ensure no unintended clear is triggered when interacting inside the dropdown
+    expect.verifySteps([]);
+});

--- a/addons/web/static/tests/views/fields/font_awesome_icon_field.test.js
+++ b/addons/web/static/tests/views/fields/font_awesome_icon_field.test.js
@@ -1,0 +1,93 @@
+import { expect, test } from "@odoo/hoot";
+import { click, press, queryFirst } from "@odoo/hoot-dom";
+import { animationFrame } from "@odoo/hoot-mock";
+import { defineModels, fields, models, mountView } from "@web/../tests/web_test_helpers";
+
+class Partner extends models.Model {
+    icon = fields.Char();
+}
+
+defineModels([Partner]);
+
+test("fa_icon in form view renders icon class value", async () => {
+    Partner._records = [{ id: 1, icon: "fa fa-user" }];
+
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `<form><field name="icon" widget="fa_icon"/></form>`,
+    });
+
+    const input = queryFirst(".o_select_menu_input");
+    expect(input.value).toEqual("fa fa-user");
+});
+
+test("fa_icon updates value when selecting icon", async () => {
+    Partner._records = [{ id: 1, icon: "" }];
+
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `<form><field name="icon" widget="fa_icon"/></form>`,
+    });
+
+    const input = queryFirst(".o_select_menu_input");
+    // placeholder should be visible when no icon is selected
+    expect(input.placeholder).toEqual("Select icon");
+
+    // open dropdown
+    await click(input);
+    await animationFrame();
+    expect(".o_fa_icon_field_selector_menu").toHaveCount(1);
+
+    // select fa-user icon
+    await click(queryFirst(".fa-user"));
+    await animationFrame();
+
+    // value should now be set to "fa fa-user"
+    expect(input.value).toEqual("fa fa-user");
+});
+
+test("fa_icon does not open dropdown if readonly", async () => {
+    Partner._records = [{ id: 1, icon: "fa fa-user" }];
+
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `<form>
+            <field name="icon" widget="fa_icon" readonly="1"/>
+        </form>`,
+    });
+
+    // dropdown should not appear
+    expect(".o_select_menu_input").toHaveCount(0);
+});
+
+test.tags("desktop");
+test("fa_icon clears value when backspace is pressed", async () => {
+    Partner._records = [{ id: 1, icon: "fa fa-user" }];
+
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `<form><field name="icon" widget="fa_icon"/></form>`,
+    });
+
+    const input = queryFirst(".o_select_menu_input");
+
+    // Verify initial value
+    expect(input.value).toEqual("fa fa-user");
+
+    // Focus input and simulate backspace key press
+    await click(input);
+    await animationFrame();
+    await press("Backspace");
+    await animationFrame();
+
+    // Input should now be cleared
+    expect(input.value).toEqual("");
+});


### PR DESCRIPTION
Previously at some places an icon can be set but it should
be set by writing the name/class of the icon.

This commit will add a widget on char field that allows to
select a icon and that writes the name of the icon in the field.

Enterprise PR : https://github.com/odoo/enterprise/pull/108440

Task-5469997

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
