### PR TITLE
[FIX] l10n_hu_edi: Prevent tax audit export from setting invoice chain

### DIFF
--- a/addons/l10n_hu_edi/tests/test_invoice_xml.py
+++ b/addons/l10n_hu_edi/tests/test_invoice_xml.py
@@ -149,6 +149,9 @@ class L10nHuEdiTestInvoiceXml(L10nHuEdiTestCommon):
                     self.get_xml_tree_from_string(expected_xml_file.read()),
                 )
 
+            # Assert that the `l10n_hu_chain_index` is not silently set by the tax audit export
+            self.assertFalse(invoice.l10n_hu_invoice_chain_index, "The chain index shouldn't be set by the tax audit report")
+
     def test_invoice_simple_deduction(self):
         with freeze_time('2024-02-01'):
             invoice = self.create_invoice_simple_discount()

--- a/addons/l10n_hu_edi/wizard/l10n_hu_edi_tax_audit_export.py
+++ b/addons/l10n_hu_edi/wizard/l10n_hu_edi_tax_audit_export.py
@@ -94,7 +94,7 @@ class L10nHuEdiTaxAuditExport(models.TransientModel):
             with zipfile.ZipFile(buf, mode='w', compression=zipfile.ZIP_DEFLATED, allowZip64=False) as zf:
                 # To correctly generate the XML for invoices created before l10n_hu_edi was installed,
                 # we need to temporarily set the chain index and line numbers, so we do this in a savepoint.
-                with contextlib.closing(self.env.cr.savepoint(flush=False)):
+                with contextlib.closing(self.env.cr.savepoint()):
                     for invoice in invoices.sorted(lambda i: i.create_date):
                         if invoice.l10n_hu_edi_state:
                             # Case 1: An XML was already generated for this invoice.


### PR DESCRIPTION
At the moment, the Hungarian tax audit export wizard's `action_export` creates a savepoint with `flush=False`.

The intention of this savepoint is to roll back the changes to `l10n_hu_edi_invoice_chain` once the savepoint exits. But because the changes to `l10n_hu_edi_invoice_chain` stay in cache, and the cache is not flushed before the savepoint is created nor cleared afterwards, those changes end up being committed to DB. Which is precisely what the savepoint was there to prevent.

Solution: we use `flush=True` to make sure the cache is flushed before and cleared after the savepoint.

task-none