### PR TITLE
[IMP] point_of_sale: account statements in config cash journal

### DIFF
--- a/addons/point_of_sale/data/orders_demo.xml
+++ b/addons/point_of_sale/data/orders_demo.xml
@@ -94,7 +94,8 @@
             eval="[[ref('pos_closed_session_1')], '']" />
 
         <function model="pos.session" name="action_pos_session_closing_control"
-            eval="[[ref('pos_closed_session_1')]]" />
+            eval="[[ref('pos_closed_session_1')]]"
+            context="{'skip_pdf_attachment_generation': True}" />
 
         <!-- Closed Session 2 -->
 
@@ -189,6 +190,7 @@
             eval="[[ref('pos_closed_session_2')], '']" />
 
         <function model="pos.session" name="action_pos_session_closing_control"
-            eval="[[ref('pos_closed_session_2')]]" />
+            eval="[[ref('pos_closed_session_2')]]"
+            context="{'skip_pdf_attachment_generation': True}" />
     </data>
 </odoo>

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -368,8 +368,7 @@ class PosSession(models.Model):
         for session in self.filtered(lambda session: session.state == 'opening_control'):
             values = {}
             if session.config_id.cash_control and not session.rescue:
-                last_session = self.search([('config_id', '=', session.config_id.id), ('id', '!=', session.id)], limit=1)
-                session.cash_register_balance_start = last_session.cash_register_balance_end_real  # defaults to 0 if lastsession is empty
+                session.cash_register_balance_start = session.cash_journal_id.current_statement_balance
             session.write(values)
         return True
 
@@ -477,6 +476,12 @@ class PosSession(models.Model):
         self.env.flush_all()  # ensure sale.report is up to date
         return True
 
+    def _create_bank_statement_with_lines(self, name, lines):
+        return self.env['account.bank.statement'].sudo().create({
+            'name': name,
+            'line_ids': [Command.create(line_val) for line_val in lines],
+        })
+
     def _post_statement_difference(self, amount):
         if amount:
             if self.config_id.cash_control:
@@ -505,7 +510,7 @@ class PosSession(models.Model):
                 st_line_vals['payment_ref'] = _("Cash difference observed during the counting (Profit) - closing")
                 st_line_vals['counterpart_account_id'] = self.cash_journal_id.profit_account_id.id
 
-            created_line = self.env['account.bank.statement.line'].with_context(no_retrieve_partner=True).create(st_line_vals)
+            created_line = self._create_bank_statement_with_lines(_("Closing cash difference %s", self.name), [st_line_vals]).line_ids
 
             if created_line:
                 created_line.move_id.message_post(body=_(
@@ -1215,13 +1220,13 @@ class PosSession(models.Model):
                 )
 
         # create the statement lines and account move lines
-        BankStatementLine = self.env['account.bank.statement.line'].with_context(no_retrieve_partner=True)
         split_cash_statement_lines = {}
         combine_cash_statement_lines = {}
         split_cash_receivable_lines = {}
         combine_cash_receivable_lines = {}
-        split_cash_statement_lines = BankStatementLine.create(split_cash_statement_line_vals).mapped('move_id.line_ids').filtered(lambda line: line.account_id.account_type == 'asset_receivable')
-        combine_cash_statement_lines = BankStatementLine.create(combine_cash_statement_line_vals).mapped('move_id.line_ids').filtered(lambda line: line.account_id.account_type == 'asset_receivable')
+        statement_name = _("Closing %s", self.name)
+        split_cash_statement_lines = self._create_bank_statement_with_lines(statement_name, split_cash_statement_line_vals).line_ids.mapped('move_id.line_ids').filtered(lambda line: line.account_id.account_type == 'asset_receivable')
+        combine_cash_statement_lines = self._create_bank_statement_with_lines(statement_name, combine_cash_statement_line_vals).line_ids.mapped('move_id.line_ids').filtered(lambda line: line.account_id.account_type == 'asset_receivable')
         split_cash_receivable_lines = MoveLine.create(split_cash_receivable_vals)
         combine_cash_receivable_lines = MoveLine.create(combine_cash_receivable_vals)
 
@@ -1718,6 +1723,26 @@ class PosSession(models.Model):
         ).search([('code', '=', 'pos.session'), ('company_id', 'in', [self.config_id.company_id.id, False])], order='company_id', limit=1)
 
         self.name = (self.config_id.name if sequence.prefix == '/' else '') + sequence.next_by_code('pos.session') + (self.name if self.name != '/' else '')
