### PR TITLE
[FIX] html_editor: handle formatting behavior in inline code

### DIFF
--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -250,11 +250,12 @@ export class ClipboardPlugin extends Plugin {
         this.dispatchTo("before_paste_handlers", selection);
         // refresh selection after potential changes from `before_paste` handlers
         selection = this.dependencies.selection.getEditableSelection();
-
-        this.handlePasteUnsupportedHtml(selection, ev.clipboardData) ||
-            this.handlePasteOdooEditorHtml(ev.clipboardData) ||
-            this.handlePasteHtml(selection, ev.clipboardData) ||
-            this.handlePasteText(selection, ev.clipboardData);
+        if (!this.delegateTo("paste_overrides", selection, ev.clipboardData)) {
+            this.handlePasteUnsupportedHtml(selection, ev.clipboardData) ||
+                this.handlePasteOdooEditorHtml(ev.clipboardData) ||
+                this.handlePasteHtml(selection, ev.clipboardData) ||
+                this.handlePasteText(selection, ev.clipboardData);
+        }
 
         this.dispatchTo("after_paste_handlers", selection);
         this.dependencies.history.addStep();

--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -292,6 +292,10 @@ export class FormatPlugin extends Plugin {
                 )
         );
 
+        const textNodesToFormat = selectedTextNodes.filter(
+            (n) => this.checkPredicates("is_formattable_node_predicates", n) ?? true
+        );
+
         const tagetedFieldNodes = new Set(
             this.dependencies.selection
                 .getTargetedNodes()
@@ -299,7 +303,7 @@ export class FormatPlugin extends Plugin {
                 .filter((node) => node && this.dependencies.selection.isNodeEditable(node))
         );
         const formatSpec = formatsSpecs[formatName];
-        for (const node of selectedTextNodes) {
+        for (const node of textNodesToFormat) {
             const inlineAncestors = [];
             /** @type { Node } */
             let currentNode = node;

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -260,10 +260,15 @@ export class ColorPlugin extends Plugin {
             }
         }
 
-        const selectedNodes =
-            mode === "backgroundColor" && color
-                ? targetedNodes.filter((node) => !closestElement(node, "table.o_selected_table"))
-                : targetedNodes;
+        const selectedNodes = targetedNodes.filter((node) => {
+            if (!(this.checkPredicates("is_formattable_node_predicates", node) ?? true)) {
+                return false;
+            }
+            if (mode === "backgroundColor" && color) {
+                return !closestElement(node, "table.o_selected_table");
+            }
+            return true;
+        });
 
         const targetedFieldNodes = new Set(
             this.dependencies.selection

--- a/addons/html_editor/static/src/main/inline_code.js
+++ b/addons/html_editor/static/src/main/inline_code.js
@@ -1,11 +1,12 @@
 import { Plugin } from "@html_editor/plugin";
+import { closestBlock, isBlock } from "@html_editor/utils/blocks";
 import { splitTextNode } from "@html_editor/utils/dom";
-import { closestElement, selectElements } from "@html_editor/utils/dom_traversal";
+import { closestElement, findFurthest, selectElements } from "@html_editor/utils/dom_traversal";
 import { DIRECTIONS } from "@html_editor/utils/position";
 
 export class InlineCodePlugin extends Plugin {
     static id = "inlineCode";
-    static dependencies = ["selection", "history", "input", "feff"];
+    static dependencies = ["clipboard", "feff", "history", "input", "selection", "split"];
     resources = {
         input_handlers: this.onInput.bind(this),
         normalize_handlers: this.normalize.bind(this),
@@ -16,6 +17,38 @@ export class InlineCodePlugin extends Plugin {
                 result.push(feff);
             }
             return result;
+        },
+
+        /** Overrides */
+        paste_overrides: (selection, clipboardData) => {
+            const caretNode =
+                selection.direction === DIRECTIONS.RIGHT
+                    ? selection.anchorNode
+                    : selection.focusNode;
+            if (closestElement(caretNode, "code.o_inline_code")) {
+                this.dependencies.clipboard.pasteText(
+                    selection,
+                    clipboardData.getData("text/plain")
+                );
+                return true;
+            }
+        },
+
+        /** Predicates */
+        is_formattable_node_predicates: (node) => {
+            if (closestElement(node, "code.o_inline_code")) {
+                return false;
+            }
+        },
+        is_powerbox_available_predicates: (node) => {
+            if (closestElement(node, "code.o_inline_code")) {
+                return false;
+            }
+        },
+        toolbar_visibility_predicates: (node) => {
+            if (closestElement(node, "code.o_inline_code")) {
+                return false;
+            }
         },
     };
 
@@ -75,16 +108,17 @@ export class InlineCodePlugin extends Plugin {
             if (startOffset) {
                 splitTextNode(textNode, startOffset);
             }
-            // Remove ticks.
-            textNode.textContent = textNode.textContent.substring(
-                1,
-                textNode.textContent.length - 1
-            );
-            // Insert code element.
+            const splitLimit = findFurthest(textNode, closestBlock(textNode), (n) => !isBlock(n));
+            const splitNode = this.dependencies.split.splitAroundUntil(textNode, splitLimit);
+            // Insert code element with plain text.
             const codeElement = this.document.createElement("code");
             codeElement.classList.add("o_inline_code");
-            textNode.before(codeElement);
-            codeElement.append(textNode);
+            // Remove ticks from the text content.
+            codeElement.textContent = splitNode.textContent.substring(
+                1,
+                splitNode.textContent.length - 1
+            );
+            splitNode.replaceWith(codeElement);
             if (
                 !codeElement.previousSibling ||
                 codeElement.previousSibling.nodeType !== Node.TEXT_NODE

--- a/addons/html_editor/static/src/main/media/file_plugin.js
+++ b/addons/html_editor/static/src/main/media/file_plugin.js
@@ -40,7 +40,11 @@ export class FilePlugin extends Plugin {
         /** Predicates */
         functional_empty_node_predicates: (node) =>
             node?.nodeName === "SPAN" && node.classList.contains("o_file_box"),
-        toolbar_visibility_predicates: (node) => !closestElement(node, ".o_file_box"),
+        toolbar_visibility_predicates: (node) => {
+            if (closestElement(node, ".o_file_box")) {
+                return false;
+            }
+        },
     };
 
     setup() {

--- a/addons/html_editor/static/src/main/powerbox/search_powerbox_plugin.js
+++ b/addons/html_editor/static/src/main/powerbox/search_powerbox_plugin.js
@@ -114,6 +114,14 @@ export class SearchPowerboxPlugin extends Plugin {
     }
     openSearchPowerbox() {
         const selection = this.dependencies.selection.getEditableSelection();
+        if (
+            !(
+                this.checkPredicates("is_powerbox_available_predicates", selection.anchorNode) ??
+                true
+            )
+        ) {
+            return;
+        }
         this.offset = selection.startOffset - 1;
         this.enabledCommands = this.dependencies.powerbox.getAvailablePowerboxCommands();
         this.dependencies.powerbox.openPowerbox({

--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -302,7 +302,7 @@ export class ToolbarPlugin extends Plugin {
             .filter(
                 (node) =>
                     this.dependencies.selection.isNodeEditable(node) &&
-                    this.getResource("toolbar_visibility_predicates").every((p) => p(node)) &&
+                    (this.checkPredicates("toolbar_visibility_predicates", node) ?? true) &&
                     (!isTextNode(node) || (node.textContent.trim().length && !isZWS(node)))
             );
     }

--- a/addons/html_editor/static/src/plugin.js
+++ b/addons/html_editor/static/src/plugin.js
@@ -52,6 +52,34 @@ export class Plugin {
     }
 
     /**
+     * Test the given arguments against all the predicates registered under
+     * `resourceId` (which ends with "_predicates" by convention), and return
+     * true if any predicate returns `true` and none returns `false` (ignoring
+     * those that return `undefined`).
+     *
+     * Important note: since this function treats booleans and nullish results
+     * differently, make sure that:
+     * 1. Predicates only return a boolean when it's meaningful.
+     * 2. Any call to `checkPredicates` involves the declaration of a default
+     *    value in case it returns `undefined`.
+     *
+     * Example:
+     * ```js
+     * const isTrue = this.checkPredicates("my_predicates", arg1, arg2) ?? true;
+     * ```
+     *
+     * @param {string} resourceId
+     * @param  {...any} args The arguments to pass to the predicates.
+     * @returns {boolean | undefined}
+     */
+    checkPredicates(resourceId, ...args) {
+        const results = this.getResource(resourceId)
+            .map((predicate) => predicate(...args))
+            .filter((result) => result !== undefined);
+        return results.length ? results.every(Boolean) : undefined;
+    }
+
+    /**
      * @param {string} resourceId
      * @returns {Array}
      */

--- a/addons/html_editor/static/tests/format/inline_code.test.js
+++ b/addons/html_editor/static/tests/format/inline_code.test.js
@@ -1,7 +1,10 @@
-import { test } from "@odoo/hoot";
-import { press } from "@odoo/hoot-dom";
-import { testEditor } from "../_helpers/editor";
+import { animationFrame, expect, test, waitFor } from "@odoo/hoot";
+import { click, press } from "@odoo/hoot-dom";
+import { setupEditor, testEditor } from "../_helpers/editor";
 import { deleteBackward, deleteForward, insertText } from "../_helpers/user_actions";
+import { expectElementCount } from "../_helpers/ui_expectations";
+import { getContent } from "../_helpers/selection";
+import { contains } from "@web/../tests/web_test_helpers";
 
 test("should merge successive inline code", async () => {
     await testEditor({
@@ -52,4 +55,95 @@ test("should allow plain text insertion after inline code", async () => {
         },
         contentAfter: `<ul><li><code class="o_inline_code">x</code>![]</li><li><code class="o_inline_code">y</code>abc</li></ul>`,
     });
+});
+
+test("should create inline code and exclude surrounding formatting", async () => {
+    await testEditor({
+        contentBefore: "<p><strong><em><u>a`bcd[]ef</u></em></strong></p>",
+        stepFunction: async (editor) => {
+            await insertText(editor, "`");
+        },
+        contentAfter: `<p><strong><em><u>a</u></em></strong>\u200b<code class="o_inline_code">bcd</code>\u200b[]<strong><em><u>ef</u></em></strong></p>`,
+    });
+});
+
+test("should paste external block html as plain text inside inline code", async () => {
+    await testEditor({
+        contentBefore: `<p>ab<code class="o_inline_code">[]</code>cd</p>`,
+        stepFunction: async (editor) => {
+            const clipboardData = new DataTransfer();
+            clipboardData.setData("text/plain", "Titlepara bolda");
+            clipboardData.setData(
+                "text/html",
+                `<h2>Title</h2><p>para <strong>bold</strong></p><ul><li>a</li></ul>`
+            );
+            const pasteEvent = new ClipboardEvent("paste", {
+                clipboardData,
+                bubbles: true,
+            });
+            editor.editable.dispatchEvent(pasteEvent);
+        },
+        contentAfter: `<p>ab<code class="o_inline_code">Titlepara bolda[]</code>cd</p>`,
+    });
+});
+
+test("should paste Odoo editor html as plain text inside inline code", async () => {
+    await testEditor({
+        contentBefore: `<p>ab<code class="o_inline_code">[]</code>cd</p>`,
+        stepFunction: async (editor) => {
+            const clipboardData = new DataTransfer();
+            clipboardData.setData("text/plain", "Hello Odoo self.env.cr._enable_logging()");
+            clipboardData.setData(
+                "application/vnd.odoo.odoo-editor",
+                `<p class="o_paragraph">Hello <strong>Odoo </strong><a href="http://self.env.cr">self.env.cr</a>._enable_logging()</p>`
+            );
+            const pasteEvent = new ClipboardEvent("paste", {
+                clipboardData,
+                bubbles: true,
+            });
+            editor.editable.dispatchEvent(pasteEvent);
+        },
+        contentAfter: `<p>ab<code class="o_inline_code">Hello Odoo self.env.cr._enable_logging()[]</code>cd</p>`,
+    });
+});
+
+test("should not open powerbox inside inline code", async () => {
+    const { editor } = await setupEditor(`<p>abc<code class="o_inline_code">tes[]t</code>def</p>`);
+    await insertText(editor, "/");
+    await expectElementCount(".o-we-powerbox", 0);
+});
+
+test.tags("desktop");
+test("should not open toolbar when selection is inside inline code", async () => {
+    await setupEditor(`<p>abc<code class="o_inline_code">t[es]t</code>def</p>`);
+    await expectElementCount(".o-we-toolbar", 0);
+});
+
+test("should open toolbar for mixed selection and apply formatting outside inline code", async () => {
+    const { el } = await setupEditor(`<p>abc<code class="o_inline_code">t[est</code>de]f</p>`);
+
+    // Toolbar should be visible as election is not fully inside inline code.
+    await expectElementCount(".o-we-toolbar", 1);
+
+    // Apply bold should affect only the part outside inline code ("de").
+    await click(".o-we-toolbar button[name='bold']");
+    await animationFrame();
+    expect(getContent(el)).toBe(
+        `<p>abc<code class="o_inline_code">t[est</code><strong>de]</strong>f</p>`
+    );
+
+    // Apply text color should still affect only the non-inline-code portion.
+    await click(".o-we-toolbar .o-select-color-foreground");
+    await contains("button[data-color='#0000FF']").click();
+    expect(getContent(el)).toBe(
+        `<p>abc<code class="o_inline_code">t[est</code><font style="color: rgb(0, 0, 255);"><strong>de]</strong></font>f</p>`
+    );
+
+    // Apply font size formatting should wrap only the external text.
+    await contains(".o-we-toolbar [name='font-size'] .dropdown-toggle").click();
+    await waitFor(".o_font_size_selector_menu .dropdown-item:contains('80')");
+    await click(".o_font_size_selector_menu .dropdown-item:contains('80')");
+    expect(getContent(el)).toBe(
+        `<p>abc<code class="o_inline_code">t[est</code><span class="display-1-fs"><font style="color: rgb(0, 0, 255);"><strong>de]</strong></font></span>f</p>`
+    );
 });


### PR DESCRIPTION
### Purpose of this commit:

- Prevent the powerbox and toolbar from opening when the selection is fully inside inline code. When the selection spans inline code and regular text, keep the toolbar visible but ensure formatting commands are applied only to the non-inline-code content.
- Ensure that pasted external and editor HTML is converted to plain text when inserted inside inline code.

task-5502939

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
