### PR TITLE
[FIX] pos_self_order: Fix UI of pills selection popup in mobile

### DIFF
--- a/addons/pos_self_order/static/src/app/components/pills_selection_popup/pills_selection_popup.scss
+++ b/addons/pos_self_order/static/src/app/components/pills_selection_popup/pills_selection_popup.scss
@@ -1,6 +1,10 @@
+.modal-dialog:has(.self_order_pills_selection_popup_dialog) {
+    margin: 0;
+    --bs-modal-margin: 0px;
+}
+
 .self_order_pills_selection_popup_dialog {
     border-radius: 35px 35px 0 0 !important;
-    bottom: 0;
 }
 
 .no-scrollbar {
@@ -12,10 +16,24 @@
     display: none;  /* Chrome, Safari and Opera */
 }
 
+/* On mobile screens (<576px) */
+@media (max-width: 575px) {
+    /* If modal-dialog-centered is present, it will center; override it */
+    .modal-dialog-centered:has(.self_order_pills_selection_popup_dialog) {
+      align-items: flex-end;
+      min-height: 100%;
+    }
+
+    .modal-dialog:has(.self_order_pills_selection_popup_dialog) {
+      margin: 0;
+    }
+  }
+
 /* On small screens (576px - 767px) */
 @media (min-width: 576px) and (max-width: 767px) {
     .self_order_pills_selection_popup_dialog {
         max-height: 75vh;
+        bottom: 0;
     }
 
     .self_order_pills_selection_popup {


### PR DESCRIPTION
Small modification of the pills selection popup in order to make it starting at the bottom of the screen and not with a fixed size, which caused in certain cases, weird UI.

task: 5952769

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
