### PR TITLE
[FIX] sale_mrp: correct qty_delivered for kit with same components

### DIFF
--- a/addons/sale_mrp/models/stock_rule.py
+++ b/addons/sale_mrp/models/stock_rule.py
@@ -9,17 +9,3 @@ class StockRule(models.Model):
         if values.get('sale_line_id'):
             res['sale_line_id'] = values['sale_line_id']
         return res
-
-    def _get_stock_move_values(self, product_id, product_qty, product_uom, location_dest_id, name, origin, company_id, values):
-        move_values = super()._get_stock_move_values(product_id, product_qty, product_uom, location_dest_id, name, origin, company_id, values)
-        if (sol_id := values.get('sale_line_id')) is not None and 'product_id' in move_values:
-            # if the SOL is for a kit
-            sol = self.env['sale.order.line'].browse(sol_id)
-            if move_values['product_id'] != sol.product_id.id:
-                active_moves = sol.move_ids.filtered(lambda m: m.state != 'cancel')
-                bom_line_id = active_moves.bom_line_id.filtered(
-                    lambda bl: bl.product_id.id == move_values.get('product_id')
-                )[:1].id
-                if bom_line_id:
-                    move_values['bom_line_id'] = bom_line_id
-        return move_values

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -2613,7 +2613,9 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
         """Test that a Sale Order with a kit product containing multiple identical components
         can be confirmed, and that the picking is created correctly. Then verify that the
         Sale Order can be cancelled and re-confirmed, resulting in a new picking with moves
-        properly linked to each BOM line. Finally, test returning a kit component for exchange."""
+        properly linked to each BOM line. Finally, test returning a kit component for exchange
+        and ensure the delivered quantity is correctly computed.
+        """
         # Create a kit product with two identical components by duplicating the first BOM line
         self.bom_kit_1.bom_line_ids = self.bom_kit_1.bom_line_ids[0]
         self.env['mrp.bom.line'].create([
@@ -2662,10 +2664,8 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
         exchange_picking = so.picking_ids.filtered(lambda so: so.state == 'assigned')
         exchange_picking.button_validate()
         so.order_line._compute_qty_delivered()
-        # In the case where the kit has multiple identical components, only the first BOM line
-        # is linked to all moves (this is a known limitation).
-        self.assertEqual(exchange_picking.move_ids.bom_line_id, self.bom_kit_1.bom_line_ids[0], "All moves in the exchange picking should be linked to the first BOM line.")
-        self.assertEqual(exchange_picking.move_ids.quantity, 2)
+        self.assertEqual(exchange_picking.move_ids.bom_line_id, self.bom_kit_1.bom_line_ids, "All moves in the exchange picking should be linked to it's corresponding BOM line.")
+        self.assertEqual(so.order_line.qty_delivered, 1, "Exchange return of a kit with identical components must correctly calculate the delivered quantity.")
 
     def test_delivery_after_splitting_production(self):
         """

--- a/addons/sale_mrp/wizard/__init__.py
+++ b/addons/sale_mrp/wizard/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import models
-from . import wizard
+from . import stock_return_picking

--- a/addons/sale_mrp/wizard/stock_return_picking.py
+++ b/addons/sale_mrp/wizard/stock_return_picking.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class StockReturnPicking(models.TransientModel):
+    _inherit = 'stock.return.picking'
+
+    def _get_proc_values(self, line):
+        proc_values = super()._get_proc_values(line)
+        proc_values['bom_line_id'] = line.move_id.bom_line_id.id
+        return proc_values


### PR DESCRIPTION
Issue before this commit:
-------------------------
When creating a return with exchange for a kit product containing
multiple identical components (same product in different BOM lines),
the exchange picking was created with a single merged move instead of
separate moves per BOM line. This resulted in an incorrect
`qty_delivered` value on the sale order line.

Steps to reproduce:
-------------------
1. Create a SO with a kit product (e.g., Table Kit) that has two BOM
   lines with the same component (e.g., 2x Wood Panel).
2. Confirm the SO and validate the delivery.
3. Create a return for both Wood Panel components and select the
   exchange option.
4. Validate the return, then validate the exchange picking.
5. Check the SO line `Delivered Quantity (qty_delivered)`.
   Expected: 1
   Actual: 0

Cause of the issue:
-------------------
When procurements were created for the exchange picking, both identical
components were assigned the same `bom_line_id` [1], resulting in the
moves being merged.
[1] https://github.com/odoo/odoo/blob/e6ec487c54917f134bac9bfb2b6a6a0c6087af64/addons/sale_mrp/models/stock_rule.py#L18-L24

Since the delivered quantity of a kit is computed based on moves grouped
by `bom_line_id`, the system still expected the other identical
component to be delivered, as the corresponding move no longer existed
after merging.
[2] https://github.com/odoo/odoo/blob/e6ec487c54917f134bac9bfb2b6a6a0c6087af64/addons/mrp/models/stock_move.py#L753-L766

A previous attempt (PR https://github.com/odoo/odoo/pull/207955) fixed this issue for kits with
different components. However, the issue persisted for kits with
identical components because the `bom_line_id` was not preserved during
exchange procurement creation.

After this commit:
------------------
The `bom_line_id` is now preserved from the original move when creating
exchange procurements. This ensures that each BOM line generates its
own move in the exchange picking, allowing `qty_delivered` to be
computed correctly (1 instead of 0).