### PR TITLE
[FIX] project: fix send email when creating task from template

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -913,12 +913,13 @@ class ProjectTask(models.Model):
         copied_tasks = super(ProjectTask, self.with_context(
             mail_auto_subscribe_no_notify=True,
             mail_create_nosubscribe=True,
-            mail_create_nolog=True,
+            mail_create_nolog=bool(not self.env.context.get('copy_from_template')),
         )).copy(default=default)
 
         self._resolve_copied_dependencies(copied_tasks)
-        log_message = _("Task Created")
-        copied_tasks._message_log_batch(bodies={task.id: log_message for task in copied_tasks})
+        if not self.env.context.get('copy_from_template'):
+            log_message = _("Task Created")
+            copied_tasks._message_log_batch(bodies={task.id: log_message for task in copied_tasks})
 
         return copied_tasks
 

--- a/addons/project/tests/test_task_templates.py
+++ b/addons/project/tests/test_task_templates.py
@@ -1,7 +1,8 @@
+from odoo.addons.mail.tests.common import MailCase
 from odoo.addons.project.tests.test_project_base import TestProjectCommon
 
 
-class TestTaskTemplates(TestProjectCommon):
+class TestTaskTemplates(TestProjectCommon, MailCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -94,3 +95,14 @@ class TestTaskTemplates(TestProjectCommon):
             task | child,
             "The search should find the non template task and its child",
         )
+
+    def test_send_creation_email_on_task_creation_from_template(self):
+        self.template_task.project_id.message_subscribe(
+            partner_ids=self.user_projectuser.partner_id.ids,
+            subtype_ids=(self.env.ref('mail.mt_comment') + self.env.ref('project.mt_task_new')).ids
+        )
+        with self.mock_mail_gateway():
+            task_id = self.template_task.with_user(self.user_projectmanager).action_create_from_template()
+        task = self.env["project.task"].browse(task_id)
+        self.assertEqual(task.message_ids[0].subtype_id, self.env.ref('project.mt_task_new'))
+        self.assertEqual(task.message_ids[0].notified_partner_ids, self.user_projectuser.partner_id)


### PR DESCRIPTION
Steps to reproduce:

- Open form view project that has task templates.
- Add a partner to follow project when task is created.
- From `New` button click on any available task templates .

Issue:

- Mail is not sent when task is created from template.

Fix:

- Now we are treating creating task from template same as we do copy.

Solution:

- Make sure we send a mail and stop the normal logging which happens when copying the task.
