### PR TITLE
[FIX] point_of_sale: Fix IOS latency and pinch zoom issues

### DIFF
--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.xml
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.xml
@@ -56,7 +56,7 @@
                         <t t-set-slot="content">
                             <div class="d-flex gap-2 p-2 border-bottom">
                                 <ProxyStatus t-if="pos.config.useProxy" />
-                                <span t-on-click="openCustomerDisplay" t-attf-class="{{pos.config.useProxy ? 'd-flex align-items-center justify-content-center' : ''}} btn btn-secondary btn-lg w-100 text-center" title="Customer Display">
+                                <span t-on-click="openCustomerDisplay" role="button" t-attf-class="{{pos.config.useProxy ? 'd-flex align-items-center justify-content-center' : ''}} btn btn-secondary btn-lg w-100 text-center" title="Customer Display">
                                     <i class="fa fa-fw fa-desktop"/>
                                 </span>
                             </div>
@@ -88,7 +88,7 @@
                                 </DropdownItem>
                             </div>
                             <div class="border-top p-2">
-                                <span t-on-click="openLnaPopup" t-attf-class="btn btn-{{this.pos.lnaState.type}} btn-sm rounded" title="Local Network Access">
+                                <span t-on-click="openLnaPopup" role="button" t-attf-class="btn btn-{{this.pos.lnaState.type}} btn-sm rounded" title="Local Network Access">
                                     <i class="fa fa-wifi" aria-hidden="true" /> Local Network Access
                                 </span>
                             </div>

--- a/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.xml
@@ -6,7 +6,7 @@
             <div class="d-flex flex-wrap gap-3 align-items-center">
                 <t t-foreach="props.attribute.values()" t-as="value" t-key="value.id">
                     <div class="attribute-name-cell form-check">
-                        <input 
+                        <input
                             type="radio"
                             t-att-checked="value.id === props.selected.id"
                             t-on-change="() => props.setSelected(value)"
@@ -14,7 +14,7 @@
                             t-attf-id="{{ value.attribute_id.id }}_{{ value.id }}"
                             class="form-check-input radio-check"
                         />
-                        <label t-attf-for="{{ value.attribute_id.id }}_{{ value.id }}">
+                        <label role="button" t-attf-for="{{ value.attribute_id.id }}_{{ value.id }}">
                             <span t-att-class="{ 'text-muted': pos.doHaveConflictWith(value, props.allSelectedValues) }" t-esc="value.name"/>
                             <div t-if="value.price_extra" class="price-extra-cell d-inline-block ms-2">
                                 <span class="price_extra px-2 py-1 rounded-pill text-bg-info">
@@ -36,15 +36,16 @@
             <div class="d-flex flex-wrap gap-2">
                 <t t-foreach="props.attribute.values()" t-as="value" t-key="value.id">
                     <div class="attribute-name-cell">
-                        <input 
+                        <input
                             type="radio"
                             t-att-checked="value.id === props.selected.id"
-                            t-on-change="() => props.setSelected(value)" 
-                            t-att-name="value.attribute_id.id" 
+                            t-on-change="() => props.setSelected(value)"
+                            t-att-name="value.attribute_id.id"
                             t-attf-id="{{ value.attribute_id.id }}_{{ value.id }}" 
                             class="form-check-input d-none"
                         />
                         <label
+                            role="button"
                             t-attf-class="btn btn-secondary btn-lg lh-lg d-flex {{ value.id == props.selected.id ? 'active' : '' }}"
                             t-att-name="value.name"
                             t-attf-for="{{ value.attribute_id.id }}_{{ value.id }}">
@@ -94,16 +95,16 @@
                     <t t-set="img_style" t-value="value.image ? 'background:url(/web/image/product.template.attribute.value/' + value.id + '/image); background-size:cover;' : ''"/>
                     <t t-set="color_style" t-value="value.is_custom ? '' : 'background-color: ' + value.html_color" />
                     <span class="d-flex flex-row justify-content-center align-items-center">
