### PR TITLE
[IMP] web,purchase,sale: support hotkey on x2many list controls

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1214,10 +1214,10 @@
                                        options="{'hide_composition': True, 'hide_prices': True, 'subsections': True}">
                                     <list name="journal_items" editable="bottom" string="Journal Items" default_order="sequence, id">
                                         <control>
-                                            <create name="add_line_control" string="Add a line"/>
-                                            <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
-                                            <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
-                                            <button name="action_add_from_catalog" string="Catalog" type="object" class="btn-link" context="{'order_id': parent.id}"/>
+                                            <create name="add_line_control" string="Add a line" data-hotkey="l"/>
+                                            <create name="add_section_control" string="Add a section" data-hotkey="shift+h" context="{'default_display_type': 'line_section'}"/>
+                                            <create name="add_note_control" string="Add a note" data-hotkey="shift+n" context="{'default_display_type': 'line_note'}"/>
+                                            <button name="action_add_from_catalog" string="Catalog" data-hotkey="shift+k" type="object" class="btn-link" context="{'order_id': parent.id}"/>
                                         </control>
 
                                         <!-- Displayed fields -->

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -256,10 +256,10 @@
                                 <list string="Purchase Order Lines" editable="bottom" limit="200"
                                       decoration-warning="purchase_line_warn_msg">
                                     <control>
-                                        <create name="add_product_control" string="Add a product"/>
-                                        <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
-                                        <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
-                                        <button name="action_add_from_catalog" string="Catalog" type="object" class="px-4 btn-link" context="{'order_id': parent.id}"/>
+                                        <create name="add_product_control" string="Add a product" data-hotkey="shift+p"/>
+                                        <create name="add_section_control" string="Add a section" data-hotkey="shift+h" context="{'default_display_type': 'line_section'}"/>
+                                        <create name="add_note_control" string="Add a note" data-hotkey="shift+n" context="{'default_display_type': 'line_note'}"/>
+                                        <button name="action_add_from_catalog" string="Catalog" data-hotkey="shift+k" type="object" class="px-4 btn-link" context="{'order_id': parent.id}"/>
                                     </control>
                                     <field name="tax_calculation_rounding_method" column_invisible="True"/>
                                     <field name="display_type" column_invisible="True"/>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -696,11 +696,12 @@
                                 decoration-warning="(state in ['draft', 'sent'] and is_product_archived) or sale_line_warn_msg"
                             >
                                 <control>
-                                    <create name="add_product_control" string="Add a product"/>
-                                    <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
-                                    <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
+                                    <create name="add_product_control" string="Add a product" data-hotkey="shift+p"/>
+                                    <create name="add_section_control" string="Add a section" data-hotkey="shift+h" context="{'default_display_type': 'line_section'}"/>
+                                    <create name="add_note_control" string="Add a note" data-hotkey="shift+n" context="{'default_display_type': 'line_note'}"/>
                                     <button
                                         string="Catalog"
+                                        data-hotkey="shift+k"
                                         name="action_add_from_catalog"
                                         type="object"
                                         class="px-4 btn-link"

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -270,7 +270,7 @@
                                 context="{'default_company_id': company_id, 'default_date': scheduled_date, 'default_date_deadline': date_deadline, 'picking_type_code': picking_type_code, 'default_picking_id': id, 'form_view_ref': 'stock.view_stock_move_operations', 'address_in_id': partner_id, 'default_picking_type_id': picking_type_id, 'default_location_id': location_id, 'default_location_dest_id': location_dest_id, 'default_partner_id': partner_id, 'picking_state': state}">
                                 <list decoration-muted="is_scrap or state == 'cancel' or (state == 'done' and is_locked == True)" string="Stock Moves" editable="bottom">
                                     <control>
-                                        <create string="Add a Product"/>
+                                        <create string="Add a Product" hotkey="shift+p"/>
                                     </control>
                                     <field name="company_id" column_invisible="True"/>
                                     <field name="state" readonly="0" column_invisible="True"/>

--- a/addons/web/static/src/views/list/list_arch_parser.js
+++ b/addons/web/static/src/views/list/list_arch_parser.js
@@ -176,6 +176,7 @@ export class ListArchParser {
                             context: childNode.getAttribute("context"),
                             string: childNode.getAttribute("string"),
                             invisible: childNode.getAttribute("invisible"),
+                            hotkey: childNode.getAttribute("data-hotkey"),
                         });
                     } else if (childNode.tagName === "delete") {
                         controls.push({

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -162,7 +162,7 @@ export class ListRenderer extends Component {
 
         this.controls = this.props.archInfo.controls.length
             ? this.props.archInfo.controls
-            : [{ type: "create", string: _t("Add a line") }];
+            : [{ type: "create", string: _t("Add a line"), hotkey: "shift+l" }];
         this.deleteControl = this.controls.find((control) => control.type === "delete") || {};
 
         this.cellToFocus = null;

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -152,6 +152,7 @@
                             t-if="control.type === 'create' and !this.evalColumnInvisible(control.invisible)"
                             t-attf-class="btn btn-link #{control_index !== 0 ? 'ml16' : ''}"
                             t-att-tabindex="this.props.list.editedRecord ? '-1' : '0'"
+                            t-att-data-hotkey="control.hotkey || false"
                             t-on-click.stop.prevent="() => this.add({ context: control.context })"
                         >
                             <t t-out="control.string"/>
@@ -161,6 +162,7 @@
                             className="`${control.className} ${control_index !== 0 ? 'ml16' : ''}`"
                             clickParams="control.clickParams"
                             icon="control.icon"
+                            attrs="control.attrs"
                             record="this.props.list"
                             string="control.string"
                             title="control.title"

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -20316,3 +20316,38 @@ test(`widget column visibility with column_invisible attribute`, async () => {
     expect(`thead th:not(.o_list_record_selector)`).toHaveCount(2);
     expect(`.o_data_row .test_widget`).toHaveCount(0);
 });
+
+test(`x2many list: create control supports hotkey`, async () => {
+    Foo._records[0].o2m = [1];
+
+    await mountView({
+        resModel: "foo",
+        type: "form",
+        arch: `
+            <form>
+                <sheet>
+                    <field name="o2m">
+                        <list editable="bottom">
+                            <control>
+                                <create string="Add a line"/>
+                                <create string="Add a note" data-hotkey="n"/>
+                                <button type="object" name="custom_button" string="Catalog" data-hotkey="k"/>
+                            </control>
+                            <field name="name"/>
+                        </list>
+                    </field>
+                </sheet>
+            </form>
+        `,
+        resId: 1,
+    });
+
+    expect(queryAllTexts(`.o_field_x2many_list_row_add button`)).toEqual([
+        "Add a line",
+        "Add a note",
+        "Catalog",
+    ]);
+    expect(`.o_field_x2many_list_row_add button:eq(0)`).not.toHaveAttribute("data-hotkey");
+    expect(`.o_field_x2many_list_row_add button:eq(1)`).toHaveAttribute("data-hotkey", "n");
+    expect(`.o_field_x2many_list_row_add button:eq(2)`).toHaveAttribute("data-hotkey", "k");
+});


### PR DESCRIPTION
Allow defining a hotkey on `<create>` controls inside x2many list views.

This makes it possible to trigger create actions (e.g. "Add a note") using keyboard shortcuts, improving usability and consistency with other view types.

task-5956115

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
