### PR TITLE
Rename resource use to save document

### DIFF
--- a/addons/html_builder/static/src/@types/plugins.d.ts
+++ b/addons/html_builder/static/src/@types/plugins.d.ts
@@ -13,7 +13,7 @@ declare module "plugins" {
     import { OperationShared } from "@html_builder/core/operation_plugin";
     import { get_overlay_buttons, OverlayButtonsShared, should_show_overlay_buttons_of_ancestor_predicates } from "@html_builder/core/overlay_buttons/overlay_buttons_plugin";
     import { is_node_empty_predicates, is_unremovable_selector, on_removed_handlers, on_will_remove_handlers, RemoveShared } from "@html_builder/core/remove_plugin";
-    import { on_saved_handlers, on_will_save_handlers, dirty_els_providers, on_will_save_element_handlers, save_elements_overrides, on_will_reset_history_after_saving_handlers, SaveShared } from "@html_builder/core/save_plugin";
+    import { on_saved_handlers, on_will_save_handlers, dirty_els_providers, on_will_save_element_handlers, save_elements_overrides, on_ready_to_save_document_handlers, SaveShared } from "@html_builder/core/save_plugin";
     import { after_setup_editor_overrides, on_will_setup_editor_handlers, savable_selectors, SetupEditorShared } from "@html_builder/core/setup_editor_plugin";
     import { on_target_hidden_handlers, on_target_shown_handlers, VisibilityShared } from "@html_builder/core/visibility_plugin";
     import { default_shape_providers, image_shape_groups_providers, on_shape_computed_handlers } from "@html_builder/plugins/image/image_shape_option_plugin";
@@ -98,7 +98,7 @@ declare module "plugins" {
         on_will_save_handlers: on_will_save_handlers;
         on_will_save_element_handlers: on_will_save_element_handlers;
         on_will_setup_editor_handlers: on_will_setup_editor_handlers;
-        on_will_reset_history_after_saving_handlers: on_will_reset_history_after_saving_handlers;
+        on_ready_to_save_document_handlers: on_ready_to_save_document_handlers;
 
         // Overrides
         after_setup_editor_overrides: after_setup_editor_overrides;

--- a/addons/html_builder/static/src/core/cached_model_plugin.js
+++ b/addons/html_builder/static/src/core/cached_model_plugin.js
@@ -15,7 +15,7 @@ export class CachedModelPlugin extends Plugin {
     static dependencies = ["history"];
     /** @type {import("plugins").BuilderResources} */
     resources = {
-        on_will_reset_history_after_saving_handlers: this.savePendingRecords.bind(this),
+        on_ready_to_save_document_handlers: this.savePendingRecords.bind(this),
     };
     setup() {
         this.ormReadCache = new Cache(

--- a/addons/html_builder/static/src/core/save_plugin.js
+++ b/addons/html_builder/static/src/core/save_plugin.js
@@ -19,8 +19,8 @@ import { uniqueId } from "@web/core/utils/functions";
  * @typedef {((el: HTMLElement) => Promise<void>)[]} on_will_save_element_handlers
  * Called when saving an element (in parallel to saving the view).
  *
- * @typedef {(() => Promise<boolean>)[]} on_will_reset_history_after_saving_handlers
- * Called at the very end of the save process.
+ * @typedef {(() => Promise<boolean>)[]} on_ready_to_save_document_handlers
+ * Called concurrently as part of the save process.
  *
  * @typedef {((cleanedEls: HTMLElement[]) => Promise<boolean>)[]} save_elements_overrides
  *
@@ -104,7 +104,7 @@ export class SavePlugin extends Plugin {
             }
         });
         // used to track dirty out of the editable scope, like header, footer or wrapwrap
-        const willSaves = this.trigger("on_will_reset_history_after_saving_handlers");
+        const willSaves = this.trigger("on_ready_to_save_document_handlers");
         await Promise.all(saveProms.concat(willSaves));
         this.dependencies.history.reset();
     }

--- a/addons/website/static/src/builder/plugins/customize_website_plugin.js
+++ b/addons/website/static/src/builder/plugins/customize_website_plugin.js
@@ -81,7 +81,7 @@ export class CustomizeWebsitePlugin extends Plugin {
                 return `o_cc${getCSSVariableValue(combination, style)}`;
             }
         }),
