### PR TITLE
[FIX] website: hoot test for websiteUrlPicker debounce

### DIFF
--- a/addons/website/static/tests/builder/custom_tab/builder_components/website_urlpicker.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/website_urlpicker.test.js
@@ -6,7 +6,7 @@ import {
     defineWebsiteModels,
     setupWebsiteBuilder,
 } from "@website/../tests/builder/website_helpers";
-import { delay } from "@web/core/utils/concurrency";
+import { advanceTime } from "@odoo/hoot-dom";
 
 defineWebsiteModels();
 
@@ -96,7 +96,7 @@ test("opens dropdown when typing /", async () => {
     await contains(":iframe .test-options-target").click();
 
     await contains(".we-bg-options-container input").edit("/", { confirm: false });
-    await delay(250);
+    await advanceTime(250);
     expect.verifySteps(["button_immediate_install"]);
     expect(document.querySelector(".o_website_ui_autocomplete")).toBeVisible();
 });
@@ -111,7 +111,7 @@ test("selects and commits value from dropdown", async () => {
     await contains(":iframe .test-options-target").click();
 
     await contains(".we-bg-options-container input").edit("/", { confirm: false });
-    await delay(250);
+    await advanceTime(250);
     await contains(document.querySelector(".o_website_ui_autocomplete > li:first-child a")).click();
     expect(document.querySelector(".o_website_ui_autocomplete")).toBe(null);
     expect(".we-bg-options-container input").toHaveValue("/page1");
@@ -131,7 +131,7 @@ test("collects anchors in current page and suggests them", async () => {
     `);
     await contains(":iframe .test-options-target").click();
     await contains(".we-bg-options-container input").edit("#", { confirm: false });
-    await delay(250);
+    await advanceTime(250);
 
     // Check autocomplete suggests both anchors
     const els = document.querySelectorAll(".o_website_ui_autocomplete > li a");


### PR DESCRIPTION
Issue:
The websiteUrlPicker input has a 250ms debounce. The test was relying
on a real 250ms delay to wait it out, creating a race condition that
caused non-deterministic failures.

Fix:
The test now uses `advanceTime()` to advance the time to past the
debounce.

runbot-[241087](https://runbot.odoo.com/odoo/runbot.build.error/241087)