### PR TITLE
[IMP] web: limits number of m2m tags displayed

### DIFF
--- a/addons/calendar/static/src/views/fields/many2many_attendee_expandable.js
+++ b/addons/calendar/static/src/views/fields/many2many_attendee_expandable.js
@@ -14,7 +14,7 @@ export class Many2ManyAttendeeExpandable extends Many2ManyAttendee {
         this.uncertainCount = this.attendeesCount - this.acceptedCount - this.declinedCount;
     }
 
-    get visibleItemsLimit() {
+    get tagLimit() {
         return this.state.expanded ? Number.POSITIVE_INFINITY : 5;
     }
 

--- a/addons/hr_skills/static/src/core/web/avatar_card/avatar_card_patch.xml
+++ b/addons/hr_skills/static/src/core/web/avatar_card/avatar_card_patch.xml
@@ -5,7 +5,7 @@
             <div t-if="this.skillTags.length > 0">
                 <span class="fw-bold">Skills</span>
                 <div class="d-flex flex-wrap gap-1 o_employee_skills_tags mt-1 overflow-hidden">
-                    <TagsList tags="this.skillTags" visibleItemsLimit="5" t-slot-scope="tag">
+                    <TagsList tags="this.skillTags" tagLimit="5" t-slot-scope="tag">
                         <BadgeTag text="tag.text" color="tag.color"/>
                     </TagsList>
                 </div>

--- a/addons/mail/static/src/views/web/fields/many2many_avatar_user_field/many2many_avatar_user_field.scss
+++ b/addons/mail/static/src/views/web/fields/many2many_avatar_user_field/many2many_avatar_user_field.scss
@@ -15,9 +15,6 @@
             .o_m2m_avatar_empty {
                 width: 20px;
                 height: 20px;
-                margin-left: 0px;
-                background-color: $o-gray-300;
-                vertical-align: bottom;
             }
         }
     }

