### PR TITLE
[FIX] hr_holidays: add missing list view for report by employee

### DIFF
--- a/addons/hr_holidays/report/hr_leave_employee_report_views.xml
+++ b/addons/hr_holidays/report/hr_leave_employee_report_views.xml
@@ -24,6 +24,21 @@
         </field>
     </record>
 
+    <record id="hr_leave_employee_report_view_list" model="ir.ui.view">
+        <field name="model">hr.leave.employee.report</field>
+        <field name="arch" type="xml">
+            <list create="0" edit="0" delete="0">
+                <field name="employee_id"/>
+                <field name="holiday_status_id"/>
+                <field name="working_schedule_aligned_date_from"/>
+                <field name="number_of_days" string="Number of Days"/>
+                <field name="number_of_hours" string="Number of Hours"/>
+                <field name="state"/>
+                <field name="description"/>
+            </list>
+        </field>
+    </record>
+
     <record id="hr_leave_employee_report_filter" model="ir.ui.view">
         <field name="model">hr.leave.employee.report</field>
         <field name="arch" type="xml">


### PR DESCRIPTION
**Steps to reproduce**
- Go to Time Off > Reporting > By Employee
- Switch to graph view
- Click on one of the columns

Issue: only the id of the records is displayed in the list view

**Cause**
There's no list view defined for the `hr.leave.employee.report` Issue present since the rework in 1c3f5633ef87f6d9c5a6169eefd51cd42ef442d5

opw-5977793