### PR TITLE
[FIX] hr_holidays_attendance: restore removed method and set deprecated

### DIFF
--- a/addons/hr_holidays_attendance/models/hr_leave.py
+++ b/addons/hr_holidays_attendance/models/hr_leave.py
@@ -84,6 +84,16 @@ class HRLeave(models.Model):
         self.sudo().overtime_id.unlink()
         return res
 
+    def _update_leaves_overtime(self):
+        # Deprecated - will be removed in master
+        employee_dates = defaultdict(set)
+        for leave in self:
+            if leave.employee_id and leave.employee_company_id.hr_attendance_overtime:
+                for d in range((leave.date_to - leave.date_from).days + 1):
+                    employee_dates[leave.employee_id].add(self.env['hr.attendance']._get_day_start_and_day(leave.employee_id, leave.date_from + timedelta(days=d)))
+        if employee_dates:
+            self.env['hr.attendance'].sudo()._update_overtime(employee_dates)
+
     def unlink(self):
         # TODO master change to ondelete
         self.sudo().overtime_id.unlink()


### PR DESCRIPTION
In https://github.com/odoo/odoo/pull/229723, we removed the `_update_leaves_overtime` method as it was moved to another model, however, the method could still be in use in customizations so we restore it here add a comment that states it will be removed in master.

