### PR TITLE
[FIX] website: clean up event listeners on iframe reload

### DIFF
--- a/addons/website/static/src/core/website_edit_service.js
+++ b/addons/website/static/src/core/website_edit_service.js
@@ -297,12 +297,12 @@ export const websiteEditService = {
             callShared,
         };
 
-        window.parent.document.addEventListener("edit_page", (ev) => {
+        const handleEditPage = (ev) => {
             stop(ev.detail.iframeDocument);
-        });
+        };
 
         // Transfer the iframe website_edit service to the EditInteractionPlugin
-        window.parent.document.addEventListener("edit_interaction_plugin_loaded", (ev) => {
+        const handlePluginLoaded = (ev) => {
             ev.currentTarget.dispatchEvent(
                 new CustomEvent("transfer_website_edit_service", {
                     detail: {
@@ -313,6 +313,22 @@ export const websiteEditService = {
             Object.assign(shared, ev.shared);
             historyCallbacks.ignoreDOMMutations = shared.history.ignoreDOMMutations;
             setupIgnoreDOMMutations(shared.history.ignoreDOMMutations);
+        };
+
+        window.parent.document.addEventListener("edit_page", handleEditPage);
+        window.parent.document.addEventListener(
+            "edit_interaction_plugin_loaded",
+            handlePluginLoaded
+        );
+
+        // Clean up parent document listeners when iframe unloads to prevent
+        // stale handlers from serving an outdated service to new plugins.
+        window.addEventListener("beforeunload", () => {
+            window.parent.document.removeEventListener("edit_page", handleEditPage);
+            window.parent.document.removeEventListener(
+                "edit_interaction_plugin_loaded",
+                handlePluginLoaded
+            );
         });
 
         return websiteEditService;


### PR DESCRIPTION
Steps to reproduce:
===================

1. In Website > Shop, open any product.
2. Click "Edit" on the product.
3. Make a change (for example, toggle "Zoom on click") 2 times.

-> In the second time a traceback will appear `(Safari, Epiphany)`.

Cause:
======

The website builder uses two contexts:
- The **iframe** runs services (e.g. websiteEditService)
- The **parent window** runs editor plugins (e.g. EditInteractionPlugin)

They communicate via custom events on window.parent.document. The service (in the iframe) registers a listener for
"edit_interaction_plugin_loaded" on the parent document, and responds with a "transfer_website_edit_service" event carrying its service object.

When the iframe reloads after a save, the old listener was never removed from window.parent.document. The new iframe added a second listener. This meant two listeners existed on the parent document:

  1. Old listener → responds with OLD websiteEditService (stale)
  2. New listener → responds with NEW websiteEditService (correct)

Both fire when the plugin dispatches "edit_interaction_plugin_loaded". But the plugin only accepts the first response ({ once: true }), and since listeners fire in registration order, it always received the OLD stale service.

With the stale service:
- installPatches() early-returned (patches.length > 0 from session 1)
- destroy() called uninstallPatches() on the old service, removing stopInteractionByName from the old prototype
- stopInteraction() then tried to call the now-deleted method → crash: TypeError: publicInteractions.stopInteractionByName is not a function

Solution:
=========

Extract the anonymous event handlers into named functions and register a "beforeunload" listener on the iframe's window that removes them from window.parent.document. This ensures that when the iframe reloads, the old listeners are cleaned up before the new iframe registers its own, so the plugin always receives the current service.

opw-5864798

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
