### PR TITLE
[FIX] html_builder: fix CSS zero value comparison

### DIFF
--- a/addons/html_builder/static/src/utils/utils_css.js
+++ b/addons/html_builder/static/src/utils/utils_css.js
@@ -204,7 +204,7 @@ export function areCssValuesEqual(value1, value2, cssProp, htmlStyle) {
     }
     const numValue1 = data[0];
     // Zero values don't need unit conversion (0px === 0rem === 0em === 0)
-    const numValue2 = parseInt(numValue1) === 0
+    const numValue2 = parseFloat(numValue1) === 0
         ? getNumericAndUnit(value2)[0]
         : convertValueToUnit(value2, data[1], htmlStyle);
     return Math.abs(numValue1 - numValue2) < Number.EPSILON;


### PR DESCRIPTION
**Description:**

Replace parseInt() with parseFloat() in areCssValuesEqual() zero check. parseInt("0.1rem") incorrectly returns 0, causing fractional values like 0.1rem to be treated as zero and skip unit conversion.

opw-5412414