### PR TITLE
[IMP] point_of_sale: allow multiple cash payment lines

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -457,17 +457,12 @@ export class PosOrder extends PosOrderAccounting {
     /* ---- Payment Lines --- */
     addPaymentline(payment_method) {
         this.assertEditable();
-        const existingCash = this.payment_ids.find((pl) => pl.payment_method_id.is_cash_count);
 
         if (this.electronicPaymentInProgress()) {
             return {
                 status: false,
                 data: _t("There is already an electronic payment in progress."),
             };
-        }
-
-        if (existingCash && payment_method.is_cash_count) {
-            return { status: false, data: _t("There is already a cash payment line.") };
         }
 
         const totalAmountDue = this.getDefaultAmountDueToPayIn(payment_method);

--- a/addons/point_of_sale/static/tests/unit/models/pos_order.test.js
+++ b/addons/point_of_sale/static/tests/unit/models/pos_order.test.js
@@ -81,8 +81,15 @@ test("addPaymentline", async () => {
     const cashPaymentMethod = store.models["pos.payment.method"].get(1);
     // Test that the payment line is correctly created
     const result = order.addPaymentline(cashPaymentMethod);
-    expect(result.data.payment_method_id.id).toBe(cashPaymentMethod.id);
-    expect(result.data.amount).toBe(17.85);
+    const cashPaymentLine = result.data;
+    expect(cashPaymentLine.payment_method_id.id).toBe(cashPaymentMethod.id);
+    expect(cashPaymentLine.amount).toBe(17.85);
+    // Update the cash payment line amount to 10 to confirm that the second created cash payment
+    // line will take the remaining amount to pay (7.85)
+    cashPaymentLine.setAmount(10);
+    const result2 = order.addPaymentline(cashPaymentMethod);
+    expect(result2.data.payment_method_id.id).toBe(cashPaymentMethod.id);
+    expect(result2.data.amount).toBe(7.85);
 });
 
 test("getTotalDiscount", async () => {


### PR DESCRIPTION
Before this commit:
============
- The user is not able to process multiple cash payment lines. An error pop-up appears saying `There is already a cash payment line.`

After this commit:
============
- The user can process multiple cash payment lines.

Use Case:
-----------
- If a group of people goes to a restaurant and one person leaves earlier, he decides to pay $10 at the cashier and leave. When the others pay later, the cashier will see that $10 has already been paid and can add another cash payment line for the remaining amount.

Task-5969853
