### PR TITLE
[IMP] account,*: hide trailing zero decimals for quantity in reports

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -221,12 +221,12 @@
                                                         <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">Bacon Burger</span>
                                                     </td>
                                                     <td name="td_quantity" class="o_td_quantity text-end">
-                                                        <span t-field="line.quantity" class="text-nowrap">3.00</span>
+                                                        <span t-field="line.quantity" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}" class="text-nowrap">3.00</span>
                                                         <span t-field="line.product_uom_id"  groups="uom.group_uom">units</span>
                                                         <span t-if="line.product_uom_id != line.product_id.uom_id" groups="uom.group_uom" class="text-muted small">
                                                             <br/>
                                                             <t t-set="product_uom_qty" t-value="line.product_uom_id._compute_quantity(line.quantity, line.product_id.uom_id)"/>
-                                                            <span t-out="product_uom_qty" t-options="{'widget': 'float', 'decimal_precision': 'Product Unit'}" data-oe-demo="3.00"/> <span t-field="line.product_id.uom_id" data-oe-demo="units"/>
+                                                            <span t-out="product_uom_qty" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}" data-oe-demo="3.00"/> <span t-field="line.product_id.uom_id" data-oe-demo="units"/>
                                                         </span>
                                                     </td>
                                                     <td name="td_price_unit" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
@@ -309,18 +309,18 @@
                                                         class="o_td_quantity text-end">
                                                         <!-- If line is hide composition, always show 1 unit -->
                                                         <div t-if="hide_details">
-                                                            <span>1.00</span>
+                                                            <span>1</span>
                                                             <span groups="uom.group_uom">Units</span>
                                                         </div>
                                                         <!-- Else, show the line quantity -->
                                                         <div t-if="hide_prices and grouped_line['display_type'] not in ('line_section', 'line_subsection')">
-                                                            <span t-out="grouped_line['quantity']" t-options="{'widget': 'float', 'decimal_precision': 'Product Unit'}">1.00</span>
+                                                            <span t-out="grouped_line['quantity']" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}">1.00</span>
                                                             <t t-if="grouped_line.get('line_uom')">
                                                                 <span t-out="grouped_line['line_uom'].display_name" groups="uom.group_uom">Unit</span>
                                                                 <span t-if="grouped_line.get('product_uom') != grouped_line['line_uom']" groups="uom.group_uom" class="text-muted small">
                                                                     <br/>
                                                                     <t t-set="product_uom_qty" t-value="grouped_line['line_uom']._compute_quantity(grouped_line['quantity'], grouped_line['product_uom'])"/>
-                                                                    <span t-out="product_uom_qty" t-options="{'widget': 'float', 'decimal_precision': 'Product Unit'}" data-oe-demo="3.00"/> <span t-out="grouped_line['product_uom'].display_name" data-oe-demo="units"/>
+                                                                    <span t-out="product_uom_qty" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}" data-oe-demo="3.00"/> <span t-out="grouped_line['product_uom'].display_name" data-oe-demo="units"/>
                                                                 </span>
                                                             </t>
                                                         </div>

--- a/addons/mrp/report/mrp_production_templates.xml
+++ b/addons/mrp/report/mrp_production_templates.xml
@@ -42,12 +42,12 @@
                         </div>
                         <div class="col-3">
                             <strong>Quantity to Produce:</strong><br/>
-                            <span t-field="o.product_qty">100</span>
+                            <span t-field="o.product_qty" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}">100</span>
                             <span t-field="o.uom_id.name" groups="uom.group_uom">Units</span>
                         </div>
                         <div class="col-3" t-if="o.qty_producing">
                             <strong>Quantity Producing:</strong><br/>
-                            <span t-field="o.qty_producing">50</span>
+                            <span t-field="o.qty_producing" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}">50</span>
                             <span t-field="o.uom_id.name" groups="uom.group_uom">Units</span>
                         </div>
                     </div>
@@ -118,11 +118,11 @@
                 </td>
                 <td t-attf-class="{{ 'text-end' if not has_product_barcode else '' }}" t-if="o.state in ('progress', 'to_close','done')">
                     <div>
