### PR TITLE
[FIX] point_of_sale: prevent reload cancellation on Android mobile

### DIFF
--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.xml
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.xml
@@ -80,7 +80,7 @@
                                 <DropdownItem t-if="hardwareProxy.printer" onSelected="() => this.showSaleDetails()">
                                     Print Report
                                 </DropdownItem>
-                                <DropdownItem onSelected="() => pos.closePos()">
+                                <DropdownItem closingMode="'none'" onSelected="() => pos.closePos()">
                                     Backend
                                 </DropdownItem>
                                 <DropdownItem onSelected="() => this.pos.closeSession()">

--- a/addons/point_of_sale/static/tests/unit/components/navbar.test.js
+++ b/addons/point_of_sale/static/tests/unit/components/navbar.test.js
@@ -1,0 +1,38 @@
+import { test, expect } from "@odoo/hoot";
+import { click } from "@odoo/hoot-dom";
+import { animationFrame } from "@odoo/hoot-mock";
+import { mountWithCleanup, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { Navbar } from "@point_of_sale/app/components/navbar/navbar";
+import { setupPosEnv } from "@point_of_sale/../tests/unit/utils";
+import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
+
+definePosModels();
+
+test("Backend button should not close the menu (closingMode='none')", async () => {
+    const store = await setupPosEnv();
+
+    patchWithCleanup(store, {
+        async closePos() {},
+    });
+
+    await mountWithCleanup(Navbar);
+
+    // 1. Open the burger menu dropdown
+    await click(".status-buttons .o-dropdown.dropdown-toggle");
+    await animationFrame();
+
+    // Verify menu is open
+    expect(".pos-burger-menu-items").toHaveCount(1);
+
+    // 2. Find and click "Backend"
+    const backendItem = [
+        ...document.querySelectorAll(".pos-burger-menu-items .dropdown-item"),
+    ].find((el) => el.textContent.includes("Backend"));
+    expect(Boolean(backendItem)).toBe(true);
+
+    await click(backendItem);
+    await animationFrame();
+
+    // 3. Verify the menu is STILL OPEN
+    expect(".pos-burger-menu-items").toHaveCount(1);
+});


### PR DESCRIPTION
On mobile, the POS burger menu renders as a BottomSheet. When clicking items that trigger a page reload or navigation (e.g. "Switch to Dark Mode", "Backend"), the DropdownItem's default behavior closes all parent dropdowns after the callback. This triggers the BottomSheet's slideOut() which calls history.pushState(), racing with location.reload() and causing Android Chrome to cancel the pending navigation. Set closingMode="none" on DropdownItems that trigger page reload/redirect so the BottomSheet teardown doesn't interfere.

task-id: 5960120

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
