### PR TITLE
[FIX] mail: handle bin/plain attachments

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -36,6 +36,7 @@ from requests import Session
 from ..web_push import push_to_end_point, DeviceUnreachableError, ENCRYPTION_BLOCK_OVERHEAD, ENCRYPTION_HEADER_SIZE, MAX_PAYLOAD_SIZE
 
 MAX_DIRECT_PUSH = 5
+BAD_CONTENT_TYPES = ('binary/octet-stream', '*/*', 'bin/plain')  # replaced by application/octet-stream
 
 _logger = logging.getLogger(__name__)
 
@@ -1569,11 +1570,8 @@ class MailThread(models.AbstractModel):
                     # the parent email that might be added at the end
                     # (e.g. for outlook / yahoo bounce email)
                     break
-                if part.get_content_type() == 'binary/octet-stream':
-                    _logger.warning("Message containing an unexpected Content-Type 'binary/octet-stream', assuming 'application/octet-stream'")
-                    part.replace_header('Content-Type', 'application/octet-stream')
-                if part.get_content_type() == '*/*':
-                    _logger.warning("Message containing an unexpected Content-Type '*/*', assuming 'application/octet-stream'")
+                if (bad_content_type := part.get_content_type()) in BAD_CONTENT_TYPES:
+                    _logger.warning("Message containing an unexpected Content-Type %r, assuming 'application/octet-stream'", bad_content_type)
                     part.replace_header('Content-Type', 'application/octet-stream')
                 if part.get_content_type() == 'multipart/alternative':
                     alternative = True

--- a/addons/test_mail/data/test_mail_data.py
+++ b/addons/test_mail/data/test_mail_data.py
@@ -278,34 +278,6 @@ Content-ID: <f_lfosfm0l0>
 --000000000000b951de05f7c47a9e--
 """
 
-MAIL_MULTIPART_BINARY_OCTET_STREAM = """X-Original-To: raoul@grosbedon.fr
-Delivered-To: raoul@grosbedon.fr
-Received: by mail1.grosbedon.com (Postfix, from userid 10002)
-    id E8166BFACA; Fri, 10 Nov 2021 06:04:01 +0200 (CEST)
-From: "Bruce Wayne" <bruce@wayneenterprises.com>
-Content-Type: multipart/alternative;
- boundary="Apple-Mail=_9331E12B-8BD2-4EC7-B53E-01F3FBEC9227"
-Message-Id: <6BB1FAB2-2104-438E-9447-07AE2C8C4A92@sexample.com>
-Mime-Version: 1.0 (Mac OS X Mail 7.3 \\(1878.6\\))
-
---Apple-Mail=_9331E12B-8BD2-4EC7-B53E-01F3FBEC9227
-Content-Transfer-Encoding: 7bit
-Content-Type: text/plain;
-    charset=us-ascii
-
-The attached file contains b"Hello world\\n"
-
---Apple-Mail=_9331E12B-8BD2-4EC7-B53E-01F3FBEC9227
-Content-Disposition: attachment;
- filename="hello_world.dat"
-Content-Type: binary/octet-stream;
- name="hello_world.dat"
-Content-Transfer-Encoding: base64
-
-SGVsbG8gd29ybGQK
---Apple-Mail=_9331E12B-8BD2-4EC7-B53E-01F3FBEC9227--
-"""
-
 MAIL_MULTIPART_INVALID_ENCODING = """Return-Path: <whatever-2a840@postmaster.twitter.com>
 To: {to}
 cc: {cc}

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -26,35 +26,23 @@ from odoo.tools import email_split_and_format, formataddr, mute_logger
 @tagged('mail_gateway')
 class TestEmailParsing(MailCommon):
 
