### PR TITLE
[FIX] account_edi_ubl_cii : manage charges in UBL docs

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -1,7 +1,7 @@
 from odoo import _, models, Command
 from odoo.addons.base.models.res_bank import sanitize_account_number
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools import float_is_zero, float_repr, find_xml_value
+from odoo.tools import float_compare, float_is_zero, float_repr, find_xml_value
 from odoo.tools.float_utils import float_round
 from odoo.tools.misc import clean_context, formatLang
 from odoo.tools.zeep import Client
@@ -671,10 +671,13 @@ class AccountEdiCommon(models.AbstractModel):
         # discount
         discount = 0
         amount_fixed_taxes = sum(d['tax_amount'] * billed_qty for d in fixed_taxes_list)
+        currency = invoice_line.currency_id or self.env.company.currency_id
         if billed_qty * price_unit != 0 and price_subtotal is not None:
-            currency = invoice_line.currency_id or self.env.company.currency_id
             inferred_discount = 100 * (1 - (price_subtotal - amount_fixed_taxes) / currency.round(billed_qty * price_unit))
             discount = inferred_discount if not float_is_zero(inferred_discount, currency.decimal_places) else 0.0
+        elif not float_is_zero(billed_qty, currency.decimal_places) and price_subtotal is not None:
+            # Unit price is 0, so no discount could be inferred.
+            price_unit += (price_subtotal - amount_fixed_taxes) / currency.round(billed_qty)
 
         # Sometimes, the xml received is very bad; e.g.:
         #   * unit price = 0, qty = 0, but price_subtotal = -200
@@ -682,7 +685,7 @@ class AccountEdiCommon(models.AbstractModel):
         #   * unit price = 1, qty = 0, but price_subtotal = -200
         # for instance, when filling a down payment as an invoice line. The equation in the docstring is not
         # respected, and the result will not be correct, so we just follow the simple rule below:
-        if net_price_unit is not None and price_subtotal != net_price_unit * (billed_qty / basis_qty) - allow_charge_amount:
+        if net_price_unit is not None and float_compare(price_subtotal, net_price_unit * (billed_qty / basis_qty) - allow_charge_amount, currency.decimal_places):
             if net_price_unit == 0 and billed_qty == 0:
                 quantity = 1
                 price_unit = price_subtotal

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_unit_price_zero_but_charges.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_out_invoice_unit_price_zero_but_charges.xml
@@ -1,0 +1,160 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+  <cbc:ID>INV/2017/01/0002</cbc:ID>
+  <cbc:IssueDate>2017-01-01</cbc:IssueDate>
+  <cbc:DueDate>2017-02-28</cbc:DueDate>
+  <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+  <cbc:Note>test narration</cbc:Note>
+  <cbc:DocumentCurrencyCode>USD</cbc:DocumentCurrencyCode>
+  <cbc:BuyerReference>ref_partner_2</cbc:BuyerReference>
+  <cac:OrderReference>
+    <cbc:ID>___ignore___</cbc:ID>
+  </cac:OrderReference>
+  <cac:AdditionalDocumentReference>
+    <cbc:ID>___ignore___</cbc:ID>
+    <cac:Attachment>
+      <cbc:EmbeddedDocumentBinaryObject>___ignore___</cbc:EmbeddedDocumentBinaryObject>
+    </cac:Attachment>
+  </cac:AdditionalDocumentReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0208">0202239951</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0208">0202239951</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>partner_1</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Chaussée de Namur 40</cbc:StreetName>
+        <cbc:CityName>Ramillies</cbc:CityName>
+        <cbc:PostalZone>1367</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>BE0202239951</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_1</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="0208">0202239951</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>partner_1</cbc:Name>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0208">0477472701</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="0208">0477472701</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Rue des Bourlottes 9</cbc:StreetName>
+        <cbc:CityName>Ramillies</cbc:CityName>
+        <cbc:PostalZone>1367</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>BE0477472701</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_2</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="0208">0477472701</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryLocation>
+      <cac:Address>
+        <cbc:StreetName>Rue des Bourlottes 9</cbc:StreetName>
+        <cbc:CityName>Ramillies</cbc:CityName>
+        <cbc:PostalZone>1367</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:Address>
+    </cac:DeliveryLocation>
+  </cac:Delivery>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+    <cbc:PaymentID>+++000/0000/26268+++</cbc:PaymentID>
+    <cac:PayeeFinancialAccount>
+      <cbc:ID>BE15001559627230</cbc:ID>
+    </cac:PayeeFinancialAccount>
+  </cac:PaymentMeans>
+  <cac:PaymentTerms>
+    <cbc:Note>Payment terms: 30% Advance End of Following Month</cbc:Note>
+  </cac:PaymentTerms>
+  <cac:InvoiceLine>
+    <cbc:ID>904</cbc:ID>
+    <cbc:LineExtensionAmount currencyID="USD">10</cbc:LineExtensionAmount>
+    <cac:AllowanceCharge>
+      <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+      <cbc:AllowanceChargeReason>Some Positive Charge</cbc:AllowanceChargeReason>
+      <cbc:Amount currencyID="EUR">10</cbc:Amount>
+    </cac:AllowanceCharge>
+    <cac:Item>
+      <cbc:Description>product_b</cbc:Description>
+      <cbc:Name>product_b</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">0.00</cbc:PriceAmount>
+      <cbc:BaseQuantity unitCode="EA">1</cbc:BaseQuantity>
+    </cac:Price>
+  </cac:InvoiceLine>
+  <cac:InvoiceLine>
+    <cbc:ID>905</cbc:ID>
+    <cbc:LineExtensionAmount currencyID="USD">5</cbc:LineExtensionAmount>
+    <cac:AllowanceCharge>
+      <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+      <cbc:AllowanceChargeReason>Some Positive Charge 2</cbc:AllowanceChargeReason>
+      <cbc:Amount currencyID="EUR">20</cbc:Amount>
+    </cac:AllowanceCharge>
+    <cac:AllowanceCharge>
+      <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+      <cbc:AllowanceChargeReason>Some Negative Charge</cbc:AllowanceChargeReason>
+      <cbc:Amount currencyID="EUR">15</cbc:Amount>
+    </cac:AllowanceCharge>
+    <cac:Item>
+      <cbc:Description>product_b</cbc:Description>
+      <cbc:Name>product_b</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">0.00</cbc:PriceAmount>
+      <cbc:BaseQuantity unitCode="EA">1</cbc:BaseQuantity>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
@@ -1329,3 +1329,13 @@ class TestUBLBE(TestUBLCommon, TestAccountMoveSendCommon):
             list_line_subtotals=[1000, 1000, 1000], currency_id=self.currency_data['currency'].id, list_line_price_unit=[1000, 100, 10],
             list_line_discount=[0, 0, 0], list_line_taxes=[tax_21, tax_21, tax_21], list_line_quantity=[1, 10, 100], move_type='out_invoice',
         )
