### PR TITLE
[FIX]: mrp,purchase_stock: select only one default route

### DIFF
--- a/addons/mrp/wizard/product_replenish.py
+++ b/addons/mrp/wizard/product_replenish.py
@@ -46,7 +46,7 @@ class ProductReplenish(models.TransientModel):
     def _get_route_domain(self, product_tmpl_id):
         domain = super()._get_route_domain(product_tmpl_id)
         company = product_tmpl_id.company_id or self.env.company
-        manufacture_route = self.env['stock.rule'].search([('action', '=', 'manufacture'), ('company_id', '=', company.id)]).route_id
+        manufacture_route = self.env['stock.rule'].search([('action', '=', 'manufacture'), ('company_id', '=', company.id)], limit=1).route_id
         if manufacture_route and product_tmpl_id.bom_ids:
             domain = Domain.OR([domain, Domain('id', '=', manufacture_route.id)])
         return domain

--- a/addons/purchase_stock/wizard/product_replenish.py
+++ b/addons/purchase_stock/wizard/product_replenish.py
@@ -91,7 +91,7 @@ class ProductReplenish(models.TransientModel):
     def _get_route_domain(self, product_tmpl_id):
         domain = super()._get_route_domain(product_tmpl_id)
         company = product_tmpl_id.company_id or self.env.company
-        buy_route = self.env['stock.rule'].search([('action', '=', 'buy'), ('company_id', '=', company.id)]).route_id
+        buy_route = self.env['stock.rule'].search([('action', '=', 'buy'), ('company_id', '=', company.id)], limit=1).route_id
         if buy_route and product_tmpl_id.seller_ids:
             domain = Domain.OR([domain, Domain('id', '=', buy_route.id)])
         return domain


### PR DESCRIPTION
Followup to previous fix: 705e27a2d3d9e3c4d075a1e8fb599333a504a316 

If the user configured his database with more than one Buy or Manufacture route, the `_get_route_domain` would trigger a Singleton Error.

# Steps to Reproduce:
- Create new Manufacture Route:
  - Create new Warehouse W2
  - Create new 'Manufacture 2' route (no rule yet)
  - Go to the 'Manufacture' route
  - Select the new rule for W2, expand popup
  - Update the route to 'Manufacture 2'
- Create new Product P
  - Storable
  - Create Basic BoM
- Product form -> Actions wheel -> Replenish => Singleton Error

OPW-5960493

---

## Configuration
<img width="1844" height="628" alt="image" src="https://github.com/user-attachments/assets/b90c070c-4af5-427c-bd3d-79904a7881a0" />


## Traceback
```
RPC_ERROR

Odoo Server Error

Occured on 102180409-19-0-design-theme.runbot119.odoo.com on model product.replenish on 2026-02-25 08:12:03 GMT

Traceback (most recent call last):
  File "/data/build/odoo/odoo/http.py", line 2273, in _serve_db
    return service_model.retrying(serve_func, env=self.env)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/odoo/service/model.py", line 185, in retrying
    result = func()
             ^^^^^^
  File "/data/build/odoo/odoo/http.py", line 2328, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/odoo/http.py", line 2543, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/odoo/addons/base/models/ir_http.py", line 355, in _dispatch
    result = endpoint(**request.params)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/odoo/http.py", line 788, in route_wrapper
    result = endpoint(self, *args, **params_ok)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/addons/web/controllers/dataset.py", line 32, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/odoo/service/model.py", line 94, in call_kw
    result = method(recs, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/addons/web/models/models.py", line 1964, in onchange
    defaults = self.default_get(missing_names)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/addons/purchase_stock/wizard/product_replenish.py", line 12, in default_get
    res = super().default_get(fields)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/addons/stock/wizard/product_replenish.py", line 77, in default_get
    res['route_id'] = self.env['stock.route'].search(self._get_route_domain(product_tmpl_id), limit=1).id
                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/addons/purchase_stock/wizard/product_replenish.py", line 92, in _get_route_domain
    domain = super()._get_route_domain(product_tmpl_id)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/addons/mrp/wizard/product_replenish.py", line 51, in _get_route_domain
    domain = Domain.OR([domain, Domain('id', '=', manufacture_route.id)])
                                                  ^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/odoo/orm/fields_misc.py", line 114, in __get__
    raise ValueError("Expected singleton: %s" % record)
ValueError: Expected singleton: stock.route(6, 20)
```


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
