### PR TITLE
[FIX] spreadsheet_dashboard: weird select for chart granularity in chrome

### DIFF
--- a/addons/spreadsheet_dashboard/static/src/bundle/chart/chart_dashboard_menu.scss
+++ b/addons/spreadsheet_dashboard/static/src/bundle/chart/chart_dashboard_menu.scss
@@ -1,5 +1,8 @@
 .o-spreadsheet .o-figure {
     select {
+        display: flex;
+        align-items: center;
+
         // Firefox does not support custom select styles, it uses a native picker.
         // reset a few things to un-break it with Firefox
         appearance: none;
@@ -14,7 +17,6 @@
 
     select:hover, select:open {
         color: $black;
-        opacity: 1 !important;
     }
 
     ::picker(select) {
@@ -42,12 +44,14 @@
     }
 
     select::picker-icon {
-        content: $o-caret-down;
-        opacity: 0.6;
-        transform: translateY(-12%);
+        width: 7px;
+        height: 4px;
+        background-color: currentColor;
+        mask: $o-caret-down center / contain no-repeat;
+        transition: rotate 0.4s;
     }
 
     select:open::picker-icon {
-        transform: rotate(180deg);
+        rotate: 180deg;
     }
 }


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:

Current behavior before PR:
- In Chrome, the select dropdown showed label and picker icon stacked vertically.
- In dark mode, the picker icon was not clearly visible due to a change in picker color.

Desired behavior after PR is merged:
- Use flex + align-items: center to align label and icon horizontally.
- Use a fixed spreadsheet color for the icon to ensure visibility.
- Add a transition for smooth picker icon rotation.

Task: [5418157](https://www.odoo.com/odoo/project/2328/tasks/5418157)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr