### PR TITLE
[REF] mail: clean getPartner method

### DIFF
--- a/addons/mail/controllers/webclient.py
+++ b/addons/mail/controllers/webclient.py
@@ -88,6 +88,12 @@ class WebclientController(ThreadController):
                     fields_params={"request_list": params["request_list"]},
                     as_thread=True,
                 )
+        if name == "res.partner":
+            partner = request.env["res.partner"].search_fetch([("id", "=", params["id"])])
+            store.add(partner, "_store_partner_fields")
+        if name == "res.users":
+            user = request.env["res.users"].search_fetch([("id", "=", params["id"])])
+            store.add(user, "_store_user_fields")
         if name == "/mail/poll_option/votes":
             option_id = params.get("poll_option_id")
             # sudo - mail.poll.option: validated by "_get_thread_with_access" afterwards.

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -429,6 +429,9 @@ class ResUsers(models.Model):
             },
         )
 
+    def _store_user_fields(self, res: Store.FieldList):
+        res.one("partner_id", "_store_partner_fields")
+
     @api.model
     def _get_activity_groups(self):
         search_limit = self.env['ir.config_parameter'].sudo().get_int('mail.activity.systray.limit') or 1000

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -7,7 +7,6 @@ import {
 } from "@mail/utils/common/format";
 import { compareDatetime } from "@mail/utils/common/misc";
 
-
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
@@ -58,7 +57,6 @@ export class Store extends BaseStore {
             return this.store.env.services.ui.isSmall || isMobileOS();
         },
     });
-    users = {};
     /** @type {number} */
     internalUserGroupId;
     mt_comment = fields.One("mail.message.subtype");
@@ -428,7 +426,26 @@ export class Store extends BaseStore {
      * @param {number} param0.partnerId
      */
     async getChat({ userId, partnerId }) {
-        const partner = await this.getPartner({ userId, partnerId });
+        let partner;
+        if (userId) {
+            const user = await this["res.users"].getOrFetch(userId, ["partner_id"]);
+            if (!user?.partner_id) {
+                this.env.services.notification.add(_t("You can only chat with existing users."), {
+                    type: "warning",
+                });
+                return;
+            }
+            partner = user.partner_id;
+        } else if (partnerId) {
+            partner = await this["res.partner"].getOrFetch(partnerId, ["main_user_id"]);
+            if (!partner?.main_user_id) {
+                this.env.services.notification.add(
+                    _t("You can only chat with partners that have a dedicated user."),
+                    { type: "info" }
+                );
+                return;
+            }
+        }
         if (!partner) {
             return;
         }
@@ -584,62 +601,6 @@ export class Store extends BaseStore {
             temporaryIdOffset = 0.01;
         }
         return lastMessageId + temporaryIdOffset;
-    }
-
-    /**
-     * Search and fetch for a partner with a given user or partner id.
-     * @param {Object} param0
-     * @param {number} param0.userId
-     * @param {number} param0.partnerId
-     * @returns {Promise<import("models").ResPartner>}
-     */
-    async getPartner({ userId, partnerId }) {
-        if (userId) {
-            let user = this.users[userId];
-            if (!user) {
-                this.users[userId] = { id: userId };
-                user = this.users[userId];
-            }
-            if (!user.partner_id) {
-                const [userData] = await this.env.services.orm.silent.read(
-                    "res.users",
-                    [user.id],
-                    ["partner_id"],
-                    { context: { active_test: false } }
-                );
-                if (userData) {
-                    user.partner_id = userData.partner_id[0];
-                }
-            }
-            if (!user.partner_id) {
-                this.env.services.notification.add(_t("You can only chat with existing users."), {
-                    type: "warning",
-                });
-                return;
-            }
-            partnerId = user.partner_id;
-        }
-        if (partnerId) {
-            const partner = this["res.partner"].insert({ id: partnerId });
-            if (!partner.main_user_id) {
-                const [userId] = await this.env.services.orm.silent.search(
-                    "res.users",
-                    [["partner_id", "=", partnerId]],
-                    { context: { active_test: false } }
-                );
-                if (!userId) {
-                    this.env.services.notification.add(
-                        _t("You can only chat with partners that have a dedicated user."),
-                        { type: "info" }
-                    );
-                    return;
-                }
-                if (!partner.main_user_id) {
-                    partner.main_user_id = userId;
-                }
-            }
-            return partner;
-        }
     }
 
     async joinChat(id, forceOpen = false) {

--- a/addons/mail/static/src/model/record.js
+++ b/addons/mail/static/src/model/record.js
@@ -49,6 +49,25 @@ export class Record {
         const Model = toRaw(this);
         return this.records[Model.localId(data)];
     }
+    /**
+     * Gets a record by id, fetching it from the server if it doesn't exist in the store or if some
+     * of the specified fields are missing.
+     * Only works for models that are explicitly supported in /mail/data controller.
+     *
+     * @param {number} id
+     * @param {string[]} field_names
+     */
+    static async getOrFetch(id, field_names = []) {
+        let record = this.get(id);
+        if (!record || field_names.some((fieldName) => record[fieldName] === undefined)) {
+            await this.store.fetchStoreData(this.getName(), { id, field_names });
+            record = this.get(id);
+            if (!record?.exists()) {
+                return;
+            }
+        }
+        return record;
+    }
     static getName() {
         return this._name || this.name;
     }

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -1004,6 +1004,14 @@ function _process_request_for_all(store, name, params, context = {}) {
             store.add(channel, makeKwArgs({ delete: true }));
         }
     }
+    if (name === "res.partner") {
+        const [partnerId] = ResPartner.search([["id", "=", params["id"]]]);
+        store.add(ResPartner.browse(partnerId));
+    }
+    if (name === "res.users") {
+        const [userId] = ResUsers.search([["id", "=", params["id"]]]);
+        store.add(ResUsers.browse(userId));
+    }
     if (name === "/discuss/channel/messages") {
         /** @type {import("mock_models").MailMessage} */
         const MailMessage = this.env["mail.message"];

--- a/addons/mail/static/tests/mock_server/mock_models/res_users.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_users.js
@@ -216,4 +216,8 @@ export class ResUsers extends webModels.ResUsers {
             ),
         ];
     }
