### PR TITLE
[FIX] stock: compute quantities through to_date

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -5,6 +5,7 @@ from ast import literal_eval
 from collections import defaultdict
 from collections.abc import Iterable
 from dateutil.relativedelta import relativedelta
+from datetime import datetime
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
@@ -166,6 +167,8 @@ class ProductProduct(models.Model):
         dates_in_the_past = False
         # only to_date as to_date will correspond to qty_available
         to_date = fields.Datetime.to_datetime(to_date)
+        if to_date and to_date.time() == datetime.min.time():
+            to_date = datetime.combine(to_date, datetime.max.time())
         if to_date and to_date < fields.Datetime.now():
             dates_in_the_past = True
 

--- a/addons/stock/tests/test_stock_flow.py
+++ b/addons/stock/tests/test_stock_flow.py
@@ -2864,3 +2864,29 @@ class TestStockFlowPostInstall(TestStockCommon):
 
         new_location_complete_name = self.env['stock.location'].name_create('NoPrefixLocation')[1]
         self.assertEqual(new_location_complete_name, 'NoPrefixLocation')
+
+    def test_past_qty_available(self):
+        """
+        Test that available quantity at a date (not datetime) is computed at the end of
+        that date.
+        """
+        TEST_DATE = fields.Datetime.to_datetime('2026-01-01 11:11:11')
+
+        # .date() simulates behavior of "As of" in the Stock Valuation report
+        # (Specifies date but no time)
+        self.assertEqual(0, self.productA.with_context(to_date=TEST_DATE.date()).qty_available)
+
+        receipt = self.env['stock.picking'].create({
+            'picking_type_id': self.picking_type_in.id,
+            'move_ids': [Command.create({
+                'product_id': self.productA.id,
+                'product_uom_qty': 10,
+            })]
+        })
+
+        receipt.action_confirm()
+        receipt.button_validate()
+
+        receipt.write({'date_done': TEST_DATE})
+
+        self.assertEqual(10, self.productA.with_context(to_date=TEST_DATE.date()).qty_available)


### PR DESCRIPTION
### Problem:
If `_compute_quantities` is called with only a date specified in `to_date` context (no timestamp), Odoo will assume midnight (00:00:00) instead of end of day (23:59:59). This contradicts logic in other places, such as `_compute_total_value`, which opts for the convention that "As of \<date>" means "through \<date>".

### Solution:
We will run `_compute_quantities` with `to_date` at 23:59:59.

### Steps to replicate (Runbot 19):
1. Receive a valued and tracked product (you can make the impact more obvious by setting the cost very high)
2. Backdate the receipt to some day in the past using the method of your choice (inspector tool, server action)
3. Go to the Inventory Valuation report, set "As of" date to the backdated receipt date, note that the value of the validated receipt is not there
4. Set "As of" to the day AFTER the receipt date, note the value is now shown

opw-5893999