+
+    def test_import_unit_price_zero_but_charges(self):
+        """ Tests invoice lines with unit price set to zero but with allowance charges
+        """
+        subfolder = "tests/test_files/from_odoo"
+        self._assert_imported_invoice_from_file(
+            subfolder=subfolder, filename='bis3_out_invoice_unit_price_zero_but_charges.xml', amount_total=18.15, amount_tax=3.15,
+            list_line_subtotals=[10, 5], currency_id=self.currency_data['currency'].id, list_line_price_unit=[10, 5], list_line_discount=[0, 0],
+            list_line_quantity=[1, 1],
+        )


### PR DESCRIPTION
# How to reproduce
Import in a Vendor Bill an UBL document with InvoiceLines the following properties (the linked ticket has an exemple document) :
- The PriceAmount of Item is set to 0
- There are multiple positive and negative AllowanceCharges
- The sum of the AllowanceCharges is correctly equal to the LineExtensionAmount

# The problem
The issue depends on the version, for 17.0+ it is as follows :

The AllowanceCharge are NOT added to the invoice as invoice lines, contrary to later versions. Instead they are used to compute the discount of the invoice line but when that discount cannot be applied, they are then ignored. In our case, this makes it so every invoice line has a price of 0, coming from PriceAmount of Item.

This issue is funnily enough most of the time resolved by another issue. Indeed, in the unit price calculation for the invoice line, there is a fallback for bad xml that sets the unit price to the subtotal (the right amount in our case). This fallback is based on a condition that compares two floats using the != operator. Due to the floating point imprecision, the fallback is trigerred randomly.

In the end, some invoice lines have a price unit of 0 (when the fallback is NOT trigerred) and some others have the correct price unit (when the fallback is trigerred).

Correcting the floats comparison would correctly make it so the fallback is never trigerred (since our xml is good), setting the price unit of all the invoice lines to 0. So we also need to add the AllowanceCharge in the calculation of the price unit.

opw-5926387

Related to : https://github.com/odoo/odoo/pull/250323

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
