### PR TITLE
[FIX] (stock_)account: accrual wizard

### DIFF
--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -204,6 +204,10 @@ class ProductTemplate(models.Model):
         included_computed_price = self.taxes_id.with_context(force_price_include=True).compute_all(price, self.currency_id)
         return included_computed_price['total_excluded']
 
+    def _get_price_diff_account(self):
+        self.ensure_one()
+        return False
+
 
 class ProductProduct(models.Model):
     _inherit = "product.product"
@@ -337,3 +341,6 @@ class ProductProduct(models.Model):
             if len(name) > 4:
                 sorted_domains.append((20, Domain('name', 'ilike', name)))
         return sorted_domains
+
+    def _get_price_diff_account(self):
+        return self.product_tmpl_id._get_price_diff_account()

--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -150,8 +150,9 @@ class AccountAccruedOrdersWizard(models.TransientModel):
             raise UserError(_('Cannot create an accrual entry with orders in different currencies.'))
         orders_with_entries = []
         total_balance = 0.0
-        amounts_by_perpetual_account = defaultdict(float)
+        perpetual_data_by_accounts_and_order_line = defaultdict(dict)
         price_diff_values = []
+        already_visited_invoice_lines = self.env['account.move.line']
 
         for order, product_lines in lines.grouped('order_id').items():
             if len(orders) == 1 and product_lines and self.amount and order.order_line:
@@ -253,10 +254,14 @@ class AccountAccruedOrdersWizard(models.TransientModel):
                             amount = order.currency_id._convert(amount_currency, self.company_id.currency_id, self.company_id)
                         elif qty_to_invoice < 0:
                             # Invoiced not delivered.
-                            posted_invoice_line = order_line.invoice_lines.filtered(lambda ivl: ivl.move_id.state == 'posted')[0]
-                            price_unit = posted_invoice_line.price_unit
-                            amount_currency = qty_to_invoice * price_unit
-                            amount = order.currency_id._convert(amount_currency, self.company_id.currency_id, self.company_id)
+                            amount_currency, amount, processed_qty = 0, 0, 0
+                            for inv_line in order_line.invoice_lines.filtered(lambda ivl: ivl.move_id.state == 'posted').sorted(reverse=True):
+                                amount_currency -= inv_line.price_subtotal
+                                amount -= order.currency_id._convert(inv_line.price_subtotal, self.company_id.currency_id, self.company_id)
+                                processed_qty += inv_line.quantity
+                                if processed_qty >= abs(qty_to_invoice):
+                                    break
+                            price_unit = abs(amount / processed_qty)
                         label = _(
                             '%(order)s - %(order_line)s; %(quantity_invoiced)s Invoiced, %(quantity_delivered)s Delivered at %(unit_price)s each',
                             order=order.name,
@@ -266,35 +271,42 @@ class AccountAccruedOrdersWizard(models.TransientModel):
                             unit_price=formatLang(self.env, price_unit, currency_obj=order.currency_id),
                         )
                         if expense_account and stock_variation_account:
+                            posted_invoice_lines = order_line.invoice_lines.filtered(lambda inv_line:
+                                inv_line.move_id.state == 'posted' and inv_line.quantity)
+                            expense_invoice_lines = self.env['account.move.line']
+                            for account_move in posted_invoice_lines.move_id:
+                                expense_invoice_line = account_move.line_ids.filtered(lambda inv_line:
+                                    inv_line.move_id.state == 'posted' and
+                                    inv_line.account_id == expense_account and
+                                    inv_line.product_id == order_line.product_id and
+                                    inv_line not in already_visited_invoice_lines
+                                )[:1]
+                                already_visited_invoice_lines += expense_invoice_line
+                                expense_invoice_lines += expense_invoice_line
+
                             # Evaluate if there are more invoiced or more delivered.
                             if qty_to_invoice > 0:
                                 # Invoices to be issued.
                                 # First, compute the delivered value.
-                                stock_moves = order_line.move_ids.filtered(lambda m: m.state == 'done')
+                                stock_moves = order_line.move_ids.filtered(lambda m:
+                                    m.state == 'done' and m.is_out
+                                )
                                 delivered_value = sum(m.value for m in stock_moves)
                                 # Then, compute the already invoiced value.
-                                posted_invoice_lines = order_line.invoice_lines.filtered(lambda ivl: ivl.move_id.state == 'posted')
-                                expense_invoice_lines = posted_invoice_lines.move_id.line_ids.filtered(lambda ivl:
-                                    ivl.move_id.state == 'posted' and
-                                    ivl.account_id == expense_account
-                                )
-                                invoiced_value = sum(l.balance for l in expense_invoice_lines)
+                                invoiced_value = sum(expense_invoice_lines.mapped('balance'))
                                 # The amount to invoice is equal to the delivered value minus the already invoiced value.
                                 perpetual_amount = delivered_value - invoiced_value
