### PR TITLE
[FIX] hr_attendance : overtime_update_domain correctly selects the week

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -270,8 +270,8 @@ class HrAttendance(models.Model):
             return Domain.FALSE
         domain_list = [Domain.AND([
             Domain('employee_id', '=', employee.id),
-            Domain('date', '<=', max(attendances.mapped('check_out')).date() + relativedelta(SU)),
-            Domain('date', '>=', min(attendances.mapped('check_in')).date() + relativedelta(MO(-1))),
+            Domain('date', '<=', max(attendances.mapped('check_out')).date() + relativedelta(weekday=SU)),
+            Domain('date', '>=', min(attendances.mapped('check_in')).date() + relativedelta(weekday=MO(-1))),
         ]) for employee, attendances in self.filtered(lambda att: att.check_out).grouped('employee_id').items()]
         if not domain_list:
             return Domain.FALSE

--- a/addons/hr_attendance/tests/__init__.py
+++ b/addons/hr_attendance/tests/__init__.py
@@ -8,3 +8,4 @@ from . import test_hr_attendance_kiosk
 from . import test_hr_attendance_rulesets
 from . import test_performance
 from . import test_hr_attendance_manager
+from . import test_hr_attendance

--- a/addons/hr_attendance/tests/test_hr_attendance.py
+++ b/addons/hr_attendance/tests/test_hr_attendance.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+
+from odoo.tests.common import tagged, TransactionCase
+
+
+@tagged('hr_attendance')
+class TestHrAttendanceCommon(TransactionCase):
+    """Tests for attendances"""
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestHrAttendanceCommon, cls).setUpClass()
+        cls.attendance = cls.env['hr.attendance']
+        cls.employee = cls.env['hr.employee'].create({'name': "Jacky", 'ruleset_id': False})
+
+    def test_get_overtimes_to_update_domain(self):
+        attendance = self.attendance.create({
+            'employee_id': self.employee.id,
+            'check_in': datetime(2026, 1, 7, 8, 0),
+            'check_out': datetime(2026, 1, 7, 20, 0)
+        })
+
+        expected_domain = f"['&', '&', ('employee_id', '=', {self.employee.id}), ('date', '<=', datetime.date(2026, 1, 11)), ('date', '>=', datetime.date(2026, 1, 5))]"
+        self.assertEqual(expected_domain, str(attendance._get_overtimes_to_update_domain()))
+
+
+    def test_get_overtimes_to_update_domain_same_week(self):
+        attendance = self.attendance.create([{
+            'employee_id': self.employee.id,
+            'check_in': datetime(2026, 1, 7, 8, 0),
+            'check_out': datetime(2026, 1, 7, 20, 0)
+        },
+        {
+            'employee_id': self.employee.id,
+            'check_in': datetime(2026, 1, 8, 8, 0),
+            'check_out': datetime(2026, 1, 8, 20, 0)
+        },
+        ])
+
+        expected_domain = f"['&', '&', ('employee_id', '=', {self.employee.id}), ('date', '<=', datetime.date(2026, 1, 11)), ('date', '>=', datetime.date(2026, 1, 5))]"
+        self.assertEqual(expected_domain, str(attendance._get_overtimes_to_update_domain()))
+
+
+    def test_get_overtimes_to_update_domain_double_week(self):
+        attendance = self.attendance.create([{
+            'employee_id': self.employee.id,
+            'check_in': datetime(2026, 1, 3, 8, 0),
+            'check_out': datetime(2026, 1, 3, 20, 0)
+        },
+        {
+            'employee_id': self.employee.id,
+            'check_in': datetime(2026, 1, 8, 8, 0),
+            'check_out': datetime(2026, 1, 8, 20, 0)
+        },
+        ])
+
+        expected_domain = f"['&', '&', ('employee_id', '=', {self.employee.id}), ('date', '<=', datetime.date(2026, 1, 11)), ('date', '>=', datetime.date(2025, 12, 29))]"
+        self.assertEqual(expected_domain, str(attendance._get_overtimes_to_update_domain()))


### PR DESCRIPTION
The domain is supposed to cover the whole week the attendance is in, but an error in the use of relativedelta makes it only return the day itself, as relativedelta(SU) does nothing.
