### PR TITLE
[IMP] point_of_sale: accept multiple currencies in pos

### DIFF
--- a/addons/point_of_sale/models/account_journal.py
+++ b/addons/point_of_sale/models/account_journal.py
@@ -7,7 +7,8 @@ from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 
 
 class AccountJournal(models.Model):
-    _inherit = 'account.journal'
+    _name = 'account.journal'
+    _inherit = ['account.journal', 'pos.load.mixin']
 
     pos_payment_method_ids = fields.One2many('pos.payment.method', 'journal_id', string='Point of Sale Payment Methods')
 
@@ -16,6 +17,10 @@ class AccountJournal(models.Model):
         methods = self.env['pos.payment.method'].sudo().search([("journal_id", "in", self.ids)])
         if methods:
             raise ValidationError(_("This journal is associated with a payment method. You cannot modify its type"))
+
+    @api.model
+    def _load_pos_data_fields(self, config):
+        return ['id', 'name', 'currency_id']
 
     def _check_no_active_payments(self):
         linked_payment_methods = self.env['pos.payment.method'].sudo().search([('journal_id', 'in', self.ids)], limit=1)

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -533,11 +533,6 @@ class PosConfig(models.Model):
             if config.use_pricelist and config.pricelist_id and config.pricelist_id not in config.available_pricelist_ids:
                 raise ValidationError(_("The default pricelist must be included in the available pricelists."))
 
-            # Check if the config's payment methods are compatible with its currency
-            for pm in config.payment_method_ids:
-                if pm.journal_id and pm.journal_id.currency_id and pm.journal_id.currency_id != config.currency_id:
-                    raise ValidationError(_("All payment methods must be in the same currency as the Sales Journal or the company currency if that is not set."))
-
             if config.use_pricelist and any(config.available_pricelist_ids.mapped(lambda pricelist: pricelist.currency_id != config.currency_id)):
                 raise ValidationError(_("All available pricelists must be in the same currency as the company or"
                                         " as the Sales Journal set on this point of sale if you use"

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -568,16 +568,6 @@ class PosConfig(models.Model):
             if config.use_pricelist and config.pricelist_id and config.pricelist_id not in config.available_pricelist_ids:
                 raise ValidationError(_("The default pricelist must be included in the available pricelists."))
 
-            # Check if the config's payment methods are compatible with its currency
-            for pm in config.payment_method_ids:
-                if pm.journal_id and pm.journal_id.currency_id and pm.journal_id.currency_id != config.currency_id:
-                    raise ValidationError(_("All payment methods must be in the same currency as the Sales Journal or the company currency if that is not set."))
-
-            if config.use_pricelist and any(config.available_pricelist_ids.mapped(lambda pricelist: pricelist.currency_id != config.currency_id)):
-                raise ValidationError(_("All available pricelists must be in the same currency as the company or"
-                                        " as the Sales Journal set on this point of sale if you use"
-                                        " the Accounting application."))
-
     def _check_payment_method_ids(self):
         self.ensure_one()
         if not self.payment_method_ids:

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -187,7 +187,7 @@ class PosOrder(models.Model):
 
     def _compute_amount_paid(self):
         paid_payment_ids = self.payment_ids.filtered(lambda p: not p.payment_status or p.payment_status == "done")
-        return sum(paid_payment_ids.mapped('amount'))
+        return sum(x.amount * x.currency_rate for x in paid_payment_ids)
 
     def _process_payment_lines(self, pos_order, order, pos_session, draft):
         """Create account.bank.statement.lines from the dictionary given to the parent function.

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -204,7 +204,7 @@ class PosOrder(models.Model):
 
     def _compute_amount_paid(self):
         paid_payment_ids = self.payment_ids.filtered(lambda p: not p.payment_status or p.payment_status == "done")
-        return sum(paid_payment_ids.mapped('amount'))
+        return sum(x._get_amount_in_config_currency() for x in paid_payment_ids)
 
     def _process_payment_lines(self, pos_order, order, pos_session, draft):
         """Create account.bank.statement.lines from the dictionary given to the parent function.
@@ -225,10 +225,13 @@ class PosOrder(models.Model):
             cash_payment_method = pos_session.payment_method_ids.filtered(lambda pm: pm.type == 'cash')[:1]
             if not cash_payment_method:
                 raise UserError(_("No cash statement found for this session. Unable to record returned cash."))
+            # The client sends the change in the currency of the order, but the amount of a
+            # payment is expressed in the currency of its payment method's journal.
+            change_currency = cash_payment_method.journal_id.currency_id or order.currency_id
             return_payment_vals = {
                 'name': _('return'),
                 'pos_order_id': order.id,
-                'amount': pos_order['amount_return'],
+                'amount': order.currency_id._convert(pos_order['amount_return'], change_currency, order.company_id, order.date_order.date()),
                 'payment_date': fields.Datetime.now(),
                 'payment_method_id': cash_payment_method.id,
                 'is_change': True,
@@ -413,8 +416,9 @@ class PosOrder(models.Model):
 
     def _get_order_tax_totals(self):
         self.ensure_one()
-        self.amount_paid = sum(payment.amount for payment in self.payment_ids)
-        self.amount_return = -sum((payment.amount < 0 and payment.amount) or 0 for payment in self.payment_ids)
+        amounts = [payment._get_amount_in_config_currency() for payment in self.payment_ids]
+        self.amount_paid = sum(amounts)
+        self.amount_return = -sum(amount for amount in amounts if amount < 0)
         base_lines = self.lines._prepare_base_lines_for_taxes_computation()
         self.env['account.tax']._add_tax_details_in_base_lines(base_lines, self.company_id)
         self.env['account.tax']._round_base_lines_tax_details(base_lines, self.company_id)
@@ -1411,12 +1415,13 @@ class PosOrder(models.Model):
 
         for payment in self.payment_ids:
             pm = payment.payment_method_id
-            combined.setdefault(pm, 0.0)
-            combined[pm] += payment.amount
+            amounts = combined.setdefault(pm, {'payment_in_config_currency': 0.0, 'payment': 0.0})
+            amounts['payment_in_config_currency'] += payment._get_amount_in_config_currency()
+            amounts['payment'] += payment.amount
 
         # Combined payments: aggregate all orders for a given PM into one slot
         result = []
-        for pm, amount in combined.items():
+        for pm, amounts in combined.items():
             partner_account = partner.property_account_receivable_id if partner else None
             destination_account = partner_account or session._get_receivable_account()
 
@@ -1427,10 +1432,11 @@ class PosOrder(models.Model):
                     'account_id': destination_account.id,
                     'partner_id': partner.id if partner else None,
                     'date_maturity': today,
-                    'amount_currency': amount,
+                    'amount_currency': amounts['payment_in_config_currency'],
                 },
                 'metadata': {
                     'payment_method_id': pm,
+                    'amount': amounts['payment'],
                 },
             })
 
