### PR TITLE
[IMP] website,website_sale,product,pos_restaurant: add ribbon-based shop filters in shop sidebar

### DIFF
--- a/addons/pos_restaurant/data/scenarios/restaurant_demo_data.xml
+++ b/addons/pos_restaurant/data/scenarios/restaurant_demo_data.xml
@@ -6,37 +6,34 @@
             <field name="implied_ids" eval="[(4, ref('product.group_product_variant'))]"/>
         </record>
 
-        <!-- Sides product attribute -->
-        <record id="pa_sides" model="product.attribute">
-            <field name="name">Sides</field>
-            <field name="create_variant">no_variant</field>
-            <field name="display_type">pills</field>
-            <field name="sequence">100</field>
+        <!-- Activate the Sides attribute defined in product and add its values -->
+        <record id="product.pa_sides" model="product.attribute">
+            <field name="active" eval="True"/>
         </record>
 
         <record id="pav_sides_fries" model="product.attribute.value">
             <field name="name">Belgian fresh homemade fries</field>
-            <field name="attribute_id" ref="pa_sides"/>
+            <field name="attribute_id" ref="product.pa_sides"/>
         </record>
 
         <record id="pav_sides_sweet_potato" model="product.attribute.value">
             <field name="name">Sweet potato fries</field>
-            <field name="attribute_id" ref="pa_sides"/>
+            <field name="attribute_id" ref="product.pa_sides"/>
         </record>
 
         <record id="pav_sides_smashed_sweet_potato" model="product.attribute.value">
             <field name="name">Smashed sweet potatoes</field>
-            <field name="attribute_id" ref="pa_sides"/>
+            <field name="attribute_id" ref="product.pa_sides"/>
         </record>
 
         <record id="pav_sides_potato_thyme" model="product.attribute.value">
             <field name="name">Potatoes with thyme</field>
-            <field name="attribute_id" ref="pa_sides"/>
+            <field name="attribute_id" ref="product.pa_sides"/>
         </record>
 
         <record id="pav_sides_grilled_vegetables" model="product.attribute.value">
             <field name="name">Grilled vegetables</field>
-            <field name="attribute_id" ref="pa_sides"/>
+            <field name="attribute_id" ref="product.pa_sides"/>
         </record>
 
         <!-- Extras product attribute -->
@@ -98,7 +95,7 @@
 
         <record model="product.template.attribute.line" id="product_attribute_line_bacon_sides">
             <field name="product_tmpl_id" ref="pos_restaurant.product_bacon_burger_template"/>
-            <field name="attribute_id" ref="pa_sides"/>
+            <field name="attribute_id" ref="product.pa_sides"/>
             <field
                 name="value_ids"
                 eval="[Command.set([
@@ -134,7 +131,7 @@
 
         <record model="product.template.attribute.line" id="product_attribute_line_cheese_side">
             <field name="product_tmpl_id" ref="pos_restaurant.product_cheese_burger_template"/>
-            <field name="attribute_id" ref="pa_sides"/>
+            <field name="attribute_id" ref="product.pa_sides"/>
             <field
                 name="value_ids"
                 eval="[Command.set([

--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -149,6 +149,9 @@ class PosConfig(models.Model):
         convert.convert_file(self._env_with_clean_context(), 'pos_restaurant', 'data/scenarios/restaurant_category_data.xml', idref=None, mode='init', noupdate=True)
         if with_demo_data:
             convert.convert_file(self._env_with_clean_context(), 'pos_restaurant', 'data/scenarios/restaurant_demo_data.xml', idref=None, mode='init', noupdate=True)
