### PR TITLE
[FIX] html_builder, website: reset image shape transformation

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_shape_option.js
+++ b/addons/html_builder/static/src/plugins/image/image_shape_option.js
@@ -31,6 +31,9 @@ export class ImageShapeOption extends BaseOptionComponent {
                 showImageShapeTransform: this.imageShapeOption.isTransformableShape(shape),
                 showImageShapeAnimation: this.imageShapeOption.isAnimableShape(shape),
                 togglableRatio: this.imageShapeOption.isTogglableRatioShape(shape),
+                hasShapeTransformation:
+                    !!editingElement.dataset.shapeFlip ||
+                    !!parseInt(editingElement.dataset.shapeRotate),
             };
         });
     }

--- a/addons/html_builder/static/src/plugins/image/image_shape_option.xml
+++ b/addons/html_builder/static/src/plugins/image/image_shape_option.xml
@@ -40,6 +40,12 @@
                 action="'rotateImageShape'" actionParam="{side: 'left'}" />
             <BuilderButton title.translate="Rotate right" icon="'fa-rotate-right'"
                 action="'rotateImageShape'" actionParam="{side: 'right'}" />
+            <BuilderButton
+                title.translate="Reset shape transformation"
+                icon="'oi-close'"
+                action="'resetImageShapeTransformation'"
+                className="'btn-danger-color-hover'"
+                t-if="this.state.hasShapeTransformation"/>
         </BuilderRow>
 
         <BuilderRow label.translate="Speed" level="1" t-if="this.state.showImageShapeAnimation" preview="false">

--- a/addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js
@@ -68,6 +68,7 @@ export class ImageShapeOptionPlugin extends Plugin {
             FlipImageShapeAction,
             RotateImageShapeAction,
             SetImageShapeSpeedAction,
+            ResetImageShapeTransformationAction,
             ToggleImageShapeRatioAction,
         },
         process_image_warmup_handlers: this.processImageWarmup.bind(this),
@@ -422,7 +423,11 @@ export class SetImageShapeAction extends BuilderAction {
     static id = "setImageShape";
     static dependencies = ["imageShapeOption"];
     async load({ editingElement: img, value: shapeId }) {
-        const params = { shape: shapeId };
+        const params = {
+            shape: shapeId,
+            shapeFlip: undefined,
+            shapeRotate: undefined,
+        };
         // A crop is applied to the image at the same time as certain shapes,
         // which is why we reset the crop here or when the shape is removed.
         // However, we don’t reset it when the crop was applied intentionally.
@@ -514,6 +519,19 @@ export class SetImageShapeSpeedAction extends BuilderAction {
     async load({ editingElement: img, value: speed }) {
         return this.dependencies.imageShapeOption.loadShape(img, {
             shapeAnimationSpeed: speed,
+        });
+    }
+    apply({ loadResult: updateImageAttributes }) {
+        updateImageAttributes();
+    }
+}
+export class ResetImageShapeTransformationAction extends BuilderAction {
+    static id = "resetImageShapeTransformation";
+    static dependencies = ["imageShapeOption"];
+    async load({ editingElement: img }) {
+        return this.dependencies.imageShapeOption.loadShape(img, {
+            shapeFlip: undefined,
+            shapeRotate: undefined,
         });
     }
     apply({ loadResult: updateImageAttributes }) {

--- a/addons/website/static/tests/builder/image_shape.test.js
+++ b/addons/website/static/tests/builder/image_shape.test.js
@@ -592,3 +592,44 @@ test("Should keep colors when changing speed and vice versa", async () => {
 
     expect(imgSelector).toHaveAttribute("data-shape-animation-speed", "2");
 });
+test("Should reset shape transformation with reset button and when switching shape", async () => {
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`
+        <div class="test-options-target">
+            <img src='/web/image/website.s_text_image_default_image'
+                data-original-id="1"
+                data-original-src="/website/static/src/img/snippets_demo/s_text_image.jpg"
+                data-mimetype-before-conversion="image/jpeg"
+                data-shape="html_builder/geometric/geo_tetris"
+                data-shape-colors=";;;;"
+                data-shape-flip="xy"
+                data-shape-rotate="270"
+            >
+        </div>
+    `);
+    const imgSelector = ":iframe .test-options-target img";
+
+    await contains(imgSelector).click();
+    await waitSidebarUpdated();
+
+    await contains("[data-action-id='resetImageShapeTransformation']").click();
+    await waitSidebarUpdated();
+
+    expect(imgSelector).toHaveAttribute("data-shape", "html_builder/geometric/geo_tetris");
+    expect(imgSelector).not.toHaveAttribute("data-shape-flip");
+    expect(imgSelector).not.toHaveAttribute("data-shape-rotate");
+
+    await contains(`[data-action-id="flipImageShape"]:has(.oi-arrows-h)`).click();
+    await contains(`[data-action-id="rotateImageShape"]:has(.fa-rotate-right)`).click();
+    await waitSidebarUpdated();
+
+    expect(imgSelector).toHaveAttribute("data-shape-flip", "x");
+    expect(imgSelector).toHaveAttribute("data-shape-rotate", "90");
+
+    await contains("[data-label='Shape'] .dropdown").click();
+    await contains("[data-action-value='html_builder/geometric/geo_shuriken']").click();
+    await waitSidebarUpdated();
+
+    expect(imgSelector).toHaveAttribute("data-shape", "html_builder/geometric/geo_shuriken");
+    expect(imgSelector).not.toHaveAttribute("data-shape-flip");
+    expect(imgSelector).not.toHaveAttribute("data-shape-rotate");
+});


### PR DESCRIPTION
Image shape transformations (flip and rotate) were never reset when
changing or removing a shape; the dataset persisted indefinitely.
Additionally, there was no way to manually reset a transformation,
without undoing each operation manually.

This commit ensures the dataset is cleaned when SetImageShapeAction is
called and introduces a new button to manually reset transformations.

Steps to reproduce:
- Drop a snippet with image
- Apply `solid_blob_4` shape on image (supports transformation)
- Rotate or flip the shape
- Change to `solid_blob_2` (does not support transformation)
- Switch back to `solid_blob_4`, the first transformation is still
  there, it should have been reset

task-5972945