-                                amounts_by_perpetual_account[expense_account, stock_variation_account] += perpetual_amount
+                                price_unit = delivered_value / (sum(sm.quantity for sm in stock_moves) or 1)
+                                perpetual_data = (price_unit, perpetual_amount)
+                                perpetual_data_by_accounts_and_order_line[expense_account, stock_variation_account][order_line] = perpetual_data
                             elif qty_to_invoice < 0:
                                 # Invoiced not delivered.
-                                label += " (*)"
-                                posted_invoice_lines = order_line.invoice_lines.filtered(lambda ivl: ivl.move_id.state == 'posted')
-                                expense_invoice_lines = posted_invoice_lines.move_id.line_ids.filtered(lambda ivl:
-                                    ivl.move_id.state == 'posted' and
-                                    ivl.account_id == expense_account
-                                )
                                 invoiced_quantity = sum(posted_invoice_lines.mapped('quantity'))
                                 sum_amount = sum(expense_invoice_lines.mapped('debit'))
                                 invoiced_unit_price = sum_amount / invoiced_quantity
                                 perpetual_amount = invoiced_unit_price * qty_to_invoice
-                                amounts_by_perpetual_account[expense_account, stock_variation_account] += perpetual_amount
+                                perpetual_data = (invoiced_unit_price, perpetual_amount)
+                                perpetual_data_by_accounts_and_order_line[expense_account, stock_variation_account][order_line] = perpetual_data
 
                     distribution = order_line.analytic_distribution if order_line.analytic_distribution else {}
                     values = _get_aml_vals(order, amount, amount_currency, account.id, label=label, analytic_distribution=distribution)
@@ -314,16 +326,27 @@ class AccountAccruedOrdersWizard(models.TransientModel):
             values = _get_aml_vals(orders, -total_balance, 0.0, self.account_id.id, label=_('Accrued total'), analytic_distribution=analytic_distribution)
             move_lines.append(Command.create(values))
 
-        for (expense_account, stock_variation_account), amount in amounts_by_perpetual_account.items():
-            if amount == 0:
-                continue
-            if amount > 0:
-                label = _('(*) Goods Delivered not Invoiced (perpetual valuation)')
-            else:
-                label = _('(*) Goods Invoiced not Delivered (perpetual valuation)')
-            values = _get_aml_vals(orders, amount, 0.0, stock_variation_account.id, label=label)
-            move_lines.append(Command.create(values))
-            values = _get_aml_vals(orders, -amount, 0.0, expense_account.id, label=label)
+        for (expense_account, stock_variation_account), perpetual_data_by_order_line in perpetual_data_by_accounts_and_order_line.items():
+            expense_amount = 0
+            for order_line, perpetual_data in perpetual_data_by_order_line.items():
+                price_unit, amount = perpetual_data
+                expense_amount -= amount
+                if amount == 0:
+                    continue
+                if amount > 0:
+                    label = _('Goods Delivered not Invoiced (perpetual valuation)')
+                else:
+                    label = _('Goods Invoiced not Delivered (perpetual valuation)')
+                values = _get_aml_vals(orders, amount, 0.0, stock_variation_account.id, label=_(
+                    "%(order)s - %(order_line)s; %(qty_invoiced)s invoiced, %(qty_delivered)s delivered at %(unit_price)s",
+                    order=order.display_name,
+                    order_line=_ellipsis(order_line.name, 20),
+                    qty_invoiced=order_line.qty_invoiced_at_date,
+                    qty_delivered=order_line.qty_delivered_at_date,
+                    unit_price=formatLang(self.env, price_unit, currency_obj=order.currency_id),
+                ))
+                move_lines.append(Command.create(values))
+            values = _get_aml_vals(orders, expense_amount, 0.0, expense_account.id, label=label)
             move_lines.append(Command.create(values))
 
         for values in price_diff_values:

--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -215,9 +215,7 @@ class AccountAccruedOrdersWizard(models.TransientModel):
                         )
 
                         # Generate price diff account move lines if needed.
-                        price_diff_account = False
-                        if product.cost_method == 'standard':
-                            price_diff_account = product.categ_id.property_price_difference_account_id
+                        price_diff_account = product._get_price_diff_account()
                         if price_diff_account:
                             qty_to_invoice = order_line.qty_received_at_date - order_line.qty_invoiced_at_date
                             diff_label = _('%(order)s - %(order_line)s; price difference for %(product)s',

--- a/addons/sale_stock/tests/test_sale_stock_accrued_entries.py
+++ b/addons/sale_stock/tests/test_sale_stock_accrued_entries.py
@@ -280,6 +280,172 @@ class TestAccruedStockSaleOrders(TestSaleCommon):
             {'account_id': self.account_expense.id, 'debit': 80, 'credit': 0},
         ])
 
