### PR TITLE
[REF] mail: refactor attachment list

### DIFF
--- a/addons/mail/static/src/core/common/attachment_list.js
+++ b/addons/mail/static/src/core/common/attachment_list.js
@@ -164,4 +164,26 @@ export class AttachmentList extends Component {
     showUploaded(attachment) {
         return !attachment.isImage && !attachment.uploading && this.env.inComposer;
     }
+
+    get gridSize() {
+        if (this.env.inComposer) {
+            if (this.env.inChatter) {
+                return "g-col-md-3 g-col-lg-3 g-col-xxl-3";
+            }
+            if (this.env.inDiscussApp) {
+                return "g-col-md-2 g-col-lg-2 g-col-xxl-2";
+            }
+        }
+        if (this.env.inChatter) {
+            return "g-col-md-3 g-col-lg-3 g-col-xxl-4";
+        }
+        // Before inDiscussApp to avoid the return
+        if (this.env.inAttachmentPanel) {
+            return "g-col-xxs-12";
+        }
+        if (this.env.inDiscussApp) {
+            return "g-col-md-3 g-col-lg-3 g-col-xxl-3";
+        }
+        return "";
+    }
 }

--- a/addons/mail/static/src/core/common/attachment_list.scss
+++ b/addons/mail/static/src/core/common/attachment_list.scss
@@ -1,19 +1,31 @@
-$o-mail-attachment-height: 10em;
+.o-mail-AttachmentList-grid {
+    --gap: 12px;
+}
+
+.o-container {
+    container-name: attachments;
+    container-type: size;
+}
 
 .o-mail-AttachmentContainer {
-    &.o-inMessage.o-isImage:not(.o-inChatter) {
-        min-width: 13em;
-        min-height: $o-mail-attachment-height;
+    .o-mail-AttachmentCard-tumbnail-icon {
+        aspect-ratio: 18/11;
     }
-    &:not(.o-inMessage.o-isImage),&.o-inChatter.o-inMessage.o-isImage {
-        width: 13em;
-        height: $o-mail-attachment-height;
+    &.o-isImage {
+        border: $card-border-width solid $card-border-color;
+        img {
+            aspect-ratio: 12/10;
+        }
     }
-    background-color: $gray-200;
+}
 
-    @include media-breakpoint-down(sm) {
-        width: 12em;
-    }
+.only-one .o-mail-AttachmentContainer:first-child {
+    grid-column-start: 7;
+}
+
+.o-mail-AttachmentCard {
+    --card-border-radius: var(--border-radius-lg);
+    --card-inner-border-radius: var(--border-radius-lg);
 }
 
 .o-mail-AttachmentCard-image, .o-mail-Attachment-hover-image {
@@ -40,12 +52,10 @@ $o-mail-attachment-height: 10em;
     line-height: 1.25;
 }
 
-.o-mail-AttachmentImage.o-inMessage:not(.o-inComposer) {
-    max-height: 300px;
-}
-
-.o-mail-AttachmentImage.o-inComposer {
-    max-height: $o-mail-attachment-height;
+@container attachments (width < 300px) {
+    .grid .g-col-xxs-12 {
+        grid-column: auto/span 12;
+    }
 }
 
 .o-viewable {

--- a/addons/mail/static/src/core/common/attachment_list.xml
+++ b/addons/mail/static/src/core/common/attachment_list.xml
@@ -2,69 +2,26 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.AttachmentList">
-        <div class="o-mail-AttachmentList overflow-y-auto d-flex flex-column mt-1"
-            t-att-class="{
-                'o-inComposer': this.env.inComposer,
-                'o-inChatWindow': this.env.inChatWindow,
-            }"
-            t-custom-ref="root"
-        >
-            <div class="d-flex flex-wrap gap-2" t-att-class="{'justify-content-end': this.isInChatWindowAndIsAlignedRight and !this.env.inComposer}" role="menu" >
+        <div class="o-mail-AttachmentList mt-1" t-att-class="{ 'o-container': env.inAttachmentPanel }" t-custom-ref="root">
+            <div class="o-mail-AttachmentList-grid grid" t-att-class="{'only-one': this.isInChatWindowAndIsAlignedRight and !this.env.inComposer and this.props.attachments.length === 1}" role="menu">
                 <div t-foreach="this.props.attachments" t-as="attachment" t-key="attachment.id"
                      t-att-aria-label="attachment.name"
-                     class="o-mail-AttachmentContainer d-flex border position-relative rounded-3"
-                     t-att-title="attachment.name ? attachment.name : undefined"
+                     class="o-mail-AttachmentContainer position-relative g-col-6"
+                     t-att-title="attachment.name"
                      t-att-class="{
-                        'o-inMessage': this.env.inMessage,
-                        'o-inChatter': this.env.inChatter,
-                        'o-isImage': attachment.isImage,
+                        'o-isImage rounded-3': attachment.isImage,
                         'o-isUploading opacity-25': attachment.uploading,
                         'o-viewable': attachment.isViewable,
-                    }"
+                     }"
+                     t-attf-class="{{ this.gridSize }}"
                      tabindex="0"
                      t-att-data-mimetype="attachment.mimetype"
                      t-on-click="() => this.onClickAttachment(attachment)"
                      role="menuitem"
                 >
-                    <!-- display of image attachments-->
-                    <Gif
-                        t-if="attachment.mimetype === 'image/gif'"
-                        src="this.getImageUrl(attachment)"
-                        paused="attachment.gifPaused"
-                        alt="attachment.name"
-                        class="this.attClassObjectToString({
-                            'o-mail-AttachmentImage img img-fluid w-100 rounded-3': true,
-                            'o-inMessage': this.env.inMessage,
-                            'o-inChatter object-fit-scale': this.env.inChatter,
-                            'object-fit-contain': !this.env.inChatter and this.env.inMessage,
-                            'object-fit-cover': !this.env.inChatter and !this.env.inMessage,
-                        })"
-                    />
-                    <img
-                        t-elif="attachment.isImage"
-                        class="o-mail-AttachmentImage img img-fluid w-100 rounded-3"
-                        t-att-class="{
-                            'o-inComposer': this.env.inComposer,
-                            'o-inMessage': this.env.inMessage,
-                            'o-inChatter object-fit-scale': this.env.inChatter,
-                            'object-fit-contain': !this.env.inChatter and this.env.inMessage,
-                            'object-fit-cover': !this.env.inChatter and !this.env.inMessage,
-                        }"
-                        t-att-src="this.getImageUrl(attachment)"
-                        t-att-alt="attachment.name"
-                        t-on-load="this.onImageLoaded"
-                    />
-                    <!-- display of non image attachments -->
-                    <div t-else="" class="o-mail-AttachmentCard d-flex flex-column w-100 h-100">
-                        <div class="d-flex justify-content-center align-items-center flex-grow-1 bg-white position-relative rounded-3 rounded-bottom-0" t-on-click="() => this.onClickAttachment(attachment)">
-                            <div t-if="!attachment.has_thumbnail" class="o_image" role="menuitem" aria-label="Preview" t-att-tabindex="-1" t-att-aria-disabled="false" t-att-data-mimetype="attachment.mimetype"/>
-                            <img t-else="" t-att-src="attachment.thumbnailUrl" t-att-alt="attachment.name"/>
-                        </div>
-                         <div class="o-mail-AttachmentCard-info d-flex align-items-center px-2 py-1 bg-200 rounded-bottom-3">
-                            <div class="o-mail-AttachmentCard-image o_image me-2 flex-shrink-0" role="menuitem" aria-label="Preview" t-att-tabindex="-1" t-att-aria-disabled="false" t-att-data-mimetype="attachment.mimetype"/>
-                            <div t-if="attachment.name" class="text-truncate align-items-center fw-bold" t-out="this.props.messageSearch?.highlight(attachment.name) ?? attachment.name"/>
-                        </div>
-                    </div>
+                    <t t-if="attachment.mimetype === 'image/gif'" t-call="mail.AttachmentListGif"/>
+                    <t t-elif="attachment.isImage" t-call="mail.AttachmentListImage" />
+                    <t t-else="" t-call="mail.AttachmentListCard"/>
                     <!-- hover information (not for mobile view) -->
                     <div t-if="!this.isMobileOS" class="o-mail-Attachment-hover position-absolute top-0 bottom-0 start-0 end-0 p-2 d-flex flex-column align-items-start o-opacity-hoverable opacity-100-hover opacity-0 rounded-3" t-att-class="{ 'o-image': attachment.isImage }">
                         <div class="d-flex flex-row align-items-start gap-2">
