### PR TITLE
[FIX] l10n_dk_nemhandel: fix PartyIdentification node

### DIFF
--- a/addons/l10n_dk_nemhandel/models/account_edi_xml_oioubl_21.py
+++ b/addons/l10n_dk_nemhandel/models/account_edi_xml_oioubl_21.py
@@ -165,6 +165,13 @@ class AccountEdiXmlOIOUBL21(models.AbstractModel):
                 '_text': f'{prefix}{partner.nemhandel_identifier_value}',
                 'schemeID': SCHEME_ID_MAPPING[partner.nemhandel_identifier_type],
             }
+        if partner.nemhandel_identifier_value or partner.ref:
+            party_node['cac:PartyIdentification'] = {
+                'cbc:ID': {
+                    '_text': partner.nemhandel_identifier_value or partner.ref,
+                    'schemeID': SCHEME_ID_MAPPING[partner.nemhandel_identifier_type],
+                }
+            }
 
         return party_node
 

--- a/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_invoice_discount.xml
+++ b/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_invoice_discount.xml
@@ -22,6 +22,9 @@
   <cac:AccountingSupplierParty>
     <cac:Party>
       <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="DK:CVR">12345674</cbc:ID>
+      </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>company_1_data</cbc:Name>
       </cac:PartyName>
@@ -80,6 +83,9 @@
   <cac:AccountingCustomerParty>
     <cac:Party>
       <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="DK:CVR">12345674</cbc:ID>
+      </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>SUPER DANISH PARTNER</cbc:Name>
       </cac:PartyName>

--- a/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_invoice_foreign_partner_be.xml
+++ b/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_invoice_foreign_partner_be.xml
@@ -24,6 +24,9 @@
   <cac:AccountingSupplierParty>
     <cac:Party>
       <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="DK:CVR">12345674</cbc:ID>
+      </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>company_1_data</cbc:Name>
       </cac:PartyName>
@@ -85,6 +88,9 @@
   <cac:AccountingCustomerParty>
     <cac:Party>
       <cbc:EndpointID schemeID="GLN">5798009811512</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="GLN">5798009811512</cbc:ID>
+      </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>SUPER BELGIAN PARTNER</cbc:Name>
       </cac:PartyName>

--- a/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_invoice_foreign_partner_fr.xml
+++ b/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_invoice_foreign_partner_fr.xml
@@ -22,6 +22,9 @@
   <cac:AccountingSupplierParty>
     <cac:Party>
       <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="DK:CVR">12345674</cbc:ID>
+      </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>company_1_data</cbc:Name>
       </cac:PartyName>
@@ -80,6 +83,9 @@
   <cac:AccountingCustomerParty>
     <cac:Party>
       <cbc:EndpointID schemeID="GLN">5798009811639</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="GLN">5798009811639</cbc:ID>
+      </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>SUPER FRENCH PARTNER</cbc:Name>
       </cac:PartyName>

--- a/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_invoice_partner_dk.xml
+++ b/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_invoice_partner_dk.xml
@@ -22,6 +22,9 @@
   <cac:AccountingSupplierParty>
     <cac:Party>
       <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="DK:CVR">12345674</cbc:ID>
+      </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>company_1_data</cbc:Name>
       </cac:PartyName>
@@ -80,6 +83,9 @@
   <cac:AccountingCustomerParty>
     <cac:Party>
       <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="DK:CVR">12345674</cbc:ID>
+      </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>SUPER DANISH PARTNER</cbc:Name>
       </cac:PartyName>

--- a/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_refund_foreign_partner_fr.xml
+++ b/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_refund_foreign_partner_fr.xml
@@ -21,6 +21,9 @@
   <cac:AccountingSupplierParty>
     <cac:Party>
       <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="DK:CVR">12345674</cbc:ID>
+      </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>company_1_data</cbc:Name>
       </cac:PartyName>
@@ -79,6 +82,9 @@
   <cac:AccountingCustomerParty>
     <cac:Party>
       <cbc:EndpointID schemeID="GLN">5798009811639</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="GLN">5798009811639</cbc:ID>
+      </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>SUPER FRENCH PARTNER</cbc:Name>
       </cac:PartyName>

--- a/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_refund_partner_dk.xml
+++ b/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_refund_partner_dk.xml
@@ -21,6 +21,9 @@
   <cac:AccountingSupplierParty>
     <cac:Party>
       <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="DK:CVR">12345674</cbc:ID>
+      </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>company_1_data</cbc:Name>
       </cac:PartyName>
@@ -79,6 +82,9 @@
   <cac:AccountingCustomerParty>
     <cac:Party>
       <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="DK:CVR">12345674</cbc:ID>
+      </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>SUPER DANISH PARTNER</cbc:Name>
       </cac:PartyName>

--- a/addons/l10n_dk_nemhandel/tests/test_xml_oioubl_21.py
+++ b/addons/l10n_dk_nemhandel/tests/test_xml_oioubl_21.py
@@ -40,6 +40,7 @@ class TestUBLDKOIOUBL21(TestUBLCommon, TestAccountMoveSendCommon):
             'city': 'Aalborg',
             'zip': '9430',
             'vat': 'DK12345674',
+            'nemhandel_identifier_value': '12345674',
             'phone': '+45 32 12 35 56',
             'street': 'Paradisæblevej, 11',
             'country_id': cls.env.ref('base.dk').id,


### PR DESCRIPTION
Nemhandel follows the OIOUBL 2.1 XML format. To specify the Buyer identifier,
we use the <cac:PartyIdentification> node. But we are missing the `schemeID`
attribute, which should be for DK "DK:CVR".

This commit adds this attribute.

opw-5232123
