### PR TITLE
[FIX] stock_account: Correctly change the cost of a lot valuated product

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -76,6 +76,17 @@ class ProductTemplate(models.Model):
             product_template.valuation = product_template.categ_id.with_company(
                 product_template.company_id).property_valuation or self.env.company.inventory_valuation
 
+    @api.onchange('standard_price')
+    def _onchange_standard_price(self):
+        if self.lot_valuated:
+            return {
+                'warning': {
+                    'title': _("Warning"),
+                    'message': _("This product is valuated by lot/serial number. Changing the cost "
+                        "will update the cost of every lot/serial number in stock."),
+                }
+            }
+
     def write(self, vals):
         product_ids_to_update = set()
         lot_ids_to_update = set()
@@ -278,6 +289,17 @@ class ProductProduct(models.Model):
         products.with_context(valuation_date=datetime.min)._change_standard_price({product: 0 for product in products if product.standard_price})
         return products
 
+    @api.onchange('standard_price')
+    def _onchange_standard_price(self):
+        if self.lot_valuated:
+            return {
+                'warning': {
+                    'title': _("Warning"),
+                    'message': _("This product is valuated by lot/serial number. Changing the cost "
+                        "will update the cost of every lot/serial number in stock."),
+                }
+            }
+
     def write(self, vals):
         old_price = False
         if 'standard_price' in vals and not self.env.context.get('disable_auto_revaluation'):
@@ -313,11 +335,11 @@ class ProductProduct(models.Model):
                 'description': _('Price update from %(old_price)s to %(new_price)s by %(user)s',
                     old_price=old_price.get(product), new_price=product.standard_price, user=self.env.user.name)
             })
-        self.env['product.value'].sudo().create(product_values)
         if product_ids_lot_valuated:
             for (product, lots) in self.env['stock.lot']._read_group(
                     [('product_id', 'in', product_ids_lot_valuated)], ['product_id'], ['id:recordset']):
                 lots.with_context(disable_auto_revaluation=True).standard_price = product.standard_price
+        self.env['product.value'].sudo().create(product_values)
         return
 
     def _get_standard_price_at_date(self, date=None):

--- a/addons/stock_account/tests/test_lot_valuation.py
+++ b/addons/stock_account/tests/test_lot_valuation.py
@@ -359,6 +359,28 @@ class TestLotValuation(TestStockValuationCommon):
         self.assertEqual(self.lot3.total_value, 110)
         self.assertEqual(self.lot3.standard_price, 10)
 
+    def test_change_standard_price_with_standard_costing_method(self):
+        """ Changing product's standard price will reevaluate all lots
+            even if the costing method is standard """
+        self.product.product_tmpl_id.categ_id.property_cost_method = 'standard'
+        self._make_in_move(self.product, 10, 0, lot_ids=[self.lot1, self.lot2])
+        self._make_in_move(self.product, 8, 0, lot_ids=[self.lot3])
+        self._make_in_move(self.product, 6, 0, lot_ids=[self.lot2, self.lot3])
+        self.assertEqual(self.lot1.total_value, 50)
+        self.assertEqual(self.lot1.standard_price, 10)
+        self.assertEqual(self.lot2.total_value, 80)
+        self.assertEqual(self.lot2.standard_price, 10)
+        self.assertEqual(self.lot3.total_value, 110)
+        self.assertEqual(self.lot3.standard_price, 10)
+        self.product.product_tmpl_id.standard_price = 20
+
+        self.assertEqual(self.lot1.total_value, 100)
+        self.assertEqual(self.lot1.standard_price, 20)
+        self.assertEqual(self.lot2.total_value, 160)
+        self.assertEqual(self.lot2.standard_price, 20)
+        self.assertEqual(self.lot3.total_value, 220)
+        self.assertEqual(self.lot3.standard_price, 20)
+
     def test_value_multicompanies(self):
         """ Test having multiple layers on different companies give a correct value"""
         c1 = self.company


### PR DESCRIPTION

Problem:
Changing the cost of a product that uses Valuation by Lot/Serial Number
gets neglected. The cost is shown as changed but then gets reverted and
returns to the old cost without showing the user that the change will
be reverted.

Steps to reproduce:
1. Create a product with a standard price cost method
2. Track this product by lots, and activate the valuation by lot/serial
number
3. Adjust the quantity on hand, to have at least 1 unit of the product
4. Change the cost of the product
5. Save your change
6. Refresh the page
7. Notice how the cost gets reverted to the old cost without any warning
or error message to the user

Cause:
When product's cost is changed, product.write() triggers
_change_standard_price, which creates a product_value record to track
the change. https://github.com/odoo/odoo/blob/339ec30e872cd2d68d9889541fabaaa1ab22b079/addons/stock_account/models/product.py#L319
Creating that record triggers a stock move revaluation, which in turn
calls _update_standard_price on the product that tries to update the
product's standard price with its avg_cost. https://github.com/odoo/odoo/blob/339ec30e872cd2d68d9889541fabaaa1ab22b079/addons/stock_account/models/product.py#L631
Because the product is using the standard costing method, its avg_cost
is the average cost of the stock lots. https://github.com/odoo/odoo/blob/339ec30e872cd2d68d9889541fabaaa1ab22b079/addons/stock_account/models/product.py#L226-L228
When using the standard costing method, the average cost of a stock lot
is basically the lot's standard price. https://github.com/odoo/odoo/blob/339ec30e872cd2d68d9889541fabaaa1ab22b079/addons/stock_account/models/stock_lot.py#L39-L41
But because all of this is triggered before the stock lots' prices get
updated, the stock lots' standard prices haven't been updated with the
new price. As a result, the old standard price is used as the avg_cost
of stock lots, which is then used to update the product's standard price
and override the new price with the old one.

Solution:
Create the product_value records after the stock lots have been updated
with the new price.

opw-5949146