### PR TITLE
[FIX] purchase_stock: fix race condition and broken xpath in product catalog search panel

### DIFF
--- a/addons/purchase_stock/static/src/product_catalog/search/search_model.js
+++ b/addons/purchase_stock/static/src/product_catalog/search/search_model.js
@@ -49,7 +49,7 @@ export class PurchaseStockProductCatalogSearchModel extends AccountProductCatalo
      */
     async _fetchSections() {
         this._editSuggestContext();
-        super._fetchSections(...arguments);
+        await super._fetchSections(...arguments);
     }
 
     /**

--- a/addons/purchase_stock/static/src/product_catalog/search/search_panel.xml
+++ b/addons/purchase_stock/static/src/product_catalog/search/search_panel.xml
@@ -8,9 +8,10 @@
     </t>
     <t t-name="purchase_stock.ProductCatalogSearchPanelContent" t-inherit="account.ProductCatalogSearchPanelContent" t-inherit-mode="primary">
         <xpath expr="//section[hasclass('o_search_panel_sections')]" position="attributes">
-            <t t-if="suggest.suggestToggle.isOn">
-                <attribute name="class">o_search_panel_sections mt-4</attribute>
-            </t>
+            <attribute name="t-att-class">
+                suggest.suggestToggle.isOn ? 'mt-4' : 'mt-5'
+            </attribute>
+            <attribute name="class" separator=" " remove="mt-5"/>
         </xpath>
         <xpath expr="//section[hasclass('o_search_panel_sections')]" position="before">
             <t t-if="displaySuggest">


### PR DESCRIPTION
- `PurchaseStockProductCatalogSearchModel._fetchSections()` was calling `super._fetchSections()` without `await`, causing `sectionsPromise` to resolve immediately before sections finished loading. This made `expandDefaultValue()`, `expandValues()`, and `updateActiveValues()` run with empty sections in `onWillStart`, leaving `state.expanded` and `state.active` uninitialized and causing a crash when the template accessed `state.expanded[section.id][valueId]`.

```
UncaughtPromiseError > OwlError

Uncaught Promise > An error occured in the owl lifecycle (see this Error's "cause" property)

Occured on 127.0.0.19:8069 on 2026-02-24 10:16:04 GMT

OwlError: An error occured in the owl lifecycle (see this Error's "cause" property)
    Error: An error occured in the owl lifecycle (see this Error's "cause" property)
        at handleError (http://127.0.0.19:8069/web/assets/9723d8e/web.assets_web.min.js:762:101)
        at App.handleError (http://127.0.0.19:8069/web/assets/9723d8e/web.assets_web.min.js:1420:29)
        at Fiber._render (http://127.0.0.19:8069/web/assets/9723d8e/web.assets_web.min.js:787:19)
        at Fiber.render (http://127.0.0.19:8069/web/assets/9723d8e/web.assets_web.min.js:785:6)
        at ComponentNode.initiateRender (http://127.0.0.19:8069/web/assets/9723d8e/web.assets_web.min.js:855:47)

Caused by: TypeError: Cannot read properties of undefined (reading '1')
    at PurchaseSuggestCatalogSearchPanel.template (eval at compile (http://127.0.0.19:8069/web/assets/9723d8e/web.assets_web.min.js:1375:421), <anonymous>:25:69)
    at App.callTemplate (http://127.0.0.19:8069/web/assets/9723d8e/web.assets_web.min.js:1011:129)
    at PurchaseSuggestCatalogSearchPanel.template (eval at compile (http://127.0.0.19:8069/web/assets/9723d8e/web.assets_web.min.js:1375:421), <anonymous>:85:15)
    at PurchaseSuggestCatalogSearchPanel.template (eval at compile (http://127.0.0.19:8069/web/assets/9723d8e/web.assets_web.min.js:1375:421), <anonymous>:138:34)
    at PurchaseSuggestCatalogSearchPanel.template (eval at compile (http://127.0.0.19:8069/web/assets/9723d8e/web.assets_web.min.js:1375:421), <anonymous>:19:29)
    at Fiber._render (http://127.0.0.19:8069/web/assets/9723d8e/web.assets_web.min.js:786:96)
    at Fiber.render (http://127.0.0.19:8069/web/assets/9723d8e/web.assets_web.min.js:785:6)
    at ComponentNode.initiateRender (http://127.0.0.19:8069/web/assets/9723d8e/web.assets_web.min.js:855:47)
```

- `purchase_stock.ProductCatalogSearchPanelContent` had a broken xpath: a `<t t-if>` element inside `<xpath position="attributes">`. OWL's `modifyAttributes()` silently skips non-`<attribute>` children, so the conditional class was never applied. Replaced with a proper `t-att-class` ternary binding.