### PR TITLE
[IMP] html_editor: show separator for divider/line search

### DIFF
--- a/addons/html_editor/static/src/main/separator_plugin.js
+++ b/addons/html_editor/static/src/main/separator_plugin.js
@@ -30,6 +30,7 @@ export class SeparatorPlugin extends Plugin {
         powerbox_items: withSequence(1, {
             categoryId: "structure",
             commandId: "insertSeparator",
+            keywords: [_t("divider"), _t("line")],
         }),
         content_not_editable_providers: (rootEl) => [...selectElements(rootEl, "hr")],
         contenteditable_to_remove_selector: "hr[contenteditable]",

--- a/addons/html_editor/static/tests/powerbox.test.js
+++ b/addons/html_editor/static/tests/powerbox.test.js
@@ -108,6 +108,23 @@ describe("search", () => {
         );
     });
 
+    test("should filter Separator commands with term 'divider' and 'line'", async () => {
+        const { el, editor } = await setupEditor("<p>ab[]</p>");
+        await insertText(editor, "/");
+        await animationFrame();
+        expect(commandNames(el).length).toBe(27);
+        await insertText(editor, "line");
+        await animationFrame();
+        expect(commandNames(el).includes("Separator")).toBe(true);
+        // Replace "line" by "divider"
+        for (let i = 0; i < 4; i++) {
+            press("backspace");
+        }
+        await insertText(editor, "/divider");
+        await animationFrame();
+        expect(commandNames(el).includes("Separator")).toBe(true);
+    });
+
     test("should hide categories when you have a search term", async () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>");
         await insertText(editor, "/");


### PR DESCRIPTION
#### Desired behavior after PR is merged:

- Separator command now appears when searching for “divider” or “line” in the powerbox.

task-5977288

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
