### PR TITLE
[FIX] website: fix popup image in gallery slider

### DIFF
--- a/addons/website/static/src/snippets/s_image_gallery/gallery_slider.js
+++ b/addons/website/static/src/snippets/s_image_gallery/gallery_slider.js
@@ -23,6 +23,7 @@ export class GallerySlider extends Interaction {
     };
 
     setup() {
+        this.liEls = [];
         this.hideOnClickIndicator = true;
         this.carouselEl = this.el.classList.contains("carousel")
             ? this.el


### PR DESCRIPTION
From version 19.1, a new image pop-up functionality was introduced. Now, when an image is added to the website,
and the pop-up image option is enabled,
Clicking the image raises a traceback.

To reproduce the issue:
- Connect to a saas~19.1 runbot,
- open the website module, and enter edit mode.
- Add an image, click it, and enable the pop-up image option.
- Save the changes.
- Clicking the image will display the pop-up, but a traceback will appear behind it.

<img width="1920" height="931" alt="Home-Odoo-02-25-2026_05_43_PM" src="https://github.com/user-attachments/assets/73662dc7-cf0e-4246-b6cd-685c758fb4d7" />

This change reintroduces the check because `this.liEls` can be undefined when only one image is added, which was causing errors when the length check was performed without it.
<img width="240" height="53" alt="2026-02-25_17-45" src="https://github.com/user-attachments/assets/daea05a4-3fc9-4208-aaa6-345bd62c27c6" />

[opw-5973719](https://www.odoo.com/odoo/project/974/tasks/5973719?debug=1)
Customer reported issue [here](https://www.odoo.com/odoo/project/70/tasks/5962120?debug=1)


Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
