### PR TITLE
[FIX] website: prevent additional dropzones below invisible popups

### DIFF
--- a/addons/website/static/src/builder/plugins/popup_visibility_plugin.js
+++ b/addons/website/static/src/builder/plugins/popup_visibility_plugin.js
@@ -89,7 +89,7 @@ export class PopupVisibilityPlugin extends Plugin {
      * @param {HTMLElement} targetEl the element
      */
     hidePopupsWithoutTarget(targetEl) {
-        const openPopupEls = this.editable.querySelectorAll(".s_popup:not([data-invisible='1']");
+        const openPopupEls = this.editable.querySelectorAll(".s_popup:not([data-invisible='1'])");
         if (!openPopupEls.length) {
             return;
         }

--- a/addons/website/static/src/interactions/popup/shared_popup.edit.js
+++ b/addons/website/static/src/interactions/popup/shared_popup.edit.js
@@ -3,7 +3,9 @@ import { registry } from "@web/core/registry";
 
 export const SharedPopupEdit = (I) => class extends I {
     setup() {
-        this.popupShown = true;
+        // Sync the status of the popup in the editor with its visibility 
+        // status `data-invisible`
+        this.popupShown = this.el.dataset.invisible !== "1";
     }
 };
 

--- a/addons/website/static/tests/builder/website_builder/popup_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/popup_option.test.js
@@ -104,6 +104,7 @@ describe("Popup options: popup in page before edit", () => {
         await advanceTime(5000);
         expect(":iframe .s_popup .modal").not.toBeVisible();
         expect(":iframe .s_popup").toHaveAttribute("data-invisible", "1");
+        expect(":iframe .s_popup").toHaveClass("d-none");
     });
 
     test("closing s_popup with the X button updates the invisible elements panel", async () => {
@@ -113,10 +114,12 @@ describe("Popup options: popup in page before edit", () => {
         await waitFor(":iframe .s_popup .modal", { visible: true });
         expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye");
         expect(":iframe .s_popup .modal").toBeVisible();
+        expect(":iframe .s_popup").not.toHaveClass("d-none");
         await expectToTriggerEvent(":iframe .s_popup .modal", "hidden.bs.modal", () =>
             contains(":iframe .s_popup div.js_close_popup").click()
         );
         expect(":iframe .s_popup .modal").not.toBeVisible();
+        expect(":iframe .s_popup").toHaveClass("d-none");
         expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye-slash");
         // Ensure that no mutations were registered in the history.
         // `addStep` return the created step, or false if there was no mutations


### PR DESCRIPTION
## Description

There was a desync issue with popup states between normal mode and edit mode. That caused:
- Hidden popups contributed extra dropzones during drag-and-drop
- Hidden popups lost `d-none` class after dropping unrelated snippets

## How to reproduce

### Bug 1: extra dropzones from hidden popup desync
1. Enter website edit mode.
2. Drop popup in the page
3. Drag another snippet as you were adding it to the page
4. An additional dropzone appears below the invisible popup snippet

### Bug 2: hidden popup loses `d-none` class
1. Enter edit mode.
2. Drop a popup.
3. Close it so `.s_popup` gets `d-none`.
4. Drop any other snippet on the page arbitrarily.
5. Popup loses `d-none` class.

## Expected behavior after fix

- Popup hidden/shown state remains stable across editor refreshes and
snippet drops.
- Drag-and-drop no longer creates extra dropzones from hidden popups.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
