### PR TITLE
[IMP] hr_expense: Bills now use expense duplicate logic

### DIFF
--- a/addons/hr_expense/models/account_move.py
+++ b/addons/hr_expense/models/account_move.py
@@ -27,6 +27,18 @@ class AccountMove(models.Model):
             )
         super(AccountMove, self - own_expense_moves)._compute_commercial_partner_id()
 
+    @api.depends('expense_ids')
+    def _compute_duplicated_ref_ids(self):
+        """ EXTENDS 'account'
+        If the bill is linked to expenses, apply the expense-based duplication logic.
+        For all other moves, keep the default logic.
+        """
+        expense_bills = self.filtered(lambda move: move.move_type == 'in_invoice' and move.expense_ids)
+        for move in expense_bills:
+            duplicate_expenses = move.expense_ids.duplicate_expense_ids
+            move.duplicated_ref_ids = duplicate_expenses.account_move_id - move if duplicate_expenses else self.env['account.move']
+        return super(AccountMove, self - expense_bills)._compute_duplicated_ref_ids()
+
     @api.constrains('expense_ids')
     def _check_expense_ids(self):
         for move in self:

--- a/addons/hr_expense/models/account_move.py
+++ b/addons/hr_expense/models/account_move.py
@@ -27,6 +27,21 @@ class AccountMove(models.Model):
             )
         super(AccountMove, self - own_expense_moves)._compute_commercial_partner_id()
 
+    @api.depends('expense_ids')
+    def _compute_duplicated_ref_ids(self):
+        """ EXTENDS 'account'
+        If the bill is linked to expenses, apply the expense-based duplication logic.
+        For all other moves, keep the default logic.
+        """
+        expense_bills = self.filtered(lambda move: move.move_type == 'in_invoice' and move.expense_ids)
+        for move in expense_bills:
+            duplicate_expenses = move.expense_ids.duplicate_expense_ids
+            move.duplicated_ref_ids = (
+                duplicate_expenses.mapped('account_move_id') - move
+                if duplicate_expenses else self.env['account.move']
+            )
+        return super(AccountMove, self - expense_bills)._compute_duplicated_ref_ids()
+
     @api.constrains('expense_ids')
     def _check_expense_ids(self):
         for move in self:

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -1145,3 +1145,32 @@ class TestExpenses(TestExpenseCommon):
         expense.unlink()
         self.assertFalse(expense.exists())
         self.assertFalse(attachment.exists())
+
+    def test_expense_based_bill_duplicate_detection(self):
+        """ Test that bills linked to expenses use expense-based duplication logic. """
+        all_expenses = expense_1, expense_2 = self.create_expenses([
+            {
+                'name': 'Expense 1',
+                'employee_id': self.expense_employee.id,
+                'product_id': self.product_c.id,
+                'total_amount_currency': 100.0,
+                'payment_mode': 'own_account',
+                'company_id': self.company_data['company'].id,
+            },
+            {
+                'name': 'Expense 2',
+                'employee_id': self.expense_employee.id,
+                'product_id': self.product_c.id,
+                'total_amount_currency': 100.0,
+                'payment_mode': 'own_account',
+                'company_id': self.company_data['company'].id,
+            },
+        ])
+
+        all_expenses.action_submit()
+        all_expenses._do_approve()  # Skip duplicate wizard
+        self.post_expenses_with_wizard(expense_1)
+        self.post_expenses_with_wizard(expense_2)
+
+        self.assertTrue(expense_1.account_move_id.duplicated_ref_ids)
+        self.assertTrue(expense_2.account_move_id.duplicated_ref_ids)

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -1127,3 +1127,33 @@ class TestExpenses(TestExpenseCommon):
                 {'name': 'file_4.png', 'res_model': 'account.move', 'res_id': expense_2.account_move_id.id},
             ]
         )
+
+    def test_expense_based_bill_duplicate_detection(self):
+        """ Test that bills linked to expenses use expense-based duplication logic. """
+        expense_1, expense_2 = self.create_expenses([
+            {
+                'name': 'Expense 1',
+                'employee_id': self.expense_employee.id,
+                'product_id': self.product_a.id,
+                'total_amount_currency': 100.0,
+                'payment_mode': 'own_account',
+                'company_id': self.company_data['company'].id,
+            },
+            {
+                'name': 'Expense 2',
+                'employee_id': self.expense_employee.id,
+                'product_id': self.product_a.id,
+                'total_amount_currency': 100.0,
+                'payment_mode': 'own_account',
+                'company_id': self.company_data['company'].id,
+            },
+        ])
+
+        all_expenses = expense_1 | expense_2
+        all_expenses.action_submit()
+        all_expenses._do_approve()  # Skip duplicate wizard
+        self.post_expenses_with_wizard(expense_1)
+        self.post_expenses_with_wizard(expense_2)
+
+        self.assertTrue(expense_1.account_move_id.duplicated_ref_ids)
+        self.assertTrue(expense_2.account_move_id.duplicated_ref_ids)


### PR DESCRIPTION
Bills linked to expenses now rely on the expense duplication logic instead of
the standard bill duplication. This ensures that when two expenses are marked as
duplicates, their corresponding bills are also recognized as duplicates.

task-5262550
