### PR TITLE
[IMP] {stock, mrp}_landed_costs: apply landed cost on specific products

### DIFF
--- a/addons/mrp_landed_costs/models/stock_landed_cost.py
+++ b/addons/mrp_landed_costs/models/stock_landed_cost.py
@@ -29,6 +29,10 @@ class StockLandedCost(models.Model):
         )
 
     @api.depends('mrp_production_ids')
+    def _compute_allowed_product_ids(self):
+        super()._compute_allowed_product_ids()
+
+    @api.depends('mrp_production_ids')
     def _compute_mrp_productions_count(self):
         for cost in self:
             cost.mrp_productions_count = len(cost.mrp_production_ids)

--- a/addons/stock_landed_costs/models/product.py
+++ b/addons/stock_landed_costs/models/product.py
@@ -13,6 +13,10 @@ class ProductTemplate(models.Model):
     split_method_landed_cost = fields.Selection(
         SPLIT_METHOD, string="Default Split Method",
         help="Default Split Method when used for Landed Cost")
+    landed_cost_on_product_ids = fields.Many2many(
+        'product.product', string="Apply Landed Cost On", domain=[('type', '=', 'consu')],
+        help="The landed cost is by default applied only on these products, if they are included in the transfer.\n"
+             "Even if landed costs can be applied on all goods, only products valued using the AVCO or FIFO methods will have their calculated value affected by landed costs.")
 
     def write(self, vals):
         for product in self:

--- a/addons/stock_landed_costs/models/product.py
+++ b/addons/stock_landed_costs/models/product.py
@@ -13,6 +13,8 @@ class ProductTemplate(models.Model):
     split_method_landed_cost = fields.Selection(
         SPLIT_METHOD, string="Default Split Method",
         help="Default Split Method when used for Landed Cost")
+    target_product_ids = fields.Many2many('product.product', string="Apply Landed Cost On", domain=[('type', '=', 'consu')],
+        help="The landed cost is by default applied only on these products, if they are included in the transfer.")
 
     def write(self, vals):
         for product in self:

--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -3,9 +3,8 @@
 
 from collections import defaultdict
 
-from odoo import api, fields, models, tools, _
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError
-from odoo.tools.float_utils import float_is_zero
 
 
 SPLIT_METHOD = [
@@ -68,6 +67,7 @@ class StockLandedCost(models.Model):
     vendor_bill_id = fields.Many2one(
         'account.move', 'Vendor Bill', copy=False, domain=[('move_type', '=', 'in_invoice')], index='btree_not_null')
     currency_id = fields.Many2one('res.currency', related='company_id.currency_id')
+    allowed_product_ids = fields.Many2many('product.product', compute='_compute_allowed_product_ids')
 
     @api.depends('cost_lines.price_unit')
     def _compute_total_amount(self):
@@ -78,6 +78,11 @@ class StockLandedCost(models.Model):
     def _compute_pickings_count(self):
         for cost in self:
             cost.pickings_count = len(cost.picking_ids)
+
+    @api.depends('picking_ids')
+    def _compute_allowed_product_ids(self):
+        for cost in self:
+            cost.allowed_product_ids = cost._get_targeted_move_ids().product_id
 
     @api.onchange('target_model')
     def _onchange_target_model(self):
@@ -160,11 +165,10 @@ class StockLandedCost(models.Model):
 
     def get_valuation_lines(self):
         self.ensure_one()
-        lines = []
+        move_values = []
 
         for move in self._get_targeted_move_ids():
-            # it doesn't make sense to make a landed cost for a product that isn't set as being valuated in real time at real cost
-            if move.product_id.cost_method not in ('fifo', 'average') or move.state == 'cancel' or not move.quantity:
+            if move.state == 'cancel' or not move.quantity:
                 continue
             qty = move.uom_id._compute_quantity(move.quantity, move.product_id.uom_id)
 
@@ -174,78 +178,78 @@ class StockLandedCost(models.Model):
                 'quantity': qty,
                 'former_cost': move._get_value(),
                 'weight': move.product_id.weight * qty,
-                'volume': move.product_id.volume * qty
+                'volume': move.product_id.volume * qty,
             }
-            lines.append(vals)
+            move_values.append(vals)
 
