### PR TITLE
[FIX] point_of_sale: fix pos_payment uiState test

### DIFF
--- a/addons/point_of_sale/static/tests/unit/models/pos_payment.test.js
+++ b/addons/point_of_sale/static/tests/unit/models/pos_payment.test.js
@@ -1,13 +1,15 @@
 import { test, expect } from "@odoo/hoot";
 import { getFilledOrder, setupPosEnv, createPaymentLine } from "../utils";
 import { definePosModels } from "../data/generate_model_definitions";
-import { mockDate } from "@odoo/hoot-mock";
-const { DateTime } = luxon;
+const { DateTime, Settings } = luxon;
 
 definePosModels();
 
 test("uiState", async () => {
-    mockDate("2025-01-09 12:00:00");
+    const fixedTs = new Date("2025-01-09T12:00:00").valueOf();
+    const memoNow = Settings.now;
+    Settings.now = () => fixedTs;
+
     const store = await setupPosEnv();
     const order = await getFilledOrder(store);
     const card = store.models["pos.payment.method"].get(2);
@@ -15,8 +17,10 @@ test("uiState", async () => {
 
     expect(paymentline.uiState).toEqual({
         qrCode: null,
-        initStateDate: new DateTime.now(),
+        initStateDate: DateTime.fromMillis(fixedTs),
     });
+
+    Settings.now = memoNow;
 });
 
 test("updateCustomerDisplayQrCode", async () => {


### PR DESCRIPTION
The “uiState” test of the pos_payment model was relying on the `mockDate` utility to mock the current date. However, `mockDate` does not fully freeze time and allows the timeline to continue progressing, which caused the test to fail intermittently due to millisecond differences.

To resolve this, we override Luxon's `Settings.now` function to return a fixed timestamp. This guarantees that every call to `DateTime.now()` returns the exact same value, ensuring deterministic and stable test behavior.

---

Task: https://www.odoo.com/odoo/project/1737/tasks/4875917
Error Runbot: https://runbot.odoo.com/odoo/runbot.build.error/241181