### PR TITLE
[FIX] web: remove `user-select-none` from bootstrap_overridden.scss

### DIFF
--- a/addons/web/static/src/scss/bootstrap_overridden.scss
+++ b/addons/web/static/src/scss/bootstrap_overridden.scss
@@ -320,7 +320,3 @@ $input-placeholder-color: mix($gray-400, $gray-500) !default;
 $card-bg: $o-view-background-color !default;
 $card-spacer-y: $spacer !default; // BS Default
 $card-cap-padding-y: $card-spacer-y !default;
-
-.user-select-none {
-    -webkit-user-select: none !important; // not included in BS by default
-}


### PR DESCRIPTION
Before this commit, a `.user-select-none` CSS rule was present in a file intended to only contain variable definitions. Plus, Bootstrap already provides this utility class natively, making the declaration entirely redundant.

This commit removes the said rule from bootstrap_overridden.scss

task-5952407

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