+    def test_accrued_order_in_anglo_saxon_standard_perpetual_multiple_so_lines(self):
+        """ Ensure the accrual lines are correctly computed even when there is multiple
+        SO lines and even when some of those lines are for the same product."""
+        stock_price_diff_acc_id = self.env['account.account'].create({
+            'name': 'default_account_stock_price_diff',
+            'code': 'STOCKDIFF',
+            'reconcile': True,
+            'account_type': 'asset_current',
+        })
+        product_category = self.env['product.category'].create({
+            'name': 'Test Category',
+            'property_account_income_categ_id': self.account_revenue.id,
+            'property_account_expense_categ_id': self.account_expense.id,
+            'property_price_difference_account_id': stock_price_diff_acc_id.id,
+            'property_valuation': 'real_time',
+        })
+        account_variation = product_category.property_stock_valuation_account_id.account_stock_variation_id
+        product1, product2 = self.env['product.product'].create([{
+            'name': name,
+            'categ_id': product_category.id,
+            'invoice_policy': 'order',
+            'is_storable': True,
+            'standard_price': price,
+            'uom_id': self.uom_unit.id,
+        } for (name, price) in (('Product 1', 50), ('Product 2', 30))])
+
+        # Create a SO with three lines (2 of them are for the same product.)
+        sale_order = self.env['sale.order'].with_context(tracking_disable=True).create({
+            'partner_id': self.partner_a.id,
+            'order_line': [
+                Command.create({
+                    'product_id': product1.id,
+                    'product_uom_qty': 10,
+                    'tax_ids': False,
+                }),
+                Command.create({
+                    'product_id': product2.id,
+                    'product_uom_qty': 10,
+                    'tax_ids': False,
+                }),
+                Command.create({
+                    'product_id': product1.id,
+                    'product_uom_qty': 10,
+                    'price_unit': 55,
+                    'tax_ids': False,
+                }),
+            ]
+        })
+        sale_order.action_confirm()
+
+        # Partially invoice the quantity.
+        invoice = sale_order._create_invoices()
+        invoice.line_ids[0].quantity = 5  # 5x standard cost ($ 50) = $ 250.00
+        invoice.line_ids[0].price_unit = 52
+        invoice.line_ids[1].quantity = 3  # 3x standard cost ($ 30) = $ 90.00
+        invoice.line_ids[1].price_unit = 33
+        invoice.line_ids[2].quantity = 2  # 2x standard cost ($ 50) = $ 100.00
+        invoice.action_post()
+
+        # Use accrued order wizard and check generated values.
+        wizard = self.env['account.accrued.orders.wizard'].with_context({
+            'active_model': 'sale.order.line',
+            'active_ids': sale_order.order_line.ids,
+        }).create({
+            'account_id': self.account_expense.id,
+            'date': fields.Date.today(),
+        })
+        account_move_domain = wizard.create_entries()['domain']
+        account_move = self.env['account.move'].search(account_move_domain)
+        self.assertRecordValues(account_move.line_ids.sorted('id'), [
+            # Accrued revenues entries.
+            # Following lines refer to invoice lines' price.
+            {'account_id': self.account_revenue.id, 'debit': 260, 'credit': 0},
+            {'account_id': self.account_revenue.id, 'debit': 99, 'credit': 0},
+            {'account_id': self.account_revenue.id, 'debit': 110, 'credit': 0},
+            {'account_id': self.account_expense.id, 'debit': 0, 'credit': 469},
+            # Following lines refer to product cost.
+            {'account_id': account_variation.id, 'debit': 250, 'credit': 0},
+            {'account_id': account_variation.id, 'debit': 90, 'credit': 0},
+            {'account_id': account_variation.id, 'debit': 100, 'credit': 0},
+            {'account_id': self.account_expense.id, 'debit': 0, 'credit': 440},
+            # Reversal of accrued revenues entries.
+            # Following lines refer to invoice lines' price.
+            {'account_id': self.account_revenue.id, 'debit': 0, 'credit': 260},
+            {'account_id': self.account_revenue.id, 'debit': 0, 'credit': 99},
+            {'account_id': self.account_revenue.id, 'debit': 0, 'credit': 110},
+            {'account_id': self.account_expense.id, 'debit': 469, 'credit': 0},
+            # Following lines refer to product cost.
+            {'account_id': account_variation.id, 'debit': 0, 'credit': 250},
+            {'account_id': account_variation.id, 'debit': 0, 'credit': 90},
+            {'account_id': account_variation.id, 'debit': 0, 'credit': 100},
+            {'account_id': self.account_expense.id, 'debit': 440, 'credit': 0},
+        ])
+
+    def test_accrued_order_in_anglo_saxon_standard_perpetual_multiple_invoices(self):
+        """ Ensure the accrual lines are correctly computed even when there is
+        multiple invoices by SO line."""
+        stock_price_diff_acc_id = self.env['account.account'].create({
+            'name': 'default_account_stock_price_diff',
+            'code': 'STOCKDIFF',
+            'reconcile': True,
+            'account_type': 'asset_current',
+        })
+        product_category = self.env['product.category'].create({
+            'name': 'Test Category',
+            'property_account_income_categ_id': self.account_revenue.id,
+            'property_account_expense_categ_id': self.account_expense.id,
+            'property_price_difference_account_id': stock_price_diff_acc_id.id,
+            'property_valuation': 'real_time',
+        })
+        account_variation = product_category.property_stock_valuation_account_id.account_stock_variation_id
+        product = self.env['product.product'].create({
+            'name': 'Product 1',
+            'categ_id': product_category.id,
+            'invoice_policy': 'order',
+            'is_storable': True,
+            'list_price': 50,
+            'standard_price': 30,
+            'uom_id': self.uom_unit.id,
+        })
+
+        # Create a SO with three lines (2 of them are for the same product.)
+        sale_order = self.env['sale.order'].with_context(tracking_disable=True).create({
+            'partner_id': self.partner_a.id,
+            'order_line': [
+                Command.create({
+                    'product_id': product.id,
+                    'product_uom_qty': 10,
+                    'tax_ids': False,
+                }),
+            ]
+        })
+        sale_order.action_confirm()
+
+        # Partially invoice the quantity.
+        invoice_1 = sale_order._create_invoices()
+        invoice_1.line_ids.quantity = 1
+        invoice_1.line_ids.price_unit = 55
+        invoice_1.action_post()
+        invoice_2 = sale_order._create_invoices()
+        invoice_2.line_ids.quantity = 9
+        invoice_2.action_post()
+
+        # Use accrued order wizard and check generated values.
+        wizard = self.env['account.accrued.orders.wizard'].with_context({
+            'active_model': 'sale.order.line',
+            'active_ids': sale_order.order_line.ids,
+        }).create({
+            'account_id': self.account_expense.id,
+            'date': fields.Date.today(),
+        })
+        account_move_domain = wizard.create_entries()['domain']
+        account_move = self.env['account.move'].search(account_move_domain)
+        self.assertRecordValues(account_move.line_ids.sorted('id'), [
+            # Accrued revenues entries.
+            {'account_id': self.account_revenue.id, 'debit': 505, 'credit': 0},
+            {'account_id': self.account_expense.id, 'debit': 0, 'credit': 505},
+            {'account_id': account_variation.id, 'debit': 300, 'credit': 0},
+            {'account_id': self.account_expense.id, 'debit': 0, 'credit': 300},
+            # Reversal of accrued revenues entries.
+            {'account_id': self.account_revenue.id, 'debit': 0, 'credit': 505},
+            {'account_id': self.account_expense.id, 'debit': 505, 'credit': 0},
+            {'account_id': account_variation.id, 'debit': 0, 'credit': 300},
+            {'account_id': self.account_expense.id, 'debit': 300, 'credit': 0},
+        ])
+
     def test_accrued_order_in_anglo_saxon_avco_perpetual(self):
         """ Ensure the COGS accrual lines are correctly computed for AVCO costing method product."""
         # Create a product using anglox-saxon valuation.

--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -121,6 +121,12 @@ class ProductTemplate(models.Model):
         })
         return accounts
 
+    def _get_price_diff_account(self):
+        price_diff_account = super()._get_price_diff_account()
+        if self.cost_method == 'standard':
+            price_diff_account = self.categ_id.property_price_difference_account_id
+        return price_diff_account
+
 
 class ProductProduct(models.Model):
     _inherit = 'product.product'


### PR DESCRIPTION
### [FIX] (stock_)account: cost method
> Before this commit, we tried to access to `product.product` `cost_method` field in `account` module.
> The issue is: this field is defined in `stock_account` which means we can try to read an unexisting field if we try to generate accruals from a sale order or a purchase order without `stock` installed.
> 
> This commit creates an helper method, overrided in `stock_account`, to avoid this issue.

### [FIX] account: split stock variation accrual lines
> Before this commit, accrual lines created for stock variations in case of already incoived not delivered quantities were summed together.
> This commit keeps them separate: one line by sale order line.
>  
> Also, those lines' label is rewritten to be more specific, giving the amount of invoiced and delivered qties, and with what unit price.
    
task-5934232