### PR TITLE
[FIX] website, html_builder: show invisible snippets in preview dialog

### DIFF
--- a/addons/html_builder/static/src/snippets/snippet_viewer.js
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.js
@@ -5,6 +5,7 @@ import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { InputConfirmationDialog } from "./input_confirmation_dialog";
 import { fuzzyLookup } from "@web/core/utils/search";
+import { Img } from "@html_builder/core/img";
 
 export class SnippetViewer extends Component {
     static template = "html_builder.SnippetViewer";
@@ -21,6 +22,58 @@ export class SnippetViewer extends Component {
         this.dialog = useService("dialog");
         this.content = useRef("content");
         this.backendDirection = localization.direction;
+    }
+
+    /**
+     * @typedef {Object} PrefixIconInfo
+     * @property {string} keyClass class to add on the span containing the icon
+     * @property {string} title the tooltip content
+     * @property {Component?} Component the component to show the icon
+     * @property {Object?} props props for the component
+     * @property {import("@web/core/utils/html").Markup?} content the markup to
+     * show the icon, if no `Component`
+     */
+    /**
+     * Gets the info for icons that are shown before the name of the given
+     * custom snippet
+     *
+     * @param {HTMLElement} snippetContentEl
+     * @returns {PrefixIconInfo[]}
+     */
+    getPrefixIcons(snippetContentEl) {
+        /** @type {PrefixIconInfo[]} */
+        const icons = [];
+        const styleProps = { style: "height: 1em", attrs: { fill: "var(--body-color)" } };
+        if (snippetContentEl.matches(".o_snippet_desktop_invisible")) {
+            icons.push({
+                keyClass: "o_prefix_desktop_invisible",
+                title: "Invisible on desktop",
+                Component: Img,
+                props: {
+                    src: "/html_builder/static/img/options/desktop_invisible.svg",
+                    ...styleProps,
+                },
+            });
+        }
+        if (snippetContentEl.matches(".o_snippet_mobile_invisible")) {
+            icons.push({
+                keyClass: "o_prefix_mobile_invisible",
+                title: "Invisible on mobile",
+                Component: Img,
+                props: {
+                    src: "/html_builder/static/img/options/mobile_invisible.svg",
+                    ...styleProps,
+                },
+            });
+        }
+        if (snippetContentEl.matches(".o_conditional_hidden")) {
+            icons.push({
+                keyClass: "o_prefix_conditional",
+                title: "Conditionally visible",
+                content: markup`<span class="fa fa-eye-slash"/>`,
+            });
+        }
+        return icons;
     }
 
     getRenameBtnLabel(snippetName) {

--- a/addons/html_builder/static/src/snippets/snippet_viewer.scss
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.scss
@@ -86,6 +86,16 @@
                         }
                     }
                 }
