### PR TITLE
[IMP] im_livechat: open file viewer in live chat shadow DOM

### DIFF
--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -136,6 +136,7 @@ Help your customers with this chat, and analyse their feedback.
             'web/static/src/views/fields/formatters.js',
             'web/static/src/views/fields/file_handler.*',
             'web/static/src/scss/mimetypes.scss',
+            ('remove', 'web/static/src/**/*.dark.scss'),
             'bus/static/src/*.js',
             'bus/static/src/services/**/*.js',
             'bus/static/src/workers/*.js',

--- a/addons/mail/static/src/core/common/attachment_list.js
+++ b/addons/mail/static/src/core/common/attachment_list.js
@@ -12,6 +12,7 @@ import { useFileViewer } from "@web/core/file_viewer/file_viewer_hook";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { url } from "@web/core/utils/urls";
+import { useRef } from "@web/owl2/utils";
 
 class Actions extends Component {
     static components = { Dropdown, DropdownItem };
@@ -40,6 +41,7 @@ export class AttachmentList extends Component {
         super.setup();
         this.ui = useService("ui");
         this.dialog = useService("dialog");
+        this.root = useRef("root");
         this.fileViewer = useFileViewer();
         this.actionsMenuState = useDropdownState();
         this.isMobileOS = isMobileOS();
@@ -82,9 +84,12 @@ export class AttachmentList extends Component {
             return this.props.unlinkAttachment(attachment);
         }
         this.dialog.add(ConfirmationDialog, {
-            title: _t('Delete Attachment'),
-            body: _t('Are you sure you want to delete "%s"?\nThis action cannot be undone.', attachment.name),
-            confirmLabel: _t('Delete Attachment'),
+            title: _t("Delete Attachment"),
+            body: _t(
+                'Are you sure you want to delete "%s"?\nThis action cannot be undone.',
+                attachment.name
+            ),
+            confirmLabel: _t("Delete Attachment"),
             cancel: () => {},
             confirm: () => this.onConfirmUnlink(attachment),
         });

--- a/addons/mail/static/src/core/common/attachment_list.xml
+++ b/addons/mail/static/src/core/common/attachment_list.xml
@@ -7,6 +7,7 @@
                 'o-inComposer': env.inComposer,
                 'o-inChatWindow': env.inChatWindow,
             }"
+            t-ref="root"
         >
             <div class="d-flex flex-wrap gap-2" t-att-class="{'justify-content-end': isInChatWindowAndIsAlignedRight and !env.inComposer}" role="menu" >
                 <div t-foreach="props.attachments" t-as="attachment" t-key="attachment.id"


### PR DESCRIPTION
Before this commit, the file viewer was mounted in the main component container. In the odoo website, this means the file viewer is outside of the live chat shadow DOM.

It's not ideal because it can be impacted by outter styles, and it's below the chat windows.

This PR ensures the file viewer is mounted in the live chat shadow DOM by mounting it in the overlay container, and by passing the "owner" context which will allow the outside overlay container to discard the file viewer coming from the shadow DOM.

task-5081594

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
