### PR TITLE
[FIX] web: Call `Record._save` `onError` only with `RPCError`

### DIFF
--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -12,6 +12,7 @@ import {
     getFieldsSpec,
     parseServerValue,
 } from "./utils";
+import { RPCError } from "@web/core/network/rpc";
 
 /**
  * Redefine default 'Record' type
@@ -1185,7 +1186,7 @@ export class Record extends DataPoint {
                 kwargs
             );
         } catch (e) {
-            if (onError) {
+            if (onError && e instanceof RPCError) {
                 return onError(e, {
                     discard: () => this._discard(),
                     retry: () => this._save(...arguments),


### PR DESCRIPTION
The _save method was previously passing any caught error to the onError callback. However, onError (and its typical implementation onSaveError) is designed to handle functional server-side errors where user interaction is needed.

Infrastructure or network-level errors, such as:

- ConnectionLostError (502, network failure, etc.)
- RequestEntityTooLargeError (413)

...should not be intercepted by the record's error handler. By checking if (error instanceof RPCError), we ensure these technical errors are rethrown and handled by the global RPC/Service bus