### PR TITLE
[REV][FIX] web: search_bar: `isComposing` on Safari during IME input

### DIFF
--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -9,7 +9,7 @@ import { _t } from "@web/core/l10n/translation";
 import { SearchBarMenu } from "../search_bar_menu/search_bar_menu";
 import { Component, status, useRef, useState } from "@odoo/owl";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
-import { hasTouch, isIOS } from "@web/core/browser/feature_detection";
+import { hasTouch } from "@web/core/browser/feature_detection";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { useNavigation } from "@web/core/navigation/navigation";
@@ -669,9 +669,6 @@ export class SearchBar extends Component {
     onSearchInput(ev) {
         if (!hasTouch()) {
             this.searchBarDropdownState.close();
-        }
-        if (isIOS() && !ev.key) {
-            return;
         }
         const query = ev.target.value;
         if (query.trim()) {


### PR DESCRIPTION
This reverts commit 2ff4e7b12b66a2d973f285006e6676e49087ca7d.

Search filter doesn't work for iOS users.
A new fix has to be found.

opw-5966697

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
