### PR TITLE
[FIX] html_editor: prevent icon toolbar from appearing unexpectedly

### DIFF
--- a/addons/html_editor/static/src/main/media/icon_plugin.js
+++ b/addons/html_editor/static/src/main/media/icon_plugin.js
@@ -63,14 +63,13 @@ export class IconPlugin extends Plugin {
                     return;
                 }
                 const isIconInTargetedNodes = targetedNodes.some(isIconElement);
-                // All nodes should be icons, their ZWS children, or their ancestors.
+                // All nodes should be icons or their ZWS children.
                 // FEFF nodes are only considered valid if an icon is selected and the
                 // FEFF is directly adjacent to it.
                 const isIconRelatedNode = (node) => {
                     if (
                         node.classList?.contains("fa") ||
-                        node.parentElement?.classList.contains("fa") ||
-                        (node.querySelector?.(".fa") && node.isContentEditable !== false)
+                        node.parentElement?.classList.contains("fa")
                     ) {
                         return true;
                     }

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -19,6 +19,7 @@ import {
     waitFor,
     hover,
     manuallyDispatchProgrammaticEvent,
+    advanceTime,
 } from "@odoo/hoot-dom";
 import { Deferred, animationFrame, mockSendBeacon, tick } from "@odoo/hoot-mock";
 import { onWillDestroy, xml } from "@odoo/owl";
@@ -2728,4 +2729,32 @@ test("should always have a block before a Table of Contents", async () => {
     expect(firstChild).toHaveOuterHTML(
         '<div class="o-paragraph" data-selection-placeholder="" style="margin: 8px 0px -9px;"><br></div>'
     );
+});
+
+test.tags("desktop");
+test("should not open icon toolbar when creating table of contents inside a list", async () => {
+    Partner._records = [
+        {
+            id: 1,
+            txt: `<ol><li><br></li></ol>`,
+        },
+    ];
+    await mountView({
+        type: "form",
+        resId: 1,
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="txt" widget="html"/>
+            </form>`,
+    });
+    setSelectionInHtmlField("li");
+    await insertText(htmlEditor, "/tableofcontents");
+    await waitFor(".o-we-powerbox");
+    expect(queryAllTexts(".o-we-command-name")[0]).toBe("Table of Contents");
+    await press("Enter");
+    await animationFrame();
+    setSelectionInHtmlField("li");
+    await advanceTime(200);
+    await expectElementCount(".o-we-toolbar", 0);
 });

--- a/addons/html_editor/static/tests/rating_star.test.js
+++ b/addons/html_editor/static/tests/rating_star.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { click, press } from "@odoo/hoot-dom";
+import { advanceTime, click, press } from "@odoo/hoot-dom";
 import { setupEditor, testEditor } from "./_helpers/editor";
 import {
     deleteBackward,
@@ -140,4 +140,14 @@ test("stars line should be reachable with up/down", async () => {
     await simulateArrowKeyPress(editor, "ArrowUp");
     await simulateArrowKeyPress(editor, "ArrowDown");
     expect(getContent(el)).toBe(`<p>abc</p><p>[]\uFEFF${stars}\uFEFF</p><p>def</p>`);
+});
+
+test.tags("desktop");
+test("should not open icon toolbar when inserting a paragraph break before the star element", async () => {
+    const { editor } = await setupEditor(
+        `<p>\u200B[]<span contenteditable="false" class="o_stars o_three_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i></span>\u200B</p>`
+    );
+    splitBlock(editor);
+    await advanceTime(100);
+    await expectElementCount(".o-we-toolbar", 0);
 });


### PR DESCRIPTION
Steps to Reproduce:
- Go to To-Do.
- Inside a list, insert a Table of Contents.
- Click at the top, outside of the Table of Contents.

Description of the issue
- The icon toolbar appears unnecessarily.

Cause:
- This happens because the `icon_plugin` checks whether a node’s child contains an icon and, if so, displays the icon toolbar. Although the Table of Contents contains an icon, this condition passes, causing the toolbar to appear.
- The same issue can occur with other elements that contain an icon. For example pressing enter before a star element also opens the icon toolbar.

Solution:
- Remove the condition that checks whether a node’s child contains an icon.

task-5954459