### PR TITLE
[FIX] web: action_service: push URL immediately onError

### DIFF
--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -898,7 +898,7 @@ export function makeActionManager(env, router = _router) {
                         if (controller.isMounted) {
                             return;
                         }
-                        pushState(nextStack);
+                        pushState(nextStack, { sync: true });
                     },
                 });
                 if (action.target !== "new") {
@@ -1780,7 +1780,7 @@ export function makeActionManager(env, router = _router) {
         return Object.assign(newState, pick(newState.actionStack.at(-1), ...stateKeys));
     }
 
-    function pushState(cStack = controllerStack) {
+    function pushState(cStack = controllerStack, options) {
         if (!cStack.length) {
             return;
         }
@@ -1788,7 +1788,7 @@ export function makeActionManager(env, router = _router) {
         const newState = makeState(cStack);
 
         cStack.at(-1).state = newState;
-        router.pushState(newState, { replace: true });
+        router.pushState(newState, Object.assign({ replace: true }, options));
     }
     return {
         doAction,

--- a/addons/web/static/tests/webclient/actions/multi_company_action.test.js
+++ b/addons/web/static/tests/webclient/actions/multi_company_action.test.js
@@ -15,6 +15,7 @@ import {
 import { animationFrame } from "@odoo/hoot-dom";
 import { browser } from "@web/core/browser/browser";
 import { FormViewDialog } from "@web/views/view_dialogs/form_view_dialog";
+import { router } from "@web/core/browser/router";
 
 class Partner extends models.Model {
     _name = "res.partner";
@@ -80,6 +81,17 @@ test("open record withtout the correct company (doAction)", async () => {
         });
     });
 
+    const _pushState = router.pushState;
+    patchWithCleanup(router, {
+        pushState: (state, options) => {
+            expect(browser.location.href).toBe("https://www.hoot.test/");
+            const res = _pushState(state, options);
+            expect.step("pushState");
+            expect(browser.location.href).toBe("http://example.com/odoo/res.partner/1");
+            return res;
+        },
+    });
+
     await mountWebClient();
     getService("action").doAction({
         type: "ir.actions.act_window",
@@ -89,7 +101,7 @@ test("open record withtout the correct company (doAction)", async () => {
     });
     await animationFrame();
     expect(cookie.get("cids")).toBe("1-2");
-    expect.verifySteps(["reload"]);
+    expect.verifySteps(["pushState", "reload"]);
     expect(browser.location.href).toBe("http://example.com/odoo/res.partner/1", {
         message: "url should contain the information of the doAction",
     });


### PR DESCRIPTION
Have a flow where an action act_window is executed and wants to open a record in the form view, but that record is not in one of the companies that the current user is logged in.

The ORM will crash with an access denied, that the JS catches cleverly (see odoo/odoo@6213c40932236101b529b82f0ea9fce1829c8c24) and tries to reload on that failed action after altering the allowed companies.

Before this commit, this flow was imperfect because the url (that allows to reload at the right place) was not written immediately. So, more often than not, we ended up on the wrong view after reload.

After this commit, we end up in the right action after reload.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
