### PR TITLE
[FIX] mail: action list active background in light mode

### DIFF
--- a/addons/mail/static/src/core/common/action_list.scss
+++ b/addons/mail/static/src/core/common/action_list.scss
@@ -14,7 +14,7 @@
         &:not(.o-hasBtnBg) {
             background-color: inherit;
         }
-    
+
         &.o-simulateDarkTheme.o-hasBtnBg:hover {
             filter: brightness(1.3);
         }
@@ -26,7 +26,12 @@
                 &:where(.rounded-circle) {
                     aspect-ratio: 1;
                 }
-                &:hover, &:focus, &:active, &.active, &:focus-visible {
+
+                &:hover,
+                &:focus,
+                &:active,
+                &.active,
+                &:focus-visible {
                     color: var(--o-mail-ActionList-Button-color--hover);
                     opacity: var(--o-mail-ActionList-Button-opacity--hover);
                 }
@@ -41,8 +46,9 @@
             }
         }
 
-        &:not(.o-inline) > i {
+        &:not(.o-inline)>i {
             opacity: 65%;
+
             .o_bottom_sheet_sheet:has(&) {
                 opacity: 100%;
             }
@@ -52,7 +58,8 @@
             color: white !important;
         }
 
-        &.o-tag-JOIN_LEAVE_CALL.o-dropdown-item, .o-mail-ChatWindow &.o-tag-JOIN_LEAVE_CALL {
+        &.o-tag-JOIN_LEAVE_CALL.o-dropdown-item,
+        .o-mail-ChatWindow &.o-tag-JOIN_LEAVE_CALL {
             i {
                 opacity: 100%;
                 background: var(--btn-bg);
@@ -65,21 +72,26 @@
                 box-sizing: content-box;
             }
 
-            &:hover, &:focus-visible {
+            &:hover,
+            &:focus-visible {
                 i {
                     background: var(--btn-hover-bg);
                     color: var(--btn-hover-color);
                 }
             }
         }
+
         &.o-tag-JOIN_LEAVE_CALL.o-dropdown-item i {
             font-size: 0.7em !important;
+
             &.fa-phone::before {
                 transform: translateY(1px);
             }
         }
+
         .o-mail-ChatWindow &.o-tag-JOIN_LEAVE_CALL i {
             font-size: 0.9em !important;
+
             &.fa-phone::before {
                 transform: translateY(.5px);
             }
@@ -91,12 +103,15 @@
                     background-color: rgba($color, 0.75);
                     color: white;
                 }
+
                 &:not(.focus) {
                     color: var(--o-mail-ActionList-#{$status}NoBgColor, #{$color});
                 }
             }
+
             &.o-inline.btn-#{$status}:not(.o-tag-JOIN_LEAVE_CALL):not(.o-hasBtnBg) {
                 color: var(--o-mail-ActionList-#{$status}NoBgColor, #{$color});
+
                 &:active {
                     background-color: inherit;
                 }
@@ -104,7 +119,7 @@
         }
     }
 
-    .o_popover > & {
+    .o_popover>& {
         .o-mail-ActionList-button {
             --btn-group-gap: 0px;
         }
@@ -117,4 +132,15 @@
             font-weight: $o-font-weight-medium !important;
         }
     }
+
+    & button.o-simulateDarkTheme.o-hasBtnBg:not(.o-tag-DANGER):not(.o-tag-SUCCESS):not(.o-tag-PRIMARY) {
+        background-color: #{$gray-700};
+
+        &.active {
+            // Same colors than dark theme since dark theme is simulated for call view.
+            background-color: #17373b;
+            border-color: #03f9e3 !important;
+        }
+    }
+
 }

--- a/addons/mail/static/src/core/common/action_list.xml
+++ b/addons/mail/static/src/core/common/action_list.xml
@@ -100,10 +100,9 @@
     })"/>
     <!-- simulated dark theme -->
     <t t-set="btnClass" t-value="attClassObjectToString({
-        [btnClass]: true,
-        'o-text-white border-0 o-simulateDarkTheme': store.shouldSimulateDarkTheme(this),
-        'bg-700': store.shouldSimulateDarkTheme(this) and !action.tags.includes('DANGER') and !action.tags.includes('SUCCESS') and hasBtnBg,
-        'bg-transparent': store.shouldSimulateDarkTheme(this) and !hasBtnBg,
+       [btnClass]: true,
+        'o-text-white border-transparent o-simulateDarkTheme': store.shouldSimulateDarkTheme(this),
+       'bg-transparent': store.shouldSimulateDarkTheme(this) and !hasBtnBg,
     })"/>
     <!-- dynamic classes-->
     <t t-set="btnClass" t-value="attClassObjectToString({


### PR DESCRIPTION
In light mode, the call view uses the same color palette than in dark theme. To do so, buttons are tweaked to force dark colors.

However, active styles are not properly tweaked, leading to a lack of visual feedback for active buttons.

This commit ensures the same styles than in dark theme are applied.

task-5969686


<img width="304" height="73" alt="image" src="https://github.com/user-attachments/assets/d6ef089b-aba1-4fff-a7d5-f450ff345279" />