### PR TITLE
[FIX] pos_sale: add downpayment product in sol

### DIFF
--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -102,6 +102,7 @@ class SaleOrder(models.Model):
             and base_line['record']._name == 'pos.order.line'
         ):
             pos_order_line = base_line['record']
+            so_line_values['product_id'] = base_line['product_id'].id
             so_line_values['name'] = _(
                 "Down payment (ref: %(order_reference)s on \n %(date)s)",
                 order_reference=pos_order_line.name,

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -705,7 +705,9 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.assertEqual(invoice_pdf_content.count('Product B'), 1)
         self.assertEqual(invoice_pdf_content.count('Product C'), 1)
 
-        for order_line in sale_order.order_line.filtered(lambda l: l.product_id == self.downpayment_product):
+        downpayment_lines = sale_order.order_line.filtered(lambda l: l.product_id == self.downpayment_product)
+        self.assertEqual(len(downpayment_lines), 3)
+        for order_line in downpayment_lines:
             order_line = order_line.with_context(lang=partner_test.lang)
             self.assertIn(format_date(order_line.env, order_line.order_id.date_order), order_line.name)
 


### PR DESCRIPTION
Step to reproduce
- install pos_sale
- create a SO (make sure it is in draft)
- open pos, make sure it has downpayment product
- do a downpayment for that SO
- go to backend, open SO

Observation:
- The downpayment product is not linked to downpayment line

Cause:
- After refactor [1], downpayment product is not added in sale line
[1] https://github.com/odoo/odoo/commit/175daa5db6a3f16be6b636a36e2b8462306b2eb4

Fix:
- Added the product when creating downpayment line

**Note:**
- Actual issue reported was different, and was side effect of this issue
- there, the downpayment was not considered when trying to settle SO from pos

opw-5934461

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
