### PR TITLE
[FIX] website, html_builder: keep groups unfolded across reload

### DIFF
--- a/addons/html_builder/static/src/core/builder_options_plugin.js
+++ b/addons/html_builder/static/src/core/builder_options_plugin.js
@@ -56,6 +56,7 @@ import { closestElement } from "@html_editor/utils/dom_traversal";
  * @property { BuilderOptionsPlugin['getRemoveDisabledReason'] } getRemoveDisabledReason
  * @property { BuilderOptionsPlugin['getCloneDisabledReason'] } getCloneDisabledReason
  * @property { BuilderOptionsPlugin['getReloadSelector'] } getReloadSelector
+ * @property { BuilderOptionsPlugin['getFolded'] } getFolded
  * @property { BuilderOptionsPlugin['setNextTarget'] } setNextTarget
  * @property { BuilderOptionsPlugin['getBuilderOptionContext'] } getBuilderOptionContext
  */
@@ -129,6 +130,7 @@ export class BuilderOptionsPlugin extends Plugin {
         "getRemoveDisabledReason",
         "getCloneDisabledReason",
         "getReloadSelector",
+        "getFolded",
         "setNextTarget",
         "getBuilderOptionContext",
     ];
@@ -143,6 +145,13 @@ export class BuilderOptionsPlugin extends Plugin {
             if (this.config.initialTarget) {
                 const el = this.editable.querySelector(this.config.initialTarget);
                 this.updateContainers(el);
+                for (
+                    let i = 0;
+                    i < this.lastContainers.length && i < this.config.initialFolded.length;
+                    i++
+                ) {
+                    this.lastContainers[i].folded &&= this.config.initialFolded[i];
+                }
             }
         },
         get_options_container_top_buttons: (el) => {
@@ -257,6 +266,10 @@ export class BuilderOptionsPlugin extends Plugin {
             return "footer";
         }
         return null;
+    }
+
+    getFolded() {
+        return this.lastContainers.map((c) => c.folded);
     }
 
     updateContainers(target, { forceUpdate = false } = {}) {

--- a/addons/html_builder/static/src/core/utils.js
+++ b/addons/html_builder/static/src/core/utils.js
@@ -671,8 +671,9 @@ function useOperationWithReload(callApply, reload) {
             env.editor.shared.history.addStep();
             await env.editor.shared.savePlugin.save();
             const target = env.editor.shared.builderOptions.getReloadSelector(editingElement);
+            const folded = env.editor.shared.builderOptions.getFolded(editingElement);
             const url = reload.getReloadUrl?.();
-            await env.editor.config.reloadEditor({ target, url });
+            await env.editor.config.reloadEditor({ target, folded, url });
         }
         env.services.ui.unblock();
     };

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -66,6 +66,7 @@ export class WebsiteBuilderClientAction extends Component {
 
     setup() {
         this.target = null;
+        this.folded = [];
         this.orm = useService("orm");
         this.notification = useService("notification");
         this.dialog = useService("dialog");
@@ -228,6 +229,7 @@ export class WebsiteBuilderClientAction extends Component {
             onlyCustomizeTab: this.translation,
             config: {
                 initialTarget: this.target,
+                initialFolded: this.folded,
                 builderSidebar: {
                     withHiddenSidebar: async (cb) => {
                         try {
@@ -544,6 +546,7 @@ export class WebsiteBuilderClientAction extends Component {
     async reloadEditor(param = {}) {
         this.initialTab = param.initialTab;
         this.target = param.target || null;
+        this.folded = param.folded || [];
         await this.reloadIframe(this.state.isEditing, param.url);
         // Disable the current instance of the builder and trigger a new
         // instance of it with `t-key`
@@ -554,6 +557,7 @@ export class WebsiteBuilderClientAction extends Component {
     async reloadIframeAndCloseEditor() {
         delete this.initialTab;
         this.target = null;
+        this.folded = [];
         const isEditing = false;
         this.state.isEditing = isEditing;
         this.addSystrayItems();

--- a/addons/website/static/tests/builder/save.test.js
+++ b/addons/website/static/tests/builder/save.test.js
@@ -23,6 +23,7 @@ import {
     getDragHelper,
     getDragMoveHelper,
     modifyText,
+    unfoldAllOptionsGroups,
     waitForEndOfOperation,
     wrapExample,
 } from "@html_builder/../tests/helpers";
@@ -206,7 +207,7 @@ test("reload save with target, then discard and edit again should not reselect t
     deferred.resolve();
     expect.verifySteps(["save"]);
     await animationFrame();
-    // NOTE: the goal of the following assertion is to ensure that the relaod is
+    // NOTE: the goal of the following assertion is to ensure that the reload is
     // completed. This relies on the "save" mocked for this test that does
     // nothing to save anything and the reload (mocked in `setupWebsiteBuilder`)
     // resets to initial content
@@ -216,6 +217,54 @@ test("reload save with target, then discard and edit again should not reselect t
     await contains(".o-snippets-top-actions button[data-action='cancel']").click();
     await contains(".o_edit_website_container button").click();
     expect(".o-website-builder_sidebar button[data-name=blocks]").toHaveClass("active");
+});
+
+test("reload should reopen the builder with the reloadable target, and the same unfolded groups", async () => {
+    onRpc("ir.ui.view", "save", ({ args }) => {
+        expect.step("save");
+        return true;
+    });
+    addActionOption({
+        testAction: class extends BuilderAction {
+            static id = "testAction";
+            reload = {};
+            apply({ editingElement }) {
+                editingElement.dataset.applied = "true";
+            }
+        },
+    });
+    addOption({
+        selector: ".test-option",
+        template: xml`<BuilderButton action="'testAction'"/>`,
+        reloadTarget: true,
+    });
+    addOption({
+        selector: ".parent-option",
+        template: xml`<BuilderButton classAction="'parent-option-applied'"/>`,
+    });
+    const deferred = Promise.withResolvers();
+    await setupWebsiteBuilder(`<div class="parent-option"><div class="test-option">b</div></div>`, {
+        delayReload: async () => await deferred.promise,
+    });
+    await contains(":iframe .test-option").click();
+    expect(".options-container-header:has(i.fa-caret-right)").toHaveCount(1);
+    expect(".options-container-header:has(i.fa-caret-down)").toHaveCount(1);
+    await unfoldAllOptionsGroups();
+    await contains("[data-action-id=testAction]").click();
+    expect(":iframe .test-option").toHaveAttribute("data-applied");
+    expect(".options-container-header:has(i.fa-caret-right)").toHaveCount(0);
+    expect(".options-container-header:has(i.fa-caret-down)").toHaveCount(2);
+    deferred.resolve();
+    expect.verifySteps(["save"]);
+    await animationFrame();
+    // NOTE: the goal of the following assertion is to ensure that the reload is
+    // completed. This relies on the "save" mocked for this test that does
+    // nothing to save anything and the reload (mocked in `setupWebsiteBuilder`)
+    // resets to initial content
+    expect(":iframe .test-option").not.toHaveAttribute("data-applied");
+
+    expect(".options-container-header:has(i.fa-caret-right)").toHaveCount(0);
+    expect(".options-container-header:has(i.fa-caret-down)").toHaveCount(2);
 });
 
 test("preview shouldn't let o_dirty", async () => {


### PR DESCRIPTION
When the user has unfolded a group, then click on an action that reloads the builder, the groups got folded.

This commit preserves the unfolded groups, in a similar way as the target was already preserved.

Steps to reproduce:
- Open website builder on `/shop`
- Click on a product card
- Unfold the "Products page" group
- Click on a reloading action (for example "Floating")
- Bug: the unfolded group is folded after the reload

task-5973113