### PR TITLE
[FIX] account_edi_ubl_cii: allow zero subtotal lines

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -598,11 +598,8 @@ class AccountEdiCommon(models.AbstractModel):
         # line_net_subtotal (mandatory)
         price_subtotal = None
         line_total_amount_node = tree.find(xpath_dict['line_total_amount'])
-        if line_total_amount_node is None or line_total_amount_node.text is None or not line_total_amount_node.text.strip():
-            return None
-        price_subtotal = float(line_total_amount_node.text)
-        if price_subtotal == 0:
-            return None
+        if line_total_amount_node is not None and line_total_amount_node.text and line_total_amount_node.text.strip():
+            price_subtotal = float(line_total_amount_node.text)
 
         ####################################################
         # Setting the values on the invoice_line
@@ -639,6 +636,7 @@ class AccountEdiCommon(models.AbstractModel):
             'discount': discount,
             'product_uom_id': product_uom_id,
             'fixed_taxes_list': fixed_taxes_list,
+            'price_subtotal': price_subtotal,
         }
 
     def _import_retrieve_fixed_tax(self, invoice_line_form, fixed_tax_vals):


### PR DESCRIPTION
Versions:
---
Reproducible on 18.0+
Fix targets 16.0 to keep the code consistent across versions

Issue:
---
Due to this issue, a line with zero subtotal amount will be discarded
in quotation document upload.

Steps to reproduce:
---
1- In sale app, upload a quotation document without line amount. (You could use the one attached in the ticket)
2- As you see, lines are discarded.

Cause:
---
This regression is introduced in https://github.com/odoo/odoo/pull/245862, to prevent lines with zero amount in accounting. The https://github.com/odoo/odoo/pull/245862 targets 16.0. However, the `sale_edi_ubl` is introduced on 18.0.

Fix:
---
Instead of `_retrieve_line_vals` (`_import_fill_invoice_line_values` on 16.0) returning `None` when `price_subtotal` is not present, it can keep returning `dict` with an extra key `price_subtotal`, and filter out unwanted line in `_retrieve_invoice_line_vals` itself.

opw-5977735