-    def test_message_parse_and_replace_binary_octetstream(self):
-        """ Incoming email containing a wrong Content-Type as described in RFC2046/section-3 """
-        received_mail = self.from_string(test_mail_data.MAIL_MULTIPART_BINARY_OCTET_STREAM)
-        with self.assertLogs('odoo.addons.mail.models.mail_thread', level="WARNING") as capture:
-            extracted_mail = self.env['mail.thread']._message_parse_extract_payload(received_mail, {})
+    def test_message_parse_and_replace_bad_content_type(self):
+        """Incoming emails with unsupported attachment Content-Types should not crash parsing."""
+        for content_type in ('binary/octet-stream', '*/*', 'bin/plain'):
+            with self.subTest(content_type=content_type):
+                received_mail = self.format(test_mail_data.MAIL_PDF_MIME_TEMPLATE, pdf_mime=content_type)
+                self.assertIn(f"Content-Type: {content_type}", received_mail, f"{content_type} content-type not found")
+                with self.assertLogs("odoo.addons.mail.models.mail_thread", level="WARNING") as capture:
+                    extracted_mail = self.env['mail.thread'].message_parse(self.from_string(received_mail))
 
-        self.assertEqual(len(extracted_mail['attachments']), 1)
-        attachment = extracted_mail['attachments'][0]
-        self.assertEqual(attachment.fname, 'hello_world.dat')
-        self.assertEqual(attachment.content, b'Hello world\n')
-        self.assertEqual(capture.output, [
-            ("WARNING:odoo.addons.mail.models.mail_thread:Message containing an unexpected "
-             "Content-Type 'binary/octet-stream', assuming 'application/octet-stream'"),
-        ])
-
-    def test_message_parse_and_replace_wildcard(self):
-        """Incoming email containing a wrong Content-Type (*/*) as described in RFC2046/section-3"""
-        mail_with_wildcard_mime = self.format(test_mail_data.MAIL_PDF_MIME_TEMPLATE, pdf_mime="*/*")
-        self.assertIn("Content-Type: */*", mail_with_wildcard_mime, "Wildcard for content-type not found")
-        with self.assertLogs("odoo.addons.mail.models.mail_thread", level="WARNING") as capture:
-            extracted_mail = self.env['mail.thread'].message_parse(self.from_string(mail_with_wildcard_mime))
-
-        self.assertEqual(len(extracted_mail['attachments']), 1)
-        attachment = extracted_mail['attachments'][0]
-        self.assertEqual(attachment.fname, 'scan_soraya.lernout_1691652648.pdf')
-        self.assertEqual(capture.output, [
-            ("WARNING:odoo.addons.mail.models.mail_thread:Message containing an unexpected "
-             "Content-Type '*/*', assuming 'application/octet-stream'"),
-        ])
+                self.assertEqual(len(extracted_mail['attachments']), 1)
+                attachment = extracted_mail['attachments'][0]
+                self.assertEqual(attachment.fname, 'scan_soraya.lernout_1691652648.pdf')
+                self.assertEqual(attachment.content, test_mail_data.PDF_PARSED)
+                self.assertEqual(capture.output, [
+                    ("WARNING:odoo.addons.mail.models.mail_thread:Message containing an unexpected "
+                    f"Content-Type '{content_type}', assuming 'application/octet-stream'"),
+                ])
 
     def test_message_parse_body(self):
         # test pure plaintext


### PR DESCRIPTION
When parsing incoming emails, mail.thread normalizes some malformed MIME types before calling part.get_content(). However, attachments using Content-Type `bin/plain` are not normalized.

As a result, Python's email content manager raises KeyError('bin/plain') during parsing, which aborts the whole message processing. This prevents the incoming email from being processed, including vendor bill creation from email aliases.

Steps to reproduce:
- build an email with an attachment using Content-Type `bin/plain`
- parse it through `mail.thread.message_parse`

Before this commit, parsing crashes with KeyError('bin/plain').

This commit treats `bin/plain` like the other unsupported attachment MIME types already handled in stable, by falling back to `application/octet-stream`, allowing the message to be parsed and the attachment to be preserved.

opw-5439156

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr