### PR TITLE
[CLN] website, website_livechat: remove leftover cookies toggle SCSS

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -2369,12 +2369,6 @@ $ribbon-padding: 100px;
     height: 0px;
 }
 
-.o_cookies_bar_toggle {
-    inset-inline-end: 1rem;
-    inset-block-end: var(--cookies-bar-toggle-inset-block-end, 1rem);
-    z-index: $zindex-modal + 1; // Over the modal backdrop.
-}
-
 // Search results
 .o_search_result_item_detail {
     flex: 1;

--- a/addons/website_livechat/__manifest__.py
+++ b/addons/website_livechat/__manifest__.py
@@ -42,7 +42,6 @@
         ],
         'web.assets_frontend': [
             "website_livechat/static/src/**/common/**/*",
-            'website_livechat/static/src/**/frontend/**/*',
         ],
         'web.assets_backend': [
             "website_livechat/static/src/**/common/**/*",

--- a/addons/website_livechat/static/src/frontend/website_patch.scss
+++ b/addons/website_livechat/static/src/frontend/website_patch.scss
@@ -1,7 +1,0 @@
-// Shift cookies bar show/hide button to the side of livechat button.
-.o_cookies_bar_toggle {
-    $-o-livechat-button-margin: 3%; // LivechatButton is set at 97% from left and top
-    // LivechatButton size + margin + arbitrary gap.
-    inset-inline-end: calc(56px + #{$-o-livechat-button-margin} + 1rem);
-    inset-block-end: var(--cookies-bar-toggle-inset-block-end, #{$-o-livechat-button-margin});
-}


### PR DESCRIPTION
After [1], the cookies bar toggle was reworked and is no longer an
absolutely positioned button injected via interaction. The related SCSS
became obsolete but was still loaded.

This commit removes those unused styles.

[1]: https://github.com/odoo/odoo/commit/7ffc121c777d36d1f62a61ca32838f2f18c2abc7

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
