### PR TITLE
[IMP] im_livechat,*: improve 'preferences' menu 

### DIFF
--- a/addons/im_livechat/views/res_users_views.xml
+++ b/addons/im_livechat/views/res_users_views.xml
@@ -10,11 +10,12 @@
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='outgoing_mail_server_type']" position="after">
                     <field name="has_access_livechat" invisible="1"/>
-                    <field name="livechat_username" string="Live Chat Name" invisible="not has_access_livechat"/>
+                    <field name="livechat_username" string="Live Chat Name" invisible="not has_access_livechat" help="Nickname used in live chat conversations to protect your real name from visitors."/>
                     <field name="livechat_lang_ids" string="Spoken Languages"
                            options="{'no_create': True, 'no_edit': True, 'no_create_edit': True}"
                            widget="many2many_tags"
-                           invisible="not has_access_livechat"/>
+                           invisible="not has_access_livechat"
+                           help="Languages you can speak for live chat conversations."/>
                     <field name="livechat_expertise_ids" string="Expertise"
                            widget="many2many_tags"
                            options="{'no_create': True}"
@@ -31,11 +32,12 @@
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='outgoing_mail_server_type']" position="after">
                     <field name="has_access_livechat" invisible="1"/>
-                    <field name="livechat_username" string="Live Chat Name" invisible="not has_access_livechat"/>
+                    <field name="livechat_username" string="Live Chat Name" invisible="not has_access_livechat" help="Nickname used in live chat conversations to protect your real name from visitors."/>
                     <field name="livechat_lang_ids" string="Spoken Languages"
                            options="{'no_create': True, 'no_edit': True}"
                            widget="many2many_tags"
-                           invisible="not has_access_livechat"/>
+                           invisible="not has_access_livechat"
+                           help="Languages you can speak for live chat conversations."/>
                     <field name="livechat_expertise_ids" string="Expertise"
                            widget="many2many_tags"
                            options="{'no_create': True}"

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -32,9 +32,9 @@ class ResUsers(models.Model):
         'Notification', required=True, default='email',
         compute='_compute_notification_type', inverse='_inverse_notification_type', store=True,
         user_writeable=True,
-        help="Policy on how to handle Chatter notifications:\n"
-             "- By Emails: notifications are sent to your email address\n"
-             "- In Odoo: notifications appear in your Odoo Inbox")
+        help="How notifications for document messages and system updates are delivered:\n"
+             "- By email: Notifications are sent to your email address.\n"
+             "- In Odoo: Notifications appear in your Odoo inbox.")
     presence_ids = fields.One2many("mail.presence", "user_id", groups="base.group_system")
     # OOO management
     out_of_office_from = fields.Datetime(user_writeable=True)

--- a/addons/mail/static/src/discuss/call/common/call_permission_denied_dialog.js
+++ b/addons/mail/static/src/discuss/call/common/call_permission_denied_dialog.js
@@ -1,16 +1,14 @@
-import { Component } from "@odoo/owl";
-
-import { Dialog } from "@web/core/dialog/dialog";
 import { _t } from "@web/core/l10n/translation";
+import { NotificationAlertDialog } from "@web/core/notification_alert_dialog/notification_alert_dialog";
 import { useService } from "@web/core/utils/hooks";
 
