### PR TITLE
[IMP] html_editor: add code wrapping toggle in code toolbar

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/code_toolbar.js
+++ b/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/code_toolbar.js
@@ -30,6 +30,7 @@ export class CodeToolbar extends Component {
         onLanguageChange: { type: Function },
         currentLanguage: { type: String },
         convertToParagraph: { type: Function },
+        toggleCodeWrap: { type: Function },
     };
     static components = { Dropdown, DropdownItem, CopyButton };
 

--- a/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/code_toolbar.xml
+++ b/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/code_toolbar.xml
@@ -19,6 +19,10 @@
                     </t>
                 </Dropdown>
                 <CopyButton content="this.props.getContent" copyText.translate="Copy" successText.translate="Code copied to the clipboard." t-on-pointerdown.prevent="() => {}"/>
+                <button class="text-nowrap btn" name="wrap" t-on-click="this.props.toggleCodeWrap" title="Wrap the code">
+                    <span class="mx-1 fa fa-level-down fa-rotate-90"></span>
+                    <span>Wrap</span>
+                </button>
                 <button class="text-nowrap btn"
                     t-on-click="this.props.convertToParagraph"
                 >

--- a/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/syntax_highlighting.js
+++ b/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/syntax_highlighting.js
@@ -20,6 +20,7 @@ export class EmbeddedSyntaxHighlightingComponent extends Component {
     static props = {
         value: { type: String },
         languageId: { type: String },
+        codeWrap: { type: Boolean, optional: true },
         onTextareaFocus: { type: Function },
         convertToParagraph: { type: Function },
         host: { type: Object },
@@ -175,6 +176,18 @@ export class EmbeddedSyntaxHighlightingComponent extends Component {
             this.props.onTextareaFocus();
             this.embeddedState.languageId = languageId;
         }
+    }
+
+    /**
+     * Toggles content wrapping via the code toolbar.
+     */
+    toggleCodeWrap() {
+        if (Object.hasOwn(this.embeddedState, "codeWrap")) {
+            delete this.embeddedState.codeWrap;
+        } else {
+            this.embeddedState.codeWrap = true;
+        }
+        this.props.host.classList.toggle("o-code-wrap", this.embeddedState.codeWrap);
     }
 }
 

--- a/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/syntax_highlighting.xml
+++ b/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/syntax_highlighting.xml
@@ -5,6 +5,7 @@
         <CodeToolbar target="this.state.host" currentLanguage="this.embeddedState.languageId"
             getContent="() => this.textarea.value" onLanguageChange="this.onLanguageChange.bind(this)"
             convertToParagraph="this.props.convertToParagraph"
+            toggleCodeWrap="this.toggleCodeWrap.bind(this)"
         />
         <pre t-custom-ref="pre"/>
         <textarea t-custom-ref="textarea" class="o_prism_source" contenteditable="true" placeholder="Code"

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_blueprint.xml
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_blueprint.xml
@@ -1,6 +1,7 @@
 <templates>
     <t t-name="html_editor.EmbeddedSyntaxHighlightingBlueprint">
         <div t-att-data-embedded-props="embeddedProps" data-embedded="syntaxHighlighting"
