### PR TITLE
[IMP] l10n_id_efaktur_coretax: NPWP adapt as per company_type removal

### DIFF
--- a/addons/l10n_id_efaktur_coretax/models/res_partner.py
+++ b/addons/l10n_id_efaktur_coretax/models/res_partner.py
@@ -3,6 +3,7 @@
 from odoo import api, fields, models
 from odoo.addons.l10n_id_efaktur_coretax.models.account_move import TAX_TRANSACTION_CODE
 
+
 class Partner(models.Model):
     _inherit = "res.partner"
 
@@ -28,6 +29,19 @@ class Partner(models.Model):
         default='04',
         tracking=True,
     )
+
+    @api.depends('vat', 'parent_id', 'l10n_id_tku', 'country_code')
+    def _compute_is_company(self):
+        l10n_id_partners = self.filtered(lambda p: p.country_code == 'ID')
+        for partner in l10n_id_partners:
+            vat = partner.vat or ''
+            tku = (partner.l10n_id_tku or '000000').strip()
+            is_commercial_partner = partner.commercial_partner_id == partner
+            partner.is_company = (
+                (not is_commercial_partner and tku != '000000') or
+                (is_commercial_partner and vat.startswith(('0', '10')))
+            )
+        super(Partner, self - l10n_id_partners)._compute_is_company()
 
     @api.depends('vat', 'country_code')
     def _compute_l10n_id_pkp(self):

--- a/addons/l10n_id_efaktur_coretax/tests/__init__.py
+++ b/addons/l10n_id_efaktur_coretax/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_l10n_id_efaktur_coretax
 from . import test_l10n_id_efaktur_download
+from . import test_l10n_id_is_company

--- a/addons/l10n_id_efaktur_coretax/tests/test_l10n_id_is_company.py
+++ b/addons/l10n_id_efaktur_coretax/tests/test_l10n_id_is_company.py
@@ -1,0 +1,109 @@
+from odoo.tests import tagged
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class L10nIDPartnerCompanyTest(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        indonesia = cls.env.ref('base.id')
+
+        # Parent Contact - Company (rule: starts with 10)
+        cls.partner_company = cls.partner_a
+        cls.partner_company.write({
+            'name': 'ID Parent Company',
+            'country_id': indonesia.id,
+            'vat': '1000000000014256',
+            'l10n_id_tku': '000000',
+        })
+
+        # Parent Contact - Company (rule: starts with 0X)
+        cls.partner_company_zero = cls.env['res.partner'].create({
+            'name': 'ID Parent Company 0X',
+            'country_id': indonesia.id,
+            'vat': '0864099064063000',
+            'l10n_id_tku': '000000',
+        })
+
+        # Parent Contact - Individual
+        cls.partner_individual = cls.partner_b
+        cls.partner_individual.write({
+            'name': 'ID Parent Individual',
+            'country_id': indonesia.id,
+            'vat': '3273061809970002',
+            'l10n_id_tku': '000000',
+            'parent_id': False,
+        })
+
+        # Child Contact - Branch
+        cls.partner_branch = cls.env['res.partner'].create({
+            'name': 'ID Branch',
+            'country_id': indonesia.id,
+            'parent_id': cls.partner_company.id,
+            'l10n_id_tku': '123456',
+        })
+
+        # Child Contact - Individual
+        cls.partner_child_individual = cls.env['res.partner'].create({
+            'name': 'ID Child Individual',
+            'country_id': indonesia.id,
+            'parent_id': cls.partner_company.id,
+        })
+
+    def test_id_partner_company_classification(self):
+        """
+        Ensure Indonesian partners are categorized correctly:
+
+        Parent Contact - Company
+            parent_id: False
+            TKU: 000000
+            VAT rule:
+                - first digit = 0
+                OR
+                - first digit = 1 and second digit = 0
+            is_company: True
+
+        Parent Contact - Individual
+            parent_id: False
+            TKU: 000000
+            VAT prefix: not matching company rule
+            is_company: False
+
+        Child Contact - Branch
+            parent_id: True
+            TKU != 000000
+            is_company: True
+
+        Child Contact - Individual
+            parent_id: True
+            TKU empty
+            is_company: False
+        """
+
+        self.assertTrue(
+            self.partner_company.is_company,
+            "VAT starting with '10' should be treated as a company."
+        )
+
+        self.assertTrue(
+            self.partner_company_zero.is_company,
+            "VAT starting with '0X' should be treated as a company."
+        )
+
+        self.assertFalse(
+            self.partner_individual.is_company,
+            "with VAT not matching the company rule should be treated as an individual."
+        )
+
+        self.assertTrue(
+            self.partner_branch.is_company,
+            "Child partner with TKU different from 000000 should be treated as a branch company."
+        )
+
+        self.assertFalse(
+            self.partner_child_individual.is_company,
+            "Child partner with empty TKU should be treated as an individual contact."
+        )


### PR DESCRIPTION
For Indonesia, NPWP is distinguishable between an individual and company by prefix If an NPWP starts with 001, 002, or 003, treat it as a Company. Anything else is likely an Individual (local or foreign).

For Indonesia, NPWP is distinguishable between an individual and company by prefix
An NPWP must consist 16 digits 
How to distinguish between individual and company details:
- Individual (Local) -> first two digit is province code start from 11 to 92
- Individual (Expat/Foreign) -> first digit = 0, second and third digit 07-09
- Company (Local or Foreign) -> first digit = 0, second and third digit 01-03

Task [#5915988](https://www.odoo.com/web#model=project.task&id=5915988)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
