### PR TITLE
[FIX] account: fix click handling in showProductColumn helper

### DIFF
--- a/addons/account/static/src/js/tours/tour_utils.js
+++ b/addons/account/static/src/js/tours/tour_utils.js
@@ -9,9 +9,9 @@ export function showProductColumn() {
         {
             content: "Show product column",
             trigger: '.o-dropdown-item input[name="product_id"], .o-dropdown-item input[name="product_template_id"]',
-            run: function (actions) {
-                if (!this.anchor.checked) {
-                    actions.click();
+            run: function ({ anchor }) {
+                if (!anchor.checked) {
+                    anchor.click();
                 }
             },
         },


### PR DESCRIPTION
- Destructure `{ anchor }` from the `run` method arguments instead of using the `this` context.
- Swap `actions.click()` for native `anchor.click()` to ensure the checkbox state is toggled correctly.

runbot-234872

Note: backport of https://github.com/odoo/odoo/commit/6fdc329838ee099524e61eea9698373949881c1e
missed the 19.2 freeze.