### PR TITLE
[FIX] website_sale: make the placeholder of the search bar translatable

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -948,7 +948,7 @@
                 <input
                     type="text"
                     class="o_wsale_attribute_search_bar form-control"
-                    t-att-placeholder="'Search %s (%s)' % (a.name, len(a.value_ids))"
+                    t-attf-placeholder="Search {{a.name}} ({{len(a.value_ids)}})"
                     t-att-data-container-id="'searchable-values-%s' % a.id"
                 />
             </div>


### PR DESCRIPTION
The placeholder of the search bar for attributes in eCommerce was not translatable, because it was using a Python expression to set its value.

This commit replaces the Python expression with a t-attf-placeholder, which allows the placeholder to be translated.

opw-5978276