### PR TITLE
[FIX] account_edi_ubl_cii: avoid potential KeyError

### DIFF
--- a/addons/account_edi_ubl_cii/wizard/account_move_send.py
+++ b/addons/account_edi_ubl_cii/wizard/account_move_send.py
@@ -72,7 +72,7 @@ class AccountMoveSend(models.TransientModel):
     def _need_invoice_document(self, invoice):
         result = super()._need_invoice_document(invoice)
         invoice_data = self.env.context.get('invoice_data')
-        if invoice_data and invoice_data['ubl_cii_xml'] and invoice._need_ubl_cii_xml():
+        if invoice_data and invoice_data.get('ubl_cii_xml') and invoice._need_ubl_cii_xml():
             return True
         return result
 


### PR DESCRIPTION
This PR completes the changes introduced in https://github.com/odoo/odoo/pull/246350

A KeyError could occur in some edge cases due to a missing key ubl_cii_xml in `_need_invoice_document()`
This fix ensures the value is safely retrieved and prevents the exception

opw-5490217
