### PR TITLE
[FIX] point_of_sale: fix runbot error

### DIFF
--- a/addons/point_of_sale/static/tests/tours/chrome_tour.js
+++ b/addons/point_of_sale/static/tests/tours/chrome_tour.js
@@ -300,5 +300,6 @@ registry.category("web_tour.tours").add("test_set_opening_note_without_cash_meth
                 run: "edit Opening Notes",
             },
             Dialog.confirm("Open Register"),
+            Chrome.waitRequest(),
         ].flat(),
 });

--- a/addons/pos_self_order/tests/test_self_order_prices.py
+++ b/addons/pos_self_order/tests/test_self_order_prices.py
@@ -38,6 +38,8 @@ class TestSelfOrderCombo(SelfOrderCommonTest):
             'name': 'Big Combo',
             'type': 'combo',
             'lst_price': 200.0,
+            'available_in_pos': True,
+            'self_order_available': True,
             'uom_id': self.env.ref('uom.product_uom_unit').id,
             'combo_ids': [(6, 0, [self.combo1.id, self.combo2.id, self.combo3.id])],
             'pos_categ_ids': [(6, 0, [self.combo_category.id])],
@@ -46,6 +48,8 @@ class TestSelfOrderCombo(SelfOrderCommonTest):
         self.env['product.product'].create({
             'name': 'Random Product 1',
             'type': 'consu',
+            'available_in_pos': True,
+            'self_order_available': True,
             'lst_price': 15.0,
             'taxes_id': [(6, 0, [self.tax_21.id])],
             'pos_categ_ids': [(6, 0, [self.combo_category.id])],
@@ -54,6 +58,8 @@ class TestSelfOrderCombo(SelfOrderCommonTest):
             'name': 'Random Product 2',
             'type': 'consu',
             'lst_price': 25.0,
+            'available_in_pos': True,
+            'self_order_available': True,
             'taxes_id': [(6, 0, [self.tax_12.id])],
             'pos_categ_ids': [(6, 0, [self.combo_category.id])],
         })
@@ -61,6 +67,8 @@ class TestSelfOrderCombo(SelfOrderCommonTest):
             'name': 'Random Product 3',
             'type': 'consu',
             'lst_price': 35.0,
+            'available_in_pos': True,
+            'self_order_available': True,
             'taxes_id': [(6, 0, [self.tax_6.id])],
             'pos_categ_ids': [(6, 0, [self.combo_category.id])],
         })
@@ -69,6 +77,7 @@ class TestSelfOrderCombo(SelfOrderCommonTest):
             'name': 'Product with attributes',
             'is_storable': True,
             'available_in_pos': True,
+            'self_order_available': True,
             'lst_price': 100.95,
             'pos_categ_ids': [(6, 0, [self.combo_category.id])],
             'taxes_id': [(6, 0, [self.tax_21.id])],
@@ -123,6 +132,7 @@ class TestSelfOrderCombo(SelfOrderCommonTest):
             'name': f'{name} 1',
             'is_storable': True,
             'available_in_pos': True,
+            'self_order_available': True,
             'lst_price': lst_price[0],
             'taxes_id': [(6, 0, [self.tax_6.id])],
         })
@@ -130,6 +140,7 @@ class TestSelfOrderCombo(SelfOrderCommonTest):
             'name': f'{name} 2',
             'is_storable': True,
             'available_in_pos': True,
+            'self_order_available': True,
             'lst_price': lst_price[1],
             'taxes_id': [(6, 0, [self.tax_12.id])],
         })
@@ -137,6 +148,7 @@ class TestSelfOrderCombo(SelfOrderCommonTest):
             'name': f'{name} 3',
             'is_storable': True,
             'available_in_pos': True,
+            'self_order_available': True,
             'lst_price': lst_price[2],
             'taxes_id': [(6, 0, [self.tax_21.id])],
         })


### PR DESCRIPTION
https://runbot.odoo.com/odoo/runbot.build.error/241044
We were not waiting the last request to be processed before ending the
test, which could cause some random errors.

https://runbot.odoo.com/odoo/runbot.build.error/241151
All products were not available in PoS and Self, which caused some
errors on community builds.