### PR TITLE
[FIX] mail: prevent lost cursor with mention

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -47,7 +47,8 @@ import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { useComposerActions } from "@mail/core/common/composer_actions";
 import { ActionList } from "@mail/core/common/action_list";
-import { lastLeaf } from "@html_editor/utils/dom_traversal";
+import { closestElement, lastLeaf } from "@html_editor/utils/dom_traversal";
+import { rightPos } from "@html_editor/utils/position";
 
 const EDIT_CLICK_TYPE = {
     CANCEL: "cancel",
@@ -195,6 +196,7 @@ export class Composer extends Component {
                 }
                 if (focus && this.editor) {
                     this.editor.shared.selection.focusEditable();
+                    this.editor.shared.selection.selectAroundNonEditable();
                 }
             },
             () => [this.props.autofocus + this.props.composer.autofocus, this.props.placeholder]
@@ -255,10 +257,25 @@ export class Composer extends Component {
                 return;
             }
             setElementContent(this.editor.editable, composerHtml);
-            this.editor.shared.selection.setCursorEnd(lastLeaf(this.editor.editable));
+            this.setEditorCursorEnd();
             this.editor.shared.history.addStep();
         });
         void composerProxy.composerHtml; // start observing
+    }
+
+    setEditorCursorEnd() {
+        const lastNode = lastLeaf(this.editor?.editable);
+        if (!lastNode) {
+            return;
+        }
+        const nonEditableAncestor = closestElement(lastNode, (el) => !el.isContentEditable);
+        if (nonEditableAncestor && this.editor.editable.contains(nonEditableAncestor)) {
+            const [anchorNode, anchorOffset] = rightPos(nonEditableAncestor);
+            this.editor.shared.selection.setSelection({ anchorNode, anchorOffset });
+        } else {
+            this.editor.shared.selection.setCursorEnd(lastNode);
+        }
+        this.editor.shared.selection.selectAroundNonEditable();
     }
 
     get areAllActionsDisabled() {
@@ -303,7 +320,7 @@ export class Composer extends Component {
             classList: ["o-mail-Composer-html"],
             onChange: () => this.onChangeWysiwygContent(),
             onEditorReady: () => {
-                this.editor.shared.selection.setCursorEnd(lastLeaf(this.editor.editable));
+                this.setEditorCursorEnd();
                 this.editor.shared.history.addStep();
             },
         };

--- a/addons/mail/static/src/core/common/plugin/mention_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mention_plugin.js
@@ -6,7 +6,6 @@ export class MentionPlugin extends Plugin {
     static id = "mention";
     static dependencies = ["baseContainer", "selection", "history"];
     resources = {
-        selectionchange_handlers: this.detectMentions.bind(this),
         is_node_editable_predicates: (node) => {
             for (const { selector } of this.MENTION_SELECTORS) {
                 if (closestElement(node, selector)) {
@@ -15,6 +14,9 @@ export class MentionPlugin extends Plugin {
             }
         },
         select_all_overrides: this.selectAll.bind(this),
+        selectionchange_handlers: this.detectMentions.bind(this),
+        selectors_for_feff_providers: () =>
+            this.MENTION_SELECTORS.map(({ selector }) => selector).join(", "),
     };
 
     setup() {

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -612,7 +612,7 @@ test("mentions and special mentions are kept when editing message", async () => 
     });
     await click(".o-mail-Message [title='Edit']");
     await contains(".o-mail-Message .o-mail-Composer-html", {
-        text: "Hello @Mitchell Admin and @everyone",
+        text: "Hello \uFEFF@Mitchell Admin\uFEFF and \uFEFF@everyone",
         contains: [
             ["a.o_mail_redirect[contenteditable=false]", { text: "@Mitchell Admin" }],
             ["a.o-discuss-mention[contenteditable=false]", { text: "@everyone" }],
@@ -624,9 +624,10 @@ test("mentions and special mentions are kept when editing message", async () => 
             ".o-mail-Message .o-mail-Composer-html.odoo-editor-editable"
         ),
     };
+    const paragraph = editor.editable.querySelector("div.o-paragraph");
     setSelection({
-        anchorNode: editor.editable.querySelector("div.o-paragraph"),
-        anchorOffset: 4 /* at the end = after 4 nodes: "Hello" <first mention> "and" <second mention> */,
+        anchorNode: paragraph,
+        anchorOffset: paragraph.childNodes.length,
     });
     await htmlInsertText(editor, " abc");
     await click(".o-mail-Message button", { text: "save" });

--- a/addons/mail/static/tests/message/message_reply.test.js
+++ b/addons/mail/static/tests/message/message_reply.test.js
@@ -1,3 +1,4 @@
+import { insertText as htmlInsertText } from "@html_editor/../tests/_helpers/user_actions";
 import {
     click,
     contains,
@@ -10,7 +11,7 @@ import {
 import { describe, test } from "@odoo/hoot";
 import { queryFirst } from "@odoo/hoot-dom";
 import { disableAnimations } from "@odoo/hoot-mock";
-import { serverState } from "@web/../tests/web_test_helpers";
+import { getService, serverState } from "@web/../tests/web_test_helpers";
 import { deserializeDateTime } from "@web/core/l10n/dates";
 
 import { getOrigin } from "@web/core/utils/urls";
@@ -160,6 +161,36 @@ test("can reply to logged note in chatter", async () => {
     await click(".o-mail-Message:contains('@Partner B') [title='Expand']");
     await contains(".o-dropdown-item:contains('Delete')");
     await contains(".o-dropdown-item:contains('Reply')", { count: 0 });
+});
+
+test.tags("html composer");
+test("reply to logged note in chatter keeps prefilled mention in html composer", async () => {
+    const pyEnv = await startServer();
+    const partnerBId = pyEnv["res.partner"].create({ name: "Partner B" });
+    pyEnv["mail.message"].create({
+        author_id: partnerBId,
+        body: "Test message from B",
+        model: "res.partner",
+        res_id: serverState.partnerId,
+        subtype_id: pyEnv["mail.message.subtype"].search([
+            ["subtype_xmlid", "=", "mail.mt_note"],
+        ])[0],
+    });
+    await start();
+    getService("mail.composer").setHtmlComposer();
+    await openFormView("res.partner", serverState.partnerId);
+    await click(".o-mail-Message:contains('Test message from B') [title='Reply']");
+    await contains("button.active:text('Log note')");
+    await contains(".o-mail-Composer.o-focused .o-mail-Composer-html.odoo-editor-editable");
+    await contains(".o-mail-Composer-html.odoo-editor-editable a.o_mail_redirect:text('@Partner B')");
+    const editor = {
+        document,
+        editable: queryFirst(".o-mail-Composer-html.odoo-editor-editable"),
+    };
+    await htmlInsertText(editor, "Hello");
+    await contains(".o-mail-Composer-send:enabled");
+    await click(".o-mail-Composer-send:enabled");
+    await contains(".o-mail-Message:contains('Hello') a.o_mail_redirect:text('@Partner B')");
 });
 
 test("Replying to a message containing line breaks should be correctly inlined", async () => {


### PR DESCRIPTION
In chatter, using "Reply" in HTML composer could focus the composer without giving a usable caret. The inserted partner mention is a non-editable link (`contenteditable="false"`), and selection could end up inside that node, so typing would not insert text.

This also fix the related firefox issue:
mentions are rendered as `a[contenteditable=false]`. Firefox is stricter than Chrome for carret
positions around non-editable inline nodes, so clicking before a mention or moving left from its right edge could make stuck.

so we register mention selectors as FEFF providers in the mention plugin. (a feature of html_editor FEFF plugin to add invisible boundary characters around mentions, which gives firefox what it need to move carret around.

some tests had to be adapted to take the insertion of FEFFs in the composer text into account

task-5262368

