### PR TITLE
[FIX] project_timesheet_holidays: Only create timesheets for validate…

### DIFF
--- a/addons/project_timesheet_holidays/models/resource_calendar_leaves.py
+++ b/addons/project_timesheet_holidays/models/resource_calendar_leaves.py
@@ -241,6 +241,7 @@ class ResourceCalendarLeaves(models.Model):
             ('company_id', '=', self.company_id.id),
             ('date_from', '<=', self.date_to),
             ('date_to', '>=', self.date_from),
+            ('state', '=', 'validate'),
         ]
         if self.calendar_id:
             leave_domain += [('resource_calendar_id', 'in', [False, self.calendar_id.id])]


### PR DESCRIPTION
…d leaves

Description of the issue/feature this PR addresses:
When a public holiday is edited or deleted, the timesheet re-creation is erroneously done for *all* leaves, even those which are canceled or still in draft.

Steps to Reproduce:
1. Create a Time Off request for a timesheet-creating leave type (i.e. `timesheet_generate = True`) that overlaps with a public holiday.
2. Refuse the Time Off request.
3. Delete the public holiday the request overlaps with.

Current behavior before PR:
The deletion of the holiday causes timesheet entries to be created, even though it's a refused request.

Desired behavior after PR is merged:
The deletion or editing of the public holiday only re-creates the timesheets for the leaves that are actually valid and thus need timesheet entries.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
