### PR TITLE
[FIX] pos_self_order: print prep tickets from self order mobile

### DIFF
--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -477,9 +477,6 @@ export class SelfOrder extends Reactive {
     }
 
     initHardware() {
-        if (this.config.self_ordering_mode !== "kiosk") {
-            return;
-        }
         let useLna = false;
         for (const printerConfig of this.config.preparation_printer_ids) {
             const printer = this.createPrinter(printerConfig);
@@ -490,6 +487,11 @@ export class SelfOrder extends Reactive {
 
             useLna = useLna || printerConfig.use_lna;
         }
+
+        if (this.config.self_ordering_mode !== "kiosk") {
+            return;
+        }
+
         for (const relPrinter of this.config.receipt_printer_ids) {
             const printerDevice = this.createPrinter(relPrinter);
             this.printer.setFallbackPrinter(printerDevice);


### PR DESCRIPTION
Steps to reproduce
------------------
1. Setup a preparation printer for PoS
2. Enable "mobile" self order
3. From self order, make an order

-> Notice it's not been sent to the preparation display.

Reason
------
In c72f119dceb390e8c4e054905f359b835861f0ba, we added support for LNA, and part of that, we stopped initializing the preparation printers for "mobile" mode; that seems like a mistake, as prep printers can also be used to print the preparation tickets when self ordering using kiosk mode, but also mobile mode!

Fix
---
Initialize the prep printers for "mobile" mode too.

opw-5904620
