### PR TITLE
[FIX] sale_timesheet: allow create so without project user group

### DIFF
--- a/addons/sale_timesheet/models/sale_order.py
+++ b/addons/sale_timesheet/models/sale_order.py
@@ -16,7 +16,7 @@ class SaleOrder(models.Model):
     timesheet_total_duration = fields.Integer("Timesheet Total Duration", compute='_compute_timesheet_total_duration',
         help="Total recorded duration, expressed in the encoding UoM, and rounded to the unit", compute_sudo=True,
         groups="hr_timesheet.group_hr_timesheet_user", export_string_translation=False)
-    show_hours_recorded_button = fields.Boolean(compute="_compute_show_hours_recorded_button", groups="hr_timesheet.group_hr_timesheet_user", export_string_translation=False)
+    show_hours_recorded_button = fields.Boolean(compute="_compute_show_hours_recorded_button", groups="hr_timesheet.group_hr_timesheet_user", export_string_translation=False, compute_sudo=True)
 
 
     def _compute_timesheet_count(self):


### PR DESCRIPTION
Issue:
---
Users cannot create so without project user group.

Steps to reproduce:
---
1- Install `sale_timesheet`, `sale_project`
2- Change demo user access:
   - Sales: own documents
   - Timesheets: own documents
   - Project: No

3- Login demo user and create a SO.

SO creation fails on `read` operation on `project_count`.

Cause and Fix:
---
This is due to `_compute_show_hours_recorded_button`, which needs `project_count` to be computed. However, `SO.project_count` is only accessible by `project.group_project_user`.
This can be fixed by a `compute_sudo` on show_hours_recorded_button.
Security-wise this should be fine, as `show_hours_recorded_button` itself is only accessible by `hr_timesheet.group_hr_timesheet_user`.

opw-5944881

