### PR TITLE
[FIX] pos_self_order: enforce preset selection on product pages navigation

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
@@ -23,8 +23,19 @@ export class ComboPage extends Component {
             this.goBack();
             return;
         }
-        useSubEnv({ selectedValues: {} });
+
         this.selfOrder = useSelfOrder();
+
+        if (
+            this.selfOrder.hasPresets() &&
+            !this.selfOrder.currentOrder.preset_id &&
+            this.selfOrder.config.self_ordering_mode !== "kiosk"
+        ) {
+            this.router.navigate("location");
+            return;
+        }
+
+        useSubEnv({ selectedValues: {} });
         this.state = useState({
             selectedChoiceIndex: 0,
             choices: [],

--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.js
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.js
@@ -30,6 +30,15 @@ export class ProductListPage extends Component {
         if (initCategories) {
             this.selfOrder.computeAvailableCategories();
         }
+
+        if (
+            this.selfOrder.hasPresets() &&
+            !this.selfOrder.currentOrder.preset_id &&
+            this.selfOrder.config.self_ordering_mode !== "kiosk"
+        ) {
+            this.router.navigate("location");
+            return;
+        }
         const availableCategories = this.selfOrder.availableCategories;
         const topCategories = availableCategories.filter((category) => !category.parent_id);
         const selectedCategory =

--- a/addons/pos_self_order/static/src/app/pages/product_page/product_page.js
+++ b/addons/pos_self_order/static/src/app/pages/product_page/product_page.js
@@ -23,6 +23,15 @@ export class ProductPage extends Component {
             return;
         }
 
+        if (
+            this.selfOrder.hasPresets() &&
+            !this.selfOrder.currentOrder.preset_id &&
+            this.selfOrder.config.self_ordering_mode !== "kiosk"
+        ) {
+            this.router.navigate("location");
+            return;
+        }
+
         const editedLine = this.selfOrder.editedLine;
         useSubEnv({ selectedValues: {} });
 

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -382,6 +382,18 @@ export class SelfOrder extends Reactive {
             const isPaid = o.state === "paid";
             const isZeroAmount = o.amount_total === 0;
             const isKiosk = this.config.self_ordering_mode === "kiosk";
+            const isEach = this.config.self_ordering_pay_after === "each";
+
+            if (
+                isEach &&
+                !isKiosk &&
+                o.isSynced &&
+                o.lines.length > 0 &&
+                o.state === "draft" &&
+                !["confirmation", "cart", "payment"].includes(this.router.activeSlot)
+            ) {
+                return false;
+            }
 
             return (
                 isDraft ||
@@ -400,7 +412,10 @@ export class SelfOrder extends Reactive {
             this.selectedOrderUuid = existingOrder.uuid;
             return existingOrder;
         }
-        return this.createNewOrder();
+        const newOrder = this.createNewOrder();
+        const orderObj = Array.isArray(newOrder) ? newOrder[0] : newOrder;
+        this.selectedOrderUuid = orderObj?.uuid;
+        return orderObj;
     }
 
     createNewOrder() {
@@ -734,7 +749,12 @@ export class SelfOrder extends Reactive {
             }
             this.data.debouncedSynchronizeLocalDataInIndexedDB();
 
-            if (this.config.self_ordering_pay_after === "each") {
+            // Do not reset selectedOrderUuid if we are immediately transitioning to payment.
+            // The payment page needs to access the current order to process it.
+            if (
+                this.config.self_ordering_pay_after === "each" &&
+                !["cart", "payment"].includes(this.router.activeSlot)
+            ) {
                 this.selectedOrderUuid = null;
             }
 
@@ -777,7 +797,16 @@ export class SelfOrder extends Reactive {
             });
             const result = this.models.connectNewData(data);
             const openOrder = result["pos.order"]?.find((o) => o.state === "draft");
-            if (openOrder && this.router.activeSlot !== "confirmation") {
+            const isEach = this.config.self_ordering_pay_after === "each";
+            const isViewingPage = ["confirmation", "cart", "payment"].includes(
+                this.router.activeSlot
+            );
+
+            if (
+                openOrder &&
+                this.router.activeSlot !== "confirmation" &&
+                (!isEach || isViewingPage)
+            ) {
                 this.selectedOrderUuid = openOrder.uuid;
 
                 // Remove all other open orders in draft and add orderline in the current order


### PR DESCRIPTION
Before this commit, when "Pay after each" and presets were enabled, navigating directly to the `/products` URL bypassed the initial location screen. This allowed users to browse the catalog and create new orders without a defined preset, causing issues later in the checkout flow.
This commit enforces the preset requirement directly on the product, combo, and product list pages. If an active order lacks a preset, the user is now automatically redirected to the location selection screen before they can proceed.

task-id: 5973990

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
