### PR TITLE
[FIX] pos_restaurant: transfer to booked table

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -265,9 +265,7 @@ patch(PosStore.prototype, {
         this.set_order(null);
     },
     getActiveOrdersOnTable(table) {
-        return this.models["pos.order"].filter(
-            (o) => o.table_id?.id === table.id && !o.finalized && o.lines.length
-        );
+        return this.models["pos.order"].filter((o) => o.table_id?.id === table.id && !o.finalized);
     },
     tableHasOrders(table) {
         return Boolean(table.getOrder());
@@ -302,7 +300,7 @@ patch(PosStore.prototype, {
             await this.setTable(destinationTable);
             return;
         }
-        if (!this.tableHasOrders(destinationTable)) {
+        if (!destinationOrder) {
             order.update({ table_id: destinationTable });
             this.set_order(order);
             this.addPendingOrder([order.id]);

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -849,3 +849,29 @@ registry.category("web_tour.tours").add("test_combo_children_qty_updated_with_no
             Order.hasLine({ productName: "Combo Product 6", quantity: 2 }),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_transfer_order_to_booked_table", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+
+            //Transfer sent product on table with same product sent
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            ProductScreen.clickOrderButton(),
+            Dialog.confirm(),
+            ProductScreen.orderlinesHaveNoChange("Coca-Cola"),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("4"),
+            ProductScreen.clickBookTable(),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickControlButton("Transfer"),
+            FloorScreen.clickTable("4"),
+            ProductScreen.orderlinesHaveNoChange("Coca-Cola"),
+            ProductScreen.orderLineHas("Coca-Cola", "1"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+        ].flat(),
+});

--- a/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
@@ -63,3 +63,14 @@ export function bookOrReleaseTable() {
         },
     ];
 }
+
+export function clickBookTable() {
+    return [
+        ProductScreen.clickReview(),
+        {
+            content: "click book table",
+            trigger: ".product-screen .book-table",
+            run: "click",
+        },
+    ];
+}

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -560,3 +560,7 @@ class TestFrontend(TestFrontendCommon):
         self.pos_config.write({'printer_ids': False})
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_combo_children_qty_updated_with_note')
+
+    def test_transfer_order_to_booked_table(self):
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_transfer_order_to_booked_table', login="pos_user")


### PR DESCRIPTION
Step to reproduce:
- Make a pos order
- Book a table without orderlines
- Transfer the order to the booked table
- Traceback

Issue:

The transferOrder method was retrieving non-finalized table orders that contained order lines using getActiveOrdersOnTable. However, it later checked for the existence of any non-finalized order using tableHasOrders, regardless of whether it had order lines. This caused inconsistent behavior in cases where a table was booked but had no order lines.

opw-5965705

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