-                        <span t-field="raw_line.quantity">2</span>
+                        <span t-field="raw_line.quantity" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}">2</span>
                     </div>
                 </td>
                 <td t-attf-class="{{ 'text-end' if not has_product_barcode else '' }}">
-                    <span t-field="raw_line.product_uom_qty">25</span>
+                    <span t-field="raw_line.product_uom_qty" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}">25</span>
                     <span t-field="raw_line.uom_id" groups="uom.group_uom">Pieces</span>
                 </td>
                 <td t-if="has_product_barcode" width="15%" class="text-center">
@@ -178,8 +178,8 @@
                                     <div class="o_label_name o_label_4x12 fw-bold">
                                         <span t-out="move_line.product_id.display_name">Product</span>
                                         <div><span>Quantity: </span>
-                                            <span t-if="move_line.product_id.uom_id._has_common_reference(uom_unit)">1.0</span>
-                                            <span t-else="" t-out="move_line.quantity">5</span>
+                                            <span t-if="move_line.product_id.uom_id._has_common_reference(uom_unit)" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}">1.0</span>
+                                            <span t-else="" t-out="move_line.quantity" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}">5</span>
                                             <span t-field="move_line.uom_id" groups="uom.group_uom">UOM id</span>
                                         </div>
                                     </div>

--- a/addons/mrp/report/mrp_report_bom_structure.xml
+++ b/addons/mrp/report/mrp_report_bom_structure.xml
@@ -26,11 +26,11 @@
                     <tbody>
                         <tr>
                             <td name="td_mrp_bom" t-out="data['name']"/>
-                            <td class="text-end" t-out="data['quantity']" t-options='{"widget": "float", "decimal_precision": "Product Unit"}'/>
+                            <td class="text-end" t-out="data['quantity']" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}"/>
                             <td class="text-start" groups="uom.group_uom" t-out="data['uom_name']"/>
                             <td t-if="data['forecast_mode']" class="text-center">
-                                <t t-out="data['quantity_available']" t-options='{"widget": "float", "decimal_precision": "Product Unit"}'/> /
-                                <t t-out="data['quantity_on_hand']" t-options='{"widget": "float", "decimal_precision": "Product Unit"}'/>
+                                <t t-out="data['quantity_available']" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}"/> /
+                                <t t-out="data['quantity_on_hand']" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}"/>
                             </td>
                             <td t-if="data['forecast_mode']" class="text-center">
                                 <t t-if="data['status']">
@@ -105,13 +105,13 @@
                 </td>
                 <td class="text-end">
                     <t t-if="l['type'] == 'operation'" t-out="l['quantity']" t-options='{"widget": "float_time"}'/>
-                    <t t-else="" t-out="l['quantity']" t-options='{"widget": "float", "decimal_precision": "Product Unit"}'/>
+                    <t t-else="" t-out="l['quantity']" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}"/>
                 </td>
                 <td class="text-start" groups="uom.group_uom" t-out="l['uom']"/>
                 <td t-if="data['forecast_mode']" class="text-center">
                     <t t-if="l.get('is_storable', False)">
-                        <t t-out="l['quantity_available']" t-options='{"widget": "float", "decimal_precision": "Product Unit"}'/> /
-                        <t t-out="l['quantity_on_hand']" t-options='{"widget": "float", "decimal_precision": "Product Unit"}'/>
+                        <t t-out="l['quantity_available']" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}"/> /
+                        <t t-out="l['quantity_on_hand']" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}"/>
                     </t>
                 </td>
                 <td t-if="data['forecast_mode']" class="text-center">

--- a/addons/mrp/report/mrp_report_mo_overview.xml
+++ b/addons/mrp/report/mrp_report_mo_overview.xml
@@ -149,17 +149,17 @@
             <td t-if="data['show_replenishments']" class="text-center" t-out="line.get('formatted_state', '')"/>
             <td t-attf-class="text-end {{ data['get_color'](line.get('quantity_decorator')) }}">
                 <t t-if="line.get('model') == 'mrp.workorder'" t-out="line['quantity']" t-options="{'widget': 'float_time'}"/>
