### PR TITLE
[FIX] web: Allows users to filter date(time) propertie fields

### DIFF
--- a/addons/web/static/src/core/tree_editor/condition_tree.js
+++ b/addons/web/static/src/core/tree_editor/condition_tree.js
@@ -98,8 +98,8 @@ export function complexCondition(value) {
  * @param {boolean} [negate=false]
  * @returns {Condition}
  */
-export function condition(path, operator, value, negate = false) {
-    return { type: "condition", path, operator, value, negate };
+export function condition(path, operator, value, negate = false, isProperty = false) {
+    return { type: "condition", path, operator, value, negate, isProperty };
 }
 
 export const TRUE_TREE = condition(1, "=", 1);

--- a/addons/web/static/src/core/tree_editor/construct_tree_from_domain.js
+++ b/addons/web/static/src/core/tree_editor/construct_tree_from_domain.js
@@ -35,6 +35,7 @@ function _constructTree(ASTs, distributeNot = false, negate = false) {
         tree.negate = negate;
         tree.operator = toValue(operatorAST);
         tree.value = toValue(valueAST);
+        tree.isProperty = false;
         if (["any", "not any"].includes(tree.operator)) {
             try {
                 tree.value = constructTreeFromDomain(formatAST(valueAST), distributeNot);

--- a/addons/web/static/src/core/tree_editor/tree_editor.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor.js
@@ -186,6 +186,7 @@ export class TreeEditor extends Component {
         node.negate = false;
         node.operator = this.props.getDefaultOperator(fieldDef);
         node.value = getDefaultValue(fieldDef, node.operator);
+        node.isProperty = fieldDef?.is_property;
     }
 
     async updatePath(node, path) {

--- a/addons/web/static/src/core/tree_editor/virtual_operators.js
+++ b/addons/web/static/src/core/tree_editor/virtual_operators.js
@@ -13,15 +13,26 @@ import {
     TRUE_TREE,
 } from "./condition_tree";
 
-function splitPath(path) {
-    const pathParts = typeof path === "string" ? path.split(".") : [];
+function splitPath(path, is_property) {
+    if (typeof path !== "string" || path === "") {
+        return { initialPath: "", lastPart: "" };
+    }
+
+    const pathParts = path.split(".");
+    if (is_property && pathParts.length >= 2) {
+        return {
+            initialPath: pathParts.slice(0, -2).join("."),
+            lastPart: pathParts.slice(-2).join("."),
+        };
+    }
+
     const lastPart = pathParts.pop() || "";
     const initialPath = pathParts.join(".");
     return { initialPath, lastPart };
 }
 
-function isSimplePath(path) {
-    return typeof path === "string" && !splitPath(path).initialPath;
+function isSimplePath(path, isProperty) {
+    return typeof path === "string" && !splitPath(path, isProperty).initialPath;
 }
 
 function wrapInAny(tree, initialPath, negate) {
@@ -55,12 +66,12 @@ function introduceSetOperators(tree, options = {}) {
 
 function eliminateSetOperators(tree) {
     function _removeSetOperator(c) {
-        const { negate, path, operator, value } = c;
+        const { negate, path, operator, value, isProperty } = c;
         if (["set", "not set"].includes(operator)) {
             if (value === true) {
-                return condition(path, operator === "set" ? "=" : "!=", value, negate);
+                return condition(path, operator === "set" ? "=" : "!=", value, negate, isProperty);
             }
-            return condition(path, operator === "set" ? "!=" : "=", value, negate);
+            return condition(path, operator === "set" ? "!=" : "=", value, negate, isProperty);
         }
     }
     return operate(_removeSetOperator, tree);
@@ -68,7 +79,7 @@ function eliminateSetOperators(tree) {
 
 function introduceStartsWithOperators(tree, options) {
     function _introduceStartsWithOperator(c, options) {
-        const { negate, path, operator, value } = c;
+        const { negate, path, operator, value, isProperty } = c;
         const fieldType = options.getFieldDef?.(path)?.type;
         if (
             ["char", "text", "html"].includes(fieldType) &&
@@ -76,7 +87,7 @@ function introduceStartsWithOperators(tree, options) {
             typeof value === "string"
         ) {
             if (value.endsWith("%")) {
-                return condition(path, "starts with", value.slice(0, -1), negate);
+                return condition(path, "starts with", value.slice(0, -1), negate, isProperty);
             }
         }
     }
@@ -85,9 +96,9 @@ function introduceStartsWithOperators(tree, options) {
 
 function eliminateStartsWithOperators(tree) {
     function _eliminateStartsWithOperator(c) {
-        const { negate, path, operator, value } = c;
+        const { negate, path, operator, value, isProperty } = c;
         if (operator === "starts with") {
-            return condition(path, "=ilike", `${value}%`, negate);
+            return condition(path, "=ilike", `${value}%`, negate, isProperty);
         }
     }
     return operate(_eliminateStartsWithOperator, tree);
@@ -119,8 +130,11 @@ function isBetween(c) {
     return false;
 }
 
-function makeBetween(path, value1, value2) {
-    return connector("&", [condition(path, ">=", value1), condition(path, "<=", value2)]);
+function makeBetween(path, value1, value2, isProperty) {
+    return connector("&", [
+        condition(path, ">=", value1, false, isProperty),
+        condition(path, "<=", value2, false, isProperty),
+    ]);
 }
 
 function isStrictBetween(c) {
@@ -136,8 +150,11 @@ function isStrictBetween(c) {
     return false;
 }
 
-function makeStrictBetween(path, value1, value2) {
-    return connector("&", [condition(path, ">=", value1), condition(path, "<", value2)]);
+function makeStrictBetween(path, value1, value2, isProperty) {
+    return connector("&", [
+        condition(path, ">=", value1, false, isProperty),
+        condition(path, "<", value2, false, isProperty),
+    ]);
 }
 
 function boundDate(delta) {
@@ -195,8 +212,10 @@ function introduceInRangeOperators(tree, options = {}) {
                 "generateSmartDates" in options ? options.generateSmartDates : true;
             // @ts-ignore
             const { path, value1, value2 } = res1;
-            const fieldType = options.getFieldDef?.(path)?.type;
-            if (["date", "datetime"].includes(fieldType) && isSimplePath(path)) {
+            const fieldDef = options.getFieldDef?.(path);
+            const fieldType = fieldDef?.type;
+            const isProperty = fieldDef?.is_property;
+            if (["date", "datetime"].includes(fieldType) && isSimplePath(path, isProperty)) {
                 const bounds = getBounds(generateSmartDates, fieldType);
                 for (const [valueType, leftBound, rightBound] of bounds) {
                     if (
@@ -204,7 +223,13 @@ function introduceInRangeOperators(tree, options = {}) {
                             ? value1 === leftBound && value2 === rightBound
                             : value1._expr === leftBound._expr && value2._expr === rightBound._expr
                     ) {
-                        return condition(path, "in range", [fieldType, valueType, false, false]);
+                        return condition(
+                            path,
+                            "in range",
+                            [fieldType, valueType, false, false],
+                            false,
+                            isProperty
+                        );
                     }
                 }
             }
@@ -213,14 +238,22 @@ function introduceInRangeOperators(tree, options = {}) {
         if (res2) {
             // @ts-ignore
             const { path, value1, value2 } = res2;
-            const fieldType = options.getFieldDef?.(path)?.type;
-            if (["date", "datetime"].includes(fieldType) && isSimplePath(path)) {
-                return condition(path, "in range", [
-                    fieldType,
-                    "custom range",
-                    // @ts-ignore
-                    ...normalizeValue([value1, value2]),
-                ]);
+            const fieldDef = options.getFieldDef?.(path);
+            const fieldType = fieldDef?.type;
+            const isProperty = fieldDef?.is_property;
+            if (["date", "datetime"].includes(fieldType) && isSimplePath(path, isProperty)) {
+                return condition(
+                    path,
+                    "in range",
+                    [
+                        fieldType,
+                        "custom range",
+                        // @ts-ignore
+                        ...normalizeValue([value1, value2]),
+                    ],
+                    false,
+                    isProperty
+                );
             }
         }
     }
@@ -234,22 +267,22 @@ function introduceInRangeOperators(tree, options = {}) {
 
 function eliminateInRangeOperators(tree, options = {}) {
     function _eliminateInRangeOperator(c, options) {
-        const { negate, path, operator, value } = c;
+        const { negate, path, operator, value, isProperty } = c;
         // @ts-ignore
         if (operator !== "in range") {
             return;
         }
-        const { initialPath, lastPart } = splitPath(path);
+        const { initialPath, lastPart } = splitPath(path, isProperty);
         const [fieldType, valueType, value1, value2] = value;
         let tree;
         if (valueType === "custom range") {
-            tree = makeBetween(lastPart, value1, value2);
+            tree = makeBetween(lastPart, value1, value2, isProperty);
         } else {
             const generateSmartDates =
                 "generateSmartDates" in options ? options.generateSmartDates : true;
             const bounds = getBounds(generateSmartDates, fieldType);
             const [, leftBound, rightBound] = bounds.find(([v]) => v === valueType);
-            tree = makeStrictBetween(lastPart, leftBound, rightBound);
+            tree = makeStrictBetween(lastPart, leftBound, rightBound, isProperty);
         }
         return wrapInAny(tree, initialPath, negate);
     }
@@ -279,13 +312,17 @@ function introduceBetweenOperators(tree, options = {}) {
 
 function eliminateBetweenOperators(tree) {
     function _eliminateBetweenOperator(c) {
-        const { negate, path, operator, value } = c;
+        const { negate, path, operator, value, isProperty } = c;
         // @ts-ignore
         if (operator !== "between") {
             return;
         }
-        const { initialPath, lastPart } = splitPath(path);
-        return wrapInAny(makeBetween(lastPart, value[0], value[1]), initialPath, negate);
+        const { initialPath, lastPart } = splitPath(path, isProperty);
+        return wrapInAny(
+            makeBetween(lastPart, value[0], value[1], isProperty),
+            initialPath,
+            negate
+        );
     }
     return operate(_eliminateBetweenOperator, tree);
 }
@@ -302,7 +339,13 @@ function _eliminateAnyOperator(c) {
         !value.negate &&
         ["between", "in range"].includes(value.operator)
     ) {
-        return condition(`${path}.${value.path}`, value.operator, value.value);
+        return condition(
+            `${path}.${value.path}`,
+            value.operator,
+            value.value,
+            false,
+            value.isProperty
+        );
     }
 }
 
@@ -312,11 +355,11 @@ function eliminateAnyOperators(tree) {
 
 function removeFalseTrueLeaves(tree) {
     function _removeFalseTrueLeave(c) {
-        const { path, operator, value, negate } = c;
-        if (areEqualTrees(condition(path, operator, value), FALSE_TREE)) {
+        const { path, operator, value, negate, isProperty } = c;
+        if (areEqualTrees(condition(path, operator, value, false, isProperty), FALSE_TREE)) {
             return connector(negate ? "&" : "|", []);
         }
-        if (areEqualTrees(condition(path, operator, value), TRUE_TREE)) {
+        if (areEqualTrees(condition(path, operator, value, false, isProperty), TRUE_TREE)) {
             return connector(negate ? "|" : "&", []);
         }
     }

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -1,4 +1,4 @@
-import { expect, test } from "@odoo/hoot";
+import { expect, test, getFixture } from "@odoo/hoot";
 import { press, queryAll, queryAllAttributes, queryAllTexts, queryOne } from "@odoo/hoot-dom";
 import { animationFrame, mockDate, mockTimeZone, runAllTimers } from "@odoo/hoot-mock";
 import { Component, useState, xml } from "@odoo/owl";
@@ -1061,7 +1061,7 @@ test("support properties", async () => {
         },
         {
             name: "xphone_prop_5",
-            domain: `[("properties", "any", ["&", ("xphone_prop_5", ">=", "today"), ("xphone_prop_5", "<", "today +1d")])]`,
+            domain: `["&", ("properties.xphone_prop_5", ">=", "today"), ("properties.xphone_prop_5", "<", "today +1d")]`,
             options: [
                 label("in range"),
                 label("="),
@@ -2674,4 +2674,132 @@ test(`swith from [(0, "=", 1)] to other condition`, async () => {
         label("not set"),
     ]);
     expect.verifySteps([`["&", ("datetime", ">=", "today"), ("datetime", "<", "today +1d")]`]);
+});
+
+test("properties field: date & datetime", async () => {
+    mockDate("2077-01-02 10:00:00", 0);
+    Partner._fields.properties = fields.Properties({
+        string: "partner_properties",
+        definition_record: "product_id",
+        definition_record_field: "definitions",
+    });
+
+    Product._fields.properties = fields.Properties({
+        string: "product_properties",
+        definition_record: "partner_id",
+        definition_record_field: "definitions",
+    });
+
+    Product._fields.partner_id = fields.Many2one({ relation: "partner" });
+    Product._fields.definitions = fields.PropertiesDefinition({
+        string: "Definitions",
+    });
+
+    Product._records[0].definitions = [
+        { name: "date_properties", string: "date_properties", type: "date" },
+        { name: "datetime_properties", string: "datetime_properties", type: "datetime" },
+    ];
+
+    Partner._fields.definitions = fields.PropertiesDefinition({
+        string: "Definitions",
+    });
+
+    Partner._records[1].definitions = [
+        { name: "date_properties", string: "date_properties", type: "date" },
+        { name: "datetime_properties", string: "datetime_properties", type: "datetime" },
+    ];
+    const domain = `[(0, "=", 1)]`;
+    await makeDomainSelector({
+        isDebugMode: true,
+        domain,
+    });
+    const target = getFixture();
+    const checkEditor = async (value) => {
+        const { fields, operator, expectedDomain, treeValue } = value;
+        await contains(`.o_domain_selector_debug_container textarea`).edit(domain);
+        await contains(".o_model_field_selector").click();
+        for (const [index, field] of fields.entries()) {
+            await contains(".o_model_field_selector_popover_search input").edit(field, {
+                confirm: false,
+            });
+            await runAllTimers();
+            await animationFrame();
+            if (index != fields.length - 1) {
+                await contains(".o_model_field_selector_popover_search input").press("ArrowRight");
+            } else {
+                await contains(".o_model_field_selector_popover_search input").press("Enter");
+            }
+        }
+        await selectOperator(operator);
+        if (treeValue) {
+            await selectValue(treeValue);
+        }
+        await runAllTimers();
+        await animationFrame();
+        await expect(
+            target.querySelector(".o_domain_selector_debug_container textarea").value
+        ).toBe(expectedDomain);
+    };
+    const values = [
+        {
+            fields: ["partner_properties", "date_properties"],
+            operator: "in range",
+            expectedDomain: `["&", ("properties.date_properties", ">=", "today"), ("properties.date_properties", "<", "today +1d")]`,
+        },
+        {
+            fields: ["partner_properties", "datetime_properties"],
+            operator: "in range",
+            expectedDomain: `["&", ("properties.datetime_properties", ">=", "today"), ("properties.datetime_properties", "<", "today +1d")]`,
+        },
+        {
+            fields: ["product", "product_properties", "date_properties"],
+            operator: "in range",
+            expectedDomain:
+                '[("product_id", "any", ["&", ("properties.date_properties", ">=", "today"), ("properties.date_properties", "<", "today +1d")])]',
+        },
+        {
+            fields: ["product", "product_properties", "datetime_properties"],
+            operator: "in range",
+            expectedDomain:
+                '[("product_id", "any", ["&", ("properties.datetime_properties", ">=", "today"), ("properties.datetime_properties", "<", "today +1d")])]',
+        },
+        {
+            fields: ["product", "product_properties", "date_properties"],
+            operator: "=",
+            expectedDomain: '[("product_id.properties.date_properties", "=", "2077-01-02")]',
+        },
+        {
+            fields: ["product", "product_properties", "datetime_properties"],
+            operator: "=",
+            expectedDomain:
+                '[("product_id.properties.datetime_properties", "=", "2077-01-02 00:00:00")]',
+        },
+        {
+            fields: ["product", "product_properties", "date_properties"],
+            operator: ">",
+            expectedDomain: '[("product_id.properties.date_properties", ">", "2077-01-02")]',
+        },
+        {
+            fields: ["product", "product_properties", "datetime_properties"],
+            operator: "<",
+            expectedDomain:
+                '[("product_id.properties.datetime_properties", "<", "2077-01-02 00:00:00")]',
+        },
+        {
+            fields: ["product", "product_properties", "datetime_properties"],
+            operator: "in range",
+            treeValue: "last 12 months",
+            expectedDomain:
+                '[("product_id", "any", ["&", ("properties.datetime_properties", ">=", "today =1d -12m"), ("properties.datetime_properties", "<", "today =1d")])]',
+        },
+        {
+            fields: ["product", "product_properties", "date_properties"],
+            operator: "in range",
+            treeValue: "year to date",
+            expectedDomain: `[("product_id", "any", ["&", ("properties.date_properties", ">=", "today =1m =1d"), ("properties.date_properties", "<", "today +1d")])]`,
+        },
+    ];
+    for (const value of values) {
+        await checkEditor(value);
+    }
 });

--- a/odoo/addons/test_orm/tests/test_domain.py
+++ b/odoo/addons/test_orm/tests/test_domain.py
@@ -1005,3 +1005,58 @@ class TestDomainOptimize(TransactionCase):
             list(base_domain.optimize_full(model.sudo())),
             [('currency_id', 'not in', [2, False])],
         )
+
+    def subset_condition_optimize_properties_date(self, date_type='date'):
+        message_model = self.env['test_orm.message'].with_context(tz='UTC')
+        discussion_model = self.env['test_orm.discussion'].with_context(tz='UTC')
+
+        is_dt = date_type == 'datetime'
+        hour_str = ' 13:05:34' if is_dt else ''
+        discussion = self.env['test_orm.discussion'].create({
+            'name': 'Test Discussion',
+            'participants': [Command.link(self.env.user.id)],
+            'attributes_definition': [{
+                'name': 'mydate',
+                'string': 'Prop',
+                'type': date_type,
+            }],
+        })
+
+        message_model.create({
+            'discussion': discussion.id,
+            'name': 'Test Message',
+            'attributes': {
+                'mydate': f'2077-05-02{hour_str}',
+            },
+        })
+
+        with freeze_time(f'2027-05-02{hour_str}'):
+            self.assertEqual(
+                Domain('attributes.mydate', '=', '+50y').optimize_full(message_model),
+                Domain('attributes.mydate', 'in', OrderedSet([f'2077-05-02{hour_str}'])),
+            )
+
+            self.assertEqual(
+                Domain(
+                    'messages',
+                    'any',
+                    Domain.AND([
+                        Domain('attributes.mydate', '>=', 'today'),
+                        Domain('attributes.mydate', '<', '+60y'),
+                    ]),
+                ).optimize_full(discussion_model),
+                Domain(
+                    'messages',
+                    'any!',
+                    Domain.AND([
+                        Domain('attributes.mydate', '<', f'2087-05-02{hour_str}'),
+                        Domain('attributes.mydate', '>=', f"2027-05-02{' 00:00:00' if is_dt else ''}"),
+                    ]),
+                ),
+            )
+
+    def test_condition_optimize_properties_date(self):
+        self.subset_condition_optimize_properties_date("date")
+
+    def test_condition_optimize_properties_datetime(self):
+        self.subset_condition_optimize_properties_date("datetime")

--- a/odoo/addons/test_orm/tests/test_properties.py
+++ b/odoo/addons/test_orm/tests/test_properties.py
@@ -4,7 +4,6 @@ import psycopg2
 import unittest
 from collections import abc
 from unittest.mock import patch
-
 import babel.dates
 
 from odoo.addons.base.tests.test_expression import TransactionExpressionCase
@@ -2594,7 +2593,7 @@ class PropertiesGroupByCase(TestPropertiesMixin):
         self.message_3.attributes = {'mychar': 'boum'}
 
         Model = self.env['test_orm.message']
-        with self.assertQueryCount(6):  # 3 for formatted_read_group + 1 query by group opened
+        with self.assertQueryCount(9):  # 3 for formatted_read_group + 1 query by group opened + 1 query by get_property_definition
             result = Model.web_read_group(
                 domain=[],
                 aggregates=['__count'],
@@ -2602,6 +2601,7 @@ class PropertiesGroupByCase(TestPropertiesMixin):
                 auto_unfold=True,
                 unfold_read_specification={'id': {}},
             )
+
         groups = result['groups']
 
         self.assertEqual(len(groups), 3)

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -1652,6 +1652,36 @@ def _optimize_type_datetime_relative(condition, model):
     return DomainCondition(condition.field_expr, operator, value)
 
 
+@field_type_optimization(['properties'], level=OptimizationLevel.DYNAMIC_VALUES)
+def _optimize_properties_date_datetime(condition, model):
+    operator = condition.operator
+    if (
+        operator not in ('in', 'not in', '>', '<', '<=', '>=')
+        or condition.field_expr.count('.') != 1
+        or not isinstance(condition.value, (str, OrderedSet))
+    ):
+        return condition
+    definition = model.get_property_definition(condition.field_expr)
+    property_type = definition.get("type")
+
+    if property_type == 'date':
+        value = _value_to_date(condition.value, model.env)
+    elif property_type == 'datetime':
+        value, _ = _value_to_datetime(condition.value, model.env)
+    else:
+        return condition
+    # we need to serialize the value as a string to be able to use with properties
+    if isinstance(value, COLLECTION_TYPES):
+        value = OrderedSet(
+            str(item) if isinstance(item, (date, datetime)) else item
+            for item in value
+        )
+    elif isinstance(value, (date, datetime)):
+        value = str(value)
+
+    return DomainCondition(condition.field_expr, operator, value)
+
+
 @field_type_optimization(['binary'])
 def _optimize_type_binary_attachment(condition, model):
     field = condition._field(model)


### PR DESCRIPTION
Steps:
- Install crm
- Add a propertie field date type
- try to filter with this field
- Invalid domain

Currently tree_editor does not take into account if a path is a property field or not, with this commit there is a new `is_property` attribut in node

opw-5906605