+            pa_sides = self.env.ref('pos_restaurant.pa_sides', raise_if_not_found=False)
+            if pa_sides and 'visibility' in self.env['product.attribute']._fields:
+                pa_sides.visibility = 'hidden'
         restaurant_categories = self.get_record_by_ref([
             'pos_restaurant.food',
             'pos_restaurant.drinks',

--- a/addons/product/data/product_attribute_demo.xml
+++ b/addons/product/data/product_attribute_demo.xml
@@ -560,4 +560,13 @@
         <field name="attribute_id" ref="pa_shoe_size"/>
     </record>
 
+    <!-- Sides (used by pos_restaurant, archived until pos_restaurant activates it) -->
+    <record id="pa_sides" model="product.attribute">
+        <field name="name">Sides</field>
+        <field name="create_variant">no_variant</field>
+        <field name="display_type">pills</field>
+        <field name="sequence">100</field>
+        <field name="active" eval="False"/>
+    </record>
+
 </odoo>

--- a/addons/website/static/lib/multirange/multirange_custom.js
+++ b/addons/website/static/lib/multirange/multirange_custom.js
@@ -78,7 +78,7 @@ export class Multirange {
 
         /* Wrap the input and add its ghost */
         this.rangeDiv = document.createElement("div");
-        this.rangeDiv.classList.add("multirange-wrapper", "position-relative", "mb-5");
+        this.rangeDiv.classList.add("multirange-wrapper", "position-relative", "mb-3");
         this.countersWrapper = document.createElement("small");
         this.countersWrapper.classList.add("d-flex", "justify-content-between", "mt-2");
         this.rangeDiv.appendChild(this.countersWrapper);

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -141,7 +141,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
     def _get_search_order(self, post):
         # OrderBy will be parsed in orm and so no direct sql injection
         # id is added to be sure that order is a unique sort key
-        order = post.get("order") or self.env['website'].get_current_website().shop_default_sort
+        order = post.get("order") or self.env["website"].get_current_website().shop_default_sort
         return "is_published desc, %s, id desc" % order
 
     def _add_search_subdomains_hook(self, _search):
@@ -150,7 +150,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
     def _get_shop_domain(
         self, search, category, attribute_value_dict, search_in_description=True, tags=None
     ):
-        website = request.env['website'].get_current_website()
+        website = request.env["website"].get_current_website()
         domains = [website.sale_product_domain()]
         if search:
             for srch in search.split(" "):
@@ -257,7 +257,15 @@ class WebsiteSale(payment_portal.PaymentPortal):
         return fuzzy_search_term, product_count, search_result
 
     def _shop_get_query_url_kwargs(
-        self, search, min_price, max_price, order=None, tags=None, **_kwargs
+        self,
+        search,
+        min_price,
+        max_price,
+        order=None,
+        tags=None,
+        on_sale=None,
+        in_stock=None,
+        **_kwargs,
     ):
         return {
             "search": search,
@@ -265,6 +273,8 @@ class WebsiteSale(payment_portal.PaymentPortal):
             "max_price": max_price,
             "order": order,
             "tags": tags,
+            "on_sale": on_sale,
+            "in_stock": in_stock,
             **request.session.get("attribute_value_params", {}),
         }
 
@@ -296,7 +306,18 @@ class WebsiteSale(payment_portal.PaymentPortal):
         # Return a 404 instead of a 403 error in case of an access error.
         handle_params_access_error=lambda e, **_kwargs: NotFound.code,  # noqa: ARG005
     )
-    def shop(self, page=0, category=None, search="", min_price=0.0, max_price=0.0, tags="", **post):
+    def shop(
+        self,
+        page=0,
+        category=None,
+        search="",
+        min_price=0.0,
+        max_price=0.0,
+        tags="",
+        on_sale=None,
+        in_stock=None,
+        **post,
+    ):
         website = self.env["website"].get_current_website()
         if not website.has_ecommerce_access():
             return request.redirect(f"/web/login?redirect={request.httprequest.path}")
@@ -372,7 +393,10 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
         url = category.website_url if category else SHOP_PATH
         keep = QueryURL(
-            url, **self._shop_get_query_url_kwargs(search, min_price, max_price, **post)
+            url,
+            **self._shop_get_query_url_kwargs(
+                search, min_price, max_price, on_sale=on_sale, in_stock=in_stock, **post
+            ),
         )
 
         # Check if we need to refresh the cached pricelist
@@ -388,10 +412,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         if filter_by_price_enabled:
             company_currency = website.company_id.sudo().currency_id
             conversion_rate = self.env["res.currency"]._get_conversion_rate(
-                company_currency,
-                website.currency_id,
-                website.company_id,
-                fields.Date.today(),
+                company_currency, website.currency_id, website.company_id, fields.Date.today()
             )
         else:
             conversion_rate = 1
@@ -491,6 +512,38 @@ class WebsiteSale(payment_portal.PaymentPortal):
         else:
             filtered_query = shop_query
 
+        # Dynamic ribbon filters ("On sale" / "In stock")
+        on_sale_active = on_sale == "1"
+        in_stock_active = in_stock == "1"
+        auto_assign_ribbons = self.env["product.ribbon"].sudo().search([("assign", "!=", "manual")])
+        ribbon_assign_values = set(auto_assign_ribbons.mapped("assign"))
+
+        on_sale_ids = set()
+        sold_out_ids = set()
+        if "sale" in ribbon_assign_values:
+            sales_prices = search_product._get_sales_prices(
+                request.pricelist.with_context(self.env.context),
+                request.fiscal_position.with_context(self.env.context),
+                website.with_context(self.env.context),
+            )
+            on_sale_ids = {pid for pid, prices in sales_prices.items() if "base_price" in prices}
+        if "out_of_stock" in ribbon_assign_values:
+            sold_out_ids = {p.id for p in search_product if p._is_sold_out()}
+
+        show_on_sale_filter = bool(on_sale_ids) or (
+            on_sale_active and "sale" in ribbon_assign_values
+        )
+        show_in_stock_filter = bool(sold_out_ids) or (
+            in_stock_active and "out_of_stock" in ribbon_assign_values
+        )
+
+        if on_sale_active and "sale" in ribbon_assign_values:
+            search_product = search_product.filtered(lambda p: p.id in on_sale_ids)
+        if in_stock_active and "out_of_stock" in ribbon_assign_values:
+            search_product = search_product.filtered(lambda p: p.id not in sold_out_ids)
+        if on_sale_active or in_stock_active:
+            product_count = len(search_product)
+
         ProductTag = self.env["product.tag"]
         if filter_by_tags_enabled and search_product:
             all_tags = ProductTag.search_fetch(
@@ -527,20 +580,16 @@ class WebsiteSale(payment_portal.PaymentPortal):
                 lambda c: c.website_id.id in (website.id, False)
             )
             category_entries = (
-                (not search
-                and available_categories)
-                or available_categories.filtered(lambda c: c.id in search_categories.ids)
-            )
+                not search and available_categories
+            ) or available_categories.filtered(lambda c: c.id in search_categories.ids)
             if not category_entries:
                 parent = category.parent_id
                 available_categories = parent.child_id.filtered(
                     lambda c: c.website_id.id in (website.id, False)
                 )
                 category_entries = (
-                    (not search
-                    and available_categories)
-                    or available_categories.filtered(lambda c: c.id in search_categories.ids)
-                )
+                    not search and available_categories
+                ) or available_categories.filtered(lambda c: c.id in search_categories.ids)
             if not search and not self.env.user._is_internal():
                 # We know the user has access to `categs` and `search_categories` because they come
                 # from a regular `search`, but we have not checked access to `category`'s children,
