### PR TITLE
[FIX] im_livechat: crash during session creation

### DIFF
--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -218,9 +218,7 @@ export class LivechatService {
             {
                 channel_id: this.options.channel_id,
                 anonymous_name: this.options.default_username ?? _t("Visitor"),
-                chatbot_script_id: this.savedState
-                    ? this.thread.chatbot?.script.id
-                    : this.rule.chatbotScript?.id,
+                chatbot_script_id: this.thread?.chatbot?.script.id ?? this.rule.chatbotScript?.id,
                 previous_operator_id: expirableStorage.getItem(OPERATOR_STORAGE_KEY),
                 temporary_id: this.thread?.id,
                 persisted: persist,


### PR DESCRIPTION
Since [1], a crash could occur when starting several live chat sessions quickly.

Before this PR, the `thread` getter depended on `savedState`. In [1], `thread` became a field on the live chat service. There can be a slight delay where thread has been cleared, but saved state still exists.

The `_createThread` method shouldn't rely on `savedState` to determine if there is a thread.

[1]: https://github.com/odoo/odoo/pull/173197

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
