### PR TITLE
[FIX] *: missed attributes being set on model classes

### DIFF
--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -1030,8 +1030,8 @@ class TestChatterTweaks(ThreadRecipients):
             (2, False),  # zut alors, 2 recipients is the limit !
             (10, True),
         ):
-            MailTestSimple._CUSTOMER_HEADERS_LIMIT_COUNT = recipients_limit
-            with self.mock_mail_gateway(mail_unlink_sent=False), \
+            with patch.object(MailTestSimple, '_CUSTOMER_HEADERS_LIMIT_COUNT', recipients_limit, create=True), \
+                self.mock_mail_gateway(mail_unlink_sent=False), \
                     self.mock_mail_app():
                 message = test_record.message_post(
                     body='With To Headers',

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -837,7 +837,7 @@ SETATTR_SOURCES = {
     '_instanciate': ('/mail/models/ir_model.py',),
     # account manipulates _template_register
     '_template_register': ('/account/models/chart_template.py',),
-    '_setup_complete': ('/account/models/chart_template.py',),
+    '_post_model_setup__': ('/account/models/chart_template.py',),
     # ...
     'patch': ('/base_automation/models/base_automation.py',),
     # .....


### PR DESCRIPTION
Followup / fixup to #249005, as these can / do cause trouble due to overlogging (mostly the chart_template one).
