### PR TITLE
[FIX] microsoft_calendar: fix test imports and _sync_odoo2microsoft call

### DIFF
--- a/addons/microsoft_calendar/tests/__init__.py
+++ b/addons/microsoft_calendar/tests/__init__.py
@@ -7,3 +7,6 @@ from . import test_create_events
 from . import test_update_events
 from . import test_delete_events
 from . import test_answer_events
+from . import test_sync_microsoft2odoo
+from . import test_sync_odoo2microsoft
+

--- a/addons/microsoft_calendar/tests/test_sync_microsoft2odoo.py
+++ b/addons/microsoft_calendar/tests/test_sync_microsoft2odoo.py
@@ -257,7 +257,7 @@ class TestSyncMicrosoft2Odoo(TransactionCase):
             'partner_ids': [(4, partner.id)],
         })
         with self.assertRaises(ValidationError):
-            event._sync_odoo2microsoft(MicrosoftCal)
+            event._sync_odoo2microsoft()
 
     def test_cancel_occurence_of_recurrent_event(self):
         """ The user is invited to a recurrent event. When synced, all events are present, there are three occurrences:

--- a/addons/microsoft_calendar/tests/test_sync_odoo2microsoft.py
+++ b/addons/microsoft_calendar/tests/test_sync_odoo2microsoft.py
@@ -81,7 +81,7 @@ class TestSyncOdoo2Microsoft(TransactionCase):
         })
 
         user.with_user(user).restart_microsoft_synchronization()
-        event.with_user(user)._sync_odoo2microsoft(self.microsoft_service)
+        event.with_user(user)._sync_odoo2microsoft()
         microsoft_guid = self.env['ir.config_parameter'].sudo().get_param('microsoft_calendar.microsoft_guid', False)
         self.assertMicrosoftEventPatched(event.microsoft_id, {
             'id': event.microsoft_id,

--- a/doc/cla/individual/teraformerrr.md
+++ b/doc/cla/individual/teraformerrr.md
@@ -1,0 +1,20 @@
+UAE, 2026-02-25
+
+
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+
+Agreement v1.0.
+
+
+
+I declare that I am authorized and able to make this agreement and sign
+
+this declaration.
+
+
+
+Signed,
+
+Mohamed Jamshed mohamedjamsheddxb@gmail.com https://github.com/Teraformerrr
+


### PR DESCRIPTION
The test files test_sync_microsoft2odoo.py and test_sync_odoo2microsoft.py were not imported in tests/__init__.py, so they were never run.

Additionally, both files called _sync_odoo2microsoft() with an extra positional argument, but the method accepts only self.

Fixes #250663

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
