### PR TITLE
[FIX] hr: Add HR group to PIN field on user view

### DIFF
--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -72,7 +72,7 @@
                     </h5>
                 </xpath>
                 <xpath expr="//group[@name='other_preferences']" position="inside">
-                    <field name="pin" string="Attendance PIN"/>
+                    <field name="pin" string="Attendance PIN" groups="hr.group_hr_user"/>
                 </xpath>
                 <xpath expr="//group[@name='other_calendar_preferences']" position="inside">
                     <field name="work_location_id" string="Main Work Location" options="{'no_create': True}"/>


### PR DESCRIPTION
The field `res_users.pin` is restricted to members of `hr.group_hr_user` but is added to the form view, so if a user with HR access rights tries to view another user, it will trigger an access error:

```
odoo.exceptions.AccessError: You do not have enough rights to access the field "pin" on Employee (hr.employee). Please contact your system administrator.
```

To reproduce:
- With `hr` installed, remove its access rights from the admin and try to view another user.

This error is related to recent changes[^1] in the access of employee fields, it might be possible to have a different approach to this error. It will break while trying to access the employee field for which the user doesn't have access:
https://github.com/odoo/odoo/blob/012f510e70d7d0afd226e4198b2e1759db3ca18d/addons/hr/models/res_users.py#L29-L36

In earlier versions, the field was not accessed directly. It was just automatically hidden from the view if the user didn't have the right group.
[^1]:https://github.com/odoo/odoo/commit/012f510e70d7d0afd226e4198b2e1759db3ca18d