### PR TITLE
[FIX] web: Hoot - backport fixes

### DIFF
--- a/addons/web/static/lib/hoot-dom/helpers/dom.js
+++ b/addons/web/static/lib/hoot-dom/helpers/dom.js
@@ -90,6 +90,10 @@ import { waitUntil } from "./time";
  *  raw?: boolean;
  * }} QueryTextOptions
  *
+ * @typedef {{
+ *  raw?: boolean;
+ * }} QueryValueOptions
+ *
  * @typedef {"both" | "x" | "y"} ScrollAxis
  *
  * @typedef {import("./time").WaitOptions} WaitOptions
@@ -344,7 +348,7 @@ function getNodeContent(node) {
         case "textarea":
             return getNodeValue(node);
         case "select":
-            return [...node.selectedOptions].map(getNodeValue).join(",");
+            return [...node.selectedOptions].map((node) => getNodeValue(node)).join(",");
     }
     return getNodeText(node);
 }
@@ -377,6 +381,13 @@ function getQueryFilter(pseudoClass, content) {
         }
         throw new HootDomError(message);
     }
+}
+
+/**
+ * @param {Node} node
+ */
+function getRawValue(node) {
+    return node.value;
 }
 
 /**
@@ -512,7 +523,7 @@ function isWhiteSpace(char) {
 }
 
 /**
- * @param {(node: Node) => NodeValue} getContent
+ * @param {(node: Node) => string} getContent
  * @param {boolean} exact
  */
 function makePseudoClassMatcher(getContent, exact) {
@@ -520,17 +531,17 @@ function makePseudoClassMatcher(getContent, exact) {
         const regex = parseRegExp(content);
         if (isInstanceOf(regex, RegExp)) {
             return function stringMatches(node) {
-                return regex.test(String(getContent(node)));
+                return regex.test(getContent(node));
             };
         } else {
             const lowerContent = content.toLowerCase();
             if (exact) {
                 return function stringEquals(node) {
-                    return String(getContent(node)).toLowerCase() === lowerContent;
+                    return getContent(node).toLowerCase() === lowerContent;
                 };
             } else {
                 return function stringContains(node) {
-                    return String(getContent(node)).toLowerCase().includes(lowerContent);
+                    return getContent(node).toLowerCase().includes(lowerContent);
                 };
             }
         }
@@ -1138,7 +1149,7 @@ customPseudoClasses
     .set("selected", () => isNodeSelected)
     .set("shadow", () => getNodeShadowRoot)
     .set("text", makePseudoClassMatcher(getInlineNodeText, true))
-    .set("value", makePseudoClassMatcher(getNodeValue, false))
+    .set("value", makePseudoClassMatcher(getRawValue, false))
     .set("viewPort", () => isNodeInViewPort)
     .set("visible", () => isNodeVisible);
 
@@ -1202,29 +1213,31 @@ export function getNodeAttribute(node, attribute) {
 
 /**
  * @param {Node} node
- * @param {boolean} [raw]
+ * @param {QueryValueOptions} [options]
  * @returns {NodeValue}
  */
-export function getNodeValue(node, raw) {
-    if (!raw) {
-        switch (node.type) {
-            case "checkbox":
-            case "radio":
-                return node.checked;
-            case "file":
-                return [...node.files];
-            case "number":
-            case "range":
-                return node.valueAsNumber;
-            case "date":
-            case "datetime-local":
-            case "month":
-            case "time":
-            case "week":
-                return node.valueAsDate.toISOString();
-        }
+export function getNodeValue(node, options) {
+    if (options?.raw) {
+        return getRawValue(node);
     }
-    return node.value;
+    switch (node.type) {
+        case "checkbox":
+        case "radio":
+            return node.checked;
+        case "file":
+            return [...node.files];
+        case "number":
+        case "range":
+            return node.valueAsNumber;
+        case "date":
+        case "datetime-local":
+        case "month":
+        case "time":
+        case "week":
+            return node.valueAsDate.toISOString();
+        default:
+            return node.value || "";
+    }
 }
 
 /**
@@ -2028,12 +2041,12 @@ export function queryAllTexts(target, options) {
  * *values* of the matching nodes.
  *
  * @param {Target} target
- * @param {QueryOptions} [options]
+ * @param {QueryOptions & QueryValueOptions} [options]
  * @returns {NodeValue[]}
  */
 export function queryAllValues(target, options) {
     [target, options] = parseRawArgs(arguments);
-    return _guardedQueryAll(target, options).map(getNodeValue);
+    return _guardedQueryAll(target, options).map((node) => getNodeValue(node, options));
 }
 
 /**
@@ -2133,12 +2146,12 @@ export function queryText(target, options) {
  * the matching node.
  *
  * @param {Target} target
- * @param {QueryOptions} [options]
+ * @param {QueryOptions & QueryValueOptions} [options]
  * @returns {NodeValue}
  */
 export function queryValue(target, options) {
     [target, options] = parseRawArgs(arguments);
-    return getNodeValue(_queryOne(target, options));
+    return getNodeValue(_queryOne(target, options), options);
 }
 
 /**

--- a/addons/web/static/lib/hoot/core/expect.js
+++ b/addons/web/static/lib/hoot/core/expect.js
@@ -179,7 +179,7 @@ function detailsFromValues(...args) {
  * @param {...unknown} args
  */
 function detailsFromValuesWithDiff(...args) {
-    return detailsFromValues(...args).concat(Markup.diff(...args));
+    return detailsFromValues(...args).concat([Markup.diff(...args)]);
 }
 
 /**

--- a/addons/web/static/lib/hoot/mock/network.js
+++ b/addons/web/static/lib/hoot/mock/network.js
@@ -1214,7 +1214,7 @@ export class MockXMLHttpRequest extends MockEventTarget {
             this._setReadyState(XMLHttpRequest.LOADING);
             if (!this._responseMimeType) {
                 if (this._response.url.startsWith("blob:")) {
-                    this._responseMimeType = "blob";
+                    this._responseMimeType = MIME_TYPE.blob;
                 } else {
                     this._responseMimeType = this._response.headers.get(HEADER.contentType);
                 }


### PR DESCRIPTION
### [FIX] web: Hoot - backport fixes

This commit backports the following fixes that have been applied in
further versions:
- add correct mime type to XHR blob responses [1];
- fix missing diff from failed test results [2];
- wrap 'raw' value option in a dictionnary to limit unintended use,
use 'raw' as a default for text-based matchers [3].

[1] 9156bf1
[2] 2216a0b
[3] 3080362

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr