### PR TITLE
[FIX] mrp,purchase_stock,stock_dropshipping: protect wizard replenish regression

### DIFF
--- a/addons/mrp/tests/test_replenish.py
+++ b/addons/mrp/tests/test_replenish.py
@@ -384,3 +384,15 @@ class TestMrpReplenish(TestMrpCommon):
             'product_id': self.bom_2.product_id.id,
         })
         self.assertEqual(orderpoint.company_id, company_2)
+
+    def test_product_replenish_wizard_multiple_manufacture_routes(self):
+        self.route_manufacture.copy()
+        wizard_form = Form(self.env['product.replenish'].with_context(
+            default_product_tmpl_id=self.product_4.product_tmpl_id.id
+        ))
+        manufacture_route = self.env['stock.rule'].search([
+            ('action', '=', 'manufacture'),
+            ('company_id', '=', self.company.id),
+            ('location_dest_id.usage', '=', 'internal'),
+        ], limit=1).route_id
+        self.assertEqual(wizard_form.route_id, manufacture_route)

--- a/addons/mrp/wizard/product_replenish.py
+++ b/addons/mrp/wizard/product_replenish.py
@@ -46,7 +46,7 @@ class ProductReplenish(models.TransientModel):
     def _get_route_domain(self, product_tmpl_id):
         domain = super()._get_route_domain(product_tmpl_id)
         company = product_tmpl_id.company_id or self.env.company
-        manufacture_route = self.env['stock.rule'].search([('action', '=', 'manufacture'), ('company_id', '=', company.id)], limit=1).route_id
+        manufacture_route = self.env['stock.rule'].search([('action', '=', 'manufacture'), ('company_id', '=', company.id)]).route_id
         if manufacture_route and product_tmpl_id.bom_ids:
-            domain = Domain.OR([domain, Domain('id', '=', manufacture_route.id)])
+            domain = Domain.OR([domain, Domain('id', 'in', manufacture_route.ids)])
         return domain

--- a/addons/purchase_stock/tests/test_replenish_wizard.py
+++ b/addons/purchase_stock/tests/test_replenish_wizard.py
@@ -555,3 +555,21 @@ class TestReplenishWizard(PurchaseTestCommon):
         self.assertEqual(po.order_line.product_uom_id, replenish_wizard.product_uom_id, 'Generated PO line must respect the requested UOM from the wizard')
         self.assertEqual(po.order_line.price_unit, 5, 'Generated PO line must respect the supplier price of UoM "Pack of 6" because the quantity matches the "Pack of 6" pricelist')
         po.button_cancel()
+
+    def test_product_replenish_wizard_multiple_buy_routes(self):
+        self.route_buy.copy()
+        self.product.write({
+            'seller_ids': [Command.create({
+                'partner_id': self.vendor.id,
+            })]
+        })
+
+        replenish_wizard = Form(self.env['product.replenish'].with_context(
+            default_product_tmpl_id=self.product.product_tmpl_id.id
+        ))
+        buy_route = self.env['stock.rule'].search([
+            ('action', '=', 'buy'),
+            ('company_id', '=', self.company.id),
+            ('location_dest_id.usage', '=', 'internal'),
+        ], limit=1).route_id
+        self.assertEqual(replenish_wizard.route_id, buy_route)

--- a/addons/purchase_stock/wizard/product_replenish.py
+++ b/addons/purchase_stock/wizard/product_replenish.py
@@ -91,7 +91,11 @@ class ProductReplenish(models.TransientModel):
     def _get_route_domain(self, product_tmpl_id):
         domain = super()._get_route_domain(product_tmpl_id)
         company = product_tmpl_id.company_id or self.env.company
-        buy_route = self.env['stock.rule'].search([('action', '=', 'buy'), ('company_id', '=', company.id)], limit=1).route_id
+        buy_route = self.env['stock.rule'].search([
+            ('action', '=', 'buy'),
+            ('company_id', '=', company.id),
+            ('picking_type_id.code', '=', 'incoming'),
+        ]).route_id
         if buy_route and product_tmpl_id.seller_ids:
-            domain = Domain.OR([domain, Domain('id', '=', buy_route.id)])
+            domain = Domain.OR([domain, Domain('id', 'in', buy_route.ids)])
         return domain

--- a/addons/stock_dropshipping/tests/test_dropship.py
+++ b/addons/stock_dropshipping/tests/test_dropship.py
@@ -558,3 +558,20 @@ class TestDropshipPostInstall(common.TransactionCase):
         purchase_order.button_confirm()
         sale_order._action_cancel()
         self.assertEqual(len(purchase_order.activity_ids), 1)
+
+    def test_product_replenish_wizard_excludes_dropship_routes(self):
+        '''
+        Ensure the dropship route is not included in the replenish wizard.
+        '''
+        buy_route = self.env['stock.rule'].search([
+            ('action', '=', 'buy'),
+            ('company_id', '=', self.env.company.id),
+            ('location_dest_id.usage', '=', 'internal'),
+        ], limit=1).route_id
+        # Ensure no buy route so the widget tries to default to dropship
+        buy_route.action_archive()
+        self.dropship_product.route_ids = False
+        replenish_wizard = Form(self.env['product.replenish'].with_context(
+            default_product_tmpl_id=self.dropship_product.product_tmpl_id.id
+        ))
+        self.assertNotEqual(replenish_wizard.route_id, self.env.ref('stock_dropshipping.route_drop_shipping'))


### PR DESCRIPTION
Fix 705e27a caused a `Singleton Error`, which was then addressed in cd66456.

This commit improves the follow up fix and adds a test.