### PR TITLE
[FIX] base: increase nb_lines in PDF page overflow tests for wkhtmlto…

### DIFF
--- a/odoo/addons/base/tests/test_reports.py
+++ b/odoo/addons/base/tests/test_reports.py
@@ -443,7 +443,7 @@ class TestReportsRendering(TestReportsRenderingCommon):
         self.assertEqual(pages_contents, expected_pages_contents)
 
     def test_pdf_render_page_overflow(self):
-        nb_lines = 80
+        nb_lines = 120
 
         page_content = f'''
             <div class="page">
@@ -501,7 +501,7 @@ class TestReportsRendering(TestReportsRenderingCommon):
         """
             Check that thead and t-foot are repeated after page break inside a tbody
         """
-        nb_lines = 50
+        nb_lines = 60
         page_content = f'''
             <div class="page">
                 <table class="table">


### PR DESCRIPTION
## Problem
test_pdf_render_page_overflow and test_thead_tbody_repeat fail with 
wkhtmltopdf 0.12.6.1 (with patched qt), as shipped in odoo:18.0-20260217 
Docker image.

Both tests expect 6 pages but only produce 4, because nb_lines values 
were calibrated for an older wkhtmltopdf version that rendered fewer 
lines per page.

## Root Cause
wkhtmltopdf 0.12.6.1 renders more content per page than previous versions,
so nb_lines=80 and nb_lines=50 no longer force 3 pages per record.

## Fix
- test_pdf_render_page_overflow: nb_lines 80 → 120
- test_thead_tbody_repeat: nb_lines 50 → 60

## Steps to Reproduce
docker run odoo:18.0-20260217
python odoo-bin --test-filter=TestReportsRendering.test_pdf_render_page_overflow

## Environment
- wkhtmltopdf 0.12.6.1 (with patched qt)
- Docker image: odoo:18.0-20260217
- Odoo version: 18.0
