### PR TITLE
[FIX] im_livechat: avoid messaging menu category flicker

### DIFF
--- a/addons/im_livechat/models/res_users.py
+++ b/addons/im_livechat/models/res_users.py
@@ -152,6 +152,14 @@ class ResUsers(models.Model):
     def _store_init_global_fields(self, res: Store.FieldList):
         super()._store_init_global_fields(res)
         res.attr("has_access_livechat", self.has_access_livechat)
+        if self._is_internal():
+            domain = [
+                ("channel_id.channel_type", "=", "livechat"),
+                ("is_self", "=", True),
+                ("is_pinned", "=", True),
+            ]
+            has_pinned_livechats = self.env["discuss.channel.member"].search_count(domain, limit=1) > 0
+            res.attr("show_livechat_category", has_pinned_livechats)
 
     def _store_init_fields(self, res: Store.FieldList):
         super()._store_init_fields(res)

--- a/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
@@ -25,6 +25,13 @@ const discussChannelPatch = {
         this.livechat_expertise_ids = fields.Many("im_livechat.expertise");
         this.livechat_lang_id = fields.One("res.lang");
         this.livechat_looking_for_help_since_dt = fields.Datetime();
+        this.storeAsPinnedLivechats = fields.One("Store", {
+            compute() {
+                if (this.channel_type === "livechat" && this.self_member_id?.is_pinned) {
+                    return this.store;
+                }
+            },
+        });
         /** @type {"in_progress"|"need_help"|undefined} */
         this.livechat_status = fields.Attr(undefined, {
             onUpdate() {

--- a/addons/im_livechat/static/src/core/public_web/messaging_menu_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/messaging_menu_patch.js
@@ -10,10 +10,7 @@ const messagingMenuPatch = {
      */
     get _tabs() {
         const items = super._tabs;
-        const hasLivechats = Object.values(this.store["discuss.channel"].records).some(
-            (channel) => channel.channel_type === "livechat"
-        );
-        if (hasLivechats) {
+        if (this.store.show_livechat_category) {
             items.push({
                 counter: this.store.discuss.livechats.reduce(
                     (acc, channel) =>

--- a/addons/im_livechat/static/src/core/web/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/web/@types/models.d.ts
@@ -8,6 +8,7 @@ declare module "models" {
     export interface Store {
         goToOldestUnreadLivechatThread: () => boolean;
         has_access_livechat: boolean;
+        show_livechat_category: boolean;
         livechatChannels: ReturnType<Store['makeCachedFetchData']>;
         livechatSelfExpertises: ReturnType<Store['makeCachedFetchData']>;
         livechatStatusButtons: Readonly<object[]>;

--- a/addons/im_livechat/static/src/core/web/store_service_patch.js
+++ b/addons/im_livechat/static/src/core/web/store_service_patch.js
@@ -1,4 +1,5 @@
 import { Store } from "@mail/core/common/store_service";
+import { fields } from "@mail/model/misc";
 import { compareDatetime } from "@mail/utils/common/misc";
 import { _t } from "@web/core/l10n/translation";
 
@@ -11,6 +12,20 @@ const storePatch = {
         this.livechatChannels = this.makeCachedFetchData("im_livechat.channel");
         this.livechatSelfExpertises = this.makeCachedFetchData("/im_livechat/fetch_self_expertise");
         this.has_access_livechat = false;
+        this.pinnedLivechats = fields.Many("discuss.channel", {
+            inverse: "storeAsPinnedLivechats",
+        });
+        /**
+         * Determine if the live chat category should be shown in the messaging menu.
+         * First received as part of the store initialization (`_store_init_global_fields`)
+         * to avoid flickering, then updated by the client compute.
+         */
+        this.show_livechat_category = fields.Attr(false, {
+            compute() {
+                return this.pinnedLivechats.length > 0;
+            },
+            eager: true,
+        });
     },
     /**
      * @override

--- a/addons/im_livechat/static/tests/mock_server/mock_models/res_users.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/res_users.js
@@ -10,6 +10,14 @@ export class ResUsers extends mailModels.ResUsers {
         store.add({
             has_access_livechat: this.env.user?.group_ids.includes(serverState.groupLivechatId),
         });
+        /** @type {import("mock_models").DiscussChannelMember} */
+        const DiscussChannelMember = this.env["discuss.channel.member"];
+        const pinnedMembers = DiscussChannelMember._filter([
+            ["partner_id", "=", this.env.user.partner_id],
+        ]).filter((member) => member.is_pinned);
+        store.add({
+            show_livechat_category: pinnedMembers.length > 0,
+        });
         store.add(this.browse(this.env.uid), {
             is_livechat_manager: this.env.user?.group_ids.includes(
                 serverState.groupLivechatManagerId

--- a/addons/mail/static/src/discuss/core/public_web/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/store_service_patch.js
@@ -10,13 +10,6 @@ const StorePatch = {
         super.setup(...arguments);
         this.channels = this.makeCachedFetchData("channels_as_member");
         this.fetchSsearchConversationsSequential = useSequential();
-        /**
-         * Determines whether there is at least one unpinned conversation for the current user. This
-         * value is not dynamic, but statically fetched during `/discuss/search` to determine if the
-         * "View hidden conversations" should be displayed.
-         * @type {boolean}
-         */
-        this.has_unpinned_channels;
     },
     /** @param {string} searchValue */
     async searchConversations(searchValue) {

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -36,7 +36,10 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #   2: hasCannedResponses
     #       - fetch res_groups_users_rel
     #       - search mail_canned_response
-    _query_count_init_store = 19
+    #   2: show_livechat_category
+    #       - search discuss_channel_member (is_self for ACL check)
+    #       - search_count discuss_channel_member
+    _query_count_init_store = 21
     # Queries for _query_count_init_messaging (in order):
     #   1: insert res_device_log
     #   3: _search_is_member (for current user, first occurence _search_is_member for chathub given channel ids)
@@ -415,8 +418,8 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                     "active": True,
                     "avatar_128_access_token": partner_0._get_avatar_128_access_token(),
                     "id": self.users[0].partner_id.id,
-                    "im_status": 'online',
-                    "im_status_access_token": self.users[0].partner_id._get_im_status_access_token(),
+                    "im_status": "online",
+                    "im_status_access_token": partner_0._get_im_status_access_token(),
                     "main_user_id": self.users[0].id,
                     "name": "Ernest Employee",
                     "tz": "Europe/Brussels",
@@ -454,6 +457,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "mt_note": self.env.ref("mail.mt_note").id,
                 "odoobot": self.user_root.partner_id.id,
                 "self_user": self.users[0].id,
+                "show_livechat_category": True,
                 "settings": {
                     "channel_notifications": False,
                     "id": self.env["res.users.settings"]._find_or_create_for_user(self.users[0]).id,


### PR DESCRIPTION
Before this PR, the live chat category in the messaging menu would flicker when opened initially.

This occurs because the category is displayed only when users have live chats to show. However, this information is available only after the channels are fully fetched, which causes the flicker.

This is problematic because users may accidentally click and end up in a different category.

This commit fixes the issue by introducing the `show_livechat_category` field, which is initially returned by the server depending on whether the user has pinned live chats and is later updated by its compute function.

task-5475290

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