-        if not lines:
-            target_model_descriptions = dict(self._fields['target_model']._description_selection(self.env))
-            raise UserError(_("You cannot apply landed costs on the chosen %s(s). Landed costs can only be applied for products with FIFO or average costing method.", target_model_descriptions[self.target_model]))
-        return lines
+        if not move_values:
+            return []
+
+        valuation_line_values = []
+        for cost_line in self.cost_lines:
+            apply_on_product_ids = set(cost_line.apply_on_product_ids.ids)
+            total_qty = total_weight = total_volume = total_cost = total_line = 0.0
+            for move_value in move_values:
+                if apply_on_product_ids and move_value['product_id'] not in apply_on_product_ids:
+                    continue
+                total_qty += move_value['quantity']
+                total_weight += move_value['weight']
+                total_volume += move_value['volume']
+                total_cost += self.currency_id.round(move_value['former_cost'])
+                total_line += 1
+
+            if not total_line:
+                continue
+
+            cost_line_valuation_values = []
+            allocated_cost = 0.0
+            for move_value in move_values:
+                if apply_on_product_ids and move_value['product_id'] not in apply_on_product_ids:
+                    continue
+                additional_cost = 0.0
+                if cost_line.split_method == 'by_quantity' and total_qty:
+                    unit_cost = (cost_line.price_unit / total_qty)
+                    additional_cost = move_value['quantity'] * unit_cost
+                elif cost_line.split_method == 'by_weight' and total_weight:
+                    unit_cost = (cost_line.price_unit / total_weight)
+                    additional_cost = move_value['weight'] * unit_cost
+                elif cost_line.split_method == 'by_volume' and total_volume:
+                    unit_cost = (cost_line.price_unit / total_volume)
+                    additional_cost = move_value['volume'] * unit_cost
+                elif cost_line.split_method == 'equal':
+                    additional_cost = (cost_line.price_unit / total_line)
+                elif cost_line.split_method == 'by_current_cost_price' and total_cost:
+                    unit_cost = (cost_line.price_unit / total_cost)
+                    additional_cost = move_value['former_cost'] * unit_cost
+                else:
+                    additional_cost = (cost_line.price_unit / total_line)
+
+                additional_cost = self.currency_id.round(additional_cost)
+                allocated_cost += additional_cost
+                cost_line_valuation_values.append({
+                    **move_value,
+                    'cost_id': self.id,
+                    'cost_line_id': cost_line.id,
+                    'additional_landed_cost': additional_cost,
+                })
+
+            rounding_diff = self.currency_id.round(cost_line.price_unit - allocated_cost)
+            if not self.currency_id.is_zero(rounding_diff):
+                cost_line_valuation_values[-1]['additional_landed_cost'] += rounding_diff
+            valuation_line_values.extend(cost_line_valuation_values)
+
+        return valuation_line_values
 
     def compute_landed_cost(self):
         AdjustementLines = self.env['stock.valuation.adjustment.lines']
         AdjustementLines.search([('cost_id', 'in', self.ids)]).unlink()
 
-        towrite_dict = {}
-        for cost in self.filtered(lambda cost: cost._get_targeted_move_ids()):
+        for cost in self:
+            if not cost.cost_lines or not cost._get_targeted_move_ids():
+                continue
             cost = cost.with_company(cost.company_id)
-            rounding = cost.currency_id.rounding
-            total_qty = 0.0
-            total_cost = 0.0
-            total_weight = 0.0
-            total_volume = 0.0
-            total_line = 0.0
-            all_val_line_values = cost.get_valuation_lines()
-            for val_line_values in all_val_line_values:
-                for cost_line in cost.cost_lines:
-                    val_line_values.update({'cost_id': cost.id, 'cost_line_id': cost_line.id})
-                    self.env['stock.valuation.adjustment.lines'].create(val_line_values)
-                total_qty += val_line_values.get('quantity', 0.0)
-                total_weight += val_line_values.get('weight', 0.0)
-                total_volume += val_line_values.get('volume', 0.0)
-
-                former_cost = val_line_values.get('former_cost', 0.0)
-                # round this because former_cost on the valuation lines is also rounded
-                total_cost += cost.currency_id.round(former_cost)
-
-                total_line += 1
-
-            for line in cost.cost_lines:
-                value_split = 0.0
-                for valuation in cost.valuation_adjustment_lines:
-                    value = 0.0
-                    if valuation.cost_line_id and valuation.cost_line_id.id == line.id:
-                        if line.split_method == 'by_quantity' and total_qty:
-                            per_unit = (line.price_unit / total_qty)
-                            value = valuation.quantity * per_unit
-                        elif line.split_method == 'by_weight' and total_weight:
-                            per_unit = (line.price_unit / total_weight)
-                            value = valuation.weight * per_unit
-                        elif line.split_method == 'by_volume' and total_volume:
-                            per_unit = (line.price_unit / total_volume)
-                            value = valuation.volume * per_unit
-                        elif line.split_method == 'equal':
-                            value = (line.price_unit / total_line)
-                        elif line.split_method == 'by_current_cost_price' and total_cost:
-                            per_unit = (line.price_unit / total_cost)
-                            value = valuation.former_cost * per_unit
-                        else:
-                            value = (line.price_unit / total_line)
-
-                        if rounding:
-                            value = tools.float_round(value, precision_rounding=rounding, rounding_method='HALF-UP')
-                            value_split += value
-
-                        if valuation.id not in towrite_dict:
-                            towrite_dict[valuation.id] = value
-                        else:
-                            towrite_dict[valuation.id] += value
-                rounding_diff = cost.currency_id.round(line.price_unit - value_split)
-                if not cost.currency_id.is_zero(rounding_diff):
-                    towrite_dict[max(towrite_dict.keys())] += rounding_diff
-        for key, value in towrite_dict.items():
-            AdjustementLines.browse(key).write({'additional_landed_cost': value})
+            if valuation_line_values := cost.get_valuation_lines():
+                AdjustementLines.create(valuation_line_values)
         return True
 
     def action_view_pickings(self):
