### PR TITLE
[IMP] iot_drivers: add tare support

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/SerialScaleDriver.py
+++ b/addons/hw_drivers/iot_handlers/drivers/SerialScaleDriver.py
@@ -87,6 +87,7 @@ class ScaleDriver(SerialDriver):
         self.device_type = 'scale'
         self._set_actions()
         self._is_reading = True
+        self.tare_mode = False
 
         # The HW Proxy can only expose one scale,
         # only the last scale connected is kept
@@ -152,6 +153,10 @@ class ScaleDriver(SerialDriver):
         answer = self._get_raw_response(self._connection)
         match = re.search(self._protocol.measureRegexp, answer)
         if match:
+            if self.net_weight_char and self.net_weight_char in answer:
+                self.tare_mode = True
+            else:
+                self.tare_mode = False
             self.data = {
                 'value': float(match.group(1)),
                 'status': self._status
@@ -183,6 +188,7 @@ class Toledo8217Driver(ScaleDriver):
     def __init__(self, identifier, device):
         super(Toledo8217Driver, self).__init__(identifier, device)
         self.device_manufacturer = 'Toledo'
+        self.net_weight_char = b'N'
 
     @classmethod
     def supported(cls, device):
@@ -238,6 +244,9 @@ class Toledo8217Driver(ScaleDriver):
             binary_status_char = format(ord(status_char), '08b')  # Example: '00001101'
             for index, bit in enumerate(binary_status_char[1:][::-1]):  # Read the bits in reverse order (LSB is at the last char) + ignore the first "parity" bit
                 if int(bit):
+                    # Ignore the 'Net weight' error as it's normal in tare mode
+                    if index == 5 and self.tare_mode:
+                        continue
                     _logger.debug("Scale error: %s. Status string: %s. Scale answer: %s.", status_char_error_bits[index], binary_status_char, answer)
                     self.data = {
                         'value': 0,
@@ -257,6 +266,7 @@ class AdamEquipmentDriver(ScaleDriver):
         self._is_reading = False
         self._last_weight_time = 0
         self.device_manufacturer = 'Adam'
+        self.net_weight_char = b''
 
     def _check_last_weight_time(self):
         """The ADAM doesn't make the difference between a value of 0 and "the same value as last time":


### PR DESCRIPTION
This PR adds some support for the tare button on the scale. When pressed the scale reset its weight to 0 and sends the weight with 'N' in it
The status byte string also sends back '1' for the 5th 'net weight' byte which can be not treated as an error

Enterprise PR: odoo/enterprise#109093

Task [link](https://www.odoo.com/odoo/project.task/5977538)
task-5977538