### PR TITLE
[FIX] l10n_br: make sure company has valid chars

### DIFF
--- a/addons/l10n_br/models/res_partner_bank.py
+++ b/addons/l10n_br/models/res_partner_bank.py
@@ -88,7 +88,7 @@ class ResPartnerBank(models.Model):
         res = super()._get_qr_code_vals_list(*args, **kwargs)
         if self.country_code == "BR":
             res[5] = (res[5][0], float_repr(res[5][1], 2) if res[5][1] else None)  # amount
-            res[7] = (res[7][0], res[7][1].upper())  # merchant_name
+            res[7] = (res[7][0], re.sub(r"[^a-zA-Z0-9 ]", "", res[7][1]).upper())  # merchant_name
             res[8] = (res[8][0], res[8][1].upper())  # merchant_city
             if not res[9][1]:
                 res[9] = (res[9][0], self._get_additional_data_field("***"))  # default comment if none is set

--- a/addons/l10n_br/tests/test_l10n_br_pix.py
+++ b/addons/l10n_br/tests/test_l10n_br_pix.py
@@ -67,14 +67,14 @@ class TestL10nBrPix(AccountTestInvoicingCommon):
     def test_get_qr_vals(self):
         self.assertEqual(
             self._get_qr_code_string(),
-            "00020101021226580014br.gov.bcb.pix013671d6c6e1-64ea-4a11-9560-a10870c40ca2520400005303986540512.305802BR5914COMPANY_1_DATA62150511NFeTEST000163044CCF",
+            "00020101021226580014br.gov.bcb.pix013671d6c6e1-64ea-4a11-9560-a10870c40ca2520400005303986540512.305802BR5912COMPANY1DATA62150511NFeTEST00016304A5C7",
         )
 
     def test_get_qr_vals_without_reference(self):
         self.partner_bank.include_reference = False
         self.assertEqual(
             self._get_qr_code_string(),
-            "00020101021226580014br.gov.bcb.pix013671d6c6e1-64ea-4a11-9560-a10870c40ca2520400005303986540512.305802BR5914COMPANY_1_DATA62070503***6304B27F",
+            "00020101021226580014br.gov.bcb.pix013671d6c6e1-64ea-4a11-9560-a10870c40ca2520400005303986540512.305802BR5912COMPANY1DATA62070503***6304F1E4",
         )
 
     def test_get_qr_vals_for_pos_default_qr(self):
@@ -82,7 +82,7 @@ class TestL10nBrPix(AccountTestInvoicingCommon):
         self.invoice.invoice_line_ids.price_unit = 0
         qr_code_str = (
             "00020101021226580014br.gov.bcb.pix013671d6c6e1-64ea-4a11-9560-"
-            "a10870c40ca25204000053039865802BR5914COMPANY_1_DATA62070503***63044FC8"
+            "a10870c40ca25204000053039865802BR5912COMPANY1DATA62070503***630490CA"
         )
         self.assertEqual(
             self._get_qr_code_string(),
@@ -93,4 +93,12 @@ class TestL10nBrPix(AccountTestInvoicingCommon):
             self._get_qr_code_string(),
             qr_code_str,
             "An invoice line of $0.01 shouldn't return the same code as $0.00",
+        )
+
+    def test_get_qr_vals_company_with_emoji(self):
+        self.partner_bank.include_reference = False
+        self.env.company.name = "Company with émoji 😇"
+        self.assertEqual(
+            self._get_qr_code_string(),
+            "00020101021226580014br.gov.bcb.pix013671d6c6e1-64ea-4a11-9560-a10870c40ca2520400005303986540512.305802BR5919COMPANY WITH EMOJI 62070503***63043984",
         )


### PR DESCRIPTION
When generating the QR code for PIX payment, if the company name contained incorrect characters (like emojis), the generated code was invalid and the payment could not be processed.

Steps to reproduce:
-------------------
* Install l10n_br and PoS
* Create a PIX payment method and set it on the PoS session
* Change the company name to contain an emoji (e.g. "Company emoji 😇")
* Open the PoS session and try to pay with PIX
> Observation: If you try to verify the generated QR code, it will be
  invalid

Why the fix:
------------
We apply the same regex as defined here:
https://github.com/odoo/odoo/blob/72654c3596660e3ec4b6885c5b957739465de097/addons/l10n_br/models/res_partner_bank.py#L81 To make sure the company name only contains valid characters, and the generated QR code is correct.
This also modify the other tests because it removes the `_` that is not
an allowed character.

opw-5907530