@@ -595,10 +644,11 @@ class WebsiteSale(payment_portal.PaymentPortal):
         product_query_params = self._get_product_query_params(**post)
 
         values = {
-            "auto_assign_ribbons": self
-            .env["product.ribbon"]
-            .sudo()
-            .search([("assign", "!=", "manual")]),
+            "auto_assign_ribbons": auto_assign_ribbons,
+            "show_on_sale_filter": show_on_sale_filter,
+            "show_in_stock_filter": show_in_stock_filter,
+            "on_sale_active": on_sale_active,
+            "in_stock_active": in_stock_active,
             "search": fuzzy_search_term or search,
             "original_search": fuzzy_search_term and search,
             "order": post.get("order", ""),
@@ -670,7 +720,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         handle_params_access_error=lambda e, **_kwargs: NotFound.code,  # noqa: ARG005
     )
     def product(self, product, pricelist=None, **kwargs):
-        website = self.env['website'].get_current_website()
+        website = self.env["website"].get_current_website()
         if not website.has_ecommerce_access():
             return request.redirect(f"/web/login?redirect={request.httprequest.path}")
 
@@ -920,7 +970,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         return product.sudo()._is_add_to_cart_allowed()
 
     def _prepare_product_values(self, product, **kwargs):
-        website = self.env['website'].get_current_website()
+        website = self.env["website"].get_current_website()
         category = product.public_categ_ids.filtered(
             lambda categ: categ.website_id.id in (website.id, False)
         )[:1]
@@ -1049,10 +1099,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
                     min_price = float(min_price)
                     args["min_price"] = min_price and str(
                         prev_pricelist.currency_id._convert(
-                            min_price,
-                            pricelist.currency_id,
-                            website.company_id,
-                            round=False,
+                            min_price, pricelist.currency_id, website.company_id, round=False
                         )
                     )
                 except (ValueError, TypeError):
@@ -1061,10 +1108,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
                     max_price = float(max_price)
                     args["max_price"] = max_price and str(
                         prev_pricelist.currency_id._convert(
-                            max_price,
-                            pricelist.currency_id,
-                            website.company_id,
-                            round=False,
+                            max_price, pricelist.currency_id, website.company_id, round=False
                         )
                     )
                 except (ValueError, TypeError):
@@ -1670,13 +1714,11 @@ class WebsiteSale(payment_portal.PaymentPortal):
         list_as_website_content=system_page_extra_info,
     )
     def extra_info(self, **post):
-        website = request.env['website'].get_current_website()
+        website = request.env["website"].get_current_website()
         # Check that this option is activated
         extra_step = website.viewref("website_sale.extra_info")
         if not extra_step.active:
