### PR TITLE
[FIX] html_editor: render embedded file components in pdf reports

### DIFF
--- a/addons/html_editor/models/ir_qweb_fields.py
+++ b/addons/html_editor/models/ir_qweb_fields.py
@@ -433,6 +433,62 @@ class IrQwebFieldHtml(models.AbstractModel):
     _inherit = ['ir.qweb.field.html']
 
     @api.model
+    def value_to_html(self, value, options):
+        if value and 'data-embedded' in str(value):
+            value = self._process_embedded_components(value)
+        return super().value_to_html(value, options)
+
+    def _process_embedded_components(self, value):
+        """Convert embedded Owl components to static HTML for server-side
+        rendering (PDF reports, emails). Embedded components only render
+        client-side via JavaScript which is unavailable in wkhtmltopdf."""
+        try:
+            body = html.fromstring("<body>%s</body>" % value)
+        except (etree.XMLSyntaxError, ValueError, TypeError):
+            return value
+
+        modified = False
+        for element in body.iter():
+            if element.get('data-embedded') == 'file':
+                if self._convert_embedded_file(element):
+                    modified = True
+
+        if modified:
+            return etree.tostring(body, encoding='unicode', method='html')[6:-7]
+        return value
+
+    def _convert_embedded_file(self, element):
+        """Replace an embedded file component with a plain download link."""
+        props_str = element.get('data-embedded-props', '{}')
+        try:
+            props = json.loads(props_str)
+        except (json.JSONDecodeError, TypeError):
+            return False
+
+        file_data = props.get('fileData', {})
+        filename = file_data.get('name') or file_data.get('filename', 'File')
+        file_id = file_data.get('id')
+        access_token = file_data.get('access_token', '')
+
+        if file_id:
+            download_url = '/web/content/%s?download=true' % file_id
+            if access_token:
+                download_url += '&access_token=%s' % access_token
+        elif file_data.get('url'):
+            download_url = file_data['url']
+        else:
+            return False
+
+        for child in list(element):
+            element.remove(child)
+        element.attrib.clear()
+        element.tag = 'a'
+        element.set('href', download_url)
+        element.text = filename
+
+        return True
+
+    @api.model
     def attributes(self, record, field_name, options, values=None):
         attrs = super().attributes(record, field_name, options, values)
         if options.get('inherit_branding'):


### PR DESCRIPTION
**Steps to reproduce:**
* Install the *purchase* module.
* Create a *Purchase Order*.
* Edit the *Terms and Conditions* (Html field `note`).
* Upload a file (PDF) using the editor's file upload.
* Save the record.
* Click on *Print* → *Purchase Order* to generate the PDF report.

**Issue:**
The uploaded file is completely invisible in the printed PDF. 
The file card that appears in the web UI is missing from the report output.

**Expected:**
The file name should appear as a download link in the PDF,
 just like it did in Odoo 18.4.

**Root cause**:
`ir.actions.report` → `_render_qweb_pdf()`
Renders QWeb report template (e.g. `purchase.report_purchaseorder`)
Template contains `<p t-field='o.note'/>` for the Html field `t-field` directive 
calls `ir.qweb.field.html` → `value_to_html()` Base `value_to_html()` 
only sanitizes attributes — it does NOT
transform embedded components

The report is rendered with t-js="false" and processed by wkhtmltopdf,
which does not execute JavaScript.

Since `EmbeddedFilePlugin` relies on Owl/JS hydration,
the span remains empty and nothing is rendered.

Before [commit](https://github.com/odoo/odoo/pull/216572/changes/86c7176833fc36b9ca7d2989d31587c353bd5800) uploaded files were stored using the static file box mechanism from `web_editor`.
 The editor directly inserted plain HTML links such as:
`<a href="/web/content/...">filename</a>`
Because those links were static HTML, they rendered correctly
in PDF reports without requiring JavaScript.

After the introduction of `EmbeddedFilePlugin` in `html_editor`, files are stored as:

`<span data-embedded="file" data-embedded-props="..."/>`

These elements require client-side JavaScript to render the file component.
However, PDF reports and other server-side
do not execute JS, which results in invisible content.

**Fix:**
Extend the HTML rendering logic to detect
data-embedded="file" elements and convert them into plain `<a href="/web/content/...">filename</a>`
download links before delegating to the base renderer.


<details>
    <summary>Click here to see the results:</summary>
    Before:
    <img src="https://github.com/user-attachments/assets/f32e5c58-140f-443a-b27c-80d8cb24f6dd"/>
    After:
   <img src="https://github.com/user-attachments/assets/8db93082-0ef2-4d1e-93cd-5fd7dad5966a" />

</details>

---

opw-5931436

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
