### PR TITLE
[FIX] l10n_ar: correct footer display in invoices

### DIFF
--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -88,6 +88,7 @@
             <t t-set="custom_footer">
                 <div class="row">
                     <div name="footer_left_column" class="col-8 text-start">
+                        <span t-field="o.company_id.report_footer"/>
                     </div>
                     <div name="footer_right_column" class="col-4 text-end">
                         <div name="pager" t-if="report_type == 'pdf'">


### PR DESCRIPTION
Steps to reproduce:
1- Install Accounting and 'l10n_ar' modules
2- Switch to Argentina company, go to [Settings -> Configure Document Layout] and make sure there is some text in the footer field
3- Issue an invoice and preview it

The issue:
The footer text is missing at the bottom of the invoice

Expected behavior:
The footer text should be displayed at the bottom

Why this happens?
The xml file was missing the field definition of the footer text

opw-5927246