### PR TITLE
[IMP] core: enable ANSI colored logs on Windows terminals

### DIFF
--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -270,7 +270,7 @@ def init_logger():
     def is_a_tty(stream):
         return hasattr(stream, 'fileno') and os.isatty(stream.fileno())
 
-    if os.name == 'posix' and isinstance(handler, logging.StreamHandler) and (is_a_tty(handler.stream) or os.environ.get("ODOO_PY_COLORS")):
+    if isinstance(handler, logging.StreamHandler) and (is_a_tty(handler.stream) or os.environ.get("ODOO_PY_COLORS")):
         formatter = ColoredFormatter(format)
         perf_filter = ColoredPerfFilter()
     else:


### PR DESCRIPTION
enable ANSI colored logging on Windows (os.name == 'nt') for modern terminals.

previously, colored logs were restricted to posix systems, even though modern Windows environments natively support ANSI escape sequences.

since Windows 10 (Build 16257), the Windows Console officially supports Virtual Terminal (ANSI) sequences.
Reference: Microsoft Learn – Console Virtual Terminal Sequences, see: https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences