### PR TITLE
[FIX] html_editor : allow file download from incognito

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -668,7 +668,7 @@ export class LinkPopover extends Component {
     async uploadFile() {
         const { upload, getURL } = this.uploadService;
         const { resModel, resId } = this.props.recordInfo;
-        const [attachment] = await upload({ resModel, resId, accessToken: true });
+        const [attachment] = await upload({ resModel, resId }, { accessToken: true });
         if (!attachment) {
             // No file selected or upload failed
             return;


### PR DESCRIPTION
# How to reproduce
- Go to the website in edit mode
- Select some text
- Upload and link an attachment to that text
- Open a new incognito tab
- Try to download the attachment

# The problem
An error 404 is displayed

# Why
The access token of the attachment is not correctly added in the link URL. This is because link_popover.js does not correctly call the upload function from the uploadLocalFile services.

The signature of that function is :
```py
async function upload(
            { resId, resModel },
            { accept = "*/*", multiple = false, accessToken = false } = {}
        ) {
```

opw-5500362

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
