### PR TITLE
[FIX] base: do not rotate session from websocket routes

### DIFF
--- a/addons/bus/tests/test_websocket_controller.py
+++ b/addons/bus/tests/test_websocket_controller.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.http import root, SESSION_ROTATION_INTERVAL
 from odoo.tests import JsonRpcException
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 
@@ -64,3 +65,19 @@ class TestWebsocketController(HttpCaseWithUserDemo):
                 'last': 0,
                 'is_first_poll': False,
             })
+
+    def test_do_not_rotate_session_when_peeking_notifications(self):
+        self.authenticate('admin', 'admin')
+        self.url_open('/odoo')
+        original_session = self.opener.cookies['session_id']
+        original_session_obj = root.session_store.get(original_session)
+        original_session_obj['create_time'] -= SESSION_ROTATION_INTERVAL
+        root.session_store.save(original_session_obj)
+        self.make_jsonrpc_request('/websocket/peek_notifications', {
+            'channels': [],
+            'last': 0,
+            'is_first_poll': True,
+        })
+        self.assertEqual(self.opener.cookies['session_id'], original_session)
+        self.url_open("/odoo")
+        self.assertNotEqual(self.opener.cookies['session_id'], original_session)

--- a/addons/mail/tests/test_websocket_controller.py
+++ b/addons/mail/tests/test_websocket_controller.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.http import root, SESSION_ROTATION_INTERVAL
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.addons.bus.models.bus import channel_with_db, json_dump
 
@@ -57,3 +58,20 @@ class TestWebsocketController(HttpCaseWithUserDemo):
         self.assertEqual(notification["message"]["payload"]["partner_id"], self.partner_demo.id)
         self.assertEqual(notification["message"]["payload"]["im_status"], "online")
         self.assertEqual(notification["message"]["payload"]["presence_status"], "online")
+
+    def test_do_not_rotate_session_when_updating_presence(self):
+        self.authenticate('admin', 'admin')
+        self.url_open('/odoo')
+        original_session = self.opener.cookies['session_id']
+        original_session_obj = root.session_store.get(original_session)
+        original_session_obj['create_time'] -= SESSION_ROTATION_INTERVAL
+        root.session_store.save(original_session_obj)
+        self.make_jsonrpc_request('/websocket/peek_notifications', {
+            'channels': [],
+            'last': 0,
+            'is_first_poll': True,
+        })
+        self.make_jsonrpc_request('/websocket/update_bus_presence', {'inactivity_period': 0})
+        self.assertEqual(self.opener.cookies['session_id'], original_session)
+        self.url_open("/odoo")
+        self.assertNotEqual(self.opener.cookies['session_id'], original_session)

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -311,6 +311,12 @@ SESSION_LIFETIME = 60 * 60 * 24 * 7
 # session id (also on the cookie) but keeping the same content.
 SESSION_ROTATION_INTERVAL = 60 * 60 * 3
 
+# URL paths for which automatic session rotation is disabled.
+SESSION_ROTATION_EXCLUDED_PATHS = (
+    '/websocket/peek_notifications',
+    '/websocket/update_bus_presence',
+)
+
 # After a session is rotated, the session should be kept for a couple of
 # seconds to account for network delay between multiple requests which are
 # made at the same time and all use the same old cookie.
@@ -2123,7 +2129,11 @@ class Request:
 
         if sess.should_rotate:
             root.session_store.rotate(sess, env)  # it saves
-        elif sess.uid and time.time() >= sess['create_time'] + SESSION_ROTATION_INTERVAL:
+        elif (
+            sess.uid
+            and time.time() >= sess['create_time'] + SESSION_ROTATION_INTERVAL
+            and request.httprequest.path not in SESSION_ROTATION_EXCLUDED_PATHS
+        ):
             root.session_store.rotate(sess, env, True)
         elif sess.is_dirty:
             root.session_store.save(sess)


### PR DESCRIPTION
Before this commit, calling `/websocket/peek_notifications` or
`/websocket/update_bus_presence` could rotate the session.

Since those routes are not called by the client, the cookie
is unchanged on the client side, leading to expire sessions
error later on.

This commit ensure we won't rotate the sessions for those routes.

opw-5445323