### PR TITLE
[IMP] web: Make count obvious in list group header

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -1995,6 +1995,13 @@ export class ListRenderer extends Component {
     /**
      * @param {Group} group
      */
+    formattedGroupCount(group) {
+        return _t("Count: %s", group.count);
+    }
+
+    /**
+     * @param {Group} group
+     */
     showGroupConfigMenu(group) {
         return group.value && ["many2one", "many2many"].includes(group.groupByField.type);
     }

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -246,7 +246,7 @@
                     </div>
                     <div class="d-flex align-items-center ms-auto gap-2">
                         <t t-if="!showGroupPager(group)" class="m-1">
-                            <span><t t-out="group.count"/></span>
+                            <span class="text-muted"><t t-out="formattedGroupCount(group)"/></span>
                         </t>
                         <div t-att-class="showGroupPager(group) ? '' : 'o_pager_hidden'" t-on-click.stop="">
                             <Pager t-props="getGroupPagerProps(group)"/>

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -2514,7 +2514,10 @@ test(`group a list view with the aggregable field 'value'`, async () => {
         groupBy: ["bar"],
     });
     expect(`.o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual(["No 1 1", "Yes 3 3"]);
+    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([
+        "No Count: 1 1",
+        "Yes Count: 3 3",
+    ]);
 });
 
 test(`basic grouped list rendering with groupby m2m field`, async () => {
@@ -2532,10 +2535,10 @@ test(`basic grouped list rendering with groupby m2m field`, async () => {
     expect(`.o_group_header`).toHaveCount(4, { message: "should contain 4 open groups" });
     expect(`.o_group_open`).toHaveCount(0, { message: "no group is open" });
     expect(queryAllTexts(`.o_group_header .o_group_name`, { inline: true })).toEqual([
-        "Value 1 3",
-        "Value 2 2",
-        "Value 3 1",
-        "None 1",
+        "Value 1 Count: 3",
+        "Value 2 Count: 2",
+        "Value 3 Count: 1",
+        "None Count: 1",
     ]);
 
     // Open all groups
@@ -2545,16 +2548,16 @@ test(`basic grouped list rendering with groupby m2m field`, async () => {
     await contains(`.o_group_name:eq(3)`).click();
     expect(`.o_group_open`).toHaveCount(4, { message: "all groups are open" });
     expect(queryAllTexts(`.o_list_view tbody > tr`, { inline: true })).toEqual([
-        "Value 1 3",
+        "Value 1 Count: 3",
         "yop Value 1 Value 2",
         "blip Value 1 Value 2 Value 3",
         "blip Value 1",
-        "Value 2 2",
+        "Value 2 Count: 2",
         "yop Value 1 Value 2",
         "blip Value 1 Value 2 Value 3",
-        "Value 3 1",
+        "Value 3 Count: 1",
         "blip Value 1 Value 2 Value 3",
-        "None 1",
+        "None Count: 1",
         "gnap",
     ]);
 });
@@ -2575,27 +2578,30 @@ test(`grouped list rendering with groupby m2o and m2m field`, async () => {
     expect(`.o_list_footer td > button`).toHaveCount(0, {
         message: "no quick create since no default groupby",
     });
-    expect(queryAllTexts(`tbody > tr`, { inline: true })).toEqual(["Value 1 3", "Value 2 1"]);
+    expect(queryAllTexts(`tbody > tr`, { inline: true })).toEqual([
+        "Value 1 Count: 3",
+        "Value 2 Count: 1",
+    ]);
 
     await contains(`th.o_group_name`).click();
     expect(queryAllTexts(`tbody > tr`, { inline: true })).toEqual([
-        "Value 1 3",
-        "Value 1 2",
-        "Value 2 1",
-        "None 1",
-        "Value 2 1",
+        "Value 1 Count: 3",
+        "Value 1 Count: 2",
+        "Value 2 Count: 1",
+        "None Count: 1",
+        "Value 2 Count: 1",
     ]);
 
     await contains(`tbody th.o_group_name:eq(4)`).click();
     expect(queryAllTexts(`.o_list_view tbody > tr`, { inline: true })).toEqual([
-        "Value 1 3",
-        "Value 1 2",
-        "Value 2 1",
-        "None 1",
-        "Value 2 1",
-        "Value 1 1",
-        "Value 2 1",
-        "Value 3 1",
+        "Value 1 Count: 3",
+        "Value 1 Count: 2",
+        "Value 2 Count: 1",
+        "None Count: 1",
+        "Value 2 Count: 1",
+        "Value 1 Count: 1",
+        "Value 2 Count: 1",
+        "Value 3 Count: 1",
     ]);
 });
 
@@ -2610,7 +2616,10 @@ test(`grouped list rendering with default_group_by m2o field: add group`, async 
         arch: `<list default_group_by="m2o"><field name="foo"/></list>`,
     });
     expect(`.o_group_header:eq(0) th`).toHaveCount(2);
-    expect(queryAllTexts(".o_group_name", { inline: true })).toEqual(["Value 1 3", "Value 2 1"]);
+    expect(queryAllTexts(".o_group_name", { inline: true })).toEqual([
+        "Value 1 Count: 3",
+        "Value 2 Count: 1",
+    ]);
     expect(`.o_list_footer td > button`).toHaveText("Add a M2o");
     await contains(`.o_list_footer td > button`).click();
     expect(`.o_list_footer td > button`).toHaveCount(0);
@@ -2619,9 +2628,9 @@ test(`grouped list rendering with default_group_by m2o field: add group`, async 
     await contains(`.o_list_footer .o_list_group_confirm`).click();
     expect.verifySteps(["name_create"]);
     expect(queryAllTexts(".o_group_name", { inline: true })).toEqual([
-        "Value 1 3",
-        "Value 2 1",
-        "New group 0",
+        "Value 1 Count: 3",
+        "Value 2 Count: 1",
+        "New group Count: 0",
     ]);
 });
 
@@ -2659,7 +2668,10 @@ test(`grouped list rendering with groupby m2o field: edit group`, async () => {
     await mountWithCleanup(WebClient);
     await getService("action").doAction(1);
 
-    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual(["Value 1 3", "Value 2 1"]);
+    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual([
+        "Value 1 Count: 3",
+        "Value 2 Count: 1",
+    ]);
     expect(`.o_group_header:first th:last .o_group_config`).toHaveCount(1);
     await contains(`.o_group_header:first .o_group_config button`, { visible: false }).click();
     expect(`.o-dropdown--group-config-menu`).toHaveCount(1);
@@ -2672,7 +2684,10 @@ test(`grouped list rendering with groupby m2o field: edit group`, async () => {
     await contains(`.o_dialog .o_form_button_save`).click();
     expect(`.o_dialog`).toHaveCount(0);
     expect.verifySteps(["web_save"]);
-    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual(["Value edit 3", "Value 2 1"]);
+    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual([
+        "Value edit Count: 3",
+        "Value 2 Count: 1",
+    ]);
     await contains(`.o_group_header:first .o_group_config button`, { visible: false }).click();
     if (getMockEnv().isSmall) {
         await contains(".o_bottom_sheet_backdrop").click();
@@ -2696,7 +2711,10 @@ test(`grouped list rendering with groupby m2o field: delete group`, async () => 
         groupBy: ["m2o"],
     });
 
-    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual(["Value 1 3", "Value 2 1"]);
+    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual([
+        "Value 1 Count: 3",
+        "Value 2 Count: 1",
+    ]);
     expect(`.o_group_header:first .o_group_config`).toHaveCount(1);
     await contains(`.o_group_header:first .o_group_config button`, { visible: false }).click();
     expect(`.o-dropdown--group-config-menu`).toHaveCount(1);
@@ -2705,7 +2723,10 @@ test(`grouped list rendering with groupby m2o field: delete group`, async () => 
     expect(`.o_dialog .modal-body`).toHaveText("Are you sure you want to delete this column?");
     await contains(`.o_dialog footer button:contains(Delete)`).click();
     expect.verifySteps(["unlink"]);
-    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual(["Value 2 1", "None 3"]);
+    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual([
+        "Value 2 Count: 1",
+        "None Count: 3",
+    ]);
 });
 
 test(`grouped list rendering with groupby non m2o field`, async () => {
@@ -2766,7 +2787,10 @@ test(`list view with multiple groupbys`, async () => {
     });
     expect(`.o_view_nocontent`).toHaveCount(0);
     expect(`.o_group_has_content`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_has_content`, { inline: true })).toEqual(["No 1", "Yes 3"]);
