### PR TITLE
[FIX] website_sale_collect: hide pickup for excluded products

### DIFF
--- a/addons/website_sale_collect/models/product_template.py
+++ b/addons/website_sale_collect/models/product_template.py
@@ -14,10 +14,12 @@ class ProductTemplate(models.Model):
         res = super()._get_additionnal_combination_info(
             product_or_template, quantity, date, website
         )
+        in_store_dm = website.sudo().in_store_dm_id
         if (
-            bool(website.sudo().in_store_dm_id)  # Click & Collect is enabled.
+            bool(in_store_dm)  # Click & Collect is enabled.
             and product_or_template.is_product_variant
             and product_or_template.is_storable
+            and not (in_store_dm.excluded_tag_ids & product_or_template.all_product_tag_ids)
         ):
             res['show_click_and_collect_availability'] = True
             order_sudo = website.sale_get_order()

--- a/addons/website_sale_collect/tests/__init__.py
+++ b/addons/website_sale_collect/tests/__init__.py
@@ -5,5 +5,6 @@ from . import test_click_and_collect_express_checkout
 from . import test_click_and_collect_flow
 from . import test_payment_provider
 from . import test_payment_transaction
+from . import test_product_template
 from . import test_sale_order
 from . import test_website

--- a/addons/website_sale_collect/tests/test_product_template.py
+++ b/addons/website_sale_collect/tests/test_product_template.py
@@ -1,0 +1,24 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import datetime
+
+from odoo import Command
+from odoo.tests import tagged
+
+from odoo.addons.website.tools import MockRequest
+from odoo.addons.website_sale_collect.tests.common import ClickAndCollectCommon
+
+
+@tagged('post_install', '-at_install')
+class TestProductTemplate(ClickAndCollectCommon):
+
+    def test_click_and_collect_unavailable_for_product_with_excluded_tag(self):
+        """Pick Up in Store hidden when product has a tag excluded by the delivery method."""
+        excluded_tag = self.env["product.tag"].create({"name": "Multiple Products"})
+        self.in_store_dm.excluded_tag_ids = [Command.set(excluded_tag.ids)]
+        self.storable_product.all_product_tag_ids = [Command.set(excluded_tag.ids)]
+        with MockRequest(self.env, website=self.website, sale_order_id=self.cart.id):
+            combination_info = self.env['product.template']._get_additionnal_combination_info(
+                self.storable_product, quantity=3, date=datetime(2000, 1, 1), website=self.website
+            )
+        self.assertFalse(combination_info.get("show_click_and_collect_availability"))
+        self.assertFalse(combination_info.get("in_store_stock"))


### PR DESCRIPTION
Currently, when a product has a tag that is configured as an Excluded Tag on the Pick Up in Store delivery method, the method is still shown on the product page.

Steps to produce:
---
- Install `website_sale` module.
- Enable `Click and Collect` in settings.
- Go to `website > ecommerce > products > product tags.`
- Create a new tag and add a product in product template.
- Go to` website > configuration > ecommerce > delivery method.`
- Open` pick up in store`:
    - In the `Stores` tab, set your company warehouse.
    - In the `Availability` tab, add the created tag to Excluded Tags.
    - Publish the delivery method.
- Open the tagged product on the website.

Issue:
---
- The Pick Up in Store option is still displayed on the product page, even though the product has a tag listed in the carrier’s Excluded Tags.

Root cause:
---
- Here at [1], the method `_get_additional_combination_info ()` does not check whether the product has tags that are excluded by the delivery method.
- However, at [2], during checkout, the exclusion works correctly because `_match_excluded_tags` in `delivery.carrier` filters the carrier based on excluded tags.

Solution:
---
- Hide the Pick Up in Store option when the product has tags excluded
  for that delivery method. This keeps the behavior consistent across
  the website, avoids showing unavailable delivery options, does not
  impact other flows and aligns with the existing behavior during
  checkout.

[1]https://github.com/odoo/odoo/blob/1c483c3a8d7d079bd34a378f9f8716551e4bab93/addons/website_sale_collect/models/product_template.py#L17-L21
[2]https://github.com/odoo/odoo/blob/1c483c3a8d7d079bd34a378f9f8716551e4bab93/addons/delivery/models/delivery_carrier.py#L192-L194

opw-5921268

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
