### PR TITLE
[FIX] point_of_sale : handle preset name too long

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/action_pad/action_pad.xml
@@ -8,7 +8,7 @@
                 <t t-if="props.onClickMore">
                     <SelectPartnerButton partner="props.partner"/>
                     <button t-if="pos.config.use_presets and currentOrder"
-                        class="btn btn-secondary btn-lg flex-shrink-0 border-0"
+                        class="btn btn-secondary btn-lg border-0 text-truncate"
                         t-attf-class="{{`o_colorlist_item_color_${currentOrder.preset_id?.color}`}}"
                         t-on-click="() => this.pos.selectPreset()">
                         <span t-if="currentOrder.preset_id?.name" t-esc="currentOrder.preset_id?.name" />

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -7,7 +7,7 @@
             <InternalNoteButton label.translate="Note" class="buttonClass"/>
         </t>
         <button t-if="pos.config.use_presets and !props.showRemainingButtons"
-            class="btn btn-secondary btn-lg flex-shrink-0 border-0"
+            class="btn btn-secondary btn-lg border-0 text-truncate"
             t-attf-class="{{currentOrder.preset_id?.color and `o_colorlist_item_color_${currentOrder.preset_id?.color}`}}"
             t-on-click="() => this.pos.selectPreset()">
             <span t-if="currentOrder.preset_id?.name" t-esc="currentOrder.preset_id?.name" />


### PR DESCRIPTION
# How to reproduce
- Enable Take out / Delivery / Members in PoS Configuration
- Create a preset with a very long name and set it as default
- Open the register

# The problem
The preset button takes too much space and hide the other buttons

opw-5938578

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
