### PR TITLE
[FIX] html_editor: use static file box instead of embedded

### DIFF
--- a/addons/html_editor/static/src/plugin_sets.js
+++ b/addons/html_editor/static/src/plugin_sets.js
@@ -69,7 +69,6 @@ import { ToggleBlockPlugin } from "@html_editor/others/embedded_components/plugi
 import { EmbeddedVideoPlugin } from "@html_editor/others/embedded_components/plugins/video_plugin/embedded_video_plugin";
 import { EmbeddedYoutubePlugin } from "./others/embedded_components/plugins/video_plugin/embedded_youtube_plugin";
 import { CaptionPlugin } from "@html_editor/others/embedded_components/plugins/caption_plugin/caption_plugin";
-import { EmbeddedFilePlugin } from "@html_editor/others/embedded_components/plugins/embedded_file_plugin/embedded_file_plugin";
 import { SyntaxHighlightingPlugin } from "@html_editor/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin";
 import { QWebPlugin } from "./others/qweb_plugin";
 import { EditorVersionPlugin } from "./core/editor_version_plugin";
@@ -145,6 +144,7 @@ export const MAIN_PLUGINS = [
     TextDirectionPlugin,
     InlineCodePlugin,
     TableResizePlugin,
+    FilePlugin,
     PlaceholderPlugin,
     SelectionPlaceholderPlugin,
 ];
@@ -163,11 +163,10 @@ export const EMBEDDED_COMPONENT_PLUGINS = [
     EmbeddedVideoPlugin,
     EmbeddedYoutubePlugin,
     CaptionPlugin,
-    EmbeddedFilePlugin,
     SyntaxHighlightingPlugin,
 ];
 
