### PR TITLE
[REF] website: remove registerWebsitePreviewTourLegacy

### DIFF
--- a/addons/test_website/static/tests/tours/systray.js
+++ b/addons/test_website/static/tests/tours/systray.js
@@ -2,7 +2,7 @@
 import {
     clickOnEditAndWaitEditMode,
     clickOnSave,
-    registerWebsitePreviewTourLegacy,
+    registerWebsitePreviewTour,
 } from "@website/js/tours/tour_utils";
 import { stepUtils } from "@web_tour/tour_utils";
 
@@ -209,10 +209,9 @@ const ensureWebsiteSwitcherIsVisible = [
 ];
 
 const register = (title, steps, undeterministicTour_doNotCopy) => {
-    registerWebsitePreviewTourLegacy(
+    registerWebsitePreviewTour(
         title,
         {
-            url: "/test_model/1",
             undeterministicTour_doNotCopy,
         },
         steps

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -518,47 +518,6 @@ export function clickOnExtraMenuItem(stepOptions, backend = false) {
  * @param {boolean} [options.edition] If the tour starts in edit mode
  * @param {() => TourStep[]} steps The steps of the tour. Has to be a function to avoid direct interpolation of steps.
  */
-export function registerWebsitePreviewTourLegacy(name, options, steps) {
-    if (typeof steps !== "function") {
-        throw new Error(`tour.steps has to be a function that returns TourStep[]`);
-    }
-    registry.category("web_tour.tours").remove(name);
-    return registry.category("web_tour.tours").add(name, {
-        ...omit(options, "edition"),
-        url: getClientActionUrl(options.url, !!options.edition),
-        steps: () => {
-            const tourSteps = [...steps()];
-            // Note: for both non edit mode and edit mode, we set a high timeout for the
-            // first step. Indeed loading both the backend and the frontend (in the
-            // iframe) and potentially starting the edit mode can take a long time in
-            // automatic tests. We'll try and decrease the need for this high timeout
-            // of course.
-            if (options.edition) {
-                tourSteps.unshift({
-                    content: "Wait for the edit mode to be started",
-                    trigger: ".o_builder_sidebar_open",
-                    timeout: 30000,
-                });
-            } else {
-                tourSteps[0].timeout = 20000;
-            }
-            return tourSteps.map((step) => {
-                delete step.noPrepend;
-                return step;
-            });
-        },
-    });
-}
-
-/**
- * Registers a tour that will go in the website client action.
- *
- * @param {string} name The tour's name
- * @param {object} options The tour options
- * @param {string} options.url The page to edit
- * @param {boolean} [options.edition] If the tour starts in edit mode
- * @param {() => TourStep[]} steps The steps of the tour. Has to be a function to avoid direct interpolation of steps.
- */
 export function registerWebsitePreviewTour(name, options, steps) {
     if (typeof steps !== "function") {
         throw new Error(`tour.steps has to be a function that returns TourStep[]`);
@@ -594,11 +553,9 @@ export function registerThemeHomepageTour(name, steps) {
     if (typeof steps !== "function") {
         throw new Error(`tour.steps has to be a function that returns TourStep[]`);
     }
-    return registerWebsitePreviewTourLegacy(
+    return registerWebsitePreviewTour(
         "homepage", // it overrides the community tour with the associated theme tour
-        {
-            url: "/",
-        },
+        {},
         () => [
             ...clickOnEditAndWaitEditMode(),
             // FIXME(?) this should probably reuse the prepend_trigger function
@@ -615,7 +572,7 @@ export function registerBackendAndFrontendTour(name, options, steps) {
         throw new Error(`tour.steps has to be a function that returns TourStep[]`);
     }
     if (window.location.pathname === "/odoo") {
-        return registerWebsitePreviewTourLegacy(name, options, () => {
+        return registerWebsitePreviewTour(name, options, () => {
             const newSteps = [];
             for (const step of steps()) {
                 const newStep = Object.assign({}, step);

--- a/addons/website/static/tests/tours/snippet_translation.js
+++ b/addons/website/static/tests/tours/snippet_translation.js
@@ -4,13 +4,15 @@ import {
     clickOnEditAndWaitEditMode,
     clickOnEditAndWaitEditModeInTranslatedPage,
     clickOnSave,
+    getClientActionUrl,
     insertSnippet,
-    registerWebsitePreviewTourLegacy,
+    registerWebsitePreviewTour,
     testSwitchWebsite,
 } from "@website/js/tours/tour_utils";
 import { stepUtils } from "@web_tour/tour_utils";
 
-registerWebsitePreviewTourLegacy("snippet_translation", {}, () => [
+registerWebsitePreviewTour("snippet_translation", {}, () => [
+    stepUtils.goToUrl(getClientActionUrl()),
     {
         content: "Wait for website preview and check language",
         trigger: ":iframe html:has(body:contains(welcome to your)):has(.o_top_fixed_element)",
@@ -33,12 +35,13 @@ registerWebsitePreviewTourLegacy("snippet_translation", {}, () => [
         trigger: '.btn[data-action="save"]:contains("Save in fu_GB")',
     },
 ]);
-registerWebsitePreviewTourLegacy(
+registerWebsitePreviewTour(
     "snippet_translation_changing_lang",
     {
         undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     },
     () => [
+        stepUtils.goToUrl(getClientActionUrl()),
         stepUtils.waitIframeIsReady(),
         {
             content: "Open dropdown language selector",
@@ -93,7 +96,8 @@ registerWebsitePreviewTourLegacy(
         },
     ]
 );
-registerWebsitePreviewTourLegacy("snippet_translation_switching_website", {}, () => [
+registerWebsitePreviewTour("snippet_translation_switching_website", {}, () => [
+    stepUtils.goToUrl(getClientActionUrl()),
     ...clickOnEditAndWaitEditModeInTranslatedPage(),
     ...insertSnippet({ id: "s_cover", name: "Cover", groupName: "Intro" }),
     {
@@ -109,7 +113,8 @@ registerWebsitePreviewTourLegacy("snippet_translation_switching_website", {}, ()
         trigger: ":iframe .s_cover .btn-outline-secondary:contains('Fake User Lang')",
     },
 ]);
-registerWebsitePreviewTourLegacy("snippet_dialog_rtl", {}, () => [
+registerWebsitePreviewTour("snippet_dialog_rtl", {}, () => [
+    stepUtils.goToUrl(getClientActionUrl()),
     ...clickOnEditAndWaitEditMode(),
     {
         trigger: ".o_builder_sidebar_open",

--- a/addons/website/static/tests/tours/specific_website_editor.js
+++ b/addons/website/static/tests/tours/specific_website_editor.js
@@ -1,10 +1,10 @@
 import { registry } from "@web/core/registry";
 import {
     clickOnEditAndWaitEditMode,
-    registerWebsitePreviewTourLegacy,
+    registerWebsitePreviewTour,
 } from "@website/js/tours/tour_utils";
 
-registerWebsitePreviewTourLegacy(
+registerWebsitePreviewTour(
     "generic_website_editor",
     {
         edition: true,

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -337,7 +337,7 @@ class TestUiTranslate(odoo.tests.HttpCase):
 class TestUi(HttpCaseWithWebsiteUser):
 
     def test_01_admin_tour_homepage(self):
-        self.start_tour("/odoo", 'homepage', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'homepage', login='admin')
 
     def test_02_restricted_editor(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'restricted_editor', login="website_user")
@@ -386,7 +386,7 @@ class TestUi(HttpCaseWithWebsiteUser):
         self.assertNotEqual(new_website_bundle_modified.get_version('js'), base_website_js_version, "js version for new website should now have been changed")
 
         url_params = url_encode({'path': '/@/'})
-        self.start_tour(f'/website/force/{website_default.id}?{url_params}', "generic_website_editor", login="website_user")
+        self.start_tour(f'/odoo/action-website.website_preview?{url_params}&enable_editor=1', "generic_website_editor", login="website_user")
         self.start_tour(f'/website/force/{new_website.id}?{url_params}', "specific_website_editor", login="website_user")
 
     def test_07_snippet_version(self):


### PR DESCRIPTION
In this commit, we remove uses of registerWebsitePreviewTourLegacy that
still use `url` key in tour API.

The URL key in a tour's JavaScript file implies a redirect to that URL
once the browser opens. If this URL is the same as the one used
in `start_tour()` (Python), then it serves no purpose. It's even
detrimental because it implies a redirect (and therefore a waste of
time). The URL key in the JS file is (for now) only used for onboarding
tours. This key will be defined later in the .xml file for onboarding
tours.

That's why we're removing the URL keys from the registries here.