### PR TITLE
[FIX] stock: prevent error when NewIds are passed

### DIFF
--- a/addons/stock/report/report_stock_reception.py
+++ b/addons/stock/report/report_stock_reception.py
@@ -187,6 +187,7 @@ class ReportStockReport_Reception(models.AbstractModel):
 
     def _get_docs(self, docids):
         docids = self.env.context.get('default_picking_ids', docids)
+        docids = [id for id in docids if isinstance(id, int)]
         return self.env['stock.picking'].search([('id', 'in', docids), ('picking_type_code', '!=', 'outgoing'), ('state', '!=', 'cancel')])
 
     def _get_doc_model(self):

--- a/addons/stock/tests/test_report.py
+++ b/addons/stock/tests/test_report.py
@@ -6,6 +6,7 @@ from re import findall
 
 from odoo.tests import tagged, Form, TransactionCase
 from odoo import Command
+from odoo.api import NewId
 
 
 class TestReportsCommon(TransactionCase):
@@ -2098,3 +2099,8 @@ class TestReports(TestReportsCommon):
         self.assertEqual(picking_out.move_ids.mapped('quantity'), [0.0, 2.0])
         self.env['report.stock.report_reception'].action_assign(out_move.ids, [1.0], picking_in.move_ids.ids)
         self.assertEqual(picking_out.move_ids.mapped('quantity'), [1.0, 2.0])
+
+    def test_newids_while_opening_reception_report(self):
+        report_values = self.env['report.stock.report_reception']._get_report_values(docids=[NewId()])
+        self.assertEqual(report_values['pickings'], False)
+        self.assertEqual(report_values['reason'], 'No transfers selected or a delivery order selected')


### PR DESCRIPTION
Currently an error occurs when user tries to open reception report through web studio.

Steps to replicate:
- Install stock, web_studio with demo.
- Open receipts and turn on studio mode.
- Go to reports and try to open `Reception Report`.

Error:
```
psycopg2.ProgrammingError: can't adapt type 'NewId'
```

Cause:
- Error occurs after this [PR] that prevents passing of falsy ids to orm.
- As a result the [line] passes `api.NewId()` that is received as `docids` in the function `_get_docs()` performs search using the `NewId` [here] which causes this error to occur.
- In the previous version the id passed was passed a static list `[0]` and then changed to `api.NewId()` which works perfectly fine with `browse()` but with any other operation that fires direct queries like `search()` or `_read_group()` it will cause this error to occur.

Solution:
- Removed NewIds from docids before the search.

[PR]: https://github.com/odoo/enterprise/pull/95117/changes#diff-cf8f46a54f86279b4d773f0d39b23d22f046eb6d33a39c851f2a86dcd2b5b202R645

[line]: https://github.com/odoo/enterprise/blob/431d1b513f26188f693abd949f78a893514205f0/web_studio/controllers/report.py#L649

[here]: https://github.com/odoo/odoo/blob/3263a7f54948d57f13176cf0416b1419150e9d87/addons/stock/report/report_stock_reception.py#L190

sentry-7236339558
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
