### PR TITLE
[FIX] account: `_user_can_trust` ensure one

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -666,9 +666,9 @@ class AccountJournal(models.Model):
             for journal in self.filtered(lambda r: r.type == 'bank' and not r.bank_account_id):
                 journal.set_bank_account(vals.get('bank_acc_number'), vals.get('bank_id'))
         if 'bank_acc_number' in vals or 'bank_account_id' in vals:
-            bank = self.filtered(lambda r: r.type == 'bank').bank_account_id
-            if bank._user_can_trust():
-                bank.allow_out_payment = True
+            for bank in self.filtered(lambda r: r.type == 'bank').bank_account_id:
+                if bank._user_can_trust():
+                    bank.allow_out_payment = True
         for record in self:
             if record.restrict_mode_hash_table and not record.secure_sequence_id:
                 record._create_secure_sequence(['secure_sequence_id'])

--- a/addons/account/models/res_partner_bank.py
+++ b/addons/account/models/res_partner_bank.py
@@ -308,7 +308,7 @@ class ResPartnerBank(models.Model):
         ):
             raise UserError(_("You cannot modify the account number or partner of an account that has been trusted."))
 
-        if 'allow_out_payment' in vals and not self._user_can_trust():
+        if 'allow_out_payment' in vals and any(not bank._user_can_trust() for bank in self):
             raise UserError(_("You do not have the rights to trust or un-trust accounts."))
 
         res = super().write(vals)


### PR DESCRIPTION
In some cases, the check was done on multiple records, though the method should be called on one and only one record.