@@ -1609,7 +1615,7 @@ class PosOrder(models.Model):
             for session, payments in total_payments_by_session.items():
                 for payment in payments:
                     pm = payment['metadata']['payment_method_id']
-                    amount = payment['account.move.line']['amount_currency']
+                    amount = payment['metadata']['amount']
                     all_payment_lines |= pm._create_payment_line(
                         session,
                         amount,

--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -22,8 +22,8 @@ class PosPayment(models.Model):
     amount = fields.Monetary(string='Amount', required=True, currency_field='currency_id', help="Total amount of the payment.")
     payment_method_id = fields.Many2one('pos.payment.method', string='Payment Method', required=True)
     payment_date = fields.Datetime(string='Date', required=True, readonly=True, default=lambda self: fields.Datetime.now())
-    currency_id = fields.Many2one('res.currency', string='Currency', related='pos_order_id.currency_id')
-    currency_rate = fields.Float(string='Conversion Rate', related='pos_order_id.currency_rate', help='Conversion rate from company currency to order currency.')
+    currency_id = fields.Many2one('res.currency', string='Currency', compute='_compute_currency')
+    currency_rate = fields.Float(string='Conversion Rate', compute='_compute_conversion_rate', help='Conversion rate from config currency to payment currency.')
     partner_id = fields.Many2one('res.partner', string='Customer', related='pos_order_id.partner_id')
     session_id = fields.Many2one('pos.session', string='Session', related='pos_order_id.session_id', store=True, index=True)
     user_id = fields.Many2one('res.users', string='Employee', related='session_id.user_id')
@@ -66,6 +66,21 @@ class PosPayment(models.Model):
                 payment.display_name = f'{payment.name} {formatLang(self.env, payment.amount, currency_obj=payment.currency_id)}'
             else:
                 payment.display_name = formatLang(self.env, payment.amount, currency_obj=payment.currency_id)
+
+    @api.depends('payment_method_id', 'pos_order_id.currency_id')
+    def _compute_conversion_rate(self):
+        for payment in self:
+            fromCurrency = self.currency_id
+            toCurrency = self.pos_order_id.currency_id
+            payment.currency_rate = toCurrency._get_conversion_rate(fromCurrency, toCurrency)
+
+    @api.depends('payment_method_id.journal_id', 'payment_method_id.journal_id.currency_id')
+    def _compute_currency(self):
+        for payment in self:
+            if payment.payment_method_id.journal_id.currency_id:
+                payment.currency_id = payment.payment_method_id.journal_id.currency_id
+            else:
+                payment.currency_id = payment.pos_order_id.currency_id
 
     @api.constrains('amount')
     def _check_amount(self):

--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -21,10 +21,10 @@ class PosPayment(models.Model):
     name = fields.Char(string='Label', readonly=True)
     pos_order_id = fields.Many2one('pos.order', string='Order', required=True, index=True, ondelete='cascade')
     amount = fields.Monetary(string='Amount', required=True, currency_field='currency_id', help="Total amount of the payment.")
-    payment_method_id = fields.Many2one('pos.payment.method', string='Payment Method', required=True)
+    payment_method_id = fields.Many2one('pos.payment.method', string='Payment Method', required=True, index=True)
     payment_date = fields.Datetime(string='Date', required=True, readonly=True, default=lambda self: fields.Datetime.now())
-    currency_id = fields.Many2one('res.currency', string='Currency', related='pos_order_id.currency_id')
-    currency_rate = fields.Float(string='Conversion Rate', related='pos_order_id.currency_rate', help='Conversion rate from company currency to order currency.')
+    currency_id = fields.Many2one('res.currency', string='Currency', compute='_compute_currency', store=True)
+    currency_rate = fields.Float(string='Conversion Rate', compute='_compute_conversion_rate', help='Conversion rate from the payment currency to the currency of the point of sale.')
     partner_id = fields.Many2one('res.partner', string='Customer', related='pos_order_id.partner_id')
     session_id = fields.Many2one('pos.session', string='Session', related='pos_order_id.session_id', store=True, index=True)
     user_id = fields.Many2one('res.users', string='Employee', related='session_id.user_id')
@@ -67,6 +67,28 @@ class PosPayment(models.Model):
                 payment.display_name = f'{payment.name} {formatLang(self.env, payment.amount, currency_obj=payment.currency_id)}'
             else:
                 payment.display_name = formatLang(self.env, payment.amount, currency_obj=payment.currency_id)
+
+    @api.depends('currency_id', 'pos_order_id.config_id.currency_id', 'pos_order_id.date_order')
+    def _compute_conversion_rate(self):
+        for payment in self:
+            order = payment.pos_order_id
+            payment.currency_rate = self.env['res.currency']._get_conversion_rate(
+                payment.currency_id, order.config_id.currency_id, order.company_id, order.date_order.date())
+
+    @api.depends('payment_method_id.journal_id', 'payment_method_id.journal_id.currency_id')
+    def _compute_currency(self):
+        for payment in self:
+            if payment.payment_method_id.journal_id.currency_id:
+                payment.currency_id = payment.payment_method_id.journal_id.currency_id
+            else:
+                payment.currency_id = payment.pos_order_id.currency_id
+
+    def _get_amount_in_config_currency(self):
+        """
+        Returns the amount of the payment converted to the currency of the pos config
+        """
+        self.ensure_one()
+        return self.pos_order_id.config_id.currency_id.round(self.amount * self.currency_rate)
 
     @api.constrains('amount')
     def _check_amount(self):

--- a/addons/point_of_sale/models/pos_payment_method.py
+++ b/addons/point_of_sale/models/pos_payment_method.py
@@ -131,7 +131,7 @@ class PosPaymentMethod(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config):
-        return ['id', 'name', 'is_cash_count', 'payment_provider', 'split_transactions', 'type', 'image', 'sequence', 'payment_method_type', 'default_qr']
+        return ['id', 'name', 'is_cash_count', 'payment_provider', 'split_transactions', 'type', 'image', 'sequence', 'payment_method_type', 'default_qr', 'journal_id']
 
     @api.depends('payment_method_type')
     def _compute_hide_qr_code_method(self):

--- a/addons/point_of_sale/models/pos_payment_method.py
+++ b/addons/point_of_sale/models/pos_payment_method.py
@@ -133,7 +133,7 @@ class PosPaymentMethod(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config):
-        return ['id', 'name', 'payment_provider', 'type', 'image', 'sequence', 'payment_method_type', 'default_qr']
+        return ['id', 'name', 'payment_provider', 'type', 'image', 'sequence', 'payment_method_type', 'default_qr', 'journal_id']
 
     @api.depends('payment_method_type')
     def _compute_hide_qr_code_method(self):

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -136,7 +136,8 @@ class PosSession(models.Model):
             'pos.category', 'pos.bill', 'res.company', 'account.tax', 'account.tax.group', 'product.template', 'product.product', 'product.attribute', 'product.attribute.custom.value',
             'product.template.attribute.line', 'product.template.attribute.value', 'product.combo', 'product.combo.item', 'res.users', 'res.partner', 'product.uom',
             'decimal.precision', 'uom.uom', 'res.country', 'res.country.state', 'res.lang', 'product.category', 'product.pricelist', 'product.pricelist.item',
-            'account.cash.rounding', 'account.fiscal.position', 'res.currency', 'pos.note', 'product.tag', 'ir.module.module', 'account.move', 'account.account', 'pos.product.template.snooze']
+            'account.cash.rounding', 'account.fiscal.position', 'res.currency', 'pos.note', 'product.tag', 'ir.module.module', 'account.move', 'account.account',
+            'pos.product.template.snooze', 'account.journal']
 
     @api.model
     def _load_pos_data_domain(self, data, config):