+
+                // Force visibility on root snippets if desktop/mobile invisible
+                // and on conditionally visible elements
+                &.o_snippet_desktop_invisible, &.o_snippet_mobile_invisible, &.o_conditional_hidden, & .o_conditional_hidden {
+                    display: block !important;
+
+                    &.d-lg-flex, &.d-md-flex, &.o_half_screen_height, &.o_full_screen_height {
+                        display: flex !important;
+                    }
+                }
             }
             &[data-label]:not([data-label=""])::before {
                 content: attr(data-label);
@@ -170,6 +180,8 @@
 
     &.o_add_snippets_preview--dark {
         .o_custom_snippet_edit {
+            --body-color: #{$white};
+
             color: $white;
         }
     }

--- a/addons/html_builder/static/src/snippets/snippet_viewer.xml
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.xml
@@ -25,7 +25,12 @@
                     <button t-if="snippet.moduleId" class="o_snippet_preview_install_btn btn text-white rounded-1 mx-auto p-2 bottom-50"
                             t-esc="this.getButtonInstallName(snippet)"/>
                 </div>
-                <div t-if="snippet.isCustom" class="d-grid mt-2 mx-5 gap-2 d-md-flex justify-content-md-end o_custom_snippet_edit">
+                <div t-if="snippet.isCustom" class="d-grid mt-2 mx-5 gap-2 d-md-flex justify-content-md-end align-items-md-center o_custom_snippet_edit">
+                    <span t-foreach="this.getPrefixIcons(snippet.content)" t-as="icon" t-key="icon.keyClass" t-attf-class="me-2 #{icon.keyClass}" t-att-title="icon.title">
+                        <span class="visually-hidden" t-out="icon.title"/>
+                        <t t-if="icon.Component" t-component="icon.Component" t-props="icon.props"/>
+                        <t t-else="" t-out="icon.content"/>
+                    </span>
                     <span class="w-100" t-esc="snippet.title"></span>
                     <button class="o_btn_reset me-md-2" t-on-click="() => this.onClickRename(snippet)">
                         <span class="visually-hidden" t-esc="getRenameBtnLabel(snippet.title)"/>

--- a/addons/website/static/tests/builder/invisible_elements.test.js
+++ b/addons/website/static/tests/builder/invisible_elements.test.js
@@ -1,8 +1,8 @@
 import { InvisibleElementsPanel } from "@html_builder/sidebar/invisible_elements_panel";
 import { getSnippetStructure, waitForEndOfOperation } from "@html_builder/../tests/helpers";
 import { unformat } from "@html_editor/../tests/_helpers/format";
-import { expect, test } from "@odoo/hoot";
-import { click, queryAllTexts, queryFirst, queryOne } from "@odoo/hoot-dom";
+import { describe, expect, test } from "@odoo/hoot";
+import { click, queryAllTexts, queryFirst, queryOne, waitFor } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
 import { contains, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import {
@@ -165,4 +165,159 @@ test("invisible elements efficiency", async () => {
     expect.verifySteps(["update invisible panel"]);
     await contains("button[data-action='mobile']").click();
     expect.verifySteps(["update invisible panel"]);
+});
+
+describe("drop invisible elements", () => {
+    addDropZoneSelector({ selector: "*", dropNear: "section" });
+    const snippetMobileInvisible = `
+        <section class="s_mobile_test o_snippet_mobile_invisible d-none d-lg-block" data-snippet="s_mobile_test" data-name="Test mobile">
+            <p>Hello Desktop</p>
+        </section>`;
+    const snippetDesktopInvisible = `
+        <section class="s_desktop_test o_snippet_desktop_invisible d-lg-none" data-snippet="s_desktop_test" data-name="Test desktop">
+            <p>Hello Mobile</p>
+        </section>`;
+    const snippetInnerDesktopInvisible = `
+        <section class="s_desktop_test" data-snippet="s_desktop_test" data-name="Test desktop">
+            <p>Hello All</p>
+            <section class="o_snippet_desktop_invisible d-lg-none">
+                <p>Hello Mobile</p>
+            </section>
+        </section>`;
+    const snippetConditionalInvisible = `
+        <section class="s_conditional_test o_conditional_hidden" data-visibility="conditional" data-snippet="s_conditional_test" data-name="Test conditional">
+            <p>Hello All</p>
+            <section class="o_conditional_hidden" data-visibility="conditional" data-snippet="s_inner_conditional_test">
+                <p>Hello Sometimes</p>
+            </section>
+        </section>`;
+    const snippetDesktopAndConditionalInvisible = `
+        <section class="s_desktop_and_conditional_test o_snippet_desktop_invisible d-lg-none o_conditional_hidden" data-visibility="conditional" data-snippet="s_desktop_and_conditional_test" data-name="Test desktop and conditional">
+            <p>Hello Mobile Sometimes</p>
+        </section>`;
+
+    function getSnippetInfos(snippet) {
+        return {
+            snippet_groups: [
+                '<div name="A" data-oe-snippet-id="123" data-o-snippet-group="a"><section data-snippet="s_snippet_group"></section></div>',
+                '<div name="Custom" data-oe-snippet-id="123" data-o-snippet-group="custom"><section data-snippet="s_snippet_group"></section></div>',
+            ],
+            snippet_structure: [
+                getSnippetStructure({
+                    name: "Test",
+                    groupName: "a",
+                    content: unformat(snippet),
+                }),
+            ],
+            snippet_custom: [
+                getSnippetStructure({
+                    name: "Custom Test",
+                    groupName: "custom",
+                    content: unformat(snippet),
+                }),
+            ],
+        };
+    }
+
+    describe("snippets shown with invisible elements in snippet dialog", () => {
+        test("elements with o_conditional_hidden are visible", async () => {
+            await setupWebsiteBuilder(`<section>test</section>`, {
+                snippets: getSnippetInfos(snippetConditionalInvisible),
+            });
+            await contains(
+                ".o-snippets-menu #snippet_groups div[data-snippet-group=a] .o_snippet_thumbnail .o_snippet_thumbnail_area"
+            ).click();
+            await waitForSnippetDialog();
+            expect(
+                ".o_add_snippet_dialog :iframe .s_conditional_test p:contains(Sometimes)"
+            ).toBeVisible();
+        });
+
+        test("snippets which are desktop invisible are visible", async () => {
+            await setupWebsiteBuilder(`<section>test</section>`, {
+                snippets: getSnippetInfos(snippetDesktopInvisible),
+            });
+            await contains(
+                ".o-snippets-menu #snippet_groups div[data-snippet-group=a] .o_snippet_thumbnail .o_snippet_thumbnail_area"
+            ).click();
+            await waitForSnippetDialog();
+            expect(
+                ".o_add_snippet_dialog :iframe .s_desktop_test p:contains(Hello Mobile)"
+            ).toBeVisible();
+        });
+
+        test("elements which are desktop invisible inside a snippet are invisible", async () => {
+            await setupWebsiteBuilder(`<section>test</section>`, {
+                snippets: getSnippetInfos(snippetInnerDesktopInvisible),
+            });
+            await contains(
+                ".o-snippets-menu #snippet_groups div[data-snippet-group=a] .o_snippet_thumbnail .o_snippet_thumbnail_area"
+            ).click();
+            await waitForSnippetDialog();
+            expect(
+                ".o_add_snippet_dialog :iframe .s_desktop_test p:contains(Mobile)"
+            ).not.toBeVisible();
+        });
+    });
+
+    describe("invisible snippets have an indicator in snippet dialog telling they are invisible", () => {
+        test("mobile invisible snippet", async () => {
+            await setupWebsiteBuilder(`<section>test</section>`, {
+                snippets: getSnippetInfos(snippetMobileInvisible),
+            });
+            await contains(
+                ".o-snippets-menu #snippet_groups div[data-snippet-group=custom] .o_snippet_thumbnail .o_snippet_thumbnail_area"
+            ).click();
+            await waitForSnippetDialog();
+            await waitFor(".o_add_snippet_dialog :iframe .o_custom_snippet_edit");
+            expect(
+                ".o_add_snippet_dialog :iframe .o_custom_snippet_edit .o_prefix_mobile_invisible"
+            ).toHaveCount(1);
+        });
+
+        test("desktop invisible snippet", async () => {
+            await setupWebsiteBuilder(`<section>test</section>`, {
+                snippets: getSnippetInfos(snippetDesktopInvisible),
+            });
+            await contains(
+                ".o-snippets-menu #snippet_groups div[data-snippet-group=custom] .o_snippet_thumbnail .o_snippet_thumbnail_area"
+            ).click();
+            await waitForSnippetDialog();
+            await waitFor(".o_add_snippet_dialog :iframe .o_custom_snippet_edit");
+            expect(
+                ".o_add_snippet_dialog :iframe .o_custom_snippet_edit .o_prefix_desktop_invisible"
+            ).toHaveCount(1);
+        });
+
+        test("conditionally visible snippet", async () => {
+            await setupWebsiteBuilder(`<section>test</section>`, {
+                snippets: getSnippetInfos(snippetConditionalInvisible),
+            });
+            await contains(
+                ".o-snippets-menu #snippet_groups div[data-snippet-group=custom] .o_snippet_thumbnail .o_snippet_thumbnail_area"
+            ).click();
+            await waitForSnippetDialog();
+            await waitFor(".o_add_snippet_dialog :iframe .o_custom_snippet_edit");
+            expect(
+                ".o_add_snippet_dialog :iframe .o_custom_snippet_edit .o_prefix_conditional"
+            ).toHaveCount(1);
+        });
+
+        test("both desktop invisible and conditionally visible snippet", async () => {
+            await setupWebsiteBuilder(`<section>test</section>`, {
+                snippets: getSnippetInfos(snippetDesktopAndConditionalInvisible),
+            });
+            await contains(
+                ".o-snippets-menu #snippet_groups div[data-snippet-group=custom] .o_snippet_thumbnail .o_snippet_thumbnail_area"
+            ).click();
+            await waitForSnippetDialog();
+            await waitFor(".o_add_snippet_dialog :iframe .o_custom_snippet_edit");
+            expect(
+                ".o_add_snippet_dialog :iframe .o_custom_snippet_edit .o_prefix_conditional"
+            ).toHaveCount(1);
+            expect(
+                ".o_add_snippet_dialog :iframe .o_custom_snippet_edit .o_prefix_desktop_invisible"
+            ).toHaveCount(1);
+        });
+    });
 });


### PR DESCRIPTION
The (saved custom) snippets which were invisible on desktop or conditionally invisible, appeared as empty in the dialog to preview snippet.

This commit changes the css rules so that
- conditionally visible elements are always visible in preview
- snippet that are device invisible are show with the overlay (and inner elements that are device invisible are not shown)

Steps to reproduce:
- Open website builder
- Drop a section
- Change the "Visibility" to hide on desktop
- Click on the eye to show it
- Save the snippet as a custom snippet
- Open the dialog to add a snippet
- Bug: the newly saved snippet is shown as empty

Same for "Visibility" to "Conditionally". And Same for "Visibility" to hide on mobile, if the window size is reduced when showing the dialog.

task-5149984