### PR TITLE
[IMP] *: support input with list and lazy load dynamic snippet carousel

### DIFF
--- a/addons/html_builder/static/src/core/builder_component_plugin.js
+++ b/addons/html_builder/static/src/core/builder_component_plugin.js
@@ -23,6 +23,8 @@ import { Plugin } from "@html_editor/plugin";
 import { Image } from "./img";
 import { BuilderUrlPicker } from "./building_blocks/builder_urlpicker";
 import { BuilderFontFamilyPicker } from "./building_blocks/builder_fontfamilypicker";
+import { BuilderInputSelectNumber } from "./building_blocks/builder_input_select_number";
+import { BuilderInputSelectText } from "./building_blocks/builder_input_select_text";
 
 /** @typedef {import("@odoo/owl").Component} Component */
 /**
@@ -51,6 +53,8 @@ export class BuilderComponentPlugin extends Plugin {
             BuilderButton,
             BuilderTextInput,
             BuilderNumberInput,
+            BuilderInputSelectNumber,
+            BuilderInputSelectText,
             BuilderRange,
             BuilderColorPicker,
             BuilderSelect,

--- a/addons/html_builder/static/src/core/building_blocks/builder_input_select_base.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_input_select_base.js
@@ -1,0 +1,21 @@
+import { BuilderSelect } from "@html_builder/core/building_blocks/builder_select";
+
+export class BuilderInputSelectBase extends BuilderSelect {
+    /**
+     * Closes the dropdown when Enter or Tab key is pressed.
+     *
+     * @param {KeyboardEvent} ev
+     */
+    onInputKeydown(ev) {
+        if (ev.key === "Enter" || ev.key === "Tab") {
+            this.dropdown.close();
+        }
+    }
+
+    /**
+     * Opens the dropdown when clicked.
+     */
+    onClick() {
+        this.dropdown.open();
+    }
+}

--- a/addons/html_builder/static/src/core/building_blocks/builder_input_select_number.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_input_select_number.js
@@ -1,0 +1,19 @@
+import { BuilderInputSelectBase } from "@html_builder/core/building_blocks/builder_input_select_base";
+import { BuilderNumberInput } from "@html_builder/core/building_blocks/builder_number_input";
+import { pick } from "@web/core/utils/objects";
+
+export class BuilderInputSelectNumber extends BuilderInputSelectBase {
+    static template = "html_builder.BuilderInputSelectNumber";
+    static components = { ...BuilderInputSelectBase.components, BuilderNumberInput };
+    static props = {
+        ...BuilderNumberInput.props,
+        ...BuilderInputSelectBase.props,
+    };
+
+    get inputSelectNumberProps() {
+        return {
+            ...pick(this.props, ...Object.keys(BuilderNumberInput.props)),
+            selectTextOnFocus: true,
+        };
+    }
+}

--- a/addons/html_builder/static/src/core/building_blocks/builder_input_select_number.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_input_select_number.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="html_builder.BuilderInputSelectNumber" t-inherit="html_builder.BuilderSelect">
+    <xpath expr="//button" position="replace">
+        <BuilderNumberInput
+            t-props="inputSelectNumberProps"
+            t-on-click="onClick"
+            t-on-keydown.stop="onInputKeydown"
+        />
+    </xpath>
+</t>
+
+</templates>

--- a/addons/html_builder/static/src/core/building_blocks/builder_input_select_text.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_input_select_text.js
@@ -1,0 +1,19 @@
+import { BuilderInputSelectBase } from "@html_builder/core/building_blocks/builder_input_select_base";
+import { BuilderTextInput } from "@html_builder/core/building_blocks/builder_text_input";
+import { pick } from "@web/core/utils/objects";
+
+export class BuilderInputSelectText extends BuilderInputSelectBase {
+    static template = "html_builder.BuilderInputSelectText";
+    static components = { ...BuilderInputSelectBase.components, BuilderTextInput };
+    static props = {
+        ...BuilderTextInput.props,
+        ...BuilderInputSelectBase.props,
+    };
+
+    get inputSelectTextProps() {
+        return {
+            ...pick(this.props, ...Object.keys(BuilderTextInput.props)),
+            selectTextOnFocus: true,
+        };
+    }
+}

