### PR TITLE
[FIX] mrp{,_account}: use company compenent price for unbuild

### DIFF
--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -166,7 +166,7 @@ class MrpUnbuild(models.Model):
         self.ensure_one()
         self._check_company()
         # remove the default_* keys that were only needed in the unbuild wizard
-        self = self.with_env(self.env(context=clean_context(self.env)))  # noqa: PLW0642
+        self = self.with_env(self.env(context=clean_context(self.env.context)))  # noqa: PLW0642
         if self.product_id.tracking != 'none' and not self.lot_id.id:
             raise UserError(_('You should provide a lot number for the final product.'))
 

--- a/addons/mrp_account/tests/test_mrp_account.py
+++ b/addons/mrp_account/tests/test_mrp_account.py
@@ -176,6 +176,29 @@ class TestMrpAccount(TestBomPriceCommon):
         mo_1 = self._create_mo(self.bom_1, 1)
         mo_1.with_user(mrp_user).button_mark_done()
 
+    def test_unbuild_component_cost_no_MO_multi_company(self):
+        """ Check that when unbuild is created, unrelated to a MO,
+        the price used for the incoming moves of the component, is the
+        price from the company from which de unbuild was made.
+        """
+        company_2 = self.env['res.company'].create({'name': 'other company new name'})
+        finished = self.dining_table
+        finished.qty_available = 1
+        comp = self.screw
+        comp.categ_id = self.category_standard_auto
+        comp.standard_price = 10
+        comp.with_company(company_2).standard_price = 9
+        self.bom_1.bom_line_ids.filtered(lambda bl: bl.product_id == comp).product_qty = 1
+
+        unbuild_form = Form(self.env['mrp.unbuild'])
+        unbuild_form.product_id = self.dining_table
+        unbuild_form.bom_id = self.bom_1
+        unbuild_form.product_qty = 1
+        unbuild_order = unbuild_form.save()
+        unbuild_order.with_company(company_2).action_unbuild()
+        comp_move_value = unbuild_order.produce_line_ids.filtered(lambda m: m.product_id == comp).value
+        self.assertEqual(comp_move_value, 9)
+
 
 class TestMrpAccountWorkorder(TestBomPriceOperationCommon):
 


### PR DESCRIPTION
**Problem:**
When unbuilding a product (not from a specific MO)
from another company than the user company, the incoming 
moves for the components will have the standard price of 
the component in the user's company.

**Steps to reproduce:**
from main company :
- create two tracked product one finished prod and one comp
- set a price of 10 on the comp and avco perpetual on the category

from other company:
- create a bom from the finished prod with 1 quantity of the comp
- change the cost of the comp to 9
- make sure the category is avco perpetual also from this company
- make sure this other company has a warehouse (or create it)
- set an on hand positive quantity for the finished product
- open 'unbuild orders' and create a new one for the finished prod
- click on 'unbuild'
- open inventory/reporting/stock

**Current behavior:**
the comp product has a unit cost of 10

**Expected behavior:**
the unit cost should be 9

**Cause of the issue:**
At the beginning of action_unbuild() we create a new environment
and we call clean context to remove the default_* keys from 
the current context and pass it to the new env. 
https://github.com/odoo/odoo/blob/0cca4c6ec28499392c862de01022c241b44b00b6/addons/mrp/models/mrp_unbuild.py#L169
But clean_context is mistakenly called with self.env as the argument
instead of self.env.context. 
So we actually lose all the current context, including 
'allowed_company_ids'. 
Which means the next time we will use 
self.env.company, inside the cached_property company, 
company_ids will be empty and the return value will 
be the user company
https://github.com/odoo/odoo/blob/0cca4c6ec28499392c862de01022c241b44b00b6/odoo/orm/environments.py#L236-L243


Later, when set_value() is called on the component move, 
we will use _get_value() because the move is incoming. 
https://github.com/odoo/odoo/blob/0cca4c6ec28499392c862de01022c241b44b00b6/addons/stock_account/models/stock_move.py#L282
Inside, get_value_data, 
get_value_from_return will return no quantity because the unbuild was not 
created from a MO so there is no origin_returned_move_id on the move
https://github.com/odoo/odoo/blob/0cca4c6ec28499392c862de01022c241b44b00b6/addons/stock_account/models/stock_move.py#L442-L443
so inside get_value_data will call _get_value_from_std_price()
https://github.com/odoo/odoo/blob/0cca4c6ec28499392c862de01022c241b44b00b6/addons/stock_account/models/stock_move.py#L386-L387
and there, because self.env.company is no more the other 
company but the company of the user, self.product_id.standard_price 
will return the standard price of the user's company.
https://github.com/odoo/odoo/blob/0cca4c6ec28499392c862de01022c241b44b00b6/addons/stock_account/models/stock_move.py#L452-L453

opw-5906444