-                        <label t-attf-class="configurator_color rounded-circle border position-relative {{ value.id == props.selected.id ? 'active border-3' : 'border-3 border-secondary' }}"
+                        <label role="button" t-attf-class="configurator_color rounded-circle border position-relative {{ value.id == props.selected.id ? 'active border-3' : 'border-3 border-secondary' }}"
                             t-att-class="{'ptav-not-available' : value.excluded}"
                             t-attf-style="{{ img_style or color_style }}" t-att-data-color="value.name" t-att-title="value.name">
-                            <input 
+                            <input
                                 type="radio"
                                 t-att-checked="value.id === props.selected.id"
                                 t-on-change="() => props.setSelected(value)"
                                 t-att-name="value.attribute_id.id"
                                 t-attf-id="{{ value.attribute_id.id }}_{{ value.id }}"
-                                class="m-2 opacity-0" 
+                                class="m-2 opacity-0"
                             />
                         </label>
                         <div t-if="value.price_extra" class="price-extra-cell d-inline-block ms-2" t-att-class="{'ptav-not-available' : value.excluded}">
@@ -130,6 +131,7 @@
                     t-on-change="() => this.onChange(value)"
                     />
                 <label
+                    role="button"
                     t-attf-class="form-check-label btn btn-secondary btn-lg lh-lg d-flex {{ this.state.is_value_selected[value.id] === true ? 'active' : '' }}"
                     t-attf-name="multi-{{value.id}}"
                     t-attf-for="multi-{{value.id}}">
@@ -155,6 +157,7 @@
                     <t t-set="color_style" t-value="value.is_custom ? '' : 'background-color: ' + value.html_color" />
                     <span class="d-flex flex-column justify-content-center align-items-center">
                         <label
+                            role="button"
                             t-attf-class="configurator_color rounded-3 border position-relative {{ value.id == props.selected.id ? 'active border-3' : 'border-3 border-secondary' }}"
                             t-att-class="{'ptav-not-available' : value.excluded}"
                             t-attf-style="height: 62px; aspect-ratio: 1; {{ img_style or color_style }}"
@@ -197,24 +200,24 @@
                 </div>
                 <div t-foreach="this.validAttributeLineIds" t-as="attribute" t-key="attribute.id" class="attribute mb-3">
                     <div class="attribute_name mb-2 fw-bolder" t-esc="attribute.attribute_id.name"/>
-                    <RadioProductAttribute t-if="attribute.attribute_id.display_type === 'radio'" attribute="attribute" 
-                        selected="this.state.attributes[attribute.attribute_id.id].selected" setSelected="this.setSelected(attribute)" 
+                    <RadioProductAttribute t-if="attribute.attribute_id.display_type === 'radio'" attribute="attribute"
+                        selected="this.state.attributes[attribute.attribute_id.id].selected" setSelected="this.setSelected(attribute)"
                         customValue="this.state.attributes[attribute.attribute_id.id].custom_value" setCustomValue="setCustomValue(attribute)"
                         allSelectedValues="this.selectedValues"/>
-                    <PillsProductAttribute t-elif="attribute.attribute_id.display_type === 'pills'" attribute="attribute" 
-                        selected="this.state.attributes[attribute.attribute_id.id].selected" setSelected="this.setSelected(attribute)" 
+                    <PillsProductAttribute t-elif="attribute.attribute_id.display_type === 'pills'" attribute="attribute"
+                        selected="this.state.attributes[attribute.attribute_id.id].selected" setSelected="this.setSelected(attribute)"
                         customValue="this.state.attributes[attribute.attribute_id.id].custom_value" setCustomValue="setCustomValue(attribute)"
                         allSelectedValues="this.selectedValues"/>
-                    <SelectProductAttribute t-elif="attribute.attribute_id.display_type === 'select'" attribute="attribute" 
-                        selected="this.state.attributes[attribute.attribute_id.id].selected" setSelected="this.setSelected(attribute)" 
+                    <SelectProductAttribute t-elif="attribute.attribute_id.display_type === 'select'" attribute="attribute"
+                        selected="this.state.attributes[attribute.attribute_id.id].selected" setSelected="this.setSelected(attribute)"
                         customValue="this.state.attributes[attribute.attribute_id.id].custom_value" setCustomValue="setCustomValue(attribute)"
                         allSelectedValues="this.selectedValues"/>
