### PR TITLE
[IMP] hr_holidays: fix half-days visibility in calendar view

### DIFF
--- a/addons/hr_holidays/static/src/views/calendar/calendar_model.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_model.js
@@ -6,7 +6,6 @@ import {
     serializeDateTime,
 } from "@web/core/l10n/dates";
 import { Cache } from "@web/core/utils/cache";
-const { DateTime } = luxon;
 
 export class TimeOffCalendarModel extends CalendarModel {
     setup(params, services) {
@@ -34,11 +33,6 @@ export class TimeOffCalendarModel extends CalendarModel {
             if (!result.title.startsWith(employee)) {
                 result.title = [employee, result.title].join(" ");
             }
-        }
-        if (rawRecord.date_from && rawRecord.date_to) {
-            const dateFrom = DateTime.fromSQL(rawRecord.date_from);
-            const dateTo = DateTime.fromSQL(rawRecord.date_to);
-            result.sameDay = dateFrom.hasSame(dateTo, 'day');
         }
         if (rawRecord.request_unit_half) {
             result.requestDateFromPeriod = rawRecord.request_date_from_period;

--- a/addons/hr_holidays/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_renderer.scss
@@ -29,14 +29,6 @@
             .hr_mandatory_day_#{$size - 1} {
                 --mandatory-day-color: #{nth($o-colors, $size)};
             }
-        }
-
-        .o_event_half_left {
-          clip-path: polygon(0 0, 50% 0, 50% 100%, 0% 100%);
-        }
-
-        .o_event_half_right {
-          clip-path: polygon(100% 0, 50% 0, 50% 100%, 100% 100%);
-        }
+        }   
     }
 }

--- a/addons/hr_holidays/static/src/views/calendar/year/calendar_year_renderer.js
+++ b/addons/hr_holidays/static/src/views/calendar/year/calendar_year_renderer.js
@@ -67,27 +67,83 @@ export class TimeOffCalendarYearRenderer extends CalendarYearRenderer {
         return [...super.getDayCellClassNames(info), ...this.mandatoryDays(info)];
     }
 
+    _halfDayStyleCache = new Set();
+    ensureHalfDayClass(start, end) {
+        const className = `o_event_half_${start}_${end}`;
+        if (this._halfDayStyleCache.has(className)) return className;
+
+        const css = `
+            .fc-event-start.${className} {
+                clip-path: polygon(${start}% 0%, 100% 0%, 100% 100%, ${start}% 100%);
+            }
+            .fc-event-end.${className} {
+                clip-path: polygon(0% 0%, ${end}% 0%, ${end}% 100%, 0% 100%);
+            }
+            .fc-event-start.fc-event-end.${className} {
+                clip-path: polygon(${start}% 0%, ${end}% 0%, ${end}% 100%, ${start}% 100%);
+            }
+        `;
+        let styleSheet = document.getElementById('half-day-dynamic-styles');
+        if (!styleSheet) {
+            styleSheet = document.createElement('style');
+            styleSheet.id = 'half-day-dynamic-styles';
+            document.head.appendChild(styleSheet);
+        }
+
+        styleSheet.textContent += css;
+        this._halfDayStyleCache.add(className);
+
+        return className;
+    }
+
     /**
      * @override
      */
     eventClassNames({ event }) {
-        const classesToAdd = super.eventClassNames(...arguments);
-        const record = this.props.model.records[event.id];
-        if (record && record.requestDateFromPeriod && record.sameDay) {
-            if (record.requestDateFromPeriod === "am" && record.requestDateToPeriod === "am") {
-                classesToAdd.push("o_event_half_left")
-            } else if (record.requestDateFromPeriod === "pm" && record.requestDateToPeriod === "pm") {
-                classesToAdd.push("o_event_half_right")
+    const classesToAdd = super.eventClassNames(...arguments);
+    const record = this.props.model.records[event.id];
+    if (record) {
+        const isHalfStart = record.requestDateFromPeriod === "pm" ||
+            (record?.rawRecord?.request_unit_hours && record.start.c.hour >= 12);
+        const isHalfEnd = record.requestDateToPeriod === "am" ||
+            (record?.rawRecord?.request_unit_hours && record.end.c.hour <= 12);
+
+        if (!isHalfStart && !isHalfEnd) return classesToAdd;
+
+        const isMultiWeek = record.start.localWeekNumber != record.end.localWeekNumber
+        let start = 0;
+        let end = 100;
+
+        if (!isMultiWeek) {
+            const lastRowStart = record.start > record.end.startOf('month') ? record.start : record.end.startOf('month');
+            const firstRowEnd = record.end < record.start.endOf('month') ? record.end : record.start.endOf('month');
+            const daysInFirstRow = firstRowEnd.startOf('day').diff(record.start.startOf('day'), 'days').days + 1;
+            const daysInLastRow = record.end.startOf('day').diff(lastRowStart.startOf('day'), 'days').days + 1;
+
+            start = isHalfStart ? Math.round(50 / daysInFirstRow) : 0;
+            end = isHalfEnd ? Math.round(100 - (50 / daysInLastRow)) : 100;
+        }
+        else {
+            // Multi-week: first slice — only care about start
+            if (isHalfStart) {
+                const rowEnd = record.start.endOf('week') < record.start.endOf('month')
+                    ? record.start.endOf('week').minus({ days: 1 })
+                    : record.start.endOf('month');
+                const daysInFirstRow = rowEnd.startOf('day').diff(record.start.startOf('day'), 'days').days + 1;
+                start = Math.round(50 / daysInFirstRow);
+            }
+            // Multi-week: last slice — only care about end
+            if (isHalfEnd) {
+                const rowStart = record.end.startOf('week') > record.end.startOf('month')
+                    ? record.end.startOf('week').minus({ days: 1 })
+                    : record.end.startOf('month');
+                const daysInLastRow = record.end.startOf('day').diff(rowStart.startOf('day'), 'days').days + 1;
+                end = Math.round(100 - (50 / daysInLastRow));
             }
         }
-        // handling half pill UX for custom_hours
-        if (record?.rawRecord?.request_unit_hours && record.sameDay) {
-            if (record.end.c.hour < 12) {
-                classesToAdd.push("o_event_half_left");
-            } else if (record.end.c.hour >= 12 && record.start.c.hour >= 12) {
-                classesToAdd.push("o_event_half_right");
-            }
-        }
-        return classesToAdd;
+
+        classesToAdd.push(this.ensureHalfDayClass(start, end));
     }
+    return classesToAdd;
+}
 }


### PR DESCRIPTION
-When the leave includes a half day (for example, 4.5 or 3.5 days), the half-day portion is not displayed on the dashboard. 
--Rendering logic has been adjusted to count for half-days.
