### PR TITLE
[IMP] account: clarify chatter message on failed bill import

### DIFF
--- a/addons/account/models/account_document_import_mixin.py
+++ b/addons/account/models/account_document_import_mixin.py
@@ -167,7 +167,11 @@ class AccountDocumentImportMixin(models.AbstractModel):
 
         # Call _extend_with_attachments at the end, because it commits the transaction.
         for record, file_data_group in zip(records, file_data_groups):
-            record._extend_with_attachments(file_data_group, new=True)
+            record_extended = record._extend_with_attachments(file_data_group, new=True)
+            if not record_extended:
+                record.message_post(
+                    body=self.env._("There was an error while importing the bill, you can find attached the incoming XML"),
+                )
 
         return records
 


### PR DESCRIPTION
When a bill import (including Peppol) fails, an empty bill is created with the XML attached in the chatter, which can be confusing for users.

This commit adds a clearer chatter message indicating that an error occurred and that the incoming XML is attached.

task-5932172

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
