### PR TITLE
[FIX] html_builder: hide loading screen if the UI is already blocked

### DIFF
--- a/addons/html_builder/static/src/core/operation.js
+++ b/addons/html_builder/static/src/core/operation.js
@@ -165,13 +165,13 @@ export class Operation {
      * @returns {Function}
      */
     addLoadingElement(withLoadingEffect, loadingEffectDelay, shouldInterceptClick) {
-        const loadingScreenEl = document.createElement("div");
-        loadingScreenEl.classList.add(
+        this.loadingScreenEl = document.createElement("div");
+        this.loadingScreenEl.classList.add(
             ...["o_loading_screen", "d-flex", "justify-content-center", "align-items-center"]
         );
         const spinnerEl = document.createElement("img");
         spinnerEl.setAttribute("src", "/web/static/img/spin.svg");
-        loadingScreenEl.appendChild(spinnerEl);
+        this.loadingScreenEl.appendChild(spinnerEl);
 
         let removeClickListener = () => {};
         if (shouldInterceptClick) {
@@ -192,24 +192,56 @@ export class Operation {
             this.editableDocument.addEventListener("click", onClick);
             removeClickListener = () => this.editableDocument.removeEventListener("click", onClick);
         }
+        if (this.isUIBlocked) {
+            this.loadingScreenEl.classList.add("d-none");
+        }
 
-        this.editableDocument.body.appendChild(loadingScreenEl);
+        this.editableDocument.body.appendChild(this.loadingScreenEl);
 
         // If specified, add a loading effect on that element after a delay.
         let loadingTimeout;
         if (withLoadingEffect) {
             loadingTimeout = setTimeout(
-                () => loadingScreenEl.classList.add("o_we_ui_loading"),
+                () => this.loadingScreenEl?.classList.add("o_we_ui_loading"),
                 loadingEffectDelay
             );
         }
-
         return () => {
             if (loadingTimeout) {
                 clearTimeout(loadingTimeout);
             }
             removeClickListener();
-            loadingScreenEl.remove();
+            this.loadingScreenEl.remove();
+            this.loadingScreenEl = null;
         };
+    }
+
+    /**
+     * Handles the "BLOCK" UI event dispatched by the ui service.
+     *
+     * @param {CustomEvent} ev
+     * @param {Object} ev.detail
+     * @param {Number} [ev.detail.delay] delay in ms before the UI is considered
+     *   blocked
+     */
+    onBlockUI(ev) {
+        this.blockUITimeout = setTimeout(() => {
+            this.isUIBlocked = true;
+            if (this.loadingScreenEl) {
+                this.loadingScreenEl.classList.add("d-none");
+            }
+        }, ev.detail?.delay);
+    }
+
+    /**
+     * Handles the "UNBLOCK" UI event dispatched by the ui service. Cancels any
+     * pending block timeout and marks the UI as no longer blocked
+     */
+    onUnblockUI() {
+        clearTimeout(this.blockUITimeout);
+        this.isUIBlocked = false;
+        if (this.loadingScreenEl) {
+            this.loadingScreenEl.classList.remove("d-none");
+        }
     }
 }

--- a/addons/html_builder/static/src/core/operation_plugin.js
+++ b/addons/html_builder/static/src/core/operation_plugin.js
@@ -25,6 +25,20 @@ export class OperationPlugin extends Plugin {
         // this may lose the user input while the apply was running
         this.addDomListener(this.editable, "keydown", () => this.next());
         this.addDomListener(this.editable, "beforeinput", () => this.next());
+
+        // We want to hide the loading screen if the ui gets blocked, to avoid
+        // multiple loading screens
+        const ui = this.services.ui;
+        const onBlockUI = this.operation.onBlockUI.bind(this.operation);
+        const onUnblockUI = this.operation.onUnblockUI.bind(this.operation);
+
+        ui.bus.addEventListener("BLOCK", onBlockUI);
+        ui.bus.addEventListener("UNBLOCK", onUnblockUI);
+
+        this._cleanups.push(() => {
+            ui.bus.removeEventListener("BLOCK", onBlockUI);
+            ui.bus.removeEventListener("UNBLOCK", onUnblockUI);
+        });
     }
 
     /**

--- a/addons/html_builder/static/tests/operation.test.js
+++ b/addons/html_builder/static/tests/operation.test.js
@@ -6,10 +6,10 @@ import {
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { Operation } from "@html_builder/core/operation";
 import { HistoryPlugin } from "@html_editor/core/history_plugin";
-import { beforeEach, describe, expect, test } from "@odoo/hoot";
+import { animationFrame, beforeEach, describe, expect, test } from "@odoo/hoot";
 import { advanceTime, delay, hover, press, tick } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
-import { contains, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { contains, getService, patchWithCleanup } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 
@@ -139,7 +139,6 @@ describe("Block editable", () => {
         await setupHTMLBuilder(`<div class="test-options-target">TEST</div>`, {
             loadIframeBundles: true,
         });
-
         await contains(":iframe .test-options-target").click();
         await contains("[data-action-id='customAction']").click();
         expect(":iframe .o_loading_screen:not(.o_we_ui_loading)").toHaveCount(1);
@@ -151,6 +150,49 @@ describe("Block editable", () => {
         await tick();
         expect(":iframe .o_loading_screen.o_we_ui_loading").toHaveCount(0);
         expect(":iframe .test-options-target").toHaveClass("custom-action");
+    });
+
+    test("Loading screen hides when ui is blocked", async () => {
+        const customActionDef = Promise.withResolvers();
+        addBuilderAction({
+            customAction: class extends BuilderAction {
+                static id = "customAction";
+                load() {
+                    return customActionDef.promise;
+                }
+                apply({ editingElement }) {
+                    editingElement.classList.add("custom-action");
+                }
+            },
+        });
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderButton action="'customAction'"/>`,
+        });
+        await setupHTMLBuilder(`<div class="test-options-target">TEST</div>`, {
+            loadIframeBundles: true,
+        });
+        await contains(":iframe .test-options-target").click();
+        await contains("[data-action-id='customAction']").click();
+        expect(":iframe .o_loading_screen:not(.o_we_ui_loading)").toHaveCount(1);
+        await advanceTime(50); // cancelTime=50 trigger by the preview
+        await advanceTime(500); // setTimeout in addLoadingElement
+        expect(":iframe .o_loading_screen.o_we_ui_loading").toHaveCount(1);
+        const ui = getService("ui");
+        ui.block();
+
+        await animationFrame();
+        expect(".o_blockUI").toHaveCount(1);
+        expect(":iframe .o_loading_screen.o_we_ui_loading").toHaveClass("d-none");
+
+        ui.unblock();
+        await animationFrame();
+        expect(".o_blockUI").toHaveCount(0);
+        expect(":iframe .o_loading_screen.o_we_ui_loading").not.toHaveClass("d-none");
+
+        customActionDef.resolve();
+        await tick();
+        expect(":iframe .o_loading_screen.o_we_ui_loading").toHaveCount(0);
     });
 });
 


### PR DESCRIPTION
When adding a loading screen, we should check if the UI is already
blocked before showing it, and also hide the loading screen when the
UI gets blocked. This can prevent multiple loading screens from
being displayed simultaneously.

Steps to reproduce:
1. Throttle your network to "Slow 4g" in the dev tools
2. Open Website and start editing
3. Go to the `Theme` tab
4. Click on "Colors"
5. Change one of the main colors (if changing a custom color, close
the color picker to apply the changes)

=> Notice that we have multiple loading screens.

task-5965711