### PR TITLE
[FIX] html_editor: prevent selection resetting after command palette

### DIFF
--- a/addons/html_editor/static/src/core/shortcut_plugin.js
+++ b/addons/html_editor/static/src/core/shortcut_plugin.js
@@ -20,13 +20,32 @@ import { Plugin } from "../plugin";
 
 export class ShortCutPlugin extends Plugin {
     static id = "shortcut";
-    static dependencies = ["userCommand"];
+    static dependencies = ["userCommand", "selection"];
 
     setup() {
         const hotkeyService = this.services.hotkey;
         if (!hotkeyService) {
             throw new Error("ShorcutPlugin needs hotkey service to properly work");
         }
+
+        // We override the command palette shortcut to open a palette with an
+        // onClose callback to focus the editor and keep the selection without
+        // scrolling. We also pass the editable as the area option for this
+        // hotkey override, so it only applies when calling the command palette
+        // from the editor.
+        this.removeEditorCommandPalette = this.services.hotkey.add(
+            "control+k",
+            () => {
+                this.services.command.openMainPalette({}, () => {
+                    this.dependencies.selection.focusEditable();
+                });
+            },
+            {
+                bypassEditableProtection: true,
+                global: true,
+                area: () => this.editable,
+            }
+        );
         if (document !== this.document) {
             hotkeyService.registerIframe({ contentWindow: this.document.defaultView });
         }
@@ -36,6 +55,10 @@ export class ShortCutPlugin extends Plugin {
                 command.run(shortcut.commandParams);
             });
         }
+    }
+
+    destroy() {
+        this.removeEditorCommandPalette();
     }
 
     addShortcut(hotkey, action) {

--- a/addons/html_editor/static/tests/selection.test.js
+++ b/addons/html_editor/static/tests/selection.test.js
@@ -1745,3 +1745,14 @@ describe("crash fixes", () => {
         expect(getContent(el)).toBe("<p>x[]</p>");
     });
 });
+
+describe("Focus changes", () => {
+    test("Should not lose selection on focus change from the command palette", async () => {
+        const { el } = await setupEditor("<p>ab[]cd</p>");
+        await press(["ctrl", "k"]);
+        await animationFrame();
+        await press(["Escape"]);
+        await animationFrame();
+        expect(getContent(el)).toBe("<p>ab[]cd</p>");
+    });
+});


### PR DESCRIPTION
Before this commit: when the whole editable regains the focus, the selection in the editable is reset to the start of it.

After this commit: We create a override for hotkey service to open the
command palette with an onClose to refocus the editable area without
losing the current selection. For the hotkey override, we pass the area
option so it's only valid in the editable area. Outside the editable,
the command palette is opened in the default way.

task-5949705

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
