### PR TITLE
[FIX] point_of_sale: fix QR-code cache issue

### DIFF
--- a/addons/point_of_sale/static/src/app/printer/render_service.js
+++ b/addons/point_of_sale/static/src/app/printer/render_service.js
@@ -126,6 +126,7 @@ export const htmlToCanvas = async (el, options) => {
                 height: Math.ceil(el.clientHeight),
                 width: Math.ceil(el.clientWidth),
                 pixelRatio: 1,
+                includeQueryParams: true,
             });
         },
     });


### PR DESCRIPTION
**Step to reproduce:**
- install "l10n_es_edi_verifactu_pos"
- setup "ePOS printer" for a pos
- open pos and settle a order below 400$
- notice we get l10n_es_edi_verifactu_qr_code in our receipt
- click on "Print receipt"
- repeat above steps for one more order

**Observation:**
- when we print the second order receipt, the QR still points to 1 order invoice

**Issue:**
- [getCacheKey](https://github.com/odoo/odoo/blob/0cee3350df09b06af77c879f0eba74bf6a8dd2c9/addons/point_of_sale/static/src/app/utils/html-to-image.js#L351C10-L355
) was trimming query strings when generating cache keys. URLs like:
`  http://localhost:9000/report/barcode/?barcode_type=QR&value=... `
were reduced to:
`  http://localhost:9000/report/barcode/`

- As a result, different QR code requests shared the same cache key. Subsequent requests reused the previously cached image instead of fetching a new one, producing incorrect QR codes for different orders.

**Solution:**
Add an `includeQueryParams` flag to `resourceToDataURL` so the full URL, including query parameters, is used as the cache key when needed. This ensures unique QR code URLs are cached and fetched correctly.

opw-5455807


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
