### PR TITLE
[FIX] account_edi_ubl_cii: automate bill line grouping

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -358,6 +358,9 @@ class AccountEdiCommon(models.AbstractModel):
 
         # === Import the embedded documents in the xml if some are found ===
         attachments = self.env['ir.attachment']
+        if invoice.message_main_attachment_id:
+            # Invoice look like it was already imported, don't import attachments again
+            return True
         additional_docs = tree.findall('./{*}AdditionalDocumentReference')
         for document in additional_docs:
             attachment_name = document.find('{*}ID')

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -957,6 +957,22 @@ class AccountEdiXmlUBL20(models.AbstractModel):
             invl_logs = self._import_fill_invoice_line_form(invl_el, invoice_line, qty_factor)
             logs += invl_logs
 
+        # group lines
+        if invoice.journal_id.type == 'sale':
+            move_types = invoice.get_sale_types(include_receipts=True)
+        else:
+            move_types = invoice.get_purchase_types(include_receipts=True)
+        if not self.env.context.get('ungroup_lines'):
+            last_bill_from_vendor = self.env['account.move'].search([
+                ('move_type', 'in', move_types),
+                ('partner_id', '=', invoice.partner_id.id),
+                ('state', '=', 'posted'),
+                ('id', '!=', invoice.id),
+                *invoice.journal_id._check_company_domain(invoice.journal_id.company_id),
+            ], order="create_date desc", limit=1)
+            if last_bill_from_vendor and last_bill_from_vendor._has_lines_grouped():
+                invoice._group_lines_by_tax()
+
         # ==== Payable Rounding amount ====
 
         payable_rounding_node = tree.find('./{*}LegalMonetaryTotal/{*}PayableRoundingAmount')

--- a/addons/account_edi_ubl_cii/models/account_move.py
+++ b/addons/account_edi_ubl_cii/models/account_move.py
@@ -120,8 +120,6 @@ class AccountMove(models.Model):
         """
         Perform checks to evaluate if a move is eligible to grouping/ungrouping
         """
-        if not self.is_purchase_document(include_receipts=True):
-            raise UserError(_("You can only (un)group lines of a incoming invoice (vendor bill)"))
         if self.state != 'draft':
             raise UserError(_("You can only (un)group lines of a draft invoice"))
         # TO REMOVE IN 18.0+ as purchase_edi_ubl_bis module is created

--- a/addons/account_edi_ubl_cii/models/account_move.py
+++ b/addons/account_edi_ubl_cii/models/account_move.py
@@ -30,13 +30,7 @@ class AccountMove(models.Model):
         self.ensure_one()
         self._check_move_for_group_ungroup_lines_by_tax()
 
-        # Check if lines look like they're grouped
-        lines_grouped = any(
-            re.match(re.escape(self.partner_id.name or _("Unknown partner")) + r' - \d+ - .*', line.name)
-            for line in self.line_ids.filtered(lambda x: x.display_type == 'product')
-        )
-
-        if lines_grouped:
+        if self._has_lines_grouped():
             self._ungroup_lines()
         else:
             self._group_lines_by_tax()
@@ -61,7 +55,7 @@ class AccountMove(models.Model):
             if ubl_cii_xml_builder is None:
                 continue
             self.invoice_line_ids = [Command.clear()]
-            res = ubl_cii_xml_builder._import_invoice_ubl_cii(self, file_data)
+            res = ubl_cii_xml_builder.with_context(ungroup_lines=True)._import_invoice_ubl_cii(self, file_data)
             if res:
                 success = True
                 self._message_log(body=_("Ungrouped lines from %s", file_data['attachment'].name))
@@ -134,6 +128,17 @@ class AccountMove(models.Model):
         if 'purchase_order_id' in self.env['account.move.line']._fields:  # purchase field
             if any(line.purchase_order_id for line in self.line_ids):
                 raise UserError(_("You can only (un)group lines of an invoice not linked to a purchase order"))
