### PR TITLE
[IMP] web:  increase search more limit

### DIFF
--- a/addons/web/static/src/core/record_selectors/record_autocomplete.js
+++ b/addons/web/static/src/core/record_selectors/record_autocomplete.js
@@ -6,7 +6,7 @@ import { registry } from "@web/core/registry";
 import { useOwnedDialogs, useService } from "@web/core/utils/hooks";
 
 const SEARCH_LIMIT = 7;
-const SEARCH_MORE_LIMIT = 320;
+const SEARCH_MORE_LIMIT = 1000;
 
 export class RecordAutocomplete extends Component {
     static props = {

--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
@@ -74,7 +74,6 @@ export class Many2ManyTagsField extends Component {
     };
 
     static RECORD_COLORS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
-    static SEARCH_MORE_LIMIT = 320;
 
     visibleItemsLimit = Number.POSITIVE_INFINITY;
 

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -224,7 +224,7 @@ export class Many2XAutocomplete extends Component {
         quickCreate: null,
         searchLimit: 7,
         searchThreshold: 0,
-        searchMoreLimit: 320,
+        searchMoreLimit: 1000,
         setInputFloats: () => {},
         specification: {},
         value: "",

--- a/addons/web/static/tests/core/record_selectors/multi_record_selector.test.js
+++ b/addons/web/static/tests/core/record_selectors/multi_record_selector.test.js
@@ -10,7 +10,7 @@ import {
     onRpc,
 } from "@web/../tests/web_test_helpers";
 import { click, fill, press, queryAllTexts } from "@odoo/hoot-dom";
-import { animationFrame } from "@odoo/hoot-mock";
+import { animationFrame, runAllTimers } from "@odoo/hoot-mock";
 
 class Partner extends models.Model {
     _name = "partner";
@@ -299,4 +299,40 @@ test("Can pass domain to search more", async () => {
     await animationFrame();
 
     expect(".o_data_row").toHaveCount(8, { message: "should contain 8 records" });
+});
+
+test.tags("desktop");
+test("Quick search dialog uses 1000 records limit when clicking search more", async () => {
+    Partner._records = [];
+    for (let i = 0; i < 10; i++) {
+        Partner._records.push({
+            id: i + 1,
+            name: "Partner " + i,
+        });
+    }
+
+    let searchLimit;
+    onRpc("partner", "name_search", ({ kwargs }) => {
+        expect.step("name_search");
+        searchLimit = kwargs.limit;
+    });
+
+    Partner._views["list"] = /* xml */ `<list><field name="name"/></list>`;
+    await mountMultiRecordSelector({
+        resModel: "partner",
+        resIds: [],
+    });
+
+    await contains(".o-autocomplete input").edit("Partner", { confirm: false });
+    await runAllTimers();
+    expect.verifySteps(["name_search"]);
+    expect(searchLimit).toBe(8, { message: "The name_search should have been called with a limit of 8" });
+
+    await click(".o_multi_record_selector .o_m2o_dropdown_option");
+    await animationFrame();
+    expect.verifySteps(["name_search"]);
+    expect(searchLimit).toBe(1000, { message: "The name_search should have been called with a limit of 1000" });
+
+    expect(".modal .modal-dialog").toHaveCount(1);
+    expect(".modal .modal-dialog .o_data_row").toHaveCount(10, { message: "should contain 10 records" });
 });

--- a/addons/web/static/tests/views/view_dialogs/select_create_dialog.test.js
+++ b/addons/web/static/tests/views/view_dialogs/select_create_dialog.test.js
@@ -866,6 +866,13 @@ test("SelectCreateDialog with open action", async () => {
             expect.step(`execute_action: ${name}`, params);
         },
     });
+
+    let searchLimit;
+    onRpc("instrument", "name_search", ({ kwargs }) => {
+        expect.step("name_search");
+        searchLimit = kwargs.limit;
+    });
+
     Instrument._views["list"] = /* xml */ `
         <list action="test_action" type="object">
             <field name="name"/>
@@ -888,6 +895,15 @@ test("SelectCreateDialog with open action", async () => {
     ).click();
     expect("input").toHaveValue("Instrument 10");
     expect.verifySteps([]);
+
+    await contains(".o_field_widget[name=instrument] input").edit("Instrument", { confirm: false });
+    await runAllTimers();
+    await contains(`.o_field_widget[name="instrument"] .o_m2o_dropdown_option_search_more`).click();
+    expect.verifySteps(["name_search"]);
+    expect(searchLimit).toBe(1000, { message: "The name_search should have been called with a limit of 1000" });
+
+    expect(".modal .modal-lg").toHaveCount(1);
+    expect(".modal .modal-lg .o_data_row").toHaveCount(25, { message: "should contain 25 records" });
 });
 
 test.tags("mobile");


### PR DESCRIPTION
The purpose of this commit is to increase the `Search more...` limit in the quick search. Previously, when a user typed a keyword in `Many2xAutocomplete` or any record selector, the results were limited to **320 records**, even if more matching records existed. With this change, the limit has been increased to **1000 records**, allowing users to access a larger set of matching results. The new limit is inspired by the **product variant creation limit**, which is also set to 1000.

task-5871990

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
