### PR TITLE
[FIX] l10n_ar: Specific taxes computation multi-currency in AR

### DIFF
--- a/addons/l10n_ar/__manifest__.py
+++ b/addons/l10n_ar/__manifest__.py
@@ -115,4 +115,12 @@ Master Data:
     ],
     'installable': True,
     'license': 'LGPL-3',
+    'assets': {
+        'web.assets_backend': [
+            'l10n_ar/static/src/helpers/*.js',
+        ],
+        'web.assets_frontend': [
+            'l10n_ar/static/src/helpers/*.js',
+        ],
+    },
 }

--- a/addons/l10n_ar/models/__init__.py
+++ b/addons/l10n_ar/models/__init__.py
@@ -17,3 +17,4 @@ from . import uom_uom
 from . import account_chart_template
 from . import account_move
 from . import account_move_line
+from . import account_tax

--- a/addons/l10n_ar/models/account_tax.py
+++ b/addons/l10n_ar/models/account_tax.py
@@ -1,0 +1,138 @@
+from odoo import api, models
+
+
+class AccountTax(models.Model):
+    _inherit = 'account.tax'
+
+    @api.model
+    def _round_tax_details_tax_amounts(self, base_lines, company, mode='mixed'):
+        # EXTENDS 'account'
+        country_code = company.account_fiscal_country_id.code
+        if country_code == 'AR':
+            mode = 'excluded'
+
+        super()._round_tax_details_tax_amounts(base_lines, company, mode=mode)
+
+        if country_code != 'AR':
+            return
+
+        company_currency = company.currency_id
+
+        def grouping_function(base_line, tax_data):
+            if not tax_data:
+                return
+            return {
+                'tax': tax_data['tax'],
+                'currency': base_line['currency_id'],
+                'is_refund': base_line['is_refund'],
+                'is_reverse_charge': tax_data['is_reverse_charge'],
+                'price_include': tax_data['price_include'],
+                'rate': base_line['rate'],
+            }
+
+        base_lines_aggregated_values = self._aggregate_base_lines_tax_details(base_lines, grouping_function)
+        values_per_grouping_key = self._aggregate_base_lines_aggregated_values(base_lines_aggregated_values)
+        for grouping_key, values in values_per_grouping_key.items():
+            if (
+                not grouping_key
+                or grouping_key['currency'] == company_currency
+                or not grouping_key['rate']
+            ):
+                continue
+
+            # Tax amount.
+            current_total_tax_amount = values['tax_amount']
+            expected_total_tax_amount = company_currency.round(values['tax_amount_currency'] / grouping_key['rate'])
+            delta_total_tax_amount = expected_total_tax_amount - current_total_tax_amount
+
+            if not company_currency.is_zero(delta_total_tax_amount):
+                target_factors = [
+                    {
+                        'factor': tax_data['tax_amount'],
+                        'tax_data': tax_data,
+                    }
+                    for _base_line, taxes_data in values['base_line_x_taxes_data']
+                    for tax_data in taxes_data
+                ]
+                amounts_to_distribute = self._distribute_delta_amount_smoothly(
+                    precision_digits=company_currency.decimal_places,
+                    delta_amount=delta_total_tax_amount,
+                    target_factors=target_factors,
+                )
+                for target_factor, amount_to_distribute in zip(target_factors, amounts_to_distribute):
+                    tax_data = target_factor['tax_data']
+                    tax_data['tax_amount'] += amount_to_distribute
+
+            # Base amount.
+            current_total_base_amount = values['base_amount']
+            expected_total_base_amount = company_currency.round(values['base_amount_currency'] / grouping_key['rate'])
+            delta_total_base_amount = expected_total_base_amount - current_total_base_amount
+
+            if not company_currency.is_zero(delta_total_base_amount):
+                target_factors = [
+                    {
+                        'factor': tax_data['base_amount'],
+                        'tax_data': tax_data,
+                    }
+                    for _base_line, taxes_data in values['base_line_x_taxes_data']
+                    for tax_data in taxes_data
+                ]
+                amounts_to_distribute = self._distribute_delta_amount_smoothly(
+                    precision_digits=company_currency.decimal_places,
+                    delta_amount=delta_total_base_amount,
+                    target_factors=target_factors,
+                )
+                for target_factor, amount_to_distribute in zip(target_factors, amounts_to_distribute):
+                    tax_data = target_factor['tax_data']
+                    tax_data['base_amount'] += amount_to_distribute
+
+    @api.model
+    def _round_tax_details_base_lines(self, base_lines, company, mode='mixed'):
+        # EXTENDS 'account'
+        country_code = company.account_fiscal_country_id.code
+        if country_code == 'AR':
+            mode = 'excluded'
+
+        super()._round_tax_details_base_lines(base_lines, company, mode=mode)
+
+        if country_code != 'AR':
+            return
+
+        company_currency = company.currency_id
+
+        def grouping_function(base_line, tax_data):
+            return {
+                'currency': base_line['currency_id'],
+                'is_refund': base_line['is_refund'],
+                'rate': base_line['rate'],
+            }
+
+        base_lines_aggregated_values = self._aggregate_base_lines_tax_details(base_lines, grouping_function)
+        values_per_grouping_key = self._aggregate_base_lines_aggregated_values(base_lines_aggregated_values)
+        for grouping_key, values in values_per_grouping_key.items():
+            if (
+                not grouping_key
+                or grouping_key['currency'] == company_currency
+                or not grouping_key['rate']
+            ):
+                continue
+
+            current_total_base_amount = values['total_excluded']
+            expected_total_base_amount = company_currency.round(values['total_excluded_currency'] / grouping_key['rate'])
+            delta_total_base_amount = expected_total_base_amount - current_total_base_amount
+
+            target_factors = [
+                {
+                    'factor': base_line['tax_details']['raw_total_excluded'],
+                    'base_line': base_line,
+                }
+                for base_line, _taxes_data in values['base_line_x_taxes_data']
+            ]
+            amounts_to_distribute = self._distribute_delta_amount_smoothly(
+                precision_digits=company_currency.decimal_places,
+                delta_amount=delta_total_base_amount,
+                target_factors=target_factors,
+            )
+            for target_factor, amount_to_distribute in zip(target_factors, amounts_to_distribute):
+                base_line = target_factor['base_line']
+                base_line['tax_details']['delta_total_excluded'] += amount_to_distribute

