### PR TITLE
[FIX] website, web_editor: load empty iframes on Firefox 148

### DIFF
--- a/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
+++ b/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
@@ -66,8 +66,9 @@ export class AddSnippetDialog extends Component {
 
         onMounted(async () => {
             const isFirefox = isBrowserFirefox();
-            if (isFirefox) {
-                // Make sure empty preview iframe is loaded.
+            if (isFirefox && !(this.iframeDocument.readyState === "complete")) {
+                // Make sure empty preview iframe is loaded. This was necessary
+                // in Firefox < 148 as it created and parsed a new document.
                 // This event is never triggered on Chrome.
                 await new Promise(resolve => {
                     this.iframeDocument.body.onload = resolve;

--- a/addons/website/static/src/components/dialog/add_page_dialog.js
+++ b/addons/website/static/src/components/dialog/add_page_dialog.js
@@ -133,8 +133,9 @@ export class AddPageTemplatePreview extends Component {
             const iframeEl = this.iframeRef.el;
             // Firefox replaces the built content with about:blank.
             const isFirefox = isBrowserFirefox();
-            if (isFirefox) {
-                // Make sure empty preview iframe is loaded.
+            if (isFirefox && !(iframeEl?.contentDocument.readyState === "complete")) {
+                // Make sure empty preview iframe is loaded. This was necessary
+                // in Firefox < 148 as it created and parsed a new document.
                 // This event is never triggered on Chrome.
                 await new Promise(resolve => {
                     iframeEl.contentDocument.body.onload = resolve;


### PR DESCRIPTION
Firefox 148 fixed the behavior of `about:blank` documents, as explained
in their [release notes]:

> The initial about:blank document is now Web-compatible. If the first
> navigation of a browsing context goes to about:blank, it completes
> synchronously and is no longer replaced by a second parser-generated
> document.

Commit [e0796020] added the new page dialog in website, and used empty
iframes to load each page template.
Commit [edf81c13] added the add snippets dialog in website, and used an
empty iframe to load the snippets previews.
In both cases, before Firefox' fix, it meant we had to wait the
recreation of the 2nd document before proceeding. This is no longer the
case in Firefox >= 148.

[release notes]: https://www.firefox.com/en-US/firefox/148.0/releasenotes/
[e0796020]: https://github.com/odoo/odoo/commit/e0796020ee0c3188e1e9d9fa077de73a2211c6f7
[edf81c13]: https://github.com/odoo/odoo/commit/edf81c13d8f2f6d29a77d68cbfa0dc9216da3c2a