### PR TITLE
[IMP] payment: Enable Tokenization for ACH Direct Debit

### DIFF
--- a/addons/payment/data/payment_method_data.xml
+++ b/addons/payment/data/payment_method_data.xml
@@ -31,7 +31,7 @@
         <field name="sequence">1000</field>
         <field name="active">False</field>
         <field name="image" type="bytes" file="payment/static/img/ach_direct_debit.png"/>
-        <field name="support_tokenization">False</field>
+        <field name="support_tokenization">True</field>
         <field name="support_express_checkout">False</field>
         <field name="support_manual_capture">none</field>
         <field name="support_refund">partial</field>


### PR DESCRIPTION
Enable tokenization for ACH Direct Debit as supported by
Adyen, Authorize, and Stripe.

task-5896095