-            return request.redirect(
-                website._get_next_breadcrumb_step_href("/shop/extra_info")
-            )
+            return request.redirect(website._get_next_breadcrumb_step_href("/shop/extra_info"))
 
         order_sudo = request.cart
         if redirect := self.env["website.checkout.step"].validate_checkout_progress(
@@ -1699,7 +1741,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
     # === CHECKOUT FLOW - PAYMENT/CONFIRMATION METHODS === #
 
     def _get_shop_payment_values(self, order, **_kwargs):
-        website = request.env['website'].get_current_website()
+        website = request.env["website"].get_current_website()
         checkout_page_values = {
             "sale_order": order,
             "website_sale_order": order,
@@ -1709,11 +1751,9 @@ class WebsiteSale(payment_portal.PaymentPortal):
             "only_services": order.only_services,
             **website._get_checkout_step_values("/shop/payment"),
         }
-        website = request.env['website'].get_current_website()
+        website = request.env["website"].get_current_website()
         payment_form_values = {
-            **sale_portal.CustomerPortal._get_payment_values(
-                self, order, website_id=website.id
-            ),
+            **sale_portal.CustomerPortal._get_payment_values(self, order, website_id=website.id),
             "display_submit_button": False,  # The submit button is re-added outside the form.
             "transaction_route": f"/shop/payment/transaction/{order.id}",
             "landing_route": "/shop/payment/validate",
@@ -1826,7 +1866,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             "website_sale_order": order,
             "order_tracking_info": self.order_2_return_dict(order),
         }
-        website = self.env['website'].get_current_website()
+        website = self.env["website"].get_current_website()
         if (
             self.env["res.users"]._get_signup_invitation_scope() == "b2c"
             and website.is_public_user()
@@ -2058,7 +2098,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
     @staticmethod
     def _populate_currency_and_pricelist(kwargs):
-        website = request.env['website'].get_current_website()
+        website = request.env["website"].get_current_website()
         kwargs.update({"currency_id": website.currency_id.id, "pricelist_id": request.pricelist.id})
 
     @staticmethod
@@ -2076,7 +2116,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         ProductCategory = request.env["product.public.category"]
         if category and isinstance(category, str) and not category.isdigit():
             return ProductCategory
-        website = request.env['website'].get_current_website()
+        website = request.env["website"].get_current_website()
         if (
             category := ProductCategory.browse(category and int(category)).exists()
         ) and category.website_id.id in (website.id, False):

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -254,7 +254,15 @@ class WebsiteSale(payment_portal.PaymentPortal):
         return fuzzy_search_term, product_count, search_result
 
     def _shop_get_query_url_kwargs(
-        self, search, min_price, max_price, order=None, tags=None, **_kwargs
+        self,
+        search,
+        min_price,
+        max_price,
+        order=None,
+        tags=None,
+        on_sale=None,
+        in_stock=None,
+        **_kwargs,
     ):
         attribute_values = request.session.get("attribute_values", [])
         return {
@@ -264,6 +272,8 @@ class WebsiteSale(payment_portal.PaymentPortal):
             "order": order,
             "tags": tags,
             "attribute_values": attribute_values,
+            "on_sale": on_sale,
+            "in_stock": in_stock,
         }
 
     def _get_additional_shop_values(self, _values, **_kwargs):
@@ -295,7 +305,18 @@ class WebsiteSale(payment_portal.PaymentPortal):
         # Sends a 404 error in case of any Access error instead of 403.
         handle_params_access_error=lambda e, **_kwargs: NotFound.code,  # noqa: ARG005
     )
-    def shop(self, page=0, category=None, search="", min_price=0.0, max_price=0.0, tags="", **post):
+    def shop(
+        self,
+        page=0,
+        category=None,
+        search="",
+        min_price=0.0,
+        max_price=0.0,
+        tags="",
+        on_sale=None,
+        in_stock=None,
+        **post,
+    ):
         if not request.website.has_ecommerce_access():
             return request.redirect(f"/web/login?redirect={request.httprequest.path}")
 
@@ -348,7 +369,10 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
         url = self._get_shop_path(category)
         keep = QueryURL(
-            url, **self._shop_get_query_url_kwargs(search, min_price, max_price, **post)
+            url,
+            **self._shop_get_query_url_kwargs(
+                search, min_price, max_price, on_sale=on_sale, in_stock=in_stock, **post
+            ),
         )
 
         # Check if we need to refresh the cached pricelist
@@ -429,6 +453,28 @@ class WebsiteSale(payment_portal.PaymentPortal):
                         max_price if max_price >= available_min_price else available_max_price
                     )
                     post["max_price"] = max_price
