### PR TITLE
[FIX] l10n_ch: fix formula of expressions in tax report

### DIFF
--- a/addons/l10n_ch/data/account_tax_report_data.xml
+++ b/addons/l10n_ch/data/account_tax_report_data.xml
@@ -71,7 +71,7 @@
                             <record id="account_tax_report_line_chtax_221_tag" model="account.report.expression">
                                 <field name="label">balance</field>
                                 <field name="engine">tax_tags</field>
-                                <field name="formula">221</field>
+                                <field name="formula">-221</field>
                             </record>
                         </field>
                     </record>


### PR DESCRIPTION
**Steps to Reproduce:**
1. Create a database in version 19 and install the `l10n_ch` module.
2. Create a journal entry using tax grid `221`.
3. Open the Tax Report and check the line `Supplies provided abroad`.
4. The value appears negative instead of positive.

- This issue occurred due to the major tax revamp introduced in version 19 [commit](https://github.com/odoo/odoo/commit/17a6117ed88c29b5bc4db0c872bcdbc109a7d98b#diff-3441c5d05315ec0562923797f973eae66488452a6772d23e198998c1890aa06c)
- To resolve this issue, the formula has been modified from `221` to `-221`.

**Before fix:**

<img width="1919" height="963" alt="image" src="https://github.com/user-attachments/assets/cea87440-9e7b-4d5e-80d9-6a3d745e5d71" />

**After fix:**

<img width="1919" height="963" alt="image" src="https://github.com/user-attachments/assets/f69e3a62-ec6a-4a24-a0cc-b44fab16eefa" />


OPW: 5945876

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