@@ -808,13 +809,13 @@ class PosSession(models.Model):
         combine_inv_payment_receivable_lines = defaultdict(lambda: self.env['account.move.line'])
         split_inv_payment_receivable_lines = defaultdict(lambda: self.env['account.move.line'])
         pos_receivable_account = self.company_id.account_default_pos_receivable_account_id
-        currency_rounding = self.currency_id.rounding
         closed_orders = self._get_closed_orders()
         for order in closed_orders:
             order_is_invoiced = order.is_invoiced
             for payment in order.payment_ids:
+                currency = payment.currency_id
                 amount = payment.amount
-                if float_is_zero(amount, precision_rounding=currency_rounding):
+                if float_is_zero(amount, precision_rounding=currency.rounding):
                     continue
                 date = payment.payment_date
                 payment_method = payment.payment_method_id
@@ -827,22 +828,22 @@ class PosSession(models.Model):
                 # pos receivable lines from the invoice payments.
                 if payment_type != 'pay_later':
                     if is_split_payment and payment_type == 'cash':
-                        split_receivables_cash[payment] = self._update_amounts(split_receivables_cash[payment], {'amount': amount}, date)
+                        split_receivables_cash[payment] = self._update_amounts(split_receivables_cash[payment], {'amount': amount, 'currency': currency}, date)
                     elif not is_split_payment and payment_type == 'cash':
-                        combine_receivables_cash[payment_method] = self._update_amounts(combine_receivables_cash[payment_method], {'amount': amount}, date)
+                        combine_receivables_cash[payment_method] = self._update_amounts(combine_receivables_cash[payment_method], {'amount': amount, 'currency': currency}, date)
                     elif is_split_payment and payment_type == 'bank':
-                        split_receivables_bank[payment] = self._update_amounts(split_receivables_bank[payment], {'amount': amount}, date)
+                        split_receivables_bank[payment] = self._update_amounts(split_receivables_bank[payment], {'amount': amount, 'currency': currency}, date)
                     elif not is_split_payment and payment_type == 'bank':
-                        combine_receivables_bank[payment_method] = self._update_amounts(combine_receivables_bank[payment_method], {'amount': amount}, date)
+                        combine_receivables_bank[payment_method] = self._update_amounts(combine_receivables_bank[payment_method], {'amount': amount, 'currency': currency}, date)
 
                     # Create the vals to create the pos receivables that will balance the pos receivables from invoice payment moves.
                     if order_is_invoiced:
                         if is_split_payment:
                             split_inv_payment_receivable_lines[payment] |= payment.account_move_id.line_ids.filtered(lambda line: line.account_id == pos_receivable_account)
-                            split_invoice_receivables[payment] = self._update_amounts(split_invoice_receivables[payment], {'amount': payment.amount}, order.date_order)
+                            split_invoice_receivables[payment] = self._update_amounts(split_invoice_receivables[payment], {'amount': payment.amount, 'currency': currency}, order.date_order)
                         else:
                             combine_inv_payment_receivable_lines[payment_method] |= payment.account_move_id.line_ids.filtered(lambda line: line.account_id == pos_receivable_account)
-                            combine_invoice_receivables[payment_method] = self._update_amounts(combine_invoice_receivables[payment_method], {'amount': payment.amount}, order.date_order)
+                            combine_invoice_receivables[payment_method] = self._update_amounts(combine_invoice_receivables[payment_method], {'amount': payment.amount, 'currency': currency}, order.date_order)
 
                 # If pay_later, we create the receivable lines.
                 #   if split, with partner
@@ -850,9 +851,9 @@ class PosSession(models.Model):
                 # But only do if order is *not* invoiced because no account move is created for pay later invoice payments.
                 if payment_type == 'pay_later' and not order_is_invoiced:
                     if is_split_payment:
-                        split_receivables_pay_later[payment] = self._update_amounts(split_receivables_pay_later[payment], {'amount': amount}, date)
+                        split_receivables_pay_later[payment] = self._update_amounts(split_receivables_pay_later[payment], {'amount': amount, 'currency': currency}, date)
                     elif not is_split_payment:
-                        combine_receivables_pay_later[payment_method] = self._update_amounts(combine_receivables_pay_later[payment_method], {'amount': amount}, date)
+                        combine_receivables_pay_later[payment_method] = self._update_amounts(combine_receivables_pay_later[payment_method], {'amount': amount, 'currency': currency}, date)
 
             if not order_is_invoiced:
                 base_lines = order.with_context(linked_to_pos=True)._prepare_tax_base_line_values()
@@ -1105,12 +1106,15 @@ class PosSession(models.Model):
         combine_cash_statement_line_vals = []
         combine_cash_receivable_vals = []
         for payment_method, amounts in combine_receivables_cash.items():
-            if not float_is_zero(amounts['amount'] , precision_rounding=self.currency_id.rounding):
+            currency = payment_method.journal_id.currency_id
+            if not currency:
+                currency = self.currency_id
+            if not float_is_zero(amounts['amount'], precision_rounding=currency.rounding):
                 combine_cash_statement_line_vals.append(
                     self._get_combine_statement_line_vals(
                         payment_method.journal_id,
                         amounts['amount'],
-                        payment_method
+                        payment_method,
                     )
                 )
                 combine_cash_receivable_vals.append(
@@ -1378,10 +1382,12 @@ class PosSession(models.Model):
         new_amounts = { **old_amounts }
 
         amount = amounts_to_add.get('amount')
-        if self.is_in_company_currency or force_company_currency:
+        currency = amounts_to_add.get('currency') or self.currency_id
+        if not currency and (self.is_in_company_currency or force_company_currency):
             amount_converted = amount
         else:
-            amount_converted = self._amount_converter(amount, date, round)
+            currency = currency or self.currency_id
+            amount_converted = currency._convert(amount, self.company_id.currency_id, self.company_id, date, round=round)
 
         # update amount and amount converted
         new_amounts['amount'] += amount

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -194,7 +194,7 @@ class PosSession(models.Model):
             'res.lang', 'product.category', 'product.pricelist', 'product.pricelist.item',
             'account.cash.rounding', 'account.fiscal.position', 'res.currency', 'pos.note',
             'product.tag', 'ir.module.module', 'account.move', 'account.account',
-            'pos.snooze', 'pos.prep.order', 'pos.prep.line',
+            'pos.snooze', 'pos.prep.order', 'pos.prep.line', 'account.journal',
         ]
 
     @api.model
