### PR TITLE
[IMP] hr_version: add validation constraints for work hours

### DIFF
--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -284,6 +284,14 @@ class HrVersion(models.Model):
             if not contract_period_exists:
                 dates_per_employee[version.employee_id].append((version.contract_date_start, version.contract_date_end, version))
 
+    @api.constrains('hours_per_week', 'hours_per_day')
+    def _verify_hours(self):
+        for employee in self:
+            if (employee.hours_per_week < 0 or employee.hours_per_week > 168):
+                raise ValidationError(self.env._("Hours per week must be between 0 and 168."))
+            if (employee.hours_per_day < 0 or employee.hours_per_day > 24):
+                raise ValidationError(self.env._("Average hours per day must be between 0 and 24."))
+
     def check_contract_finished(self):
         if self.contract_date_start and not self.contract_date_end:
             raise ValidationError(self.env._("Before creating a new contract, close the current one by setting an end date."))


### PR DESCRIPTION
Add Python constraints to hr_version to ensure that hours_per_week stays within a physically possible range (0-168) and hours_per_day stays within (0-24).

Task: 5976392
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
