### PR TITLE
[FIX] project : Set the newly created sub-task at the bottom

### DIFF
--- a/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_list.js
+++ b/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_list.js
@@ -39,7 +39,7 @@ export class SubtaskKanbanList extends Component {
     get closedList() {
         return this.list.records.filter((child) => {
             return !["1_done", "1_canceled"].includes(child.data.state);
-        });
+        }).sort((subtask1, subtask2) => subtask1.resId - subtask2.resId);
     }
 
     get fieldInfo() {


### PR DESCRIPTION
### Steps to reproduce:
	- Create a project and a task in this project
	- Create a subtask for the created task
	- Go for the kanban view and add another subtask
	- Notice the last created subtask is on the top of the list

### Cause:
This is happening as we show the list of the subtasks as it is without sorting it.

### Fix:
We sort the closedList for subtasks ascendingly according to their IDs

opw-5943741