@@ -104,7 +61,7 @@
     </t>
 
     <t t-name="mail.Actions">
-        <div class="position-absolute end-0 p-1 o-text-white">
+        <div class="position-absolute top-0 end-0 p-1 o-text-white">
             <button t-if="this.props.actions.length === 1" class="btn btn-sm btn-light rounded px-1 py-0" tabindex="0" t-att-aria-label="this.props.actions[0].label" t-att-title="this.props.actions[0].label" role="menuitem" t-on-click.stop="this.props.actions[0].onSelect">
                 <i t-att-class="this.props.actions[0].icon"/>
             </button>
@@ -121,5 +78,57 @@
             </Dropdown>
         </div>
     </t>
-
+    <t t-name="mail.AttachmentListGif">
+        <Gif
+            src="getImageUrl(attachment)"
+            paused="attachment.gifPaused"
+            alt="attachment.name"
+            class="attClassObjectToString({
+                   'o-mail-AttachmentImage img img-fluid w-100 rounded-3': true,
+                   'o-inMessage': this.env.inMessage,
+                   'o-inChatter object-fit-scale': this.env.inChatter,
+                   'object-fit-contain': !this.env.inChatter and this.env.inMessage,
+                   'object-fit-cover': !this.env.inChatter and !this.env.inMessage,
+            })"
+        />
+    </t>
+    <t t-name="mail.AttachmentListImage">
+        <img
+            class="o-mail-AttachmentImage img w-100 rounded-3"
+            t-att-class="{
+                'object-fit-scale': this.env.inChatter,
+                'object-fit-contain': !this.env.inChatter and this.env.inMessage,
+                'object-fit-cover': !this.env.inChatter and !this.env.inMessage,
+            }"
+            t-att-src="getImageUrl(attachment)"
+            t-att-alt="attachment.name"
+            t-on-load="onImageLoaded"
+        />
+    </t>
+    <t t-name="mail.AttachmentListCard">
+        <div class="o-mail-AttachmentCard card h-100">
+            <div t-if="!attachment.has_thumbnail" class="o-mail-AttachmentCard-tumbnail-icon d-flex h-100 align-items-center">
+                <div class="o_image flex-fill"
+                    role="menuitem" aria-label="Preview" t-att-tabindex="-1"
+                    t-att-aria-disabled="false"
+                    t-att-data-mimetype="attachment.mimetype" />
+            </div>
+            <img
+                t-else=""
+                t-att-src="attachment.thumbnailUrl"
+                t-att-alt="attachment.name"
+                class="card-img-top"
+            />
+            <div class="o-mail-AttachmentCard-info card-body d-flex align-items-center">
+                <div
+                    class="o-mail-AttachmentCard-image o_image me-2 flex-shrink-0"
+                    role="menuitem" aria-label="Preview" t-att-tabindex="-1"
+                    t-att-aria-disabled="false"
+                    t-att-data-mimetype="attachment.mimetype" />
+                <div t-if="attachment.name"
+                    class="text-truncate align-items-center fw-bold"
+                    t-out="this.props.messageSearch?.highlight(attachment.name) ?? attachment.name" />
+            </div>
+        </div>
+    </t>
 </templates>

