### PR TITLE
[FIX] website: prevent traceback when opening image popup

### DIFF
--- a/addons/website/static/src/snippets/s_image_gallery/gallery_slider.js
+++ b/addons/website/static/src/snippets/s_image_gallery/gallery_slider.js
@@ -11,7 +11,8 @@ import { isVisible } from "@html_editor/utils/dom_info";
  **/
 export class GallerySlider extends Interaction {
     // TODO in master: use `.o_slideshow:not([data-vjs])`
-    static selector = ".o_slideshow:not([data-vcss]), .o_slideshow[data-vcss='001']";
+    static selector =
+        ".o_slideshow:not([data-vcss]):not(.o_image_lightbox .o_slideshow), .o_slideshow[data-vcss='001']";
     dynamicContent = {
         ".carousel": {
             "t-on-slide.bs.carousel": this.onSlideCarousel,


### PR DESCRIPTION
Problem:
Clicking on an image configured to open in a popup triggers a traceback.

Cause:
The `ImagePopUp` interaction renders `o_slideshow` without controls due to `shouldShowControls`. As a result, `carousel-indicators` and their children are not rendered. This makes `GallerySlider.liEls` `undefined`, which later causes a traceback in `hide`.

Solution:
Since `ImagePopUp` always displays a single image, `GallerySlider` is not needed in this case. Exclude `o_image_popup` from initializing `GallerySlider` to avoid accessing undefined elements.

Steps to reproduce:
- Drop an Image snippet.
- Enable “popup on click”.
- Save the page.
- Click on the image.
- Observe the traceback.

opw-5974260

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