@@ -312,6 +316,10 @@ class StockLandedCostLines(models.Model):
              "By Volume: Cost will be divided depending on its volume.")
     account_id = fields.Many2one('account.account', 'Account')
     currency_id = fields.Many2one('res.currency', related='cost_id.currency_id')
+    apply_on_product_ids = fields.Many2many('product.product', string="Apply On",
+        compute='_compute_apply_on_product_ids', readonly=False, store=True,
+        help="The landed cost is by default applied only on these products, if they are included in the transfer.\n"
+             "Even if landed costs can be applied on all goods, only products valued using the AVCO or FIFO methods will have their calculated value affected by landed costs.")
 
     @api.onchange('product_id')
     def onchange_product_id(self):
@@ -320,6 +328,13 @@ class StockLandedCostLines(models.Model):
         self.price_unit = self.product_id.standard_price or 0.0
         accounts_data = self.product_id.product_tmpl_id.get_product_accounts()
         self.account_id = accounts_data['expense']
+
+    @api.depends('product_id', 'cost_id.allowed_product_ids')
+    def _compute_apply_on_product_ids(self):
+        for line in self:
+            line.apply_on_product_ids = (
+                line.apply_on_product_ids._origin | line.product_id.landed_cost_on_product_ids
+            ) & line.cost_id.allowed_product_ids._origin
 
 
 class StockValuationAdjustmentLines(models.Model):

--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -68,6 +68,7 @@ class StockLandedCost(models.Model):
     vendor_bill_id = fields.Many2one(
         'account.move', 'Vendor Bill', copy=False, domain=[('move_type', '=', 'in_invoice')], index='btree_not_null')
     currency_id = fields.Many2one('res.currency', related='company_id.currency_id')
+    allowed_product_ids = fields.Many2many('product.product', compute='_compute_allowed_product_ids')
 
     @api.depends('cost_lines.price_unit')
     def _compute_total_amount(self):
@@ -78,6 +79,11 @@ class StockLandedCost(models.Model):
     def _compute_pickings_count(self):
         for cost in self:
             cost.pickings_count = len(cost.picking_ids)
+
+    @api.depends('picking_ids')
+    def _compute_allowed_product_ids(self):
+        for cost in self:
+            cost.allowed_product_ids = cost._get_targeted_move_ids().product_id
 
     @api.onchange('target_model')
     def _onchange_target_model(self):
@@ -191,27 +197,19 @@ class StockLandedCost(models.Model):
         for cost in self.filtered(lambda cost: cost._get_targeted_move_ids()):
             cost = cost.with_company(cost.company_id)
             rounding = cost.currency_id.rounding
-            total_qty = 0.0
-            total_cost = 0.0
-            total_weight = 0.0
-            total_volume = 0.0
-            total_line = 0.0
             all_val_line_values = cost.get_valuation_lines()