+    expect(queryAllTexts(`.o_group_has_content`, { inline: true })).toEqual([
+        "No Count: 1",
+        "Yes Count: 3",
+    ]);
 });
 
 test(`enabling archive in list when groupby m2m field`, async () => {
@@ -3116,10 +3140,10 @@ test(`add record in list grouped by m2m`, async () => {
 
     expect(`.o_group_header`).toHaveCount(4);
     expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([
-        "Value 1 3",
-        "Value 2 2",
-        "Value 3 1",
-        "None 1",
+        "Value 1 Count: 3",
+        "Value 2 Count: 2",
+        "Value 3 Count: 1",
+        "None Count: 1",
     ]);
 
     await contains(`.o_group_header`).click();
@@ -4926,8 +4950,8 @@ test(`monetary aggregates in grouped list`, async () => {
     await contains(`.o_group_header:last`).click();
     // Don't handle currencies in aggregates for non monetary fields even with the widget:
     // it is bad practice and the server won't send the information anyway
-    expect(`.o_group_header:first`).toHaveText("USD 3 $ 800.00 19.00", { inline: true });
-    expect(`.o_group_header:last`).toHaveText("EUR 1 1,200.00 € 0.40", { inline: true });
+    expect(`.o_group_header:first`).toHaveText("USD Count: 3 $ 800.00 19.00", { inline: true });
+    expect(`.o_group_header:last`).toHaveText("EUR Count: 1 1,200.00 € 0.40", { inline: true });
     expect(`.o_list_footer .o_list_number span:first`).toHaveText("$ 1,400.00?");
     await toggleMultiCurrencyPopover(".o_list_footer .o_list_number span:first sup");
     expect(".o_multi_currency_popover").toHaveCount(1);
@@ -4950,8 +4974,8 @@ test(`monetary aggregates in grouped list (!= currencies in same group)`, async 
     expect(`.o_group_header`).toHaveCount(2);
     await contains(`.o_group_header:first`).click();
     await contains(`.o_group_header:last`).click();
-    expect(`.o_group_header:first`).toHaveText("No 1 $ 0.00", { inline: true });
-    expect(`.o_group_header:last`).toHaveText("Yes 3 $ 2,000.00?", { inline: true });
+    expect(`.o_group_header:first`).toHaveText("No Count: 1 $ 0.00", { inline: true });
+    expect(`.o_group_header:last`).toHaveText("Yes Count: 3 $ 2,000.00?", { inline: true });
     expect(`.o_list_footer .o_list_number span`).toHaveText("$ 2,000.00?");
 });
 
@@ -4970,7 +4994,7 @@ test(`monetary aggregates in grouped list (!= currencies in same group, delete)`
         actionMenus: {},
     });
     expect(`.o_group_header`).toHaveCount(2);
-    expect(`.o_group_header:last`).toHaveText("Yes 3 $ 2,000.00?", { inline: true });
+    expect(`.o_group_header:last`).toHaveText("Yes Count: 3 $ 2,000.00?", { inline: true });
     await contains(`.o_group_header:last`).click();
     expect(`.o_data_row`).toHaveCount(3);
     await selectAllRecords();
@@ -4979,7 +5003,7 @@ test(`monetary aggregates in grouped list (!= currencies in same group, delete)`
     await toggleMenuItem("Delete");
     await contains(`.o_dialog footer .btn-danger`).click(); // confirm
     expect(`.o_data_row`).toHaveCount(0);
-    expect(`.o_group_header:last`).toHaveText("Yes 0 0.00", { inline: true });
+    expect(`.o_group_header:last`).toHaveText("Yes Count: 0 0.00", { inline: true });
 });
 
 test(`list with monetary field with attribute column_invisible="1"`, async () => {
@@ -5032,8 +5056,8 @@ test(`handle false values in aggregates`, async () => {
         groupBy: ["bar"],
     });
     expect.verifySteps(["web_read_group"]);
-    expect(`.o_group_header:first`).toHaveText("No 1 9.00 $ 0.00 $ 0.00", { inline: true });
-    expect(`.o_group_header:last`).toHaveText("Yes 3 $ 2,000.00?", {
+    expect(`.o_group_header:first`).toHaveText("No Count: 1 9.00 $ 0.00 $ 0.00", { inline: true });
+    expect(`.o_group_header:last`).toHaveText("Yes Count: 3 $ 2,000.00?", {
         inline: true,
         message: "false values are just hidden except for monetary field with multiple currencies",
     });
@@ -5078,7 +5102,10 @@ test(`date field aggregates in grouped lists`, async () => {
         `,
     });
     expect(`.o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([`Value 1 3`, `Value 2 1`]);
+    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([
+        `Value 1 Count: 3`,
+        `Value 2 Count: 1`,
+    ]);
 });
 
 test(`hide aggregated value in grouped lists when no data provided by RPC call`, async () => {
@@ -5408,8 +5435,8 @@ test(`groups can be sorted on the first field of the groupBy`, async () => {
         arch: `<list default_order="bar desc"><field name="foo"/><field name="bar"/></list>`,
         groupBy: ["bar"],
     });
-    expect(`.o_group_header:eq(0)`).toHaveText("Yes 3", { inline: true });
-    expect(`.o_group_header:eq(-1)`).toHaveText("No 1", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("Yes Count: 3", { inline: true });
+    expect(`.o_group_header:eq(-1)`).toHaveText("No Count: 1", { inline: true });
     expect.verifySteps(["web_read_group"]);
 });
 
@@ -6285,9 +6312,9 @@ test(`grouped, update the count of the group (and ancestors) when a record is de
         groupBy: ["foo", "bar"],
         actionMenus: {},
     });
-    expect(`.o_group_header:eq(0)`).toHaveText("blip 6", { inline: true });
-    expect(`.o_group_header:eq(1)`).toHaveText("No 2", { inline: true });
-    expect(`.o_group_header:eq(2)`).toHaveText("Yes 4", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("blip Count: 6", { inline: true });
+    expect(`.o_group_header:eq(1)`).toHaveText("No Count: 2", { inline: true });
+    expect(`.o_group_header:eq(2)`).toHaveText("Yes Count: 4", { inline: true });
 
     await contains(`.o_group_header:eq(2)`).click();
     expect(`.o_data_row`).toHaveCount(4);
@@ -6296,8 +6323,8 @@ test(`grouped, update the count of the group (and ancestors) when a record is de
     await toggleActionMenu();
     await toggleMenuItem("Delete");
     await contains(`.modal .btn-danger`).click();
-    expect(`.o_group_header:eq(0)`).toHaveText("blip 5", { inline: true });
-    expect(`.o_group_header:eq(2)`).toHaveText("Yes 3", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("blip Count: 5", { inline: true });
+    expect(`.o_group_header:eq(2)`).toHaveText("Yes Count: 3", { inline: true });
 });
 
 test(`grouped list, reload aggregates when a record is deleted`, async () => {
@@ -7803,12 +7830,12 @@ test(`list grouped by m2o with sample data with more than 5 real groups`, async 
     expect(`.o_list_table`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(6);
     expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([
-        "Value 1 3",
-        "Value 2 3",
-        "Value 3 3",
-        "Value 4 3",
-        "Value 5 2",
-        "Value 6 2",
+        "Value 1 Count: 3",
+        "Value 2 Count: 3",
+        "Value 3 Count: 3",
+        "Value 4 Count: 3",
+        "Value 5 Count: 2",
+        "Value 6 Count: 2",
     ]);
 });
 
@@ -8879,7 +8906,10 @@ test(`list view with nested groups`, async () => {
 
     // basic rendering tests
     expect(`.o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual(["Value 1 4", "Value 2 2"]);
+    expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual([
+        "Value 1 Count: 4",
+        "Value 2 Count: 2",
+    ]);
     expect(`.o_group_name .fa-caret-right`).toHaveCount(2);
     expect(`.o_group_header:eq(0) span:first`).toHaveStyle({ "--o-list-group-level": "0" });
     expect(queryAllTexts(`.o_group_header .o_list_number`)).toEqual(["16", "14"]);
@@ -8888,11 +8918,11 @@ test(`list view with nested groups`, async () => {
     await contains(`.o_group_header:eq(0)`).click();
     expect.verifySteps(["web_read_group"]);
     expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual([
-        "Value 1 4",
-        "blip 2",
-        "gnap 1",
-        "yop 1",
-        "Value 2 2",
+        "Value 1 Count: 4",
+        "blip Count: 2",
+        "gnap Count: 1",
+        "yop Count: 1",
+        "Value 2 Count: 2",
     ]);
     expect(`.o_group_name:eq(0) .fa-caret-down`).toHaveCount(1);
     expect(`.o_group_header:eq(1) span:first`).toHaveStyle({ "--o-list-group-level": "1" });
@@ -8968,11 +8998,11 @@ test(`grouped list on selection field at level 2`, async () => {
         message: "should contain 2 groups at first level and 3 groups at second level",
     });
     expect(queryAllTexts(`.o_group_header .o_group_name`, { inline: true })).toEqual([
-        "Value 1 5",
-        "Low 3",
-        "Medium 1",
-        "High 1",
-        "Value 2 1",
+        "Value 1 Count: 5",
+        "Low Count: 3",
+        "Medium Count: 1",
+        "High Count: 1",
+        "Value 2 Count: 1",
     ]);
 });
 
@@ -10858,8 +10888,8 @@ test(`editable grouped list with handle widget`, async () => {
     expect(`.o_group_header`).toHaveCount(2);
     await contains(`.o_group_header:first`).click();
     await contains(`.o_group_header:last`).click();
-    expect(`.o_group_header:first`).toHaveText("No 1 0", { inline: true });
-    expect(`.o_group_header:last`).toHaveText("Yes 3 2,000", { inline: true });
+    expect(`.o_group_header:first`).toHaveText("No Count: 1 0", { inline: true });
+    expect(`.o_group_header:last`).toHaveText("Yes Count: 3 2,000", { inline: true });
     expect(`tbody .o_data_row:eq(0) td:eq(-2)`).toHaveText("0", {
         message: "default fourth record should have amount 0",
     });
@@ -10882,8 +10912,8 @@ test(`editable grouped list with handle widget`, async () => {
         ["web_resequence", [3], "int_field", 2],
     ]);
     // Aggregates are not updated, todo later?
-    expect(`.o_group_header:first`).toHaveText("No 2 0", { inline: true });
-    expect(`.o_group_header:last`).toHaveText("Yes 2 2,000", { inline: true });
+    expect(`.o_group_header:first`).toHaveText("No Count: 2 0", { inline: true });
+    expect(`.o_group_header:last`).toHaveText("Yes Count: 2 2,000", { inline: true });
     expect(`tbody .o_data_row:eq(0) td:eq(-2)`).toHaveText("300", {
         message: "new first record should have amount 300",
     });
@@ -10918,8 +10948,8 @@ test(`editable grouped list with handle widget (group by date)`, async () => {
     expect(`.o_group_header`).toHaveCount(2);
     await contains(`.o_group_header:first`).click();
     await contains(`.o_group_header:last`).click();
-    expect(`.o_group_header:first`).toHaveText("January 2017 1 1,200", { inline: true });
-    expect(`.o_group_header:last`).toHaveText("None 3 800", { inline: true });
+    expect(`.o_group_header:first`).toHaveText("January 2017 Count: 1 1,200", { inline: true });
+    expect(`.o_group_header:last`).toHaveText("None Count: 3 800", { inline: true });
     expect(`.o_field_handle:first span`).not.toBeEnabled();
 });
 
@@ -10938,8 +10968,8 @@ test(`editable grouped list with handle widget (multiple group by)`, async () =>
     expect(`.o_group_header`).toHaveCount(2);
     await contains(`.o_group_header:first`).click();
     await contains(`.o_group_header:eq(1)`).click(); // sub group
-    expect(`.o_group_header:first`).toHaveText("No 1 0", { inline: true });
-    expect(`.o_group_header:eq(1)`).toHaveText("blip 1 0", { inline: true });
+    expect(`.o_group_header:first`).toHaveText("No Count: 1 0", { inline: true });
+    expect(`.o_group_header:eq(1)`).toHaveText("blip Count: 1 0", { inline: true });
     expect(`.o_field_handle:first span`).not.toBeEnabled();
 });
 
@@ -12920,7 +12950,7 @@ test(`list grouped by date:month`, async () => {
         groupBy: ["date:month"],
     });
     expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual(
-        ["January 2017 1", "None 3"],
+        ["January 2017 Count: 1", "None Count: 3"],
         {
             message: "the group names should be correct",
         }
@@ -13134,10 +13164,10 @@ test(`grouped list view move to previous page of group when all records from las
         actionMenus: {},
         groupBy: ["m2o"],
     });
-    expect(`th:contains(Value 1 3)`).toHaveCount(1, {
+    expect(`th:contains(Value 1 Count: 3)`).toHaveCount(1, {
         message: "Value 1 should contain 3 records",
     });
-    expect(`th:contains(Value 2 1)`).toHaveCount(1, {
+    expect(`th:contains(Value 2 Count: 1)`).toHaveCount(1, {
         message: "Value 2 should contain 1 record",
     });
 
@@ -13175,10 +13205,10 @@ test(`grouped list view move to previous page of group when all records from las
         actionMenus: {},
         groupBy: ["m2o"],
     });
-    expect(`th:contains(Value 1 5)`).toHaveCount(1, {
+    expect(`th:contains(Value 1 Count: 5)`).toHaveCount(1, {
         message: "Value 1 should contain 3 records",
     });
-    expect(`th:contains(Value 2 1)`).toHaveCount(1, {
+    expect(`th:contains(Value 2 Count: 1)`).toHaveCount(1, {
         message: "Value 2 should contain 1 record",
     });
     await contains(`.o_group_header:eq(0)`).click();
@@ -13219,8 +13249,8 @@ test(`grouped list view move to next page when all records from the current page
         actionMenus: {},
         groupBy: ["m2o"],
     });
-    expect(`tr.o_group_header:eq(0) th:eq(0)`).toHaveText("Value 1 6", { inline: true });
-    expect(`tr.o_group_header:eq(1) th:eq(0)`).toHaveText("Value 2 1", { inline: true });
+    expect(`tr.o_group_header:eq(0) th:eq(0)`).toHaveText("Value 1 Count: 6", { inline: true });
+    expect(`tr.o_group_header:eq(1) th:eq(0)`).toHaveText("Value 2 Count: 1", { inline: true });
 
     const firstGroup = queryFirst(`tr.o_group_header:eq(0)`);
     await contains(firstGroup).click();
@@ -13523,21 +13553,21 @@ test(`multi level grouped list with groups_limit attribute`, async () => {
     });
     expect(`.o_pager_limit:eq(0)`).toHaveText("4");
     expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([
-        "blip 2",
-        "foo 5",
-        "gnap 1",
+        "blip Count: 2",
+        "foo Count: 5",
+        "gnap Count: 1",
     ]);
 
     // open foo group
     await contains(`.o_group_header:eq(1)`).click();
     expect(`.o_group_header`).toHaveCount(6);
     expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([
-        "blip 2",
+        "blip Count: 2",
         "foo 1-3 / 5",
-        "50 1",
-        "51 1",
-        "52 1",
-        "gnap 1",
+        "50 Count: 1",
+        "51 Count: 1",
+        "52 Count: 1",
+        "gnap Count: 1",
     ]);
 });
 
@@ -13629,29 +13659,29 @@ test(`grouped lists with expand attribute and a lot of groups`, async () => {
     expect(`.o_data_row`).toHaveCount(10); // two groups contains two records
     expect(`.o_pager:eq(0)`).toBeVisible(); // has a pager
     expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual([
-        "-4 1",
-        "0 1",
-        "1 1",
-        "2 1",
-        "3 1",
-        "4 1",
-        "5 1",
-        "6 1",
-        "7 1",
-        "8 1",
+        "-4 Count: 1",
+        "0 Count: 1",
+        "1 Count: 1",
+        "2 Count: 1",
+        "3 Count: 1",
+        "4 Count: 1",
+        "5 Count: 1",
+        "6 Count: 1",
+        "7 Count: 1",
+        "8 Count: 1",
     ]);
 
     await pagerNext(); // switch to page 2
     expect(`.o_group_header`).toHaveCount(7); // page 2
     expect(`.o_data_row`).toHaveCount(9); // two groups contains two records
     expect(queryAllTexts(`.o_group_name`, { inline: true })).toEqual([
-        "9 2",
-        "10 2",
-        "11 1",
-        "12 1",
-        "13 1",
-        "14 1",
-        "17 1",
+        "9 Count: 2",
+        "10 Count: 2",
+        "11 Count: 1",
+        "12 Count: 1",
+        "13 Count: 1",
+        "14 Count: 1",
+        "17 Count: 1",
     ]);
     expect.verifySteps([
         "web_read_group", // web_read_group page 1
@@ -14619,7 +14649,7 @@ test(`keyboard navigation from last cell in editable grouped list`, async () => 
     expect(`.o_selected_row`).toHaveCount(0);
 
     // Click on last data row of first group
-    expect(`.o_group_header:eq(0)`).toHaveText("No 1 -4", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("No Count: 1 -4", { inline: true });
     await contains(`.o_data_row:eq(0) [name=foo]`).click();
     expect(`.o_data_row:eq(0) [name=foo] input`).toBeFocused();
 
@@ -14627,13 +14657,13 @@ test(`keyboard navigation from last cell in editable grouped list`, async () => 
     await press("Enter");
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(6);
-    expect(`.o_group_header:eq(0)`).toHaveText("No 2 -4", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("No Count: 2 -4", { inline: true });
 
     // Enter should discard the edited row as it is pristine + get to next data row
     await press("Enter");
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(5);
-    expect(`.o_group_header:eq(0)`).toHaveText("No 1 -4", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("No Count: 1 -4", { inline: true });
     expect(`.o_data_row:eq(1) [name=foo] input`).toBeFocused();
 
     // Shift+Tab should focus back the last field of first row
@@ -14645,12 +14675,12 @@ test(`keyboard navigation from last cell in editable grouped list`, async () => 
     await press("Enter");
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(6);
-    expect(`.o_group_header:eq(0)`).toHaveText("No 2 -4", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("No Count: 2 -4", { inline: true });
 
     // Edit the row and press enter: should add a new row
     await contains(`.o_data_row:eq(1) [name=foo] input`).edit("zzapp", { confirm: "enter" });
     expect(`.o_data_row`).toHaveCount(7);
-    expect(`.o_group_header:eq(0)`).toHaveText("No 3 -4", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("No Count: 3 -4", { inline: true });
     expect(`.o_data_row:eq(2) [name=foo] input`).toBeFocused();
 });
 
@@ -14721,7 +14751,7 @@ test(`keyboard navigation from last cell in multi-edit list`, async () => {
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(5);
     expect(`.o_selected_row`).toHaveCount(0);
-    expect(`.o_group_header:eq(0)`).toHaveText("No 1 -4", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("No Count: 1 -4", { inline: true });
 
     // Click on last data row of first group
     await contains(`.o_data_row:eq(0) [name=foo]`).click();
@@ -14731,13 +14761,13 @@ test(`keyboard navigation from last cell in multi-edit list`, async () => {
     await press("Enter");
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(6);
-    expect(`.o_group_header:eq(0)`).toHaveText("No 2 -4", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("No Count: 2 -4", { inline: true });
 
     // Enter should discard the edited row as it is pristine + get to next data row
     await press("Enter");
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(5);
-    expect(`.o_group_header:eq(0)`).toHaveText("No 1 -4", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("No Count: 1 -4", { inline: true });
     expect(`.o_data_row:eq(1) [name=foo] input`).toBeFocused();
 
     // Shift+Tab should focus back the last field of first row
@@ -14749,13 +14779,13 @@ test(`keyboard navigation from last cell in multi-edit list`, async () => {
     await press("Enter");
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(6);
-    expect(`.o_group_header:eq(0)`).toHaveText("No 2 -4", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("No Count: 2 -4", { inline: true });
 
     // Edit the row and press enter: should add a new row
     expect(`.o_data_row:eq(1) [name=foo] input`).toBeFocused();
     await contains(`.o_data_row:eq(1) [name=foo] input`).edit("zzapp", { confirm: "enter" });
     expect(`.o_data_row`).toHaveCount(7);
-    expect(`.o_group_header:eq(0)`).toHaveText("No 3 -4", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("No Count: 3 -4", { inline: true });
     expect(`.o_data_row:eq(2) [name=foo] input`).toBeFocused();
 });
 
@@ -14866,22 +14896,22 @@ test(`editable grouped list: adding a second record pass the first in readonly`,
     await contains(`.o_group_header:eq(0)`).click();
     await contains(`.o_group_header:eq(1)`).click();
     expect(`.o_data_row`).toHaveCount(4);
-    expect(`.o_group_header:eq(0)`).toHaveText("No 1", { inline: true });
-    expect(`.o_group_header:eq(1)`).toHaveText("Yes 3", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("No Count: 1", { inline: true });
+    expect(`.o_group_header:eq(1)`).toHaveText("Yes Count: 3", { inline: true });
 
     // add a row in first group
     await contains(`.o_group_field_row_add:eq(0) a`).click();
     expect(`.o_selected_row`).toHaveCount(1);
     expect(`.o_data_row`).toHaveCount(5);
-    expect(`.o_group_header:eq(0)`).toHaveText("No 2", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("No Count: 2", { inline: true });
     expect(`.o_data_row:eq(1) [name=foo] input`).toBeFocused();
 
     // add a row in second group
     await contains(`.o_group_field_row_add:eq(1) a`).click();
     expect(`.o_selected_row`).toHaveCount(1);
     expect(`.o_data_row`).toHaveCount(5);
-    expect(`.o_group_header:eq(1)`).toHaveText("Yes 4", { inline: true });
-    expect(`.o_group_header:eq(0)`).toHaveText("No 1", { inline: true });
+    expect(`.o_group_header:eq(1)`).toHaveText("Yes Count: 4", { inline: true });
+    expect(`.o_group_header:eq(0)`).toHaveText("No Count: 1", { inline: true });
     expect(`.o_data_row:eq(4) [name=foo] input`).toBeFocused();
 });
 
@@ -15213,7 +15243,7 @@ test(`add a new row in grouped editable="top" list`, async () => {
     expect(`.o_data_row`).toHaveCount(4);
 
     await contains(`.o_group_field_row_add a:eq(1)`).click(); // create row in second group "Yes"
-    expect(`.o_group_name:eq(1)`).toHaveText("Yes 4", {
+    expect(`.o_group_name:eq(1)`).toHaveText("Yes Count: 4", {
         inline: true,
         message: "group should have correct name and count",
     });
@@ -16639,7 +16669,7 @@ test(`go to the next page after leaving and coming back to a grouped list view`,
     });
     expect(`.o_list_view`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(1);
-    expect(`.o_group_header`).toHaveText("No 1", { inline: true });
+    expect(`.o_group_header`).toHaveText("No Count: 1", { inline: true });
 
     // unfold the second group
     await contains(`.o_group_header`).click();
@@ -16652,11 +16682,11 @@ test(`go to the next page after leaving and coming back to a grouped list view`,
 
     await contains(`.breadcrumb-item a, .o_back_button`).click();
     expect(`.o_group_header`).toHaveCount(1);
-    expect(`.o_group_header`).toHaveText("No 1", { inline: true });
+    expect(`.o_group_header`).toHaveText("No Count: 1", { inline: true });
 
     await pagerNext();
     expect(`.o_group_header`).toHaveCount(1);
-    expect(`.o_group_header`).toHaveText("Yes 3", { inline: true });
+    expect(`.o_group_header`).toHaveText("Yes Count: 3", { inline: true });
 });
 
 test(`keep order after grouping`, async () => {
@@ -16679,7 +16709,11 @@ test(`keep order after grouping`, async () => {
 
     await toggleSearchBarMenu();
     await toggleMenuItem("Foo");
-    expect(queryAllTexts(".o_group_name", { inline: true })).toEqual(["yop 1", "gnap 1", "blip 2"]);
+    expect(queryAllTexts(".o_group_name", { inline: true })).toEqual([
+        "yop Count: 1",
+        "gnap Count: 1",
+        "blip Count: 2",
+    ]);
 
     await toggleMenuItem("Foo");
     expect(queryAllTexts`.o_data_row td[name=foo]`).toEqual(["yop", "gnap", "blip", "blip"]);
@@ -17058,7 +17092,10 @@ test(`have some records, then go to next page in pager then group by some field:
     await toggleSearchBarMenu();
     await toggleMenuItem("Bar");
     expect(`tbody .o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`tbody .o_group_header`, { inline: true })).toEqual(["No 1", "Yes 3"]);
+    expect(queryAllTexts(`tbody .o_group_header`, { inline: true })).toEqual([
+        "No Count: 1",
+        "Yes Count: 3",
+    ]);
 
     await removeFacet("Bar");
     expect(`tbody .o_data_row`).toHaveCount(2);
@@ -17071,7 +17108,10 @@ test(`have some records, then go to next page in pager then group by some field:
     await toggleSearchBarMenu();
     await toggleMenuItem("Bar");
     expect(`tbody .o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`tbody .o_group_header`, { inline: true })).toEqual(["No 1", "Yes 3"]);
+    expect(queryAllTexts(`tbody .o_group_header`, { inline: true })).toEqual([
+        "No Count: 1",
+        "Yes Count: 3",
+    ]);
 });
 
 test(`optional field selection do not unselect current row`, async () => {
@@ -18964,7 +19004,7 @@ test(`display 'None' for false group, when grouped by char field`, async () => {
         groupBy: ["foo"],
     });
 
-    expect(`tbody tr:nth-child(3)`).toHaveText("None 1", { inline: true });
+    expect(`tbody tr:nth-child(3)`).toHaveText("None Count: 1", { inline: true });
 });
 
 test(`display '0' for false group, when grouped by int field`, async () => {
@@ -18977,7 +19017,7 @@ test(`display '0' for false group, when grouped by int field`, async () => {
         groupBy: ["int_field"],
     });
 
-    expect(`tbody tr:nth-child(2)`).toHaveText("0 1", { inline: true });
+    expect(`tbody tr:nth-child(2)`).toHaveText("0 Count: 1", { inline: true });
 });
 
 test(`display the field's falsy_value_label for false group, if defined`, async () => {
@@ -18991,7 +19031,7 @@ test(`display the field's falsy_value_label for false group, if defined`, async 
         groupBy: ["foo"],
     });
 
-    expect(`tbody tr:nth-child(3)`).toHaveText("I'm the false group 1", { inline: true });
+    expect(`tbody tr:nth-child(3)`).toHaveText("I'm the false group Count: 1", { inline: true });
 });
 
 test(`hide pager in the list view with sample data`, async () => {
@@ -19466,7 +19506,10 @@ test(`cache web_read_group (no change)`, async () => {
     await getService("action").doAction(1);
     expect(`.o_list_view`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual(["No 1", "Yes 3"]);
+    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([
+        "No Count: 1",
+        "Yes Count: 3",
+    ]);
 
     // execute another action to remove the list from the DOM
     await getService("action").doAction(2);
@@ -19477,14 +19520,20 @@ test(`cache web_read_group (no change)`, async () => {
     await getService("action").doAction(1);
     expect(`.o_list_view`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual(["No 1", "Yes 3"]);
+    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([
+        "No Count: 1",
+        "Yes Count: 3",
+    ]);
 
     // simulate the return of web_read_group => nothing should have changed
     def.resolve();
     await animationFrame();
     expect(`.o_list_view`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual(["No 1", "Yes 3"]);
+    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([
+        "No Count: 1",
+        "Yes Count: 3",
+    ]);
 });
 
 test(`cache web_read_group (change)`, async () => {
@@ -19526,10 +19575,10 @@ test(`cache web_read_group (change)`, async () => {
     expect(`.o_list_view`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(4);
     expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([
-        "-4 1",
-        "9 1",
-        "10 1",
-        "17 1",
+        "-4 Count: 1",
+        "9 Count: 1",
+        "10 Count: 1",
+        "17 Count: 1",
     ]);
 
     // simulate the create of new records by someone else
@@ -19545,10 +19594,10 @@ test(`cache web_read_group (change)`, async () => {
     expect(`.o_list_view`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(4);
     expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([
-        "-4 1",
-        "9 1",
-        "10 1",
-        "17 1",
+        "-4 Count: 1",
+        "9 Count: 1",
+        "10 Count: 1",
+        "17 Count: 1",
     ]);
 
     // simulate the return of web_read_group => the data should have been updated
@@ -19557,11 +19606,11 @@ test(`cache web_read_group (change)`, async () => {
     expect(`.o_list_view`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(5);
     expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([
-        "-4 2",
-        "9 1",
-        "10 1",
-        "17 1",
-        "44 1",
+        "-4 Count: 2",
+        "9 Count: 1",
+        "10 Count: 1",
+        "17 Count: 1",
+        "44 Count: 1",
     ]);
 });
 
@@ -19675,7 +19724,10 @@ test(`cache web_read_group (with sample data, change)`, async () => {
     await animationFrame();
     expect(`.o_list_view`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual(["-4 1", "44 1"]);
+    expect(queryAllTexts(`.o_group_header`, { inline: true })).toEqual([
+        "-4 Count: 1",
+        "44 Count: 1",
+    ]);
 });
 
 test.tags("desktop");


### PR DESCRIPTION
The group header count was sometimes mistaken for a field. Adding
`Count: ` in front of it to avoid confusion.

task-5976034