### PR TITLE
[IMP] project: redirect portal editors to project sharing view

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -2081,6 +2081,24 @@ class ProjectTask(models.Model):
             child_tasks.action_archive()
         return super().action_archive()
 
+    def _get_access_action(self, access_uid=None, force_website=False):
+        self.ensure_one()
+        user = self.env['res.users'].sudo().browse(access_uid) if access_uid else self.env.user
+        if (
+            user
+            and user._is_portal()
+            and self.with_user(user).has_access('read')
+            and self.project_id
+            and self.project_id.with_user(user).has_access('read')
+            and self.project_id._check_project_sharing_access()
+        ):
+            return {
+                'type': 'ir.actions.act_url',
+                'url': f'/my/projects/{self.project_id.id}/project_sharing/{self.id}',
+                'target': 'self',
+            }
+        return super()._get_access_action(access_uid, force_website)
+
     # ---------------------------------------------------
     # Rating business
     # ---------------------------------------------------

--- a/addons/project/tests/test_project_mail_features.py
+++ b/addons/project/tests/test_project_mail_features.py
@@ -702,3 +702,25 @@ Content-Type: text/html;
         task = self.env['project.task'].browse(task_id)
         self.assertEqual(task.name, "In a cage")
         self.assertEqual(task.project_id, self.project_pigs)
+
+    def test_task_access_action(self):
+        """ Test that the access action link is correctly generated for portal users """
+        project_portal = self.env['project.project'].create({
+            'name': 'Portal Project',
+            'privacy_visibility': 'portal',
+        })
+        task_portal = self.env['project.task'].create({
+            'name': 'Test Task Portal',
+            'project_id': project_portal.id,
+        })
+
+        # Portal User + Project Sharing -> Project Sharing Link
+        project_portal.message_subscribe(partner_ids=self.user_portal.partner_id.ids)
+        project_portal._add_collaborators(self.user_portal.partner_id)
+        action = task_portal.with_user(self.user_portal)._get_access_action()
+        self.assertEqual(action['type'], 'ir.actions.act_url')
+        self.assertIn(
+            f'/my/projects/{project_portal.id}/project_sharing/{task_portal.id}',
+            action['url'],
+            "Portal user with edit access should get a link to project sharing",
+        )


### PR DESCRIPTION
Before this commit, the action link sent in task email notifications to portal users always redirected to the standard, read-only portal view, even if the user had edit rights to the project via Project Sharing.

This commit ensures that:
- If a portal user has access to the task and the project has Project Sharing enabled for them, the action URL redirects directly to the editable project sharing view instead of the static portal page.

task-5221400