### PR TITLE
[FIX] html_editor, *: fix small issues after resource renaming

### DIFF
--- a/addons/html_builder/static/src/@types/plugins.d.ts
+++ b/addons/html_builder/static/src/@types/plugins.d.ts
@@ -81,7 +81,7 @@ declare module "plugins" {
         on_removed_handlers: on_removed_handlers;
         on_replicated_handlers: on_replicated_handlers;
         on_saved_handlers: on_saved_handlers;
-        on_shape_computed_handlers: on_post_compute_shape_handlers;
+        on_shape_computed_handlers: on_shape_computed_handlers;
         on_snippet_dragged_handlers: on_snippet_dragged_handlers;
         on_snippet_dropped_handlers: on_snippet_dropped_handlers;
         on_snippet_dropped_near_handlers: on_snippet_dropped_near_handlers;

--- a/addons/html_builder/static/src/core/save_plugin.js
+++ b/addons/html_builder/static/src/core/save_plugin.js
@@ -13,7 +13,7 @@ import { uniqueId } from "@web/core/utils/functions";
 
 /**
  * @typedef {((el?: HTMLElement) => void)[]} on_saved_handlers
- * @typedef {((el: HTMLElement) => Promise<void>, groupedEls?: Object.<string, HTMLElement[]>)[]} on_will_save_handlers
+ * @typedef {((el?: HTMLElement, groupedEls?: Object.<string, HTMLElement[]>) => Promise<void>)[]} on_will_save_handlers
  * Called before the save process.
  *
  * @typedef {((el: HTMLElement) => Promise<void>)[]} on_will_save_element_handlers

--- a/addons/html_editor/static/src/@types/plugins.d.ts
+++ b/addons/html_editor/static/src/@types/plugins.d.ts
@@ -39,7 +39,7 @@ declare module "plugins" {
     import { delete_image_overrides, image_name_providers, ImageShared } from "@html_editor/main/media/image_plugin";
     import { ImagePostProcessShared, on_image_updated_handlers, on_image_processed_handlers, on_will_process_image_handlers } from "@html_editor/main/media/image_post_process_plugin";
     import { closest_savable_providers, ImageSaveShared, on_image_saved_handlers } from "@html_editor/main/media/image_save_plugin";
-    import { after_save_media_dialog_handlers, media_dialog_extra_tabs, MediaShared, on_media_added_handlers, on_will_save_media_dialog_handlers, on_media_replaced_handlers } from "@html_editor/main/media/media_plugin";
+    import { media_dialog_extra_tabs, MediaShared, on_media_added_handlers, on_media_dialog_saved_handlers, on_will_save_media_dialog_handlers, on_media_replaced_handlers } from "@html_editor/main/media/media_plugin";
     import { move_node_blacklist_selectors, move_node_whitelist_selectors, on_movable_element_set_handlers, on_will_unset_movable_element_handlers } from "@html_editor/main/movenode_plugin";
     import { on_layout_geometry_change_handlers } from "@html_editor/main/position_plugin";
     import { power_buttons, should_show_power_buttons_predicates } from "@html_editor/main/power_buttons_plugin";

--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -157,15 +157,15 @@ import { trackOccurrences, trackOccurrencesPair } from "../utils/tracking";
  * @typedef {((step: HistoryStep) => boolean | undefined)[]} is_step_reversible_predicates
  *
  * @typedef {((
- *    value: string,
  *    arg: {
  *      target: Node,
  *      attributeName: string,
  *      oldValue: string,
+ *      value: string,
  *      reverse: boolean,
  *    },
  *    options: { forNewStep: boolean }
- *  ) => void)[]} attribute_change_processors
+ *  ) => arg)[]} attribute_change_processors
  * @typedef {((step: HistoryStep) => HistoryStep)[]} history_step_processors
  * @typedef {((childTreesToSerialize: Tree[], node: Node) => Tree[])[]} serializable_descendants_processors
  * @typedef {((node: Node, attributeName: string, attributeValue: string) => boolean)[]} set_attribute_overrides

--- a/addons/html_editor/static/src/editor.js
+++ b/addons/html_editor/static/src/editor.js
@@ -56,8 +56,8 @@ import { isMobileOS } from "@web/core/browser/feature_detection";
  */
 
 /**
- * @typedef {((root HTMLElement = EditorContext["editable"]) => HTMLElement)[]} clean_for_save_processors
- * @typedef {(() => void)[]} start_edition_handlers
+ * @typedef {((root: HTMLElement = EditorContext["editable"]) => HTMLElement)[]} clean_for_save_processors
+ * @typedef {(() => void)[]} on_editor_started_handlers
  */
 
 /**


### PR DESCRIPTION
*: html_builder, mass_mailing

Commits from 1eb9999ca85118b630f5ada134d0c65eeb1f381a to 44a25a644a7374f42c0646d5ac1cc8d5b8e2766b refactored the resources (mostly renaming).

`on_post_compute_shape_handlers` was used in `plugins.d.ts`, but this resource never existed. This was an intermediary name (during the refactor) for `post_compute_shape_listeners` which has been finally renamed to `on_shape_computed_handlers`.

`on_will_save_handlers` had an incorrect typing declaration.

`after_save_media_dialog_handlers` was renamed during the refactor to `on_media_dialog_saved_handlers`, but the import in `plugin.d.ts` was missed.

`attribute_change_processors` typing was changed during the refactor, but incorrectly regarding to how it is finally used, this commit fixes the typing.

`clean_for_save_processors` had incorrect typing declaration.

`start_edition_handlers` was renamed `on_editor_started_handlers` during renaming, but the typing definition was missed.