### PR TITLE
[FIX] web: search_bar: isComposing on Safari during IME input

### DIFF
--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -40,6 +40,8 @@ const FOLDABLE_TYPES = ["properties", "many2one", "many2many"];
 let nextItemId = 1;
 const SUB_ITEMS_DEFAULT_LIMIT = 8;
 
+export const DROPDOWN_CLOSE_DELAY = 10;
+
 export class SearchBar extends Component {
     static template = "web.SearchBar";
     static components = {
@@ -667,6 +669,8 @@ export class SearchBar extends Component {
      * @param {InputEvent} ev
      */
     onSearchInput(ev) {
+        clearTimeout(this.searchDropdownCloseTimeout);
+
         if (!hasTouch()) {
             this.searchBarDropdownState.close();
         }
@@ -678,8 +682,10 @@ export class SearchBar extends Component {
             }
             this.computeState({ query, expanded: [], subItems: [] });
         } else if (this.items.length) {
-            this.inputDropdownState.close();
-            this.resetState();
+            this.searchDropdownCloseTimeout = setTimeout(() => {
+                this.inputDropdownState.close();
+                this.resetState();
+            }, DROPDOWN_CLOSE_DELAY);
         }
     }
 

--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -1,5 +1,6 @@
 import { expect, test } from "@odoo/hoot";
 import {
+    advanceTime,
     clear,
     click,
     edit,
@@ -46,7 +47,7 @@ import {
     validateSearch,
 } from "@web/../tests/web_test_helpers";
 import { cookie } from "@web/core/browser/cookie";
-import { SearchBar } from "@web/search/search_bar/search_bar";
+import { SearchBar, DROPDOWN_CLOSE_DELAY } from "@web/search/search_bar/search_bar";
 import { useSearchBarToggler } from "@web/search/search_bar/search_bar_toggler";
 class Partner extends models.Model {
     name = fields.Char();
@@ -531,6 +532,44 @@ test("update suggested filters in autocomplete menu with Japanese IME", async ()
     expect(`.o_searchview_autocomplete`).toHaveCount(1);
     expect(queryFirst`.o_searchview_autocomplete .o-dropdown-item`).toHaveText(
         `Search Foo for: ${TEST}`
+    );
+});
+
+test("intermediate Backspace events from iOS Korean IME shouldn't close autocomplete", async () => {
+    // This test simulates the behavior of the iOS Korean IME during composition.
+    // On iOS, `isComposing` is not set, but the IME sends a Backspace before
+    // rewriting the composing syllable. Our component (SearchBar) must handle
+    // this without closing the autocomplete dropdown.
+
+    // Typing 'ㄱ' followed by 'ㅏ' produces the precomposed syllable '가'.
+    const COMPOSED_SYLLABLE = "가";
+
+    await mountWithSearch(SearchBar, {
+        resModel: "partner",
+        searchMenuTypes: [],
+        searchViewId: false,
+    });
+
+    await click(".o_searchview input");
+
+    // User types the initial consonant 'ㄱ'
+    await press("ㄱ");
+
+    // Wait search autocomplete
+    await animationFrame();
+
+    // User types the second character 'ㅏ'
+    // iOS sends Backspace to remove previous char and inserts the precomposed syllable
+    await press("Backspace");
+    await press("가");
+
+    // Autocomplete should remain open even after composition with backspace.
+    await animationFrame();
+    await advanceTime(DROPDOWN_CLOSE_DELAY);
+    await animationFrame();
+    expect(queryFirst`.o_searchview input`).toHaveValue(COMPOSED_SYLLABLE);
+    expect(`.o_searchview_autocomplete .o-dropdown-item:first`).toHaveText(
+        `Search Foo for: ${COMPOSED_SYLLABLE}`
     );
 });
 
@@ -1079,6 +1118,8 @@ test("search a property", async () => {
 
     // search for a partner, and expand the many2many property
     await contains(`.o_searchview_input`).clear();
+    // wait for autocomplete to close to make sure it updates its state
+    await advanceTime(DROPDOWN_CLOSE_DELAY);
     await editSearch("Bo");
     await contains(".o_expand").click();
     await contains(".o_searchview_autocomplete .o-dropdown-item:nth-child(3) .o_expand").click();


### PR DESCRIPTION
Safari does not reliably set `KeyboardEvent.isComposing` during IME composition (e.g. Korean). As a result, the search value was processed too early and got cleared while composition was still in progress.

Interestingly, the issue could not be reproduced with the Japanese keyboard, which appeared to behave correctly. See [1].

This commit introduces a short delay before closing the autocomplete. On iOS, the IME temporarily triggers a Backspace event to remove the previously composed character before inserting the updated one. This Backspace incorrectly causes the autocomplete to close. With this change, we wait briefly (10ms) before closing it. If a new input event is received during that delay (corresponding to the newly composed character generated by the IME), the close action is cancelled.

This ensures that the autocomplete remains open while the IME composition process completes.

Steps to reproduce:
- Configure a Korean keyboard on an iPhone
- Open a Sale Order
- Focus the search bar
- Type a character, then type a second one to combine them
- The search input value gets reset

[1] #222151

opw-5448385

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
