### PR TITLE
[FIX] project: grant admin access to project stage

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -162,6 +162,8 @@ class ProjectProject(models.Model):
         tracking=True, index=True, copy=False, default=_default_stage_id, group_expand='_read_group_expand_full')
     stage_id_color = fields.Integer(string='Stage Color', related="stage_id.color", export_string_translation=False)
     duration_tracking = fields.Json(groups="project.group_project_stages")
+    rotting_days = fields.Integer(groups="project.group_project_stages")
+    is_rotting = fields.Boolean(groups="project.group_project_stages")
     date_last_stage_update = fields.Datetime(string='Last Stage Update', index=True, default=fields.Datetime.now)
 
     update_ids = fields.One2many('project.update', 'project_id', export_string_translation=False)


### PR DESCRIPTION
## Steps to Reproduce:
1. Ensure the “Project Stage” option is disabled.
2. Open the form view of any project.
3. Click the Studio button.
4. An access error appears, indicating that the current user does not have permission to access stage_id, preventing the project form view from being edited.

## Expected Behavior After the PR:
The admin user should have access to stage_id even when the “Project Stage” option is disabled. This ensures that Studio can be opened without triggering an access rights error.

## Task :

task-[5892227](https://www.odoo.com/odoo/project/4105/tasks/5892227)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
