### PR TITLE
[FIX] google_calendar: stop syncing birthday events

### DIFF
--- a/addons/google_calendar/models/res_users.py
+++ b/addons/google_calendar/models/res_users.py
@@ -52,9 +52,12 @@ class ResUsers(models.Model):
     def _sync_google_calendar(self, calendar_service: GoogleCalendarService):
         self.ensure_one()
         results = self._sync_request(calendar_service)
-        if not results or (not results.get('events') and not self._check_pending_odoo_records()):
+        if not results:
             return False
         events, default_reminders, full_sync = results.values()
+        events = self._sync_google_calendar_filter_remote_events(events)
+        if not events and not self._check_pending_odoo_records():
+            return False
         # Google -> Odoo
         send_updates = not full_sync
         events.clear_type_ambiguity(self.env)
@@ -81,6 +84,12 @@ class ResUsers(models.Model):
         (events - synced_events).with_context(send_updates=send_updates)._sync_odoo2google(calendar_service)
 
         return bool(results) and (bool(events | synced_events) or bool(recurrences | synced_recurrences))
+
+    def _sync_google_calendar_filter_remote_events(self, google_events):
+        """Filter out events coming from google which should not be synced into odoo."""
+        # Birthday events appear in a separate virtual calendar in the UI of google calendar which can be confusing.
+        # They require special handling and are not very useful in business flows so they are ignored for now.
+        return google_events.filter(lambda google_event: google_event.eventType != 'birthday')
 
     def _sync_single_event(self, calendar_service: GoogleCalendarService, odoo_event, event_id):
         self.ensure_one()

--- a/addons/google_calendar/tests/test_sync_google2odoo.py
+++ b/addons/google_calendar/tests/test_sync_google2odoo.py
@@ -1227,6 +1227,33 @@ class TestSyncGoogle2Odoo(TestSyncGoogle):
             self.assertEqual(len(events.exists()), 2)
 
     @patch_api
+    def test_new_google_birthday_event(self):
+        """Birthday events are not supported, so they should not be synced in."""
+        birthday_google_id = "20260226"
+        values = [{
+            'id': birthday_google_id,
+            'kind': 'calendar#event',
+            'sequence': 0,
+            'status': 'confirmed',
+            'summary': "Bob's birthday",
+            'creator': {'email': self.organizer_user.partner_id.email, 'self': True},
+            'organizer': {'email': self.organizer_user.partner_id.email, 'self': True},
+            'originalStartTime': {'date': '2026-02-26'}, 'start': {'date': '2026-02-26'}, 'end': {'date': '2026-02-27'},
+            'recurringEventId': 'abc', 'iCalUID': 'abc@google.com',
+            'transparency': 'transparent', 'visibility': 'private',
+            'birthdayProperties': {'type': 'birthday'},
+            'eventType': 'birthday',
+        }]
+        with patch.object(GoogleCalendarService, 'get_events', return_value=(
+            GoogleEvent(values), None, [{'method': 'popup', 'minutes': 30}],
+        )):
+            self.organizer_user.sudo()._sync_google_calendar(self.google_service)
+        recurrences = self.env["calendar.recurrence"].search([('google_id', '=', birthday_google_id)])
+        events = self.env["calendar.recurrence"].search([('google_id', '=', birthday_google_id)])
+        self.assertFalse(recurrences, 'Birthday recurrent events should be ignored when syncing from google, as not supported.')
+        self.assertFalse(events, 'Birthday recurrent events should be ignored when syncing from google, as not supported.')
+
+    @patch_api
     def test_new_google_notifications(self):
         """ Event from Google should not create notifications and trigger. It ruins the perfs on large databases """
         cron_id = self.env.ref('calendar.ir_cron_scheduler_alarm').id


### PR DESCRIPTION
Birthday events are a special kind of yearly-recurrent event that notably cannot be simply deleted like other events. They also appear as a separate calendar in the google UI to an extent, similar to tasks.

As they require special handling, have little functional value and can be confusing due to that "fake calendar" behavior. We will now always filter them out of broad calendar sync.

task-5966907