### PR TITLE
[FIX] website_sale_collect: exclude branch locations from collect

### DIFF
--- a/addons/website_sale_collect/models/delivery_carrier.py
+++ b/addons/website_sale_collect/models/delivery_carrier.py
@@ -89,7 +89,7 @@ class DeliveryCarrier(models.Model):
 
         pickup_locations = []
         order_sudo = request.cart
-        for wh in self.warehouse_ids:
+        for wh in self.warehouse_ids.filtered(lambda wh: wh.company_id == self.env.company):
             pickup_location_values = wh._prepare_pickup_location_data()
             if not pickup_location_values:  # Ignore warehouses with badly configured addresses.
                 continue

--- a/addons/website_sale_collect/models/website.py
+++ b/addons/website_sale_collect/models/website.py
@@ -48,4 +48,5 @@ class Website(models.Model):
         return max([
             product.with_context(warehouse_id=wh.id).free_qty
             for wh in self.sudo().in_store_dm_id.warehouse_ids
+                .filtered(lambda wh: wh.company_id == self.company_id)
         ], default=0)

--- a/addons/website_sale_collect/tests/common.py
+++ b/addons/website_sale_collect/tests/common.py
@@ -26,6 +26,15 @@ class ClickAndCollectCommon(PaymentCustomCommon, WebsiteSaleStockCommon):
             name="Example in-store delivery",
             is_published=True,
         )
+        cls.admin_user = cls.env.ref('base.user_admin')
+        cls.branch_company = cls.env['res.company'].with_user(cls.admin_user).create({
+            'name': "Branch Company",
+            'parent_id': cls.env.company.id,
+        })
+        cls.branch_wh = cls.env['stock.warehouse'].with_company(cls.branch_company).create({
+            'name': 'Branch Company Warehouse',
+            'code': 'WHB',
+        })
 
     def _create_in_store_delivery_order(self, **values):
         default_values = {

--- a/addons/website_sale_collect/tests/test_delivery_carrier.py
+++ b/addons/website_sale_collect/tests/test_delivery_carrier.py
@@ -72,6 +72,9 @@ class TestDeliveryCarrier(ClickAndCollectCommon, WebsiteSaleStockCommon):
             ],
         })
 
+        # Branch companies' warehouses should not be included in the results.
+        self.in_store_dm.warehouse_ids = [Command.link(self.branch_wh.id)]
+
         with patch(
             'odoo.addons.base_geolocalize.models.res_partner.ResPartner.geo_localize',
             return_value=True

--- a/addons/website_sale_collect/tests/test_website.py
+++ b/addons/website_sale_collect/tests/test_website.py
@@ -70,3 +70,8 @@ class TestWebsite(ClickAndCollectCommon):
         self._add_product_qty_to_wh(self.storable_product.id, 15, self.warehouse_2.lot_stock_id.id)
         free_qty = self.website._get_max_in_store_product_available_qty(self.storable_product)
         self.assertEqual(free_qty, 15)
+        # Branch companies' warehouses should not be included in the results.
+        self.in_store_dm.warehouse_ids = [Command.link(self.branch_wh.id)]
+        self._add_product_qty_to_wh(self.storable_product.id, 40, self.branch_wh.lot_stock_id.id)
+        free_qty = self.website._get_max_in_store_product_available_qty(self.storable_product)
+        self.assertEqual(free_qty, 15)


### PR DESCRIPTION
Issue
-----
When choosing the delivery method, the user cannot change the pick up location to one of a branch company.

Steps to reproduce
-----
- In settings, enable Click & Collect
- Create a branch company with a warehouse
- Open the "Pick up in store" delivery method
    - Add the branch warehouse to the list
- Go to the website and purchase a product
- Select the pick up delivery method
- Choose the main company warehouse
- Change to the branch warehouse

> Nothing happens

Additional issue
-----
If a product is only available in the branch company's warehouse, on its' product page, it shows as out of stock but available for pickup in the branch WH.

Cause
-----
The SO has `_check_company_auto` to True, so we go through

https://github.com/odoo/odoo/blob/b071bc3cb9e1d91d9d0fbce7961c3c75f28ef874/odoo/orm/models.py#L4516-L4517

where an inconsistency is found between the new WH's `company_id` and the SO's.


-----
Ticket:
opw-5891079