### PR TITLE
[18.0][FIX] mail: It is not possible to respond to messages within the context of another company

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4799,6 +4799,8 @@ class MailThread(models.AbstractModel):
     @api.model
     def _get_thread_with_access(self, thread_id, mode="read", **kwargs):
         thread = self.browse(thread_id)
-        if thread.exists() and thread.sudo(False).has_access(mode):
+        if thread.exists() and thread.sudo(False).with_context(
+            allowed_company_ids=[]
+        ).has_access(mode):
             return thread
         return self.browse()

--- a/addons/test_mail/tests/test_mail_multicompany.py
+++ b/addons/test_mail/tests/test_mail_multicompany.py
@@ -482,3 +482,39 @@ class TestMultiCompanyControllers(TestMailMCCommon, HttpCase):
                 )
                 self.assertEqual(response.status_code, 200)
                 self.assertNotIn('cids', response.request._cookies)
+
+    def test_mail_message_post_other_company_with_cids(self):
+        """
+        Ensure that a user can post a message on a thread belonging to another
+        company when:
+
+        - The user has access to both companies via `company_ids`.
+        - The active company context only includes the other company.
+        - The target record belongs to a different company than the active one.
+
+        This reproduces the scenario where a user receives a notification from a
+        record in Company A while being active in Company B, and attempts to reply
+        from the inbox.
+        """
+        self.user_employee_c2.write({'company_ids': [(6, 0, [self.user_employee.company_id.id, self.company_2.id])]})
+        record_c1 = self.env["mail.test.multi.company"].sudo().create({
+            "name": "Thread in C1",
+            "company_id": self.user_employee.company_id.id,  # company 1
+        })
+        self.authenticate('employee_c2', 'employee_c2')
+        self.opener.cookies.set('cids', str(self.company_2.id))
+        payload = {
+            "thread_model": record_c1._name,
+            "thread_id": record_c1.id,
+            "post_data": {
+                "body": "<p>Reply from inbox</p>",
+                "message_type": "comment",
+                "subtype_xmlid": "mail.mt_comment",
+            },
+            "context": {
+                "allowed_company_ids": self.company_2.ids,
+            }
+        }
+        result = self.make_jsonrpc_request("/mail/message/post", payload)
+        self.assertEqual(result["mail.message"][0]["body"], payload["post_data"]["body"])
+        self.assertTrue(record_c1.message_ids.filtered(lambda m: "Reply from inbox" in (m.body or "")))


### PR DESCRIPTION
Before these changes, messages from other companies were received, but when trying to reply to them, an error occurred that prevented the response.

Steps to reproduce the issue in runbot:
1. In one tab, log in as admin, and in another incognito tab, open demo.
2. Make sure demo has Handle Notifications in Odoo enabled.
3. Set admin in one company and demo in another company.
4. Assign a task to demo.
5. Click on the notification to open the chatter and try to reply.

An error is thrown

With these changes, the response can be logged when the user has access to the company from which the task was assigned.

cc @Tecnativa TT61176

ping @pedrobaeza 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