+
+        # Dynamic ribbon filters ("On sale" / "In stock")
+        on_sale_active = on_sale == "1"
+        in_stock_active = in_stock == "1"
+        auto_assign_ribbons = (
+            request.env["product.ribbon"].sudo().search([("assign", "!=", "manual")])
+        )
+        ribbon_assign_values = set(auto_assign_ribbons.mapped("assign"))
+        has_sale_ribbon = "sale" in ribbon_assign_values
+        has_out_of_stock_ribbon = "out_of_stock" in ribbon_assign_values
+        unfiltered_products = search_product
+        unfiltered_prices = {}
+
+        if on_sale_active and has_sale_ribbon:
+            unfiltered_prices = unfiltered_products._get_sales_prices(website)
+            on_sale_ids = {tid for tid, pv in unfiltered_prices.items() if "base_price" in pv}
+            search_product = search_product.filtered(lambda p: p.id in on_sale_ids)
+            product_count = len(search_product)
+        if in_stock_active and has_out_of_stock_ribbon:
+            sold_out_ids = {p.id for p in search_product.sudo() if p._is_sold_out()}
+            search_product = search_product.filtered(lambda p: p.id not in sold_out_ids)
+            product_count = len(search_product)
 
         ProductTag = request.env["product.tag"]
         if filter_by_tags_enabled and search_product:
@@ -530,11 +576,25 @@ class WebsiteSale(payment_portal.PaymentPortal):
             .grouped("attribute_id")
         )
 
+        has_on_sale_filter = False
+        has_in_stock_filter = False
+        if has_sale_ribbon:
+            if not unfiltered_prices:
+                unfiltered_prices = unfiltered_products._get_sales_prices(website)
+            has_on_sale_filter = on_sale_active or any(
+                "base_price" in pv for pv in unfiltered_prices.values()
+            )
+        if has_out_of_stock_ribbon:
+            has_in_stock_filter = in_stock_active or any(
+                p._is_sold_out() for p in unfiltered_products.sudo()
+            )
+
         values = {
-            "auto_assign_ribbons": self
-            .env["product.ribbon"]
-            .sudo()
-            .search([("assign", "!=", "manual")]),
+            "auto_assign_ribbons": auto_assign_ribbons,
+            "has_on_sale_filter": has_on_sale_filter,
+            "has_in_stock_filter": has_in_stock_filter,
+            "on_sale_active": on_sale_active,
+            "in_stock_active": in_stock_active,
             "search": fuzzy_search_term or search,
             "original_search": fuzzy_search_term and search,
             "order": post.get("order", ""),
@@ -896,8 +956,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
         if last_attributes_search := request.session.get("attribute_values", []):
             keep = QueryURL(
-                self._get_shop_path(original_category),
-                attribute_values=last_attributes_search
+                self._get_shop_path(original_category), attribute_values=last_attributes_search
             )
         else:
             keep = QueryURL(self._get_shop_path(original_category))
@@ -934,7 +993,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             "attribute_value_images": attribute_value_images,
             "categories": ProductCategory.search([("parent_id", "=", False)]),
             "category": category,
-            'original_category': original_category,
+            "original_category": original_category,
             "combination_info": combination_info,
             "has_available_uoms": len(product._get_available_uoms()) > 0,
             "keep": keep,

--- a/addons/website_sale/data/demo.xml
+++ b/addons/website_sale/data/demo.xml
@@ -25,6 +25,9 @@
         <record id="product.pa_shoe_size" model="product.attribute">
             <field name="visibility">hidden</field>
         </record>
+        <record id="product.pa_sides" model="product.attribute">
+            <field name="visibility">hidden</field>
+        </record>
 
         <record id="product.product_product_24" model="product.product">
             <field name="is_published" eval="True"/>

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -1134,7 +1134,7 @@ class ProductTemplate(models.Model):
         ]
 
     @api.model
-    def _search_get_detail(self, website, order, options):
+    def _search_get_detail(self, website, order, options):  # noqa: ARG002
         domains = [website.sale_product_domain()]
         category = options.get("category")
         tags = options.get("tags")
