### PR TITLE
[FIX] mass_mailing: implement urgent updateValue

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -220,6 +220,9 @@ export class HtmlField extends Component {
 
     onChange() {
         this.isDirty = true;
+        // Ensure that FormController.beforeLeave is able to save record
+        // changes.
+        this.props.record.setDirty();
         this.props.record.model.bus.trigger("FIELD_IS_DIRTY", true);
     }
 

--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -95,6 +95,7 @@ export class HtmlField extends Component {
         });
 
         useRecordObserver((record) => {
+            const key = this.state.key;
             // Reset Wysiwyg when we discard or onchange value
             const newValue = fixInvalidHTML(record.data[this.props.name]);
             if (!this.isDirty) {
@@ -104,6 +105,10 @@ export class HtmlField extends Component {
                     this.state.containsComplexHTML = computeContainsComplexHTML(newValue);
                     this.lastValue = value;
                 }
+            }
+            if (key === this.state.key && record.resId !== this.props.record.resId) {
+                // Ensure key is reset for 2 different records with identical html values
+                this.state.key++;
             }
         });
         useRecordObserver((record) => {

--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -168,6 +168,7 @@ For more specific needs, you may also assign custom-defined actions
             ('remove', 'mail/static/src/discuss/**/*.dark.scss'),
             'mail/static/src/views/fields/**/*',
             ('remove', 'mail/static/src/views/web/activity/**'),
+            'mail/static/src/convert_inline/**/*',
         ],
         'web.assets_backend_lazy': [
             'mail/static/src/views/web/activity/**',

--- a/addons/mail/static/src/convert_inline/convert_inline_service.js
+++ b/addons/mail/static/src/convert_inline/convert_inline_service.js
@@ -1,0 +1,43 @@
+import { Component, onMounted, useRef, xml } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+
+const mainComponents = registry.category("main_components");
+
+export class ConvertInlineContainer extends Component {
+    static template = xml`<div class="o-convert-inline" t-ref="root"></div>`;
+    static props = { share: Object };
+
+    setup() {
+        this.root = useRef("root");
+        Object.assign(this.props.share, {
+            root: this.root,
+        });
+        onMounted(() => {
+            this.props.share.resolve();
+        });
+    }
+}
+
+export const convertInlineIframeService = {
+    start() {
+        const { promise, resolve } = Promise.withResolvers();
+        const share = {
+            readyPromise: promise,
+            resolve,
+        };
+
+        mainComponents.add("ConvertInlineContainer", {
+            Component: ConvertInlineContainer,
+            props: { share },
+        });
+
+        const add = (iframe) => {
+            share.root.el.append(iframe);
+            return () => iframe.remove();
+        };
+
+        return { add, readyPromise: promise };
+    },
+};
+
+registry.category("services").add("convert_inline_iframe", convertInlineIframeService);

--- a/addons/mail/static/src/convert_inline/email_html_converter.xml
+++ b/addons/mail/static/src/convert_inline/email_html_converter.xml
@@ -1,0 +1,21 @@
+<templates>
+    <t t-name="mail.EmailHtmlConverterReferenceIframe">
+        <iframe t-att-sandbox="isBrowserSafari() ? 'allow-same-origin allow-scripts' : 'allow-same-origin'"
+            aria-hidden="true"
+            t-attf-style="
+                visibility: hidden !important;
+                pointer-events: none !important;
+                position: absolute !important;
+                top: 0 !important;
+                left: -9999px !important;
+            "/>
+    </t>
+    <t t-name="mail.EmailHtmlConverterReference">
+        <div style="width: 100% !important"/>
+    </t>
+    <t t-name="mail.EmailHtmlConverterHead">
+        <meta http-equiv="Content-Security-Policy" content="script-src 'none';"/>
+        <meta charset="utf-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"/>
+    </t>
+</templates>

--- a/addons/mail/static/src/convert_inline/hooks.js
+++ b/addons/mail/static/src/convert_inline/hooks.js
@@ -1,0 +1,133 @@
+import { onMounted, onWillDestroy, onWillUnmount, status, useComponent } from "@odoo/owl";
+import { isBrowserSafari } from "@web/core/browser/feature_detection";
+import { renderToElement, renderToFragment } from "@web/core/utils/render";
+import { getCSSRules, toInline } from "@mail/views/web/fields/html_mail_field/convert_inline";
+import { loadIframeBundles, loadIframe } from "@mail/convert_inline/iframe_utils";
+import { useService } from "@web/core/utils/hooks";
+
+export const EMAIL_DESKTOP_DIMENSIONS = {
+    width: 1320,
+    height: 1000,
+};
+export const EMAIL_MOBILE_DIMENSIONS = {
+    width: 360,
+    height: 1000,
+};
+
+/**
+ * Hook to handle email HTML conversion in a mail HtmlField.
+ * @param {Array<string>} [options.bundles] bundles to load for the conversion
+ * @returns {Object}
+ */
+export function useEmailHtmlConverter({ bundles = [] }) {
+    let reference, referenceDocument; // Element and Document in which the conversion takes place.
+    let currentConfig = {};
+    const cmp = useComponent();
+    const convertInlineIframeService = useService("convert_inline_iframe");
+    const referenceIframe = renderToElement("mail.EmailHtmlConverterReferenceIframe", {
+        isBrowserSafari,
+    });
+    const setupIframe = async () => {
+        await convertInlineIframeService.readyPromise;
+        if (status(cmp) === "destroyed") {
+            return;
+        }
+        convertInlineIframeService.add(referenceIframe);
+        const assetsPromise = loadIframeBundles(referenceIframe, bundles);
+        const contentPromise = loadIframe(referenceIframe, () => {
+            referenceDocument = referenceIframe.contentDocument;
+            referenceDocument.head.append(renderToFragment("mail.EmailHtmlConverterHead"));
+            // The iframe body must exactly have the iframe horizontal dimensions.
+            referenceDocument.body.setAttribute(
+                "style",
+                `margin: 0 !important;
+                padding: 0 !important;`
+            );
+        });
+        const loadPromise = Promise.all([contentPromise, assetsPromise]);
+        loadPromise.catch((error) => {
+            if (status(cmp) === "destroyed") {
+                // Ignore loading errors if the Component was destroyed, since the
+                // iframe was removed, there is nothing to load for.
+                return;
+            }
+            throw error;
+        });
+        return loadPromise;
+    };
+    const iframeLoaded = setupIframe();
+
+    const updateLayoutDimensions = ({ width, height } = EMAIL_DESKTOP_DIMENSIONS) => {
+        referenceIframe.style.setProperty("max-width", `${width}px`, "important");
+        referenceIframe.style.setProperty("min-width", `${width}px`, "important");
+        referenceIframe.style.setProperty("min-height", `${height}px`, "important");
+    };
+    const cleanupEmailHtmlConversion = () => {
+        if (reference?.isConnected) {
+            reference.remove();
+            reference = undefined;
+        }
+    };
+    const prepareEmailHtmlConversion = async (fragment) => {
+        await iframeLoaded;
+        cleanupEmailHtmlConversion();
+        reference = renderToElement("mail.EmailHtmlConverterReference");
+        reference.append(fragment);
+        referenceDocument.body.append(reference);
+    };
+    const getCurrentConfig = (newConfig) => {
+        if (newConfig) {
+            currentConfig = newConfig;
+        }
+        return {
+            ...currentConfig,
+            reference,
+            referenceDocument,
+        };
+    };
+    const convertToEmailHtml = async (fragment, config) => {
+        await prepareEmailHtmlConversion(fragment);
+        updateLayoutDimensions();
+        config = getCurrentConfig(config);
+        for (const cb of config.preProcessCallbacks ?? []) {
+            cb(config.reference);
+        }
+        const cssRules = getCSSRules(config.referenceDocument);
+        await toInline(config.reference, cssRules);
+        cleanupEmailHtmlConversion();
+        return config.reference.innerHTML;
+    };
+
+    let isReady = false;
+    onMounted(() => {
+        isReady = true;
+    });
+    onWillUnmount(() => {
+        isReady = false;
+        cleanupEmailHtmlConversion();
+    });
+    onWillDestroy(() => {
+        referenceIframe.remove();
+    });
+
+    return {
+        /**
+         * @param {DocumentFragment} fragment reference content to convert as
+         *        mail compliant HTML.
+         * @param {Object} [config]
+         * @returns {Promise<string>} mail compliant HTML.
+         */
+        convertToEmailHtml: (fragment, config) => {
+            if (!isReady) {
+                return null;
+            }
+            return convertToEmailHtml(fragment, config);
+        },
+        /**
+         * @param {Object} dimensions
+         * @param {Number} dimensions.width
+         * @param {Number} dimensions.height
+         */
+        updateLayoutDimensions,
+    };
+}

--- a/addons/mail/static/src/convert_inline/iframe_utils.js
+++ b/addons/mail/static/src/convert_inline/iframe_utils.js
@@ -1,0 +1,49 @@
+import { loadBundle } from "@web/core/assets";
+
+/**
+ * Execute a callback once an iframe is ready/loaded in the DOM. The iframe must
+ * have same origin sandbox policy enabled, and must be in the DOM (Chrome does
+ * not dispatch the "load" event for an iframe without `src`).
+ *
+ * @param {HTMLIFrameElement} iframe
+ * @param {Function} [callback]
+ * @returns {Promise}
+ */
+export function loadIframe(iframe, callback = () => {}) {
+    const { promise: iframeLoaded, resolve } = Promise.withResolvers();
+    const onIframeLoaded = () => {
+        if (iframe.isConnected) {
+            resolve(callback(iframe));
+        }
+        resolve(null);
+    };
+    if (iframe.contentDocument?.readyState === "complete") {
+        // Browsers like Chrome don't make use of the load event for iframes without `src`
+        onIframeLoaded();
+    } else {
+        // Browsers like Firefox only make iframe document available after dispatching "load"
+        iframe.addEventListener("load", () => onIframeLoaded(), { once: true });
+    }
+    return iframeLoaded;
+}
+
+/**
+ * Loads asset bundles inside an iframe. The iframe must have same origin
+ * sandbox policy enabled, and must be in the DOM (Chrome does not dispatch the
+ * "load" event for an iframe without `src`).
+ *
+ * @param {HTMLIFrameElement} iframe
+ * @param {Array<string>} bundles assets bundle names
+ * @param {Object} [options] type of files to load
+ * @returns {Promise}
+ */
+export function loadIframeBundles(iframe, bundles, { css = true, js = false } = {}) {
+    return loadIframe(iframe, async () =>
+        Promise.all(
+            bundles.map(
+                async (bundle) =>
+                    await loadBundle(bundle, { targetDoc: iframe.contentDocument, css, js })
+            )
+        )
+    );
+}

--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -124,13 +124,17 @@
             'mass_mailing/static/src/scss/mass_mailing_mail.scss',
             'mass_mailing/static/src/iframe_assets/**/*',
         ],
+        # style assets used to view the mail content with a basic editor
+        'mass_mailing.assets_inside_basic_editor_iframe': [
+            ('include', 'mass_mailing.assets_iframe_style'),
+            ('include', 'html_editor.assets_editor'),
+        ],
         # style assets used to view the mail content in Odoo, but not used
         # during html conversion, specific to the builder
         'mass_mailing.assets_inside_builder_iframe': [
+            ('include', 'mass_mailing.assets_iframe_style'),
+            ('include', 'html_editor.assets_editor'),
             ('include', 'html_builder.assets_inside_builder_iframe'),
-            # TODO ABD: fix bundles usages so that html_editor files don't
-            # have to be cherry picked individually.
-            'html_editor/static/src/main/selection_placeholder_plugin.scss',
             'mass_mailing/static/src/builder/**/*.inside.scss'
         ],
         'mass_mailing.iframe_add_dialog': [

--- a/addons/mass_mailing/static/src/builder/mass_mailing_builder.js
+++ b/addons/mass_mailing/static/src/builder/mass_mailing_builder.js
@@ -44,6 +44,7 @@ export class MassMailingBuilder extends Component {
             "AddDocumentsAttachmentPlugin",
             "BannerPlugin",
             "CTABadgeOptionPlugin",
+            "OperationPlugin",
         ];
         const massMailingPlugins = removePlugins(
             [

--- a/addons/mass_mailing/static/src/builder/plugins/operation_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/operation_plugin.js
@@ -1,0 +1,27 @@
+import { OperationPlugin } from "@html_builder/core/operation_plugin";
+import { registry } from "@web/core/registry";
+
+export class MassMailingOperationPlugin extends OperationPlugin {
+    static shared = [...OperationPlugin.shared, "getUnlockedDef"];
+
+    /**
+     * Does not throw if the editor was destroyed before the operation could be
+     * completed.
+     * @override
+     */
+    async next() {
+        return super.next(...arguments).catch((error) => {
+            if (!this.isDestroyed) {
+                throw error;
+            }
+        });
+    }
+
+    getUnlockedDef() {
+        return this.operation.mutex.getUnlockedDef();
+    }
+}
+
+registry
+    .category("mass_mailing-plugins")
+    .add(MassMailingOperationPlugin.id, MassMailingOperationPlugin);

--- a/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
@@ -5,7 +5,14 @@ import { MAIN_PLUGINS as MAIN_EDITOR_PLUGINS } from "@html_editor/plugin_sets";
 import { normalizeHTML, parseHTML } from "@html_editor/utils/html";
 import { MassMailingIframe } from "@mass_mailing/iframe/mass_mailing_iframe";
 import { ThemeSelector } from "@mass_mailing/themes/theme_selector/theme_selector";
-import { onWillUpdateProps, status, toRaw, useEffect, useRef } from "@odoo/owl";
+import {
+    onWillUpdateProps,
+    status,
+    toRaw,
+    useEffect,
+    useExternalListener,
+    useRef,
+} from "@odoo/owl";
 import { loadBundle } from "@web/core/assets";
 import { Domain } from "@web/core/domain";
 import { registry } from "@web/core/registry";
@@ -61,6 +68,7 @@ export class MassMailingHtmlField extends HtmlField {
 
         this.resetIframe();
         this.iframeRef = useChildRef();
+        this.iframeWrapperRef = useChildRef();
         this.codeViewButtonRef = useRef("codeViewButtonRef");
 
         onWillUpdateProps((nextProps) => {
@@ -115,6 +123,8 @@ export class MassMailingHtmlField extends HtmlField {
             },
             () => [this.codeViewRef.el]
         );
+
+        useExternalListener(window, "pointerdown", this.onPointerDown.bind(this));
     }
 
     get withBuilder() {
@@ -183,7 +193,9 @@ export class MassMailingHtmlField extends HtmlField {
         const props = {
             config: this.getConfig(),
             iframeRef: this.iframeRef,
-            onBlur: this.onBlur.bind(this),
+            iframeWrapperRef: this.iframeWrapperRef,
+            onFocus: this.onFocus.bind(this),
+            onBlur: this.onBlur.bind(this), // deprecated
             onEditorLoad: this.onEditorLoad.bind(this),
             onIframeLoad: this.onIframeLoad.bind(this),
             readonly: this.props.readonly,
@@ -298,6 +310,33 @@ export class MassMailingHtmlField extends HtmlField {
         // editable directly by the user).
         this.props.record.resetFieldValidity(this.props.inlineField);
         super.onChange();
+    }
+
+    onFocus() {
+        this.activeElement = this.iframeWrapperRef.el;
+    }
+
+    /**
+     * Simulate a tuned down "blur", based around the edition area, comprised
+     * of the edition iframe and the builder, to avoid committing changes when
+     * the user is actively interacting inside that zone. Also avoid cases
+     * where the user clicks inside an overlay or other element inside the
+     * main component container, because the builder uses a lot of these.
+     */
+    onPointerDown(ev) {
+        const isTargetOutsideActiveElement =
+            this.activeElement && !this.activeElement.contains(ev.target);
+        const ignoredTargetContainer =
+            isTargetOutsideActiveElement &&
+            ev.target?.closest(".o-main-components-container, .o_form_status_indicator_buttons");
+        const shouldIgnoreTarget =
+            ignoredTargetContainer && !ignoredTargetContainer.contains(this.activeElement);
+        if (isTargetOutsideActiveElement && !shouldIgnoreTarget) {
+            this.activeElement = undefined;
+            this.onBlur();
+        } else if (this.iframeWrapperRef.el.contains(ev.target)) {
+            this.activeElement = this.iframeWrapperRef.el;
+        }
     }
 
     onTextareaInput(ev) {

--- a/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
@@ -82,13 +82,6 @@ export class MassMailingHtmlField extends HtmlField {
             if (nextProps.readonly) {
                 toRaw(this.state).showThemeSelector = false;
             }
-            if (nextProps.record.isNew) {
-                Object.assign(toRaw(this.state), {
-                    activeTheme: undefined,
-                    showCodeView: false,
-                    showThemeSelector: true,
-                });
-            }
         });
 
         let currentKey = this.state.key;
@@ -128,7 +121,7 @@ export class MassMailingHtmlField extends HtmlField {
     }
 
     get withBuilder() {
-        return !this.props.readonly && this.state.activeTheme !== "basic";
+        return this.state.activeTheme !== "basic" && !this.props.readonly;
     }
 
     resetIframe() {
@@ -342,6 +335,23 @@ export class MassMailingHtmlField extends HtmlField {
     onTextareaInput(ev) {
         this.onChange();
         ev.target.style.height = ev.target.scrollHeight + "px";
+    }
+
+    /**
+     * Ensure that the emailHtmlConverter is kept alive (in the DOM) until the
+     * change has been committed to the record (even if this component is
+     * destroyed in the meantime).
+     * @override
+     */
+    async commitChanges({ urgent } = {}) {
+        if (!urgent) {
+            await this.mutex.exec(() => {
+                if (this.withBuilder && this.editor && !this.editor.isDestroyed) {
+                    return this.editor.shared.operation.getUnlockedDef();
+                }
+            });
+        }
+        return super.commitChanges(...arguments);
     }
 
     /**

--- a/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
@@ -5,7 +5,6 @@ import { MAIN_PLUGINS as MAIN_EDITOR_PLUGINS } from "@html_editor/plugin_sets";
 import { normalizeHTML, parseHTML } from "@html_editor/utils/html";
 import { MassMailingIframe } from "@mass_mailing/iframe/mass_mailing_iframe";
 import { ThemeSelector } from "@mass_mailing/themes/theme_selector/theme_selector";
-import { getCSSRules, toInline } from "@mail/views/web/fields/html_mail_field/convert_inline";
 import { onWillUpdateProps, status, toRaw, useEffect, useRef } from "@odoo/owl";
 import { loadBundle } from "@web/core/assets";
 import { Domain } from "@web/core/domain";
@@ -15,6 +14,7 @@ import { effect } from "@web/core/utils/reactive";
 import { useChildRef, useService } from "@web/core/utils/hooks";
 import { batched } from "@web/core/utils/timing";
 import { PowerButtonsPlugin } from "@html_editor/main/power_buttons_plugin";
+import { useEmailHtmlConverter } from "@mail/convert_inline/hooks";
 
 export class MassMailingHtmlField extends HtmlField {
     static template = "mass_mailing.HtmlField";
@@ -42,6 +42,9 @@ export class MassMailingHtmlField extends HtmlField {
             }
         });
         super.setup();
+        this.converter = useEmailHtmlConverter({
+            bundles: ["mass_mailing.assets_iframe_style"],
+        });
         this.themeService = useService("mass_mailing.themes");
         this.ui = useService("ui");
         Object.assign(this.state, {
@@ -124,6 +127,7 @@ export class MassMailingHtmlField extends HtmlField {
 
     async ensureIframeLoaded() {
         const iframeLoaded = this.iframeLoaded;
+        // iframeInfo is deprecated
         const iframeInfo = await iframeLoaded;
         return iframeLoaded === this.iframeLoaded ? iframeInfo : undefined;
     }
@@ -288,6 +292,14 @@ export class MassMailingHtmlField extends HtmlField {
         };
     }
 
+    onChange() {
+        // Ensure that a change in the edited field will reset the validity
+        // of the inlineField (since it is most likely invisible and not
+        // editable directly by the user).
+        this.props.record.resetFieldValidity(this.props.inlineField);
+        super.onChange();
+    }
+
     onTextareaInput(ev) {
         this.onChange();
         ev.target.style.height = ev.target.scrollHeight + "px";
@@ -320,52 +332,47 @@ export class MassMailingHtmlField extends HtmlField {
 
     /**
      * Complete rewrite of `updateValue` to ensure that both the field and the
-     * inlineField are saved at the same time. Depends on the iframe to compute
+     * inlineField keep consistent values. Depends on the iframe to compute
      * the style of the inlineField.
      * @override
      */
     async updateValue(value) {
-        const iframeInfo = await this.ensureIframeLoaded();
-        if (!iframeInfo) {
-            return;
-        }
-        const { bundleControls } = iframeInfo;
-        this.lastValue = normalizeHTML(value, this.clearElementToCompare.bind(this));
-        this.isDirty = false;
-        const shouldRestoreDisplayNone = this.iframeRef.el.classList.contains("d-none");
-        // d-none must be removed for style computation.
-        this.iframeRef.el.classList.remove("d-none");
-        // The browser resets the size of the `iframe` inside `toInline`
-        // if we just set `width`. So as a workaround we set both `min-width`
-        // and `max-width` to force the size of the `iframe` for a proper
-        // inline conversion.
-        this.iframeRef.el.style.setProperty("min-width", "1320px", "important");
-        this.iframeRef.el.style.setProperty("max-width", "1320px", "important");
-        const processingEl = this.iframeRef.el.contentDocument.createElement("DIV");
-        processingEl.append(parseHTML(this.iframeRef.el.contentDocument, value));
-        const processingContainer = this.iframeRef.el.contentDocument.querySelector(
-            ".o_mass_mailing_processing_container"
-        );
-        bundleControls["mass_mailing.assets_inside_builder_iframe"]?.toggle(false);
-        processingContainer.append(processingEl);
-        this.preprocessFilterDomains(processingEl);
-        const cssRules = getCSSRules(this.iframeRef.el.contentDocument);
-        await toInline(processingEl, cssRules);
-        const inlineValue = processingEl.innerHTML;
-        processingEl.remove();
-        bundleControls["mass_mailing.assets_inside_builder_iframe"]?.toggle(true);
-        this.iframeRef.el.style.minWidth = "";
-        this.iframeRef.el.style.maxWidth = "";
-        if (shouldRestoreDisplayNone) {
-            this.iframeRef.el.classList.add("d-none");
-        }
-        await this.props.record
+        const record = this.props.record;
+        // Ensure the edited value is updated immediately to avoid data loss,
+        // and reset the inline field (need async computation) to avoid
+        // transient state where inline data is obsolete.
+        // If the following computation is aborted, at least it can be
+        // recovered by reloading the field.
+        const urgentUpdatePromise = record
             .update({
                 [this.props.name]: value,
-                [this.props.inlineField]: inlineValue,
+                [this.props.inlineField]: "",
             })
+            .then(() => {
+                record.model.bus.trigger("FIELD_IS_DIRTY", false);
+            });
+        this.lastValue = normalizeHTML(value, this.clearElementToCompare.bind(this));
+        const valueFragment = parseHTML(document, value);
+        let inlineValue;
+        try {
+            inlineValue = await this.converter.convertToEmailHtml(valueFragment, {
+                preProcessCallbacks: [this.preprocessFilterDomains.bind(this)],
+            });
+        } catch (error) {
+            if (status(this) !== "destroyed") {
+                throw error;
+            }
+            inlineValue = null;
+        }
+        await urgentUpdatePromise;
+        if (record.resId !== this.props.record?.resId || inlineValue === null) {
+            return;
+        }
+        this.isDirty = false;
+        await record
+            .update({ [this.props.inlineField]: inlineValue })
             .catch(() => (this.isDirty = true));
-        this.props.record.model.bus.trigger("FIELD_IS_DIRTY", this.isDirty);
+        record.model.bus.trigger("FIELD_IS_DIRTY", this.isDirty);
     }
     /**
      * Processes the data-filter-domain to be converted to a t-if that will be interpreted on send
@@ -406,6 +413,7 @@ export const massMailingHtmlField = {
         });
         return props;
     },
+    // Deprecated (to be defined in the view)
     fieldDependencies: [{ name: "body_html", type: "html", readonly: "false" }],
 };
 

--- a/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.js
+++ b/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.js
@@ -22,12 +22,9 @@ import { closestScrollableY } from "@web/core/utils/scrolling";
 import { _t } from "@web/core/l10n/translation";
 import { localization } from "@web/core/l10n/localization";
 import { isBrowserSafari } from "@web/core/browser/feature_detection";
+import { loadIframe } from "@mail/convert_inline/iframe_utils";
 
 const IFRAME_VALUE_SELECTOR = ".o_mass_mailing_value";
-const MASS_MAILING_IFRAME_ASSETS = [
-    "mass_mailing.assets_iframe_style",
-    "mass_mailing.assets_inside_builder_iframe",
-];
 
 /**
  * The MassMailingIframe will use this modified overlay service that will guarantee:
@@ -95,14 +92,7 @@ export class MassMailingIframe extends Component {
         });
         this.iframeLoaded = new Deferred();
         onMounted(() => {
-            if (this.iframeRef.el.contentDocument.readyState === "complete") {
-                this.setupIframe();
-            } else {
-                // Browsers like Firefox only make iframe document available after dispatching "load"
-                this.iframeRef.el.addEventListener("load", () => this.setupIframe(), {
-                    once: true,
-                });
-            }
+            this.setupIframe();
         });
         if (!this.props.readonly && !this.props.withBuilder) {
             this.editor = new Editor(this.props.config, this.env.services);
@@ -225,11 +215,29 @@ export class MassMailingIframe extends Component {
         return isBrowserSafari();
     }
 
+    getIframeBundles({ readonly, withBuilder } = this.props) {
+        if (readonly) {
+            return ["mass_mailing.assets_iframe_style"];
+        } else if (withBuilder) {
+            return ["mass_mailing.assets_inside_builder_iframe"];
+        }
+        return ["mass_mailing.assets_inside_basic_editor_iframe"];
+    }
+
     async setupIframe() {
-        this.iframeRef.el?.contentDocument.head.appendChild(this.renderHeadContent());
-        this.bundleControls = await this.loadIframeAssets();
+        let loadingError;
+        try {
+            this.bundleControls = await loadIframe(this.iframeRef.el, (iframe) => {
+                iframe.contentDocument?.head.appendChild(this.renderHeadContent());
+                return this.loadIframeAssets();
+            });
+        } catch (error) {
+            loadingError = error;
+        }
         if (status(this) === "destroyed") {
             return;
+        } else if (loadingError) {
+            throw loadingError;
         }
         const htmlResizeObserver = new ResizeObserver(this.throttledResize);
         this.iframeRef.el.contentDocument.body.classList.add("o_in_iframe");
@@ -256,6 +264,7 @@ export class MassMailingIframe extends Component {
         this.iframeRef.el.contentWindow.addEventListener("blur", this.onBlur.bind(this));
         this.iframeLoaded.resolve({
             iframe: this.iframeRef.el,
+            // TODO EGGMAIL: deprecated bundleControls
             bundleControls: this.bundleControls,
         });
         this.props.onIframeLoad?.(this.iframeLoaded);
@@ -305,9 +314,10 @@ export class MassMailingIframe extends Component {
 
     /**
      * @returns {Object} bundleControls { bundleName: activatorObject }
+     * TODO EGGMAIL: bundleControls are deprecated (unused)
      */
     async loadIframeAssets() {
-        const bundleEntryPromises = MASS_MAILING_IFRAME_ASSETS.map(async (bundle) => {
+        const bundleEntryPromises = this.getIframeBundles().map(async (bundle) => {
             const targets = (
                 await loadBundle(bundle, {
                     targetDoc: this.iframeRef.el.contentDocument,
@@ -354,6 +364,7 @@ export class MassMailingIframe extends Component {
     getBuilderProps() {
         return {
             overlayRef: this.overlayRef,
+            // TODO EGGMAIL: iframeInfo is deprecated (should resolve to iframe directly)
             iframeLoaded: this.iframeLoaded.then((iframeInfo) => iframeInfo.iframe),
             snippetsName: "mass_mailing.email_designer_snippets",
             config: this.props.config,

--- a/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.js
+++ b/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.js
@@ -2,7 +2,6 @@ import {
     Component,
     onMounted,
     onWillDestroy,
-    onWillUpdateProps,
     status,
     useComponent,
     useEffect,
@@ -88,11 +87,6 @@ export class MassMailingIframe extends Component {
             showFullscreen: false,
             isMobile: false,
             ready: false,
-        });
-        onWillUpdateProps((nextProps) => {
-            if (nextProps.showCodeView) {
-                this.state.showFullscreen = false;
-            }
         });
         this.iframeLoaded = new Deferred();
         onMounted(() => {

--- a/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.js
+++ b/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.js
@@ -57,24 +57,28 @@ export class MassMailingIframe extends Component {
     static props = {
         config: { type: Object },
         iframeRef: { type: Function },
+        iframeWrapperRef: { type: Function },
         showThemeSelector: { type: Boolean, optional: true },
         onIframeLoad: { type: Function, optional: true },
         showCodeView: { type: Boolean, optional: true },
         toggleCodeView: { type: Function, optional: true },
         readonly: { type: Boolean, optional: true },
         onEditorLoad: { type: Function, optional: true },
-        onBlur: { type: Function, optional: true },
+        onBlur: { type: Function, optional: true }, // deprecated
+        onFocus: { type: Function, optional: true },
         extraClass: { type: String, optional: true },
         withBuilder: { type: Boolean, optional: true },
     };
     static defaultProps = {
         onEditorLoad: () => {},
+        onFocus: () => {},
     };
 
     setup() {
         useOverlayServiceOffset();
         this.overlayRef = useChildRef();
         this.iframeRef = useForwardRefToParent("iframeRef");
+        this.iframeWrapperRef = useForwardRefToParent("iframeWrapperRef");
         this.sidebarRef = useRef("sidebarRef");
         this.isRTL = localization.direction === "rtl";
         useSubEnv({
@@ -261,7 +265,7 @@ export class MassMailingIframe extends Component {
         this.iframeRef.el.contentWindow.addEventListener("beforeUnload", () => {
             this.iframeRef.el.removeAttribute("is-ready");
         });
-        this.iframeRef.el.contentWindow.addEventListener("blur", this.onBlur.bind(this));
+        this.iframeRef.el.contentWindow.addEventListener("focus", this.props.onFocus.bind(this));
         this.iframeLoaded.resolve({
             iframe: this.iframeRef.el,
             // TODO EGGMAIL: deprecated bundleControls
@@ -347,6 +351,9 @@ export class MassMailingIframe extends Component {
         return Object.fromEntries(await Promise.all(bundleEntryPromises));
     }
 
+    /**
+     * @deprecated
+     */
     onBlur(ev) {
         if (!this.props.readonly) {
             this.props.onBlur(ev);

--- a/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.xml
+++ b/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.xml
@@ -43,6 +43,7 @@
                 <t t-out="props.config.value"/>
             </t>
         </div>
+        <!-- Deprecated, unused element -->
         <div class="o_mass_mailing_processing_container" style="
             position: absolute;
             top: -9999px;

--- a/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.xml
+++ b/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.xml
@@ -34,6 +34,7 @@
     <t t-name="mass_mailing.IframeHead">
         <meta http-equiv="Content-Security-Policy" content="script-src 'none';"/>
         <meta charset="utf-8"/>
+        <!-- Deprecated, useless element -->
         <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
         <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"/>
     </t>

--- a/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.xml
+++ b/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.xml
@@ -1,6 +1,7 @@
 <templates>
     <t t-name="mass_mailing.MassMailingIframe">
         <div class="o_mass_mailing_iframe_wrapper"
+            t-ref="iframeWrapperRef"
             t-att-class="{
                 'o_mass_mailing_fullscreen': state.showFullscreen,
                 [props.extraClass]: props.extraClass,

--- a/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
+++ b/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
@@ -12,11 +12,12 @@ import {
     getPagerLimit,
 } from "@web/../tests/web_test_helpers";
 import { click, queryAny, queryOne, waitFor } from "@odoo/hoot-dom";
-import { runAllTimers } from "@odoo/hoot-mock";
+import { animationFrame, runAllTimers } from "@odoo/hoot-mock";
 import { defineMailModels } from "@mail/../tests/mail_test_helpers";
 import { unmockedOrm } from "@web/../tests/_framework/module_set.hoot";
 import { MassMailingIframe } from "../src/iframe/mass_mailing_iframe";
 import { MassMailingHtmlField } from "../src/fields/html_field/mass_mailing_html_field";
+import { FormController } from "@web/views/form/form_controller";
 
 class Mailing extends models.Model {
     _name = "mailing.mailing";
@@ -205,6 +206,12 @@ describe("field HTML", () => {
             // Css assets are not needed for these tests.
             loadIframeAssets() {
                 return {
+                    "mass_mailing.assets_iframe_style": {
+                        toggle: () => {},
+                    },
+                    "mass_mailing.assets_inside_basic_editor_iframe": {
+                        toggle: () => {},
+                    },
                     "mass_mailing.assets_inside_builder_iframe": {
                         toggle: () => {},
                     },
@@ -251,7 +258,111 @@ describe("field HTML", () => {
         // assert that tElement style has inline attibute
         expect(tElement).toHaveAttribute("data-oe-t-inline", "true");
     });
-
+    test("switch out from a notebook tab with html field should update the record", async () => {
+        const arch = `
+            <form>
+                <field name="mailing_model_name" invisible="1"/>
+                <field name="mailing_model_id" invisible="1"/>
+                <field name="mailing_model_real" invisible="1"/>
+                <field name="state" invisible="1"/>
+                <notebook>
+                    <page string="body_arch" name="body_arch">
+                        <field name="body_arch" class="o_mail_body_mailing" widget="mass_mailing_html"
+                            options="{
+                                'inline_field': 'body_html',
+                                'dynamic_placeholder': true,
+                                'dynamic_placeholder_model_reference_field': 'mailing_model_real'
+                                }" readonly="state in ('sending', 'done')"/>
+                    </page>
+                    <page string="body_html" name="body_html">
+                        <field name="body_html" class="o_mail_body_inline" readonly="true"/>
+                    </page>
+                </notebook>
+            </form>
+        `;
+        await mountView({
+            type: "form",
+            resModel: "mailing.mailing",
+            resId: 5,
+            arch,
+        });
+        await waitFor(":iframe .o_layout .container:contains(Builder)", { timeout: 3000 });
+        // ensure conversion of the existing html content
+        await htmlField.commitChanges();
+        const oldConvert = htmlField.converter.convertToEmailHtml;
+        const { promise: conversionDelay, resolve: resumeConversion } = Promise.withResolvers();
+        htmlField.converter.convertToEmailHtml = (fragment, config) =>
+            conversionDelay.then(() => oldConvert(fragment, config));
+        const p = htmlField.editor.editable.querySelector("p");
+        p.append(htmlField.editor.document.createTextNode("Updated"));
+        htmlField.editor.shared.history.addStep();
+        await contains(".o_notebook a[name='body_html']").click();
+        await animationFrame();
+        await waitFor(".o_notebook a[name='body_html']");
+        resumeConversion();
+        expect(
+            (
+                await waitFor(".o_field_widget[name='body_html']:contains(BuilderUpdated)", {
+                    timeout: 3000,
+                })
+            ).innerText.trim()
+        ).toBe("BuilderUpdated");
+    });
+    test("beforeLeave a FormController with html field should save the record", async () => {
+        let formController;
+        patchWithCleanup(FormController.prototype, {
+            setup() {
+                formController = this;
+                super.setup();
+            },
+        });
+        const arch = `
+            <form>
+                <field name="mailing_model_name" invisible="1"/>
+                <field name="mailing_model_id" invisible="1"/>
+                <field name="mailing_model_real" invisible="1"/>
+                <field name="state" invisible="1"/>
+                <notebook>
+                    <page string="body_arch" name="body_arch">
+                        <field name="body_arch" class="o_mail_body_mailing" widget="mass_mailing_html"
+                            options="{
+                                'inline_field': 'body_html',
+                                'dynamic_placeholder': true,
+                                'dynamic_placeholder_model_reference_field': 'mailing_model_real'
+                                }" readonly="state in ('sending', 'done')"/>
+                        <field name="body_html" class="o_mail_body_inline" readonly="true"/>
+                    </page>
+                </notebook>
+            </form>
+        `;
+        await mountView({
+            type: "form",
+            resModel: "mailing.mailing",
+            resId: 5,
+            arch,
+        });
+        await waitFor(":iframe .o_layout .container:contains(Builder)", { timeout: 3000 });
+        // ensure conversion of the existing html content
+        await htmlField.commitChanges();
+        expect(
+            (
+                await waitFor(".o_field_widget[name='body_html']:contains(Builder)", {
+                    timeout: 3000,
+                })
+            ).innerText.trim()
+        ).toBe("Builder");
+        const p = htmlField.editor.editable.querySelector("p");
+        p.append(htmlField.editor.document.createTextNode("Updated"));
+        htmlField.editor.shared.history.addStep();
+        await formController.beforeLeave();
+        expect(
+            (
+                await waitFor(".o_field_widget[name='body_html']:contains(BuilderUpdated)", {
+                    timeout: 3000,
+                })
+            ).innerText.trim()
+        ).toBe("BuilderUpdated");
+    });
     test("builder in modal -- owl reconciliation iframe unload", async () => {
         // Related to ad-hoc fix where in modal, some editor's popovers
         // get to be spawned before the modal in the DOM and in OWL

--- a/addons/mass_mailing/static/tests/tours/mailing_campaign.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_campaign.js
@@ -31,6 +31,9 @@ registry.category('web_tour.tours').add('mailing_campaign', {
             run: "click",
         },
         {
+            trigger: ":iframe .o_mass_mailing_value .o_layout",
+        },
+        {
             content: 'Fill in Subject',
             trigger: '#subject_0',
             run: "edit TestFromTour",

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -266,6 +266,7 @@
                                             'dynamic_placeholder': true,
                                             'dynamic_placeholder_model_reference_field': 'mailing_model_real',
                                         }" readonly="state in ('sending', 'done')"/>
+                                    <field name="body_html" invisible="1" required="body_arch"/>
                                     <field name="is_body_empty" invisible="1"/>
                                 </div>
                             </page>

--- a/addons/web/static/src/core/notebook/notebook.js
+++ b/addons/web/static/src/core/notebook/notebook.js
@@ -1,4 +1,5 @@
 import { Component, onWillRender, onWillUpdateProps, useEffect, useRef, useState } from "@odoo/owl";
+import { KeepLast } from "@web/core/utils/concurrency";
 
 /**
  * A notebook component that will render only the current page and allow
@@ -55,6 +56,7 @@ export class Notebook extends Component {
         className: "",
         orientation: "horizontal",
         onPageUpdate: () => {},
+        onWillActivatePage: () => {},
     };
     static props = {
         slots: { type: Object, optional: true },
@@ -65,6 +67,7 @@ export class Notebook extends Component {
         orientation: { type: String, optional: true },
         icons: { type: Object, optional: true },
         onPageUpdate: { type: Function, optional: true },
+        onWillActivatePage: { type: Function, optional: true },
     };
 
     setup() {
@@ -73,6 +76,7 @@ export class Notebook extends Component {
         this.invalidPages = new Set();
         this.state = useState({ currentPage: null });
         this.state.currentPage = this.computeActivePage(this.props.defaultPage, true);
+        this.keepLastPageTransition = new KeepLast();
         useEffect(
             () => {
                 this.props.onPageUpdate(this.state.currentPage);
@@ -100,10 +104,14 @@ export class Notebook extends Component {
         return page.Component && page;
     }
 
-    activatePage(pageIndex) {
+    async activatePage(pageIndex) {
         if (!this.disabledPages.includes(pageIndex) && this.state.currentPage !== pageIndex) {
-            this.activePane.el?.classList.remove("show");
-            this.state.currentPage = pageIndex;
+            const prom = (async () => this.props.onWillActivatePage(pageIndex))();
+            const canProceed = await this.keepLastPageTransition.add(prom);
+            if (canProceed !== false) {
+                this.activePane.el?.classList.remove("show");
+                this.state.currentPage = pageIndex;
+            }
         }
     }
 

--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -266,6 +266,15 @@ export class Record extends DataPoint {
     }
 
     /**
+     * Sometimes necessary when fields have an expensive computation to do
+     * before an update (e.g. HtmlField). Could be removed when external usages
+     * of dirty are replaced by isDirty() (e.g. FormController.beforeLeave)
+     */
+    setDirty() {
+        this.dirty = true;
+    }
+
+    /**
      * @param {string} fieldName
      */
     async setInvalidField(fieldName) {

--- a/addons/web/static/src/views/form/form_compiler.js
+++ b/addons/web/static/src/views/form/form_compiler.js
@@ -528,6 +528,10 @@ export class FormCompiler extends ViewCompiler {
             "onPageUpdate",
             `(page) => __comp__.props.onNotebookPageChange(${noteBookId}, page)`
         );
+        noteBook.setAttribute(
+            "onWillActivatePage",
+            `(page) => __comp__.onWillChangeNotebookPage?.(${noteBookId}, page)`
+        );
 
         for (const child of el.children) {
             if (getTag(child, true) !== "page") {

--- a/addons/web/static/src/views/form/form_renderer.js
+++ b/addons/web/static/src/views/form/form_renderer.js
@@ -146,4 +146,10 @@ export class FormRenderer extends Component {
         this.state.isStatusbarStickyPinned =
             !this.env.inDialog && !this.env.isSmall && ev.target.scrollTop !== 0;
     }
+
+    async onWillChangeNotebookPage() {
+        // Hack to force _askChanges
+        await this.props.record.isDirty();
+        return true;
+    }
 }

--- a/addons/web/static/tests/core/notebook.test.js
+++ b/addons/web/static/tests/core/notebook.test.js
@@ -354,3 +354,64 @@ test("icons can be given for each page tab", async () => {
     expect(".nav-item:nth-child(3) i").toHaveClass("fa-pencil");
     expect(".nav-item:nth-child(3)").toHaveText("page3");
 });
+
+test("switch notebook page after async work", async () => {
+    let { promise, resolve } = Promise.withResolvers();
+    class Page extends Component {
+        static template = xml`<h3>Coucou</h3>`;
+        static props = ["*"];
+    }
+
+    class Parent extends Component {
+        static template = xml`<Notebook pages="this.pages" onWillActivatePage="() => this.onWillActivatePage()"/>`;
+        static components = { Notebook };
+        static props = ["*"];
+        setup() {
+            this.pages = [
+                {
+                    Component: Page,
+                    index: 1,
+                    title: "Page 1",
+                },
+                {
+                    Component: Page,
+                    index: 2,
+                    title: "Page 2",
+                },
+            ];
+        }
+        onWillActivatePage() {
+            return promise;
+        }
+    }
+
+    await mountWithCleanup(Parent);
+    const h3Capture1 = queryFirst("h3");
+    expect(h3Capture1).toBeInstanceOf(HTMLElement);
+
+    await click(".o_notebook_headers .nav-item:nth-child(2) a");
+    await animationFrame();
+    // async work is not finished
+    const h3Capture2 = queryFirst("h3");
+    expect(h3Capture2).toBe(h3Capture1);
+
+    resolve(true);
+    await animationFrame();
+    // async work completed successfully
+    const h3Capture3 = queryFirst("h3");
+    expect(h3Capture3).toBeInstanceOf(HTMLElement);
+    expect(h3Capture3).not.toBe(h3Capture1);
+
+    ({ promise, resolve } = Promise.withResolvers());
+    await click(".o_notebook_headers .nav-item:nth-child(1) a");
+    await animationFrame();
+    // async work is not finished
+    const h3Capture4 = queryFirst("h3");
+    expect(h3Capture4).toBe(h3Capture3);
+
+    resolve(false);
+    await animationFrame();
+    // async work resolved with false, preventing the page change
+    const h3Capture5 = queryFirst("h3");
+    expect(h3Capture5).toBe(h3Capture3);
+});

--- a/addons/web/static/tests/views/form/form_compiler.test.js
+++ b/addons/web/static/tests/views/form/form_compiler.test.js
@@ -133,7 +133,7 @@ test("properly compile notebook", () => {
     const expected = /*xml*/ `
         <t t-translation="off">
             <div class="o_form_renderer o_form_nosheet" t-att-class="__comp__.props.class" t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-block {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}" t-ref="compiled_view_root">
-                <Notebook defaultPage="__comp__.props.record.isNew ? undefined : __comp__.props.activeNotebookPages[0]" onPageUpdate="(page) =&gt; __comp__.props.onNotebookPageChange(0, page)">
+                <Notebook defaultPage="__comp__.props.record.isNew ? undefined : __comp__.props.activeNotebookPages[0]" onPageUpdate="(page) =&gt; __comp__.props.onNotebookPageChange(0, page)" onWillActivatePage="(page) =&gt; __comp__.onWillChangeNotebookPage?.(0, page)">
                     <t t-set-slot="page_1" title="\`Page1\`" name="\`p1\`" isVisible="true" fieldnames="[&quot;charfield&quot;]">
                         <Field id="'charfield'" name="'charfield'" record="__comp__.props.record" fieldInfo="__comp__.props.archInfo.fieldNodes['charfield']" readonly="__comp__.props.readonly"/>
                     </t>


### PR DESCRIPTION
Main issue:

Prior to this commit, updateValue would guarantee that `body_arch` and
`body_html` were always updated in sync (to avoid an inconsistent state where
the user thinks they updated the mailing, and they see the new html in the
editor, but the email html is obsolete and would be sent as is).

However this caused another issue, that the user would lose their work when
switching tab in the Notebook, because computing the `body_html` may be slower
than the view patch to switch tab (`updateValue` is interrupted). In such a
case, neither `body_arch` nor `body_html` was updated on the record, and when
the user comes back to edit them, they see that all changes were lost.

To prevent this, a new strategy is adopted:
- `body_arch` is now updated as soon as possible to save the latest user
  changes
- `body_html` is set to an empty string to avoid inconsistencies, and in order
  to trigger `convert_inline` automatically the next time the
  `mass_mailing_html_field` is instanced without any user action.
- after `convert_inline`, if `updateValue` was not aborted, the record is
  updated again with the new value for `body_html`

Minor issues:

1) Prior to this commit, the iframe would flicker during `convert_inline`
because it was done inside that very iframe, and the `convert_inline` needs a
specific width (1320px) for it to work properly, meaning that if the iframe was
not at that specific dimension, it was resized temporarily for that process.
This commit introduces hooks to execute the `convert_inline` process in a
separate iframe, outside of the user view, which removes this flickering.

2) Prior to this commit, assets for readonly/basic editor/builder were all
loaded inside the iframe, and then toggled on/off depending on which were
needed. Since the `convert_inline` process is moved in another iframe, it's as
good time as any to deprecate this toggling (as it could be a bit unreliable and
could cause some flickering when unloading/reloading the style). There is now a
separate asset bundle for the 3 use case, and only one of them is loaded per
iframe depending on the needs.

3) Prior to this commit, `body_html` was hard-coded as a dependency of the
`mass_mailing_html_field`, and that dependency lacked the `required` attribute,
which should depend on the value of `body_arch`. The dependency is now added in
the related views, and the field is now generic. This also prevents the user
from leaving the view if `convert_inline` could not be completed successfully.

4) Prior to this commit, switching to another view through `doAction` could
throw an error if the field was dirty, as the `form view` would be destroyed
before `commitChanges` had the time to be completed. Now, `commitChanges`
promise is properly awaited by the `action_service` if the field is dirty before
`doAction` (unless `forceLeave` is true).

5) Prior to this commit, the record was updated through a `blur` event on the
iframe window. However, it means that every time the iframe looses focus when
the users interacts with the builder, a popover or the form status indicator,
that blur event would fire, triggering the `convert_inline` process. This commit
reduces the amount of such updates by only triggering the update outside of
these elements, as we don't need to update the record value while the user is
still actively editing the mailing.
Blur handlers/props are deprecated with this commit and will be removed further
down the line.

6) Ensure that in the rare case where a `html_field` value is exactly the same
on different records, the `html_field` state key is updated (triggers a
wysiwyg/mass_mailing_iframe reset).

7) Remove an erroneous part in `onWillUpdateProps` of `mass_mailing_html_field`
which could display the theme selector again on the same record just after
selecting a theme if props were updated.

8) Ensure `withBuilder` getter of `mass_mailing_html_field` properly reads the
state activeTheme every time it is used (if it does not, it could cause issues
with the reactivity, since reading on the state is required for a property
subscription).

9) Remove a useless `onWillUpdateProps` of `mass_mailing_iframe` which was never
used because when `props.showCodeView` changes, the iframe is always destroyed,
so there is no need to update its state.

10) Deprecate usage of `<meta http-equiv="X-UA-Compatible" content="IE=edge"/>`,
to be removed further down the line, as it is useless in the modern web.

11) Ignore errors during a builder "Operation" that was not finished before the
editor was destroyed. In `mass_mailing`, the editor is expected to be
destroyable synchronously to work inside an Odoo view, unlike in `website`.
What's already in the DOM just before destruction will be updated on the
`record`, and the rest of the operation will be lost. However, an attempt is
made to wait for ongoing operations at the start of the
`HtmlField.commitChanges`.

task-5976348