### PR TITLE
[FIX] payment_stripe: "charge.refunded" webhook event.type sends a si…

### DIFF
--- a/addons/payment_stripe/controllers/main.py
+++ b/addons/payment_stripe/controllers/main.py
@@ -106,31 +106,11 @@ class StripeController(http.Controller):
                     stripe_object['payment_method'] = payment_method
                     self._include_setup_intent_in_payment_data(stripe_object, data)
                 elif event['type'] == 'charge.refunded':  # Refund operation (refund creation).
-                    refunds = stripe_object['refunds']['data']
-
-                    # The refunds linked to this charge are paginated, fetch the remaining refunds.
-                    has_more = stripe_object['refunds']['has_more']
-                    while has_more:
-                        payload = {
-                            'charge': stripe_object['id'],
-                            'starting_after': refunds[-1]['id'],
-                            'limit': 100,
-                        }
-                        additional_refunds = tx_sudo._send_api_request(
-                            'GET', 'refunds', data=payload
-                        )
-                        refunds += additional_refunds['data']
-                        has_more = additional_refunds['has_more']
-
-                    # Process the refunds for which a refund transaction has not been created yet.
-                    processed_refund_ids = tx_sudo.child_transaction_ids.filtered(
-                        lambda tx: tx.operation == 'refund'
-                    ).mapped('provider_reference')
-                    for refund in filter(lambda r: r['id'] not in processed_refund_ids, refunds):
-                        refund_tx_sudo = self._create_refund_tx_from_refund(tx_sudo, refund)
-                        self._include_refund_in_payment_data(refund, data)
-                        refund_tx_sudo._process('stripe', data)
-                    # Don't process the payment data for the source transaction.
+                    #stripe doesnt batch, they will send individual requests per refund
+                    refund = stripe_object
+                    refund_tx_sudo = self._create_refund_tx_from_refund(tx_sudo, refund)
+                    self._include_refund_in_payment_data(refund, data)
+                    refund_tx_sudo._process('stripe', data)
                     return request.make_json_response('')
                 elif event['type'] == 'charge.refund.updated':  # Refund operation (with update).
                     # A refund was updated by Stripe after it was already processed (possibly to


### PR DESCRIPTION
…ngle refund per transaction call. Our integration assumes batch refunds and stripe does not do that with the current version.

Issue: Customer trys to make a refund in stripe( single or multi selected in the transactions list view) and it returns a 500 internal error, due to the stripe object not having a keyword "refunds". The stripe object with the 'charge.refunded' event type is the refund.

Fix: Removed the batching of the refunds and made the refund the stripe object.

opw-5977783

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
