### PR TITLE
[FIX] mail,im_livechat: allow non-member agents to edit live chat des…

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -224,6 +224,13 @@ class DiscussChannel(models.Model):
         store.bus_send()
         return result
 
+    def channel_change_description(self, description):
+        self.ensure_one()
+        if self.channel_type == "livechat" and self.env.user.has_access_livechat:
+            # sudo: discuss.channel - live chat users can update description of accessible live chat channels.
+            return super(DiscussChannel, self.sudo()).channel_change_description(description)
+        return super().channel_change_description(description)
+
     @api.depends("livechat_end_dt")
     def _compute_duration(self):
         for record in self:

--- a/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/discuss_channel_model_patch.js
@@ -25,6 +25,12 @@ const discussChannelPatch = {
     get allowDescriptionTypes() {
         return [...super.allowDescriptionTypes, "livechat"];
     },
+    get allowEditDescription() {
+        return (
+            super.allowEditDescription ||
+            (this.channel_type === "livechat" && this.store.has_access_livechat)
+        );
+    },
     get allowedToLeaveChannelTypes() {
         return [...super.allowedToLeaveChannelTypes, "livechat"];
     },

--- a/addons/im_livechat/tests/test_discuss_channel.py
+++ b/addons/im_livechat/tests/test_discuss_channel.py
@@ -96,6 +96,23 @@ class TestDiscussChannel(TestImLivechatCommon, TestGetOperatorCommon, MailCase):
         ):
             channel.description = "Description of the conversation"
 
+    def test_livechat_description_editable_by_non_member_operator(self):
+        operator = new_test_user(
+            self.env,
+            "operator_non_member",
+            groups="base.group_user,im_livechat.im_livechat_group_user",
+        )
+        self.livechat_channel.user_ids |= operator
+        data = self.make_jsonrpc_request(
+            "/im_livechat/get_session",
+            {"channel_id": self.livechat_channel.id},
+        )
+        channel = self.env["discuss.channel"].browse(data["channel_id"])
+        self.assertNotIn(operator.partner_id, channel.channel_member_ids.partner_id)
+        self.assertTrue(operator.has_access_livechat)
+        channel.with_user(operator).channel_change_description("Updated by non-member operator")
+        self.assertEqual(channel.description, "Updated by non-member operator")
+
     def test_livechat_note_sync_to_internal_user_bus(self):
         """Test that a livechat note is sent to the internal user bus."""
         data = self.make_jsonrpc_request(

--- a/addons/mail/static/src/core/public_web/discuss_content.xml
+++ b/addons/mail/static/src/core/public_web/discuss_content.xml
@@ -32,14 +32,14 @@
                             onValidate.bind="renameThread"
                             value="thread.displayName || ''"
                         />
-                        <t t-if="thread.channel?.allowDescription and (thread.is_editable or (!thread.is_editable and thread.description))">
+                        <t t-if="thread.channel?.allowDescription and (thread.channel?.allowEditDescription or thread.description)">
                             <div class="flex-shrink-0 mx-1 py-2 border-start"/>
                             <t t-set="autogrowDescriptionPlaceholder">Add a description</t>
                             <AutoresizeInput
                                 className="attClassObjectToString(threadDescriptionAttClass)"
-                                enabled="thread.is_editable"
+                                enabled="thread.channel?.allowEditDescription"
                                 onValidate.bind="updateThreadDescription"
-                                placeholder="thread.is_editable ? autogrowDescriptionPlaceholder : ''"
+                                placeholder="thread.channel?.allowEditDescription ? autogrowDescriptionPlaceholder : ''"
                                 value="thread.description or ''"
                             />
                         </t>

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -92,6 +92,9 @@ export class DiscussChannel extends Record {
     get allowDescription() {
         return this.allowDescriptionTypes.includes(this.channel_type);
     }
+    get allowEditDescription() {
+        return this.thread.is_editable;
+    }
     get allowedToLeaveChannelTypes() {
         return ["channel", "group"];
     }


### PR DESCRIPTION
…cription

**Before this PR**, only users who were channel members could edit the description of a live chat conversation.

With this change, agents who have live chat access can now edit the channel description **even if they are not members** of that specific live chat channel.

task-5046015

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
