### PR TITLE
[FIX] sale_timesheet: include timesheet SOL in domain

### DIFF
--- a/addons/sale_timesheet/models/hr_timesheet.py
+++ b/addons/sale_timesheet/models/hr_timesheet.py
@@ -24,10 +24,8 @@ class AccountAnalyticLine(models.Model):
     _inherit = 'account.analytic.line'
 
     def _domain_so_line(self):
-        domain = super()._domain_so_line()
-
         return Domain.AND([
-            domain,
+            Domain.OR([super()._domain_so_line(), Domain('qty_delivered_method', '=', 'timesheet')]),
             self.env['sale.order.line']._sellable_lines_domain(),
             self.env['sale.order.line']._domain_sale_line_service(),
             [
@@ -38,6 +36,7 @@ class AccountAnalyticLine(models.Model):
     billable_type = fields.Selection(selection_add=TIMESHEET_BILLABLE_TYPES)
     commercial_partner_id = fields.Many2one('res.partner', compute="_compute_commercial_partner")
     so_line = fields.Many2one(
+        domain=lambda self: str(self._domain_so_line()),
         falsy_value_label="Non-billable",
         help="Sales order item to which the time spent will be added in order to be invoiced to your customer. Remove the sales order item for the timesheet entry to be non-billable."
     )

--- a/addons/sale_timesheet/tests/test_sale_timesheet.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet.py
@@ -1,8 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import re
 from datetime import timedelta
 
 from odoo import Command
 from odoo.fields import Date
+from odoo.tools.safe_eval import expr_eval
 from odoo.tools import float_is_zero
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.addons.sale_timesheet.tests.common import TestCommonSaleTimesheet
@@ -1464,3 +1466,28 @@ class TestSaleTimesheetAnalyticPlan(TestCommonSaleTimesheet):
             analytic_account1 | analytic_account2,
             "As the timesheet SOL's distribution only contains the main account of the project, we fallback on the project's accounts and add them to the distribution.",
         )
+
+    def test_so_line_domain(self):
+        sale_order = self.env['sale.order'].create({
+            'name': 'SO Test',
+            'partner_id': self.partner_a.id,
+            'order_line': [
+                Command.create({
+                    'product_id': self.product_order_timesheet2.id,
+                }),
+                Command.create({
+                    'product_id': self.product_order_timesheet4.id,
+                }),
+            ],
+        })
+        sale_order.action_confirm()
+        timesheet = self.env['account.analytic.line'].create({
+            'name': 'Test Line',
+            'project_id': self.project_global.id,
+            'employee_id': self.employee_user.id,
+        })
+        self.project_global.partner_id = self.partner_a.id
+        domain = timesheet._domain_so_line()
+        evaluated_domain = expr_eval(re.sub(r"\bcommercial_partner_id\b(?!')", str(self.project_global.partner_id.id), repr(domain)))
+        so_line = self.env['sale.order.line'].search(evaluated_domain)
+        self.assertEqual(sale_order.order_line, so_line, "Expected sale order lines of the associated partner.")


### PR DESCRIPTION
Steps to reproduce:
- Install sale_timesheet
- Create a Sales Order with multiple Service-type Sale Order Lines
- Create a timesheet from the Sales Order stat button or from the Timesheets app

Issue:
It is not possible to select another SOL. If the default SOL is removed.

Cause:
The so_line domain does not include SOLs
with `qty_delivered_method = 'timesheet'`.

Fix:
Include timesheet SOLs in the domain.

Task-5969200