### PR TITLE
[FIX] web: keep dropdown open for upload widget actions on small screens

### DIFF
--- a/addons/web/static/src/views/fields/file_handler.xml
+++ b/addons/web/static/src/views/fields/file_handler.xml
@@ -2,19 +2,21 @@
 <templates xml:space="preserve">
 
     <t t-name="web.FileUploader">
-        <t t-if="state.isUploading and props.showUploadingText">Uploading...</t>
-        <span t-else="" t-on-click.prevent="onSelectFileButtonClick" style="display:contents">
-            <t t-slot="toggler"/>
-        </span>
-        <t t-slot="default"/>
-        <input
-            type="file"
-            t-att-name="props.inputName"
-            t-ref="fileInput"
-            t-attf-class="o_input_file d-none {{ props.fileUploadClass or '' }}"
-            t-att-multiple="props.multiUpload ? 'multiple' : false" t-att-accept="props.acceptedFileExtensions or '*'"
-            t-on-change="onFileChange"
-        />
+        <div t-on-click.stop="">
+            <t t-if="state.isUploading and props.showUploadingText">Uploading...</t>
+            <span t-else="" t-on-click.prevent="onSelectFileButtonClick" style="display:contents">
+                <t t-slot="toggler"/>
+            </span>
+            <t t-slot="default"/>
+            <input
+                type="file"
+                t-att-name="props.inputName"
+                t-ref="fileInput"
+                t-attf-class="o_input_file d-none {{ props.fileUploadClass or '' }}"
+                t-att-multiple="props.multiUpload ? 'multiple' : false" t-att-accept="props.acceptedFileExtensions or '*'"
+                t-on-change="onFileChange"
+            />
+        </div>
     </t>
 
 </templates>

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -9,6 +9,7 @@ import {
     queryAllAttributes,
     queryAllTexts,
     queryFirst,
+    setInputFiles,
     waitFor,
 } from "@odoo/hoot-dom";
 import {
@@ -56,6 +57,7 @@ import {
     toggleActionMenu,
     toggleMenuItem,
     toggleSearchBarMenu,
+    waitForSteps,
 } from "@web/../tests/web_test_helpers";
 
 import { browser } from "@web/core/browser/browser";
@@ -75,6 +77,7 @@ import { X2ManyField, x2ManyField } from "@web/views/fields/x2many/x2many_field"
 import { FormController } from "@web/views/form/form_controller";
 import { AttachDocumentWidget } from "@web/views/widgets/attach_document/attach_document";
 import { WebClient } from "@web/webclient/webclient";
+import { FileUploader } from "@web/views/fields/file_handler";
 
 const fieldsRegistry = registry.category("fields");
 const widgetsRegistry = registry.category("view_widgets");
@@ -9628,6 +9631,45 @@ test(`support header button as widgets on form statusbar on mobile`, async () =>
     await contains(`.o_cp_action_menus button:has(.fa-cog)`).click();
     expect(`button.o_attachment_button`).toHaveCount(1);
     expect(`span.o_attach_document`).toHaveText("Attach document");
+});
+
+test.tags("mobile");
+test("support header button as widgets in submenu on form statusbar on mobile", async () => {
+    class TestUploadWidget extends Component {
+        static props = ["*"];
+        static template = xml`
+            <FileUploader onUploaded="this.onUploaded">
+                <t t-set-slot="toggler">
+                    <button>Upload Test</button>
+                </t>
+            </FileUploader>`
+        static components = { FileUploader };
+
+        onUploaded(ev) {
+            expect(ev.name).toBe("fake_file.txt");
+            expect.step("File changed");
+        }
+    }
+    registry.category("view_widgets").add("test_upload_widget", { component: TestUploadWidget });
+
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `<form><header>
+            <button name="main" string="Main"/>
+            <widget name="test_upload_widget"/>
+        </header></form>`,
+    });
+
+    await contains(".o_statusbar_buttons button:has(.oi-ellipsis-v)").click();
+    expect(".o-dropdown--menu button:contains(Upload Test)").toHaveCount(1);
+    await contains(".o-dropdown--menu button:contains(Upload Test)").click();
+    expect(".o-dropdown--menu button:contains(Upload Test)").toHaveCount(1);
+
+    const file = new File(["test"], "fake_file.txt", { type: "text/plain" });
+    await contains("input.o_input_file", { visible: false }).click();
+    await setInputFiles([file]);
+    await waitForSteps(["File changed"]);
 });
 
 test(`basic support for widgets: onchange update`, async () => {


### PR DESCRIPTION
## Issue:
On small screens, when an upload widget is placed inside a dropdown
(e.g., Upload Bill from a Purchase Order), the action does not work

Clicking the dropdown item closes the dropdown immediately,
which prevents the widget action from completing

## Cause:
Widget actions require an accessible anchor element to function properly.
However, dropdown items automatically close the dropdown on click

As a result, the widget is triggered but immediately detached from the DOM
before its action can fully execute

## Steps to reproduce:
- Install `purchase_stock` (to have the Upload Bill widget available)
- Create and confirm a Purchase Order (the Receive button must be available)
- Reduce the browser width until the action buttons collapse into the three-dots menu
- Click Upload Bill and try to upload a document

opw-5918379