### PR TITLE
[IMP] hr_expense: remove tax amount from expense form view

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -221,7 +221,6 @@
                             <div class="o_input_box" invisible="product_has_cost">
                                 <field name="total_amount_currency" widget='monetary' options="{'currency_field': 'currency_id'}"
                                        readonly="not is_editable"/>
-                                <span class="o_input_box_overlay_end" invisible="tax_amount == 0">(incl <field name="tax_amount" class="mx-1"/> tax)</span>
                             </div>
                             <field name="currency_id" string="Currency"
                                 options="{'no_create': True, 'no_open': True}"
@@ -243,6 +242,7 @@
                                        widget="many2many_tax_tags"
                                        readonly="not is_editable"
                                        options="{'no_create': True}"/>
+                                <field name="tax_amount_currency"/>
                             </div>
                             <field name="employee_id" groups="!hr.group_hr_user"
                                    context="{'default_company_id': company_id}" widget="many2one_avatar_employee"


### PR DESCRIPTION
Remove `tax_amount` field from expense form view, as we have Included taxes right underneath it and it was bit redundant.

Revert of https://github.com/odoo/odoo/commit/7e655235dae846dd01a69d0fb506a3ec8dbb9091, as we still want to see tax amount.

task-5712223