### PR TITLE
[FIX] purchase: avoid incorrect PO total_match when importing bill

### DIFF
--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -272,7 +272,7 @@ class AccountMove(models.Model):
         # Sort the purchase order lines by unit price and remaining quantity to speed up matching
         purchase_lines = sorted(
             po_lines,
-            key=lambda line: (line.price_unit, line.product_qty - line.qty_invoiced),
+            key=lambda line: (line.price_unit, line.qty_to_invoice),
             reverse=True
         )
         matched_po_lines = []
@@ -297,7 +297,7 @@ class AccountMove(models.Model):
                         break
 
                     if (float_compare(invoice_line.price_unit, purchase_line.price_unit, precision_digits=precision) == 0
-                            and invoice_line.quantity <= purchase_line.product_qty - purchase_line.qty_invoiced):
+                            and invoice_line.quantity <= purchase_line.qty_to_invoice):
                         # The current purchase line is a possible match for the current invoice line.
                         # We calculate the name match ratio and continue with other possible matches.
                         #
@@ -388,7 +388,7 @@ class AccountMove(models.Model):
                 po_lines = [line for line in matching_purchase_orders.order_line if line.product_qty]
                 po_lines_with_amount = [{
                     'line': line,
-                    'amount_to_invoice': (1 - line.qty_invoiced / line.product_qty) * line.price_total,
+                    'amount_to_invoice': (line.qty_to_invoice / line.product_qty) * line.price_total,
                 } for line in po_lines]
 
                 # If the sum of all remaining amounts to be invoiced for these purchase orders' lines is within a
@@ -436,7 +436,24 @@ class AccountMove(models.Model):
             if len(matching_purchase_orders) == 1:
                 # We found exactly one match on vendor and total amount (within tolerance).
                 # We return all purchase order lines of the purchase order whose total amount matched our vendor bill.
-                return 'total_match', matching_purchase_orders.order_line, None
+                # For a total match the remaining quantity to invoice should match as all lines are replaced
+                po_lines = [line for line in matching_purchase_orders.order_line if line.product_qty]
+                if (amount_total - TOLERANCE
+                        < sum((line.qty_to_invoice / line.product_qty) * line.price_total for line in po_lines)
+                        < amount_total + TOLERANCE):
+                    return 'total_match', matching_purchase_orders.order_line, None
+                else:
+                    # We have an invoice from an EDI document, so we try to match individual invoice lines with
+                    # individual purchase order lines from referenced purchase orders.
+                    matching_po_lines, matching_inv_lines = self._find_matching_po_and_inv_lines(
+                        po_lines, self.invoice_line_ids, timeout)
+
+                    if matching_po_lines:
+                        # We found a subset of purchase order lines that match a subset of the vendor bill lines.
+                        # We return the matching purchase order lines and vendor bill lines.
+                        return ('subset_match',
+                                self.env['purchase.order.line'].union(*matching_po_lines),
+                                matching_inv_lines)
 
         # We couldn't find anything, so we return no lines.
         return ('no_match', matching_purchase_orders.order_line, None)

--- a/addons/purchase/tests/test_purchase_invoice.py
+++ b/addons/purchase/tests/test_purchase_invoice.py
@@ -770,6 +770,48 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
         self.assertEqual(inv.invoice_line_ids[2].name, f"{pol_prod_product_in_name.name}", "When description contains the product name, the invoice line name should only be the description")
         self.assertEqual(inv.invoice_line_ids[3].name, f"{pol_prod_name_in_product.product_id.display_name}\n{pol_prod_name_in_product.name}", "When the product name contains the description, the invoice line name should be the product name and the description")
 
+    def test_import_bill_from_attachment_keep_full_quantity_with_partial_delivery(self):
+        """
+        Ensure that bills created from attachments do not trigger the a PO full match unexpectedly.
+
+        Even if a Purchase Order exists for the same partner with only partial deliveries,
+        the imported bill should reflect the exact quantities from the document attachment
+        rather than being restricted to the 'received' quantities suggested by the PO link.
+        """
+        company_partner = self.env.company.partner_id
+        self.product_a.purchase_method = 'receive'
+        po = self.env['purchase.order'].with_context(tracking_disable=True).create({
+            'partner_id': company_partner.id,
+            'order_line': [Command.create({
+                'name': self.product_a.name,
+                'product_id': self.product_a.id,
+                'product_qty': 2,
+                'product_uom': self.product_a.uom_id.id,
+                'price_unit': 100,
+            })]
+        })
+        po.button_confirm()
+        po.order_line.qty_received = 1
+
+        invoice = self.env['account.move'].create({
+            'partner_id': company_partner.id,
+            'move_type': 'out_invoice',
+            'journal_id': self.company_data['default_journal_sale'].id,
+            'line_ids': [Command.create({
+                'name': self.product_a.name,
+                'product_id': self.product_a.id,
+                'quantity': 2,
+                'product_uom_id': self.product_a.uom_id.id,
+                'price_unit': 100,
+            })]
+        })
+        invoice.action_post()
+        invoice._generate_and_send()
+
+        new_bill = self.company_data['default_journal_purchase'].with_context(default_move_type='in_invoice')._create_document_from_attachment(invoice.attachment_ids[0].ids)
+        self.assertEqual(2.0, new_bill.invoice_line_ids.quantity)
+        self.assertFalse(po.invoice_ids, "The Purchase Order should not be automatically linked to the Bill.")
+
 
 @tagged('post_install', '-at_install')
 class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):


### PR DESCRIPTION
## Issue:
When a Purchase Order is created for a quantity of 2 and only 1 unit is received, importing a vendor bill with quantity 2 and the same unit price incorrectly results in a full match

The PO is linked, but the bill line quantity is overwritten to 1 (the received quantity), leading to an inconsistency between the imported bill and the original document

## Cause:
In `_match_purchase_orders()`, a match is performed based on `partner_id` and `amount_total`:
https://github.com/odoo/odoo/blob/92a3fe87c711f18d955ddf454ce1f4194dfcda20/addons/purchase/models/account_invoice.py#L429-L439

However, the previous safeguard logic
related to `total_match` is missing:
https://github.com/odoo/odoo/blob/92a3fe87c711f18d955ddf454ce1f4194dfcda20/addons/purchase/models/account_invoice.py#L388-L400

This check is not only meant to compare total amounts; it should also ensure that the `amount_to_invoice` is consistent

When the purchase method is based on received quantities, the full ordered quantity should not be considered a full match if part of it has not yet been delivered

## Steps to reproduce:
We'll use the default company as vendor, choose depending on your setup
- Install `purchase`
- Create a Product (invoicing policy: ordered qty, and control policy: delivered qty)
- Create and confirm a PO (Vendor: Default Company, Product: Created Product, Quantity: 2, Unit Price: 100)
- Set the received quantity to 1
- Create and post an Invoice (Customer: Default Company, Product: Created Product, Quantity: 2, Unit Price: 100)
- Download the PDF
- Go in Bills and import the PDF Before the fix, the match should be done and there is a quantity mismatch

opw-5043054