### PR TITLE
[FIX] l10n_dk: add street number to demo data

### DIFF
--- a/addons/l10n_dk/demo/demo_company.xml
+++ b/addons/l10n_dk/demo/demo_company.xml
@@ -3,7 +3,7 @@
     <record id="base.partner_demo_company_dk" model="res.partner" forcecreate="1">
         <field name="name">DK Company</field>
         <field name="vat">DK58403288</field>
-        <field name="street">G</field>
+        <field name="street">G 1</field>
         <field name="city">Aalborg</field>
         <field name="country_id" ref="base.dk"/>
 


### PR DESCRIPTION
This commit adds the street number to the DK demo company,
because we need it for nemhandel.

no-task
