### PR TITLE
[FIX] website_profile : allow edit profile on mobile

### DIFF
--- a/addons/website_profile/views/website_profile.xml
+++ b/addons/website_profile/views/website_profile.xml
@@ -90,9 +90,9 @@
                     <div class="col-12 col-md-4 col-lg-3">
                         <div t-attf-class="d-flex align-items-start h-100 #{'justify-content-between' if (request.env.user == user) else 'justify-content-around' }">
                             <div class="o_wprofile_pict d-inline-block mb-3 mb-md-0" t-attf-style="background-image: url(#{website.image_url(user, 'avatar_1024')});"/>
-                            <a class="btn btn-primary d-inline-block d-md-none"
-                                t-if="request.env.user == user and user.karma != 0"
-                                data-bs-toggle="modal" data-bs-target="#o_wprofile_edit_profile_modal">
+                            <a class="o_wprofile_editor btn btn-primary d-inline-block d-md-none"
+                                t-if="(request.env.user == user and user.karma != 0) or request.env.user._is_admin()"
+                                t-att-data-user-id="user.id">
                                 <i class="fa fa-pencil me-1"/>EDIT
                             </a>
                         </div>


### PR DESCRIPTION
# How to reproduce
- Install the eLearning module
- On the website, go to the Courses tab
- View a user (Administrator for example)
- In mobile view, click on Edit

# The problem
An traceback is shown and the user cannot edit their profile

# Why
This commit (https://github.com/odoo/odoo/commit/69785c1a64d61f2831804bcdcc4887ad43d27fbb) improved the profile edition. It is mentioned that they moved away from the simple bootstrap modal and used an OWL view instead. However, for the mobile view, they left a call to a modal that does not exist.

This fix removes the call to the undefined modal and replaces it with the same OWL Dialog used in the desktop view (thanks to the .o_wprofile_editor class)

opw-5960586

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
