### PR TITLE
[FIX] spreadsheet: Missing Chart types placeholder names

### DIFF
--- a/addons/spreadsheet/static/src/chart/plugins/odoo_chart_core_plugin.js
+++ b/addons/spreadsheet/static/src/chart/plugins/odoo_chart_core_plugin.js
@@ -16,6 +16,14 @@ const CHART_PLACEHOLDER_DISPLAY_NAME = {
     odoo_line: _t("Odoo Line Chart"),
     odoo_pie: _t("Odoo Pie Chart"),
     odoo_radar: _t("Odoo Radar Chart"),
+    odoo_geo: _t("Odoo Geo Chart"),
+    odoo_treemap: _t("Odoo Treemap Chart"),
+    odoo_sunburst: _t("Odoo Sunburst Chart"),
+    odoo_waterfall: _t("Odoo Waterfall Chart"),
+    odoo_pyramid: _t("Odoo Pyramid Chart"),
+    odoo_scatter: _t("Odoo Scatter Chart"),
+    odoo_combo: _t("Odoo Combo Chart"),
+    odoo_funnel: _t("Odoo Funnel Chart"),
 };
 
 export class OdooChartCorePlugin extends OdooCorePlugin {

--- a/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin.test.js
+++ b/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin.test.js
@@ -34,6 +34,7 @@ import { waitForDataLoaded } from "@spreadsheet/helpers/model";
 import { setGlobalFilterValue } from "../../helpers/commands";
 
 const { toZone } = spreadsheet.helpers;
+const { chartRegistry } = spreadsheet.registries;
 
 const cumulativeDateServerData = getBasicServerData();
 cumulativeDateServerData.models.partner.records = [
@@ -880,6 +881,36 @@ test("Odoo chart datasource display name has a default when the chart title is e
         sheetId,
     });
     expect(model.getters.getOdooChartDisplayName(chartId)).toBe("(#1) Odoo Line Chart");
+});
+
+test("Every Odoo chart type has a default title", async () => {
+    const { model } = await createSpreadsheetWithChart({ type: "odoo_line" });
+    const sheetId = model.getters.getActiveSheetId();
+    const chartId = model.getters.getChartIds(sheetId)[0];
+    const figureId = model.getters.getFigureIdFromChartId(chartId);
+    const chartTypes = chartRegistry.getKeys().filter((type) => type.startsWith("odoo_"));
+    model.dispatch("UPDATE_CHART", {
+        definition: { ...model.getters.getChartDefinition(chartId), title: { text: undefined } },
+        chartId,
+        figureId,
+        sheetId,
+    });
+
+    for (const chartType of chartTypes) {
+        const definition = {
+            ...model.getters.getChartDefinition(chartId),
+            type: chartType,
+        };
+        model.dispatch("UPDATE_CHART", {
+            definition,
+            chartId,
+            figureId,
+            sheetId,
+        });
+        await waitForDataLoaded(model);
+        const chartName = chartRegistry.get(chartType).name;
+        expect(model.getters.getOdooChartDisplayName(chartId)).toBe(`(#1) Odoo ${chartName} Chart`);
+    }
 });
 
 test("See records when clicking on a bar chart bar", async () => {


### PR DESCRIPTION
We recently added a lot of chart types that handle Odoo data but we failed to add a placeholder name (which is handy to differentiate them in the datasource menu).

Task-5979722

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
