### PR TITLE
[FIX] pos_self_order: missing fields in whitelist load data

### DIFF
--- a/addons/point_of_sale/models/pos_category.py
+++ b/addons/point_of_sale/models/pos_category.py
@@ -40,7 +40,9 @@ class PosCategory(models.Model):
     def _load_pos_data_domain(self, data, config):
         domain = []
         if config.limit_categories:
-            domain += [('id', 'in', config.iface_available_categ_ids.ids)]
+            preparation_categories = [printer['product_categories_ids'] for printer in data['pos.printer']]
+            flattened_preparation_categories = [item for sublist in preparation_categories for item in sublist]
+            domain += [('id', 'in', flattened_preparation_categories + config.iface_available_categ_ids.ids)]
         return domain
 
     @api.model

--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -110,7 +110,7 @@ class PosConfig(models.Model):
             'default_fiscal_position_id', 'use_pricelist', 'module_pos_restaurant', 'is_header_or_footer',
             'rounding_method', 'cash_rounding', 'only_round_cash_method', 'has_active_session',
             'available_preset_ids', 'default_preset_id', 'epson_printer_ip', 'use_presets', 'iface_tax_included',
-            'status', 'self_ordering_image_background_ids',
+            'status', 'self_ordering_image_background_ids', 'other_devices',
         ]
 
     def _update_access_token(self):
@@ -302,10 +302,10 @@ class PosConfig(models.Model):
 
     def _load_self_data_models(self):
         return ['pos.session', 'pos.preset', 'resource.calendar.attendance', 'pos.order', 'pos.order.line', 'pos.payment', 'pos.payment.method', 'res.partner',
-            'res.currency', 'pos.category', 'product.template', 'product.product', 'product.combo', 'product.combo.item', 'res.company', 'account.tax',
-            'account.tax.group', 'pos.printer', 'res.country', 'product.category', 'product.pricelist', 'product.pricelist.item', 'account.fiscal.position',
+            'res.currency', 'pos.printer', 'pos.category', 'product.template', 'product.product', 'product.combo', 'product.combo.item', 'res.company', 'account.tax',
+            'account.tax.group', 'res.country', 'product.category', 'product.pricelist', 'product.pricelist.item', 'account.fiscal.position',
             'res.lang', 'product.attribute', 'product.attribute.custom.value', 'product.template.attribute.line', 'product.template.attribute.value', 'product.tag',
-            'decimal.precision', 'uom.uom', 'pos.printer', 'pos_self_order.custom_link', 'restaurant.floor', 'restaurant.table', 'account.cash.rounding',
+            'decimal.precision', 'uom.uom', 'pos_self_order.custom_link', 'restaurant.floor', 'restaurant.table', 'account.cash.rounding',
             'res.country', 'res.country.state', 'mail.template']
 
     @api.model

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -439,7 +439,9 @@ export class SelfOrder extends Reactive {
     }
 
     initProducts() {
-        this.productCategories = this.models["pos.category"].getAll();
+        this.productCategories = this.config.limit_categories
+            ? this.config.iface_available_categ_ids
+            : this.models["pos.category"].getAll();
         this.productByCategIds = this.models["product.template"].getAllBy("pos_categ_ids");
 
         const excludedProductTemplateIds = new Set(

--- a/addons/pos_self_order/static/tests/tours/self_order_common_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_common_tour.js
@@ -1,3 +1,5 @@
+/* global posmodel */
+
 import { registry } from "@web/core/registry";
 import * as Utils from "@pos_self_order/../tests/tours/utils/common";
 import * as LandingPage from "@pos_self_order/../tests/tours/utils/landing_page_util";
@@ -116,5 +118,48 @@ registry.category("web_tour.tours").add("kiosk_order_pos_closed", {
             false
         ),
         Utils.checkIsNoBtn("Add to cart"),
+    ],
+});
+
+registry.category("web_tour.tours").add("test_preparation_categories_are_loaded", {
+    steps: () => [
+        Utils.clickBtn("Order Now"),
+        {
+            trigger: "body",
+            run: async () => {
+                const availableCategIds = posmodel.availableCategories.map((categ) => categ.name);
+                if (!availableCategIds.includes("MOOL") || availableCategIds.length !== 1) {
+                    throw new Error("Preparation categories are not correctly loaded");
+                }
+            },
+        },
+        {
+            content: `Check category 'MOOL' is not visible`,
+            trigger: `.category_btn:contains('MOOL')`,
+        },
+        Utils.negateStep({
+            content: `Check category 'MODA' is not visible`,
+            trigger: `.category_btn:contains('MODA')`,
+        }),
+        Utils.negateStep({
+            content: `Check category 'STVA' is not visible`,
+            trigger: `.category_btn:contains('STVA')`,
+        }),
+        Utils.negateStep({
+            content: `Check category 'MANV' is not visible`,
+            trigger: `.category_btn:contains('MANV')`,
+        }),
+        Utils.negateStep({
+            content: `Check category 'LTRA' is not visible`,
+            trigger: `.category_btn:contains('LTRA')`,
+        }),
+        Utils.negateStep({
+            content: `Check category 'LOWE' is not visible`,
+            trigger: `.category_btn:contains('LOWE')`,
+        }),
+        Utils.negateStep({
+            content: `Check category 'ADGU' is not visible`,
+            trigger: `.category_btn:contains('ADGU')`,
+        }),
     ],
 });

