### PR TITLE
[IMP] web: support (column_)invisible on widgets in list view

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -332,7 +332,9 @@
                 </t>
                 <t t-if="column.type === 'widget'">
                     <td class="o_data_cell" t-att-class="this.getCellClass(column, record)">
-                        <Widget t-props="column.props" record="record"/>
+                        <t t-if="!evalInvisible(column.invisible, record)">
+                            <Widget t-props="column.props" record="record"/>
+                        </t>
                     </td>
                 </t>
             </t>

--- a/addons/web/static/src/views/widgets/widget.js
+++ b/addons/web/static/src/views/widgets/widget.js
@@ -80,6 +80,9 @@ export class Widget extends Component {
             if (name === "options") {
                 widgetInfo.options = evaluateExpr(value);
             } else if (!name.startsWith("t-att")) {
+                if (["column_invisible", "invisible"].includes(name)) {
+                    widgetInfo[name] = value;
+                }
                 // all other (non dynamic) attributes
                 widgetInfo.attrs[name] = value;
             }

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -3569,7 +3569,8 @@ test(`edit field in editable field without editing the row`, async () => {
     const cellRect = queryFirst(`.o_boolean_toggle_cell`);
     const inputRect = queryFirst(`.o_data_row .o_field_boolean_toggle .form-check`);
     const { paddingRight, paddingLeft } = getComputedStyle(cellRect);
-    const expectedSelectedWidth = cellRect.clientWidth - parseFloat(paddingRight) - parseFloat(paddingLeft);
+    const expectedSelectedWidth =
+        cellRect.clientWidth - parseFloat(paddingRight) - parseFloat(paddingLeft);
     expect(inputRect.clientWidth).not.toEqual(expectedSelectedWidth);
     // toggle the boolean value after switching the row in edition
     expect(`.o_selected_row`).toHaveCount(0);
@@ -20120,4 +20121,48 @@ test(`custom button that creates record in list with sample data`, async () => {
     await contains(".custom_create").click();
     expect(`.o_list_view .o_content`).not.toHaveClass("o_view_sample_data");
     expect(`.o_data_row`).toHaveCount(1);
+});
+
+test(`widget visibility with invisible attribute`, async () => {
+    class TestWidget extends Component {
+        static template = xml`<div class="test_widget">Widget Content</div>`;
+        static props = ["*"];
+    }
+    registry.category("view_widgets").add("test_widget", { component: TestWidget });
+
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <list>
+                <field name="foo"/>
+                <widget name="test_widget" invisible="foo == 'yop'"/>
+            </list>
+        `,
+    });
+
+    expect(`.o_data_row`).toHaveCount(4);
+    expect(`.o_data_row .test_widget`).toHaveCount(3);
+});
+
+test(`widget column visibility with column_invisible attribute`, async () => {
+    class TestWidget extends Component {
+        static template = xml`<div class="test_widget">Widget Content</div>`;
+        static props = ["*"];
+    }
+    registry.category("view_widgets").add("test_widget", { component: TestWidget });
+
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <list>
+                <field name="foo"/>
+                <field name="bar"/>
+                <widget name="test_widget" column_invisible="1"/>
+            </list>
+        `,
+    });
+    expect(`thead th:not(.o_list_record_selector)`).toHaveCount(2);
+    expect(`.o_data_row .test_widget`).toHaveCount(0);
 });

--- a/odoo/addons/base/rng/common.rng
+++ b/odoo/addons/base/rng/common.rng
@@ -434,6 +434,8 @@
             <rng:attribute name="name"/>
             <rng:optional><rng:attribute name="options"/></rng:optional>
             <rng:optional><rng:attribute name="width"/></rng:optional>
+            <rng:optional><rng:attribute name="column_invisible"/></rng:optional>
+            <rng:optional><rng:attribute name="invisible"/></rng:optional>
         </rng:element>
     </rng:define>
 


### PR DESCRIPTION
This PR aligns the behavior of the `<widget>` tag with standard `<field>` tags in list views by introducing support for visibility modifiers.

### **This PR addresses:**

The limitation where widgets in list views were always rendered regardless of any visibility attributes in the architecture. It enables developers to use `invisible` and `column_invisible` on widgets.

### **Key Improvements:**

* **Row-level visibility:** `invisible` attribute support in `ListRenderer`.
* **Column-level visibility:** `column_invisible` support for widget columns.
* **Schema validation:** RNG updates to allow `invisible` and `column_invisible` on `<widget>`.
* **Attribute parsing:** `evaluateBooleanExpr` integration in `ListArchParser` for widgets.

### **New Attributes:**

* **`invisible`**: A boolean expression to hide the widget on specific rows.
* **`column_invisible`**: A boolean expression to hide the entire column from the list view.

**Task-5870703**