### PR TITLE
[FIX] base: fallback selection value to raw

### DIFF
--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -363,7 +363,7 @@ class IrQwebFieldSelection(models.AbstractModel):
     def value_to_html(self, value, options):
         if not value:
             return ''
-        return escape(options['selection'][value] or '')
+        return escape(options['selection'].get(value, value) or '')
 
     @api.model
     def record_to_html(self, record, field_name, options):


### PR DESCRIPTION
When a selection field contains a value not found in the current options list, display the raw value instead of raising an error.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
