### PR TITLE
[FIX] base: Fix UnboundLocalError

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -323,6 +323,7 @@ actual arch.
     @api.depends('arch', 'inherit_id')
     def _compute_invalid_locators(self):
         def assess_locator(source, spec):
+            node = None
             with suppress(ValidationError):  # Syntax error
                 # If locate_node returns None here:
                 # Invalid expression: Ok Syntax, but cannot be anchored to the parent view.


### PR DESCRIPTION
When syntax error will raise ``node`` will not assign. So, assign ``None`` before error will surpess.

Note:- found it during testing. 

```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/19.0/odoo/http.py", line 2273, in _serve_db
    return service_model.retrying(serve_func, env=self.env)
  File "/home/odoo/src/odoo/19.0/odoo/service/model.py", line 185, in retrying
    result = func()
  File "/home/odoo/src/odoo/19.0/odoo/http.py", line 2328, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/home/odoo/src/odoo/19.0/odoo/http.py", line 2543, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/home/odoo/src/odoo/19.0/odoo/addons/base/models/ir_http.py", line 355, in _dispatch
    result = endpoint(**request.params)
  File "/home/odoo/src/odoo/19.0/odoo/http.py", line 788, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/home/odoo/src/odoo/19.0/addons/web/controllers/dataset.py", line 32, in call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/home/odoo/src/odoo/19.0/odoo/service/model.py", line 94, in call_kw
    result = method(recs, *args, **kwargs)
  File "/home/odoo/src/odoo/19.0/addons/web/models/models.py", line 113, in web_read
    values_list: list[dict] = self.read(fields_to_read, load=None)
  File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 3490, in read
    return self._read_format(fnames=fields, load=load)
  File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 3747, in _read_format
    vals[name] = convert(record[name], record, use_display_name)
  File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 6686, in __getitem__
    return self._fields[key].__get__(self)
  File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 1746, in __get__
    self.compute_value(recs)
  File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 1917, in compute_value
    records._compute_field_value(self)
  File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 4952, in _compute_field_value
    determine(field.compute, self)
  File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 81, in determine
    return needle(*args)
  File "/home/odoo/src/odoo/19.0/odoo/addons/base/models/ir_ui_view.py", line 366, in _compute_invalid_locators
    if invalid_locator := assess_locator(source, spec):
  File "/home/odoo/src/odoo/19.0/odoo/addons/base/models/ir_ui_view.py", line 330, in assess_locator
    if node is None:
UnboundLocalError: local variable 'node' referenced before assignment
```
opw-5956964





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
