### PR TITLE
[FIX] website_sale: Fix images aspect ratio

### DIFF
--- a/addons/website_sale/views/product_tile_templates.xml
+++ b/addons/website_sale/views/product_tile_templates.xml
@@ -90,7 +90,7 @@
                 <!-- Primary image -->
                 <span
                     t-field="primary_image_holder.image_1920"
-                    t-options="{'widget': 'image', 'preview_image': 'image_1024', 'class': 'oe_product_image_img h-100 w-100'}"
+                    t-options="{'widget': 'image', 'preview_image': 'image_1024', 'class': 'oe_product_image_img mh-100 mw-100'}"
                     class="oe_product_image_img_wrapper oe_product_image_img_wrapper_primary d-flex h-100 justify-content-center align-items-center"
                 />
 
@@ -98,7 +98,7 @@
                 <span
                     t-if="secondary_image_holder"
                     t-field="secondary_image_holder.image_1920"
-                    t-options="{'widget': 'image', 'preview_image': 'image_1024', 'class': 'oe_product_image_img_secondary h-100 w-100'}"
+                    t-options="{'widget': 'image', 'preview_image': 'image_1024', 'class': 'oe_product_image_img_secondary mh-100 mw-100'}"
                     class="oe_product_image_img_wrapper oe_product_image_img_wrapper_secondary h-100 justify-content-center align-items-center"
                 />
 


### PR DESCRIPTION
Issue:
-------
In the grid view, when an image(s) of a product has max height and min width or
 max width and min height then those images are way too zoomed to fit into
the image holder which displays the image improper/zoomed.

Solution:
------------
To overcome the zooming, using `mh-100 & mw-100`.
This will display the image of any aspect ratio correctly.

Simple `h-100  & w-100` along with the class `oe_product_image_img` is causing the zooming issue.

Steps to reproduce:
-----------------------
1. In v19.0, create few products with images having different aspect ratio.
2. Publish that product in the website, and open it in the grid design/style.
3. Preferably, use Landscape Image ratio.(But that doesn't really matter).
4. Finally, the product(s) will be zoomed to fit into that card holder.

- OPW - [5951564](https://www.odoo.com/odoo/project/70/tasks/5951564)

**Preferably use images for testing:**
![Copper whetstone holder](https://github.com/user-attachments/assets/588b094c-85b6-460f-affb-18eb2a558dda)
![Carbon steel and beechwood traditional 17cm](https://github.com/user-attachments/assets/bba2208d-93ff-4872-9fe8-32ad0dee9f64)


**Reference Images:**
<img width="716" height="439" alt="image" src="https://github.com/user-attachments/assets/e20b8666-c354-481a-afb1-44224abf52cc" />
<img width="752" height="426" alt="image" src="https://github.com/user-attachments/assets/3ca4f0bf-4ec3-406a-b5de-e569744aa745" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
