### PR TITLE
REF] *: remove url from js file tours

### DIFF
--- a/addons/hr/static/tests/tours/hr_employee_flow.js
+++ b/addons/hr/static/tests/tours/hr_employee_flow.js
@@ -28,7 +28,6 @@ registry.category("web_tour.tours").add("hr_employee_tour", {
 });
 
 registry.category("web_tour.tours").add("hr_officer_create_employee_tour", {
-    url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/hr_holidays_attendance/static/tests/tours/attendance_calendar_overtime_leave_tour.js
+++ b/addons/hr_holidays_attendance/static/tests/tours/attendance_calendar_overtime_leave_tour.js
@@ -6,7 +6,6 @@ const leaveDateFrom = "01/04/2021";
 const leaveDateTo = "01/04/2021";
 
 registry.category("web_tour.tours").add("request_overtime_leave_from_attendance_calendar", {
-    url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/mail/static/tests/tours/mail_template_dynamic_field_tour.js
+++ b/addons/mail/static/tests/tours/mail_template_dynamic_field_tour.js
@@ -4,7 +4,6 @@ import { delay } from "@web/core/utils/concurrency";
 
 registry.category("web_tour.tours").add("mail_template_dynamic_field_tour", {
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/point_of_sale/static/src/backend/tours/point_of_sale.js
+++ b/addons/point_of_sale/static/src/backend/tours/point_of_sale.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add("point_of_sale_tour", {
-    url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/project/static/src/js/tours/project.js
+++ b/addons/project/static/src/js/tours/project.js
@@ -5,7 +5,6 @@ import { stepUtils } from "@web_tour/tour_utils";
 import { markup } from "@odoo/owl";
 
 registry.category("web_tour.tours").add('project_tour', {
-    url: "/odoo",
     steps: () => [stepUtils.showAppsMenuItem(), {
     isActive: ["community"],
     trigger: '.o_app[data-menu-xmlid="project.menu_main_pm"]',

--- a/addons/project/static/tests/tours/project_sharing_tour.js
+++ b/addons/project/static/tests/tours/project_sharing_tour.js
@@ -166,7 +166,6 @@ registry.category("web_tour.tours").add("project_sharing_with_blocked_task_tour"
 ]});
 
 registry.category("web_tour.tours").add("portal_project_sharing_tour_with_disallowed_milestones", {
-    url: "/my/projects",
     steps: () => [
         {
             id: "project_sharing_feature",
@@ -213,7 +212,6 @@ registry.category("web_tour.tours").add("portal_project_sharing_tour_with_disall
 });
 
 registry.category("web_tour.tours").add("test_04_project_sharing_chatter_message_reactions", {
-    url: "/my/projects",
     steps: () => [
         {
             trigger: "table > tbody > tr a:has(span:contains(Project Sharing))",
@@ -228,7 +226,6 @@ registry.category("web_tour.tours").add("test_04_project_sharing_chatter_message
 });
 
 registry.category("web_tour.tours").add("portal_project_sharing_chatter_mention_users", {
-    url: "/my/projects",
     steps: () => [
         {
             trigger: "table > tbody > tr a:has(span:contains(Project Sharing))",

--- a/addons/project/static/tests/tours/project_tags_filter_tour_tests.js
+++ b/addons/project/static/tests/tours/project_tags_filter_tour_tests.js
@@ -21,7 +21,6 @@ function changeFilter(filterName) {
 }
 
 registry.category("web_tour.tours").add("project_tags_filter_tour", {
-    url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/project/static/tests/tours/project_task_history.js
+++ b/addons/project/static/tests/tours/project_task_history.js
@@ -49,7 +49,6 @@ function insertEditorContent(newContent) {
 }
 
 registry.category("web_tour.tours").add("project_task_history_tour", {
-    url: "/odoo?debug=1,tests",
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {
@@ -208,7 +207,6 @@ registry.category("web_tour.tours").add("project_task_history_tour", {
 
 registry.category("web_tour.tours").add("project_task_last_history_steps_tour", {
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: "/odoo?debug=1,tests",
     steps: () => [stepUtils.showAppsMenuItem(), {
         content: "Open the project app",
         trigger: ".o_app[data-menu-xmlid='project.menu_main_pm']",

--- a/addons/project/static/tests/tours/project_task_templates_tour.js
+++ b/addons/project/static/tests/tours/project_task_templates_tour.js
@@ -3,7 +3,6 @@ import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add("project_task_templates_tour", {
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/project/tests/test_project_ui.py
+++ b/addons/project/tests/test_project_ui.py
@@ -47,4 +47,4 @@ class TestUi(odoo.tests.HttpCase):
             'project_id': project.id,
         })
 
-        self.start_tour('/odoo', 'project_task_last_history_steps_tour', login='admin')
+        self.start_tour('/odoo?debug=1,tests', 'project_task_last_history_steps_tour', login='admin')

--- a/addons/project_todo/static/tests/tours/project_todo_history.js
+++ b/addons/project_todo/static/tests/tours/project_todo_history.js
@@ -28,7 +28,6 @@ function changeDescriptionContentAndSave(newContent) {
 
 registry.category("web_tour.tours").add("project_todo_history_tour", {
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: "/odoo?debug=1,tests",
     steps: () => [stepUtils.showAppsMenuItem(), {
         content: "Open the Todo app",
         trigger: ".o_app[data-menu-xmlid='project_todo.menu_todo_todos']",

--- a/addons/purchase/static/src/js/tours/purchase.js
+++ b/addons/purchase/static/src/js/tours/purchase.js
@@ -5,7 +5,6 @@ import { stepUtils } from "@web_tour/tour_utils";
 import PurchaseAdditionalTourSteps from "@purchase/js/tours/purchase_steps";
 
 registry.category("web_tour.tours").add("purchase_tour", {
-    url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/purchase_product_matrix/static/tests/tours/purchase_product_matrix_tour.js
+++ b/addons/purchase_product_matrix/static/tests/tours/purchase_product_matrix_tour.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add('purchase_matrix_tour', {
-    url: "/odoo",
     steps: () => [stepUtils.showAppsMenuItem(), {
     trigger: '.o_app[data-menu-xmlid="purchase.menu_purchase_root"]',
     run: "click",

--- a/addons/sale/static/src/js/tours/sale.js
+++ b/addons/sale/static/src/js/tours/sale.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add("sale_tour", {
-    url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/sale_project/static/tests/tours/project_create_sol_tour.js
+++ b/addons/sale_project/static/tests/tours/project_create_sol_tour.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_utils";
 
 registry.category("web_tour.tours").add('project_create_sol_tour', {
-    url: "/odoo",
     steps: () => [
     stepUtils.showAppsMenuItem(), {
         trigger: ".o_app[data-menu-xmlid='project.menu_main_pm']",

--- a/addons/survey/static/src/js/tours/survey_tour.js
+++ b/addons/survey/static/src/js/tours/survey_tour.js
@@ -5,7 +5,6 @@ import { stepUtils } from "@web_tour/tour_utils";
 import { markup } from "@odoo/owl";
 
 registry.category("web_tour.tours").add('survey_tour', {
-    url: "/odoo",
     steps: () => [
     ...stepUtils.goToAppSteps('survey.menu_surveys', markup(_t("Ready to change the way you <b>gather data</b>?"))),
 {

--- a/addons/survey/static/tests/tours/certification_failure.js
+++ b/addons/survey/static/tests/tours/certification_failure.js
@@ -189,6 +189,5 @@ var lastSteps = [{
 }];
 
 registry.category("web_tour.tours").add("test_certification_failure", {
-    url: "/survey/start/4ead4bc8-b8f2-4760-a682-1fde8daaaaac",
     steps: () => [].concat(patchSteps, failSteps, retrySteps, failSteps, lastSteps),
 });

--- a/addons/survey/static/tests/tours/certification_success.js
+++ b/addons/survey/static/tests/tours/certification_success.js
@@ -15,7 +15,6 @@ function patchSurveyForm() {
 }
 
 registry.category("web_tour.tours").add("test_certification_success", {
-    url: "/survey/start/4ead4bc8-b8f2-4760-a682-1fde8daaaaac",
     steps: () => [
         {
             content: "Patching Survey Form Interaction",

--- a/addons/survey/static/tests/tours/survey.js
+++ b/addons/survey/static/tests/tours/survey.js
@@ -82,7 +82,6 @@ const survey_steps = (checkPageTranslation) => [
 ];
 
 registry.category("web_tour.tours").add("test_survey", {
-    url: "/survey/start/b137640d-14d4-4748-9ef6-344caaaaaae",
     steps: () => [
         {
             content: "Check that the language selector is hidden",
@@ -94,7 +93,6 @@ registry.category("web_tour.tours").add("test_survey", {
 
 registry.category("web_tour.tours").add("test_survey_multilang", {
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: "/survey/start/b137640d-14d4-4748-9ef6-344caaaaaae",
     steps: () => {
         return [
             {

--- a/addons/test_base_automation/static/tests/tour/base_automation_tour.js
+++ b/addons/test_base_automation/static/tests/tour/base_automation_tour.js
@@ -618,7 +618,6 @@ registry.category("web_tour.tours").add("test_form_view_mail_triggers", {
 });
 
 registry.category("web_tour.tours").add("base_automation.on_change_rule_creation", {
-    url: "/odoo/action-base_automation.base_automation_act",
     steps: () => [
         {
             trigger: ".o-kanban-button-new",

--- a/addons/test_discuss_full/static/tests/tours/chatbot_redirect_to_portal_tour.js
+++ b/addons/test_discuss_full/static/tests/tours/chatbot_redirect_to_portal_tour.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("chatbot_redirect_to_portal", {
-    url: "/contactus",
     steps: () => [
         {
             trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",

--- a/addons/test_sale_product_configurators/static/tests/tours/event_sale_with_product_configurator_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/event_sale_with_product_configurator_ui.js
@@ -5,7 +5,6 @@ import * as tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add("event_sale_with_product_configurator_tour", {
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: "/odoo",
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
         ...tourUtils.createNewSalesOrder(),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_attribute_with_multi_type.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_attribute_with_multi_type.js
@@ -4,7 +4,6 @@ import configuratorTourUtils from "@sale/js/tours/product_configurator_tour_util
 import * as tourUtils from "@sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add("product_attribute_multi_type", {
-    url: "/odoo",
     steps: () => [
         ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
         ...tourUtils.createNewSalesOrder(),

--- a/addons/test_website/static/tests/tours/error_views.js
+++ b/addons/test_website/static/tests/tours/error_views.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("test_error_website", {
-    url: "/test_error_view",
     steps: () => [
         // RPC ERROR
         {

--- a/addons/test_website/static/tests/tours/page_manager.js
+++ b/addons/test_website/static/tests/tours/page_manager.js
@@ -73,7 +73,6 @@ registry.category("web_tour.tours").add("test_website_page_manager", {
 });
 
 registry.category("web_tour.tours").add("test_website_page_manager_js_class_bug", {
-    url: "/odoo/action-test_website.action_test_model_multi_website_js_class_bug",
     steps: () => [
         {
             content: "Click on Kanban View",
@@ -88,7 +87,6 @@ registry.category("web_tour.tours").add("test_website_page_manager_js_class_bug"
 });
 
 registry.category("web_tour.tours").add("test_website_page_manager_no_website_id", {
-    url: "/odoo/action-test_website.action_test_model",
     steps: () => [
         {
             content: "Click on Kanban View",

--- a/addons/test_website/static/tests/tours/website_settings.js
+++ b/addons/test_website/static/tests/tours/website_settings.js
@@ -4,7 +4,6 @@ import { stepUtils } from "@web_tour/tour_utils";
 const websiteName = "Website Test Settings";
 
 registry.category("web_tour.tours").add("website_settings_m2o_dirty", {
-    url: "/odoo",
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/test_website_modules/static/tests/tours/configurator_flow.js
+++ b/addons/test_website_modules/static/tests/tours/configurator_flow.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("configurator_flow", {
-    url: "/odoo/action-website.action_website_configuration",
     steps: () => [
         {
             content: "click on create new website",

--- a/addons/web/static/tests/tours/favorite_management_tour.js
+++ b/addons/web/static/tests/tours/favorite_management_tour.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("test_favorite_management", {
-    url: "/odoo/apps",
     steps: () => [
         {
             trigger:

--- a/addons/web/static/tests/tours/test_user_group_settings_tour.js
+++ b/addons/web/static/tests/tours/test_user_group_settings_tour.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("test_user_group_settings", {
-    url: "/odoo/settings?debug=assets,tests",
     steps: () => [
         // create new privileges
         {

--- a/addons/web/static/tests/tours/user_switch_tour.js
+++ b/addons/web/static/tests/tours/user_switch_tour.js
@@ -38,7 +38,6 @@ function logout() {
 }
 
 registry.category("web_tour.tours").add("test_user_switch", {
-    url: "/odoo",
     steps: () => [
         ...logout(),
         {

--- a/addons/web/tests/test_res_users.py
+++ b/addons/web/tests/test_res_users.py
@@ -51,4 +51,4 @@ class TestResUsers(TransactionCase):
 @tagged('post_install', '-at_install')
 class TestUserSettings(HttpCaseWithUserDemo):
     def test_user_group_settings(self):
-        self.start_tour('/odoo?debug=1', 'test_user_group_settings', login='admin')
+        self.start_tour('/odoo/settings?debug=assets,tests', 'test_user_group_settings', login='admin')

--- a/addons/website/static/tests/tours/alt_a.js
+++ b/addons/website/static/tests/tours/alt_a.js
@@ -41,7 +41,6 @@ registry.category("web_tour.tours").add("alt_a_edit", {
 });
 
 registry.category("web_tour.tours").add("alt_a_translation", {
-    url: "/fr",
     steps: () => [
         pressAltA(),
         {

--- a/addons/website/static/tests/tours/client_action_redirect.js
+++ b/addons/website/static/tests/tours/client_action_redirect.js
@@ -39,7 +39,6 @@ const checkEditorSteps = [
 ];
 
 registry.category("web_tour.tours").add("client_action_redirect", {
-    url: testUrl,
     steps: () => [
         // Case 1: From frontend, click on `enable_editor=1` link without `/@/` in it
         {

--- a/addons/website/static/tests/tours/conditional_visibility_frontend.js
+++ b/addons/website/static/tests/tours/conditional_visibility_frontend.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("conditional_visibility_2", {
-    url: "/?utm_medium=Email",
     steps: () => [
         {
             content: "The content previously hidden should now be visible",

--- a/addons/website/static/tests/tours/configurator_translation.js
+++ b/addons/website/static/tests/tours/configurator_translation.js
@@ -77,7 +77,6 @@ function runConfiguratorFlow(industrySearchText, featureOrPageName) {
 }
 
 registry.category("web_tour.tours").add("configurator_translation", {
-    url: "/website/configurator",
     steps: () => [
         ...runConfiguratorFlow("in fr", "Parseltongue_pricing"),
         {
@@ -108,7 +107,6 @@ registry.category("web_tour.tours").add("configurator_translation", {
 });
 
 registry.category("web_tour.tours").add("configurator_page_creation", {
-    url: "/website/configurator",
     steps: () => [
         ...runConfiguratorFlow("abbey", "Pricing Plan"),
         // Verify configurator page templates exist in landing pages category.

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -14,7 +14,6 @@ import {
 
 registry.category("web_tour.tours").add("parent_child_menu", {
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: "/odoo/action-website.action_website_menu",
     steps: () => [
         {
             content: "Open Menu Form View",

--- a/addons/website/static/tests/tours/edit_translated_page.js
+++ b/addons/website/static/tests/tours/edit_translated_page.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { clickOnEditAndWaitEditModeInTranslatedPage } from "@website/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add("edit_translated_page_redirect", {
-    url: "/nl/contactus",
     steps: () => [
         {
             content: "Enter backend",

--- a/addons/website/static/tests/tours/page_manager.js
+++ b/addons/website/static/tests/tours/page_manager.js
@@ -297,7 +297,6 @@ registerWebsitePreviewTour(
 );
 
 registry.category("web_tour.tours").add("website_page_manager_direct_access", {
-    url: "/odoo/action-website.action_website_pages_list",
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         {

--- a/addons/website/static/tests/tours/skip_website_configurator.js
+++ b/addons/website/static/tests/tours/skip_website_configurator.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("skip_website_configurator", {
-    url: "/odoo/action-website.action_website_configuration",
     steps: () => [
         {
             content: "create a new website",

--- a/addons/website/static/tests/tours/website_form_editor_frontend.js
+++ b/addons/website/static/tests/tours/website_form_editor_frontend.js
@@ -224,7 +224,6 @@ registry.category("web_tour.tours").add("website_form_editor_tour_results", {
 });
 registry.category("web_tour.tours").add("website_form_contactus_submit", {
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: "/contactus",
     steps: () => [
         // As the demo portal user, only two inputs needs to be filled to send
         // the email
@@ -255,7 +254,6 @@ registry.category("web_tour.tours").add("website_form_contactus_submit", {
     ],
 });
 registry.category("web_tour.tours").add("website_form_contactus_check_changed_email", {
-    url: "/contactus",
     steps: () => [
         {
             content: "Check that the recipient email is updated",

--- a/addons/website/tests/test_page_manager.py
+++ b/addons/website/tests/test_page_manager.py
@@ -21,7 +21,7 @@ class TestWebsitePageManager(odoo.tests.HttpCase):
         })
 
         website.domain = self.base_url()
-        self.start_tour('/odoo#action=website.action_website_pages_list', 'website_page_manager_direct_access', login='admin')
+        self.start_tour('/odoo/action-website.action_website_pages_list', 'website_page_manager_direct_access', login='admin')
 
     def test_generic_page_diverged_not_shown(self):
         Page = self.env['website.page']

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -426,7 +426,7 @@ class TestUi(HttpCaseWithWebsiteUser):
 
     def test_10_website_conditional_visibility(self):
         self.start_tour(self.env['website'].get_client_action_url('/', True), 'conditional_visibility_1', login='admin')
-        self.start_tour('/odoo', 'conditional_visibility_2', login='website_user')
+        self.start_tour('/?utm_medium=Email', 'conditional_visibility_2', login='website_user')
         self.start_tour(self.env['website'].get_client_action_url('/', True), 'conditional_visibility_3', login='admin', timeout=180)
         self.start_tour(self.env['website'].get_client_action_url('/', True), 'conditional_visibility_4', login='admin')
         self.start_tour(self.env['website'].get_client_action_url('/', True), 'conditional_visibility_5', login='admin')
@@ -771,7 +771,7 @@ class TestUi(HttpCaseWithWebsiteUser):
 
     def test_alt_a_with_foreign_language(self):
         self.add_fr_language_to_website()
-        self.start_tour('/', 'alt_a_translation', login='admin')
+        self.start_tour('/fr', 'alt_a_translation', login='admin')
 
     def test_alt_a_not_on_foreign_language_page(self):
         self.add_fr_language_to_website()

--- a/addons/website_blog/static/tests/tours/blog_search_with_date.js
+++ b/addons/website_blog/static/tests/tours/blog_search_with_date.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
  * Makes sure that blog search can be used with the date filtering.
  */
 registry.category("web_tour.tours").add("blog_autocomplete_with_date", {
-    url: "/blog",
     steps: () => [
         {
             content: "Select first month",

--- a/addons/website_event/static/tests/tours/tickets_questions.js
+++ b/addons/website_event/static/tests/tours/tickets_questions.js
@@ -1,6 +1,5 @@
 import { registry } from "@web/core/registry";
 registry.category("web_tour.tours").add("test_tickets_questions", {
-    url: "/event",
     steps: () => [
         {
             content: "Click on the Design Fair event",

--- a/addons/website_event/tests/test_website_event.py
+++ b/addons/website_event/tests/test_website_event.py
@@ -133,7 +133,7 @@ class TestUi(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
             })]
         })
 
-        self.start_tour("/", 'test_tickets_questions', login="portal")
+        self.start_tour("/event", 'test_tickets_questions', login="portal")
 
         registrations = self.env['event.registration'].search([
             ('email', 'in', ['attendee-a@gmail.com', 'attendee-b@gmail.com'])

--- a/addons/website_event_booth_exhibitor/static/tests/tours/website_event_booth_exhibitor.js
+++ b/addons/website_event_booth_exhibitor/static/tests/tours/website_event_booth_exhibitor.js
@@ -3,7 +3,6 @@
 
 
     registry.category("web_tour.tours").add("webooth_exhibitor_register", {
-        url: "/event",
         steps: () => [{
         content: 'Go on "Online Reveal" page',
         trigger: 'a[href*="/event"]:contains("Online Reveal"):first',

--- a/addons/website_event_sale/static/tests/tours/website_event_sale.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import * as wsTourUtils from "@website_sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add("event_buy_tickets", {
-    url: "/event",
     steps: () => [
         {
             content: "Go to the `Events` page",

--- a/addons/website_event_sale/static/tests/tours/website_event_sale_pricelists.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale_pricelists.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { getPriceListChecksSteps } from "@website_event_sale/../tests/tours/helpers/WebsiteEventSaleTourMethods";
 
 registry.category("web_tour.tours").add("event_sale_pricelists_different_currencies", {
-    url: "/event",
     steps: () => [
         // Register for tickets
         {

--- a/addons/website_event_sale/tests/test_frontend_buy_tickets.py
+++ b/addons/website_event_sale/tests/test_frontend_buy_tickets.py
@@ -89,7 +89,7 @@ class TestUi(HttpCaseWithUserDemo, TestWebsiteEventSaleCommon):
         })
         transfer_provider._transfer_ensure_pending_msg_is_set()
 
-        self.start_tour("/", 'event_buy_tickets', login="admin")
+        self.start_tour("/event", 'event_buy_tickets', login="admin")
 
     def test_demo(self):
         self.env['product.pricelist'].with_context(active_test=False).search([]).unlink()
@@ -103,7 +103,7 @@ class TestUi(HttpCaseWithUserDemo, TestWebsiteEventSaleCommon):
         #  Ensure the use of USD (company currency)
         self.env['product.pricelist'].create({'name': "Public Pricelist"})
 
-        self.start_tour("/", 'event_buy_tickets', login="demo")
+        self.start_tour("/event", 'event_buy_tickets', login="demo")
 
     def test_buy_last_ticket(self):
         transfer_provider = self.env.ref('payment.payment_provider_transfer')
@@ -117,7 +117,7 @@ class TestUi(HttpCaseWithUserDemo, TestWebsiteEventSaleCommon):
 
     def test_pricelists_different_currencies(self):
         self.env.user.group_ids += self.env.ref('product.group_product_pricelist')
-        self.start_tour("/", 'event_sale_pricelists_different_currencies', login='admin')
+        self.start_tour("/event", 'event_sale_pricelists_different_currencies', login='admin')
     # TO DO - add public test with new address when convert to web.tour format.
 
 

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_redirect.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_redirect.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_livechat.chatbot_redirect", {
-    url: "/contactus",
     steps: () => [
         {
             trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_trigger_selection_tour.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_trigger_selection_tour.js
@@ -19,7 +19,6 @@ const answerBothQuestions = [
     },
 ];
 registry.category("web_tour.tours").add("website_livechat.chatbot_trigger_selection", {
-    url: "/contactus",
     steps: () => [
         {
             trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",

--- a/addons/website_payment/static/tests/tours/donation_form_custom_fields.js
+++ b/addons/website_payment/static/tests/tours/donation_form_custom_fields.js
@@ -55,7 +55,6 @@ registerWebsitePreviewTour(
 );
 
 registry.category("web_tour.tours").add("donation_form_custom_field_submit", {
-    url: "/donation/pay",
     steps: () => [
         {
             content: "Verify that the donation form is displayed",

--- a/addons/website_profile/static/tests/tours/tour_website_profile_description.js
+++ b/addons/website_profile/static/tests/tours/tour_website_profile_description.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('website_profile_description', {
-    url: "/profile/users",
     steps: () => [{
         content: "Click on one user profile card",
         trigger: "div[onclick]:contains(\"test_user\")",

--- a/addons/website_profile/tests/test_website_profile.py
+++ b/addons/website_profile/tests/test_website_profile.py
@@ -41,4 +41,4 @@ class TestWebsiteProfile(HttpCaseGamification):
         self.env.ref('base.user_admin').write({
             'email': 'mitchell.admin@example.com',
         })
-        self.start_tour("/", 'website_profile_description', login="admin")
+        self.start_tour("/profile/users", 'website_profile_description', login="admin")

--- a/addons/website_sale_loyalty/static/tests/tours/ewallet.js
+++ b/addons/website_sale_loyalty/static/tests/tours/ewallet.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import * as wsTourUtils from "@website_sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add("website_sale_loyalty.ewallet", {
-    url: "/shop",
     steps: () => [
         // Add a $50 gift card to the order
         ...wsTourUtils.addToCart({ productName: "TEST - Gift Card", expectUnloadPage: true }),

--- a/addons/website_sale_loyalty/tests/test_shop_sale_coupon.py
+++ b/addons/website_sale_loyalty/tests/test_shop_sale_coupon.py
@@ -240,7 +240,7 @@ class WebsiteSaleLoyaltyTestUi(TestSaleCommon, HttpCase):
             'program_id': program_id,
             'points': 1000,
         } for program_id in ewallet_programs.ids])
-        self.start_tour('/', 'website_sale_loyalty.ewallet', login='admin')
+        self.start_tour('/shop', 'website_sale_loyalty.ewallet', login='admin')
 
 
 @tagged('post_install', '-at_install')

--- a/addons/website_sale_mrp/static/tests/tours/test_website_sale_product_availability.js
+++ b/addons/website_sale_mrp/static/tests/tours/test_website_sale_product_availability.js
@@ -4,7 +4,6 @@ import { registry } from "@web/core/registry";
 import { addToCart, searchProduct } from "@website_sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add("test_website_sale_availability_kit", {
-    url: "/shop",
     steps: () => [
         ...addToCart({ productName: "Consumable Component", expectUnloadPage: true }),
         { trigger: "a[href='/shop']", run: "click", expectUnloadPage: true },

--- a/addons/website_slides/static/tests/tours/slides_course_reviews.js
+++ b/addons/website_slides/static/tests/tours/slides_course_reviews.js
@@ -6,7 +6,6 @@ import { registry } from "@web/core/registry";
  * add only one review and react to them.
  */
 registry.category("web_tour.tours").add("course_reviews", {
-    url: "/slides",
     steps: () => [
         {
             trigger: "a:contains(Basics of Gardening - Test)",

--- a/addons/website_slides/static/tests/tours/slides_course_reviews_comment.js
+++ b/addons/website_slides/static/tests/tours/slides_course_reviews_comment.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("course_reviews_comment", {
-    url: "/slides",
     steps: () => [
         {
             trigger: "a:contains(Basics of Gardening - Test)",

--- a/addons/website_slides/static/tests/tours/slides_course_reviews_reaction_public.js
+++ b/addons/website_slides/static/tests/tours/slides_course_reviews_reaction_public.js
@@ -6,7 +6,6 @@ import { registry } from "@web/core/registry";
  * This tour tests that a public user can not react to messages
  */
 registry.category("web_tour.tours").add("course_reviews_reaction_public", {
-    url: "/slides",
     steps: () => [
         {
             trigger: "a:contains(Basics of Gardening - Test)",
@@ -24,7 +23,9 @@ registry.category("web_tour.tours").add("course_reviews_reaction_public", {
         {
             trigger: "#chatterRoot:shadow .o-mail-Message .o-mail-Message-actions",
             run: async () => {
-                const addReactionButton = document.querySelector('#chatterRoot').shadowRoot.querySelector("[title='Add a Reaction']")
+                const addReactionButton = document
+                    .querySelector("#chatterRoot")
+                    .shadowRoot.querySelector("[title='Add a Reaction']");
                 if (addReactionButton) {
                     throw new Error("Public user is able to react");
                 }
@@ -33,7 +34,9 @@ registry.category("web_tour.tours").add("course_reviews_reaction_public", {
         {
             trigger: "#chatterRoot:shadow .o-mail-Message-core",
             run: () => {
-                const reactionButton = document.querySelector("#chatterRoot").shadowRoot.querySelector(".o-mail-MessageReaction")
+                const reactionButton = document
+                    .querySelector("#chatterRoot")
+                    .shadowRoot.querySelector(".o-mail-MessageReaction");
                 reactionButton.dispatchEvent(new Event("mouseenter"));
             },
         },
@@ -47,9 +50,13 @@ registry.category("web_tour.tours").add("course_reviews_reaction_public", {
         {
             trigger: "#chatterRoot:shadow .o-mail-Message-core",
             run: () => {
-                const addReaction = document.querySelector("#chatterRoot").shadowRoot.querySelector(".o-mail-MessageReactions-add")
+                const addReaction = document
+                    .querySelector("#chatterRoot")
+                    .shadowRoot.querySelector(".o-mail-MessageReactions-add");
                 if (addReaction) {
-                    throw new Error("Non-authenticated user should not be able to add a reaction to a message");
+                    throw new Error(
+                        "Non-authenticated user should not be able to add a reaction to a message"
+                    );
                 }
             },
         },

--- a/odoo/addons/test_assetsbundle/static/tests/test_css_error.js
+++ b/odoo/addons/test_assetsbundle/static/tests/test_css_error.js
@@ -1,7 +1,6 @@
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("css_error_tour", {
-    url: "/odoo",
     steps: () => [
         {
             content: "Error message",
@@ -14,7 +13,6 @@ registry.category("web_tour.tours").add("css_error_tour", {
 });
 
 registry.category("web_tour.tours").add("css_error_tour_frontend", {
-    url: "/",
     steps: () => [
         {
             content: "Error message",

--- a/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/main_flow.js
@@ -6,7 +6,6 @@ import { markup } from "@odoo/owl";
 
 registry.category("web_tour.tours").add('main_flow_tour', {
     undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
-    url: "/odoo",
     steps: () => [
 ...stepUtils.toggleHomeMenu().map(step => {
     step.isActive = ["community", "mobile"];


### PR DESCRIPTION
The URL key in a tour's JavaScript file implies a redirect to that URL
once the browser opens. If this URL is the same as the one used
in `start_tour()` (Python), then it serves no purpose. It's even
detrimental because it implies a redirect (and therefore a waste of
time). The URL key in the JS file is (for now) only used for onboarding
tours. This key will be defined later in the .xml file for onboarding
tours.

That's why we're removing the URL keys from the registries here.