### PR TITLE
[FIX] spreadsheet: Fix pivot drilldown helper

### DIFF
--- a/addons/spreadsheet/static/src/pivot/pivot_actions.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_actions.js
@@ -58,7 +58,7 @@ export const SEE_RECORDS_PIVOT_VISIBLE = (position, getters) => {
         pivotCell.type !== "EMPTY" &&
         cell &&
         cell.isFormula &&
-        getNumberOfPivotFunctions(cell.compiledFormula) === 1 &&
+        getNumberOfPivotFunctions(cell.compiledFormula, getters) === 1 &&
         getters.getPivotCoreDefinition(pivotId).type === "ODOO" &&
         getters.getPivot(pivotId).getPivotCellDomain(pivotCell.domain)
     );

--- a/addons/spreadsheet/static/tests/pivots/pivot_see_records.test.js
+++ b/addons/spreadsheet/static/tests/pivots/pivot_see_records.test.js
@@ -220,7 +220,9 @@ test("Can see records on PIVOT cells", async function () {
         for (const [xc, formula] of Object.entries(cells)) {
             // let's check the cell formula is what we expect
             const cell = getCell(model, xc, firstSheetId);
-            const content = !cell.isFormula ? cell?.content : cell?.compiledFormula.toFormulaString(model.getters);
+            const content = !cell.isFormula
+                ? cell?.content
+                : cell?.compiledFormula.toFormulaString(model.getters);
             expect(content).toBe(formula, {
                 message: `${xc} on the first sheet is ${formula}`,
             });
@@ -276,6 +278,31 @@ test("Can see records on PIVOT cells", async function () {
     // set the function in A3 such as the data cells matches the ones in the first sheet
     setCellContent(model, "A3", `=PIVOT("1",,,FALSE,,FALSE)`, "42");
     await checkCells(data_cells);
+});
+
+test("Can see records of a pivot cell with references as parameters", async function () {
+    const actions = [];
+    const fakeActionService = {
+        doAction: (actionRequest, options = {}) => {
+            expect.step("doAction");
+            actions.push(actionRequest);
+        },
+    };
+    mockService("action", fakeActionService);
+    const { env, model } = await createSpreadsheetWithPivot({ pivotType: "static" });
+    setCellContent(model, "A1", `1`);
+    setCellContent(model, "B1", '=PIVOT.VALUE(1,"probability:avg","bar",TRUE,"foo",A1)');
+    selectCell(model, "B1");
+    let action = await getActionMenu(cellMenuRegistry, ["pivot_see_records"], env);
+    expect(action.isVisible(env)).toBe(true);
+    await doMenuAction(cellMenuRegistry, ["pivot_see_records"], env);
+    setCellContent(model, "G7", "=B1");
+    selectCell(model, "G7");
+    action = await getActionMenu(cellMenuRegistry, ["pivot_see_records"], env);
+    expect(action.isVisible(env)).toBe(true);
+    await doMenuAction(cellMenuRegistry, ["pivot_see_records"], env);
+    expect(actions[0]).toEqual(actions[1], { message: "both actions are the same" });
+    expect.verifySteps(["doAction", "doAction"]);
 });
 
 test("Cannot see records of pivot formula without value", async function () {


### PR DESCRIPTION
The helper `getNumberOfPivotFunctions` now requires the getters following a recent refactoring. This would cause crashes when we tried to determine if the drilldown of pivot cells could be displayed.

How to reproduce:
Go to the livechart dashboard and scroll a bit...

Task-5969008

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
