### PR TITLE
[IMP] base_automation: rewrite using mixins

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -874,105 +874,6 @@ class BaseAutomation(models.Model):
         """ Patch models that should trigger action rules based on creation,
             modification, deletion of records and form onchanges.
         """
-        #
-        # Note: the patched methods must be defined inside another function,
-        # otherwise their closure may be wrong. For instance, the function
-        # create refers to the outer variable 'create', which you expect to be
-        # bound to create itself. But that expectation is wrong if create is
-        # defined inside a loop; in that case, the variable 'create' is bound to
-        # the last function defined by the loop.
-        #
-
-        def make_create():
-            """ Instanciate a create method that processes automation rules. """
-            @api.model_create_multi
-            def create(self, vals_list, **kw):
-                # retrieve the automation rules to possibly execute
-                automations = self.env['base.automation']._get_actions(self, CREATE_TRIGGERS)
-                if not automations:
-                    return create.origin(self, vals_list, **kw)
-                # call original method
-                records = create.origin(self.with_env(automations.env), vals_list, **kw)
-                # check postconditions, and execute actions on the records that satisfy them
-                for automation in automations.with_context(old_values=None):
-                    automation._process(automation._filter_post(records, feedback=True), trigger='create')
-                return records.with_env(self.env)
-
-            return create
-
-        def make_write():
-            """ Instanciate a write method that processes automation rules. """
-            def write(self, vals, **kw):
-                # retrieve the automation rules to possibly execute
-                automations = self.env['base.automation']._get_actions(self, WRITE_TRIGGERS)
-                if not (automations and self):
-                    return write.origin(self, vals, **kw)
-                records = self.with_env(automations.env).filtered('id')
-                # check preconditions on records
-                pre = {a: a._filter_pre(records) for a in automations}
-                # read old values before the update
-                old_values = {
-                    record.id: {field_name: record[field_name] for field_name in vals if field_name in record._fields and record._fields[field_name].store}
-                    for record in records
-                }
-                # call original method
-                write.origin(self.with_env(automations.env), vals, **kw)
-                # check postconditions, and execute actions on the records that satisfy them
-                for automation in automations.with_context(old_values=old_values):
-                    records, domain_post = automation._filter_post_export_domain(pre[automation], feedback=True)
-                    automation._process(records, domain_post=domain_post, trigger='write')
-                return True
-
-            return write
-
-        def make_compute_field_value():
-            """ Instanciate a compute_field_value method that processes automation rules. """
-            #
-            # Note: This is to catch updates made by field recomputations.
-            #
-            def _compute_field_value(self, field):
-                # determine fields that may trigger an automation
-                stored_fnames = [f.name for f in self.pool.field_computed[field] if f.store]
-                if not stored_fnames:
-                    return _compute_field_value.origin(self, field)
-                # retrieve the action rules to possibly execute
-                automations = self.env['base.automation']._get_actions(self, WRITE_TRIGGERS)
-                records = self.filtered('id').with_env(automations.env)
-                if not (automations and records):
-                    _compute_field_value.origin(self, field)
-                    return True
-                # check preconditions on records
-                # changed fields are all fields computed by the function
-                changed_fields = [f for f in records._fields.values() if f.compute == field.compute]
-                pre = {a: a._filter_pre(records, changed_fields=changed_fields) for a in automations}
-                # read old values before the update
-                old_values = {
-                    record.id: {fname: record[fname] for fname in stored_fnames}
-                    for record in records
-                }
-                # call original method
-                _compute_field_value.origin(self, field)
-                # check postconditions, and execute automations on the records that satisfy them
-                for automation in automations.with_context(old_values=old_values):
-                    records, domain_post = automation._filter_post_export_domain(pre[automation], feedback=True)
-                    automation._process(records, domain_post=domain_post, trigger='_compute_field_value')
-                return True
-
-            return _compute_field_value
-
-        def make_unlink():
-            """ Instanciate an unlink method that processes automation rules. """
-            def unlink(self, **kwargs):
-                # retrieve the action rules to possibly execute
-                automations = self.env['base.automation']._get_actions(self, ['on_unlink'])
-                records = self.with_env(automations.env)
-                # check conditions, and execute actions on the records that satisfy them
-                for automation in automations:
-                    automation._process(automation._filter_post(records, feedback=True), trigger='unlink')
-                # call original method
-                return unlink.origin(self, **kwargs)
-
-            return unlink
 
         def make_onchange(automation_rule_id):
             """ Instanciate an onchange method for the given automation rule. """
@@ -1009,42 +910,13 @@ class BaseAutomation(models.Model):
 
             return base_automation_onchange
 
