### PR TITLE
[FIX] base: correct Qatar currency label

### DIFF
--- a/odoo/addons/base/data/res_currency_data.xml
+++ b/odoo/addons/base/data/res_currency_data.xml
@@ -1582,7 +1582,7 @@
             <field name="symbol">QR</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Rial</field>
+            <field name="currency_unit_label">Riyal</field>
             <field name="currency_subunit_label">Dirham</field>
         </record>
 


### PR DESCRIPTION
Steps to reproduce:
1- Install Accounting and 'l10n_qa' modules
2- Switch to Qatar company and enable "Total amount of invoice in letters" under accounting settings
3. Issue an invoice and preview it

The issue:
The description of the amount uses "Rial"

Expected behavior:
The amount should use "Riyal"

opw-5919587