### PR TITLE
[FIX] sale: prevent sending draft quotation

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1743,7 +1743,7 @@ class SaleOrder(models.Model):
             return groups
 
         self.ensure_one()
-        if self._context.get('proforma'):
+        if self._context.get('proforma') or self.state == 'draft':
             for group in [g for g in groups if g[0] in ('portal_customer', 'portal', 'follower', 'customer')]:
                 group[2]['has_button_access'] = False
             return groups


### PR DESCRIPTION
Issue:
---
Draft quotation can be accessed by portal user if a message is sent to portal user. They can sign and pay the quotation.

Steps to reproduce:
---
1- Create a SO with portal user as partner. Don't confirm it.
2- Using chatter, send a message to the partner.
3- Open the email.

You can access the quotation using portal user which is not expected.

Cause:
---
After #124486, portal users can accept or pay the draft sale orders if they can access the quote.

Fix:
---
We can prevent sending quotation to customers when the order is in draft state.

opw-5969465
