### PR TITLE
[FIX] website: correct parallax behavior inside carousel

### DIFF
--- a/addons/website/static/src/interactions/parallax/parallax.js
+++ b/addons/website/static/src/interactions/parallax/parallax.js
@@ -36,8 +36,24 @@ export class Parallax extends Interaction {
     }
 
     start() {
-        this.updateBackgroundHeight();
-        this.updateContent();
+        if (this.el.classList.contains("carousel-item")) {
+            // CarouselSlider.computeMaxHeight() sets a stable min-height on all
+            // carousel items in its own start(), which may run after this one.
+            // Wait one frame so that min-height is in place before we take our
+            // initial measurement. This ensures the height used here equals the
+            // height used after any animation completes, preventing a snap on
+            // the very first animation.
+            this.waitForAnimationFrame(() => {
+                this.updateBackgroundHeight();
+            });
+        } else {
+            this.updateBackgroundHeight();
+            this.updateContent();
+        }
+    }
+
+    get targetEl() {
+        return this.el.classList.contains("carousel-item") ? this.el.parentElement : this.el;
     }
 
     updateBackgroundHeight() {
@@ -46,7 +62,7 @@ export class Parallax extends Interaction {
             return;
         }
         this.viewportHeight = document.body.clientHeight;
-        this.parallaxHeight = this.el.getBoundingClientRect().height;
+        this.parallaxHeight = this.targetEl.getBoundingClientRect().height;
 
         // The parallax is in the viewport if it is between these two values
         // min : bottom of the parallax in at the top of the page
@@ -70,7 +86,7 @@ export class Parallax extends Interaction {
     }
 
     onScroll() {
-        const currentPosition = this.el.getBoundingClientRect().top;
+        const currentPosition = this.targetEl.getBoundingClientRect().top;
         if (
             this.speed === 0 ||
             this.speed === 1 ||

--- a/addons/website/static/src/interactions/parallax/parallax.js
+++ b/addons/website/static/src/interactions/parallax/parallax.js
@@ -46,7 +46,7 @@ export class Parallax extends Interaction {
             return;
         }
         this.viewportHeight = document.body.clientHeight;
-        this.parallaxHeight = this.el.getBoundingClientRect().height;
+        this.parallaxHeight = (this.el.classList.contains('carousel-item')) ? this.el.parentElement.getBoundingClientRect().height : this.el.getBoundingClientRect().height;
 
         // The parallax is in the viewport if it is between these two values
         // min : bottom of the parallax in at the top of the page
@@ -70,7 +70,7 @@ export class Parallax extends Interaction {
     }
 
     onScroll() {
-        const currentPosition = this.el.getBoundingClientRect().top;
+        const currentPosition = (this.el.classList.contains('carousel-item')) ? this.el.parentElement.getBoundingClientRect().top : this.el.getBoundingClientRect().top;
         if (
             this.speed === 0 ||
             this.speed === 1 ||

--- a/addons/website/static/tests/interactions/parallax.test.js
+++ b/addons/website/static/tests/interactions/parallax.test.js
@@ -1,6 +1,7 @@
 import { startInteractions, setupInteractionWhiteList } from "@web/../tests/public/helpers";
 
 import { describe, expect, getFixture, test } from "@odoo/hoot";
+import { animationFrame } from "@odoo/hoot-mock";
 import { manuallyDispatchProgrammaticEvent, queryOne, queryRect, scroll } from "@odoo/hoot-dom";
 
 setupInteractionWhiteList("website.parallax");
@@ -77,4 +78,19 @@ test("[scroll down] s_parallax_bg does not move when the speed is 1", async () =
     for (let i = 0; i < spacings.length - 1; i++) {
         expect(Math.round(spacings[i] - spacings[i + 1])).toBe(0);
     }
+});
+
+test("parallax on carousel-item uses parent height", async () => {
+    const { core } = await startInteractions(`
+        <div class="carousel-inner" style="height: 600px; display: block;">
+            <div class="carousel-item parallax" data-scroll-background-ratio="2" style="height: 0px; display: block;">
+                <div class="s_parallax_bg" style="height: 500px;"></div>
+            </div>
+        </div>
+    `);
+    await animationFrame();
+    // Verify that the parallaxHeight is set by carousel-inner (600px)
+    // instead of carousel-item (0px).
+    const parallaxInteraction = core.interactions[0].interaction;
+    expect(parallaxInteraction.parallaxHeight).toBe(600);
 });


### PR DESCRIPTION
Steps to reproduce:
---

Case 1:

1. Add a carousel at the top of the page.
2. Apply the parallax effect to all slides.
3. Reload the page and navigate to the second slide without scrolling.
4. Scroll slightly and observe the jump in background position.
5. Scroll back to the top and notice the changed background position.

Case 2:

1. Add a carousel to the page.
2. Apply the parallax effect to each slide.
3. Add text over the carousel and enable animation on appearance and on every time.
4. Slide between images and observe the bouncing effect.


https://github.com/user-attachments/assets/d11ee430-8b95-4903-b001-1b9ba8ee58cd

Why this change?
---

When the parallax effect is applied to carousel slides, only the first slide is initialized with the correct [parallaxHeight](https://github.com/odoo/odoo/blob/616e82d7b3a53b1facf481e783baed3e99393d3c/addons/website/static/src/interactions/parallax/parallax.js#L49). The remaining slides are initialized while hidden, resulting in a computed height of 0. When scrolling, the background height is recalculated with the correct value, producing a visible jump effect.

Additionally, when text or any animated content is added on top of the carousel (especially animations triggered on appearance or on every slide change), a [resize event](https://github.com/odoo/odoo/blob/616e82d7b3a53b1facf481e783baed3e99393d3c/addons/website/static/src/interactions/animation.js#L111) is triggered on each transition. This causes `updateBackgroundHeight()` to run again. Since hidden slides were initialized with height 0 and later receive their actual height, the recalculation produces a noticeable bouncing effect.

After this commit:
---

The parallax computation now relies on the parent element’s `getBoundingClientRect().height` when used inside a carousel. Since the carousel slide height is already defined and consistent, this ensures correct initialization even when the slide is not yet visible.


OPW: 5909351




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
