### PR TITLE
[FIX] hr_attendance: fix access error on attendance record

### DIFF
--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -199,7 +199,8 @@
                             </group>
                         </group>
                     </group>
-                    <notebook invisible="not overtime_status">
+                    <notebook invisible="not overtime_status"
+                        groups="hr.group_hr_manager,hr_attendance.group_hr_attendance_own">
                         <page string="Overtime Details">
                             <field name="linked_overtime_ids">
                                 <list editable="bottom">


### PR DESCRIPTION
Steps to Reproduce:
- Log in as user which has no access of attendance
- Try to open attendance record with overtime

Issue:
- As users below Self Attendance edit and hr administrator does not have access to rule_ids

Fix:
- Added groups on 'Overtime Details' section as other user does not have access to read.

task-5886324

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
