### PR TITLE
[FIX] mrp_subcontracting_purchase: Correctly select last subcontract

### DIFF
--- a/addons/mrp_subcontracting_purchase/models/stock_move.py
+++ b/addons/mrp_subcontracting_purchase/models/stock_move.py
@@ -15,7 +15,7 @@ class StockMove(models.Model):
         valuation_data = super()._get_value_from_account_move(quantity, at_date=at_date)
         last_subcontract_done_receipt = self.move_dest_ids.filtered(
             lambda m: m.state == 'done' and m.is_subcontract and m.purchase_line_id
-        )
+        ).sorted('create_date', reverse=True)[:1]
         if not self.production_id or not last_subcontract_done_receipt:
             return valuation_data
 

--- a/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
+++ b/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
@@ -638,6 +638,41 @@ class MrpSubcontractingPurchaseTest(TestAccountSubcontractingFlows):
         comp_receipt.button_validate()
         self.assertEqual(ressuply_pick.state, 'assigned')
 
+    def test_subcontract_with_multi_receipts(self):
+        """
+        Compute the value of a subcontract move with multiple receipts
+        Up to 18.4: a stock move could have multiple move_dest_ids
+        """
+        self.env['mrp.bom'].create({
+            'product_tmpl_id': self.product.product_tmpl_id.id,
+            'product_qty': 1.0,
+            'type': 'subcontract',
+            'subcontractor_ids': [(4, self.subcontractor_partner1.id)],
+        })
+        po = self.env['purchase.order'].create({
+            'partner_id': self.subcontractor_partner1.id,
+            'order_line': [Command.create({
+                'product_id': self.product.id,
+                'product_qty': 5,
+                'product_uom_id': self.product.uom_id.id,
+            })],
+        })
+        po.button_confirm()
+
+        self.assertEqual(len(po.picking_ids), 1)
+        self.assertEqual(len(po.picking_ids.move_line_ids), 1)
+
+        po.picking_ids.move_line_ids.quantity = 2
+        Form.from_action(self.env, po.picking_ids.button_validate()).save().process()
+
+        po.picking_ids.filtered(lambda x: x.state == 'assigned').button_validate()
+
+        subcontract_mo_move = po.picking_ids.move_ids.move_orig_ids[0]
+        subcontract_mo_move.move_dest_ids = po.picking_ids.move_ids
+        self.assertEqual(len(subcontract_mo_move.move_dest_ids), 2)
+
+        self.assertEqual(subcontract_mo_move._get_value_from_account_move(1).get('value'), 20.0)
+
     def test_update_qty_purchased_with_subcontracted_product(self):
         """
         Test That we can update the quantity of a purchase order line with a subcontracted product


### PR DESCRIPTION
With older subcontracting MOs, a singleton error will be thrown when the MO has more than one `move_dest_ids` and we try to do an inventory valuation

Steps to reproduce:
1. A product with `qty_available`, that is not `lot_valuated`
2. The product has a stock move with a `production_id` where `is_in` is true
3. The stock move has more than 1 `move_dest_ids` where `done` and `is_subcontract` is true
4. Open an inventory valuation report from any date in the past. One can access inventory valuation reports from Accounting app > Review menu
        > Inventory > Inventory Valuation. You will get a singleton error

Issue:
Followup to previous fix: dae71a2ba5a51ad5a07c4294ecdd6192d8752b07

Because older subcontracting MOs may have multiple destination receipts, a singleton error will occur if there are more than one of these `last_subcontract_done_receipt` records. This is due to the recordset calling `_get_value_from_account_move` on itself, which expects only 1 record and results in a singleton access error when it reaches: https://github.com/odoo/odoo/blob/e7ebe07e1d60659f3d468255808a305e7423741b/addons/purchase_stock/models/stock_move.py#L184

Solution:
Limit `last_subcontract_done_receipt` to 1 record. Because we have no way of knowing which receipt move is the absolute last done receipt, we assume it is the last one created that is also 'done'.
This solution was taken from @kihy-odoo on the PR https://github.com/odoo/odoo/pull/245662

opw-5489433
opw-5416006