### PR TITLE
[FIX] l10n_gt: add missing dependency

### DIFF
--- a/addons/l10n_gt/__manifest__.py
+++ b/addons/l10n_gt/__manifest__.py
@@ -17,6 +17,7 @@ taxes and the Quetzal currency.""",
     'depends': [
         'base',
         'account',
+        'base_address_extended',
     ],
     'auto_install': ['account'],
     'data': [


### PR DESCRIPTION
**PROBLEM**
https://github.com/odoo/odoo/pull/247719
adds the city of guatemala as module data.
But the module declaring the model "res.city" isn't listed in the dependencies.

opw-5980424