### PR TITLE
[FIX] point_of_sale: correct combo price recomputation

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -358,27 +358,27 @@ export class PosOrder extends PosOrderAccounting {
         );
         for (const pLine of combo_parent_lines) {
             const { childLineFree, childLineExtra } = this.getFreeAndExtraChildLines(pLine);
-            attributes_prices[pLine.id] = computeComboItems(
+            attributes_prices[pLine.uuid] = computeComboItems(
                 pLine.product_id,
                 childLineFree,
                 pricelist,
                 this.models["decimal.precision"].getAll(),
                 this.models["product.template.attribute.value"].getAllBy("id"),
                 childLineExtra,
-                this.config_id.currency_id
+                this.currency
             );
         }
         const combo_children_lines = this.lines.filter(
             (line) => line.price_type === "original" && line.combo_parent_id
         );
         combo_children_lines.forEach((line) => {
-            const currentItem = attributes_prices[line.combo_parent_id.id].find(
+            const currentItem = attributes_prices[line.combo_parent_id.uuid].find(
                 (item) => item.combo_item_id.id === line.combo_item_id.id
             );
             line.setUnitPrice(currentItem.price_unit);
             // Removing to be able to have extras that are the same as free products
-            attributes_prices[line.combo_parent_id.id].splice(
-                attributes_prices[line.combo_parent_id.id].indexOf(currentItem),
+            attributes_prices[line.combo_parent_id.uuid].splice(
+                attributes_prices[line.combo_parent_id.uuid].indexOf(currentItem),
                 1
             );
         });
@@ -388,23 +388,32 @@ export class PosOrder extends PosOrderAccounting {
         const childLineFree = [];
         const childLineExtra = [];
         const comboRemainingFree = {};
+        const parentQty = pLine.getQuantity() || 1;
+
         for (const cLine of pLine.combo_line_ids) {
-            if (!(cLine.combo_item_id.combo_id.id in comboRemainingFree)) {
-                comboRemainingFree[cLine.combo_item_id.combo_id.id] =
-                    cLine.combo_item_id.combo_id.qty_free;
+            const comboId = cLine.combo_item_id.combo_id.id;
+
+            if (!(comboId in comboRemainingFree)) {
+                comboRemainingFree[comboId] = cLine.combo_item_id.combo_id.qty_free * parentQty;
             }
-            const newQty = comboRemainingFree[cLine.combo_item_id.combo_id.id] - cLine.qty;
+
+            const childQty = cLine.getQuantity();
+            if (childQty <= 0) {
+                continue;
+            }
+
+            const newQty = comboRemainingFree[comboId] - childQty;
             const baseData = { combo_item_id: cLine.combo_item_id };
+
             if (cLine.attribute_value_ids) {
                 baseData.configuration = { attribute_value_ids: cLine.attribute_value_ids };
             }
-            if (cLine.qty) {
-                if (newQty >= 0) {
-                    comboRemainingFree[cLine.combo_item_id.combo_id.id] = newQty;
-                    childLineFree.push({ ...baseData, qty: cLine.qty });
-                } else {
-                    childLineExtra.push({ ...baseData, qty: cLine.qty });
-                }
+
+            if (newQty >= 0) {
+                comboRemainingFree[comboId] = newQty;
+                childLineFree.push({ ...baseData, qty: childQty / parentQty });
+            } else {
+                childLineExtra.push({ ...baseData, qty: childQty / parentQty });
             }
         }
         return { childLineFree, childLineExtra };

--- a/addons/point_of_sale/static/tests/unit/models/pos_combo.test.js
+++ b/addons/point_of_sale/static/tests/unit/models/pos_combo.test.js
@@ -1,0 +1,63 @@
+import { test, expect } from "@odoo/hoot";
+import { setupPosEnv } from "../utils";
+import { definePosModels } from "../data/generate_model_definitions";
+
+definePosModels();
+
+test("combo price remains consistent when recomputing prices", async () => {
+    const store = await setupPosEnv();
+    const pricelistA = store.models["product.pricelist"].get(1);
+    const pricelist90 = store.models["product.pricelist"].get(3);
+
+    const template = store.models["product.template"].get(7);
+    const comboItem1 = store.models["product.combo.item"].get(1);
+    const comboItem3 = store.models["product.combo.item"].get(3);
+
+    const order = store.addNewOrder();
+    order.setPricelist(pricelistA);
+
+    await store.addLineToOrder(
+        {
+            product_tmpl_id: template,
+            payload: [
+                [{ combo_item_id: comboItem1, qty: 1 }],
+                [{ combo_item_id: comboItem3, qty: 1 }],
+            ],
+            qty: 2,
+        },
+        order
+    );
+
+    const comboParentLine = order.lines.find(
+        (l) => l.product_id.product_tmpl_id.id === template.id
+    );
+
+    expect(comboParentLine.getQuantity()).toBe(2);
+    expect(comboParentLine.price_unit).toBe(0);
+
+    const childLines = order.lines.filter((l) => l.combo_parent_id?.uuid === comboParentLine.uuid);
+    expect(childLines).toHaveLength(2);
+
+    const item1Line = childLines.find((l) => l.combo_item_id.id === 1);
+    const item3Line = childLines.find((l) => l.combo_item_id.id === 3);
+
+    expect(item1Line.getQuantity()).toBe(2);
+    expect(item1Line.price_unit).toBe(3);
+
+    expect(item3Line.getQuantity()).toBe(2);
+    expect(item3Line.price_unit).toBe(200);
+
+    // Total = (0*2) + (3*2) + (200*2) = 0 + 6 + 400 = 406.
+    // Tax 25% -> 406 * 1.25 = 507.5.
+    expect(order.priceIncl).toBe(507.5);
+
+    order.setPricelist(pricelist90);
+
+    expect(comboParentLine.price_unit).toBe(0);
+    expect(item1Line.price_unit).toBe(100);
+
+    expect(item3Line.price_unit).toBeGreaterThan(0);
+
+    expect(order.priceIncl).not.toBe(507.5);
+    expect(order.priceIncl).toBeGreaterThan(0);
+});


### PR DESCRIPTION
Fix combo prices doubling when quantity > 1 during pricelist changes.
Correctly scale free items in 'getFreeAndExtraChildLines' and ensure parent unit prices are updated in 'setPricelist'.

task-id: 5971935

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
