### PR TITLE
[FIX] html_builder, website: filter dropzones on snippet group click

### DIFF
--- a/addons/html_builder/static/src/sidebar/block_tab.js
+++ b/addons/html_builder/static/src/sidebar/block_tab.js
@@ -82,8 +82,13 @@ export class BlockTab extends Component {
                                 // Add the dropzones corresponding to the snippet
                                 // and make them invisible.
                                 const selectors = this.shared.dropzone.getSelectors(snippetEl);
-                                const dropzoneEls =
-                                    this.shared.dropzone.activateDropzones(selectors);
+                                let dropzoneEls = this.shared.dropzone.activateDropzones(selectors);
+
+                                dropzoneEls = dropzoneEls.filter(
+                                    (dropzoneEl) =>
+                                        !dropzoneEl.closest("[data-snippet]:not(:has(> .modal))")
+                                );
+
                                 this.editable
                                     .querySelectorAll(".oe_drop_zone")
                                     .forEach((dropzoneEl) => dropzoneEl.classList.add("invisible"));

--- a/addons/website/static/tests/tours/snippet_countdown.js
+++ b/addons/website/static/tests/tours/snippet_countdown.js
@@ -18,7 +18,7 @@ registerWebsitePreviewTour('snippet_countdown', {
     // widgets_start_request is triggered.
     {
         content: "Hover an option which has a preview",
-        trigger: "[data-action-param='o_half_screen_height']",
+        trigger: "[data-container-title='Countdown'] [data-action-param='o_half_screen_height']",
         run: "hover",
     },
     {

--- a/addons/website/static/tests/tours/snippet_table_of_content.js
+++ b/addons/website/static/tests/tours/snippet_table_of_content.js
@@ -12,7 +12,7 @@ const scrollToHeading = function (position) {
         content: `Scroll to h2 number ${position}`,
         trigger: `:iframe .s_table_of_content h2:eq(${position})`,
         run: function () {
-            this.anchor.scrollIntoView({ behavior: "smooth", block: "center" });
+            this.anchor.scrollIntoView(true);
         },
     };
 };
@@ -59,7 +59,7 @@ registerWebsitePreviewTour('snippet_table_of_content', {
     scrollToHeading(2),
     checkTOCNavBar(1, 0),
     scrollToHeading(3),
-    checkTOCNavBar(1, 0),
+    checkTOCNavBar(1, 1),
     ...clickOnEditAndWaitEditMode(),
     {
         content: "Click on the first TOC's title",


### PR DESCRIPTION
After https://github.com/odoo/odoo/pull/240547 was merged, an issue appeared with the snippets that could also be dropped as inner content. Instead of only having the dropzones for sections, all dropzones were activated, meaning that snippets such as countdown would sometimes be dropped as inner content.

Steps to reproduce the issue:
- Go to Website
- Go to Edit mode
- From an empty website, click on the snippet group "Content"
- Select the countdown
=> The countdown was dropped in the footer instead of the main

To fix this issue, this commit restores the missing filter (removed when the new builder was added). However, since the drag and drop was updated to only display dropzones of the "active" element, there is no need to filter the dropzones within #website_cookies_bar. Finally, the filter is no longer based on the s_popup snippet, as the drag and drop mechanic was moved outside of the website module.

This commit also partially reverts the commit 5cb4f5c, since it made the tour fail with the changes of this PR (s_banner snippets can no longer be dropped inside of the s_table_of_content)

The tour testing the Countdown was updated since it did not fail prior to saas-19.2, because it was not precise enough.

Related to task-5428387