### PR TITLE
[FIX] iot_box_image: restore escpos dependency

### DIFF
--- a/addons/iot_box_image/configuration/requirements.txt
+++ b/addons/iot_box_image/configuration/requirements.txt
@@ -13,6 +13,7 @@ PyKCS11==1.5.16; sys_platform == "win32"
 schedule==1.2.1; sys_platform == "win32"
 
 # The following requirements are needed on every platforms:
+python-escpos==3.1
 websocket-client==1.9.0
 
 # The following requirements are needed only on Test IoT server:


### PR DESCRIPTION
In odoo/odoo#249819 the `python-escpos` module was removed. However, the Windows IoT installer was then built without the module installed, but can still be paired with stable DBs that have the old driver code that relies on it.

To fix this we restore the dependency in 19.0 only (as this is the version Windows IoT builds are based on).

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
