### PR TITLE
[FIX] im_livechat: fix chat bot double restart

### DIFF
--- a/addons/im_livechat/static/src/core/common/chatbot_model.js
+++ b/addons/im_livechat/static/src/core/common/chatbot_model.js
@@ -82,11 +82,10 @@ export class Chatbot extends Record {
         });
         this.store.insert(store_data);
         this.thread.messages.add(message_id);
+        this.thread.livechat_active = true;
         if (this.currentStep) {
             this.currentStep.isLast = false;
-            this.thread.livechat_active = true;
         }
-        this.start();
     }
 
     /**

--- a/addons/im_livechat/static/src/embed/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_model_patch.js
@@ -57,7 +57,9 @@ patch(Thread.prototype, {
         this.livechat_active = false;
         this._toggleChatbot = fields.Attr(false, {
             compute() {
-                return this.chatbot && this.isLoaded && this.livechat_active;
+                return (
+                    this.chatbot && !this.chatbot.completed && this.isLoaded && this.livechat_active
+                );
             },
             onUpdate() {
                 if (this._toggleChatbot) {


### PR DESCRIPTION
Since [1], restarting the chat bot after reload could lead to multiple steps being executed at the same time.

Steps to reproduce:
- Go to the `/im_livechat/support/2` page.
- Chat with the support bot until the end of the conversation.
- Reload the page.
- Click on the restart button.
- Two question selections are displayed at the same time.

This occurs because the bot starts from the `_toggleChatbot` field's `onUpdate` method. The `restart` method also calls `start` on the chat bot.

To fix this issue, the call to `start` is removed from the `restart` method.

[1]: https://github.com/odoo/odoo/pull/194399

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
