### PR TITLE
[FIX] web: prevent crash when returning to views without a renderer

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -176,7 +176,10 @@ export class KanbanController extends Component {
                         const { scrollPositions } = this.props.state || {};
                         if (scrollPositions) {
                             const { scrollLeft, columnScrollTops } = scrollPositions;
-                            this.rootRef.el.querySelector(".o_renderer").scrollLeft = scrollLeft;
+                            const renderer = this.rootRef.el?.querySelector(".o_renderer");
+                            if (renderer) {
+                                renderer.scrollLeft = scrollLeft;
+                            }
                             const groups = this.model.root.groups;
                             for (const [serverValue, scrollTop] of columnScrollTops) {
                                 const group = groups.find((g) => g.serverValue === serverValue);


### PR DESCRIPTION
**Steps to Reproduce:**
1. Open Payroll->Payslips->Pay Runs
2. Click on a Pay Run in Mobile View (Width < 600px).
3. Return to the previous view using the breadcrumb.
4. The system crashes with Traceback: TypeError: Cannot set properties of null (setting 'scrollLeft')

**Bug Cause:**
The base Kanban controller's scroll restoration logic assumes the presence of a '.o_renderer' element. In this specific hr_payroll view, The 'back' breadcumb returns to a view which does not have a (".o_renderer"). 
So, querySelector(".o_renderer") receives null, and crashes when accessing the 'scrollLeft' property.

**Solution:**
Added a safety check to verify the existence of the renderer element before attempting to manipulate its scroll position.

Task: 5971861
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
