### PR TITLE
[IMP] spreadsheet: allow public spreadsheet to open sheet from URL

### DIFF
--- a/addons/spreadsheet/static/src/public_readonly_app/public_readonly.js
+++ b/addons/spreadsheet/static/src/public_readonly_app/public_readonly.js
@@ -1,5 +1,6 @@
 import { useChildSubEnv, useState } from "@web/owl2/utils";
 import { Component, markRaw, onWillStart } from "@odoo/owl";
+import { browser } from "@web/core/browser/browser";
 import { useService } from "@web/core/utils/hooks";
 import { download } from "@web/core/network/download";
 
@@ -74,6 +75,18 @@ export class PublicReadonlySpreadsheet extends Component {
             // eslint-disable-next-line no-import-assign
             spreadsheet.__DEBUG__ = spreadsheet.__DEBUG__ || {};
             spreadsheet.__DEBUG__.model = this.model;
+        }
+
+        // Activate sheet from URL `sheet_id` param and remove it after use.
+        const url = new URL(browser.location.href);
+        const sheetId = url.searchParams.get("sheet_id");
+        if (sheetId) {
+            this.model.dispatch("ACTIVATE_SHEET", {
+                sheetIdFrom: this.model.getters.getActiveSheetId(),
+                sheetIdTo: sheetId,
+            });
+            url.searchParams.delete("sheet_id");
+            browser.history.replaceState({}, "", url.pathname + url.search);
         }
     }
 

--- a/addons/spreadsheet/static/tests/public_spreadsheet/public_spreadsheet.test.js
+++ b/addons/spreadsheet/static/tests/public_spreadsheet/public_spreadsheet.test.js
@@ -1,4 +1,4 @@
-import { contains, mockService } from "@web/../tests/web_test_helpers";
+import { contains, mockService, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { defineSpreadsheetModels } from "@spreadsheet/../tests/helpers/data";
 import { expect, test } from "@odoo/hoot";
 
@@ -7,6 +7,7 @@ import { THIS_YEAR_GLOBAL_FILTER } from "@spreadsheet/../tests/helpers/global_fi
 import { addGlobalFilter } from "@spreadsheet/../tests/helpers/commands";
 import { freezeOdooData } from "@spreadsheet/helpers/model";
 import { createModelWithDataSource } from "@spreadsheet/../tests/helpers/model";
+import { browser } from "@web/core/browser/browser";
 
 defineSpreadsheetModels();
 
@@ -64,6 +65,25 @@ test("click close button in filter panel will close the panel", async function (
     await contains(".o-public-spreadsheet-filters-close-button").click();
     expect(fixture.querySelector(".o-public-spreadsheet-filter-button")).toBeVisible();
     expect(fixture.querySelector(".o-public-spreadsheet-filters")).toBe(null);
+});
+
+test("public spreadsheet activates sheet from URL param", async function () {
+    const sheetId2 = "sheet2";
+    const { model } = await createModelWithDataSource({
+        spreadsheetData: {
+            sheets: [
+                { id: "sheet1", name: "Sheet1" },
+                { id: sheetId2, name: "Sheet2" },
+            ],
+        },
+    });
+    data = await freezeOdooData(model);
+    patchWithCleanup(browser.location, {
+        href: `${browser.location.href}?sheet_id=${sheetId2}`,
+    });
+    const fixture = await mountPublicSpreadsheet("dashboardDataUrl", "spreadsheet", false);
+    const activeTab = fixture.querySelector(".o-all-sheets .o-sheet-list .o-sheet.active");
+    expect(activeTab).toHaveText("Sheet2");
 });
 
 test.tags("desktop");


### PR DESCRIPTION
Public spreadsheets now open the specified sheet when `sheet_id` is provided in the URL.

Task: [4760176](https://www.odoo.com/odoo/project/2328/tasks/4760176)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr