### PR TITLE
[FIX] website_blog: prevent error when there is invalid url

### DIFF
--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -80,7 +80,7 @@ class WebsiteBlog(http.Controller):
 
         if date_begin and date_end:
             domain &= Domain("published_date", ">=", date_begin) & Domain("published_date", "<=", date_end)
-        active_tag_ids = tags and [request.env['ir.http']._unslug(tag)[1] for tag in tags.split(',')] or []
+        active_tag_ids = tags and [tag_id for tag_id in [request.env['ir.http']._unslug(tag)[1] for tag in tags.split(',')] if tag_id] or []
         active_tags = BlogTag
         if active_tag_ids:
             active_tags = BlogTag.browse(active_tag_ids).exists()

--- a/addons/website_blog/tests/test_website_blog_flow.py
+++ b/addons/website_blog/tests/test_website_blog_flow.py
@@ -227,3 +227,17 @@ class TestWebsiteBlogTranslationFlow(HttpCase, TestWebsiteBlogCommon):
         self.url_open('/website/field/translation/update', data=json.dumps(payload), headers=self.headers)
         self.assertEqual('Todos os blogs', blog_post.with_context(lang=br_lang.code).content)
         self.assertEqual('Updated blogs', blog_post.with_context(lang=en_lang.code).content)
+
+    def test_url_with_falsy_value(self):
+        """Test that accessing a tag without id in the url does not crash."""
+        blog = self.env['blog.blog'].create({'name': 'Test Blog'})
+        blog_tag = self.env['blog.tag'].create({'name': 'demo'})
+        self.env['blog.post'].create({
+            'name': 'Test Blog Post',
+            'blog_id': blog.id,
+            'tag_ids': [(6, 0, [blog_tag.id])],
+            'author_id': self.env.user.id,
+            'is_published': True,
+        })
+        response = self.url_open('/blog/tag/demo')
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Steps to reproduce:
- Install `website_blog` module(with demo data)
- Change URL (eg: /blog/tag/hotels)

Traceback:
`AssertionError: Invalid falsy real id`

We are encountering this error because [active_tag_ids] contains `[None]`, and falsy IDs are no longer allowed in `browse()`.

[active_tag_ids]: https://github.com/odoo/odoo/blob/4e4d1dba32ef45567eda004fc1a3584591508720/addons/website_blog/controllers/main.py#L83

sentry-7289765426


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
