### PR TITLE
[IMP] account: Better handling of BE VCS-OGM

### DIFF
--- a/addons/account/tests/test_structured_reference.py
+++ b/addons/account/tests/test_structured_reference.py
@@ -37,6 +37,7 @@ class StructuredReferenceTest(TransactionCase):
         self.assertTrue(is_valid_structured_reference_be('***020/3430/57642*** '))
         # Accept references in unstructured format
         self.assertTrue(is_valid_structured_reference_be(' 020343057642'))
+        self.assertTrue(is_valid_structured_reference_be('020/3430/57642'))
         # Validates edge case where result of % 97 = 0
         self.assertTrue(is_valid_structured_reference_be('020343053497'))
 

--- a/addons/account/tools/structured_reference.py
+++ b/addons/account/tools/structured_reference.py
@@ -13,7 +13,7 @@ def sanitize_structured_reference(reference):
              `***020/3430/57642***` -> `020343057642`
     """
     ref = re.sub(r'\s', '', reference)
-    if re.match(r'(\+{3}|\*{3})\d{3}/\d{4}/\d{5}(\+{3}|\*{3})', ref):
+    if re.fullmatch(r'(\+{3}|\*{3}|)\d{3}/\d{4}/\d{5}\1', ref):
         return re.sub(r'[+*/]', '', ref)
     return ref
 


### PR DESCRIPTION
The aim of this commit is handling the case where
the Belgian VCS-OGM is not starting with + or *.
Before this commit, transactions without one of
these 2 characters wasn't marked as structured.
With this commit, we do handle this format as well: xxx/xxxx/xxxxx

task-5403947

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
