### PR TITLE
[IMP] product,sale,purchase: allow selecting UoMs from product catalog

### DIFF
--- a/addons/product/models/product_catalog_mixin.py
+++ b/addons/product/models/product_catalog_mixin.py
@@ -85,6 +85,10 @@ class ProductCatalogMixin(models.AbstractModel):
             }
             if self.env['res.groups']._is_feature_enabled('uom.group_uom') and not order_line_info[product.id]['uomDisplayName']:
                 order_line_info[product.id]['uomDisplayName'] = product.uom_id.display_name
+            if not order_line_info[product.id].get('uomId'):
+                order_line_info[product.id]['uomId'] = product.uom_id.id
+            if not order_line_info[product.id].get('availableUoms'):
+                order_line_info[product.id]['availableUoms'] = product._get_available_uoms().read(['name', 'factor'])
 
         default_data = self._default_order_line_values(child_field)
         products = self.env['product.product'].browse(product_ids)
@@ -131,6 +135,7 @@ class ProductCatalogMixin(models.AbstractModel):
             'productType': product.type,
             'price': product.standard_price,
             'code': product.code if product.code else '',
+            'availableUoms': product._get_available_uoms().read(['name', 'factor']),
             **self._get_product_catalog_uom_data(product, product.uom_id)
         }
 

--- a/addons/product/models/product_catalog_mixin.py
+++ b/addons/product/models/product_catalog_mixin.py
@@ -85,6 +85,10 @@ class ProductCatalogMixin(models.AbstractModel):
             }
             if self.env['res.groups']._is_feature_enabled('uom.group_uom') and not order_line_info[product.id]['uomDisplayName']:
                 order_line_info[product.id]['uomDisplayName'] = product.uom_id.display_name
+            if not order_line_info[product.id].get('uomId'):
+                order_line_info[product.id]['uomId'] = product.uom_id.id
+            if not order_line_info[product.id].get('availableUoms'):
+                order_line_info[product.id]['availableUoms'] = product._get_available_uoms().read(['name'])
 
         default_data = self._default_order_line_values(child_field)
         products = self.env['product.product'].browse(product_ids)
@@ -131,6 +135,7 @@ class ProductCatalogMixin(models.AbstractModel):
             'productType': product.type,
             'price': product.standard_price,
             'code': product.code if product.code else '',
+            'availableUoms': product._get_available_uoms().read(['name']),
             **self._get_product_catalog_uom_data(product, product.uom_id)
         }
 

--- a/addons/product/static/src/product_catalog/kanban_model.js
+++ b/addons/product/static/src/product_catalog/kanban_model.js
@@ -80,6 +80,8 @@ export class ProductCatalogKanbanModel extends RelationalModel {
                 productType: "consu",
                 readOnly: false,
                 uomDisplayName: _t("Units"),
+                uomId: 1,
+                availableUoms: [{ id: 1, name: _t("Units") }],
             };
         }
         return sampleOrderLineInfo;

--- a/addons/product/static/src/product_catalog/kanban_model.js
+++ b/addons/product/static/src/product_catalog/kanban_model.js
@@ -74,6 +74,8 @@ export class ProductCatalogKanbanModel extends RelationalModel {
                 productType: "consu",
                 readOnly: false,
                 uomDisplayName: _t("Units"),
+                uomId: 1,
+                availableUoms: [{ id: 1, name: _t("Units") }],
             };
         }
         return sampleOrderLineInfo;

--- a/addons/product/static/src/product_catalog/kanban_record.js
+++ b/addons/product/static/src/product_catalog/kanban_record.js
@@ -30,6 +30,7 @@ export class ProductCatalogKanbanRecord extends KanbanRecord {
             increaseQuantity: this.increaseQuantity.bind(this),
             setQuantity: this.setQuantity.bind(this),
             decreaseQuantity: this.decreaseQuantity.bind(this),
+            setUom: this.setUom.bind(this),
             childField: this.props.record.context.child_field,
         });
     }
@@ -80,13 +81,31 @@ export class ProductCatalogKanbanRecord extends KanbanRecord {
             quantity: this.productCatalogData.quantity,
             res_model: this.env.orderResModel,
             child_field: this.env.childField,
-            uom_id: this.productCatalogData.uomId,
+            uom_id: this.productCatalogData.uomId || false,
         };
     }
 
     //--------------------------------------------------------------------------
     // Handlers
     //--------------------------------------------------------------------------
