### PR TITLE
[IMP] core: XDG standard locations for the config

### DIFF
--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -536,14 +536,23 @@ class configmanager:
             f'/var/lib/{release.product_name}'
         )
 
-        if os.name == 'nt':
+        default_config_dir = (
+            appdirs.user_config_dir(release.product_name, release.author)
+            if os.path.isdir(os.path.expanduser('~')) else
+            appdirs.site_config_dir(release.product_name, release.author)
+        )
+        default_config_file = os.path.join(default_config_dir, 'odoo.conf')
+
+        if os.path.isfile(default_config_file):
+            rcfilepath = default_config_file
+        elif os.name == 'nt':
             rcfilepath = os.path.join(os.path.abspath(os.path.dirname(sys.argv[0])), 'odoo.conf')
         elif os.path.isfile(rcfilepath := os.path.expanduser('~/.odoorc')):
             pass
         elif os.path.isfile(rcfilepath := os.path.expanduser('~/.openerp_serverrc')):
             self._warn("Since ages ago, the ~/.openerp_serverrc file has been replaced by ~/.odoorc", DeprecationWarning)
         else:
-            rcfilepath = '~/.odoorc'
+            rcfilepath = default_config_file
         self._default_options['config'] = self._normalize(rcfilepath)
 
     _log_entries = []   # helpers for log() and warn(), accumulate messages

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -528,14 +528,23 @@ class configmanager:
             f'/var/lib/{release.product_name}'
         )
 
-        if os.name == 'nt':
+        default_config_dir = (
+            appdirs.user_config_dir(release.product_name, release.author)
+            if os.path.isdir(os.path.expanduser('~')) else
+            appdirs.site_config_dir(release.product_name, release.author)
+        )
+        default_config_file = os.path.join(default_config_dir, 'odoo.conf')
+
+        if os.path.isfile(default_config_file):
+            rcfilepath = default_config_file
+        elif os.name == 'nt':
             rcfilepath = os.path.join(os.path.abspath(os.path.dirname(sys.argv[0])), 'odoo.conf')
         elif os.path.isfile(rcfilepath := os.path.expanduser('~/.odoorc')):
             pass
         elif os.path.isfile(rcfilepath := os.path.expanduser('~/.openerp_serverrc')):
             self._warn("Since ages ago, the ~/.openerp_serverrc file has been replaced by ~/.odoorc", DeprecationWarning)
         else:
-            rcfilepath = '~/.odoorc'
+            rcfilepath = default_config_file
         self._default_options['config'] = self._normalize(rcfilepath)
 
     _log_entries = []   # helpers for log() and warn(), accumulate messages


### PR DESCRIPTION
Odoo look for several default places in order to load a configuration
file in case `-c/--config` is missing.

Before this commit, the default *lookup* order was:

* (Windows) odoo.conf next to odoo-bin
* ~/.odoorc
* ~/.openerp_serverrc

With this commit, it is:

* `appdirs.user_config_dir`:
  * (POSIX) /home/$USER/.config/Odoo/odoo.conf
  * (Windows) C:\Users\%USERNAME%\AppData\Local\odoo\odoo\odoo.conf
* `appdirs.site_config_dir`:
  * (POSIX) /etc/xdg/xdg-cinnamon/odoo (on the author's PC, will vary)
  * (Windows) C:\ProgramData\odoo\odoo\odoo.conf
* (Windows) odoo.conf next to odoo-bin
* ~/.odoorc
* ~/.openerp_serverrc

In addition to the lookup order (i.e. find an existing file to load),
there also is a default "save" location where to write a configuration
file (with `--save`) should `-c` be missing and the above lookup order
found no file.

On Windows that default save location remains odoo.conf next to
odoo-bin.

On other OSes it was ~/.odoorc, it now is appdirs.user_config_dir if it
exists and otherwise appdirs.site_config_dir.

Note: not tested on windows and darwin, a very naive approach despite comments saying not to use it on windows vista 12 years ago
