### PR TITLE
[FIX] mail: ignore signature when creating tracking value for properties

### DIFF
--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -270,7 +270,7 @@ class Base(models.AbstractModel):
                     )]
                     # Show the properties in the same order as in the definition
                     for property_ in initial_value[::-1]
-                    if property_['type'] not in ('separator', 'html') and property_.get('value')
+                    if property_['type'] not in ('separator', 'html', 'signature') and property_.get('value')
                 )
                 continue
 

--- a/addons/test_mail/tests/test_message_track.py
+++ b/addons/test_mail/tests/test_message_track.py
@@ -452,6 +452,7 @@ class TestTrackingInternals(MailCommon):
                 {'name': 'property_int', 'string': 'Property Int', 'type': 'integer', 'default': 1337},
                 {'name': 'property_m2o', 'string': 'Property M2O', 'type': 'many2one',
                  'default': (cls.properties_linked_records[0].id, cls.properties_linked_records[0].display_name), 'comodel': 'mail.test.ticket'},
+                {'name': 'property_signature', 'string': 'Property Signature', 'type': 'signature'},
             ],
         }, {
             'definition_properties': [
@@ -466,6 +467,9 @@ class TestTrackingInternals(MailCommon):
         }])
         cls.properties_record_1, cls.properties_record_2 = cls.env['mail.test.track.all'].create([{
             'properties_parent_id': cls.properties_parent_1.id,
+            'properties': {
+                'property_signature': 'R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
+            },
         }, {
             'properties_parent_id': cls.properties_parent_2.id,
 
@@ -706,7 +710,11 @@ class TestTrackingInternals(MailCommon):
         self.assertEqual(formatted_values[2]['oldValue'], 1337)
         self.assertEqual(formatted_values[3]['fieldInfo']['changedField'], 'Properties: Property Char')
         self.assertEqual(formatted_values[3]['oldValue'], 'char value')
-
+        # Ensure that no tracking value was created for the 'signature' type
+        self.assertFalse(
+            any((t.get('fieldInfo') or {}).get('fieldType') == 'signature' for t in formatted_values),
+            "Signature property must be ignored in tracking even when other properties change"
+        )
         # changing the parent and then changing again
         # to the original one to not create tracking values
         with self.mock_mail_gateway():


### PR DESCRIPTION
With https://github.com/odoo/odoo/pull/232814, the signature type was introduced as a valid property in properties field type.

When a property field of type signature is marked as tracked and its parent field changes, the system attempts to track the signature update. Since tracking image or binary content is not supported and is not implemented, this leads to a NotImplementedError.

To prevent this crash, signature property fields are now excluded from tracking.

task-5966544

