### PR TITLE
[IMP] account: show e-invoice buttons on Vendor Bills action

### DIFF
--- a/addons/account/static/src/components/fetch_einvoices/fetch_einvoices_cog.js
+++ b/addons/account/static/src/components/fetch_einvoices/fetch_einvoices_cog.js
@@ -7,6 +7,77 @@ import { ACTIONS_GROUP_NUMBER } from "@web/search/action_menus/action_menus";
 
 const cogMenuRegistry = registry.category("cogMenu");
 
+const BUTTON_CONFIG = {
+    fetch: {
+        action: "button_fetch_in_einvoices",
+        field: "show_fetch_in_einvoices_button",
+        journalType: "purchase",
+        moveTypePrefix: "in_",
+        label: _t("Fetch e-Invoices"),
+    },
+    refresh: {
+        action: "button_refresh_out_einvoices_status",
+        field: "show_refresh_out_einvoices_status_button",
+        journalType: "sale",
+        moveTypePrefix: "out_",
+        label: _t("Refresh e-Invoices Status"),
+    },
+};
+
+function getButtonConfig(searchModel) {
+    const { globalContext, context } = searchModel;
+    const defaultMoveType = context.default_move_type || "";
+    for (const buttonConfig of Object.values(BUTTON_CONFIG)) {
+        if (globalContext[buttonConfig.field] || defaultMoveType.startsWith(buttonConfig.moveTypePrefix)) {
+            return buttonConfig;
+        }
+    }
+
+    return null;
+}
+
+async function getVisibleJournalIds(searchModel, buttonConfig, domain) {
+    const journals = await searchModel.orm.searchRead(
+        "account.journal",
+        domain,
+        ["id", buttonConfig.field],
+        { context: searchModel.context }
+    );
+    return journals.filter((j) => j[buttonConfig.field]).map((j) => j.id);
+}
+
+async function getRelevantJournalIds(searchModel, buttonConfig = getButtonConfig(searchModel)) {
+    if (!buttonConfig) {
+        return [];
+    }
+
+    const journalId = searchModel.globalContext.default_journal_id;
+    if (journalId) {
+        if (searchModel.globalContext[buttonConfig.field]) {
+            return [journalId];
+        }
+
+        return getVisibleJournalIds(searchModel, buttonConfig, [["id", "=", journalId]]);
+    }
+
+    // The button-visibility fields are computed/unstored, so filter after reading.
+    return getVisibleJournalIds(searchModel, buttonConfig, [["type", "=", buttonConfig.journalType]]);
+}
+
+async function getActionData(searchModel) {
+    const buttonConfig = getButtonConfig(searchModel);
+    if (!buttonConfig) {
+        return null;
+    }
+
+    const journalIds = await getRelevantJournalIds(searchModel, buttonConfig);
+    if (!journalIds.length) {
+        return null;
+    }
+
+    return { buttonConfig, journalIds };
+}
+
 export class FetchEInvoices extends Component {
     static template = "account.FetchEInvoices";
     static props = {};
@@ -17,28 +88,26 @@ export class FetchEInvoices extends Component {
         this.action = useService("action");
     }
 
-    get buttonAction() {
-        return this.env.searchModel.globalContext.show_fetch_in_einvoices_button
-            ? "button_fetch_in_einvoices"
-            : "button_refresh_out_einvoices_status";
+    get buttonConfig() {
+        return getButtonConfig(this.env.searchModel);
     }
 
     get buttonLabel() {
-        return this.env.searchModel.globalContext.show_fetch_in_einvoices_button
-            ? _t("Fetch e-Invoices")
-            : _t("Refresh e-Invoices Status");
+        return this.buttonConfig?.label;
     }
 
-    fetchEInvoices() {
-        const journalId = this.env.searchModel.globalContext.default_journal_id;
-        if (!journalId) {
+    async fetchEInvoices() {
+        const actionData = await getActionData(this.env.searchModel);
+        if (!actionData) {
             return;
         }
 
-        this.action.doActionButton({
+        const { buttonConfig, journalIds } = actionData;
+
+        await this.action.doActionButton({
             type: "object",
-            resId: journalId,
-            name: this.buttonAction,
+            resIds: journalIds,
+            name: buttonConfig.action,
             resModel: "account.journal",
             onClose: () => window.location.reload(),
         });
@@ -48,12 +117,13 @@ export class FetchEInvoices extends Component {
 export const fetchEInvoicesActionMenu = {
     Component: FetchEInvoices,
     groupNumber: ACTIONS_GROUP_NUMBER,
-    isDisplayed: ({ config, searchModel }) =>
-        searchModel.resModel === "account.move" &&
-        (searchModel.globalContext.default_journal_id || false) &&
-        (searchModel.globalContext.show_fetch_in_einvoices_button ||
-            searchModel.globalContext.show_refresh_out_einvoices_status_button ||
-            false),
+    isDisplayed: async ({ searchModel }) => {
+        if (searchModel.resModel !== "account.move") {
+            return false;
+        }
+
+        return Boolean(await getActionData(searchModel));
+    },
 };
 
 cogMenuRegistry.add("account-fetch-e-invoices", fetchEInvoicesActionMenu, { sequence: 11 });


### PR DESCRIPTION
Currently, when accessing Vendor Bills from the accounting menu, the 'Fetch e-invoices' and 'Refresh status' buttons may not be visible because the required journal visibility flags are missing from the context.

This commit replaces the static window action for the Vendor Bills menu with a new server action (`action_move_in_invoice_server`). This server action dynamically fetches the company's purchase journal and injects `default_journal_id`, `show_fetch_in_einvoices_button`, and `show_refresh_out_einvoices_status_button` directly into the action's context, ensuring the e-invoicing buttons are properly displayed in the list view.

Task-5945247

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
