### PR TITLE
[IMP] mail: prevent invite and create options for assignee selection

### DIFF
--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -148,7 +148,7 @@
                         <group>
                             <field name="date_deadline"/>
                         </group>
-                        <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
+                        <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]" options="{'no_create': True}"/>
                     </group>
                     <field name="note" class="oe-bordered-editor embedded-editor-height-4" placeholder="Log a note..." widget="html_mail"/>
                     <footer>
@@ -273,7 +273,7 @@
                 <field name="summary" string="Summary"/>
                 <field name="res_name" string="Linked to"/>
                 <field name="activity_type_id" optional="hide"/>
-                <field name="user_id" widget="many2one_avatar_user" optional="hide"/>
+                <field name="user_id" widget="many2one_avatar_user" optional="hide" options="{'no_create': True}"/>
                 <field name="date_deadline" widget="remaining_days"/>
                 <field name="date_done" string="Done Date" optional="hide"/>
                 <field name="feedback" optional="hide"/>

--- a/addons/mail/wizard/mail_activity_schedule_views.xml
+++ b/addons/mail/wizard/mail_activity_schedule_views.xml
@@ -49,7 +49,7 @@
                             </group>
                             <group>
                                 <field name="date_deadline" string="Due Date"/>
-                                <field name="activity_user_id" widget="many2one_avatar_user" placeholder="Unassigned" domain="[('share', '=', False)]"/>
+                                <field name="activity_user_id" widget="many2one_avatar_user" placeholder="Unassigned" domain="[('share', '=', False)]" options="{'no_create': True}"/>
                                 <field name="res_model" widget="activity_model_selector" string="Link to"
                                     invisible="id or context.get('active_model')" required="activity_user_id != context.get('uid')"/>
                             </group>


### PR DESCRIPTION
Disabled the Invite option in the assignee selection while scheduling activities to prevent unintended user invitations from here. Also, remove the 'Create New' button on Search more.

Task-5936169




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
