### PR TITLE
[FIX] pos_self_order: prevent adding items to synced order in 'pay after each'

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
@@ -19,12 +19,21 @@ export class ComboPage extends Component {
 
     setup() {
         this.router = useService("router");
+        this.selfOrder = useSelfOrder();
+
+        if (
+            this.selfOrder.isSyncedOrderRestricted ||
+            (this.selfOrder.hasPresets() && !this.selfOrder.currentOrder.preset_id)
+        ) {
+            this.router.navigate("default");
+            return;
+        }
+
         if (!this.props.productTemplate) {
             this.goBack();
             return;
         }
         useSubEnv({ selectedValues: {} });
-        this.selfOrder = useSelfOrder();
         this.state = useState({
             selectedChoiceIndex: 0,
             choices: [],

--- a/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.js
+++ b/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.js
@@ -10,6 +10,11 @@ export class EatingLocationPage extends Component {
     setup() {
         this.selfOrder = useSelfOrder();
         this.router = useService("router");
+
+        if (this.selfOrder.isSyncedOrderRestricted) {
+            this.router.navigate("default");
+            return;
+        }
         this.scrollContainerRef = useRef("scrollContainer");
         this.scrollShadow = useScrollShadow(this.scrollContainerRef);
     }

--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.js
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.js
@@ -21,6 +21,14 @@ export class ProductListPage extends Component {
         this.selfOrder = useSelfOrder();
         this.router = useService("router");
         this.dialog = useService("dialog");
+
+        if (
+            this.selfOrder.isSyncedOrderRestricted ||
+            (this.selfOrder.hasPresets() && !this.selfOrder.currentOrder.preset_id)
+        ) {
+            this.router.navigate("default");
+            return;
+        }
         this.categoryListRef = useRef("category_list");
         this.subCategoryListRef = useRef("sub_category_list");
         this.productListRef = useRef("product_list");

--- a/addons/pos_self_order/static/src/app/pages/product_page/product_page.js
+++ b/addons/pos_self_order/static/src/app/pages/product_page/product_page.js
@@ -18,6 +18,14 @@ export class ProductPage extends Component {
         this.selfOrder = useSelfOrder();
         this.router = useService("router");
 
+        if (
+            this.selfOrder.isSyncedOrderRestricted ||
+            (this.selfOrder.hasPresets() && !this.selfOrder.currentOrder.preset_id)
+        ) {
+            this.router.navigate("default");
+            return;
+        }
+
         if (!this.props.productTemplate) {
             this.goBack();
             return;

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -430,6 +430,14 @@ export class SelfOrder extends Reactive {
         return this.config.self_ordering_mode === "kiosk";
     }
 
+    get isSyncedOrderRestricted() {
+        return (
+            !this.kioskMode &&
+            this.config.self_ordering_pay_after === "each" &&
+            this.currentOrder.isSynced
+        );
+    }
+
     markupDescriptions() {
         for (const product of this.models["product.template"].getAll()) {
             product.public_description = product.public_description

--- a/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
@@ -478,3 +478,26 @@ registry.category("web_tour.tours").add("test_delete_mobile_order_from_backend",
             ProductPage.isShown(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("self_mobile_each_synced_order_redirect", {
+    steps: () => [
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickProduct("Coca-Cola"),
+        Utils.clickBtn("Checkout"),
+        CartPage.checkProduct("Coca-Cola", "2.53", "1"),
+        Utils.clickBtn("Order"),
+        ConfirmationPage.isShown(),
+        Utils.clickBtn("Ok"),
+        // Order is now synced — try to navigate to product list
+        {
+            content: "Try to navigate to product list via router",
+            trigger: "body",
+            run: () => {
+                posmodel.router.navigate("product_list");
+            },
+        },
+        // Should be redirected back to landing page (no product list visible)
+        Utils.checkIsNoBtn("Order Now"),
+        Utils.checkBtn("My Order"),
+    ],
+});

--- a/addons/pos_self_order/static/tests/unit/components/order_widget.test.js
+++ b/addons/pos_self_order/static/tests/unit/components/order_widget.test.js
@@ -65,6 +65,7 @@ test("shouldGoBack", async () => {
     expect(comp.shouldGoBack()).toBe(true);
 
     const product5 = store.models["product.template"].get(5);
+    store.config.self_ordering_pay_after = "meal";
     store.addToCart(product5, 2, "");
     expect(comp.shouldGoBack()).toBe(false);
 

--- a/addons/pos_self_order/static/tests/unit/models/pos_order.test.js
+++ b/addons/pos_self_order/static/tests/unit/models/pos_order.test.js
@@ -6,6 +6,7 @@ definePosSelfModels();
 
 test("isTakeaway", async () => {
     const store = await setupSelfPosEnv();
+    store.config.use_presets = true;
     const order = await getFilledSelfOrder(store);
 
     expect(order.lines).toHaveLength(2);

--- a/addons/pos_self_order/static/tests/unit/services/self_order_service.test.js
+++ b/addons/pos_self_order/static/tests/unit/services/self_order_service.test.js
@@ -99,6 +99,7 @@ test("showComboSelectionPage", async () => {
 
 test("createNewOrder", async () => {
     const store = await setupSelfPosEnv();
+    store.config.use_presets = true;
     const models = store.models;
     {
         expect(store.config.available_preset_ids.length > 1).toBe(true);
@@ -491,4 +492,26 @@ describe("getKioskPrintingCategoriesChanges", () => {
         expect(orderLines.length).toBe(1);
         expect(orderLines[0].product_id.id).toBe(this.testProduct2.id);
     });
+});
+
+test("isSyncedOrderRestricted", async () => {
+    const store = await setupSelfPosEnv("mobile", "counter", "each");
+
+    // Not synced yet → should not be restricted
+    expect(store.isSyncedOrderRestricted).toBe(false);
+
+    // Sync the order
+    await getFilledSelfOrder(store);
+    await store.sendDraftOrderToServer();
+    expect(store.currentOrder.isSynced).toBe(true);
+    expect(store.isSyncedOrderRestricted).toBe(true);
+
+    // Kiosk mode → should not be restricted
+    store.config.self_ordering_mode = "kiosk";
+    expect(store.isSyncedOrderRestricted).toBe(false);
+
+    // Back to mobile, meal mode → should not be restricted
+    store.config.self_ordering_mode = "mobile";
+    store.config.self_ordering_pay_after = "meal";
+    expect(store.isSyncedOrderRestricted).toBe(false);
 });

--- a/addons/pos_self_order/static/tests/unit/utils.js
+++ b/addons/pos_self_order/static/tests/unit/utils.js
@@ -69,6 +69,7 @@ export const setupSelfPosEnv = async (
     store.config.self_ordering_mode = mode;
     store.config.self_ordering_service_mode = service_mode;
     store.config.self_ordering_pay_after = pay_after;
+    store.config.use_presets = false;
 
     await mountWithCleanup(selfOrderIndex);
     return store;

--- a/addons/pos_self_order/tests/test_self_order_mobile.py
+++ b/addons/pos_self_order/tests/test_self_order_mobile.py
@@ -380,3 +380,20 @@ class TestSelfOrderMobile(SelfOrderCommonTest):
 
         order = self.pos_config.current_session_id.order_ids[0]
         self.assertEqual(order.self_ordering_table_id, order.table_id)
+
+    def test_self_order_synced_order_redirect(self):
+        """
+        Verify that after syncing an order in 'pay after each' mode,
+        navigating to product pages redirects back to the landing page.
+        """
+        self.pos_config.write({
+            'self_ordering_mode': 'mobile',
+            'self_ordering_pay_after': 'each',
+            'self_ordering_service_mode': 'counter',
+            'use_presets': False,
+        })
+
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+        self_route = self.pos_config._get_self_order_route()
+        self.start_tour(self_route, "self_mobile_each_synced_order_redirect")


### PR DESCRIPTION
When the Point of Sale is configured with the Self-Ordering "Pay After Each"
mode, users should not be able to add new items to an order that has already
been sent to the server.
Before this commit, it was still possible to bypass this restriction by
forcing the URL to the product pages.

This commit prevents this behavior. If a user tries to add products or
access product pages with a synchronized order, the user will be redirected to the default page.

task-id: 5973990

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