-                    <ColorProductAttribute t-elif="attribute.attribute_id.display_type === 'color'" attribute="attribute" 
-                        selected="this.state.attributes[attribute.attribute_id.id].selected" setSelected="this.setSelected(attribute)" 
+                    <ColorProductAttribute t-elif="attribute.attribute_id.display_type === 'color'" attribute="attribute"
+                        selected="this.state.attributes[attribute.attribute_id.id].selected" setSelected="this.setSelected(attribute)"
                         customValue="this.state.attributes[attribute.attribute_id.id].custom_value" setCustomValue="setCustomValue(attribute)"
                         allSelectedValues="this.selectedValues"/>
-                    <MultiProductAttribute t-elif="attribute.attribute_id.display_type === 'multi'" attribute="attribute" 
-                        selected="this.state.attributes[attribute.attribute_id.id]?.selected" setSelected="this.setSelected(attribute)" 
+                    <MultiProductAttribute t-elif="attribute.attribute_id.display_type === 'multi'" attribute="attribute"
+                        selected="this.state.attributes[attribute.attribute_id.id]?.selected" setSelected="this.setSelected(attribute)"
                         customValue="this.state.attributes[attribute.attribute_id.id]?.custom_value" setCustomValue="setCustomValue(attribute)"
                         allSelectedValues="this.selectedValues"/>
                     <ImageProductAttribute t-elif="attribute.attribute_id.display_type === 'image'" attribute="attribute"

--- a/addons/point_of_sale/static/src/app/components/product_card/product_card.xml
+++ b/addons/point_of_sale/static/src/app/components/product_card/product_card.xml
@@ -3,6 +3,7 @@
 
     <t t-name="point_of_sale.ProductCard">
         <article tabindex="0"
+            role="button"
             t-attf-class="{{props.class}} {{props.color ? `o_colorlist_item_color_transparent_${props.color}` : ''}} product position-relative btn btn-light d-flex align-items-stretch p-0 rounded-3 text-start cursor-pointer {{ props.imgUrl ? 'd-flex align-items-stretch' : ''}}"
             t-on-keypress="(event) => event.code === 'Space' ? props.onClick(event) : ()=>{}"
             t-on-click.stop="props.onClick"

--- a/addons/point_of_sale/static/src/app/pos_app.scss
+++ b/addons/point_of_sale/static/src/app/pos_app.scss
@@ -10,7 +10,10 @@
        -moz-user-select: none;
             user-select: none;
     text-shadow: none;
-    touch-action: manipulation;
+}
+
+* {
+    touch-action: pan-x pan-y;
 }
 /*  ********* Generic element styling  ********* */
 

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_line/partner_line.xml
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_line/partner_line.xml
@@ -3,7 +3,7 @@
 
     <t t-name="point_of_sale.PartnerLine">
         <t t-if="ui.isSmall">
-            <div class="partner-info d-flex flex-column p-1 border-bottom" t-att-class="{'selected': props.isSelected}" t-att-data-id="props.partner.id"
+            <div class="partner-info d-flex flex-column p-1 border-bottom" role="button" t-att-class="{'selected': props.isSelected}" t-att-data-id="props.partner.id"
                 t-on-click="() => this.props.onClickPartner(props.partner)">
                 <div class="d-flex justify-content-between align-items-center p-1">
                     <div>
@@ -40,7 +40,7 @@
             </div>
         </t>
         <t t-else="">
-            <tr class="partner-line partner-info" t-att-class="{'selected': props.isSelected}" t-att-data-id="props.partner.id"
+            <tr class="partner-line partner-info" role="button" t-att-class="{'selected': props.isSelected}" t-att-data-id="props.partner.id"
                 t-on-click="() => this.props.onClickPartner(props.partner)">
                 <td class="text-break w-25">
                     <b t-esc="props.partner.name or ''" />

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_lines/payment_lines.xml
@@ -7,7 +7,7 @@
                     <t t-if="line.isSelected()">
                         <div t-attf-class="paymentline selected d-flex align-items-center rounded-3"
                             t-att-class="selectedLineClass(line)">