-            for val_line_values in all_val_line_values:
-                for cost_line in cost.cost_lines:
-                    val_line_values.update({'cost_id': cost.id, 'cost_line_id': cost_line.id})
-                    self.env['stock.valuation.adjustment.lines'].create(val_line_values)
-                total_qty += val_line_values.get('quantity', 0.0)
-                total_weight += val_line_values.get('weight', 0.0)
-                total_volume += val_line_values.get('volume', 0.0)
-
-                former_cost = val_line_values.get('former_cost', 0.0)
-                # round this because former_cost on the valuation lines is also rounded
-                total_cost += cost.currency_id.round(former_cost)
-
-                total_line += 1
-
             for line in cost.cost_lines:
+                total_qty = total_cost = total_weight = total_volume = total_line = 0.0
+                for val_line_values in all_val_line_values:
+                    if not line.target_product_ids or val_line_values.get('product_id') in line.target_product_ids.ids:
+                        val_line_values.update({'cost_id': cost.id, 'cost_line_id': line.id})
+                        self.env['stock.valuation.adjustment.lines'].create(val_line_values)
+                        total_qty += val_line_values.get('quantity', 0.0)
+                        total_weight += val_line_values.get('weight', 0.0)
+                        total_volume += val_line_values.get('volume', 0.0)
+                        total_cost += cost.currency_id.round(val_line_values.get('former_cost', 0.0))
+                        total_line += 1
+
                 value_split = 0.0
                 for valuation in cost.valuation_adjustment_lines:
                     value = 0.0
@@ -242,7 +240,7 @@ class StockLandedCost(models.Model):
                         else:
                             towrite_dict[valuation.id] += value
                 rounding_diff = cost.currency_id.round(line.price_unit - value_split)
-                if not cost.currency_id.is_zero(rounding_diff):
+                if not cost.currency_id.is_zero(rounding_diff) and towrite_dict:
                     towrite_dict[max(towrite_dict.keys())] += rounding_diff
         for key, value in towrite_dict.items():
             AdjustementLines.browse(key).write({'additional_landed_cost': value})
@@ -312,6 +310,7 @@ class StockLandedCostLines(models.Model):
              "By Volume: Cost will be divided depending on its volume.")
     account_id = fields.Many2one('account.account', 'Account')
     currency_id = fields.Many2one('res.currency', related='cost_id.currency_id')
+    target_product_ids = fields.Many2many('product.product', string="Apply On", compute='_compute_target_product_ids', readonly=False, store=True)
 
     @api.onchange('product_id')
     def onchange_product_id(self):
@@ -320,6 +319,14 @@ class StockLandedCostLines(models.Model):
         self.price_unit = self.product_id.standard_price or 0.0
         accounts_data = self.product_id.product_tmpl_id.get_product_accounts()
         self.account_id = accounts_data['expense']
+
+    @api.depends('product_id', 'cost_id.allowed_product_ids')
+    def _compute_target_product_ids(self):
+        for line in self:
+            line.target_product_ids = (
+                line.target_product_ids.filtered(lambda product: product in line.cost_id.allowed_product_ids)
+                | line.cost_id.allowed_product_ids._origin & line.product_id.target_product_ids
+            )
 
 
 class StockValuationAdjustmentLines(models.Model):

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs.py
@@ -2,10 +2,11 @@
 
 from unittest import skip
 
-from odoo.addons.stock_landed_costs.tests.common import TestStockLandedCostsCommon
+from odoo import Command, fields
 from odoo.exceptions import ValidationError
-from odoo.tests import tagged
-from odoo import fields
+from odoo.tests import Form, tagged
+
+from odoo.addons.stock_landed_costs.tests.common import TestStockLandedCostsCommon
 
 
 @tagged('post_install', '-at_install')
@@ -244,3 +245,44 @@ class TestStockLandedCosts(TestStockLandedCostsCommon):
         )
         move_line_no_landed = account_move.line_ids.filtered(lambda line: line.product_id == self.product)
         self.assertFalse(move_line_no_landed.is_landed_costs_line, "The landed cost should not be set to True.")
