### PR TITLE
[FIX] hr: restrict "End of Collaboration" server action to form view

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -994,6 +994,7 @@
             <field name="name">End of Collaboration</field>
             <field name="model_id" ref="model_hr_employee"/>
             <field name="binding_model_id" ref="model_hr_employee"/>
+            <field name="binding_view_types">form</field>
             <field name="group_ids" eval="[Command.link(ref('hr.group_hr_user'))]"/>
             <field name="state">code</field>
             <field name="code">


### PR DESCRIPTION
## Steps to reproduce:
- Go to Employees list view
- Select multiple employees
- Action menu > "End of Collaboration"
- ValueError is raised: "Expected singleton: hr.employee(...)"

## Reason:
- The server action `action_hr_employee_departure` had no explicit `binding_view_types`, so it defaulted to `list,form`.
- When triggered from the list view with multiple records selected, it called `action_new_departure()` which enforces `ensure_one()`, causing a crash.
- Multiple departures are no longer supported https://github.com/odoo/odoo/pull/245519/changes/774853c1e13a556edd61eea7f4bce65e8b7fc163

## Fix:
- Action is only surfaced in the form view, where the recordset is always a singleton.

Task-3505331