### PR TITLE
[FIX] website: save partial AI translation success


### DIFF
--- a/addons/website/static/src/builder/plugins/translation_tab/customize_translation_tab_plugin.js
+++ b/addons/website/static/src/builder/plugins/translation_tab/customize_translation_tab_plugin.js
@@ -176,14 +176,20 @@ class TranslateToAction extends BuilderAction {
         // Limit concurrency to avoid
         // "Oops, it looks like our AI is unreachable!" error
         // when too many requests are sent in a short time.
-        const concurrencyLimit = 5;
+        const concurrencyLimit = 3;
         const allResults = [];
         const executing = new Set();
         for (const task of tasks) {
             if (executing.size >= concurrencyLimit) {
                 await Promise.race(executing);
             }
-            const promise = task().finally(() => executing.delete(promise));
+            const promise = task()
+                .catch((error) => {
+                    // Ignore failed request to save successfull ones
+                    console.warn("Translation chunck failed:", error);
+                    return {};
+                })
+                .finally(() => executing.delete(promise));
             executing.add(promise);
             allResults.push(promise);
         }
@@ -199,13 +205,12 @@ class TranslateToAction extends BuilderAction {
      * @return {Number} Count of failed translation nodes
      */
     applyTranslationsToDOM(translationMap, responses) {
-        let numOfFailedTranslationNodes = 0;
+        let numOfFailedTranslationNodes = translationMap.size;
         for (const response of responses) {
             let translations;
             try {
                 translations = JSON.parse(response);
             } catch {
-                numOfFailedTranslationNodes += translationMap.size;
                 continue;
             }
 
@@ -216,9 +221,9 @@ class TranslateToAction extends BuilderAction {
                 }
                 const translated = (text || "").trim();
                 if (!translated) {
-                    numOfFailedTranslationNodes++;
                     continue;
                 }
+                numOfFailedTranslationNodes--;
                 node.textContent = translated;
                 const parentEl = node.parentElement?.closest("[data-oe-translation-state]");
                 if (parentEl) {

--- a/addons/website/static/tests/builder/translation.test.js
+++ b/addons/website/static/tests/builder/translation.test.js
@@ -458,6 +458,54 @@ test("'Translate to' button should be visible in translate mode", async () => {
     expect(":iframe .o_editable").toHaveText("Bonjour");
 });
 
+test("'Translate to' works with partial request failure", async () => {
+    const originalText = "a".repeat(2000);
+    await setupSidebarBuilderForTranslation({
+        websiteContent:
+            getTranslateEditable({ inWrap: `${originalText}1`, sourceSha: "1" }) +
+            getTranslateEditable({ inWrap: `${originalText}2`, sourceSha: "2" }) +
+            getTranslateEditable({ inWrap: `${originalText}3`, sourceSha: "3" }) +
+            getTranslateEditable({ inWrap: `${originalText}4`, sourceSha: "4" }) +
+            getTranslateEditable({ inWrap: `${originalText}5`, sourceSha: "5" }) +
+            getTranslateEditable({ inWrap: `${originalText}6`, sourceSha: "6" }),
+    });
+    onRpc("/html_editor/generate_text", async (data) => {
+        const { params } = await data.json();
+        const prompt = JSON.parse(params.prompt)[0];
+        const number = prompt.text.slice(-1);
+        if (["2", "4", "5"].includes(number)) {
+            throw new Error("ConnectionLostError");
+        }
+        return JSON.stringify([
+            {
+                id: prompt.id,
+                text: `${prompt.text}french`,
+            },
+        ]);
+    });
+    await contains(".modal .btn:contains(Ok, never show me this again)").click();
+    expectElementCount("button[data-action-id='translateWebpageAI']", 1);
+    patchWithCleanup(console, {
+        warn: (msg, error) => expect.step(msg),
+    });
+    await contains("button[data-action-id='translateWebpageAI']").click();
+    await animationFrame();
+    expect(":iframe .container:nth-child(1) .o_editable").toHaveText(`${originalText}1french`);
+    expect(":iframe .container:nth-child(2) .o_editable").toHaveText(`${originalText}2`);
+    expect(":iframe .container:nth-child(3) .o_editable").toHaveText(`${originalText}3french`);
+    expect(":iframe .container:nth-child(4) .o_editable").toHaveText(`${originalText}4`);
+    expect(":iframe .container:nth-child(5) .o_editable").toHaveText(`${originalText}5`);
+    expect(":iframe .container:nth-child(6) .o_editable").toHaveText(`${originalText}6french`);
+    expect(".o_notification_content").toHaveText(
+        "Translation Error. 3 text blocks were skipped during translation. Please try again."
+    );
+    expect.verifySteps([
+        "Translation chunck failed:",
+        "Translation chunck failed:",
+        "Translation chunck failed:",
+    ]);
+});
+
 test("trying to translate an element inside a .o_not_editable should add a notification", async () => {
     mockService("notification", {
         add(message, options = {}) {


### PR DESCRIPTION
Scenario:

- be on odoo SaaS instance
- be on non-translated page with enough content to do 4 requests
  to /html_editor/generate_text (that are done in chunk of 2000
  characters per request currently)
- open the editor and use "Translate to {lang}" (ai translation)

Result: you see a message "Connection lost. Trying to reconnect..." and
after waiting 10-20 seconds, no translation are inserted in the page.
In reality the requests after the 3 first ones were cancelled (with
error 429 too many requests) by nginx, and the 3 first ones worked
correctly but their result was not used because of the error of the
other ones.

Fix:

- decrease the number of concurrent request from 5 to 3 which is the
  current default for this route on SaaS

- adapt the code so if there is errors on one request, successfull
  requests will still be applied with the text "Translation Error.
  {number} text blocks were skipped during translation. Please try
  again." for the blocks that were missed.

This way even if there is an error, the translation is not totally
blocked and doesn't need to be restarted from zero (making it impossible
in the original scenario).

Side note: the number of text blocks not translated was a multiplication
of the total number of text blocks by the number of failed response.
This fix adapts it to just the total of words substrating the number of
translation applied.

opw-5892402