-export class CallPermissionDeniedDialog extends Component {
-    static template = "discuss.CallPermissionDeniedDialog";
-    static components = { Dialog };
-    static props = {
-        close: Function,
-        permissionType: { type: String, optional: true },
+export class CallPermissionDeniedDialog extends NotificationAlertDialog {
+    static defaultProps = {
+        ...NotificationAlertDialog.defaultProps,
+        animateMouse: false,
     };
+    static props = [...NotificationAlertDialog.props, "permissionType?"];
+    static template = "discuss.CallPermissionDeniedDialog";
 
     setup() {
         this.ui = useService("ui");

--- a/addons/mail/static/src/discuss/call/common/call_permission_denied_dialog.xml
+++ b/addons/mail/static/src/discuss/call/common/call_permission_denied_dialog.xml
@@ -1,85 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="discuss.CallPermissionDeniedDialog">
-        <Dialog title="''" size="'md'" contentClass="'o-discuss-CallPermissionDeniedDialog'">
-            <div class="d-flex align-items-center justify-content-between gap-4" t-att-class="this.ui.isSmall ? 'flex-column': 'flex-row pb-2'">
-                <div t-att-class="this.ui.isSmall ? 'w-100': 'w-50'">
-                    <t t-call="discuss.CallPermissionDeniedDialog.illustrationAnimated"/>
-                </div>
-                <div class="d-flex flex-column gap-3">
-                    <h2 class="mb-0" t-out="this.title" />
-                    <ol class="ps-3 fs-6 d-flex flex-column gap-2 text-muted" t-attf-style="width: {{ this.ui.isSmall ? '100%' : '85%' }};">
-                        <li>
-                            Click the
-                            <t t-call="discuss.CallPermissionDeniedDialog.slidersIcon"/>
-                            page info icon in your browser's address bar
-                        </li>
-                        <li t-out="this.stepTwoText"/>
-                    </ol>
-                </div>
-            </div>
-        </Dialog>
+        <PermissionPromptDialog title="''" size="'md'" close="this.props.close" illustrationPosition="'left'" contentClass="'o-discuss-CallPermissionDeniedDialog'">
+            <t t-set-slot="illustration">
+                <t t-call="discuss.CallPermissionDeniedDialog.illustrationAnimated"/>
+            </t>
+            <t t-set-slot="instructions">
+                <h2 t-out="this.title" />
+                <ol class="ps-3 fs-6 d-flex flex-column gap-2 text-muted">
+                    <li t-out="this.stepOneText"/>
+                    <li t-out="this.stepTwoText"/>
+                </ol>
+            </t>
+        </PermissionPromptDialog>
     </t>
 
     <t t-name="discuss.CallPermissionDeniedDialog.illustrationAnimated">
-        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="o-discuss-CallPermissionDeniedDialog-illustrationAnimated" role="img" aria-label="Permissions Toggle - Animated illustration" width="100%" height="auto" viewBox="0 0 264 250" fill="none">
-            <title>Permissions Toggle</title>
-            <description>Animated illustration showing toggles for camera and microphone permissions</description>
+        <t t-call="web.PermissionIllustration">
+            <t t-set="viewBoxHeight" t-value="250"/>
             <g>
-                <path d="M281 1H7C3.68629 1 1 3.68629 1 7V253" stroke="var(--border-color)" stroke-width="2"/>
-                <g>
-                    <rect x="27" y="119" width="20" height="17" stroke="var(--primary)" stroke-width="2" stroke-linejoin="round"/>
-                    <path d="M53 122V134L47 131V125L53 122Z" stroke="var(--primary)" stroke-width="2" stroke-linejoin="round"/>
-                </g>
-                <g>
-                    <rect class="o-discuss-CallPermissionDeniedDialog-illustrationAnimated-camera-toggleRect" x="94" y="116" width="45" height="24" rx="12" fill="var(--gray-300)"/>
-                    <circle class="o-discuss-CallPermissionDeniedDialog-illustrationAnimated-camera-toggleCircle" cx="106" cy="128" r="10" fill="#ffffff"/>
-                </g>
-                <g>
-                    <path d="M39.6367 164C42.1763 164 44.2422 166.069 44.2422 168.631V177.976C44.2421 180.537 42.1762 182.606 39.6367 182.606C37.0971 182.606 35.0304 180.537 35.0303 177.976V168.631C35.0303 166.069 37.097 164 39.6367 164Z" stroke="var(--primary)" stroke-width="2"/>
-                    <path d="M39.6364 186.561C34.8666 186.561 31 182.626 31 177.773M39.6364 186.561C44.4061 186.561 48.2727 182.626 48.2727 177.773M39.6364 186.561V193" stroke="var(--primary)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                </g>
-                <g>
-                    <rect class="o-discuss-CallPermissionDeniedDialog-illustrationAnimated-mic-toggleRect" x="94" y="164" width="45" height="24" rx="12" fill="var(--gray-300)"/>
-                    <circle class="o-discuss-CallPermissionDeniedDialog-illustrationAnimated-mic-toggleCircle" cx="106" cy="176" r="10" fill="#ffffff"/>
-                </g>
-                <path d="M299 38.7333H227.173C221.65 38.7333 217.173 34.2562 217.173 28.7333V17C217.173 11.4772 212.695 7 207.173 7H108.934C103.411 7 98.9339 11.4771 98.9339 17V28.7333C98.9339 34.2562 94.4568 38.7333 88.9339 38.7333H3M3 82L299 81.2237" stroke="var(--gray-300)" stroke-width="2"/>
-                <g>
-                    <path d="M30 60.5H18M18 60.5L22.8649 65M18 60.5L22.8649 56" stroke="var(--border-color)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                    <path d="M48 60H59M59 60L54.5405 64.5M59 60L54.5405 55.5" stroke="var(--border-color)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                    <path d="M91 60.1179C91 61.3024 90.559 62.4464 89.7592 63.3369C88.9594 64.2274 87.8553 64.8036 86.6526 64.9582C85.45 65.1128 84.2308 64.8352 83.2222 64.1772C82.2135 63.5192 81.4843 62.5256 81.1704 61.3815C80.8564 60.2374 80.9791 59.0209 81.5156 57.9587C82.0522 56.8964 82.9659 56.0608 84.0866 55.6075C85.2073 55.1543 86.4585 55.1143 87.6072 55.495C88.7559 55.8757 89.7236 56.6512 90.3301 57.6769M90.3301 57.6769H87.6072M90.3301 57.6769V55" stroke="var(--border-color)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                    <g>
-                        <rect x="171" y="47" width="120" height="26" fill="var(--gray-300)" stroke="var(--border-color)" stroke-width="2"/>
-                        <circle cx="145" cy="60.5" r="34" fill="var(--body-bg)" stroke="var(--primary)" stroke-width="2"/>
-                        <path d="M165.947 35C173.306 41.0523 178 50.2279 178 60.5C178 71.9795 172.137 82.0882 163.244 88H143.473V87.9619C129.296 87.261 118 75.6956 118 61.5C118 47.3045 129.296 35.7391 143.473 35.0381V35H165.947Z" fill="var(--gray-300)"/>
-                        <circle cx="145" cy="61.7496" r="21" fill="var(--body-bg)"/>
-                        <g>
-                            <circle cx="135.333" cy="55.0829" r="3.33333" stroke="var(--primary)" stroke-width="3"/>
-                            <path d="M144.5 55.0829L157 55.0829" stroke="var(--primary)" stroke-width="3" stroke-linecap="round"/>
-                            <circle cx="3.33333" cy="3.33333" r="3.33333" transform="matrix(-1 0 0 1 157 65.0829)" stroke="var(--primary)" stroke-width="3"/>
-                            <path d="M144.5 68.4163H132" stroke="var(--primary)" stroke-width="3" stroke-linecap="round"/>
-                        </g>
-                    </g>
-                </g>
-                <path d="M160.387 73.9249C160.751 73.7657 161.175 73.8367 161.467 74.1065L179.036 90.3575C179.283 90.5866 179.399 90.9253 179.343 91.2579C179.286 91.5906 179.066 91.8727 178.757 92.0079L172.914 94.5606L177.038 103.995V103.996C177.748 105.622 177.007 107.517 175.381 108.229C173.754 108.94 171.858 108.197 171.147 106.57L167.023 97.1358L161.181 99.6895C160.872 99.8246 160.516 99.7942 160.233 99.6094C159.951 99.4246 159.781 99.1099 159.781 98.7725L159.787 74.8409C159.787 74.4437 160.023 74.0841 160.387 73.9249Z" fill="var(--white)" stroke="var(--gray-400)" stroke-width="2" stroke-linejoin="round"/>
-                <g>
-                    <circle cx="40" cy="21" r="5" fill="var(--border-color)"/>
-                    <circle cx="60" cy="21" r="5" fill="var(--border-color)"/>
-                    <circle cx="20" cy="21" r="5" fill="var(--border-color)"/>
-                </g>
+                <rect x="27" y="119" width="20" height="17" stroke="var(--primary)" stroke-width="2" stroke-linejoin="round"/>
+                <path d="M53 122V134L47 131V125L53 122Z" stroke="var(--primary)" stroke-width="2" stroke-linejoin="round"/>
             </g>
-        </svg>
-    </t>
-
-    <t t-name="discuss.CallPermissionDeniedDialog.slidersIcon">
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-            viewBox="0 0 24 24" fill="none" stroke="currentColor"
-            stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"
-        >
-            <path d="M14 17H5"></path>
-            <path d="M19 7h-9"></path>
-            <circle cx="17" cy="17" r="3"></circle>
-            <circle cx="7" cy="7" r="3"></circle>
-        </svg>
+            <g>
+                <rect class="o-discuss-CallPermissionDeniedDialog-illustrationAnimated-camera-toggleRect" x="94" y="116" width="45" height="24" rx="12" fill="var(--gray-300)"/>
+                <circle class="o-discuss-CallPermissionDeniedDialog-illustrationAnimated-camera-toggleCircle" cx="106" cy="128" r="10" fill="#ffffff"/>
+            </g>
+            <g>
+                <path d="M39.6367 164C42.1763 164 44.2422 166.069 44.2422 168.631V177.976C44.2421 180.537 42.1762 182.606 39.6367 182.606C37.0971 182.606 35.0304 180.537 35.0303 177.976V168.631C35.0303 166.069 37.097 164 39.6367 164Z" stroke="var(--primary)" stroke-width="2"/>
+                <path d="M39.6364 186.561C34.8666 186.561 31 182.626 31 177.773M39.6364 186.561C44.4061 186.561 48.2727 182.626 48.2727 177.773M39.6364 186.561V193" stroke="var(--primary)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </g>
+            <g>
+                <rect class="o-discuss-CallPermissionDeniedDialog-illustrationAnimated-mic-toggleRect" x="94" y="164" width="45" height="24" rx="12" fill="var(--gray-300)"/>
+                <circle class="o-discuss-CallPermissionDeniedDialog-illustrationAnimated-mic-toggleCircle" cx="106" cy="176" r="10" fill="#ffffff"/>
+            </g>
+        </t>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/call/common/call_permission_dialog.js
+++ b/addons/mail/static/src/discuss/call/common/call_permission_dialog.js
@@ -1,11 +1,10 @@
 import { Component } from "@odoo/owl";
-import { Dialog } from "@web/core/dialog/dialog";
-
 import { _t } from "@web/core/l10n/translation";
+import { PermissionPromptDialog } from "@web/core/permission_prompt_dialog/permission_prompt_dialog";
 import { useService } from "@web/core/utils/hooks";
 
 export class CallPermissionDialog extends Component {
-    static components = { Dialog };
+    static components = { PermissionPromptDialog };
     static props = {
         close: Function,
         media: {

--- a/addons/mail/static/src/discuss/call/common/call_permission_dialog.xml
+++ b/addons/mail/static/src/discuss/call/common/call_permission_dialog.xml
@@ -2,19 +2,19 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.CallPermissionDialog">
-        <Dialog title="''" size="'md'">
-            <div class="d-flex flex-fill align-items-center gap-3" t-att-class="{ 'flex-column-reverse': this.ui.isSmall }">
-                <div>
-                    <h2 t-out="this.permissionPrompt"/>
-                    <p class="text-muted" t-out="this.permissionNote"/>
-                </div>
+        <PermissionPromptDialog title="''" close="this.props.close" illustrationPosition="'right'">
+            <t t-set-slot="illustration">
                 <t t-call="discuss.CallPermissionDialogImg"/>
-            </div>
+            </t>
+            <t t-set-slot="instructions">
+                <h2 t-out="this.permissionPrompt"/>
+                <p class="text-muted" t-out="this.permissionNote"/>
+            </t>
             <t t-set-slot="footer">
                 <button class="btn btn-primary" t-on-click="this.props.media === 'microphone' ? this.onClickUseMicrophone : this.onClickUseCamera" t-out="this.primaryActionText"/>
                 <button class="btn btn-secondary" t-if="this.props.suggestAllMedias and this.rtc.cameraPermission !== 'granted' and this.rtc.microphonePermission !== 'granted'" t-on-click="this.onClickUseMicAndCamera">Use microphone and camera</button>
             </t>
-        </Dialog>
+        </PermissionPromptDialog>
     </t>
 
     <t t-name="discuss.CallPermissionDialogImg">

--- a/addons/web/static/src/core/notification_alert_dialog/notification_alert_dialog.js
+++ b/addons/web/static/src/core/notification_alert_dialog/notification_alert_dialog.js
@@ -1,0 +1,20 @@
+import { Component, markup } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
+import { PermissionPromptDialog } from "@web/core/permission_prompt_dialog/permission_prompt_dialog";
+
+const SLIDERS_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M14 17H5"></path><path d="M19 7h-9"></path><circle cx="17" cy="17" r="3"></circle><circle cx="7" cy="7" r="3"></circle></svg>`;
+
+export class NotificationAlertDialog extends Component {
+    static components = { PermissionPromptDialog };
+    static defaultProps = {
+        animateMouse: true,
+    };
+    static props = ["animateMouse?", "close"];
+    static template = "web.NotificationAlertDialog";
+
+    get stepOneText() {
+        return _t("Click the %(icon)s page info icon in your browser's address bar.", {
+            icon: markup(SLIDERS_ICON_SVG),
+        });
+    }
+}

--- a/addons/web/static/src/core/notification_alert_dialog/notification_alert_dialog.scss
+++ b/addons/web/static/src/core/notification_alert_dialog/notification_alert_dialog.scss
@@ -1,0 +1,38 @@
+.o-NotificationAlertDialog-toggleRect {
+    animation: o-NotificationAlertDialog-toggle-fill 4.6s linear infinite;
+    animation-delay: 1.8s;
+}
+
+.o-NotificationAlertDialog-toggleCircle {
+    animation: o-NotificationAlertDialog-toggle-move 4.6s linear infinite;
+    animation-delay: 1.8s;
+}
+
+.o-PermissionIllustration-mouse {
+    animation: o-PermissionIllustration-mouse-move 4.6s linear infinite;
+    animation-delay: 1s;
+}
+
+@keyframes o-NotificationAlertDialog-toggle-fill {
+    0%   { fill: var(--gray-300); }
+    6.5% { fill: var(--primary); }
+    45%  { fill: var(--primary); }
+    52%  { fill: var(--gray-300); }
+    100% { fill: var(--gray-300); }
+}
+
+@keyframes o-NotificationAlertDialog-toggle-move {
+    0%   { transform: translateX(0); }
+    6.5% { transform: translateX(21px); }
+    45%  { transform: translateX(21px); }
+    52%  { transform: translateX(0); }
+    100% { transform: translateX(0); }
+}
+
+@keyframes o-PermissionIllustration-mouse-move {
+    0%   { transform: translate(0 , 0); }
+    10% { transform: translate(-50px , 55px); }
+    30%  { transform: translate(-50px , 55px); }
+    45%  { transform: translate(0 , 0); }
+    100% { transform: translate(0 , 0); }
+}

--- a/addons/web/static/src/core/notification_alert_dialog/notification_alert_dialog.xml
+++ b/addons/web/static/src/core/notification_alert_dialog/notification_alert_dialog.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="web.NotificationAlertDialog">
+        <PermissionPromptDialog title.translate="Want to stay updated with notifications?" size="'sm'" close="this.props.close">
+            <t t-set-slot="illustration">
+                <t t-call="web.NotificationAlertDialog.illustrationAnimated"/>
+            </t>
+            <t t-set-slot="instructions">
+                <ol class="ps-3 fs-5 d-flex flex-column gap-2 text-muted mb-2">
+                    <li t-out="this.stepOneText"/>
+                    <li>Enable notifications.</li>
+                </ol>
+            </t>
+        </PermissionPromptDialog>
+    </t>
+
+    <t t-name="web.NotificationAlertDialog.illustrationAnimated">
+        <t t-call="web.PermissionIllustration">
+            <g>
+                <path id="notifications" d="M32.5544 136.75C32.2003 136.75 31.9034 136.63 31.6638 136.391C31.4242 136.151 31.3044 135.854 31.3044 135.5C31.3044 135.146 31.4242 134.849 31.6638 134.609C31.9034 134.37 32.2003 134.25 32.5544 134.25H33.8044V125.5C33.8044 123.771 34.3253 122.234 35.3669 120.891C36.4086 119.547 37.7628 118.667 39.4294 118.25V117.375C39.4294 116.854 39.6117 116.411 39.9763 116.047C40.3409 115.682 40.7836 115.5 41.3044 115.5C41.8253 115.5 42.268 115.682 42.6326 116.047C42.9972 116.411 43.1794 116.854 43.1794 117.375V118.25C44.8461 118.667 46.2003 119.547 47.2419 120.891C48.2836 122.234 48.8044 123.771 48.8044 125.5V134.25H50.0544C50.4086 134.25 50.7055 134.37 50.9451 134.609C51.1847 134.849 51.3044 135.146 51.3044 135.5C51.3044 135.854 51.1847 136.151 50.9451 136.391C50.7055 136.63 50.4086 136.75 50.0544 136.75H32.5544ZM41.3044 140.5C40.6169 140.5 40.0284 140.255 39.5388 139.766C39.0492 139.276 38.8044 138.688 38.8044 138H43.8044C43.8044 138.688 43.5597 139.276 43.0701 139.766C42.5805 140.255 41.9919 140.5 41.3044 140.5ZM36.3044 134.25H46.3044V125.5C46.3044 124.125 45.8149 122.948 44.8357 121.969C43.8565 120.99 42.6794 120.5 41.3044 120.5C39.9294 120.5 38.7524 120.99 37.7732 121.969C36.794 122.948 36.3044 124.125 36.3044 125.5V134.25Z" fill="var(--primary)" />
+            </g>
+            <g>
+                <rect class="o-NotificationAlertDialog-toggleRect" x="94" y="116" width="45" height="24" rx="12" fill="var(--gray-300)"/>
+                <circle class="o-NotificationAlertDialog-toggleCircle" cx="106" cy="128" r="10" fill="#ffffff"/>
+            </g>
+        </t>
+    </t>
+
+    <t t-name="web.PermissionIllustration">
+        <svg class="o-PermissionIllustration" role="img" aria-label="Permissions Toggle - Animated illustration" width="100%" height="auto" t-attf-viewBox="0 0 264 {{viewBoxHeight or 180}}" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+            <title>Permissions Toggle</title>
+            <description>Animated illustration showing toggles for permissions</description>
+            <g>
+                <path d="M281 1H7C3.68629 1 1 3.68629 1 7V253" stroke="var(--border-color)" stroke-width="2"/>
+                <t t-out="0"/>
+                <path d="M299 38.7333H227.173C221.65 38.7333 217.173 34.2562 217.173 28.7333V17C217.173 11.4772 212.695 7 207.173 7H108.934C103.411 7 98.9339 11.4771 98.9339 17V28.7333C98.9339 34.2562 94.4568 38.7333 88.9339 38.7333H3M3 82L299 81.2237" stroke="var(--gray-300)" stroke-width="2"/>
+                <g>
+                    <path d="M30 60.5H18M18 60.5L22.8649 65M18 60.5L22.8649 56" stroke="var(--border-color)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M48 60H59M59 60L54.5405 64.5M59 60L54.5405 55.5" stroke="var(--border-color)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M91 60.1179C91 61.3024 90.559 62.4464 89.7592 63.3369C88.9594 64.2274 87.8553 64.8036 86.6526 64.9582C85.45 65.1128 84.2308 64.8352 83.2222 64.1772C82.2135 63.5192 81.4843 62.5256 81.1704 61.3815C80.8564 60.2374 80.9791 59.0209 81.5156 57.9587C82.0522 56.8964 82.9659 56.0608 84.0866 55.6075C85.2073 55.1543 86.4585 55.1143 87.6072 55.495C88.7559 55.8757 89.7236 56.6512 90.3301 57.6769M90.3301 57.6769H87.6072M90.3301 57.6769V55" stroke="var(--border-color)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    <g>
+                        <rect x="171" y="47" width="120" height="26" fill="var(--gray-300)" stroke="var(--border-color)" stroke-width="2"/>
+                        <circle cx="145" cy="60.5" r="34" fill="var(--body-bg)" stroke="var(--primary)" stroke-width="2"/>
+                        <path d="M165.947 35C173.306 41.0523 178 50.2279 178 60.5C178 71.9795 172.137 82.0882 163.244 88H143.473V87.9619C129.296 87.261 118 75.6956 118 61.5C118 47.3045 129.296 35.7391 143.473 35.0381V35H165.947Z" fill="var(--gray-300)"/>
+                        <circle cx="145" cy="61.7496" r="21" fill="var(--body-bg)"/>
+                        <g>
+                            <circle cx="135.333" cy="55.0829" r="3.33333" stroke="var(--primary)" stroke-width="3"/>
+                            <path d="M144.5 55.0829L157 55.0829" stroke="var(--primary)" stroke-width="3" stroke-linecap="round"/>
+                            <circle cx="3.33333" cy="3.33333" r="3.33333" transform="matrix(-1 0 0 1 157 65.0829)" stroke="var(--primary)" stroke-width="3"/>
+                            <path d="M144.5 68.4163H132" stroke="var(--primary)" stroke-width="3" stroke-linecap="round"/>
+                        </g>
+                    </g>
+                </g>
+                <path t-att-class="this.props.animateMouse ? 'o-PermissionIllustration-mouse' : ''" d="M160.387 73.9249C160.751 73.7657 161.175 73.8367 161.467 74.1065L179.036 90.3575C179.283 90.5866 179.399 90.9253 179.343 91.2579C179.286 91.5906 179.066 91.8727 178.757 92.0079L172.914 94.5606L177.038 103.995V103.996C177.748 105.622 177.007 107.517 175.381 108.229C173.754 108.94 171.858 108.197 171.147 106.57L167.023 97.1358L161.181 99.6895C160.872 99.8246 160.516 99.7942 160.233 99.6094C159.951 99.4246 159.781 99.1099 159.781 98.7725L159.787 74.8409C159.787 74.4437 160.023 74.0841 160.387 73.9249Z" fill="var(--white)" stroke="var(--gray-400)" stroke-width="2" stroke-linejoin="round"/>
+                <g>
+                    <circle cx="40" cy="21" r="5" fill="var(--border-color)"/>
+                    <circle cx="60" cy="21" r="5" fill="var(--border-color)"/>
+                    <circle cx="20" cy="21" r="5" fill="var(--border-color)"/>
+                </g>
+            </g>
+        </svg>
+    </t>
+
+</templates>

--- a/addons/web/static/src/core/permission_prompt_dialog/permission_prompt_dialog.js
+++ b/addons/web/static/src/core/permission_prompt_dialog/permission_prompt_dialog.js
@@ -1,0 +1,20 @@
+import { Component } from "@odoo/owl";
+import { Dialog } from "@web/core/dialog/dialog";
+import { useService } from "@web/core/utils/hooks";
+
+export class PermissionPromptDialog extends Component {
+    static components = { Dialog };
+    static template = "web.PermissionPromptDialog";
+    static props = [
+        "title?",
+        "contentClass?",
+        "close?",
+        "slots?",
+        "size?",
+        "illustrationPosition?",
+    ];
+
+    setup() {
+        this.ui = useService("ui");
+    }
+}

--- a/addons/web/static/src/core/permission_prompt_dialog/permission_prompt_dialog.xml
+++ b/addons/web/static/src/core/permission_prompt_dialog/permission_prompt_dialog.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="web.PermissionPromptDialog">
+        <Dialog title="this.props.title or ''" size="this.props.size or 'md'" contentClass="this.props.contentClass">
+            <t t-if="this.props.illustrationPosition === 'left'">
+                <div class="d-flex align-items-center justify-content-between gap-4" t-att-class="this.ui.isSmall ? 'flex-column': 'flex-row pb-2'">
+                    <div t-att-class="this.ui.isSmall ? 'w-100': 'w-50'">
+                        <t t-slot="illustration"/>
+                    </div>
+                    <div t-if="this.props.slots.instructions" class="d-flex flex-column gap-3">
+                        <t t-slot="instructions"/>
+                    </div>
+                </div>
+            </t>
+            <t t-elif="this.props.illustrationPosition === 'right'">
+                <div class="d-flex flex-fill align-items-center gap-3" t-att-class="this.ui.isSmall ? 'flex-column-reverse' : ''">
+                    <div t-if="this.props.slots.instructions">
+                        <t t-slot="instructions"/>
+                    </div>
+                    <t t-slot="illustration"/>
+                </div>
+            </t>
+            <t t-else="">
+                <div class="d-flex flex-column align-items-center gap-4">
+                    <div class="w-75">
+                        <t t-slot="illustration"/>
+                    </div>
+                    <t t-if="this.props.slots.instructions">
+                        <t t-slot="instructions"/>
+                    </t>
+                </div>
+            </t>
+            <t t-if="this.props.slots.footer" t-set-slot="footer">
+                <t t-slot="footer"/>
+            </t>
+        </Dialog>
+    </t>
+</templates>

--- a/addons/web/static/src/views/widgets/notification_alert/notification_alert.js
+++ b/addons/web/static/src/views/widgets/notification_alert/notification_alert.js
@@ -1,16 +1,10 @@
+import { Component } from "@odoo/owl";
+
 import { browser } from "@web/core/browser/browser";
-import { Dialog } from "@web/core/dialog/dialog";
+import { NotificationAlertDialog } from "@web/core/notification_alert_dialog/notification_alert_dialog";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
-
-import { Component } from "@odoo/owl";
-
-export class NotificationAlertDialog extends Component {
-    static components = { Dialog };
-    static props = ["close"];
-    static template = "web.NotificationAlertDialog";
-}
 
 export class NotificationAlert extends Component {
     static props = standardWidgetProps;

--- a/addons/web/static/src/views/widgets/notification_alert/notification_alert.js
+++ b/addons/web/static/src/views/widgets/notification_alert/notification_alert.js
@@ -1,15 +1,31 @@
 import { browser } from "@web/core/browser/browser";
+import { Dialog } from "@web/core/dialog/dialog";
 import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
 import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
 
 import { Component } from "@odoo/owl";
+
+export class NotificationAlertDialog extends Component {
+    static components = { Dialog };
+    static props = ["close"];
+    static template = "web.NotificationAlertDialog";
+}
 
 export class NotificationAlert extends Component {
     static props = standardWidgetProps;
     static template = "web.NotificationAlert";
 
+    setup() {
+        this.dialog = useService("dialog");
+    }
+
     get isNotificationBlocked() {
         return browser.Notification && browser.Notification.permission === "denied";
+    }
+
+    openNotificationDialog() {
+        this.dialog.add(NotificationAlertDialog);
     }
 }
 

--- a/addons/web/static/src/views/widgets/notification_alert/notification_alert.xml
+++ b/addons/web/static/src/views/widgets/notification_alert/notification_alert.xml
@@ -1,8 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="web.NotificationAlert">
-        <div t-if="this.isNotificationBlocked" class="alert alert-primary text-center">
-            Odoo Push notifications have been blocked. Go to your browser settings to allow them.
+        <div t-if="this.isNotificationBlocked" class="alert alert-info text-center">
+            Push notifications are blocked. Enable them in your browser settings to stay updated when you're away.
+            <button class="btn btn-link p-0 align-baseline" t-on-click="this.openNotificationDialog">(?)</button>
         </div>
+    </t>
+
+    <t t-name="web.NotificationAlertDialog">
+        <Dialog title="''" size="'md'">
+            <div>
+                <!-- Space for Design Illustration -->
+            </div>
+            <t t-set-slot="footer">
+                <button class="btn btn-primary" t-on-click="props.close">Got it</button>
+            </t>
+        </Dialog>
     </t>
 </templates>

--- a/addons/web/static/src/views/widgets/notification_alert/notification_alert.xml
+++ b/addons/web/static/src/views/widgets/notification_alert/notification_alert.xml
@@ -6,15 +6,4 @@
             <button class="btn btn-link p-0 align-baseline" t-on-click="this.openNotificationDialog">(?)</button>
         </div>
     </t>
-
-    <t t-name="web.NotificationAlertDialog">
-        <Dialog title="''" size="'md'">
-            <div>
-                <!-- Space for Design Illustration -->
-            </div>
-            <t t-set-slot="footer">
-                <button class="btn btn-primary" t-on-click="props.close">Got it</button>
-            </t>
-        </Dialog>
-    </t>
 </templates>


### PR DESCRIPTION
*= mail, web

**Purpose of this PR:**

Before this commit, preferences for notifications and live chat were not clear: 
`notification_type` had no explanation of email vs in-app delivery, Live Chat Name and Spoken Languages had no help text and the push notification banner used unclear wording. When push notifications were blocked, users only saw a plain alert with no guidance.

After this commit, help texts and the push notification message explain what each option does and what users should do, so partners and end users can configure notifications and live chat more easily. A dialog with an illustration is now shown when push notifications are blocked, giving users clearer context and actionable guidance.

design PR: https://github.com/odoo-dev/odoo/pull/5030

Visual of `notificationAlertDialog` : credits @edi-odoo :sparkles:

![vokoscreenNG-2026-03-02_18-46-05](https://github.com/user-attachments/assets/798f9e10-5eb8-43a8-9b33-824eb67fb7f2)



task-5873818