### PR TITLE
[FIX] web: model: properly disable sample data at reload

### DIFF
--- a/addons/web/static/src/model/model.js
+++ b/addons/web/static/src/model/model.js
@@ -158,6 +158,16 @@ export function useModelWithSampleData(ModelClass, params, options = {}) {
 
     const model = new ModelClass(component.env, params, services);
 
+    // disable the sample model if `load` is called directly by the view itself
+    const originalLoad = model.load;
+    model.load = async function (searchParams, disableSampleModel = true) {
+        const result = originalLoad.apply(this, searchParams ? [searchParams] : []);
+        if (disableSampleModel) {
+            this.useSampleModel = false;
+        }
+        return result;
+    };
+
     useBus(
         model.bus,
         "update",
@@ -179,13 +189,13 @@ export function useModelWithSampleData(ModelClass, params, options = {}) {
 
     async function load(props) {
         const searchParams = getSearchParams(props);
-        await model.load(searchParams);
+        await model.load(searchParams, false);
         if (useSampleModel && !model.hasData()) {
             sampleORM =
                 sampleORM || buildSampleORM(component.props.resModel, component.props.fields, user);
             // Load data with sampleORM then restore real ORM.
             model.orm = sampleORM;
-            await model.load(searchParams);
+            await model.load(searchParams, false);
             model.orm = orm;
         } else {
             useSampleModel = false;

--- a/addons/web/static/src/views/graph/graph_model.js
+++ b/addons/web/static/src/views/graph/graph_model.js
@@ -150,7 +150,7 @@ export class GraphModel extends Model {
         if ("measure" in params) {
             const metaData = this._buildMetaData(params);
             await this._fetchDataPoints(metaData);
-            this.useSampleModel = false;
+            this.useSampleModel = false; // can be removed
         } else {
             await this.race.getCurrentProm();
             this.metaData = Object.assign({}, this.metaData, params);

--- a/addons/web/static/src/views/pivot/pivot_model.js
+++ b/addons/web/static/src/views/pivot/pivot_model.js
@@ -781,7 +781,7 @@ export class PivotModel extends Model {
             metaData.activeMeasures.push(fieldName);
             const config = { metaData, data: this.data };
             await this._loadData(config);
-            this.useSampleModel = false;
+            this.useSampleModel = false; // can be removed
         }
         this.nextActiveMeasures = null;
         this.notify();

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -16704,3 +16704,28 @@ test(`basic open record with allowOpenAction`, async () => {
     await contains(".o_field_cell").click();
     expect.verifySteps([]);
 });
+
+test(`custom button that creates record in list with sample data`, async () => {
+    Foo._records = [];
+    onRpc("custom_create", () => {
+        MockServer.env.foo.create({ foo: "new record" });
+        return false;
+    });
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <list sample="1">
+                <header>
+                    <button class="custom_create" type="object" name="custom_create" string="Custom create" display="always"/>
+                </header>
+                <field name="foo"/>
+            </list>
+        `,
+    });
+    expect(`.o_list_view .o_content`).toHaveClass("o_view_sample_data");
+
+    await contains(".custom_create").click();
+    expect(`.o_list_view .o_content`).not.toHaveClass("o_view_sample_data");
+    expect(`.o_data_row`).toHaveCount(1);
+});


### PR DESCRIPTION
Have a view (e.g. list) with no real records but sample data. In the control panel, have a button that, when clicked, creates new records which match the current filter, i.e. which are displayed directly in the UI.

Before this commit, the new records were correctly displayed, but the sample data overlay (opacity) was still there.

The problem came from the fact that the sample data are automatically disabled when the view is reloaded **from above** (typically from the WithSearch component, when the user interacts with the search view). However, in the faulty scenario, the `load` function of the model is called directly by the view itself, so we don't go through WithSearch, and the code of model.js that ensures that we leave the sample mode.

We already faced that issue in pivot and graph, and we solved it locally. This commit fixes it globally, by creating a small override of model.load which leaves the sample mode.

task~5980226

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
