### PR TITLE
[IMP] hr_timesheet,_*: remove project_time_mode_id and total_timesheet_time fields

### DIFF
--- a/addons/hr_timesheet/controllers/project.py
+++ b/addons/hr_timesheet/controllers/project.py
@@ -19,11 +19,11 @@ class ProjectCustomerPortal(CustomerPortal):
         session_info = super()._prepare_project_sharing_session_info(project)
         company = request.env['res.company'].sudo().browse(session_info['user_companies']['current_company'])
         timesheet_encode_uom = company.timesheet_encode_uom_id
-        project_time_mode_uom = company.project_time_mode_id
+        uom_hour = request.env.ref('uom.product_uom_hour')
 
         session_info['user_companies']['allowed_companies'][company.id].update(
             timesheet_uom_id=timesheet_encode_uom.id,
-            timesheet_uom_factor=project_time_mode_uom._compute_quantity(
+            timesheet_uom_factor=uom_hour._compute_quantity(
                 1.0,
                 timesheet_encode_uom,
                 round=False
@@ -35,7 +35,7 @@ class ProjectCustomerPortal(CustomerPortal):
                     'id': uom.id,
                     'name': uom.name,
                     'timesheet_widget': uom.timesheet_widget,
-                } for uom in [timesheet_encode_uom, project_time_mode_uom]
+                } for uom in [timesheet_encode_uom, uom_hour]
         }
         session_info['user_context']['allow_timesheets'] = project.allow_timesheets
         return session_info

--- a/addons/hr_timesheet/models/account_analytic_line.py
+++ b/addons/hr_timesheet/models/account_analytic_line.py
@@ -214,6 +214,7 @@ class AccountAnalyticLine(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         user_timezone = self.env.tz
+        uom_hour_id = self.env.ref('uom.product_uom_hour').id
         # Before creating a timesheet, we need to put a valid employee_id in the vals
         default_user_id = self._default_user()
         user_ids = []
@@ -257,7 +258,7 @@ class AccountAnalyticLine(models.Model):
             })
 
             if not vals.get('product_uom_id'):
-                vals['product_uom_id'] = company.project_time_mode_id.id
+                vals['product_uom_id'] = uom_hour_id
 
             if not vals.get('name'):
                 vals['name'] = '/'
@@ -301,8 +302,6 @@ class AccountAnalyticLine(models.Model):
                 if not vals.get('company_id'):
                     company = HrEmployee_sudo.browse(employee_in_id).company_id
                     vals['company_id'] = company.id
-                if not vals.get('product_uom_id'):
-                    vals['product_uom_id'] = company.project_time_mode_id.id if company else self.env['res.company'].browse(vals.get('company_id', self.env.company.id)).project_time_mode_id.id
                 if employee_in_id in valid_employee_per_id:
                     vals['user_id'] = valid_employee_per_id[employee_in_id].sudo().user_id.id   # (A) OK
                     continue
@@ -326,8 +325,6 @@ class AccountAnalyticLine(models.Model):
                 if not vals.get('company_id'):
                     company = HrEmployee_sudo.browse(employee_out_id).company_id
                     vals['company_id'] = company.id
-                if not vals.get('product_uom_id'):
-                    vals['product_uom_id'] = company.project_time_mode_id.id if company else self.env['res.company'].browse(vals.get('company_id', self.env.company.id)).project_time_mode_id.id
             else:  # ...and raise an error if they fail
                 raise ValidationError(error_msg)
 

--- a/addons/hr_timesheet/models/ir_http.py
+++ b/addons/hr_timesheet/models/ir_http.py
@@ -14,11 +14,12 @@ class IrHttp(models.AbstractModel):
         result = super().session_info()
         if self.env.user._is_internal():
             company_ids = self.env.user.company_ids
