### PR TITLE
[FIX] im_livechat: create one channel when posting multiple messages

### DIFF
--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -121,6 +121,10 @@ export class LivechatService {
         if (this.state === SESSION_STATE.PERSISTED) {
             return this.thread;
         }
+        if (this._persistResolvers) {
+            return this._persistResolvers.promise;
+        }
+        this._persistResolvers = Promise.withResolvers();
         const temporaryThread = this.thread;
         await this._createThread({ persist: true });
         if (temporaryThread) {
@@ -134,6 +138,8 @@ export class LivechatService {
         this.store.chatHub.opened.add({ thread: this.thread }).autofocus++;
         await this.busService.addChannel(`mail.guest_${this.guestToken}`);
         await this.env.services["mail.store"].initialize();
+        this._persistResolvers.resolve(this.thread);
+        this._persistResolvers = null;
         return this.thread;
     }
 


### PR DESCRIPTION
Before this commit, sending multiple messages before the channel creation can result in multiple channels being created.

It occurs because the post function is overriden to first persist the channel. When the persist call is still in progress, we shouldn't issue a new one.

task-4756758

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
