### PR TITLE
[FIX] hr_recruitment: change access rights to trackers tab

### DIFF
--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -367,8 +367,8 @@
                 </button>
             </div>
             <xpath expr="//page[@name='job_description_page']" position="after">
-                <page string="Trackers" name="trackers_page" groups="hr.group_hr_user">
-                    <field name="job_source_ids" groups="hr_recruitment.group_hr_recruitment_interviewer"/>
+                <page string="Trackers" name="trackers_page" groups="hr_recruitment.group_hr_recruitment_user">
+                    <field name="job_source_ids" groups="hr_recruitment.group_hr_recruitment_user"/>
                 </page>
             </xpath>
             <xpath expr="//sheet" position="after">


### PR DESCRIPTION
According to the linked task, the Trackers tab has the wrong access rights. Indeed, it doesn't make any sense for it to have different access rights from the objects that it contains because there will be cases where the tab will be shown but not populated with anything.

Here we change the access rights to the correct ones.

Task: 5969309