--- a/addons/l10n_ar/static/src/helpers/account_tax.js
+++ b/addons/l10n_ar/static/src/helpers/account_tax.js
@@ -1,0 +1,171 @@
+import { floatIsZero, roundPrecision } from "@web/core/utils/numbers";
+import { patch } from "@web/core/utils/patch";
+
+import { accountTaxHelpers } from "@account/helpers/account_tax";
+
+// -------------------------------------------------------------------------
+// HELPERS IN BOTH PYTHON/JAVASCRIPT (account_tax.js / account_tax.py)
+// -------------------------------------------------------------------------
+
+patch(accountTaxHelpers, {
+    // EXTENDS 'account'
+    round_tax_details_tax_amounts(base_lines, company, { mode = "mixed" } = {}) {
+        const country_code = company.account_fiscal_country_id.code;
+        if (country_code === "AR") {
+            mode = "excluded";
+        }
+
+        super.round_tax_details_tax_amounts(base_lines, company, { mode: mode });
+
+        if (country_code !== "AR") {
+            return;
+        }
+
+        const company_currency = company.currency_id;
+
+        function grouping_function(base_line, tax_data) {
+            if (!tax_data) {
+                return;
+            }
+            return {
+                tax: tax_data.tax,
+                currency: base_line.currency_id,
+                is_refund: base_line.is_refund,
+                is_reverse_charge: tax_data.is_reverse_charge,
+                price_include: tax_data.price_include,
+                rate: base_line.rate,
+            };
+        }
+
+        const base_lines_aggregated_values = this.aggregate_base_lines_tax_details(
+            base_lines,
+            grouping_function
+        );
+        const values_per_grouping_key = this.aggregate_base_lines_aggregated_values(
+            base_lines_aggregated_values
+        );
+        for (const values of Object.values(values_per_grouping_key)) {
+            const grouping_key = values.grouping_key;
+            if (!grouping_key || grouping_key.currency === company_currency || !grouping_key.rate) {
+                continue;
+            }
+
+            // Tax amount
+            const current_total_tax_amount = values.tax_amount;
+            const expected_total_tax_amount = roundPrecision(
+                values.tax_amount_currency / grouping_key.rate,
+                company_currency.rounding
+            );
+            const delta_total_tax_amount = expected_total_tax_amount - current_total_tax_amount;
+
+            if (!floatIsZero(delta_total_tax_amount, company_currency.decimal_places)) {
+                const target_factors = values.base_line_x_taxes_data.flatMap(([_, taxes_data]) =>
+                    taxes_data.map((tax_data) => ({
+                        factor: tax_data.tax_amount,
+                        tax_data: tax_data,
+                    }))
+                );
+                const amounts_to_distribute = this.distribute_delta_amount_smoothly(
+                    company_currency.decimal_places,
+                    delta_total_tax_amount,
+                    target_factors
+                );
+                for (let i = 0; i < target_factors.length; i++) {
+                    const tax_data = target_factors[i].tax_data;
+                    const amount_to_distribute = amounts_to_distribute[i];
+                    tax_data.tax_amount += amount_to_distribute;
+                }
+            }
+
+            // Base amount
+            const current_total_base_amount = values.base_amount;
+            const expected_total_base_amount = roundPrecision(
+                values.base_amount_currency / grouping_key.rate,
+                company_currency.rounding
+            );
+            const delta_total_base_amount = expected_total_base_amount - current_total_base_amount;
+
+            if (!floatIsZero(delta_total_base_amount, company_currency.decimal_places)) {
+                const target_factors = values.base_line_x_taxes_data.flatMap(([_, taxes_data]) =>
+                    taxes_data.map((tax_data) => ({
+                        factor: tax_data.base_amount,
+                        tax_data: tax_data,
+                    }))
+                );
+                const amounts_to_distribute = this.distribute_delta_amount_smoothly(
+                    company_currency.decimal_places,
+                    delta_total_base_amount,
+                    target_factors
+                );
+                for (let i = 0; i < target_factors.length; i++) {
+                    const tax_data = target_factors[i].tax_data;
+                    const amount_to_distribute = amounts_to_distribute[i];
+                    tax_data.base_amount += amount_to_distribute;
+                }
+            }
+        }
+    },
+
+    // EXTENDS 'account'
+    round_tax_details_base_lines(base_lines, company, { mode = "mixed" } = {}) {
+        const country_code = company.account_fiscal_country_id.code;
+        if (country_code === "AR") {
+            mode = "excluded";
+        }
+
+        super.round_tax_details_base_lines(base_lines, company, { mode: mode });
+
+        if (country_code !== "AR") {
+            return;
+        }
+
+        const company_currency = company.currency_id;
+
+        function grouping_function(base_line, tax_data) {
+            if (!tax_data) {
+                return;
+            }
+            return {
+                currency: base_line.currency_id,
+                is_refund: base_line.is_refund,
+                rate: base_line.rate,
+            };
+        }
+
+        const base_lines_aggregated_values = this.aggregate_base_lines_tax_details(
+            base_lines,
+            grouping_function
+        );
+        const values_per_grouping_key = this.aggregate_base_lines_aggregated_values(
+            base_lines_aggregated_values
+        );
+        for (const values of Object.values(values_per_grouping_key)) {
+            const grouping_key = values.grouping_key;
+            if (!grouping_key || grouping_key.currency === company_currency || !grouping_key.rate) {
+                continue;
+            }
+
+            const current_total_base_amount = values.total_excluded;
+            const expected_total_base_amount = roundPrecision(
+                values.total_excluded_currency / grouping_key.rate,
+                company_currency.rounding
+            );
+            const delta_total_base_amount = expected_total_base_amount - current_total_base_amount;
+
+            const target_factors = values.base_line_x_taxes_data.map(([base_line]) => ({
+                factor: base_line.tax_details.raw_total_excluded,
+                base_line: base_line,
+            }));
+            const amounts_to_distribute = this.distribute_delta_amount_smoothly(
+                company_currency.decimal_places,
+                delta_total_base_amount,
+                target_factors
+            );
+            for (let i = 0; i < target_factors.length; i++) {
+                const base_line = target_factors[i].base_line;
+                const amount_to_distribute = amounts_to_distribute[i];
+                base_line.tax_details.delta_total_excluded += amount_to_distribute;
+            }
+        }
+    },
+});

