### PR TITLE
[FIX] mail: restrict activity direct form to current user

### DIFF
--- a/addons/mail/static/src/views/web/kanban/mail_activity_my_kanban_controller.js
+++ b/addons/mail/static/src/views/web/kanban/mail_activity_my_kanban_controller.js
@@ -18,4 +18,8 @@ export class MailActivityMyKanbanController extends KanbanController {
                 await this.model.root.load();
             });
     }
+
+    get canQuickCreate() {
+        return false;
+    }
 }


### PR DESCRIPTION
**Steps to reproduce:**
- Go to View all activities
- Switch to kanban view
- Group by Activity Type to show the quick_create button
- Try to create a new activity in one of the column
- First call to name_create will fail (no user_id as it's not required)
`The operation cannot be completed: Activities must be assigned if not attached to a document.`
- On failure it opens the activity creation form
- Change the user to someone else
- Doing so will raise an access error

**Issue:**
Form allows the user to be modified but is restricted to personal activities as we can't add the related target model. Different forms are used between the `New` button and the quick_create logic (`mail.activity` vs `mail.activity.schedule`).

**Fix:**
Restrict the form creation to the current user to avoid access error.

Could also:
- Allow setting a related model on the `mail.activity` form, using something like `widget="activity_model_selector"` to match `mail.activity.schedule` flow
- Overwrite the quick create on the activities to use the same flow as the scheduler
- Remove the quick create in this case

similar issue: https://github.com/odoo/odoo/commit/24919c7288cc2aed1c5ba92ea21ec1e805b3954f
personal activities: https://github.com/odoo/odoo/commit/165b060473be8a5d33d62d311f0dc55ed6332d69

opw-5939969