### PR TITLE
[IMP] hr_{attendance, holidays, presence}: sync presence status and checkout

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -540,6 +540,10 @@ class HrEmployee(models.Model):
         """
         dayfield = self._get_current_day_location_field()
         for employee in self:
+            if not employee.active:
+                employee.hr_icon_display = 'presence_archive'
+                employee.show_hr_icon_display = True
+                continue
             today_employee_location_id = employee.sudo().exceptional_location_id or employee[dayfield]
             if not today_employee_location_id:
                 employee.hr_icon_display = 'presence_' + employee.hr_presence_state

--- a/addons/hr/static/src/components/hr_presence_status/hr_presence_status.js
+++ b/addons/hr/static/src/components/hr_presence_status/hr_presence_status.js
@@ -28,7 +28,7 @@ export class HrPresenceStatus extends Component {
     }
 
     get color() {
-        if (this.location) {
+        if (this.isActive && this.location) {
             let color = "text-muted";
             if (this.props.record.data.hr_presence_state !== "out_of_working_hour") {
                 color = this.props.record.data.hr_presence_state === "present" ?  "text-success" : "o_icon_employee_absent";
@@ -49,7 +49,7 @@ export class HrPresenceStatus extends Component {
     }
 
     get icon() {
-        if (this.location) {
+        if (this.isActive && this.location) {
             switch (this.location) {
                 case "home":
                     return "fa-home";
@@ -67,7 +67,7 @@ export class HrPresenceStatus extends Component {
     }
 
     get label() {
-        if (this.location) {
+        if (this.isActive && this.location) {
             return this.props.record.data.work_location_name || _t("Unspecified");
         }
         return this.value !== false
@@ -84,11 +84,16 @@ export class HrPresenceStatus extends Component {
     get value() {
         return this.props.record.data[this.props.name];
     }
+
+    get isActive() {
+        return this.props.record.data.active;
+    }
 }
 
 export const hrPresenceStatus = {
     component: HrPresenceStatus,
     fieldDependencies: [
+        { name: "active", type: "boolean" },
         { name: "hr_presence_state", type: "selection" },
         { name: "work_location_type", type: "char" },
         { name: "work_location_name", type: "char" },

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -123,7 +123,7 @@
                         </div>
                         <div class="d-flex flex-column flex-sm-row align-items-center" name="employee_photo_and_info">
                             <div class="o_employee_avatar ms-2 p-0">
-                                <field name="hr_icon_display" invisible="not show_hr_icon_display or not id or not active" widget="hr_presence_status"/>
+                                <field name="hr_icon_display" invisible="not show_hr_icon_display or not id" widget="hr_presence_status"/>
                                 <field name="image_1920" widget='image' class="m-0" options='{"size": [128,158], "zoom": true, "preview_image":"avatar_128"}'/>
                                 <field name="show_hr_icon_display" invisible="1" />
                             </div>

--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -93,6 +93,16 @@ class HrEmployee(models.Model):
             elif not employee.attendance_manager_id:
                 employee.attendance_manager_id = False
 
+    def action_archive(self):
+        super().action_archive()
+        # check-out all checked-in employees.
+        self.env['hr.attendance'].search([
+            ('employee_id', 'in', self.ids),
+            ('check_out', '=', False),
+        ]).write({
+            'check_out': fields.Datetime.now(),
+        })
+
     @api.depends('overtime_ids.manual_duration', 'overtime_ids', 'overtime_ids.status')
     def _compute_total_overtime(self):
         mapped_validated_overtimes = dict(
@@ -250,7 +260,7 @@ class HrEmployee(models.Model):
         Attendance has the second highest priority after login
         """
         super()._compute_presence_state()
-        employees = self.filtered(lambda e: e.hr_presence_state != "present")
+        employees = self.filtered(lambda e: e.active and e.hr_presence_state != "present")
         employee_to_check_working = self.filtered(lambda e: e.sudo().attendance_state == "checked_out"
                                                             and e.hr_presence_state == "out_of_working_hour")
         working_now_list = employee_to_check_working._get_employee_working_now()
@@ -270,6 +280,8 @@ class HrEmployee(models.Model):
         res = super()._compute_presence_icon()
         # All employee must chek in or check out. Everybody must have an icon
         for employee in self:
