### PR TITLE
[FIX] website_event: Fixing rendering of new registration

### DIFF
--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -265,6 +265,8 @@ class WebsiteEventController(http.Controller):
     @http.route(['/event/<model("event.event"):event>/registration/new'], type='json', auth="public", methods=['POST'], website=True)
     def registration_new(self, event, **post):
         values = self._prepare_registration_new_values(event, **post)
+        if not values:
+            return values
         return request.env['ir.ui.view']._render_template("website_event.registration_attendee_details", values)
 
     def _process_attendees_form(self, event, form_details):


### PR DESCRIPTION
After splitting the controller, the return early was omitted, and there was a try to render the template if there weren't tickets to sell, and it gave an error.

Now, this is being fixed.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