+
+    get _to_store_defaults() {
+        return [mailDataHelpers.Store.one("partner_id")];
+    }
 }

--- a/addons/test_mail/static/tests/properties_field.test.js
+++ b/addons/test_mail/static/tests/properties_field.test.js
@@ -1,12 +1,14 @@
 import {
     click,
     contains,
+    listenStoreFetch,
     openFormView,
     registerArchs,
     start,
     startServer,
+    waitStoreFetch,
 } from "@mail/../tests/mail_test_helpers";
-import { describe, expect, test } from "@odoo/hoot";
+import { describe, test } from "@odoo/hoot";
 import { defineTestMailModels } from "@test_mail/../tests/test_mail_test_helpers";
 import { onRpc } from "@web/../tests/web_test_helpers";
 
@@ -28,11 +30,7 @@ async function testPropertyFieldAvatarOpenChat(propertyType) {
         `,
     });
     onRpc("mail.test.properties", "has_access", () => true);
-    onRpc("res.users", "read", () => {
-        expect.step("read res.users");
-        return [{ id: userId, partner_id: [partnerId, "Partner Test"] }];
-    });
-    onRpc("res.users", "search_read", () => [{ id: userId, name: "User Test" }]);
+    listenStoreFetch("res.users");
     await start();
     const partnerId = pyEnv["res.partner"].create({ name: "Partner Test" });
     const userId = pyEnv["res.users"].create({ partner_id: partnerId });
@@ -53,11 +51,11 @@ async function testPropertyFieldAvatarOpenChat(propertyType) {
     });
 
     await openFormView("mail.test.properties", childId);
-    await expect.waitForSteps([]);
+    await waitStoreFetch();
     await click(
         propertyType === "many2one" ? ".o_field_property_many2one_value img" : ".o_m2m_avatar"
     );
-    await expect.waitForSteps(["read res.users"]);
+    await waitStoreFetch("res.users");
     await contains(".o-mail-ChatWindow", { text: "Partner Test" });
 }
 


### PR DESCRIPTION
This is an old method that is called in only one place and uses a local users cache rather than using the res.users model in Store.

Update the code to recent standards and remove the method to inline its code in caller.

This will avoid unnecessary RPC when information is already known.

Part of task-5946571