-                            <div class="payment-infos d-flex align-items-center justify-content-between flex-grow-1 px-3 py-3 text-truncate cursor-pointer fs-2" t-on-click="() => this.selectLine(line)">
+                            <div class="payment-infos d-flex align-items-center justify-content-between flex-grow-1 px-3 py-3 text-truncate cursor-pointer fs-2" role="button" t-on-click="() => this.selectLine(line)">
                                  <span class="payment-name"><t t-esc="line.payment_method_id.name"/></span>
                                  <div class="payment-amount px-3">
                                     <PriceFormatter price="env.utils.formatCurrency(line.getAmount())" />
@@ -32,7 +32,7 @@
                                     <div class="electronic_status">
                                         Payment request pending
                                     </div>
-                                    <div class="button send_payment_request highlight text-bg-primary" title="Send Payment Request" t-on-click="() => this.props.sendPaymentRequest(line)">
+                                    <div class="button send_payment_request highlight text-bg-primary" role="button" title="Send Payment Request" t-on-click="() => this.props.sendPaymentRequest(line)">
                                         Send
                                     </div>
                                 </t>
@@ -40,7 +40,7 @@
                                     <div class="electronic_status">
                                         Transaction cancelled
                                     </div>
-                                    <div class="button send_payment_request highlight text-bg-primary" title="Send Payment Request" t-on-click="() => this.props.sendPaymentRequest(line)">
+                                    <div class="button send_payment_request highlight text-bg-primary" role="button" title="Send Payment Request" t-on-click="() => this.props.sendPaymentRequest(line)">
                                         Retry
                                     </div>
                                 </t>
@@ -48,7 +48,7 @@
                                     <div class="electronic_status">
                                         Connection error
                                     </div>
-                                    <div class="button send_force_done" title="Force Done" t-on-click="() => this.props.sendForceDone(line)">
+                                    <div class="button send_force_done" role="button" title="Force Done" t-on-click="() => this.props.sendForceDone(line)">
                                         Force done
                                     </div>
                                 </t>
@@ -62,10 +62,10 @@
                                         </t>
                                     </div>
                                     <div>
-                                        <div class="button send_force_done" title="Force Done" t-on-click="() => this.props.sendForceDone(line)">
+                                        <div class="button send_force_done" role="button" title="Force Done" t-on-click="() => this.props.sendForceDone(line)">
                                             Force done
                                         </div>
-                                        <div t-if="!this.props.isRefundOrder" class="button send_payment_cancel" title="Cancel Payment Request" t-on-click="() => this.props.sendPaymentCancel(line)">
+                                        <div t-if="!this.props.isRefundOrder" class="button send_payment_cancel" role="button" title="Cancel Payment Request" t-on-click="() => this.props.sendPaymentCancel(line)">
                                             Cancel
                                         </div>
                                     </div>
@@ -76,10 +76,10 @@
                                     </div>
                                     <div>
                                         <i class="fa fa-circle-o-notch fa-spin" role="img" />
-                                        <div t-if="line.payment_status == 'waiting'" class="button send_force_done" title="Force Done" t-on-click="() => this.props.sendForceDone(line)">
+                                        <div t-if="line.payment_status == 'waiting'" class="button send_force_done" role="button" title="Force Done" t-on-click="() => this.props.sendForceDone(line)">
                                             Force done
                                         </div>
-                                        <div t-if="line.payment_status == 'waitingCancel'" class="button send_force_done" title="Force Cancel" t-on-click="() => line.setPaymentStatus('retry')">
+                                        <div t-if="line.payment_status == 'waitingCancel'" class="button send_force_done" role="button" title="Force Cancel" t-on-click="() => line.setPaymentStatus('retry')">
                                             Force cancel
                                         </div>
                                     </div>
@@ -102,7 +102,7 @@
                                         </t>
                                     </div>
                                     <t t-if="line.can_be_reversed">
-                                        <div class="button send_payment_reversal" title="Reverse Payment" t-on-click="() => this.props.sendPaymentReverse(line)">
+                                        <div class="button send_payment_reversal" role="button" title="Reverse Payment" t-on-click="() => this.props.sendPaymentReverse(line)">
                                             Reverse
                                         </div>
                                     </t>
