### PR TITLE
[IMP] product_matrix: improve product variants popup clarity

### DIFF
--- a/addons/product_matrix/models/product_template.py
+++ b/addons/product_matrix/models/product_template.py
@@ -20,7 +20,7 @@ class ProductTemplate(models.Model):
             line.product_template_value_ids._only_active().ids for line in attribute_lines
         ]
 
-        header = [{"name": self.display_name}] + [
+        header = [{"name": ""}] + [
             attr._grid_header_cell(
                 fro_currency=self.currency_id,
                 to_currency=currency_id,

--- a/addons/product_matrix/static/src/js/matrix_configurator_hook.js
+++ b/addons/product_matrix/static/src/js/matrix_configurator_hook.js
@@ -4,13 +4,14 @@ import { ProductMatrixDialog } from "./product_matrix_dialog";
 export function useMatrixConfigurator() {
     const dialog = useService("dialog");
 
-    const openDialog = (rootRecord, jsonInfo, productTemplateId, editedCellAttributes) => {
+    const openDialog = (rootRecord, jsonInfo, productTemplate, editedCellAttributes) => {
         const infos = JSON.parse(jsonInfo);
         dialog.add(ProductMatrixDialog, {
             header: infos.header,
             rows: infos.matrix,
+            dialogTitle: productTemplate.display_name,
             editedCellAttributes: editedCellAttributes.toString(),
-            product_template_id: productTemplateId,
+            product_template_id: productTemplate.id,
             record: rootRecord,
         });
     };
@@ -38,7 +39,7 @@ export function useMatrixConfigurator() {
         openDialog(
             rootRecord,
             rootRecord.data.grid,
-            record.data.product_template_id.id,
+            record.data.product_template_id,
             updatedLineAttributes
         );
 

--- a/addons/product_matrix/static/src/js/product_matrix_dialog.js
+++ b/addons/product_matrix/static/src/js/product_matrix_dialog.js
@@ -9,6 +9,7 @@ export class ProductMatrixDialog extends Component {
     static props = {
         header: { type: Object },
         rows: { type: Object },
+        dialogTitle: { type: String }, 
         editedCellAttributes: { type: String },
         product_template_id: { type: Number },
         record: { type: Object },
@@ -50,6 +51,10 @@ export class ProductMatrixDialog extends Component {
                 document.getElementsByClassName('o_matrix_input')[0].select();
             }
         });
+    }
+
+    toggleOpacity(ev) {
+        ev.target.classList.toggle('opacity-25', ev.target.value === '0');
     }
 
     _format({price, currency_id}) {

--- a/addons/product_matrix/static/src/xml/product_matrix.xml
+++ b/addons/product_matrix/static/src/xml/product_matrix.xml
@@ -32,10 +32,14 @@
                             class="o_matrix_input_td text-end"
                             t-attf-class="{{cell_last?'o_matrix_pe':''}}">
                             <div t-if="cell.is_possible_combination" class="input-group">
-                                <input  type="number"
-                                        class="o_input o_field_number o_matrix_input border-0 text-end"
-                                        t-att="{'ptav_ids': cell.ptav_ids,'value': cell.qty}"
-                                        onClick="this.select();"/>
+                                <input  
+                                    type="number"
+                                    class="o_input o_field_number o_matrix_input border-0 text-end"
+                                    onClick="this.select();"
+                                    t-att="{'ptav_ids': cell.ptav_ids, 'value': cell.qty}"
+                                    t-att-class="{ 'opacity-25': cell.qty === 0 }"
+                                    t-on-input="toggleOpacity"
+                                />
                             </div>
                             <span t-else=""
                                   class="text-muted overflow-auto">

--- a/addons/product_matrix/static/src/xml/product_matrix_dialog.xml
+++ b/addons/product_matrix/static/src/xml/product_matrix_dialog.xml
@@ -1,6 +1,6 @@
 <templates>
     <t t-name="product_matrix.dialog">
-        <Dialog size="this.size" title.translate="Choose Product Variants" withBodyPadding="false">
+        <Dialog size="this.size" title="props.dialogTitle" withBodyPadding="false">
             <t t-call="product_matrix.matrix">
                 <t t-set="header" t-value="this.props.header"/>
                 <t t-set="rows" t-value="this.props.rows"/>

--- a/addons/test_sale_product_configurators/static/tests/tours/product_matrix_tour.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_matrix_tour.js
@@ -3,7 +3,7 @@ import { stepUtils } from "@web_tour/tour_utils";
 import * as tourUtils from "@sale/js/tours/tour_utils";
 
 let EXPECTED = [
-    "Matrix", "PAV11", "PAV12 + $ 50.00",
+    "", "PAV11", "PAV12 + $ 50.00",
 ];
 for (let no of ['PAV41', 'PAV42']) {
     for (let dyn of ['PAV31', 'PAV32']) {


### PR DESCRIPTION
Before the commit:
- The variants popup displayed the generic title "Choose Product Variants" instead of the actual product name, reducing context visibility.
-  Attribute values were shown without their corresponding attribute names, leading to confusion for end users. 
- Additionally, "0" values in the matrix had the same opacity as other values, making it hard to distinguish where quantities were actually added.

After the commit:
- Replaced the popup title with the product name to provide clearer context.
-  Displayed attribute names along with attribute values to improve readability and avoid confusion.
-  Adjusted the opacity of "0" values to visually differentiate them from entered quantities.

task-5914179
