### PR TITLE
[IMP] account_reports: vertical_percentage comparison mode

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -182,6 +182,11 @@ class AccountReport(models.Model):
         compute=lambda x: x._compute_report_option_filter('filter_growth_comparison', True),
         precompute=True, readonly=False, store=True, depends=['root_report_id', 'section_main_report_ids'],
     )
+    filter_line_comparison = fields.Boolean(
+        string="Report Line Comparison",
+        compute=lambda x: x._compute_report_option_filter('filter_line_comparison', False),
+        precompute=True, readonly=False, store=True, depends=['root_report_id', 'section_main_report_ids'],
+    )
     filter_journals = fields.Boolean(
         string="Journals",
         compute=lambda x: x._compute_report_option_filter('filter_journals'), readonly=False,


### PR DESCRIPTION
This commit adds `filter_line_comparison` for controlling availability of Report Line Comparison based on report type.

task-5144252

Related Enterprise PR: https://github.com/odoo/enterprise/pull/98245