### PR TITLE
fix: replace 23 bare except clauses with except Exception

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -652,7 +652,7 @@ class AccountReportExpression(models.Model):
             try:
                 domain = ast.literal_eval(expression.formula)
                 self.env['account.move.line']._search(domain)
-            except:
+            except Exception:
                 raise_formula_error(expression)
 
         for expression in expressions_by_engine.get('account_codes', []):

--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -145,7 +145,7 @@ class AuthSignupHome(Home):
                 token_infos = request.env['res.partner'].sudo()._signup_retrieve_info(qcontext.get('token'))
                 for k, v in token_infos.items():
                     qcontext.setdefault(k, v)
-            except:
+            except Exception:
                 qcontext['error'] = _("Invalid signup token")
                 qcontext['invalid_token'] = True
         return qcontext

--- a/addons/mail/controllers/mail.py
+++ b/addons/mail/controllers/mail.py
@@ -203,7 +203,7 @@ class MailController(http.Controller):
         if kwargs.get('message_id'):
             try:
                 message = request.env['mail.message'].sudo().browse(int(kwargs['message_id'])).exists()
-            except:
+            except Exception:
                 message = request.env['mail.message']
             if message:
                 model, res_id = message.model, message.res_id

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4708,7 +4708,7 @@ class MailThread(models.AbstractModel):
             try: # avoid to make an exists, lets be optimistic and try to read it.
                 if user.active:
                     return [(user.partner_id.id, default_subtype_ids, 'mail.message_user_assigned' if user != self.env.user else False)]
-            except:
+            except Exception:
                 pass
         return []
 

--- a/addons/mass_mailing/models/mailing_filter.py
+++ b/addons/mass_mailing/models/mailing_filter.py
@@ -29,7 +29,7 @@ class MailingFilter(models.Model):
             if mailing_filter.mailing_domain != "[]":
                 try:
                     self.env[mailing_filter.mailing_model_id.model].search_count(literal_eval(mailing_filter.mailing_domain))
-                except:
+                except Exception:
                     raise ValidationError(
                         _("The filter domain is not valid for this recipients.")
                     )

--- a/addons/mass_mailing_sms/controllers/main.py
+++ b/addons/mass_mailing_sms/controllers/main.py
@@ -14,7 +14,7 @@ class MailingSMSController(http.Controller):
     def _check_trace(self, mailing_id, trace_code):
         try:
             mailing = request.env['mailing.mailing'].sudo().search([('id', '=', mailing_id)])
-        except:
+        except Exception:
             mailing = False
         if not mailing:
             return {'error': 'mailing_error'}

--- a/addons/microsoft_account/models/microsoft_service.py
+++ b/addons/microsoft_account/models/microsoft_service.py
@@ -172,7 +172,7 @@ class MicrosoftService(models.AbstractModel):
 
             try:
                 ask_time = datetime.strptime(res.headers.get('date'), "%a, %d %b %Y %H:%M:%S %Z")
-            except:
+            except Exception:
                 pass
         except requests.HTTPError as error:
             if error.response.status_code in RESOURCE_NOT_FOUND_STATUSES:

--- a/addons/mrp/__init__.py
+++ b/addons/mrp/__init__.py
@@ -32,5 +32,5 @@ def uninstall_hook(env):
     try:
         with env.cr.savepoint():
             pbm_routes.unlink()
-    except:
+    except Exception:
         pass

--- a/addons/mrp_subcontracting/__init__.py
+++ b/addons/mrp_subcontracting/__init__.py
@@ -22,5 +22,5 @@ def uninstall_hook(env):
         with env.cr.savepoint():
             subcontracting_routes.unlink()
             operations_type_to_remove.unlink()
-    except:
+    except Exception:
         pass

--- a/addons/pos_online_payment/controllers/payment_portal.py
+++ b/addons/pos_online_payment/controllers/payment_portal.py
@@ -15,7 +15,7 @@ class PaymentPortal(payment_portal.PaymentPortal):
         try:
             order_sudo = self._document_check_access(
                 'pos.order', pos_order_id, access_token)
-        except:
+        except Exception:
             raise AccessError(
                 _("The provided order or access token is invalid."))
 

--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -160,7 +160,7 @@ class Survey(http.Controller):
         survey_sudo, dummy = self._fetch_from_access_token(survey_token, False)
         try:
             answer_sudo = survey_sudo._create_answer(user=request.env.user, test_entry=True)
