### PR TITLE
[FIX] core: ensure non zero size for pdf attachment

### DIFF
--- a/odoo/tools/pdf/__init__.py
+++ b/odoo/tools/pdf/__init__.py
@@ -569,7 +569,7 @@ class OdooPdfFileWriter(PdfFileWriter):
                 DictionaryObject({
                     NameObject('/CheckSum'): createStringObject(md5(attachment['content']).hexdigest()),
                     NameObject('/ModDate'): createStringObject(datetime.now().strftime(DEFAULT_PDF_DATETIME_FORMAT)),
-                    NameObject('/Size'): NameObject(f"/{len(attachment['content'])}"),
+                    NameObject('/Size'): NumberObject(len(attachment['content'])),
                 }),
         })
         if attachment.get('subtype'):


### PR DESCRIPTION
Currently, the size parameter of the embedded file is defined as a NameObject. This is leading some readers to not interpreting it as an Integer value and results in a zero size for the attachment.

A fix was implemented in versions 18 and above (https://github.com/odoo/odoo/pull/248769), this is a backport of it.

opw-5928269

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
