### PR TITLE
[FIX] resource_mail: display m2m_avatar_resource in activity as kanban

### DIFF
--- a/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.js
+++ b/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.js
@@ -133,3 +133,4 @@ export const kanbanMany2ManyAvatarResourceField = {
     component: KanbanMany2ManyAvatarResourceField,
 };
 registry.category("fields").add("kanban.many2many_avatar_resource", kanbanMany2ManyAvatarResourceField);
+registry.category("fields").add("activity.many2many_avatar_resource", kanbanMany2ManyAvatarResourceField);

--- a/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.js
+++ b/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.js
@@ -25,7 +25,10 @@ export class AvatarResourceMany2XAutocomplete extends Many2XAutocomplete {
             "search_read",
             [this.getDomain(request), ["id", "display_name", "resource_type", "color"]],
             {
-                context: this.props.context,
+                context: {
+                    ...this.props.context,
+                    formatted_display_name: true,
+                },
                 limit: this.props.searchLimit + 1,
             }
         );


### PR DESCRIPTION
This commit adds `activity.many2many_avatar_resource` in the registry to be able to have the same render than kanban view in the activity view.

task-5921961

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