+        if self.cash_journal_id:
+            self._create_opening_cash_statement(cashbox_value)
+
+    def _get_opening_cash_statement_line_vals(self, is_first_session, cashbox_value):
+        # Here, we intentionally avoid adding pos_session_id to the opening bank statement because
+        # opening balance statement lines should not be included in cash in/out lines.
+        return {
+            'journal_id': self.cash_journal_id.id,
+            'payment_ref': _('Opening cash balance') if is_first_session else _('Opening cash difference'),
+            'amount': cashbox_value - self.cash_journal_id.current_statement_balance,
+            'date': fields.Date.context_today(self),
+            'partner_id': self.env.user.partner_id.id,
+        }
+
+    def _create_opening_cash_statement(self, cashbox_value):
+        is_first_session = len(self.config_id.session_ids) == 1
+        self._create_bank_statement_with_lines(
+            _("Initial deposit %s", self.name) if is_first_session else _("Opening cash difference %s", self.name),
+            [self._get_opening_cash_statement_line_vals(is_first_session, cashbox_value)],
+        )
 
     def _post_cash_details_message(self, state, expected, difference, notes):
         expected_formatted = self.currency_id.format(expected)
@@ -1784,22 +1809,22 @@ class PosSession(models.Model):
             'journal_id': session.cash_journal_id.id,
             'amount': sign * amount,
             'date': fields.Date.context_today(self),
-            'payment_ref': '-'.join([session.name, extras['translatedType'], reason]),
+            'payment_ref': _('Cash %(type)s - %(reason)s', type=extras['translatedType'], reason=reason),
             'partner_id': partner_id,
         }
 
     def try_cash_in_out(self, _type, amount, reason, partner_id, extras):
+        self.ensure_one()
         sign = 1 if _type == 'in' else -1
-        sessions = self.filtered('cash_journal_id')
-        if not sessions:
-            raise UserError(_("There is no cash payment method for this PoS Session"))
-
-        vals_list = [
-            self._prepare_account_bank_statement_line_vals(session, sign, amount, reason, partner_id, extras)
-            for session in sessions
-        ]
-
-        self.env['account.bank.statement.line'].with_context(no_retrieve_partner=True).create(vals_list)
+        statement_line_vals = self._prepare_account_bank_statement_line_vals(self, sign, amount, reason, partner_id, extras)
+        if bank_statement := self.env['account.bank.statement'].sudo().with_context(lang='en_US').search([
+            ('journal_id', '=', self.cash_journal_id.id),
+            ('name', '=', 'Cash In/Out - ' + self.name),
+        ], limit=1):
+            bank_statement.line_ids = [Command.create(statement_line_vals)]
+            bank_statement.balance_end_real = bank_statement.balance_end
+        else:
+            self._create_bank_statement_with_lines(_("Cash In/Out - %s", self.name), [statement_line_vals])
 
     def delete_cash_in_out(self, absl_id, partner_id):
         if not self.env.user.has_group('account.group_account_basic'):
@@ -1810,6 +1835,8 @@ class PosSession(models.Model):
         cashier_name = absl.partner_id.name
         amount = absl.amount
         action = cashier_name + ': ' + str(amount)
+        absl.statement_id.balance_end_real -= absl.amount
+        absl.statement_id = False
         absl.unlink()
         self.log_partner_message(partner_id, action, "CASH_IN_OUT_UNLINK")
 

