### PR TITLE
[IMP] hr_holidays: avoid time off creation from different company

### DIFF
--- a/addons/hr/static/tests/mock_server/mock_models/hr_employee.js
+++ b/addons/hr/static/tests/mock_server/mock_models/hr_employee.js
@@ -13,6 +13,7 @@ export class HrEmployee extends models.ServerModel {
     work_location_type = fields.Char();
     work_location_id = fields.Many2one({ relation: "hr.work.location" });
     job_title = fields.Char();
+    company_id = fields.Many2one({ relation: "res.company" });
 
     _get_store_avatar_card_fields({ add_user = true, ...args } = {}) {
         const res = [

--- a/addons/hr_holidays/static/src/dashboard/time_off_dashboard.js
+++ b/addons/hr_holidays/static/src/dashboard/time_off_dashboard.js
@@ -1,9 +1,23 @@
 import { useState } from "@web/owl2/utils";
+import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { TimeOffCard } from "./time_off_card";
 import { useNewAllocationRequest } from "@hr_holidays/views/hooks";
-import { useBus, useService } from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
+import { useBus, useService, useOwnedDialogs } from "@web/core/utils/hooks";
 import { DateTimeInput } from "@web/core/datetime/datetime_input";
 import { Component, onWillStart } from "@odoo/owl";
+import { userHasEmployeeInCurrentCompany } from "@hr_holidays/utils";
+
+function useUniqueDialog() {
+    const displayDialog = useOwnedDialogs();
+    let close = null;
+    return (...args) => {
+        if (close) {
+            close();
+        }
+        close = displayDialog(...args);
+    };
+}
 
 export class TimeOffDashboard extends Component {
     static components = { TimeOffCard, DateTimeInput };
@@ -20,6 +34,7 @@ export class TimeOffDashboard extends Component {
             holidays: [],
             allocationRequests: 0,
         });
+        this.displayDialog = useUniqueDialog();
         useBus(this.env.timeOffBus, "update_dashboard", async () => {
             await this.loadDashboardData();
         });
@@ -54,6 +69,14 @@ export class TimeOffDashboard extends Component {
     }
 
     async newAllocationRequest() {
+        const hasEmployee = await userHasEmployeeInCurrentCompany(this.orm);
+        if (!this.props.employeeId && !hasEmployee) {
+            this.displayDialog(AlertDialog, {
+                title: _t("UserError"),
+                body: _t("This operation is not allowed as you are not linked to an employee in the current company."),
+            });
+            return;
+        }
         await this.newRequest(this.props.employeeId);
     }
 

--- a/addons/hr_holidays/static/src/utils.js
+++ b/addons/hr_holidays/static/src/utils.js
@@ -1,0 +1,7 @@
+import { user } from "@web/core/user";
+
+export async function userHasEmployeeInCurrentCompany(orm) {
+
+    const [readUser] = await orm.read("res.users", [user.userId], ["employee_id"]);
+    return Boolean(readUser.employee_id);
+}

--- a/addons/hr_holidays/static/src/views/calendar/calendar_controller.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_controller.js
@@ -1,7 +1,8 @@
 import { useSubEnv } from "@web/owl2/utils";
 import { _t } from "@web/core/l10n/translation";
-import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { CalendarController } from "@web/views/calendar/calendar_controller";
+import { AlertDialog, ConfirmationDialog} from "@web/core/confirmation_dialog/confirmation_dialog";
+import { userHasEmployeeInCurrentCompany } from "@hr_holidays/utils";
 
 import { serializeDate } from "@web/core/l10n/dates";
 
@@ -9,7 +10,7 @@ import { TimeOffCalendarSidePanel } from "./calendar_side_panel/calendar_side_pa
 import { TimeOffCalendarMobileFilterPanel } from "./calendar_filter_panel/calendar_mobile_filter_panel";
 import { TimeOffFormViewDialog } from "../view_dialog/form_view_dialog";
 import { useLeaveCancelWizard } from "../hooks";
-import { EventBus } from "@odoo/owl";
+import { EventBus, onWillStart } from "@odoo/owl";
 
 export class TimeOffCalendarController extends CalendarController {
     static components = {
@@ -24,6 +25,16 @@ export class TimeOffCalendarController extends CalendarController {
             timeOffBus: new EventBus(),
         });
         this.leaveCancelWizard = useLeaveCancelWizard();
+
+        onWillStart(async () => {
+            this.hasEmployee = await userHasEmployeeInCurrentCompany(this.orm);
+            if (!this.employeeId && !this.hasEmployee) {
+                this.env.services.notification.add(
+                    _t("You are not linked to an employee in the current company, so you cannot create requests for yourself."),
+                    { type: "warning", sticky: true }
+                );
+            }
+        });
     }
 
     get employeeId() {
@@ -31,6 +42,13 @@ export class TimeOffCalendarController extends CalendarController {
     }
 
     newTimeOffRequest() {
+        if (!this.employeeId && !this.hasEmployee) {
+            this.displayDialog(AlertDialog, {
+                title: _t("UserError"),
+                body: _t("This operation is not allowed as you are not linked to an employee in the current company."),
+            });
+            return;
+        }
         const context = {};
         if (this.props.context.active_id && this.props.context.active_model === "hr.employee") {
             context["default_employee_id"] = this.props.context.active_id;
@@ -87,6 +105,13 @@ export class TimeOffCalendarController extends CalendarController {
     }
 
     _editRecord(record, context, props = {}) {
+        if (!this.employeeId && !this.hasEmployee) {
+            this.displayDialog(AlertDialog, {
+                title: _t("UserError"),
+                body: _t("This operation is not allowed as you are not linked to an employee in the current company."),
+            });
+            return;
+        }
         const onDialogClosed = () => {
             this.model.load();
             this.env.timeOffBus.trigger("update_dashboard");

--- a/addons/hr_holidays/static/src/views/list/holidays_list_controller.js
+++ b/addons/hr_holidays/static/src/views/list/holidays_list_controller.js
@@ -3,6 +3,9 @@ import { useService } from "@web/core/utils/hooks";
 import { registry } from "@web/core/registry";
 import { listView } from "@web/views/list/list_view";
 import { ListController } from "@web/views/list/list_controller";
+import { onWillStart } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
+import { userHasEmployeeInCurrentCompany } from "@hr_holidays/utils";
 
 export class HolidaysListController extends ListController {
     static template = "hr_holidays.HolidaysListView";
@@ -16,6 +19,21 @@ export class HolidaysListController extends ListController {
 
         useSubEnv({
             onClickViewButton: (params) => this.handleViewButtonClick(params),
+        });
+
+        onWillStart(async () => {
+            const hasEmployee = await userHasEmployeeInCurrentCompany(this.orm);
+            const ignoreActions = [
+                "hr_holidays.hr_leave_action_action_approve_department",
+                "hr_holidays.hr_leave_allocation_action_approve_department",
+            ];
+            const ignoreHasEmployee = ignoreActions.includes(this.env.config.actionXmlId);
+            if (!hasEmployee && !ignoreHasEmployee) {
+                this.env.services.notification.add(
+                    _t("You are not linked to an employee in the current company, so you cannot create requests for yourself."),
+                    { type: "warning", sticky: true }
+                );
+            }
         });
     }
 

--- a/addons/hr_holidays/static/tests/mock_server/mock_models/hr_employee.js
+++ b/addons/hr_holidays/static/tests/mock_server/mock_models/hr_employee.js
@@ -11,6 +11,7 @@ export class HrEmployee extends hrModels.HrEmployee {
             id: 100,
             name: "Richard",
             department_id: 11,
+            company_id: 1,
         },
         {
             id: 200,

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -113,6 +113,9 @@
                     <field name="state" widget="statusbar" statusbar_visible="confirm,validate,validate1" invisible="validation_type != 'both'"/>
                     <field name="state" widget="statusbar" statusbar_visible="confirm,validate" invisible="validation_type == 'both'"/>
                 </header>
+                <div class="alert alert-warning" role="alert" invisible="employee_id" name="warning_wrong_company">
+                    You are not assigned to any employee in the current company. Therefore, you can't request time off allocations for yourself.
+                </div>
                 <sheet>
                     <div class="oe_button_box" name="button_box"/>
                     <div id="title" class="oe_title">
@@ -226,6 +229,7 @@
             <div id="no_limit_label" position="replace">
                 <div id="no_limit_label" class="oe_read_only" invisible="not id or date_to">No limit</div>
             </div>
+            <xpath expr="//div[@name='warning_wrong_company']" position="replace"/>
         </field>
     </record>
 

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -358,6 +358,12 @@
                 <field name="state" widget="statusbar" statusbar_visible="confirm,validate,validate1" invisible="validation_type != 'both'"/>
                 <field name="state" widget="statusbar" statusbar_visible="confirm,validate" invisible="validation_type == 'both'"/>
             </header>
+            <div class="alert alert-warning"
+                    name="warning_wrong_company"
+                    role="alert"
+                    invisible="employee_id">
+                You are not assigned to any employee in the current company. Therefore, you can't request time off for yourself.
+            </div>
             <sheet>
                 <field name="dashboard_warning_message" class="alert alert-danger d-flex mt-2" role="alert" style="white-space: pre-wrap;" invisible="not dashboard_warning_message"/>
                 <field name="work_entry_type_increases_duration" class="alert alert-info d-flex mt-2" role="alert" style="white-space: pre-wrap;" invisible="not work_entry_type_increases_duration"/>
@@ -582,6 +588,7 @@
                                     ('allows_negative', '=', False),
                 ]</attribute>
             </xpath>
+            <xpath expr="//div[@name='warning_wrong_company']" position="replace"/>
         </field>
     </record>
 


### PR DESCRIPTION
The main problem this PR is trying to solve is that when, from the time off app, we try to create a time off request or a time off allocation while the selected company is not the company of the employee related to our user, the Employee field on the creation wizard is empty (and can't be modified), causing an impossibility to create the request and confusion for the user.

Note that this doesn't happen if we do the request from the time off view reached by clicking the time off smart button on an employee's profile, because the context that is passed allows for filling the employee field on the request.

To solve the problem described in the beginning, we use context information to show a banner informing the user if it can't create a time off request/allocation from the current situation, and also show an AlertDialog if the user still clicks the buttons.

As stated in chatter of the task, the case of the New button in the list view of the personal allocation requests is special, because it doesn't call a specific function, but rather it is the default button of the list view. If we want to show the AlertDialog when clicking it, we would have to override the behavior with some JS, which we decided was not worth it. Instead, we show the usual warning in the top right when accessing the page and show a banner inside the wizard telling the user that it can't create the leave allocation.

Task: 5921087