+
+    def test_landed_cost_for_specific_products(self):
+        """Ensure that landed costs apply only to the products specified in the "Apply On" field
+        of the landed cost lines, and exclude all other products from the related pickings.
+        """
+        self.product_a.is_storable = True
+        self.landed_cost.landed_cost_on_product_ids = self.product_refrigerator
+        picking = self.env['stock.picking'].create({
+            'picking_type_id': self.warehouse.in_type_id.id,
+            'location_id': self.supplier_location_id,
+            'location_dest_id': self.warehouse.lot_stock_id.id,
+            'move_ids': [
+                Command.create({'product_id': product.id, 'product_uom_qty': qty})
+                for product, qty in [(self.product_oven, 1), (self.product_refrigerator, 3), (self.product_a, 5)]
+            ],
+        })
+        picking.action_confirm()
+        picking.button_validate()
+
+        lc_form = Form(self.env['stock.landed.cost'])
+        lc_form.picking_ids.add(picking)
+        with lc_form.cost_lines.new() as cost_line:
+            cost_line.product_id = self.landed_cost
+            cost_line.price_unit = 100
+            cost_line.split_method = 'by_quantity'
+        lc = lc_form.save()
+
+        self.assertEqual(lc.cost_lines.apply_on_product_ids, self.product_refrigerator)
+
+        lc.cost_lines.write({'apply_on_product_ids': [Command.link(self.product_oven.id)]})
+        lc.compute_landed_cost()
+
+        valuation_lines = lc.valuation_adjustment_lines
+        self.assertEqual(len(valuation_lines), 2)
+
+        oven_val_line = valuation_lines.filtered(lambda line: line.product_id == self.product_oven)
+        refrigerator_val_line = valuation_lines - oven_val_line
+
+        self.assertEqual(oven_val_line.additional_landed_cost, 25)
+        self.assertEqual(refrigerator_val_line.additional_landed_cost, 75)
+        self.assertFalse(valuation_lines.filtered(lambda line: line.product_id == self.product_a))

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs.py
@@ -2,10 +2,11 @@
 
 from unittest import skip
 
-from odoo.addons.stock_landed_costs.tests.common import TestStockLandedCostsCommon
+from odoo import Command, fields
 from odoo.exceptions import ValidationError
-from odoo.tests import tagged
-from odoo import fields
+from odoo.tests import Form, tagged
+
+from odoo.addons.stock_landed_costs.tests.common import TestStockLandedCostsCommon
 
 
 @tagged('post_install', '-at_install')
@@ -238,3 +239,44 @@ class TestStockLandedCosts(TestStockLandedCostsCommon):
         )
         move_line_no_landed = account_move.line_ids.filtered(lambda line: line.product_id == self.product)
         self.assertFalse(move_line_no_landed.is_landed_costs_line, "The landed cost should not be set to True.")
+
+    def test_landed_cost_for_specific_products(self):
+        """Ensure that landed costs apply only to the products specified in the "Apply On" field
+        of the landed cost lines, and exclude all other products from the related pickings.
+        """
+        self.product_a.is_storable = True
+        self.landed_cost.target_product_ids = self.product_refrigerator
+        picking = self.env['stock.picking'].create({
+            'picking_type_id': self.warehouse.in_type_id.id,
+            'location_id': self.supplier_location_id,
+            'location_dest_id': self.warehouse.lot_stock_id.id,
+            'move_ids': [
+                Command.create({'product_id': product.id, 'product_uom_qty': qty})
+                for product, qty in [(self.product_oven, 1), (self.product_refrigerator, 3), (self.product_a, 5)]
+            ],
+        })
+        picking.action_confirm()
+        picking.button_validate()
+
+        lc_form = Form(self.env['stock.landed.cost'])
+        lc_form.picking_ids.add(picking)
+        with lc_form.cost_lines.new() as cost_line:
+            cost_line.product_id = self.landed_cost
+            cost_line.price_unit = 100
+            cost_line.split_method = 'by_quantity'
+        lc = lc_form.save()
+
+        self.assertEqual(lc.cost_lines.target_product_ids, self.product_refrigerator)
+
+        lc.cost_lines.write({'target_product_ids': [Command.link(self.product_oven.id)]})
+        lc.compute_landed_cost()
+
+        valuation_lines = lc.valuation_adjustment_lines
+        self.assertEqual(len(valuation_lines), 2)
+
+        oven_val_line = valuation_lines.filtered(lambda line: line.product_id == self.product_oven)
+        refrigerator_val_line = valuation_lines - oven_val_line
+
+        self.assertEqual(oven_val_line.additional_landed_cost, 25)
+        self.assertEqual(refrigerator_val_line.additional_landed_cost, 75)
+        self.assertFalse(valuation_lines.filtered(lambda line: line.product_id == self.product_a))

--- a/addons/stock_landed_costs/views/product_views.xml
+++ b/addons/stock_landed_costs/views/product_views.xml
@@ -8,6 +8,15 @@
             <field name="arch" type="xml">
                 <group name="bill" position="inside">
                     <field name="landed_cost_ok" invisible="type != 'service'"/>
