### PR TITLE
[FIX] website: fix `website_auto_hide_menu` tour

### DIFF
--- a/addons/website/static/tests/tours/auto_hide_menu.js
+++ b/addons/website/static/tests/tours/auto_hide_menu.js
@@ -64,11 +64,8 @@ registerWebsitePreviewTour(
             run: "click",
         },
         {
-            content: "Check that modal has disappeared",
-            trigger: "body:not(:has(.modal))",
-        },
-        {
-            trigger: `:iframe .o_homepage_editor_welcome_message:contains(welcome to your homepage)`,
+            content: "Check that the menus have been saved",
+            trigger: ":iframe #top_menu:has(a[role='menuitem']:contains(name):count(5))",
         },
         ...clickOnEditAndWaitEditMode(),
         getTheLayoutChildren,


### PR DESCRIPTION
__Before commit__
Since the delay between tour steps was removed [1], this tour fails frequently. After saving menus, the page reloads, but the tour attempts to click the edit button before the reload completes, preventing the builder sidebar from opening.

__Fix__
Wait for the five new menu items to appear to ensure they have been saved and the page has successfully reloaded before proceeding.

[1]: https://github.com/odoo/odoo/commit/769b193

runbot-237842