### PR TITLE
[FIX] point_of_sale, pos_restaurant: prevent cancelling outdated orders

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1182,6 +1182,12 @@ class PosOrder(models.Model):
         (payment_receivable_lines | invoice_receivable_lines).sudo().with_company(invoice.company_id).reconcile()
 
     def action_pos_order_cancel(self):
+        if context := self.env.context.get('last_orders_date'):
+            for order in self:
+                date = context[str(order.id)]
+                if order.write_date and order.write_date.strftime("%Y-%m-%d %H:%M:%S") != date:
+                    raise UserError(_('The order has been modified since the last time it was loaded. You cannot cancel it.'))
+
         draft_orders = self.filtered(lambda o: o.state == 'draft')
         if self.env.context.get('active_ids'):
             orders = self.browse(self.env.context.get('active_ids'))

--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -39,6 +39,7 @@ export class PosData {
             offline: false,
             loading: true,
             unsyncData: [],
+            requestCount: 0,
         });
 
         if (!navigator.onLine) {
@@ -537,6 +538,7 @@ export class PosData {
 
             let result = true;
             let limitedFields = false;
+            this.network.requestCount++;
             if (fields.length === 0) {
                 fields = this.fields[model] || [];
             }
@@ -550,10 +552,10 @@ export class PosData {
 
             switch (type) {
                 case "write":
-                    result = await this.orm.write(model, ids, values);
+                    result = await this.orm.write(model, ids, values, kwargs);
                     break;
                 case "delete":
-                    result = await this.orm.unlink(model, ids);
+                    result = await this.orm.unlink(model, ids, kwargs);
                     break;
                 case "call":
                     result = await this.orm.call(model, method, args, kwargs);
@@ -563,6 +565,7 @@ export class PosData {
                     result = await this.orm.read(model, ids, fields, {
                         ...options,
                         load: false,
+                        context: kwargs.context,
                     });
                     break;
                 case "search_read":
@@ -570,6 +573,7 @@ export class PosData {
                     result = await this.orm.searchRead(model, args, fields, {
                         ...options,
                         load: false,
+                        context: kwargs.context,
                     });
             }
 
@@ -683,6 +687,7 @@ export class PosData {
                 throw error;
             }
         } finally {
+            this.network.requestCount--;
             this.network.loading = false;
         }
     }

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -593,10 +593,21 @@ export class PosStore extends WithLazyGetterTrap {
 
     async deleteOrders(orders, serverIds = [], ignoreChange = false) {
         const ordersToDelete = [];
+        const orderToCancelOnServer = [];
         const actionPosOrderCancelCall = async (orderIds) => {
+            const orderContext = orderIds.reduce((acc, id) => {
+                const order = this.models["pos.order"].get(id);
+                if (!order || typeof order.id !== "number") {
+                    return acc;
+                }
+
+                acc[order.id] = order.raw.write_date;
+                return acc;
+            }, {});
             await this.data.call("pos.order", "action_pos_order_cancel", [orderIds], {
                 context: {
                     device_identifier: this.device.identifier,
+                    last_orders_date: orderContext,
                 },
             });
         };
@@ -618,13 +629,20 @@ export class PosStore extends WithLazyGetterTrap {
                         }
                     }
 
-                    if (order.isSynced) {
-                        await actionPosOrderCancelCall([order.id]);
+                    if (typeof order.id === "number") {
+                        orderToCancelOnServer.push(order);
+                    } else {
+                        ordersToDelete.push(order);
                     }
-                    ordersToDelete.push(order);
                 } else {
                     return false;
                 }
+            }
+
+            if (orderToCancelOnServer.length) {
+                const ids = orderToCancelOnServer.map((order) => order.id);
+                await actionPosOrderCancelCall(ids);
+                ordersToDelete.push(...orderToCancelOnServer);
             }
 
             if (serverIds.length > 0) {

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/order_summary/order_summary.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/order_summary/order_summary.xml
@@ -4,7 +4,7 @@
         <xpath expr="//OrderDisplay/t[@t-set-slot='details']" position="inside">
             <div class="d-flex flex-column align-items-center gap-2">
                 <button t-if="showBookButton()" class="btn btn-primary btn-lg py-2 book-table" style="border:none; font-size: 20px;" t-on-click="bookTable">Book table</button>
-                <button t-if="showUnbookButton()" class="btn btn-primary btn-lg py-2 unbook-table" style="border:none; font-size: 20px;" t-on-click="unbookTable">
+                <button t-if="showUnbookButton()" class="btn btn-primary btn-lg py-2 unbook-table" style="border:none; font-size: 20px;" t-on-click="unbookTable" t-att-disabled="pos.data.network.requestCount > 0">
                     <t t-if="pos.selectedTable">Release table</t>
                     <t t-else="">Release Order</t>
                 </button>

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -619,6 +619,7 @@ registry.category("web_tour.tours").add("test_preset_delivery_restaurant", {
             Dialog.confirm("Open Register"),
             Dialog.isNot(),
             FloorScreen.clickTable("2"),
+            Chrome.waitRequest(),
             ProductScreen.clickCustomer("Partner Full"),
             ProductScreen.clickDisplayedProduct("Coca-Cola", true),
             ProductScreen.clickControlButton("Cancel Order"),
@@ -628,6 +629,7 @@ registry.category("web_tour.tours").add("test_preset_delivery_restaurant", {
             ProductScreen.clickControlButton("Cancel Order"),
             Dialog.confirm("ok"),
             Dialog.isNot(),
+            Chrome.waitRequest(),
             FloorScreen.hasTable("2"),
         ].flat(),
 });


### PR DESCRIPTION
When cancelling an order, the POS backend checks if the order has been modified since it was loaded by comparing the last_order_date in the context with the write_date of the order. If they differ, it means the order has been modified and a UserError is raised to prevent cancelling an outdated order.