-                <t t-else="" t-out="line['quantity']" t-options="{'widget': 'float', 'precision': line['uom_precision']}"/>
+                <t t-else="" t-out="line['quantity']" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}"/>
             </td>
             <td t-if="data['show_uom']" class="text-start" t-out="line['uom_name']"/>
             <td t-if="data['show_availabilities']" class="text-end">
                 <t t-if="line.get('quantity_on_hand', False) is not False">
-                    <t t-out="line['quantity_free']" t-options="{'widget': 'float', 'precision': line['uom_precision']}"/> /
-                    <t t-out="line['quantity_on_hand']" t-options="{'widget': 'float', 'precision': line['uom_precision']}"/>
+                    <t t-out="line['quantity_free']" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}"/> /
+                    <t t-out="line['quantity_on_hand']" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}"/>
                 </t>
             </td>
             <td t-if="data['show_availabilities']" class="text-end">
-                <t t-if="line.get('quantity_reserved', False) is not False" t-out="line['quantity_reserved']" t-options="{'widget': 'float', 'precision': line['uom_precision']}"/>
+                <t t-if="line.get('quantity_reserved', False) is not False" t-out="line['quantity_reserved']" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}"/>
             </td>
             <td t-if="data['show_receipts']" class="text-end">
                 <span t-if="line.get('receipt')" t-att-class="data['get_color'](line['receipt'].get('decorator'))" t-out="line['receipt']['display']"/>
@@ -209,7 +209,7 @@
                 </td>
                 <td t-if="data['show_replenishments']" class="text-center"/>
                 <td t-attf-class="text-end {{ data['get_color'](summary.get('quantity_decorator')) }}">
-                    <t t-if="summary.get('done')" t-out="summary['quantity']" t-options="{'widget': 'float', 'precision': operations[0].get('uom_precision', 0)}"/>
+                    <t t-if="summary.get('done')" t-out="summary['quantity']" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}"/>
                     <t t-else="" t-out="summary['quantity']" t-options="{'widget': 'float_time'}"/>
                 </td>
                 <td t-if="data['show_uom']" class="text-start" t-out="summary['uom_name']"/>

--- a/addons/mrp/report/mrp_workorder_templates.xml
+++ b/addons/mrp/report/mrp_workorder_templates.xml
@@ -35,7 +35,7 @@
                         </div>
                         <div class="col-3">
                             <strong>Quantity to Produce:</strong><br/>
-                            <span t-field="o.qty_production">2</span>
+                            <span t-field="o.qty_production" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}">2</span>
                             <span t-field="o.uom_id.name" groups="uom.group_uom">Unit</span>
                         </div>
                     </div>

--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -77,11 +77,11 @@
                                     <span t-field="line.name"/>
                                 </td>
                                 <td class="text-end">
-                                    <span t-field="line.product_qty"/>
+                                    <span t-field="line.product_qty" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}"/>
                                     <span t-field="line.uom_id.name" groups="uom.group_uom"/>
                                     <span t-if="line.uom_id != line.product_id.uom_id" class="text-muted small">
                                         <br/>
-                                        <span t-field="line.product_uom_qty" t-options="{'widget': 'float', 'decimal_precision': 'Product Unit'}"/> <span t-field="line.product_id.uom_id"/>
+                                        <span t-field="line.product_uom_qty" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}"/> <span t-field="line.product_id.uom_id"/>
                                     </span>
                                 </td>
                                 <td class="text-end">

--- a/addons/purchase/report/purchase_quotation_templates.xml
+++ b/addons/purchase/report/purchase_quotation_templates.xml
@@ -46,11 +46,11 @@
                                     <span t-field="order_line.date_planned" t-options="{'date_only': 'true'}"/>
                                 </td>
                                 <td class="text-end">
-                                    <span t-field="order_line.product_qty"/>
+                                    <span t-field="order_line.product_qty" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}"/>
                                     <span t-field="order_line.uom_id" groups="uom.group_uom"/>
                                     <span t-if="order_line.uom_id != order_line.product_id.uom_id" class="text-muted small">
                                     <br/>
-                                        <span t-field="order_line.product_uom_qty" t-options="{'widget': 'float', 'decimal_precision': 'Product Unit'}"/> <span t-field="order_line.product_id.uom_id"/>
+                                        <span t-field="order_line.product_uom_qty" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}"/> <span t-field="order_line.product_id.uom_id"/>
                                     </span>
                                 </td>
                             </t>

