### PR TITLE
[IMP] project: make project name clickable in kanban view

### DIFF
--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -491,7 +491,9 @@
                             <main class="o_project_kanban_main">
                                 <div class="d-flex align-items-baseline gap-1">
                                     <field name="is_favorite" widget="project_is_favorite" nolabel="1"/>
-                                    <span class="text-truncate d-block fs-4 fw-bold" t-att-title="record.display_name.value"><field name="display_name"/></span>
+                                    <a type="open" class="text-truncate d-block fs-4 fw-bold text-primary" t-att-title="record.display_name.value">
+                                        <field name="display_name"/>
+                                    </a>
                                 </div>
                                 <div class="o_project_kanban_body min-w-0 pb-4 me-2">
                                     <span name="partner_name" class="text-muted d-flex align-items-baseline" t-if="record.partner_id.value">


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

In the project kanban view, clicking anywhere on the card opens the task list (`action_view_tasks`). There is currently no direct way to open the project form view from the kanban card.

This PR makes the project name clickable (type="open"), allowing users to open the project form directly, while keeping the existing card-level behavior unchanged.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