+            uom_hour = self.env.ref('uom.product_uom_hour')
 
             for company in company_ids:
                 result["user_companies"]["allowed_companies"][company.id].update({
                     "timesheet_uom_id": company.timesheet_encode_uom_id.id,
-                    "timesheet_uom_factor": company.project_time_mode_id._compute_quantity(
+                    "timesheet_uom_factor": uom_hour._compute_quantity(
                         1.0,
                         company.timesheet_encode_uom_id,
                         round=False
@@ -31,7 +32,7 @@ class IrHttp(models.AbstractModel):
     def get_timesheet_uoms(self):
         company_ids = self.env.user.company_ids
         uom_ids = company_ids.mapped('timesheet_encode_uom_id') | \
-                  company_ids.mapped('project_time_mode_id')
+                  self.env.ref('uom.product_uom_hour')
         return {
             uom.id:
                 {

--- a/addons/hr_timesheet/models/project_project.py
+++ b/addons/hr_timesheet/models/project_project.py
@@ -241,11 +241,6 @@ class ProjectProject(models.Model):
     def get_create_edit_project_ids(self):
         return []
 
-    def _convert_project_uom_to_timesheet_encode_uom(self, time):
-        uom_from = self.company_id.project_time_mode_id
-        uom_to = self.env.company.timesheet_encode_uom_id
-        return round(uom_from._compute_quantity(time, uom_to, raise_if_failure=False), 2)
-
     def action_project_timesheets(self):
         action = self.env['ir.actions.act_window']._for_xml_id('hr_timesheet.act_hr_timesheet_line_by_project')
         if not self.env.context.get('from_embedded_action'):

--- a/addons/hr_timesheet/models/project_project.py
+++ b/addons/hr_timesheet/models/project_project.py
@@ -1,9 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from collections import defaultdict
 
 from odoo import api, fields, models
 from odoo.exceptions import RedirectWarning, ValidationError
-from odoo.tools import SQL, float_round
+from odoo.tools import SQL
 from odoo.tools.translate import _
 
 
@@ -24,9 +23,6 @@ class ProjectProject(models.Model):
 
     timesheet_ids = fields.One2many('account.analytic.line', 'project_id', 'Associated Timesheets', export_string_translation=False)
     timesheet_encode_uom_id = fields.Many2one('uom.uom', compute='_compute_timesheet_encode_uom_id', export_string_translation=False)
-    total_timesheet_time = fields.Float(
-        compute='_compute_total_timesheet_time', groups='hr_timesheet.group_hr_timesheet_user',
-        string="Total amount of time (in the proper unit) recorded in the project, rounded to the unit.", export_string_translation=False)
     encode_uom_in_days = fields.Boolean(compute='_compute_encode_uom_in_days', export_string_translation=False)
     is_internal_project = fields.Boolean(compute='_compute_is_internal_project', search='_search_is_internal_project', export_string_translation=False)
     remaining_hours = fields.Float(compute='_compute_remaining_hours', string='Time Remaining', compute_sudo=True)
@@ -81,7 +77,7 @@ class ProjectProject(models.Model):
             project.remaining_hours = project.allocated_hours - project.effective_hours
             project.is_project_overtime = project.remaining_hours < 0
 
-    @api.depends('allow_timesheets', 'total_timesheet_time', 'allocated_hours', 'timesheet_encode_uom_id')
+    @api.depends('allow_timesheets', 'effective_hours', 'allocated_hours', 'timesheet_encode_uom_id')
     def _compute_timesheet_stat_values(self):
         for project in self:
             if not project.allow_timesheets or not self.env.user.has_group("hr_timesheet.group_hr_timesheet_user"):
@@ -93,7 +89,7 @@ class ProjectProject(models.Model):
             uom_ratio = self.env.ref('uom.product_uom_hour').factor / encode_uom.factor
 
             allocated = project.allocated_hours * uom_ratio
-            effective = project.total_timesheet_time
+            effective = project.effective_hours * uom_ratio
 
             stat_timesheet_value = False
             stat_extra_time_value = False
@@ -161,29 +157,6 @@ class ProjectProject(models.Model):
                     "To use the timesheets feature, you need an analytic account for your project. Please set one up in the plan '%(plan_name)s' or turn off the timesheets feature.",
                     plan_name=project_plan.name
                 ))
-
-    @api.depends('timesheet_ids', 'timesheet_encode_uom_id')
-    def _compute_total_timesheet_time(self):
-        timesheets_read_group = self.env['account.analytic.line']._read_group(
-            [('project_id', 'in', self.ids)],
-            ['project_id', 'product_uom_id'],
-            ['unit_amount:sum'],
-        )
-        timesheet_time_dict = defaultdict(list)
-        for project, product_uom, unit_amount_sum in timesheets_read_group:
-            timesheet_time_dict[project.id].append((product_uom, unit_amount_sum))
-
-        for project in self:
-            # Timesheets may be stored in a different unit of measure, so first
-            # we convert all of them to the reference unit
-            # if the timesheet has no product_uom_id then we take the one of the project
-            total_time = 0.0
-            for product_uom, unit_amount in timesheet_time_dict[project.id]:
-                factor = (product_uom or project.timesheet_encode_uom_id).factor
-                total_time += unit_amount * (1.0 if project.encode_uom_in_days else factor)
-            # Now convert to the proper unit of measure set in the settings
-            total_time /= project.timesheet_encode_uom_id.factor
-            project.total_timesheet_time = float_round(total_time, precision_digits=2)
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/hr_timesheet/models/project_update.py
+++ b/addons/hr_timesheet/models/project_update.py
@@ -34,6 +34,6 @@ class ProjectUpdate(models.Model):
             update.write({
                 "uom_id": encode_uom,
                 "allocated_time": round(project.allocated_hours * ratio),
-                "timesheet_time": round(project.sudo().total_timesheet_time),
+                "timesheet_time": round(project.effective_hours * ratio),
             })
         return updates

--- a/addons/hr_timesheet/models/res_company.py
+++ b/addons/hr_timesheet/models/res_company.py
@@ -9,18 +9,9 @@ class ResCompany(models.Model):
     _inherit = 'res.company'
 
     @api.model
-    def _default_project_time_mode_id(self):
-        return self.env.ref('uom.product_uom_hour', raise_if_not_found=False)
-
-    @api.model
     def _default_timesheet_encode_uom_id(self):
         return self.env.ref('uom.product_uom_hour', raise_if_not_found=False)
 
-    project_time_mode_id = fields.Many2one('uom.uom', string='Project Time Unit',
-        default=_default_project_time_mode_id,
-        help="This will set the unit of measure used in projects and tasks.\n"
-             "If you use the timesheet linked to projects, don't "
-             "forget to setup the right unit of measure in your employees.")
     timesheet_encode_uom_id = fields.Many2one('uom.uom', string="Timesheet Encoding Unit",
         default=_default_timesheet_encode_uom_id)
     internal_project_id = fields.Many2one(

--- a/addons/hr_timesheet/models/res_config_settings.py
+++ b/addons/hr_timesheet/models/res_config_settings.py
@@ -11,11 +11,6 @@ class ResConfigSettings(models.TransientModel):
         compute="_compute_timesheet_modules", store=True, readonly=False)
     reminder_user_allow = fields.Boolean(string="Employee Reminder")
     reminder_allow = fields.Boolean(string="Approver Reminder")
-    project_time_mode_id = fields.Many2one(
-        'uom.uom', related='company_id.project_time_mode_id', string='Project Time Unit', readonly=False,
-        help="This will set the unit of measure used in projects and tasks.\n"
-             "If you use the timesheet linked to projects, don't "
-             "forget to setup the right unit of measure in your employees.")
     is_encode_uom_days = fields.Boolean(compute='_compute_is_encode_uom_days', export_string_translation=False)
     timesheet_encode_method = fields.Selection([
         ('hours', 'Hours / Minutes'),

--- a/addons/hr_timesheet/tests/test_project_project.py
+++ b/addons/hr_timesheet/tests/test_project_project.py
@@ -1,6 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import Command
 from odoo.tests import TransactionCase, tagged
 
 
@@ -62,32 +61,3 @@ class TestProjectProject(TransactionCase):
         }])
         self.assertEqual(project1.account_id, analytic_account, 'Project 1 should have the default analytic account')
         self.assertEqual(project2.account_id, analytic_account, 'Project 2 should have the default analytic account')
-
-    def test_compute_total_timesheet_time(self):
-        employee = self.env['hr.employee'].create({
-             'name': 'Test Employee',
-        })
-
-        project = self.env['project.project'].create({
-            'name': 'Test Project',
-            'allocated_hours': 1.0,
-        })
-
-        self.env['project.task'].create({
-            'name': 'Test Task',
-            'project_id': project.id,
-            'timesheet_ids': [
-                Command.create({
-                    'name': '/',
-                    'employee_id': employee.id,
-                    'unit_amount': 0.5,
-                }),
-                Command.create({
-                    'name': '/',
-                    'employee_id': employee.id,
-                    'unit_amount': 0.25,
-                }),
-            ],
-        })
-
-        self.assertEqual(project.total_timesheet_time, 0.75, 'The total timesheet time should be 0.75 (00:45) hours.')

--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -570,7 +570,7 @@ class TestTimesheet(TestCommonTimesheet):
 
     def test_ensure_product_uom_set_in_timesheet(self):
         self.assertFalse(self.project_customer.timesheet_ids, 'No timesheet should be recorded in this project')
-        self.assertFalse(self.project_customer.total_timesheet_time, 'The total time recorded should be equal to 0 since no timesheet is recorded.')
+        self.assertFalse(self.project_customer.effective_hours, 'The total time recorded should be equal to 0 since no timesheet is recorded.')
 
         timesheet1, timesheet2 = self.env['account.analytic.line'].with_user(self.user_employee).create([
             {'unit_amount': 1.0, 'project_id': self.project_customer.id},
@@ -585,11 +585,11 @@ class TestTimesheet(TestCommonTimesheet):
             timesheet2.product_uom_id,
             self.project_customer.account_id.company_id.timesheet_encode_uom_id,
             'Even if the product_uom_id field is empty in the vals, the product_uom_id should have a UoM by default,'
-            ' otherwise the `total_timesheet_time` in project should not included the timesheet.'
+            ' otherwise the `effective_hours` in project should not included the timesheet.'
         )
         self.assertEqual(self.project_customer.timesheet_ids, timesheet1 + timesheet2)
         self.assertEqual(
-            self.project_customer.total_timesheet_time,
+            self.project_customer.effective_hours,
             timesheet1.unit_amount + timesheet2.unit_amount,
             'The total timesheet time of this project should be equal to 4.'
         )
@@ -675,7 +675,7 @@ class TestTimesheet(TestCommonTimesheet):
         # Clear cached computed project values before the UoM change
         self.env['project.project'].invalidate_model()
         self.env.company.timesheet_encode_uom_id = self.env.ref('uom.product_uom_day')
-        self.assertEqual(project.total_timesheet_time, 1, "Total timesheet time should be 1 day")
+        self.assertEqual(project.effective_hours, 8, "Hours Spent should be 8 hours")
         project.allocated_hours = 0.0
         self.assertEqual(project.timesheet_encode_uom_id, self.env.company.timesheet_encode_uom_id, "Timesheet encode uom should be the one from the company of the env, since the project has no company.")
         project_update_days = self.env['project.update'].create({

--- a/addons/hr_timesheet/tests/test_timesheet.py
+++ b/addons/hr_timesheet/tests/test_timesheet.py
@@ -142,7 +142,7 @@ class TestTimesheet(TestCommonTimesheet):
     def test_log_timesheet(self):
         """ Test when log timesheet: check analytic account, user and employee are correctly set. """
         Timesheet = self.env['account.analytic.line']
-        timesheet_uom = self.project_customer.account_id.company_id.project_time_mode_id
+        timesheet_uom = self.env.ref('uom.product_uom_hour')
         # employee 1 log some timesheet on task 1
         timesheet1 = Timesheet.with_user(self.user_employee).create({
             'project_id': self.project_customer.id,
@@ -615,23 +615,24 @@ class TestTimesheet(TestCommonTimesheet):
 
     def test_create_timesheet_with_companyless_analytic_account(self):
         """ This test ensures that a timesheet can be created on an analytic account whose company_id is set to False"""
+        timesheet_uom = self.env.ref('uom.product_uom_hour')
         self.project_customer.account_id.company_id = False
         timesheet_with_project = self.env['account.analytic.line'].with_user(self.user_employee).create(
             {'unit_amount': 1.0, 'project_id': self.project_customer.id})
-        self.assertEqual(timesheet_with_project.product_uom_id, self.project_customer.company_id.project_time_mode_id,
+        self.assertEqual(timesheet_with_project.product_uom_id, timesheet_uom,
                          "The product_uom_id of the timesheet should be equal to the project's company uom "
                          "if the project's analytic account has no company_id and no task_id is defined in the vals")
         timesheet_with_task = self.env['account.analytic.line'].with_user(self.user_employee).create({
             'unit_amount': 1.0, 'task_id': self.task1.id
         })
-        self.assertEqual(timesheet_with_task.product_uom_id, self.task1.company_id.project_time_mode_id,
+        self.assertEqual(timesheet_with_task.product_uom_id, timesheet_uom,
                          "The product_uom_id of the timesheet should be equal to the task's company uom "
                          "if the project's analytic account has no company_id")
         # Remove the company also on the project to be sure we find a UoM
         self.project_customer.company_id = False
         timesheet_with_project.with_user(self.user_employee).write(
             {'unit_amount': 2.0, 'project_id': self.project_customer.id})
-        self.assertEqual(timesheet_with_project.product_uom_id, self.env.company.project_time_mode_id,
+        self.assertEqual(timesheet_with_project.product_uom_id, timesheet_uom,
                          "The product_uom_id of the timesheet should be equal to the company uom "
                          "if the project's analytic account and the project have no company_id")
 

--- a/addons/hr_timesheet/views/res_config_settings_views.xml
+++ b/addons/hr_timesheet/views/res_config_settings_views.xml
@@ -9,9 +9,6 @@
             <xpath expr="//form" position="inside">
                 <app data-string="Timesheets" string="Timesheets" name="hr_timesheet" groups="hr_timesheet.group_timesheet_manager" id="timesheets">
                     <block title="Time Encoding" name="time_encoding_setting_container">
-                        <setting id="time_mode_setting" company_dependent="1" invisible="project_time_mode_id">
-                            <field name="project_time_mode_id" options="{'no_create': True, 'no_open': True}"/>
-                        </setting>
                         <setting company_dependent="1" help="Time unit used to record your timesheets" id="time_unit_timesheets_setting">
                             <field name="timesheet_encode_method" class="col-lg-5 ps-0" widget="radio"/>
                             <field name="is_encode_uom_days" invisible="1"/>

--- a/addons/sale_timesheet/models/account_move.py
+++ b/addons/sale_timesheet/models/account_move.py
@@ -34,8 +34,9 @@ class AccountMove(models.Model):
         ], ['reinvoice_move_id'], ['unit_amount:sum'])
         timesheet_unit_amount_dict = defaultdict(float)
         timesheet_unit_amount_dict.update({timesheet_invoice.id: amount for timesheet_invoice, amount in group_data})
+        uom_hour = self.env.ref('uom.product_uom_hour')
         for invoice in self:
-            total_time = invoice.company_id.project_time_mode_id._compute_quantity(
+            total_time = uom_hour._compute_quantity(
                 timesheet_unit_amount_dict[invoice.id],
                 invoice.timesheet_encode_uom_id,
                 rounding_method='HALF-UP',

--- a/addons/sale_timesheet/models/sale_order.py
+++ b/addons/sale_timesheet/models/sale_order.py
@@ -32,15 +32,16 @@ class SaleOrder(models.Model):
         for order in self:
             order.timesheet_count = timesheets_per_so.get(order.id, 0)
 
-    @api.depends('company_id.project_time_mode_id', 'company_id.timesheet_encode_uom_id', 'order_line.timesheet_ids')
+    @api.depends('company_id.timesheet_encode_uom_id', 'order_line.timesheet_ids')
     def _compute_timesheet_total_duration(self):
         group_data = self.env['account.analytic.line']._read_group([
             ('order_id', 'in', self.ids), ('project_id', '!=', False)
         ], ['order_id'], ['unit_amount:sum'])
         timesheet_unit_amount_dict = defaultdict(float)
         timesheet_unit_amount_dict.update({order.id: unit_amount for order, unit_amount in group_data})
+        uom_hour = self.env.ref('uom.product_uom_hour')
         for sale_order in self:
-            total_time = sale_order.company_id.project_time_mode_id._compute_quantity(
+            total_time = uom_hour._compute_quantity(
                 timesheet_unit_amount_dict[sale_order.id],
                 sale_order.timesheet_encode_uom_id,
                 rounding_method='HALF-UP',

--- a/addons/sale_timesheet/models/sale_order_line.py
+++ b/addons/sale_timesheet/models/sale_order_line.py
@@ -22,10 +22,11 @@ class SaleOrderLine(models.Model):
         with_remaining_hours = self.env.context.get('with_remaining_hours') and not self.env.context.get('skip_remaining_hours', False)
         if with_remaining_hours and any(line.remaining_hours_available for line in self):
             company = self.env.company
+            uom_hour = self.env.ref('uom.product_uom_hour')
             encoding_uom = company.timesheet_encode_uom_id
             is_hour = is_day = False
             unit_label = ''
-            if encoding_uom == self.env.ref('uom.product_uom_hour'):
+            if encoding_uom == uom_hour:
                 is_hour = True
                 unit_label = _('remaining')
             elif encoding_uom == self.env.ref('uom.product_uom_day'):
@@ -37,7 +38,7 @@ class SaleOrderLine(models.Model):
                     if is_hour:
                         remaining_time = f' ({format_duration(line.remaining_hours)} {unit_label})'
                     elif is_day:
-                        remaining_days = company.project_time_mode_id._compute_quantity(line.remaining_hours, encoding_uom, round=False)
+                        remaining_days = uom_hour._compute_quantity(line.remaining_hours, encoding_uom, round=False)
                         remaining_time = f' ({remaining_days:.02f} {unit_label})'
                     if self.env.context.get('formatted_display_name'):
                         name = f'{line.display_name} --{remaining_time}--'
@@ -94,16 +95,17 @@ class SaleOrderLine(models.Model):
     ###########################################
 
     def _convert_qty_company_hours(self, dest_company):
-        company_time_uom_id = dest_company.project_time_mode_id
-        allocated_hours = 0.0
+        uom_hour = self.env.ref('uom.product_uom_hour')
         product_uom = self.product_uom_id
         if product_uom == self.env.ref('uom.product_uom_unit'):
-            product_uom = self.env.ref('uom.product_uom_hour')
-        if product_uom != company_time_uom_id and product_uom._has_common_reference(company_time_uom_id):
-            allocated_hours = product_uom._compute_quantity(self.product_uom_qty, company_time_uom_id, rounding_method='HALF-UP')
-        else:
-            allocated_hours = self.product_uom_qty
-        return allocated_hours
+            product_uom = uom_hour
+        if product_uom != uom_hour and product_uom._has_common_reference(uom_hour):
+            return product_uom._compute_quantity(
+                self.product_uom_qty,
+                uom_hour,
+                rounding_method='HALF-UP',
+            )
+        return self.product_uom_qty
 
     def _timesheet_create_project(self):
         project = super()._timesheet_create_project()
@@ -114,7 +116,6 @@ class SaleOrderLine(models.Model):
                 'allow_timesheets': True,
             })
             return project
-        project_uom = self.company_id.project_time_mode_id
         uom_unit = self.env.ref('uom.product_uom_unit')
         uom_hour = self.env.ref('uom.product_uom_hour')
 
@@ -134,7 +135,7 @@ class SaleOrderLine(models.Model):
                     and line.product_id.service_tracking in ['task_in_project', 'project_only'] \
                     and line.product_id.project_template_id == self.product_id.project_template_id \
                     and line.product_uom_id.id in factor_per_id:
-                uom_factor = factor_per_id[line.product_uom_id.id] / project_uom.factor
+                uom_factor = factor_per_id[line.product_uom_id.id] / uom_hour.factor
                 allocated_hours += line.product_uom_qty * uom_factor
 
         project.write({

--- a/addons/sale_timesheet_margin/models/sale_order_line.py
+++ b/addons/sale_timesheet_margin/models/sale_order_line.py
@@ -29,14 +29,15 @@ class SaleOrderLine(models.Model):
                 so_line.id: - amount_sum / unit_amount_sum if unit_amount_sum else 0.0
                 for so_line, amount_sum, unit_amount_sum in group_amount
             }
+            uom_hour = self.env.ref('uom.product_uom_hour')
             for line in timesheet_sols:
                 line = line.with_company(line.company_id)
                 product_cost = mapped_sol_timesheet_amount.get(line.id, line.product_id.standard_price)
                 product_uom = line.product_uom_id or line.product_id.uom_id
-                if product_uom != line.company_id.project_time_mode_id:
+                if product_uom != uom_hour:
                     product_cost = product_uom._compute_quantity(
                         product_cost,
-                        line.company_id.project_time_mode_id
+                        uom_hour
                     )
 
                 line.purchase_price = line._convert_to_sol_currency(

--- a/addons/sale_timesheet_margin/tests/test_sale_timesheet_margin.py
+++ b/addons/sale_timesheet_margin/tests/test_sale_timesheet_margin.py
@@ -83,7 +83,7 @@ class TestSaleTimesheetMargin(TestCommonSaleTimesheet):
         # Cost is expressed in SO line uom
         expected_cost = self.uom_day._compute_quantity(
             self.employee_manager.hourly_cost,
-            self.env.company.project_time_mode_id
+            self.env.ref('uom.product_uom_hour')
         )
         self.assertEqual(sale_order.order_line.purchase_price, expected_cost, "Sale order line cost should be number of working hours on one day * timesheet cost of the employee set on the timesheet linked to the SOL.")
 


### PR DESCRIPTION
_* = sale_timesheet, sale_timesheet_margin

- Remove project_time_mode_id from `res.company` and `res.config.settings`.

- Timesheets are now always stored in hours in the database, making the project time mode configuration obsolete. The related fields and associated logic are removed to simplify the configuration and ensure consistent behavior.

- This commit removes the `total_timesheet_time` field and updates the logic to use the project’s total duration computed from `effective_hours` instead.

task-3508445



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
