### PR TITLE
[FIX] mail: reduce visibility of reply-to part of message

### DIFF
--- a/addons/mail/static/src/core/common/message_in_reply.dark.scss
+++ b/addons/mail/static/src/core/common/message_in_reply.dark.scss
@@ -3,6 +3,8 @@
 }
 
 .o-mail-MessageInReply-core {
+    --mail-MessageInReply-messageOpacityNonHover: 50%;
+
     background-color: rgba($gray-100, .35) !important;
 
     &.o-blue {

--- a/addons/mail/static/src/core/common/message_in_reply.scss
+++ b/addons/mail/static/src/core/common/message_in_reply.scss
@@ -13,9 +13,17 @@
     border-left-color: var(--o-message-bubble-color-base) !important;;
     background-color: rgba($o-view-background-color, .5) !important;
 
+    .o-mail-MessageInReply-message {
+        opacity: var(--mail-MessageInReply-messageOpacityNonHover, 65%);
+    }
+
     &:hover, &:focus-visible {
         transform: translateY(#{$border-width * -2});
         transition: $transition-base;
+
+        .o-mail-MessageInReply-message {
+            opacity: 100%;
+        }
     }
 }
 


### PR DESCRIPTION
Before this commit, conversations that had a lot of replies were quite exhausting. This comes from the visual of "reply" text that had its text that is too visible, contributing to having a feeling that there's too much text on the screen.

This commit fixes the issue by reducing the visibility of reply to part, so that it's easier to read conversations with lots of reply-to. Opacity has been reduced to keep the reply-to content recognizable enough, and this reduced visibility is canceled on mouse-hover, also making the hover effect on reply-to more apparent.

Before / After
<img width="604" height="520" alt="Screenshot 2026-02-27 at 19 06 03" src="https://github.com/user-attachments/assets/04a118bc-5fc0-47d6-ad62-3b7e26f835da" /> <img width="604" height="525" alt="Screenshot 2026-02-27 at 19 05 50" src="https://github.com/user-attachments/assets/37974f2c-054c-44bc-bf9a-044825908abc" />
