### PR TITLE
[FIX] web: prevent duplicate IDs in hoot mock models

### DIFF
--- a/addons/web/static/tests/_framework/mock_server/mock_model.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_model.js
@@ -1591,6 +1591,7 @@ export class Model extends Array {
     _fold_name = "fold";
     /** @type {string | null} */
     _inherit = null;
+    _lastRecId = 0;
     /** @type {string} */
     _name = "";
     /** @type {Record<string, (record: ModelRecord) => any>} */
@@ -3315,7 +3316,7 @@ export class Model extends Array {
      * @private
      */
     _getNextId() {
-        return Math.max(0, ...this.map((record) => record?.id || 0)) + 1;
+        return ++this._lastRecId;
     }
 
     /**

--- a/addons/web/static/tests/_framework/mock_server/mock_server.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_server.js
@@ -1045,6 +1045,7 @@ export class MockServer {
                 }
                 model.push(record);
             }
+            model._lastRecId = Math.max(model._lastRecId, ...seenIds, 0);
             model._records = [];
 
             // Records without ID are assigned later to avoid collisions

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -3158,7 +3158,7 @@ test("delete a column in grouped on m2o", async () => {
     await validateKanbanColumn();
 
     expect.verifySteps(["name_create", "web_resequence"]);
-    expect(resequencedIDs).toEqual([3, 4], {
+    expect(resequencedIDs).toEqual([3, 6], {
         message: "creating a column should trigger a resequence",
     });
 
@@ -3166,7 +3166,7 @@ test("delete a column in grouped on m2o", async () => {
         queryAll(".o_kanban_group")[2]
     );
 
-    expect(resequencedIDs).toEqual([3, 4], {
+    expect(resequencedIDs).toEqual([3, 6], {
         message: "moving the Undefined column should not affect order of other columns",
     });
 
@@ -3175,7 +3175,7 @@ test("delete a column in grouped on m2o", async () => {
         queryAll(".o_kanban_group")[2]
     );
     expect.verifySteps(["web_resequence"]);
-    expect(resequencedIDs).toEqual([4, 3], {
+    expect(resequencedIDs).toEqual([6, 3], {
         message: "moved column should be resequenced accordingly",
     });
 });


### PR DESCRIPTION
Previously, new record IDs were generated using the maximum existing ID. If the last record was deleted, newly created records could reuse the same ID.

This change stores the last generated ID on the model and uses it to generate new records, ensuring uniqueness.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