+            if not employee.active:
+                continue
             employee.show_hr_icon_display = employee.company_id.hr_presence_control_attendance or bool(employee.user_id)
         return res
 

--- a/addons/hr_attendance/tests/test_hr_attendance_process.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_process.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from datetime import datetime, UTC
+from datetime import date, datetime, UTC
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
-from odoo import fields
+from odoo import Command, fields
 from odoo.tests import Form, new_test_user
 from odoo.tests.common import tagged, TransactionCase, freeze_time
 
@@ -27,6 +27,17 @@ class TestHrAttendance(TransactionCase):
         cls.employee_kiosk = cls.env['hr.employee'].create({
             'name': "Machiavel",
             'pin': '5678',
+        })
+        cls.calendar_40h = cls.env['resource.calendar'].create({
+            'attendance_ids': [
+                Command.create({
+                        'dayofweek': weekday,
+                        'hour_from': 8.0,
+                        'hour_to': 17.0,
+                })
+                for weekday in ['0', '1', '2', '3', '4']
+            ],
+            'name': 'calendar 40h/week',
         })
 
     def setUp(self):
@@ -108,6 +119,34 @@ class TestHrAttendance(TransactionCase):
         attendance_form.check_in = False
         with self.assertRaises(AssertionError):
             attendance_form.save()
+
+    @freeze_time("2024-02-01 10:00:00")
+    def test_attendance_checkout_while_employee_archived(self):
+        """An employee should be checked out by the system, if employee is getting archive.
+            additionally his presence_state should be in archive state.
+        """
+
+        self.jonathon_user = new_test_user(self.env, login='jonathan_user', groups='base.group_user')
+        jonathon_employee = self.env['hr.employee'].create({
+            'contract_date_start': date(2021, 1, 1),
+            'date_version': date(2021, 1, 1),
+            'email': 'jonathan.joestar@example.com',
+            'name': 'jonathan joestar',
+            'resource_calendar_id': self.calendar_40h.id,
+            'user_id': self.jonathon_user.id,
+        })
+        self.assertEqual(jonathon_employee.hr_icon_display, 'presence_absent')
+
+        jonathon_attendance = self.env['hr.attendance'].create({
+            'check_in': datetime(2024, 1, 2, 8, 0),
+            'employee_id': jonathon_employee.id,
+        })
+        self.assertEqual(jonathon_employee.hr_icon_display, 'presence_present')
+
+        with freeze_time("2024-01-03 20:00:00"):
+            jonathon_employee.action_archive()
+            self.assertEqual(jonathon_employee.hr_icon_display, 'presence_archive')
+            self.assertEqual(jonathon_attendance.check_out, fields.Datetime.now())
 
     # @freeze_time("2024-02-1")
     # def test_change_in_out_mode_when_manual_modification(self):

--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -65,7 +65,7 @@ class HrEmployee(models.Model):
 
     def _compute_presence_state(self):
         super()._compute_presence_state()
-        employees = self.filtered(lambda employee: employee.hr_presence_state != 'present' and employee.is_absent)
+        employees = self.filtered(lambda employee: employee.active and employee.hr_presence_state != 'present' and employee.is_absent)
         employees.update({'hr_presence_state': 'absent'})
 
     def _compute_allocation_count(self):
@@ -112,6 +112,8 @@ class HrEmployee(models.Model):
         super()._compute_presence_icon()
         dayfield = self._get_current_day_location_field()
         for employee in self:
+            if not employee.active:
+                continue
             today_employee_location_id = employee.sudo().exceptional_location_id or employee[dayfield]
             if employee.is_absent:
                 employee.hr_icon_display = f'presence_holiday_{"absent" if employee.hr_presence_state != "present" else "present"}'

