### PR TITLE
[FIX] html_builder, website: preserve dropzone messages on save

### DIFF
--- a/addons/html_builder/static/src/core/setup_editor_plugin.js
+++ b/addons/html_builder/static/src/core/setup_editor_plugin.js
@@ -77,11 +77,6 @@ export class SetupEditorPlugin extends Plugin {
         root.querySelectorAll(".o_editable").forEach((el) => {
             el.classList.remove("o_editable");
         });
-
-        [root, ...root.querySelectorAll("[data-editor-message]")].forEach((el) => {
-            el.removeAttribute("data-editor-message");
-            el.removeAttribute("data-editor-message-default");
-        });
     }
 
     /**

--- a/addons/website/static/tests/builder/content_editable.test.js
+++ b/addons/website/static/tests/builder/content_editable.test.js
@@ -109,7 +109,7 @@ test("feff on links are cleaned up", async () => {
     onRpc("ir.ui.view", "save", ({ args }) => {
         // Check that the saved content has no feff
         expect(args[1]).toBe(
-            `<div id="wrap" class="oe_structure oe_empty" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch"><section class="o_colored_level"><a href="http://test.test">texst</a></section></div>`
+            `<div id="wrap" class="oe_structure oe_empty" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch" data-editor-message-default="true" data-editor-message="DRAG BUILDING BLOCKS HERE"><section class="o_colored_level"><a href="http://test.test">texst</a></section></div>`
         );
         expect.step("save");
         return true;

--- a/addons/website/static/tests/builder/invisibility_options.test.js
+++ b/addons/website/static/tests/builder/invisibility_options.test.js
@@ -86,7 +86,7 @@ test("check invisible element after save", async () => {
     await contains(".o_we_invisible_el_panel .o_we_invisible_entry").click();
     await contains(".o-snippets-top-actions button:contains(Save)").click();
     expect(resultSave[0]).toBe(
-        `<div id="wrap" class="oe_structure oe_empty" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch">
+        `<div id="wrap" class="oe_structure oe_empty" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch" data-editor-message-default="true" data-editor-message="DRAG BUILDING BLOCKS HERE">
         <section class="o_colored_level">
             <div class="container">
                 <div class="row">

--- a/addons/website/static/tests/builder/save.test.js
+++ b/addons/website/static/tests/builder/save.test.js
@@ -43,7 +43,7 @@ test("basic save", async () => {
     await contains(".o-snippets-top-actions button:contains(Save)").click();
     expect(resultSave.length).toBe(1);
     expect(resultSave[0]).toBe(
-        '<div id="wrap" class="oe_structure oe_empty" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch"><h1 class="title">H1ello</h1></div>'
+        '<div id="wrap" class="oe_structure oe_empty" data-oe-model="ir.ui.view" data-oe-id="539" data-oe-field="arch" data-editor-message-default="true" data-editor-message="DRAG BUILDING BLOCKS HERE"><h1 class="title">H1ello</h1></div>'
     );
     expect(":iframe #wrap").not.toHaveClass("o_dirty");
     expect(":iframe #wrap").not.toHaveClass("o_editable");


### PR DESCRIPTION
Steps to reproduce:
- Open the website shop page in edit mode.
- Drag and drop a block in the shop header dropzone.
- Save the page and re-enter edit mode.
- Check the shop header dropzone message.
=> The custom message is replaced by the default one.

Before this commit, `SetupEditorPlugin.cleanForSave()` removed
`data-editor-message` and `data-editor-message-default` on the saved
HTML clone, including custom messages defined in website templates.

This cleanup was originally introduced in `web_editor` in [1]. Since the
builder refactor in [2], website page saves now use the shared
`html_builder` save cleanup flow and wrongly inherited that behavior,
which introduced this regression in website.

This commit removes that cleanup from `html_builder`, as it does not
provide useful value in this save flow and drops custom dropzone
messages.

After this commit, custom dropzone messages are preserved after saving
website pages.

[1]: bab673488e185ddd7792aedecc3870663290fed3
[2]: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

task-5921283