### PR TITLE
[FIX] hr_attendance: use browser's geolocalisation in barcode scan

### DIFF
--- a/addons/hr_attendance/controllers/main.py
+++ b/addons/hr_attendance/controllers/main.py
@@ -130,13 +130,16 @@ class HrAttendance(http.Controller):
                 return self._get_employee_info_response(employee)
         return {}
 
-    @http.route('/hr_attendance/attendance_barcode_scanned', type="json", auth="public")
     def scan_barcode(self, token, barcode):
+        return self.scan_barcode_with_geolocation(token, barcode)
+
+    @http.route('/hr_attendance/attendance_barcode_scanned', type="json", auth="public")
+    def scan_barcode_with_geolocation(self, token, barcode, latitude=False, longitude=False):
         company = self._get_company(token)
         if company:
             employee = request.env['hr.employee'].sudo().search([('barcode', '=', barcode), ('company_id', '=', company.id)], limit=1)
             if employee:
-                employee._attendance_action_change(self._get_geoip_response('kiosk'))
+                employee._attendance_action_change(self._get_geoip_response('kiosk', latitude=latitude, longitude=longitude))
                 return self._get_employee_info_response(employee)
         return {}
 

--- a/addons/hr_attendance/controllers/main.py
+++ b/addons/hr_attendance/controllers/main.py
@@ -129,13 +129,16 @@ class HrAttendance(http.Controller):
                 return self._get_employee_info_response(employee)
         return {}
 
-    @http.route('/hr_attendance/attendance_barcode_scanned', type="json", auth="public")
     def scan_barcode(self, token, barcode):
+        return self.scan_barcode_with_geolocation(token, barcode)
+
+    @http.route('/hr_attendance/attendance_barcode_scanned', type="json", auth="public")
+    def scan_barcode_with_geolocation(self, token, barcode, latitude=False, longitude=False):
         company = self._get_company(token)
         if company:
             employee = request.env['hr.employee'].sudo().search([('barcode', '=', barcode), ('company_id', '=', company.id)], limit=1)
             if employee:
-                employee._attendance_action_change(self._get_geoip_response('kiosk'))
+                employee._attendance_action_change(self._get_geoip_response('kiosk', latitude=latitude, longitude=longitude))
                 return self._get_employee_info_response(employee)
         return {}
 

--- a/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.js
+++ b/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.js
@@ -197,7 +197,8 @@ class kioskAttendanceApp extends Component{
 
         let result;
         try {
-            result = await rpc("attendance_barcode_scanned", {
+            result = await this.makeRpcWithGeolocation('attendance_barcode_scanned',
+            {
                 barcode: barcode,
                 token: this.props.token,
             });


### PR DESCRIPTION
**Issue**
Check-in and check-out performed in kiosk mode via the barcode scanner were less accurate than those made via the manual selection.
The reported inacurracy between the actual and real locations was several kilometers.

**Cause**
`attendance_barcode_scanned` was called without a location coming from the browser's geolocation API.
In that case, the location was determined by the geoip database
https://github.com/odoo/odoo/blob/51f59a293de1e86f66f30257f8fc0c419463d18c/addons/hr_attendance/controllers/main.py#L69-L70 which is generally not as accurate as the location provided by the browser.

opw-5889102