### PR TITLE
Saas 18.4 fix image upload error handling html editor dtda

### DIFF
--- a/addons/html_editor/static/src/main/media/media_dialog/image_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/image_selector.js
@@ -167,11 +167,22 @@ export class ImageSelector extends FileSelector {
     }
 
     async uploadFiles(files) {
-        await this.uploadService.uploadFiles(
+        let abortFn;
+
+        const uploadPromise = this.uploadService.uploadFiles(
             files,
-            { resModel: this.props.resModel, resId: this.props.resId, isImage: true },
-            (attachment) => this.onUploaded(attachment)
+            {
+                resModel: this.props.resModel,
+                resId: this.props.resId,
+                isImage: true,
+            },
+            (attachment) => this.onUploaded(attachment),
+            (abort) => {
+                abortFn = abort;
+            }
         );
+        this.props.setAbortUploadsCallback(() => abortFn?.());
+        await uploadPromise;
     }
 
     async validateUrl(...args) {

--- a/addons/html_editor/static/src/main/media/media_dialog/media_dialog.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/media_dialog.js
@@ -83,6 +83,7 @@ export class MediaDialog extends Component {
             },
             () => [this.selectedMedia[this.state.activeTab].length, this.state.isSaving]
         );
+         this.abortUploads = null;
     }
 
     get initialActiveTab() {
@@ -116,6 +117,7 @@ export class MediaDialog extends Component {
                 selectMedia: (...args) =>
                     this.selectMedia(...args, tab.id, additionalProps.multiSelect),
                 save: this.save.bind(this),
+                setAbortUploadsCallback: (abortFunc) => this.abortUploads = abortFunc,
                 onAttachmentChange: this.props.onAttachmentChange,
                 errorMessages: (errorMessage) => (this.errorMessages[tab.id] = errorMessage),
                 modalRef: this.modalRef,
@@ -329,5 +331,13 @@ export class MediaDialog extends Component {
 
     onTabChange(tab) {
         this.state.activeTab = tab;
+    }
+    async close() {
+        if (this.abortUploads) {
+            this.abortUploads();
+            delete this.abortUploads;
+        }
+        this.state.isSaving = false;
+        await this.props.close();
     }
 }

--- a/addons/html_editor/static/src/main/media/media_dialog/media_dialog.xml
+++ b/addons/html_editor/static/src/main/media/media_dialog/media_dialog.xml
@@ -7,7 +7,7 @@
         <Notebook pages="notebookPages" onPageUpdate.bind="onTabChange" defaultPage="state.activeTab"/>
         <t t-set-slot="footer">
             <button class="btn btn-primary" t-on-click="() => this.save()" t-ref="add-button">Add</button>
-            <button class="btn btn-secondary" t-on-click="() => this.props.close()">Discard</button>
+            <button class="btn btn-secondary" t-on-click="() => this.close()">Discard</button>
         </t>
     </Dialog>
 </t>

--- a/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_service.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_service.js
@@ -39,6 +39,37 @@ export const uploadService = {
                 progressToast.isVisible = false;
             }
         };
+
+        const convertWebpToJpeg = async (dataURL, name, attachmentId) => {
+            const image = document.createElement("img");
+            image.src = `data:image/webp;base64,${dataURL.split(",")[1]}`;
+            await new Promise((res, rej) => {
+                image.onload = res;
+                image.onerror = rej;
+            });
+
+            const canvas = document.createElement("canvas");
+            canvas.width = image.width;
+            canvas.height = image.height;
+
+            const ctx = canvas.getContext("2d");
+            ctx.fillStyle = "white";
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+            ctx.drawImage(image, 0, 0);
+
+            const altDataURL = canvas.toDataURL("image/jpeg", 0.75);
+
+            await rpc("/web_editor/attachment/add_data", {
+                name: name.replace(/\.webp$/, ".jpg"),
+                data: altDataURL.split(",")[1],
+                res_id: attachmentId,
+                res_model: "ir.attachment",
+                is_image: true,
+                width: 0,
+                quality: 0,
+            });
+        };
+
         return {
             get progressToast() {
                 return progressToast;
@@ -136,31 +167,10 @@ export const uploadService = {
                         } else {
                             if (attachment.mimetype === "image/webp") {
                                 // Generate alternate format for reports.
-                                const image = document.createElement("img");
-                                image.src = `data:image/webp;base64,${dataURL.split(",")[1]}`;
-                                await new Promise((resolve) =>
-                                    image.addEventListener("load", resolve)
-                                );
-                                const canvas = document.createElement("canvas");
-                                canvas.width = image.width;
-                                canvas.height = image.height;
-                                const ctx = canvas.getContext("2d");
-                                ctx.fillStyle = "rgb(255, 255, 255)";
-                                ctx.fillRect(0, 0, canvas.width, canvas.height);
-                                ctx.drawImage(image, 0, 0);
-                                const altDataURL = canvas.toDataURL("image/jpeg", 0.75);
-                                await rpc(
-                                    "/html_editor/attachment/add_data",
-                                    {
-                                        name: file.name.replace(/\.webp$/, ".jpg"),
-                                        data: altDataURL.split(",")[1],
-                                        res_id: attachment.id,
-                                        res_model: "ir.attachment",
-                                        is_image: true,
-                                        width: 0,
-                                        quality: 0,
-                                    },
-                                    { xhr }
+                                await convertWebpToJpeg(
+                                    dataURL,
+                                    file.name,
+                                    attachment.id
                                 );
                             }
                             file.uploaded = true;

--- a/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_service.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/upload_progress_toast/upload_service.js
@@ -97,11 +97,34 @@ export const uploadService = {
              * @param {Array<File>} files
              * @param {Object} options
              * @param {Function} onUploaded
+             * @param {Function} setAbortCallback // Optional - To abort uploads
              */
-            uploadFiles: async (files, { resModel, resId, isImage }, onUploaded) => {
+            uploadFiles: async (
+                files,
+                { resModel, resId, isImage },
+                onUploaded,
+                setAbortCallback
+            ) => {
                 // Upload the smallest file first to block the user the least possible.
                 const sortedFiles = Array.from(files).sort((a, b) => a.size - b.size);
+
+                const controller = new AbortController();
+                const { signal } = controller;
+
+                let currentXHR = null;
+                let addAttachmentRpc = null;
+
+                setAbortCallback?.(() => {
+                    controller.abort();
+                    addAttachmentRpc?.abort?.();
+                    currentXHR?.abort?.();
+                });
+
                 for (const file of sortedFiles) {
+                    if (signal.aborted) {
+                        return;
+                    }
+
                     let fileSize = file.size;
                     if (!checkFileSize(fileSize, notification)) {
                         return null;
@@ -126,10 +149,17 @@ export const uploadService = {
                 // Upload one file at a time: no need to parallel as upload is
                 // limited by bandwidth.
                 for (const sortedFile of sortedFiles) {
+                    if (signal.aborted) {
+                        break;
+                    }
+
                     const file = progressToast.files[sortedFile.progressToastId];
                     let dataURL;
                     try {
                         dataURL = await getDataURLFromFile(sortedFile);
+                        if (signal.aborted) {
+                            break;
+                        }
                     } catch {
                         deleteFile(file.id);
                         env.services.notification.add(
@@ -138,17 +168,22 @@ export const uploadService = {
                         );
                         continue;
                     }
+
+                    currentXHR = new XMLHttpRequest();
+                    addAttachmentRpc = null;
+
+                    const onProgress = (ev) => {
+                        if (ev.lengthComputable) {
+                            file.progress = (ev.loaded / ev.total) * 100;
+                        }
+                    };
+                    const onLoad = () => (file.progress = 100);
+
+                    currentXHR.upload.addEventListener("progress", onProgress);
+                    currentXHR.upload.addEventListener("load", onLoad);
+
                     try {
-                        const xhr = new XMLHttpRequest();
-                        xhr.upload.addEventListener("progress", (ev) => {
-                            const rpcComplete = (ev.loaded / ev.total) * 100;
-                            file.progress = rpcComplete;
-                        });
-                        xhr.upload.addEventListener("load", function () {
-                            // Don't show yet success as backend code only starts now
-                            file.progress = 100;
-                        });
-                        const attachment = await rpc(
+                        addAttachmentRpc = rpc(
                             "/html_editor/attachment/add_data",
                             {
                                 name: file.name,
@@ -159,34 +194,60 @@ export const uploadService = {
                                 width: 0,
                                 quality: 0,
                             },
-                            { xhr }
+                            { xhr: currentXHR }
                         );
+
+                        const attachment = await addAttachmentRpc;
+                        if (signal.aborted) {
+                            break;
+                        }
+
                         if (attachment.error) {
                             file.hasError = true;
                             file.errorMessage = attachment.error;
                         } else {
                             if (attachment.mimetype === "image/webp") {
-                                // Generate alternate format for reports.
-                                await convertWebpToJpeg(
-                                    dataURL,
-                                    file.name,
-                                    attachment.id
-                                );
+                                try {
+                                    // Generate alternate format for reports.
+                                    await convertWebpToJpeg(
+                                        dataURL,
+                                        file.name,
+                                        attachment.id
+                                    );
+                                } catch (convErr) {
+                                    console.warn(
+                                        "[uploadService] webp conversion failed:",
+                                        convErr
+                                    );
+                                }
                             }
                             file.uploaded = true;
                             await onUploaded(attachment);
                         }
+                    } catch (err) {
+                        if (signal.aborted) {
+                            break;
+                        }
+                        file.hasError = true;
+                        console.error("Upload error:", err);
+                        throw err;
+                    } finally {
+                        currentXHR.upload.removeEventListener(
+                            "progress",
+                            onProgress
+                        );
+                        currentXHR.upload.removeEventListener("load", onLoad);
                         // If there's an error, display the error message for longer
                         const message_autoclose_delay = file.hasError
                             ? AUTOCLOSE_DELAY_LONG
                             : AUTOCLOSE_DELAY;
                         setTimeout(() => deleteFile(file.id), message_autoclose_delay);
-                    } catch (error) {
-                        file.hasError = true;
-                        setTimeout(() => deleteFile(file.id), AUTOCLOSE_DELAY_LONG);
-                        throw error;
+                        dataURL = null;
                     }
                 }
+
+                currentXHR = null;
+                addAttachmentRpc = null;
             },
         };
     },


### PR DESCRIPTION
Steps to Reproduce:

Open the website module.
Open the media upload dialog to upload an image by either
double-clicking the logo or replacing the existing image.
Upload a large file.
Abort the upload before it finishes by clicking the 'Discard'
button in the media dialog box.
After performing these steps, a traceback is observed.
Before this commit:

Image upload failures would throw uncaught exceptions.
These exceptions would interrupt the flow and result in a poor user
experience with no clear feedback.
Even after clicking the discard button the image was still
getting uploaded.
After this commit:

Uploads can be safely aborted when the media dialog is discarded.
Ongoing XHR requests and RPC calls are properly cancelled.
The upload loop stops immediately when an abort is triggered with
no traceback.
Users get a predictable and clean exit instead of a broken state.
Files are no longer uploaded after clicking Discard.

task-4752497

Correction Pr for: https://github.com/odoo/odoo/pull/250030
Original PR from Issue: https://github.com/odoo/odoo/pull/219081
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
