### PR TITLE
[REF] mail, hr, hr_holidays: support user in ImStatus/DiscussAvatar

### DIFF
--- a/addons/hr/static/src/core/common/im_status_patch.js
+++ b/addons/hr/static/src/core/common/im_status_patch.js
@@ -4,7 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 imStatusDataRegistry.add(
     "hr-homeworking-home",
     {
-        condition: ({ persona }) => persona.main_user_id?.employee_id?.work_location_type === "home",
+        condition: ({ user }) => user?.employee_id?.work_location_type === "home",
         icon: "fa fa-home",
         title: {
             online: _t("User is at home and online"),
@@ -19,7 +19,7 @@ imStatusDataRegistry.add(
 imStatusDataRegistry.add(
     "hr-homeworking-office",
     {
-        condition: ({ persona }) => persona.main_user_id?.employee_id?.work_location_type === "office",
+        condition: ({ user }) => user?.employee_id?.work_location_type === "office",
         icon: "fa fa-building",
         title: {
             online: _t("User is at the office and online"),
@@ -34,7 +34,7 @@ imStatusDataRegistry.add(
 imStatusDataRegistry.add(
     "hr-homeworking-other",
     {
-        condition: ({ persona }) => persona.main_user_id?.employee_id?.work_location_type === "other",
+        condition: ({ user }) => user?.employee_id?.work_location_type === "other",
         icon: "fa fa-map-marker",
         title: {
             online: _t("User is at other location and online"),

--- a/addons/hr_holidays/static/src/core/common/im_status_patch.js
+++ b/addons/hr_holidays/static/src/core/common/im_status_patch.js
@@ -4,7 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 imStatusDataRegistry.add(
     "hr-holidays",
     {
-        condition: ({ persona }) => Boolean(persona.main_user_id?.employee_id?.leave_date_to),
+        condition: ({ user }) => Boolean(user?.employee_id?.leave_date_to),
         icon: "fa fa-plane",
         title: {
             online: _t("User is on leave and online"),

--- a/addons/im_livechat/static/src/core/common/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/common/@types/models.d.ts
@@ -41,6 +41,7 @@ declare module "models" {
         livechat_looking_for_help_since_dt: import("luxon").DateTime;
         livechat_status: "in_progress"|"need_help"|undefined;
         livechatShouldAskLeaveConfirmation: Readonly<boolean>;
+        storeAsPinnedLivechats: Store;
         unpinOnThreadSwitch: boolean;
     }
     export interface LivechatChannel {

--- a/addons/im_livechat/static/src/core/public_web/discuss_app/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/public_web/discuss_app/@types/models.d.ts
@@ -6,7 +6,4 @@ declare module "models" {
         livechatLookingForHelpCategory: DiscussAppCategory;
         livechats: DiscussChannel[];
     }
-    export interface DiscussAppCategory {
-        livechat_channel_id: LivechatChannel;
-    }
 }

--- a/addons/im_livechat/static/src/core/web/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/web/@types/models.d.ts
@@ -8,10 +8,11 @@ declare module "models" {
     export interface Store {
         goToOldestUnreadLivechatThread: () => boolean;
         has_access_livechat: boolean;
-        show_livechat_category: boolean;
         livechatChannels: ReturnType<Store['makeCachedFetchData']>;
         livechatSelfExpertises: ReturnType<Store['makeCachedFetchData']>;
         livechatStatusButtons: Readonly<object[]>;
+        pinnedLivechats: DiscussChannel[];
+        show_livechat_category: boolean;
     }
     export interface Thread {
         hasFetchedLivechatSessionData: boolean;

--- a/addons/im_livechat/static/src/core/web/partner_compare.js
+++ b/addons/im_livechat/static/src/core/web/partner_compare.js
@@ -2,7 +2,7 @@ import { partnerCompareRegistry } from "@mail/core/common/partner_compare";
 
 partnerCompareRegistry.add(
     "im_livechat.available",
-    (p1, p2, { thread }) => {
+    function available(p1, p2, { thread }) {
         if (thread?.channel?.channel_type === "livechat" && p1.is_available !== p2.is_available) {
             return p1.is_available ? -1 : 1;
         }
@@ -12,7 +12,7 @@ partnerCompareRegistry.add(
 
 partnerCompareRegistry.add(
     "im_livechat.invite-count",
-    (p1, p2, { thread }) => {
+    function inviteCount(p1, p2, { thread }) {
         if (
             thread?.channel?.channel_type === "livechat" &&
             p1.invite_by_self_count !== p2.invite_by_self_count

--- a/addons/mail/static/src/core/common/@types/registry.d.ts
+++ b/addons/mail/static/src/core/common/@types/registry.d.ts
@@ -1,35 +1,47 @@
 declare module "registries" {
-    import { ResPartner } from "@mail/core/common/res_partner_model";
-    import { ChannelMember } from "@mail/discuss/core/common/channel_member_model";
+    import { ChannelMember, ResPartner, ResUsers } from "models";
     import { _t } from "@web/core/l10n/translation";
 
     type TranslatableString = ReturnType<typeof _t> | string;
 
     interface IconInfo {
-        online: string,
-        away: string,
-        busy: string,
-        offline: string,
-        bot?: string,
-        default: string,
+        online: string;
+        away: string;
+        busy: string;
+        offline: string;
+        bot?: string;
+        default: string;
     }
 
     interface TitleInfo {
-        online: TranslatableString,
-        away: TranslatableString,
-        busy: TranslatableString,
-        offline: TranslatableString,
-        bot?: TranslatableString,
-        default: TranslatableString,
+        online: TranslatableString;
+        away: TranslatableString;
+        busy: TranslatableString;
+        offline: TranslatableString;
+        bot?: TranslatableString;
+        default: TranslatableString;
     }
 
     interface ImStatusDataItemShape {
-        condition: (data: { persona: ResPartner, member: ChannelMember }) => boolean;
-        icon: IconInfo | string,
-        title: TitleInfo | TranslatableString,
+        condition: (data: { persona: ResPartner, member: ChannelMember, user: ResUsers }) => boolean;
+        icon: IconInfo | string;
+        title: TitleInfo | TranslatableString;
+    }
+
+    interface PartnerCompareDataItemShape {
+        (p1: ResPartner, p2: ResPartner, options: {
+            context: {
+                memberPartnerIds?: Set<number>,
+                recentChatPartnerIds?: number[],
+            },
+            searchTerm?: string;
+            store: import("models").Store,
+            thread?: import("models").Thread,
+        }): number;
     }
 
     interface GlobalRegistryCategories {
         "mail.im_status_data": ImStatusDataItemShape;
+        "mail.partner_compare": PartnerCompareDataItemShape;
     }
 }

--- a/addons/mail/static/src/core/common/discuss_avatar.js
+++ b/addons/mail/static/src/core/common/discuss_avatar.js
@@ -16,6 +16,7 @@ export class DiscussAvatar extends Component {
         "typing?",
         "className?",
         "imgRoundedClass?",
+        "user?",
     ];
     static defaultProps = { className: "", size: 32, typing: true };
     static components = { ImStatus, ThreadIcon };
@@ -27,6 +28,10 @@ export class DiscussAvatar extends Component {
 
     get channel() {
         return this.props.channel ?? this.props.thread?.channel;
+    }
+
+    get persona() {
+        return this.props.user?.partner_id || this.props.persona || this.props.member?.persona;
     }
 
     get thread() {
@@ -50,9 +55,13 @@ export class DiscussAvatar extends Component {
         if (this.channel) {
             return this.channel.showThreadIcon({ ignoreTyping: !this.props.typing });
         }
-        if (this.props.member || this.props.persona) {
+        if (this.props.member || this.persona) {
             return true;
         }
         return false;
+    }
+
+    get user() {
+        return this.props.user || this.persona?.main_user_id;
     }
 }

--- a/addons/mail/static/src/core/common/discuss_avatar.xml
+++ b/addons/mail/static/src/core/common/discuss_avatar.xml
@@ -14,7 +14,8 @@
                     <foreignObject x="0" y="0" width="25" height="15">
                         <ThreadIcon t-if="this.thread" thread="this.thread" typing="this.props.typing"/>
                         <ImStatus t-elif="this.props.member" member="this.props.member" className="'d-flex'" size="'md'" typing="this.props.typing"/>
-                        <ImStatus t-elif="this.props.persona" persona="this.props.persona" typing="this.props.typing"/>
+                        <ImStatus t-elif="this.user" user="this.user" typing="this.props.typing"/>
+                        <ImStatus t-elif="this.persona" persona="this.persona" typing="this.props.typing"/>
                     </foreignObject>
                 </svg>
             </g>
@@ -24,6 +25,12 @@
     <t t-name="mail.DiscussAvatar.avatarImg">
         <img t-if="this.thread" class="w-100 h-100 object-fit-cover" t-att-class="{ [this.props.imgRoundedClass]: this.props.imgRoundedClass, 'rounded-2': !this.props.imgRoundedClass }" t-att-src="this.thread.channel?.parent_channel_id?.avatarUrl ?? this.thread.channel?.avatarUrl ?? this.thread.avatarUrl" alt="Thread Image"/>
         <img t-elif="this.props.member" alt="" class="w-100 h-100 object-fit-cover" t-att-class="{ [this.props.imgRoundedClass]: this.props.imgRoundedClass, 'rounded-3': !this.props.imgRoundedClass }" t-att-src="this.props.member.avatarUrl"/>
-        <img t-elif="this.props.persona" alt="" class="w-100 h-100 object-fit-cover" t-att-class="{ [this.props.imgRoundedClass]: this.props.imgRoundedClass, 'rounded': !this.props.imgRoundedClass }" t-att-src="this.props.persona.avatarUrl"/>
+        <img
+            t-elif="this.user or this.persona"
+            class="w-100 h-100 object-fit-cover"
+            t-att-class="{ [this.props.imgRoundedClass]: this.props.imgRoundedClass, 'rounded': !this.props.imgRoundedClass }"
+            t-att-src="(this.user || this.persona).avatarUrl"
+            alt=""
+        />
     </t>
 </templates>

--- a/addons/mail/static/src/core/common/im_status.js
+++ b/addons/mail/static/src/core/common/im_status.js
@@ -31,7 +31,16 @@ imStatusDataRegistry.add(
 );
 
 export class ImStatus extends Component {
-    static props = ["persona?", "className?", "style?", "member?", "slots?", "size?", "typing?"];
+    static props = [
+        "className?",
+        "member?",
+        "persona?",
+        "size?",
+        "slots?",
+        "style?",
+        "typing?",
+        "user?",
+    ];
     static template = "mail.ImStatus";
     static defaultProps = { className: "", style: "", size: "lg", typing: true };
     static components = { Typing };
@@ -42,7 +51,7 @@ export class ImStatus extends Component {
     }
 
     get persona() {
-        return this.props.persona ?? this.props.member?.persona;
+        return this.props.user?.partner_id || this.props.persona || this.props.member?.persona;
     }
 
     get showTypingIndicator() {
@@ -61,7 +70,7 @@ export class ImStatus extends Component {
     get activeImStatusData() {
         return imStatusDataRegistry
             .getAll()
-            .find((r) => r.condition({ persona: this.persona, member: this.props.member }));
+            .find((r) => r.condition({ member: this.props.member, user: this.user }));
     }
 
     get icon() {
@@ -88,5 +97,9 @@ export class ImStatus extends Component {
             default:
                 return "opacity-75";
         }
+    }
+
+    get user() {
+        return this.props.user || this.persona?.main_user_id;
     }
 }

--- a/addons/mail/static/src/core/common/im_status_dropdown.xml
+++ b/addons/mail/static/src/core/common/im_status_dropdown.xml
@@ -2,7 +2,9 @@
 <templates xml:space="preserve">
     <t t-name="mail.ImStatusDropdown">
         <Dropdown menuClass="'o-mail-ImStatusDropdown'">
-            <a href="#" t-att-class="{ 'd-block text-body py-3 fs-4 d-flex flex-row gap-2': this.env.isSmall }"><ImStatus persona='this.store.self'/> <span t-out="this.readableImStatus"/> <i t-if="this.env.isSmall" class="oi oi-chevron-right ms-auto mt-1"/></a>
+            <a href="#" t-att-class="{ 'd-block text-body py-3 fs-4 d-flex flex-row gap-2': this.env.isSmall }">
+                <ImStatus user="this.store.self_user"/> <span t-out="this.readableImStatus"/> <i t-if="this.env.isSmall" class="oi oi-chevron-right ms-auto mt-1"/>
+            </a>
             <t t-set-slot="content">
                 <DropdownItem class="{ 'active': this.store.self.im_status === 'online' }" onSelected="() => this.setManualImStatus('online')"><i class="fa fa-circle text-success me-1" title="Online" role="img"/> Online</DropdownItem>
                 <hr class="my-1"/>

--- a/addons/mail/static/src/core/common/partner_compare.js
+++ b/addons/mail/static/src/core/common/partner_compare.js
@@ -11,7 +11,7 @@ export const partnerCompareRegistry = registry.category("mail.partner_compare");
 
 partnerCompareRegistry.add(
     "mail.archived-last-except-odoobot",
-    (p1, p2) => {
+    function archivedLastExceptOdoobot(p1, p2) {
         const p1active = p1.active || p1.eq(p1.store.odoobot);
         const p2active = p2.active || p2.eq(p2.store.odoobot);
         if (!p1active && p2active) {
@@ -26,7 +26,7 @@ partnerCompareRegistry.add(
 
 partnerCompareRegistry.add(
     "mail.self-last",
-    (p1, p2, { store }) => {
+    function selfLast(p1, p2, { store }) {
         const isSelf1 = p1.eq(store.self);
         const isSelf2 = p2.eq(store.self);
         if (isSelf1 && !isSelf2) {
@@ -41,7 +41,7 @@ partnerCompareRegistry.add(
 
 partnerCompareRegistry.add(
     "mail.internal-users",
-    (p1, p2) => {
+    function internalUsers(p1, p2) {
         const isAInternalUser = p1.main_user_id?.share === false;
         const isBInternalUser = p2.main_user_id?.share === false;
         if (isAInternalUser && !isBInternalUser) {
@@ -56,7 +56,7 @@ partnerCompareRegistry.add(
 
 partnerCompareRegistry.add(
     "mail.followers",
-    (p1, p2, { thread }) => {
+    function followers(p1, p2, { thread }) {
         if (thread) {
             const followerList = [...thread.followers];
             if (thread.selfFollower) {
@@ -77,7 +77,7 @@ partnerCompareRegistry.add(
 
 partnerCompareRegistry.add(
     "mail.name",
-    (p1, p2, { searchTerm }) => {
+    function name(p1, p2, { searchTerm }) {
         const cleanedName1 = cleanTerm(p1.name);
         const cleanedName2 = cleanTerm(p2.name);
         if (cleanedName1.startsWith(searchTerm) && !cleanedName2.startsWith(searchTerm)) {
@@ -98,7 +98,7 @@ partnerCompareRegistry.add(
 
 partnerCompareRegistry.add(
     "mail.email",
-    (p1, p2, { searchTerm }) => {
+    function email(p1, p2, { searchTerm }) {
         const cleanedEmail1 = cleanTerm(p1.email);
         const cleanedEmail2 = cleanTerm(p2.email);
         if (cleanedEmail1.startsWith(searchTerm) && !cleanedEmail1.startsWith(searchTerm)) {

--- a/addons/mail/static/src/core/common/res_users_model.js
+++ b/addons/mail/static/src/core/common/res_users_model.js
@@ -2,6 +2,8 @@ import { createElementWithContent } from "@web/core/utils/html";
 import { fields, Record } from "@mail/model/export";
 import { getOuterHtml } from "@mail/utils/common/html";
 
+import { imageUrl } from "@web/core/utils/urls";
+
 export class ResUsers extends Record {
     static _name = "res.users";
     static _inherits = { "res.partner": "partner_id" };
@@ -20,6 +22,13 @@ export class ResUsers extends Record {
     share;
     /** @type {ReturnType<import("@odoo/owl").markup>|string|undefined} */
     signature = fields.Html(undefined);
+
+    get avatarUrl() {
+        if (this.partner_id) {
+            return this.partner_id.avatarUrl;
+        }
+        return imageUrl("res.users", this.id, "avatar_128", { unique: this.write_date });
+    }
 
     /**
      * Get the signature with its typical layout when inserted in html

--- a/addons/mail/static/src/core/common/suggestion_service.js
+++ b/addons/mail/static/src/core/common/suggestion_service.js
@@ -286,7 +286,6 @@ export class SuggestionService {
             }
             for (const fn of compareFunctions) {
                 const result = fn(p1, p2, {
-                    env: this.env,
                     store: this.store,
                     searchTerm: cleanedSearchTerm,
                     thread,

--- a/addons/mail/static/src/core/web/@types/models.d.ts
+++ b/addons/mail/static/src/core/web/@types/models.d.ts
@@ -19,13 +19,10 @@ declare module "models" {
         activityGroups: Object[];
         computeGlobalCounter: () => number;
         globalCounter: number;
-        history: Thread;
-        inbox: Thread;
         onLinkFollowed: (fromThread: Thread) => void;
         onUpdateActivityGroups: () => void;
-        scheduleActivity: (resModel: string, resIds: number[], defaultActivityTypeId: number|undefined) => Promise<void>;
-        bookmarkBox: Thread;
         removeAllBookmarks: () => Promise<void>;
+        scheduleActivity: (resModel: string, resIds: number[], defaultActivityTypeId: number|undefined) => Promise<void>;
         updateAppBadge: () => void;
     }
     export interface Thread {

--- a/addons/mail/static/src/discuss/core/common/partner_compare.js
+++ b/addons/mail/static/src/discuss/core/common/partner_compare.js
@@ -2,9 +2,9 @@ import { partnerCompareRegistry } from "@mail/core/common/partner_compare";
 
 partnerCompareRegistry.add(
     "discuss.recent-chats",
-    (p1, p2, { env, context }) => {
+    function recentChats(p1, p2, { context, store }) {
         const recentChatPartnerIds =
-            context.recentChatPartnerIds || env.services["mail.store"].getRecentChatPartnerIds();
+            context.recentChatPartnerIds || store.getRecentChatPartnerIds();
         const recentChatIndex_p1 = recentChatPartnerIds.findIndex(
             (partnerId) => partnerId === p1.id
         );
@@ -26,7 +26,7 @@ partnerCompareRegistry.add(
 
 partnerCompareRegistry.add(
     "discuss.members",
-    (p1, p2, { thread, context: { memberPartnerIds } }) => {
+    function members(p1, p2, { thread, context: { memberPartnerIds } }) {
         if (thread?.channel) {
             const isMember1 = memberPartnerIds.has(p1.id);
             const isMember2 = memberPartnerIds.has(p2.id);

--- a/addons/mail/static/src/discuss/core/public_web/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/public_web/@types/models.d.ts
@@ -23,7 +23,6 @@ declare module "models" {
     export interface Store {
         channels: ReturnType<Store['makeCachedFetchData']>;
         fetchSsearchConversationsSequential: () => Promise<any>;
-        has_unpinned_channels: boolean;
         searchConversations: (searchValue: string) => Promise<void>;
     }
 }

--- a/addons/mail/static/src/discuss/core/web/burger_menu_patch.xml
+++ b/addons/mail/static/src/discuss/core/web/burger_menu_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">  
     <t t-inherit="web.BurgerMenu" t-inherit-mode="extension">
         <xpath expr="//img[hasclass('o_burger_menu_avatar')]" position="replace">
-            <DiscussAvatar persona="store.self" size="26"/>
+            <DiscussAvatar user="this.store.self_user" size="26"/>
         </xpath>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/core/web/user_menu_patch.xml
+++ b/addons/mail/static/src/discuss/core/web/user_menu_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="web.UserMenu" t-inherit-mode="extension">
         <xpath expr="//img[hasclass('o_user_avatar')]" position="replace">
-            <DiscussAvatar persona="store.self" size="26"/>
+            <DiscussAvatar user="this.store.self_user" size="26"/>
         </xpath>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.js
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.js
@@ -70,6 +70,9 @@ export class AvatarCardPopover extends Component {
         if (this.props.model === "res.users") {
             return this.store["res.users"].get(this.props.id);
         }
+        if (this.props.model === "res.partner") {
+            return this.partner?.main_user_id;
+        }
         return undefined;
     }
 

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
@@ -9,8 +9,8 @@
                             t-attf-src="/web/image/{{this.props.model}}/{{this.props.id}}/avatar_128"
                             class="rounded"
                         />
-                        <span t-if="this.partner?.im_status and this.partner.im_status !== 'im_partner'" name="icon" class="o_card_avatar_im_status position-absolute d-flex align-items-center justify-content-center bg-inherit">
-                            <ImStatus persona="this.partner" />
+                        <span t-if="this.user and this.partner?.im_status and this.partner.im_status !== 'im_partner'" name="icon" class="o_card_avatar_im_status position-absolute d-flex align-items-center justify-content-center bg-inherit">
+                            <ImStatus user="this.user"/>
                         </span>
                     </span>
                     <div class="d-flex flex-column o_card_user_infos overflow-hidden">

--- a/addons/mail/static/tests/chatter/web/chatter.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter.test.js
@@ -676,8 +676,8 @@ test("Mentions in composer should still work when using pager", async () => {
     await click("button:text('Log note')");
     await click(".o_pager_next");
     await insertText(".o-mail-Composer-input", "@");
-    // all records in DB: Mitchell Admin | Hermit | Public user except OdooBot
-    await contains(".o-mail-Composer-suggestion", { count: 3 });
+    // all active records in DB with a name: Mitchell Admin | Hermit
+    await contains(".o-mail-Composer-suggestion", { count: 2 });
 });
 
 test("form views in dialogs do not have chatter", async () => {

--- a/addons/mail/static/tests/core/web/user_menu.test.js
+++ b/addons/mail/static/tests/core/web/user_menu.test.js
@@ -1,0 +1,10 @@
+import { defineMailModels, start } from "@mail/../tests/mail_test_helpers";
+import { describe, test, waitFor } from "@odoo/hoot";
+
+describe.current.tags("desktop");
+defineMailModels();
+
+test("User menu shows im_status icon", async () => {
+    await start();
+    await waitFor(".o_user_menu .o-mail-ImStatus");
+});

--- a/addons/mail/static/tests/suggestion/suggestion.test.js
+++ b/addons/mail/static/tests/suggestion/suggestion.test.js
@@ -265,7 +265,7 @@ test("[text composer] Do not fetch if search more specific and fetch had no resu
     await openFormView("res.partner", serverState.partnerId);
     await click("button:text('Send message')");
     await insertText(".o-mail-Composer-input", "@");
-    await contains(".o-mail-Composer-suggestion", { count: 3 }); // Mitchell Admin, Hermit, Public user
+    await contains(".o-mail-Composer-suggestion", { count: 2 }); // Mitchell Admin, Hermit
     await contains(".o-mail-Composer-suggestion:has(:text('Mitchell Admin'))");
     await expect.waitForSteps(["get_mention_suggestions"]);
     await insertText(".o-mail-Composer-input", "x");
@@ -293,7 +293,7 @@ test("Do not fetch if search more specific and fetch had no result", async () =>
     };
     await focus(".o-mail-Composer-html.odoo-editor-editable");
     await htmlInsertText(editor, "@");
-    await contains(".o-mail-Composer-suggestion", { count: 3 }); // Mitchell Admin, Hermit, Public user
+    await contains(".o-mail-Composer-suggestion", { count: 2 }); // Mitchell Admin, Hermit
     await contains(".o-mail-Composer-suggestion:has(:text('Mitchell Admin'))");
     await expect.waitForSteps(["get_mention_suggestions"]);
     await htmlInsertText(editor, "x");
@@ -889,7 +889,7 @@ test("[text composer] Current user is last suggested partner", async () => {
     await openFormView("res.partner", serverState.partnerId);
     await click("button:text('Send message')");
     await insertText(".o-mail-Composer-input", "@");
-    await contains(".o-mail-Composer-suggestion", { count: 5 });
+    await contains(".o-mail-Composer-suggestion", { count: 4 }); // Mitchell Admin, Hermit, Person A, Person B
     await contains(".o-mail-Composer-suggestion:has(:text('Person B (b@test.com)'))", {
         before: [".o-mail-Composer-suggestion:has(:text('Mitchell Admin'))"],
     });
@@ -926,7 +926,7 @@ test("Current user is last suggested partner", async () => {
     };
     await focus(".o-mail-Composer-html.odoo-editor-editable");
     await htmlInsertText(editor, "@");
-    await contains(".o-mail-Composer-suggestion", { count: 5 });
+    await contains(".o-mail-Composer-suggestion", { count: 4 }); // Mitchell Admin, Hermit, Person A, Person B
     await contains(".o-mail-Composer-suggestion:has(:text('Person B (b@test.com)'))", {
         before: [".o-mail-Composer-suggestion:has(:text('Mitchell Admin'))"],
     });

--- a/addons/pos_event/static/tests/unit/components/event_registration_popup.test.js
+++ b/addons/pos_event/static/tests/unit/components/event_registration_popup.test.js
@@ -2,6 +2,7 @@ import { expect, test } from "@odoo/hoot";
 import { EventRegistrationPopup } from "@pos_event/app/components/popup/event_registration_popup/event_registration_popup";
 import { mountPosDialog, setupPosEnv } from "@point_of_sale/../tests/unit/utils";
 import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
+import { serverState } from "@web/../tests/web_test_helpers";
 
 definePosModels();
 
@@ -47,7 +48,7 @@ test("confirm payload", async () => {
 
 test("autofill first ticket with customer data", async () => {
     const store = await setupPosEnv();
-    const partner = store.models["res.partner"].get(18);
+    const partner = store.models["res.partner"].get(serverState.partnerId);
     partner.email = "john@example.com";
     partner.phone = "+1234567890";
     partner.parent_name = "Don";
@@ -69,7 +70,7 @@ test("autofill first ticket with customer data", async () => {
     const [first, second] = comp.state.byRegistration.map((r) => r.questions);
 
     expect(Object.values(first)).toEqual([
-        "Public user",
+        "Mitchell Admin",
         "john@example.com",
         "+1234567890",
         "",

--- a/addons/pos_restaurant/static/tests/unit/models/pos_order.test.js
+++ b/addons/pos_restaurant/static/tests/unit/models/pos_order.test.js
@@ -1,6 +1,7 @@
 import { test, describe, expect } from "@odoo/hoot";
 import { setupPosEnv, getFilledOrder } from "@point_of_sale/../tests/unit/utils";
 import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
+import { serverState } from "@web/../tests/web_test_helpers";
 
 definePosModels();
 
@@ -23,9 +24,9 @@ describe("pos.order restaurant patches", () => {
     test("setPartner", async () => {
         const store = await setupPosEnv();
         const order = store.addNewOrder();
-        const partner = store.models["res.partner"].get(18);
+        const partner = store.models["res.partner"].get(serverState.partnerId);
         order.setPartner(partner);
-        expect(order.floating_order_name).toBe("Public user");
+        expect(order.floating_order_name).toBe("Mitchell Admin");
     });
 
     test("cleanCourses", async () => {

--- a/addons/web/static/tests/_framework/mock_server/mock_models/res_partner.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_models/res_partner.js
@@ -37,7 +37,7 @@ export class ResPartner extends ServerModel {
         },
         {
             id: serverState.publicPartnerId,
-            active: true,
+            active: false,
             is_public: true,
             name: serverState.publicPartnerName,
         },

--- a/addons/web/static/tests/_framework/mock_server/mock_models/res_users.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_models/res_users.js
@@ -20,6 +20,7 @@ export class ResUsers extends ServerModel {
             login: "public",
             partner_id: serverState.publicPartnerId,
             password: "public",
+            share: true,
         },
         {
             id: serverState.odoobotUid,


### PR DESCRIPTION
Supporting user simplifies the code and makes it more correct as it removes the need to rely on `main_user_id` in some cases.

This highlighted some issues in the rest of the code that are fixed at the same time:

- added proper type hints to partner compare methods
- added named functions to partner compare methods for easier debugging
- removed env from partner compare methods as it was only used to get store and store is already given too
- updated d.ts files (some not updated from previous commits)
- public partner should be archived in mock server
- public user should be properly flagged as a share user in mock server

Part of task-5946571

https://github.com/odoo/enterprise/pull/110442