### PR TITLE
[FIX] account_peppol: fix wrong company_registry value in peppol

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -11,6 +11,7 @@ from odoo.addons.account_edi_ubl_cii.models.account_edi_common import (
 from odoo.addons.account_edi_ubl_cii.models.account_edi_xml_ubl_20 import UBL_NAMESPACES
 
 from stdnum.no import mva
+from stdnum.be import vat as be_vat
 
 CHORUS_PRO_PEPPOL_ID = "0009:11000201100044"
 
@@ -505,6 +506,18 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
                     "The VAT number of the supplier does not seem to be valid. It should be of the form: NO179728982MVA."
                 ) if not mva.is_valid(vat) or len(vat) != 14 or vat[:2] != 'NO' or vat[-3:] != 'MVA' else "",
             })
+
+        if vals['supplier'].country_id.code == 'BE' and vals['supplier'].company_registry:
+            if not be_vat.is_valid(vals['supplier'].company_registry):
+                constraints.update({
+                    'PEPPOL-COMMON-R043_supplier': _('%s should have a valid KBO/BCE number in the Company ID field', vals['supplier'].display_name),
+                })
+
+        if vals['customer'].country_id.code == 'BE' and vals['customer'].company_registry:
+            if not be_vat.is_valid(vals['customer'].company_registry):
+                constraints.update({
+                    'PEPPOL-COMMON-R043_customer': _('%s should have a valid KBO/BCE number in the Company ID field', vals['customer'].display_name),
+                })
         return constraints
 
     def _import_retrieve_partner_vals(self, tree, role):
@@ -777,6 +790,18 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
                     "The VAT number of the supplier does not seem to be valid. It should be of the form: NO179728982MVA."
                 ) if not mva.is_valid(vat) or len(vat) != 14 or vat[:2] != 'NO' or vat[-3:] != 'MVA' else "",
             })
+
+        if vals['supplier'].country_id.code == 'BE' and vals['supplier'].company_registry:
+            if not be_vat.is_valid(vals['supplier'].company_registry):
+                constraints.update({
+                    'PEPPOL-COMMON-R043_supplier': _('%s should have a valid KBO/BCE number in the Company ID field', vals['supplier'].display_name),
+                })
+
+        if vals['customer'].country_id.code == 'BE' and vals['customer'].company_registry:
+            if not be_vat.is_valid(vals['customer'].company_registry):
+                constraints.update({
+                    'PEPPOL-COMMON-R043_customer': _('%s should have a valid KBO/BCE number in the Company ID field', vals['customer'].display_name),
+                })
         return constraints
 
     # -------------------------------------------------------------------------
@@ -965,7 +990,7 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
         if commercial_partner.country_code == 'BE' and commercial_partner.company_registry:
             nodes.append({
                 'cbc:ID': {
-                    '_text': commercial_partner.company_registry,
+                    '_text': be_vat.compact(commercial_partner.company_registry),
                     'schemeID': '0208',
                 },
             })
@@ -1048,7 +1073,7 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
             nodes.append({
                 'cbc:RegistrationName': {'_text': commercial_partner.name},
                 'cbc:CompanyID': {
-                    '_text': commercial_partner.company_registry,
+                    '_text': be_vat.compact(commercial_partner.company_registry),
                     'schemeID': '0208',
                 },
             })

--- a/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
@@ -5,6 +5,7 @@ try:
 except ImportError:
     contents = None
 
+from odoo.exceptions import UserError
 from odoo.tests import tagged
 
 
@@ -688,6 +689,21 @@ class TestUblExportBis3BE(TestUblBis3Common, TestUblCiiBECommon):
             partner=partner_be_invoice_address,
             test_file='test_invoice_customer_party_identifiers_partner_be_invoice_address',
         )
+
+        # VAT in company_registry should render the CBE Numer only
+        self.partner_be.company_registry = 'BE0477472701'
+        self._assert_invoice_partner_party_identifiers(
+            partner=self.partner_be,
+            test_file='test_invoice_customer_party_identifiers_partner_be_vat_and_company_registry',
+        )
+
+        # Malformed company_registry should raise
+        self.partner_be.company_registry = 'BEWrongOne'
+        with self.assertRaises(UserError):
+            self._assert_invoice_partner_party_identifiers(
+                partner=self.partner_be,
+                test_file='test_invoice_customer_party_identifiers_partner_be_vat_and_company_registry',
+            )
 
     def test_invoice_customer_party_identifiers_partner_lu(self):
         # Both VAT and company registry are not set.


### PR DESCRIPTION
We expect people to put BCE number in the company registry. 
But it is not enforced client-side, resulting in invoices in error.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
