### PR TITLE
[FIX] stock: prevent traceback when using replenishment multiples

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -266,7 +266,7 @@ class StockWarehouseOrderpoint(models.Model):
                 orderpoint.qty_to_order = orderpoint.product_max_qty - orderpoint.qty_forecast
                 remainder = orderpoint.replenishment_uom_id and orderpoint.qty_to_order % orderpoint.replenishment_uom_id.factor or 0.0
                 if not orderpoint.product_uom.is_zero(remainder):
-                    orderpoint.qty_to_order += orderpoint.replenishment_uom_id - remainder
+                    orderpoint.qty_to_order -= remainder
         try:
             self._procure_orderpoint_confirm(company_id=self.env.company)
         except UserError as e:

--- a/addons/stock/tests/test_proc_rule.py
+++ b/addons/stock/tests/test_proc_rule.py
@@ -605,6 +605,11 @@ class TestProcRule(TransactionCase):
         self.assertEqual(orderpoint.qty_forecast, 10.0)
         orderpoint.action_replenish(force_to_max=True)
         self.assertEqual(orderpoint.qty_forecast, 200.0)
+        # Test that changing the replenishment UoM does not cause issues when replenishing to max
+        orderpoint.replenishment_uom_id = self.env.ref('uom.product_uom_dozen')
+        orderpoint.product_max_qty = 240
+        orderpoint.action_replenish(force_to_max=True)
+        self.assertEqual(orderpoint.qty_forecast, 236.0, "qty to order should be 3 dozens converted to the product UoM (36) and added to the current forecasted quantity")
 
     def test_orderpoint_location_archive(self):
         warehouse = self.env['stock.warehouse'].create({


### PR DESCRIPTION
Backport of: https://github.com/odoo/odoo/commit/fe806166968d55a70f5bf335dcb3633e18d8ecc7

Steps to reproduce:
- Create a storable product “P1”:
  - UoM: Unit and Pack of 6
  - Purchase tab: add any vendor
- Go to Replenishment and create a new rule:
  - Product: P1
  - Min: 10
  - Max: 100
  - Replenishment Multiple: Pack of 6
- Select the line and click “Replenish” → “Order to Max”

Issue:
A traceback is raised:
“TypeError: unsupported operand types in: uom.uom(2,) - 4.0”

In `_get_qty_to_order`, we compute the quantity to order and then adjust it according to the replenishment multiple, but we try to Subtract the rounded remainder from the uom (which is a recordset) instead of the quantity (which is a float).

opw-5947919