### PR TITLE
[FIX] point_of_sale: remove duplicate company name from receipt

### DIFF
--- a/addons/point_of_sale/receipt/pos_receipt_common.xml
+++ b/addons/point_of_sale/receipt/pos_receipt_common.xml
@@ -5,27 +5,19 @@
             <table class="w-100 text-small mt-2">
                 <tbody name="company_info">
                     <tr>
-                        <td class="text-start" t-out="company['name']" />
-                        <td class="text-end">
-                            Tel. <t t-out="config['phone']" />
+                        <td class="text-start top w-60" >
+                            <div t-out="config['name']"/>
+                            <div t-out="config['receipt_address']"/>
+                        </td>
+
+                        <td class="text-end top w-40" >
+                            <div>Tel: <t t-out="config['phone']"/></div>
+                            <div t-out="config['email']"/>
+                            <div t-out="config['website']"/>
                         </td>
                     </tr>
                     <tr>
-                        <td class="text-start" t-out="config['receipt_address']" />
-                    </tr>
-                    <tr>
-                        <td class="text-start" t-out="config['email']">
-                        </td>
-                        <td class="text-end" t-out="config['website']" />
-                    </tr>
-                    <tr>
-                        <td class="text-start" t-out="company['name']" />
-                        <td class="text-end">
-                            Tel. <t t-out="company['phone']" />
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="text-start" t-if="company.get('vat') and extra_data.get('vat_label')" name="company_info_vat">
+                        <td colspan="2" class="text-start" t-if="company.get('vat') and extra_data.get('vat_label')" name="company_info_vat">
                             <t t-out="extra_data['vat_label']" />: <t t-out="company['vat']" />
                         </td>
                     </tr>

--- a/addons/point_of_sale/static/tests/pos/tours/order_receipt.js
+++ b/addons/point_of_sale/static/tests/pos/tours/order_receipt.js
@@ -39,6 +39,12 @@ registry.category("web_tour.tours").add("test_receipt_data", {
                     if (!html.innerHTML.includes("This is a test footer for receipt")) {
                         throw new Error("Receipt footer not found in generated HTML");
                     }
+                    const configNameOccurrences = Array.from(html.querySelectorAll("td")).filter(
+                        (el) => el.textContent.trim() === data.config.name
+                    );
+                    if (configNameOccurrences.length > 1) {
+                        throw new Error("Config name appears more than once in generated HTML");
+                    }
 
                     try {
                         await posmodel.data.call("pos.order", "get_order_frontend_receipt_data", [


### PR DESCRIPTION
Before this commit:
===================
The POS receipt displayed the company name twice, resulting in duplicated
company information. Additionally, the company name was shown instead of the
PoS config name.

After this commit:
==================
The receipt now correctly displays the POS config name only once.
Duplicate company information has been removed to ensure a clean and
accurate receipt layout.

Task-5951599