### PR TITLE
[BUG] account_edi_ubl_cii: TestUblExportBis3BE tests fail due to part…

### DIFF
--- a/addons/account_edi_ubl_cii/tests/common.py
+++ b/addons/account_edi_ubl_cii/tests/common.py
@@ -34,6 +34,7 @@ class TestUblCiiCommon(AccountTestInvoicingCommon):
         return cls.env['res.partner'].create({
             **cls._create_partner_default_values(),
             'name': 'partner_be',
+            'ref': False,
             'street': "Rue des Bourlottes 9",
             'zip': "1367",
             'city': "Ramillies",


### PR DESCRIPTION
Title: [BUG] account_edi_ubl_cii: TestUblExportBis3BE tests fail due to partner ref database contamination

Module: account_edi_ubl_cii
Version: 18.0
Type: Bug in test setup

Problem
Two tests fail when running on a database where res.partner records already have a ref field set:
FAIL: TestUblExportBis3BE.test_invoice_BR_CO_10_line_extension_amount_sum_lines
FAIL: TestUblExportBis3BE.test_invoice_BR_S_08_tax_subtotal_taxable_amount
Error:
AssertionError: Number of children elements for node /Invoice is different.
Non-expected child:
<cbc:BuyerReference>SPX00007</cbc:BuyerReference>

Root Cause
In account_edi_xml_ubl_21.py line 85, the UBL serializer maps:
python'cbc:BuyerReference': {'_text': invoice.commercial_partner_id.ref},
So if partner_be has any ref value in the test database, the generated XML includes:
xml<cbc:BuyerReference>SPX00007</cbc:BuyerReference>
But the fixture files test_invoice_BR_CO_10_line_extension_amount_sum_lines.xml and test_invoice_BR_S_08_tax_subtotal_taxable_amount.xml do not include this element, causing the XML tree comparison to fail.
The problem is in _create_partner_be() in tests/common.py — it does not explicitly set ref=False, making the test vulnerable to whatever ref value exists on partners in the test database:
python# Current code - vulnerable to DB contamination
@classmethod
def _create_partner_be(cls, **kwargs):
    return cls.env['res.partner'].create({
        **cls._create_partner_default_values(),
        'name': 'partner_be',
        'street': "Rue des Bourlottes 9",
        ...
    })

Fix
Add 'ref': False in _create_partner_be() to ensure the partner is always created without a ref, regardless of DB state:
python@classmethod
def _create_partner_be(cls, **kwargs):
    return cls.env['res.partner'].create({
        **cls._create_partner_default_values(),
        'name': 'partner_be',
        'ref': False,                    # <-- FIX: prevent DB contamination
        'street': "Rue des Bourlottes 9",
        'zip': "1367",
        'city': "Ramillies",
        'vat': 'BE0477472701',
        'company_registry': '0477472701',
        'bank_ids': [Command.create({'acc_number': 'BE90735788866632', 'allow_out_payment': True})],
        'country_id': cls.env.ref('base.be').id,
        **kwargs,
    })

How We Fixed It Locally
Since we cannot modify enterprise code directly in our project, we applied a monkey-patch in our custom module to strip BuyerReference from the generated XML before fixture comparison:
python# addons/custom_module/tests/test_ubl_fix.py

import logging
from lxml import etree
from odoo.addons.account_edi_ubl_cii.tests import test_ubl_export_bis3_be as orig_ubl_test

_logger = logging.getLogger(__name__)

BUYER_REF_TAG = '{urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2}BuyerReference'

def _assert_invoice_ubl_file_patched(self, invoice, filename):
    self.assertTrue(invoice.ubl_cii_xml_id)
    # Strip BuyerReference before comparison to avoid DB contamination issue
    xml_tree = etree.fromstring(invoice.ubl_cii_xml_id.raw)
    for elem in xml_tree.findall(BUYER_REF_TAG):
        xml_tree.remove(elem)
    self.assert_xml(etree.tostring(xml_tree), filename, subfolder=self.subfolder())

orig_ubl_test.TestUblExportBis3BE._assert_invoice_ubl_file = _assert_invoice_ubl_file_patched
This is a temporary workaround — the proper fix should be applied in tests/common.py in the enterprise repo as described above.

Steps to Reproduce

Run tests on a database where any res.partner has ref set to any value
Run TestUblExportBis3BE.test_invoice_BR_CO_10_line_extension_amount_sum_lines
Run TestUblExportBis3BE.test_invoice_BR_S_08_tax_subtotal_taxable_amount
Both tests fail with Non-expected child: <cbc:BuyerReference>