### PR TITLE
[FIX] web: filter cached inaccessible x2many records in web_read

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -134,25 +134,36 @@ class Base(models.AbstractModel):
 
                 co_records = self[field_name]
 
-                if 'order' in field_spec and field_spec['order']:
+                field_spec_order = field_spec.get('order')
+                field_spec_has_fields = 'fields' in field_spec
+
+                if field_spec_order or field_spec_has_fields:
+                    # Re-search the records to apply read record rules
+                    # (cache may contain inaccessible ids after write/read) and apply order.
                     co_records = co_records.with_context(active_test=False).search(
-                        [('id', 'in', co_records.ids)], order=field_spec['order'],
+                        [('id', 'in', co_records.ids)], order=field_spec_order,
                     ).with_context(co_records.env.context)  # Reapply previous context
+
+                    co_records_ids = set(co_records.ids)
+
+                    for values in values_list:
+                        # filter out inaccessible corecords in case of "cache pollution"
+                        values[field_name] = [id_ for id_ in values[field_name] if id_ in co_records_ids]
+
+                if field_spec_order:
                     order_key = {
                         co_record.id: index
                         for index, co_record in enumerate(co_records)
                     }
                     for values in values_list:
-                        # filter out inaccessible corecords in case of "cache pollution"
-                        values[field_name] = [id_ for id_ in values[field_name] if id_ in order_key]
                         values[field_name] = sorted(values[field_name], key=order_key.__getitem__)
 
                 if 'context' in field_spec:
                     co_records = co_records.with_context(**field_spec['context'])
 
-                if 'fields' in field_spec:
-                    if field_spec.get('limit') is not None:
-                        limit = field_spec['limit']
+                if field_spec_has_fields:
+                    limit = field_spec.get('limit')
+                    if limit is not None:
                         ids_to_read = OrderedSet(
                             id_
                             for values in values_list

--- a/addons/web/tests/__init__.py
+++ b/addons/web/tests/__init__.py
@@ -16,6 +16,7 @@ from . import test_read_progress_bar
 from . import test_assets
 from . import test_assets_xml
 from . import test_login
+from . import test_web_read
 from . import test_web_search_read
 from . import test_web_read_group
 from . import test_domain

--- a/addons/web/tests/test_web_read.py
+++ b/addons/web/tests/test_web_read.py
@@ -1,0 +1,106 @@
+from odoo import Command
+from odoo.tests import TransactionCase, tagged
+from odoo.tests.common import new_test_user
+
+
+@tagged('post_install', '-at_install')
+class TestWebReadX2manyAccessRules(TransactionCase):
+    """ x2many cache pollution in web_read."""
+
+    def test_web_read_filters_inaccessible_x2many_records(self):
+        # web_read must filter inaccessible x2many records when the ORM cache
+        # contains unaccessible ids.
+        #
+        # Context:
+        # - There are two companies:
+        #       Company A (allowed) and Company B (blocked).
+        # - There are one user:
+        #       user_with_restricted_access who has access only to company A.
+        # - There are two partners:
+        #       partner_accessible in company A and partner_blocked in company B.
+        # - There are a partner category:
+        #       links the two partners via a x2many field (partner_ids).
+        # Steps:
+        # - We use web_read twice on the partner category with the restricted user.
+        # - The first web_read call populates the x2many cache with only partner_accessible id.
+        # - We invalidate the x2many cache and repopulate it with a sudo fetch. Now cache contains both partner_accessible and partner_blocked ids.
+        # - The second web_read call must not return the blocked partner, even if its id is in the cache.
+        #
+        # Expected:
+        # - web_read must read only accessible partners.
+        company_allowed = self.env['res.company'].create({'name': 'Company A'})
+        company_blocked = self.env['res.company'].create({'name': 'Company B'})
+
+        user_with_restricted_access = new_test_user(
+            self.env,
+            login='restricted@test.com',
+            groups='base.group_user,base.group_partner_manager',
+            name='User with Restricted Access',
+            company_id=company_allowed.id,
+            company_ids=[Command.set([company_allowed.id])],
+        )
+
+        # We create one internal user and one portal user to get two partner records
+        # Behaviors:
+        # - internal user's partner is readable by the restricted user,
+        # - portal user's partner has partner_share=True and is blocked by record rules
+        #   when it belongs to another company.
+
+        partner_accessible = self.env['res.partner'].create({
+            'name': 'Accessible Partner',
+            'company_id': company_allowed.id,
+        })
+
+        portal_user = new_test_user(
+            self.env,
+            login='blocked@test.com',
+            groups='base.group_portal',
+            name='Blocked Partner',
+            company_id=company_blocked.id,
+        )
+        partner_blocked = portal_user.partner_id
+        partner_blocked.company_id = company_blocked.id
+
+        category = self.env['res.partner.category'].create({
+            'name': 'Odoo Lovers',
+            'partner_ids': [Command.set([
+                partner_accessible.id,
+                partner_blocked.id,
+            ])],
+        })
+
+        web_specification = {
+            'id': {},
+            'name': {},
+            'partner_ids': {'fields': {'display_name': {}}},
+        }
+
+        # Start with a clean cache.
+        self.env.invalidate_all()
+
+        # Use the restricted user.
+        record = category.with_user(user_with_restricted_access).with_context(
+            allowed_company_ids=[company_allowed.id], active_test=False
+        )
+
+        # First web_read must only return accessible partner.
+        result = record.web_read(web_specification)
+        ids_returned = [p['id'] for p in result[0]['partner_ids']]
+        self.assertIn(partner_accessible.id, ids_returned)
+        self.assertNotIn(
+            partner_blocked.id, ids_returned,
+            "First web_read must not expose the blocked partner.",
+        )
+
+        # Simulate pollution cache: remove cache from previous web_read, then repopulate with sudo.
+        category.invalidate_recordset(['partner_ids'], flush=False)
+        category.sudo().fetch(['partner_ids'])
+
+        # Second web_read must always return only accessible partner.
+        result = record.web_read(web_specification)
+        ids_returned = [p['id'] for p in result[0]['partner_ids']]
+        self.assertIn(partner_accessible.id, ids_returned)
+        self.assertNotIn(
+            partner_blocked.id, ids_returned,
+            "Second web_read must not expose inaccessible x2many records.",
+        )

--- a/odoo/addons/test_new_api/tests/test_unity_read.py
+++ b/odoo/addons/test_new_api/tests/test_unity_read.py
@@ -238,7 +238,7 @@ class TestUnityRead(TransactionCase):
         })
         self.env.invalidate_all()
         with self.assertQueryCount(1        # read the course with author id
-                                   + 1      # read the lessons of the course
+                                   + 2      # read the lessons of the course
                                    + 1      # read the author name of course
                                    + 1      # ids of the teachers of each lesson
                                    + 1):    # read the teacher name of each lessons in one query