--- a/addons/l10n_ar/tests/__init__.py
+++ b/addons/l10n_ar/tests/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import common
 from . import test_manual
+from . import test_taxes_tax_totals_summary

--- a/addons/l10n_ar/tests/test_taxes_tax_totals_summary.py
+++ b/addons/l10n_ar/tests/test_taxes_tax_totals_summary.py
@@ -1,0 +1,77 @@
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.account.tests.test_taxes_tax_totals_summary import TestTaxesTaxTotalsSummary
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n')
+class TestTaxesTaxTotalsSummaryL10nAr(TestTaxesTaxTotalsSummary):
+
+    @classmethod
+    @AccountTestInvoicingCommon.setup_country('ar')
+    def setUpClass(cls):
+        super().setUpClass()
+
+    def _test_taxes_l10n_ar(self):
+        tax_21 = self.percent_tax(21, tax_group_id=self.tax_groups[0].id)
+        tax_0_2 = self.percent_tax(0.2, tax_group_id=self.tax_groups[1].id)
+
+        document = self.populate_document(self.init_document(
+            lines=[
+                {'quantity': 7.0, 'price_unit': 124.0, 'tax_ids': tax_21 + tax_0_2},
+            ],
+            currency=self.foreign_currency,
+            rate=1 / 1129.179,
+        ))
+        expected_values = {
+            'same_tax_base': True,
+            'currency_id': self.foreign_currency.id,
+            'company_currency_id': self.currency.id,
+            'base_amount_currency': 868.0,
+            'base_amount': 980127.37,
+            'tax_amount_currency': 184.02,
+            'tax_amount': 207791.52,
+            'total_amount_currency': 1052.02,
+            'total_amount': 1187918.89,
+            'subtotals': [
+                {
+                    'name': "Untaxed Amount",
+                    'base_amount_currency': 868.0,
+                    'base_amount': 980127.37,
+                    'tax_amount_currency': 184.02,
+                    'tax_amount': 207791.52,
+                    'tax_groups': [
+                        {
+                            'id': self.tax_groups[0].id,
+                            'base_amount_currency': 868.0,
+                            'base_amount': 980127.37,
+                            'tax_amount_currency': 182.28,
+                            'tax_amount': 205826.75,
+                            'display_base_amount_currency': 868.0,
+                            'display_base_amount': 980127.37,
+                        },
+                        {
+                            'id': self.tax_groups[1].id,
+                            'base_amount_currency': 868.0,
+                            'base_amount': 980127.37,
+                            'tax_amount_currency': 1.74,
+                            'tax_amount': 1964.77,
+                            'display_base_amount_currency': 868.0,
+                            'display_base_amount': 980127.37,
+                        },
+                    ],
+                },
+            ],
+        }
+        yield 1, document, expected_values
+
+    def test_taxes_l10n_ar_generic_helpers(self):
+        for test_index, document, expected_values in self._test_taxes_l10n_ar():
+            with self.subTest(test_index=test_index):
+                self.assert_tax_totals_summary(document, expected_values)
+        self._run_js_tests()
+
+    def test_taxes_l10n_ar_invoices(self):
+        for test_index, document, expected_values in self._test_taxes_l10n_ar():
+            with self.subTest(test_index=test_index):
+                invoice = self.convert_document_to_invoice(document)
+                self.assert_invoice_tax_totals_summary(invoice, expected_values)


### PR DESCRIPTION
In argentina, the rate has to be applied after everything has been rounded in foreign currency first. Let's take an example.
Suppose a single line having quantity=7, price_unit=124, rate=1/1129.179, taxes: 21% + 0.2% Currently in odoo, the tax amount in company currency for the 0.2% tax is computed as: round(7 * 124 * 0.002 * 1129.179) = 1960.25
It should be: round(round(7 * 124 * 0.002) * 1129.179) = 1964.77

task: 5207596

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
