### PR TITLE
[FIX] hr: Hide employee related fields for non-hr users

### DIFF
--- a/addons/hr/models/res_partner_bank.py
+++ b/addons/hr/models/res_partner_bank.py
@@ -27,7 +27,7 @@ class ResPartnerBank(models.Model):
                 bank.employee_salary_amount, bank.employee_salary_amount_is_percentage = bank.employee_id.get_bank_account_salary_allocation(bank.id)
                 continue
             bank.employee_salary_amount_is_percentage = True
-            if bank.employee_id.salary_distribution:
+            if bank.employee_id and bank.employee_id.salary_distribution:
                 bank.employee_salary_amount = bank.employee_id.get_remaining_percentage()
             else:
                 bank.employee_salary_amount = 0

--- a/addons/hr/views/res_partner_bank_views.xml
+++ b/addons/hr/views/res_partner_bank_views.xml
@@ -14,7 +14,7 @@
                     <span invisible="not employee_salary_amount_is_percentage">%</span>
                     <field name="currency_id" invisible="employee_salary_amount_is_percentage" readonly="True"/>
                 </div>
-                <field name="employee_id" invisible="not employee_id" widget="many2many_avatar_employee"/>
+                <field name="employee_id" invisible="not employee_id" widget="many2many_avatar_employee" groups="hr.group_hr_user"/>
             </xpath>
             <xpath expr="//page" position="before">
                 <page string="Bank Information" invisible="not bank_id">


### PR DESCRIPTION
The field `employee_id` on model `res.partner.bank` requires hr-related rights and is present in the form view for `res.partner.bank` regardless of the user rights. A user without HR manager rights will be greeted with the following error:

Failed to write field res.partner.bank.employee_id You are not allowed to access 'Employee' (hr.employee) records.

This operation is allowed for the following groups:
	- Employees/Officer: Manage all employees
	- Role / Administrator

Contact your administrator to request access if necessary.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
