### PR TITLE
[FIX] html_editor: define localoverlaycontainers in studio

### DIFF
--- a/addons/html_editor/static/src/main/table/table_menu.js
+++ b/addons/html_editor/static/src/main/table/table_menu.js
@@ -1,4 +1,4 @@
-import { Component, onMounted, onWillUpdateProps, useRef } from "@odoo/owl";
+import { Component, onMounted, onWillUpdateProps, useExternalListener, useRef } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { _t } from "@web/core/l10n/translation";
@@ -17,6 +17,7 @@ export class TableMenu extends Component {
         close: Function,
         dropdownState: Object,
         target: { validate: (el) => el.nodeType === Node.ELEMENT_NODE },
+        document: { validate: (el) => el.nodeType === Node.DOCUMENT_NODE },
         direction: { type: String, optional: true },
     };
     static defaultProps = { direction: "ltr" };
@@ -40,6 +41,16 @@ export class TableMenu extends Component {
             this.overlayEl = this.dropdownRef.el;
             this.updatePosition(this.props);
         });
+        if (this.props.document.defaultView.frameElement) {
+            useExternalListener(this.props.document, "scroll", () => {
+                this.updatePosition(this.props);
+            });
+            useExternalListener(this.props.document, "pointerdown", (ev) => {
+                if (!this.overlayEl.contains(ev.target)) {
+                    this.props.close();
+                }
+            });
+        }
     }
 
     get hasCustomSize() {
@@ -54,22 +65,35 @@ export class TableMenu extends Component {
         if (!this.overlayEl || !target) {
             return;
         }
+        let frameRect = { top: 0, left: 0 };
+        let frameElement;
+        try {
+            frameElement = this.props.document.defaultView.frameElement;
+        } catch {
+            // We don't access the frameElement if we don't have access to it.
+            // (i.e. iframe origin or sandbox restriction)
+        }
+        if (frameElement) {
+            frameRect = frameElement.getBoundingClientRect();
+        }
         const targetRect = target.getBoundingClientRect();
         const container = this.overlayEl.parentElement;
         const containerRect = container.getBoundingClientRect();
+        const top = frameRect.top + targetRect.top - containerRect.top;
+        const left = frameRect.left + targetRect.left - containerRect.left;
         if (type === "column") {
             Object.assign(this.overlayEl.style, {
-                top: `${targetRect.top - containerRect.top - this.overlayEl.offsetHeight}px`,
-                left: `${targetRect.left - containerRect.left}px`,
+                top: `${top - this.overlayEl.offsetHeight}px`,
+                left: `${left}px`,
                 width: `${targetRect.width}px`,
             });
         } else {
             const isLTR = direction === "ltr";
             const inlineStartOffset = isLTR
-                ? targetRect.left - containerRect.left
-                : containerRect.right - targetRect.right;
+                ? left
+                : containerRect.right - (frameRect.left + targetRect.right);
             Object.assign(this.overlayEl.style, {
-                top: `${targetRect.top - containerRect.top}px`,
+                top: `${top}px`,
                 insetInlineStart: `${inlineStartOffset - this.overlayEl.offsetWidth}px`,
                 height: `${targetRect.height}px`,
             });

--- a/addons/html_editor/static/src/main/table/table_menu.js
+++ b/addons/html_editor/static/src/main/table/table_menu.js
@@ -81,8 +81,10 @@ export class TableMenu extends Component {
         const containerRect = container.getBoundingClientRect();
         const top = frameRect.top + targetRect.top - containerRect.top;
         const left = frameRect.left + targetRect.left - containerRect.left;
+        this.overlayEl.classList.remove("h-100", "w-100");
         if (type === "column") {
             Object.assign(this.overlayEl.style, {
+                position: "absolute",
                 top: `${top - this.overlayEl.offsetHeight}px`,
                 left: `${left}px`,
                 width: `${targetRect.width}px`,
@@ -93,6 +95,7 @@ export class TableMenu extends Component {
                 ? left
                 : containerRect.right - (frameRect.left + targetRect.right);
             Object.assign(this.overlayEl.style, {
+                position: "absolute",
                 top: `${top}px`,
                 insetInlineStart: `${inlineStartOffset - this.overlayEl.offsetWidth}px`,
                 height: `${targetRect.height}px`,

--- a/addons/html_editor/static/src/main/table/table_menu.scss
+++ b/addons/html_editor/static/src/main/table/table_menu.scss
@@ -2,7 +2,6 @@
     border: $border-width solid rgba($color: $o-brand-odoo, $alpha: 1.0);
     color: #fff;
     background-color: rgba($color: $o-brand-odoo, $alpha: 0.7);
-    position: absolute;
 
     &.fa-ellipsis-v {
         width: 17px;

--- a/addons/html_editor/static/src/main/table/table_menu.xml
+++ b/addons/html_editor/static/src/main/table/table_menu.xml
@@ -1,7 +1,7 @@
 <templates xml:space="preserve">
     <t t-name="html_editor.TableMenu">
         <Dropdown menuClass="'m-0'" position="props.type === 'column' ? 'bottom' : 'right'" state="props.dropdownState">
-            <button t-on-pointerdown.prevent="() => {}" t-att-data-type="props.type" class="o-we-table-menu fa" t-attf-class="fa-ellipsis-{{props.type === 'column' ? 'h' : 'v'}}" t-ref="dropdown"/>
+            <button t-on-pointerdown.prevent="() => {}" t-att-data-type="props.type" class="o-we-table-menu fa" t-attf-class="fa-ellipsis-{{props.type === 'column' ? 'h w-100' : 'v h-100'}}" t-ref="dropdown"/>
             <t t-set-slot="content">
                 <div t-on-pointerdown.stop="() => {}">
                     <t t-foreach="items" t-as="item" t-key="item_index">

--- a/addons/html_editor/static/src/main/table/table_ui_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_ui_plugin.js
@@ -155,6 +155,7 @@ export class TableUIPlugin extends Plugin {
             registry.category(this.config.localOverlayContainers.key).add(this.rowMenuOverlayKey, {
                 Component: TableMenu,
                 props: {
+                    document: this.document,
                     type: "row",
                     target: td,
                     dropdownState: this.createDropdownState(this.closeColumnMenu.bind(this)),
@@ -170,6 +171,7 @@ export class TableUIPlugin extends Plugin {
                 .add(this.columnMenuOverlayKey, {
                     Component: TableMenu,
                     props: {
+                        document: this.document,
                         type: "column",
                         target: td,
                         dropdownState: this.createDropdownState(this.closeRowMenu.bind(this)),


### PR DESCRIPTION
Description of the issue:

Commit [1] replaces `overlay` with `localOverlay` for the table menu. However, studio uses its own `wysiwyg` instance and config, which does not define `localOverlayContainers`, causing a traceback when `table_menu` accesses `this.config.localOverlayContainers.key`.

Solution:
- Define `localOverlayContainers` and its corresponding key in studio’s `wysiwyg` config.
- Additionally, adjust the table menu position calculation when the table cell is inside an iframe.

ENT PR: https://github.com/odoo/enterprise/pull/108724

[1]: https://github.com/odoo/odoo/commit/7d523d6402c9bff3c2e4bcd0329f486a2d0f45ec