--- a/addons/repair/report/repair_templates_repair_order.xml
+++ b/addons/repair/report/repair_templates_repair_order.xml
@@ -55,7 +55,7 @@
                                     <p t-if="line.repair_line_type == 'recycle'">(<i>Recycle</i>) <span t-field="line.product_id" data-oe-demo="Product C"/></p>
                                 </td>
                                 <td class="text-end">
-                                    <span t-field="line.product_uom_qty">5</span>
+                                    <span t-field="line.product_uom_qty" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}">5</span>
                                     <span groups="uom.group_uom" t-field="line.uom_id.name">Units</span>
                                 </td>
                             </tr>

--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -198,7 +198,7 @@
                                     <span t-field="line.name">Combo Product</span>
                                 </td>
                                 <td name="td_combo_quantity" class="text-end">
-                                    <span t-field="line.product_uom_qty"/>
+                                    <span t-field="line.product_uom_qty" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}"/>
                                     <span t-field="line.product_uom_id"/>
                                 </td>
                                 <td
@@ -226,11 +226,11 @@
                                     <span t-field="line.name">Bacon Burger</span>
                                 </td>
                                 <td name="td_product_quantity" class="o_td_quantity text-end">
-                                    <span t-field="line.product_uom_qty" class="text-nowrap">3</span>
+                                    <span t-field="line.product_uom_qty" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}" class="text-nowrap">3</span>
                                     <span t-field="line.product_uom_id">units</span>
                                     <span t-if="line.product_uom_id != line.product_id.uom_id" class="text-muted small">
                                         <t t-set="quantity_in_product_uom" t-value="line.product_uom_id._compute_quantity(line.product_uom_qty, line.product_id.uom_id)"/>
-                                        <br/><span t-out="quantity_in_product_uom" t-options="{'widget': 'float', 'decimal_precision': 'Product Unit'}"/> <span t-field="line.product_id.uom_id"/>
+                                        <br/><span t-out="quantity_in_product_uom" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}"/> <span t-field="line.product_id.uom_id"/>
                                     </span>
                                 </td>
                                 <td name="td_product_priceunit" class="text-end text-nowrap">

--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -69,7 +69,6 @@
                         </div>
                     </div>
                     <div class="oe_structure"></div>
-                    <t t-set="format_number" t-value="lambda x: int(x) if x == int(x) else x"/>
                     <table class="table table-sm table-borderless" t-if="o.state!='done'" name="stock_move_table">
                         <thead>
                             <tr>
@@ -88,20 +87,20 @@
                                     </p>
                                 </td>
                                 <td class="o_td_quantity text-end">
-                                    <span t-out="format_number(move.product_uom_qty)" class="text-nowrap">3.00</span>
+                                    <span t-out="move.product_uom_qty" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}" class="text-nowrap">3.00</span>
                                     <span t-field="move.uom_id" groups="uom.group_uom">units</span>
                                     <t t-if="move.packaging_uom_id != move.uom_id" groups="uom.group_uom">
                                         <br/>
-                                        <span class="text-muted" t-field="move.packaging_uom_qty">1.00</span>
+                                        <span class="text-muted" t-field="move.packaging_uom_qty" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}">1.00</span>
                                         <span class="text-muted" t-field="move.packaging_uom_id">Pack of 6</span>
                                     </t>
                                 </td>
                                 <td class="o_td_quantity text-end">
-                                    <span t-out="format_number(move.quantity)" class="text-nowrap">3.00</span>
+                                    <span t-out="move.quantity" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}" class="text-nowrap">3.00</span>
                                     <span t-field="move.uom_id" groups="uom.group_uom">units</span>
                                     <t t-if="move.packaging_uom_id != move.uom_id" groups="uom.group_uom">
                                         <br/>
-                                        <span class="text-muted" t-out="move.uom_id._compute_quantity(move.quantity, move.packaging_uom_id)">1.00</span>
+                                        <span class="text-muted" t-out="move.uom_id._compute_quantity(move.quantity, move.packaging_uom_id)" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}">1.00</span>
                                         <span class="text-muted" t-field="move.packaging_uom_id">Pack of 6</span>
                                     </t>
                                 </td>
