### PR TITLE
[REF] mail, im_livechat: use user in channel._broadcast

### DIFF
--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -175,8 +175,8 @@ class LivechatController(http.Controller):
             channel_id = channel.id
             if is_chatbot_script:
                 chatbot_script._post_welcome_steps(channel)
-            if agents := channel.livechat_agent_partner_ids:
-                channel._broadcast(agents.ids)
+            if agents := channel.livechat_agent_partner_ids.user_ids:
+                channel._broadcast(agents)
             if guest:
                 store.add_global_values(guest_token=guest.sudo()._format_auth_cookie())
         store.add_global_values(request.env.user.sudo(False)._store_init_global_fields)

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -935,7 +935,7 @@ class DiscussChannel(models.Model):
                 operator_name=human_operator.livechat_username if human_operator.livechat_username else human_operator.name,
             )
             channel_sudo._add_next_step_message_to_store(chatbot_script_step)
-            channel_sudo._broadcast(human_operator.partner_id.ids)
+            channel_sudo._broadcast(human_operator)
             self.self_member_id.last_interest_dt = fields.Datetime.now()
         else:
             # sudo: discuss.channel - visitor tried getting operator, outcome must be updated

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1154,16 +1154,15 @@ class DiscussChannel(models.Model):
     # ------------------------------------------------------------
 
     # Anonymous method
-    def _broadcast(self, partner_ids):
-        """ Broadcast the current channel header to the given partner ids
-            :param partner_ids : the partner to notify
+    def _broadcast(self, users):
+        """ Broadcast the current channel header to the given users
+            :param users : the users to notify
         """
-        for partner in self.env['res.partner'].browse(partner_ids):
-            if user := partner.main_user_id:
-                Store(bus_channel=user).add(
-                    self.with_user(user).with_context(allowed_company_ids=[]),
-                    "_store_channel_fields",
-                ).bus_send()
+        for user in users:
+            Store(bus_channel=user).add(
+                self.with_user(user).with_context(allowed_company_ids=[]),
+                "_store_channel_fields",
+            ).bus_send()
 
     # ------------------------------------------------------------
     # INSTANT MESSAGING API
@@ -1397,7 +1396,7 @@ class DiscussChannel(models.Model):
             channel = self.browse(result[0].get('channel_id'))
             # pin or open the channel for the current partner
             channel.self_member_id.write({"last_interest_dt": last_interest_dt, "unpin_dt": False})
-            channel._broadcast(self.env.user.partner_id.ids)
+            channel._broadcast(self.env.user)
         else:
             # create a new one
             channel = self.create(
@@ -1418,7 +1417,7 @@ class DiscussChannel(models.Model):
                     "name": ", ".join(partners.mapped("name")),
                 }
             )
-            channel._broadcast(partners.ids)
+            channel._broadcast(partners.user_ids)
         return channel
 
     def _allow_invite_by_email(self):
@@ -1519,7 +1518,7 @@ class DiscussChannel(models.Model):
                 "name": name,
             }
         )
-        channel._broadcast(channel.channel_member_ids.partner_id.ids)
+        channel._broadcast(channel.channel_member_ids.partner_id.user_ids)
         return channel
 
     def _create_sub_channel(self, from_message_id=None, name=None):

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -234,8 +234,6 @@ export class DiscussChannel extends models.ServerModel {
 
         /** @type {import("mock_models").DiscussChannel} */
         const DiscussChannel = this.env["discuss.channel"];
-        /** @type {import("mock_models").ResPartner} */
-        const ResPartner = this.env["res.partner"];
 
         const id = this.create({
             channel_member_ids: [Command.create({ partner_id: this.env.user.partner_id })],
@@ -252,8 +250,7 @@ export class DiscussChannel extends models.ServerModel {
                 message_type: "notification",
             })
         );
-        const [partner] = ResPartner.read(this.env.user.partner_id);
-        this._broadcast([id], [partner]);
+        this._broadcast([id], [this.env.user.id]);
         return DiscussChannel.browse(id);
     }
 
@@ -346,7 +343,7 @@ export class DiscussChannel extends models.ServerModel {
         });
         this._broadcast(
             [id],
-            partners.map(({ id }) => id)
+            partners.flatMap((partner) => partner.user_ids)
         );
         return DiscussChannel.browse(id);
     }
@@ -504,7 +501,7 @@ export class DiscussChannel extends models.ServerModel {
         });
         this._broadcast(
             [id],
-            partners.map((partner) => partner.id)
+            partners.flatMap((partner) => partner.user_ids)
         );
         return DiscussChannel.browse(id);
     }
@@ -521,7 +518,7 @@ export class DiscussChannel extends models.ServerModel {
         const MailMessage = this.env["mail.message"];
         /** @type {import("mock_models").BusBus} */
         const BusBus = this.env["bus.bus"];
-        /** @type {import {"mock_model"}.ResPartner} */
+        /** @type {import("mock_models").ResPartner} */
         const ResPartner = this.env["res.partner"];
         const self = this.browse(ids)[0];
         let message;
@@ -854,30 +851,30 @@ export class DiscussChannel extends models.ServerModel {
 
     /**
      * @param {number[]} ids
-     * @param {number[]} partner_ids
+     * @param {number[]} user_ids
      */
-    _broadcast(ids, partner_ids) {
-        const kwargs = getKwArgs(arguments, "ids", "partner_ids");
+    _broadcast(ids, user_ids) {
+        const kwargs = getKwArgs(arguments, "ids", "user_ids");
         ids = kwargs.ids;
         delete kwargs.ids;
-        partner_ids = kwargs.partner_ids;
+        user_ids = kwargs.user_ids;
 
         /** @type {import("mock_models").BusBus} */
         const BusBus = this.env["bus.bus"];
 
-        const notifications = this._channel_channel_notifications(ids, partner_ids);
+        const notifications = this._channel_channel_notifications(ids, user_ids);
         BusBus._sendmany(notifications);
     }
 
     /**
      * @param {number} id
-     * @param {number[]} partner_ids
+     * @param {number[]} user_ids
      */
-    _channel_channel_notifications(ids, partner_ids) {
-        const kwargs = getKwArgs(arguments, "ids", "partner_ids");
+    _channel_channel_notifications(ids, user_ids) {
+        const kwargs = getKwArgs(arguments, "ids", "user_ids");
         ids = kwargs.ids;
         delete kwargs.ids;
-        partner_ids = kwargs.partner_ids;
+        user_ids = kwargs.user_ids;
 
         /** @type {import("mock_models").DiscussChannel} */
         const DiscussChannel = this.env["discuss.channel"];
@@ -887,14 +884,14 @@ export class DiscussChannel extends models.ServerModel {
         const ResUsers = this.env["res.users"];
 
         const notifications = [];
-        for (const partner_id of partner_ids) {
-            const user = ResUsers._filter([["partner_id", "in", partner_id]])[0];
+        for (const user_id of user_ids) {
+            const user = ResUsers.browse(user_id)[0];
             if (!user) {
                 continue;
             }
             // Note: `_to_store` on the server is supposed to be called with
             // the proper user context but this is not done here for simplicity.
-            const [relatedPartner] = ResPartner.search_read([["id", "=", partner_id]]);
+            const [relatedPartner] = ResPartner.search_read([["id", "=", user.partner_id]]);
             for (const channelId of ids) {
                 notifications.push([
                     relatedPartner,


### PR DESCRIPTION
Sending to a partner makes no sense as only users are able to receive bus notifications.

Part of task-5946571

https://github.com/odoo/enterprise/pull/109232