### PR TITLE
[IMP] web: Burger Menu: style menu subtitles

### DIFF
--- a/addons/web/static/src/webclient/navbar/navbar.scss
+++ b/addons/web/static/src/webclient/navbar/navbar.scss
@@ -255,3 +255,14 @@ body.o_is_superuser .o_menu_systray {
     border-image: repeating-linear-gradient(135deg, #d9b904, #d9b904 10px, #373435 10px, #373435 20px) 2;
     border-image-width: map-get($border-widths, 2);
 }
+
+.o_app_menu_sidebar .o_burger_menu_content.o_burger_menu_app li {
+    color: $dropdown-link-color;
+    font-weight: 400;
+}
+
+.o-navbar-section {
+    color: $dropdown-header-color;
+    font-weight: 500;
+    @include font-size($font-size-sm);
+}

--- a/addons/web/static/src/webclient/navbar/navbar.xml
+++ b/addons/web/static/src/webclient/navbar/navbar.xml
@@ -50,7 +50,7 @@
             t-att-class="{
                 'fw-bolder text-900 pt-3 pb-2': !isNested,
                 'border-top': !isNested &amp;&amp; subMenu_index != 0,
-                'py-2': isNested,
+                'o-navbar-section py-2': isNested,
             }"
             t-att-data-menu-xmlid="section.xmlid" t-esc="section.name"/>
         <ul class="list-unstyled ps-0">


### PR DESCRIPTION
On small screens, users cannot distinguish between clickable items in small screen menus.

Steps to reproduce:

- Open Accounting on small screen;
- Open the menu burger menu;
  > All submenus inside are not distinguishable from regular menu items.

task-5359079

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
