### PR TITLE
[IMP] hr: add data warning banner on employee form

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -348,6 +348,7 @@ class HrEmployee(models.Model):
         compute='_compute_has_country_contract_type',
         groups="hr.group_hr_user",
     )
+    issues = fields.Json(compute='_compute_issues')
 
     @api.model
     def _get_current_day_location_field(self):
@@ -372,6 +373,43 @@ class HrEmployee(models.Model):
                 **{k: v for k, v in version_vals.items() if k in version_fields},
             })
         return new_vals_list
+
+    @api.depends('is_trusted_bank_account', 'is_in_contract', 'bank_account_ids')
+    def _compute_issues(self):
+        for employee in self:
+            sudo_emp = employee.sudo()
+            issues = {}
+            cnt = 0
+            if not sudo_emp.is_in_contract:
+                issues[cnt] = {
+                    'message': _("Employee does not have running contract."),
+                    'level': 'warning',
+                }
+                cnt += 1
+            if not sudo_emp.bank_account_ids:
+                issues[cnt] = {
+                    'message': _("Employee does not have a bank account."),
+                    'level': 'warning',
+                }
+                cnt += 1
+            elif any(not b.allow_out_payment for b in sudo_emp.bank_account_ids):
+                untrusted_banks = sudo_emp.bank_account_ids.filtered(lambda b: not b.allow_out_payment)
+                issues[cnt] = {
+                    'message': _("Untrusted bank accounts"),
+                    'level': 'warning',
+                    'action_text': _("Bank Accounts"),
+                    'action': {
+                        'type': 'ir.actions.act_window',
+                        'name': _('Bank Accounts'),
+                        'res_model': 'res.partner.bank',
+                        'view_mode': 'list,form',
+                        'views': [[False, 'list'], [False, 'form']],
+                        'domain': [('id', 'in', untrusted_banks.ids)],
+                        'context': {'create': False},
+                    },
+                }
+                cnt += 1
+            employee.issues = issues
 
     @api.depends('bank_account_ids.allow_out_payment')
     def _compute_is_trusted_bank_account(self):

--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -175,6 +175,8 @@ class HrVersion(models.Model):
                                        groups="hr.group_hr_manager")
     additional_note = fields.Text(string='Additional Note', groups="hr.group_hr_user", tracking=1)
 
+    issues = fields.Json(compute='_compute_issues', compute_sudo=True)
+
     def _get_hr_responsible_domain(self):
         return "[('share', '=', False), ('company_ids', 'in', company_id), ('all_group_ids', 'in', %s)]" % self.env.ref('hr.group_hr_user').id
 
@@ -197,6 +199,47 @@ class HrVersion(models.Model):
         'CHECK(wage >= 0)',
         'The wage must be a positive value.',
     )
+
+    @api.depends('is_in_contract', 'employee_id.bank_account_ids')
+    def _compute_issues(self):
+        for version in self:
+            issues = {}
+            cnt = 0
+
+            if not version.is_in_contract:
+                issues[str(cnt)] = {
+                    'message': self.env._("Employee does not have running contract."),
+                    'level': 'warning',
+                }
+                cnt += 1
+
+            employee = version.employee_id
+            if employee:
+                if not employee.bank_account_ids:
+                    issues[str(cnt)] = {
+                        'message': self.env._("Employee does not have a bank account."),
+                        'level': 'warning',
+                    }
+                    cnt += 1
+                elif any(not b.allow_out_payment for b in employee.bank_account_ids):
+                    untrusted_banks = employee.bank_account_ids.filtered(lambda b: not b.allow_out_payment)
+                    issues[str(cnt)] = {
+                        'message': self.env._("Untrusted bank accounts"),
+                        'level': 'warning',
+                        'action_text': self.env._("Bank Accounts"),
+                        'action': {
+                            'type': 'ir.actions.act_window',
+                            'name': self.env._('Bank Accounts'),
+                            'res_model': 'res.partner.bank',
+                            'view_mode': 'list,form',
+                            'views': [[False, 'list'], [False, 'form']],
+                            'domain': [('id', 'in', untrusted_banks.ids)],
+                            'context': {'create': False},
+                        },
+                    }
+                    cnt += 1
+
+            version.issues = issues
 
     @api.depends('employee_id.company_id')
     def _compute_company_id(self):

--- a/addons/hr/static/src/js/employee_warnings/employee_warnings.js
+++ b/addons/hr/static/src/js/employee_warnings/employee_warnings.js
@@ -1,0 +1,32 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { Component } from "@odoo/owl";
+import { standardFieldProps } from "@web/views/fields/standard_field_props";
+import { useService } from "@web/core/utils/hooks";
+
+export class EmployeeWarnings extends Component {
+    static template = "hr.EmployeeWarnings";
+    static props = standardFieldProps;
+
+    setup() {
+        this.actionService = useService("action");
+    }
+
+    async onActionClick(action) {
+        if (!action) return;
+        await this.actionService.doAction(action, {
+            onClose: () => this.env.model.load(),
+        });
+    }
+
+    get issues() {
+        return Object.values(this.props.record.data[this.props.name] || {});
+    }
+}
+
+export const employeeWarnings = {
+    component: EmployeeWarnings,
+};
+
+registry.category("fields").add("employee_warnings", employeeWarnings);

--- a/addons/hr/static/src/js/employee_warnings/employee_warnings.xml
+++ b/addons/hr/static/src/js/employee_warnings/employee_warnings.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <t t-name="hr.EmployeeWarnings">
+        <div t-if="issues.length > 0" class="alert alert-warning mb-2 px-3 py-2" role="alert">
+            <div t-foreach="issues" t-as="issue" t-key="issue_index" class="d-flex align-items-center">
+                <span class="me-2"><t t-esc="issue.message"/></span>
+
+                <t t-if="issue.action">
+                    <a href="#" class="alert-info fw-bold" t-on-click.prevent="() => this.onActionClick(issue.action)">
+                        <i class="oi oi-arrow-right me-1"/>
+                        <t t-esc="issue.action_text"/>
+                    </a>
+                </t>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -116,6 +116,7 @@
                         <field name="version_id" widget="versions_timeline" invisible="not id" options="{'clickable': True}" readonly="False"/>
                     </header>
                     <sheet>
+                        <field name="issues" class="w-100" invisible="not issues" widget="employee_warnings"/>
                         <div name="button_box" class="oe_button_box">
                             <button name="action_open_versions"
                                 class="oe_stat_button"

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -107,6 +107,7 @@
                         <field name="version_id" widget="versions_timeline" invisible="not id" options="{'clickable': True}" readonly="False"/>
                     </header>
                     <sheet>
+                        <field name="issues" class="w-100" invisible="not issues" widget="employee_warnings"/>
                         <div name="button_box" class="oe_button_box">
                             <button name="action_open_versions"
                                 class="oe_stat_button"


### PR DESCRIPTION
To ensure HR officers can quickly identify missing or incorrect employee data, this commit adds a centralized warning banner to the top of the Employee form view.

This visual feedback is crucial for validating data integrity (e.g., missing bank accounts, contracts, or missing pay runs) without needing to navigate to separate menus or wait for payroll errors.

`Changes:
   - Added the `issues` computed field in `hr` to aggregate core warnings (e.g., "No bank account", "Untrusted bank accounts", "No running contract").
   - Added a 'level' key to base issues to ensure downstream widget compatibility.
   - Introduced `employee_warnings`: A new OWL widget in `hr` that renders the `issues` dictionary as an actionable alert banner.
   - Updated `hr.view_employee_form` to display the `employee_warnings` widget immediately after the sheet header.

task-5118781

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
