### PR TITLE
[REF] web_tour: remove unused api keys

### DIFF
--- a/addons/web_tour/static/src/js/tour_service.js
+++ b/addons/web_tour/static/src/js/tour_service.js
@@ -53,10 +53,8 @@ const stepSchemaDebug = {
 };
 
 const tourSchema = {
-    name: { type: String, optional: true },
     steps: Function,
     url: { type: String, optional: true },
-    wait_for: { type: [Function, Object], optional: true },
     undeterministicTour_doNotCopy: { type: Boolean, optional: true },
 };
 
@@ -187,21 +185,15 @@ export class TourService {
                     : Array.isArray(tour.steps)
                     ? tour.steps
                     : [],
-            waitFor: tour.wait_for || Promise.resolve(),
         };
     }
 
     /**
-     * Wait the tour is ready (only for automatic tour)
+     * Check that the registry contains the tour (only for automatic tour)
      * @param {string} name The name of the tour
      */
-    async isTourReady(name) {
-        if (!tourRegistry.contains(name)) {
-            return false;
-        }
-        const tour = tourRegistry.get(name);
-        await (tour.wait_for || Promise.resolve());
-        return true;
+    isTourReady(name) {
+        return tourRegistry.contains(name);
     }
 
     async resumeTour() {


### PR DESCRIPTION
In this commit, we remove `name` and `wait_for` keys from API.
- The key `name` never been used. It's a mistake that was introduced
when schema has been added in tour_service.
- The key `wait_for` is no longer used and can be replace in all cases
by a async run function at the first step of the tour.