### PR TITLE
[FIX] hr: make action_create_employee return a result

### DIFF
--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -285,7 +285,7 @@ class ResUsers(models.Model):
         self.ensure_one()
         if self.env.company not in self.company_ids:
             raise AccessError(_("You are not allowed to create an employee because the user does not have access rights for %s", self.env.company.name))
-        self.env['hr.employee'].create(dict(
+        return self.env['hr.employee'].create(dict(
             name=self.name,
             company_id=self.env.company.id,
             **self.env['hr.employee']._sync_user(self)


### PR DESCRIPTION
Since 19.1, the admin user doesn't have an employee profile automatically created.
So we added a way to create one rapidly when using workorder functions. For that,
we want to make direct use of the employee created by action_create_employee
without needing to do a search.

see https://github.com/odoo/enterprise/pull/107439

task 5932500

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
