### PR TITLE
[FIX] pos_self_order: whitelist fields use wrong command

### DIFF
--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -119,7 +119,7 @@ class PosOrder(models.Model):
 
     @api.model
     def _check_pos_order_lines(self, pos_config, order, line, fiscal_position_id):
-        existing_order = pos_config.env['pos.order'].browse(order.get('id'))
+        existing_order = pos_config.env['pos.order']._get_open_order(order)
         existing_lines = existing_order.lines if existing_order.exists() else pos_config.env['pos.order.line']
 
         if line[0] == Command.DELETE and line[1] in existing_lines.ids:
@@ -131,8 +131,10 @@ class PosOrder(models.Model):
 
             product = pos_config.env['product.product'].browse(line_data.get('product_id'))
             tax_ids = fiscal_position_id.map_tax(product.taxes_id)
+            command = Command.CREATE if line[0] == Command.CREATE else Command.UPDATE
+            id_to_use = line[1] if line[0] == Command.UPDATE else 0
 
-            return [Command.CREATE, 0, {
+            return [command, id_to_use, {
                 'combo_id': line_data.get('combo_id'),
                 'product_id': line_data.get('product_id'),
                 'tax_ids': tax_ids.ids,
@@ -164,21 +166,31 @@ class PosOrder(models.Model):
         if not preset_id and pos_config.use_presets:
             raise UserError(_("Invalid preset"))
 
-        pos_reference, tracking_number = pos_config._get_next_order_refs()
-        prefix = f"K{pos_config.id}-" if device_type == "kiosk" else "S"
+        existing_order = pos_config.env['pos.order']._get_open_order(order)
+        if not existing_order.exists():
+            pos_reference, tracking_number = pos_config._get_next_order_refs()
+            prefix = f"K{pos_config.id}-" if device_type == "kiosk" else "S"
+
+            if device_type == 'kiosk':
+                floating_order_name = f"Table tracker {order['table_stand_number']}" if order.get('table_stand_number') else tracking_number
+
+            if not order.get('floating_order_name') and table:
+                floating_order_name = f"Self-Order T {table.table_number}"
+            elif not order.get('floating_order_name'):
+                floating_order_name = f"Self-Order {tracking_number}"
+
+            tracking_number = f"{prefix}{tracking_number}"
+        else:
+            pos_reference = existing_order.pos_reference
+            floating_order_name = existing_order.floating_order_name
+            tracking_number = existing_order.tracking_number
+
         fiscal_position_id = preset_id.fiscal_position_id if preset_id else pos_config.default_fiscal_position_id
         pricelist_id = preset_id.pricelist_id if preset_id else pos_config.pricelist_id
         lines = [self._check_pos_order_lines(pos_config, order, line, fiscal_position_id) for line in order.get('lines', [])]
+        lines = [line for line in lines if len(line)]
         partner_id = order.get('partner_id')
         partner = pos_config.env['res.partner'].browse(partner_id) if partner_id else None
-
-        if device_type == 'kiosk':
-            floating_order_name = f"Table tracker {order['table_stand_number']}" if order.get('table_stand_number') else tracking_number
-
-        if not order.get('floating_order_name') and table:
-            floating_order_name = f"Self-Order T {table.table_number}"
-        elif not order.get('floating_order_name'):
-            floating_order_name = f"Self-Order {tracking_number}"
 
         return {
             'id': order.get('id'),
@@ -201,7 +213,7 @@ class PosOrder(models.Model):
             'fiscal_position_id': fiscal_position_id.id if fiscal_position_id else False,
             'preset_id': preset_id.id if preset_id else False,
             'preset_time': order.get('preset_time'),
-            'tracking_number': f"{prefix}{tracking_number}",
+            'tracking_number': tracking_number,
             'source': 'kiosk' if device_type == 'kiosk' else 'mobile',
             'email': partner.email if partner else order.get('email'),
             'mobile': order.get('mobile'),

--- a/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
@@ -478,3 +478,63 @@ registry.category("web_tour.tours").add("test_delete_mobile_order_from_backend",
             ProductPage.isShown(),
         ].flat(),
 });
+
+const syncAnCheckTrackingNumber = {
+    trigger: "body",
+    run: async () => {
+        if (typeof posmodel.currentOrder.id !== "number") {
+            return;
+        }
+
+        const trackingNumber = posmodel.currentOrder.tracking_number;
+        const posReference = posmodel.currentOrder.pos_reference;
+        const noOfLines = posmodel.currentOrder.lines.length;
+        const result = await posmodel.sendDraftOrderToServer();
+        if (!result) {
+            throw new Error("Failed to sync order with server");
+        }
+
+        if (posmodel.currentOrder.lines.length !== noOfLines) {
+            throw new Error(
+                `Number of lines changed after sync. Before: ${noOfLines}, After: ${posmodel.currentOrder.lines.length}`
+            );
+        }
+
+        if (posmodel.currentOrder.tracking_number !== trackingNumber) {
+            throw new Error(
+                `Tracking number changed after sync. Before: ${trackingNumber}, After: ${posmodel.currentOrder.tracking_number}`
+            );
+        }
+        if (posmodel.currentOrder.pos_reference !== posReference) {
+            throw new Error(
+                `POS reference changed after sync. Before: ${posReference}, After: ${posmodel.currentOrder.pos_reference}`
+            );
+        }
+    },
+};
+
+registry
+    .category("web_tour.tours")
+    .add("test_self_order_meal_do_not_change_tracking_number_on_sync", {
+        steps: () =>
+            [
+                Utils.checkIsNoBtn("My Order"),
+                Utils.clickBtn("Order Now"),
+                ProductPage.clickProduct("Coca-Cola"),
+                {
+                    trigger: "body",
+                    run: async () => {
+                        const table = posmodel.models["restaurant.table"].getFirst();
+                        posmodel.currentOrder.table_id = table;
+                        await posmodel.sendDraftOrderToServer();
+                    },
+                },
+                ProductPage.clickProduct("Coca-Cola"),
+                syncAnCheckTrackingNumber,
+                ProductPage.clickProduct("Coca-Cola"),
+                ProductPage.clickProduct("Fanta"),
+                syncAnCheckTrackingNumber,
+                ProductPage.clickProduct("Coca-Cola"),
+                syncAnCheckTrackingNumber,
+            ].flat(),
+    });

--- a/addons/pos_self_order/static/tests/tours/self_order_prices_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_prices_tour.js
@@ -12,7 +12,11 @@ const comparePricesWithBackend = {
         const order = posmodel.currentOrder;
         const orderTotal = order.displayPrice;
         const allUnitPrices = order.lines.map((l) => l.price_unit);
-        await posmodel.sendDraftOrderToServer();
+        const result = await posmodel.sendDraftOrderToServer();
+        if (!result) {
+            throw new Error("Failed to sync order with server");
+        }
+
         const orderTotalAfterSync = order.displayPrice;
         const allUnitPricesAfterSync = order.lines.map((l) => l.price_unit);
 
@@ -223,7 +227,11 @@ registry.category("web_tour.tours").add("test_prices_are_immutable_from_frontend
 
                 // 257.58 Order total
                 // 106.44 Line price unit
-                await posmodel.sendDraftOrderToServer();
+                const result = await posmodel.sendDraftOrderToServer();
+                if (!result) {
+                    throw new Error("Failed to sync order with server");
+                }
+
                 const orderTotalAfterSync = order.displayPrice;
                 const allUnitPricesAfterSync = order.lines.map((l) => l.price_unit);
 
@@ -288,7 +296,11 @@ registry.category("web_tour.tours").add("test_pricelist_should_not_be_changed_fr
                     );
                 }
 
-                await posmodel.sendDraftOrderToServer();
+                const result = await posmodel.sendDraftOrderToServer();
+                if (!result) {
+                    throw new Error("Failed to sync order with server");
+                }
+
                 const amountTotalAfterSync = order.displayPrice;
                 if (amountTotalAfterSync === 0) {
                     throw new Error(

--- a/addons/pos_self_order/tests/test_self_order_mobile.py
+++ b/addons/pos_self_order/tests/test_self_order_mobile.py
@@ -380,3 +380,15 @@ class TestSelfOrderMobile(SelfOrderCommonTest):
 
         order = self.pos_config.current_session_id.order_ids[0]
         self.assertEqual(order.self_ordering_table_id, order.table_id)
+
+    def test_self_order_meal_do_not_change_tracking_number_on_sync(self):
+        self.pos_config.write({
+            'self_ordering_mode': 'mobile',
+            'self_ordering_pay_after': 'meal',
+            'self_ordering_service_mode': 'table',
+            'use_presets': False,
+        })
+
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+        self.start_tour(self.pos_config._get_self_order_route(), 'test_self_order_meal_do_not_change_tracking_number_on_sync')


### PR DESCRIPTION
Before this commit, all lines even updated one were using Command.CREATE instead of Command.UPDATE.

This commit fix the issued.

Also fix another issue which was recreating the order tracking number at each sync.