--- a/addons/html_builder/static/src/core/building_blocks/builder_input_select_text.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_input_select_text.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="html_builder.BuilderInputSelectText" t-inherit="html_builder.BuilderSelect">
+    <xpath expr="//button" position="replace">
+        <BuilderTextInput
+            t-props="inputSelectTextProps"
+            t-on-click="onClick"
+            t-on-keydown.stop="onInputKeydown"
+        />
+    </xpath>
+</t>
+
+</templates>

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_input_select.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_input_select.test.js
@@ -1,0 +1,74 @@
+import { addBuilderOption, setupHTMLBuilder } from "@html_builder/../tests/helpers";
+import { BaseOptionComponent } from "@html_builder/core/utils";
+import { expect, queryAll, test } from "@odoo/hoot";
+import { xml } from "@odoo/owl";
+import { contains } from "@web/../tests/web_test_helpers";
+
+const INPUT_SELECTOR = ".we-bg-options-container input";
+const MENU_SELECTOR = ".o-dropdown--menu div[role='menuitem']";
+
+function setupTestEnv() {
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static selector = ".test-options-target";
+            static template = xml`
+            <BuilderInputSelectNumber styleAction="'width'" unit="'px'">
+                <t t-foreach="['100px','75px','50px','25px','10px']" t-as="value" t-key="value">
+                    <BuilderSelectItem styleActionValue="value" t-out="value"/>
+                </t>
+            </BuilderInputSelectNumber>`;
+        }
+    );
+    return setupHTMLBuilder(
+        `<div class="test-options-target" style="width: 100px;">Builder Input Select</div>`
+    );
+}
+
+test("Click on Input should open/close dropdown", async () => {
+    await setupTestEnv();
+    await contains(":iframe .test-options-target").click();
+    await contains(INPUT_SELECTOR).click();
+    expect(queryAll(MENU_SELECTOR)).toHaveLength(5);
+    await contains(INPUT_SELECTOR).click();
+    expect(queryAll(MENU_SELECTOR)).toHaveLength(0);
+});
+
+test("Pressing Tab/Enter on Input should close dropdown", async () => {
+    await setupTestEnv();
+    await contains(":iframe .test-options-target").click();
+    await contains(INPUT_SELECTOR).click();
+    expect(queryAll(MENU_SELECTOR)).toHaveLength(5);
+    await contains(INPUT_SELECTOR).press("Enter");
+    expect(queryAll(MENU_SELECTOR)).toHaveLength(0);
+    await contains(INPUT_SELECTOR).click();
+    expect(queryAll(MENU_SELECTOR)).toHaveLength(5);
+    await contains(INPUT_SELECTOR).press("Tab");
+    expect(queryAll(MENU_SELECTOR)).toHaveLength(0);
+});
+
+test("Selecting dropdown value should update input and commit value", async () => {
+    const { getEditableContent } = await setupTestEnv();
+    await contains(":iframe .test-options-target").click();
+    await contains(INPUT_SELECTOR).click();
+    expect(INPUT_SELECTOR).toHaveValue(100);
+    await contains(".o-dropdown--menu div[data-style-action-value='50px']").click();
+    expect(INPUT_SELECTOR).toHaveValue(50);
+    const contentEl = getEditableContent();
+    expect(contentEl).toHaveInnerHTML(
+        `<div class="test-options-target" style="width: 50px;">Builder Input Select</div>`
+    );
+});
+
+test("Manually inserting value in input should commit the value", async () => {
+    const { getEditableContent } = await setupTestEnv();
+    await contains(":iframe .test-options-target").click();
+    const input = contains(INPUT_SELECTOR);
+    expect(INPUT_SELECTOR).toHaveValue(100);
+    await input.click();
+    await input.edit("30");
+    await input.press("Enter");
+    const contentEl = getEditableContent();
+    expect(contentEl).toHaveInnerHTML(
+        `<div class="test-options-target" style="width: 30px;">Builder Input Select</div>`
+    );
+});

--- a/addons/website/models/website_snippet_filter.py
+++ b/addons/website/models/website_snippet_filter.py
@@ -58,7 +58,7 @@ class WebsiteSnippetFilter(models.Model):
                 if not field_name.strip():
                     raise ValidationError(_("Empty field name in “%s”", record.field_names))
 
-    def _render(self, template_key, limit, search_domain=None, with_sample=False, res_model=None, res_id=None, **custom_template_data):
+    def _render(self, template_key, limit, offset=0, search_domain=None, with_sample=False, res_model=None, res_id=None, **custom_template_data):
         """Renders the website dynamic snippet items"""
         self and self.ensure_one()
 
