### PR TITLE
[18.0][REF] mrp: Get costs hour with method for workorder, workcenter, operation

### DIFF
--- a/addons/mrp/models/mrp_routing.py
+++ b/addons/mrp/models/mrp_routing.py
@@ -189,6 +189,9 @@ class MrpRoutingWorkcenter(models.Model):
         cycle_number = float_round(quantity / capacity, precision_digits=0, rounding_method='UP')
         return workcenter._get_expected_duration(product) + cycle_number * self.time_cycle * 100.0 / workcenter.time_efficiency
 
+    def _get_costs_hour(self):
+        return self.workcenter_id._get_costs_hour()
+
     def _compute_operation_cost(self):
         duration = self.env.context.get('op_duration', self.time_cycle)
-        return (duration / 60.0) * (self.workcenter_id.costs_hour)
+        return (duration / 60.0) * (self._get_costs_hour)

--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -427,6 +427,10 @@ class MrpWorkcenter(models.Model):
         capacity = self.capacity_ids.filtered(lambda p: p.product_id == product_id)
         return capacity.time_start + capacity.time_stop if capacity else self.time_start + self.time_stop
 
+    def _get_costs_hour(self):
+        self.ensure_one()
+        return self.costs_hour
+
 
 class WorkcenterTag(models.Model):
     _name = 'mrp.workcenter.tag'

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -586,6 +586,10 @@ class MrpWorkorder(models.Model):
         vals['leave_id'] = leave.id
         self.write(vals)
 
+    def _get_costs_hour(self):
+        self.ensure_one()
+        return self.costs_hour or self.workcenter_id._get_costs_hour()
+
     def _cal_cost(self, date=False):
         """Returns total cost of time spent on workorder.
 
@@ -598,7 +602,7 @@ class MrpWorkorder(models.Model):
                 for t in workorder.time_ids if t.date_end and (not date or t.date_end < date)
             ])
             duration = sum_intervals(intervals)
-            total += duration * workorder.workcenter_id.costs_hour
+            total += duration * workorder._get_costs_hour()
         return total
 
     def button_start(self, raise_on_invalid_state=False):
@@ -677,7 +681,7 @@ class MrpWorkorder(models.Model):
                 'qty_produced': workorder.qty_produced or workorder.qty_producing or workorder.qty_production,
                 'state': 'done',
                 'date_finished': date_finished,
-                'costs_hour': workorder.workcenter_id.costs_hour
+                'costs_hour': workorder._get_costs_hour(),
             }
             if not workorder.date_start or date_finished < workorder.date_start:
                 vals['date_start'] = date_finished
@@ -732,7 +736,7 @@ class MrpWorkorder(models.Model):
         return self.write({
             'state': 'done',
             'date_finished': end_date,
-            'costs_hour': self.workcenter_id.costs_hour
+            'costs_hour': self._get_costs_hour(),
         })
 
     def button_scrap(self):
@@ -923,10 +927,10 @@ class MrpWorkorder(models.Model):
                 wo.duration_percent = 100
 
     def _compute_expected_operation_cost(self, without_employee_cost=False):
-        return (self.duration_expected / 60.0) * (self.costs_hour or self.workcenter_id.costs_hour)
+        return (self.duration_expected / 60.0) * self._get_costs_hour()
 
     def _compute_current_operation_cost(self):
-        return (self.get_duration() / 60.0) * (self.costs_hour or self.workcenter_id.costs_hour)
+        return (self.get_duration() / 60.0) * self._get_costs_hour()
 
     def _get_current_theorical_operation_cost(self, without_employee_cost=False):
-        return (self.get_duration() / 60.0) * (self.costs_hour or self.workcenter_id.costs_hour)
+        return (self.get_duration() / 60.0) * self._get_costs_hour()

--- a/addons/mrp/report/mrp_report_bom_structure.py
+++ b/addons/mrp/report/mrp_report_bom_structure.py
@@ -471,7 +471,7 @@ class ReportBomStructure(models.AbstractModel):
 
     @api.model
     def _get_operation_cost(self, operation, workcenter, duration):
-        return (duration / 60.0) * workcenter.costs_hour
+        return (duration / 60.0) * workcenter._get_costs_hour()
 
     @api.model
     def _get_operation_line(self, product, bom, qty, level, index, bom_report_line, simulated_leaves_per_workcenter):

--- a/addons/mrp/report/mrp_report_mo_overview.py
+++ b/addons/mrp/report/mrp_report_mo_overview.py
@@ -92,7 +92,7 @@ class ReportMoOverview(models.AbstractModel):
                 line_cost = line.product_id.uom_id._compute_price(line.product_id.standard_price, line.product_uom_id) * line.product_qty
                 initial_bom_cost += currency.round(line_cost * production.product_uom_qty / production.bom_id.product_qty)
             for operation in missing_operations:
-                cost = (operation._get_duration_expected(production.product_id, production.product_qty) / 60.0) * operation.workcenter_id.costs_hour
+                cost = (operation._get_duration_expected(production.product_id, production.product_qty) / 60.0) * operation._get_costs_hour()
                 bom_cost = self.env.company.currency_id.round(cost)
                 initial_bom_cost += currency.round(bom_cost * production.product_uom_qty / production.bom_id.product_qty)
 
@@ -378,7 +378,7 @@ class ReportMoOverview(models.AbstractModel):
         total_duration = total_duration_expected = total_cost = total_mo_cost = 0
         total_bom_cost = False
         for index, workorder in enumerate(production.workorder_ids):
-            hourly_cost = workorder.costs_hour or workorder.workcenter_id.costs_hour
+            hourly_cost = workorder._get_costs_hour()
             duration = workorder.get_duration() / 60
             operation_cost = duration * hourly_cost
             mo_cost = workorder._compute_expected_operation_cost(without_employee_cost=True) if workorder.duration_expected\

--- a/addons/mrp_account/models/mrp_routing.py
+++ b/addons/mrp_account/models/mrp_routing.py
@@ -9,4 +9,4 @@ class MrpRoutingWorkcenter(models.Model):
 
     def _total_cost_per_hour(self):
         self.ensure_one()
-        return self.workcenter_id.costs_hour
+        return self._get_costs_hour()

--- a/addons/mrp_account/models/mrp_workorder.py
+++ b/addons/mrp_account/models/mrp_workorder.py
@@ -43,7 +43,7 @@ class MrpWorkorder(models.Model):
             if not wo.id:
                 continue
             hours = wo.duration / 60.0
-            value = -hours * wo.workcenter_id.costs_hour
+            value = -hours * wo._get_costs_hour()
             wo._create_or_update_analytic_entry_for_record(value, hours)
 
     def _create_or_update_analytic_entry_for_record(self, value, hours):


### PR DESCRIPTION
This PR introduces `_get_costs_hour` for `mrp.workorder`, `mrp.workcenter`, `mrp.routing.workcenter`. 
This allows to customize the return value. 

In our scenario it depends on the product to manufacture which hourly costs the we have to expect for a workcenter.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