@@ -121,6 +121,7 @@
                         </t>
                         <t t-if="this.props.isRefundOrder and line.payment_method_id.use_payment_terminal and !line.payment_status">
                             <div class="button send_refund_request highlight text-bg-primary p-4 text-center"
+                                role="button"
                                 title="Send Refund Request"
                                 t-on-click="() => this.props.sendPaymentRequest(line)">
                                 Refund
@@ -130,7 +131,7 @@
                     <t t-else="">
                         <div class="paymentline d-flex align-items-center bg-view border rounded-3"
                             t-att-class="unselectedLineClass(line)">
-                             <div class="payment-infos d-flex align-items-center justify-content-between flex-grow-1 px-3 py-3 text-truncate cursor-pointer fs-2" t-on-click="() => this.selectLine(line)">
+                             <div class="payment-infos d-flex align-items-center justify-content-between flex-grow-1 px-3 py-3 text-truncate cursor-pointer fs-2" role="button" t-on-click="() => this.selectLine(line)">
                                  <t t-esc="line.payment_method_id?.name" />
                                  <div class="payment-amount px-3">
                                     <PriceFormatter price="env.utils.formatCurrency(line.getAmount())" />
@@ -138,6 +139,7 @@
                              </div>
                             <t t-if="!line.payment_status or !['done', 'reversed'].includes(line.payment_status)">
                                 <div class="delete-button delete-button btn btn-link mx-2 px-3"
+                                    role="button"
                                     t-on-click="() => this.props.deleteLine(line.uuid)"
                                     aria-label="Delete" title="Delete">
                                     <i class="oi oi-close text-danger" />

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.xml
@@ -157,6 +157,7 @@
             <div class="paymentmethods gap-1 gap-lg-2" t-att-class="{ 'd-grid p-1 gap-1 overflow-y-auto rounded-3 bg-200': ui.isSmall, 'd-flex flex-column gap-lg-2': !ui.isSmall }">
                 <t t-foreach="payment_methods_from_config" t-as="paymentMethod" t-key="paymentMethod.id">
                     <div t-if="!(this.pos.cashier._role === 'minimal' and paymentMethod.type === 'pay_later')" class="button paymentmethod btn btn-secondary btn-lg lh-lg flex-fill"
+                        role="button"
                         t-att-class="{'opacity-50': this.pos.paymentTerminalInProgress and paymentMethod.use_payment_terminal, 'd-flex justify-content-between align-items-center': true}"
                         t-on-click="() => this.addNewPaymentLine(paymentMethod)">
                         <div class="payment-method-display d-flex align-items-center gap-2 text-wrap text-start lh-sm">

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.xml
@@ -15,7 +15,7 @@
                                 </span>
                                 <div class="fs-4 fw-bold d-flex justify-content-center align-items-center gap-2">
                                     <span t-esc="orderAmountPlusTip" />
-                                    <span t-if="this.pos.canEditPayment(currentOrder)" class="edit-order-payment badge bg-success text-white rounded cursor-pointer pt-1" t-on-click="() => this.pos.orderDetails(this.currentOrder)">Edit Payment</span>
+                                    <span t-if="this.pos.canEditPayment(currentOrder)" class="edit-order-payment badge bg-success text-white rounded cursor-pointer pt-1" role="button" t-on-click="() => this.pos.orderDetails(this.currentOrder)">Edit Payment</span>
                                 </div>
                             </div>
                             <div class="receipt-options d-flex flex-column gap-2">
@@ -64,7 +64,7 @@
                     </div>
                 </div>
                 <div  id="action_btn_mobile" t-if="ui.isSmall" class="switchpane d-flex gap-2 p-2">
