### PR TITLE
[IMP] base: show account_holder_name in res.partner.bank form view

### DIFF
--- a/odoo/addons/base/views/res_bank_views.xml
+++ b/odoo/addons/base/views/res_bank_views.xml
@@ -86,6 +86,7 @@
                             <field name="acc_number"/>
                             <field name="bank_id"/>
                             <field name="partner_id"/>
+                            <field name="acc_holder_name"/>
                         </group>
                         <group>
                             <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>


### PR DESCRIPTION
`account_holder_name` was removed from the view in 18.0 by mistake in 0eddc18b08d2b3a374162dc24ea93dd0350dbdc2 and should be shown again since we want the account holder name to be independent of the partner name.

task-5967143