### PR TITLE
[IMP] html_builder: always display label in tooltip if it is too long

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_row.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_row.js
@@ -36,7 +36,7 @@ export class BuilderRow extends Component {
         this.state = useState({
             expanded: this.props.expand,
         });
-        this.hasTooltip = this.props.tooltip ? true : undefined;
+        this.tooltipText = undefined;
         this.isBackendRTL = localization.direction === "rtl";
 
         if (this.props.slots.collapse) {
@@ -130,13 +130,23 @@ export class BuilderRow extends Component {
     }
 
     openTooltip() {
-        if (this.hasTooltip === undefined) {
-            const labelEl = this.labelRef.el;
-            this.hasTooltip = labelEl && labelEl.clientWidth < labelEl.scrollWidth;
+        const labelEl = this.labelRef.el;
+        if (this.tooltipText === undefined) {
+            const isLabelTooLong = labelEl.offsetWidth < labelEl.scrollWidth;
+            if (isLabelTooLong) {
+                this.tooltipText = this.props.tooltip
+                    ? `${this.props.label}\u00A0: ${this.props.tooltip}`
+                    : this.props.label;
+            } else if (this.props.tooltip) {
+                this.tooltipText = this.props.tooltip;
+            } else {
+                this.tooltipText = "";
+            }
         }
-        if (this.hasTooltip) {
-            const tooltip = this.props.tooltip || this.props.label;
-            this.removeTooltip = this.tooltip.add(this.labelRef.el, { tooltip });
+        if (this.tooltipText) {
+            this.removeTooltip = this.tooltip.add(labelEl, {
+                tooltip: this.tooltipText,
+            });
         }
     }
 

--- a/addons/html_builder/static/src/core/building_blocks/builder_row.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_row.scss
@@ -55,7 +55,7 @@
         flex: 0 0 44%;
         z-index: $_z-index;
         background-color: var(--o-hb-row-bg-color, #{$o-we-bg-lighter});
-        padding: $o-hb-row-spacing 0 $o-hb-row-spacing $o-hb-row-padding-left;
+        padding: $o-hb-row-spacing $o-hb-row-spacing $o-hb-row-spacing $o-hb-row-padding-left;
         align-self: baseline;
     }
 

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_row.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_row.test.js
@@ -406,4 +406,23 @@ describe("HTML builder tests", () => {
         await contains(":iframe .test-options-target").hover();
         expect(".o-tooltip").toHaveCount(0);
     });
+    test("show row label before tooltip when label is truncated", async () => {
+        addBuilderOption(
+            class extends BaseOptionComponent {
+                static selector = ".test-options-target";
+                static template = xml`<BuilderRow label="'Supercalifragilisticexpalidocious'" tooltip="'my tooltip'">Palais chatouille</BuilderRow>`;
+            }
+        );
+        await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
+        await contains(":iframe .test-options-target").click();
+        await hover("[data-label='Supercalifragilisticexpalidocious'] .text-truncate");
+        await advanceTime(OPEN_DELAY);
+        await waitFor(".o-tooltip");
+        const label = queryOne("[data-label='Supercalifragilisticexpalidocious'] .text-truncate");
+        expect(label.scrollWidth).toBeGreaterThan(label.clientWidth); // the text is longer than the available width.
+        expect(".o-tooltip").toHaveText("Supercalifragilisticexpalidocious : my tooltip");
+
+        await contains(":iframe .test-options-target").hover();
+        expect(".o-tooltip").toHaveCount(0);
+    });
 });


### PR DESCRIPTION
Before this commit, the tooltip when hovering a builder row would either display the tooltip (if any) or the label (if it was too long). However, when both needed to be displayed, only the tooltip provided in the props would be shown, meaning the user could not read the entire option label.

This commit fixes the issue by always displaying the label when necessary, putting it before the tooltip if the option had any.

task-5948138