### PR TITLE
[FIX] crm_iap_mine: Handle no credit properly

### DIFF
--- a/addons/crm_iap_mine/models/crm_iap_lead_mining_request.py
+++ b/addons/crm_iap_mine/models/crm_iap_lead_mining_request.py
@@ -251,15 +251,17 @@ class CRMLeadMiningRequest(models.Model):
         }
         try:
             response = self._iap_contact_mining(params, timeout=300)
+
+            if response.get('credit_error'):
+                self.error_type = 'credits'
+                self.state = 'error'
+                return False
+
             if not response.get('data'):
                 self.error_type = 'no_result'
                 return False
 
             return response['data']
-        except iap_tools.InsufficientCreditError as e:
-            self.error_type = 'credits'
-            self.state = 'error'
-            return False
         except Exception as e:
             raise UserError(_("Your request could not be executed: %s", e))
 

--- a/addons/crm_iap_mine/tests/common.py
+++ b/addons/crm_iap_mine/tests/common.py
@@ -32,8 +32,6 @@ class MockIAPReveal(MockIAPEnrich):
         def _iap_contact_mining(params, timeout):
             self.assertMineCallParams(params)
 
-            if sim_error and sim_error == 'credit':
-                raise iap_tools.InsufficientCreditError('InsufficientCreditError')
             if sim_error and sim_error == 'jsonrpc_exception':
                 raise exceptions.AccessError(
                     'The url that this service requested returned an error. Please contact the author of the app. The url it tried to contact was [STRIPPED]'
@@ -56,7 +54,7 @@ class MockIAPReveal(MockIAPEnrich):
 
             return {
                 'data': response,
-                'credit_error': False
+                'credit_error': sim_error == 'credit',
             }
 
         with patch.object(CRMLeadMiningRequest, '_iap_contact_mining', side_effect=_iap_contact_mining), \


### PR DESCRIPTION
Before this commit, when the user uses CRM to generate new leads and does not have credits, the error message they would get is "Your request did not return any result (no credits were used). Try removing some filters."

This commit fixes this in _perform_request by instead of expecting InsufficientCreditError raised it now expects the credit_error flag to be set.

task-5925047