@@ -1009,7 +1009,7 @@ class PosSession(models.Model):
         payment_lines = self.env['account.move.line']
         for payment in payments:
             pm = payment['metadata']['payment_method_id']
-            amount = payment['account.move.line']['amount_currency']
+            amount = payment['metadata']['amount']
             payment_lines |= pm._create_payment_line(
                 self,
                 amount,

--- a/addons/point_of_sale/models/res_currency.py
+++ b/addons/point_of_sale/models/res_currency.py
@@ -8,10 +8,10 @@ class ResCurrency(models.Model):
     @api.model
     def _load_pos_data_domain(self, data, config):
         company_currency_id = config.company_id.currency_id.id
-        config_currency_id = config.currency_id.id
-        if company_currency_id != config_currency_id:
-            return [('id', 'in', [company_currency_id, config_currency_id])]
-        return [('id', '=', config_currency_id)]
+        journals = config.payment_method_ids.journal_id
+        currency_ids = journals.currency_id.ids
+        currency_ids.append(company_currency_id)
+        return [('id', 'in', currency_ids)]
 
     @api.model
     def _load_pos_data_fields(self, config):

--- a/addons/point_of_sale/models/res_currency.py
+++ b/addons/point_of_sale/models/res_currency.py
@@ -7,7 +7,9 @@ class ResCurrency(models.Model):
 
     @api.model
     def _load_pos_data_domain(self, data, config):
-        currency_ids = {config.company_id.currency_id.id, config.currency_id.id}
+        journals = config.payment_method_ids.journal_id
+        currency_ids = set(journals.currency_id.ids)
+        currency_ids.update({config.company_id.currency_id.id, config.currency_id.id})
         currency_ids.update(pricelist['currency_id'] for pricelist in data['product.pricelist'])
         return [('id', 'in', list(currency_ids))]
 

--- a/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
@@ -151,6 +151,10 @@ export class ClosePosPopup extends Component {
             this.state.payments[paymentId].counted
         );
     }
