### PR TITLE
[FIX] website: correct and complete configurator loading messages

### DIFF
--- a/addons/website/controllers/backend.py
+++ b/addons/website/controllers/backend.py
@@ -66,8 +66,10 @@ class WebsiteBackend(http.Controller):
         website features being installed and their dependencies in order to
         show the progress between installed and yet to install features.
         """
-        features_not_installed = request.env['website.configurator.feature']\
-            .browse(selected_features).module_id.upstream_dependencies(exclude_states=('',))\
+        features = request.env['website.configurator.feature'].search([
+            ('sequence', 'in', selected_features)
+        ])
+        features_not_installed = features.module_id.upstream_dependencies(exclude_states=('',))\
             .filtered(lambda feature: feature.state != 'installed')
 
         # On the 1st run, the total tallies the targeted, not yet installed

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -394,6 +394,7 @@ class Website(models.Model):
         configurator_features = self.env['website.configurator.feature'].search([])
         r['features'] = [{
             'id': feature.id,
+            'sequence': feature.sequence,
             'name': feature.name,
             'description': feature.description,
             'type': 'page' if feature.page_view_id else 'app',

--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -360,10 +360,12 @@ class ApplyConfiguratorScreen extends Component {
         };
 
         if (themeName !== undefined) {
-            const selectedFeatures = Object.values(this.state.features).filter((feature) => feature.selected).map((feature) => feature.id);
+            const selectedFeatures = Object.values(this.state.features).filter(
+                (feature) => feature.selected
+            );
             this.websiteService.showLoader({
                 showTips: true,
-                selectedFeatures: selectedFeatures,
+                selectedFeatures: selectedFeatures.map((feature) => feature.sequence),
                 showWaitingMessages: true,
             });
             let selectedPalette = this.state.selectedPalette.name;
@@ -378,7 +380,7 @@ class ApplyConfiguratorScreen extends Component {
             }
 
             const data = {
-                'selected_features': selectedFeatures,
+                selected_features: selectedFeatures.map((feature) => feature.id),
                 'industry_id': this.state.selectedIndustry.id,
                 'industry_name': this.state.selectedIndustry.label.toLowerCase(),
                 'selected_palette': selectedPalette,

--- a/addons/website/static/src/components/website_loader/website_loader.js
+++ b/addons/website/static/src/components/website_loader/website_loader.js
@@ -185,52 +185,77 @@ export class WebsiteLoader extends Component {
     };
 
     /**
+     * Returns the feature messages configuration. Override this method to add
+     * additional feature messages.
+     */
+    getFeatureMessages() {
+        return [{
+            sequence: 6,
+            title: _t("Enabling your %s."),
+            name: _t("blog"),
+            description: _t("Share your thoughts and ideas with the world."),
+        }, {
+            sequence: 7,
+            title: _t("Setting up your %s."),
+            name: _t("success stories"),
+            description: _t("Showcase your best case studies."),
+        }, {
+            sequence: 8,
+            title: _t("Integrating your %s."),
+            name: _t("recruitment platform"),
+            description: _t("Find the best talent for your team."),
+        }, {
+            sequence: 9,
+            title: _t("Activating your %s."),
+            name: _t("online store"),
+            description: _t("Start selling your products and services today."),
+        }, {
+            sequence: 10,
+            title: _t("Setting up your %s."),
+            name: _t("events"),
+            description: _t("Publish on-site and online events."),
+        }, {
+            sequence: 11,
+            title: _t("Setting up your %s."),
+            name: _t("forum"),
+            description: _t("Engage with your community and build relationships."),
+        }, {
+            sequence: 12,
+            title: _t("Activating your %s."),
+            name: _t("live chat"),
+            description: _t("Chat with visitors in real time."),
+        }, {
+            sequence: 13,
+            title: _t("Installing your %s."),
+            name: _t("e-learning platform"),
+            description: _t("Offer online courses and learning opportunities."),
+        }, {
+            sequence: 15,
+            title: _t("Configuring your %s."),
+            name: _t("store locator"),
+            description: _t("Help customers find your locations."),
+        }];
+    }
+
+    /**
      * Depending on the features selected, returns the right waiting messages.
      *
      * @param {integer[]} selectedFeatures
      * @returns {Object[]} - the messages filtered by the selected features
      */
     getWaitingMessages(selectedFeatures) {
-        const websiteFeaturesMessages = [{
-            id: 5,
-            title: _t("Enabling your %s."),
-            name: _t("blog"),
-            description: _t("Share your thoughts and ideas with the world."),
-        }, {
-            id: 7,
-            title: _t("Integrating your %s."),
-            name: _t("recruitment platform"),
-            description: _t("Find the best talent for your team."),
-        }, {
-            id: 8,
-            title: _t("Activating your %s."),
-            name: _t("online store"),
-            description: _t("Start selling your products and services today."),
-        }, {
-            id: 9,
-            title: _t("Configuring your %s."),
-            name: _t("online appointment system"),
-            description: _t("Make it easy for clients to book appointments with you."),
-        }, {
-            id: 10,
-            title: _t("Setting up your %s."),
-            name: _t("forum"),
-            description: _t("Engage with your community and build relationships."),
-        }, {
-            id: 12,
-            title: _t("Installing your %s."),
-            name: _t("e-learning platform"),
-            description: _t("Offer online courses and learning opportunities."),
-        }, {
-            // Always the last message if there is at least 1 feature selected.
-            id: "last",
-            title: _t("Activating the last features."),
-            description: _t("A bit more patience as your website takes shape."),
-        }];
+        const featureMessages = [
+            ...this.getFeatureMessages(),
+            {
+                sequence: "last",
+                title: _t("Activating the last features."),
+                description: _t("A bit more patience as your website takes shape."),
+            },
+        ];
 
-        const filteredIds = [...selectedFeatures, "last"];
-        const messagesList = websiteFeaturesMessages.filter((msg) => {
-            if (filteredIds.includes(msg.id)) {
+        const selectedSequences = [...selectedFeatures, "last"];
+        return featureMessages.filter((msg) => {
+            if (selectedSequences.includes(msg.sequence)) {
                 if (msg.name) {
                     const highlight = sprintf(
                         '<span class="o_website_loader_text_highlight">%s</span>', msg.name
@@ -240,7 +265,6 @@ export class WebsiteLoader extends Component {
                 return true;
             }
         });
-        return messagesList;
     };
 
     /**


### PR DESCRIPTION
When creating a website through the configurator, the loading screen
displayed incorrect or missing feature messages.

The loader matched messages using the `website.configurator.feature`
record ID. Some mappings were incorrect and caused wrong messages to
appear.

For example, selecting the "Events" feature displayed the "Appointment"
message instead.

This commit:
- Corrects the feature-to-message associations.
- Replaces the ID-based mapping with the `sequence` field, which is
  defined in XML and visible in the codebase, allowing an explicit and
  reliable mapping in code.
- Adds loading messages for features that were missing them
  (e.g., Success Stories, Events, Live Chat, Store Locator).
- Removes the appointment loading message from community, as it
  belongs to enterprise.
- Introduces an overridable `getFeatureMessages()` method so modules
  can extend the loader with their own feature messages cleanly.