### PR TITLE
[FIX] l10n_din5008: correct translation in printing invoices (DE company)

### DIFF
--- a/addons/l10n_din5008/report/din5008_report.xml
+++ b/addons/l10n_din5008/report/din5008_report.xml
@@ -197,7 +197,7 @@
                                 <td><t t-out="o.invoice_date" t-options="{'widget': 'date'}"/></td>
                             </tr>
                             <tr t-if="o.invoice_date_due">
-                                <td>Invoice Date Due</td>
+                                <td>Invoice Due Date</td>
                                 <td><t t-out="o.invoice_date_due" t-options="{'widget': 'date'}"/></td>
                             </tr>
                             <tr t-if="o.delivery_date">


### PR DESCRIPTION
### Issue before the commit:
While printing an invoice in english but for a german company the label
for the date was "Invoice Date Due" instead of "Invoice Due Date" as
for companies of other nationalities.

### Steps to reproduce the issue:
Create a new german company
Download Accounting app
Go to customers > invoices
Create and print an invoice
You can see the mistaken label in the printed invoice
Cause of the issue:
Error in writing the label within the code.

### Reason to introduce the fix:
Aligning international printed invoices with the English template and
correct the english mistake.

### Fix details:
Error line: <td>Invoice Date Due</td>
Corrected line: <td>Invoice Due Date</td>

opw-5909107