### PR TITLE
[FIX] auth_totp_portal: fix secret copy button

### DIFF
--- a/addons/auth_totp_portal/static/src/components/totp_confirmation_dialog.js
+++ b/addons/auth_totp_portal/static/src/components/totp_confirmation_dialog.js
@@ -1,0 +1,38 @@
+/** @odoo-module **/
+
+import { useEffect } from "@odoo/owl";
+import { InputConfirmationDialog } from "@portal/js/components/input_confirmation_dialog/input_confirmation_dialog";
+import { browser } from "@web/core/browser/browser";
+import { _t } from "@web/core/l10n/translation";
+import { usePopover } from "@web/core/popover/popover_hook";
+import { Tooltip } from "@web/core/tooltip/tooltip";
+
+/**
+ * This is a quick-and-dirty fix to enable the copy of the TOTP secret in the 
+ * portal.
+ */
+export class TotpConfirmationDialog extends InputConfirmationDialog {
+    setup() {
+        super.setup();
+        this.tooltip = usePopover(Tooltip, { position: "bottom" });
+
+        const onClickClipboardButton = async (ev) => {
+            ev.preventDefault();
+            const clipboardButtonEl = ev.currentTarget;
+            const secretSpan = this.modalRef.el.querySelector("span[name='secret']");
+            browser.navigator.clipboard.writeText(secretSpan.textContent).then(() => {
+                this.tooltip.open(clipboardButtonEl, { tooltip: _t("Copied!") });
+                setTimeout(this.tooltip.close, 800);
+            });
+        };
+        useEffect(
+            (clipboardButtonEl) => {
+                if (clipboardButtonEl) {
+                    clipboardButtonEl.addEventListener("click", onClickClipboardButton);
+                    return () => clipboardButtonEl.removeEventListener("click", onClickClipboardButton);
+                }
+            },
+            () => [this.modalRef.el?.querySelector("#collapseTotpSecret .o_clipboard_button")]
+        );
+    }
+}

--- a/addons/auth_totp_portal/static/src/js/totp_frontend.js
+++ b/addons/auth_totp_portal/static/src/js/totp_frontend.js
@@ -2,11 +2,10 @@
 
 import { _t } from "@web/core/l10n/translation";
 import { markup } from "@odoo/owl";
-import { InputConfirmationDialog } from "@portal/js/components/input_confirmation_dialog/input_confirmation_dialog";
+import { TotpConfirmationDialog } from "../components/totp_confirmation_dialog";
 import { handleCheckIdentity } from "@portal/js/portal_security";
 import publicWidget from "@web/legacy/js/public/public_widget";
 import { session } from "@web/session";
-import { browser } from "@web/core/browser/browser";
 
 /**
  * Replaces specific <field> elements by normal HTML, strip out the rest entirely
@@ -48,13 +47,6 @@ function fromField(f, record) {
 
         const copyButton = document.createElement('button');
         copyButton.setAttribute('class', 'btn btn-sm btn-primary o_clipboard_button o_btn_char_copy py-0 px-2');
-        copyButton.onclick = async function(event) {
-            event.preventDefault();
-            $(copyButton).tooltip({title: _t("Copied!"), trigger: "manual", placement: "bottom"});
-            await browser.navigator.clipboard.writeText($(secretSpan)[0].innerText);
-            $(copyButton).tooltip('show');
-            setTimeout(() => $(copyButton).tooltip("hide"), 800);
-        };
 
         copyButton.appendChild(copySpanIcon);
         copyButton.appendChild(copySpanText);
@@ -162,7 +154,7 @@ publicWidget.registry.TOTPButton = publicWidget.Widget.extend({
         const xmlBody = doc.querySelector('sheet *');
         const [body, ,] = fixupViewBody(xmlBody, record);
 
-        this.call("dialog", "add", InputConfirmationDialog, {
+        this.call("dialog", "add", TotpConfirmationDialog, {
             body: markup(body.outerHTML),
             onInput: ({ inputEl }) => {
                 inputEl.setCustomValidity("");


### PR DESCRIPTION
__Problem__
Since odoo/odoo@e3da5f1 the onclick listener set on `copyButton` is lost
because we give the HTML of the body as argument at the dialog creation.

__Steps to reproduce__
1. Go to `/my/security`
2. Click on "Enable two-factor authentication"
3. Confirm password
4. Click on "Cannot scan it?"
5. The "Copy" button doesn't work

__Fix__
- Inherit from `InputConfirmationDialog` to add a listener to the
  button.
- At the same time, remove the remaining jQuery dependency in this part
  of the code

