### PR TITLE
[FIX] web: prevent crash when saving property default values

### DIFF
--- a/addons/web/static/src/views/fields/properties/properties_definition_field.js
+++ b/addons/web/static/src/views/fields/properties/properties_definition_field.js
@@ -95,6 +95,8 @@ export class PropertiesDefinitionField extends PropertiesField {
     }
 
     // In this case, we do not want to add the 'value' parameter, as this is a definition, and not a property
+    _setDefaultPropertyValue(propertyName) { }
+
     _toggleSeparatorValue(property, forceState) { }
 
     _isFolded(property) {

--- a/addons/web/static/tests/views/fields/properties_field.test.js
+++ b/addons/web/static/tests/views/fields/properties_field.test.js
@@ -2849,6 +2849,42 @@ test("properties: signature", async () => {
     });
 });
 
+test("properties definition: default value should not add value key", async () => {
+    onRpc("has_access", () => true);
+    onRpc("web_save", ({ args }) => {
+        expect.step("web_save");
+        expect("value" in args[1].definitions.at(-1)).toBe(false);
+    });
+
+    await mountView({
+        type: "form",
+        resModel: "res.company",
+        resId: 37,
+        arch: /* xml */ `
+            <form>
+                <sheet>
+                    <group>
+                        <field name="id" invisible="1"/>
+                        <field name="definitions" widget="properties_definition"/>
+                    </group>
+                </sheet>
+            </form>`,
+        actionMenus: {},
+    });
+
+    await toggleActionMenu();
+    await toggleMenuItem("Edit Properties");
+
+    await click(".o_field_property_add button");
+    await waitFor(".o_property_field_popover");
+    await changeType("boolean");
+    await click(".o_field_property_definition_value .o-checkbox input");
+    await closePopover();
+
+    await clickSave();
+    expect.verifySteps(["web_save"]);
+});
+
 /**
  * tests todo: edit, delete, display
  */


### PR DESCRIPTION
Steps to reproduce:
- Open any worksheet template
- Add a new property of type Checkbox, Date, DateTime, or Selection
- Set a default value and close the popover
- Click Save

Current behavior:
Server error 'Some key are not allowed for a properties definition [value]'

Expected behavior:
Template saves successfully with the default value stored

When closing a newly created property popover, the base widget copies `default` into `value` for runtime display. This is correct for properties (per-record values) but invalid for properties_definition (schema-only) since the backend validator rejects the `value` key. Skip this propagation for definition widgets

task-5966665

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
