### PR TITLE
[FIX] account: fixed tax rounding

### DIFF
--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -210,7 +210,7 @@ export const accountTaxHelpers = {
                 batch.reduce((sum, batch_tax) => sum + batch_tax.amount, 0) / 100.0;
             const to_price_excluded_factor =
                 total_percentage !== -1 ? 1 / (1 + total_percentage) : 0.0;
-            return (raw_base * to_price_excluded_factor * tax.amount) / 100.0;
+            return (float_round((raw_base * to_price_excluded_factor), precision_rounding=0.01) * tax.amount) / 100.0;
         }
 
         if (tax.amount_type === "division") {


### PR DESCRIPTION
The included method calculates with the to_price_excluded_factor during computation and thus gets the entire float value. However, the exclude function gets a rounded raw_base, which in certain scenarios can cause the amount to be off by a point.

eval_tax_amount_price_included
(raw_base * to_price_excluded_factor * tax.amount) / 100.0
(33.33 * 0.8474576271186441 * 18) / 100.0 => -5.0842372881355935 (5.08)

eval_tax_amount_price_excluded
(raw_base * tax.amount) / 100.0;
(28.25 * 18) / 100.0 => 5.085 (5.09)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