@@ -1176,12 +1176,31 @@ class ProductTemplate(models.Model):
         mapping = {
             "name": {"name": "name", "type": "text", "match": True},
             "website_url": {"name": "website_url", "type": "text", "truncate": False},
-            "search_item_metadata": {"name": "price", "type": "html", "display_currency": options["display_currency"]},
+            "search_item_metadata": {
+                "name": "price",
+                "type": "html",
+                "display_currency": options["display_currency"],
+            },
             "image_url": {"name": "image_url", "type": "html"},
-            "description": {"name": "description_ecommerce", "type": "text", "html": True, "match": True},
+            "description": {
+                "name": "description_ecommerce",
+                "type": "text",
+                "html": True,
+                "match": True,
+            },
             "tags": {"name": "product_tag_ids", "type": "tags", "match": True},
-            "attribute_value_ids": {"name": "attribute_value_ids", "type": "tags", "match": True, "force_show": True},
-            "description_sale": {"name": "description_sale", "type": "text", "html": True, "match": True},
+            "attribute_value_ids": {
+                "name": "attribute_value_ids",
+                "type": "tags",
+                "match": True,
+                "force_show": True,
+            },
+            "description_sale": {
+                "name": "description_sale",
+                "type": "text",
+                "html": True,
+                "match": True,
+            },
         }
         return {
             "model": "product.template",
@@ -1201,9 +1220,7 @@ class ProductTemplate(models.Model):
             values = product.mapped("attribute_line_ids.value_ids")
             data["attribute_value_ids"] = values.read(["id", "name"])
             data["product_tag_ids"] = product.product_tag_ids.read(["name"])
-            price = self._search_render_results_prices(
-                mapping, combination_info
-            )
+            price = self._search_render_results_prices(mapping, combination_info)
             if price:
                 data["price"] = price
             data["image_url"] = "/web/image/product.template/%s/image_128" % data["id"]
@@ -1212,12 +1229,10 @@ class ProductTemplate(models.Model):
     def _search_render_results_prices(self, mapping, combination_info):
         if combination_info.get("hide_price"):
             return None
-
         monetary_options = {"display_currency": mapping["search_item_metadata"]["display_currency"]}
-        price = self.env["ir.qweb.field.monetary"].value_to_html(
+        return self.env["ir.qweb.field.monetary"].value_to_html(
             combination_info["price"], monetary_options
         )
-        return price
 
     def _get_google_analytics_data(self, product, combination_info):
         self.ensure_one()
@@ -1235,6 +1250,13 @@ class ProductTemplate(models.Model):
         if request and request.is_frontend and not pricelist:
             return request.pricelist
         return pricelist
+
+    def _is_sold_out(self):
+        """Return whether the product is sold out. Overridden in ``website_sale_stock``.
+
+        :rtype: bool
+        """
+        return False
 
     def _website_show_quick_add(self):
         self.ensure_one()

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -31,6 +31,7 @@
         }
 
         .o_wsale_products_grid_before_rail{
+            height: calc(100vh - var(--o_ws_sidebar_top_gap));
             scrollbar-width: none;
             -ms-overflow-style: none;
         }

--- a/addons/website_sale/templates/shop_page_templates.xml
+++ b/addons/website_sale/templates/shop_page_templates.xml
@@ -190,6 +190,8 @@
                     (opt_wsale_categories and categories)
                     or (opt_wsale_attributes and (attributes or all_tags or opt_wsale_filter_price))
                     or show_price_filter
+                    or show_on_sale_filter
+                    or show_in_stock_filter
                 "
             />
 
@@ -232,7 +234,7 @@
                             class="d-none d-lg-block position-sticky align-self-start col clearfix pt-2"
                         >
                             <t t-call="website_sale.sidebar_dropzone_at_top"/>
-                            <div class="o_wsale_products_grid_before_rail vh-100 ms-n2 px-lg-2 ps-2 overflow-y-scroll">
+                            <div class="o_wsale_products_grid_before_rail ms-n2 px-lg-2 ps-2 overflow-y-scroll">
                                 <t
                                     t-set="is_sidebar_collapsible"
                                     t-value="is_view_active('website_sale.products_categories_list_collapsible')"
@@ -244,14 +246,23 @@
                                 >
                                     <t t-call="website_sale.products_categories_list"/>
                                 </div>
-                                <div
-                                    t-if="attrib_values or tags or (
-                                        show_price_filter and isFilteringByPrice
+                                <t
+                                    t-set="has_active_filters"
+                                    t-value="(
+                                        attrib_values
+                                        or tags
+                                        or (show_on_sale_filter and on_sale_active)
+                                        or (show_in_stock_filter and in_stock_active)
+                                        or (show_price_filter and isFilteringByPrice)
                                     )"
-                                    class="py-3 border-bottom"
-                                >
+                                />
+                                <div t-if="has_active_filters" class="py-3 border-bottom">
                                     <a
-                                        t-att-href="keep(**reset_attribute_value_params, tags=0, min_price=0, max_price=0)"
+                                        t-att-href="keep(
+                                            **reset_attribute_value_params, tags=0,
+                                            min_price=0, max_price=0,
+                                            on_sale=0, in_stock=0,
+                                        )"
                                         t-attf-class="btn btn-{{navClass}} d-flex align-items-center py-1"
                                         title="Clear Filters"
                                     >
@@ -268,6 +279,12 @@
                                     _classes.f="{{is_sidebar_collapsible and 'accordion accordion-flush'}} {{is_sidebar_collapsible and (opt_wsale_categories or len(attributes) > 0) and 'border-top'}}"
                                 >
                                 </t>
+                                <div
+                                    t-if="show_on_sale_filter or show_in_stock_filter"
+                                    class="d-flex flex-wrap gap-2 py-3 border-top"
+                                >
+                                    <t t-call="website_sale.ribbon_filter_pills"/>
+                                </div>
                                 <t t-call="website_sale.sidebar_dropzone_at_bottom"/>
                             </div>
                         </aside>
@@ -1025,12 +1042,34 @@
                    _classes.f="o_wsale_offcanvas_title accordion accordion-flush"
                    _classes_title.f="ms-n1 pt-3 pb-2"
                    isOffcanvas="True"/>
