### PR TITLE
[FIX] html_editor: ensure icons are padded with feff on editor load

### DIFF
--- a/addons/html_builder/static/src/core/field_change_replication_plugin.js
+++ b/addons/html_builder/static/src/core/field_change_replication_plugin.js
@@ -92,6 +92,7 @@ export class FieldChangeReplicationPlugin extends Plugin {
             );
             if (targetEls.length) {
                 const cloneEl = sourceEl.cloneNode(true);
+                cloneEl.toggleAttribute("contenteditable", sourceEl.isContentEditable);
                 this.dependencies.dom.removeSystemProperties(cloneEl);
                 this.dispatchTo("clean_for_save_handlers", { root: cloneEl });
                 for (const targetEl of targetEls) {

--- a/addons/html_builder/static/tests/field_change_replication_plugin.test.js
+++ b/addons/html_builder/static/tests/field_change_replication_plugin.test.js
@@ -56,7 +56,7 @@ describe("replicate changes", () => {
         queryOne(":iframe .test-4 a").append("!"); // the feff should not be forwarded
         editor.shared.history.addStep();
         expect(":iframe .test-1 b").toHaveText("Travel Abroad!");
-        expect(":iframe .test-2 a").toHaveText("Travel Abroad!");
+        expect(":iframe .test-2 a").toHaveText("Travel Abroad!", { raw: true });
         expect(":iframe .test-3 span").toHaveText("Travel Abroad!");
         expect(":iframe .test-4 a").toHaveInnerHTML("\u{FEFF}Travel Abroad!\u{FEFF}");
     });

--- a/addons/html_editor/static/src/main/feff_plugin.js
+++ b/addons/html_editor/static/src/main/feff_plugin.js
@@ -5,6 +5,7 @@ import { prepareUpdate } from "@html_editor/utils/dom_state";
 import { descendants, selectElements } from "@html_editor/utils/dom_traversal";
 import { leftPos, rightPos } from "@html_editor/utils/position";
 import { callbacksForCursorUpdate } from "@html_editor/utils/selection";
+import { withSequence } from "../utils/resource";
 
 /** @typedef {import("../core/selection_plugin").Cursors} Cursors */
 
@@ -34,7 +35,7 @@ export class FeffPlugin extends Plugin {
 
     /** @type {import("plugins").EditorResources} */
     resources = {
-        normalize_handlers: this.updateFeffs.bind(this),
+        normalize_handlers: withSequence(Infinity, this.updateFeffs.bind(this)),
         clean_for_save_handlers: this.cleanForSave.bind(this),
         intangible_char_for_keyboard_navigation_predicates: (ev, char, lastSkipped) =>
             // Skip first FEFF, but not the second one (unless shift is pressed).

--- a/addons/html_editor/static/src/main/media/icon_plugin.js
+++ b/addons/html_editor/static/src/main/media/icon_plugin.js
@@ -4,6 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { MediaDialog } from "./media_dialog/media_dialog";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 import { ICON_SELECTOR, isElement } from "@html_editor/utils/dom_info";
+import { isIconElement, isZwnbsp } from "../../utils/dom_info";
 
 export class IconPlugin extends Plugin {
     static id = "icon";
@@ -58,16 +59,31 @@ export class IconPlugin extends Plugin {
         ],
         toolbar_namespace_providers: [
             (targetedNodes) => {
-                if (
-                    targetedNodes.length &&
-                    targetedNodes.every(
-                        // All nodes should be icons, its ZWS child or its ancestors
-                        (node) =>
-                            node.classList?.contains("fa") ||
-                            node.parentElement.classList.contains("fa") ||
-                            (node.querySelector?.(".fa") && node.isContentEditable !== false)
-                    )
-                ) {
+                if (!targetedNodes.length) {
+                    return;
+                }
+                const isIconInTargetedNodes = targetedNodes.some(isIconElement);
+                // All nodes should be icons, their ZWS children, or their ancestors.
+                // FEFF nodes are only considered valid if an icon is selected and the
+                // FEFF is directly adjacent to it.
+                const isIconRelatedNode = (node) => {
+                    if (
+                        node.classList?.contains("fa") ||
+                        node.parentElement?.classList.contains("fa") ||
+                        (node.querySelector?.(".fa") && node.isContentEditable !== false)
+                    ) {
+                        return true;
+                    }
+                    if (isZwnbsp(node) && isIconInTargetedNodes) {
+                        return (
+                            node.nextElementSibling?.classList?.contains("fa") ||
+                            node.previousElementSibling?.classList?.contains("fa")
+                        );
+                    }
+                    return false;
+                };
+
+                if (targetedNodes.every(isIconRelatedNode)) {
                     return this.toolbarNamespace;
                 }
             },

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -21,6 +21,7 @@ import { getContent, setSelection } from "./_helpers/selection";
 import { expandToolbar } from "./_helpers/toolbar";
 import { expectElementCount } from "./_helpers/ui_expectations";
 import { execCommand } from "./_helpers/userCommands";
+import { delay } from "@web/core/utils/concurrency";
 
 test("can set foreground color", async () => {
     const { el } = await setupEditor("<p>[test]</p>");
@@ -1349,4 +1350,27 @@ describe("color preview", () => {
         await animationFrame();
         expect("p font").toHaveStyle({ backgroundImage: initialGradient });
     });
+});
+
+test("Should not close the color picker on icon color change", async () => {
+    const { el } = await setupEditor(
+        `<p><span class="fa fa-glass" contenteditable="false"></span></p>`
+    );
+    await animationFrame();
+    const icon = el.querySelector(".fa");
+    setSelection({
+        anchorNode: icon.previousSibling,
+        anchorOffset: 1,
+        focusNode: icon.nextSibling,
+        focusOffset: 0,
+    });
+    await delay(50);
+    await click(".o-select-color-foreground");
+    await animationFrame();
+    await hover('[data-color="o-color-1"]');
+    await animationFrame();
+    expect('[data-color="o-color-1"]').toHaveCount(1);
+    await hover('[data-color="o-color-2"]');
+    await delay(50);
+    expect('[data-color="o-color-2"]').toHaveCount(1);
 });

--- a/addons/html_editor/static/tests/normalize.test.js
+++ b/addons/html_editor/static/tests/normalize.test.js
@@ -51,3 +51,10 @@ test("should remove `style.color` from table and apply it to td without `style.c
         `),
     });
 });
+
+test("Should properly add feffs around icons", async () => {
+    await testEditor({
+        contentBefore: `<div><span class="fa fa-glass" contenteditable="false"></span></div>`,
+        contentBeforeEdit: `<div class="o-paragraph">\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeff</div>`,
+    });
+});


### PR DESCRIPTION
Problem:
When content is added to the editor, icons are not surrounded by
`feff`s.

Cause:
The selector used to pad elements with `feff`s relies on
`o-paragraph`, which is added during normalization.
However, `BaseContainerPlugin.normalize_handlers` runs last, so when
`FeffPlugin.normalize_handlers` executes, it cannot find icons through
`selectors_for_feff_providers` because the expected paragraph-related
parent is not yet in place.

Solution:
Execute `FeffPlugin.normalize_handlers` immediately after
`BaseContainerPlugin.normalize_handlers`, ensuring the DOM structure is
ready before attempting to add surrounding `feff`s.

Steps to reproduce:
- Add an icon.
- Reload the page.
- Do not make any changes (so normalization is not triggered again).
- Inspect the icon and observe that it does not have surrounding
  `feff`s.

task-5960097

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
