### PR TITLE
[FIX] im_livechat: rephrase chatbot completion message in composer

### DIFF
--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_service.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_service.js
@@ -394,7 +394,7 @@ export class ChatBotService {
             return "";
         }
         if (this.completed) {
-            return _t("Conversation ended...");
+            return _t("This conversation has ended.");
         }
         switch (this.currentStep?.type) {
             case "question_selection":


### PR DESCRIPTION
This commit updates the chatbot completion message from 'Conversation ended...' to 'Conversation has ended.'

The previous version used ellipses, which typically suggest an incomplete thought. Since the message is meant to clearly indicate that the conversation has concluded, the ellipses were unnecessary and potentially confusing.
