### PR TITLE
[FIX] account_edi_ubl_cii: Changing tax exemption reason when no tax

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -271,7 +271,7 @@ class AccountEdiCommon(models.AbstractModel):
         if supplier.country_id == customer.country_id:
             if not tax or tax.amount == 0:
                 # in theory, you should indicate the precise law article
-                return create_dict(tax_category_code='E', tax_exemption_reason=_('Articles 226 items 11 to 15 Directive 2006/112/EN'))
+                return create_dict(tax_category_code='E')
             elif tax.has_negative_factor:
                 # Special case: Purchase reverse-charge taxes for self-billed invoices.
                 # From the buyer's perspective, this is a standard tax with a non-zero percentage but
@@ -306,7 +306,7 @@ class AccountEdiCommon(models.AbstractModel):
         if tax.amount != 0:
             return create_dict(tax_category_code='S')
         else:
-            return create_dict(tax_category_code='E', tax_exemption_reason=_('Articles 226 items 11 to 15 Directive 2006/112/EN'))
+            return create_dict(tax_category_code='E')
 
     def _get_tax_category_code(self, customer, supplier, tax):
         if not tax:

--- a/addons/account_edi_ubl_cii/models/account_edi_ubl.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_ubl.py
@@ -1763,7 +1763,13 @@ class AccountEdiUBL(models.AbstractModel):
 
     def _ubl_tax_totals_node_grouping_key(self, base_line, tax_data, vals, currency):
         tax_category_key = self._ubl_default_tax_category_grouping_key(base_line, tax_data, vals, currency)