--- a/addons/mail/static/tests/web/fields/many2many_tags_email.test.js
+++ b/addons/mail/static/tests/web/fields/many2many_tags_email.test.js
@@ -137,16 +137,17 @@ test("many2many_tags_email expands to show all tags when focused", async () => {
 
 test("many2many_tags_email widget can load more than 40 records", async () => {
     const pyEnv = await startServer();
-    const partnerIds = [];
+    const partnerData = [];
     for (let i = 100; i < 200; i++) {
-        partnerIds.push(pyEnv["res.partner"].create({ display_name: `partner${i}` }));
+        partnerData.push({ display_name: `partner${i}`, email: `${i}@j.com` });
     }
+    const partnerIds = pyEnv["res.partner"].create(partnerData);
     const messageId = pyEnv["mail.message"].create({ partner_ids: partnerIds });
     await start();
     await openFormView("mail.message", messageId, {
         arch: `
             <form>
-            <field name='partner_ids' widget='many2many_tags' options="{'tag_limit': 0}"/>
+            <field name='partner_ids' widget='many2many_tags_email' options="{'tag_limit': 0}"/>
             </form>`,
     });
     await contains('.o_field_widget[name="partner_ids"] .badge', { count: 100 });

--- a/addons/mail/static/tests/web/fields/many2many_tags_email.test.js
+++ b/addons/mail/static/tests/web/fields/many2many_tags_email.test.js
@@ -64,10 +64,7 @@ test("fieldmany2many tags email (edition)", async () => {
         count: 2,
     });
     expect(tags[0].innerText).toBe("gold");
-    expect(tags[0]).toHaveAttribute(
-        "data-tooltip",
-        "coucou@petite.perruche"
-    );
+    expect(tags[0]).toHaveAttribute("data-tooltip", "coucou@petite.perruche");
     // should have read Partner_2 2 times: when opening the dropdown and when saving the new email.
     await expect.waitForSteps([`web_read [${partnerId_2}]`, `web_save [${partnerId_2}]`]);
 });
@@ -103,6 +100,41 @@ test("fieldmany2many tags email popup close without filling", async () => {
     await contains(".o-mail-RecipientsInputTagsListPopover", { count: 0 });
 });
 
+test("many2many_tags_email expands to show all tags when focused", async () => {
+    const pyEnv = await startServer();
+    const partnerIds = pyEnv["res.partner"].create([
+        { name: "1", email: "1" },
+        { name: "2", email: "2" },
+        { name: "3", email: "3" },
+        { name: "4", email: "" },
+    ]);
+    const messageId = pyEnv["mail.message"].create({ partner_ids: partnerIds.slice(0, 3) });
+    await start();
+    await openFormView("mail.message", messageId, {
+        arch: `
+            <form>
+                <field name="partner_ids" widget="many2many_tags_email" options="{'tag_limit': 2}"/>
+            </form>
+        `,
+    });
+    await contains(".o_field_widget[name='partner_ids'] .badge", { count: 2 });
+    await click(".o_field_widget[name='partner_ids'] .o_field_many2many_selection input"); // Editing tags should show all
+    await contains(".o_field_widget[name='partner_ids'] .badge", { count: 3 });
+
+    // Adding tags should also keep showing all tags even if the mail popover appears
+    await clickFieldDropdownItem("partner_ids", "4");
+    await contains(".o-mail-RecipientsInputTagsListPopover");
+    await contains(".o_field_widget[name='partner_ids'] .badge", { count: 4 }); // 1 new record, even if not valid email yet
+
+    await insertText(".o-mail-RecipientsInputTagsListPopover input", "coucou@petite.perruche");
+    await click(".o-mail-RecipientsInputTagsListPopover .btn-primary");
+    await contains(".o_field_widget[name='partner_ids'] .badge", { count: 4 }); // 1 new record, email validated
+
+    // Deleting tags should also keep showing all tags
+    await click(".o_tags_input .o_tag:first-child .o_delete");
+    await contains(".o_field_widget[name='partner_ids'] .badge", { count: 3 });
+});
+
 test("many2many_tags_email widget can load more than 40 records", async () => {
     const pyEnv = await startServer();
     const partnerIds = [];
@@ -112,7 +144,10 @@ test("many2many_tags_email widget can load more than 40 records", async () => {
     const messageId = pyEnv["mail.message"].create({ partner_ids: partnerIds });
     await start();
     await openFormView("mail.message", messageId, {
-        arch: "<form><field name='partner_ids' widget='many2many_tags'/></form>",
+        arch: `
+            <form>
+            <field name='partner_ids' widget='many2many_tags' options="{'tag_limit': 0}"/>
+            </form>`,
     });
     await contains('.o_field_widget[name="partner_ids"] .badge', { count: 100 });
     await contains(".o_form_editable");

--- a/addons/web/static/src/core/tags_list/tags_list.js
+++ b/addons/web/static/src/core/tags_list/tags_list.js
@@ -1,31 +1,35 @@
 import { Component } from "@odoo/owl";
+import { BadgeTag } from "@web/core/tags_list/badge_tag";
+import { useState } from "@web/owl2/utils";
 
 export class TagsList extends Component {
     static template = "web.TagsList";
+    static components = { BadgeTag };
     static props = {
         slots: { type: Object },
         tags: { type: Array, element: Object },
-        mapTooltip: { type: Function, optional: true }, // not great but does the job for now
-        visibleItemsLimit: { type: Number },
+        tagLimit: { type: Number },
     };
-    static defaultProps = {
-        mapTooltip: (tag) => tag.tooltip || tag.text,
-    };
+
+    setup() {
+        this.state = useState({ expanded: false });
+    }
 
     get invisibleTags() {
         return this.props.tags.slice(this.visibleTagCount);
     }
 
-    get tooltipInfo() {
-        return JSON.stringify({
-            tags: this.invisibleTags.map((tag) => this.props.mapTooltip(tag)),
-        });
+    showAllTags() {
+        this.state.expanded = true;
     }
 
     get visibleTagCount() {
+        if (this.state.expanded) {
+            return this.props.tags.length;
+        }
         // remove an item to display the counter instead
-        const counter = this.props.tags.length > this.props.visibleItemsLimit ? 1 : 0;
-        return this.props.visibleItemsLimit - counter;
+        const counter = this.props.tags.length > this.props.tagLimit ? 1 : 0;
+        return this.props.tagLimit - counter;
     }
 
     get visibleTags() {

--- a/addons/web/static/src/core/tags_list/tags_list.xml
+++ b/addons/web/static/src/core/tags_list/tags_list.xml
@@ -5,17 +5,8 @@
         <t t-foreach="this.visibleTags" t-as="tag" t-key="tag.id or tag_index">
             <t t-slot="default" t-props="tag"/>
         </t>
-        <t t-set="invisibleTagCount" t-value="this.invisibleTags.length"/>
-        <t t-if="invisibleTagCount">
-            <span class="o_tags_list_counter o_m2m_avatar_empty rounded text-center fw-bold cursor-default" data-tooltip-template="web.TagsList.Tooltip" data-tooltip-position="right" t-att-data-tooltip-info="this.tooltipInfo" t-on-click.stop="">
-                <span t-out="invisibleTagCount gt 9 ? '9+' : '+' + invisibleTagCount"/>
-            </span>
-        </t>
-    </t>
-
-    <t t-name="web.TagsList.Tooltip">
-        <t t-foreach="this.tags" t-as="tag" t-key="tag_index">
-            <div t-out="tag"/>
+        <t t-if="this.invisibleTags.length">
+            <BadgeTag color="0" cssClass="'bg-secondary o_m2m_avatar_empty fw-bold cursor-pointer'" text="'+' + this.invisibleTags.length" tooltip.translate="Click to show more" t-on-click.stop="this.showAllTags"/>
         </t>
     </t>
 

--- a/addons/web/static/src/views/fields/many2many_tags/kanban_many2many_tags_field.xml
+++ b/addons/web/static/src/views/fields/many2many_tags/kanban_many2many_tags_field.xml
@@ -3,9 +3,9 @@
 
     <t t-name="web.KanbanMany2ManyTagsField">
         <div class="d-flex flex-wrap gap-1">
-            <t t-foreach="this.tags" t-as="tag" t-key="tag.id">
-                <Tag color="tag.props.color" text="tag.props.text"/>
-            </t>
+            <TagsList t-props="this.tagsListProps" t-slot-scope="tag">
+                <Tag t-props="tag.props"/>
+            </TagsList>
         </div>
     </t>
 </templates>

--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
@@ -1,4 +1,4 @@
-import { useRef } from "@web/owl2/utils";
+import { useRef, useState } from "@web/owl2/utils";
 import { _t } from "@web/core/l10n/translation";
 import { CheckBox } from "@web/core/checkbox/checkbox";
 import { ColorList } from "@web/core/colorlist/colorlist";
@@ -58,14 +58,17 @@ export class Many2ManyTagsField extends Component {
         createExpression: { type: String, optional: true },
         domain: { type: [Array, Function], optional: true },
         context: { type: Object, optional: true },
+        tagLimit: { type: Number, optional: true },
         placeholder: { type: String, optional: true },
         nameCreateField: { type: String, optional: true },
         searchThreshold: { type: Number, optional: true },
         string: { type: String, optional: true },
     };
+
     static defaultProps = {
         canCreate: true,
         canQuickCreate: true,
+        tagLimit: 8,
         canCreateEdit: true,
         nameCreateField: "name",
         context: {},
@@ -73,9 +76,8 @@ export class Many2ManyTagsField extends Component {
 
     static RECORD_COLORS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
 
-    visibleItemsLimit = Number.POSITIVE_INFINITY;
-
     setup() {
+        this.state = useState({ expanded: false });
         this.orm = useService("orm");
         this.previousColorsMap = {};
         this.popover = usePopover(this.constructor.components.Popover);
@@ -153,10 +155,10 @@ export class Many2ManyTagsField extends Component {
     }
 
     get tagsListProps() {
+        const limit = this.state.expanded ? 0 : this.props.tagLimit;
         return {
-            mapTooltip: (tag) => tag.props.tooltip,
             tags: this.tags,
-            visibleItemsLimit: this.visibleItemsLimit,
+            tagLimit: limit === 0 ? Number.POSITIVE_INFINITY : limit,
         };
     }
 
@@ -212,6 +214,10 @@ export class Many2ManyTagsField extends Component {
         await tagRecord.update(changes);
         await tagRecord.save();
         this.popover.close();
+    }
+
+    onFocusIn() {
+        this.state.expanded = true;
     }
 
     get tags() {
@@ -319,6 +325,15 @@ export const many2ManyTagsField = {
             availableTypes: ["char"],
         },
         {
+            label: _t("Maximum Visible Tags"),
+            name: "tag_limit",
+            type: "number",
+            default: Many2ManyTagsField.defaultProps.tagLimit,
+            help: _t(
+                "Maximum number of tags to display before showing a counter. Set to 0 to always show all tags."
+            ),
+        },
+        {
             label: _t("On tag click"),
             name: "on_tag_click",
             type: "selection",
@@ -355,6 +370,7 @@ export const many2ManyTagsField = {
             createExpression: attrs.create,
             context: dynamicInfo.context,
             domain: dynamicInfo.domain,
+            tagLimit: options.tag_limit,
             placeholder,
             searchThreshold: options.search_threshold,
             string,

--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.xml
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.xml
@@ -6,6 +6,7 @@
             class="o_field_tags d-inline-flex flex-wrap gap-1 mw-100"
             t-att-class="{'o_tags_input o_input': !this.props.readonly}"
             t-custom-ref="many2ManyTagsField"
+            t-on-focusin="this.onFocusIn"
         >
             <TagsList t-props="this.tagsListProps" t-slot-scope="tag">
                 <Tag t-props="tag.props"/>

--- a/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.js
@@ -60,7 +60,10 @@ export const many2ManyTagsAvatarField = {
 registry.category("fields").add("many2many_tags_avatar", many2ManyTagsAvatarField);
 
 export class ListMany2ManyTagsAvatarField extends Many2ManyTagsAvatarField {
-    visibleItemsLimit = 5;
+    static defaultProps = {
+        ...Many2ManyTagsAvatarField.defaultProps,
+        tagLimit: 5,
+    };
 }
 
 export const listMany2ManyTagsAvatarField = {
@@ -111,7 +114,11 @@ export class KanbanMany2ManyTagsAvatarField extends Many2ManyTagsAvatarField {
         isEditable: { type: Boolean, optional: true },
     };
     static PopoverClass = Many2ManyTagsAvatarFieldPopover;
-    visibleItemsLimit = 3;
+
+    static defaultProps = {
+        ...Many2ManyTagsAvatarField.defaultProps,
+        tagLimit: 3,
+    };
 
     setup() {
         super.setup();
@@ -129,6 +136,7 @@ export class KanbanMany2ManyTagsAvatarField extends Many2ManyTagsAvatarField {
         const props = { ...this.props, specification: this.specification };
         delete props.isEditable;
         delete props.relation;
+        props.tagLimit = 0; // See all tags when editing in popover
         return props;
     }
 

--- a/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.scss
+++ b/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.scss
@@ -33,6 +33,12 @@
             }
         }
     }
+    .o_field_many2many_tags_avatar{
+        .o_m2m_avatar_empty {
+            padding: 5px; 
+            border-radius: 6px !important;
+        }
+    }
 }
 
 .o_list_view .o_field_widget.o_field_many2many_tags_avatar {

--- a/addons/web/static/tests/core/tags_list.test.js
+++ b/addons/web/static/tests/core/tags_list.test.js
@@ -1,22 +1,22 @@
 import { expect, test } from "@odoo/hoot";
-import { queryAttribute } from "@odoo/hoot-dom";
+import { click } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { Component, useState, xml } from "@odoo/owl";
 import { mountWithCleanup } from "@web/../tests/web_test_helpers";
 import { TagsList } from "@web/core/tags_list/tags_list";
 
-test("Limiting the visible tags displays a counter", async () => {
+test("Limiting the visible tags displays a clickable counter badge", async () => {
     class Parent extends Component {
         static props = ["*"];
         static components = { TagsList };
         static template = xml`
-            <TagsList tags="this.tags" visibleItemsLimit="this.state.visibleItemsLimit" t-slot-scope="tag">
-                <span class="o_tag" t-out="tag.text"/>
+            <TagsList tags="this.tags" tagLimit="this.state.tagLimit" t-slot-scope="tag">
+                <span class="custom_tag" t-out="tag.text"/>
             </TagsList>
         `;
         setup() {
             this.state = useState({
-                visibleItemsLimit: 3,
+                tagLimit: 3,
             });
             this.tags = [
                 { id: "tag1", text: "Water" },
@@ -30,25 +30,36 @@ test("Limiting the visible tags displays a counter", async () => {
     }
 
     const parent = await mountWithCleanup(Parent);
-    // visibleItemsLimit = 3 -> displays 2 tags + 1 counter (4 tags left)
-    expect(".o_tag").toHaveCount(2);
-    expect(".o_tags_list_counter").toHaveText("+4", {
+    // tagLimit = 3 -> displays 2 tags + 1 counter (4 tags left)
+    expect(".custom_tag").toHaveCount(2);
+    expect(".o_badge.bg-secondary").toHaveText("+4", {
         message: "the counter displays 4 more items",
     });
-    expect(JSON.parse(queryAttribute(".o_tags_list_counter", "data-tooltip-info"))).toEqual(
-        { tags: ["Fire", "Earth", "Wind", "Dust"] },
-        { message: "the counter has a tooltip displaying other items" }
-    );
+    expect(".o_badge.bg-secondary").toHaveAttribute("data-tooltip", "Click to show more", {
+        message: "the counter has the correct static tooltip",
+    });
 
-    parent.state.visibleItemsLimit = 5;
+    parent.state.tagLimit = 5;
     await animationFrame();
-    // visibleItemsLimit = 5 -> displays 4 tags + 1 counter (2 tags left)
-    expect(".o_tag").toHaveCount(4);
-    expect(".o_tags_list_counter").toHaveText("+2");
 
-    parent.state.visibleItemsLimit = 6;
+    // limit = 5 -> displays 4 tags + 1 counter (2 tags left)
+    expect(".custom_tag").toHaveCount(4);
+    expect(".o_badge.bg-secondary").toHaveText("+2");
+
+    parent.state.tagLimit = 6;
     await animationFrame();
-    // visibleItemsLimit = 6 -> displays 6 tags + 0 counter (0 tag left)
-    expect(".o_tag").toHaveCount(6);
-    expect(".o_tags_list_counter").toHaveCount(0);
+    expect(".custom_tag").toHaveCount(6);
+    expect(".o_badge.bg-secondary").toHaveCount(0);
+
+    // Test the click-to-expand behavior
+    parent.state.tagLimit = 4;
+    await animationFrame();
+    expect(".custom_tag").toHaveCount(3);
+    // Clicking should override the limit and display ALL tags
+    await click(".o_badge.bg-secondary");
+    await animationFrame();
+    expect(".custom_tag").toHaveCount(6);
+    expect(".o_badge.bg-secondary").toHaveCount(0, {
+        message: "The counter badge should disappear after expansion",
+    });
 });

--- a/addons/web/static/tests/views/fields/many2many_tags_avatar_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_avatar_field.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { press, queryAllTexts, queryOne } from "@odoo/hoot-dom";
+import { press, queryAllTexts } from "@odoo/hoot-dom";
 import { animationFrame, runAllTimers } from "@odoo/hoot-mock";
 import { getOrigin } from "@web/core/utils/urls";
 
@@ -154,19 +154,6 @@ test("widget many2many_tags_avatar in list view", async () => {
         ".o_data_row:nth-child(4) .o_field_many2many_tags_avatar .o_m2m_avatar_empty"
     ).toHaveText("+9");
 
-    // check data-tooltip attribute (used by the tooltip service)
-    const tag = queryOne(
-        ".o_data_row:nth-child(2) .o_field_many2many_tags_avatar .o_m2m_avatar_empty"
-    );
-    expect(tag).toHaveAttribute("data-tooltip-template", "web.TagsList.Tooltip");
-    expect(tag).toHaveAttribute(
-        "data-tooltip-info",
-        JSON.stringify({ tags: ["record 6", "record 7"] }),
-        {
-            message: "shows a tooltip on hover",
-        }
-    );
-
     await contains(".o_data_row .o_many2many_tags_avatar_cell:eq(0)").click();
     await contains(
         ".o_data_row .o_many2many_tags_avatar_cell:eq(0) .o-autocomplete--input"
@@ -296,7 +283,7 @@ test("widget many2many_tags_avatar in kanban view", async () => {
     ).toHaveCount(1);
     expect(
         ".o_kanban_record:nth-child(4) .o_field_many2many_tags_avatar .o_m2m_avatar_empty"
-    ).toHaveText("9+");
+    ).toHaveText("+11");
     expect(".o_field_many2many_tags_avatar .o_field_many2many_selection").toHaveCount(0);
     await contains(".o_kanban_record:nth-child(3) .o_quick_assign", { visible: false }).click();
     await animationFrame();
@@ -311,14 +298,14 @@ test("widget many2many_tags_avatar in kanban view", async () => {
     expect(".o_kanban_record:nth-child(3) .o_tag").toHaveCount(3);
     // select first non selected input
     await contains(".o-overlay-container .o-autocomplete--dropdown-item:eq(4)").click();
-    expect(".o-overlay-container .o_tag").toHaveCount(4);
-    expect(".o_kanban_record:nth-child(3) .o_tag").toHaveCount(2);
+    expect(".o-overlay-container .o_tag").toHaveCount(4); // Should show full list above m2m autocomplete input
+    expect(".o_kanban_record:nth-child(3) .o_tag").toHaveCount(3); // But keep truncate in the card
     // load more
     await contains(".o-overlay-container .o_m2o_dropdown_option_search_more").click();
     // first non already selected item
     await contains(".o_dialog .o_list_table .o_data_row .o_data_cell:eq(3)").click();
     expect(".o-overlay-container .o_tag").toHaveCount(5);
-    expect(".o_kanban_record:nth-child(3) .o_tag").toHaveCount(2);
+    expect(".o_kanban_record:nth-child(3) .o_tag").toHaveCount(3);
     expect(
         `.o_kanban_record:nth-child(2) img.o_m2m_avatar[data-src='${getOrigin()}/web/image/partner/4/avatar_128?unique=1676282400000']`
     ).toHaveCount(1);

--- a/addons/web/static/tests/views/fields/many2many_tags_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_field.test.js
@@ -1,5 +1,5 @@
 import { expect, getFixture, test } from "@odoo/hoot";
-import { hover, press, queryAllTexts, queryOne } from "@odoo/hoot-dom";
+import { click, hover, press, queryAllTexts, queryOne } from "@odoo/hoot-dom";
 import { animationFrame, Deferred, runAllTimers } from "@odoo/hoot-mock";
 
 import {
@@ -759,7 +759,7 @@ test("Many2ManyTagsField can load more than 40 records", async () => {
     await mountView({
         type: "form",
         resModel: "partner",
-        arch: '<form><field name="partner_ids" widget="many2many_tags"/></form>',
+        arch: `<form><field name="partner_ids" widget="many2many_tags" options="{'tag_limit': 0}"/></form>`,
         resId: 1,
     });
     expect('.o_field_widget[name="partner_ids"] .badge').toHaveCount(100);
@@ -1062,7 +1062,7 @@ test("Many2ManyTagsField: select multiple records on desktop", async () => {
         resId: 1,
         arch: `
             <form>
-                <field name="timmy" widget="many2many_tags"/>
+                <field name="timmy" widget="many2many_tags" options="{'tag_limit': 0}"/>
             </form>`,
     });
 
@@ -1101,9 +1101,9 @@ test("Many2ManyTagsField: select multiple records doesn't show already added tag
         resModel: "partner",
         resId: 1,
         arch: `
-                <form>
-                    <field name="timmy" widget="many2many_tags"/>
-                </form>`,
+            <form>
+                <field name="timmy" widget="many2many_tags" options="{'tag_limit': 0}"/>
+            </form>`,
     });
 
     await selectFieldDropdownItem("timmy", "Search more...");
@@ -2090,22 +2090,26 @@ test("Many2ManyTagsField: keyboard navigation", async () => {
         { id: 15, name: "platinium", color: 10 },
     ];
 
-    Partner._records[0].timmy = [12, 14];
+    Partner._records[0].timmy = [12, 14, 15];
 
     await mountView({
         type: "form",
         resModel: "partner",
         arch: `
             <form>
-                <field name="timmy" widget="many2many_tags"/>
+                <field name="timmy" widget="many2many_tags" options="{'tag_limit': 2}"/>
             </form>`,
         resId: 1,
     });
 
     const input = ".o_field_many2many_tags input";
 
-    // 2. Test RIGHT arrow: Should close dropdown and focus the FIRST tag
+    // 1. Should expand on focus
+    expect(".o_field_many2many_tags .o_tag").toHaveCount(2); // 1 normal tag + 1 counter tag
     await contains(input).click();
+    expect(".o_field_many2many_tags .o_tag").toHaveCount(3); // 3 normal tags
+
+    // 2. Test RIGHT arrow: Should close dropdown and focus the FIRST tag
     expect(".o-autocomplete--dropdown-menu").toHaveCount(1);
     await press("ArrowRight");
     expect(".o_tag:eq(0)").toBeFocused();
@@ -2117,7 +2121,7 @@ test("Many2ManyTagsField: keyboard navigation", async () => {
     // 3. Test LEFT arrow: Should close dropdown and focus the LAST tag
     await contains(input).click();
     await press("ArrowLeft");
-    expect(".o_tag:eq(1)").toBeFocused();
+    expect(".o_tag:last").toBeFocused();
 
     // Ensure dropdown closed
     await animationFrame();
@@ -2141,4 +2145,82 @@ test("Many2ManyTagsField: keyboard navigation", async () => {
 
     // Dropdown should still be visible (filtering)
     expect(".o-autocomplete--dropdown-menu").toHaveCount(1);
+});
+
+test.tags("desktop");
+test("many2many_tags widget with more records than limit can be edited", async () => {
+    PartnerType._records.push({ id: 15, name: "bronze" }, { id: 16, name: "copper" });
+    Partner._records[0].timmy = [12, 14, 15, 16];
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `
+            <form>
+                <field name="timmy" widget="many2many_tags" options="{'tag_limit': 3}"/>
+            </form>`,
+    });
+
+    expect(".o_field_many2many_tags .o_tag").toHaveCount(3); // The counter badge also has the .o_tag class
+    expect(".o_field_many2many_tags .o_m2m_avatar_empty").toHaveCount(1); // .o_m2m_avatar_empty is the counter badge
+    expect(".o_field_many2many_tags .o_m2m_avatar_empty").toHaveText("+2"); // 4 records in total, 2 displayed / 2 hidden
+
+    // When editing we should see all elements and many2many drop down should appear
+    expect(".o-autocomplete--dropdown-menu").toHaveCount(0);
+    await contains(".o_field_widget[name='timmy'] .o_field_many2many_selection input").click();
+    expect(".o_field_many2many_tags .o_tag").toHaveCount(4);
+    expect(".o-autocomplete--dropdown-menu").toHaveCount(1);
+});
+
+test.tags("mobile");
+test("many2many_tags widget enforces limit in desktop form view", async () => {
+    PartnerType._records.push({ id: 15, name: "bronze" }, { id: 16, name: "copper" });
+    Partner._records[0].timmy = [12, 14, 15, 16];
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `
+            <form>
+                <field name="timmy" widget="many2many_tags" options="{'tag_limit': 3}"/>
+            </form>`,
+    });
+
+    expect(".o_field_many2many_tags .o_tag").toHaveCount(3); // The counter badge also has the .o_tag class
+    expect(".o_field_many2many_tags .o_m2m_avatar_empty").toHaveCount(1); // .o_m2m_avatar_empty is the counter badge
+    expect(".o_field_many2many_tags .o_m2m_avatar_empty").toHaveText("+2");
+
+    // When editing we should see all elements and should open a new screen with list of tags
+    await contains(".o_field_widget[name='timmy'] .o_field_many2many_selection input").click();
+    expect("article.o_kanban_record:contains('gold')").toHaveCount(1); // New screen with list of tags
+
+    // When coming back we should see all tags
+    await click(".modal-header button.oi-arrow-left");
+    expect(".o_field_many2many_tags .o_tag").toHaveCount(4);
+});
+
+test.tags("desktop");
+test("many2many_tags limit and edit color on click", async () => {
+    PartnerType._records.push(
+        { id: 15, name: "a", color: 3 },
+        { id: 16, name: "b", color: 4 },
+        { id: 17, name: "c", color: 5 }
+    );
+    Partner._records[0].timmy = [15, 16, 17];
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `
+            <form>
+                <field name="timmy" widget="many2many_tags" options="{'tag_limit': 2, 'on_tag_click': 'edit_color', 'color_field': 'color'}"/>
+            </form>`,
+    });
+
+    // Show the color list on first click even if tags list is truncated.
+    expect(".o_colorlist").toHaveCount(0);
+    expect(".o_field_many2many_tags .o_tag").toHaveCount(2);
+    await contains("[name=timmy] .o_tag").click();
+    expect(".o_colorlist").toHaveCount(1);
+    expect(".o_field_many2many_tags .o_tag").toHaveCount(3); // Clicking on a tag should also expand all tags
 });


### PR DESCRIPTION
Currently we don't have a way to limit the number of m2m tags displayed, which can lead to ugly UI. This commit introduces such a limit, making it editable via studio and passable as a widget options.

BEFORE: All tags were displayed. 

NOW:  If there are more tags the limit, we only the display the "x" first tags, as well a a new tag with "+yy", where y represents the number of hidden tags. The "+yy" tag can be clicked to display all tags and has a tooltip: "Click to show more". 

We use 8 as a default number of m2m tags displayed (which is also the number of records we display in m2m dropdowns). Setting a value of 0 can be used to display all tags regardless of how many they are.

Documentation PR: odoo/documentation#16667
Enterpirse PR: odoo/enterprise#112647

task#5799365
