### PR TITLE
[FIX] mail, documents: prevent ACL crash on portal document views

### DIFF
--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.js
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.js
@@ -8,6 +8,7 @@ import { useDynamicInterval } from "@mail/utils/common/misc";
 import { formatLocalDateTime } from "@mail/utils/common/dates";
 import { useChannelMemberActions } from "@mail/discuss/core/common/channel_member_actions";
 import { ActionList } from "@mail/core/common/action_list";
+import { user } from "@web/core/user";
 
 export class AvatarCardPopover extends Component {
     static template = "mail.AvatarCardPopover";
@@ -91,7 +92,7 @@ export class AvatarCardPopover extends Component {
     }
 
     get showViewProfileBtn() {
-        return this.partner;
+        return this.partner && user.isInternalUser;
     }
 
     get hasFooter() {

--- a/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/kanban_many2one_avatar_user_field.js
+++ b/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/kanban_many2one_avatar_user_field.js
@@ -9,6 +9,7 @@ import {
     Many2OneField,
 } from "@web/views/fields/many2one/many2one_field";
 import { Avatar } from "../avatar/avatar";
+import { user } from "@web/core/user";
 
 export class KanbanMany2OneAvatarUserField extends Component {
     static template = "mail.KanbanMany2OneAvatarUserField";
@@ -31,7 +32,7 @@ export class KanbanMany2OneAvatarUserField extends Component {
     }
 
     get uniqueId() {
-        return this.value ? this.value.write_date.toMillis() : undefined;
+        return this.value?.write_date ? this.value.write_date.toMillis() : undefined;
     }
 }
 
@@ -39,7 +40,7 @@ export class KanbanMany2OneAvatarUserField extends Component {
 const fieldDescr = {
     ...buildM2OFieldDescription(KanbanMany2OneAvatarUserField),
     additionalClasses: ["o_field_many2one_avatar_kanban", "o_field_many2one_avatar"],
-    relatedFields: [{ name: "write_date", type: "datetime" }],
+    relatedFields: user.isInternalUser ? [{ name: "write_date", type: "datetime" }] : [],
     extractProps(staticInfo, dynamicInfo) {
         return {
             ...extractM2OFieldProps(staticInfo, dynamicInfo),


### PR DESCRIPTION
Steps to reproduce:
1. Create a fully restricted folder in Documents.
2. Share it with a portal user as an editor.
3. Insert a file into the folder.
4. Log in as the portal user and access the Documents portal.
5. The view crashes and the file is not visible.

Cause:
Recent changes added `write_date` to the `many2one_avatar_user` widget
for image cache-busting. When portal views load, the frontend requests
this field for the document's `owner_id`. Since portal users lack read
access to `res.users`, this triggers an Access Error and crashes the
view. Furthermore, clicking the avatar opens a popover with a "View
Profile" button that also crashes for portal users, as they cannot
access backend form views.

Solution:
1. Register a new `many2one_avatar_user_no_unique_cache` widget that
inherits the standard avatar but drops the `write_date` requirement.
2. Apply this widget to the `owner_id` field in Documents portal
views to prevent the ACL error while keeping the avatar visible.
3. Update the avatar card popover to only show the "View Profile"
button if the current user is internal (`user.isInternalUser`).

Task-5977195