-        def make_message_post():
-            def _message_post(self, *args, **kwargs):
-                message = _message_post.origin(self, *args, **kwargs)
-                # Don't execute automations for a message emitted during
-                # the run of automations for a real message
-                # Don't execute if we know already that a message is only internal
-                message_sudo = message.sudo().with_context(active_test=False)
-                if "__action_done"  in self.env.context or message_sudo.is_internal or message_sudo.subtype_id.internal:
-                    return message
-                if message_sudo.message_type in ('notification', 'auto_comment', 'user_notification'):
-                    return message
-
-                # always execute actions when the author is a customer
-                # if author is not set, it means the message is coming from outside
-                mail_trigger = "on_message_received" if not message_sudo.author_id or message_sudo.author_id.partner_share else "on_message_sent"
-                automations = self.env['base.automation']._get_actions(self, [mail_trigger])
-                for automation in automations.with_context(old_values=None):
-                    records = automation._filter_pre(self, feedback=True)
-                    automation._process(records, trigger='_message_post')
-
-                return message
-            return _message_post
-
-        patched_models = defaultdict(set)
-
-        def patch(model, name, method):
-            """ Patch method `name` on `model`, unless it has been patched already. """
-            if model not in patched_models[name]:
-                patched_models[name].add(model)
-                ModelClass = model.env.registry[model._name]
-                method.origin = getattr(ModelClass, name)
-                setattr(ModelClass, name, method)
+        mixins = defaultdict(set)
+        onchanges = defaultdict(lambda: defaultdict(list))
 
         # retrieve all actions, and patch their corresponding model
         for automation_rule in self.with_context({}).search([]):
-            Model = self.env.get(automation_rule.model_name)
+            model_name = automation_rule.model_name
+            Model = self.env.get(model_name)
 
             # Do not crash if the model of the base_action_rule was uninstalled
             if Model is None:
@@ -1052,38 +924,55 @@ class BaseAutomation(models.Model):
                     "Automation rule with name '%s' (ID %d) depends on model %s (ID: %d)",
                     automation_rule.name,
                     automation_rule.id,
-                    automation_rule.model_name,
+                    model_name,
                     automation_rule.model_id.id)
                 continue
 
             if automation_rule.trigger in CREATE_WRITE_SET:
                 if automation_rule.trigger in CREATE_TRIGGERS:
-                    patch(Model, 'create', make_create())
+                    mixins[model_name].add(CreateMixin)
                 if automation_rule.trigger in WRITE_TRIGGERS:
-                    patch(Model, 'write', make_write())
-                    patch(Model, '_compute_field_value', make_compute_field_value())
+                    mixins[model_name].add(WriteMixin)
 
             elif automation_rule.trigger == 'on_unlink':
-                patch(Model, 'unlink', make_unlink())
+                mixins[model_name].add(UnlinkMixin)
 
             elif automation_rule.trigger == 'on_change':
+                _ = mixins[model_name]  # ensure this is marked for augmentation
                 # register an onchange method for the automation_rule
                 method = make_onchange(automation_rule.id)
                 for field in automation_rule.on_change_field_ids:
-                    Model._onchange_methods[field.name].append(method)
+                    onchanges[model_name][field.name].append(method)
 
             if automation_rule.model_id.is_mail_thread and automation_rule.trigger in MAIL_TRIGGERS:
-                patch(Model, "message_post", make_message_post())
+                mixins[model_name].add(MailMixin)
+
+        for model, bases in mixins.items():
+            Model = self.pool[model]
+            if Model.__module__ == __name__:
+                if all(issubclass(Model, base) for base in bases):
+                    continue
+                # get base model to redo augmentation
+                Model = Model.__bases__[-1]
+
+            attrs = {'_register': False, '__module__': __name__}
+            if onchanges := onchanges[model]:
+                m = dict(Model(self.env, (), ())._onchange_methods)
+                for f, ms in onchanges.items():
+                    m[f] = m.get(f, []) + ms  # do not iadd, we don't want to update m[f]
+                attrs['_onchange_methods'] = m
+            m = self.pool[model] = type(
+                "".join(w.capitalize() for w in model.split('.')) + "Automation",
+                (*bases, Model),
+                attrs
+            )
 
     def _unregister_hook(self):
         """ Remove the patches installed by _register_hook() """
-        NAMES = ['create', 'write', '_compute_field_value', 'unlink', '_onchange_methods', "message_post"]
-        for Model in self.env.registry.values():
-            for name in NAMES:
-                try:
-                    delattr(Model, name)
-                except AttributeError:
-                    pass
+        for model, Model in self.env.registry.items():
+            # FIXME: should this be searched through the entire MRO in case somebody else pushed an override?
+            if Model.__module__ == __name__:
+                self.env.registry[model] = Model.__bases__[-1]
 
     @api.model
     def _get_calendar(self, automation, record):
@@ -1213,3 +1102,105 @@ class BaseAutomation(models.Model):
         if final_exception is not None:
             # raise the last found exception to mark the cron job as failing
             raise final_exception
