### PR TITLE
[FIX] hr_holidays: prevent backdated leaves consuming current balance

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -782,7 +782,42 @@ Attempting to double-book your time off won't magically make your vacation 2x be
             if holiday.state in ['cancel', 'refuse', 'validate1', 'validate']:
                 raise ValidationError(_("This modification is not allowed in the current state."))
 
+    def _get_accrual_allocations_across_carryover(self):
+        """Return accrual allocations for which these leaves fall in a previous
+        period (before a carryover that has already been processed)."""
+        valid_leaves = self.filtered(
+            lambda l: l.date_from and l.date_to and l.employee_id and l.holiday_status_id
+        )
+        if not valid_leaves:
+            return self.env['hr.leave.allocation']
+
+        allocs = self.env['hr.leave.allocation'].search([
+            ('employee_id', 'in', valid_leaves.employee_id.ids),
+            ('holiday_status_id', 'in', valid_leaves.holiday_status_id.ids),
+            ('allocation_type', '=', 'accrual'),
+            ('state', '=', 'validate'),
+            ('accrual_plan_id', '!=', False),
+        ])
+        if not allocs:
+            return self.env['hr.leave.allocation']
+
+        leave_by_employee_status = {
+            (l.employee_id.id, l.holiday_status_id.id): l for l in valid_leaves
+        }
+        affected_allocations = self.env['hr.leave.allocation']
+        for alloc in allocs:
+            leave = leave_by_employee_status.get((alloc.employee_id.id, alloc.holiday_status_id.id))
+            if leave and alloc.lastcall:
+                carryover_date = alloc._get_carryover_date(leave.date_from.date())
+                if leave.date_from.date() < carryover_date <= alloc.lastcall:
+                    affected_allocations |= alloc
+        return affected_allocations
+
     def _check_validity(self):
+        affected_allocations = self._get_accrual_allocations_across_carryover()
+        if affected_allocations:
+            affected_allocations.sudo()._recompute_accrual_allocations()
+
         sorted_leaves = defaultdict(lambda: self.env['hr.leave'])
         for leave in self:
             sorted_leaves[(leave.holiday_status_id, leave.date_from.date())] |= leave
@@ -1040,10 +1075,14 @@ Attempting to double-book your time off won't magically make your vacation 2x be
                 raise UserError(error_message % (state_description_values.get(holiday.state),))
 
     def unlink(self):
+        affected_allocations = self._get_accrual_allocations_across_carryover()
         self._force_cancel(_("deleted by %s (uid=%d).",
             self.env.user.display_name, self.env.user.id
         ))
-        return super(HolidaysRequest, self.with_context(leave_skip_date_check=True)).unlink()
+        res = super(HolidaysRequest, self.with_context(leave_skip_date_check=True)).unlink()
+        if affected_allocations:
+            affected_allocations.sudo()._recompute_accrual_allocations()
+        return res
 
     def copy_data(self, default=None):
         if default and 'request_date_from' in default and 'request_date_to' in default:
@@ -1219,11 +1258,14 @@ Attempting to double-book your time off won't magically make your vacation 2x be
     def action_draft(self):
         if any(holiday.state not in ['confirm', 'refuse'] for holiday in self):
             raise UserError(_('Time off request state must be "Refused" or "To Approve" in order to be reset to draft.'))
+        affected_allocations = self._get_accrual_allocations_across_carryover()
         self.write({
             'state': 'draft',
             'first_approver_id': False,
             'second_approver_id': False,
         })
+        if affected_allocations:
+            affected_allocations.sudo()._recompute_accrual_allocations()
         linked_requests = self.mapped('linked_request_ids')
         if linked_requests:
             linked_requests.action_draft()
@@ -1445,6 +1487,10 @@ Attempting to double-book your time off won't magically make your vacation 2x be
                 holiday.message_post(
                     body=_('Your %(leave_type)s planned on %(date)s has been refused', leave_type=holiday.holiday_status_id.display_name, date=holiday.date_from),
                     partner_ids=holiday.employee_id.user_id.partner_id.ids)
+
+        affected_allocations = self._get_accrual_allocations_across_carryover()
+        if affected_allocations:
+            affected_allocations.sudo()._recompute_accrual_allocations()
 
         self.activity_update()
         return True

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -472,7 +472,8 @@ class HolidaysAllocation(models.Model):
             employee_days_per_allocation = allocation.employee_id.with_context(precomputed_allocations=precomputed_allocations)._get_consumed_leaves(
                 allocation.holiday_status_id, allocation.nextcall, ignore_future=True)[0]
             origin = allocation._origin
