### PR TITLE
[IMP] {hr_}calendar: add a getter method for `businessHours`

### DIFF
--- a/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_model.js
+++ b/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_model.js
@@ -204,6 +204,14 @@ export class AttendeeCalendarModel extends CalendarModel {
         await this._archiveRecord(record.id, recurrenceUpdate);
     }
 
+    /**
+     * The business hours mode specifying the calculation of business hours.
+     * It is currently used in the appointment & hr_calendar.
+     */
+    get businessHoursMode() {
+        return "";
+    }
+
     async _archiveRecord(id, recurrenceUpdate) {
         if (!recurrenceUpdate && recurrenceUpdate !== "self_only") {
             await this.orm.call(this.resModel, "action_archive", [[id]]);

--- a/addons/hr_calendar/static/src/calendar/calendar_model.js
+++ b/addons/hr_calendar/static/src/calendar/calendar_model.js
@@ -8,13 +8,19 @@ patch(AttendeeCalendarModel.prototype, {
         this.data.workingHours = {};
     },
 
+    get businessHoursMode() {
+        return super.businessHoursMode || "working_hours";
+    },
+
     get workingHours() {
         return this.data.workingHours;
     },
 
     async updateData(data) {
         await super.updateData(...arguments)
-        data.workingHours = await this.fetchWorkingHours(data);
+        if (this.businessHoursMode === "working_hours") {
+            data.workingHours = await this.fetchWorkingHours(data);
+        }
     },
 
     async fetchWorkingHours(data){

--- a/addons/hr_calendar/static/src/calendar/common/calendar_common_renderer.js
+++ b/addons/hr_calendar/static/src/calendar/common/calendar_common_renderer.js
@@ -3,15 +3,21 @@ import { patch } from "@web/core/utils/patch";
 import { onWillUpdateProps } from "@odoo/owl";
 
 patch(AttendeeCalendarCommonRenderer.prototype, {
-	setup() {
-		super.setup(...arguments);
-		onWillUpdateProps(() => {
-			this.fc.api.setOption("businessHours", this.props.model.workingHours)
-		});
-	},
-	get options() {
-		return Object.assign(super.options, {
-			businessHours: this.props.model.workingHours,
-		});
-	},
+    setup() {
+        super.setup(...arguments);
+        if (this.props.model.businessHoursMode === "working_hours") {
+            onWillUpdateProps(() => {
+                this.fc.api.setOption("businessHours", this.props.model.workingHours);
+            });
+        }
+    },
+    get options() {
+        if (this.props.model.businessHoursMode !== "working_hours") {
+            return super.options;
+        }
+
+        return Object.assign(super.options, {
+            businessHours: this.props.model.workingHours,
+        });
+    },
 });

--- a/search.yaml
+++ b/search.yaml
@@ -1,0 +1,9 @@
+rules:
+  - id: search
+    languages:
+      - python
+    severity: ERROR
+    message: |
+      Semgrep found a match
+    pattern: |
+      (Store.FieldList $X).extend(...), $X.attr(...)


### PR DESCRIPTION
This commit adds a getter method to define mode for calculating `businessHours`. The need for this getter is to provide a way to override `businessHours` for the `attendee_calendar`. The enterprise part adds the unavailabilities in the calendar view of  appointments events. For the calendar view of the same, `businessHours` is defined as available appointment slots.

Task-5416962
