### PR TITLE
[FIX] pos_sale: settle sale order with down payment and extra lines

### DIFF
--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -72,9 +72,8 @@ class SaleOrder(models.Model):
             online_payments_invoices = sale_order.transaction_ids.filtered(lambda tx_move: tx_move.state in ('authorized', 'done')).mapped('invoice_ids')
             invoice_lines = sale_order.order_line.invoice_lines.filtered(lambda l: l.parent_state in ('draft', 'posted') and l.move_id not in online_payments_invoices)
             total_invoices_paid = sum(invoice_lines.mapped(lambda l: math.copysign(l.price_total, -l.balance)))
-            pos_orders = sale_order.order_line.pos_order_line_ids.order_id
-            total_pos_orders_paid = sum(pos_orders.mapped('amount_total'))
-            sale_order.amount_unpaid = max(sale_order.amount_total - total_invoices_paid - total_pos_orders_paid - sale_order.amount_paid, 0.0)
+            total_pos_paid = sum(sale_order.order_line.filtered(lambda l: not l.display_type).mapped('pos_order_line_ids.price_subtotal_incl'))
+            sale_order.amount_unpaid = max(sale_order.amount_total - total_invoices_paid - total_pos_paid - sale_order.amount_paid, 0.0)
 
     @api.depends('order_line.pos_order_line_ids')
     def _compute_amount_to_invoice(self):

--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -686,3 +686,16 @@ registry.category("web_tour.tours").add("test_settle_changed_price_with_lots", {
             }),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("PoSApplyDownpaymentWithExtraLine", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            PosSale.downPaymentFirstOrder("+10"),
+            ProductScreen.clickDisplayedProduct("product_a"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+        ].flat(),
+});

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -2121,6 +2121,27 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
 
         self.assertEqual(sale_order.amount_unpaid, 0.0)
 
+    def test_advance_payment_with_extra_lines(self):
+        so = self.env['sale.order'].sudo().create({
+            'partner_id': self.partner_a.id,
+            'order_line': [
+                (0, 0, {
+                    'name': self.product_a.name,
+                    'product_id': self.product_a.id,
+                    'product_uom_qty': 1.0,
+                    'price_unit': 100,
+                    'tax_ids': False,
+                })],
+        })
+        so.action_confirm()
+        self.product_a.write({'available_in_pos': True})
+
+        # Apply 10% down payment and add a product to the PoS order
+        self.main_pos_config.open_ui()
+        self.main_pos_config.down_payment_product_id = self.env.ref("pos_sale.default_downpayment_product")
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PoSApplyDownpaymentWithExtraLine', login="accountman")
+        self.assertEqual(so.amount_unpaid, 90)
+
 
 @tagged('post_install', '-at_install')
 class TestPoSSalePayment(TestPointOfSaleHttpCommon, PaymentCommon):


### PR DESCRIPTION
The following commit introduced a change in compute_unpaid_amount. https://github.com/odoo/odoo/commit/b8b50a797cdc0053643f959eb2d04800163fe005

The unpaid_amount is now computed from the PoS order total instead of the settle payment order line.

This causes an issue when the PoS order contains additional product lines besides the settle payment line.

In such cases, the total amount may exceed the sale order amount, preventing the sale order from being settled again from the PoS.

How to reproduce:
- Create a sale order.
- Apply a down payment in the PoS.
- Add other products before validating the payment.
- Ensure the total exceeds the sale order amount.
- Pay the order.
- Try to settle the same sale order from PoS, cannot find it.

opw-5821232