+                <div
+                    t-if="show_on_sale_filter or show_in_stock_filter"
+                    class="d-flex flex-wrap gap-2 px-4 py-3 border-top"
+                >
+                    <t t-call="website_sale.ribbon_filter_pills"/>
+                </div>
             </div>
             <div class="offcanvas-body d-flex justify-content-between flex-grow-0 flex-shrink-0 border-top overflow-hidden">
-                <a t-attf-class="btn btn-{{navClass}} d-flex py-1 mb-2 {{(not attrib_values and not isFilteringByPrice and not tags) and 'disabled' }}"
-                   t-att-aria-disabled="(not attrib_values and not isFilteringByPrice and not tags) and 'true' or 'false'"
-                   t-att-href="keep(**reset_attribute_value_params, tags=0, min_price=0, max_price=0)"
-                   title="Clear Filters">
+                <t
+                    t-set="has_active_filters"
+                    t-value="(
+                        attrib_values
+                        or tags
+                        or (show_on_sale_filter and on_sale_active)
+                        or (show_in_stock_filter and in_stock_active)
+                        or isFilteringByPrice
+                    )"
+                />
+                <a
+                    t-attf-class="btn btn-{{navClass}} d-flex py-1 mb-2 {{not has_active_filters and 'disabled'}}"
+                    t-att-aria-disabled="'true' if not has_active_filters else 'false'"
+                    t-att-href="keep(
+                        **reset_attribute_value_params, tags=0,
+                        min_price=0, max_price=0,
+                        on_sale=0, in_stock=0,
+                    )"
+                    title="Clear Filters"
+                >
                     Clear Filters
                 </a>
             </div>
@@ -1557,6 +1596,30 @@
                 <label class="form-check-label fw-normal" t-attf-for="tag_#{tag.id}" t-field="tag.name"/>
             </div>
         </t>
+    </template>
+
+    <template id="website_sale.ribbon_filter_pills" name="Ribbon Filter Pills">
+        <t
+            t-set="active_pill_class"
+            t-value="'btn border active bg-primary-subtle border-primary text-primary-emphasis'"
+        />
+        <t t-set="inactive_pill_class" t-value="'btn border'"/>
+        <a
+            t-if="show_on_sale_filter"
+            t-att-href="keep(on_sale=0 if on_sale_active else 1)"
+            t-att-class="active_pill_class if on_sale_active else inactive_pill_class"
+            aria-label="Filter by on sale products"
+        >
+            On sale
+        </a>
+        <a
+            t-if="show_in_stock_filter"
+            t-att-href="keep(in_stock=0 if in_stock_active else 1)"
+            t-att-class="active_pill_class if in_stock_active else inactive_pill_class"
+            aria-label="Filter by in stock products"
+        >
+            In stock
+        </a>
     </template>
 
     <!-- Enable HTML previews in edition mode. The template is active by default, but can be

--- a/addons/website_sale/templates/shop_page_templates.xml
+++ b/addons/website_sale/templates/shop_page_templates.xml
@@ -220,7 +220,7 @@
                             class="d-none d-lg-block position-sticky align-self-start col clearfix pt-2"
                         >
                             <t t-call="website_sale.sidebar_dropzone_at_top"/>
-                            <div class="o_wsale_products_grid_before_rail vh-100 ms-n2 px-lg-2 ps-2 overflow-y-scroll">
+                            <div class="o_wsale_products_grid_before_rail ms-n2 px-lg-2 ps-2 overflow-y-scroll">
                                 <t
                                     t-set="is_sidebar_collapsible"
                                     t-value="is_view_active('website_sale.products_categories_list_collapsible')"
@@ -236,14 +236,19 @@
                                     t-set="show_price_filter"
                                     t-value="opt_wsale_filter_price and opt_wsale_attributes"
                                 />
-                                <div
-                                    t-if="attrib_values or tags or (
-                                        show_price_filter and isFilteringByPrice
-                                    )"
-                                    class="py-3 border-bottom"
-                                >
+                                <t
+                                    t-set="has_active_filters"
+                                    t-value="attrib_values or tags or on_sale_active
+                                        or in_stock_active
+                                        or (show_price_filter and isFilteringByPrice)"
+                                />
+                                <div t-if="has_active_filters" class="py-3 border-bottom">
                                     <a
-                                        t-att-href="keep(attribute_values=0, tags=0, min_price=0, max_price=0)"
+                                        t-att-href="keep(
+                                            attribute_values=0, tags=0,
+                                            min_price=0, max_price=0,
+                                            on_sale=None, in_stock=None,
+                                        )"
                                         t-attf-class="btn btn-{{navClass}} d-flex align-items-center py-1"
                                         title="Clear Filters"
                                     >
