### PR TITLE
[FIX] pwa css syntax

### DIFF
--- a/addons/web/static/src/core/pwa/pwa_service.js
+++ b/addons/web/static/src/core/pwa/pwa_service.js
@@ -125,7 +125,7 @@ const pwaService = {
         async function getManifest() {
             if (!_manifest) {
                 const manifest = await get(
-                    document.querySelector("link[rel=manifest")?.getAttribute("href"),
+                    document.querySelector("link[rel=manifest]")?.getAttribute("href"),
                     "text"
                 );
                 _manifest = JSON.parse(manifest);

--- a/doc/cla/individual/takahii03.md
+++ b/doc/cla/individual/takahii03.md
@@ -1,0 +1,11 @@
+Japan, 2026-03-01
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Takahiro SUNAGA t.sunaga@takahii.co https://github.com/takahii03


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Fixes a typo in the manifest selector used by the PWA service.
document.querySelector("link[rel=manifest") was missing the closing ], making the selector invalid.

Current behavior before PR:
Calling getManifest() could throw a DOMException due to an invalid CSS selector, preventing manifest retrieval and potentially breaking PWA install flow.

Desired behavior after PR is merged:
getManifest() correctly queries link[rel=manifest], retrieves the manifest URL, and keeps the existing manifest-fetch behavior intact (including test coverage already present in pwa_service.test.js).

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
