### PR TITLE
[FIX] website_sale: display price per unit in ecommerce in boxed layout

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2365,7 +2365,18 @@
         <xpath expr="//div[@id='o_wsale_cta_wrapper']" position="inside">
             <div class="d-flex gap-5 flex-grow-1 justify-content-between align-items-center order-first w-100 mb-3 pb-3 border-bottom">
                 <span name="o_wsale_cta_wrapper_boxed_price_label" class="text-muted">Price</span>
-                <t t-call="website_sale.product_price"/>
+                <div>
+                    <t t-call="website_sale.product_price"/>
+                    <small 
+                        t-if="combination_info.get('base_unit_price')"
+                        class="ms-1 text-muted o_base_unit_price_wrapper d-none"
+                    >
+                        <t
+                            t-call="website_sale.base_unit_price"
+                            base_unit_price="combination_info['base_unit_price']"
+                        />
+                    </small>
+                </div>
             </div>
         </xpath>
     </template>


### PR DESCRIPTION
### Issue before the commit:
In the product page of ecommerce app choosing the "boxed" style layout the price per unit was not displayed.

### Steps to reproduce the issue:
- Download website and create one
- Activate "Product reference type" from settings
- Create a product inserting selling price and base unit count
- Go to website with smart button
- Edit and go to "style" tab
- The "purchase style" is not working for "boxed" style

### Cause of the issue:
During the refactoring of the product page templates from version 18.4 to 19.0 (commit 670b1daa2254d7600b54bae675dd673f457aa8fa), in the website_sale.product template, the logic responsible for rendering the unit price information was omitted in the "boxed" layout, whereas it remains correctly implemented in the "default" and "large" views.

### Reason to introduce the fix:
To ensure UI uniformity across all available layout styles and to restore the visibility of critical unit price data for customers.

### Fix details:
Added the base_unit_price in the website_sale.cta_wrapper_boxed layout: 
```
<small t-if="combination_info.get('base_unit_price')"
    class="ms-1 text-muted o_base_unit_price_wrapper d-none">
    <t t-call="website_sale.base_unit_price">
        <t t-set="base_unit_price" t-value="combination_info['base_unit_price']"/>
    </t>
</small>
```
Before the change:
<img width="489" height="373" alt="image" src="https://github.com/user-attachments/assets/1cee4cfc-0109-4647-a925-b183a19cad48" />

After the change:
<img width="471" height="362" alt="image" src="https://github.com/user-attachments/assets/863e98b2-6297-4388-a538-5ee0c1a568fa" />

opw-5920598


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
