### PR TITLE
[IMP] sale: move `invoice_policy` required from view to python field

### DIFF
--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -45,6 +45,7 @@ class ProductTemplate(models.Model):
         precompute=True,
         store=True,
         readonly=False,
+        required=True,
         tracking=True,
         help="Ordered Quantity: Invoice quantities ordered by the customer.\n"
         "Delivered Quantity: Invoice quantities delivered to the customer.",

--- a/addons/sale/views/product_views.xml
+++ b/addons/sale/views/product_views.xml
@@ -16,7 +16,6 @@
             <field name="type" position="after">
                 <field
                     name="invoice_policy"
-                    required="1"
                     invisible="not sale_ok or type == 'combo'"
                 />
             </field>


### PR DESCRIPTION
In 19.0, `invoice_policy` is stored and precomputed but not required at the ORM level. The requirement was only enforced in the view, which allows importing products without triggering any ORM validation.

Move the `required` constraint from the view to the Python field definition so the constraint is consistently enforced, including during imports.

opw-5982012