--- a/addons/pos_self_order/tests/test_self_order_controller.py
+++ b/addons/pos_self_order/tests/test_self_order_controller.py
@@ -176,3 +176,58 @@ class TestSelfOrderController(SelfOrderCommonTest):
         data = self.make_request_to_controller('/pos-self-order/get-user-data', params)
         self.assertEqual(len(data['pos.order']), 1)
         self.assertEqual(data['pos.order'][0]['id'], pos_order.id)
+
+    def test_preparation_categories_are_loaded(self):
+        """
+        Preparation categories needs to be loaded in the self-ordering interface
+        if there are printers linked to those categories, even if those
+        categories are not available for the self-ordering interface.
+        If a category is missing changes cannot be computed
+        """
+        moda_categ = self.env['pos.category'].create({'name': 'MODA'})
+        stva_categ = self.env['pos.category'].create({'name': 'STVA'})
+        adgu_categ = self.env['pos.category'].create({'name': 'ADGU'})
+        manv_categ = self.env['pos.category'].create({'name': 'MANV'})
+        ltra_categ = self.env['pos.category'].create({'name': 'LTRA'})
+        lowe_categ = self.env['pos.category'].create({'name': 'LOWE'})
+        mool_categ = self.env['pos.category'].create({'name': 'MOOL'})
+        self.cola.pos_categ_ids = [moda_categ.id, stva_categ.id, lowe_categ.id, mool_categ.id, adgu_categ.id, manv_categ.id, ltra_categ.id]
+
+        printer_1 = self.env['pos.printer'].create({
+            'name': 'Preparation Printer',
+            'epson_printer_ip': '127.0.0.1',
+            'printer_type': 'epson_epos',
+            'product_categories_ids': [moda_categ.id, stva_categ.id],
+        })
+
+        printer_2 = self.env['pos.printer'].create({
+            'name': 'Preparation Printer',
+            'epson_printer_ip': '127.0.0.1',
+            'printer_type': 'epson_epos',
+            'product_categories_ids': [adgu_categ.id, manv_categ.id, ltra_categ.id],
+        })
+
+        self.pos_config.write({
+            'use_presets': False,
+            'self_ordering_mode': 'mobile',
+            'self_ordering_pay_after': 'each',
+            'limit_categories': True,
+            'iface_available_categ_ids': [mool_categ.id],
+            'printer_ids': [printer_1.id, printer_2.id],
+        })
+
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+        self_route = self.pos_config._get_self_order_route()
+        data = self.make_request_to_controller('/pos-self/data/' + str(self.pos_config.id), {
+            'access_token': self.pos_config.access_token,
+        })
+        loaded_category_ids = [category['id'] for category in data['pos.category']]
+        self.assertIn(mool_categ.id, loaded_category_ids, "The category linked to the printer should be loaded")
+        self.assertIn(adgu_categ.id, loaded_category_ids, "The category linked to the printer should be loaded")
+        self.assertIn(manv_categ.id, loaded_category_ids, "The category linked to the printer should be loaded")
+        self.assertIn(ltra_categ.id, loaded_category_ids, "The category linked to the printer should be loaded")
+        self.assertIn(moda_categ.id, loaded_category_ids, "The category linked to the printer should be loaded")
+        self.assertIn(stva_categ.id, loaded_category_ids, "The category linked to the printer should be loaded")
+        self.assertNotIn(lowe_categ.id, loaded_category_ids, "The category not linked to any printer should not be loaded")
+        self.start_tour(self_route, "test_preparation_categories_are_loaded")


### PR DESCRIPTION
Missing `other_devices` in `pos.config` model in whitelist load data, which causes the field to be missing in the form view of pos config.