+
+    async setUom(uomId) {
+        if (this.productCatalogData.readOnly) {
+            return;
+        }
+        const data = this.productCatalogData;
+        const newUom = data.availableUoms.find(u => u.id === uomId);
+        const oldUom = data.availableUoms.find(u => u.id === data.uomId);
+        if (newUom && oldUom) {
+            data.uomId = newUom.id;
+            data.uomDisplayName = newUom.name;
+            if (data.productUomFactor !== undefined) {
+                data.productUomFactor = data.productUomFactor * oldUom.factor / newUom.factor;
+            }
+            const price = await this._updateQuantityAndGetPrice();
+            data.price = parseFloat(price);
+        }
+    }
 
     updateQuantity(quantity) {
         if (this.productCatalogData.readOnly) {

--- a/addons/product/static/src/product_catalog/kanban_record.js
+++ b/addons/product/static/src/product_catalog/kanban_record.js
@@ -30,6 +30,7 @@ export class ProductCatalogKanbanRecord extends KanbanRecord {
             increaseQuantity: this.increaseQuantity.bind(this),
             setQuantity: this.setQuantity.bind(this),
             decreaseQuantity: this.decreaseQuantity.bind(this),
+            setUom: this.setUom.bind(this),
             childField: this.props.record.context.child_field,
         });
     }
@@ -80,13 +81,26 @@ export class ProductCatalogKanbanRecord extends KanbanRecord {
             quantity: this.productCatalogData.quantity,
             res_model: this.env.orderResModel,
             child_field: this.env.childField,
-            uom_id: this.productCatalogData.uomId,
+            uom_id: this.productCatalogData.uomId || false,
         };
     }
 
     //--------------------------------------------------------------------------
     // Handlers
     //--------------------------------------------------------------------------