-        except:
+        except Exception:
             return request.redirect('/')
         return request.redirect('/survey/start/%s?%s' % (survey_sudo.access_token, keep_query('*', answer_token=answer_sudo.access_token)))
 
@@ -186,7 +186,7 @@ class Survey(http.Controller):
                 test_entry=answer_sudo.test_entry,
                 **self._prepare_retry_additional_values(answer_sudo)
             )
-        except:
+        except Exception:
             return request.redirect("/")
         return request.redirect('/survey/start/%s?%s' % (survey_sudo.access_token, keep_query('*', answer_token=retry_answer_sudo.access_token)))
 
@@ -239,7 +239,7 @@ class Survey(http.Controller):
         if not answer_sudo:
             try:
                 survey_sudo.with_user(request.env.user).check_access('read')
-            except:
+            except Exception:
                 return request.redirect("/")
             else:
                 return request.render("survey.survey_403_page", {'survey': survey_sudo})

--- a/addons/website_crm/controllers/website_form.py
+++ b/addons/website_crm/controllers/website_form.py
@@ -26,7 +26,7 @@ class WebsiteForm(form.WebsiteForm):
         if model_record:
             try:
                 data = self.extract_data(model_record, request.params)
-            except:
+            except Exception:
                 # no specific management, super will do it
                 pass
             else:

--- a/addons/website_crm_partner_assign/tests/test_partner_assign.py
+++ b/addons/website_crm_partner_assign/tests/test_partner_assign.py
@@ -92,7 +92,7 @@ class TestPartnerAssign(TransactionCase):
         lead_forwarded = self.env['crm.lead.forward.to.partner'].with_context(context).create({})
         try:
             lead_forwarded.action_forward()
-        except:
+        except Exception:
             pass
 
 

--- a/addons/website_profile/controllers/main.py
+++ b/addons/website_profile/controllers/main.py
@@ -32,7 +32,7 @@ class WebsiteProfile(http.Controller):
         frontend applications like forum or elearning. """
         try:
             user = request.env['res.users'].sudo().browse(user_id).exists()
-        except:
+        except Exception:
             return False
         if user:
             return user.website_published and user.karma > 0

--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -784,7 +784,7 @@ class WebAsset(object):
             raise AssetError('%s is not utf-8 encoded.' % self.name)
         except IOError:
             raise AssetNotFound('File %s does not exist.' % self.name)
-        except:
+        except Exception:
             raise AssetError('Could not get content for %s.' % self.name)
 
     def minify(self):

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -348,7 +348,7 @@ class IrActionsAct_Window(models.Model):
                     eval_ctx = dict(self.env.context)
                     try:
                         ctx = safe_eval(values.get('context', '{}'), eval_ctx)
-                    except:
+                    except Exception:
                         ctx = {}
                     values['help'] = self.with_context(**ctx).env[model].get_empty_list_help(values.get('help', ''))
         return result

--- a/odoo/addons/base/tests/test_ir_actions.py
+++ b/odoo/addons/base/tests/test_ir_actions.py
@@ -79,7 +79,7 @@ _logger.warning("This is a %s warning %s", "test", "log")
 _logger.error("This is a %s error %s", "test", "log")
 try:
     0/0
-except:
+except Exception:
     _logger.exception("This is a %s exception %s", "test", "log")
 """,
         })

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -816,7 +816,7 @@ class GeventServer(CommonServer):
         _logger.info('Evented Service (longpolling) running on %s:%s', self.interface, self.port)
         try:
             self.httpd.serve_forever()
-        except:
+        except Exception:
             _logger.exception("Evented Service (longpolling): uncaught error during main loop")
             raise
 
@@ -1306,7 +1306,7 @@ class Worker(object):
                 if not self.alive:
                     break
                 self.process_work()
-        except:
+        except Exception:
             _logger.exception("Worker %s (%s) Exception occurred, exiting...", self.__class__.__name__, self.pid)
             sys.exit(1)
 

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -1457,7 +1457,7 @@ def parse_date(env: Environment, value: str, lang_code: str | None = None) -> da
     locale = babel_locale_parse(lang.code)
     try:
         return babel.dates.parse_date(value, locale=locale)
-    except:
+    except Exception:
         return value
 
 


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` for PEP 8 compliance. Bare except catches all exceptions including SystemExit, KeyboardInterrupt, and GeneratorExit, which is rarely intended.