### PR TITLE
[FIX] account: sequence mixin cache on cr.cache instead of precommit

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -409,7 +409,7 @@ class AccountBankStatementLine(models.Model):
                 )
             to_write = {'statement_line_id': st_line.id, 'narration': st_line.narration, 'name': False}
             with self.env.protecting(self.env['account.move']._get_protected_vals(vals, st_line)):
-                st_line.move_id.write(to_write)
+                st_line.move_id.with_context(clear_sequence_mixin_cache=False).write(to_write)
         self.env['account.move.line'].create(to_create_lines_vals)
         self.env.add_to_compute(self.env['account.move']._fields['name'], st_lines.move_id)
 

--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -89,9 +89,11 @@ class SequenceMixin(models.AbstractModel):
         # To avoid requiring multiple savepoints when generating successive
         # sequence numbers within a single transaction, we cache the sequence value
         # for the duration of the in-flight transaction.
-        # The `precommit.data` container is used instead of `cr.cache` to
-        # reduce the need for manual invalidation and ensure that the
-        # cache does not survive a commit or rollback.
+        #
+        # We use `cr.cache` and expects any savepoint rollback or commit to clear the cache.
+        # This is important because as soon as the lock is released, there might be a record
+        # consumming the next sequence in a concurent transaction for which the cache can't be
+        # aware.
         #
         # Before adding an entry for a sequence to this `sequence.mixin` cache,
         # the transaction must have locked the corresponding unique constraint,
@@ -107,7 +109,7 @@ class SequenceMixin(models.AbstractModel):
         # See also:
         # - https://postgres.ai/blog/20210831-postgresql-subtransactions-considered-harmful
         # - the documentation in _locked_increment()
-        return self.env.cr.precommit.data.setdefault('sequence.mixin', {})
+        return self.env.cr.cache.setdefault('sequence.mixin', {})
 
     def write(self, vals):
         if self._sequence_field in vals and self.env.context.get('clear_sequence_mixin_cache', True):

--- a/addons/account/tests/test_sequence_mixin.py
+++ b/addons/account/tests/test_sequence_mixin.py
@@ -976,3 +976,49 @@ class TestSequenceMixinConcurrency(TransactionCase):
         # check the values
         moves = env0['account.move'].browse(self.data['move_ids'])
         self.assertEqual(moves.mapped('name'), ['CT/2016/01/0001', False, 'CT/2016/01/0002'])
+
+
+@tagged('post_install', '-at_install')
+class TestSequenceMixinBankStatementLoadImport(TestSequenceMixinCommon):
+    def test_failed_import_bank_statement_cache_shouldnt_get_invalidated(self):
+        """ Ensure that even with a failed import, we mostly hit the sequence cache and don't create tons of savepoint"""
+        bank_journal = self.company.bank_journal_ids[:1]  # there could be several journal in some builds
+        fields_list = ['company_id.id', 'date', 'payment_ref', 'amount', 'journal_id.id']
+        data = [
+            [self.company.id, '2026-03-30', '10 euros', 10.0, bank_journal.id],
+            [self.company.id, '2026-03-30', '20 euros', 20.0, bank_journal.id],
+            [self.company.id, '2026-03-30', '50 euros', 50.0, bank_journal.id],
+        ]
+
+        # ensure the creation of those record will crashes when calling `load`
+        original_load_records_create = self.env['account.bank.statement.line']._load_records_create
+
+        def new_load_records_create(vals_list):
+            # only crash after a few attempts to trigger the sequence.mixin several time
+            if any(vals.get('payment_ref') == '50 euros' for vals in vals_list):
+                raise ValidationError("Load process intentionally interrupted for testing")
+            return original_load_records_create(vals_list)
+
+        # track call to the cache and the number of time it was empty
+        empty_cache_count = 0
+        original_get_sequence_cache = self.env['sequence.mixin']._get_sequence_cache
+
+        def count_empty_cache():
+            nonlocal empty_cache_count
+            cache = original_get_sequence_cache()
+            if not cache:
+                empty_cache_count += 1
+            return cache
+
+        with (
+            patch.object(self.env.registry['account.bank.statement.line'], '_load_records_create', side_effect=new_load_records_create),
+            patch.object(self.env.registry['sequence.mixin'], '_get_sequence_cache', side_effect=count_empty_cache),
+        ):
+            results = self.env['account.bank.statement.line'].load(fields_list, data)
+
+        self.assertEqual(empty_cache_count, 1, "The cache should have been filled the first time")
+        self.assertCountEqual(
+            [{k: v for k, v in m.items() if k in ('record', 'message')} for m in results["messages"]],
+            [{"record": 0, "message": "Load process intentionally interrupted for testing"},
+             {"record": 2, "message": "Load process intentionally interrupted for testing"}],
+        )


### PR DESCRIPTION
## [FIX] account: sequence mixin cache on cr.cache instead of precommit
The aim of this commit is to prevent the creation of Savepoint in chain.
This is achieved by preventing the `sequence.mixin` cache to be cleared
as soon as a flush happens and to prevent the `bank.statement.line`
creation to clear the cache.

### Context:
During an import of document, like a big CSV of bank statement for
example, if any issue arises, the ORM rollback to the savepoint of
import and retry to import one record at a time and rollback again
later on to collect the errors and show the faulting line to the
customer.

### Cause:
1) As we flush for every single record, the `precommit.data.cache` gets
   cleared during the flush and the `sequence.mixin` cache gets wiped
   out.
2) The creation of bank statement set the name of its move_id to False
   which results in the `sequence.mixin` code to clear its own cache by
   itself.
   [name set to False](https://github.com/odoo/odoo/blob/1361c0bc98c91f1e601b0fc3beaa948df3a3bfcd/addons/account/models/account_bank_statement_line.py#L410-L412)

Both (1) and (2) results in the sequence.mixin code to recreate the
cache and, for that, to create a new Savepoint.
This is done at each iteration of the import loop which could results
in this case in 300+ savepoints existing at the same time eating all
Postgres shared buffers memory putting the whole production database
on its knees.

task-id: None (investigated for odoo.com)