### PR TITLE
[FIX] point_of_sale: prevent error when a combo product is archived

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2949,8 +2949,8 @@ export class PosStore extends WithLazyGetterTrap {
         const combos = this.models["product.combo"].getAll();
         const comboItems = combos.flatMap((combo) => combo.combo_item_ids);
         const totalQtyAvailable = comboItems.reduce((acc, item) => {
-            const productId = item.product_id.id;
-            if (productInOrder[productId]) {
+            const productId = item.product_id?.id;
+            if (productId && productInOrder[productId]) {
                 acc[item.combo_id.id] =
                     (acc[item.combo_id.id] || 0) + productInOrder[productId].totalQty;
             }

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -4,7 +4,7 @@ import re
 from collections import defaultdict
 
 from odoo import _, api, fields, models, tools
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Domain
 from odoo.tools import float_compare, groupby, OrderedSet
 from odoo.tools.image import is_image_size_above
@@ -722,6 +722,14 @@ class ProductProduct(models.Model):
 
     def action_archive(self):
         records = self.filtered('active')
+        combo_items = self.env['product.combo.item'].search([('product_id', 'in', records.ids)])
+        if combo_items:
+            combo_names = ', '.join(combo_items.combo_id.mapped('name'))
+            raise UserError(_(
+                "You cannot archive a product that is part of a combo. "
+                "Please remove it from the following combos first: %s",
+                combo_names,
+            ))
         super().action_archive()
         # We deactivate product templates which are active with no active variants.
         records.product_tmpl_id.filtered(

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -683,6 +683,17 @@ class ProductTemplate(models.Model):
                 product_template.combo_ids = False
         return res
 
+    def action_archive(self):
+        combo_items = self.env['product.combo.item'].search([('product_id', 'in', self.product_variant_ids.ids)])
+        if combo_items:
+            combo_names = ', '.join(combo_items.combo_id.mapped('name'))
+            raise UserError(_(
+                "You cannot archive a product that is part of a combo. "
+                "Please remove it from the following combos first: %s",
+                combo_names,
+            ))
+        return super().action_archive()
+
     def copy_data(self, default=None):
         default = dict(default or {})
         vals_list = super().copy_data(default=default)


### PR DESCRIPTION
Before this commit, when a combo product was archived, and the PoS was reopened, an error was raised.

opw-5952006

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
