### PR TITLE
[FIX] l10n_sa: display correctly totals in Saudi invoice pdf creation

### DIFF
--- a/addons/l10n_sa/views/report_invoice.xml
+++ b/addons/l10n_sa/views/report_invoice.xml
@@ -186,7 +186,7 @@
         <!-- End Credit/Debit notes reasons -->
         <!-- Call custom tax totals templates -->
          <div id="right-elements" position="attributes">
-            <attribute name="t-attf-class">#{'col-6 mt-5' if report_type == 'pdf' else 'col-12 col-md-5'} ms-5 d-inline-block float-end</attribute>
+            <attribute name="t-attf-class">#{'col-auto mt-5' if report_type == 'pdf' else 'col-12 col-md-5'} ms-5 d-inline-block float-end</attribute>
          </div>
         <t t-call="l10n_gcc_invoice.l10n_gcc_document_tax_totals" position="attributes">
             <attribute name="t-call">l10n_sa.l10n_sa_document_tax_totals</attribute>


### PR DESCRIPTION
### Issue before this commit:
When generating an Invoice PDF for a Saudi Arabian company using the Fira Mono font layout, a visual regression occurs in the tax totals section. As a result, when processing invoices with high amounts (e.g. 1,000,000,000.00 SR), the numerical values, including decimals and the currency symbol, are pushed beyond the right margin of the PDF page, rendering them invisible or partially cut off.

### Steps to reproduce the issue:
1. Create and switch to a Saudi Arabian company
2. Go to Settings / Company / Configure document layout
3. Select Text as 'Fira Mono'
7. Go to Accounting / Invoices
8. Select one invoice with a total amount with more than 6 digits
9. Click on the wheel button next to the name of the invoice
10. Then Print / Invoice PDF
11. The total amount is partially exiting the PDF

### Cause of the issue:
The layout breakage is caused by the rigid constraint of a fixed column width combined with an inflexible text-nowrap rule. When an invoice contains high-value amounts, the combined length of the bilingual label and the long numerical string exceeds the allocated fifty percent of the page width. Since the container is forced to the right margin and forbidden from wrapping, the PDF rendering engine has no choice but to push the currency and decimal values beyond the physical edge of the document.

### Reason to introduce the fix:
Having the full total amount displayed in the Invoice PDF even with high amounts of money.

opw-5437320

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
