### PR TITLE
[FIX] website: avoid "narrow" mega menus taking too much space

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1736,7 +1736,7 @@ header {
     .o_mega_nav, .o_mega_menu {
         @include transition(opacity $offcanvas-transition-duration ease-in-out, visibility $offcanvas-transition-duration ease-in-out);
         z-index: $o-mega-menu-zindex;
-        max-width: $offcanvas-horizontal-width;
+        max-width: $offcanvas-horizontal-width !important;
         opacity: 0;
         pointer-events: none;
 


### PR DESCRIPTION
The property "max-width" of the mega menu in mobile view was set with the class o_mega_menu_is_offcanvas of its ancestor.

However, when the user set the mega menu template size to "Narrow", new CSS rules were added to change the mega menu size based on the screen size. The first rule was overridden, resulting in the mega menu being larger than the mobile navbar width.

This commit sets the property "max-width" as "important" to prevent this issue from occurring.

task-5972284