### PR TITLE
[FIX] website_sale_stock: prevent error when opening the shop

### DIFF
--- a/addons/website_sale_stock/models/product_template.py
+++ b/addons/website_sale_stock/models/product_template.py
@@ -30,7 +30,7 @@ class ProductTemplate(models.Model):
         """
         if not self.is_storable or self.allow_out_of_stock_order:
             return False
-        return self.product_variant_id._is_sold_out()
+        return not self.product_variant_id or self.product_variant_id._is_sold_out()
 
     def _website_show_quick_add(self):
         return (

--- a/addons/website_sale_stock/tests/test_website_sale_stock_product_warehouse.py
+++ b/addons/website_sale_stock/tests/test_website_sale_stock_product_warehouse.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests import tagged
+from odoo import Command
+from odoo.tests import HttpCase, tagged
 
 from odoo.addons.product.tests.test_product_attribute_value_config import (
     TestProductAttributeValueCommon,
@@ -12,7 +13,7 @@ from odoo.addons.website_sale_stock.tests.common import WebsiteSaleStockCommon
 
 @tagged('post_install', '-at_install')
 class TestWebsiteSaleStockProductWarehouse(
-    TestProductAttributeValueCommon, WebsiteSaleStockCommon
+    TestProductAttributeValueCommon, HttpCase, WebsiteSaleStockCommon
 ):
 
     @classmethod
@@ -92,3 +93,21 @@ class TestWebsiteSaleStockProductWarehouse(
             values = so._cart_update_line_quantity(line_id=so.order_line.id, quantity=30)
             self.assertTrue(values.get('warning', False))
             self.assertEqual(values.get('quantity'), 25)
+
+    def test_open_shop_when_product_has_no_variants(self):
+        """Test opening the shop page after deleting all variants of product."""
+        product_template = self.product.product_tmpl_id
+        product_template.write({
+            'is_storable': True,
+            'allow_out_of_stock_order': False,
+        })
+
+        self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': product_template.id,
+            'attribute_id': self.ssd_attribute.id,
+            'value_ids': [Command.set((self.ssd_256.id, self.ssd_512.id))],
+        })
+        product_template.product_variant_ids.unlink()
+
+        response = self.url_open('/shop')
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Currently, an error occurs when the user opens the shop page.

**Steps to Reproduce:**

 - Install `website_sale_stock` module.
 - Go to `Settings` and enable `Product Variants`.
 - Create a `product template` of type `Goods`.
 - Enable `Track Inventory`.
 - In the `Sales tab`, disable `Sell when Out-of-Stock`.
 - In the `Attributes & Variants` tab, add one attribute with two values and save.
 - Delete all variants using the `Variants smart button` or from Inventory > Products > Product Variants.
 - Go to `Website` > `Shop`.

**Error:**
`ValueError: Expected singleton: product.product()`

After [this commit], when opening the shop page, it calculates the quick add availability [1] 
for every product. It checks whether the product is sold out [2] to determine whether the quick 
add to cart button should be displayed or not. Since the product has no variants, it raises the 
error here [3]. Before 19.0, the quick add availability was calculated if the product had variants [4].

This commit ensures that if a product has no variants, it is treated as sold out. As a result, the 
quick add to cart button is not shown, as in the previous version.

[this commit]: https://github.com/odoo/odoo/commit/43d5226b500d64c3902eb1528e5d8e461766982c

[1]: https://github.com/odoo/odoo/blob/aeaace7c70b7ac3db68f188c9c517f1ff849e55d/addons/website_sale_stock/models/product_template.py#L35-L39

[2]: https://github.com/odoo/odoo/blob/aeaace7c70b7ac3db68f188c9c517f1ff849e55d/addons/website_sale_stock/models/product_template.py#L33

[3]: https://github.com/odoo/odoo/blob/aeaace7c70b7ac3db68f188c9c517f1ff849e55d/addons/website_sale_stock/models/product_product.py#L41

[4]: https://github.com/odoo/odoo/blob/18d9baa690d6b103fbf8dbe875b3e00b056dd873/addons/website_sale/views/templates.xml#L400-L403

sentry-7287364112


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
