### PR TITLE
[FIX] mail: sync breadcrumbs and navbar colors in dark mode

### DIFF
--- a/addons/mail/static/src/core/public_web/discuss.dark.scss
+++ b/addons/mail/static/src/core/public_web/discuss.dark.scss
@@ -16,12 +16,10 @@
 }
 
 .o_web_client:has(.o-mail-Discuss) {
+    --mail-Discuss-surface-dark: #{mix($white, $o-webclient-background-color, 15%)};
+    --NavBar-entry-backgroundColor: var(--mail-Discuss-surface-dark);
 
-    .o_main_navbar {
-        background-color: mix($white, $o-webclient-background-color, 15%);
-    }
-
-    .o_control_panel {
-        background-color: mix($white, $o-webclient-background-color, 15%);
+    .o_main_navbar, .o_control_panel {
+        background-color: var(--mail-Discuss-surface-dark);
     }
 }

--- a/addons/mail/static/src/core/public_web/discuss.dark.scss
+++ b/addons/mail/static/src/core/public_web/discuss.dark.scss
@@ -19,7 +19,11 @@
     --mail-Discuss-surface-dark: #{mix($white, $o-webclient-background-color, 15%)};
     --NavBar-entry-backgroundColor: var(--mail-Discuss-surface-dark);
 
-    .o_main_navbar, .o_control_panel {
+    .o_main_navbar, .o_control_panel, .breadcrumb {
         background-color: var(--mail-Discuss-surface-dark);
+    }
+    .breadcrumb .btn-light {
+        --btn-bg: var(--mail-Discuss-surface-dark);
+        border-color: transparent;
     }
 }


### PR DESCRIPTION
The background color of navbar buttons and breadcrumbs in discuss app differed from that of control panel.
This PR aligns and syncs these colors for a consistent UI.

| Before | After |
|--------|-------|
|<img width="467" height="99" alt="image" src="https://github.com/user-attachments/assets/2def30f8-18aa-4399-a5d1-1cdc70b4cd81" /> |<img width="458" height="111" alt="image" src="https://github.com/user-attachments/assets/5578cd25-7686-4543-a8dc-3e0fe5aeb4fc" />|

This PR contains backport of #217608

task-[4936733](https://www.odoo.com/odoo/project/1519/tasks/4936733)
task-[5487197](https://www.odoo.com/odoo/project/1519/tasks/5487197)