-        on_will_reset_history_after_saving_handlers: this.onSave.bind(this),
+        on_ready_to_save_document_handlers: this.onSave.bind(this),
     };
 
     async onSave() {

--- a/addons/website/static/src/builder/plugins/options/mega_menu_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/mega_menu_option_plugin.js
@@ -22,7 +22,7 @@ export class MegaMenuOptionPlugin extends Plugin {
             dropIn: ".o_mega_menu nav",
             dropNear: ".o_mega_menu .nav-link",
         },
-        on_will_reset_history_after_saving_handlers: this.saveMegaMenuClasses.bind(this),
+        on_ready_to_save_document_handlers: this.saveMegaMenuClasses.bind(this),
         no_parent_containers: ".o_mega_menu",
         is_unremovable_selector: ".o_mega_menu > section",
         is_node_splittable_predicates: (node) => {

--- a/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
@@ -163,7 +163,7 @@ class SocialMediaOptionPlugin extends Plugin {
             AddSocialMediaLinkAction,
         },
         normalize_processors: this.normalize.bind(this),
-        on_will_reset_history_after_saving_handlers: this.saveRecordedSocialMedia.bind(this),
+        on_ready_to_save_document_handlers: this.saveRecordedSocialMedia.bind(this),
         content_not_editable_selectors: [".s_share"],
         content_editable_selectors: [
             ".s_share a > i",

--- a/addons/website/static/src/builder/plugins/options/website_page_config_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/website_page_config_option_plugin.js
@@ -56,7 +56,7 @@ class WebsitePageConfigOptionPlugin extends Plugin {
         ],
         on_target_shown_handlers: this.onTargetVisibilityToggle.bind(this, true),
         on_target_hidden_handlers: this.onTargetVisibilityToggle.bind(this, false),
-        on_will_reset_history_after_saving_handlers: this.onSave.bind(this),
+        on_ready_to_save_document_handlers: this.onSave.bind(this),
     };
 
     /**

--- a/addons/website/static/tests/builder/save.test.js
+++ b/addons/website/static/tests/builder/save.test.js
@@ -481,7 +481,7 @@ describe("Add Language", () => {
             class extends Plugin {
                 static id = "test";
                 resources = {
-                    on_will_reset_history_after_saving_handlers: async () => {
+                    on_ready_to_save_document_handlers: async () => {
                         await deferSave.promise;
                         throw "save fails for the test";
                     },
@@ -540,7 +540,7 @@ test("attempt to prevent closing window with unsaved changes", async () => {
     addPlugin(
         class extends Plugin {
             static id = "test";
-            resources = { on_will_reset_history_after_saving_handlers: () => deferSave.promise };
+            resources = { on_ready_to_save_document_handlers: () => deferSave.promise };
         }
     );
     setupSaveAndReloadIframe();

--- a/addons/website_sale/static/src/website_builder/product_header_category_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/product_header_category_option_plugin.js
@@ -27,7 +27,7 @@ class ProductHeaderCategoryOptionPlugin extends Plugin {
             ToggleCategoryAlignContentAction,
         },
 
-        on_will_reset_history_after_saving_handlers: this.onSave.bind(this),
+        on_ready_to_save_document_handlers: this.onSave.bind(this),
     };
 
     async onSave() {

--- a/addons/website_sale/static/src/website_builder/products_design_panel_plugin.js
+++ b/addons/website_sale/static/src/website_builder/products_design_panel_plugin.js
@@ -18,7 +18,7 @@ export class ProductsDesignPanelPlugin extends Plugin {
             ProductsDesignPanel,
         },
         on_new_records_handled_handlers: this.handleMutations.bind(this),
-        on_will_reset_history_after_saving_handlers: this.onSave.bind(this),
+        on_ready_to_save_document_handlers: this.onSave.bind(this),
         product_design_list_to_save: {
             selector: "#o_wsale_products_grid",
             getData(el) {


### PR DESCRIPTION
Commit b966432e85a7e19c0e4e4bfbb34f673b64fc84e6 renamed handler resources to highlight in their name the event to which they react. The resource that used to be called `save_handlers` was renamed `on_will_reset_history_after_saving_handlers` (as the history is reset just after).
As this resource is implemented to save bits of the document (and nothing really cares about the history reset), it is now renamed to `on_ready_to_save_document_handlers`. To convey that:
- the event is "the builder is ready to save the document"
- this is about saving the whole document (and not a custom snippet)
