### PR TITLE
[FIX] hr_recruitment: prevent displaying archived email templates

### DIFF
--- a/addons/hr_recruitment/tests/test_recruitment.py
+++ b/addons/hr_recruitment/tests/test_recruitment.py
@@ -253,3 +253,33 @@ class TestRecruitment(TransactionCase):
 
         job._compute_activities()
         self.assertEqual(job.activities_today, 0)
+
+    def test_default_template_applicant_refuse_reason_when_archived(self):
+        """
+        Ensure that an archived email template linked to a refuse reason
+        is not automatically set on the refuse wizard
+        """
+        candidate = self.env['hr.candidate'].create({'partner_name': 'Test'})
+        email_template = self.env['mail.template'].create({
+            'model_id': self.env['ir.model']._get('hr.applicant').id,
+            'name': 'template1',
+        })
+        application = self.env['hr.applicant'].create({'candidate_id': candidate.id})
+        refuse_reason = self.env['hr.applicant.refuse.reason'].create({
+            'name': 'Fired',
+            'template_id': email_template.id,
+        })
+        wizard = self.env['applicant.get.refuse.reason'].create({
+            'refuse_reason_id': refuse_reason.id,
+            'applicant_ids': [application.id],
+        })
+
+        self.assertEqual(wizard.template_id, email_template)
+
+        email_template.active = False
+        wizard = self.env['applicant.get.refuse.reason'].create({
+            'refuse_reason_id': refuse_reason.id,
+            'applicant_ids': [application.id],
+        })
+
+        self.assertFalse(wizard.template_id)

--- a/addons/hr_recruitment/wizard/applicant_refuse_reason.py
+++ b/addons/hr_recruitment/wizard/applicant_refuse_reason.py
@@ -16,7 +16,7 @@ class ApplicantGetRefuseReason(models.TransientModel):
     applicant_ids = fields.Many2many('hr.applicant')
     send_mail = fields.Boolean("Send Email", compute='_compute_send_mail', store=True, readonly=False)
     template_id = fields.Many2one('mail.template', string='Email Template',
-        compute='_compute_send_mail', store=True, readonly=False,
+        compute='_compute_send_mail', store=True, readonly=False, context={'active_test': True},
         domain="[('model', '=', 'hr.applicant')]")
     applicant_without_email = fields.Text(compute='_compute_applicant_without_email',
         string='Applicant(s) not having email')
@@ -29,8 +29,8 @@ class ApplicantGetRefuseReason(models.TransientModel):
     def _compute_send_mail(self):
         for wizard in self:
             template = wizard.refuse_reason_id.template_id
-            wizard.send_mail = template and not wizard.applicant_without_email
-            wizard.template_id = template
+            wizard.send_mail = template.active and not wizard.applicant_without_email
+            wizard.template_id = template.active and template
 
     @api.depends('applicant_ids', 'single_applicant_email')
     def _compute_applicant_without_email(self):


### PR DESCRIPTION
Pre-requisites:
---------------
1. Create or duplicate any `hr.applicant` email template.
2. Archive the newly created template.
3. Archive the email template linked to a refuse reason.

Steps to reproduce:
-------------------------
1. Install hr_recruitment.
4. Go to Recruitment > Applications > All Applications and open an applicant.
5. Click on the "Refuse" button to open the refuse wizard.
6. Click on the "Email Template"  and click on 'Search More'
7. Observe available templates

Issue:
-------
1. Archived email templates are displayed in the Email Template field.
2. If a refuse reason is linked to an archived email template,
the wizard automatically pre-fills that archived template

Cause:
----------
1. After the [refactoring of Many2oneField](https://github.com/odoo-dev/odoo/commit/3670f78be767396f322ff3ebf068af5c2f547b36) to use dynamicInfo.context,
now ensures that global context keys propagate to relational fields. 

The archive_applicant method opens the refuse wizard with **'active_test': False**
in the context to allow refusing archived applicants. As a result, this context is now
applied when fetching the email templates, causing archived records to be included in
the search results.
https://github.com/odoo/odoo/blob/7966fae0c1fd7cfb6023efc0c274b8b395bf862f/addons/web/static/src/views/fields/relational_utils.js#L313-L321

2. Moreover, the `_compute_send_mail` method automatically assigns
the template from the refuse reason without checking whether
the template is active, which allows archived templates to be
pre-filled in the wizard.
https://github.com/odoo/odoo/blob/a3bf9264ca25ec11b0c9742e142d2404cac6d261/addons/hr_recruitment/wizard/applicant_refuse_reason.py#L29-L33


Solution:
-----------
- Pass `context="{'active_test': True}"` to the `template_id` field to ensure
archived templates are excluded by default, while still allowing users
to manually search for them if needed.
- Update `_compute_send_mail` to ensure only active templates are
  automatically assigned.


**NOTE:**
Issue 1 only exists till saas-18.4. From saas-18.4, email templates are fetched using [search_read](https://github.com/odoo/odoo/blob/90db6b197edb93814d980345af01c56c2b6e553e/addons/mail/static/src/core/web/mail_composer_template_selector.js#L33-L46) without passing
the context. Additionally, [search_read removes 'active_test'](https://github.com/odoo/odoo/blob/90db6b197edb93814d980345af01c56c2b6e553e/odoo/orm/models.py#L5780-L5785)
before formatting the result, so archived records are not included.

opw-5974244




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
