### PR TITLE
[FIX] purchase_stock: prefetch quantity field to avoid memory error

### DIFF
--- a/addons/purchase_stock/models/res_partner.py
+++ b/addons/purchase_stock/models/res_partner.py
@@ -32,7 +32,7 @@ class ResPartner(models.Model):
             ('state', '=', 'done')])
         # Fetch fields from db and put them in cache.
         order_lines.read(['date_planned', 'partner_id', 'product_uom_qty'], load='')
-        moves.read(['purchase_line_id', 'date'], load='')
+        moves.read(['purchase_line_id', 'date', 'quantity'], load='')
         moves = moves.filtered(lambda m: m.date.date() <= m.purchase_line_id.date_planned.date())
         for move, quantity in zip(moves, moves.mapped('quantity')):
             lines_quantity[move.purchase_line_id.id] += quantity


### PR DESCRIPTION
While mapping the quantity field on stock moves, an out-of-memory issue occurred. To prevent this, the field is now prefetched in the same way as other fields.

Note: the issue is faced during 16.0 version too but as 16.0 is no more supported for bug fix. So, doing it from 17.0 version. 
```py

Traceback (most recent call last):
  File "/tmp/tmpstui3bd7/migrations/base/tests/test_mock_crawl.py", line 333, in crawl_menu
    self.mock_action(action_vals)
  File "/tmp/tmpstui3bd7/migrations/base/tests/test_mock_crawl.py", line 346, in mock_action
    return self.mock_act_window(action)
  File "/tmp/tmpstui3bd7/migrations/base/tests/test_mock_crawl.py", line 506, in mock_act_window
    mock_method(model, view, fields_list, domain, group_by)
  File "/tmp/tmpstui3bd7/migrations/base/tests/test_mock_crawl.py", line 550, in mock_view_form
    [data] = record.read(fields_list)
  File "/home/odoo/src/odoo/16.0/odoo/models.py", line 3038, in read
    return self._read_format(fnames=fields, load=load)
  File "/home/odoo/src/odoo/16.0/odoo/models.py", line 3219, in _read_format
    vals[name] = convert(record[name], record, use_name_get)
  File "/home/odoo/src/odoo/16.0/odoo/models.py", line 6007, in __getitem__
    return self._fields[key].__get__(self, self.env.registry[self._name])
  File "/home/odoo/src/odoo/16.0/odoo/fields.py", line 1222, in __get__
    self.compute_value(recs)
  File "/home/odoo/src/odoo/16.0/odoo/fields.py", line 1404, in compute_value
    records._compute_field_value(self)
  File "/home/odoo/src/odoo/16.0/addons/mail/models/mail_thread.py", line 403, in _compute_field_value
    return super()._compute_field_value(field)
  File "/home/odoo/src/odoo/16.0/odoo/models.py", line 4276, in _compute_field_value
    fields.determine(field.compute, self)
  File "/home/odoo/src/odoo/16.0/odoo/fields.py", line 101, in determine
    return needle(records, *args)
  File "/home/odoo/src/odoo/16.0/odoo/fields.py", line 702, in _compute_related
    record[self.name] = self._process_related(value[self.related_field.name])
  File "/home/odoo/src/odoo/16.0/odoo/models.py", line 6007, in __getitem__
    return self._fields[key].__get__(self, self.env.registry[self._name])
  File "/home/odoo/src/odoo/16.0/odoo/fields.py", line 1222, in __get__
    self.compute_value(recs)
  File "/home/odoo/src/odoo/16.0/odoo/fields.py", line 1404, in compute_value
    records._compute_field_value(self)
  File "/home/odoo/src/odoo/16.0/addons/mail/models/mail_thread.py", line 403, in _compute_field_value
    return super()._compute_field_value(field)
  File "/home/odoo/src/odoo/16.0/odoo/models.py", line 4276, in _compute_field_value
    fields.determine(field.compute, self)
  File "/home/odoo/src/odoo/16.0/odoo/fields.py", line 98, in determine
    return needle(*args)
  File "/home/odoo/src/odoo/16.0/addons/purchase_stock/models/res_partner.py", line 37, in _compute_on_time_rate
    for move, qty_done in zip(moves, moves.mapped('quantity_done')):
  File "/home/odoo/src/odoo/16.0/odoo/models.py", line 5470, in mapped
    recs = recs._fields[name].mapped(recs)
  File "/home/odoo/src/odoo/16.0/odoo/fields.py", line 1296, in mapped
    self.__get__(first(remaining), type(remaining))
  File "/home/odoo/src/odoo/16.0/odoo/fields.py", line 1187, in __get__
    recs._fetch_field(self)
  File "/home/odoo/src/odoo/16.0/odoo/models.py", line 3245, in _fetch_field
    self._read(fnames)
  File "/home/odoo/src/odoo/16.0/odoo/models.py", line 3322, in _read
    cr.execute(query_str, params + [sub_ids])
  File "/home/odoo/src/odoo/16.0/odoo/sql_db.py", line 547, in execute
    return self._cursor.execute(*args, **kwargs)
  File "/home/odoo/src/odoo/16.0/odoo/sql_db.py", line 324, in execute
    res = self._obj.execute(query, params)
psycopg2.DatabaseError: out of memory for query result
```

opw-5921410
upg-3891767

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