--- a/addons/mail/static/src/discuss/core/common/attachment_panel.js
+++ b/addons/mail/static/src/discuss/core/common/attachment_panel.js
@@ -2,7 +2,7 @@ import { DateSection } from "@mail/core/common/date_section";
 import { ActionPanel } from "@mail/discuss/core/common/action_panel";
 import { AttachmentList } from "@mail/core/common/attachment_list";
 
-import { Component, onWillStart, onWillUpdateProps } from "@odoo/owl";
+import { Component, onWillStart, onWillUpdateProps, useSubEnv } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 import { useSequential, useVisible } from "@mail/utils/common/hooks";
 
@@ -35,6 +35,7 @@ export class AttachmentPanel extends Component {
                 this.props.channel.fetchMoreAttachments();
             }
         });
+        useSubEnv({ inAttachmentPanel: true });
     }
 
     /**

--- a/addons/mail/static/src/discuss/voice_message/common/attachment_list_patch.xml
+++ b/addons/mail/static/src/discuss/voice_message/common/attachment_list_patch.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
-    <t t-inherit="mail.AttachmentList" t-inherit-mode="extension">
+    <t t-inherit="mail.AttachmentListCard" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('o-mail-AttachmentCard-info')]" position="replace">
             <t t-if="attachment.voice">
                 <VoicePlayer attachment="attachment"/>
             </t>
             <t t-else="">$0</t>
         </xpath>
+    </t>
+    <t t-inherit="mail.AttachmentList" t-inherit-mode="extension">
         <xpath expr="(//div[@t-if='!this.isMobileOS'])" position="attributes">
             <attribute name="t-if">!this.isMobileOS and !attachment.voice</attribute>
         </xpath>


### PR DESCRIPTION
This commit refactors the attachment list to use the Bootstrap CSS grid.
This allows better support across multiple screen sizes.

task-5873835


https://github.com/user-attachments/assets/0458f0d9-9e69-41f3-a8af-1113fce510e3

<img width="1021" height="891" alt="image" src="https://github.com/user-attachments/assets/1d2dfb4d-98ff-4f52-8b73-68adf7cb0c7d" />
<img width="696" height="772" alt="image" src="https://github.com/user-attachments/assets/c7b108bf-c964-4629-8c92-73714d8afd4e" />
<img width="1260" height="885" alt="image" src="https://github.com/user-attachments/assets/fc1c97a0-6ba4-4eb2-8b26-5d543356c457" />
<img width="911" height="932" alt="image" src="https://github.com/user-attachments/assets/3261a708-4cf7-4472-836d-13ff90b57eaf" />
<img width="478" height="693" alt="image" src="https://github.com/user-attachments/assets/0d53964b-6185-47bc-9f68-0dd3b965c59c" />
<img width="442" height="666" alt="image" src="https://github.com/user-attachments/assets/3089945e-8683-4c81-a225-9449ccaf9e57" />
<img width="446" height="659" alt="image" src="https://github.com/user-attachments/assets/89bfb4ae-8c55-4345-9a6c-6ed647254b2c" />
<img width="1152" height="935" alt="image" src="https://github.com/user-attachments/assets/a7babd47-34b5-4a91-8acb-2573f6be0a80" />
