### PR TITLE
[IMP] point_of_sale: add address details on ticketscreen for the address preset

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.scss
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.scss
@@ -26,6 +26,18 @@
     width: 30px;
 }
 
+.address-cell {
+    max-width: 180px;
+}
+
+.address-text {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    overflow: hidden;
+}
+
 @include media-breakpoint-down(sm) {
     .screen-full-width {
         flex-direction: column;

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -39,11 +39,11 @@
                                     <t t-foreach="_filteredOrderList" t-as="order" t-key="order.uuid">
                                         <tr role="button" class="order-row" t-attf-class="{{ isHighlighted(order) ? 'highlight active': '' }}" t-att-orderUuid="order.uuid"
                                             t-on-click="() => this.onClickOrder(order)" t-on-dblclick="() => this.onDblClickOrder(order)" >
-                                            <td>
+                                            <td class="align-middle">
                                                 <div class="fs-6 fw-bolder"><t t-esc="this.pos.getDate(order.date_order)"></t></div>
                                                 <div class="small text-muted"><t t-esc="this.pos.getTime(order.date_order)"></t></div>
                                             </td>
-                                            <td class="order-name">
+                                            <td class="order-name align-middle">
                                                 <div class="fw-bolder"><t t-esc="order.getName()"></t></div>
                                                 <div class="small text-muted"><t t-esc="order.pos_reference"></t></div>
                                             </td>
@@ -52,6 +52,11 @@
                                                 <div id="order-tags" t-if="usePreset" t-attf-class="badge rounded o_colorlist_item_color_{{order.preset_id?.color}}" style="font-size: 0.75rem !important;">
                                                     <t t-esc="order.preset_id?.name"></t>
                                                 </div>
+                                            </td>
+                                            <td class="align-middle address-cell">
+                                                <span t-if="order.preset_id?.identification === 'address'"
+                                                    class="address-text"
+                                                    t-out="order.partner_id?.pos_contact_address"/>
                                             </td>
                                             <td class="align-middle">
                                                 <t t-if="order.presetTime">

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -1222,9 +1222,11 @@ registry.category("web_tour.tours").add("test_preset_customer_selection", {
         [
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
-            PartnerList.searchCustomerValue("Test Partner", true),
-            PartnerList.clickPartner("Test Partner"),
-            ProductScreen.customerIsSelected("Test Partner"),
+            PartnerList.searchCustomerValue("Partner Full", true),
+            PartnerList.clickPartner("Partner Full"),
+            ProductScreen.customerIsSelected("Partner Full"),
+            Chrome.clickOrders(),
+            TicketScreen.checkCustomerAddress("77 Santa Barbara Rd Pleasant Hill"),
             Chrome.endTour(),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/pos/tours/utils/ticket_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/ticket_screen_util.js
@@ -267,3 +267,12 @@ export function isShown() {
         },
     ];
 }
+
+export function checkCustomerAddress(addressText) {
+    return [
+        {
+            isActive: ["desktop"],
+            trigger: `.ticket-screen tbody tr > td:contains("${addressText}")`,
+        },
+    ];
+}

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -3411,13 +3411,6 @@ class TestUi(TestPointOfSaleHttpCommon):
             'name': 'Delivery',
             'identification': 'address',
         })
-        self.env['res.partner'].create({
-            'name': 'Test Partner',
-            'street': '123 Test Street',
-            'city': 'Test City',
-            'zip': '12345',
-            'country_id': self.env['res.country'].search([], limit=1).id,
-        })
         self.main_pos_config.write({
             'use_presets': True,
             'default_preset_id': self.preset_delivery.id,


### PR DESCRIPTION
In this commit:
===============
- Added address details on the TicketScreen when the order preset identification type is `address`.
- This helps to easily see the delivery address while scheduling the delivery.

Task-5974595



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
