### PR TITLE
[FIX] purchase_stock,mrp:  prevent buy to resupply from reenabling automatically

### DIFF
--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -890,5 +890,7 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         """Unchecking Manufacture to Resupply should keep manufacture_to_resupply disabled."""
         manufacture_route = self.warehouse.manufacture_pull_id.route_id
         self.warehouse.manufacture_to_resupply = False
+        # Invalidate recordset to avoid cached `manufacture_to_resupply`
+        self.warehouse.invalidate_recordset(["manufacture_to_resupply"])
         self.assertFalse(self.warehouse.manufacture_to_resupply)
         self.assertNotIn(self.warehouse, manufacture_route.warehouse_ids)

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -54,7 +54,7 @@ class StockWarehouse(models.Model):
     def _compute_buy_to_resupply(self):
         for warehouse in self:
             buy_route = warehouse.buy_pull_id.route_id
-            warehouse.buy_to_resupply = bool(buy_route.product_selectable or buy_route.warehouse_ids.filtered(lambda w: w.id == warehouse.id))
+            warehouse.buy_to_resupply = warehouse.id in buy_route.warehouse_ids.ids
 
     def _inverse_buy_to_resupply(self):
         for warehouse in self:

--- a/addons/purchase_stock/tests/test_routes.py
+++ b/addons/purchase_stock/tests/test_routes.py
@@ -67,3 +67,13 @@ class TestRoutes(TransactionCase):
 
         wh.reception_steps = 'two_steps'
         self.assertEqual(wh.reception_steps, 'two_steps')
+
+    def test_buy_to_resupply_unchecks_and_unlinks_warehouse(self):
+        """Unchecking Buy to Resupply should keep buy_to_resupply disabled."""
+        wh = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        buy_route = wh.buy_pull_id.route_id
+        wh.buy_to_resupply = False
+        # Invalidate recordset to avoid cached `buy_to_resupply`
+        wh.invalidate_recordset(["buy_to_resupply"])
+        self.assertFalse(wh.buy_to_resupply)
+        self.assertNotIn(wh, buy_route.warehouse_ids)


### PR DESCRIPTION
Steps to produce:
---
- Install `purchase_stock` module.
- Inventory > Configuration > Settings > Warehouse > enable `Multi-Step Routes`.
- Go to Configuration > Warehouse Management > Warehouses.
- Open `YourCompany` record.
- Click on Routes > open `Buy` > enable `Products`.
- Return to `YourCompany` and disable `Buy to Resupply`.

Issue:
---
- After disabling `Buy to Resupply`, the option is automatically re-enabled.

Root cause:
---
- In [1], `buy_to_resupply` is set to true if either buy route is product selectable OR the current warehouse is included in buy route warehouses.
- In the `_inverse_buy_to_resupply` method, unchecking the flag only unlinks the warehouse from the route. However, if `product_selectable` is still enabled, the compute logic will continue to set the field back to true.

Solution:
---
- `warehouse.buy_to_resupply` is now set to True only when the warehouse ID is present in the buy route’s warehouse_ids.

[1] https://github.com/odoo/odoo/blob/aeaace7c70b7ac3db68f188c9c517f1ff849e55d/addons/purchase_stock/models/stock.py#L57

opw-5476302
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
