### PR TITLE
[FIX] mrp, purchase_stock: prevent error when multiple routes present

### DIFF
--- a/addons/mrp/wizard/product_replenish.py
+++ b/addons/mrp/wizard/product_replenish.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
-from odoo.fields import Domain
 
 
 class ProductReplenish(models.TransientModel):
@@ -42,11 +41,3 @@ class ProductReplenish(models.TransientModel):
         if product_tmpl_id and product_tmpl_id.bom_ids:
             delay += product_tmpl_id.bom_ids[0].produce_delay + product_tmpl_id.bom_ids[0].days_to_prepare_mo
         return fields.Datetime.add(date, days=delay)
-
-    def _get_route_domain(self, product_tmpl_id):
-        domain = super()._get_route_domain(product_tmpl_id)
-        company = product_tmpl_id.company_id or self.env.company
-        manufacture_route = self.env['stock.rule'].search([('action', '=', 'manufacture'), ('company_id', '=', company.id)]).route_id
-        if manufacture_route and product_tmpl_id.bom_ids:
-            domain = Domain.OR([domain, Domain('id', '=', manufacture_route.id)])
-        return domain

--- a/addons/purchase_mrp/tests/test_replenishment.py
+++ b/addons/purchase_mrp/tests/test_replenishment.py
@@ -104,16 +104,11 @@ class TestReplenishment(TestStockCommon):
         })
         manufacture_route = self.warehouse_1.route_ids.filtered(lambda r: any(rule.action == 'manufacture' for rule in r.rule_ids))
         buy_route = self.warehouse_1.route_ids.filtered(lambda r: any(rule.action == 'buy' for rule in r.rule_ids))
-        self.productA.route_ids = False
 
         # No resupply methods should be set for Product A
         self.assertRecordValues(self.productA, [{'route_ids': self.env['stock.route'], 'seller_ids': self.env['product.supplierinfo'], 'bom_ids': self.env['mrp.bom']}])
         replenish_empty = create_replenish_wizard(self.warehouse_1, self.productA)
         self.assertFalse(replenish_empty.allowed_route_ids)
-
-        # Add the MTO route to the product, it should never show in allowed_route_ids
-        self.warehouse_1.mto_pull_id.route_id.active = True
-        self.productA.route_ids = self.warehouse_1.mto_pull_id.route_id
 
         # Add a BoM for Product A. This should make it eligible for Manufacture routes
         self.env['mrp.bom'].create({

--- a/addons/purchase_stock/wizard/product_replenish.py
+++ b/addons/purchase_stock/wizard/product_replenish.py
@@ -90,8 +90,7 @@ class ProductReplenish(models.TransientModel):
 
     def _get_route_domain(self, product_tmpl_id):
         domain = super()._get_route_domain(product_tmpl_id)
-        company = product_tmpl_id.company_id or self.env.company
-        buy_route = self.env['stock.rule'].search([('action', '=', 'buy'), ('company_id', '=', company.id)]).route_id
-        if buy_route and product_tmpl_id.seller_ids:
-            domain = Domain.OR([domain, Domain('id', '=', buy_route.id)])
+        buy_route = self.env.ref('purchase_stock.route_warehouse0_buy', raise_if_not_found=False)
+        if buy_route and not product_tmpl_id.seller_ids:
+            domain = Domain.AND([domain, Domain('id', '!=', buy_route.id)])
         return domain

--- a/addons/stock/models/stock_replenish_mixin.py
+++ b/addons/stock/models/stock_replenish_mixin.py
@@ -36,5 +36,4 @@ class StockReplenishMixin(models.AbstractModel):
             base_domain,
             Domain('rule_ids.location_src_id', '!=', stock_location_inter_company_id),
             Domain('rule_ids.location_dest_id', '!=', stock_location_inter_company_id),
-            Domain('rule_ids.location_dest_id.warehouse_id', '!=', False),
         ])


### PR DESCRIPTION
Commit [1] introduces a regression

Steps to replicate:
- Install `mrp_subcontracting_dropshipping` and turn on `Multi-step Routes`
- Create a product > From the Purchase tab add a Vendor to this product
- Click on cog menu, Click Replenish

Note: This error can also be replicated using duplicating the `Buy` route

Error:
ValueError: Expected singleton: stock.route(4, 13)

Reason:
Cf for instance in `/mrp:ProductReplenish._get_route_domain`
The search might find several rule of several routes
Therefore, doing `manufacture_route.id` will lead to the error

The case will be protected with a test in another PR

[1] https://github.com/odoo/odoo/commit/705e27a2d3d9e3c4d075a1e8fb599333a504a316

sentry-7287557500
opw-5961814
opw-5973658
opw-5969160
opw-5969487
opw-5972463
opw-5972805