--- a/addons/hr_holidays/static/src/components/hr_presence_status/hr_presence_status.js
+++ b/addons/hr_holidays/static/src/components/hr_presence_status/hr_presence_status.js
@@ -7,6 +7,9 @@ import { HrPresenceStatusPrivate, hrPresenceStatusPrivate } from "@hr/components
 const patchHrPresenceStatus = () => ({
 
     get label() {
+        if (!this.isActive) {
+            return super.label;
+        }
         if (this.value.includes("holiday")) {
             return _t("%(label)s, back on %(date)s",
                 {
@@ -29,6 +32,9 @@ const patchHrPresenceStatus = () => ({
     },
 
     get icon() {
+        if (!this.isActive) {
+            return super.icon;
+        }
         if (this.value?.includes("holiday")) {
             return "fa-plane";
         } else if (this.location) {
@@ -45,6 +51,9 @@ const patchHrPresenceStatus = () => ({
     },
 
     get color() {
+        if (!this.isActive) {
+            return super.color;
+        }
         if (this.value?.includes("holiday")) {
             return `${this.value === "presence_holiday_present" ? "text-success" : "o_icon_employee_absent"}`;
         } else if (this.location) {
@@ -65,6 +74,9 @@ patch(HrPresenceStatusPrivate.prototype, patchHrPresenceStatus());
 // Applies patch on one component and the other should be affected also, since it's extended from it.
 patch(HrPresenceStatusPrivate.prototype, {
     get label() {
+        if (!this.isActive) {
+            return super.label;
+        }
         if (this.props.record.data.current_work_entry_type_id){
             let label = this.props.record.data.current_work_entry_type_id.display_name;
             if (this.props.record.data.leave_date_to) {

--- a/addons/hr_holidays/tests/test_holidays_flow.py
+++ b/addons/hr_holidays/tests/test_holidays_flow.py
@@ -9,12 +9,12 @@ from psycopg2 import IntegrityError
 
 from odoo.tools import date_utils, mute_logger, test_reports
 
-from odoo.tests import tagged
+from odoo.tests import new_test_user
 
-from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
+from odoo.addons.hr_holidays.tests.common import TestHolidayContract, TestHrHolidaysCommon
 
 
-class TestHolidaysFlow(TestHrHolidaysCommon):
+class TestHolidaysFlow(TestHrHolidaysCommon, TestHolidayContract):
 
     @mute_logger('odoo.addons.base.models.ir_model', 'odoo.models')
     def test_00_leave_request_flow_unlimited(self):
@@ -293,3 +293,19 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
                 'request_date_from': date.today() + relativedelta(day=11),
                 'request_date_to': date.today() + relativedelta(day=10),
             })
+
+    @freeze_time("2024-02-01 10:00:00")
+    def test_employee_presence_after_archived(self):
+        """when an employee is archived his presence_state should be in archive state"""
+        self.jules_emp.write({
+            'resource_calendar_id': self.company.resource_calendar_id.id,
+            'user_id': new_test_user(self.env, login='jules_emp', groups='base.group_user').id,
+        })
+        self.create_leave(
+            date_from=datetime(2024, 2, 1, 8, 0, 0),
+            date_to=datetime(2024, 2, 1, 17, 0, 0),
+            employee_id=self.jules_emp.id,
+        ).action_approve()
+        self.assertEqual(self.jules_emp.hr_icon_display, 'presence_holiday_absent')
+        self.jules_emp.action_archive()
+        self.assertEqual(self.jules_emp.hr_icon_display, 'presence_archive')

--- a/addons/hr_presence/models/hr_employee.py
+++ b/addons/hr_presence/models/hr_employee.py
@@ -147,7 +147,8 @@ Thank you for your prompt attention to this matter.""")
         company = self.env.company
         working_now_list = self._get_employee_working_now()
         for employee in self:
-            if not employee.company_id.hr_presence_control_email and not employee.company_id.hr_presence_control_ip:
+            if not employee.active or \
+                (not employee.company_id.hr_presence_control_email and not employee.company_id.hr_presence_control_ip):
                 continue
             if company.hr_presence_last_compute_date and employee.id in working_now_list and \
                     company.hr_presence_last_compute_date.day == fields.Datetime.now().day and \


### PR DESCRIPTION
## In this PR:
### When an employee is archived:
- We will automatically check out checked-in user at the current timestamp.
- We will preserve the archived state across all views. This means we will always show presence = archive in all cases, regardless of other modules. This ensures consistency in archive state at all times

Task: 5916700

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
