### PR TITLE
[FIX] stock: Ensure newly generated sequence numbers are correctly incremented

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1100,7 +1100,7 @@ Please change the quantity done or the rounding precision in your settings.""",
                         'id': value,
                         'display_name': self.env['stock.move.line'][key].browse(value).display_name
                     }
-        first_number = product.lot_sequence_id.number_next_actual - product.lot_sequence_id.number_increment
+        first_number = product.lot_sequence_id.number_next_actual
         if (first_lot and first_lot == product.lot_sequence_id.get_next_char(first_number)):
             product.lot_sequence_id.sudo().write({'number_next_actual': first_number + len(lot_qties)})
         return vals_list

--- a/addons/stock/tests/test_generate_serial_numbers.py
+++ b/addons/stock/tests/test_generate_serial_numbers.py
@@ -450,24 +450,25 @@ class StockGenerateCommon(TransactionCase):
         )
         first_num = self.product_serial.lot_sequence_id.number_next_actual
         self.product_serial.lot_sequence_id.invalidate_recordset(['number_next_actual'])
+        next_char = self.product_serial.lot_sequence_id.get_next_char
         move_line_vals = self.env['stock.move'].with_user(inventory_user.id).action_generate_lot_line_vals(
-            action_context, 'generate', self.product_serial.lot_sequence_id.next_by_id(), 5, False
+            action_context, 'generate', next_char(self.product_serial.lot_sequence_id.number_next_actual), 5, False
         )
         self.assert_move_line_vals_values(move_line_vals, [
-            {'quantity': 1, 'lot_name': self.product_serial.lot_sequence_id.get_next_char(first_num)},
-            {'quantity': 1, 'lot_name': self.product_serial.lot_sequence_id.get_next_char(first_num + 1)},
-            {'quantity': 1, 'lot_name': self.product_serial.lot_sequence_id.get_next_char(first_num + 2)},
-            {'quantity': 1, 'lot_name': self.product_serial.lot_sequence_id.get_next_char(first_num + 3)},
-            {'quantity': 1, 'lot_name': self.product_serial.lot_sequence_id.get_next_char(first_num + 4)},
+            {'quantity': 1, 'lot_name': next_char(first_num)},
+            {'quantity': 1, 'lot_name': next_char(first_num + 1)},
+            {'quantity': 1, 'lot_name': next_char(first_num + 2)},
+            {'quantity': 1, 'lot_name': next_char(first_num + 3)},
+            {'quantity': 1, 'lot_name': next_char(first_num + 4)},
         ])
 
         move_line_vals = self.env['stock.move'].with_user(inventory_user.id).action_generate_lot_line_vals(
-            action_context, 'generate', self.product_serial.lot_sequence_id.next_by_id(), 5, False
+            action_context, 'generate', next_char(self.product_serial.lot_sequence_id.number_next_actual), 5, False
         )
         self.assert_move_line_vals_values(move_line_vals, [
-            {'quantity': 1, 'lot_name': self.product_serial.lot_sequence_id.get_next_char(first_num + 5)},
-            {'quantity': 1, 'lot_name': self.product_serial.lot_sequence_id.get_next_char(first_num + 6)},
-            {'quantity': 1, 'lot_name': self.product_serial.lot_sequence_id.get_next_char(first_num + 7)},
-            {'quantity': 1, 'lot_name': self.product_serial.lot_sequence_id.get_next_char(first_num + 8)},
-            {'quantity': 1, 'lot_name': self.product_serial.lot_sequence_id.get_next_char(first_num + 9)},
+            {'quantity': 1, 'lot_name': next_char(first_num + 5)},
+            {'quantity': 1, 'lot_name': next_char(first_num + 6)},
+            {'quantity': 1, 'lot_name': next_char(first_num + 7)},
+            {'quantity': 1, 'lot_name': next_char(first_num + 8)},
+            {'quantity': 1, 'lot_name': next_char(first_num + 9)},
         ])


### PR DESCRIPTION
The Sequence used for generating serial numbers is not incremented. 
In previous versions the sequence writing logic was moved to python side to handle an access error with this PR:
https://github.com/odoo/odoo/pull/240368 
The logic expected `sequence.number_next_actual` to be higher than the first number when checking whether to increment sequence or not, because using the 'New' button used to increment the sequence once
 
(19.0):
https://github.com/odoo/odoo/blob/e10d23eba9cb6526ad68f037a493696992d1614c/addons/stock/models/stock_move.py#L1103-L1105  `first_number` is `number_next_actual` decremented once

https://github.com/odoo/odoo/blob/e10d23eba9cb6526ad68f037a493696992d1614c/addons/stock/static/src/widgets/generate_serial.js#L52-L54

As of 19.1 a change was implemented to make next serial number be filled automatically without having to press the button: https://github.com/odoo/odoo/pull/230221
(19.1)
https://github.com/odoo/odoo/blob/3263a7f54948d57f13176cf0416b1419150e9d87/addons/stock/static/src/widgets/generate_serial.js#L67-L68
These two changes resulted in the write logic not being triggered anymore.

**Steps to reproduce:**

- Go to Inventory->Operations->Receipts
- Create a new receipt
- Add a new product tracked by serial number
- Specify any number in the demand
- Mark as Todo
- Select Details on the product line -> Generate Serials/Lots
- You'll see 000001 as the First Serial Number
- Validate, you'll see some serial number generated
- If you try again the First Serial Number will still be 000001 when it should have incremented

opw-5368553