### PR TITLE
[FIX] account: sequence mixin cache on cr.cache instead of precommit

### DIFF
--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -89,9 +89,7 @@ class SequenceMixin(models.AbstractModel):
         # To avoid requiring multiple savepoints when generating successive
         # sequence numbers within a single transaction, we cache the sequence value
         # for the duration of the in-flight transaction.
-        # The `precommit.data` container is used instead of `cr.cache` to
-        # reduce the need for manual invalidation and ensure that the
-        # cache does not survive a commit or rollback.
+        # We use `cr.cache` and expect any savepoint rollback to clear the cache.
         #
         # Before adding an entry for a sequence to this `sequence.mixin` cache,
         # the transaction must have locked the corresponding unique constraint,
@@ -107,7 +105,7 @@ class SequenceMixin(models.AbstractModel):
         # See also:
         # - https://postgres.ai/blog/20210831-postgresql-subtransactions-considered-harmful
         # - the documentation in _locked_increment()
-        return self.env.cr.precommit.data.setdefault('sequence.mixin', {})
+        return self.env.cr.cache.setdefault('sequence.mixin', {})
 
     def write(self, vals):
         if self._sequence_field in vals and self.env.context.get('clear_sequence_mixin_cache', True):

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -120,6 +120,7 @@ class Savepoint:
             self._close(rollback)
 
     def rollback(self):
+        self._cr.cache.clear()  # The cache could be lying now
         self._cr.execute('ROLLBACK TO SAVEPOINT "%s"' % self.name)
 
     def _close(self, rollback: bool):


### PR DESCRIPTION
## [FIX] odoo: clear `cr.cache` for any rollback
The aim of this commit is to wipe out the cache as soon as we rollback
to a previous savepoint as we can't trust it anymore.

task-id: None

## [FIX] account: sequence mixin cache on cr.cache instead of precommit
The aim of this commit is to prevent the sequence mixin cache to be
cleared as soon as a flush happens in order to avoid triggering tons of
savepoint during import.

### Context:
During an import of document, like a big CSV of bank statement for
example, if any issue arise, we rollback to the savepoint of import and
the ORM retries the import one record at a time to collect the errors
and rollback later on.

As we flush for every single record, the `precommit.cache` gets cleared
during the flush and the sequence mixin cache gets wiped out.
This results in the sequence mixin code to recreate the cache AND create
a new savepoint at each iteration of the import loop.
This could results in 300+ savepoints existing at the same time eating
all postgres memory and putting the whole production on its knees.

task-id: None