### PR TITLE
[FIX] mail: ignore archived blacklists

### DIFF
--- a/addons/mail/models/mail_thread_blacklist.py
+++ b/addons/mail/models/mail_thread_blacklist.py
@@ -85,7 +85,7 @@ class MailBlackListMixin(models.AbstractModel):
     def _compute_is_blacklisted(self):
         # TODO : Should remove the sudo as compute_sudo defined on methods.
         # But if user doesn't have access to mail.blacklist, doen't work without sudo().
-        blacklist = set(self.env['mail.blacklist'].sudo().search([
+        blacklist = set(self.env['mail.blacklist'].sudo().with_context(active_test=True).search([
             ('email', 'in', self.mapped('email_normalized'))]).mapped('email'))
         for record in self:
             record.is_blacklisted = record.email_normalized in blacklist

--- a/addons/mail/tests/__init__.py
+++ b/addons/mail/tests/__init__.py
@@ -3,6 +3,7 @@
 from . import test_ir_mail_server
 from . import test_link_preview
 from . import test_mail_activity
+from . import test_mail_blacklist
 from . import test_mail_composer
 from . import test_mail_mail
 from . import test_mail_mail_stable_selection

--- a/addons/mail/tests/test_mail_blacklist.py
+++ b/addons/mail/tests/test_mail_blacklist.py
@@ -1,0 +1,41 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import TransactionCase
+
+
+class TestMailBlacklist(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.email = "archived@test.example.com"
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "Archived Blacklist Test",
+                "email": cls.email,
+            }
+        )
+        cls.blacklist_entry = cls.env["mail.blacklist"].create(
+            {
+                "email": cls.email,
+                "active": False,
+            }
+        )
+
+    def test_is_blacklisted_ignores_archived(self):
+        self.assertFalse(
+            self.partner.is_blacklisted,
+            "Archived blacklist entries should not mark partner as blacklisted",
+        )
+
+    def test_is_blacklisted_active_entry(self):
+        self.blacklist_entry.action_unarchive()
+        self.assertTrue(
+            self.partner.is_blacklisted,
+            "Active blacklist entries should mark partner as blacklisted",
+        )
+
+    def test_active_test_false_context_works(self):
+        self.assertFalse(
+            self.partner.with_context(active_test=False).is_blacklisted,
+            "Always blacklisted, even if context searches for archived records",
+        )


### PR DESCRIPTION
Same as https://github.com/odoo/odoo/pull/249466, but for v17 and with tests.

> When computing wether the user is blacklisted, disabled records must be ignored.
> 
> https://www.loom.com/share/41ea437477f8416f8b50f9ef979d82bf
> 
> 
> ---
> I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
> 
> @moduon MT-13153 OPW-5952301