-            leaves_taken = employee_days_per_allocation[origin.employee_id][origin.holiday_status_id][origin]['leaves_taken']
+            leaves_field = 'virtual_leaves_taken' if self.env.context.get('include_pending_leaves') else 'leaves_taken'
+            leaves_taken = employee_days_per_allocation[origin.employee_id][origin.holiday_status_id][origin][leaves_field]
             return leaves_taken
 
         date_to = date_to or fields.Date.today()
@@ -583,6 +584,35 @@ class HolidaysAllocation(models.Model):
             '|', ('date_to', '=', False), ('date_to', '>', fields.Datetime.now()),
             '|', ('nextcall', '=', False), ('nextcall', '<=', today)])
         allocations._process_accrual_plans()
+
+    def _recompute_accrual_allocations(self):
+        """Replay accrual plans from scratch for allocations whose balance
+        may have changed because a backdated leave was validated, refused,
+        or cancelled."""
+        for allocation in self:
+            if allocation.allocation_type != 'accrual' or allocation.state != 'validate':
+                continue
+            if not allocation.accrual_plan_id or not allocation.accrual_plan_id.level_ids:
+                continue
+            if not allocation.lastcall:
+                continue
+
+            fake_allocation = self.env['hr.leave.allocation'].new(origin=self)
+            fake_allocation.nextcall = False
+            fake_allocation.lastcall = allocation.date_from
+            fake_allocation.already_accrued = False
+            if allocation.accrual_plan_id.accrued_gain_time == 'start':
+                first_level = allocation.accrual_plan_id.level_ids.sorted('sequence')[0]
+                initial_days = first_level.added_value
+                if first_level.added_value_type == 'hour':
+                    initial_days /= (allocation.employee_id.sudo().resource_id.calendar_id.hours_per_day or HOURS_PER_DAY)
+                fake_allocation.number_of_days = initial_days
+            else:
+                fake_allocation.number_of_days = 0
+
+            fake_allocation.sudo().with_context(include_pending_leaves=True)._process_accrual_plans(date_to=allocation.lastcall, log=False)
+            allocation.number_of_days = fake_allocation.number_of_days
+            fake_allocation.invalidate_recordset()
 
     def _get_future_leaves_on(self, accrual_date):
         # As computing future accrual allocation days automatically updates the allocation,

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -65,6 +65,23 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'maximum_leave': 10,
             })],
         })
