### PR TITLE
[FIX] hr_holidays : Consider leaves for allocation with no date_to

### DIFF
--- a/addons/hr_holidays/report/hr_leave_employee_type_report.py
+++ b/addons/hr_holidays/report/hr_leave_employee_type_report.py
@@ -95,7 +95,11 @@ class LeaveReport(models.Model):
                         ON vl.employee_id = oa.employee_id
                         AND vl.leave_type = oa.leave_type
                         AND vl.date_from <= COALESCE(oa.date_to, 'infinity')
-                        AND vl.date_to   >= oa.date_from
+                        AND (
+                            oa.date_to IS NULL
+                            OR
+                            vl.date_to >= oa.date_from
+                        )
                     GROUP BY oa.allocation_id
                 ),
 

--- a/addons/hr_holidays/tests/__init__.py
+++ b/addons/hr_holidays/tests/__init__.py
@@ -26,3 +26,4 @@ from . import test_timeoff_event
 from . import test_working_hours
 from . import test_dashboard
 from . import test_expiring_leaves
+from . import test_hr_leave_report

--- a/addons/hr_holidays/tests/test_hr_leave_report.py
+++ b/addons/hr_holidays/tests/test_hr_leave_report.py
@@ -1,0 +1,80 @@
+
+from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
+
+
+class TestHrLeaveReport(TestHrHolidaysCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.overtime_leave_type = cls.env['hr.leave.type'].create({
+            'name': 'Overtime Type',
+            'requires_allocation': 'yes',
+            'leave_validation_type': 'no_validation',
+            'request_unit': 'hour',
+            'time_type': 'leave',
+        })
+
+    def test_hr_leave_employee_report(self):
+        self.env['hr.leave.allocation'].create([
+            {
+                'name': 'Overtime',
+                'employee_id': self.employee_emp.id,
+                'holiday_status_id': self.overtime_leave_type.id,
+                'date_from': '2025-12-01',
+                'number_of_days': '1.875',
+            },
+            {
+                'name': 'Overtime',
+                'employee_id': self.employee_emp.id,
+                'holiday_status_id': self.overtime_leave_type.id,
+                'date_from': '2026-01-01',
+                'number_of_days': '12.6875',
+            },
+            {
+                'name': 'Overtime',
+                'employee_id': self.employee_emp.id,
+                'holiday_status_id': self.overtime_leave_type.id,
+                'date_from': '2026-02-01',
+                'number_of_days': '1.5',
+            },
+        ]).action_validate()
+
+        self.env['hr.leave'].create([
+            {
+                'employee_id': self.employee_emp.id,
+                'holiday_status_id': self.overtime_leave_type.id,
+                'request_date_from': '2025-12-02',
+                'request_unit_hours': True,
+                'request_hour_from': 8,
+                'request_hour_to': 17,
+            },
+            {
+                'employee_id': self.employee_emp.id,
+                'holiday_status_id': self.overtime_leave_type.id,
+                'request_date_from': '2026-01-02',
+                'request_unit_hours': True,
+                'request_hour_from': 8,
+                'request_hour_to': 17,
+            },
+            {
+                'employee_id': self.employee_emp.id,
+                'holiday_status_id': self.overtime_leave_type.id,
+                'request_date_from': '2026-02-02',
+                'request_unit_hours': True,
+                'request_hour_from': 8,
+                'request_hour_to': 17,
+            },
+        ]).action_validate()
+
+        domain = [
+            ('company_id', '=', self.employee_emp.company_id.id),
+            ('employee_id', '=', self.employee_emp.id),
+            ('leave_type', '=', self.overtime_leave_type.id),
+        ]
+        leave_balance = self.env['hr.leave.employee.type.report'].search(domain)
+
+        left_allocation = leave_balance.filtered(lambda l: l.holiday_status == 'left')
+        taken_allocation = leave_balance.filtered(lambda l: l.holiday_status == 'taken')
+
+        self.assertEqual(sum(left_allocation.mapped('number_of_hours')), 104.5)
+        self.assertEqual(sum(taken_allocation.mapped('number_of_hours')), 24.0)


### PR DESCRIPTION
### Steps to reproduce:
	- Create a Overtime hours time off type
	- Create mutliple allocations with different start dates but no end date
	- Create some leaves for the created allocations one after each allocation start date
	- Compare the number of hours remaining for the allocations' employee in his time off dashboard and in the Balance report.

### Cause:
After this commit https://github.com/odoo/odoo/pull/245860/changes/d9bb4d206e91d10eac7311adede307b8c5019213 we changed the way we match leaves with allocations but we were strict that the leave has to lie in between the allocation dates and this created a wrong accumlated taken_hours in the taken_per_allocation subquery.

### Fix:
Following the same approach we use in  if
the allocation has no expiry date we don't check if the leave.date_to > allocation.date_from as we are going to treat all allocations as they form one big allocation that started in the earliest start date

opw-5474596