### PR TITLE
[FIX] mail: allow admin to see all mail.mail

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -97,6 +97,14 @@ class MailMail(models.Model):
         help="If set, the queue manager will send the email after the date. If not set, the email will be send as soon as possible. Unless a timezone is specified, it is considered as being in UTC timezone.")
     fetchmail_server_id = fields.Many2one('fetchmail.server', "Inbound Mail Server", readonly=True, index='btree_not_null')
 
+    def _post_model_setup__(self):  # noqa: PLW3201
+        # Hack to make all inherited field computed in sudo because users may
+        # not have access to all fields.
+        for field in self._fields.values():
+            if field.inherited:
+                field.compute_sudo = True
+        return super()._post_model_setup__()
+
     @api.constrains('mail_message_id', 'mail_server_id')
     def _check_mail_server_id(self):
         for mail in self:

--- a/addons/mail/tests/test_mail_mail.py
+++ b/addons/mail/tests/test_mail_mail.py
@@ -29,3 +29,20 @@ class MailCase(TransactionCase):
         )
         # if we get here SMTPServerDisconnected was not raised
         self.assertEqual(mail.state, "outgoing")
+
+    def test_mail_mail_read_all(self):
+        """E-mail created by root has message which is not visible to admin.
+        Yet, the admin must be able to see it.
+        """
+        mail = self.env["mail.mail"].create({})
+        mail = mail.with_user(self.ref('base.user_admin'))
+        self.assertTrue(mail.has_access('read'))
+        msg = mail.mail_message_id
+        self.assertFalse(msg.has_access('read'))
+        mail.invalidate_model()
+
+        # should be able to read the following items
+        for field_name in ('message_type', 'body'):
+            with self.subTest(field=field_name):
+                msg.invalidate_model()
+                mail[field_name]


### PR DESCRIPTION
The model mail.mail inherits from mail.message. However, the administrator that has access to mail.mail, does not necessarily have access to the message. Since we removed fetching all messages in sudo, we get errors when trying to read messages. To restore the previous behaviour, we add back a sudo on all inherited fields.

task-5954851


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
