### PR TITLE
[FIX] account: prevent empty first page on multi-page invoice PDFs

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -169,7 +169,7 @@
                         <t t-set="display_taxes" t-value="any(l.tax_ids for l in o.invoice_line_ids)"/>
                         <div class="oe_structure"></div>
                         <t t-set="has_long_desc" t-value="any(line.name and line.name.count('\n') > 30 for line in o.invoice_line_ids if line.name)"/>
-                        <div class="table-responsive-sm">
+                        <div class="table-responsive-sm overflow-visible">
                             <table class="o_has_total_table table o_main_table table-borderless mb-0" name="invoice_line_table">
                                 <thead t-attf-style="#{has_long_desc and 'display: table-row-group;' or ''}">
                                     <tr>


### PR DESCRIPTION
Steps to reproduce:
1. Create an invoice with enough lines to span at least two pages.
2. Print the Invoice PDF. Observation: The first page appears empty (except for the header), and the entire invoice lines table is pushed to the second page.

Cause:
The introduction of the 'table-responsive-sm' wrapper in saas-19.1 includes 'overflow-x: auto'. The wkhtmltopdf rendering engine treats elements with overflow properties as unbreakable atomic blocks. If the block's height exceeds the remaining space on the current page, the engine moves the entire container to the next page rather than splitting it.

Solution:
Apply 'overflow: visible !important' to the 'table-responsive-sm' div. This overrides the Bootstrap default for the reporting engine, allowing the internal table rows to break naturally across pages while retaining the responsive wrapper for web/portal views."

opw-5937043