### PR TITLE
[IMP] im_livechat: update menu labels and add group-by filter

### DIFF
--- a/addons/im_livechat/report/im_livechat_report_channel_views.xml
+++ b/addons/im_livechat/report/im_livechat_report_channel_views.xml
@@ -110,7 +110,7 @@
         </record>
 
         <record id="im_livechat_report_channel_action" model="ir.actions.act_window">
-            <field name="name">Sessions</field>
+            <field name="name">Sessions Analysis</field>
             <field name="res_model">im_livechat.report.channel</field>
             <field name="view_mode">graph,pivot</field>
             <field name="context">
@@ -140,7 +140,7 @@
 
         <menuitem
             id="menu_reporting_livechat_channel"
-            name="Sessions"
+            name="Sessions Analysis"
             parent="menu_reporting_livechat"
             sequence="20"
             action="im_livechat_report_channel_action"/>

--- a/addons/im_livechat/views/discuss_channel_views.xml
+++ b/addons/im_livechat/views/discuss_channel_views.xml
@@ -33,6 +33,7 @@
                         <filter name="group_by_agent" string="Agent" domain="[]" context="{'group_by':'livechat_agent_partner_ids'}"/>
                         <filter name="group_by_rating" string="Rating" domain="[]" context="{'group_by':'rating_last_text'}"/>
                         <filter name="group_by_country" string="Country" domain="[]" context="{'group_by':'country_id'}"/>
+                        <filter name="group_by_language" string="Language" domain="[]" context="{'group_by':'livechat_lang_id'}"/>
                         <filter name="group_by_customer_partner" string="Customer" domain="[]" context="{'group_by':'livechat_customer_partner_ids'}"/>
                         <separator orientation="vertical"/>
                         <filter name="group_by_month" string="Session Date" domain="[]" context="{'group_by':'create_date:month'}"/>

--- a/addons/im_livechat/views/im_livechat_channel_member_history_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_member_history_views.xml
@@ -120,7 +120,7 @@
             </field>
         </record>
         <record id="im_livechat_agent_history_action" model="ir.actions.act_window">
-            <field name="name">Agents</field>
+            <field name="name">Agents Performance</field>
             <field name="res_model">im_livechat.channel.member.history</field>
             <field name="view_mode">pivot,graph</field>
             <field name="domain">[('livechat_member_type', '=', 'agent')]</field>
@@ -141,7 +141,7 @@
         </record>
         <menuitem
             id="menu_reporting_livechat_agent"
-            name="Agents"
+            name="Agents Performance"
             parent="menu_reporting_livechat"
             sequence="10"
             action="im_livechat_agent_history_action"


### PR DESCRIPTION


**Before this PR**:
- Breadcrumb and menu titles were not clear.
- There was no option to group by language.
    
**After this PR**:
 - Update breadcrumb and menu titles with proper names
   (Agents > Agents Performance & Sessions > Sessions Analysis).
  - Add a group-by filter using the language field.

task-5879807



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
