### PR TITLE
[FIX] web: remove public_root_instance from tests setup assets

### DIFF
--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -451,6 +451,7 @@ This module provides the core of the Odoo Web Client.
 
             'web/static/src/polyfills/set.js',
             'web/static/src/public/**/*.js',
+            ("remove", 'web/static/src/public/public_root_instance.js'),
             'web/static/src/public/**/*.xml',
             'web/static/tests/public/**/*.xml',
             ('remove', 'web/static/src/public/database_manager.js'),


### PR DESCRIPTION
Because of odoo/odoo@dd13994674d4ef4683f5a4d46a1f604650cfb92b which made it to import all of the web/public directory in assets_unit_tests_setup and because of odoo/odoo@d4e74d7dd8b8403aae858317819f3290fc470529 which put the public root instance in those same directory, thus the same assets.

When the public_root_instance was created, and with it an env and services, some services alter some registries. Depending on the timing, the public instance could pass after a legit test, and make the hoot crash.

After this commit, the public root is not instanciated at tests setup time

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