+
+    def _has_lines_grouped(self):
+        """
+        Check if the move has its lines grouped
+        :return: True if lines look like they're grouped, False otherwise
+        """
+        self.ensure_one()
+        return any(
+            re.match(re.escape(self.partner_id.name or _("Unknown partner")) + r' - \d+ - .*', line.name)
+            for line in self.line_ids.filtered(lambda x: x.display_type == 'product')
+        )
 
     # -------------------------------------------------------------------------
     # EDI

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -784,6 +784,18 @@ comment-->1000.0</TaxExclusiveAmount></xpath>"""
         """
         Test the group/ungroup lines action on account.move
         """
+
+        def create_bill(file_path):
+            file_path = f"{self.test_module}/tests/test_files/{file_path}"
+            with file_open(file_path, 'rb') as file:
+                xml_attachment = self.env['ir.attachment'].create({
+                    'mimetype': 'application/xml',
+                    'name': 'bis3_bill_group_by_tax.xml',
+                    'raw': file.read(),
+                })
+            return self.import_attachment(xml_attachment)
+
+        # Datas
         self.env.ref('base.EUR').active = True
         tax_16 = self.env["account.tax"].create({
             'name': '16 %',
@@ -798,19 +810,7 @@ comment-->1000.0</TaxExclusiveAmount></xpath>"""
             'amount': 21.0,
         })
 
-        file_path = "bis3_bill_group_by_tax.xml"
-        file_path = f"{self.test_module}/tests/test_files/{file_path}"
-        with file_open(file_path, 'rb') as file:
-            xml_attachment = self.env['ir.attachment'].create({
-                'mimetype': 'application/xml',
-                'name': 'bis3_bill_group_by_tax.xml',
-                'raw': file.read(),
-            })
-        bill = self.import_attachment(xml_attachment)
-
-        # Should group lines by tax
-        bill.action_group_ungroup_lines_by_tax()
-        self.assertRecordValues(bill.invoice_line_ids, [
+        lines_grouped = [
             {
                 'quantity': 1.0,
                 'price_unit': 600.0,
@@ -825,16 +825,31 @@ comment-->1000.0</TaxExclusiveAmount></xpath>"""
                 'price_total': 1573.00,
                 'tax_ids': tax_21.ids,
             },
-        ])
-        self.assertRecordValues(bill, [{
+        ]
+        total_values = [{
             'amount_untaxed': 1900.0,
             'amount_tax': 369,
             'amount_total': 2269.00,
-        }])
+        }]
+
+        # Import bill
+        file_path = "bis3_bill_group_by_tax.xml"
+        bill = create_bill(file_path)
+
+        # Group lines by tax and post
+        bill.action_group_ungroup_lines_by_tax()
+        self.assertRecordValues(bill.invoice_line_ids, lines_grouped)
+        self.assertRecordValues(bill, total_values)
+        bill.action_post()
+
+        # Import the bill a second time, should be grouped as last posted bill from this supplier is grouped
+        bill_2 = create_bill(file_path)
+        self.assertRecordValues(bill_2.invoice_line_ids, lines_grouped)
+        self.assertRecordValues(bill_2, total_values)
 
         # Should ungroup lines from xml
-        bill.action_group_ungroup_lines_by_tax()
-        self.assertRecordValues(bill.invoice_line_ids, [
+        bill_2.action_group_ungroup_lines_by_tax()
+        self.assertRecordValues(bill_2.invoice_line_ids, [
             {
                 'quantity': 1.0,
                 'price_unit': 600.0,
@@ -857,11 +872,7 @@ comment-->1000.0</TaxExclusiveAmount></xpath>"""
                 'tax_ids': tax_21.ids,
             },
         ])
-        self.assertRecordValues(bill, [{
-            'amount_untaxed': 1900.0,
-            'amount_tax': 369,
-            'amount_total': 2269.00,
-        }])
+        self.assertRecordValues(bill_2, total_values)
 
     def test_ubl_split_fixed_taxes_into_allowance_charges_or_extra_invoice_lines(self):
         """Test that fixed taxes are split correctly:


### PR DESCRIPTION
[FIX] account_edi_ubl_cii: automate bill line grouping
    
This commit automates vendor bill line grouping during import based on the vendor's most recent posted bill.
- Logic: Added `_has_lines_grouped()` to `account.move` to detect if lines follow the grouping pattern.
- Heuristic: During UBL/CII import, the system now checks the last posted bill from the same vendor; if it was grouped, the new bill is automatically grouped by tax.
    
task-5979667
