### PR TITLE
[FIX] pos_loyalty: apply all rewards when changing line qty

### DIFF
--- a/addons/pos_loyalty/static/src/app/services/pos_store.js
+++ b/addons/pos_loyalty/static/src/app/services/pos_store.js
@@ -82,14 +82,25 @@ patch(PosStore.prototype, {
                 const claimableRewards = order.getClaimableRewards(false, false, true);
                 let changed = false;
                 for (const { coupon_id, reward } of claimableRewards) {
-                    if (
-                        reward.program_id.reward_ids.length === 1 &&
-                        !reward.program_id.is_nominative &&
-                        (reward.reward_type !== "product" ||
-                            (reward.reward_type == "product" && !reward.multi_product))
-                    ) {
-                        order._applyReward(reward, coupon_id);
-                        changed = true;
+                    let apply_max = true;
+                    while (apply_max) {
+                        apply_max = false;
+                        const nbr_lines = order.lines.length;
+                        if (
+                            reward.program_id.reward_ids.length === 1 &&
+                            !reward.program_id.is_nominative &&
+                            (reward.reward_type !== "product" ||
+                                (reward.reward_type == "product" && !reward.multi_product))
+                        ) {
+                            order._applyReward(reward, coupon_id);
+                            changed = true;
+                        }
+                        if (reward.reward_type === "discount" && order.lines.length > nbr_lines) {
+                            apply_max = Boolean(
+                                order.getClaimableRewards(coupon_id, reward.program_id.id, true)
+                                    .length
+                            );
+                        }
                     }
                 }
 

--- a/addons/pos_loyalty/static/tests/unit/models/pos_order.test.js
+++ b/addons/pos_loyalty/static/tests/unit/models/pos_order.test.js
@@ -2,7 +2,12 @@ import { test, describe, expect } from "@odoo/hoot";
 import { tick } from "@odoo/hoot-mock";
 import { setupPosEnv, getFilledOrder } from "@point_of_sale/../tests/unit/utils";
 import { definePosModels } from "@point_of_sale/../tests/unit/data/generate_model_definitions";
-import { addProductLineToOrder } from "@pos_loyalty/../tests/unit/utils";
+import {
+    addProductLineToOrder,
+    deactivateAllProgramsExcept,
+} from "@pos_loyalty/../tests/unit/utils";
+import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { OrderSummary } from "@point_of_sale/app/screens/product_screen/order_summary/order_summary";
 
 definePosModels();
 
@@ -310,6 +315,7 @@ describe("pos.order - loyalty", () => {
     test("getLoyaltyPoints adapts to qty decreasing", async () => {
         const store = await setupPosEnv();
         const models = store.models;
+        deactivateAllProgramsExcept(store, [7]);
         const order = store.addNewOrder();
 
         const partner1 = models["res.partner"].get(1);
@@ -355,5 +361,29 @@ describe("pos.order - loyalty", () => {
         expect(order.getOrderlines().length).toBe(2);
         const rewardLine = order._get_reward_lines()[0];
         expect(rewardLine.prices.total_included).toBe(-10);
+    });
+
+    test("apply max amount of promo when setting line qty", async () => {
+        const store = await setupPosEnv();
+        const order = store.addNewOrder();
+
+        await store.orderUpdateLoyaltyPrograms();
+        const line = await addProductLineToOrder(store, order, {
+            productId: 10,
+            templateId: 10,
+            qty: 1,
+        });
+        const orderSummary = await mountWithCleanup(OrderSummary, { props: {} });
+
+        await store.orderUpdateLoyaltyPrograms();
+        await store.updateRewards();
+        await tick();
+        expect(order.lines.length).toBe(2);
+
+        expect(order.getSelectedOrderline().id == line.id).toBe(true);
+        orderSummary._setValue(9);
+        await tick();
+        expect(order.lines.length).toBe(10);
+        expect(order.lines.filter((l) => l.is_reward_line).length).toBe(9);
     });
 });

--- a/addons/pos_loyalty/static/tests/unit/utils.js
+++ b/addons/pos_loyalty/static/tests/unit/utils.js
@@ -18,3 +18,10 @@ export const addProductLineToOrder = async (
 
     return line;
 };
+
+export const deactivateAllProgramsExcept = (store, keepIds) => {
+    const to_delete = store.models["loyalty.program"]
+        .getAllIds()
+        .filter((id) => !keepIds.includes(id));
+    store.models["loyalty.program"].deleteMany(store.models["loyalty.program"].readMany(to_delete));
+};


### PR DESCRIPTION
Currently, if you click 10 times on the same product or you add it once and change the qty to 10, the results differ in terms of the number of reward applied.

Steps to reproduce:
-------------------
* Create a promotion program, giving 1 point per unit bought among product A. As reward give 0.5$ per point on specific product (product A).
* Open pos session
* Add product A to order, change qty to 8 with the numpad button
> Only 2 rewards of 0.5$ have been added to the order
* Cancel order
* Select the product A card 8 times
> 8 reward lines of 0.5$ on the order

Why the fix:
------------
`updateRewards()` is called once and only once during the `_setValue()`. The `updateRewards` function tries to apply all possible rewards to their max quantity. https://github.com/odoo/odoo/blob/51f59a293de1e86f66f30257f8fc0c419463d18c/addons/pos_loyalty/static/src/app/services/pos_store.js#L91

For discount type rewards the maximum quantity used per application is always 1 (`_getRewardLineValuesDiscount`).
https://github.com/odoo/odoo/blob/51f59a293de1e86f66f30257f8fc0c419463d18c/addons/pos_loyalty/static/src/app/models/pos_order.js#L1186-L1198

We cannot directly change this quantity with the number of points available. When the discount is a percentage, for example, each time the reward is applied it needs to re-evaluate the price of the discountProduct.

Since `_applyReward` can only apply a quantity of 1 for discount type rewards, we exit the `updateRewardsMutex` having only added the reward once.

With the fix, when we have discount reward that can be applied, we want to call `_applyRewards()` as much as possible. The idea is to see if the call to `_applyRewards` has added a new line to the order. If it has and if the reward can be claimed again we will call `applyReward` again.

We cannot simply check that the number of lines is different, we really need to check that they are more then there was. Otherwise, when deleting a reward line it will automatically re-apply it.

We also introduce a new utils for the unit tests of loyalty. By calling individual functions in qunit we cannot guarantee that we mimic what would really happen in the point of sale. For example one could call directly `_applyReward` with the reward they are interested in but if they had called `updateRewards()` instead it's not the same reward that would have been applied first. We can now isolate which program we really care about in qunits.

opw-5483474