### PR TITLE
[FIX] web, mail: fix reopening emoji/gif pickers after click-away

### DIFF
--- a/addons/mail/static/tests/gif_picker/gif_picker.test.js
+++ b/addons/mail/static/tests/gif_picker/gif_picker.test.js
@@ -108,6 +108,10 @@ test("Composer GIF button should open the GIF picker", async () => {
     await openDiscuss(channelId);
     await click("button[title='Add GIFs']");
     await contains(".o-discuss-GifPicker");
+    await click(".o-mail-Discuss-header"); // ensure the picker reopens correctly
+    await contains(".o-discuss-GifPicker", { count: 0 });
+    await click("button[title='Add GIFs']");
+    await contains(".o-discuss-GifPicker");
 });
 
 test("Not loading of GIF categories when feature is not available", async () => {

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.js
@@ -517,7 +517,7 @@ export function usePicker(PickerComponent, ref, props, options = {}) {
         ...options,
         onClose: () => {
             state.isOpen = false;
-            options.onClose?.();
+            props.onClose?.();
         },
     };
     const popover = usePopover(PickerComponent, {
@@ -583,6 +583,7 @@ export function usePicker(PickerComponent, ref, props, options = {}) {
                     context: component,
                     onClose: () => {
                         state.isOpen = false;
+                        props.onClose?.();
                         return def.resolve(false);
                     },
                 });


### PR DESCRIPTION
**Current behavior before PR:**
When the GIF or emoji picker is dismissed by clicking outside, the component state remains out of sync because `props.onClose` isn't triggered. This causes the next attempt to open the picker to fail, requiring an extra click from the user.

**Desired behavior after PR is merged:**
Closing the picker now correctly triggers the `props.onClose`. This ensures the component state is always reset, allowing the picker to reopen immediately on the next click.

task-[5953015](https://www.odoo.com/odoo/project/1519/tasks/5953015)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