+
+    async setUom(uomId) {
+        if (this.productCatalogData.readOnly) {
+            return;
+        }
+        const uom = this.productCatalogData.availableUoms.find(u => u.id === uomId);
+        if (uom) {
+            this.productCatalogData.uomId = uom.id;
+            this.productCatalogData.uomDisplayName = uom.name;
+            const price = await this._updateQuantityAndGetPrice();
+            this.productCatalogData.price = parseFloat(price);
+        }
+    }
 
     updateQuantity(quantity) {
         if (this.productCatalogData.readOnly) {

--- a/addons/product/static/src/product_catalog/order_line/order_line.js
+++ b/addons/product/static/src/product_catalog/order_line/order_line.js
@@ -11,6 +11,7 @@ export class ProductCatalogOrderLine extends Component {
         productType: String,
         uomId: { type: Number, optional: true },
         uomDisplayName: { type: String, optional: true },
+        availableUoms: { type: Array, optional: true },
         productUomFactor: { type: Number, optional: true },
         productUomDisplayName: { type: String, optional: true },
         sellerUomFactor: { type: Number, optional: true },
@@ -18,6 +19,10 @@ export class ProductCatalogOrderLine extends Component {
         readOnly: { type: Boolean, optional: true },
         warning: { type: String, optional: true },
     };
+
+    setup() {
+        this.hasMultipleUoms = this.props.availableUoms && this.props.availableUoms.length > 1;
+    }
 
     /**
      * Focus input text when clicked
@@ -58,6 +63,15 @@ export class ProductCatalogOrderLine extends Component {
         const digits = [false, this.env.precision];
         const options = { digits, decimalPoint: ".", thousandsSep: "" };
         return parseFloat(formatFloat(this.props.quantity, options));
+    }
+
+    get uomSelectStyle() {
+        const name = this.props.uomDisplayName || "";
+        return `width: ${name.length + 5}ch;`;
+    }
+
+    onUomChange(ev) {
+        this.env.setUom(parseInt(ev.target.value));
     }
 
     get showPrice() {

--- a/addons/product/static/src/product_catalog/order_line/order_line.js
+++ b/addons/product/static/src/product_catalog/order_line/order_line.js
@@ -11,6 +11,7 @@ export class ProductCatalogOrderLine extends Component {
         productType: String,
         uomId: Number,
         uomDisplayName: { type: String, optional: true },
+        availableUoms: { type: Array, optional: true },
         productUomFactor: { type: Number, optional: true },
         productUomDisplayName: { type: String, optional: true },
         sellerUomFactor: { type: Number, optional: true },
@@ -18,6 +19,10 @@ export class ProductCatalogOrderLine extends Component {
         readOnly: { type: Boolean, optional: true },
         warning: { type: String, optional: true },
     };
+
+    setup() {
+        this.hasMultipleUoms = this.props.availableUoms && this.props.availableUoms.length > 1;
+    }
 
     /**
      * Focus input text when clicked
@@ -58,6 +63,15 @@ export class ProductCatalogOrderLine extends Component {
         const digits = [false, this.env.precision];
         const options = { digits, decimalPoint: ".", thousandsSep: "" };
         return parseFloat(formatFloat(this.props.quantity, options));
+    }
+
+    get uomSelectStyle() {
+        const name = this.props.uomDisplayName || "";
+        return `width: ${name.length + 5}ch;`;
+    }
+
+    onUomChange(ev) {
+        this.env.setUom(parseInt(ev.target.value));
     }
 
     get showPrice() {

--- a/addons/product/static/src/product_catalog/order_line/order_line.scss
+++ b/addons/product/static/src/product_catalog/order_line/order_line.scss
@@ -9,6 +9,14 @@ div.o_product_catalog_quantity {
             margin: 0;
         }
     }
+    select.form-select {
+        flex: 0 0 auto;
+        max-width: 20ch;
+        text-overflow: ellipsis;
+        // Restore form-select's right padding (overridden by input-group-text's symmetric padding).
+        padding-right: 1.5rem;
+        background-position: right 0.25rem center;
+    }
 }
 
 .o_kanban_view .o_kanban_renderer .o_kanban_record.o_product_added {

--- a/addons/product/static/src/product_catalog/order_line/order_line.xml
+++ b/addons/product/static/src/product_catalog/order_line/order_line.xml
@@ -43,8 +43,19 @@
                     t-on-change="this.env.setQuantity"
                     t-on-focus="this._onFocus"
                 />
+                <select t-if="this.hasMultipleUoms"
+                    class="input-group-text form-select rounded-0"
+                    t-att-style="this.uomSelectStyle"
+                    t-on-change="this.onUomChange"
+                >
+                    <option t-foreach="this.props.availableUoms" t-as="uom" t-key="uom.id"
+                        t-att-value="uom.id"
+                        t-att-selected="uom.id === this.props.uomId"
+                        t-out="uom.name"
+                    />
+                </select>
                 <span
-                    t-if="this.props.uomDisplayName"
+                    t-elif="this.props.uomDisplayName"
                     class="input-group-text d-block rounded-0 text-truncate cursor-default"
                     t-out="this.props.uomDisplayName" t-att-title="this.props.uomDisplayName"
                 />

--- a/addons/product/static/src/product_catalog/order_line/order_line.xml
+++ b/addons/product/static/src/product_catalog/order_line/order_line.xml
@@ -42,8 +42,19 @@
                     t-on-change="this.env.setQuantity"
                     t-on-focus="this._onFocus"
                 />
+                <select t-if="this.env.displayUoM and hasMultipleUoms"
+                    class="input-group-text form-select rounded-0"
+                    t-att-style="uomSelectStyle"
+                    t-on-change="onUomChange"
+                >
+                    <option t-foreach="props.availableUoms" t-as="uom" t-key="uom.id"
+                        t-att-value="uom.id"
+                        t-att-selected="uom.id === props.uomId"
+                        t-out="uom.name"
+                    />
+                </select>
                 <span
-                    t-if="this.props.uomDisplayName"
+                    t-elif="this.props.uomDisplayName"
                     class="input-group-text d-block rounded-0 text-truncate cursor-default"
                     t-out="this.props.uomDisplayName" t-att-title="this.props.uomDisplayName"
                 />

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -1227,6 +1227,8 @@ class PurchaseOrder(models.Model):
         product_data = super()._get_product_catalog_product_data(product)
         seller_data = self._get_product_catalog_seller_data(product)
         product_data.update(seller_data)
+        available_uoms = product._get_available_uoms() | product.seller_ids.uom_id
+        product_data['availableUoms'] = available_uoms.read(['name', 'factor'])
         return product_data
 
     def _get_product_catalog_record_lines(self, product_ids, *, section_id=None, **kwargs):
@@ -1362,9 +1364,10 @@ class PurchaseOrder(models.Model):
     ):
         """ Update purchase order line information for a given product or create
         a new one if none exists yet.
-        :param int product_id: The product, as a `product.product` id.
+        :param record product_id: The product, as a `product.product` record.
         :param int quantity: The quantity selected in the catalog.
         :param int section_id: The id of section selected in the catalog.
+        :param record uom_id: The UoM selected in the catalog, as a `uom.uom` record.
         :return: The unit price of the product, based on the pricelist of the
                  purchase order and the quantity selected.
         :rtype: float
@@ -1375,6 +1378,16 @@ class PurchaseOrder(models.Model):
             and l.get_parent_section_line().id == section_id
         )
         if pol:
+            if uom and pol.uom_id != uom:
+                old_uom = pol.uom_id
+                pol.uom_id = uom.id
+                # For real records, _origin == self, so the compute method's
+                # _origin check always passes and skips price recomputation
+                # when there's no vendor pricelist. Convert the price manually.
+                if not pol.selected_seller_id:
+                    pol.price_unit = pol.technical_price_unit = old_uom._compute_price(
+                        pol.price_unit, pol.uom_id
+                    )
             if quantity != 0:
                 pol.product_qty = quantity
             elif self.state in ['draft', 'sent']:

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -1223,6 +1223,8 @@ class PurchaseOrder(models.Model):
         product_data = super()._get_product_catalog_product_data(product)
         seller_data = self._get_product_catalog_seller_data(product)
         product_data.update(seller_data)
+        available_uoms = product._get_available_uoms() | product.seller_ids.uom_id
+        product_data['availableUoms'] = available_uoms.read(['name'])
         return product_data
 
     def _get_product_catalog_record_lines(self, product_ids, *, section_id=None, **kwargs):
@@ -1361,6 +1363,7 @@ class PurchaseOrder(models.Model):
         :param int product_id: The product, as a `product.product` id.
         :param int quantity: The quantity selected in the catalog.
         :param int section_id: The id of section selected in the catalog.
+        :param int uom_id: The UoM selected in the catalog, as a `uom.uom` id.
         :return: The unit price of the product, based on the pricelist of the
                  purchase order and the quantity selected.
         :rtype: float
@@ -1371,6 +1374,16 @@ class PurchaseOrder(models.Model):
             and l.get_parent_section_line().id == section_id
         )
         if pol:
+            if uom and pol.uom_id != uom:
+                old_uom = pol.uom_id
+                pol.uom_id = uom.id
+                # For real records, _origin == self, so the compute method's
+                # _origin check always passes and skips price recomputation
+                # when there's no vendor pricelist. Convert the price manually.
+                if not pol.selected_seller_id:
+                    pol.price_unit = pol.technical_price_unit = old_uom._compute_price(
+                        pol.price_unit, pol.uom_id
+                    )
             if quantity != 0:
                 pol.product_qty = quantity
             elif self.state in ['draft', 'sent']:

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -597,10 +597,15 @@ class PurchaseOrderLine(models.Model):
         if self:
             self.product_id.ensure_one()
             catalog_info = self[0].order_id._get_product_catalog_seller_data(self.product_id)
+            available_uoms = self.product_id._get_available_uoms() | self.product_id.seller_ids.uom_id
             catalog_info.update(
                 quantity=self[0].product_qty,
                 price=self[0].price_unit_discounted,
                 readOnly=self[0].order_id._is_readonly() or len(self) > 1,
+                availableUoms=[
+                    {'id': uom.id, 'name': uom.display_name, 'factor': uom.factor}
+                    for uom in available_uoms
+                ],
                 **self[0].order_id._get_product_catalog_uom_data(self.product_id, self[0].uom_id),
             )
             return catalog_info

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -591,10 +591,15 @@ class PurchaseOrderLine(models.Model):
         if self:
             self.product_id.ensure_one()
             catalog_info = self[0].order_id._get_product_catalog_seller_data(self.product_id)
+            available_uoms = self.product_id.product_tmpl_id._get_available_uoms() | self.product_id.seller_ids.uom_id
             catalog_info.update(
                 quantity=self[0].product_qty,
                 price=self[0].price_unit_discounted,
                 readOnly=self[0].order_id._is_readonly() or len(self) > 1,
+                availableUoms=[
+                    {'id': uom.id, 'name': uom.display_name}
+                    for uom in available_uoms
+                ],
                 **self[0].order_id._get_product_catalog_uom_data(self.product_id, self[0].uom_id),
             )
             return catalog_info

--- a/addons/purchase/tests/test_purchase_product_catalog.py
+++ b/addons/purchase/tests/test_purchase_product_catalog.py
@@ -104,7 +104,8 @@ class TestPurchaseProductCatalog(AccountTestInvoicingCommon, HttpCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()['result'], company_product_price)
 
-        purchase_order.order_line[0].uom_id = self.env.ref('uom.product_uom_pack_6')
+        pack_6_uom = self.env.ref('uom.product_uom_pack_6')
+        purchase_order.order_line[0].uom_id = pack_6_uom
         resp = self.make_jsonrpc_request(
             route='/product/catalog/update_order_line_info',
             params={
@@ -113,7 +114,7 @@ class TestPurchaseProductCatalog(AccountTestInvoicingCommon, HttpCase):
                     'product_id': other_product.id,
                     'quantity': 2,
                     'res_model': 'purchase.order',
-                    'uom_id': other_product.uom_id.id,
+                    'uom_id': pack_6_uom.id,
                 },
             headers={'Content-Type': 'application/json'},
         )

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -2696,9 +2696,10 @@ class SaleOrder(models.Model):
         """Update sale order line information for a given product or create a
         new one if none exists yet.
 
-        :param int product_id: The product, as a `product.product` id.
+        :param record product: The product, as a `product.product` record.
         :param int quantity: The quantity selected in the catalog.
         :param int section_id: The id of section selected in the catalog.
+        :param record uom: The UoM selected in the catalog, as a `uom.uom` record.
         :return: The unit price of the product, based on the pricelist of the sale order and the
                  quantity selected.
         :rtype: float
@@ -2710,6 +2711,8 @@ class SaleOrder(models.Model):
             )
         )
         if sol:
+            if uom and sol.product_uom_id != uom:
+                sol.product_uom_id = uom.id
             if quantity != 0:
                 sol.product_uom_qty = quantity
             elif self.state in ["draft", "sent"]:

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -2620,8 +2620,8 @@ class SaleOrder(models.Model):
         :param int product_id: The product, as a `product.product` id.
         :param int quantity: The quantity selected in the catalog.
         :param int section_id: The id of section selected in the catalog.
+        :param int uom_id: The UoM selected in the catalog, as a `uom.uom` id.
         :return: The unit price of the product, based on the pricelist of the sale order and the
-                 quantity selected.
         :rtype: float
         """
         request.update_context(catalog_skip_tracking=True)
@@ -2631,6 +2631,8 @@ class SaleOrder(models.Model):
             )
         )
         if sol:
+            if uom and sol.product_uom_id != uom:
+                sol.product_uom_id = uom.id
             if quantity != 0:
                 sol.product_uom_qty = quantity
             elif self.state in ["draft", "sent"]:

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1954,16 +1954,22 @@ class SaleOrderLine(models.Model):
             }
         """
         if len(self) == 1:
+            available_uoms = self.product_id._get_available_uoms()
             return {
                 "quantity": self.product_uom_qty,
                 "price": self._get_discounted_price(),
                 "readOnly": (self.order_id._is_readonly() or bool(self.combo_item_id)),
                 **self.order_id._get_product_catalog_uom_data(self.product_id, self.product_uom_id),
+                "availableUoms": [
+                    {"id": uom.id, "name": uom.display_name, "factor": uom.factor}
+                    for uom in available_uoms
+                ],
             }
         if self:
             self.product_id.ensure_one()
             order_line = self[0]
             order = order_line.order_id
+            available_uoms = self.product_id._get_available_uoms()
             return {
                 "readOnly": True,
                 "price": order.pricelist_id._get_product_price(
@@ -1981,6 +1987,11 @@ class SaleOrderLine(models.Model):
                     )
                 ),
                 "uomDisplayName": self.product_id.uom_id.display_name,
+                "uomId": self.product_id.uom_id.id,
+                "availableUoms": [
+                    {"id": uom.id, "name": uom.display_name, "factor": uom.factor}
+                    for uom in available_uoms
+                ],
             }
         return {
             "quantity": 0

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1950,16 +1950,22 @@ class SaleOrderLine(models.Model):
             }
         """
         if len(self) == 1:
+            available_uoms = self.product_id.product_tmpl_id._get_available_uoms()
             return {
                 "quantity": self.product_uom_qty,
                 "price": self._get_discounted_price(),
                 "readOnly": (self.order_id._is_readonly() or bool(self.combo_item_id)),
                 **self.order_id._get_product_catalog_uom_data(self.product_id, self.product_uom_id),
+                "availableUoms": [
+                    {"id": uom.id, "name": uom.display_name}
+                    for uom in available_uoms
+                ],
             }
         if self:
             self.product_id.ensure_one()
             order_line = self[0]
             order = order_line.order_id
+            available_uoms = self.product_id.product_tmpl_id._get_available_uoms()
             return {
                 "readOnly": True,
                 "price": order.pricelist_id._get_product_price(
@@ -1977,6 +1983,11 @@ class SaleOrderLine(models.Model):
                     )
                 ),
                 "uomDisplayName": self.product_id.uom_id.display_name,
+                "uomId": self.product_id.uom_id.id,
+                "availableUoms": [
+                    {"id": uom.id, "name": uom.display_name}
+                    for uom in available_uoms
+                ],
             }
         return {
             "quantity": 0


### PR DESCRIPTION
Previously, when selecting a product that has multiple UoMs/Packagings in
product catalog, it was only possible to select the base UoM of the
product. This commit makes it possible to select any of the product's
UoMs from the catalog directly.

Task-5917766
