### PR TITLE
[FIX] sale_gelato, website_sale{,_gelato}: prevent express checkout

### DIFF
--- a/addons/sale_gelato/models/sale_order.py
+++ b/addons/sale_gelato/models/sale_order.py
@@ -85,11 +85,11 @@ class SaleOrder(models.Model):
         :rtype: str | None
         """
         required_address_fields = ['city', 'country_id', 'email', 'name', 'street']
-        if self.partner_id.country_id.code not in const.COUNTRIES_WITHOUT_ZIPCODE:
+        if self.partner_shipping_id.country_id.code not in const.COUNTRIES_WITHOUT_ZIPCODE:
             required_address_fields.append('zip')
         missing_fields = [
-            self.partner_id._fields[field_name]
-            for field_name in required_address_fields if not self.partner_id[field_name]
+            self.partner_shipping_id._fields[field_name]
+            for field_name in required_address_fields if not self.partner_shipping_id[field_name]
         ]
         if missing_fields:
             translated_field_names = [f._description_string(self.env) for f in missing_fields]

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -907,3 +907,6 @@ class SaleOrder(models.Model):
         """Recompute taxes and prices for the current cart."""
         self._recompute_taxes()
         self._recompute_prices()
+
+    def _allow_express_checkout(self):
+        return True

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -3383,7 +3383,9 @@
             <t t-if="website_sale_order and website_sale_order.website_order_line">
                 <t
                     t-if="(website.account_on_checkout != 'mandatory' or
-                            not website.is_public_user()) and show_shorter_cart_summary"
+                            not website.is_public_user()) and
+                            show_shorter_cart_summary and
+                            website_sale_order._allow_express_checkout()"
                     t-call="payment.express_checkout"
                 />
                 <t t-if="current_website_checkout_step_href == '/shop/payment'">

--- a/addons/website_sale_gelato/models/sale_order.py
+++ b/addons/website_sale_gelato/models/sale_order.py
@@ -34,3 +34,9 @@ class SaleOrder(models.Model):
                 product_name=product.name,
             )
         return super()._verify_updated_quantity(order_line, product_id, new_qty, uom_id, **kwargs)
+
+    def _allow_express_checkout(self):
+        res = super()._allow_express_checkout()
+        if res and any(self.order_line.product_id.mapped("gelato_product_uid")):
+            return not self._ensure_partner_address_is_complete()
+        return res


### PR DESCRIPTION
Issue:
---
Public users get error using Apple/Google pay with gelato.

Steps to reproduce:
---
1- Setup gelato and stripe express checkout.
2- Using phone, in incognito mode, add a gelato product to cart.
3- Try express checkout.

Cause:
---
This is because email and street is not present in express checkout.
While gelato needs these info to generate calculate shipping cost.

Fix:
---
We can prevent the express checkout to be shown in gelato orders.

opw-5904177