### PR TITLE
[FIX] mail: missing bg color in 'Call Settings' header in chat window

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -64,7 +64,7 @@
         </div>
         <div t-if="!props.chatWindow.folded or ui.isSmall" class="d-flex flex-column h-100 overflow-auto o-scrollbar-thin position-relative bg-inherit" t-att-class="{ 'opacity-50': state.editingName }" t-ref="content">
             <t name="thread content">
-                <div t-if="threadActions.activeAction?.actionPanelComponentCondition" class="h-100" t-attf-class="{{ threadActions.activeAction.panelOuterClass }}">
+                <div t-if="threadActions.activeAction?.actionPanelComponentCondition" class="h-100 bg-inherit" t-attf-class="{{ threadActions.activeAction.panelOuterClass }}">
                     <t t-component="threadActions.activeAction.actionPanelComponent" t-props="{ ...threadActions.activeAction.actionPanelComponentProps, thread }"/>
                 </div>
                 <t t-elif="thread">


### PR DESCRIPTION
Before this commit, when opening the "Call Settings" in a chat window, the header of the action panel was missing a background color.

Because of this, when scrolling down, the Action panel title was floating above the content and the text was overlapping, making it hard to read.

This comes from `.bg-inherit` that requires the parented chain to rigorously have `.bg-inherit` too until reaching an actual bg color. In this case, one parent container lacked it, which is what this commit fixes.

Task-5867464 (point 84)

Before / After
<img width="382" height="465" alt="Screenshot 2026-02-24 at 16 06 32" src="https://github.com/user-attachments/assets/f5c4a309-c60a-4e9b-bef0-06ee7ba731b8" /> <img width="386" height="468" alt="Screenshot 2026-02-24 at 16 06 18" src="https://github.com/user-attachments/assets/fea35f8f-2a76-4c40-b51e-28dbfce3a281" />
