### PR TITLE
[FIX] html_editor: preserve heading when applying toggle list

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
@@ -526,16 +526,18 @@ export class ToggleBlockPlugin extends Plugin {
     }
 
     insertToggleBlock() {
-        let initialText;
+        let currentBlock;
         const selection = this.dependencies.selection.getSelectionData().deepEditableSelection;
         if (selection.isCollapsed) {
-            const selectedBlock = closestBlock(selection.startContainer);
-            initialText = selectedBlock.textContent;
-            selectedBlock.remove();
+            currentBlock = closestBlock(selection.startContainer);
         }
 
-        const block = this.renderToggleBlock(initialText);
-        const target = block.querySelector(`${titleSelector} > ${baseContainerGlobalSelector}`);
+        const block = this.renderToggleBlock();
+        let target = block.querySelector(`${titleSelector} > ${baseContainerGlobalSelector}`);
+        if (currentBlock && isParagraphRelatedElement(currentBlock)) {
+            target.replaceWith(currentBlock);
+            target = currentBlock;
+        }
         this.dependencies.dom.insert(block);
         this.dependencies.selection.setCursorStart(target);
         this.dependencies.history.addStep();

--- a/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
+++ b/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
@@ -18,7 +18,7 @@ import {
     toggleBlockEmbedding,
 } from "@html_editor/others/embedded_components/core/toggle_block/toggle_block";
 import { onMounted } from "@odoo/owl";
-import { animationFrame, press, queryOne, tick } from "@odoo/hoot-dom";
+import { animationFrame, press, queryOne, tick, waitFor } from "@odoo/hoot-dom";
 import { Deferred } from "@odoo/hoot-mock";
 import { browser } from "@web/core/browser/browser";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
@@ -1120,5 +1120,16 @@ describe("create with powerbox", () => {
         expect(
             "[data-embedded='toggleBlock'] [data-embedded-editable='title']:contains('abc')"
         ).toHaveCount(1);
+    });
+    test("title element should be same as current block if current block is heading", async () => {
+        const { editor } = await setupEditor(`<h1><font style="color: #ff0000">abc[]</font></h1>`, {
+            config: getConfig([toggleBlockEmbedding]),
+        });
+        await insertText(editor, "/toggle");
+        await waitFor(".o-we-powerbox");
+        await press("Enter");
+        expect("[data-embedded='toggleBlock'] [data-embedded-editable='title']").toHaveInnerHTML(
+            `<h1><font style="color: #ff0000">abc</font></h1>`
+        );
     });
 });


### PR DESCRIPTION
**Current behavior before PR:**

If current block is heading and a toggle list is created from powerbox, newly created toggle list has baseContainer as title element, even though the anchor block was heading.

**Desired behavior after PR:**

This PR ensures that if toggle list is created from heading then title element of toggle list will be same is heading.

task-5975804





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