-                    <div class="btn-switchpane validation-button btn btn-primary btn-lg py-3 flex-fill lh-lg" t-att-class="{ highlight: !locked }" t-on-click="() => this.pos.orderDone(this.currentOrder)" name="done">
+                    <div class="btn-switchpane validation-button btn btn-primary btn-lg py-3 flex-fill lh-lg" role="button" t-att-class="{ highlight: !locked }" t-on-click="() => this.pos.orderDone(this.currentOrder)" name="done">
                                 New Order
                     </div>
                 </div>

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -21,7 +21,7 @@
                             </button>
                         </div>
                         <div class="item d-none d-xl-flex align-items-center justify-content-end">
-                            <span class="page me-2" t-on-click="onClickPageNbr"><t t-esc="getPageNumber()" /></span>
+                            <span class="page me-2" role="button" t-on-click="onClickPageNbr"><t t-esc="getPageNumber()" /></span>
                             <div class="page-controls d-flex align-items-center gap-1">
                                 <button class="previous btn btn-secondary" t-on-click="() => this.onPrevPage()">
                                     <i class="fa fa-fw fa-caret-left" role="img" aria-label="Previous Order List" title="Previous Order List"></i>
@@ -37,7 +37,7 @@
                             <table t-if="!ui.isSmall"  class="table table-striped table-hover">
                                 <tbody>
                                     <t t-foreach="_filteredOrderList" t-as="order" t-key="order.uuid">
-                                        <tr class="order-row" t-attf-class="{{ isHighlighted(order) ? 'highlight active': '' }}" t-att-orderUuid="order.uuid"
+                                        <tr role="button" class="order-row" t-attf-class="{{ isHighlighted(order) ? 'highlight active': '' }}" t-att-orderUuid="order.uuid"
                                             t-on-click="() => this.onClickOrder(order)" t-on-dblclick="() => this.onDblClickOrder(order)" >
                                             <td>
                                                 <div class="fs-6 fw-bolder"><t t-esc="this.pos.getDate(order.date_order)"></t></div>
@@ -91,7 +91,7 @@
 
                             </table>
                             <t t-if="ui.isSmall" t-foreach="_filteredOrderList" t-as="order" t-key="order.uuid">
-                                <div class="mobileOrderList order-row d-flex flex-row ps-1" t-attf-class="{{ isHighlighted(order) ? 'highlight': '' }}"
+                                <div role="button" class="mobileOrderList order-row d-flex flex-row ps-1" t-attf-class="{{ isHighlighted(order) ? 'highlight': '' }}"
                                     t-on-click="() => this.onClickOrder(order)" t-on-dblclick="() => this.onDblClickOrder(order)" >
                                     <div class="p-2">
                                             <div class="fw-bolder"><t t-esc="this.pos.getDate(order.date_order)"></t></div>
@@ -115,7 +115,7 @@
                                                 </div>
                                     </div>
                                     <div class="mx-2" name="delete-column">
-                                        <div t-if="!shouldHideDeleteButton(order) and this.pos.cashier._role !== 'minimal'" class="d-flex align-items-center justify-content-center h-100" name="delete" t-on-click.stop="() => this.onDeleteOrder(order)">
+                                        <div t-if="!shouldHideDeleteButton(order) and this.pos.cashier._role !== 'minimal'" class="d-flex align-items-center justify-content-center h-100" role="button" name="delete" t-on-click.stop="() => this.onDeleteOrder(order)">
                                             <div class="btn btn-danger btn-lg">
                                                 <i class="fa fa-trash" aria-hidden="true"/>
                                             </div>

--- a/addons/pos_self_order/static/src/app/components/combo_stepper/combo_stepper.xml
+++ b/addons/pos_self_order/static/src/app/components/combo_stepper/combo_stepper.xml
@@ -5,7 +5,7 @@
           <ul class="stepper_list d-flex mw-100 overflow-y-hidden overflow-x-auto" t-ref="stepperScroll">
             <li class="d-flex text-nowrap" t-foreach="props.steps" t-as="step" t-key="step.id" t-att-data-stepper="step.id">
                 <t t-set="isSelectedStep" t-value="step.id === props.selectedStep?.id" />
