### PR TITLE
[FIX] hr_holidays: fix double penalty on backdated accrual leaves

### DIFF
--- a/addons/hr_holidays/models/hr_employee_base.py
+++ b/addons/hr_holidays/models/hr_employee_base.py
@@ -103,6 +103,11 @@ class HrEmployeeBase(models.AbstractModel):
 
         if not target_date:
             target_date = fields.Date.today()
+        elif isinstance(target_date, datetime):
+            target_date = target_date.date()
+        elif isinstance(target_date, str):
+            target_date = fields.Date.to_date(target_date)
+        today = fields.Date.today()
         if ignore_future:
             leaves_domain.append(('date_from', '<=', target_date))
         leaves = self.env['hr.leave'].search(leaves_domain)
@@ -118,6 +123,95 @@ class HrEmployeeBase(models.AbstractModel):
         allocations_per_employee_type = defaultdict(lambda: defaultdict(lambda: self.env['hr.leave.allocation']))
         for allocation in allocations:
             allocations_per_employee_type[allocation.employee_id][allocation.holiday_status_id] |= allocation
+
+        lost_surplus_buckets = {}
+        if not self.env.context.get('ignore_lost_surplus'):
+            for allocation in allocations:
+                if allocation.allocation_type != 'accrual' or not allocation.accrual_plan_id:
+                    continue
+                buckets = allocation._get_lost_surplus_buckets(target_date)
+                if not buckets:
+                    continue
+                request_unit = allocation.holiday_status_id.request_unit
+                unit_multiplier = 1
+                if request_unit == 'hour':
+                    unit_multiplier = allocation.employee_id._get_hours_per_day(allocation.date_from)
+                converted = []
+                for bucket in buckets:
+                    remaining = bucket['amount'] * unit_multiplier
+                    if remaining:
+                        converted.append({
+                            'start': bucket['start'],
+                            'end': bucket['end'],
+                            'remaining': remaining,
+                        })
+                if converted:
+                    lost_surplus_buckets[allocation] = converted
+
+        def _get_interval_duration(employee, start, end, unit):
+            if end <= start:
+                return 0
+            duration_info = employee._get_calendar_attendances(start.replace(tzinfo=pytz.UTC), end.replace(tzinfo=pytz.UTC))
+            return duration_info['hours'] if unit == 'hours' else duration_info['days']
+
+        def _get_lost_surplus_capacity(employee, interval_start, interval_end, unit, buckets):
+            capacity = 0
+            for bucket in buckets:
+                if bucket['remaining'] <= 0:
+                    continue
+                bucket_start = datetime.combine(bucket['start'], time.min)
+                bucket_end = datetime.combine(bucket['end'], time.min)
+                overlap_start = max(interval_start, bucket_start)
+                overlap_end = min(interval_end, bucket_end)
+                if overlap_end <= overlap_start:
+                    continue
+                overlap_duration = _get_interval_duration(employee, overlap_start, overlap_end, unit)
+                if overlap_duration <= 0:
+                    continue
+                capacity += min(overlap_duration, bucket['remaining'])
+            return capacity
+
+        def _consume_lost_surplus(employee, interval_start, interval_end, allocated_time, unit, buckets):
+            if allocated_time <= 0:
+                return 0
+            remaining_to_absorb = allocated_time
+            absorbed = 0
+            for bucket in buckets:
+                if remaining_to_absorb <= 0:
+                    break
+                if bucket['remaining'] <= 0:
+                    continue
+                bucket_start = datetime.combine(bucket['start'], time.min)
+                bucket_end = datetime.combine(bucket['end'], time.min)
+                overlap_start = max(interval_start, bucket_start)
+                overlap_end = min(interval_end, bucket_end)
+                if overlap_end <= overlap_start:
+                    continue
+                overlap_duration = _get_interval_duration(employee, overlap_start, overlap_end, unit)
+                if overlap_duration <= 0:
+                    continue
+                absorb_here = min(overlap_duration, bucket['remaining'], remaining_to_absorb)
+                bucket['remaining'] -= absorb_here
+                absorbed += absorb_here
+                remaining_to_absorb -= absorb_here
+            return absorbed
+
+        def _get_applicable_lost_surplus_buckets(leave, buckets, target_date):
+            if not buckets or not leave.create_date or not target_date:
+                return []
+            create_date = leave.create_date.date()
+            leave_start = leave.date_from.date()
+            applicable = []
+            for bucket in buckets:
+                carryover_date = bucket['end']
+                if target_date < carryover_date:
+                    continue
+                if leave_start >= carryover_date:
+                    continue
+                if create_date < carryover_date:
+                    continue
+                applicable.append(bucket)
+            return applicable
 
         # _get_consumed_leaves returns a tuple of two dictionnaries.
         # 1) The first is a dictionary to map the number of days/hours of leaves taken per allocation
