### PR TITLE
[FIX] website_sale: fix line price per unit in cart

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -3037,7 +3037,7 @@
                 <t t-set="product" t-value="line.product_id"/>
                 <t
                     t-set="base_unit_price"
-                    t-value="product._get_base_unit_price(product_price/line.product_uom_qty)"
+                    t-value="product._get_base_unit_price(product_price/line.product_qty)"
                 />
             </t>
         </small>


### PR DESCRIPTION
Issue:
---
Due to this issue, price per unit is not shown correctly in case of packaging.

Steps to reproduce:
---
1- Create a product. Set price: 2.6 per kg. Set `Base Unit Count` to 1.
2- Create a packaging of 0.5 kg, and add it to product in Sale tab.
3- Navigate to the shop and add 0.5 kg of the product to cart.
4- Navigate to the cart.

Expected: The line price/unit should be 2.60/kg.
Current outcome: It's shown 1.30/kg.

Cause:
---
Currently `_get_base_unit_price(product_price/line.product_uom_qty)` is shown to user as price/unit.
`product_price` is calculated using `_get_cart_display_price()` which returns each line's `subtotal` or `total`.
In our case, it will be `_get_base_unit_price(1.30/1)`, having base_unit_count set to 1, we will have 1.30 which is wrong.

Fix:
---
We would need to divide the line price by `product_qty` instead of `product_uom_qty`.
Then in our example we would have:
`_get_base_unit_price(1.30/0.5) = 2.60`.

opw-5973097