@@ -393,7 +393,7 @@ class TestUnityRead(TransactionCase):
 
     def test_read_many2many_gives_ids(self):
         with self.assertQueryCount(1        # 1 query for course
-                                   + 1      # 1 query for the lessons
+                                   + 2      # 2 queries for the lessons
                                    + 1):    # 1 query for the attendees ids
             read = self.course.web_read({'display_name': {},
                                          'lesson_ids': {
@@ -548,7 +548,7 @@ class TestUnityRead(TransactionCase):
             }])
 
     def test_many2many_order_increases_query_count(self):
-        with self.assertQueryCount(3):
+        with self.assertQueryCount(4):
             self.course.web_read(
                 {
                     'name': {},


### PR DESCRIPTION
**Description of the issue/feature this PR addresses**:
web_read on x2many fields can reuse cached ids after write/web_save. Some of these cached ids may be inaccessible with the current record rules/context (cache pollution).

**Example**:
- **Context**:
  - Two companies exist: Company A and Company B.
  - Two users exist: User A and User B.
  - User A can only access Company A (company_ids=[A], company_id=A).
  - User B is linked to both companies (company_ids=[A, B], company_id=A).
  - The "res.company" record rule is the standard one: [('id', 'in', company_ids)] (company_ids comes from allowed_company_ids).
  - User A edits User B and saves the form.

- **Steps**:
  - User A performs a web_read to load User B: company_ids contains only Company A.
  - User A performs web_save (write + internal web_read in the same request): cached ids [A, B] are reused and the code attempts to read Company B.

**Current behavior before PR (without fix)**:
After saving a form with an x2many field, web_save calls write and then web_read. In this flow, web_read can include inaccessible x2many ids from cache and raise an AccessError.

**Desired behavior after PR is merged**:
x2many records are re-filtered with current read rules before formatting, and inaccessible ids are removed from values_list.
