### PR TITLE
[FIX] project : fix portal search by assignees

### DIFF
--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -353,7 +353,7 @@ class ProjectCustomerPortal(CustomerPortal):
                 left=Markup('<span class="nolabel">'),
                 right=Markup('</span>'),
             ), 'sequence': 10},
-            'users': {'input': 'user_ids', 'label': _('Search in Assignees'), 'sequence': 20},
+            'user_ids': {'input': 'user_ids', 'label': _('Search in Assignees'), 'sequence': 20},
             'stage_id': {'input': 'stage_id', 'label': _('Search in Stages'), 'sequence': 30},
             'status': {'input': 'status', 'label': _('Search in Status'), 'sequence': 40},
             'priority': {'input': 'priority', 'label': _('Search in Priority'), 'sequence': 60},

--- a/addons/project/tests/test_portal.py
+++ b/addons/project/tests/test_portal.py
@@ -91,6 +91,7 @@ class TestPortalProject(TestProjectPortalCommon, HttpCase):
         self.authenticate(project_manager.login, project_manager.login)
         self.project_1 = self.env['project.project'].create({'name': 'Portal Search Project 1'})
         self.project_2 = self.env['project.project'].create({'name': 'Portal Search Project 2'})
+        self.project_3 = self.env['project.project'].create({'name': 'Portal Search Project 3'})
         self.task_1 = self.env['project.task'].create({
             'name': 'Test Task Name Match',
             'project_id': self.project_1.id,
@@ -103,10 +104,17 @@ class TestPortalProject(TestProjectPortalCommon, HttpCase):
             'user_ids': project_manager,
         })
 
+        self.task_3 = self.env['project.task'].create({
+            'name': 'Project Not For Manager',
+            'project_id': self.project_3.id,
+            'user_ids': self.user_projectuser
+        })
+
         url = '/my/tasks'
         response = self.url_open(url)
         self.assertIn(self.task_1.name, response.text)
         self.assertIn(self.task_2.name, response.text)
+        self.assertIn(self.task_3.name, response.text)
 
         url = '/my/tasks?search_in=name&search=Test+Task+Name+Match'
         response = self.url_open(url)
@@ -116,4 +124,10 @@ class TestPortalProject(TestProjectPortalCommon, HttpCase):
         url = '/my/tasks?search_in=project_id&search=%s' % (self.project_1.name)
         response = self.url_open(url)
         self.assertIn(self.task_1.name, response.text)
+        self.assertNotIn(self.task_2.name, response.text)
+
+        url = '/my/tasks?search_in=user_ids&search=%s' % (self.user_projectuser.name)
+        response = self.url_open(url)
+        self.assertIn(self.task_3.name, response.text)
+        self.assertNotIn(self.task_1.name, response.text)
         self.assertNotIn(self.task_2.name, response.text)


### PR DESCRIPTION
# How to reproduce
- On the website go to My Account > Tasks
- In the search bar, select Search In Assignees
- Search for an assignee

# The problem
Nothing shows up even if the is a task with the assignee that was searched

# Why
In the dictionnary of the different possible searches, the name of the Search in Assignee entry was "users" instead of "user_ids"

opw-5503738

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