+            t-att-class="{ 'o-code-wrap': isCodeWrap }"
             data-oe-protected="true" contenteditable="false" class="o_syntax_highlighting"/>
     </t>
 </templates>

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.js
@@ -61,6 +61,9 @@ export class SyntaxHighlightingPlugin extends Plugin {
             const embeddedProps = getEmbeddedProps(codeBlock);
             const value = embeddedProps.value;
             pre.dataset.languageId = embeddedProps.languageId;
+            if (embeddedProps.codeWrap) {
+                pre.setAttribute("data-code-wrap", "");
+            }
             codeBlock.before(pre);
             codeBlock.remove();
             // Remove highlighting.
@@ -85,13 +88,18 @@ export class SyntaxHighlightingPlugin extends Plugin {
         );
         for (const pre of nonEmbeddedPres) {
             const isPreInSelection = !targetedNodes.some((node) => !pre.contains(node));
-            const embeddedProps = JSON.stringify({
-                value: getPreValue(pre),
-                languageId: pre.dataset.languageId || DEFAULT_LANGUAGE_ID,
-            });
+            const embeddedProps = JSON.stringify(
+                Object.assign(
+                    {
+                        value: getPreValue(pre),
+                        languageId: pre.dataset.languageId || DEFAULT_LANGUAGE_ID,
+                    },
+                    pre.hasAttribute("data-code-wrap") ? { codeWrap: true } : {}
+                )
+            );
             const codeBlock = this.dependencies.embeddedComponents.renderBlueprintToElement(
                 "html_editor.EmbeddedSyntaxHighlightingBlueprint",
-                { embeddedProps },
+                { embeddedProps, isCodeWrap: pre.hasAttribute("data-code-wrap") },
                 () => {
                     if (preserveFocus && isPreInSelection) {
                         const textarea = codeBlock.querySelector("textarea");

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.scss
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.scss
@@ -8,7 +8,7 @@
     pre, textarea.o_prism_source {
         direction: ltr #{"/*rtl:ignore*/"};
         margin: 0;
-        padding: 8px 16px;
+        padding: 16px;
     }
 
     pre {
@@ -63,6 +63,12 @@
     &:focus-within {
         .o_code_toolbar {
             display: flex;
+        }
+    }
+
+    &.o-code-wrap {
+        pre, textarea {
+            white-space: pre-wrap !important;
         }
     }
 }

--- a/addons/html_editor/static/tests/_helpers/syntax_highlighting.js
+++ b/addons/html_editor/static/tests/_helpers/syntax_highlighting.js
@@ -105,6 +105,10 @@ const TOOLBAR = (language) =>
                 <span class="mx-1 fa fa-clipboard"></span>
                 <span>Copy</span>
             </button>
+            <button class="text-nowrap btn" name="wrap" title="Wrap the code">
+                <span class="mx-1 fa fa-level-down fa-rotate-90"></span>
+                <span>Wrap</span>
+            </button>
             <button class="text-nowrap btn"><span class="mx-1 fa fa-paragraph" title="Convert to paragraph"></span></button>
         </div>
     </div>`
@@ -133,8 +137,11 @@ export const compareHighlightedContent = async (content, expected, phase, editor
         .replaceAll("data-embedded-state", "data-saved")
         // Ignore dataset order
         .replaceAll(
-            /"languageId":"([^"]*)","value":"(([^"]|\n)*)"/g,
-            `"value":"$2","languageId":"$1"`
+            /(?:"codeWrap":([^,}]+),)?"languageId":"([^"]*)","value":"(([^"]|\n)*)"/g,
+            (_, codeWrap, languageId, value) =>
+                `"value":"${value}","languageId":"${languageId}"${
+                    codeWrap ? `,"codeWrap":${codeWrap}` : ""
+                }`
         )
         // Clean up
         .replaceAll(/([{,]),+/g, "$1")
@@ -182,19 +189,20 @@ export const compareHighlightedContent = async (content, expected, phase, editor
 export const highlightedPre = ({
     value,
     language = DEFAULT_LANGUAGE_ID,
+    codeWrap = undefined,
     textareaRange = null,
     preHtml = value.replaceAll("\n", "<br>"),
 }) =>
     unformat(
         `<div data-embedded="syntaxHighlighting" data-oe-protected="true" contenteditable="false"
-            class="o_syntax_highlighting"
+            class="o_syntax_highlighting${codeWrap ? " o-code-wrap" : ""}"
             data-saved='{"value":"${value.replaceAll(
                 "\n",
                 "\\n"
-            )}","languageId":"${language.toLowerCase()}"}'>
+            )}","languageId":"${language.toLowerCase()}"${codeWrap ? `,"codeWrap":true` : ""}}'>
             ${TOOLBAR(LANGUAGES[language])}
             <pre>//PRE//</pre>${textareaRange === null ? "" : "[]"}
-            <textarea //TEXTAREA// class="o_prism_source" contenteditable="true"  placeholder="Code"></textarea>
+            <textarea //TEXTAREA// class="o_prism_source" contenteditable="true" placeholder="Code"></textarea>
         </div>`
     )
         // Do not trim spaces within the PRE and in the textarea data:

--- a/addons/html_editor/static/tests/syntax_highlighting.test.js
+++ b/addons/html_editor/static/tests/syntax_highlighting.test.js
@@ -1263,3 +1263,63 @@ test("should keep textarea focused after copying code content", async () => {
     // Ensure focus remains on the textarea after copying
     expect(document.activeElement).toBe(textarea);
 });
+
+test("should add data-code-wrap attribute on pre when toggling wrap on", async () => {
+    await testEditorWithHighlightedContent({
+        contentBefore: "<pre>some code</pre>",
+        contentBeforeEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({ value: "some code" }) +
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
+        stepFunction: async (editor) => {
+            // Focus the textarea inside the code block
+            const textarea = editor.document.querySelector("textarea");
+            await click(textarea);
+
+            // Wait for the code toolbar and trigger the wrap action
+            await waitFor(".o_code_toolbar");
+            await click(".o_code_toolbar button[name='wrap']");
+        },
+        contentAfterEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({ value: "some code", textareaRange: 9, codeWrap: true }) +
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
+        contentAfter: `<pre data-embedded="readonlySyntaxHighlighting" data-language-id="plaintext" data-code-wrap="">some code</pre>[]`,
+    });
+});
+
+test("should toggle code wrapping via the code toolbar", async () => {
+    await testEditorWithHighlightedContent({
+        contentBefore: "<pre>some code</pre>",
+        contentBeforeEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({ value: "some code" }) +
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
+        stepFunction: async (editor) => {
+            // Focus the textarea inside the code block
+            const textarea = editor.document.querySelector("textarea");
+            await click(textarea);
+
+            // Wait for the code toolbar and trigger the wrap action
+            await waitFor(".o_code_toolbar");
+            await click(".o_code_toolbar button[name='wrap']");
+
+            await compareHighlightedContent(
+                getContent(editor.editable),
+                '<p data-selection-placeholder=""><br></p>' +
+                    highlightedPre({ value: "some code", textareaRange: 9, codeWrap: true }) +
+                    '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
+                "Code block should be wrapped after clicking the wrap button in the code toolbar",
+                editor
+            );
+
+            // Trigger the wrap action again to unwrap
+            await click(".o_code_toolbar button[name='wrap']");
+        },
+        contentAfterEdit:
+            '<p data-selection-placeholder=""><br></p>' +
+            highlightedPre({ value: "some code", textareaRange: 9 }) +
+            '<p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>',
+        contentAfter: `<pre data-embedded="readonlySyntaxHighlighting" data-language-id="plaintext">some code</pre>[]`,
+    });
+});


### PR DESCRIPTION
#### Description of the feature this PR addresses:

- Add 'Wrap' toggle button to switch between wrapped and scroll modes

task-5976497

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
