### PR TITLE
[FIX] mass_mailing: halve custom snippet title size

### DIFF
--- a/addons/mass_mailing/static/src/builder/snippet_viewer/snippet_viewer.scss
+++ b/addons/mass_mailing/static/src/builder/snippet_viewer/snippet_viewer.scss
@@ -10,6 +10,10 @@
             padding: 0;
         }
     }
+
+    .o_custom_snippet_edit > * {
+        font-size: 25px !important;
+    }
 }
 
 .o_snippet_preview_wrap {


### PR DESCRIPTION
In Mass Mailing, users can save modified snippets as Custom Snippets, allowing for their later reuse. These snippets can be found in the Custom category.

However, their title was too large. This is due to d2b56435736e8d507434c1378cb68fae23e8511f rescaling the preview snippet selector, allowing for better readability of each snippet's text from the selector. As the default builder font size for custom snippet titles was set for the previous scale (50px at 0.3 scale), it has to be halved to restore its previous appearance at the new scale (25px at 0.6 scale).

task-5959033