### PR TITLE
[FIX] project: prevent duplicate creation messages in chatter

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1596,10 +1596,13 @@ class ProjectTask(models.Model):
 
     def _creation_message(self):
         self.ensure_one()
-        if self.project_id:
-            return _('This new task has been created in the "%(project_name)s" project.',
+        if self._creation_message:
+            return ''
+        elif self.project_id:
+            return self.env._('This new task has been created in the "%(project_name)s" project.',
                      project_name=self.project_id.display_name)
-        return _('This new task is not part of any project.')
+        else:
+            return self.env._('This new task is not part of any project.')
 
     def _track_subtype(self, init_values):
         self.ensure_one()


### PR DESCRIPTION
### Steps to Reproduce:
Install the Project app
Create a new task in a project

### Issue:
When a task is created, the creation message is logged three times in the chatter.

### Cause:
Although a creation_subtype is defined, the creation_message is still displayed.  causing both mechanisms to be applied simultaneously.

### Fix
When a creation_subtype is present, the creation_message should not be displayed, avoiding duplicate chatter entries.

Task: 5786980




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
