### PR TITLE
[IMP] l10n_jo_edi_pos: make l10n_jo_edi_pos_{state, return_reason} readonly

### DIFF
--- a/addons/l10n_jo_edi_pos/models/pos_order.py
+++ b/addons/l10n_jo_edi_pos/models/pos_order.py
@@ -47,6 +47,10 @@ class PosOrder(models.Model):
             if order.country_code == 'JO' and not order.l10n_jo_edi_pos_uuid:
                 order.l10n_jo_edi_pos_uuid = uuid.uuid4()
 
+    @api.onchange('l10n_jo_edi_pos_state')
+    def _onchange_l10n_jo_edi_pos_state(self):
+        self.l10n_jo_edi_pos_qr = False
+
     def _get_order_scope_code(self):
         return '0'
 

--- a/addons/l10n_jo_edi_pos/views/pos_order_views.xml
+++ b/addons/l10n_jo_edi_pos/views/pos_order_views.xml
@@ -24,8 +24,9 @@
             </xpath>
 
             <group name="other_information" position="inside">
-                <field name="l10n_jo_edi_pos_state" invisible="country_code != 'JO'" readonly="l10n_jo_edi_pos_qr"/>
-                <field name="l10n_jo_edi_pos_return_reason" invisible="country_code !='JO' or not refunded_order_id" readonly="l10n_jo_edi_pos_qr"/>
+                <field name="l10n_jo_edi_pos_qr" invisible='1'/> <!-- Needed for _onchange_l10n_jo_edi_pos_state to update the QR properly -->
+                <field name="l10n_jo_edi_pos_state" invisible="country_code != 'JO'" readonly="l10n_jo_edi_pos_qr and l10n_jo_edi_pos_state == 'sent'"/>
+                <field name="l10n_jo_edi_pos_return_reason" invisible="country_code !='JO' or not refunded_order_id" readonly="l10n_jo_edi_pos_qr and l10n_jo_edi_pos_state == 'sent'"/>
             </group>
         </field>
     </record>


### PR DESCRIPTION
Before this commit:
- The fields `l10n_jo_edi_pos_{state, return_reason}` were readonly when 
  `l10n_jo_edi_pos_qr` was set. However, we did not take into account the fact
  that `pos.order` cannot be reset once `done/paid/invoiced`; thereby blocking
  the user with a demo transaction forever without any alternative.

After this commit:
- The fields `l10n_jo_edi_pos_{state, return_reason}` are readonly when
  `l10n_jo_edi_pos_qr and l10n_jo_edi_state == 'sent'`. Additionally, an 
  onchange is introduced on `l10n_jo_edi_pos_state` to clear 
  `l10n_jo_edi_pos_qr`. This gives back flexibility to the user to either delete
   the demo mode transaction or sync them to the production endpoint.

task-5958427