@@ -72,7 +72,7 @@ class WebsiteSnippetFilter(models.Model):
         if self.model_name and self.model_name.replace('.', '_') not in template_key:
             return ''
 
-        records = self._prepare_values(limit=limit, search_domain=search_domain, res_model=res_model, res_id=res_id)
+        records = self._prepare_values(limit=limit, search_domain=search_domain, res_model=res_model, res_id=res_id, offset=offset)
         is_sample = with_sample and not records
         if is_sample:
             records = self._prepare_sample(limit, res_model=res_model)
@@ -115,7 +115,8 @@ class WebsiteSnippetFilter(models.Model):
                 records = self.env[model_name].sudo(False).with_context(**literal_eval(filter_sudo.context)).search(
                     domain,
                     order=','.join(literal_eval(filter_sudo.sort)) or None,
-                    limit=limit
+                    limit=limit,
+                    offset=options.get('offset')
                 ) if not single_record_filter else self.env[model_name].browse([res_id])
                 return self._filter_records_to_values(records.sudo(), res_model=model_name)
             except MissingError:
@@ -127,6 +128,7 @@ class WebsiteSnippetFilter(models.Model):
                 return self.action_server_id.with_context(
                     dynamic_filter=self,
                     limit=limit,
+                    offset=options.get('offset'),
                     search_domain=search_domain,
                 ).sudo().run() or []
             except MissingError:

--- a/addons/website/static/src/builder/plugins/options/dynamic_snippet_option.xml
+++ b/addons/website/static/src/builder/plugins/options/dynamic_snippet_option.xml
@@ -51,11 +51,11 @@
         </BuilderButtonGroup>
     </BuilderRow>
     <BuilderRow id="number_of_records_opt_row" label.translate="Fetched Elements" t-if="!!dynamicOptionParams.domState.filterId or isSingleMode">
-        <BuilderSelect action="'numberOfRecords'" preview="false" id="'number_of_records_opt'">
-            <t t-foreach="['1','2','3','4','5','6','7','8','9','10','11','12','13','14','15','16']" t-as="value" t-key="value">
+        <BuilderInputSelectNumber action="'numberOfRecords'" preview="false" id="'number_of_records_opt'" default="1" min="1">
+            <t t-foreach="[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]" t-as="value" t-key="value">
                 <BuilderSelectItem actionParam="value" t-out="value"/>
             </t>
-        </BuilderSelect>
+        </BuilderInputSelectNumber>
     </BuilderRow>
     <BuilderRow label.translate="Section Title" t-if="!isSingleMode">
         <BuilderButtonGroup applyTo="'.s_dynamic_snippet_title'">

