### PR TITLE
[FIX] html_editor, *: prevent overflow by handling long text globally

### DIFF
--- a/addons/html_editor/static/src/scss/html_editor.common.scss
+++ b/addons/html_editor/static/src/scss/html_editor.common.scss
@@ -112,7 +112,7 @@ pre {
     outline: none;
 }
 [contenteditable] {
-    overflow-wrap: unset !important;
+    overflow-wrap: inherit;
 }
 
 .css_non_editable_mode_hidden {

--- a/addons/mail/static/tests/inline/convert_inline.test.js
+++ b/addons/mail/static/tests/inline/convert_inline.test.js
@@ -1515,7 +1515,7 @@ describe("Should not convert blacklisted class to inline styles", () => {
         classToStyle(editable, getCSSRules(editable.ownerDocument));
 
         expect(editable).toHaveInnerHTML(
-            `<a contenteditable="false" href="#" class="o_mail_redirect" style="text-decoration: none; padding: 0rem 0.15rem; margin: 0rem 0.025rem; box-sizing: border-box; overflow-wrap: unset;">@Marc Demo</a> Testing!`,
+            `<a contenteditable="false" href="#" class="o_mail_redirect" style="text-decoration: none; padding: 0rem 0.15rem; margin: 0rem 0.025rem; box-sizing: border-box; overflow-wrap: inherit;">@Marc Demo</a> Testing!`,
             {
                 message: "blacklisted class styles should remain unconverted",
             }
@@ -1531,7 +1531,7 @@ describe("Should not convert blacklisted class to inline styles", () => {
         editable.innerHTML = `<a contenteditable="false" href="#" class="o_mail_redirect test-style">@Marc Demo</a> Testing!`;
         classToStyle(editable, getCSSRules(editable.ownerDocument));
         expect(editable).toHaveInnerHTML(
-            `<a contenteditable="false" href="#" class="o_mail_redirect test-style" style="text-decoration: none; padding: 0rem 0.15rem; margin: 0rem 0.025rem; box-sizing: border-box; background-color: yellow; overflow-wrap: unset;"> @Marc Demo </a> Testing!`,
+            `<a contenteditable="false" href="#" class="o_mail_redirect test-style" style="text-decoration: none; padding: 0rem 0.15rem; margin: 0rem 0.025rem; box-sizing: border-box; background-color: yellow; overflow-wrap: inherit;"> @Marc Demo </a> Testing!`,
             { message: "styles marked !important should override blacklisted class restrictions" }
         );
     });
@@ -1545,7 +1545,7 @@ describe("Should not convert blacklisted class to inline styles", () => {
         editable.innerHTML = `<a contenteditable="false" href="#" class="o_mail_redirect test-color">@Marc Demo</a> Testing!`;
         classToStyle(editable, getCSSRules(editable.ownerDocument));
         expect(editable).toHaveInnerHTML(
-            `<a contenteditable="false" href="#" class="o_mail_redirect test-color" style="text-decoration: none; padding: 0rem 0.15rem; margin: 0rem 0.025rem; box-sizing: border-box; overflow-wrap: unset;"> @Marc Demo </a> Testing!`,
+            `<a contenteditable="false" href="#" class="o_mail_redirect test-color" style="text-decoration: none; padding: 0rem 0.15rem; margin: 0rem 0.025rem; box-sizing: border-box; overflow-wrap: inherit;"> @Marc Demo </a> Testing!`,
             {
                 message:
                     "should ignore styles from lower specificity class in favor of blacklisted class",

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -256,6 +256,8 @@ body {
 }
 
 #wrapwrap {
+    overflow-wrap: anywhere;
+
     @if o-website-value('body-image') {
         @include body-image-bg-style();
     }


### PR DESCRIPTION
*: mail, website

This commit will prevent long words from breaking layouts and
introducing horizontal scrollbars across website pages.

Some languages naturally contain very long words, and users may also
input long unbroken or random text. This results in overflow issues that
negatively impact readability and overall UI quality.

Since pages do not share a consistent wrapper element, and key areas
like `header` and `footer` must also be handled, applying the fix at a
higher level is necessary. Pages such as `/blog`, `/forum` and `/slides`
further highlight this inconsistency in structure.

To ensure complete and uniform coverage, the rule is applied on
`#wrapwrap`, which contains `<header>`, `<main>` and `<footer>`
content.

task-[5457179](https://www.odoo.com/odoo/project/974/tasks/5457179)

 | Before  | After |
   | ------------- | ------------- |
   Header
   | <img width="1632" height="608" alt="image" src="https://github.com/user-attachments/assets/250251f6-bb56-4523-acc5-dee9d9f15bf9" /> | <img width="1633" height="679" alt="image" src="https://github.com/user-attachments/assets/8f38c523-b0e9-40d2-84f7-a32afe83b953" /> |
   Blog Module
   | <img width="1631" height="422" alt="image" src="https://github.com/user-attachments/assets/8faa6e22-ac7a-4b59-9b54-f674978dc931" /> | <img width="1633" height="420" alt="image" src="https://github.com/user-attachments/assets/66a2de39-95e2-4871-827e-4965e571ed33" /> |
   | <img width="882" height="394" alt="image" src="https://github.com/user-attachments/assets/b807245f-0d84-47b6-a65b-ce0005037c50" /> | <img width="888" height="385" alt="image" src="https://github.com/user-attachments/assets/3c35cd12-08f2-4775-9c4d-d9d6e4555f00" /> |
   Event Module
   | <img width="1335" height="398" alt="image" src="https://github.com/user-attachments/assets/7d3af438-58f7-4a56-acd0-46e6dc90fe2a" /> | <img width="981" height="376" alt="image" src="https://github.com/user-attachments/assets/fb419243-4c0d-4c72-97ec-47812f81b378" /> |
   Sale Module
   | <img width="1581" height="625" alt="image" src="https://github.com/user-attachments/assets/a9784181-f6b2-474c-b26b-be7dce25d2dd" /> | <img width="1502" height="605" alt="image" src="https://github.com/user-attachments/assets/2bcc9d6b-d5f1-4ab7-9c6e-588889709084" /> |
   E-Learning Module
   | <img width="1534" height="317" alt="image" src="https://github.com/user-attachments/assets/3b03835c-c72b-40fb-bbf0-8fc91d3fafe5" /> | <img width="1423" height="393" alt="image" src="https://github.com/user-attachments/assets/551e332d-25af-453a-bfda-b669b04fdd39" /> |
   Footer
   | <img width="1633" height="407" alt="image" src="https://github.com/user-attachments/assets/628d98fc-bc4f-471e-8c4e-dcd9fdb5daa5" /> | <img width="1574" height="410" alt="image" src="https://github.com/user-attachments/assets/60c9edec-f9a1-43a3-b8c9-c218e256d96c" /> |