-export const NO_EMBEDDED_COMPONENTS_FALLBACK_PLUGINS = [FilePlugin, VideoPlugin, YoutubePlugin];
+export const NO_EMBEDDED_COMPONENTS_FALLBACK_PLUGINS = [VideoPlugin, YoutubePlugin];
 
 export const EXTRA_PLUGINS = [
     ...COLLABORATION_PLUGINS,

--- a/addons/html_editor/static/tests/file.test.js
+++ b/addons/html_editor/static/tests/file.test.js
@@ -1,9 +1,5 @@
 import { MAIN_EMBEDDINGS } from "@html_editor/others/embedded_components/embedding_sets";
-import {
-    EMBEDDED_COMPONENT_PLUGINS,
-    MAIN_PLUGINS,
-    NO_EMBEDDED_COMPONENTS_FALLBACK_PLUGINS,
-} from "@html_editor/plugin_sets";
+import { EMBEDDED_COMPONENT_PLUGINS, MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { isZwnbsp } from "@html_editor/utils/dom_info";
 import { describe, expect, test } from "@odoo/hoot";
 import { animationFrame, click, press, queryAll, queryOne, waitFor } from "@odoo/hoot-dom";
@@ -14,14 +10,15 @@ import { insertText } from "./_helpers/user_actions";
 import { execCommand } from "./_helpers/userCommands";
 import { expandToolbar } from "./_helpers/toolbar";
 import { nodeSize } from "@html_editor/utils/position";
+import { EmbeddedFilePlugin } from "@html_editor/others/embedded_components/plugins/embedded_file_plugin/embedded_file_plugin";
 
 const configWithEmbeddedFile = {
-    Plugins: [...MAIN_PLUGINS, ...EMBEDDED_COMPONENT_PLUGINS],
+    Plugins: [
+        ...MAIN_PLUGINS.filter((P) => P.id !== "file"),
+        EmbeddedFilePlugin,
+        ...EMBEDDED_COMPONENT_PLUGINS,
+    ],
     resources: { embedded_components: MAIN_EMBEDDINGS },
-};
-
-const configWithoutEmbeddedFile = {
-    Plugins: [...MAIN_PLUGINS, ...NO_EMBEDDED_COMPONENTS_FALLBACK_PLUGINS],
 };
 
 const patchUpload = (editor) => {
@@ -38,9 +35,7 @@ const patchUpload = (editor) => {
 
 describe("file command", () => {
     test("/file uploads a file via the system's selector, skipping the media dialog", async () => {
-        const { editor } = await setupEditor("<p>[]<br></p>", {
-            config: configWithoutEmbeddedFile,
-        });
+        const { editor } = await setupEditor("<p>[]<br></p>");
         const mockedUpload = patchUpload(editor);
         // Open powerbox.
         await insertText(editor, "/file");
@@ -56,9 +51,7 @@ describe("file command", () => {
     });
 
     test("file card should have inline display, BS alert-info style and no download button", async () => {
-        const { editor } = await setupEditor("<p>[]<br></p>", {
-            config: configWithoutEmbeddedFile,
-        });
+        const { editor } = await setupEditor("<p>[]<br></p>");
         patchUpload(editor);
         execCommand(editor, "uploadFile");
         // wait for the embedded component to be mounted
@@ -74,9 +67,7 @@ describe("file command", () => {
     describe("static file box interactions", () => {
         test.tags("desktop");
         test("should toggle file name editability independently on click", async () => {
-            const { el, editor } = await setupEditor("<p>[]<br></p>", {
-                config: configWithoutEmbeddedFile,
-            });
+            const { el, editor } = await setupEditor("<p>[]<br></p>");
             patchUpload(editor);
 
             // Upload two files.
@@ -143,9 +134,7 @@ describe("file command", () => {
 
         test.tags("desktop");
         test("ArrowUp and ArrowDown move the caret to the start and end of a file name", async () => {
-            const { editor } = await setupEditor("<p>[]<br></p>", {
-                config: configWithoutEmbeddedFile,
-            });
+            const { editor } = await setupEditor("<p>[]<br></p>");
             patchUpload(editor);
 
             // Upload a file and wait until the file name is rendered.
@@ -179,9 +168,7 @@ describe("file command", () => {
 
         test.tags("desktop");
         test("ArrowLeft at start and ArrowRight at end do nothing in a file name", async () => {
-            const { editor } = await setupEditor("<p>[]<br></p>", {
-                config: configWithoutEmbeddedFile,
-            });
+            const { editor } = await setupEditor("<p>[]<br></p>");
             patchUpload(editor);
 
             // Upload a file and wait until the file name is rendered.
@@ -215,9 +202,7 @@ describe("file command", () => {
 
         test.tags("desktop");
         test("Enter and Shift+Enter do nothing in a file name", async () => {
-            const { editor } = await setupEditor("<p>[]<br></p>", {
-                config: configWithoutEmbeddedFile,
-            });
+            const { editor } = await setupEditor("<p>[]<br></p>");
             patchUpload(editor);
 
             // Upload a file and wait until the file name is rendered.
@@ -287,7 +272,7 @@ describe("document tab in media dialog", () => {
     describe("without File nor EmbeddedFile plugin", () => {
         test("Document tab is not available by default", async () => {
             const { editor } = await setupEditor("<p>[]<br></p>", {
-                config: { Plugins: MAIN_PLUGINS },
+                config: { Plugins: MAIN_PLUGINS.filter((p) => p.id !== "file") },
             });
             execCommand(editor, "insertMedia");
             await animationFrame();
@@ -313,9 +298,7 @@ describe("document tab in media dialog", () => {
 
     describe("with File plugin (no embedded component)", () => {
         test("file upload via media dialog inserts a link in the editable", async () => {
-            const { editor } = await setupEditor("<p>[]<br></p>", {
-                config: configWithoutEmbeddedFile,
-            });
+            const { editor } = await setupEditor("<p>[]<br></p>");
             execCommand(editor, "insertMedia");
             await animationFrame();
             await click(".nav-link:contains('Documents')");
@@ -328,9 +311,7 @@ describe("document tab in media dialog", () => {
 
 describe("powerbutton", () => {
     test("file powerbutton uploads a file directly via the system's selector", async () => {
-        const { editor } = await setupEditor("<p>[]<br></p>", {
-            config: configWithoutEmbeddedFile,
-        });
+        const { editor } = await setupEditor("<p>[]<br></p>");
         const mockedUpload = patchUpload(editor);
         // Click on the upload powerbutton.
         await click(".power_button.fa-upload");
@@ -358,9 +339,7 @@ describe("powerbutton", () => {
 
 describe("zero width no-break space", () => {
     test("file card should be padded with zero-width no-break spaces", async () => {
-        const { editor } = await setupEditor("<p>[]<br></p>", {
-            config: configWithoutEmbeddedFile,
-        });
+        const { editor } = await setupEditor("<p>[]<br></p>");
         patchUpload(editor);
         execCommand(editor, "uploadFile");
         // wait for the the file to be uploaded and the card rendered

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -19,7 +19,6 @@ import { getContent, setContent, setSelection } from "../_helpers/selection";
 import { expectElementCount } from "../_helpers/ui_expectations";
 import { insertLineBreak, insertText, splitBlock, undo } from "../_helpers/user_actions";
 import { execCommand } from "../_helpers/userCommands";
-import { MAIN_PLUGINS, NO_EMBEDDED_COMPONENTS_FALLBACK_PLUGINS } from "@html_editor/plugin_sets";
 
 const base64Img =
     "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUA\n        AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO\n            9TXL0Y4OHwAAAABJRU5ErkJggg==";
@@ -1157,6 +1156,9 @@ describe("shortcut", () => {
         // Tab through all focusable elements
         await press("Tab");
         await animationFrame();
+        expect("button:has(i.fa-upload)").toBeFocused();
+        await press("Tab");
+        await animationFrame();
         expect("select[name='link_type']").toBeFocused();
         await press("Tab");
         await animationFrame();
@@ -1591,9 +1593,7 @@ describe("link in contenteditable=false", () => {
 
 describe("upload file via link popover", () => {
     test("should display upload button when url input is empty", async () => {
-        const { editor } = await setupEditor("<p>[]<br></p>", {
-            config: { Plugins: [...MAIN_PLUGINS, ...NO_EMBEDDED_COMPONENTS_FALLBACK_PLUGINS] },
-        });
+        const { editor } = await setupEditor("<p>[]<br></p>");
         execCommand(editor, "openLinkTools");
         await waitFor(".o-we-linkpopover");
         // Upload button should be visible
@@ -1620,9 +1620,7 @@ describe("upload file via link popover", () => {
         return mockedUploadPromise;
     };
     test("can create a link to an uploaded file", async () => {
-        const { editor, el } = await setupEditor("<p>[]<br></p>", {
-            config: { Plugins: [...MAIN_PLUGINS, ...NO_EMBEDDED_COMPONENTS_FALLBACK_PLUGINS] },
-        });
+        const { editor, el } = await setupEditor("<p>[]<br></p>");
         const mockedUpload = patchUpload(editor);
         execCommand(editor, "openLinkTools");
         await waitFor(".o-we-linkpopover");
@@ -1666,9 +1664,7 @@ describe("upload file via link popover", () => {
     });
 
     test("label input does not get filled on file upload if it is already filled", async () => {
-        const { editor } = await setupEditor("<p>[]<br></p>", {
-            config: { Plugins: [...MAIN_PLUGINS, ...NO_EMBEDDED_COMPONENTS_FALLBACK_PLUGINS] },
-        });
+        const { editor } = await setupEditor("<p>[]<br></p>");
         const mockedUpload = patchUpload(editor);
         execCommand(editor, "openLinkTools");
         await waitFor(".o-we-linkpopover");

--- a/addons/html_editor/static/tests/media.test.js
+++ b/addons/html_editor/static/tests/media.test.js
@@ -8,7 +8,6 @@ import { base64Img, setupEditor, testEditor } from "./_helpers/editor";
 import { getContent } from "./_helpers/selection";
 import { expectElementCount } from "./_helpers/ui_expectations";
 import { deleteBackward, deleteForward, insertText } from "./_helpers/user_actions";
-import { MAIN_PLUGINS, NO_EMBEDDED_COMPONENTS_FALLBACK_PLUGINS } from "@html_editor/plugin_sets";
 import { delay } from "@web/core/utils/concurrency";
 import { ImageCrop } from "@html_editor/main/media/image_crop";
 
@@ -51,7 +50,7 @@ test("Replace an image with link by a document should remove the link", async ()
     const env = await makeMockEnv();
     await setupEditor(
         `<p><a href="http://test.com"><img class="img-fluid" src="/web/static/img/logo.png"></a></p>`,
-        { env, config: { Plugins: [...MAIN_PLUGINS, ...NO_EMBEDDED_COMPONENTS_FALLBACK_PLUGINS] } }
+        { env }
     );
     expect("img[src='/web/static/img/logo.png']").toHaveCount(1);
     await click("img");

--- a/addons/html_editor/static/tests/power_buttons.test.js
+++ b/addons/html_editor/static/tests/power_buttons.test.js
@@ -190,7 +190,7 @@ describe("buttons", () => {
         // Open powerbox via the More options button
         click(".o_we_power_buttons .power_button.oi-ellipsis-v");
         await expectElementCount(".o-we-powerbox", 1);
-        expect(queryAllTexts(".o-we-command-name").length).toBe(26);
+        expect(queryAllTexts(".o-we-command-name").length).toBe(27);
         // Type a search term
         await insertText(editor, "head");
         await animationFrame();
@@ -205,7 +205,7 @@ describe("buttons", () => {
         }
         await animationFrame();
         // All commands should be available again
-        expect(queryAllTexts(".o-we-command-name").length).toBe(26);
+        expect(queryAllTexts(".o-we-command-name").length).toBe(27);
     });
 
     test("should close the powerbox on pointerdown outside and not reopen it on subsequent keydown", async () => {
@@ -258,7 +258,7 @@ describe("buttons", () => {
         // Open powerbox via the More options button
         click(".o_we_power_buttons .power_button.oi-ellipsis-v");
         await expectElementCount(".o-we-powerbox", 1);
-        expect(queryAllTexts(".o-we-command-name").length).toBe(26);
+        expect(queryAllTexts(".o-we-command-name").length).toBe(27);
         // Type a search term
         await insertText(editor, "head");
         await animationFrame();
@@ -276,7 +276,7 @@ describe("buttons", () => {
         // Open powerbox via the More options button
         click(".o_we_power_buttons .power_button.oi-ellipsis-v");
         await expectElementCount(".o-we-powerbox", 1);
-        expect(queryAllTexts(".o-we-command-name").length).toBe(26);
+        expect(queryAllTexts(".o-we-command-name").length).toBe(27);
         // Type a search term
         await insertText(editor, "head");
         await animationFrame();
@@ -294,7 +294,7 @@ describe("buttons", () => {
         // Open powerbox via the More options button
         click(".o_we_power_buttons .power_button.oi-ellipsis-v");
         await expectElementCount(".o-we-powerbox", 1);
-        expect(queryAllTexts(".o-we-command-name").length).toBe(26);
+        expect(queryAllTexts(".o-we-command-name").length).toBe(27);
         // Type a search term
         await insertText(editor, "head");
         await animationFrame();

--- a/addons/html_editor/static/tests/powerbox.test.js
+++ b/addons/html_editor/static/tests/powerbox.test.js
@@ -89,7 +89,7 @@ describe("search", () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>");
         await insertText(editor, "/");
         await animationFrame();
-        expect(commandNames(el).length).toBe(26);
+        expect(commandNames(el).length).toBe(27);
         await insertText(editor, "head");
         await animationFrame();
         expect(commandNames(el)).toEqual(["Heading 1", "Heading 2", "Heading 3"]);
@@ -99,7 +99,7 @@ describe("search", () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>");
         await insertText(editor, "/");
         await animationFrame();
-        expect(commandNames(el).length).toBe(26);
+        expect(commandNames(el).length).toBe(27);
         await insertText(editor, "title");
         await animationFrame();
         const commands = commandNames(el);
@@ -112,7 +112,7 @@ describe("search", () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>");
         await insertText(editor, "/");
         await animationFrame();
-        expect(commandNames(el).length).toBe(26);
+        expect(commandNames(el).length).toBe(27);
         expect(".o-we-category").toHaveCount(6);
         expect(queryAllTexts(".o-we-category")).toEqual([
             "FORMAT",
@@ -134,7 +134,7 @@ describe("search", () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>", { props: { iframe: true } });
         await insertText(editor, "/");
         await animationFrame();
-        expect(commandNames(el).length).toBe(26);
+        expect(commandNames(el).length).toBe(27);
         await insertText(editor, "head");
         await animationFrame();
         expect(commandNames(el)).toEqual(["Heading 1", "Heading 2", "Heading 3"]);
@@ -186,7 +186,7 @@ describe("search", () => {
         await insertText(editor, "/");
         await animationFrame();
         await expectElementCount(".o-we-powerbox", 1);
-        expect(commandNames(el).length).toBe(26);
+        expect(commandNames(el).length).toBe(27);
 
         await insertText(editor, "headx");
         await animationFrame();

--- a/addons/website_forum/static/src/plugins/plugin_sets.js
+++ b/addons/website_forum/static/src/plugins/plugin_sets.js
@@ -2,7 +2,7 @@ import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { ForumFontPlugin } from "./font_plugin";
 import { ForumHistoryPlugin } from "./history_plugin";
 
-const removedPlugins = new Set(["colorUi", "iconColor"]);
+const removedPlugins = new Set(["colorUi", "file", "iconColor"]);
 
 const customPlugins = {
     font: ForumFontPlugin,


### PR DESCRIPTION
Purpose of this commit:

- Restore the static file box implementation and drop the embedded component, as it breaks printing with wkhtmltopdf.
- The original issue with the static file box was fixed in [#241591](https://github.com/odoo/odoo/pull/241591)

Reverts: https://github.com/odoo/odoo/pull/216572

enterprise: https://github.com/odoo/enterprise/pull/108999

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
