### PR TITLE
[IMP] hr_attendance: parallelize hasGroup calls in AttendanceActionHelper

### DIFF
--- a/addons/hr_attendance/static/src/views/attendance_helper_view.js
+++ b/addons/hr_attendance/static/src/views/attendance_helper_view.js
@@ -14,9 +14,11 @@ export class AttendanceActionHelper extends Component {
             hasDemoData: false,
         });
         onWillStart(async () => {
-            this.isHrUser = await user.hasGroup("hr.group_hr_user");
-            this.hasAttendanceRight = await user.hasGroup("hr_attendance.group_hr_attendance_user");
-            if (this.hasAttendanceRight && this.isHrUser){
+            [this.isHrUser, this.hasAttendanceRight] = await Promise.all([
+                user.hasGroup("hr.group_hr_user"),
+                user.hasGroup("hr_attendance.group_hr_attendance_user"),
+            ]);
+            if (this.hasAttendanceRight && this.isHrUser) {
                 this.state.hasDemoData = await this.orm.call("hr.attendance", "has_demo_data", []);
             }
         });


### PR DESCRIPTION
In AttendanceActionHelper, replaced two sequential user.hasGroup() calls
with Promise.all() so both requests fire simultaneously, reducing the
time window during which the component is vulnerable to destruction.

**Task: 5972786**
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
