### PR TITLE
[IMP] account: improve partner retrieval logic

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -903,7 +903,7 @@ class ResPartner(models.Model):
     def _retrieve_partner_with_name(self, name, extra_domain):
         if not name:
             return None
-        return self.env['res.partner'].search([('name', 'ilike', name)] + extra_domain, limit=2)
+        return self.env['res.partner'].search([('name', '=ilike', name)] + extra_domain, limit=1)
 
     def _retrieve_partner(self, name=None, phone=None, mail=None, vat=None, domain=None, company=None):
         '''Search all partners and find one that matches one of the parameters.


### PR DESCRIPTION
Before this commit:
* Partner was searched using contains on the name, which could match unrelated partners with similar names (e.g. 'Global Tech' matching 'Global Technologies Ltd').

After this commit:
- Partner retrieval now uses an exact name match to avoid incorrect matches caused by partial name search.
- The search limit is set to 1 to ensure a consistent result when multiple partners are found.

Technical:
- Replaced `ilike` with `=ilike` in the name search domain.

task-5485563