### PR TITLE
[FIX] html_builder: make option container label accessible

### DIFF
--- a/addons/html_builder/static/src/sidebar/customize_tab.js
+++ b/addons/html_builder/static/src/sidebar/customize_tab.js
@@ -34,6 +34,22 @@ export class CustomizeTab extends Component {
                 this.state.hasContent = true;
             }
         });
+        this.overlayPreviewedEl = null;
+    }
+
+    toggleOverlayPreview(el, show) {
+        if (show && this.overlayPreviewedEl !== el) {
+            if (this.overlayPreviewedEl) {
+                this.env.editor.shared.builderOverlay.hideOverlayPreview(this.overlayPreviewedEl);
+            }
+            this.env.editor.shared.overlayButtons.hideOverlayButtons();
+            this.env.editor.shared.builderOverlay.showOverlayPreview(el);
+            this.overlayPreviewedEl = el;
+        } else if (!show && this.overlayPreviewedEl === el) {
+            this.env.editor.shared.overlayButtons.showOverlayButtons();
+            this.env.editor.shared.builderOverlay.hideOverlayPreview(el);
+            this.overlayPreviewedEl = null;
+        }
     }
 
     getCurrentOptionsContainers() {

--- a/addons/html_builder/static/src/sidebar/customize_tab.xml
+++ b/addons/html_builder/static/src/sidebar/customize_tab.xml
@@ -17,6 +17,7 @@
                     compProps="this.customizeComponent.props"/>
                 <t t-else="" t-foreach="currentOptionsContainers" t-as="optionsContainer" t-key="optionsContainer.id">
                     <OptionsContainer
+                        toggleOverlayPreview.bind="this.toggleOverlayPreview"
                         snippetModel="props.snippetModel"
                         folded="optionsContainer.folded"
                         toggleFold="() => optionsContainer.folded = !optionsContainer.folded"

--- a/addons/html_builder/static/src/sidebar/option_container.js
+++ b/addons/html_builder/static/src/sidebar/option_container.js
@@ -1,7 +1,7 @@
 import { BorderConfigurator } from "../plugins/border_configurator_option";
 import { ShadowOption } from "../plugins/shadow_option";
 import { getSnippetName, useOptionsSubEnv } from "@html_builder/utils/utils";
-import { onWillStart, onWillUpdateProps } from "@odoo/owl";
+import { onWillStart, onWillUpdateProps, useExternalListener, useRef } from "@odoo/owl";
 import { user } from "@web/core/user";
 import { useService } from "@web/core/utils/hooks";
 import { useOperation } from "../core/operation_plugin";
@@ -12,15 +12,17 @@ import {
     useVisibilityObserver,
 } from "../core/utils";
 import { uniqueId } from "@web/core/utils/functions";
+import { browser } from "@web/core/browser/browser";
 
 export class OptionsContainer extends BaseOptionComponent {
     static template = "html_builder.OptionsContainer";
-    static dependencies = ["builderOptions", "overlayButtons", "builderOverlay", "remove", "clone"];
+    static dependencies = ["builderOptions", "remove", "clone"];
     static components = {
         BorderConfigurator,
         ShadowOption,
     };
     static props = {
+        toggleOverlayPreview: { type: Function, optional: true },
         snippetModel: { type: Object },
         options: { type: Array },
         editingElement: true, // HTMLElement from iframe
@@ -36,6 +38,7 @@ export class OptionsContainer extends BaseOptionComponent {
         headerMiddleButtons: { type: Array, optional: true },
     };
     static defaultProps = {
+        toggleOverlayPreview: () => {},
         containerTitle: {},
         headerMiddleButtons: [],
         optionTitleComponents: [],
@@ -48,6 +51,12 @@ export class OptionsContainer extends BaseOptionComponent {
         this.notification = useService("notification");
         this.getItemValue = useGetItemValue();
         useVisibilityObserver("content", useApplyVisibility("root"));
+
+        this.rootRef = useRef("root");
+        useExternalListener(browser, "focusin", this.updateOverlayPreview);
+        useExternalListener(browser, "pointermove", this.updateOverlayPreview);
+        useExternalListener(this.document, "pointermove", this.updateOverlayPreview);
+        this.showingOverlayPreview = false;
 
         this.callOperation = useOperation();
 
@@ -98,22 +107,14 @@ export class OptionsContainer extends BaseOptionComponent {
         return (title || getSnippetName(this.env.getEditingElement())) + titleExtraInfo;
     }
 
-    toggleOverlayPreview(el, show) {
-        if (show) {
-            this.dependencies.overlayButtons.hideOverlayButtons();
-            this.dependencies.builderOverlay.showOverlayPreview(el);
-        } else {
-            this.dependencies.overlayButtons.showOverlayButtons();
-            this.dependencies.builderOverlay.hideOverlayPreview(el);
+    /** @param {PointerEvent | FocusEvent} ev */
+    updateOverlayPreview(ev) {
+        const shouldShow = this.rootRef.el?.contains(ev.target);
+        if (shouldShow === this.showingOverlayPreview) {
+            return;
         }
-    }
-
-    onPointerEnter() {
-        this.toggleOverlayPreview(this.props.editingElement, true);
-    }
-
-    onPointerLeave() {
-        this.toggleOverlayPreview(this.props.editingElement, false);
+        this.props.toggleOverlayPreview(this.props.editingElement, shouldShow);
+        this.showingOverlayPreview = shouldShow;
     }
 
     // Actions of the buttons in the title bar.

--- a/addons/html_builder/static/src/sidebar/option_container.js
+++ b/addons/html_builder/static/src/sidebar/option_container.js
@@ -11,6 +11,7 @@ import {
     useGetItemValue,
     useVisibilityObserver,
 } from "../core/utils";
+import { uniqueId } from "@web/core/utils/functions";
 
 export class OptionsContainer extends BaseOptionComponent {
     static template = "html_builder.OptionsContainer";
@@ -43,6 +44,7 @@ export class OptionsContainer extends BaseOptionComponent {
     setup() {
         useOptionsSubEnv(() => [this.props.editingElement]);
         super.setup();
+        this.containerId = uniqueId("option-container-");
         this.notification = useService("notification");
         this.getItemValue = useGetItemValue();
         useVisibilityObserver("content", useApplyVisibility("root"));

--- a/addons/html_builder/static/src/sidebar/option_container.scss
+++ b/addons/html_builder/static/src/sidebar/option_container.scss
@@ -19,8 +19,11 @@
         color: $o-we-fg-light;
         font-size: $o-we-font-size-lg;
 
-        &-actionable:hover {
-            color: $o-we-fg-lighter
+        &-actionable {
+            &:hover, &:focus {
+                color: $o-we-fg-lighter;
+                background-color: unset;
+            }
         }
     }
 

--- a/addons/html_builder/static/src/sidebar/option_container.xml
+++ b/addons/html_builder/static/src/sidebar/option_container.xml
@@ -7,20 +7,20 @@
          t-on-pointerenter="onPointerEnter" t-on-pointerleave="onPointerLeave">
         <div class="options-container-header d-flex align-items-center justify-content-between">
             <t t-set="isActionable" t-value="Object.keys(props.snippetModel).length > 0"></t>
-            <div
+            <t
+                t-tag="this.props.toggleFold ? 'button' : 'div'"
                 class="options-container-label py-2 flex-grow-1 d-flex align-items-center"
-                t-att-class="{
-                    'options-container-label-actionable cursor-pointer': isActionable,
-                }"
-                t-att-role="isActionable ? 'button' : 'heading'"
+                t-att-class="this.props.toggleFold ? 'options-container-label-actionable o-hb-btn btn' : ''"
+                t-att-aria-expanded="this.props.toggleFold ? `${!this.props.folded}` : undefined"
+                t-att-aria-controls="this.containerId"
                 t-on-click="this.props.toggleFold ?? (() => {})"
             >
-                <i t-if="this.props.toggleFold" class="fa fa-fw mx-1" role="img" t-att-class="this.props.folded ? 'fa-caret-right' : 'fa-caret-down'"></i>
+                <i t-if="this.props.toggleFold" class="fa fa-fw mx-1" aria-hidden="true" t-att-class="this.props.folded ? 'fa-caret-right' : 'fa-caret-down'"/>
                 <span t-att-class="{'ms-2': !this.props.toggleFold}" t-out="title"/>
                 <t t-if="props.optionTitleComponents" t-foreach="props.optionTitleComponents" t-as="optionTitleComponent" t-key="optionTitleComponent.id">
                     <t t-component="optionTitleComponent.Component" t-props="optionTitleComponent.props || {}"/>
                 </t>
-            </div>
+            </t>
 
             <div class="d-flex align-items-center gap-1 p-2">
                 <div t-if="props.headerMiddleButtons">
@@ -60,7 +60,7 @@
                 </t>
             </div>
         </div>
-        <div t-if="!this.props.folded" class="we-bg-options-container pb-3" t-ref="content">
+        <div t-att-id="this.containerId" t-if="!this.props.folded" class="we-bg-options-container pb-3" t-ref="content">
             <t t-foreach="this.options" t-as="OptionClass" t-key="OptionClass.name + '-' + OptionClass.template">
                 <BuilderContext applyTo="OptionClass.applyTo">
                     <t t-component="OptionClass"></t>

--- a/addons/html_builder/static/src/sidebar/option_container.xml
+++ b/addons/html_builder/static/src/sidebar/option_container.xml
@@ -3,8 +3,7 @@
 
 <t t-name="html_builder.OptionsContainer">
     <div t-if="this.options.length"
-         class="options-container mb-1" t-ref="root" t-att-data-container-title="title"
-         t-on-pointerenter="onPointerEnter" t-on-pointerleave="onPointerLeave">
+        class="options-container mb-1" t-ref="root" t-att-data-container-title="title">
         <div class="options-container-header d-flex align-items-center justify-content-between">
             <t t-set="isActionable" t-value="Object.keys(props.snippetModel).length > 0"></t>
             <t

--- a/addons/web/static/src/webclient/webclient.scss
+++ b/addons/web/static/src/webclient/webclient.scss
@@ -261,7 +261,7 @@ select {
 //== Buttons
 
 // Disable unnecessary box-shadows on mouse hover
-.btn:focus:hover {
+.btn:focus:hover:not(:focus-visible) {
   box-shadow: none;
 }
 

--- a/addons/website/static/tests/tours/website_update_column_count.js
+++ b/addons/website/static/tests/tours/website_update_column_count.js
@@ -129,7 +129,7 @@ registerWebsitePreviewTour(
                         clientY: y,
                         pointerType: "mouse",
                     });
-                    (type === "pointermove" ? window : overlayEl).dispatchEvent(event);
+                    (type === "pointermove" ? document : overlayEl).dispatchEvent(event);
                 };
 
                 // Trigger pointer down


### PR DESCRIPTION
Commit 64d35ccd6fade9e0473686b8484f561b5f4215ce added folding for groups of options when the user clicks on the name of the snippet above the group of option.

This commit brings improvement to make it accessible:
- use the `button` tag when the label can be clicked
- use correct attributes for the arrow (no `role` and `aria-hidden`)

Steps to reproduce:
- Open website builder
- Click on an element with options
- Bugs:
  - The label is not focusable with the keyboard, so it's impossible to fold/unfold a container
  - The arrow icon should not have `role="img"` and it should have `aria-hidden="true"` (as it's just decorative)

task-5993202