### PR TITLE
[FIX] pos_loyalty: remove undeterministicTour

### DIFF
--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -317,7 +317,6 @@ registry.category("web_tour.tours").add("PosLoyaltyTour9", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyTour10", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -330,9 +329,10 @@ registry.category("web_tour.tours").add("PosLoyaltyTour10", {
             ProductScreen.selectedOrderlineHas("Product Test", "1"),
             PosLoyalty.isRewardButtonHighlighted(true),
             PosLoyalty.claimReward("Free Product B"),
+            Dialog.is({ title: "Please select a product for this reward" }),
             {
                 content: `click on reward item`,
-                trigger: `.selection-item:contains("Free Product B")`,
+                trigger: `.modal .selection-item:contains("Free Product B")`,
                 run: "click",
             },
             PosLoyalty.hasRewardLine("Free Product B", "-1.00"),


### PR DESCRIPTION
With this commit, we remove the key undeterministicTour. To fix this tour, we precise 2 steps to ensure the tour take the good way.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
