### PR TITLE
[FIX] html_editor: remove duplicate code from cleanForPaste

### DIFF
--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -486,19 +486,7 @@ export class ClipboardPlugin extends Plugin {
                 }
             }
         } else if (node.nodeType !== Node.TEXT_NODE) {
-            if (node.nodeName === "THEAD") {
-                const tbody = node.nextElementSibling;
-                if (tbody) {
-                    // If a <tbody> already exists, move all rows from
-                    // <thead> into the start of <tbody>.
-                    tbody.prepend(...node.children);
-                    node.remove();
-                    node = tbody;
-                } else {
-                    // Otherwise, replace the <thead> with <tbody>
-                    node = this.dependencies.dom.setTagName(node, "TBODY");
-                }
-            } else if (["TD", "TH"].includes(node.nodeName)) {
+            if (["TD", "TH"].includes(node.nodeName)) {
                 // Insert base container into empty TD.
                 if (isEmptyBlock(node)) {
                     const baseContainer = this.dependencies.baseContainer.createBaseContainer();

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -1,11 +1,7 @@
 import { Plugin } from "@html_editor/plugin";
 import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
 import { isBlock } from "@html_editor/utils/blocks";
-import {
-    fillEmpty,
-    fillShrunkPhrasingParent,
-    removeClass,
-} from "@html_editor/utils/dom";
+import { fillEmpty, fillShrunkPhrasingParent, removeClass } from "@html_editor/utils/dom";
 import {
     getDeepestPosition,
     isProtected,
@@ -1334,8 +1330,8 @@ export class TablePlugin extends Plugin {
     }
 
     handleTableInsert(insertContainer) {
-        const thead = insertContainer.querySelector("THEAD");
-        if (thead) {
+        const theads = insertContainer.querySelectorAll("THEAD");
+        for (const thead of theads) {
             const tbody = thead.nextElementSibling;
             if (tbody) {
                 const thChildren = thead.querySelectorAll("TH");

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -75,7 +75,7 @@ describe("Html Paste cleaning - whitelist", () => {
                 );
             },
             contentAfter:
-                '<p>123a</p><table class="table table-bordered o_table"><tbody><tr><th>h</th></tr><tr><td>b</td></tr></tbody></table><p>d[]</p>',
+                '<p>123a</p><table class="table table-bordered o_table"><tbody><tr><th class="o_table_header">h</th></tr><tr><td>b</td></tr></tbody></table><p>d[]</p>',
         });
     });
 
@@ -4490,8 +4490,8 @@ ${"        "}
                         <table class="table table-bordered o_table">
                             <tbody>
                                 <tr>
-                                    <th>1</th>
-                                    <th>2</th>
+                                    <th class="o_table_header">1</th>
+                                    <th class="o_table_header">2</th>
                                 </tr>
                                 <tr>
                                     <td>1</td>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This PR removes duplicated logic in `cleanForPaste` that moves `thead` content into `tbody`. That behavior is already handled in insert (via `before_insert_processors`), so keeping it in `cleanForPaste` was redundant.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
