### PR TITLE
[IMP] account: generic CoA should not overwrite country

### DIFF
--- a/addons/account/data/template/account.tax.group-generic_coa.csv
+++ b/addons/account/data/template/account.tax.group-generic_coa.csv
@@ -1,3 +1,3 @@
-id,name,country_id,tax_payable_account_id,tax_receivable_account_id
-tax_group_15,Tax 15%,base.us,tax_payable,tax_receivable
-tax_group_0,Tax 0%,base.us,tax_payable,tax_receivable
+id,name,tax_payable_account_id,tax_receivable_account_id
+tax_group_15,Tax 15%,tax_payable,tax_receivable
+tax_group_0,Tax 0%,tax_payable,tax_receivable

--- a/addons/account/models/template_generic_coa.py
+++ b/addons/account/models/template_generic_coa.py
@@ -30,10 +30,8 @@ class AccountChartTemplate(models.AbstractModel):
 
         :rtype: dict[(str, int), dict]
         """
-        return {
-            self.env.company.id: {
+        company_data = {
                 'anglo_saxon_accounting': True,
-                'account_fiscal_country_id': 'base.us',
                 'bank_account_code_prefix': '1014',
                 'cash_account_code_prefix': '1015',
                 'transfer_account_code_prefix': '1017',
@@ -50,7 +48,12 @@ class AccountChartTemplate(models.AbstractModel):
                 'account_stock_valuation_id': 'stock_valuation',
                 'account_production_wip_account_id': 'wip',
                 'account_production_wip_overhead_account_id': 'cost_of_production',
-            },
+            }
+        if not self.env.company.account_fiscal_country_id:
+            company_data.update({'account_fiscal_country_id': 'base.us'})
+
+        return {
+            self.env.company.id: company_data,
         }
 
     @template('generic_coa', 'account.account')

--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -621,6 +621,7 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
             {
                 'name': 'BE Spoiled Kid',
                 'country_id': self.env.ref('base.be').id,
+                'account_fiscal_country_id': self.env.ref('base.us').id,
                 'parent_id': self.env.company.id,
                 'peppol_eas': '0208',
                 'peppol_endpoint': '0477472701',
@@ -629,6 +630,7 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
             {
                 'name': 'BE Independent Kid',
                 'country_id': self.env.ref('base.be').id,
+                'account_fiscal_country_id': self.env.ref('base.us').id,
                 'parent_id': self.env.company.id,
                 'peppol_eas': '0208',
                 'peppol_endpoint': '0477471111',


### PR DESCRIPTION
Before, when installing the generic CoA for a company with a country that has no CoA defined in Odoo (heavily waiting for the Cuba CoA e.g.) the fiscal country of the company would be overwritten with the Cuba company.

This also made that the 2 standard taxes defined would not be visible anymore when you set the fiscal country and the currency back to e.g. Cuba and CUP.

With this change, we keep the original country and currency and that way, the user does not have to change it back and he will already have a default tax defined that he can easily change.

Because some guy decided that if you do not have a Chart of Accounts from Odoo, you can not create an invoice...

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
