### PR TITLE
[IMP] web: enable deleting records while offline

### DIFF
--- a/addons/web/static/src/core/offline/offline_service.js
+++ b/addons/web/static/src/core/offline/offline_service.js
@@ -329,6 +329,7 @@ class OfflineManager extends Reactive {
 
             for (const [index, { key, value }] of Object.values(this._ormToSync)
                 .filter(({ value }) => !value.extras.error)
+                .sort((s1, s2) => s1.value.extras.timeStamp - s2.value.extras.timeStamp)
                 .entries()) {
                 if (index !== 0) {
                     await new Promise((r) => browser.setTimeout(r, 1000)); // Waits 1 second

--- a/addons/web/static/src/core/offline/offline_service.js
+++ b/addons/web/static/src/core/offline/offline_service.js
@@ -336,7 +336,10 @@ class OfflineManager extends Reactive {
                 try {
                     await this.orm.silent.call(value.model, value.method, value.args, value.kwargs);
                     this.removeScheduledORM(key);
-                } catch {
+                } catch (e) {
+                    if (e instanceof ConnectionLostError) {
+                        break;
+                    }
                     this.scheduleORM(value.model, value.method, value.args, value.kwargs, {
                         id: key,
                         extras: { ...value.extras, error: true },

--- a/addons/web/static/src/model/relational_model/dynamic_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_list.js
@@ -5,7 +5,8 @@ import { unique } from "@web/core/utils/arrays";
 import { DataPoint } from "./datapoint";
 import { Operation } from "./operation";
 import { Record as RelationalRecord } from "./record";
-import { getFieldsSpec, resequence } from "./utils";
+import { getFieldsSpec, getScheduleORMExtras, resequence } from "./utils";
+import { ConnectionLostError } from "@web/core/network/rpc";
 
 /**
  * @typedef {import("./record").Record} RelationalRecord
@@ -276,9 +277,27 @@ export class DynamicList extends DataPoint {
             resIds = await this.getResIds(true);
             records = this.records.filter((r) => resIds.includes(r.resId));
         }
-        const unlinked = await this.model.orm.unlink(this.resModel, resIds, {
-            context: this.context,
-        });
+        let unlinked = false;
+        try {
+            unlinked = await this.model.orm.unlink(this.resModel, resIds, {
+                context: this.context,
+            });
+        } catch (e) {
+            if (e instanceof ConnectionLostError) {
+                this.model.offline.scheduleORM(
+                    this.resModel,
+                    "unlink",
+                    [resIds],
+                    { context: this.context },
+                    {
+                        extras: getScheduleORMExtras(this.model, records),
+                    }
+                );
+                this._unSelectAll();
+                return true;
+            }
+            throw e;
+        }
         if (!unlinked) {
             return false;
         }
@@ -504,5 +523,12 @@ export class DynamicList extends DataPoint {
                 record._toggleSelection(true);
             });
         }
+    }
+
+    _unSelectAll() {
+        this.selection.forEach((record) => {
+            record.toggleSelection(false);
+        });
+        this._selectDomain(false);
     }
 }

--- a/addons/web/static/src/model/relational_model/dynamic_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_list.js
@@ -487,7 +487,26 @@ export class DynamicList extends DataPoint {
         const method = state ? "action_archive" : "action_unarchive";
         const context = this.context;
         const resIds = await this.getResIds(isSelected);
-        const action = await this.model.orm.call(this.resModel, method, [resIds], { context });
+        let action;
+        try {
+            action = await this.model.orm.call(this.resModel, method, [resIds], { context });
+        } catch (e) {
+            if (e instanceof ConnectionLostError) {
+                const records = this.records.filter((r) => resIds.includes(r.resId));
+                this.model.offline.scheduleORM(
+                    this.resModel,
+                    method,
+                    [resIds],
+                    { context: this.context },
+                    {
+                        extras: getScheduleORMExtras(this.model, records),
+                    }
+                );
+                this._unSelectAll();
+                return true;
+            }
+            throw e;
+        }
         if (
             this.isDomainSelected &&
             resIds.length === this.model.activeIdsLimit &&

--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -10,6 +10,7 @@ import {
     getBasicEvalContext,
     getFieldContext,
     getFieldsSpec,
+    getScheduleORMExtras,
     parseServerValue,
 } from "./utils";
 import { ConnectionLostError } from "@web/core/network/rpc";
@@ -188,9 +189,25 @@ export class Record extends DataPoint {
 
     delete() {
         return this.model.mutex.exec(async () => {
-            const unlinked = await this.model.orm.unlink(this.resModel, [this.resId], {
-                context: this.context,
-            });
+            let unlinked = false;
+            try {
+                unlinked = await this.model.orm.unlink(this.resModel, [this.resId], {
+                    context: this.context,
+                });
+            } catch (e) {
+                if (e instanceof ConnectionLostError) {
+                    return this.model.offline.scheduleORM(
+                        this.resModel,
+                        "unlink",
+                        [[this.resId]],
+                        { context: this.context },
+                        {
+                            extras: getScheduleORMExtras(this.model, [this]),
+                        }
+                    );
+                }
+                throw e;
+            }
             if (!unlinked) {
                 return false;
             }
@@ -335,12 +352,16 @@ export class Record extends DataPoint {
             scheduledORM = Object.values(this.model.offline.scheduledORM).find(
                 (s) =>
                     s.value.extras?.actionId === this.model.env.config.actionId &&
+                    s.value.method === "web_save" && // Only web_save changes are applied
+                    s.value.extras.viewType === "form" && // Only changes made on a view form are applied
                     s.value.args[0]?.[0] === this.resId
             );
         }
         if (scheduledORM) {
             this._offlineId = scheduledORM.key;
-            this._offlineChanges = this._parseServerValues(scheduledORM.value.extras.changes);
+            this._offlineChanges = markRaw(
+                this._parseServerValues(scheduledORM.value.extras.changes)
+            );
             this._offlineTimeStamp = scheduledORM.value.extras.timeStamp;
             return this.update(this._offlineChanges);
         }
@@ -1279,7 +1300,7 @@ export class Record extends DataPoint {
         this.dirty = false;
     }
 
-    async _offlineSave() {
+    _offlineSave() {
         this._offlineChanges = markRaw({ ...(this._offlineChanges || {}), ...this._changes });
         const offlineChanges = this._getChanges(this._offlineChanges);
         delete offlineChanges.id; // id never changes, and should not be written
@@ -1293,20 +1314,11 @@ export class Record extends DataPoint {
             {
                 id: this._offlineId,
                 extras: {
-                    actionId: this.model.env.config.actionId,
-                    actionName: this.model.env.config.actionName,
-                    viewType: this.model.env.config.viewType,
+                    ...getScheduleORMExtras(this.model, [this]),
                     changes: this._formatServerValues(this._offlineChanges),
                     originalValues: this._formatServerValues(
                         pick(this._values, ...Object.keys(this._offlineChanges))
                     ),
-                    displayName:
-                        this.data.complete_name ||
-                        this.data.name ||
-                        this.data.display_name ||
-                        this.data.x_name ||
-                        this.data.x_studio_name ||
-                        _t("Record"),
                     timeStamp: this._offlineTimeStamp,
                 },
             }

--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -1388,9 +1388,25 @@ export class Record extends DataPoint {
      */
     async _toggleArchive(state) {
         const method = state ? "action_archive" : "action_unarchive";
-        const action = await this.model.orm.call(this.resModel, method, [[this.resId]], {
-            context: this.context,
-        });
+        let action;
+        try {
+            action = await this.model.orm.call(this.resModel, method, [[this.resId]], {
+                context: this.context,
+            });
+        } catch (e) {
+            if (e instanceof ConnectionLostError) {
+                return this.model.offline.scheduleORM(
+                    this.resModel,
+                    method,
+                    [[this.resId]],
+                    { context: this.context },
+                    {
+                        extras: getScheduleORMExtras(this.model, [this]),
+                    }
+                );
+            }
+            throw e;
+        }
         if (action && Object.keys(action).length) {
             this.model.action.doAction(action, { onClose: () => this._load() });
         } else {

--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -906,3 +906,30 @@ export async function resequence({
         throw error;
     }
 }
+
+export function getScheduleORMExtras(model, records) {
+    const extras = {
+        actionId: model.env.config.actionId,
+        actionName: model.env.config.actionName,
+        viewType: model.env.config.viewType,
+        timeStamp: Date.now(),
+    };
+    if (records.length > 1) {
+        extras.displayNames = records.map((r) => getOfflineDisplayName(r));
+        extras.displayName = _t("%s Records", records.length);
+    } else {
+        extras.displayName = getOfflineDisplayName(records[0]);
+    }
+    return extras;
+}
+
+function getOfflineDisplayName(record) {
+    return (
+        record.data.complete_name ||
+        record.data.name ||
+        record.data.display_name ||
+        record.data.x_name ||
+        record.data.x_studio_name ||
+        _t("Record")
+    );
+}

--- a/addons/web/static/src/search/action_menus/action_menus.js
+++ b/addons/web/static/src/search/action_menus/action_menus.js
@@ -8,6 +8,7 @@ import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 
 import { Component, onWillStart, onWillUpdateProps } from "@odoo/owl";
+import { ConnectionLostError } from "@web/core/network/rpc";
 
 export const STATIC_ACTIONS_GROUP_NUMBER = 1;
 export const ACTIONS_GROUP_NUMBER = 100;
@@ -56,6 +57,7 @@ export class ActionMenus extends Component {
     setup() {
         this.orm = useService("orm");
         this.actionService = useService("action");
+        this.offline = useService("offline");
         this.state = useState({ printItems: [] });
         onWillStart(async () => {
             this.actionItems = await this.getActionItems(this.props);
@@ -149,11 +151,18 @@ export class ActionMenus extends Component {
                 : validActionIds.push(action.id);
         }
         if (actionWithDomainIds.length) {
-            const validActionsWithDomainIds = await this.orm.call(
-                "ir.actions.report",
-                "get_valid_action_reports",
-                [actionWithDomainIds, this.props.resModel, this.props.getActiveIds()]
-            );
+            let validActionsWithDomainIds = [];
+            try {
+                validActionsWithDomainIds = await this.orm.call(
+                    "ir.actions.report",
+                    "get_valid_action_reports",
+                    [actionWithDomainIds, this.props.resModel, this.props.getActiveIds()]
+                );
+            } catch (e) {
+                if (!(e instanceof ConnectionLostError)) {
+                    throw e;
+                }
+            }
             validActionIds.push(...validActionsWithDomainIds);
         }
         return printActions

--- a/addons/web/static/src/search/action_menus/action_menus.xml
+++ b/addons/web/static/src/search/action_menus/action_menus.xml
@@ -23,7 +23,7 @@
 
             <div t-if="this.actionItems.length" class="d-inline-block">
                 <Dropdown>
-                    <button class="btn btn-secondary" data-hotkey="u">
+                    <button class="btn btn-secondary" data-hotkey="u" data-available-offline="">
                         <i class="fa fa-cog me-1"/>
                         <span class="o_dropdown_title">Actions</span>
                     </button>
@@ -33,7 +33,10 @@
                                 <div role="separator" class="dropdown-divider"/>
                             </t>
                             <t t-if="item.Component" t-component="item.Component" t-props="item.props" />
-                            <DropdownItem t-else="" class="item.class ? item.class + ' o_menu_item' : 'o_menu_item'" onSelected="() => this.onItemSelected(item)">
+                            <DropdownItem
+                             t-else=""
+                             class="{ [item.class]: !!item.class, 'o_menu_item': true, 'pe-none text-muted opacity-50': offline.offline and !item.availableOffline }"
+                             onSelected="() => this.onItemSelected(item)">
                                 <i t-if="item.icon" t-att-class="item.icon + ' me-1 fa-fw oi-fw'"/>
                                 <t t-out="item.description"/>
                             </DropdownItem>

--- a/addons/web/static/src/search/cog_menu/cog_menu.xml
+++ b/addons/web/static/src/search/cog_menu/cog_menu.xml
@@ -5,7 +5,7 @@
         <div t-if="this.hasItems" class="o_cp_action_menus d-flex align-items-center gap-1" t-att-class="{'pe-2': !this.env.isSmall}">
             <div class="lh-1">
                 <Dropdown menuClass="'lh-base'" beforeOpen.bind="this.loadPrintItems">
-                    <button class="d-print-none btn" t-att-class="this.env.isSmall ? 'btn-secondary' : 'lh-sm p-0 border-0'" data-hotkey="u" data-tooltip="Actions" aria-label="Actions menu">
+                    <button class="d-print-none btn" t-att-class="this.env.isSmall ? 'btn-secondary' : 'lh-sm p-0 border-0'" data-hotkey="u" data-tooltip="Actions" aria-label="Actions menu" data-available-offline="">
                         <i class="fa fa-fw fa-cog"/>
                     </button>
 
@@ -42,7 +42,11 @@
 
                             <t t-if="item.Component" t-component="item.Component"/>
 
-                            <DropdownItem t-else="" class="item.class ? item.class + ' o_menu_item' : 'o_menu_item'" onSelected="() => this.onItemSelected(item)">
+                            <DropdownItem
+                                t-else=""
+                                class="{ [item.class]: !!item.class, 'o_menu_item': true, 'pe-none text-muted opacity-50': offline.offline and !(item.availableOffline and !env.model.root.isNew) }"
+                                onSelected="() => this.onItemSelected(item)"
+                            >
                                 <i t-if="item.icon" t-att-class="item.icon" class="fa-fw oi-fw me-1"/>
                                 <t t-out="item.description"/>
                             </DropdownItem>

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -578,6 +578,7 @@ export class FormController extends Component {
             },
             archive: {
                 isAvailable: () => this.archiveEnabled && this.model.root.isActive,
+                availableOffline: true,
                 sequence: 40,
                 description: _t("Archive"),
                 icon: "oi oi-archive",
@@ -587,6 +588,7 @@ export class FormController extends Component {
             },
             unarchive: {
                 isAvailable: () => this.archiveEnabled && !this.model.root.isActive,
+                availableOffline: true,
                 sequence: 45,
                 icon: "oi oi-unarchive",
                 description: _t("Unarchive"),

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -594,6 +594,7 @@ export class FormController extends Component {
             },
             delete: {
                 isAvailable: () => activeActions.delete && !this.model.root.isNew,
+                availableOffline: true,
                 sequence: 50,
                 icon: "fa fa-trash-o",
                 description: _t("Delete"),

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -446,6 +446,7 @@ export class ListController extends Component {
             },
             archive: {
                 isAvailable: () => this.archiveEnabled,
+                availableOffline: true,
                 sequence: 40,
                 icon: "oi oi-archive",
                 description: _t("Archive"),
@@ -454,6 +455,7 @@ export class ListController extends Component {
             },
             unarchive: {
                 isAvailable: () => this.archiveEnabled,
+                availableOffline: true,
                 sequence: 45,
                 icon: "oi oi-unarchive",
                 description: _t("Unarchive"),

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -461,6 +461,7 @@ export class ListController extends Component {
             },
             delete: {
                 isAvailable: () => this.activeActions.delete,
+                availableOffline: true,
                 sequence: 50,
                 icon: "fa fa-trash-o",
                 description: _t("Delete"),

--- a/addons/web/static/src/webclient/offline_systray/offline_systray.js
+++ b/addons/web/static/src/webclient/offline_systray/offline_systray.js
@@ -10,6 +10,12 @@ import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_d
 
 const { DateTime } = luxon;
 
+const STATUS = {
+    CREATED: { label: _t("Created"), color: 10 },
+    EDITED: { label: _t("Edited"), color: 3 },
+    DELETED: { label: _t("Deleted"), color: 1 },
+};
+
 class OfflineSystray extends Component {
     static template = "web.OfflineSystray";
     static props = {};
@@ -28,33 +34,35 @@ class OfflineSystray extends Component {
     get groupEntries() {
         const items = [];
         for (const { key, value } of Object.values(this.offlineService.scheduledORM)) {
-            // OfflineSystray for the moment only support web_save!
+            const timeStamp = formatDateTime(DateTime.fromMillis(value.extras.timeStamp));
+            const item = {
+                id: key,
+                timeStamp: value.extras.timeStamp,
+                actionName: value.extras.actionName,
+                displayName: value.extras.displayName,
+                clickable: this.isClickable(value),
+                error: value.extras.error,
+                tooltip: {
+                    timeStamp,
+                    records: value.extras.displayNames || [],
+                },
+            };
             if (value.method === "web_save") {
-                let tooltipDetails = Object.entries(value.extras.changes);
+                item.status = value.args[0].length ? STATUS.EDITED : STATUS.CREATED;
+                item.tooltip.changes = Object.entries(value.extras.changes);
                 if (value.args[0].length) {
-                    tooltipDetails = tooltipDetails.map((c) => [
+                    item.tooltip.changes = item.tooltip.changes.map((c) => [
                         c[0],
                         value.extras.originalValues[c[0]],
                         c[1],
                     ]);
                 }
-                const status = value.args[0].length ? _t("Edited") : _t("Created");
-                const statusColor = value.args[0].length ? "2" : "10";
-                items.push({
-                    id: key,
-                    timeStamp: value.extras.timeStamp,
-                    actionName: value.extras.actionName,
-                    displayName: value.extras.displayName,
-                    status,
-                    statusColor,
-                    clickable: this.isClickable(value),
-                    error: value.extras.error,
-                    tooltip: JSON.stringify({
-                        timeStamp: formatDateTime(DateTime.fromMillis(value.extras.timeStamp)),
-                        details: tooltipDetails,
-                    }),
-                });
             }
+            if (value.method === "unlink") {
+                item.status = STATUS.DELETED;
+            }
+            item.tooltip = JSON.stringify(item.tooltip);
+            items.push(item);
         }
         const sections = Object.entries(Object.groupBy(items, (item) => item.actionName || ""));
         sections.forEach(([_name, items]) => {
@@ -66,6 +74,7 @@ class OfflineSystray extends Component {
     isClickable(value) {
         const resId = value.args[0].length ? value.args[0][0] : false;
         return (
+            value.method === "web_save" &&
             value.extras.viewType === "form" &&
             (!this.offlineService.offline ||
                 this.offlineService.isAvailableOffline(value.extras.actionId, "form", resId))

--- a/addons/web/static/src/webclient/offline_systray/offline_systray.js
+++ b/addons/web/static/src/webclient/offline_systray/offline_systray.js
@@ -13,6 +13,8 @@ const { DateTime } = luxon;
 const STATUS = {
     CREATED: { label: _t("Created"), color: 10 },
     EDITED: { label: _t("Edited"), color: 3 },
+    ARCHIVED: { label: _t("Archived"), color: 2 },
+    UNARCHIVED: { label: _t("Unarchived"), color: 4 },
     DELETED: { label: _t("Deleted"), color: 1 },
 };
 
@@ -60,6 +62,12 @@ class OfflineSystray extends Component {
             }
             if (value.method === "unlink") {
                 item.status = STATUS.DELETED;
+            }
+            if (value.method === "action_archive") {
+                item.status = STATUS.ARCHIVED;
+            }
+            if (value.method === "action_unarchive") {
+                item.status = STATUS.UNARCHIVED;
             }
             item.tooltip = JSON.stringify(item.tooltip);
             items.push(item);

--- a/addons/web/static/src/webclient/offline_systray/offline_systray.xml
+++ b/addons/web/static/src/webclient/offline_systray/offline_systray.xml
@@ -26,7 +26,7 @@
                 <div class="o_offline_systray_content px-2">
                     <t t-foreach="this.groupEntries" t-as="entry" t-key="entry[0]">
                         <div class="o_horizontal_separator text-uppercase fw-bolder small mb-1">
-                            <span t-esc="entry[0]"/> 
+                            <span t-esc="entry[0]"/>
                         </div>
                         <t t-foreach="entry[1]" t-as="element" t-key="element.id">
                             <DropdownItem
@@ -50,8 +50,8 @@
                                     class="ms-auto"
                                     t-att-data-tooltip-template="'web.OfflineSystrayTooltip'"
                                     t-att-data-tooltip-info="element.tooltip">
-                                    <span t-attf-class="o_tag mw-100 o_badge badge rounded-pill {{ 'o_tag_color_' + element.statusColor }}">
-                                        <t class="o_tag_badge_text o_badge_text" t-esc="element.status"/>
+                                    <span t-attf-class="o_tag mw-100 o_badge badge rounded-pill {{ 'o_tag_color_' + element.status.color }}">
+                                        <t class="o_tag_badge_text o_badge_text" t-esc="element.status.label"/>
                                     </span>
                                 </div>
                                 <div>
@@ -73,9 +73,24 @@
         <div>
             On <t t-esc="this.timeStamp"/>
         </div>
-        <t t-foreach="this.details" t-as="entry" t-key="entry[0]">
+        <t t-if="this.records.length">
             <div>
-                - <t t-esc="entry[0]"/>: <t t-esc="entry[1]"/><t t-if="entry[2]"> → <t t-esc="entry[2]"/></t>
+                Records:
+                <t t-foreach="this.records" t-as="record" t-key="record_index">
+                    <div>
+                        - <t t-esc="record"/>
+                    </div>
+                </t>
+            </div>
+        </t>
+        <t t-if="this.changes">
+            <div>
+                <t t-if="this.records.length">Changes:</t>
+                <t t-foreach="this.changes" t-as="entry" t-key="entry_index">
+                    <div>
+                        - <t t-esc="entry[0]"/>: <t t-esc="entry[1]"/><t t-if="entry[2] !== undefined"> → <t t-esc="entry[2]"/></t>
+                    </div>
+                </t>
             </div>
         </t>
     </t>

--- a/addons/web/static/tests/core/offline/offline_service.test.js
+++ b/addons/web/static/tests/core/offline/offline_service.test.js
@@ -2,10 +2,11 @@ import { Component, useState, xml } from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
 import { rpc } from "@web/core/network/rpc";
 
-import { advanceTime, animationFrame, expect, test, tick } from "@odoo/hoot";
+import { advanceTime, animationFrame, expect, runAllTimers, test, tick } from "@odoo/hoot";
 import {
     getService,
     makeMockEnv,
+    mockOffline,
     mountWithCleanup,
     onRpc,
     patchWithCleanup,
@@ -369,4 +370,95 @@ test("scheduleORM", async () => {
             model: "partner",
         },
     ]);
+});
+
+test("syncORM ConnectionLost", async () => {
+    // If a ConnectionLost is detected when syncing,
+    // we should stop the syncing and don't put the scheduledORM as in error.
+    const setOffline = mockOffline();
+    const def = Promise.withResolvers();
+
+    onRpc("partner", "create", async () => {
+        await def.promise;
+        expect.step("partner create was called: returned connection lost");
+        return new Response("", { status: 502 });
+    });
+
+    onRpc("partner", "modify", () => {
+        throw Error("This shouldn't be called");
+    });
+
+    await makeMockEnv();
+    expect(getService("offline").offline).toBe(false);
+
+    // go offline
+    await setOffline(true);
+    expect(getService("offline").offline).toBe(true);
+
+    await getService("offline").scheduleORM(
+        "partner",
+        "create",
+        [22, 13],
+        { arg1: true, arg2: false },
+        { extras: { timeStamp: 11 } }
+    );
+    await getService("offline").scheduleORM(
+        "partner",
+        "modify",
+        [22, 13],
+        { arg3: true },
+        { id: 22, extras: { timeStamp: 22, toSaveMore: true } }
+    );
+
+    // go online
+    await setOffline(false);
+    expect(getService("offline").offline).toBe(false);
+
+    expect(getService("offline").syncingORM).toBe(true);
+
+    //go offline Again
+    await setOffline(true);
+    def.resolve();
+    await tick();
+    await runAllTimers(); // run the time for the rpc to sync
+
+    // SyncORM !
+    // Only the first should be try to be sync, as we go offline in the middle of the first sync
+    await expect.waitForSteps(["partner create was called: returned connection lost"]);
+
+    expect(getService("offline").syncingORM).toBe(false);
+
+    // Neither of the scheduledORM should be in error !
+    expect(getService("offline").scheduledORM).toEqual({
+        22: {
+            key: "22",
+            value: {
+                args: [22, 13],
+                extras: {
+                    toSaveMore: true,
+                    timeStamp: 22,
+                },
+                kwargs: {
+                    arg3: true,
+                },
+                method: "modify",
+                model: "partner",
+            },
+        },
+        ba559cc9: {
+            key: "ba559cc9",
+            value: {
+                args: [22, 13],
+                extras: {
+                    timeStamp: 11,
+                },
+                kwargs: {
+                    arg1: true,
+                    arg2: false,
+                },
+                method: "create",
+                model: "partner",
+            },
+        },
+    });
 });

--- a/addons/web/static/tests/search/action_menus.test.js
+++ b/addons/web/static/tests/search/action_menus.test.js
@@ -2,6 +2,7 @@ import {
     contains,
     defineModels,
     fields,
+    mockOffline,
     models,
     mountView,
     onRpc,
@@ -290,4 +291,34 @@ test("static action items are properly ordered and styled", async () => {
 
     expect(queryAllTexts(`.o_menu_item`)).toEqual(["Export", "Duplicate", "Delete"]);
     expect(`.o_menu_item:last`).toHaveClass("text-danger");
+});
+
+test("[Offline] render ActionMenus in form view", async () => {
+    const setOffline = mockOffline();
+    await mountView({
+        type: "form",
+        resModel: "foo",
+        resId: 1,
+        actionMenus: {
+            action: [],
+            print: printItems,
+        },
+        loadActionMenus: true,
+        arch: /* xml */ `
+              <form>
+                  <field name="value"/>
+              </form>
+         `,
+    });
+
+    await setOffline(true);
+
+    // select CogMenu
+    await contains(`div.o_control_panel_breadcrumbs_actions i.fa-cog`).click();
+
+    expect(queryAllTexts(`.o-dropdown--menu span.o-dropdown-item`)).toEqual([
+        "No report available.",
+        "Duplicate",
+        "Delete",
+    ]);
 });

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -4217,6 +4217,106 @@ test(`archive/unarchive a record`, async () => {
     ]);
 });
 
+test(`[Offline] archiving a record`, async () => {
+    onRpc("action_archive", () => expect.step(`action_archive`));
+    // add active field on partner model to have archive option
+    Partner._fields.active = fields.Boolean();
+    Partner._views = {
+        "form,false": `<form><field name="active"/><field name="foo"/></form>`,
+        "search,false": `<search/>`,
+    };
+    defineActions([
+        {
+            id: 1,
+            name: "Action 1",
+            res_model: "partner",
+            res_id: 1,
+            views: [[false, "form"]],
+            search_view_id: [false, "search"],
+        },
+    ]);
+
+    const setOffline = mockOffline();
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction(1);
+
+    expect(`.o_breadcrumb`).toHaveText("first record");
+    await setOffline(true);
+    expect(getService("offline").offline).toBe(true);
+
+    // open action menu and delete
+    await toggleActionMenu();
+    await toggleMenuItem("Archive");
+    expect(`.modal`).toHaveCount(1);
+
+    await contains(`.modal-footer .btn-primary`).click();
+
+    // The edited record will be saved the next time we are online
+    await contains(`.o_menu_systray .o_nav_entry .fa-chain-broken`).click();
+    expect(queryAllTexts`.o-dropdown--menu .o_offline_systray_content div`).toEqual([
+        "ACTION 1",
+        "first record",
+        "Archived",
+        "",
+    ]);
+
+    expect.verifySteps([]);
+
+    await setOffline(false);
+
+    expect(getService("offline").offline).toBe(false);
+    await expect.waitForSteps(["action_archive"]);
+});
+
+test(`[Offline] Unarchiving a record`, async () => {
+    onRpc("action_unarchive", () => expect.step(`action_unarchive`));
+    // add active field on partner model to have archive option
+    Partner._fields.active = fields.Boolean();
+    Partner._records[0].active = false;
+    Partner._views = {
+        "form,false": `<form><field name="active"/><field name="foo"/></form>`,
+        "search,false": `<search/>`,
+    };
+    defineActions([
+        {
+            id: 1,
+            name: "Action 1",
+            res_model: "partner",
+            res_id: 1,
+            views: [[false, "form"]],
+            search_view_id: [false, "search"],
+        },
+    ]);
+
+    const setOffline = mockOffline();
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction(1);
+
+    expect(`.o_breadcrumb`).toHaveText("first record");
+    await setOffline(true);
+    expect(getService("offline").offline).toBe(true);
+
+    // open action menu and delete
+    await toggleActionMenu();
+    await toggleMenuItem("Unarchive");
+
+    // The edited record will be saved the next time we are online
+    await contains(`.o_menu_systray .o_nav_entry .fa-chain-broken`).click();
+    expect(queryAllTexts`.o-dropdown--menu .o_offline_systray_content div`).toEqual([
+        "ACTION 1",
+        "first record",
+        "Unarchived",
+        "",
+    ]);
+
+    expect.verifySteps([]);
+
+    await setOffline(false);
+
+    expect(getService("offline").offline).toBe(false);
+    await expect.waitForSteps(["action_unarchive"]);
+});
+
 test(`apply custom standard action menu (archive)`, async () => {
     // add active field on partner model to have archive option
     Partner._fields.active = fields.Boolean();

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -438,46 +438,6 @@ test(`[Offline] save a form view offline (autosave when leaving)`, async () => {
     await expect.waitForSteps(["web_save"]);
 });
 
-test(`[Offline] open form with offline changes`, async () => {
-    Partner._views = {
-        form: `<form><field name="foo"/></form>`,
-    };
-    defineActions([
-        {
-            id: 1,
-            name: "Partner",
-            res_model: "partner",
-            views: [[false, "form"]],
-        },
-    ]);
-
-    await mountWithCleanup(WebClient);
-    // Open record 2, blip is the value stored
-    await getService("action").doAction(1, { props: { resId: 2 } });
-    expect(`.o_field_widget[name=foo] input`).toHaveValue("blip");
-
-    // Open record 2, with the offline modifications (blip is change to Harlod Bohy)
-    getService("offline").scheduleORM(
-        "lead",
-        "web_save",
-        [[]],
-        {},
-        {
-            id: "881ba65a",
-            extras: {
-                actionId: 33,
-                actionName: "CRM",
-                viewType: "form",
-                changes: { foo: "Harold Bohy" },
-                displayName: "Display Name",
-                timeStamp: 30,
-            },
-        }
-    );
-    await getService("action").doAction(1, { props: { offlineId: "881ba65a", resId: 2 } });
-    expect(`.o_field_widget[name=foo] input`).toHaveValue("Harold Bohy");
-});
-
 test(`form rendering with class and style attributes`, async () => {
     await mountView({
         resModel: "partner",
@@ -6250,6 +6210,55 @@ test(`deleting a record`, async () => {
     expect(`.o_field_widget[name=foo] input`).toHaveValue("blip");
 });
 
+test(`[Offline] deleting a record`, async () => {
+    onRpc("unlink", () => expect.step(`unlink`));
+    Partner._views = {
+        "form,false": `<form><field name="foo"/></form>`,
+        "search,false": `<search/>`,
+    };
+    defineActions([
+        {
+            id: 1,
+            name: "Action 1",
+            res_model: "partner",
+            res_id: 1,
+            views: [[false, "form"]],
+            search_view_id: [false, "search"],
+        },
+    ]);
+
+    const setOffline = mockOffline();
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction(1);
+
+    expect(`.o_breadcrumb`).toHaveText("first record");
+    await setOffline(true);
+    expect(getService("offline").offline).toBe(true);
+
+    // open action menu and delete
+    await toggleActionMenu();
+    await toggleMenuItem("Delete");
+    expect(`.modal`).toHaveCount(1);
+
+    await contains(`.modal-footer button.btn-danger`).click();
+
+    // The edited record will be saved the next time we are online
+    await contains(`.o_menu_systray .o_nav_entry .fa-chain-broken`).click();
+    expect(queryAllTexts`.o-dropdown--menu .o_offline_systray_content div`).toEqual([
+        "ACTION 1",
+        "first record",
+        "Deleted",
+        "",
+    ]);
+
+    expect.verifySteps([]);
+
+    await setOffline(false);
+
+    expect(getService("offline").offline).toBe(false);
+    await expect.waitForSteps(["unlink"]);
+});
+
 test.tags("desktop");
 test(`deleting a record on desktop`, async () => {
     await mountView({
@@ -10004,7 +10013,7 @@ test("support header button as widgets in submenu on form statusbar on mobile", 
                 <t t-set-slot="toggler">
                     <button>Upload Test</button>
                 </t>
-            </FileUploader>`
+            </FileUploader>`;
         static components = { FileUploader };
 
         onUploaded(ev) {

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -225,11 +225,16 @@ async function clickControlPanelAction(buttonName) {
     }
 }
 
-async function clickRecordSelector() {
+async function clickRecordSelector(count = 1) {
     if (getMockEnv().isSmall) {
-        await contains(".o_data_row").drag();
+        const cells = queryAll(".o_data_row").slice(0, count);
+        for (const cell of cells) {
+            await contains(cell).drag();
+        }
     } else {
-        await contains(`.o_data_row .o_list_record_selector input`).click();
+        for (let i = 0; i < count; i++) {
+            await contains(`.o_data_row:eq(${i}) .o_list_record_selector input`).click();
+        }
     }
 }
 
@@ -635,7 +640,7 @@ test(`[Offline] disable new button if not previously visited`, async () => {
 });
 
 test(`[Offline] create record when offline`, async () => {
-    expect.errors(2); // 2x ConnectionLostError
+    expect.errors(4); // 4x ConnectionLostError
     onRpc("web_save", () => expect.step(`web_save`));
     Foo._views = {
         "list,false": `<list><field name="foo"/></list>`,
@@ -687,6 +692,19 @@ test(`[Offline] create record when offline`, async () => {
         `Connection to "/web/dataset/call_kw/foo/web_search_read" couldn't be established`,
     ]);
 
+    // Open the created record !
+    await contains(`.o_offline_systray_content .o-dropdown-item`).click();
+    await animationFrame();
+    expect(`.o_field_widget[name='foo'] input`).toHaveValue("test");
+
+    //Came back to the list
+    await getService("action").doAction(1);
+    await animationFrame();
+    expect.verifyErrors([
+        `Connection to "/web/dataset/call_kw/foo/onchange" couldn't be established`,
+        `Connection to "/web/dataset/call_kw/foo/web_search_read" couldn't be established`,
+    ]);
+
     // go online and save the record.
     await setOffline(false);
 
@@ -700,6 +718,95 @@ test(`[Offline] create record when offline`, async () => {
     //The offline create record is there
     await getService("action").doAction(1);
     expect(`tbody tr`).toHaveCount(5);
+});
+
+test(`[Offline] edit record when offline`, async () => {
+    expect.errors(6); // 6x ConnectionLostError
+    onRpc("web_save", () => expect.step(`web_save`));
+    Foo._views = {
+        "list,false": `<list><field name="foo"/></list>`,
+        "form,false": `<form><field name="foo"/></form>`,
+        "search,false": `<search/>`,
+    };
+    defineActions([
+        {
+            id: 1,
+            name: "Action 1",
+            res_model: "foo",
+            views: [
+                [false, "list"],
+                [false, "form"],
+            ],
+            search_view_id: [false, "search"],
+        },
+    ]);
+
+    const setOffline = mockOffline();
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction(1);
+    expect(queryAllTexts(`.o_data_cell`)).toEqual(["yop", "blip", "gnap", "blip"]);
+
+    // Put in cache the on_change
+    await contains(".o_data_cell").click();
+    expect(`.o_field_widget[name='foo'] input`).toHaveValue("yop");
+    await contains(`.o_back_button`).click();
+
+    await setOffline(true);
+
+    //Open the record offline
+    await contains(".o_data_cell").click();
+    await contains(`.o_field_widget[name='foo'] input`).edit("test");
+    //Go Back to the list, this will save the record
+    await contains(`.o_back_button`).click();
+
+    expect.verifyErrors([
+        `Connection to "/web/dataset/call_kw/foo/web_read" couldn't be established`,
+        `Connection to "/web/dataset/call_kw/foo/web_search_read" couldn't be established`,
+    ]);
+
+    // The edited record will be save the next time we are online
+    await contains(`.o_menu_systray .o_nav_entry .fa-chain-broken`).click();
+    expect(queryAllTexts`.o-dropdown--menu .o_offline_systray_content div`).toEqual([
+        "ACTION 1",
+        "foo,1",
+        "Edited",
+        "",
+    ]);
+
+    // Open the created record from the Offline Dropdown!
+    await contains(`.o_offline_systray_content .o-dropdown-item`).click();
+    await animationFrame();
+    expect(`.o_field_widget[name='foo'] input`).toHaveValue("test");
+    expect.verifyErrors([
+        `Connection to "/web/dataset/call_kw/foo/web_read" couldn't be established`,
+    ]);
+
+    //Came back to the list
+    await getService("action").doAction(1);
+
+    // Open the create record from the List
+    await contains(".o_data_cell").click();
+    expect(`.o_field_widget[name='foo'] input`).toHaveValue("test");
+    await contains(`.o_back_button`).click();
+    expect.verifyErrors([
+        `Connection to "/web/dataset/call_kw/foo/web_search_read" couldn't be established`,
+        `Connection to "/web/dataset/call_kw/foo/web_read" couldn't be established`,
+        `Connection to "/web/dataset/call_kw/foo/web_search_read" couldn't be established`,
+    ]);
+
+    // go online and save the record.
+    await setOffline(false);
+
+    expect(getService("offline").offline).toBe(false);
+    await expect.waitForSteps(["web_save"]); // We sync when the connection returns
+    //The current view is not updated when the offline is sync.
+    //In this case we don't see the newly created record, until the view is reloaded.
+    expect(queryAllTexts(`.o_data_cell`)).toEqual(["yop", "blip", "gnap", "blip"]);
+
+    //Reload the view
+    //The offline create record is there
+    await getService("action").doAction(1);
+    expect(queryAllTexts(`.o_data_cell`)).toEqual(["test", "blip", "gnap", "blip"]);
 });
 
 test.tags("desktop");
@@ -19867,6 +19974,54 @@ test(`[Offline] cache web_search_read: browsing with pager online/offline`, asyn
         `Connection to "/web/dataset/call_kw/foo/web_search_read" couldn't be established`,
         `Connection to "/web/dataset/call_kw/foo/web_search_read" couldn't be established`,
     ]);
+});
+
+test(`[Offline] delete records`, async () => {
+    onRpc("unlink", () => expect.step(`unlink`));
+    Foo._views = {
+        list: `<list><field name="foo"/></list>`,
+        search: `<search/>`,
+    };
+    defineActions([
+        {
+            id: 1,
+            name: "Action 1",
+            res_model: "foo",
+            views: [[false, "list"]],
+            search_view_id: [false, "search"],
+        },
+    ]);
+
+    const setOffline = mockOffline();
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction(1);
+
+    // Check for the initial number of records
+    expect(`.o_data_row`).toHaveCount(4, { message: "Checking initial number of records" });
+
+    await setOffline(true);
+
+    await clickRecordSelector(2); //select two records
+
+    await contains(`div.o_control_panel .o_cp_action_menus .dropdown-toggle`).click(); // click on actions
+    await toggleMenuItem("Delete"); // toggle delete action
+    await contains(`.modal-footer .btn-danger`).click(); // confirm the delete action
+
+    // The deleted records will be saved the next time we are online
+    await contains(`.o_menu_systray .o_nav_entry .fa-chain-broken`).click();
+    expect(queryAllTexts`.o-dropdown--menu .o_offline_systray_content div`).toEqual([
+        "ACTION 1",
+        "2 Records",
+        "Deleted",
+        "",
+    ]);
+
+    expect.verifySteps([]);
+
+    await setOffline(false);
+
+    expect(getService("offline").offline).toBe(false);
+    await expect.waitForSteps(["unlink"]);
 });
 
 test(`[Offline] cache web_search_read: enable filter online/offline`, async () => {

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -20024,6 +20024,105 @@ test(`[Offline] delete records`, async () => {
     await expect.waitForSteps(["unlink"]);
 });
 
+test(`[Offline] archiving records`, async () => {
+    onRpc("action_archive", () => expect.step(`action_archive`));
+    // add active field on foo model and make all records active
+    Foo._fields.active = fields.Boolean({ default: true });
+    Foo._views = {
+        list: `<list><field name="foo"/></list>`,
+        search: `<search/>`,
+    };
+    defineActions([
+        {
+            id: 1,
+            name: "Action 1",
+            res_model: "foo",
+            views: [[false, "list"]],
+            search_view_id: [false, "search"],
+        },
+    ]);
+
+    const setOffline = mockOffline();
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction(1);
+
+    // Check for the initial number of records
+    expect(`.o_data_row`).toHaveCount(4, { message: "Checking initial number of records" });
+
+    await setOffline(true);
+
+    await clickRecordSelector(2); //select two records
+
+    await contains(`div.o_control_panel .o_cp_action_menus .dropdown-toggle`).click(); // click on actions
+    await toggleMenuItem("Archive"); // toggle archive action
+    await contains(`.modal-footer .btn-primary`).click(); // confirm the archive action
+
+    // The deleted records will be saved the next time we are online
+    await contains(`.o_menu_systray .o_nav_entry .fa-chain-broken`).click();
+    expect(queryAllTexts`.o-dropdown--menu .o_offline_systray_content div`).toEqual([
+        "ACTION 1",
+        "2 Records",
+        "Archived",
+        "",
+    ]);
+
+    expect.verifySteps([]);
+
+    await setOffline(false);
+
+    expect(getService("offline").offline).toBe(false);
+    await expect.waitForSteps(["action_archive"]);
+});
+
+test(`[Offline] unarchiving records`, async () => {
+    onRpc("action_unarchive", () => expect.step(`action_unarchive`));
+    // add active field on foo model and make all records active
+    Foo._fields.active = fields.Boolean({ default: true });
+    Foo._views = {
+        list: `<list><field name="foo"/></list>`,
+        search: `<search/>`,
+    };
+    defineActions([
+        {
+            id: 1,
+            name: "Action 1",
+            res_model: "foo",
+            views: [[false, "list"]],
+            search_view_id: [false, "search"],
+        },
+    ]);
+
+    const setOffline = mockOffline();
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction(1);
+
+    // Check for the initial number of records
+    expect(`.o_data_row`).toHaveCount(4, { message: "Checking initial number of records" });
+
+    await setOffline(true);
+
+    await clickRecordSelector(2); //select two records
+
+    await contains(`div.o_control_panel .o_cp_action_menus .dropdown-toggle`).click(); // click on actions
+    await toggleMenuItem("Unarchive"); // toggle archive action
+
+    // The deleted records will be saved the next time we are online
+    await contains(`.o_menu_systray .o_nav_entry .fa-chain-broken`).click();
+    expect(queryAllTexts`.o-dropdown--menu .o_offline_systray_content div`).toEqual([
+        "ACTION 1",
+        "2 Records",
+        "Unarchived",
+        "",
+    ]);
+
+    expect.verifySteps([]);
+
+    await setOffline(false);
+
+    expect(getService("offline").offline).toBe(false);
+    await expect.waitForSteps(["action_unarchive"]);
+});
+
 test(`[Offline] cache web_search_read: enable filter online/offline`, async () => {
     expect.errors(2);
     const setOffline = mockOffline();


### PR DESCRIPTION
[IMP] web: enable deleting records while offline

This commit allows users to delete records while offline.

Offline deletion is limited to the list and form views. Note that, the user
must have previously visited the list view or record when online to be able to
delete records while offline.

After the user deletes records, they will appear in the "Working Offline"
dropdown on the navbar. These records will be deleted as soon as the user goes
back online.

task-id 5429932

---

[IMP] web: enable archiving/unarchiving records while offline

This commit allows users to archive and unarchive records while offline.

Offline archiving and unarchiving are limited to the list and form views. Note
that, the user must have previously visited the list view or record when online
to be able to archive or unarchive records while offline.

After archiving or unarchiving records, they will appear in the
"Working Offline" dropdown on the navbar. These records will be archived or
unarchived as soon as the user goes back online.

task-id 5429932