-        tax_subtotal_key = tax_category_key
+        tax_subtotal_key = {
+            'currency': tax_category_key['currency'],
+            'is_withholding': tax_category_key['is_withholding'],
+            'tax_category_code': tax_category_key['tax_category_code'],
+            'scheme_id': tax_category_key['scheme_id'],
+            'percent': tax_category_key['percent'],
+        } if tax_category_key else None
         if tax_category_key:
             tax_total_key = {
                 'is_withholding': tax_category_key['is_withholding'],

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -1565,6 +1565,13 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
         if tax_total_keys['tax_total_key'] and tax_total_keys['tax_total_key']['is_withholding']:
             tax_total_keys['tax_total_key'] = None
 
+        tax_category_key = tax_total_keys['tax_category_key']
+        if (
+            tax_category_key
+            and tax_category_key['tax_category_code'] == 'E'
+            and not tax_category_key.get('tax_exemption_reason')
+            ):
+            tax_category_key['tax_exemption_reason'] = _("Exempt from tax")
         # In case of multi-currencies, there will be 2 TaxTotals but the one expressed in
         # foreign currency must not have any TaxSubtotal.
         company_currency = vals['company'].currency_id

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_fixed_tax_emptying_return_turned_as_extra_invoice_lines.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_fixed_tax_emptying_return_turned_as_extra_invoice_lines.xml
@@ -104,10 +104,10 @@
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
 	<cac:TaxTotal>
-		<cbc:TaxAmount currencyID="EUR">12.23</cbc:TaxAmount>
+		<cbc:TaxAmount currencyID="EUR">2.10</cbc:TaxAmount>
 		<cac:TaxSubtotal>
-			<cbc:TaxableAmount currencyID="EUR">58.23</cbc:TaxableAmount>
-			<cbc:TaxAmount currencyID="EUR">12.23</cbc:TaxAmount>
+			<cbc:TaxableAmount currencyID="EUR">10.00</cbc:TaxableAmount>
+			<cbc:TaxAmount currencyID="EUR">2.10</cbc:TaxAmount>
 			<cac:TaxCategory>
 				<cbc:ID>S</cbc:ID>
 				<cbc:Percent>21.0</cbc:Percent>
@@ -116,29 +116,32 @@
 				</cac:TaxScheme>
 			</cac:TaxCategory>
 		</cac:TaxSubtotal>
+		<cac:TaxSubtotal>
+			<cbc:TaxableAmount currencyID="EUR">1.00</cbc:TaxableAmount>
+			<cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+			<cac:TaxCategory>
+				<cbc:ID>E</cbc:ID>
+				<cbc:Percent>0.0</cbc:Percent>
+				<cbc:TaxExemptionReason>Exempt from tax</cbc:TaxExemptionReason>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:TaxCategory>
+		</cac:TaxSubtotal>
 	</cac:TaxTotal>
 	<cac:LegalMonetaryTotal>
-		<cbc:LineExtensionAmount currencyID="EUR">58.23</cbc:LineExtensionAmount>
-		<cbc:TaxExclusiveAmount currencyID="EUR">58.23</cbc:TaxExclusiveAmount>
-		<cbc:TaxInclusiveAmount currencyID="EUR">70.46</cbc:TaxInclusiveAmount>
+		<cbc:LineExtensionAmount currencyID="EUR">11.00</cbc:LineExtensionAmount>
+		<cbc:TaxExclusiveAmount currencyID="EUR">11.00</cbc:TaxExclusiveAmount>
+		<cbc:TaxInclusiveAmount currencyID="EUR">13.10</cbc:TaxInclusiveAmount>
 		<cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
-		<cbc:PayableAmount currencyID="EUR">70.46</cbc:PayableAmount>
+		<cbc:PayableAmount currencyID="EUR">13.10</cbc:PayableAmount>
 	</cac:LegalMonetaryTotal>
 	<cac:InvoiceLine>
 		<cbc:ID>___ignore___</cbc:ID>
-		<cbc:InvoicedQuantity unitCode="C62">10.0</cbc:InvoicedQuantity>
-		<cbc:LineExtensionAmount currencyID="EUR">58.23</cbc:LineExtensionAmount>
-		<cac:AllowanceCharge>
-			<cbc:ChargeIndicator>true</cbc:ChargeIndicator>
-			<cbc:AllowanceChargeReasonCode>ADK</cbc:AllowanceChargeReasonCode>
-			<cbc:AllowanceChargeReason>Discount</cbc:AllowanceChargeReason>
-			<cbc:MultiplierFactorNumeric>1.09</cbc:MultiplierFactorNumeric>
-			<cbc:Amount currencyID="EUR">0.63</cbc:Amount>
-			<cbc:BaseAmount currencyID="EUR">57.60</cbc:BaseAmount>
-		</cac:AllowanceCharge>
+		<cbc:InvoicedQuantity unitCode="C62">2.0</cbc:InvoicedQuantity>
+		<cbc:LineExtensionAmount currencyID="EUR">10.00</cbc:LineExtensionAmount>
 		<cac:Item>
-			<cbc:Description>Test Product</cbc:Description>
-			<cbc:Name>Test Product</cbc:Name>
+			<cbc:Name>product_a</cbc:Name>
 			<cac:ClassifiedTaxCategory>
 				<cbc:ID>S</cbc:ID>
 				<cbc:Percent>21.0</cbc:Percent>
@@ -148,7 +151,44 @@
 			</cac:ClassifiedTaxCategory>
 		</cac:Item>
 		<cac:Price>
-			<cbc:PriceAmount currencyID="EUR">5.76</cbc:PriceAmount>
+			<cbc:PriceAmount currencyID="EUR">5.0</cbc:PriceAmount>
+		</cac:Price>
+	</cac:InvoiceLine>
+	<cac:InvoiceLine>
+		<cbc:ID>___ignore___</cbc:ID>
+		<cbc:InvoicedQuantity unitCode="C62">-1.0</cbc:InvoicedQuantity>
+		<cbc:LineExtensionAmount currencyID="EUR">0.00</cbc:LineExtensionAmount>
+		<cac:Item>
+			<cbc:Name>product_a</cbc:Name>
+			<cac:ClassifiedTaxCategory>
+				<cbc:ID>E</cbc:ID>
+				<cbc:Percent>0.0</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:ClassifiedTaxCategory>
+		</cac:Item>
+		<cac:Price>
+			<cbc:PriceAmount currencyID="EUR">0.0</cbc:PriceAmount>
+		</cac:Price>
+	</cac:InvoiceLine>
+	<cac:InvoiceLine>
+		<cbc:ID>___ignore___</cbc:ID>
+		<cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+		<cbc:LineExtensionAmount currencyID="EUR">1.00</cbc:LineExtensionAmount>
+		<cac:Item>
+			<cbc:Description>Vidange</cbc:Description>
+			<cbc:Name>Vidange</cbc:Name>
+			<cac:ClassifiedTaxCategory>
+				<cbc:ID>E</cbc:ID>
+				<cbc:Percent>0.0</cbc:Percent>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:ClassifiedTaxCategory>
+		</cac:Item>
+		<cac:Price>
+			<cbc:PriceAmount currencyID="EUR">1.0</cbc:PriceAmount>
 		</cac:Price>
 	</cac:InvoiceLine>
 </Invoice>

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_tax_exempt.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_tax_exempt.xml
@@ -111,7 +111,7 @@
 			<cac:TaxCategory>
 				<cbc:ID>E</cbc:ID>
 				<cbc:Percent>0.0</cbc:Percent>
-				<cbc:TaxExemptionReason>Articles 226 items 11 to 15 Directive 2006/112/EN</cbc:TaxExemptionReason>
+				<cbc:TaxExemptionReason>Exempt from tax</cbc:TaxExemptionReason>
 				<cac:TaxScheme>
 					<cbc:ID>VAT</cbc:ID>
 				</cac:TaxScheme>

--- a/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
@@ -330,6 +330,34 @@ class TestUblExportBis3BE(TestUblBis3Common, TestUblCiiBECommon):
         self._generate_invoice_ubl_file(invoice)
         self._assert_invoice_ubl_file(invoice, 'test_invoice_custom_tax_emptying_turned_as_extra_invoice_lines')
 
+    def test_invoice_fixed_tax_emptying_return_turned_as_extra_invoice_lines(self):
+        """ Ensure the emptying taxes (a.k.a 'vidange') works on line with negative quantity for when the clients return the 'vidange'."""
+        tax_emptying = self.fixed_tax(1.0, name="Vidange")
+        tax_21 = self.percent_tax(21.0)
+        tax_0 = self.percent_tax(0)
+        invoice = self._create_invoice(
+            partner_id=self.partner_be,
+            invoice_line_ids=[
+                self._prepare_invoice_line(
+                    product_id=self.product_a,
+                    price_unit=5.0,
+                    quantity=2.0,
+                    tax_ids=tax_emptying + tax_21,
+                ),
+                # line with price zero used for returning 'vidange'.
+                self._prepare_invoice_line(
+                    product_id=self.product_a,
+                    price_unit=0.0,
+                    quantity=-1.0,
+                    tax_ids=tax_emptying + tax_0,
+                ),
+            ],
+            post=True,
+        )
+
+        self._generate_invoice_ubl_file(invoice)
+        self._assert_invoice_ubl_file(invoice, 'test_invoice_fixed_tax_emptying_return_turned_as_extra_invoice_lines')
+
     def test_invoice_manual_tax_amount(self):
         tax_12 = self.percent_tax(12.0)
         tax_21 = self.percent_tax(21.0)


### PR DESCRIPTION
**PROBLEM**
Here is the client use case:
The client uses fixed tax to do 'vidange/consignage'. When selling a product with a 'consigne/vidange', they add a fixed tax which amount correspond to the 'consigne/vidange'. When returning the 'consigne', you would create an invoice line, with a product with a price of 0, negative quantity,a 0% tax and the fixed tax for the 'consigne'. When an invoice contains such lines, it fails peppol validations.

**STEP TO REPRODUCE**
1. Create a fixed tax used for 'vidange/consigne'.
2. Create an invoice, with a line with unit price of 0, negative quantity, a 0% tax and the fixed tax for the 'consigne'.
3. Send the invoice using peppol, use a validator to validate the xml and notice you get the following errors: [BR-E-01] [BR-E-08].

**CAUSE**
Fixed tax (like the one used for vidange) are aggregated in new invoice lines by the function `_ubl_turn_emptying_taxes_as_new_base_lines()`. Let say we have the following invoice:
line 1: qty=2, unit_price=3, taxes: 21% & vidange(fixed tax of 1). line 2: qty=-1, unit_price=0, taxes: 0% & vidange.

After calling `_ubl_turn_emptying_taxes_as_new_base_lines()`, we got: line 1: qty=2, unit_price=3, taxes: 21%.
line 2: qty=-1, unit_price=0, taxes: 0%.
line 3: qty=1, unit_price=1(amount of the fixed tax), taxes:None.

When generating the VAT breakdown, we have 2 line will end up being tax exempted (line 2 and 3). Because the `tax_exemption_reason` differs, they will not be merged in the same entry in the breakdown, which break the constraint of peppol saying we can only have one VAT breakdown with code 'Exempt from tax'.
Line 2 reason comes from:
https://github.com/odoo-dev/odoo/blob/de22093ee225df499b2de80e1f07dd281ac686bc/addons/account_edi_ubl_cii/models/account_edi_common.py#L271-L274

opw-5912986