### PR TITLE
[FIX] web: remove lazyloader from `assets_unit_tests_setup`

### DIFF
--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -234,9 +234,6 @@ This module provides the core of the Odoo Web Client.
             'web/static/src/public/**/*.js',
             'web/static/src/public/**/*.xml',
             ('remove', 'web/static/src/public/database_manager.js'),
-
-            'web/static/src/public/public_root.js',
-            'web/static/src/public/public_root_instance.js',
         ],
         'web.assets_frontend_lazy': [
             ('include', 'web.assets_frontend'),
@@ -451,6 +448,8 @@ This module provides the core of the Odoo Web Client.
 
             'web/static/src/polyfills/set.js',
             'web/static/src/public/**/*.js',
+            ("remove", 'web/static/src/public/lazyloader.js'),
+            ("remove", 'web/static/src/public/public_root.js'),
             ("remove", 'web/static/src/public/public_root_instance.js'),
             'web/static/src/public/**/*.xml',
             'web/static/tests/public/**/*.xml',


### PR DESCRIPTION
__Problem__
`lazyloader.js`, `public_root.js` and `public_root_instance.js` were moved into `web/static/src/public` in [`d4e74d7`].

`assets_unit_tests_setup` already included all the js files in this folder. However they should not be included in `assets_unit_tests_setup` because they shouldn't be executed in the Hoot tests.

__Fix__
- Remove those files from `assets_unit_tests_setup`
- Also remove the explicit include of these files in `assets_frontend`; they should be in it but they are already since they are in `web/static/src/public`.

[`d4e74d7`]: https://github.com/odoo/odoo/commit/d4e74d7dd8b8403aae85831