### PR TITLE
[FIX] website: Restore proper back navigation in mega menu

### DIFF
--- a/addons/web/static/lib/odoo_ui_icons/style.css
+++ b/addons/web/static/lib/odoo_ui_icons/style.css
@@ -8,7 +8,7 @@
 
 .oi {
   display: inline-block;
-  font-family: 'odoo_ui_icons';
+  font-family: 'odoo_ui_icons' !important;
   speak: never;
   font-style: normal;
   font-weight: normal;


### PR DESCRIPTION
Steps to reproduce:
===================
1. Go to webstie and add a mega menu
2. Change Navbar font (e.g. to "Arvo")
3. Switch to mobile view and open the mega menu

-> the back arrow will have unexpected style.

Cause:
======
The selector `.navbar .nav-link` applies the custom navbar font-family (e.g., "Arvo") to all `.nav-link` elements inside the navbar. The mega menu back button has classes `btn nav-link oi oi-chevron-left`, so it matches this selector.
Since `.navbar .nav-link` has higher specificity than the base `.oi` class, the custom font overrides `font-family: 'odoo_ui_icons'`.

Solution:
=========
force the .oi font-family.

opw-5949405

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
