### PR TITLE
[IMP] website_sale: auto-unpublish out-of-stock products with website setting

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -166,6 +166,10 @@ class ProductTemplate(models.Model):
     )
     description = fields.Html(index='trigram')
     description_sale = fields.Text(index='trigram')
+    is_published = fields.Boolean(
+        compute="_compute_is_published",
+        store=True
+    )
 
     # === INDEXES === #
 
@@ -200,6 +204,16 @@ class ProductTemplate(models.Model):
         return super()._auto_init()
 
     #=== COMPUTE METHODS ===#
+
+    @api.depends('product_variant_ids.qty_available')
+    def _compute_is_published(self):
+        website = self.env['website'].get_current_website()
+        for template in self:
+            if not website or not website.auto_unpublish_out_of_stock:
+                continue
+            qty = sum(template.product_variant_ids.mapped('qty_available'))
+            if qty <= 0:
+                template.is_published = False
 
     @api.depends('is_published')
     def _compute_publish_date(self):

--- a/addons/website_sale/models/res_config_settings.py
+++ b/addons/website_sale/models/res_config_settings.py
@@ -71,6 +71,10 @@ class ResConfigSettings(models.TransientModel):
     rating_email_template_id = fields.Many2one(
         related='website_id.rating_email_template_id', readonly=False
     )
+    auto_unpublish_out_of_stock = fields.Boolean(
+        related='website_id.auto_unpublish_out_of_stock',
+        readonly=False,
+    )
 
     # Additional settings
     account_on_checkout = fields.Selection(

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -57,7 +57,9 @@ class Website(models.Model):
         return self.env.ref('sale.mail_template_sale_confirmation', raise_if_not_found=False)
 
     #=== FIELDS ===#
-
+    auto_unpublish_out_of_stock = fields.Boolean(
+        string="Auto Unpublish Out-of-Stock Products"
+    )
     salesperson_id = fields.Many2one(
         string="Salesperson",
         comodel_name='res.users',

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -107,6 +107,12 @@
                 >
                     <field name="group_product_price_comparison"/>
                 </setting>
+                  <setting 
+                    string="Unpublish out-of-stock products" 
+                    id="unpublish_products"
+                    help="Unpublish/Republish product based on stock availability">
+                    <field name="auto_unpublish_out_of_stock"/>
+                </setting>
                 <setting
                     string="Product Reference Price"
                     id="ecom_uom_price_option_setting"

--- a/addons/website_sale_stock/models/product_template.py
+++ b/addons/website_sale_stock/models/product_template.py
@@ -17,6 +17,16 @@ class ProductTemplate(models.Model):
     show_availability = fields.Boolean(string="Show availability Qty", default=False)
     out_of_stock_message = fields.Html(string="Out-of-Stock Message", translate=html_translate)
 
+    @api.depends('product_variant_ids.free_qty')
+    def _compute_is_published(self):
+        website = self.env["website"].get_current_website()
+        for template in self:
+            if not website or not website.auto_unpublish_out_of_stock:
+                continue
+            qty = sum(template.product_variant_ids.mapped("free_qty"))
+            if qty <= 0:
+                template.is_published = False
+
     def _is_sold_out(self):
         """Return whether the product is sold out (no available quantity).
 


### PR DESCRIPTION
Add a website-level setting to automatically unpublish products when they are out of stock.

- Introduce `auto_unpublish_out_of_stock` setting on website.
- Add computed field to trigger publish state update on quantity change.
- In website_sale, unpublish products based on `qty_available`.
- In website_sale_stock, override logic to use `free_qty` for stock-aware behavior.
- Ensure modular override so stock module enhances base behavior without conditional checks.

This keeps publish control website-specific and stock-aware while preserving multi-website compatibility.