-                <a class="px-3 py-2 rounded-pill fs-4 fw-medium cursor-pointer" t-on-click="()=> this.props.onStepClicked(step_index)" t-att-class="{'active text-bg-light': isSelectedStep, 'text-muted': !isSelectedStep}">
+                <a role="button" class="px-3 py-2 rounded-pill fs-4 fw-medium cursor-pointer" t-on-click="()=> this.props.onStepClicked(step_index)" t-att-class="{'active text-bg-light': isSelectedStep, 'text-muted': !isSelectedStep}">
                     <t t-esc="step.name"/>
                 </a>
              </li>

--- a/addons/pos_self_order/static/src/app/components/order_widget/order_widget.xml
+++ b/addons/pos_self_order/static/src/app/components/order_widget/order_widget.xml
@@ -12,7 +12,7 @@
                 <button t-attf-class="btn btn-secondary btn-lg d-none d-sm-inline text-nowrap btn-back btn-cancel" t-on-click="onClickleftButton" t-esc="leftButton.name" />
                 <div class="d-flex flex-nowrap ms-2 ms-sm-4 w-100 justify-content-end">
                     <div class="d-flex align-items-center flex-shrink-0 me-2 me-sm-4" >
-                        <div class="to-order d-flex flex-column align-items-start justify-content-center h-100 rounded-4" t-if="this.selfOrder.router.activeSlot === 'product_list'" t-on-click="props.action">
+                        <div class="to-order d-flex flex-column align-items-start justify-content-center h-100 rounded-4" role="button" t-if="this.selfOrder.router.activeSlot === 'product_list'" t-on-click="props.action">
                             <h4 class="d-none d-sm-block text-muted opacity-75">Total</h4>
                             <div class="d-flex align-items-center">
                                 <t t-set="orderLineNotSend" t-value="lineNotSend"/>

--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
@@ -53,6 +53,7 @@
                                     <t t-set="isOutOfStock" t-value="!product.self_order_available"/>
                                     <t t-set="extraPrice" t-value="comboItem.extra_price"/>
                                     <div t-on-click="() => this.selectItem(comboItem)"
+                                            role="button"
                                             class="combo_product_box btn btn-light position-relative d-flex flex-row-reverse flex-md-column align-items-center w-100 py-2 px-3 p-md-0 rounded-4 shadow-sm overflow-hidden border-2 text-start"
                                             t-att-class="{'border-primary': itemSelected, 'border-transparent': !itemSelected, 'opacity-50': isOutOfStock }">
                                         <div class="o_self_product_image w-25 w-sm-100 ratio ratio-1x1 flex-shrink-0 ms-2 ms-sm-0">
@@ -120,7 +121,7 @@
                         <div class="confirmation_box d-flex flex-column p-3 rounded-4 bg-white  shadow-sm ">
                             <t t-foreach="getSelection()" t-as="selection" t-key="selection.combo_choice_id.id">
                                 <t t-foreach="selection.combo_items" t-as="combo_item" t-key="combo_item.combo_item_id.id">
-                                    <div t-attf-class="d-flex align-items-center cursor-pointer  {{!combo_item_last || !selection_last ? ' pb-3 mb-3 border-bottom border-medium' : 'mb-0'}}" t-on-click="()=>this.onChoiceClicked(selection_index)" >
+                                    <div role="button" t-attf-class="d-flex align-items-center cursor-pointer  {{!combo_item_last || !selection_last ? ' pb-3 mb-3 border-bottom border-medium' : 'mb-0'}}" t-on-click="()=>this.onChoiceClicked(selection_index)" >
                                         <t t-set="product" t-value="combo_item.product_id"/>
                                         <t t-set="item_qty" t-value="combo_item.qty"/>
                                         <t t-set="attributes" t-value="combo_item.attributes"/>

--- a/addons/pos_self_order/static/src/app/pages/order_history_page/order_history_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/order_history_page/order_history_page.xml
@@ -7,14 +7,14 @@
                 <h1 t-if="orders.length > 0" class="mb-3">My Orders</h1>
                 <t t-foreach="orders" t-as="order" t-key="order.access_token">
                     <div class="o_so_order mx-auto d-flex flex-column mb-2 mb-md-3 bg-white rounded-4 shadow-sm p-3">
