### PR TITLE
[FIX] mail: proper spacing in message actions dropdown

### DIFF
--- a/addons/mail/static/src/core/common/action_list.xml
+++ b/addons/mail/static/src/core/common/action_list.xml
@@ -89,7 +89,7 @@
         'o-p-1_5':       props.inline   and  !env.inMeetingView and hasBtnBg and isInlineCircleButton and !env.inChatWindow,
         'o-px-0_5':      props.inline   and  !env.inMeetingView and !hasBtnBg and !action.icon,
         'p-1':           props.inline   and  hasBtnBg and isInlineCircleButton and env.inChatWindow,
-        'o-p-0_5':       props.inline   and  (!env.inMeetingView and !hasBtnBg and !env.inComposer) or env.inMessage,
+        'o-p-0_5':       props.inline   and  ((!env.inMeetingView and !hasBtnBg and !env.inComposer) or env.inMessage),
         'px-3 py-2':     props.dropdown and   ui.isSmall,
         'px-2 py-1':     props.dropdown and  !ui.isSmall,
     })"/>


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/249880

PR above made a fix where inline message actions were taking way too much space in meeting chat, making chat bubble too small. This fixed the issue by setting the padding of inline message actions, but due to a typo it also set the same padding in dropdown menu.

This commit fixes the issue by properly limiting the fix of PR above to inline message actions.

Before / After
<img width="342" height="228" alt="Screenshot 2026-02-26 at 18 46 45" src="https://github.com/user-attachments/assets/1e6b4f13-24c0-43d7-8837-046bc04cd85b" /> <img width="353" height="255" alt="Screenshot 2026-02-26 at 18 46 30" src="https://github.com/user-attachments/assets/59e912b7-fe1f-4aa1-89ce-ef2c6dd88743" />
