### PR TITLE
[FIX] pos_restaurant: re-enable restaurant preparation tour

### DIFF
--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -518,8 +518,10 @@ registry.category("web_tour.tours").add("test_course_restaurant_preparation_tour
             Chrome.waitRequest(),
             Dialog.bodyIs("Preparation Printer: The printer is not reachable."),
             Dialog.confirm(),
+            FloorScreen.isShown(),
             FloorScreen.clickTable("5"),
             Chrome.waitRequest(),
+            ProductScreen.payButtonNotHighlighted(),
             ProductScreen.fireCourseButtonHighlighted("Course 2"),
             checkPreparationTicketData([], {
                 visibleInDom: ["Course 2"],
@@ -530,9 +532,11 @@ registry.category("web_tour.tours").add("test_course_restaurant_preparation_tour
             Chrome.waitRequest(),
             Dialog.bodyIs("Printer: The printer is not reachable."),
             Dialog.confirm(),
+            FloorScreen.isShown(),
             FloorScreen.clickTable("5"),
             Chrome.waitRequest(),
             Chrome.isSynced(),
+            ProductScreen.payButtonNotHighlighted(),
             ProductScreen.fireCourseButtonHighlighted("Course 3"),
             checkPreparationTicketData([{ name: "Product Test", qty: 1, attribute: ["Value 1"] }], {
                 visibleInDom: ["Course 3"],

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -479,22 +479,21 @@ class TestFrontend(TestFrontendCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(f"/pos/ui/{self.main_pos_config.id}", 'PreparationPrinterContent', login="pos_user")
 
-    # FIXME: re-enable the test, was disabled to be merged before freezing
-    # def test_course_restaurant_preparation_tour(self):
-    #     self.env['pos.printer'].create({
-    #         'name': 'Printer',
-    #         'printer_type': 'epson_epos',
-    #         'printer_ip': '0.0.0.0',
-    #         'use_type': 'preparation',
-    #         'product_categories_ids': [Command.set(self.env['pos.category'].search([]).ids)],
-    #     })
+    def test_course_restaurant_preparation_tour(self):
+        self.env['pos.printer'].create({
+            'name': 'Printer',
+            'printer_type': 'epson_epos',
+            'printer_ip': '0.0.0.0',
+            'use_type': 'preparation',
+            'product_categories_ids': [Command.set(self.env['pos.category'].search([]).ids)],
+        })
 
-    #     self.main_pos_config.write({
-    #         'use_order_printer': True,
-    #         'preparation_printer_ids': [Command.set(self.env['pos.printer'].search([('use_type', '=', 'preparation')]).ids)],
-    #     })
-    #     self.pos_config.with_user(self.pos_user).open_ui()
-    #     self.start_pos_tour('test_course_restaurant_preparation_tour', login="pos_user")
+        self.main_pos_config.write({
+            'use_order_printer': True,
+            'preparation_printer_ids': [Command.set(self.env['pos.printer'].search([('use_type', '=', 'preparation')]).ids)],
+        })
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_course_restaurant_preparation_tour', login="pos_user")
 
     def test_combo_preparation_receipt(self):
         setup_product_combo_items(self)


### PR DESCRIPTION
In this commit:
---
- Re-enable `test_course_restaurant_preparation_tour`, which was previously disabled to allow merging during freeze.
- Add steps to ensure the order is properly synchronized.

task-5958387

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
