### PR TITLE
[REF] *: remove url from js file tours

### DIFF
--- a/addons/account/static/tests/tours/deductible_amount_column.js
+++ b/addons/account/static/tests/tours/deductible_amount_column.js
@@ -2,7 +2,6 @@ import { registry } from '@web/core/registry';
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add("deductible_amount_column", {
-    url: "/odoo/vendor-bills/new",
     steps: () => [
     {
         content: "Add item",

--- a/addons/account/static/tests/tours/invoice_payment_widget_tests.js
+++ b/addons/account/static/tests/tours/invoice_payment_widget_tests.js
@@ -2,7 +2,6 @@ import { accountTourSteps } from "@account/js/tours/account";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('invoice_payments_widget_exchange_tour', {
-    url: "/odoo",
     steps: () => [
     ...accountTourSteps.goToAccountMenu("Go to Invoicing"),
     {

--- a/addons/account/static/tests/tours/tax_group_tests.js
+++ b/addons/account/static/tests/tours/tax_group_tests.js
@@ -3,7 +3,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add('account_tax_group', {
-    url: "/odoo",
     steps: () => [
     ...accountTourSteps.goToAccountMenu("Go to Invoicing"),
     {

--- a/addons/account/static/tests/tours/tour_tests_shared_js_python.js
+++ b/addons/account/static/tests/tours/tour_tests_shared_js_python.js
@@ -1,16 +1,15 @@
 import { registry } from "@web/core/registry";
 
-registry.category("web_tour.tours").add('tests_shared_js_python', {
-    url: "/account/init_tests_shared_js_python",
+registry.category("web_tour.tours").add("tests_shared_js_python", {
     steps: () => [
-    {
-        content: "Click",
-        trigger: 'button',
-        run: "click",
-    },
-    {
-        content: "Wait",
-        trigger: 'button.text-success',
-        timeout: 3000,
-    },
-]});
+        {
+            content: "Click",
+            trigger: "button",
+            run: "click",
+        },
+        {
+            content: "Wait",
+            trigger: "button.text-success",
+        },
+    ],
+});

--- a/addons/auth_passkey/static/tests/passkeys_delete.js
+++ b/addons/auth_passkey/static/tests/passkeys_delete.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('passkeys_tour_delete', {
-    url: '/odoo',
     steps: () => [
         {
             content: 'Open user account menu',

--- a/addons/auth_passkey/static/tests/passkeys_login.js
+++ b/addons/auth_passkey/static/tests/passkeys_login.js
@@ -3,7 +3,6 @@ import { patch } from "@web/core/utils/patch";
 import * as passkeyLib from "../lib/simplewebauthn";
 
 registry.category("web_tour.tours").add('passkeys_tour_login', {
-    url: '/web/login',
     steps: () => [
         {
             content: "Inject authenticator data",

--- a/addons/auth_passkey/static/tests/passkeys_verify.js
+++ b/addons/auth_passkey/static/tests/passkeys_verify.js
@@ -5,7 +5,6 @@ import * as passkeyLib from "../lib/simplewebauthn";
 let unpatchPasskeyVerify;
 
 registry.category("web_tour.tours").add('passkeys_tour_verify', {
-    url: '/odoo',
     steps: () => [
         {
             content: 'Open user account menu',

--- a/addons/auth_passkey_portal/static/tests/tours/test_passkey_portal.js
+++ b/addons/auth_passkey_portal/static/tests/tours/test_passkey_portal.js
@@ -5,7 +5,6 @@ import * as passkeyLib from "@auth_passkey/../lib/simplewebauthn";
 let unpatchPasskeyRegistrationPortal;
 
 registry.category("web_tour.tours").add("passkeys_portal_create", {
-    url: "/my/security",
     steps: () => [
         {
             content: "Ensure there are no passkeys already",
@@ -93,7 +92,6 @@ registry.category("web_tour.tours").add("passkeys_portal_create", {
 });
 
 registry.category("web_tour.tours").add("passkeys_portal_rename", {
-    url: "/my/security",
     steps: () => [
         {
             content: "Ensure there is one passkey",
@@ -125,7 +123,6 @@ registry.category("web_tour.tours").add("passkeys_portal_rename", {
 });
 
 registry.category("web_tour.tours").add("passkeys_portal_delete", {
-    url: "/my/security",
     steps: () => [
         {
             content: "Ensure there is one passkey",

--- a/addons/auth_timeout/static/tests/tours/auth_timeout_tour.js
+++ b/addons/auth_timeout/static/tests/tours/auth_timeout_tour.js
@@ -74,7 +74,6 @@ const assertNoRPC = {
 };
 
 registry.category("web_tour.tours").add("auth_timeout_tour_lock_timeout_inactivity", {
-    url: "/odoo",
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         {
@@ -147,7 +146,6 @@ registry.category("web_tour.tours").add("auth_timeout_tour_lock_timeout_inactivi
 });
 
 registry.category("web_tour.tours").add("auth_timeout_tour_lock_timeout_inactivity_2fa", {
-    url: "/odoo",
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         // Check identity using a passkey, which is 2FA by itself, and check an RPC call works

--- a/addons/auth_totp/static/tests/apikeys_flow.js
+++ b/addons/auth_totp/static/tests/apikeys_flow.js
@@ -16,7 +16,6 @@ const openUserPreferenceSecurity = () => [{
 }]
 
 registry.category("web_tour.tours").add('apikeys_tour_setup', {
-    url: '/odoo?debug=1', // Needed as API key part is now only displayed in debug mode
     steps: () => [
     ...openUserPreferenceSecurity(), {
     content: "Open API keys wizard",
@@ -68,7 +67,6 @@ registry.category("web_tour.tours").add('apikeys_tour_setup', {
 
 // deletes the previously created key
 registry.category("web_tour.tours").add('apikeys_tour_teardown', {
-    url: '/odoo?debug=1', // Needed as API key part is now only displayed in debug mode
     steps: () => [{
     content: 'Open preferences',
     trigger: '.o_user_menu',

--- a/addons/auth_totp/static/tests/totp_flow.js
+++ b/addons/auth_totp/static/tests/totp_flow.js
@@ -121,7 +121,6 @@ registry.category("web_tour.tours").add('totp_tour_setup', {
 
 registry.category("web_tour.tours").add('totp_login_enabled', {
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: '/',
     steps: () => [{
     content: "check that we're on the login page or go to it",
     isActive: ["body:not(:has(input#login))"],
@@ -194,7 +193,6 @@ registry.category("web_tour.tours").add('totp_login_enabled', {
 
 registry.category("web_tour.tours").add('totp_login_device', {
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: '/',
     steps: () => [{
     content: "check that we're on the login page or go to it",
     isActive: ["body:not(:has(input#login))"],
@@ -352,7 +350,6 @@ registry.category("web_tour.tours").add('totp_login_disabled', {
 ]});
 
 registry.category("web_tour.tours").add('totp_admin_disables', {
-    url: '/odoo',
     steps: () => [stepUtils.showAppsMenuItem(), {
     content: 'Go to settings',
     trigger: '[data-menu-xmlid="base.menu_administration"]',

--- a/addons/auth_totp/tests/test_apikeys.py
+++ b/addons/auth_totp/tests/test_apikeys.py
@@ -32,7 +32,7 @@ class TestAPIKeys(TestTOTPMixin, HttpCase):
 
     def test_addremove(self):
         db = get_db_name()
-        self.start_tour('/odoo', 'apikeys_tour_setup', login=self.user_test.login)
+        self.start_tour('/odoo?debug=1', 'apikeys_tour_setup', login=self.user_test.login)
         self.assertEqual(len(self.user_test.api_key_ids), 1, "the test user should now have a key")
 
         [(_, [key], [])] = self.messages
@@ -46,12 +46,12 @@ class TestAPIKeys(TestTOTPMixin, HttpCase):
             r['login'], self.user_test.login,
             "the key should be usable as a way to perform RPC calls"
         )
-        self.start_tour('/odoo', 'apikeys_tour_teardown', login=self.user_test.login)
+        self.start_tour('/odoo?debug=1', 'apikeys_tour_teardown', login=self.user_test.login)
 
     def test_apikeys_totp(self):
         db = get_db_name()
         self.install_totphook()
-        self.start_tour('/odoo', 'apikeys_tour_setup', login=self.user_test.login)
+        self.start_tour('/odoo?debug=1', 'apikeys_tour_setup', login=self.user_test.login)
         self.start_tour('/odoo', 'totp_tour_setup', login=self.user_test.login)
         [(_, [key], [])] = self.messages  # pylint: disable=unbalanced-tuple-unpacking
         uid = self.xmlrpc_common.authenticate(db, self.user_test.login, key, {})

--- a/addons/auth_totp_mail/static/tests/totp_flow.js
+++ b/addons/auth_totp_mail/static/tests/totp_flow.js
@@ -36,7 +36,6 @@ function openAccountSettingsTab() {
 }
 
 registry.category("web_tour.tours").add('totp_admin_self_invite', {
-    url: '/odoo',
     steps: () => [stepUtils.showAppsMenuItem(), ...openAccountSettingsTab(), {
     content: "open the user's form",
     trigger: "td.o_data_cell:contains(admin)",
@@ -51,7 +50,6 @@ registry.category("web_tour.tours").add('totp_admin_self_invite', {
 }]});
 
 registry.category("web_tour.tours").add('totp_admin_invite', {
-    url: '/odoo',
     steps: () => [stepUtils.showAppsMenuItem(), ...openAccountSettingsTab(), {
     content: "open the user's form",
     trigger: "td.o_data_cell:contains(test_user)",

--- a/addons/auth_totp_portal/static/tests/totp_portal.js
+++ b/addons/auth_totp_portal/static/tests/totp_portal.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { rpc } from "@web/core/network/rpc";
 
 registry.category("web_tour.tours").add('totportal_tour_setup', {
-    url: '/my/security',
     steps: () => [{
     content: "Open totp wizard",
     trigger: 'button#auth_totp_portal_enable',
@@ -45,7 +44,6 @@ registry.category("web_tour.tours").add('totportal_tour_setup', {
 }]});
 
 registry.category("web_tour.tours").add('totportal_login_enabled', {
-    url: '/',
     steps: () => [{
     content: "check that we're on the login page or go to it",
     isActive: ["body:not(:has(input#login))"],
@@ -110,7 +108,6 @@ registry.category("web_tour.tours").add('totportal_login_enabled', {
 }]});
 
 registry.category("web_tour.tours").add('totportal_login_disabled', {
-    url: '/',
     steps: () => [{
     content: "check that we're on the login page or go to it",
     isActive: ["body:not(:has(input#login))"],

--- a/addons/calendar/static/tests/tours/calendar_tour.js
+++ b/addons/calendar/static/tests/tours/calendar_tour.js
@@ -12,7 +12,6 @@ const todayDate = function () {
 
 registry.category("web_tour.tours").add("calendar_appointments_hour_tour", {
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/contacts/static/tests/tours/debug_menu_set_defaults.js
+++ b/addons/contacts/static/tests/tours/debug_menu_set_defaults.js
@@ -3,7 +3,6 @@
     import { delay } from "@web/core/utils/concurrency";
 
     registry.category("web_tour.tours").add('debug_menu_set_defaults', {
-        url: '/odoo?debug=1',
         steps: () => [
             ...stepUtils.goToAppSteps('contacts.menu_contacts', "Open the contacts menu"),
             {

--- a/addons/contacts/tests/test_ui.py
+++ b/addons/contacts/tests/test_ui.py
@@ -23,7 +23,7 @@ class TestUi(odoo.tests.HttpCase):
         self.assertEqual(self.env['res.partner'].new().function, False)
 
         # TDE: to activate again after freeze
-        # self.start_tour("/odoo", 'debug_menu_set_defaults', login="admin")
+        # self.start_tour("/odoo?debug=1", 'debug_menu_set_defaults', login="admin")
 
     def test_vat_label_string(self):
         """ Test changing the vat_label field of the user company_id.

--- a/addons/crm/static/src/js/tours/crm.js
+++ b/addons/crm/static/src/js/tours/crm.js
@@ -5,7 +5,6 @@ import { stepUtils } from "@web_tour/tour_utils";
 import { markup } from "@odoo/owl";
 
 registry.category("web_tour.tours").add('crm_tour', {
-    url: "/odoo",
     steps: () => [stepUtils.showAppsMenuItem(), {
     isActive: ["community"],
     trigger: '.o_app[data-menu-xmlid="crm.crm_menu_root"]',

--- a/addons/crm/static/tests/tours/create_crm_team_tour.js
+++ b/addons/crm/static/tests/tours/create_crm_team_tour.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add('create_crm_team_tour', {
-    url: "/odoo",
     steps: () => [
     ...stepUtils.goToAppSteps('crm.crm_menu_root'),
 {

--- a/addons/crm/static/tests/tours/crm_email_and_phone_propagation.js
+++ b/addons/crm/static/tests/tours/crm_email_and_phone_propagation.js
@@ -2,7 +2,6 @@
     import { stepUtils } from "@web_tour/tour_utils";
 
     registry.category("web_tour.tours").add('crm_email_and_phone_propagation_edit_save', {
-        url: '/odoo',
         steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/crm/static/tests/tours/crm_forecast_tour.js
+++ b/addons/crm/static/tests/tours/crm_forecast_tour.js
@@ -3,7 +3,6 @@ import { stepUtils } from "@web_tour/tour_utils";
 const today = luxon.DateTime.now();
 
 registry.category("web_tour.tours").add('crm_forecast', {
-    url: "/odoo",
     steps: () => [
     stepUtils.showAppsMenuItem(),
     {

--- a/addons/crm/static/tests/tours/crm_rainbowman.js
+++ b/addons/crm/static/tests/tours/crm_rainbowman.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add("crm_rainbowman", {
-    url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/crm/tests/test_sales_team_ui.py
+++ b/addons/crm/tests/test_sales_team_ui.py
@@ -16,7 +16,7 @@ class TestUi(HttpCase, SalesTeamCommon):
         self.sale_manager.sudo().group_ids -= self.env.ref("base.group_multi_company")
         self.env['ir.config_parameter'].sudo().set_bool('sales_team.membership_multi', True)
 
-        self.start_tour("/", "create_crm_team_tour", login="salesmanager")
+        self.start_tour("/odoo", "create_crm_team_tour", login="salesmanager")
 
         created_team = self.env["crm.team"].search([("name", "=", "My CRM Team")])
         self.assertTrue(bool(created_team))

--- a/addons/event/static/src/js/tours/event_tour.js
+++ b/addons/event/static/src/js/tours/event_tour.js
@@ -7,7 +7,6 @@ import EventAdditionalTourSteps from "@event/js/tours/event_steps";
 import { markup } from "@odoo/owl";
 
 registry.category("web_tour.tours").add('event_tour', {
-    url: '/odoo',
     steps: () => [stepUtils.showAppsMenuItem(), {
     isActive: ["enterprise"],
     trigger: '.o_app[data-menu-xmlid="event.event_main_menu"]',

--- a/addons/event_crm/static/tests/tours/event_question_answers_rule_creation_tour.js
+++ b/addons/event_crm/static/tests/tours/event_question_answers_rule_creation_tour.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add("event_question_answers_rule_creation_tour", {
-    url: "/odoo",
     steps: () => [
         ...stepUtils.goToAppSteps("event.event_main_menu"),
         {

--- a/addons/event_sale/static/tests/tours/event_configurator_ui.js
+++ b/addons/event_sale/static/tests/tours/event_configurator_ui.js
@@ -3,7 +3,6 @@ import { stepUtils } from "@web_tour/tour_utils";
 import * as tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add("event_configurator_tour", {
-    url: "/odoo",
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
         ...tourUtils.createNewSalesOrder(),

--- a/addons/google_address_autocomplete/static/tests/tours/autocomplete_address_tour.js
+++ b/addons/google_address_autocomplete/static/tests/tours/autocomplete_address_tour.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add("autocomplete_address_tour", {
-    url: "/odoo/companies",
     steps: () => [
         {
             content: "click on new button to create a new record",

--- a/addons/hr/static/tests/tours/hr_employee_flow.js
+++ b/addons/hr/static/tests/tours/hr_employee_flow.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add("hr_employee_tour", {
-    url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/hr/static/tests/tours/hr_employee_multiple_bank_accounts.js
+++ b/addons/hr/static/tests/tours/hr_employee_multiple_bank_accounts.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add("hr_employee_multiple_bank_accounts_tour", {
-    url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/hr/static/tests/tours/version_timeline_auto_save_tour.js
+++ b/addons/hr/static/tests/tours/version_timeline_auto_save_tour.js
@@ -3,7 +3,6 @@ import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add("version_timeline_auto_save_tour", {
     undeterministicTour_doNotCopy: true,
-    url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/hr_expense/static/src/js/tours/hr_expense.js
+++ b/addons/hr_expense/static/src/js/tours/hr_expense.js
@@ -5,7 +5,6 @@ import { stepUtils } from "@web_tour/tour_utils";
 import { markup } from "@odoo/owl";
 
 registry.category("web_tour.tours").add('hr_expense_tour' , {
-    url: "/odoo",
     steps: () => [stepUtils.showAppsMenuItem(), {
     isActive: ["community"],
     trigger: '.o_app[data-menu-xmlid="hr_expense.menu_hr_expense_root"]',

--- a/addons/hr_expense/static/tests/tours/expense_category_tours.js
+++ b/addons/hr_expense/static/tests/tours/expense_category_tours.js
@@ -1,9 +1,7 @@
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
-
 registry.category("web_tour.tours").add("change_expense_category_price_tour", {
-    url: "/odoo",
     steps: () => [
         ...stepUtils.goToAppSteps("hr_expense.menu_hr_expense_root", "Go to the Expenses app"),
         {
@@ -111,7 +109,9 @@ registry.category("web_tour.tours").add("change_expense_category_price_tour", {
             run: () => {
                 const warning = document.querySelector(".modal");
                 if (warning) {
-                    throw new Error("Warning should not be displayed when changing the price of a category with no linked expense.");
+                    throw new Error(
+                        "Warning should not be displayed when changing the price of a category with no linked expense."
+                    );
                 }
             },
         },
@@ -123,6 +123,6 @@ registry.category("web_tour.tours").add("change_expense_category_price_tour", {
         {
             content: "Wait until we are back to the list view",
             trigger: ".o_list_view",
-        }
+        },
     ],
 });

--- a/addons/hr_expense/static/tests/tours/expense_form_tours.js
+++ b/addons/hr_expense/static/tests/tours/expense_form_tours.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add('create_expense_no_employee_access_tour', {
-    url: "/odoo",
     steps: () => [
     ...stepUtils.goToAppSteps('hr_expense.menu_hr_expense_root', "Go to the Expenses app"),
     {
@@ -52,7 +51,6 @@ registry.category("web_tour.tours").add('create_expense_no_employee_access_tour'
 ]});
 
 registry.category("web_tour.tours").add("do_not_create_zero_amount_expense", {
-    url: "/odoo",
     steps: () => [
         ...stepUtils.goToAppSteps("hr_expense.menu_hr_expense_root", "Go to the Expenses app"),
         {

--- a/addons/hr_expense/static/tests/tours/expense_upload_tours.js
+++ b/addons/hr_expense/static/tests/tours/expense_upload_tours.js
@@ -1,9 +1,9 @@
-    import { registry } from "@web/core/registry";
-    import { stepUtils } from "@web_tour/tour_utils";
+import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_utils";
 
-    registry.category("web_tour.tours").add('hr_expense_test_tour', {
-        url: "/odoo",
-        steps: () => [stepUtils.showAppsMenuItem(),
+registry.category("web_tour.tours").add("hr_expense_test_tour", {
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
         {
             content: "Go to Expense",
             trigger: '.o_app[data-menu-xmlid="hr_expense.menu_hr_expense_root"]',
@@ -78,12 +78,13 @@
         {
             content: "Missing Upload button in Expenses Analysis > List View",
             trigger: ".o_button_upload_expense",
-        }
-    ]});
+        },
+    ],
+});
 
-    registry.category("web_tour.tours").add('hr_expense_access_rights_test_tour', {
-        url: "/odoo",
-        steps: () => [stepUtils.showAppsMenuItem(),
+registry.category("web_tour.tours").add("hr_expense_access_rights_test_tour", {
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
         {
             content: "Go to Expense",
             trigger: '.o_app[data-menu-xmlid="hr_expense.menu_hr_expense_root"]',
@@ -101,11 +102,12 @@
         },
         {
             content: "Click Submit to Manager Button",
-            trigger: '.o_expense_submit',
+            trigger: ".o_expense_submit",
             run: "click",
         },
         {
-            content: 'Verify the expense is submitted',
+            content: "Verify the expense is submitted",
             trigger: '.o_arrow_button_current:contains("Submitted")',
         },
-    ]});
+    ],
+});

--- a/addons/hr_holidays/static/tests/tours/time_off_allocation_warning_tour.js
+++ b/addons/hr_holidays/static/tests/tours/time_off_allocation_warning_tour.js
@@ -1,14 +1,14 @@
-import { registry } from '@web/core/registry';
+import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 const today = luxon.DateTime.now();
 const pastDateFrom = today.minus({ days: 3 }).toFormat("MM/dd/yyyy");
 const pastDateTo = today.minus({ days: 2 }).toFormat("MM/dd/yyyy");
 const futureDateTo = today.plus({ days: 2 }).toFormat("MM/dd/yyyy");
-const warningText = "The allocated days cannot be used, because the allocation is set to finish in the past.";
+const warningText =
+    "The allocated days cannot be used, because the allocation is set to finish in the past.";
 
 registry.category("web_tour.tours").add("time_off_allocation_warning_tour", {
-    url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {
@@ -23,7 +23,8 @@ registry.category("web_tour.tours").add("time_off_allocation_warning_tour", {
         },
         {
             content: "Go to Allocations",
-            trigger: ".o-dropdown-item[data-menu-xmlid='hr_holidays.hr_holidays_menu_manager_approve_allocations']",
+            trigger:
+                ".o-dropdown-item[data-menu-xmlid='hr_holidays.hr_holidays_menu_manager_approve_allocations']",
             run: "click",
         },
         {
@@ -49,7 +50,7 @@ registry.category("web_tour.tours").add("time_off_allocation_warning_tour", {
         {
             content: "Edit the start date picker",
             trigger: ".o_field_widget[name='date_from'] input",
-           // Past date to trigger the warning
+            // Past date to trigger the warning
             run: `click && edit ${pastDateFrom}`,
         },
         {

--- a/addons/hr_holidays/static/tests/tours/time_off_card_tour.js
+++ b/addons/hr_holidays/static/tests/tours/time_off_card_tour.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add("time_off_card_tour", {
-    url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/hr_holidays/static/tests/tours/time_off_graph_view_tour.js
+++ b/addons/hr_holidays/static/tests/tours/time_off_graph_view_tour.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add("time_off_graph_view_tour", {
-    url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/hr_holidays/static/tests/tours/time_off_request_calendar_view.js
+++ b/addons/hr_holidays/static/tests/tours/time_off_request_calendar_view.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add("time_off_request_calendar_view", {
-    url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {
@@ -14,7 +13,9 @@ registry.category("web_tour.tours").add("time_off_request_calendar_view", {
             content: "Click on the first Thursday of the year",
             trigger: ".fc-daygrid-day.fc-day-thu",
             run: () => {
-                const el = document.querySelector(".fc-daygrid-day.fc-day-thu:not(.fc-day-disabled)").firstChild;
+                const el = document.querySelector(
+                    ".fc-daygrid-day.fc-day-thu:not(.fc-day-disabled)"
+                ).firstChild;
                 el.scrollIntoView();
 
                 const fromPosition = el.getBoundingClientRect();

--- a/addons/hr_holidays/tests/test_holidays_calendar.py
+++ b/addons/hr_holidays/tests/test_holidays_calendar.py
@@ -33,7 +33,7 @@ class TestHolidaysCalendar(HttpCase, TestHrHolidaysCommon):
         expected_leave_end = leave.date_to.hour
 
         # Tour that takes a leave on the first thursday of the year.
-        self.start_tour('/', 'time_off_request_calendar_view', login='enguerran')
+        self.start_tour('/odoo', 'time_off_request_calendar_view', login='enguerran')
 
         last_leave = self.env['hr.leave'].search([('employee_id.id', '=', self.employee_emp.id)]).sorted(lambda leave: leave.create_date)[-1]
         self.assertEqual(last_leave.date_from.weekday(), 3, "It should be Thursday")

--- a/addons/hr_holidays/tests/test_time_off_allocation_tour.py
+++ b/addons/hr_holidays/tests/test_time_off_allocation_tour.py
@@ -7,4 +7,4 @@ class TestTimeOffAllocationTour(HttpCase):
 
     def test_time_off_allocation_warning_tour(self):
         self.admin_employee = get_admin_employee(self.env)
-        self.start_tour("/", "time_off_allocation_warning_tour", login="admin")
+        self.start_tour("/odoo", "time_off_allocation_warning_tour", login="admin")

--- a/addons/hr_holidays/tests/test_time_off_card_tour.py
+++ b/addons/hr_holidays/tests/test_time_off_card_tour.py
@@ -22,4 +22,4 @@ class TestTimeOffCardTour(HttpCase):
             'allocation_type': 'regular',
             'type_request_unit': 'half_day',
         })
-        self.start_tour('/', 'time_off_card_tour', login='admin')
+        self.start_tour('/odoo', 'time_off_card_tour', login='admin')

--- a/addons/hr_holidays/tests/test_time_off_graph_view_tour.py
+++ b/addons/hr_holidays/tests/test_time_off_graph_view_tour.py
@@ -5,4 +5,4 @@ class TestTimeOffGraphViewTour(HttpCase):
 
     @users('admin')
     def test_time_off_graph_view_tour(self):
-        self.start_tour('/', 'time_off_graph_view_tour', login='admin')
+        self.start_tour('/odoo', 'time_off_graph_view_tour', login='admin')

--- a/addons/hr_recruitment/static/src/js/tours/hr_recruitment.js
+++ b/addons/hr_recruitment/static/src/js/tours/hr_recruitment.js
@@ -4,7 +4,6 @@ import { stepUtils } from "@web_tour/tour_utils";
 import { markup } from "@odoo/owl";
 
 registry.category("web_tour.tours").add('hr_recruitment_tour',{
-    url: "/odoo",
     steps: () => [stepUtils.showAppsMenuItem(), {
     isActive: ["community"],
     trigger: '.o_app[data-menu-xmlid="hr_recruitment.menu_hr_recruitment_root"]',

--- a/addons/hr_skills/static/tests/tours/skills_tour.js
+++ b/addons/hr_skills/static/tests/tours/skills_tour.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add("hr_skills_tour", {
-    url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {
@@ -71,7 +70,8 @@ registry.category("web_tour.tours").add("hr_skills_tour", {
         },
         {
             content: "Change type",
-            trigger: ".modal:contains(new resume line) .o_field_widget[name='line_type_id'] .o_selection_badge:contains(Other Experience)",
+            trigger:
+                ".modal:contains(new resume line) .o_field_widget[name='line_type_id'] .o_selection_badge:contains(Other Experience)",
             run: "click",
         },
         {

--- a/addons/hr_skills/static/tests/tours/skills_type_tours.js
+++ b/addons/hr_skills/static/tests/tours/skills_type_tours.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add("hr_skills_type_tour", {
-    url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/im_livechat/static/tests/tours/im_livechat_chatbot_steps_sequence_tour.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_chatbot_steps_sequence_tour.js
@@ -64,7 +64,6 @@ const commonSteps = [
  * Simply create a few steps in order to check the sequences.
  */
 registry.category("web_tour.tours").add("im_livechat_chatbot_steps_sequence_tour", {
-    url: "/odoo",
     steps: () => [
         ...commonSteps,
         {
@@ -77,7 +76,6 @@ registry.category("web_tour.tours").add("im_livechat_chatbot_steps_sequence_tour
  * Same as above, with an extra drag&drop at the end.
  */
 registry.category("web_tour.tours").add("im_livechat_chatbot_steps_sequence_with_move_tour", {
-    url: "/odoo",
     steps: () => [
         ...commonSteps,
         ...createChatbotSteps("Step 4", "Step 5"),

--- a/addons/l10n_dk/static/src/tours/nemhandel_onboarding.js
+++ b/addons/l10n_dk/static/src/tours/nemhandel_onboarding.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { accountTourSteps } from "@account/js/tours/account";
 
 registry.category("web_tour.tours").add("nemhandel_onboarding_tour", {
-    url: "/odoo",
     steps: () => [
         ...accountTourSteps.goToAccountMenu("Let’s register on Nemhandel."),
         {

--- a/addons/l10n_tw_edi_ecpay_website_sale/static/tests/tours/test_checkout.js
+++ b/addons/l10n_tw_edi_ecpay_website_sale/static/tests/tours/test_checkout.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add("test_validate_customer_info_error", {
-    url: "/shop",
     steps: () => [
         ...tourUtils.addToCart({ productName: "Test Product", expectUnloadPage: true }),
         tourUtils.goToCart({ quantity: 1 }),
@@ -82,7 +81,6 @@ registry.category("web_tour.tours").add("test_validate_customer_info_error", {
 });
 
 registry.category("web_tour.tours").add("test_checkout_b2c_carrier", {
-    url: "/shop",
     steps: () => [
         ...tourUtils.addToCart({ productName: "Test Product", expectUnloadPage: true }),
         tourUtils.goToCart({ quantity: 1 }),
@@ -159,7 +157,6 @@ registry.category("web_tour.tours").add("test_checkout_b2c_carrier", {
 });
 
 registry.category("web_tour.tours").add("test_checkout_b2c_love_code", {
-    url: "/shop",
     steps: () => [
         ...tourUtils.addToCart({ productName: "Test Product", expectUnloadPage: true }),
         tourUtils.goToCart({ quantity: 1 }),
@@ -232,7 +229,6 @@ registry.category("web_tour.tours").add("test_checkout_b2c_love_code", {
 });
 
 registry.category("web_tour.tours").add("test_checkout_b2b", {
-    url: "/shop",
     steps: () => [
         ...tourUtils.addToCart({ productName: "Test Product", expectUnloadPage: true }),
         tourUtils.goToCart({ quantity: 1 }),
@@ -288,7 +284,6 @@ registry.category("web_tour.tours").add("test_checkout_b2b", {
 });
 
 registry.category("web_tour.tours").add("test_checkout_b2c_mobile_barcode", {
-    url: "/shop",
     steps: () => [
         ...tourUtils.addToCart({ productName: "Test Product", expectUnloadPage: true }),
         tourUtils.goToCart({ quantity: 1 }),

--- a/addons/lunch/static/tests/tours/order_lunch.js
+++ b/addons/lunch/static/tests/tours/order_lunch.js
@@ -3,7 +3,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add('order_lunch_tour', {
-    url: "/odoo",
     steps: () => [
     stepUtils.showAppsMenuItem(),
 {

--- a/addons/lunch/tests/test_ui.py
+++ b/addons/lunch/tests/test_ui.py
@@ -48,4 +48,4 @@ class TestUi(HttpCase):
         })
 
         with freeze_time("2022-04-19 10:00"):
-            self.start_tour("/", 'order_lunch_tour', login='admin', timeout=180)
+            self.start_tour("/odoo", 'order_lunch_tour', login='admin', timeout=180)

--- a/addons/mail/static/src/js/tours/discuss_channel_tour.js
+++ b/addons/mail/static/src/js/tours/discuss_channel_tour.js
@@ -5,7 +5,6 @@ import { markup } from "@odoo/owl";
 import { delay } from "@web/core/utils/concurrency";
 
 registry.category("web_tour.tours").add("discuss_channel_tour", {
-    url: "/odoo",
     steps: () => [
         {
             isActive: ["enterprise"],

--- a/addons/mail/static/tests/tours/discuss_configuration_tour.js
+++ b/addons/mail/static/tests/tours/discuss_configuration_tour.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add("discuss_configuration_tour", {
-    url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/mass_mailing/static/src/js/tours/mass_mailing_tour.js
+++ b/addons/mass_mailing/static/src/js/tours/mass_mailing_tour.js
@@ -5,7 +5,6 @@
     import { markup } from "@odoo/owl";
 
     registry.category("web_tour.tours").add('mass_mailing_tour', {
-        url: '/odoo',
         steps: () => [stepUtils.showAppsMenuItem(), {
         isActive: ["enterprise"],
         trigger: '.o_app[data-menu-xmlid="mass_mailing.mass_mailing_menu_root"]',

--- a/addons/mass_mailing/static/tests/tours/mailing_campaign.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_campaign.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category('web_tour.tours').add('mailing_campaign', {
-    url: '/odoo',
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/mass_mailing/static/tests/tours/mailing_editor.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_editor.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add('mailing_editor', {
-    url: '/odoo',
     steps: () => [stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="mass_mailing.mass_mailing_menu_root"]',
     run: "click",

--- a/addons/mass_mailing/static/tests/tours/mailing_editor_theme.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_editor_theme.js
@@ -4,7 +4,6 @@ import { boundariesIn } from "@html_editor/utils/position";
 import { setSelection } from "@html_editor/../tests/tours/helpers/editor";
 
 registry.category("web_tour.tours").add('mailing_editor_theme', {
-    url: '/odoo',
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/mass_mailing/static/tests/tours/mass_mailing_code_view.js
+++ b/addons/mass_mailing/static/tests/tours/mass_mailing_code_view.js
@@ -3,7 +3,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add('mass_mailing_code_view_tour', {
-    url: '/odoo?debug=tests',
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/mass_mailing/static/tests/tours/mass_mailing_dynamic_placeholder_tour.js
+++ b/addons/mass_mailing/static/tests/tours/mass_mailing_dynamic_placeholder_tour.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add('mass_mailing_dynamic_placeholder_tour', {
-    url: '/odoo',
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/mass_mailing/static/tests/tours/snippets_mailing_menu_tabs.js
+++ b/addons/mass_mailing/static/tests/tours/snippets_mailing_menu_tabs.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add('snippets_mailing_menu_tabs', {
-    url: '/odoo',
     steps: () => [
     stepUtils.showAppsMenuItem(), {
         content: "Select the 'Email Marketing' app.",

--- a/addons/mass_mailing/static/tests/tours/snippets_mailing_menu_toolbar.js
+++ b/addons/mass_mailing/static/tests/tours/snippets_mailing_menu_toolbar.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add('snippets_mailing_menu_toolbar', {
-    url: '/odoo',
     steps: () => [
     stepUtils.showAppsMenuItem(), {
         content: "Select the 'Email Marketing' app.",

--- a/addons/mass_mailing/static/tests/tours/snippets_mailing_menu_toolbar_mobile.js
+++ b/addons/mass_mailing/static/tests/tours/snippets_mailing_menu_toolbar_mobile.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add('snippets_mailing_menu_toolbar_mobile', {
-    url: '/odoo',
     steps: () => [
     stepUtils.showAppsMenuItem(), {
         content: "Select the 'Email Marketing' app.",

--- a/addons/mass_mailing_sms/static/tests/tours/mailing_activities_split.js
+++ b/addons/mass_mailing_sms/static/tests/tours/mailing_activities_split.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('mailing_activities_split', {
-    url: '/odoo',
     steps: () => [
         {
             content: 'Open Activity Systray',

--- a/addons/mrp_subcontracting/static/tests/tours/subcontracting_portal_tour.js
+++ b/addons/mrp_subcontracting/static/tests/tours/subcontracting_portal_tour.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('subcontracting_portal_tour', {
-    url: '/my/productions',
     steps: () => [
         {
             trigger: 'table > tbody > tr a:has(span:contains(WH/IN/00))',

--- a/addons/portal/static/tests/tours/portal.js
+++ b/addons/portal/static/tests/tours/portal.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("portal_load_homepage", {
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: "/my",
     steps: () => [
         {
             content: "Check portal is loaded",

--- a/addons/portal/tests/test_tours.py
+++ b/addons/portal/tests/test_tours.py
@@ -24,11 +24,11 @@ class TestUi(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
             cls.env.company.country_id.enforce_cities = False
 
     def test_01_portal_load_tour(self):
-        self.start_tour("/", 'portal_load_homepage', login="portal")
+        self.start_tour("/my", 'portal_load_homepage', login="portal")
 
     def test_02_portal_load_tour_cant_edit_vat(self):
         willis = self.user_portal
-        self.start_tour("/", 'portal_load_homepage', login="portal")
+        self.start_tour("/my", 'portal_load_homepage', login="portal")
         self.assertEqual(willis.phone, "+1 555 666 7788")
 
     def test_03_skip_to_content(self):

--- a/addons/project/static/tests/tours/personal_stage_tour.js
+++ b/addons/project/static/tests/tours/personal_stage_tour.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add('personal_stage_tour', {
-    url: '/odoo',
     steps: () => [stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="project.menu_main_pm"]',
     run: "click",

--- a/addons/project/static/tests/tours/project_burndown_chart_tour.js
+++ b/addons/project/static/tests/tours/project_burndown_chart_tour.js
@@ -3,7 +3,6 @@ import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add('burndown_chart_tour', {
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: '/odoo',
     steps: () => [stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="project.menu_main_pm"]',
     run: "click",

--- a/addons/project/static/tests/tours/project_sharing_tour.js
+++ b/addons/project/static/tests/tours/project_sharing_tour.js
@@ -132,14 +132,12 @@ const projectSharingSteps = [...stepUtils.goToAppSteps("project.menu_main_pm", '
 }];
 
 registry.category("web_tour.tours").add('project_sharing_tour', {
-    url: '/odoo',
     steps: () => {
         return projectSharingSteps;
     }
 });
 
 registry.category("web_tour.tours").add("portal_project_sharing_tour", {
-    url: "/my/projects",
     steps: () => {
         // The begining of the project sharing feature
         const projectSharingStepIndex = projectSharingSteps.findIndex(s => s?.id === 'project_sharing_feature');
@@ -148,7 +146,6 @@ registry.category("web_tour.tours").add("portal_project_sharing_tour", {
 });
 
 registry.category("web_tour.tours").add("project_sharing_with_blocked_task_tour", {
-    url: "/my/projects",
     steps: () => [{
         trigger: 'table > tbody > tr a:has(span:contains("Project Sharing"))',
         content: 'Click on the portal project.',

--- a/addons/project/static/tests/tours/project_templates_tour.js
+++ b/addons/project/static/tests/tours/project_templates_tour.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add("project_templates_tour", {
-    url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/project/static/tests/tours/project_tour.js
+++ b/addons/project/static/tests/tours/project_tour.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add('project_test_tour', {
-    url: '/odoo',
     steps: () => [
     stepUtils.showAppsMenuItem(), {
         trigger: '.o_app[data-menu-xmlid="project.menu_main_pm"]',

--- a/addons/project/static/tests/tours/project_update_tour_tests.js
+++ b/addons/project/static/tests/tours/project_update_tour_tests.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add('project_update_tour', {
-    url: '/odoo',
     steps: () => [stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="project.menu_main_pm"]',
     run: "click",

--- a/addons/project/tests/test_project_sharing_ui.py
+++ b/addons/project/tests/test_project_sharing_ui.py
@@ -79,7 +79,7 @@ class TestProjectSharingUi(HttpCase):
             'stage_id': self.project_portal.type_ids[0].id,
         })
 
-        self.start_tour("/odoo", 'project_sharing_with_blocked_task_tour', login="georges1")
+        self.start_tour("/my/projects", 'project_sharing_with_blocked_task_tour', login="georges1")
 
     def test_01_project_sharing(self):
         """ Test Project Sharing UI with an internal user """

--- a/addons/project_todo/static/tests/tours/project_task_activities_split.js
+++ b/addons/project_todo/static/tests/tours/project_task_activities_split.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('project_task_activities_split', {
-    url: '/odoo',
     steps: () => [
         {
             content: 'Open Activity Systray',

--- a/addons/project_todo/static/tests/tours/project_todo_main_functions.js
+++ b/addons/project_todo/static/tests/tours/project_todo_main_functions.js
@@ -3,7 +3,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add('project_todo_main_functions', {
-    url: '/odoo',
     steps: () => [stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="project_todo.menu_todo_todos"]',
     run: "click",

--- a/addons/sale/static/tests/tours/product_attribute_value_tour.js
+++ b/addons/sale/static/tests/tours/product_attribute_value_tour.js
@@ -39,7 +39,6 @@ const deletePAV = (product_attribute_value, message) => [
 
 // This tour relies on data created on the Python test.
 registry.category("web_tour.tours").add('delete_product_attribute_value_tour', {
-    url: '/odoo',
     steps: () => [
         ...openProductAttribute("PA"),
         // Test error message on a used attribute value

--- a/addons/sale/static/tests/tours/sale_combo_configurator.js
+++ b/addons/sale/static/tests/tours/sale_combo_configurator.js
@@ -7,7 +7,6 @@ import * as tourUtils from '@sale/js/tours/tour_utils';
 registry
     .category('web_tour.tours')
     .add('sale_combo_configurator', {
-        url: '/odoo',
         steps: () => [
             ...stepUtils.goToAppSteps('sale.sale_menu_root', "Open the sales app"),
             ...tourUtils.createNewSalesOrder(),
@@ -109,7 +108,6 @@ registry
     registry
     .category('web_tour.tours')
     .add('sale_combo_configurator_with_optional_products', {
-        url: '/odoo',
         steps: () => [
             ...stepUtils.goToAppSteps('sale.sale_menu_root', "Open the sales app"),
             ...tourUtils.createNewSalesOrder(),

--- a/addons/sale/static/tests/tours/sale_combo_configurator_preconfigure_unconfigurable_ptals.js
+++ b/addons/sale/static/tests/tours/sale_combo_configurator_preconfigure_unconfigurable_ptals.js
@@ -7,7 +7,6 @@ import * as tourUtils from '@sale/js/tours/tour_utils';
 registry
     .category('web_tour.tours')
     .add('sale_combo_configurator_preconfigure_unconfigurable_ptals', {
-        url: '/odoo',
         steps: () => [
             ...stepUtils.goToAppSteps('sale.sale_menu_root', "Open the sales app"),
             ...tourUtils.createNewSalesOrder(),

--- a/addons/sale/static/tests/tours/sale_combo_configurator_preselect_single_unconfigurable_items.js
+++ b/addons/sale/static/tests/tours/sale_combo_configurator_preselect_single_unconfigurable_items.js
@@ -7,7 +7,6 @@ import * as tourUtils from '@sale/js/tours/tour_utils';
 registry
     .category('web_tour.tours')
     .add('sale_combo_configurator_preselect_single_unconfigurable_items', {
-        url: '/odoo',
         steps: () => [
             ...stepUtils.goToAppSteps('sale.sale_menu_root', "Open the sales app"),
             ...tourUtils.createNewSalesOrder(),

--- a/addons/sale/static/tests/tours/sale_signature.js
+++ b/addons/sale/static/tests/tours/sale_signature.js
@@ -3,7 +3,6 @@ import { redirect } from "@web/core/utils/urls";
 
 // This tour relies on data created on the Python test.
 registry.category("web_tour.tours").add('sale_signature', {
-    url: '/my/quotes',
     steps: () => [
     {
         content: "open the test SO",

--- a/addons/sale/tests/test_controllers.py
+++ b/addons/sale/tests/test_controllers.py
@@ -127,4 +127,4 @@ class TestSaleSignature(HttpCaseWithUserPortal):
             sales_order.message_partner_ids,
             'Do not automatically set customer as follower, will be suggested recipient')
 
-        self.start_tour("/", 'sale_signature', login="portal")
+        self.start_tour("/my/quotes", 'sale_signature', login="portal")

--- a/addons/sale/tests/test_sale_combo_configurator.py
+++ b/addons/sale/tests/test_sale_combo_configurator.py
@@ -55,7 +55,7 @@ class TestSaleComboConfigurator(HttpCase, SaleCommon):
                 Command.link(combo_b.id),
             ],
         )
-        self.start_tour('/', 'sale_combo_configurator', login='salesman')
+        self.start_tour('/odoo', 'sale_combo_configurator', login='salesman')
 
     def test_sale_combo_configurator_with_optional_products(self):
         if self.env['ir.module.module']._get('sale_management').state != 'installed':
@@ -87,7 +87,7 @@ class TestSaleComboConfigurator(HttpCase, SaleCommon):
             ],
             'optional_product_ids': [Command.link(optional_product.id)],
         })
-        self.start_tour('/', 'sale_combo_configurator_with_optional_products', login='salesman')
+        self.start_tour('/odoo', 'sale_combo_configurator_with_optional_products', login='salesman')
 
         order = self.env['sale.order'].search([('partner_id.name', '=', 'Test Partner')], limit=1)
         self.assertTrue(order, "A new Sale order should be created.")
@@ -168,9 +168,7 @@ class TestSaleComboConfigurator(HttpCase, SaleCommon):
                 Command.link(combo_with_multiple_unconfigurable_items.id),
             ],
         )
-        self.start_tour(
-            '/', 'sale_combo_configurator_preselect_single_unconfigurable_items', login='salesman'
-        )
+        self.start_tour('/odoo', 'sale_combo_configurator_preselect_single_unconfigurable_items', login='salesman')
 
     def test_sale_combo_configurator_preconfigure_unconfigurable_ptals(self):
         if self.env['ir.module.module']._get('sale_management').state != 'installed':
@@ -209,8 +207,7 @@ class TestSaleComboConfigurator(HttpCase, SaleCommon):
             type='combo',
             combo_ids=[Command.link(combo.id)],
         )
-        self.start_tour(
-            '/', 'sale_combo_configurator_preconfigure_unconfigurable_ptals', login='salesman'
+        self.start_tour('/odoo', 'sale_combo_configurator_preconfigure_unconfigurable_ptals', login='salesman'
         )
 
     def _create_combo_from_attribute(self, attribute, product_name, combo_name):

--- a/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
+++ b/addons/sale_timesheet/static/tests/tours/sale_timesheet_tour.js
@@ -5,7 +5,6 @@ import * as tourUtils from "@sale/js/tours/tour_utils";
 import { markup } from "@odoo/owl";
 
 registry.category("web_tour.tours").add('sale_timesheet_tour', {
-    url: '/odoo',
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
         ...tourUtils.createNewSalesOrder(),

--- a/addons/survey/static/tests/tours/survey_chained_conditional_questions.js
+++ b/addons/survey/static/tests/tours/survey_chained_conditional_questions.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('test_survey_chained_conditional_questions', {
-    url: '/survey/start/3cfadce3-3f7e-41da-920d-10fa0eb19527',
     steps: () => [
     {
         content: 'Click on Start',

--- a/addons/survey/static/tests/tours/survey_conditional_questions_on_different_page.js
+++ b/addons/survey/static/tests/tours/survey_conditional_questions_on_different_page.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { expectHiddenQuestion } from "@survey/../tests/tours/survey_chained_conditional_questions";
 
 registry.category("web_tour.tours").add('test_survey_conditional_question_on_different_page', {
-    url: '/survey/start/1cb935bd-2399-4ed1-9e10-c649318fb4dc',
     steps: () => [
         {
             content: 'Click on Start',

--- a/addons/survey/static/tests/tours/survey_form.js
+++ b/addons/survey/static/tests/tours/survey_form.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add('survey_tour_test_survey_form_triggers', {
-    url: '/odoo',
     steps: () => [
     stepUtils.showAppsMenuItem(),
     {

--- a/addons/survey/static/tests/tours/survey_prefill.js
+++ b/addons/survey/static/tests/tours/survey_prefill.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('test_survey_prefill', {
-    url: '/survey/start/b137640d-14d4-4748-9ef6-344caaaaaae',
     steps: () => [{      // Page-1
         trigger: 'button.btn.btn-primary.btn-lg:contains("Start Survey")',
         run: "click",

--- a/addons/survey/static/tests/tours/survey_roaming_mandatory_questions.js
+++ b/addons/survey/static/tests/tours/survey_roaming_mandatory_questions.js
@@ -1,7 +1,6 @@
 import { registry } from '@web/core/registry';
 
 registry.category('web_tour.tours').add('test_survey_roaming_mandatory_questions', {
-    url: '/survey/start/853ebb30-40f2-43bf-a95a-bbf0e367a365',
     steps: () => [{
         content: 'Click on Start',
         trigger: 'button.btn:contains("Start")',

--- a/addons/test_event_full/static/src/js/tours/wevent_register_tour.js
+++ b/addons/test_event_full/static/src/js/tours/wevent_register_tour.js
@@ -190,7 +190,6 @@ var browseBackSteps = [{
 }];
 
 registry.category("web_tour.tours").add('wevent_register', {
-    url: '/event',
     steps: () => [].concat(
         initTourSteps('Online Reveal'),
         browseTalksSteps,

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_advanced_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_advanced_ui.js
@@ -6,7 +6,6 @@ import * as tourUtils from "@sale/js/tours/tour_utils";
 let optionVariantImage;
 
 registry.category("web_tour.tours").add('sale_product_configurator_advanced_tour', {
-    url: '/odoo',
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
         ...tourUtils.createNewSalesOrder(),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_custom_value_update_tour.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_custom_value_update_tour.js
@@ -4,7 +4,6 @@ import configuratorTourUtils from "@sale/js/tours/product_configurator_tour_util
 import * as tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('sale_product_configurator_custom_value_update_tour', {
-    url: '/odoo',
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
         ...tourUtils.createNewSalesOrder(),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_edition_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_edition_ui.js
@@ -5,7 +5,6 @@ import * as tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('sale_product_configurator_edition_tour', {
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: '/odoo',
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
         ...tourUtils.createNewSalesOrder(),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_optional_products_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_optional_products_ui.js
@@ -4,7 +4,6 @@ import * as tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('sale_product_configurator_optional_products_tour', {
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: '/odoo',
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
         ...tourUtils.createNewSalesOrder(),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_pricelist_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_pricelist_ui.js
@@ -3,8 +3,7 @@ import { stepUtils } from "@web_tour/tour_utils";
 import configuratorTourUtils from "@sale/js/tours/product_configurator_tour_utils";
 import * as tourUtils from "@sale/js/tours/tour_utils";
 
-registry.category("web_tour.tours").add('sale_product_configurator_pricelist_tour', {
-    url: '/odoo',
+registry.category("web_tour.tours").add("sale_product_configurator_pricelist_tour", {
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
         ...tourUtils.createNewSalesOrder(),
@@ -13,12 +12,14 @@ registry.category("web_tour.tours").add('sale_product_configurator_pricelist_tou
         ...tourUtils.addProduct("Customizable Desk (TEST)"),
         {
             content: "check price is correct (USD)",
-            trigger: '.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) span[name="sale_product_configurator_formatted_price"]:contains("750.00")',
+            trigger:
+                '.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) span[name="sale_product_configurator_formatted_price"]:contains("750.00")',
         },
         configuratorTourUtils.increaseProductQuantity("Customizable Desk"),
         {
             content: "check price for 2",
-            trigger: '.o_sale_product_configurator_table tr:has(span:contains("Customizable Desk")) td span[name="sale_product_configurator_formatted_price"]:contains("600.00")',
+            trigger:
+                '.o_sale_product_configurator_table tr:has(span:contains("Customizable Desk")) td span[name="sale_product_configurator_formatted_price"]:contains("600.00")',
         },
         configuratorTourUtils.addOptionalProduct("Conference Chair (TEST)"),
         configuratorTourUtils.increaseProductQuantity("Conference Chair (TEST)"),
@@ -36,6 +37,6 @@ registry.category("web_tour.tours").add('sale_product_configurator_pricelist_tou
             trigger: 'span[name="amount_total"]:contains("1,437.00")',
             run: "click",
         },
-        ...stepUtils.saveForm()
-    ]
+        ...stepUtils.saveForm(),
+    ],
 });

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_recursive_optional_products.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_recursive_optional_products.js
@@ -4,7 +4,6 @@ import configuratorTourUtils from "@sale/js/tours/product_configurator_tour_util
 import * as tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('sale_product_configurator_recursive_optional_products_tour', {
-    url: '/odoo',
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
         ...tourUtils.createNewSalesOrder(),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_single_custom_attribute_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_single_custom_attribute_ui.js
@@ -4,7 +4,6 @@ import configuratorTourUtils from "@sale/js/tours/product_configurator_tour_util
 import * as tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('sale_product_configurator_single_custom_attribute_tour', {
-    url: '/odoo',
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
         ...tourUtils.createNewSalesOrder(),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_ui.js
@@ -7,7 +7,6 @@ import * as tourUtils from "@sale/js/tours/tour_utils";
 // The pricelist is tested on the other tours.
 
 registry.category("web_tour.tours").add('sale_product_configurator_tour', {
-    url: '/odoo',
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
         ...tourUtils.createNewSalesOrder(),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_uom_choice.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_uom_choice.js
@@ -3,12 +3,11 @@ import { stepUtils } from "@web_tour/tour_utils";
 import configuratorTourUtils from "@sale/js/tours/product_configurator_tour_utils";
 import * as tourUtils from "@sale/js/tours/tour_utils";
 
-registry.category("web_tour.tours").add('sale_product_configurator_uom_tour', {
-    url: '/odoo',
+registry.category("web_tour.tours").add("sale_product_configurator_uom_tour", {
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
         ...tourUtils.createNewSalesOrder(),
-        ...tourUtils.selectCustomer('Tajine Saucisse'),
+        ...tourUtils.selectCustomer("Tajine Saucisse"),
         ...tourUtils.selectPricelist("Custom pricelist (TEST)"),
         ...tourUtils.addProduct("Customizable Desk (TEST)"),
         configuratorTourUtils.assertProductPrice("Customizable Desk (TEST)", "750.00"),
@@ -39,6 +38,6 @@ registry.category("web_tour.tours").add('sale_product_configurator_uom_tour', {
             trigger: 'span[name="amount_total"]:contains("8,700.00")',
             run: "click",
         },
-        ...stepUtils.saveForm()
-    ]
+        ...stepUtils.saveForm(),
+    ],
 });

--- a/addons/test_sale_product_configurators/static/tests/tours/product_matrix_tour.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_matrix_tour.js
@@ -18,7 +18,6 @@ for (let no of ['PAV41', 'PAV42']) {
 }
 
 registry.category("web_tour.tours").add('sale_matrix_tour', {
-    url: '/odoo',
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
         ...tourUtils.createNewSalesOrder(),

--- a/addons/test_website_slides_full/static/tests/tours/slides_certification_member.js
+++ b/addons/test_website_slides_full/static/tests/tours/slides_certification_member.js
@@ -142,7 +142,6 @@ var profileSteps = [{
 }];
 
 registry.category("web_tour.tours").add('certification_member_failure', {
-    url: '/slides',
     steps: () => [].concat(
         startCertificationSurvey,
         failCertificationSteps,
@@ -154,7 +153,6 @@ registry.category("web_tour.tours").add('certification_member_failure', {
 });
 
 registry.category("web_tour.tours").add('certification_member_success', {
-    url: '/slides',
     steps: () => [].concat(
         startCertificationSurvey,
         succeedCertificationSteps,

--- a/addons/website_crm/static/tests/tours/website_crm.js
+++ b/addons/website_crm/static/tests/tours/website_crm.js
@@ -45,7 +45,6 @@ registerWebsitePreviewTour(
 
 registry.category("web_tour.tours").add('website_crm_tour', {
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: '/contactus',
     steps: () => [{
     content: "Complete name",
     trigger: "input[name=contact_name]",
@@ -82,7 +81,6 @@ registry.category("web_tour.tours").add('website_crm_tour', {
 
 registry.category("web_tour.tours").add('website_crm_catch_logged_partner_info_tour', {
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: '/contactus',
     steps: () => [
 {
     content: "Fill Company Name",

--- a/addons/website_crm/tests/test_website_crm.py
+++ b/addons/website_crm/tests/test_website_crm.py
@@ -14,7 +14,7 @@ class TestWebsiteCrm(odoo.tests.HttpCase, TestCrmCommon):
         utm_source = self.env['utm.source'].create({'name': 'Source'})
         # change action to create opportunity
         self.start_tour(self.env['website'].get_client_action_url('/contactus', True), 'website_crm_pre_tour', login='admin')
-        self.start_tour("/?utm_source=Source&utm_medium=Medium&utm_campaign=New campaign", 'website_crm_tour')
+        self.start_tour('/contactus?utm_source=Source&utm_medium=Medium&utm_campaign=New campaign', 'website_crm_tour')
 
         # check result
         record = self.env['crm.lead'].search([('description', '=', '<p>### TOUR DATA ###</p>')])
@@ -43,12 +43,12 @@ class TestWebsiteCrm(odoo.tests.HttpCase, TestCrmCommon):
         self.start_tour(self.env['website'].get_client_action_url('/contactus', True), 'website_crm_pre_tour', login=user_login)
 
         with odoo.tests.RecordCapturer(self.env['crm.lead']) as capt:
-            self.start_tour("/", "website_crm_catch_logged_partner_info_tour", login=user_login)
+            self.start_tour("/contactus", "website_crm_catch_logged_partner_info_tour", login=user_login)
         self.assertEqual(capt.records.partner_id, user_partner)
 
         # edited contact us partner info : do not propagate partner_id on lead
         with odoo.tests.RecordCapturer(self.env['crm.lead']) as capt:
-            self.start_tour("/", "website_crm_tour", login=user_login)
+            self.start_tour("/contactus", "website_crm_tour", login=user_login)
         self.assertFalse(capt.records.partner_id)
 
         # check partner has not been changed

--- a/addons/website_event_booth_sale/static/tests/tours/website_event_booth.js
+++ b/addons/website_event_booth_sale/static/tests/tours/website_event_booth.js
@@ -3,7 +3,6 @@ import * as wsTourUtils from '@website_sale/js/tours/tour_utils';
 
 
 registry.category("web_tour.tours").add('website_event_booth_tour', {
-    url: '/event',
     steps: () => [
 {
     content: 'Open "Test Event Booths" event',

--- a/addons/website_event_booth_sale/static/tests/tours/website_event_booth_sale_pricelists.js
+++ b/addons/website_event_booth_sale/static/tests/tours/website_event_booth_sale_pricelists.js
@@ -3,7 +3,6 @@ import { getPriceListChecksSteps } from '@website_event_booth_sale/../tests/tour
 import * as wsTourUtils from '@website_sale/js/tours/tour_utils';
 
 registry.category("web_tour.tours").add('event_booth_sale_pricelists_different_currencies', {
-    url: '/event',
     steps: () => [
     // Init: registering the booth
     {

--- a/addons/website_event_booth_sale/tests/test_event_booth_sale.py
+++ b/addons/website_event_booth_sale/tests/test_event_booth_sale.py
@@ -85,4 +85,4 @@ class TestWebsiteEventBoothSale(HttpCaseWithUserPortal, TestWebsiteEventSaleComm
             'state_id': self.env.ref('base.state_us_39').id,
             'phone': '+1 555-555-5555',
         })
-        self.start_tour("/odoo", 'event_booth_sale_pricelists_different_currencies', login='admin')
+        self.start_tour("/event", 'event_booth_sale_pricelists_different_currencies', login='admin')

--- a/addons/website_event_sale/static/tests/tours/website_event_sale_last_ticket.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale_last_ticket.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import * as wsTourUtils from "@website_sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('event_buy_last_ticket', {
-    url: '/event',
     steps: () => [{
         content: "Open the Last ticket test event page",
         trigger: '.o_wevent_events_list a:contains("Last ticket test")',

--- a/addons/website_event_sale/tests/test_frontend_buy_tickets.py
+++ b/addons/website_event_sale/tests/test_frontend_buy_tickets.py
@@ -113,7 +113,7 @@ class TestUi(HttpCaseWithUserDemo, TestWebsiteEventSaleCommon):
         })
         transfer_provider._transfer_ensure_pending_msg_is_set()
 
-        self.start_tour("/", 'event_buy_last_ticket')
+        self.start_tour("/event", 'event_buy_last_ticket')
 
     def test_pricelists_different_currencies(self):
         self.env.user.group_ids += self.env.ref('product.group_product_pricelist')

--- a/addons/website_forum/static/src/js/tours/website_forum.js
+++ b/addons/website_forum/static/src/js/tours/website_forum.js
@@ -6,7 +6,6 @@ import { stepUtils } from "@web_tour/tour_utils";
 
 registerBackendAndFrontendTour("question_tour", {
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: '/forum/1',
 }, () => [{
     trigger: ".o_wforum_ask_btn",
     tooltipPosition: "left",

--- a/addons/website_forum/static/tests/tours/website_forum_question.js
+++ b/addons/website_forum/static/tests/tours/website_forum_question.js
@@ -3,7 +3,6 @@ import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add('forum_question', {
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: '/forum/help-1',
     steps: () => [
     {
         content: "Ask the question in this forum by clicking on the button.",

--- a/addons/website_forum/tests/test_forum_tours.py
+++ b/addons/website_forum/tests/test_forum_tours.py
@@ -19,12 +19,12 @@ class TestUi(HttpCaseGamification):
         })
 
     def test_01_admin_forum_tour(self):
-        self.start_tour("/", 'question_tour', login="admin")
+        self.start_tour("/forum/1", 'question_tour', login="admin")
 
     def test_02_demo_question(self):
         forum = self.env.ref('website_forum.forum_help')
         demo = self.user_demo
         demo.karma = forum.karma_post + 1
-        self.start_tour("/", 'forum_question', login="demo")
+        self.start_tour("/forum/help-1", 'forum_question', login="demo")
         tags = self.env['forum.tag'].search([('name', 'in', ['Tag', 'tag', 'test tag'])])
         self.assertEqual(len(tags), 3)

--- a/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
+++ b/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
@@ -49,7 +49,6 @@ function applyForAJob(jobName, application) {
 }
 
 registry.category("web_tour.tours").add('website_hr_recruitment_tour', {
-    url: '/jobs',
     steps: () => [
     ...applyForAJob('Guru', {
         name: 'John Smith',

--- a/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
+++ b/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
@@ -27,7 +27,7 @@ class TestWebsiteHrRecruitmentForm(odoo.tests.HttpCase):
         self.start_tour(self.env['website'].get_client_action_url('/jobs'), 'website_hr_recruitment_tour_edit_form', login='admin')
 
         with odoo.tests.RecordCapturer(self.env['hr.applicant']) as capt:
-            self.start_tour("/", 'website_hr_recruitment_tour')
+            self.start_tour("/jobs", 'website_hr_recruitment_tour')
 
         # check result
         self.assertEqual(len(capt.records), 2)

--- a/addons/website_links/static/tests/tours/website_links.js
+++ b/addons/website_links/static/tests/tours/website_links.js
@@ -27,7 +27,6 @@ const sourceValue = 'Super Specific Source';
 
 registry.category("web_tour.tours").add('website_links_tour', {
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: '/r',
     steps: () => [
         // 1. Create a tracked URL
         {

--- a/addons/website_links/tests/test_ui.py
+++ b/addons/website_links/tests/test_ui.py
@@ -24,4 +24,4 @@ class TestUi(odoo.tests.HttpCase):
             'source_id': self.env['utm.source'].create({'name': 'Super Specific Source'}).id,
             'url': self.env["ir.config_parameter"].sudo().get_str("web.base.url") + '/contactus',
         }])
-        self.start_tour("/", 'website_links_tour', login="admin")
+        self.start_tour("/r", 'website_links_tour', login="admin")

--- a/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_popup_use.js
+++ b/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_popup_use.js
@@ -3,7 +3,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('snippet_newsletter_popup_use', {
-    url: '/',
     steps: () => [
     {
         content: "Check the modal is not yet opened and force it opened",

--- a/addons/website_sale_autocomplete/static/tests/autocomplete_tour.js
+++ b/addons/website_sale_autocomplete/static/tests/autocomplete_tour.js
@@ -4,7 +4,6 @@ import * as tourUtils from '@website_sale/js/tours/tour_utils';
 
 
 registry.category("web_tour.tours").add('autocomplete_tour', {
-    url: '/shop', // /shop/address is redirected if no sales order
     steps: () => [
         ...tourUtils.addToCart({ productName: "A test product", expectUnloadPage: true }),
         tourUtils.goToCart(),

--- a/addons/website_sale_autocomplete/tests/test_ui.py
+++ b/addons/website_sale_autocomplete/tests/test_ui.py
@@ -41,4 +41,4 @@ class TestUI(HttpCase):
                                      'google_place_id': MOCK_GOOGLE_ID
                                  } for x in range(5)]}):
             self.env['website'].get_current_website().google_places_api_key = MOCK_API_KEY
-            self.start_tour('/shop/address', 'autocomplete_tour')
+            self.start_tour('/shop', 'autocomplete_tour')

--- a/addons/website_sale_collect/static/src/tests/tours/buy_with_click_and_collect.js
+++ b/addons/website_sale_collect/static/src/tests/tours/buy_with_click_and_collect.js
@@ -3,7 +3,6 @@ import { clickOnElement } from '@website/js/tours/tour_utils';
 import * as tourUtils from '@website_sale/js/tours/tour_utils';
 
 registry.category('web_tour.tours').add('website_sale_collect_widget', {
-    url: '/shop',
     steps: () => [
         ...tourUtils.searchProduct("Test CAC Product", { select: true }),
         clickOnElement("Open Location selector", '[name="click_and_collect_availability"]'),
@@ -23,7 +22,6 @@ registry.category('web_tour.tours').add(
     'website_sale_collect_buy_product_default_location_pick_up_in_store',
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-        url: '/shop',
         steps: () => [
             ...tourUtils.searchProduct("Test CAC Product", { select: true }),
             ...tourUtils.addToCartFromProductPage(),

--- a/addons/website_sale_collect/tests/test_click_and_collect_flow.py
+++ b/addons/website_sale_collect/tests/test_click_and_collect_flow.py
@@ -29,7 +29,7 @@ class TestClickAndCollectFlow(HttpCase, ClickAndCollectCommon):
         Test the basic flow of buying with click and collect as a public user with more than
         one delivery method available
         """
-        self.start_tour('/', 'website_sale_collect_widget')
+        self.start_tour('/shop', 'website_sale_collect_widget')
 
     def test_default_location_is_set_for_pick_up_in_store(self):
         """
@@ -39,7 +39,7 @@ class TestClickAndCollectFlow(HttpCase, ClickAndCollectCommon):
         self.env['delivery.carrier'].search([]).active = False
         self.in_store_dm.active = True
         self.in_store_dm.is_published = True
-        self.start_tour('/', 'website_sale_collect_buy_product_default_location_pick_up_in_store')
+        self.start_tour('/shop', 'website_sale_collect_buy_product_default_location_pick_up_in_store')
 
     def test_cash_on_delivery_resets_on_in_store_type(self):
         """

--- a/addons/website_sale_loyalty/static/tests/tours/gift_card.js
+++ b/addons/website_sale_loyalty/static/tests/tours/gift_card.js
@@ -3,7 +3,6 @@ import * as wsTourUtils from "@website_sale/js/tours/tour_utils";
 import { submitCouponCode } from "@website_sale_loyalty/../tests/tours/tour_utils";
 
 registry.category("web_tour.tours").add('website_sale_loyalty.gift_card', {
-    url: '/shop',
     steps: () => [
         // Add a small drawer to the order (50$)
         ...wsTourUtils.addToCart({ productName: "TEST - Small Drawer", expectUnloadPage: true }),

--- a/addons/website_sale_loyalty/tests/test_shop_sale_coupon.py
+++ b/addons/website_sale_loyalty/tests/test_shop_sale_coupon.py
@@ -206,7 +206,7 @@ class WebsiteSaleLoyaltyTestUi(TestSaleCommon, HttpCase):
         })
 
         self.env.ref("website_sale.reduction_code").write({"active": True})
-        self.start_tour('/', 'website_sale_loyalty.gift_card', login='admin')
+        self.start_tour('/shop', 'website_sale_loyalty.gift_card', login='admin')
 
         self.assertEqual(len(gift_card_program.coupon_ids), 2, 'There should be two coupons, one with points, one without')
         self.assertEqual(len(gift_card_program.coupon_ids.filtered('points')), 1, 'There should be two coupons, one with points, one without')

--- a/addons/website_sale_stock/static/src/js/tours/website_sale_stock_reorder_from_portal.js
+++ b/addons/website_sale_stock/static/src/js/tours/website_sale_stock_reorder_from_portal.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('website_sale_stock_reorder_from_portal', {
-    url: '/my/orders',
     steps: () => [
         {
             content: 'Select first order',

--- a/addons/website_sale_stock/static/tests/tours/website_sale_stock_multilang.js
+++ b/addons/website_sale_stock/static/tests/tours/website_sale_stock_multilang.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('website_sale_stock.product_warning_multilang', {
-    url: '/fr/shop?search=unavailable',
     steps: () => [
         {
             content: "Open unavailable product page",

--- a/addons/website_sale_stock/tests/test_website_sale_stock_reorder_from_portal.py
+++ b/addons/website_sale_stock/tests/test_website_sale_stock_reorder_from_portal.py
@@ -45,4 +45,4 @@ class TestWebsiteSaleStockReorderFromPortal(HttpCase, WebsiteSaleStockCommon):
         cls._add_product_qty_to_wh(cls.partially_available_product.id, 3, stock_loc_id)
 
     def test_website_sale_stock_reorder_from_portal_stock(self):
-        self.start_tour("/", 'website_sale_stock_reorder_from_portal', login='admin')
+        self.start_tour("/my/orders", 'website_sale_stock_reorder_from_portal', login='admin')

--- a/addons/website_slides/static/tests/tours/slides_course_member.js
+++ b/addons/website_slides/static/tests/tours/slides_course_member.js
@@ -12,7 +12,6 @@ import { registry } from "@web/core/registry";
  */
 registry.category("web_tour.tours").add("course_member", {
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: "/slides",
     steps: () => [
         // eLearning: go on free course and join it
         {

--- a/addons/website_slides/static/tests/tours/slides_course_review_modification.js
+++ b/addons/website_slides/static/tests/tours/slides_course_review_modification.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("course_review_modification", {
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: "/slides",
     steps: () => [
         {
             trigger: "a:contains(Basics of Gardening - Test)",
@@ -255,7 +254,6 @@ registry.category("web_tour.tours").add("course_review_modification", {
 
 registry.category("web_tour.tours").add("course_review_modification_by_admin", {
     undeterministicTour_doNotCopy: true,
-    url: "/slides",
     steps: () => [
         {
             trigger: "a:text(Basics of Gardening - Test)",
@@ -272,7 +270,7 @@ registry.category("web_tour.tours").add("course_review_modification_by_admin", {
         {
             trigger:
                 "#chatterRoot:shadow .o-mail-Message:contains(Non admin user review) .o_website_rating_static[title='3 stars on 5']",
-            run: "hover && click #chatterRoot:shadow .o-mail-Message [title='Expand']"
+            run: "hover && click #chatterRoot:shadow .o-mail-Message [title='Expand']",
         },
         {
             trigger:

--- a/odoo/addons/base/static/tests/test_ir_model_fields_translation.js
+++ b/odoo/addons/base/static/tests/test_ir_model_fields_translation.js
@@ -2,41 +2,41 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 function checkLoginColumn(translation) {
     return [
-        stepUtils.showAppsMenuItem(), {
+        stepUtils.showAppsMenuItem(),
+        {
             content: "Settings",
             trigger: 'a[data-menu-xmlid="base.menu_administration"]',
-            run: 'click',
-        }, {
+            run: "click",
+        },
+        {
             content: "Open Users & Companies",
             trigger: '[data-menu-xmlid="base.menu_users"]',
             run: "click",
-        }, {
+        },
+        {
             content: "Open Users",
             trigger: '[data-menu-xmlid="base.menu_action_res_users"]',
             run: "click",
-        }, {
+        },
+        {
             content: `Login column should be ${translation}`,
             trigger: `[data-name="login"] span:contains("${translation}")`,
-        }
-    ]
+        },
+    ];
 }
 
-registry.category("web_tour.tours").add('ir_model_fields_translation_en_tour', {
-    url: '/odoo',
-    steps: () => checkLoginColumn('Login')
+registry.category("web_tour.tours").add("ir_model_fields_translation_en_tour", {
+    steps: () => checkLoginColumn("Login"),
 });
 
-registry.category("web_tour.tours").add('ir_model_fields_translation_en_tour2', {
-    url: '/odoo',
-    steps: () => checkLoginColumn('Login2')
+registry.category("web_tour.tours").add("ir_model_fields_translation_en_tour2", {
+    steps: () => checkLoginColumn("Login2"),
 });
 
-registry.category("web_tour.tours").add('ir_model_fields_translation_fr_tour', {
-    url: '/odoo',
-    steps: () => checkLoginColumn('Identifiant')
+registry.category("web_tour.tours").add("ir_model_fields_translation_fr_tour", {
+    steps: () => checkLoginColumn("Identifiant"),
 });
 
-registry.category("web_tour.tours").add('ir_model_fields_translation_fr_tour2', {
-    url: '/odoo',
-    steps: () => checkLoginColumn('Identifiant2')
+registry.category("web_tour.tours").add("ir_model_fields_translation_fr_tour2", {
+    steps: () => checkLoginColumn("Identifiant2"),
 });

--- a/odoo/addons/test_translation/static/tests/tours/constraint.js
+++ b/odoo/addons/test_translation/static/tests/tours/constraint.js
@@ -2,7 +2,6 @@
     import { stepUtils } from "@web_tour/tour_utils";
 
     registry.category("web_tour.tours").add('sql_constraint', {
-        url: '/odoo/action-test_translation.action_constraint?debug=1',
         steps: () => [
     {
         content: "wait web client",

--- a/odoo/addons/test_translation/tests/test_ui.py
+++ b/odoo/addons/test_translation/tests/test_ui.py
@@ -18,4 +18,4 @@ class TestUiTranslation(odoo.tests.HttpCase):
         # is rollbacked at insert and a new cursor is opened, can not test that
         # the message is translated (_load_module_terms is also) rollbacked.
         # Test individually the external id and loading of translation.
-        self.start_tour("/odoo/action-test_translation.action_constraint", 'sql_constraint', login="admin")
+        self.start_tour("/odoo/action-test_translation.action_constraint?debug=1", 'sql_constraint', login="admin")

--- a/odoo/addons/test_web/static/tests/tours/x2many.js
+++ b/odoo/addons/test_web/static/tests/tours/x2many.js
@@ -3,7 +3,6 @@
     var inc;
 
     registry.category("web_tour.tours").add('widget_x2many', {
-        url: '/odoo/action-test_orm.action_discussions?debug=tests',
         steps: () => [
     /////////////////////////////////////////////////////////////////////////////////////////////
     // Discussions


### PR DESCRIPTION
The URL key in a tour's JavaScript file implies a redirect to that URL once the browser opens. If this URL is the same as the one used in `start_tour()` (Python), then it serves no purpose. It's even detrimental because it implies a redirect (and therefore a waste of time). The URL key in the JS file is (for now) only used for onboarding tours. This key will be defined later in the .xml file for onboarding tours.

That's why we're removing the URL keys from the registries here.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
