### PR TITLE
[FIX] website: fix header templates' navbar alignment

### DIFF
--- a/addons/website/static/src/builder/plugins/options/header/header_navigation_option.xml
+++ b/addons/website/static/src/builder/plugins/options/header/header_navigation_option.xml
@@ -7,6 +7,8 @@
     </div>
 
     <t t-set="align_left_views" t-value="[
+        'website.template_header_sales_three_align_left',
+        'website.template_header_vertical_align_left',
     ]"/>
 
     <t t-set="align_center_views" t-value="[
@@ -20,7 +22,6 @@
         'website.template_header_sales_three_align_center',
         'website.template_header_sales_four_align_center',
         'website.template_header_sidebar_align_center',
-        'website.template_header_vertical_align_center',
     ]"/>
 
     <t t-set="align_right_views" t-value="[
@@ -31,7 +32,6 @@
         'website.template_header_search_align_right',
         'website.template_header_sales_one_align_right',
         'website.template_header_sales_two_align_right',
-        'website.template_header_sales_three_align_right',
         'website.template_header_sales_four_align_right',
         'website.template_header_sidebar_align_right',
         'website.template_header_vertical_align_right',

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -915,7 +915,7 @@
                         <t t-call="website.placeholder_header_call_to_action"/>
                     </ul>
                 </div>
-                <t t-call="website.navbar_nav_wrapper" _wrapper_class.f="justify-content-start">
+                <t t-call="website.navbar_nav_wrapper" _wrapper_class.f="justify-content-center">
                     <!-- Navbar -->
                     <t t-call="website.navbar_nav"
                         _nav_class.f="pb-0">
@@ -933,9 +933,9 @@
     </xpath>
 </template>
 
-<template id="template_header_vertical_align_center" inherit_id="website.template_header_vertical" active="False">
+<template id="template_header_vertical_align_left" inherit_id="website.template_header_vertical" active="False">
     <xpath expr="//t[@t-call='website.navbar_nav_wrapper']" position="attributes">
-        <attribute name="_wrapper_class.f">justify-content-center</attribute>
+        <attribute name="_wrapper_class.f">justify-content-start</attribute>
     </xpath>
 </template>
 
@@ -1262,7 +1262,7 @@
                                 _dropdown_menu_class.f="dropdown-menu-end"/>
                         </ul>
                         <!-- Navbar -->
-                        <t t-call="website.navbar_nav" _nav_class.f="justify-content-start">
+                        <t t-call="website.navbar_nav" _nav_class.f="justify-content-end">
                             <!-- Menu -->
                             <t t-foreach="website.menu_id.child_id" t-as="submenu">
                                 <t t-call="website.submenu"
@@ -1280,15 +1280,15 @@
     </xpath>
 </template>
 
-<template id="template_header_sales_three_align_center" inherit_id="website.template_header_sales_three" active="False">
+<template id="template_header_sales_three_align_left" inherit_id="website.template_header_sales_three" active="False">
     <xpath expr="//t[@t-call='website.navbar_nav']" position="attributes">
-        <attribute name="_nav_class.f">justify-content-center</attribute>
+        <attribute name="_nav_class.f">justify-content-start</attribute>
     </xpath>
 </template>
 
-<template id="template_header_sales_three_align_right" inherit_id="website.template_header_sales_three" active="False">
+<template id="template_header_sales_three_align_center" inherit_id="website.template_header_sales_three" active="False">
     <xpath expr="//t[@t-call='website.navbar_nav']" position="attributes">
-        <attribute name="_nav_class.f">justify-content-end</attribute>
+        <attribute name="_nav_class.f">justify-content-center</attribute>
     </xpath>
 </template>
 


### PR DESCRIPTION
Since changes in commit 950a5286562ca583a139a14abbaa0851adf6f3b2, The alignment of the navbar in "Vertical" and
"Menu Sale 3" templates is wrong.

To fix this we've changed the classes and updated the header navigation options.
|Before|
|------|
|<img width="1918" height="461" alt="image" src="https://github.com/user-attachments/assets/4e8b325f-cad2-4b08-897b-0d3cd25cb7c3" />
<img width="1916" height="298" alt="image" src="https://github.com/user-attachments/assets/330df0eb-4bb1-4846-9bf1-70a7fc20b2e4" />|

|After|
|-----|
|<img width="1915" height="259" alt="image" src="https://github.com/user-attachments/assets/4873860a-68f4-4765-a271-feaf807a4282" />
<img width="1916" height="329" alt="image" src="https://github.com/user-attachments/assets/45058a77-d7ec-43e5-846d-f5780b660680" />|





task-5900220



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