@@ -204,7 +203,7 @@
                                     </td>
                                     <td/>
                                     <td class="text-end w-auto">
-                                        <span t-out="format_number(bo_line.product_uom_qty)">3.00</span>
+                                        <span t-out="bo_line.product_uom_qty" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}">3.00</span>
                                         <span t-field="bo_line.uom_id" groups="uom.group_uom">units</span>
                                     </td>
                                 </tr>
@@ -257,7 +256,7 @@
             <td class="text-end"><span t-field="move_line.lot_id.name"/></td>
         </t>
         <td class="text-end" name="move_line_lot_quantity">
-            <span t-out="format_number(move_line.quantity)"/>
+            <span t-out="move_line.quantity" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}"/>
             <span t-field="move_line.uom_id"/>
         </td>
     </template>
@@ -276,7 +275,7 @@
                 </t>
             </td>
             <td class="text-end" name="move_line_aggregated_qty_ordered">
-                <span t-out="format_number(aggregated_lines[line]['qty_ordered'])"/>
+                <span t-out="aggregated_lines[line]['qty_ordered']" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}"/>
                 <span t-out="aggregated_lines[line]['uom_id'].name"/>
                 <t t-if="aggregated_lines[line]['packaging_uom_id'] != aggregated_lines[line]['uom_id']" groups="uom.group_uom">
                     <br/>
@@ -285,11 +284,11 @@
                 </t>
             </td>
             <td class="text-end" name="move_line_aggregated_quantity">
-                <span t-out="format_number(aggregated_lines[line]['quantity'])"/>
+                <span t-out="aggregated_lines[line]['quantity']" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}"/>
                 <span t-out="aggregated_lines[line]['uom_id'].name"/>
                 <t t-if="aggregated_lines[line]['packaging_uom_id'] != aggregated_lines[line]['uom_id']" groups="uom.group_uom">
                     <br/>
-                    <span class="text-muted" t-out="aggregated_lines[line]['packaging_quantity']">1.00</span>
+                    <span class="text-muted" t-out="aggregated_lines[line]['packaging_quantity']" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}">1.00</span>
                     <span class="text-muted" t-out="aggregated_lines[line]['packaging_uom_id'].name">Pack of 6</span>
                 </t>
             </td>

--- a/addons/stock/report/report_stockinventory.xml
+++ b/addons/stock/report/report_stockinventory.xml
@@ -36,7 +36,7 @@
                                         <td class="o_td_quantity text-end">
                                             <!-- If 0, then leave blank so users have space to write a number -->
                                             <t t-if="not line.env['ir.config_parameter'].get_bool('stock.show_expected_quantity_count')"><span></span></t>
-                                            <t t-else=""><span t-field="line.quantity" class="text-nowrap">7</span></t>
+                                            <t t-else=""><span t-field="line.quantity" class="text-nowrap" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}">7</span></t>
                                             <span t-field="line.uom_id" groups="uom.group_uom">Units</span>
                                         </td>
                                     </tr>

--- a/addons/stock_picking_batch/report/report_picking_batch.xml
+++ b/addons/stock_picking_batch/report/report_picking_batch.xml
@@ -93,7 +93,7 @@
                                                     <span t-field="move_operation.display_name">Product Name</span>
                                                 </td>
                                                 <td>
-                                                    <span t-out="sum(move_operation.mapped('quantity'))">Quantity Done</span>
+                                                    <span t-out="sum(move_operation.mapped('quantity'))" t-options="{'widget': 'integer', 'format_decimalized_number': True, 'precision_digits': 2}">Quantity Done</span>
                                                     <span t-field="move_operation.uom_id" groups="uom.group_uom"/>
                                                 </td>
                                                 <td>


### PR DESCRIPTION
*: mrp, purchase, repair, sale, stock, stock_picking_batch

====================================================

In PDF reports, quantities that do not have decimal values are now 
displayed as integers (e.g., 7 instead of 7.00).

This improves report readability, results in a cleaner layout, and 
avoids unnecessary extra spacing caused by trailing decimals zero.

TaskID:- 4547923