@@ -260,6 +265,12 @@
                                     _classes.f="{{is_sidebar_collapsible and 'accordion accordion-flush'}} {{is_sidebar_collapsible and (opt_wsale_categories or len(attributes) > 0) and 'border-top'}}"
                                 >
                                 </t>
+                                <div
+                                    t-if="has_on_sale_filter or has_in_stock_filter"
+                                    class="d-flex flex-wrap gap-2 py-3 border-top"
+                                >
+                                    <t t-call="website_sale.ribbon_filter_pills"/>
+                                </div>
                                 <t t-call="website_sale.sidebar_dropzone_at_bottom"/>
                             </div>
                         </aside>
@@ -1042,12 +1053,30 @@
                    _classes.f="o_wsale_offcanvas_title accordion accordion-flush px-4"
                    _classes_title.f="ms-n1 pt-3 pb-2"
                    isOffcanvas="True"/>
+                <div
+                    t-if="has_on_sale_filter or has_in_stock_filter"
+                    class="d-flex flex-wrap gap-2 px-4 py-3 border-top"
+                >
+                    <t t-call="website_sale.ribbon_filter_pills"/>
+                </div>
             </div>
             <div class="offcanvas-body d-flex justify-content-between flex-grow-0 border-top overflow-hidden">
-                <a t-attf-class="btn btn-{{navClass}} d-flex py-1 mb-2 {{(not attrib_values and not isFilteringByPrice and not tags) and 'disabled' }}"
-                   t-att-aria-disabled="(not attrib_values and not isFilteringByPrice and not tags) and 'true' or 'false'"
-                   t-att-href="keep(attribute_values=0, tags=0, min_price=0, max_price=0)"
-                   title="Clear Filters">
+                <t
+                    t-set="has_no_active_filters"
+                    t-value="not attrib_values and not isFilteringByPrice
+                        and not tags and not on_sale_active and not in_stock_active"
+                />
+                <a
+                    t-attf-class="btn btn-{{navClass}} d-flex py-1 mb-2
+                        {{has_no_active_filters and 'disabled'}}"
+                    t-att-aria-disabled="'true' if has_no_active_filters else 'false'"
+                    t-att-href="keep(
+                        attribute_values=0, tags=0,
+                        min_price=0, max_price=0,
+                        on_sale=None, in_stock=None,
+                    )"
+                    title="Clear Filters"
+                >
                     Clear Filters
                 </a>
             </div>
@@ -1473,19 +1502,19 @@
                 <div class="accordion-item">
                     <div class="accordion-header h6 mb-0">
                         <button
-                            class="accordion-button px-0 bg-transparent shadow-none"
+                            class="accordion-button collapsed px-0 bg-transparent shadow-none"
                             type="button"
                             data-bs-toggle="collapse"
                             t-attf-data-bs-target="#o_wsale_price_range_option_inner"
                             t-attf-aria-controls="o_wsale_price_range_option_inner"
-                            aria-expanded="true"
+                            aria-expanded="false"
                         >
                             <b>Price Range</b>
                         </button>
                     </div>
                     <div
                         id="o_wsale_price_range_option_inner"
-                        class="accordion-collapse collapse show"
+                        class="accordion-collapse collapse"
                     >
                         <input
                             type="range"
@@ -1557,6 +1586,30 @@
                 <label class="form-check-label fw-normal" t-attf-for="tag_#{tag.id}" t-field="tag.name"/>
             </div>
         </t>
+    </template>
+
+    <template id="website_sale.ribbon_filter_pills" name="Ribbon Filter Pills">
+        <t
+            t-set="active_pill_class"
+            t-value="'btn border active bg-primary-subtle border-primary text-primary-emphasis'"
+        />
+        <t t-set="inactive_pill_class" t-value="'btn border'"/>
+        <a
+            t-if="has_on_sale_filter"
+            t-att-href="keep(on_sale=None if on_sale_active else 1)"
+            t-att-class="active_pill_class if on_sale_active else inactive_pill_class"
+            aria-label="Filter by on sale products"
+        >
+            On sale
+        </a>
+        <a
+            t-if="has_in_stock_filter"
+            t-att-href="keep(in_stock=None if in_stock_active else 1)"
+            t-att-class="active_pill_class if in_stock_active else inactive_pill_class"
+            aria-label="Filter by in stock products"
+        >
+            In stock
+        </a>
     </template>
 
     <!-- Enable HTML previews in edition mode. The template is active by default, but can be


### PR DESCRIPTION
- Add "On sale" and "In stock" filter pills in the eCommerce shop sidebar
- Filters are derived from dynamic ribbon assignment methods (on sale,
  out_of_stock) and only shown when a matching ribbon exists and at
  least one product qualifies
- Fix spacing below the Price Range filter in offcanvas sidebar
- Hide POS-specific "Sides" attribute from eCommerce filters in demo data

task-5923039