### PR TITLE
[FIX] sale_stock: add date of order to procurement values

### DIFF
--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -288,6 +288,7 @@ class SaleOrderLine(models.Model):
             'origin': self.order_id.name,
             'reference_ids': self.order_id.stock_reference_ids,
             'sale_line_id': self.id,
+            'date_order': self.order_id.date_order,
             'date_planned': date_planned,
             'date_deadline': date_deadline,
             'route_ids': self.route_ids,

--- a/addons/stock_dropshipping/tests/test_purchase_order.py
+++ b/addons/stock_dropshipping/tests/test_purchase_order.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from unittest import skip
+from freezegun import freeze_time
 
 from odoo import Command
 from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_common import ValuationReconciliationTestCommon
@@ -8,7 +9,6 @@ from odoo.tests.common import tagged
 
 
 @tagged('-at_install', 'post_install')
-@skip('Temporary to fast merge new valuation')
 class TestPurchaseOrder(ValuationReconciliationTestCommon):
 
     @classmethod
@@ -20,6 +20,7 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
             ('company_id', '=', cls.env.company.id),
         ], limit=1)
 
+    @skip('Temporary to fast merge new valuation')
     def test_qty_received_does_sync_after_changing_validated_move_quantity(self):
         """ After validating a picking, if it is unlocked and has its move quantity modified,
         the underlying purchase order's qty_delivered value should reflect the change.
@@ -108,3 +109,48 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
 
         self.assertTrue(po, "A Purchase Order should be created from the Sale Order.")
         self.assertEqual(po.project_id, project, "The project should be propagated from the Sale Order to the Purchase Order.")
+
+    @freeze_time('2025-02-15')
+    def test_purchase_order_date_and_interpolated_name(self):
+        self.env.user.group_ids |= self.quick_ref('sales_team.group_sale_salesman')
+        self.env['ir.sequence'].search([
+            ('code', '=', 'purchase.order'),
+        ]).write({
+            'use_date_range': True,
+            'prefix': 'P/%(y)s/%(month)s/',
+            'date_range_ids': [
+                Command.create({
+                    'date_from': '2025-02-01',
+                    'date_to': '2025-02-28',
+                    'number_next_actual': 15,
+                }),
+                Command.create({
+                    'date_from': '2025-03-01',
+                    'date_to': '2025-03-31',
+                    'number_next_actual': 1,
+                })
+            ]
+        })
+        dropship_product = self.env['product.product'].create({
+            'name': 'Dropship Product',
+            'seller_ids': [Command.create({
+                'partner_id': self.partner_b.id,
+            })],
+            'route_ids': [Command.set([
+                self.env.ref('stock_dropshipping.route_drop_shipping').id
+            ])],
+        })
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'product_id': dropship_product.id,
+                'product_uom_qty': 1.0,
+            })],
+            'commitment_date': '2025-03-15',  # March
+        })
+        so.action_confirm()
+        po = self.env['purchase.order'].search([
+            ('origin', '=', so.name),
+            ('partner_id', '=', self.partner_b.id),
+        ], limit=1)
+        self.assertEqual(po.name, 'P/25/02/00015')  # Should be based on the SO's date_order (February), not the commitment_date (March)


### PR DESCRIPTION
## Issue
When confirming a *Sales Order* that includes a dropshipped product, the name of the *Purchase Order* is generated using an incorrect sequence number. If the `purchase.order` sequence is configured to use date ranges, the SO's delivery date is used to chose the date range, instead of the PO creation date.

## Steps to reproduce
1. Install *Sales* (`sale_management`), *Stock* (`stock`) and *Purchase* (`purchase`)
2. In Settings, enable *Dropshipping* and *Multi-Step Routes*
3. In Settings > Technical > Sequences, select the `purchase.order` sequence
    - Set the Prefix to something containing the current month (e.g. `P%(y)s/%(month)s/`)
    - Enable *Use subsequences per date_range* (`ir.sequence.use_date_range`)
    - Add a row for the current month, with *Next Number* set to 1
    - Add a row for the next month, with *Next Number* set to 5
4. Create a Product P:
    - In the *Purchase* tab, add a Vendor
    - In the *Inventory* tab, enable the *Dropship* route
5. Create a Sales Order:
    - Any Customer
    - One line containing Product P (any quantity)
    - In the *Other Info*, set the *Delivery Date* (`commitment_date`) to next month
    - Confirm
6. **The resulting Purchase order uses the sequence from next month (= its name ends with 5) even though it is created during the current month.**

## Cause
The `date_order` of the PO is computed here:

https://github.com/odoo/odoo/blob/e10d23eba9cb6526ad68f037a493696992d1614c/addons/purchase_stock/models/stock_rule.py#L332

In this case, the `value` dictionary does not contain `date_order`, because it is not transferred from the SO here:

https://github.com/odoo/odoo/blob/e10d23eba9cb6526ad68f037a493696992d1614c/addons/sale_stock/models/sale_order_line.py#L277-L303

## Note
The entire `TestPurchaseOrder` test class has been skipped since https://github.com/odoo/odoo/commit/08b62a4bbcc6f9a391b2cc00a621ef4c76100229 even though most of the tests pass. The `@skip` decorator has been moved to the only failing test: `test_qty_received_does_sync_after_changing_validated_move_quantity`.

opw-5950028