+                    <label for="landed_cost_on_product_ids"
+                        invisible="not landed_cost_ok or type != 'service'"
+                        string="Apply On"/>
+                    <field name="landed_cost_on_product_ids"
+                        nolabel="1"
+                        invisible="not landed_cost_ok or type != 'service'"
+                        widget="many2many_tags"
+                        placeholder="All Products"
+                        context="{'search_default_group_by_categ_id': 1}"/>
                     <field name="split_method_landed_cost" invisible="not landed_cost_ok or type != 'service'"/>
                 </group>
             </field>

--- a/addons/stock_landed_costs/views/product_views.xml
+++ b/addons/stock_landed_costs/views/product_views.xml
@@ -8,6 +8,9 @@
             <field name="arch" type="xml">
                 <group name="bill" position="inside">
                     <field name="landed_cost_ok" invisible="type != 'service'"/>
+                    <label for="target_product_ids" invisible="not landed_cost_ok or type != 'service'" string="Apply On"/>
+                    <field name="target_product_ids" nolabel="1" invisible="not landed_cost_ok or type != 'service'" widget="many2many_tags"
+                        placeholder="All Products" context="{'search_default_group_by_categ_id': 1}"/>
                     <field name="split_method_landed_cost" invisible="not landed_cost_ok or type != 'service'"/>
                 </group>
             </field>

--- a/addons/stock_landed_costs/views/stock_landed_cost_views.xml
+++ b/addons/stock_landed_costs/views/stock_landed_cost_views.xml
@@ -8,6 +8,7 @@
             <field name="arch" type="xml">
                 <form string="Landed Costs">
                     <field name="company_id" invisible="1"/>
+                    <field name="allowed_product_ids" invisible="1"/>
                     <header>
                         <button name="button_validate" string="Validate" invisible="state != 'draft'" class="oe_highlight" type="object"/>
                         <button name="button_cancel" string="Cancel" invisible="state != 'draft'" type="object"/>
@@ -68,6 +69,11 @@
                                             context="{'default_landed_cost_ok': True, 'default_type': 'service'}"/>
                                         <field name="name"/>
                                         <field name="account_id" options="{'no_create': True}"/>
+                                        <field name="apply_on_product_ids"
+                                            options="{'no_create': True}"
+                                            widget="many2many_tags"
+                                            domain="[('id', 'in', parent.allowed_product_ids)]"
+                                            placeholder="All Products"/>
                                         <field name="split_method"/>
                                         <field name="price_unit"/>
                                         <field name="currency_id" column_invisible="True"/>

--- a/addons/stock_landed_costs/views/stock_landed_cost_views.xml
+++ b/addons/stock_landed_costs/views/stock_landed_cost_views.xml
@@ -8,6 +8,7 @@
             <field name="arch" type="xml">
                 <form string="Landed Costs">
                     <field name="company_id" invisible="1"/>
+                    <field name="allowed_product_ids" invisible="1"/>
                     <header>
                         <button name="button_validate" string="Validate" invisible="state != 'draft'" class="oe_highlight" type="object"/>
                         <button name="button_cancel" string="Cancel" invisible="state != 'draft'" type="object"/>
@@ -68,6 +69,7 @@
                                             context="{'default_landed_cost_ok': True, 'default_type': 'service'}"/>
                                         <field name="name"/>
                                         <field name="account_id" options="{'no_create': True}"/>
+                                        <field name="target_product_ids" options="{'no_create': True}" widget="many2many_tags" domain="[('id', 'in', parent.allowed_product_ids)]" placeholder="All Products"/>
                                         <field name="split_method"/>
                                         <field name="price_unit"/>
                                         <field name="currency_id" column_invisible="True"/>


### PR DESCRIPTION
Currently, landed costs are distributed across all products of the
selected transfers. In practice, some costs (e.g., customs duties or
special handling fees) may apply only to specific products only,
forcing users to manually adapt the adjustment lines after computation,
which is error-prone and time-consuming.

- When creating a Landed Cost Product, users can predefine the products
  it should apply to when the cost is known to always target specific products.
- When this landed cost product is added to a cost line, the predefined
  products are automatically added to Apply On if they are present in the
  selected transfers/MO, removing the need for manual selection.
- Users can still manually add other products from the transfers/MO when the
  cost should also apply to products that were not predefined.

With this change, landed costs can be applied only to relevant products,
eliminating manual adjustments, reducing user errors, and improving
valuation accuracy and usability.

task-5214058
