### PR TITLE
[IMP] resource: default company timezone from country

### DIFF
--- a/addons/resource/models/res_company.py
+++ b/addons/resource/models/res_company.py
@@ -2,6 +2,7 @@
 
 from odoo import api, fields, models, _
 from odoo.addons.base.models.res_partner import _tz_get
+from odoo.modules.db import country_timezones as _country_timezones
 
 
 class ResCompany(models.Model):
@@ -12,8 +13,18 @@ class ResCompany(models.Model):
     resource_calendar_id = fields.Many2one(
         'resource.calendar', 'Default Working Hours', ondelete='restrict')
     tz = fields.Selection(
-        _tz_get, string='Timezone', required=True,
-        default=lambda self: self.env.context.get('tz') or self.env.user.tz or 'UTC')
+        _tz_get, string='Timezone',
+        compute='_compute_tz', store=True, readonly=False)
+
+    @api.depends('country_id')
+    def _compute_tz(self):
+        country_tz = _country_timezones()
+        for company in self:
+            company.tz = self.env.context.get('tz') or self.env.user.tz or 'UTC'
+            if company.country_id:
+                country_timezones = country_tz.get(company.country_id.code, [])
+                if len(country_timezones) == 1:
+                    company.tz = country_timezones[0]
 
     @api.model
     def _init_data_resource_calendar(self):

--- a/addons/resource/models/res_company.py
+++ b/addons/resource/models/res_company.py
@@ -2,6 +2,7 @@
 
 from odoo import api, fields, models, _
 from odoo.addons.base.models.res_partner import _tz_get
+from odoo.modules.db import country_timezones as _country_timezones
 
 
 class ResCompany(models.Model):
@@ -13,7 +14,17 @@ class ResCompany(models.Model):
         'resource.calendar', 'Default Working Hours', ondelete='restrict')
     tz = fields.Selection(
         _tz_get, string='Timezone', required=True,
-        default=lambda self: self.env.context.get('tz') or self.env.user.tz or 'UTC')
+        default=lambda self: self.env.context.get('tz') or self.env.user.tz or 'UTC',
+        compute='_compute_tz', store=True, readonly=False)
+
+    @api.depends('country_id')
+    def _compute_tz(self):
+        country_tz = _country_timezones()
+        for company in self:
+            country_timezones = country_tz.get(company.country_id.code, [])
+            if len(country_timezones) != 1:
+                continue
+            company.tz = country_timezones[0]
 
     @api.model
     def _init_data_resource_calendar(self):
@@ -38,6 +49,7 @@ class ResCompany(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         companies = super().create(vals_list)
+        companies._compute_tz()
         companies_without_calendar = companies.filtered(lambda c: not c.resource_calendar_id)
         if companies_without_calendar:
             companies_without_calendar.sudo()._create_resource_calendar()

--- a/addons/resource/models/res_users.py
+++ b/addons/resource/models/res_users.py
@@ -12,13 +12,3 @@ class ResUsers(models.Model):
     resource_calendar_id = fields.Many2one(
         'resource.calendar', 'Default Working Hours',
         related='resource_ids.calendar_id', readonly=False)
-
-    def write(self, vals):
-        rslt = super().write(vals)
-
-        # If the timezone of the admin user gets set on their first login, also update the timezone of the company
-        if (vals.get('tz') and len(self) == 1 and not self.env.user.login_date
-            and self.env.user == self.env.ref('base.user_admin', False) and self == self.env.user):
-            if self.company_id:
-                self.company_id.tz = vals['tz']
-        return rslt


### PR DESCRIPTION
Derive a company's default tz from its country_id when not set. Add _get_tz_for_country(country) helper and import country_timezones. Single-zone country → use that timezone.
Multi-zone country → prefer the current user's timezone if it matches. Otherwise → fallback to UTC.
Apply this logic in write() so existing explicit tz values are preserved. Improves defaulting for multi-region deployments and ensures company timezone better reflects country/user locale.

Task Id: 5972738
