### PR TITLE
[FIX] mrp: fix error in BoM overview when no warehouse is set

### DIFF
--- a/addons/mrp/report/mrp_report_bom_structure.py
+++ b/addons/mrp/report/mrp_report_bom_structure.py
@@ -125,7 +125,8 @@ class ReportBomStructure(models.AbstractModel):
         if self.env.context.get('warehouse_id'):
             warehouse = self.env['stock.warehouse'].browse(self.env.context.get('warehouse_id'))
         else:
-            warehouse = self.env['stock.warehouse'].browse(self.get_warehouses()[0]['id'])
+            warehouses = self.get_warehouses()
+            warehouse = self.env['stock.warehouse'].browse(warehouses[0]['id']) if warehouses else self.env['stock.warehouse']
 
         lines = self._get_bom_data(bom, warehouse, product=product, line_qty=bom_quantity, level=0)
         try:
@@ -537,7 +538,8 @@ class ReportBomStructure(models.AbstractModel):
         if self.env.context.get('warehouse_id'):
             warehouse = self.env['stock.warehouse'].browse(self.env.context.get('warehouse_id'))
         else:
-            warehouse = self.env['stock.warehouse'].browse(self.get_warehouses()[0]['id'])
+            warehouses = self.get_warehouses()
+            warehouse = self.env['stock.warehouse'].browse(warehouses[0]['id']) if warehouses else self.env['stock.warehouse']
 
         level = 1
         data = self._get_bom_data(bom, warehouse, product=product, line_qty=qty, level=0)
@@ -631,7 +633,7 @@ class ReportBomStructure(models.AbstractModel):
         found_rules = []
         if self._need_special_rules(product_info, parent_bom, parent_product):
             found_rules = self._find_special_rules(product, product_info, bom, parent_bom, parent_product)
-        if not found_rules:
+        if not found_rules and warehouse:
             found_rules = product._get_rules_from_location(warehouse.lot_stock_id)
         if not found_rules:
             return {}

--- a/addons/mrp/static/src/components/bom_overview/mrp_bom_overview.js
+++ b/addons/mrp/static/src/components/bom_overview/mrp_bom_overview.js
@@ -168,8 +168,10 @@ export class BomOverviewComponent extends Component {
                          "&operations=" + this.state.showOptions.operations +
                          "&lead_times=" + this.state.showOptions.leadTimes +
                          "&quantity=" + (this.state.bomQuantity || 1) +
-                         "&unfolded_ids=" + JSON.stringify(Array.from(this.unfoldedIds)) +
-                         "&warehouse_id=" + (this.state.currentWarehouse ? this.state.currentWarehouse.id : false);
+                         "&unfolded_ids=" + JSON.stringify(Array.from(this.unfoldedIds));
+        if (this.state.currentWarehouse) {
+            reportName += "&warehouse_id=" + this.state.currentWarehouse.id;
+        }
         if (printAll) {
             reportName += "&all_variants=1";
         } else if (this.showVariants && this.state.currentVariantId) {

--- a/addons/mrp/static/src/components/bom_overview/mrp_bom_overview.xml
+++ b/addons/mrp/static/src/components/bom_overview/mrp_bom_overview.xml
@@ -23,7 +23,7 @@
         <BomOverviewTable
             uomName="uomName"
             showOptions="state.showOptions"
-            currentWarehouseId="state.currentWarehouse.id"
+            currentWarehouseId="state.currentWarehouse?.id"
             data="state.bomData"
             precision="state.precision"
             changeFolded.bind="onChangeFolded"/>

--- a/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.js
+++ b/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.js
@@ -25,7 +25,7 @@ export class BomOverviewControlPanel extends Component {
         data: { type: Object, optional: true },
         showUom: { type: Boolean, optional: true },
         uomName: { type: String, optional: true },
-        currentWarehouse: Object,
+        currentWarehouse: { type: Object, optional: true },
         warehouses: { type: Array, optional: true },
         print: Function,
         changeWarehouse: Function,
@@ -90,7 +90,7 @@ export class BomOverviewControlPanel extends Component {
         return this.props.warehouses.map(wh => ({
             id: wh.id,
             label: wh.name,
-            class: { selected: wh.name === this.props.currentWarehouse.name },
+            class: { selected: wh.name === this.props.currentWarehouse?.name },
             onSelected: () => this.props.changeWarehouse(wh.id)
         }));
     }

--- a/addons/mrp/tests/test_multicompany.py
+++ b/addons/mrp/tests/test_multicompany.py
@@ -316,3 +316,26 @@ class TestMrpMulticompany(common.TransactionCase):
         delivery.with_company(self.company_a).action_confirm()
         delivery.with_company(self.company_a).action_assign()
         self.assertRecordValues(delivery.move_ids, [{'state': 'confirmed', 'quantity': 0.0}])
+
+    def test_bom_report_without_warehouse(self):
+        """
+        Checks that bom overview/report shows availabilities as "Not Available" when the warehouse is not active.
+        """
+        self.warehouse_a.active = False
+        product, component = self.env['product.product'].create([
+            {'name': 'p1', 'is_storable': True},
+            {'name': 'c1', 'is_storable': True},
+        ])
+        bom = self.env['mrp.bom'].create({
+            'product_tmpl_id': product.product_tmpl_id.id,
+            'company_id': self.company_a.id,
+            'bom_line_ids': [(0, 0, {'product_id': component.id})]
+        })
+        report = self.env['report.mrp.report_bom_structure'].with_company(self.company_a)
+        bom_overview = report._get_report_data(bom_id=bom.id)
+        bom_report = report._get_report_values(docids=[bom.id], data={})
+
+        self.assertFalse(bom_overview["lines"]["availability_delay"])
+        self.assertFalse(bom_report["docs"][0]["availability_delay"])
+        self.assertEqual("unavailable", bom_overview["lines"]["availability_state"])
+        self.assertEqual("unavailable", bom_report["docs"][0]["availability_state"])


### PR DESCRIPTION
**Steps to Reproduce:**
- Install MRP module.
- Create a new company and switch to it.
- Create a new BoM.
- Click on the "BoM Overview" smart button.

**Error:**
`IndexError - list index out of range`

**Cause:**
When a new company is created, no warehouse is automatically generated for it. If no warehouse is configured for the company, the list is empty, causing an error.

**Fix:**
This commit raises a redirection warning if no warehouse is linked with the company.

sentry-7286332859