--- a/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
@@ -315,6 +315,25 @@ registry.category("web_tour.tours").add("test_ctrl_number_ignored", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("test_bank_account_statements_creation_for_config", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            ProductScreen.enterOpeningAmount("100.00"),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("Monitor Stand", "2", "10"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.validateButtonIsHighlighted(true),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.clickNextOrder(),
+            ProductScreen.isShown(),
+            Chrome.doCashMove("10", "Cash Out"),
+            Chrome.clickMenuOption("Close Register"),
+            ProductScreen.closeWithCashAmount("110"),
+            Dialog.confirm("Close Register"),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("test_set_opening_note_without_cash_method", {
     steps: () =>
         [

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -3715,6 +3715,61 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_combo_no_free_item')
 
+    def test_bank_account_statements_creation_for_config(self):
+        new_pos_config = self.env['pos.config'].create({
+            'name': 'New Pos Config',
+            'module_pos_restaurant': False,
+            'cash_control': True,
+        })
+        cash_journal = self.env['account.journal'].create({
+            'name': 'Cash Journal',
+            'type': 'cash',
+            'company_id': self.env.company.id,
+        })
+        cash_method = self.env['pos.payment.method'].create({
+            'name': 'Cash Payment Method',
+            'company_id': self.env.company.id,
+            'journal_id': cash_journal.id,
+        })
+        new_pos_config.write({
+            'payment_method_ids': [(6, 0, [cash_method.id])],
+        })
+        new_pos_config.with_user(self.pos_user).open_ui()
+        current_session = new_pos_config.current_session_id
+        self.assertEqual(cash_journal.current_statement_balance, 0.0)
+        self.pos_user.write({
+            'group_ids': [
+                (4, self.env.ref('account.group_account_basic').id),
+            ],
+        })
+        # Simulate the flow for creating statements for opening cash, cash in/out and closing session
+        self.start_pos_tour(
+            'test_bank_account_statements_creation_for_config',
+            pos_config=new_pos_config,
+        )
+        current_session.post_closing_cash_details(110)
+        current_session.close_session_from_ui()
+        bank_statements = self.env["account.bank.statement"].search([('journal_id', '=', cash_journal.id)], order='id asc')
+        opening_statement = bank_statements[0]
+
+        self.assertEqual(cash_journal.current_statement_balance, 110.0)
+        self.assertEqual(opening_statement.name, f'Initial deposit {current_session.name}')
+        self.assertEqual(opening_statement.balance_end_real, 100.0)
+        self.assertEqual(opening_statement.line_ids[0].amount, 100.0)
+        self.assertEqual(opening_statement.line_ids[0].payment_ref, 'Opening cash balance')
+
+        cash_in_out_statement = bank_statements[1]
+        self.assertEqual(cash_in_out_statement.name, f'Cash In/Out - {current_session.name}')
+        self.assertEqual(cash_in_out_statement.balance_end_real, 90.0)
+        self.assertEqual(cash_in_out_statement.line_ids[0].amount, -10.0)
+        self.assertEqual(cash_in_out_statement.line_ids[0].payment_ref, 'Cash out - Cash Out')
+
+        closing_session_statement = bank_statements[2]
+        self.assertEqual(closing_session_statement.name, f'Closing {current_session.name}')
+        self.assertEqual(closing_session_statement.balance_end_real, 110.0)
+        self.assertEqual(closing_session_statement.line_ids[0].amount, 20.0)
+        self.assertEqual(closing_session_statement.line_ids[0].payment_ref, current_session.name)
+
     def test_not_available_pricelist_not_set_on_order(self):
         """ Test that when the pricelist is not available, it is not set on the order """
         not_available_pricelist, available_pricelist = self.env['product.pricelist'].create([{

--- a/addons/pos_hr/models/pos_session.py
+++ b/addons/pos_hr/models/pos_session.py
@@ -100,3 +100,10 @@ class PosSession(models.Model):
                 if cash_move.employee_id:
                     cash_in_out['cashier_name'] = cash_move.partner_id.name
         return cash_in_out_list
+
+    def _get_opening_cash_statement_line_vals(self, is_first_session, cashbox_value):
+        vals = super()._get_opening_cash_statement_line_vals(is_first_session, cashbox_value)
+        if self.employee_id:
+            vals['employee_id'] = self.employee_id.id
+            vals['partner_id'] = self.employee_id.work_contact_id.id
+        return vals

--- a/addons/pos_restaurant/data/scenarios/restaurant_demo_session.xml
+++ b/addons/pos_restaurant/data/scenarios/restaurant_demo_session.xml
@@ -87,7 +87,8 @@
         </record>
 
         <function model="pos.session" name="action_pos_session_closing_control"
-            eval="[[ref('pos_closed_session_3')]]" />
+            eval="[[ref('pos_closed_session_3')]]"
+            context="{'skip_pdf_attachment_generation': True}" />
 
         <!-- Closed Session 4 -->
 
@@ -166,7 +167,8 @@
         </record>
 
         <function model="pos.session" name="action_pos_session_closing_control"
-            eval="[[ref('pos_closed_session_4')]]" />
+            eval="[[ref('pos_closed_session_4')]]"
+            context="{'skip_pdf_attachment_generation': True}" />
 
         <!-- Open Session -->
         <record id="customer_1" model="res.partner">


### PR DESCRIPTION
In this commit:

- We will post account statements alongside account statement lines for cash changes in the POS config’s cash journal.
- We will post account statements for opening cash on the very first session opening, cash differences for subsequent openings, cash in / cash out, total cash amount sold for a particular session, and cash differences during session closing as well.

The following statements and statement lines are created for the cash journal
for different scenarios:

Case 1:
- Fresh start of config with $100 Opening balance.
- Statement: Initial deposit: $100
- Statement line: Opening Cash Balance: $100

Case 2:
- $100 Cash in and $50 Cash out
- Statement: Cash in/Cash out ${session_name}: $150
- Statement line 1: ${cashier_name} x ${session_name}-in-${reason}
- Statement line 2: ${cashier_name} x ${session_name}-out-${reason}

Case 3:
- Closing session with $126.50 in cash sales
- Statement: ${session_name}: $276.50
- Statement line:  ${session_name}: $126.50

Case 4:
- Opening session with a $200 opening balance
- Statement: Opening cash difference ${session_name}: $200
- Statement line: Opening cash difference: $-76.50

Case 5:
- Closing session with $184 in cash sales
- Statement: ${session_name}: $384
- Statement line:  ${session_name}: $184

Case 6:
- Closing cash difference $-384
- Statement: Closing cash difference ${session_name}: $0
- Statement line: Cash difference observed during the counting (Loss) - closing: $-384

Task-5937528
