### PR TITLE
[FIX] stock_account: incorrect last product value

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -267,6 +267,7 @@ class ProductProduct(models.Model):
         domain = Domain([
             ('product_id', 'in', self.ids),
             ('move_id', '=', False),
+            ('company_id', '=', self.env.company.id),
         ])
         if lot:
             domain &= Domain(['|', ('lot_id', '=', lot.id), ('lot_id', '=', False)])


### PR DESCRIPTION
Before this fix, when searching for the last product value, we don't check the company.
We search for the last product.value among all companies, even when only one company is selected.
As a result, we end up with strange values when going to Inventory / Reporting / Stock.
For instance, we may end up with:
unit cost 10, total value 100, on hand quantity 0.

OPW-5957947