+
+class CreateMixin:
+    @api.model_create_multi
+    def create(self, vals_list, **kw):
+        # retrieve the automation rules to possibly execute
+        automations = self.env['base.automation']._get_actions(self, CREATE_TRIGGERS)
+        if not automations:
+            return super().create(vals_list, **kw)
+        # call original method
+        records = super(CreateMixin, self.with_env(automations.env)).create(vals_list, **kw)
+        # check postconditions, and execute actions on the records that satisfy them
+        for automation in automations.with_context(old_values=None):
+            automation._process(automation._filter_post(records, feedback=True), trigger='create')
+        return records.with_env(self.env)
+
+
+class WriteMixin:
+    def write(self, vals, **kw):
+        # retrieve the automation rules to possibly execute
+        automations = self.env['base.automation']._get_actions(self, WRITE_TRIGGERS)
+        if not (automations and self):
+            return super().write(vals, **kw)
+        records = self.with_env(automations.env).filtered('id')
+        # check preconditions on records
+        pre = {a: a._filter_pre(records) for a in automations}
+        # read old values before the update
+        old_values = {
+            record.id: {field_name: record[field_name] for field_name in vals if field_name in record._fields and record._fields[field_name].store}
+            for record in records
+        }
+        # call original method
+        r = super(WriteMixin, self.with_env(automations.env)).write(vals, **kw)
+        # check postconditions, and execute actions on the records that satisfy them
+        for automation in automations.with_context(old_values=old_values):
+            records, domain_post = automation._filter_post_export_domain(pre[automation], feedback=True)
+            automation._process(records, domain_post=domain_post, trigger='write')
+        return r
+
+    #
+    # Note: This is to catch updates made by field recomputations.
+    #
+    def _compute_field_value(self, field):
+        # determine fields that may trigger an automation
+        stored_fnames = [f.name for f in self.pool.field_computed[field] if f.store]
+        if not stored_fnames:
+            return super()._compute_field_value(field)
+        # retrieve the action rules to possibly execute
+        automations = self.env['base.automation']._get_actions(self, WRITE_TRIGGERS)
+        records = self.filtered('id').with_env(automations.env)
+        if not (automations and records):
+            return super()._compute_field_value(field)
+        # check preconditions on records
+        # changed fields are all fields computed by the function
+        changed_fields = [f for f in records._fields.values() if f.compute == field.compute]
+        pre = {a: a._filter_pre(records, changed_fields=changed_fields) for a in automations}
+        # read old values before the update
+        old_values = {
+            record.id: {fname: record[fname] for fname in stored_fnames}
+            for record in records
+        }
+        # call original method
+        r = super()._compute_field_value(field)
+        # check postconditions, and execute automations on the records that satisfy them
+        for automation in automations.with_context(old_values=old_values):
+            records, domain_post = automation._filter_post_export_domain(pre[automation], feedback=True)
+            automation._process(records, domain_post=domain_post, trigger='_compute_field_value')
+        return r
+
+
+class UnlinkMixin:
+    def unlink(self, **kwargs):
+        # retrieve the action rules to possibly execute
+        automations = self.env['base.automation']._get_actions(self, ['on_unlink'])
+        records = self.with_env(automations.env)
+        # check conditions, and execute actions on the records that satisfy them
+        for automation in automations:
+            automation._process(automation._filter_post(records, feedback=True), trigger='unlink')
+        # call original method
+        return super().unlink(**kwargs)
+
+
+class MailMixin:
+    def _message_post(self, *args, **kwargs):
+        message = super()._message_post(*args, **kwargs)
+        # Don't execute automations for a message emitted during
+        # the run of automations for a real message
+        # Don't execute if we know already that a message is only internal
+        message_sudo = message.sudo().with_context(active_test=False)
+        if "__action_done" in self.env.context or message_sudo.is_internal or message_sudo.subtype_id.internal:
+            return message
+        if message_sudo.message_type in ('notification', 'auto_comment', 'user_notification'):
+            return message
+
+        # always execute actions when the author is a customer
+        # if author is not set, it means the message is coming from outside
+        mail_trigger = "on_message_received" if not message_sudo.author_id or message_sudo.author_id.partner_share else "on_message_sent"
+        automations = self.env['base.automation']._get_actions(self, [mail_trigger])
+        for automation in automations.with_context(old_values=None):
+            records = automation._filter_pre(self, feedback=True)
+            automation._process(records, trigger='_message_post')
+
+        return message

--- a/addons/base_automation/tests/test_automation.py
+++ b/addons/base_automation/tests/test_automation.py
@@ -8,6 +8,9 @@ from odoo.tests import Form, tagged
 
 @tagged('post_install', '-at_install')
 class TestAutomation(TransactionCaseWithUserDemo):
+    def tearDown(self):
+        self.env['base.automation']._unregister_hook()
+        super().tearDown()
 
     def test_01_on_create_or_write(self):
         """ Simple on_create with admin user """


### PR DESCRIPTION
The current implementation of base.automation is based on patching registry classes in-place, this means creating new functions every time with an ad-hoc inheritance mechanism (`$fn.origin`), but more problematically it means `_unregister_hook` is kinda broken, as it can remove methods it never patched in, it also essentially blows the `_onchange_methods` cache and forces its regeneration.

This new version uses a different tack, it creates a new class below the "normal" registry class, which has no content (except a more proper `_onchange_methods`) and a bunch of automation mixins declared statically. This does make the mro a bit longer, but also means we can just pop the class from the registry if we find it's an automation class (just swap it with its last base to find the original registry class, and its sill-cached `_onchange_methods`).
