### PR TITLE
[FIX] tools: fill AcroForm Fields in pypdf writer

### DIFF
--- a/odoo/tools/pdf/__init__.py
+++ b/odoo/tools/pdf/__init__.py
@@ -173,13 +173,13 @@ def fill_form_fields_pdf(writer, form_fields):
     :return: a filled PDF datastring
     '''
 
+    pypdf_version = parse_version(pypdf.__version__)
+
     # This solves a known problem with PyPDF2, where with some pdf software, forms fields aren't
     # correctly filled until the user click on it, see: https://github.com/py-pdf/pypdf/issues/355
     if hasattr(writer, 'set_need_appearances_writer'):
         writer.set_need_appearances_writer()
-        is_upper_version_pypdf2 = True
     else:  # This method was renamed in PyPDF2 2.0
-        is_upper_version_pypdf2 = False
         catalog = writer._root_object
         # get the AcroForm tree
         if "/AcroForm" not in catalog:
@@ -188,12 +188,23 @@ def fill_form_fields_pdf(writer, form_fields):
             })
         writer._root_object["/AcroForm"][NameObject("/NeedAppearances")] = BooleanObject(True)
 
-    nbr_pages = len(writer.pages) if is_upper_version_pypdf2 else writer.getNumPages()
+    if pypdf_version >= parse_version('3.13.0'):
+        catalog = writer._root_object
+        if "/Fields" not in catalog.get('/AcroForm'):
+            catalog.update({
+                NameObject("/AcroForm"): writer._add_object(
+                    DictionaryObject({
+                        NameObject("/Fields"): ArrayObject()
+                    })
+                )
+            })
+
+    nbr_pages = len(writer.pages) if pypdf_version >= parse_version('1.28.0') else writer.getNumPages()
 
     for page_id in range(0, nbr_pages):
         page = writer.getPage(page_id)
 
-        if is_upper_version_pypdf2:
+        if pypdf_version >= parse_version('2.11.0'):
             writer.update_page_form_field_values(page, form_fields)
         else:
             # Known bug on previous versions of PyPDF2, fixed in 2.11

--- a/odoo/tools/pdf/_pypdf.py
+++ b/odoo/tools/pdf/_pypdf.py
@@ -3,6 +3,7 @@ from typing import Dict, Any
 import pypdf
 from pypdf import errors, filters, generic, PdfReader as _Reader, PdfWriter as _Writer
 from pypdf.generic import create_string_object
+from pypdf import __version__  # noqa: F401
 
 __all__ = [
     "PdfReader",

--- a/odoo/tools/pdf/_pypdf2_1.py
+++ b/odoo/tools/pdf/_pypdf2_1.py
@@ -1,5 +1,6 @@
 from PyPDF2 import filters, generic, utils as errors, PdfFileReader, PdfFileWriter
 from PyPDF2.generic import createStringObject as create_string_object
+from PyPDF2 import __version__  # noqa: F401
 
 __all__ = [
     "PdfReader",

--- a/odoo/tools/pdf/_pypdf2_2.py
+++ b/odoo/tools/pdf/_pypdf2_2.py
@@ -1,5 +1,6 @@
 from PyPDF2 import errors, filters, generic, PdfReader, PdfWriter as _Writer
 from PyPDF2.generic import create_string_object
+from PyPDF2 import __version__  # noqa: F401
 
 __all__ = [
     "PdfReader",


### PR DESCRIPTION
Issue:
---
Due to this issue, generating PDF Quote using Quote Builder leads to traceback.

Steps to reproduce:
---
1- Using a python 3.13 env, install requirements.txt. (You could instead uninstall pypdf2 and install pypdf==5.4.0)
2- Enable Quote Builder.
3- Create a SO and in quite builder tab, select a document.
4- Print -> PDF Quote.

This will lead to traceback.

Cause:
---
There is a requirement change on https://github.com/odoo/odoo/pull/233600, as pypdf2 will not be
supported in future. Instead we use pypdf==5.4.0.

In pypdf 5.4.0 it is required to have `Fields` present in `Acro Form` (introduced in [1] v3.13.0):
https://github.com/py-pdf/pypdf/blame/f20954f2241640feb484800e191373f8fbdfa44b/pypdf/_writer.py#L1060-L1061

FIX:
---
We could add an empty `fields` dictionary when it's not present. The entry should be `/Fields`:
https://github.com/py-pdf/pypdf/blob/f20954f2241640feb484800e191373f8fbdfa44b/pypdf/constants.py#L362-L370

Note:
---
In this fix, we replace `is_upper_version_pypdf2` with specific version comparison.
To be precise `getNumPages` is depreciated in version 1.28.0 [2].

References:
---
[1]- https://github.com/py-pdf/pypdf/commit/dcf997a028e993b215457c5629cb4e78186e11c0
[2]- https://github.com/py-pdf/pypdf/blob/3ab1581a51f446f86dd445662005f8747941c2b6/pypdf/_writer.py#L507-L514

opw-5784464