@@ -178,10 +272,25 @@ class HrEmployeeBase(models.AbstractModel):
             future_leaves = 0
             if allocation.allocation_type == 'accrual' and not precomputed:
                 future_leaves = allocation._get_future_leaves_on(target_date)
-            max_leaves = allocation.number_of_hours_display\
-                if allocation.holiday_status_id.request_unit in ['hour']\
-                else allocation.number_of_days_display
-            max_leaves += future_leaves
+            use_simulation = False
+            if allocation.allocation_type == 'accrual' and allocation.accrual_plan_id and target_date and target_date < today:
+                carryover_date = allocation._get_carryover_date(target_date + relativedelta(days=1))
+                if carryover_date and carryover_date <= today:
+                    level, _level_idx = allocation._get_current_accrual_plan_level_id(carryover_date)
+                    if level and level.action_with_unused_accruals in ['lost', 'maximum']:
+                        use_simulation = True
+            if use_simulation:
+                simulated_days = allocation._get_simulated_number_of_days(target_date)
+                if allocation.holiday_status_id.request_unit in ['hour']:
+                    max_leaves = simulated_days * allocation.employee_id._get_hours_per_day(allocation.date_from)
+                else:
+                    max_leaves = simulated_days
+                future_leaves = 0
+            else:
+                max_leaves = allocation.number_of_hours_display\
+                    if allocation.holiday_status_id.request_unit in ['hour']\
+                    else allocation.number_of_days_display
+                max_leaves += future_leaves
             allocation_data.update({
                 'max_leaves': max_leaves,
                 'accrual_bonus': future_leaves,
@@ -243,6 +352,12 @@ class HrEmployeeBase(models.AbstractModel):
                             if leave.date_from != interval_start or leave.date_to != interval_end:
                                 duration_info = employee._get_calendar_attendances(interval_start.replace(tzinfo=pytz.UTC), interval_end.replace(tzinfo=pytz.UTC))
                                 duration = duration_info['hours' if leave_unit == 'hours' else 'days']
+                            buffer_capacity = 0
+                            buckets = lost_surplus_buckets.get(allocation)
+                            if buckets:
+                                buckets = _get_applicable_lost_surplus_buckets(leave, buckets, target_date)
+                            if buckets:
+                                buffer_capacity = _get_lost_surplus_capacity(employee, interval_start, interval_end, leave_unit, buckets)
                             max_allowed_duration = min(
                                 duration,
                                 leave_type_data[allocation]['virtual_remaining_leaves']
@@ -257,6 +372,13 @@ class HrEmployeeBase(models.AbstractModel):
                             if leave.state == 'validate':
                                 leave_type_data[allocation]['leaves_taken'] += allocated_time
                                 leave_type_data[allocation]['remaining_leaves'] -= allocated_time
+
+                            if buckets:
+                                absorbed = _consume_lost_surplus(employee, interval_start, interval_end, allocated_time, leave_unit, buckets)
+                                if absorbed:
+                                    leave_type_data[allocation]['virtual_remaining_leaves'] += absorbed
+                                    if leave.state == 'validate':
+                                        leave_type_data[allocation]['remaining_leaves'] += absorbed
 
                             leave_duration -= allocated_time
                             if not leave_duration:

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -413,7 +413,10 @@ class HolidaysAllocation(models.Model):
             if context_precomputed := self.env.context.get('precomputed_allocations'):
                 precomputed_allocations |= context_precomputed
             # By setting `precomputed_allocations`, avoid infinite loop (otherwise _get_consumed_leaves -> _get_future_leaves_on -> _process_accrual_plans -> ...)
-            employee_days_per_allocation = allocation.employee_id.with_context(precomputed_allocations=precomputed_allocations)._get_consumed_leaves(
+            employee_days_per_allocation = allocation.employee_id.with_context(
+                precomputed_allocations=precomputed_allocations,
+                ignore_lost_surplus=True,
+            )._get_consumed_leaves(
                 allocation.holiday_status_id, allocation.nextcall, ignore_future=True)[0]
             origin = allocation._origin
             leaves_taken = employee_days_per_allocation[origin.employee_id][origin.holiday_status_id][origin]['leaves_taken']
@@ -523,7 +526,7 @@ class HolidaysAllocation(models.Model):
                 # if it's the carry-over date, adjust days using current level's carry-over policy
                 if allocation.nextcall == carryover_date:
                     allocation.last_executed_carryover_date = carryover_date
-                    if current_level.action_with_unused_accruals in ['lost', 'maximum']:
+                    if not self.env.context.get('ignore_carryover_policy') and current_level.action_with_unused_accruals in ['lost', 'maximum']:
                         allocated_days_left = allocation.number_of_days - leaves_taken
                         allocation_max_days = 0 # default if unused_accrual are lost
                         if current_level.action_with_unused_accruals == 'maximum':
@@ -550,7 +553,7 @@ class HolidaysAllocation(models.Model):
                 #   occurred on 01/09/2023 for example, then the carryover should be applied to any day accrued between 01/01/2023 and 01/09/2023.
                 # 3. The following if block will handle the carryover for days accrued after carryover_date until carryover_period_end. Carryover period end is
                 #    adjusted if a level transition occurred. The carryover for days accrued before carryover_date is handled above.
-                if allocation.accrual_plan_id.accrued_gain_time == 'start' and allocation.last_executed_carryover_date:
+                if not self.env.context.get('ignore_carryover_policy') and allocation.accrual_plan_id.accrued_gain_time == 'start' and allocation.last_executed_carryover_date:
                     last_carryover_date = allocation.last_executed_carryover_date
                     carryover_level, carryover_level_idx = allocation._get_current_accrual_plan_level_id(last_carryover_date)
                     carryover_period_end = carryover_level._get_next_date(last_carryover_date)
@@ -646,6 +649,82 @@ class HolidaysAllocation(models.Model):
             res = round((fake_allocation.number_of_days - self.number_of_days), 2)
         fake_allocation.invalidate_recordset()
         return res
+
+    def _get_accrual_simulation_allocation(self):
+        self.ensure_one()
+        fake_allocation = self.env['hr.leave.allocation'].new(origin=self)
+        fake_allocation.lastcall = self.date_from
+        fake_allocation.actual_lastcall = self.date_from
+        fake_allocation.nextcall = False
+        fake_allocation.number_of_days = 0.0
+        fake_allocation.already_accrued = False
+        fake_allocation.carried_over_days_expiration_date = False
+        fake_allocation.expiring_carryover_days = 0
+        fake_allocation.last_executed_carryover_date = False
+        fake_allocation.yearly_accrued_amount = 0.0
+        return fake_allocation
+
+    def _get_simulated_number_of_days(self, date_to, ignore_carryover_policy=False):
+        self.ensure_one()
+        if not date_to:
+            return self.number_of_days
+        fake_allocation = self._get_accrual_simulation_allocation()
+        ctx = dict(self.env.context, ignore_lost_surplus=True)
+        if ignore_carryover_policy:
+            ctx['ignore_carryover_policy'] = True
+        fake_allocation = fake_allocation.with_context(ctx).sudo()
+        fake_allocation._process_accrual_plans(date_to, log=False)
+        number_of_days = fake_allocation.number_of_days
+        fake_allocation.invalidate_recordset()
+        return number_of_days
+
+    def _get_lost_surplus_buckets(self, target_date):
+        self.ensure_one()
+        if not target_date or self.allocation_type != 'accrual' or not self.accrual_plan_id:
+            return []
+        if isinstance(target_date, datetime):
+            target_date = target_date.date()
+        elif isinstance(target_date, str):
+            target_date = fields.Date.to_date(target_date)
+        end_date = target_date
+        if self.date_to and self.date_to < end_date:
+            end_date = self.date_to
+        if end_date < self.date_from:
+            return []
+
+        buckets = []
+        previous_carryover_date = self.date_from
+        cursor = self.date_from
+        while True:
+            carryover_date = self._get_carryover_date(cursor)
+            if carryover_date > end_date:
+                break
+            level, _level_idx = self._get_current_accrual_plan_level_id(carryover_date)
+            if level and level.action_with_unused_accruals in ['lost', 'maximum']:
+                reference_date = carryover_date
+                if self.accrual_plan_id.accrued_gain_time == 'start':
+                    reference_date = carryover_date + relativedelta(days=-1)
+                if reference_date < self.date_from:
+                    previous_carryover_date = carryover_date
+                    cursor = carryover_date + relativedelta(days=1)
+                    continue
+                remaining_before_carryover = self._get_simulated_number_of_days(reference_date, ignore_carryover_policy=True)
+                cap_days = 0
+                if level.action_with_unused_accruals == 'maximum':
+                    if level.added_value_type == 'day':
+                        cap_days = level.postpone_max_days
+                    else:
+                        cap_days = level.postpone_max_days / self.employee_id._get_hours_per_day(self.date_from)
+                lost_days = max(0, remaining_before_carryover - cap_days)
+                if lost_days:
+                    buckets.append({
+                        'start': previous_carryover_date,
+                        'end': carryover_date,
+                        'amount': lost_days,
+                    })
+            previous_carryover_date = carryover_date
+            cursor = carryover_date + relativedelta(days=1)
+        return buckets
 
     ####################################################
     # ORM Overrides methods

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -4483,3 +4483,58 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             allocation.action_refuse()
             self.env['hr.leave']._cancel_invalid_leaves()
             self.assertEqual(leave.state, 'cancel')
+
+    def test_backdated_leave_absorbed_by_surplus_buffer(self):
+        """
+        Scenario A: Backdated leave absorbed by lost surplus buffer.
+        Testing Goal: Verify that a leave taken in a previous period does NOT reduce
+        the current balance if the employee had 'lost surplus' days to cover it.
+
+        1. Setup: End of 2025, employee has 21 days. Carry-over cap is 5 days.
+        2. Refresh: Jan 1st, 2026, 16 days are 'lost' (21 - 5).
+           The new balance is 26 (5 carry-over + 21 new grant).
+        3. Action: User records a leave for Dec 31, 2025, AFTER the refresh.
+        4. Logic: Balance on Dec 31 was 21. 21 - 1 = 20. 20 is still > 5 (Cap).
+           The carry-over amount should remain 5.
+        5. Result: The 2026 balance remains 26.0. The leave was absorbed by the surplus.
+        """
+        accrual_plan = self.accrual_plan_yearly_max_postponed_days_start
+
+        with freeze_time('2025-01-01'):
+            allocation = self._create_form_test_accrual_allocation(self.leave_type, '2025-01-01', self.employee_emp, accrual_plan)
+            allocation.action_validate()
+            self.assert_virtual_leaves_equal(self.leave_type, 21, self.employee_emp)
+
+        with freeze_time('2026-01-01'):
+            allocation._update_accrual()
+            self.assert_virtual_leaves_equal(self.leave_type, 26, self.employee_emp)
+            self._take_leave(self.employee_emp, self.leave_type, '2025-12-31', '2025-12-31').action_validate()
+            self.assert_virtual_leaves_equal(self.leave_type, 26, self.employee_emp)
+
+    def test_backdated_leave_deducted_when_under_cap(self):
+        """
+        Scenario B: Backdated leave deducted when under the carry-over cap.
+        Testing Goal: Verify that a leave taken in a previous period DOES reduce
+        the current balance if the employee was already at or below their carry-over limit.
+
+        1. Setup: End of 2025, employee has 3 days. Carry-over cap is 5 days.
+        2. Refresh: Jan 1st, 2026, 0 days are lost because 3 < 5.
+           The new balance is 24 (3 carry-over + 21 new grant).
+        3. Action: User records a leave for Dec 31, 2025, AFTER the refresh.
+        4. Logic: Balance on Dec 31 was 3. 3 - 1 = 2. 2 is the new carry-over amount.
+        5. Result: The 2026 balance drops to 23.0 (2 carry-over + 21 new).
+           The leave is correctly deducted from the real savings.
+        """
+        accrual_plan = self.accrual_plan_yearly_max_postponed_days_start
+
+        with freeze_time('2025-01-01'):
+            allocation = self._create_form_test_accrual_allocation(self.leave_type, '2025-01-01', self.employee_emp, accrual_plan)
+            allocation.action_validate()
+            self.assert_virtual_leaves_equal(self.leave_type, 21, self.employee_emp)
+
+        with freeze_time('2026-01-01'):
+            allocation._update_accrual()
+            self._take_leave(self.employee_emp, self.leave_type, '2025-06-02', '2025-06-26').action_validate()
+            self.assert_virtual_leaves_equal(self.leave_type, 23, self.employee_emp)
+            self._take_leave(self.employee_emp, self.leave_type, '2025-12-31', '2025-12-31').action_validate()
+            self.assert_virtual_leaves_equal(self.leave_type, 22, self.employee_emp)


### PR DESCRIPTION
Backdated leaves recorded after an accrual carryover reset should be absorbed by the lost surplus buffer instead of deducting from the new period's balance.

opw-5870858