### PR TITLE
[FIX] point_of_sale: allow activating a pos.config with open session

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -637,6 +637,9 @@ class PosConfig(models.Model):
                 if key in vals.keys():
                     if bypass_payment_method_ids_forbidden_change and key == 'payment_method_ids':
                         continue
+                    # Allow activating a pos config even if it has an open session, but don't allow deactivating it.
+                    if key == 'active' and vals['active']:
+                        continue
                     field_name = self._fields[key].get_description(self.env)["string"]
                     forbidden_fields.append(field_name)
 


### PR DESCRIPTION
Before this commit, it was not possible to activate a pos.config if there was an open session linked to it. This was a problem because it is only possible to close the session when the pos.config is active, and it was not possible to activate.

opw-5964181

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
