### PR TITLE
[FIX] hr_attendance: removing add line on attendance line

### DIFF
--- a/addons/hr_attendance/static/src/scss/views/hr_attendance.scss
+++ b/addons/hr_attendance/static/src/scss/views/hr_attendance.scss
@@ -11,3 +11,19 @@
 .o_nocontent_help:has(.oe_view_nocontent_attendance_mobile) {
     position: relative;
 }
+
+.hide_add_line .o_list_table tr.d-print-none:hover td {
+    background-color: var(--table-hover-bg) !important;
+    box-shadow: inset 0 0 0 9999px rgba(0, 0, 0, 0.0) !important;
+}
+
+.hide_add_line .o_list_table tr.d-print-none td {
+    background-color: transparent !important;
+}
+
+.hide_add_line .o_field_x2many_list_row_add a {
+    color: transparent !important;
+    pointer-events: none !important;
+    display: block;
+    width: 100%;
+}

--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -202,7 +202,10 @@
                     <notebook invisible="not overtime_status">
                         <page string="Overtime Details">
                             <field name="linked_overtime_ids">
-                                <list editable="bottom">
+                                <list editable="bottom" create="0" class="hide_add_line">
+                                    <control>
+                                         <create string="&#160;"/>
+                                    </control>
                                     <field name="rule_ids" widget="many2many_tags" readonly="1"/>
                                     <field name="duration" widget="float_time" readonly="1"/>
                                     <field name="manual_duration" widget="float_time" readonly="0"/>


### PR DESCRIPTION
[FIX] hr_attendance: removing add line on attendance line

Bug reproduction: When version >= 19.0
    1 - Employee -> Select employee (Abigail) -> Settings -> set overtime ruleset as Default Ruleset.
    2 - Attendances app -> select really long attendance for Abigail (1 am to 4 pm) -> expand attendance in larger form -> you will see add a line in the list view

Bug cause:
    Add a line is normally was there, now it should not be there. The list view is editable and due to that add a line line comes automatically.

Bug solution:
    1 - I add a <control> tag to hide the "add a line" text
    2 - It was still clickable and I used scss to make it non-clickable.

task - 5991262

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
