### PR TITLE
[IMP] html_builder, website, *: enhance dropzones and overlays

### DIFF
--- a/addons/html_builder/static/src/core/builder_overlay/builder_overlay.scss
+++ b/addons/html_builder/static/src/core/builder_overlay/builder_overlay.scss
@@ -40,9 +40,10 @@ div[data-oe-local-overlay-id="builder-overlay-container"] {
         &.o_hover_overlay {
             opacity: 0.3;
             animation: o_hover_overlay_fade_in 0.1s ease-in-out forwards;
+
             .o_side {
                 &::before {
-                    background: rgb(126, 114, 114) !important;
+                    background: $o-we-hover-overlay-color !important;
                 }
                 background-color: transparent !important;
                 border-bottom: none !important;
@@ -69,6 +70,14 @@ div[data-oe-local-overlay-id="builder-overlay-container"] {
                 }
                 &.o_side_x {
                     width: $o-we-handle-edge-size;
+
+                    &::before {
+                        // It’s needed for "pixel-perfect" overlay corners.
+                        // Otherwise, the colors can overlap and not look good
+                        // depending on the background color behind the overlay.
+                        top: $o-we-handle-border-width/2 !important;
+                        bottom: $o-we-handle-border-width/2 !important;
+                    }
                 }
                 &.w {
                     inset: $o-we-handles-offset-to-hide auto $o-we-handles-offset-to-hide * -1 $o-we-handle-border-width * 0.5;
@@ -77,6 +86,10 @@ div[data-oe-local-overlay-id="builder-overlay-container"] {
 
                     body.o_rtl & {
                         transform: translateX(50%);
+                    }
+
+                    &::before {
+                        border-right: $o-we-handle-contrast-border;
                     }
                 }
                 &.e {
@@ -87,6 +100,10 @@ div[data-oe-local-overlay-id="builder-overlay-container"] {
                     body.o_rtl & {
                         transform: translateX(-50%);
                     }
+
+                    &::before {
+                        border-left: $o-we-handle-contrast-border;
+                    }
                 }
                 &.n {
                     inset: $o-we-handles-offset-to-hide 0 auto 0;
@@ -95,9 +112,13 @@ div[data-oe-local-overlay-id="builder-overlay-container"] {
                     &.o_grid_handle {
                         transform: translateY(-50%);
 
-                        &:before {
+                        &::before {
                             transform: translateY($o-we-handle-border-width * 0.5);
                         }
+                    }
+
+                    &::before {
+                        border-bottom: $o-we-handle-contrast-border;
                     }
                 }
                 &.s {
@@ -110,6 +131,10 @@ div[data-oe-local-overlay-id="builder-overlay-container"] {
                         &:before {
                             transform: translateY($o-we-handle-border-width * -0.5);
                         }
+                    }
+
+                    &::before {
+                        border-top: $o-we-handle-contrast-border;
                     }
                 }
                 &.ne {
@@ -172,7 +197,7 @@ div[data-oe-local-overlay-id="builder-overlay-container"] {
                 }
 
                 &.o_column_handle.o_side_y {
-                    background-color: rgba($o-we-handles-accent-color, .1);
+                    background-color: rgba($o-we-handles-accent-color, 0.1);
 
                     &::after {
                         content: '';
@@ -180,7 +205,7 @@ div[data-oe-local-overlay-id="builder-overlay-container"] {
                         height: $o-we-handles-btn-size;
                     }
                     &.n {
-                        border-bottom: dashed $o-we-handle-border-width * 0.5 rgba($o-we-handles-accent-color, 0.5);
+                        border-bottom: dashed $o-we-handle-border-width * 0.5 rgba($o-we-contrast-border-color, 0.7);
 
                         &::after {
                             inset: 0 0 auto 0;
@@ -188,7 +213,7 @@ div[data-oe-local-overlay-id="builder-overlay-container"] {
                         }
                     }
                     &.s {
-                        border-top: dashed $o-we-handle-border-width * 0.5 rgba($o-we-handles-accent-color, 0.5);
+                        border-top: dashed $o-we-handle-border-width * 0.5 rgba($o-we-contrast-border-color, 0.7);
 
                         &::after {
                             inset: auto 0 0 0;
@@ -222,7 +247,6 @@ div[data-oe-local-overlay-id="builder-overlay-container"] {
                         &.n::before {
                             margin: 0 auto auto;
                         }
-
                         &.s::before {
                             margin: auto auto 0;
                         }

--- a/addons/html_builder/static/src/core/drop_zone_plugin.edit.scss
+++ b/addons/html_builder/static/src/core/drop_zone_plugin.edit.scss
@@ -1,20 +1,21 @@
 .oe_drop_zone {
-    background: $o-we-dropzone-bg-color;
-    animation: dropZoneInsert 1s linear 0s infinite alternate;
+    @include o-we-dropzone-base-style;
 
     &.oe_insert {
         position: relative;
         width: 100%;
-        border-radius: $border-radius-lg;
-        outline: $o-we-dropzone-border-width dashed $o-we-dropzone-accent-color;
-        outline-offset: -$o-we-dropzone-border-width;
-        z-index: 2000; // TODO use $o-we-overlay-zindex instead
+        z-index: $o-we-dropzone-z-index;
     }
 
     &.o_dropzone_highlighted {
-        filter: brightness(1.5);
-        transition: 200ms;
+        filter: brightness(1.2);
     }
+}
+
+:has(> .oe_drop_zone) {
+    // Make sure the drop zone stays fully visible, even if its container is
+    // smaller than it.
+    overflow: visible !important;
 }
 
 .oe_drop_zone:not(.oe_grid_zone) {
@@ -33,24 +34,75 @@
     }
 
     &.oe_sanitized_drop_zone {
+        @include o-editor-messages;
         position: absolute;
         top: 0px;
-        height: 100%;
-        padding: 15px;
+        z-index: $o-we-dropzone-z-index - 1 !important;
+        display: flex;
         margin: 0px;
-        backdrop-filter: blur(15px);
-        background-color: rgba($o-we-bg-lighter, 0.15);
-        color: white;
-        outline-color: $o-we-bg-lighter;
-        z-index: 1999; // TODO
+        border: 1px solid $o-we-dropzone-sanitized-color !important;
+        outline: $o-we-dropzone-border-width dashed mix(white, $o-we-dropzone-sanitized-color, 50%) !important;
+        height: auto;
+        min-height: 100% !important;
+        padding: 0;
+        background: repeating-linear-gradient(
+            135deg,
+            $o-we-dropzone-sanitized-color,
+            $o-we-dropzone-sanitized-color 5px,
+            rgba($o-we-dropzone-sanitized-color, 0.6) 5px,
+            rgba($o-we-dropzone-sanitized-color, 0.6) 10px
+        ) !important;
+        backdrop-filter: blur(7px);
 
-        > p {
-            position: absolute;
-            top: 50%;
-            transform: translateY(-50%);
-            width: calc(100% - 30px);
-            text-shadow: 0px 0px 4px black;
-            font-size: 20px;
+        &::before {
+            padding: 10px;
+            width: 100%;
+            align-content: center;
+            text-shadow: 0 0 5px $o-we-dropzone-sanitized-color !important;
+        }
+    }
+}
+
+:has(> .oe_sanitized_drop_zone) {
+    position: relative;
+}
+
+:not(.oe_structure):not([data-oe-type="html"]) {
+    // "Inner content" drop zones.
+    > .oe_drop_zone.oe_insert:not(.oe_grid_zone):not(.oe_sanitized_drop_zone) {
+        height: $o-we-inner-content-dropzone-size;
+        min-height: $o-we-inner-content-dropzone-size;
+        margin: (-$o-we-inner-content-dropzone-size/2) 0;
+        outline: unset;
+        border: unset;
+
+        // Make sure no drop zone is on top of another when one is placed before
+        // a paragraph and the next is its first child.
+        + p > .oe_drop_zone.oe_insert:not(.oe_grid_zone):not(.oe_sanitized_drop_zone):first-child {
+            margin-top: $o-we-inner-content-dropzone-size;
+        }
+
+        &:not(.oe_vertical) {
+            border-bottom: $o-we-inner-content-dropzone-border;
+        }
+
+        &.oe_vertical {
+            width: $o-we-inner-content-dropzone-size;
+            min-width: $o-we-inner-content-dropzone-size;
+            margin: 1px (-$o-we-inner-content-dropzone-size/2);
+            border-right: $o-we-inner-content-dropzone-border;
+        }
+    }
+
+    // zero-width text nodes around inline buttons can create extra line boxes.
+    // Without this "line-height: 0", the editable area will become too tall if
+    // it contains buttons when the dropzones appear. (for example, a "Contact
+    // us" button in a website page header)
+    &:has(> .btn) {
+        &:has(> .oe_drop_zone.oe_insert:not(.oe_grid_zone):not(.oe_sanitized_drop_zone)) {
+            &:not(:has(> :not(.oe_drop_zone, .btn))) {
+                line-height: 0;
+            }
         }
     }
 }

--- a/addons/html_builder/static/src/core/drop_zone_plugin.js
+++ b/addons/html_builder/static/src/core/drop_zone_plugin.js
@@ -362,8 +362,7 @@ export class DropZonePlugin extends Plugin {
             "oe_drop_zone",
             "oe_insert",
             "oe_sanitized_drop_zone",
-            "text-center",
-            "text-uppercase"
+            "text-center"
         );
         const messageEl = this.document.createElement("p");
         messageEl.textContent = _t("For technical reasons, this block cannot be dropped here");

--- a/addons/html_builder/static/src/core/drop_zone_plugin.js
+++ b/addons/html_builder/static/src/core/drop_zone_plugin.js
@@ -364,9 +364,9 @@ export class DropZonePlugin extends Plugin {
             "oe_sanitized_drop_zone",
             "text-center"
         );
-        const messageEl = this.document.createElement("p");
-        messageEl.textContent = _t("For technical reasons, this block cannot be dropped here");
-        dropzoneEl.prepend(messageEl);
+        dropzoneEl.dataset.editorMessage = _t(
+            "For technical reasons, this block cannot be dropped here"
+        );
         return dropzoneEl;
     }
 
@@ -434,7 +434,10 @@ export class DropZonePlugin extends Plugin {
             if (parseInt(parentContentWidth) !== parseInt(hookOuterWidth)) {
                 vertical = true;
                 const hookOuterHeight = hookEl.getBoundingClientRect().height;
-                style.height = Math.max(hookOuterHeight, 30) + "px";
+                // Combined with the 1px top margin added by the CSS, removing
+                // 2px from the height here prevents two vertical dropzones from
+                // touching when one is placed below the other.
+                style.height = Math.max(hookOuterHeight - 2, 30) + "px";
                 if (toInsertInline) {
                     style.display = "inline-block";
                     style.verticalAlign = "middle";
@@ -516,10 +519,8 @@ export class DropZonePlugin extends Plugin {
 
         // Inserting a sanitized dropzone for each sanitized area.
         for (const sanitizedZoneEl of selectorSanitized) {
-            sanitizedZoneEl.style.position = "relative";
             sanitizedZoneEl.prepend(this.createSanitizedDropzone());
         }
-        this.sanitizedZoneEls = selectorSanitized;
 
         // Inserting a grid dropzone for each row in grid mode.
         for (const rowEl of selectorGrids) {
@@ -555,9 +556,5 @@ export class DropZonePlugin extends Plugin {
         this.editable.querySelectorAll(".oe_drop_zone").forEach((dropzoneEl) => {
             dropzoneEl.remove();
         });
-        this.sanitizedZoneEls.forEach((sanitizedZoneEl) =>
-            sanitizedZoneEl.style.removeProperty("position")
-        );
-        this.sanitizedZoneEls = [];
     }
 }

--- a/addons/html_builder/static/src/core/editor.edit.scss
+++ b/addons/html_builder/static/src/core/editor.edit.scss
@@ -1,33 +1,5 @@
-$-editor-messages-margin-x: 2%;
-
 .editor_enable .btn:hover {
     cursor: text;
-}
-
-%o-editor-messages {
-    background: $o-we-dropzone-bg-color;
-    text-align: center;
-    color: #fff;
-    outline: $o-we-dropzone-border-width dashed $o-we-dropzone-accent-color;
-    outline-offset: -$o-we-dropzone-border-width;
-
-    &:before {
-        content: attr(data-editor-message);
-        display: block;
-        font-size: 20px;
-    }
-
-    // Show the default editor message only for "empty" elements
-    &:not(:empty) {
-        &[data-editor-message-default]:before {
-            content: none;
-        }
-    }
-
-    &:after {
-        content: attr(data-editor-sub-message);
-        display: block;
-    }
 }
 
 // This style block is about the "editor message" which highlights the areas
@@ -48,7 +20,7 @@ $-editor-messages-margin-x: 2%;
 
         // Base case (website.page (#wrap), t-field (product description), ...)
         > .oe_drop_zone.oe_insert:not(.oe_vertical):not(.oe_sanitized_drop_zone) {
-            @extend %o-editor-messages;
+            @include o-editor-messages;
             height: auto;
 
             // Empty editable element during drag & drop
@@ -59,10 +31,6 @@ $-editor-messages-margin-x: 2%;
             }
 
             &:not(:only-child) {
-                &::before {
-                    font-size: 16px;
-                }
-
                 &[data-editor-message-default]::before {
                     content: none;
                 }
@@ -71,25 +39,21 @@ $-editor-messages-margin-x: 2%;
 
         // Exception 1: empty wrap NOT during drag & drop
         &#wrap:empty {
-            @extend %o-editor-messages;
+            @include o-editor-messages;
             padding: 112px 0px;
             margin: 20px $-editor-messages-margin-x;
-            border-radius: $border-radius-lg;
         }
 
         // Exception 2: empty wrap during drag & drop (override of base case)
         &#wrap > .oe_drop_zone.oe_insert:not(.oe_vertical):not(.oe_sanitized_drop_zone):only-child {
             padding: 112px 0px;
-            text-shadow: none;
-        }
-
-        > p:empty:only-child {
-            color: #aaa;
         }
     }
 
     &[data-oe-type=html].oe_empty:empty {
-        @extend %o-editor-messages;
+        @include o-editor-messages;
+        padding: 12px 0;
+        margin: 20px $-editor-messages-margin-x;
     }
 }
 

--- a/addons/html_builder/static/src/core/grid_layout/grid_layout.edit.scss
+++ b/addons/html_builder/static/src/core/grid_layout/grid_layout.edit.scss
@@ -40,6 +40,8 @@
     padding: 0;
     border: $o-we-handle-border-width * 2 solid $o-we-color-accent;
     border-radius: $o-we-item-border-radius;
+    outline: $o-we-handle-border-width/2 solid $o-we-contrast-border-color;
+    outline-offset: -$o-we-handle-border-width * 2;
 }
 
 // Highlight of the grid items padding.

--- a/addons/html_builder/static/src/core/overlay_buttons/overlay_buttons_plugin.js
+++ b/addons/html_builder/static/src/core/overlay_buttons/overlay_buttons_plugin.js
@@ -50,13 +50,13 @@ export class OverlayButtonsPlugin extends Plugin {
                         const iframeRect = this.iframe.getBoundingClientRect();
                         if (this.target && position.top < iframeRect.top) {
                             const targetRect = this.target.getBoundingClientRect();
-                            const newTop = iframeRect.top + targetRect.bottom + 15;
+                            const newTop = iframeRect.top + targetRect.bottom + 1;
                             position.top = newTop;
                             overlayEl.style.top = `${newTop}px`;
                         }
                         return;
                     },
-                    margin: 15,
+                    margin: 1,
                     flip: false,
                 },
                 closeOnPointerdown: false,

--- a/addons/html_builder/static/src/core/setup_editor_plugin.js
+++ b/addons/html_builder/static/src/core/setup_editor_plugin.js
@@ -63,7 +63,7 @@ export class SetupEditorPlugin extends Plugin {
         for (const el of dragAndDropSavableEls) {
             if (!el.hasAttribute("data-editor-message")) {
                 el.setAttribute("data-editor-message-default", true);
-                el.setAttribute("data-editor-message", _t("DRAG BUILDING BLOCKS HERE"));
+                el.setAttribute("data-editor-message", _t("Drag blocks here"));
             }
         }
     }

--- a/addons/html_builder/static/src/scss/builder.variables.scss
+++ b/addons/html_builder/static/src/scss/builder.variables.scss
@@ -36,6 +36,8 @@ $o-social-colors: (
     "threads": #000000,
 );
 
+$o-we-contrast-border-color: mix(white, $o-we-color-accent, 40%) !default;
+
 // Needed to be changed to be high enough to not overflow when a user
 // has a page with a lot of content (10000px was proven to be too small)
 $o-we-handles-offset-to-hide: 100000px !default;
@@ -45,12 +47,31 @@ $o-we-handles-accent-color-preview: $o-enterprise-color !default;
 $o-we-handle-edge-size: $o-we-handles-btn-size !default;
 $o-we-handle-border-width: 2px !default;
 $o-we-handle-inside-line-width: 3px !default;
+$o-we-handle-contrast-border: 1px solid $o-we-contrast-border-color !default;
+
+$o-we-hover-overlay-color: $o-we-contrast-border-color !default;
 
 $o-we-dropzone-size: 30px !default; // $grid-gutter-width (todo: allow to use the variable)
-$o-we-dropzone-border-width: 2px !default;
-$o-we-dropzone-border: $o-we-dropzone-border-width dashed $o-brand-odoo !default;
+$o-we-dropzone-border-width: 1px !default;
+$o-we-dropzone-border: $o-we-dropzone-border-width dashed $o-we-contrast-border-color !default;
+$o-we-dropzone-border-radius: 3px !default;
 $o-we-dropzone-accent-color: $o-we-color-accent !default;
 $o-we-dropzone-bg-color: rgba($o-we-dropzone-accent-color, .5) !default;
+$o-we-dropzone-z-index: 1029 !default;
+$o-we-dropzone-font-size: 18px !default;
+$o-we-dropzone-text-color: white !default;
+$o-we-dropzone-sanitized-color: rgba(#646464, .5) !default;
+
+$o-we-inner-content-dropzone-size: 4px !default;
+$o-we-inner-content-dropzone-border: $o-we-inner-content-dropzone-size/2 solid $o-we-contrast-border-color, !default;
+
+@mixin o-we-dropzone-base-style {
+    background: $o-we-dropzone-bg-color;
+    outline: $o-we-dropzone-border;
+    outline-offset: -$o-we-dropzone-border-width;
+    border: 1px solid $o-we-dropzone-accent-color;
+    border-radius: $o-we-dropzone-border-radius;
+}
 
 $o-we-toolbar-height: 40px !default;
 $o-we-toolbar-color-accent: #018597 !default;
@@ -602,5 +623,43 @@ $o-bg-shapes: (
     &:focus, &:focus-within {
         border-color: var(--o-hb-input-active-border, #{$o-we-sidebar-content-field-input-border-color});
         color: var(--o-hb-row-color-active, #{$o-we-fg-lighter});
+    }
+}
+
+$-editor-messages-margin-x: 2%;
+
+@mixin o-editor-messages {
+    @include o-we-dropzone-base-style;
+    min-height: $o-we-dropzone-size;
+    text-align: center;
+
+    &, &.text-muted {
+        color: $o-we-dropzone-text-color !important;
+    }
+
+    &:before {
+        content: attr(data-editor-message);
+        display: block;
+        font-size: $o-we-dropzone-font-size;
+         // Required to prevent the theme font family from being applied.
+        font-family: $o-we-font-family;
+    }
+
+    // Show the default editor message only for "empty" elements
+    &:not(:empty) {
+        &[data-editor-message-default]:before {
+            content: none;
+        }
+    }
+
+    &:after {
+        content: attr(data-editor-sub-message);
+        display: block;
+        font-size: $o-we-dropzone-font-size - 2;
+        font-family: $o-we-font-family;
+    }
+
+    &::before, &::after {
+        text-shadow: 0 0 5px $o-we-dropzone-accent-color;
     }
 }

--- a/addons/html_builder/static/tests/drop_zone.test.js
+++ b/addons/html_builder/static/tests/drop_zone.test.js
@@ -10,12 +10,12 @@ describe.current.tags("desktop");
 
 const dropzone = (hovered = false) => {
     const highlightClass = hovered ? " o_dropzone_highlighted" : "";
-    return `<div class="oe_drop_zone oe_insert${highlightClass}" data-editor-message-default="true" data-editor-message="DRAG BUILDING BLOCKS HERE"></div>`;
+    return `<div class="oe_drop_zone oe_insert${highlightClass}" data-editor-message-default="true" data-editor-message="Drag blocks here"></div>`;
 };
 
-test("wrapper element has the 'DRAG BUILDING BLOCKS HERE' message", async () => {
+test("wrapper element has the 'Drag blocks here' message", async () => {
     const { contentEl } = await setupHTMLBuilder("");
-    expect(contentEl).toHaveAttribute("data-editor-message", "DRAG BUILDING BLOCKS HERE");
+    expect(contentEl).toHaveAttribute("data-editor-message", "Drag blocks here");
 });
 
 test("drop beside dropzone inserts the snippet", async () => {

--- a/addons/mass_mailing/static/src/builder/plugins/mass_mailing_setup_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/mass_mailing_setup_plugin.js
@@ -18,7 +18,7 @@ export class MassMailingSetupPlugin extends Plugin {
         const wrapperTd = this.editable.querySelector(".o_mail_wrapper_td");
         wrapperTd?.classList.add("oe_empty");
         wrapperTd?.setAttribute("data-editor-message-default", true);
-        wrapperTd?.setAttribute("data-editor-message", _t("DRAG BUILDING BLOCKS HERE"));
+        wrapperTd?.setAttribute("data-editor-message", _t("Drag blocks here"));
     }
 
     cleanForSave(root) {

--- a/addons/mass_mailing/static/src/iframe_assets/iframe_style.scss
+++ b/addons/mass_mailing/static/src/iframe_assets/iframe_style.scss
@@ -70,26 +70,18 @@ html:has(.o_layout, .o_basic_theme) {
 
 html:has(.o_layout) {
     .editor_enable .o_mail_wrapper_td.oe_empty:empty {
-        &:not(:focus) {
-            &:before {
-                content: attr(data-editor-message);
-                pointer-events: none;
-                color: white;
-            }
-            background-color: rgba(1, 186, 210, 0.5) !important;
-        }
-        &:focus {
-            color: black;
-        }
-        text-align: center;
-        font-size: 20px;
-        display: block;
-        width: 96%;
+        width: 100% - 2 * $-editor-messages-margin-x;
         padding: 12px 0;
-        margin: 20px 2%;
-        border-radius: 0.375rem;
-        outline: 2px dashed #01bad2;
-        outline-offset: -2px;
+        margin: 20px $-editor-messages-margin-x;
+
+        &:not(:focus) {
+            @include o-editor-messages;
+            background: $o-we-dropzone-bg-color !important;
+
+            &:before {
+                pointer-events: none;
+            }
+        }
     }
 }
 

--- a/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
+++ b/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
@@ -72,7 +72,7 @@ class Mailing extends models.Model {
                 <div data_name="Mailing" class="o_layout oe_unremovable oe_unmovable o_empty_theme">
                     <div class="container o_mail_wrapper o_mail_regular oe_unremovable">
                         <div class="row">
-                            <div class="col o_mail_no_options o_mail_wrapper_td bg-white oe_structure o_savable oe_empty" data-editor-message-default="true" data-editor-message="DRAG BUILDING BLOCKS HERE" contenteditable="true">
+                            <div class="col o_mail_no_options o_mail_wrapper_td bg-white oe_structure o_savable oe_empty" data-editor-message-default="true" data-editor-message="Drag blocks here" contenteditable="true">
                                 This element <t t-out="'should be inline'"/>
                             </div>
                         </div>

--- a/addons/mass_mailing/static/tests/tours/mailing_editor.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_editor.js
@@ -20,7 +20,7 @@ registry.category("web_tour.tours").add('mailing_editor', {
     run: "click",
 }, {
     content: 'wait for the editor to be rendered',
-    trigger: '[name="body_arch"] :iframe .o_savable[data-editor-message="DRAG BUILDING BLOCKS HERE"]',
+    trigger: '[name="body_arch"] :iframe .o_savable[data-editor-message="Drag blocks here"]',
 }, {
     trigger: '.o_snippet[name="Text"] button',
     content: 'Click the "Text" snippet category to drop a snippet in the editor',

--- a/addons/website/static/src/scss/website.edit.scss
+++ b/addons/website/static/src/scss/website.edit.scss
@@ -1,0 +1,23 @@
+// --------------------------------------------------------------------------
+// This file contains the website-specific logic for the editing elements
+// shown on the frontend in edit mode, such as the dropzones, overlay, etc.
+// --------------------------------------------------------------------------
+
+// When the page hasn’t been scrolled, we want the first dropzone inside the
+// #wrap to be positioned on top of the header, so it’s more visible. In all
+// other cases, once the page has been scrolled, the dropzones should be placed
+// behind the header.
+header#top:not(.o_header_is_scrolled) + main #wrap .oe_drop_zone:first-child {
+    z-index: $o-we-dropzone-z-index + 1;
+}
+
+// The first and last dropzones in the “parallax” snippet are in the same place
+// as the dropzones just before and after it, so we shift them a bit.
+.parallax > .oe_structure > .oe_drop_zone {
+    &:first-child {
+        top: $o-we-dropzone-size/2;
+    }
+    &:last-child {
+        bottom: $o-we-dropzone-size/2;
+    }
+}

--- a/addons/website/static/tests/builder/content_editable.test.js
+++ b/addons/website/static/tests/builder/content_editable.test.js
@@ -109,7 +109,7 @@ test("feff on links are cleaned up", async () => {
     onRpc("ir.ui.view", "save", ({ args }) => {
         // Check that the saved content has no feff
         expect(args[1]).toBe(
-            `<div id="wrap" class="oe_structure oe_empty" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch" data-editor-message-default="true" data-editor-message="DRAG BUILDING BLOCKS HERE"><section class="o_colored_level"><a href="http://test.test">texst</a></section></div>`
+            `<div id="wrap" class="oe_structure oe_empty" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch" data-editor-message-default="true" data-editor-message="Drag blocks here"><section class="o_colored_level"><a href="http://test.test">texst</a></section></div>`
         );
         expect.step("save");
         return true;

--- a/addons/website/static/tests/builder/invisibility_options.test.js
+++ b/addons/website/static/tests/builder/invisibility_options.test.js
@@ -87,7 +87,7 @@ test("check invisible element after save", async () => {
     await contains(".o_we_invisible_el_panel .o_we_invisible_entry").click();
     await contains(".o-snippets-top-actions button:contains(Save)").click();
     expect(resultSave[0]).toBe(
-        `<div id="wrap" class="oe_structure oe_empty" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch" data-editor-message-default="true" data-editor-message="DRAG BUILDING BLOCKS HERE">
+        `<div id="wrap" class="oe_structure oe_empty" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch" data-editor-message-default="true" data-editor-message="Drag blocks here">
         <section class="o_colored_level">
             <div class="container">
                 <div class="row">

--- a/addons/website/static/tests/builder/save.test.js
+++ b/addons/website/static/tests/builder/save.test.js
@@ -45,7 +45,7 @@ test("basic save", async () => {
     await contains(".o-snippets-top-actions button:contains(Save)").click();
     expect(resultSave.length).toBe(1);
     expect(resultSave[0]).toBe(
-        '<div id="wrap" class="oe_structure oe_empty" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch" data-editor-message-default="true" data-editor-message="DRAG BUILDING BLOCKS HERE"><h1 class="title">H1ello</h1></div>'
+        '<div id="wrap" class="oe_structure oe_empty" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch" data-editor-message-default="true" data-editor-message="Drag blocks here"><h1 class="title">H1ello</h1></div>'
     );
     expect(":iframe #wrap").not.toHaveClass("o_dirty");
     expect(":iframe #wrap").not.toHaveClass("o_savable");

--- a/addons/website/static/tests/builder/snippets_menu.test.js
+++ b/addons/website/static/tests/builder/snippets_menu.test.js
@@ -77,17 +77,17 @@ test("undo and redo buttons", async () => {
     setContent(editableContent, "<p> Text[] </p>");
     await insertText(editor, "a");
     expect(editor.editable).toHaveInnerHTML(
-        '<div id="wrap" class="oe_structure oe_empty o_savable o_dirty" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch" data-editor-message-default="true" data-editor-message="DRAG BUILDING BLOCKS HERE" contenteditable="true"> <p> Texta </p> </div>'
+        '<div id="wrap" class="oe_structure oe_empty o_savable o_dirty" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch" data-editor-message-default="true" data-editor-message="Drag blocks here" contenteditable="true"> <p> Texta </p> </div>'
     );
     await animationFrame();
     await click(".o-snippets-menu button.fa-undo");
     await animationFrame();
     expect(editor.editable).toHaveInnerHTML(
-        '<div id="wrap" class="oe_structure oe_empty o_savable" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch" data-editor-message-default="true" data-editor-message="DRAG BUILDING BLOCKS HERE" contenteditable="true"> <p> Text </p> </div>'
+        '<div id="wrap" class="oe_structure oe_empty o_savable" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch" data-editor-message-default="true" data-editor-message="Drag blocks here" contenteditable="true"> <p> Text </p> </div>'
     );
     await click(".o-snippets-menu button.fa-repeat");
     expect(editor.editable).toHaveInnerHTML(
-        '<div id="wrap" class="oe_structure oe_empty o_savable o_dirty" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch" data-editor-message-default="true" data-editor-message="DRAG BUILDING BLOCKS HERE" contenteditable="true"> <p> Texta </p> </div>'
+        '<div id="wrap" class="oe_structure oe_empty o_savable o_dirty" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch" data-editor-message-default="true" data-editor-message="Drag blocks here" contenteditable="true"> <p> Texta </p> </div>'
     );
 });
 

--- a/addons/website/static/tests/tours/website_snippets_menu_tabs.js
+++ b/addons/website/static/tests/tours/website_snippets_menu_tabs.js
@@ -11,7 +11,7 @@ registerWebsitePreviewTour(
             trigger: "div[data-container-title='Website'] div.we-bg-options-container",
         },
         {
-            content: "Click on the empty 'DRAG BUILDING BLOCKS HERE' area.",
+            content: "Click on the empty 'Drag blocks here' area.",
             trigger: ":iframe main > .oe_structure.oe_empty",
             run: "click",
         },

--- a/addons/website_blog/static/src/scss/website_blog.scss
+++ b/addons/website_blog/static/src/scss/website_blog.scss
@@ -299,7 +299,7 @@ $o-wblog-loader-size: 50px;
             padding: 30px 0;
         }
 
-        // Hide the big "DRAG BUILDING BLOCKS HERE" box when inside a sidebar.
+        // Hide the big "Drag blocks here" box when inside a sidebar.
         // The purple lines are enough to help the user dropping snippets.
         #o_wblog_sidebar .oe_structure:empty {
             display: none;

--- a/addons/website_blog/views/website_blog_templates.xml
+++ b/addons/website_blog/views/website_blog_templates.xml
@@ -9,10 +9,9 @@
             <t t-out="0"/>
 
             <!-- Droppable-area shared across all blog's pages -->
-            <t t-set="oe_structure_blog_footer_description">Visible in all blogs' pages</t>
             <div class="oe_structure oe_empty oe_structure_not_nearest"
                 id="oe_structure_blog_footer"
-                t-att-data-editor-sub-message="oe_structure_blog_footer_description"/>
+                data-editor-message.translate="Drag blocks here to add them on all blogs"/>
         </div>
     </t>
 </template>
@@ -239,9 +238,7 @@ list of filtered posts (by date or tag).
     <t t-if="not opt_blog_post_regular_cover">
         <t t-call="website_blog.blog_post_info"/>
     </t>
-    <t t-set="editor_message">WRITE HERE OR DRAG BUILDING BLOCKS</t>
     <div t-field="blog_post.content"
-        t-att-data-editor-message="editor_message"
         t-attf-class="o_wblog_post_content_field #{'o_wblog_read_text' if opt_blog_post_readable else ''}"/>
 
     <div t-if="len(blogs) > 1 or len(blog_post.tag_ids) > 0" class="css_editable_mode_hidden text-muted">

--- a/addons/website_customer/views/website_customer_templates.xml
+++ b/addons/website_customer/views/website_customer_templates.xml
@@ -252,7 +252,7 @@
   <t t-call="website.layout">
     <div id="wrap">
         <div class="oe_structure oe_empty" id="oe_structure_website_customer_details_1"
-            data-editor-message="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL CUSTOMERS"/>
+            data-editor-message.translate="Drag blocks here to add them on all customers"/>
         <div class="container mb-3">
             <div class="row">
                 <div class="mt-4 mb-3" t-if="not edit_page">
@@ -265,7 +265,7 @@
             </div>
         </div>
         <div class="oe_structure oe_empty" id="oe_structure_website_customer_details_2"
-            data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL CUSTOMERS"/>
+            data-editor-message.translate="Drag blocks here to add them on all customers"/>
     </div>
   </t>
 </template>

--- a/addons/website_event/views/event_templates_page.xml
+++ b/addons/website_event/views/event_templates_page.xml
@@ -9,7 +9,7 @@
         <div id="wrap" t-attf-class="o_wevent_event js_event d-flex flex-column h-100 #{'o_wevent_hide_sponsors' if hide_sponsors else ''}">
             <t t-if="not hide_submenu" t-call="website_event.navbar"/>
             <t t-out="0"/>
-            <div class="oe_structure oe_empty" id="oe_structure_website_event_layout_1" data-editor-sub-message.translate="Following content will appear on all events."/>
+            <div class="oe_structure oe_empty" id="oe_structure_website_event_layout_1" data-editor-message.translate="Drag blocks here to add them on all events"/>
         </div>
 
         <!-- The registration modal is available in any event page  -->

--- a/addons/website_event_track/views/event_track_templates_agenda.xml
+++ b/addons/website_event_track/views/event_track_templates_agenda.xml
@@ -29,14 +29,14 @@
                 <t t-call="website_event_track.agenda_topbar"/>
             </div>
             <!-- Drag/Drop Area -->
-            <div class="oe_structure oe_empty" id="oe_structure_website_event_track_agenda_1" data-editor-message.translate="Available on all event Agenda pages"/>
+            <div class="oe_structure oe_empty" id="oe_structure_website_event_track_agenda_1" data-editor-message.translate="Drag blocks here to add them on all event agenda pages"/>
 
             <!-- Content -->
             <div class="o_wevent_online o_weagenda_index mb-3">
                 <t t-call="website_event_track.agenda_main"/>
             </div>
             <!-- Drag/Drop Area -->
-            <div class="oe_structure oe_empty" id="oe_structure_website_event_track_agenda_2" data-editor-message.translate="Available on all event Agenda pages"/>
+            <div class="oe_structure oe_empty" id="oe_structure_website_event_track_agenda_2" data-editor-message.translate="Drag blocks here to add them on all event agenda pages"/>
         </t>
     </t>
 </template>

--- a/addons/website_event_track/views/event_track_templates_proposal.xml
+++ b/addons/website_event_track/views/event_track_templates_proposal.xml
@@ -3,7 +3,7 @@
 
 <template id="event_track_proposal">
     <t t-call="website_event.layout" hide_submenu="True">
-        <div class="oe_structure" id="oe_structure_website_event_track_proposal_1" data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PROPOSAL PAGES OF ALL EVENTS"/>
+        <div class="oe_structure" id="oe_structure_website_event_track_proposal_1" data-editor-message.translate="Drag blocks here to add them on all event proposal pages"/>
         <div class="container">
             <t t-call="website_event.navbar"/>
 
@@ -118,7 +118,7 @@
                             </div>
                         </form>
                     </section>
-                    <div class="oe_structure" id="oe_structure_website_event_track_proposal_2" data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PROPOSAL PAGES OF ALL EVENTS"/>
+                    <div class="oe_structure" id="oe_structure_website_event_track_proposal_2" data-editor-message.translate="Drag blocks here to add them on all event proposal pages"/>
                 </div> <!-- Close main column -->
 
                 <!-- Sidebar: visible if proposals are allowed only -->
@@ -150,7 +150,7 @@
                 </aside>
             </div>
         </div>
-        <div class="oe_structure" id="oe_structure_website_event_track_proposal_3" data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PROPOSAL PAGES OF ALL EVENTS"/>
+        <div class="oe_structure" id="oe_structure_website_event_track_proposal_3" data-editor-message.translate="Drag blocks here to add them on all event proposal pages"/>
     </t>
 </template>
 

--- a/addons/website_hr_recruitment/static/src/scss/website_hr_recruitment.scss
+++ b/addons/website_hr_recruitment/static/src/scss/website_hr_recruitment.scss
@@ -8,7 +8,7 @@
         }
 
         .card {
-            &, * {
+            &, .o_unpublished_badge, & > a {
                 transition: all .1s;
             }
 

--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -64,10 +64,9 @@
                                                     open positions
                                                 </t>
                                             </h5>
-                                            <t t-set="job_desc_edition_placeholder">Insert a Job Description...</t>
                                             <div class="oe_empty text-muted mb16"
-                                                 t-field="job.description"
-                                                 t-att-data-editor-message="job_desc_edition_placeholder"/>
+                                                 data-editor-message.translate="Insert a Job Description..."
+                                                 t-field="job.description"/>
                                             <div class="o_job_infos d-flex flex-column">
                                                 <span t-field="job.address_id" class="fw-light" t-options='{"widget": "contact", "fields": ["city"], "no_tag_br": True, "null_text": "Remote"}'/>
                                                 <div t-if="job.department_id"
@@ -163,10 +162,8 @@
                     <div class="container">
                         <div class="row">
                             <div class="col-lg-8 pb32" itemprop="description">
-                                <t t-set="job_desc_edition_placeholder">Insert a Job Description...</t>
                                 <div class="lead"
-                                    t-field="job.description"
-                                    t-att-data-editor-message="job_desc_edition_placeholder"/>
+                                    t-field="job.description"/>
                             </div>
                             <div class="col-lg-3 offset-lg-1 pb32">
                                 <div t-field="job.website_rating"/>

--- a/addons/website_partner/views/website_partner_templates.xml
+++ b/addons/website_partner/views/website_partner_templates.xml
@@ -3,13 +3,13 @@
 <template id="partner_page" name="Partner Page">
     <t t-call="website.layout">
         <div id="wrap">
-            <div class="oe_structure oe_empty" id="oe_structure_website_partner_partner_1" data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PARTNERS"/>
+            <div class="oe_structure oe_empty" id="oe_structure_website_partner_partner_1" data-editor-message.translate="Drag blocks here to add them on all partners"/>
             <div class="container">
                 <div class="row">
                     <t t-call="website_partner.partner_detail" contact_details="True"/>
                 </div>
             </div>
-            <div class="oe_structure oe_empty" id="oe_structure_website_partner_partner_2" data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PARTNERS"/>
+            <div class="oe_structure oe_empty" id="oe_structure_website_partner_partner_2" data-editor-message.translate="Drag blocks here to add them on all partners"/>
         </div>
     </t>
 </template>

--- a/addons/website_partnership/views/website_partnership_templates.xml
+++ b/addons/website_partnership/views/website_partnership_templates.xml
@@ -7,12 +7,12 @@
         <t t-set="additional_title">Partners</t>
         <div id="wrap">
             <div class="oe_structure oe_empty" id="oe_structure_website_partnership_layout_1"
-                data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS PARTNERS"/>
+                data-editor-message.translate="Drag blocks here to add them on all partners"/>
             <div class="container mb-3">
                 <t t-call="website_partnership.index"/>
             </div>
             <div class="oe_structure oe_empty" id="oe_structure_website_partnership_layout_2"
-                data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS PARTNERS"/>
+                data-editor-message.translate="Drag blocks here to add them on all partners"/>
         </div>
     </t>
 </template>
@@ -115,13 +115,13 @@
 <template id="partner_page" name="Partner Page">
     <t t-call="website.layout">
         <div id="wrap">
-            <div class="oe_structure oe_empty" id="oe_structure_website_partnership_partner_1" data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PARTNERS"/>
+            <div class="oe_structure oe_empty" id="oe_structure_website_partnership_partner_1" data-editor-message.translate="Drag blocks here to add them on all partners"/>
             <div class="container">
                 <div class="row">
                     <t t-call="website_partnership.partner_detail"/>
                 </div>
             </div>
-            <div class="oe_structure oe_empty" id="oe_structure_website_partnership_partner_2" data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PARTNERS"/>
+            <div class="oe_structure oe_empty" id="oe_structure_website_partnership_partner_2" data-editor-message.translate="Drag blocks here to add them on all partners"/>
         </div>
     </t>
 </template>

--- a/addons/website_sale/templates/product_page_templates.xml
+++ b/addons/website_sale/templates/product_page_templates.xml
@@ -24,7 +24,7 @@
 
         <t t-call="website.layout" additional_title="product.name">
             <div id="wrap" class="o_wsale_product_page">
-                <div class="oe_structure oe_empty oe_structure_not_nearest" id="oe_structure_website_sale_product_1" data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PRODUCTS"/>
+                <div class="oe_structure oe_empty oe_structure_not_nearest" id="oe_structure_website_sale_product_1" data-editor-message.translate="Drag blocks here to add them on all products"/>
                 <section id="product_detail"
                          t-attf-class="oe_website_sale mt-1 mt-lg-2 mb-5 #{'discount'
                             if combination_info['has_discounted_price'] else ''}
@@ -193,7 +193,7 @@
                     t-field="product.website_description"
                     class="oe_structure oe_empty mt16"
                 />
-                <div class="oe_structure oe_empty oe_structure_not_nearest mt16" id="oe_structure_website_sale_product_2" data-editor-message.translate="DROP BUILDING BLOCKS HERE TO MAKE THEM AVAILABLE ACROSS ALL PRODUCTS"/>
+                <div class="oe_structure oe_empty oe_structure_not_nearest mt16" id="oe_structure_website_sale_product_2" data-editor-message.translate="Drag blocks here to add them on all products"/>
             </div>
         </t>
     </template>

--- a/addons/website_sale/templates/shop_page_templates.xml
+++ b/addons/website_sale/templates/shop_page_templates.xml
@@ -326,8 +326,8 @@
                                 </h1>
                                 <t t-if="category">
                                     <t t-set='editor_msg'>
-                                        Drag building blocks here to customize the header for
-                                        "<t t-out='category.name'/>" category.
+                                        Drag blocks here to customize the header of
+                                        the "<t t-out='category.name'/>" category
                                     </t>
                                     <div
                                         id="category_header"
@@ -338,7 +338,7 @@
                                 </t>
                                 <t t-else="">
                                     <t t-set="editor_msg">
-                                        Drag building blocks here to customize the header for the shop page.
+                                        Drag blocks here to customize the Shop page header
                                     </t>
                                     <div
                                         id="oe_structure_products_header_shop"
@@ -531,8 +531,8 @@
                             </div>
                             <t t-if="category">
                                 <t t-set='footer_editor_message'>
-                                    Drag building blocks here to customize the footer for
-                                    "<t t-out='category.name'/>" category.
+                                    Drag blocks here to customize the footer of
+                                    the "<t t-out='category.name'/>" category
                                 </t>
                                 <div
                                     class="mb16"

--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -285,7 +285,7 @@
             <a t-att-href="'/slides/%s/tag/%s' % (slug(slide.channel_id), slug(tag))" class="badge text-bg-info" t-out="tag.name"/>
         </t>
     </div>
-    <div class="oe_structure oe_empty" id="oe_structure_website_slides_lesson_top_1" data-editor-message.translate="BUILDING BLOCKS DROPPED HERE WILL BE SHOWN ACROSS ALL LESSONS"/>
+    <div class="oe_structure oe_empty" id="oe_structure_website_slides_lesson_top_1" data-editor-message.translate="Drag blocks here to add them on all lessons"/>
     <div t-if="slide.slide_category == 'infographic'" class="o_wslides_lesson_content_type" t-field='slide.image_1920' t-options="{'widget': 'image', 'style': 'width: 100%;'}"/>
     <div t-else="" class="o_wslides_lesson_content_type">
         <div t-if="slide.slide_category == 'document'" class="ratio ratio-4x3 embed-responsive-item mb8" style="height: 600px;">


### PR DESCRIPTION
- Before this commit, block and inner drop zones had the same thickness.
- After this commit, inner snippet drop zones are thinner than block drop zones.

| BEFORE  | AFTER |
| ------------- | ------------- |
| <img width="1123" height="595" alt="image" src="https://github.com/user-attachments/assets/51496b5e-f887-48f9-9ffc-7111f41d8c14" />  | <img width="1119" height="543" alt="image" src="https://github.com/user-attachments/assets/146f7f7f-61ad-4fa3-92db-17920930c4c7" />  |
----
- Before this commit, if a snippet background is almost the same blue as the overlay, the overlay is not visible.
- After this commit, overlays are visible on any background color.

| BEFORE  | AFTER |
| ------------- | ------------- |
| <img width="347" height="467" alt="image" src="https://github.com/user-attachments/assets/acb2d962-deda-402d-a642-b35b9721d2cb" />  | <img width="347" height="467" alt="image" src="https://github.com/user-attachments/assets/996c549e-d710-4ef2-a1d3-dbe7d8acdded" />  |
----
- Before this commit, if a snippet background is almost the same blue as the dropzones, the dropzones are not visible.
- After this commit, drop zones are visible on any background color.

| BEFORE  | AFTER |
| ------------- | ------------- |
| <img width="410" height="472" alt="image" src="https://github.com/user-attachments/assets/b5480d59-d20f-4df5-a504-c9c2e63ab5b7" />  | <img width="411" height="468" alt="image" src="https://github.com/user-attachments/assets/8af528d5-b802-40bf-a7bd-dce331a18773" />  |

----
- Before this commit, the dropzone design looked a bit outdated, with a border that was too thick and corners that were overly rounded.
- After this commit, the border is thinner and the corners are less rounded. We also reduced the text size and added a text shadow. The goal is to make the dropzones look lighter and more modern.

| BEFORE  |
| ------------- |
| <img width="684" height="68" alt="image" src="https://github.com/user-attachments/assets/7847335f-1519-4f1c-ad1e-1a48783f245d" />  |

| AFTER  |
| ------------- |
| <img width="689" height="71" alt="image" src="https://github.com/user-attachments/assets/b8c32217-61f5-46d8-ba87-b58951b1462f" />  |
----
- Before this commit, sanitized drop zones were truncated in some situations.
- After this commit, sanitized drop zones are no longer truncated, and their design has been improved.

| BEFORE  | AFTER |
| ------------- | ------------- |
| <img width="301" height="339" alt="image" src="https://github.com/user-attachments/assets/48b78911-bcdc-441c-accc-9c1efae83780" />  | <img width="303" height="348" alt="image" src="https://github.com/user-attachments/assets/c3901686-c727-4b32-bf2b-41373eaeb2bf" />  |

| BEFORE  |
| ------------- |
| <img width="1120" height="440" alt="image" src="https://github.com/user-attachments/assets/1c7bccf6-837b-4664-8f43-1f74081c31e2" />|

| AFTER |
| ------------- |
| <img width="1112" height="393" alt="image" src="https://github.com/user-attachments/assets/9daa027e-bad2-49c3-92d0-50c12be633d3" />|

task-5921283