--- a/addons/website/static/src/builder/plugins/options/dynamic_snippet_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/dynamic_snippet_option_plugin.js
@@ -392,9 +392,12 @@ export class NumberOfRecordsAction extends BuilderAction {
     isApplied({ editingElement: el, params }) {
         return el.dataset.numberOfRecords === params.mainParam;
     }
-    apply({ editingElement: el, params }) {
+    getValue({ editingElement }) {
+        return editingElement.dataset.numberOfRecords;
+    }
+    apply({ editingElement: el, params, value }) {
         const isSingleModeBefore = this.utils.isSingleModeSnippet(el.dataset);
-        el.dataset.numberOfRecords = params.mainParam;
+        el.dataset.numberOfRecords = params.mainParam || value;
         // Changing the number of records should automatically switch to a
         // "single record" filter mode if only one record is selected, and
         // conversely, revert to the default filter mode when more than one

--- a/addons/website/static/src/core/website_edit_service.js
+++ b/addons/website/static/src/core/website_edit_service.js
@@ -133,18 +133,7 @@ export const websiteEditService = {
                         return (...args) => historyCallbacks.ignoreDOMMutations(() => fn(...args));
                     },
                     addListener(target, event, fn, options) {
-                        const boundFn = fn.bind(this.interaction);
-                        if (event.startsWith("slide.bs.carousel")) {
-                            // Never allow cancelling this event in edit mode.
-                            fn = (...args) => {
-                                const ev = args[0];
-                                ev.preventDefault = () => {};
-                                ev.stopPropagation = () => {};
-                                return boundFn(...args);
-                            };
-                        } else {
-                            fn = boundFn;
-                        }
+                        fn = fn.bind(this.interaction);
                         let stealth = true;
                         const parts = event.split(".");
                         if (parts.includes("keepInHistory") || options?.keepInHistory) {
@@ -347,18 +336,7 @@ patch(Colibri.prototype, {
         };
     },
     addListener(target, event, fn, options) {
-        const boundFn = fn.bind(this.interaction);
-        if (event.startsWith("slide.bs.carousel")) {
-            // Never allow cancelling this event in edit mode.
-            fn = (...args) => {
-                const ev = args[0];
-                ev.preventDefault = () => {};
-                ev.stopPropagation = () => {};
-                return boundFn(...args);
-            };
-        } else {
-            fn = boundFn;
-        }
+        fn = fn.bind(this.interaction);
         let stealth = true;
         const parts = event.split(".");
         if (parts.includes("keepInHistory") || options?.keepInHistory) {

--- a/addons/website/static/src/snippets/s_dynamic_snippet_carousel/dynamic_snippet_carousel.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet_carousel/dynamic_snippet_carousel.js
@@ -5,15 +5,199 @@ import { utils as uiUtils } from "@web/core/ui/ui_service";
 
 export class DynamicSnippetCarousel extends DynamicSnippet {
     static selector = ".s_dynamic_snippet_carousel";
+    dynamicContent = {
+        ...this.dynamicContent,
+        _root: {
+            ...this.dynamicContent._root,
+            "t-on-slide.bs.carousel": this.onSlide,
+            "t-on-slid.bs.carousel": this.computeHidePrev,
+        },
+        ".s_dynamic_snippet_content": {
+            "t-att-class": () => ({ "d-none": this.isLoading }),
+        },
+        ".s_dynamic_content_holder": {
+            "t-att-class": () => ({ "d-none": !this.isLoading }),
+        },
+        ".carousel-control-prev": {
+            "t-att-class": () => ({ "d-none": this.hidePrev }),
+        },
+    };
 
     setup() {
         super.setup();
         this.templateKey = "website.s_dynamic_snippet.carousel";
+        this.offset = 0;
+        this.totalToFetch = 0;
+        this.hasMore = false;
+        this.fetchedData = [];
+        this.chunkSize = 16;
+        this.isLoading = true;
+        this.hidePrev = false;
     }
 
-    getQWebRenderOptions() {
-        const scrollMode = this.el.classList.contains("o_carousel_multi_items") ? "single" : "all";
-        return Object.assign(super.getQWebRenderOptions(...arguments), {
+    async willStart() {
+        this.totalToFetch = parseInt(this.el.dataset.numberOfRecords) || 0;
+        await super.willStart();
+    }
+
+    start() {
+        super.start();
+        this.isLoading = false;
+        this.computeHidePrev();
+    }
+
+    /**
+     * @returns {number} The index of the slide containing the "active" class.
+     */
+    getActiveSlideIndex() {
+        const slideEls = this.carouselEl.querySelectorAll(".carousel-item");
+        return [...slideEls].findIndex((s) => s.classList.contains("active"));
+    }
+
+    /**
+     * @returns {number} The number of visible items per carousel slide.
+     */
+    getItemsPerSlide() {
+        const itemsPerSlide = this.carouselEl.style.getPropertyValue("--o-carousel-chunk-size");
+        return itemsPerSlide ? parseInt(itemsPerSlide) : 1;
+    }
+
+    /**
+     * @returns {"single" | "all"} Carousel scrolling mode.
+     */
+    getScrollMode() {
+        return this.el.classList.contains("o_carousel_multi_items") ? "single" : "all";
+    }
+
+    /**
+     * Computes whether the "Previous" navigation button should be hidden.
+     *
+     * The button is hidden when backward navigation is not allowed:
+     * - In "single" scroll mode: hidden when at the initial position as
+     *   earlier slides may not exist yet due to lazy loading.
+     * - In "all" scroll mode: hidden when on the first slide.
+     *
+     * This prevents users from navigating to non-existent previous slides.
+     */
+    computeHidePrev() {
+        if (!this.carouselEl) {
+            return;
+        }
+        if (this.getScrollMode() === "single") {
+            this.hidePrev = this.hasMore && this.index === 0;
+        } else {
+            this.hidePrev = this.hasMore && this.getActiveSlideIndex() === 0;
+        }
+    }
+
+    /**
+     * Handles the carousel slide event and triggers lazy loading when needed.
+     *
+     * Tracks the current navigation position and loads more data when
+     * approaching the end of available slides:
+     * - In "all" scroll mode: triggers when reaching the last slide.
+     * - In "single" scroll mode: triggers 4 items before the end to ensure
+     *   smooth scrolling.
+     *
+     * Prevents the default slide behavior during data fetching, then manually
+     * advances the carousel once new data is loaded.
+     *
+     * @param {Event} ev
+     */
+    async onSlide(ev) {
+        ev.direction === "left" ? this.index++ : this.index--;
+        const slideEls = this.carouselEl.querySelectorAll(".carousel-item");
+        if (
+            this.hasMore &&
+            ((this.getActiveSlideIndex() === slideEls.length - 1 && ev.direction === "left") ||
+                (this.getScrollMode() === "single" &&
+                    this.index === this.fetchedData.length - this.getItemsPerSlide()))
+        ) {
+            ev.preventDefault();
+            this.isLoading = true;
+            this.updateContent(); // refresh immediately to update loading state
+            await this.fetchData();
+            this.isLoading = false;
+            this.updateContent();
+            this.carouselInstance.next();
+        }
+    }
+
+    /**
+     * Handles the "Load More" action.
+     *
+     * Fetches the next batch of records from the server and appends them to the
+     * existing snippet content.
+     */
+    async fetchData() {
+        const remaining = this.totalToFetch - this.data.length;
+        this.limit = Math.min(this.chunkSize, remaining);
+        await super.fetchData();
+        this.fetchedData.push(...this.data);
+        this.offset += this.limit;
+        this.hasMore =
+            this.fetchedData.length < this.totalToFetch && this.data.length === this.limit;
+        this.data = this.fetchedData;
+        this.prepareContent();
+        if (this.carouselEl) {
+            this.appendContent();
+        }
+    }
+
+    /**
+     *
+     * @override
+     */
+    getRpcParameters() {
+        return {
+            ...super.getRpcParameters(),
+            limit: this.limit,
+            offset: this.offset,
+        };
+    }
+
+    /**
+     * @override
+     *
+     * Re-initializes carousel state after the DOM is replaced.
+     *
+     * The parent's renderContent() removes the old carousel element, so we
+     * re-query carouselEl and create a new Bootstrap Carousel instance. The
+     * index is reset since the first slide becomes visible after re-render.
+     */
+    renderContent() {
+        super.renderContent();
+        this.carouselEl = this.el.querySelector(".carousel");
+        this.index = 0;
+        this.carouselInstance = window.Carousel.getOrCreateInstance(this.carouselEl);
+        this.computeHidePrev();
+    }
+
+    /**
+     * @override
+     */
+    appendContent() {
+        const templateAreaEl = this.el.querySelector(".dynamic_snippet_template");
+        const oldInnerEl = templateAreaEl.querySelector(".carousel-inner");
+        const newInnerEl = this.renderedContentNode.querySelector(".carousel-inner");
+        const newSlidesEl = [...newInnerEl.children];
+        newSlidesEl[0].classList.remove("active");
+        if (this.getScrollMode() === "single") {
+            const newSlides = newSlidesEl.slice(oldInnerEl.childElementCount);
+            const referenceNodeEl = oldInnerEl.children[this.getItemsPerSlide()];
+            newSlides.forEach((el) => oldInnerEl.insertBefore(el, referenceNodeEl));
+        } else {
+            oldInnerEl.append(...newSlidesEl.slice(oldInnerEl.childElementCount));
+        }
+        this.services["public.interactions"].startInteractions(templateAreaEl);
+    }
+
+    /**
+     * @override
+     */
+    getQWebRenderOptions(data) {
+        const scrollMode = this.getScrollMode();
+        return Object.assign(super.getQWebRenderOptions(data), {
             interval: parseInt(this.el.dataset.carouselInterval),
             rowPerSlide: parseInt(uiUtils.isSmall() ? 1 : this.el.dataset.rowPerSlide || 1),
             scrollMode: scrollMode,

--- a/addons/website/static/tests/interactions/snippets/dynamic_snippet_carousel.test.js
+++ b/addons/website/static/tests/interactions/snippets/dynamic_snippet_carousel.test.js
@@ -37,12 +37,27 @@ const testTemplate = /* xml */ `
         <section data-snippet="s_dynamic_snippet_carousel" class="s_dynamic_snippet_carousel s_dynamic pt32 pb32 o_colored_level" data-custom-template-data="{}" data-name="Dynamic Carousel"
                 data-filter-id="1"
                 data-template-key="website.dynamic_filter_template_test_item"
-                data-number-of-records="16"
+                data-number-of-records="24"
                 data-extra-classes="g-3"
                 data-column-classes="col-12 col-sm-6 col-lg-4"
                 data-carousel-interval="5000">
             <div class="container">
                 <div class="row s_nb_column_fixed">
+                    <section class="s_dynamic_snippet_holder d-none px-4 placeholder-glow">
+                        <div class="row">
+                            <span class="placeholder col-3 rounded"/>
+                            <span class="placeholder col-2 offset-7 rounded"/>
+                            <span class="placeholder mt-3 col-6 rounded"/>
+                        </div>
+                        <div class="row mt-4">
+                            <span class="placeholder col-12 rounded" style="height:250px;"/>
+                        </div>
+                    </section>
+                    <section class="s_dynamic_content_holder d-none px-4 placeholder-glow">
+                        <div class="row mt-4">
+                            <span class="placeholder col-12 rounded" style="height:250px;"/>
+                        </div>
+                    </section>
                     <section class="s_dynamic_snippet_content oe_unremovable oe_unmovable o_not_editable col o_colored_level">
                         <div class="css_non_editable_mode_hidden">
                             <div class="missing_option_warning alert alert-info fade show d-none d-print-none rounded-0">
@@ -59,45 +74,99 @@ const testTemplate = /* xml */ `
 
 test.tags("desktop");
 test("dynamic snippet carousel loads items and displays them through template (desktop)", async () => {
+    const rpcCalls = [];
     onRpc("/website/snippet/filters", async (args) => {
         const json = JSON.parse(new TextDecoder().decode(await args.arrayBuffer()));
-        expect(json.params.filter_id).toBe(1);
-        expect(json.params.template_key).toBe("website.dynamic_filter_template_test_item");
-        expect(json.params.limit).toBe(16);
-        expect(json.params.search_domain).toEqual([]);
-        return [
-            `<div class="s_test_dynamic_carousel_item" data-test-param="test1">Test Record 1</div>`,
-            `<div class="s_test_dynamic_carousel_item" data-test-param="test2">Test Record 2</div>`,
-            `<div class="s_test_dynamic_carousel_item" data-test-param="test3">Test Record 3</div>`,
-            `<div class="s_test_dynamic_carousel_item" data-test-param="test4">Test Record 4</div>`,
-            `<div class="s_test_dynamic_carousel_item" data-test-param="test5">Test Record 5</div>`,
-        ];
+        rpcCalls.push(json.params);
+        const offset = json.params.offset || 0;
+        if (offset === 0) {
+            return [
+                `<div class="s_test_dynamic_carousel_item" data-test-param="test1">Test Record 1</div>`,
+                `<div class="s_test_dynamic_carousel_item" data-test-param="test2">Test Record 2</div>`,
+                `<div class="s_test_dynamic_carousel_item" data-test-param="test3">Test Record 3</div>`,
+                `<div class="s_test_dynamic_carousel_item" data-test-param="test4">Test Record 4</div>`,
+                `<div class="s_test_dynamic_carousel_item" data-test-param="test5">Test Record 5</div>`,
+                `<div class="s_test_dynamic_carousel_item" data-test-param="test6">Test Record 6</div>`,
+                `<div class="s_test_dynamic_carousel_item" data-test-param="test7">Test Record 7</div>`,
+                `<div class="s_test_dynamic_carousel_item" data-test-param="test8">Test Record 8</div>`,
+                `<div class="s_test_dynamic_carousel_item" data-test-param="test9">Test Record 9</div>`,
+                `<div class="s_test_dynamic_carousel_item" data-test-param="test10">Test Record 10</div>`,
+                `<div class="s_test_dynamic_carousel_item" data-test-param="test11">Test Record 11</div>`,
+                `<div class="s_test_dynamic_carousel_item" data-test-param="test12">Test Record 12</div>`,
+                `<div class="s_test_dynamic_carousel_item" data-test-param="test13">Test Record 13</div>`,
+                `<div class="s_test_dynamic_carousel_item" data-test-param="test14">Test Record 14</div>`,
+                `<div class="s_test_dynamic_carousel_item" data-test-param="test15">Test Record 15</div>`,
+                `<div class="s_test_dynamic_carousel_item" data-test-param="test16">Test Record 16</div>`,
+            ];
+        } else if (offset === 16) {
+            return [
+                `<div class="s_test_dynamic_carousel_item" data-test-param="test17">Test Record 17</div>`,
+                `<div class="s_test_dynamic_carousel_item" data-test-param="test18">Test Record 18</div>`,
+                `<div class="s_test_dynamic_carousel_item" data-test-param="test19">Test Record 19</div>`,
+                `<div class="s_test_dynamic_carousel_item" data-test-param="test20">Test Record 20</div>`,
+                `<div class="s_test_dynamic_carousel_item" data-test-param="test21">Test Record 21</div>`,
+                `<div class="s_test_dynamic_carousel_item" data-test-param="test22">Test Record 22</div>`,
+                `<div class="s_test_dynamic_carousel_item" data-test-param="test23">Test Record 23</div>`,
+                `<div class="s_test_dynamic_carousel_item" data-test-param="test24">Test Record 24</div>`,
+            ];
+        }
     });
     const { core } = await startInteractions(testTemplate);
-    expect(core.interactions).toHaveLength(6);
+    expect(rpcCalls[0]).toMatchObject({
+        filter_id: 1,
+        template_key: "website.dynamic_filter_template_test_item",
+        limit: 16,
+        offset: 0,
+    });
+    expect(core.interactions).toHaveLength(17);
     const carouselEl = queryOne(".carousel");
     // Neutralize carousel automatic sliding.
     carouselEl.dataset.bsRide = "false";
-    const itemEls = queryAll(".carousel .s_test_dynamic_carousel_item");
+    let itemEls = queryAll(".carousel .s_test_dynamic_carousel_item");
+    expect(queryAll(".carousel-item")).toHaveLength(4);
     expect(itemEls[0]).toHaveAttribute("data-test-param", "test1");
-    expect(itemEls[1]).toHaveAttribute("data-test-param", "test2");
-    expect(itemEls[2]).toHaveAttribute("data-test-param", "test3");
-    expect(itemEls[3]).toHaveAttribute("data-test-param", "test4");
-    expect(itemEls[4]).toHaveAttribute("data-test-param", "test5");
+    expect(itemEls[15]).toHaveAttribute("data-test-param", "test16");
     expect(itemEls[3].closest(".carousel-item")).toHaveClass("active");
     expect(itemEls[4].closest(".carousel-item")).not.toHaveClass("active");
     await animationFrame();
+    expect(".carousel-control-prev").toHaveClass("d-none");
     await click(".carousel-control-next .oi");
-    await animationFrame();
     await advanceTime(1000); // Slide duration.
+    expect(".carousel-control-prev").not.toHaveClass("d-none");
     expect(itemEls[3].closest(".carousel-item")).not.toHaveClass("active");
     expect(itemEls[4].closest(".carousel-item")).toHaveClass("active");
+
+    await click(".carousel-control-next .oi");
+    await advanceTime(1000); // Slide duration.
+    expect(itemEls[7].closest(".carousel-item")).not.toHaveClass("active");
+    expect(itemEls[8].closest(".carousel-item")).toHaveClass("active");
+
+    await click(".carousel-control-next .oi");
+    await advanceTime(1000); // Slide duration.
+    expect(itemEls[11].closest(".carousel-item")).not.toHaveClass("active");
+    expect(itemEls[12].closest(".carousel-item")).toHaveClass("active");
+
     // Make sure element interactions are started.
     expect(itemEls[0]).toHaveAttribute("data-started", "*test1*");
-    expect(itemEls[1]).toHaveAttribute("data-started", "*test2*");
-    expect(itemEls[2]).toHaveAttribute("data-started", "*test3*");
-    expect(itemEls[3]).toHaveAttribute("data-started", "*test4*");
-    expect(itemEls[4]).toHaveAttribute("data-started", "*test5*");
+    expect(itemEls[15]).toHaveAttribute("data-started", "*test16*");
+    await click(".carousel-control-next .oi");
+    expect(".s_dynamic_content_holder").not.toHaveClass("d-none");
+    await animationFrame();
+    expect(rpcCalls[1]).toMatchObject({
+        filter_id: 1,
+        template_key: "website.dynamic_filter_template_test_item",
+        limit: 8,
+        offset: 16,
+    });
+    expect(".s_dynamic_content_holder").toHaveClass("d-none");
+    await advanceTime(1000); // Slide duration.
+    itemEls = queryAll(".carousel .s_test_dynamic_carousel_item");
+    expect(itemEls[15].closest(".carousel-item")).not.toHaveClass("active");
+    expect(itemEls[16].closest(".carousel-item")).toHaveClass("active");
+    expect(itemEls[16]).toHaveAttribute("data-started", "*test17*");
+    expect(itemEls[19]).toHaveAttribute("data-started", "*test20*");
+    expect(queryAll(".carousel-item")).toHaveLength(6);
+    expect(core.interactions).toHaveLength(25);
     core.stopInteractions();
     // Make sure element interactions are stopped.
     expect(core.interactions).toHaveLength(0);

--- a/addons/website/views/snippets/s_dynamic_snippet.xml
+++ b/addons/website/views/snippets/s_dynamic_snippet.xml
@@ -9,6 +9,9 @@
             t-att-data-custom-template-data="custom_template_data or '{}'"
             t-att-data-number-of-records="is_single_record and '1' or ''">
             <div t-attf-class="s_dynamic_snippet_container {{container_classes or 'container'}}">
+                <t t-set="placeholder_content">
+                    <span class="placeholder col-12 rounded" style="height: 250px;"/>
+                </t>
                 <div class="row s_nb_column_fixed">
                     <!-- Dynamic snippet loading effect -->
                     <section class="s_dynamic_snippet_holder d-none px-4 placeholder-glow">
@@ -18,7 +21,7 @@
                             <span class="placeholder mt-3 col-6 rounded"/>
                         </div>
                         <div class="row mt-4">
-                            <span class="placeholder col-12 rounded" style="height: 250px;"/>
+                            <t t-out="placeholder_content"/>
                         </div>
                     </section>
                     <section t-attf-class="{{is_single_record and 'd-none' or 'd-flex'}} {{snippet_heading_extra_classes or 'justify-content-between flex-column flex-md-row'}} s_dynamic_snippet_title oe_unremovable oe_unmovable mb-lg-0 pb-3 pb-md-0 s_col_no_resize">
@@ -28,6 +31,11 @@
                         </div>
                         <div t-if="main_page_url">
                             <a t-att-class="snippet_button_classes" t-att-href="main_page_url" t-out="snippet_button_text or snippet_button_text_default"/>
+                        </div>
+                    </section>
+                    <section class="s_dynamic_content_holder d-none px-4 placeholder-glow col">
+                        <div class="row mt-4">
+                            <t t-out="placeholder_content"/>
                         </div>
                     </section>
                     <section t-attf-class="s_dynamic_snippet_content oe_unremovable oe_unmovable o_not_editable col s_col_no_resize #{content_classes}">


### PR DESCRIPTION
*: html_builder, website

### 1. Introduce BuilderInputSelect* components [Commit 1]
This change introduces BuilderInputSelectBase, a new abstraction on top
of BuilderSelect that enables hybrid input + select behavior. It allows 
user to either pick a value from the dropdown or manually enter a value
(text/number).

key changes:
- Added new base class BuilderInputSelectBase extending BuilderSelect.
- Introduced BuilderInputSelectNumber and BuilderInputSelectText, 
  integrating BuilderNumberInput / BuilderTextInput with the dropdown.
- Clicking the input now selects its content and toggles the dropdown
  open/closed
- Updated the dynamic snippet to use the new BuilderInputSelectNumber
  component allowing user to select from predefined options while still
  supporting custom values when needed.

### 2. Prevent carousel slide cancellation in edit mode [Commit 2]

This reverts a [commit] that modified carousel slide handling in edit
mode to avoid blocked slide.bs.carousel / slid.bs.carousel events while
images were still loading.

Despite multiple attempts, the reported editor freeze when using Add
Slide could not be reproduced.

Until a deterministic reproduction case is identified, the original
carousel behavior is restored to avoid introducing unstable global
side effects in Colibri and carousel interactions.

[commit]: https://github.com/odoo/odoo/commit/61abb23bb5b4526f2170f99c05a5e3b61c714ea0

### 3. Lazy load dynamic snippets [Commit 3]
This commit introduces lazy loading to dynamic snippet carousels,
allowing items to load progressively instead of fetching all records at
once.

Dynamic Snippet Carousel:
- Lazy loading triggers automatically during slide navigation.
- Fetches next batch when approaching the end.
- Previous button visibility managed based on scroll position and data
  availability.

Implementation:
- `chunkSize`: max number of records per batch (default: 8)
- `offset`: current pagination position
- `limit`: number of records to fetch per request
- `fetchedData`: array of all accumulated records
- `hasMore`: flag indicating whether additional data is available


task-[4236245](https://www.odoo.com/odoo/project/974/tasks/4236245)