-                        <div class="o_so_order_header pb-2" t-on-click="() => this.editOrder(order)">
+                        <div class="o_so_order_header pb-2" role="button" t-on-click="() => this.editOrder(order)">
                             <div class="d-flex align-items-center justify-content-between">
                                 <div class="d-flex flex-column">
                                     <h4 class="mb-1" t-esc="order.pos_reference"/>
                                     <span class="text-muted">#<t t-esc="order.tracking_number" /> - <t t-esc="order.date_order.toFormat('dd/MM/yyyy')" /></span>
                                 </div>
                                 <div class="d-flex justify-content-around gap-1 align-items-center">
-                                    <div t-if="selfOrder.showDownloadButton(order)" class=" cursor-pointer p-2" t-on-click="() => this.selfOrder.downloadReceipt(order)">
+                                    <div t-if="selfOrder.showDownloadButton(order)" class=" cursor-pointer p-2" role="button" t-on-click="() => this.selfOrder.downloadReceipt(order)">
                                         <i  class="fa fa-download" aria-hidden="true" />
                                     </div>
                                     <span class="badge py-2 rounded-pill text-capitalize"

--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
@@ -19,7 +19,7 @@
                             </t>
                         </div>
                          <div class="category_end flex-shrink-0 align-items-center" t-if="!selfOrder.kioskMode">
-                             <div class="ms-1 bg-secondary rounded-2 p-2 d-flex align-content-center align-items-center justify-content-center cursor-pointer" t-on-click="()=>this.displayCategoryList(state.topCategories)" >
+                             <div class="ms-1 bg-secondary rounded-2 p-2 d-flex align-content-center align-items-center justify-content-center cursor-pointer" role="button" t-on-click="()=>this.displayCategoryList(state.topCategories)" >
                                    <i class="fa fa-list-ul" />
                              </div>
                         </div>
@@ -58,7 +58,7 @@
                          <div class="product_list grid" t-att-class="{'pt-sm-3 pt-lg-4': selfOrder.kioskMode, 'pb-2': !selfOrder.kioskMode}">
                             <div t-foreach="productList" t-as="product" t-key="product.id" class="o_self_product_box g-col-12 g-col-md-6 g-col-lg-3 rounded-4 p-3 p-lg-0 shadow-sm shadow-lg-none" t-att-class="{'g-col-kiosk-p-4': productList.length &lt;= 9 , 'g-col-kiosk-p-3': productList.length &gt; 9 }">
                                 <t t-set="not_available" t-value="!product.self_order_available || !isProductAvailable(product)" />
-                                <article t-on-click="(evt) => this.selectProduct(product, evt.target)" class="position-relative d-flex flex-row-reverse flex-lg-column align-items-start cursor-pointer" t-att-class="{'opacity-50' : not_available}">
+                                <article role="button" t-on-click="(evt) => this.selectProduct(product, evt.target)" class="position-relative d-flex flex-row-reverse flex-lg-column align-items-start cursor-pointer" t-att-class="{'opacity-50' : not_available}">
                                     <div class="product_img ratio ratio-1x1 w-lg-100 flex-shrink-0 ms-2 ms-lg-0">
                                         <img class="object-fit-cover rounded-4" t-attf-src="/web/image/product.template/#{product.id}/image_512?unique=#{product.write_date}" loading="lazy"/>
                                     </div>

--- a/addons/pos_self_order/static/src/app/self_order_index.scss
+++ b/addons/pos_self_order/static/src/app/self_order_index.scss
@@ -20,6 +20,10 @@
 
 }
 
+* {
+    touch-action: pan-x pan-y;
+}
+
 @keyframes fadeIn {
     from {
         opacity: 0;


### PR DESCRIPTION
On IOS devices, there was a latency issue when hitting different elements in the POS and self. Actually, the issue is because IOS devices don't react in the same way as Android devices. IOS adds a delay of +/-300ms when the element is not considered as a button. Instead of replacing a lot of elements with a button element we can add the parameter role="button".

I also disabled the pinch zoom in the POS, self and preparation display. It's mandatory to add the parameter touch-action: pan-x pan-y to the * selector.

task: 5976364

enterprise pr : https://github.com/odoo/enterprise/pull/109483

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
