### PR TITLE
[FIX] html_builder : search many2many with uncreated records

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/select_many2x.js
+++ b/addons/html_builder/static/src/core/building_blocks/select_many2x.js
@@ -100,7 +100,9 @@ export class SelectMany2X extends Component {
     }
     async search(searchValue) {
         const domain = Object.values(this.props.domain).filter((item) => item !== null);
-        const selectedIds = this.props.selected.map((e) => e.id);
+        const selectedIds = this.props.selected
+            .map((e) => e.id)
+            .filter((value) => typeof value === "number");
         if (selectedIds.length) {
             domain.push(["id", "not in", selectedIds]);
         }

--- a/addons/website/static/tests/builder/custom_tab/builder_components/basic_many2many.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/basic_many2many.test.js
@@ -1,7 +1,7 @@
 import { addBuilderOption } from "@html_builder/../tests/helpers";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 import { expect, test } from "@odoo/hoot";
-import { animationFrame } from "@odoo/hoot-mock";
+import { advanceTime, animationFrame } from "@odoo/hoot-mock";
 import { reactive, xml } from "@odoo/owl";
 import { contains, defineModels, fields, models, onRpc } from "@web/../tests/web_test_helpers";
 import { delay } from "@web/core/utils/concurrency";
@@ -146,4 +146,39 @@ test("basic many2many: toggle dropdown without changing search term or selection
     expect(selection).toEqual([{ id: 1, name: "First", display_name: "First" }]);
     expect(executeCount).toBe(2);
     expect.verifySteps(["name_search", "name_search"]);
+});
+
+test("basic many2many: search with uncreated records", async () => {
+    onRpc("test", "name_search", ({ kwargs }) => {
+        expect.step("name_search");
+        expect(kwargs.domain).toEqual([["id", "not in", [1, 2]]]);
+    });
+    class TestComponent extends BaseOptionComponent {
+        static selector = ".test-options-target";
+        static template = xml`<BasicMany2Many selection="this.selection" model="'test'" limit="1" setSelection="this.setSelection.bind(this)"/>`;
+        setup() {
+            this.selection = [
+                { id: 1, name: "First" },
+                { id: 2, name: "Second" },
+                { id: "new-3", name: "Third" },
+            ]
+        }
+        setSelection() {
+            //Not used but necessary for the component
+        }
+    }
+    addBuilderOption(TestComponent);
+    await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
+
+    await contains(":iframe .test-options-target").click();
+    expect(".options-container").toBeDisplayed();
+    // Number of items in selection
+    expect("table tr").toHaveCount(3);
+
+    // Click to open, 1st search should be done
+    await contains(".btn.o-dropdown").click();
+    await advanceTime(300); // debounce
+    await animationFrame();
+
+    expect.verifySteps(["name_search"]);
 });


### PR DESCRIPTION
# How to reproduce
- Go to a blog page and edit the Blog Post Cover
- Add a tag
- Try to add another one

# The problem
A traceback is shown

# Why
When adding a new record for a many 2 many relation, the framework ensure the user cannot create a record with a name that already exists via a name search. This commit (https://github.com/odoo/odoo/commit/3631757a4766bc59378bb975e01e115c92ef1dd4) changed the way the name search is done to add this domain to the request :
```py
domain.push(["id", "not in", selectedIds]);
```

But selectedIds can contain strings in the case of uncreated records, which causes the SQL query to throw an error trying to match the model id with strings

opw-5978305

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