+        cls.accrual_plan_yearly_max_postponed_days_start = cls.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
+            'name': '21 days per year, 5 carryover max',
+            'transition_mode': 'immediately',
+            'carryover_date': 'year_start',
+            'accrued_gain_time': 'start',
+            'level_ids': [
+                Command.create({
+                    "start_count": 0,
+                    "added_value": 21,
+                    "frequency": "yearly",
+                    "yearly_day": 1,
+                    "yearly_month": "jan",
+                    "action_with_unused_accruals": "maximum",
+                    "postpone_max_days": 5,
+                })
+            ],
+        })
 
     def setAllocationCreateDate(self, allocation_id, date):
         """ This method is a hack in order to be able to define/redefine the create_date
@@ -3076,3 +3093,127 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
 
     def test_get_allocation_future_leaves_regular2(self):
         self._test_get_allocation_future_leaves_regular(regular_before=True)
+
+    def test_backdated_leave_absorbed_by_surplus_buffer(self):
+        """
+        Scenario A: Backdated leave absorbed by lost surplus buffer.
+        Testing Goal: Verify that a leave taken in a previous period does NOT reduce
+        the current balance if the employee had 'lost surplus' days to cover it.
+
+        1. Setup: End of 2025, employee has 21 days. Carry-over cap is 5 days.
+        2. Refresh: Jan 1st, 2026, 16 days are 'lost' (21 - 5).
+           The new balance is 26 (5 carry-over + 21 new grant).
+        3. Action: User records a leave for Dec 31, 2025, AFTER the refresh.
+        4. Logic: Balance on Dec 31 was 21. 21 - 1 = 20. 20 is still > 5 (Cap).
+           The carry-over amount should remain 5.
+        5. Result: The 2026 balance remains 26.0. The leave was absorbed by the surplus.
+        """
+        accrual_plan = self.accrual_plan_yearly_max_postponed_days_start
+
+        with freeze_time('2025-01-01'):
+            allocation = self._create_test_allocation(self.leave_type, '2025-01-01', self.employee_emp, accrual_plan, 21)
+            allocation.action_validate()
+            self.assert_virtual_leaves_equal(self.leave_type, 21, self.employee_emp)
+
+        with freeze_time('2026-01-01'):
+            allocation._update_accrual()
+            self.assert_virtual_leaves_equal(self.leave_type, 26, self.employee_emp)
+            leave = self._take_leave_and_validate(self.employee_emp, self.leave_type, '2025-12-31', '2025-12-31')
+            self.assert_virtual_leaves_equal(self.leave_type, 26, self.employee_emp)
+            leave.action_refuse()
+            self.assert_virtual_leaves_equal(self.leave_type, 26, self.employee_emp)
+
+    def test_backdated_leave_deducted_when_under_cap(self):
+        """
+        Scenario B: Backdated leave deducted when under the carry-over cap.
+        Testing Goal: Verify that a leave taken in a previous period DOES reduce
+        the current balance if the employee was already at or below their carry-over limit.
+
+        1. Setup: End of 2025, employee has 3 days. Carry-over cap is 5 days.
+        2. Refresh: Jan 1st, 2026, 0 days are lost because 3 < 5.
+           The new balance is 23 (2 carry-over + 21 new grant).
+        3. Action: User records a leave for Dec 31, 2025, AFTER the refresh.
+        4. Logic: Balance on Dec 31 was 2. 2 - 1 = 1. 1 is the new carry-over amount.
+        5. Result: The 2026 balance drops to 22.0 (1 carry-over + 21 new).
+           The leave is correctly deducted from the real savings.
+        """
+        accrual_plan = self.accrual_plan_yearly_max_postponed_days_start
+
+        with freeze_time('2025-01-01'):
+            allocation = self._create_test_allocation(self.leave_type, '2025-01-01', self.employee_emp, accrual_plan, 21)
+            allocation.action_validate()
+            self.assert_virtual_leaves_equal(self.leave_type, 21, self.employee_emp)
+
+        with freeze_time('2026-01-01'):
+            allocation._update_accrual()
+            leave_june = self._take_leave_and_validate(self.employee_emp, self.leave_type, '2025-06-02', '2025-06-26')
+            self.assert_virtual_leaves_equal(self.leave_type, 23, self.employee_emp)
+            leave_dec = self._take_leave_and_validate(self.employee_emp, self.leave_type, '2025-12-31', '2025-12-31')
+            self.assert_virtual_leaves_equal(self.leave_type, 22, self.employee_emp)
+            leave_dec.action_refuse()
+            self.assert_virtual_leaves_equal(self.leave_type, 23, self.employee_emp)
+            leave_june.action_refuse()
+            self.assert_virtual_leaves_equal(self.leave_type, 26, self.employee_emp)
+
+    def test_backdated_leave_multi_level_accrual(self):
+        """
+            Test 'Surplus Shield' logic with a leave spanning across the year-end reset.
+
+            Scenario:
+            - 2024 (Level 1): 2 days/month (24 total). Carryover Cap: 5 days.
+            - 2025 (Level 2): 3 days/month.
+            - Initial 2025 Balance: 8.0 (5.0 carryover + 3.0 new grant).
+
+            Logic:
+            1. Nov 2024 Leave (12 days):
+            Absorbed by the 19-day surplus (24 earned - 5 cap).
+            Live balance stays 8.0.
+
+            2. Dec 23 - Jan 2 Leave (9 days total):
+            - 2024 Slice (7 days): The remaining 2024 surplus is exactly 7 days
+                (12 remaining - 5 cap). The leave consumes exactly the surplus.
+                Carryover remains intact at 5.0.
+            - 2025 Slice (2 days): Deducted from the new 3.0 grant.
+                Remaining 2025 grant: 1.0.
+
+            Final Result: 5.0 (Carryover) + 1.0 (Net Grant) = 6.0.
+        """
+        accrual_plan = self.env['hr.leave.accrual.plan'].create({
+            'name': 'Multi-level Test Plan',
+            'transition_mode': 'immediately',
+            'carryover_date': 'year_start',
+            'accrued_gain_time': 'start',
+            'level_ids': [
+                Command.create({
+                    'added_value': 2,
+                    'frequency': 'monthly',
+                    'action_with_unused_accruals': 'maximum',
+                    'postpone_max_days': 5,
+                    'start_count': 0,
+                    'start_type': 'day',
+                }),
+                Command.create({
+                    'added_value': 3,
+                    'frequency': 'monthly',
+                    'action_with_unused_accruals': 'maximum',
+                    'postpone_max_days': 10,
+                    'start_count': 1,
+                    'start_type': 'year',
+                })
+            ]
+        })
+
+        with freeze_time('2024-01-01'):
+            allocation = self._create_test_allocation(self.leave_type, '2024-01-01', self.employee_emp, accrual_plan)
+            allocation.action_validate()
+
+        with freeze_time('2025-01-01'):
+            allocation._update_accrual()
+            self.assert_virtual_leaves_equal(self.leave_type, 8, self.employee_emp)
+
+            leave_nov = self._take_leave_and_validate(self.employee_emp, self.leave_type, '2024-11-04', '2024-11-19')
+            self.assert_virtual_leaves_equal(self.leave_type, 8, self.employee_emp)
+            self._take_leave_and_validate(self.employee_emp, self.leave_type, '2024-12-23', '2025-01-02')
+            self.assert_virtual_leaves_equal(self.leave_type, 6, self.employee_emp)
+            leave_nov.action_refuse()
+            self.assert_virtual_leaves_equal(self.leave_type, 8, self.employee_emp)

--- a/addons/hr_holidays/tests/test_company_leave.py
+++ b/addons/hr_holidays/tests/test_company_leave.py
@@ -302,7 +302,7 @@ class TestCompanyLeave(TransactionCase):
         })
         company_leave._compute_date_from_to()
 
-        with self.assertQueryCount(__system__=1857):  # 770 community
+        with self.assertQueryCount(__system__=1858):  # 770 community
             # Original query count: 1987
             # Without tracking/activity context keys: 5154
             company_leave.action_validate()

--- a/addons/hr_work_entry_holidays/tests/test_performance.py
+++ b/addons/hr_work_entry_holidays/tests/test_performance.py
@@ -32,7 +32,7 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
         self.richard_emp.generate_work_entries(date(2018, 1, 1), date(2018, 1, 2))
         leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
 
-        with self.assertQueryCount(__system__=115, admin=116):  # com 96/97
+        with self.assertQueryCount(__system__=116, admin=117):  # com 96/97
             leave.action_validate()
         leave.action_refuse()
 
@@ -57,7 +57,7 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
     def test_performance_leave_confirm(self):
         leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
         leave.action_draft()
-        with self.assertQueryCount(__system__=43, admin=42):
+        with self.assertQueryCount(__system__=44, admin=43):
             leave.action_confirm()
         leave.state = 'refuse'
 


### PR DESCRIPTION
Steps to reproduce
1. Create a multi-level accrual plan (e.g., Level 1: 2 days/month, 5-day carryover cap).
2. Accrue for a full year (24 days earned) and pass the carryover date (Jan 1st).
3. Observe the balance for the new year is 8.0 (5.0 carried over + 3.0 new grant).
4. Backdate a leave request to November of the previous year (12 days) and validate it.
5. Observe the remaining balance for the current year.
6. Result: The balance drops incorrectly. It fails to recognize that the 12-day leave
   should have been absorbed by the 19 surplus days (24 earned - 5 cap) discarded
   during the reset.

Issue
When a leave is backdated into a previous accrual period (before the most recent
carryover), the system uses the current post-carryover allocation balance to
evaluate and deduct the leave. It does not account for the fact that the previous
period may have had a much higher balance, and that the leave's real impact is
only on the carried-over amount — not the full duration.

Solution
When a backdated leave crossing a carryover boundary is detected, the accrual
plan is replayed from scratch to recompute the correct allocation balance.

1. Detection (_get_accrual_allocations_across_carryover in hr.leave): Checks
   whether a leave's date falls before a carryover boundary that has already been
   processed (leave.date_from < carryover_date <= alloc.lastcall). This ensures
   the recompute only triggers for truly backdated leaves crossing a carryover.

2. Replay (_recompute_accrual_allocations in hr.leave.allocation): Creates a
   temporary allocation and replays _process_accrual_plans from the allocation's
   start date up to lastcall. The replay uses include_pending_leaves context to
   count not-yet-validated leaves via virtual_leaves_taken, so the carryover
   calculation correctly accounts for them at create time.

3. Lifecycle coverage: The recompute is triggered on all leave state changes
   that affect the allocation balance: create (_check_validity), refuse
   (action_refuse), delete (unlink), and reset to draft (action_draft).

4. The normal accrual cron (_update_accrual / _process_accrual_plans) continues
   to use leaves_taken (validated only), preserving existing behavior for
   forward-looking accrual processing.

opw-5870858