+    getCurrency(paymentId) {
+        const paymentMethod = this.pos.models["pos.payment.method"].get(paymentId);
+        return paymentMethod?.journal_id?.currency_id || this.pos.currency;
+    }
     getDifference(paymentId) {
         const counted = this.state.payments[paymentId].counted;
         if (!this.env.utils.isValidFloat(counted)) {

--- a/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.xml
@@ -43,17 +43,18 @@
                         <t t-set="_showDiff" t-value="pm.type === 'bank' and pm.number !== 0" />
                         <t t-set="diff" t-value="_showDiff ? this.getDifference(pm.id) : 0" />
                         <t t-set="counted" t-value="_showDiff ? this.env.utils.parseValidFloat(this.state.payments[pm.id].counted) : 0" />
+                        <t t-set="currency" t-value="this.getCurrency(pm.id)" />
                         <div class="d-flex align-items-center justify-content-between fs-3">
                             <span t-out="pm.name" />
-                            <span t-out="this.env.utils.formatCurrency(pm.amount)" />
+                            <span t-out="this.env.utils.formatCurrency(pm.amount, true, currency)" />
                         </div>
                         <div class="d-flex align-items-center justify-content-between text-muted border-start ps-2">
                             <span>Counted</span>
-                            <span t-out="this.env.utils.formatCurrency(counted)" />
+                            <span t-out="this.env.utils.formatCurrency(counted, true, currency)" />
                         </div>
                         <div class="d-flex align-items-center justify-content-between text-muted border-start ps-2" t-att-class="{'text-danger fw-bold': diff}">
                             <span>Difference</span>
-                            <span t-out="this.env.utils.formatCurrency(diff)" />
+                            <span t-out="this.env.utils.formatCurrency(diff, true, currency)" />
                         </div>
                     </div>
                 </div>

--- a/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
@@ -157,7 +157,15 @@ export class PosOrderAccounting extends Base {
                 // Return lines are created after the sync, should not be taken into account in
                 // the paid amount otherwise, the change would be wrong.
                 if (paymentLine.isDone() && !paymentLine.is_change) {
-                    sum += paymentLine.getAmount();
+                    var currency = paymentLine.payment_method_id.journal_id?.currency_id;
+                    if (currency) {
+                        sum +=
+                            paymentLine.getAmount() *
+                            (paymentLine.pos_order_id.currency.rate /
+                                paymentLine.payment_method_id.journal_id.currency_id.rate);
+                    } else {
+                        sum += paymentLine.getAmount();
+                    }
                 }
                 return sum;
             }, 0)

--- a/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
+++ b/addons/point_of_sale/static/src/app/models/accounting/pos_order_accounting.js
@@ -179,7 +179,15 @@ export class PosOrderAccounting extends Base {
                 // Return lines are created after the sync, should not be taken into account in
                 // the paid amount otherwise, the change would be wrong.
                 if (paymentLine.isDone() && !paymentLine.is_change) {
-                    sum += paymentLine.getAmount();
+                    var currency = paymentLine.payment_method_id.journal_id?.currency_id;
+                    if (currency) {
+                        sum +=
+                            paymentLine.getAmount() *
+                            (paymentLine.pos_order_id.currency.rate /
+                                paymentLine.payment_method_id.journal_id.currency_id.rate);
+                    } else {
+                        sum += paymentLine.getAmount();
+                    }
                 }
                 return sum;
             }, 0)

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -470,6 +470,15 @@ export class PosOrder extends PosOrderAccounting {
     addPaymentline(payment_method) {
         this.assertEditable();
 
+        // Check payment method currencies are the same
+        // or use the company currency when using a journal without a currency
+        if (!this.isCurrencyConsistent(payment_method)) {
+            return {
+                status: false,
+                data: _t("You can't pay the same order in multiple currencies"),
+            };
+        }
+
         const { status: canSend, message } = payment_method.getPaymentInterfaceStates();
         if (!canSend) {
             return { status: false, data: message };
@@ -480,12 +489,23 @@ export class PosOrder extends PosOrderAccounting {
             payment_method_id: payment_method,
         });
         this.selectPaymentline(newPaymentLine);
-        newPaymentLine.setAmount(totalAmountDue);
+        const currency = payment_method.journal_id?.currency_id || this.currency;
+        newPaymentLine.setAmount(totalAmountDue * (currency.rate / this.currency.rate));
 
         if ((payment_method.payment_interface && !this.isRefund) || payment_method.useBankQrCode) {
             newPaymentLine.setPaymentStatus("pending");
         }
         return { status: true, data: newPaymentLine };
+    }
+
+    isCurrencyConsistent(payment_method) {
+        const existingPayment = this.payment_ids[0];
+        if (!existingPayment) {
+            return true;
+        }
+        const existingCurrency =
+            existingPayment.payment_method_id.journal_id?.currency_id || this.currency;
+        return existingCurrency == (payment_method.journal_id?.currency_id || this.currency);
     }
 
     getPaymentlineByUuid(uuid) {

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -415,6 +415,15 @@ export class PosOrder extends PosOrderAccounting {
     addPaymentline(payment_method, args = {}) {
         this.assertEditable();
 
+        // Check payment method currencies are the same
+        // or use the company currency when using a journal without a currency
+        if (!this.isCurrencyConsistent(payment_method)) {
+            return {
+                status: false,
+                data: _t("You can't pay the same order in multiple currencies"),
+            };
+        }
+
         const { status: canSend, message } = payment_method.getPaymentInterfaceStates();
         if (!canSend) {
             return { status: false, data: message, size: "sm" };
@@ -425,12 +434,23 @@ export class PosOrder extends PosOrderAccounting {
             payment_method_id: payment_method,
         });
         this.selectPaymentline(newPaymentLine);
-        newPaymentLine.setAmount(totalAmountDue);
+        const currency = payment_method.journal_id?.currency_id || this.currency;
+        newPaymentLine.setAmount(totalAmountDue * (currency.rate / this.currency.rate));
 
         if ((payment_method.payment_interface && !this.isRefund) || payment_method.useBankQrCode) {
             newPaymentLine.setPaymentStatus("pending");
         }
         return { status: true, data: newPaymentLine };
+    }
+
+    isCurrencyConsistent(payment_method) {
+        const existingPayment = this.payment_ids[0];
+        if (!existingPayment) {
+            return true;
+        }
+        const existingCurrency =
+            existingPayment.payment_method_id.journal_id?.currency_id || this.currency;
+        return existingCurrency == (payment_method.journal_id?.currency_id || this.currency);
     }
 
     getPaymentlineByUuid(uuid) {

--- a/addons/point_of_sale/static/src/app/models/pos_payment.js
+++ b/addons/point_of_sale/static/src/app/models/pos_payment.js
@@ -77,6 +77,19 @@ export class PosPayment extends Base {
         return this.amount || 0;
     }
 
+    getAmountInCurrency() {
+        if (!this.payment_method_id.journal_id?.currency_id) {
+            return this.amount || 0;
+        }
+        if (!this.amount) {
+            return 0;
+        }
+        return (
+            this.amount *
+            (this.pos_order_id.currency.rate / this.payment_method_id.journal_id.currency_id.rate)
+        );
+    }
+
     getPaymentStatus() {
         return this.payment_status;
     }

--- a/addons/point_of_sale/static/src/app/models/pos_payment.js
+++ b/addons/point_of_sale/static/src/app/models/pos_payment.js
@@ -83,6 +83,19 @@ export class PosPayment extends Base {
         return this.amount || 0;
     }
 
+    getAmountInCurrency() {
+        if (!this.payment_method_id.journal_id?.currency_id) {
+            return this.amount || 0;
+        }
+        if (!this.amount) {
+            return 0;
+        }
+        return (
+            this.amount *
+            (this.pos_order_id.currency.rate / this.payment_method_id.journal_id.currency_id.rate)
+        );
+    }
+
     getPaymentStatus() {
         return this.payment_status;
     }

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.xml
@@ -16,7 +16,11 @@
                     <div class="payment-infos d-flex align-items-center justify-content-between flex-grow-1 px-3 py-3 text-truncate cursor-pointer fs-2" t-on-click="() => this.selectLine(line)">
                         <span class="payment-name" t-out="line.payment_method_id.name"/>
                         <div class="payment-amount px-3">
-                            <PriceFormatter price="this.env.utils.formatCurrency(line.getAmount())" />
+                            <t t-set="lineCurrency" t-value="line.payment_method_id.journal_id?.currency_id" />
+                            <PriceFormatter t-if="lineCurrency and lineCurrency != line.pos_order_id.currency" price="env.utils.formatCurrency(line.getAmount(), true, lineCurrency)" />
+                            <t t-else="">
+                                <PriceFormatter price="env.utils.formatCurrency(line.getAmount(), true)" />
+                            </t>
                         </div>
                     </div>
 

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.xml
@@ -16,7 +16,11 @@
                     <div class="payment-infos d-flex align-items-center justify-content-between flex-grow-1 px-3 py-3 text-truncate cursor-pointer fs-2" t-on-click="() => this.selectLine(line)">
                         <span class="payment-name" t-out="line.displayName"/>
                         <div class="payment-amount px-3">
-                            <PriceFormatter price="this.env.utils.formatCurrency(line.getAmount())" />
+                            <t t-set="lineCurrency" t-value="line.payment_method_id.journal_id?.currency_id" />
+                            <PriceFormatter t-if="lineCurrency and lineCurrency != line.pos_order_id.currency" price="this.env.utils.formatCurrency(line.getAmount(), true, lineCurrency)" />
+                            <t t-else="">
+                                <PriceFormatter price="this.env.utils.formatCurrency(line.getAmount(), true)" />
+                            </t>
                         </div>
                     </div>
 

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -133,6 +133,12 @@ export class PaymentScreen extends Component {
     get selectedPaymentLine() {
         return this.currentOrder.getSelectedPaymentline();
     }
+    get currentCurrency() {
+        return (
+            this.currentOrder.payment_ids[0]?.payment_method_id.journal_id?.currency_id ||
+            this.pos.config.currency_id
+        );
+    }
     makeAnimation() {
         this.pos.addAnimation = true;
         setTimeout(() => (this.pos.addAnimation = false), 1000);
@@ -311,6 +317,16 @@ export class PaymentScreen extends Component {
         const line = this.paymentLines.find((line) => line.uuid === uuid);
         this.currentOrder.selectPaymentline(line);
         this.numberBuffer.reset();
+    }
+
+    paymentMethodsHaveDifferentCurrencies() {
+        const methods = this.pos.config.payment_method_ids;
+        if (!methods) {
+            return false;
+        }
+        return methods.some(
+            (pm) => pm.journal_id && pm.journal_id.currency_id != this.currentOrder.currency
+        );
     }
 
     paymentMethodImage(paymentMethod) {

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -133,6 +133,12 @@ export class PaymentScreen extends Component {
     get selectedPaymentLine() {
         return this.currentOrder.getSelectedPaymentline();
     }
+    get currentCurrency() {
+        return (
+            this.currentOrder.payment_ids[0]?.payment_method_id.journal_id?.currency_id ||
+            this.pos.config.currency_id
+        );
+    }
     makeAnimation() {
         this.pos.addAnimation = true;
         setTimeout(() => (this.pos.addAnimation = false), 1000);
@@ -304,6 +310,16 @@ export class PaymentScreen extends Component {
         const line = this.paymentLines.find((line) => line.uuid === uuid);
         this.currentOrder.selectPaymentline(line);
         this.numberBuffer.reset();
+    }
+
+    paymentMethodsHaveDifferentCurrencies() {
+        const methods = this.pos.config.payment_method_ids;
+        if (!methods) {
+            return false;
+        }
+        return methods.some(
+            (pm) => pm.journal_id && pm.journal_id.currency_id != this.currentOrder.currency
+        );
     }
 
     paymentMethodImage(paymentMethod) {

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
@@ -71,8 +71,8 @@
                 'fade-effect': this.pos.addAnimation and !this.ui.isSmall,
             }">
             <div class="total text-center text-dark"
-                t-att-style="!this.ui.isSmall? 'font-size: 125px;' : ''" >
-                <PriceFormatter price="this.env.utils.formatCurrency(this.currentOrder.totalDue)" />
+                t-att-style="!ui.isSmall? 'font-size: 125px;' : ''" >
+                <PriceFormatter price="this.env.utils.formatCurrency(currentOrder.totalDue * (this.currentCurrency.rate / this.currentOrder.currency.rate), true, this.currentCurrency)" />
             </div>
         </section>
     </t>
@@ -156,7 +156,8 @@
     </t>
 
     <t t-name="point_of_sale.PaymentScreenMethods">
-        <div class="paymentmethods-container" t-att-class="this.ui.isSmall ? 'rounded-3' : 'flex-grow-1'">
+        <t t-set="differentCurrencies" t-value="this.paymentMethodsHaveDifferentCurrencies()" />
+        <div class="paymentmethods-container" t-att-class="ui.isSmall ? 'rounded-3' : 'flex-grow-1'">
         <!-- Add scrollbar if more than 4 payment methods are configured -->
             <div class="paymentmethods gap-1 gap-lg-2" t-att-class="{ 'd-grid p-1 gap-1 overflow-y-auto rounded-3 bg-200': this.ui.isSmall, 'd-flex flex-column gap-lg-2': !this.ui.isSmall }" t-att-style="this.ui.isSmall ? 'max-height: 120px;' : ''">
                 <t t-foreach="this.payment_methods_from_config" t-as="paymentMethod" t-key="paymentMethod.id">
@@ -169,6 +170,7 @@
                             <span class="payment-name" t-out="paymentMethod.name" />
                         </div>
                         <span class="text-muted" t-out="this.pos.getPaymentMethodFmtAmount(paymentMethod, this.currentOrder)"/>
+                        <sapn class="text-muted" t-out="paymentMethod.journal_id.currency_id.name" t-if="paymentMethod.journal_id and paymentMethod.journal_id.currency_id and differentCurrencies" />
                     </div>
                 </t>
             </div>

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
@@ -76,7 +76,7 @@
             }">
             <div class="total text-center text-dark"
                 t-att-style="!this.ui.isSmall? 'font-size: 125px;' : ''" >
-                <PriceFormatter price="this.env.utils.formatCurrency(this.currentOrder.totalDue)" />
+                <PriceFormatter price="this.env.utils.formatCurrency(this.currentOrder.totalDue * (this.currentCurrency.rate / this.currentOrder.currency.rate), true, this.currentCurrency)" />
             </div>
         </section>
     </t>
@@ -154,6 +154,7 @@
     </t>
 
     <t t-name="point_of_sale.PaymentScreenMethods">
+        <t t-set="differentCurrencies" t-value="this.paymentMethodsHaveDifferentCurrencies()" />
         <div class="paymentmethods-container" t-att-class="this.ui.isSmall ? 'rounded-3' : 'flex-grow-1'">
         <!-- Add scrollbar if more than 4 payment methods are configured -->
             <div class="paymentmethods gap-1 gap-lg-2" t-att-class="{ 'd-grid p-1 gap-1 overflow-y-auto rounded-3 bg-200': this.ui.isSmall, 'd-flex flex-column gap-lg-2': !this.ui.isSmall }" t-att-style="this.ui.isSmall ? 'max-height: 120px;' : ''">
@@ -167,6 +168,7 @@
                             <span class="payment-name" t-out="paymentMethod.name" />
                         </div>
                         <span class="text-muted" t-out="this.pos.getPaymentMethodFmtAmount(paymentMethod, this.currentOrder)"/>
+                        <sapn class="text-muted" t-out="paymentMethod.journal_id.currency_id.name" t-if="paymentMethod.journal_id and paymentMethod.journal_id.currency_id and differentCurrencies" />
                     </div>
                 </t>
             </div>

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_status/payment_status.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_status/payment_status.js
@@ -46,6 +46,13 @@ export class PaymentScreenStatus extends Component {
         return this.props.order;
     }
 
+    get currency() {
+        return (
+            this.order.payment_ids[0]?.payment_method_id.journal_id?.currency_id ||
+            this.order.currency
+        );
+    }
+
     get isRemaining() {
         const isNegative = this.order.totalDue < 0;
         const remainingDue = this.order.remainingDue;
@@ -67,9 +74,17 @@ export class PaymentScreenStatus extends Component {
 
     get amountText() {
         if (!this.isRemaining) {
-            return this.env.utils.formatCurrency(this.order.change);
+            return this.env.utils.formatCurrency(
+                this.order.change * (this.currency.rate / this.order.currency.rate),
+                true,
+                this.currency
+            );
         } else {
-            return this.env.utils.formatCurrency(this.order.remainingDue);
+            return this.env.utils.formatCurrency(
+                this.order.remainingDue * (this.currency.rate / this.order.currency.rate),
+                true,
+                this.currency
+            );
         }
     }
 }

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_status/payment_status.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_status/payment_status.js
@@ -47,6 +47,13 @@ export class PaymentScreenStatus extends Component {
         return this.props.order;
     }
 
+    get currency() {
+        return (
+            this.order.payment_ids[0]?.payment_method_id.journal_id?.currency_id ||
+            this.order.currency
+        );
+    }
+
     get isRemaining() {
         const isNegative = this.order.totalDue < 0;
         const remainingDue = this.order.remainingDue;
@@ -68,9 +75,17 @@ export class PaymentScreenStatus extends Component {
 
     get amountText() {
         if (!this.isRemaining) {
-            return this.env.utils.formatCurrency(this.order.change);
+            return this.env.utils.formatCurrency(
+                this.order.change * (this.currency.rate / this.order.currency.rate),
+                true,
+                this.currency
+            );
         } else {
-            return this.env.utils.formatCurrency(this.order.remainingDue);
+            return this.env.utils.formatCurrency(
+                this.order.remainingDue * (this.currency.rate / this.order.currency.rate),
+                true,
+                this.currency
+            );
         }
     }
 }

--- a/addons/point_of_sale/static/src/app/services/contextual_utils_service.js
+++ b/addons/point_of_sale/static/src/app/services/contextual_utils_service.js
@@ -32,8 +32,8 @@ export const contextualUtilsService = {
         const formatProductQty = (qty, trailingZeros = true) =>
             formatFloat(qty, { digits: [true, ProductUnit.digits], trailingZeros: trailingZeros });
 
-        const formatCurrency = (value, hasSymbol = true) =>
-            webFormatCurrency(value, res_currency.id, {
+        const formatCurrency = (value, hasSymbol = true, currency = res_currency) =>
+            webFormatCurrency(value, currency.id, {
                 noSymbol: !hasSymbol,
             });
 

--- a/addons/point_of_sale/static/src/app/utils/printer/generate_printer_data.js
+++ b/addons/point_of_sale/static/src/app/utils/printer/generate_printer_data.js
@@ -42,8 +42,12 @@ export class GeneratePrinterData {
         };
     }
 
-    formatCurrency(amount) {
-        return formatCurrency(amount, this.currency.id);
+    formatCurrency(amount, currency = this.currency) {
+        let rate = "";
+        if (currency.id != this.currency.id) {
+            rate = " (rate:" + (currency.rate / this.currency.rate).toFixed(4) + ")";
+        }
+        return formatCurrency(amount, currency.id) + rate;
     }
 
     /**
@@ -200,7 +204,10 @@ export class GeneratePrinterData {
         return this.order.payment_ids.map((line) => ({
             ...line.raw,
             payment_method_data: { name: line.payment_method_id?.name || "" },
-            amount: this.formatCurrency(line.amount),
+            amount: this.formatCurrency(
+                line.amount,
+                line.payment_method_id?.journal_id?.currency_id || this.currency
+            ),
         }));
     }
 

--- a/addons/point_of_sale/static/src/app/utils/printer/generate_printer_data.js
+++ b/addons/point_of_sale/static/src/app/utils/printer/generate_printer_data.js
@@ -39,8 +39,12 @@ export class GeneratePrinterData {
         };
     }
 
-    formatCurrency(amount) {
-        return formatCurrency(amount, this.currency.id);
+    formatCurrency(amount, currency = this.currency) {
+        let rate = "";
+        if (currency.id != this.currency.id) {
+            rate = " (rate:" + (currency.rate / this.currency.rate).toFixed(4) + ")";
+        }
+        return formatCurrency(amount, currency.id) + rate;
     }
 
     /**
@@ -202,7 +206,10 @@ export class GeneratePrinterData {
         return this.order.payment_ids.map((line) => ({
             ...line.raw,
             payment_method_data: { name: line.payment_method_id?.name || "" },
-            amount: this.formatCurrency(line.amount),
+            amount: this.formatCurrency(
+                line.amount,
+                line.payment_method_id?.journal_id?.currency_id || this.currency
+            ),
         }));
     }
 

--- a/addons/point_of_sale/static/tests/pos/tours/payment_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/payment_screen_tour.js
@@ -9,6 +9,7 @@ import * as Order from "@point_of_sale/../tests/generic_helpers/order_widget_uti
 import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
 import { negateStep } from "@point_of_sale/../tests/generic_helpers/utils";
 import { inLeftSide } from "./utils/common";
+import * as FeedbackScreen from "@point_of_sale/../tests/pos/tours/utils/feedback_screen_util";
 
 registry.category("web_tour.tours").add("PaymentScreenTour", {
     steps: () =>
@@ -162,6 +163,46 @@ registry.category("web_tour.tours").add("PaymentScreenTotalDueWithOverPayment", 
             PaymentScreen.clickPaymentMethod("Cash"),
             PaymentScreen.enterPaymentLineAmount("Cash", "5", true, {
                 change: "3",
+            }),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("PaymentScreenMixedCurrencies", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Currency Switch Test Product", true, null, 100),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.totalIs("100"),
+            PaymentScreen.clickPaymentMethod("Company Currency PM", true, {
+                amount: "100",
+                remaining: "0.0",
+            }),
+            PaymentScreen.totalIs("$"),
+            PaymentScreen.totalIs("100"),
+            PaymentScreen.countPaymentlinesIs(1),
+            PaymentScreen.clickPaymentMethod("Different Currency PM"),
+            Dialog.is({
+                title: "Oh snap !",
+                body: "You can't pay the same order in multiple currencies",
+            }),
+            Dialog.confirm(),
+            PaymentScreen.clickPaymentlineDelButton("Company Currency PM", 100),
+            PaymentScreen.clickPaymentMethod("Different Currency PM", true, {
+                amount: "50",
+                remaning: "0.0",
+            }),
+            PaymentScreen.totalIs("€"),
+            PaymentScreen.totalIs("50"),
+            PaymentScreen.countPaymentlinesIs(1),
+            PaymentScreen.clickValidate(),
+            FeedbackScreen.isShown(),
+            FeedbackScreen.checkTicketData({
+                total_amount: "100",
+                payment_lines: [
+                    { name: "Different Currency PM", amount: "50.00\xa0€ (rate:0.5000)" },
+                ],
             }),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/pos/tours/payment_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/payment_screen_tour.js
@@ -5,6 +5,7 @@ import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_
 import { registry } from "@web/core/registry";
 import * as OfflineUtil from "@point_of_sale/../tests/generic_helpers/offline_util";
 import { negateStep } from "@point_of_sale/../tests/generic_helpers/utils";
+import * as FeedbackScreen from "@point_of_sale/../tests/pos/tours/utils/feedback_screen_util";
 
 registry.category("web_tour.tours").add("PaymentScreenTour", {
     steps: () =>
@@ -66,6 +67,46 @@ registry.category("web_tour.tours").add("PaymentScreenTour", {
             PaymentScreen.clickPaymentMethod("Bank", true, { remaining: "0.0" }),
             PaymentScreen.validateButtonIsHighlighted(true),
             OfflineUtil.setOnlineMode(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("PaymentScreenMixedCurrencies", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Currency Switch Test Product", true, null, 100),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.totalIs("100"),
+            PaymentScreen.clickPaymentMethod("Company Currency PM", true, {
+                amount: "100",
+                remaining: "0.0",
+            }),
+            PaymentScreen.totalIs("$"),
+            PaymentScreen.totalIs("100"),
+            PaymentScreen.countPaymentlinesIs(1),
+            PaymentScreen.clickPaymentMethod("Different Currency PM"),
+            Dialog.is({
+                title: "Oh snap !",
+                body: "You can't pay the same order in multiple currencies",
+            }),
+            Dialog.confirm(),
+            PaymentScreen.clickPaymentlineDelButton("Company Currency PM", 100),
+            PaymentScreen.clickPaymentMethod("Different Currency PM", true, {
+                amount: "50",
+                remaning: "0.0",
+            }),
+            PaymentScreen.totalIs("€"),
+            PaymentScreen.totalIs("50"),
+            PaymentScreen.countPaymentlinesIs(1),
+            PaymentScreen.clickValidate(),
+            FeedbackScreen.isShown(),
+            FeedbackScreen.checkTicketData({
+                total_amount: "100",
+                payment_lines: [
+                    { name: "Different Currency PM", amount: "50.00\xa0€ (rate:0.5000)" },
+                ],
+            }),
         ].flat(),
 });
 

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2458,6 +2458,78 @@ class TestUi(TestPointOfSaleHttpCommon):
         order = self.env['pos.order'].search([], limit=1)
         self.assertEqual(order.payment_ids[0].payment_method_id.name, "Bank")
 
+    def test_payment_screen_mixed_currencies(self):
+        company_currency = self.env.company.currency_id
+        different_currency = self.env.ref('base.EUR')
+        if different_currency == company_currency:
+            different_currency = self.env.ref('base.USD')
+
+        different_currency.active = True
+        self.env['res.currency.rate'].create({
+            'currency_id': different_currency.id,
+            'rate': 0.5,
+            'name': date.today(),
+        })
+
+        different_currency_journal = self.env['account.journal'].create({
+            'name': 'Different Currency Journal',
+            'type': 'bank',
+            'company_id': self.env.company.id,
+            'code': 'ORDCJ',
+            'currency_id': different_currency.id,
+        })
+        company_currency_journal = self.env['account.journal'].create({
+            'name': 'Company Currency Journal',
+            'type': 'bank',
+            'company_id': self.env.company.id,
+            'code': 'COMCJ',
+            'currency_id': company_currency.id,
+        })
+        different_currency_pm = self.env['pos.payment.method'].create({
+            'name': 'Different Currency PM',
+            'journal_id': different_currency_journal.id,
+            'receivable_account_id': self.env.company.account_default_pos_receivable_account_id.id,
+            'outstanding_account_id': self.inbound_payment_method_line.payment_account_id.id,
+        })
+        company_currency_pm = self.env['pos.payment.method'].create({
+            'name': 'Company Currency PM',
+            'journal_id': company_currency_journal.id,
+            'receivable_account_id': self.env.company.account_default_pos_receivable_account_id.id,
+            'outstanding_account_id': self.inbound_payment_method_line.payment_account_id.id,
+        })
+
+        self.main_pos_config.write({
+            'payment_method_ids': [Command.set([different_currency_pm.id, company_currency_pm.id])],
+        })
+        self.env['product.product'].create({
+            'name': 'Currency Switch Test Product',
+            'list_price': 100,
+            'taxes_id': False,
+            'available_in_pos': True,
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(
+            f"/pos/ui?config_id={self.main_pos_config.id}",
+            'PaymentScreenMixedCurrencies',
+            login="pos_user",
+        )
+
+        order = self.main_pos_config.current_session_id.order_ids[-1]
+
+        self.main_pos_config.current_session_id.action_pos_session_closing_control()
+
+        self.assertEqual(order.payment_ids.payment_method_id, different_currency_pm)
+
+        payment_move_line = self.env['account.move.line'].search([
+            ('journal_id', '=', different_currency_journal.id),
+            ('account_id', '=', different_currency_pm.outstanding_account_id.id),
+        ])
+
+        self.assertEqual(len(payment_move_line), 1)
+        self.assertEqual(payment_move_line.currency_id, different_currency)
+        self.assertEqual(payment_move_line.amount_currency, 50)
+
     def test_barcode_search_attributes_preset(self):
         product = self.env['product.template'].create({
             'name': 'Product with Attributes',

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1638,6 +1638,80 @@ class TestUi(TestPointOfSaleHttpCommon):
         order = self.env['pos.order'].search([], limit=1)
         self.assertEqual(order.payment_ids[0].payment_method_id.name, "Bank")
 
+    def test_payment_screen_mixed_currencies(self):
+        company_currency = self.env.company.currency_id
+        different_currency = self.env.ref('base.EUR')
+        if different_currency == company_currency:
+            different_currency = self.env.ref('base.USD')
+
+        different_currency.active = True
+        self.env['res.currency.rate'].create({
+            'currency_id': different_currency.id,
+            'rate': 0.5,
+            'name': date.today(),
+        })
+
+        different_currency_journal = self.env['account.journal'].create({
+            'name': 'Different Currency Journal',
+            'type': 'bank',
+            'company_id': self.env.company.id,
+            'code': 'ORDCJ',
+            'currency_id': different_currency.id,
+        })
+        company_currency_journal = self.env['account.journal'].create({
+            'name': 'Company Currency Journal',
+            'type': 'bank',
+            'company_id': self.env.company.id,
+            'code': 'COMCJ',
+            'currency_id': company_currency.id,
+        })
+        different_currency_pm = self.env['pos.payment.method'].create({
+            'name': 'Different Currency PM',
+            'type': 'bank',
+            'journal_id': different_currency_journal.id,
+            'receivable_account_id': self.env.company.account_default_pos_receivable_account_id.id,
+            'outstanding_account_id': self.inbound_payment_method_line.payment_account_id.id,
+        })
+        company_currency_pm = self.env['pos.payment.method'].create({
+            'name': 'Company Currency PM',
+            'type': 'bank',
+            'journal_id': company_currency_journal.id,
+            'receivable_account_id': self.env.company.account_default_pos_receivable_account_id.id,
+            'outstanding_account_id': self.inbound_payment_method_line.payment_account_id.id,
+        })
+
+        self.main_pos_config.write({
+            'payment_method_ids': [Command.set([different_currency_pm.id, company_currency_pm.id])],
+        })
+        self.env['product.product'].create({
+            'name': 'Currency Switch Test Product',
+            'list_price': 100,
+            'taxes_id': False,
+            'available_in_pos': True,
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(
+            f"/pos/ui?config_id={self.main_pos_config.id}",
+            'PaymentScreenMixedCurrencies',
+            login="pos_user",
+        )
+
+        order = self.main_pos_config.current_session_id.order_ids[-1]
+
+        self.main_pos_config.current_session_id.close_session_from_ui()
+
+        self.assertEqual(order.payment_ids.payment_method_id, different_currency_pm)
+
+        payment_move_line = self.env['account.move.line'].search([
+            ('journal_id', '=', different_currency_journal.id),
+            ('account_id', '=', different_currency_pm.outstanding_account_id.id),
+        ])
+
+        self.assertEqual(len(payment_move_line), 1)
+        self.assertEqual(payment_move_line.currency_id, different_currency)
+        self.assertEqual(payment_move_line.amount_currency, 50)
+
     def test_barcode_search_attributes_preset(self):
         product = self.env['product.template'].create({
             'name': 'Product with Attributes',


### PR DESCRIPTION
In some countries it's common to accept multiple currencies when making sales, but we don't let users open POS configs if they assigned to the POS payment methods for journals which use different currencies.

This should let users create payment methods assigned to multiple currencies and then still open the POS.

If there are multiple currencies set up on the POS, the payment screen will show the corresponding currency for each payment method. The totals are still shown in the config currency, but when selecting a payment method in a different currency there will be the price in the new currency between brackets on the payment line.

Task-[5110998](https://www.odoo.com/odoo/project/1737/tasks/5110998)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
