### PR TITLE
[FIX] web, html_editor: props to control default theme colors usage

### DIFF
--- a/addons/html_editor/static/src/main/font/color_selector.js
+++ b/addons/html_editor/static/src/main/font/color_selector.js
@@ -27,10 +27,12 @@ export class ColorSelector extends Component {
         enabledTabs: { type: Array, optional: true },
         cssVarColorPrefix: { type: String, optional: true },
         onClose: Function,
+        useDefaultThemeColors: { type: Boolean, optional: true },
     };
     static defaultProps = {
         cssVarColorPrefix: "",
         enabledTabs: ["solid", "gradient", "custom"],
+        useDefaultThemeColors: true,
     };
 
     setup() {
@@ -70,6 +72,7 @@ export class ColorSelector extends Component {
                 colorPrefix: this.props.colorPrefix,
                 enabledTabs: this.props.enabledTabs,
                 cssVarColorPrefix: this.props.cssVarColorPrefix,
+                useDefaultThemeColors: this.props.useDefaultThemeColors,
             },
             {
                 env: this.__owl__.childEnv,

--- a/addons/web/static/src/core/color_picker/color_picker.js
+++ b/addons/web/static/src/core/color_picker/color_picker.js
@@ -63,6 +63,7 @@ export class ColorPicker extends Component {
         noTransparency: { type: Boolean, optional: true },
         close: { type: Function, optional: true },
         className: { type: String, optional: true },
+        useDefaultThemeColors: { type: Boolean, optional: true },
     };
     static defaultProps = {
         close: () => {},
@@ -70,6 +71,7 @@ export class ColorPicker extends Component {
         enabledTabs: ["solid", "custom"],
         cssVarColorPrefix: "",
         setOnCloseCallback: () => {},
+        useDefaultThemeColors: true,
     };
 
     setup() {
@@ -81,7 +83,9 @@ export class ColorPicker extends Component {
 
         this.DEFAULT_COLORS = DEFAULT_COLORS;
         this.grayscales = Object.assign({}, DEFAULT_GRAYSCALES, this.props.grayscales);
-        this.DEFAULT_THEME_COLOR_VARS = DEFAULT_THEME_COLOR_VARS;
+        this.DEFAULT_THEME_COLOR_VARS = this.props.useDefaultThemeColors
+            ? DEFAULT_THEME_COLOR_VARS
+            : [];
         this.defaultColorSet = this.getDefaultColorSet();
         this.defaultColor = this.props.state.selectedColor;
         this.focusedBtn = null;


### PR DESCRIPTION
Before this commit, there was no way to tell the ColorPicker to not use the DEFAULT_THEME_COLOR_VARS (ie classes of the form `o-color-[n]` with n some integer)

Those colors are a bit special (see full discussion on the opw)
- Their existence is described in module `web`
- Their CSS definition is implemented in module `html_editor`
- Reports don't use them at all We probably don't want reports' style to be influenced by the presence or lack thereof of the html_editor module, which was originally made to customize the interface.

Those architecture issues should be solved downstream in master, but they are practically endemic in Odoo.

This commit addresses the fact that Studio's report editor should not allow those colors as possible customization by offering the components and plugins in the chain a props to disable them.

After this commit (and more broadly the PR bundle), the default theme colors are not available in studio's report editor.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
