### PR TITLE
[FIX] l10n_tr_nilvera_edispatch: adapt submit to new _get_nilvera_client signature

### DIFF
--- a/addons/l10n_tr_nilvera_edispatch/models/stock_picking.py
+++ b/addons/l10n_tr_nilvera_edispatch/models/stock_picking.py
@@ -327,7 +327,7 @@ class StockPicking(models.Model):
                             indicates a client error (4xx), or if a server error occurs (500).
         :return: None
         """
-        with _get_nilvera_client(self.env._, self.company) as client:
+        with _get_nilvera_client(self.env._, self.env.company) as client:
             response = client.request(
                 "POST",
                 endpoint='/edespatch/Send/Xml',


### PR DESCRIPTION
# Description of the issue this PR addresses
- When sending a GİB e-Dispatch document using l10n_tr_nilvera_edispatch, an error is raised during document submission.
- The issue occurs in StockPicking._l10n_tr_nilvera_submit_document when sending request with Nilvera client.
- The signature of _get_nilvera_client was updated but the params were not

# Current behavior before PR
- When attempting to send a GİB e-Dispatch document, the system raises an error.
- The method _l10n_tr_nilvera_submit_document calls _get_nilvera_client with self.company.
- stock.picking does not have a company field.
- This results in an attribute error during client initialization and prevents document submission.

# Desired behavior after PR is merged
- The correct field self.env.company is passed to _get_nilvera_client.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
