### PR TITLE
[FIX] pos_mercado_pago: typo in webhook

### DIFF
--- a/addons/pos_mercado_pago/static/src/app/utils/payment/payment_mercado_pago.js
+++ b/addons/pos_mercado_pago/static/src/app/utils/payment/payment_mercado_pago.js
@@ -59,7 +59,7 @@ export class PaymentMercadoPago extends PaymentInterface {
                 payload.config_id === this.pos.config.id &&
                 payload.payment_method_id === this.payment_method_id.id
             ) {
-                const pendingLine = this.getPendingPaymentLine("mercado_pago");
+                const pendingLine = this.pos.getPendingPaymentLine("mercado_pago");
 
                 if (pendingLine) {
                     pendingLine.payment_method_id.payment_terminal.handleMercadoPagoWebhook();


### PR DESCRIPTION
On receiving a message from Mercado Pago on the webhook, there was a typo causing a traceback and preventing the payment from being confirmed. This commit corrects the typo.

opw-5953884


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
