### PR TITLE
[FIX] sale_mrp: compute COGS correctly for kits (avoid double counting)

### DIFF
--- a/addons/sale_mrp/models/account_move.py
+++ b/addons/sale_mrp/models/account_move.py
@@ -34,9 +34,8 @@ class AccountMoveLine(models.Model):
                 components_qty = so_line._get_bom_component_qty(bom)
                 storable_components = self.env['product.product'].search([('id', 'in', list(components_qty.keys())), ('is_storable', '=', True)])
                 for product in storable_components:
-                    factor = components_qty[product.id]['qty']
                     prod_moves = moves.filtered(lambda m: m.product_id == product)
                     product = product.with_company(self.company_id)
-                    average_price_unit += factor * prod_moves._get_price_unit()
+                    average_price_unit += prod_moves._get_price_unit()
                 price_unit = average_price_unit / bom.product_qty or price_unit
         return price_unit

--- a/addons/sale_mrp_margin/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp_margin/tests/test_sale_mrp_flow.py
@@ -66,6 +66,7 @@ class TestSaleMrpFlow(test_sale_mrp_flow.TestSaleMrpFlowCommon):
         sub_kit, kit = self._cls_create_product('Sub Kit', self.uom_unit), self._cls_create_product('Lovely Kit', self.uom_ten)
         kit.uom_ids = [Command.set([self.uom_unit.id, self.uom_ten.id])]
         self.product_category.property_cost_method = 'average'
+        self.product_category.property_valuation = 'real_time'
         (kit + sub_kit + self.component_a + self.component_b).categ_id = self.product_category
         self.env['mrp.bom'].create([
             {
@@ -122,3 +123,15 @@ class TestSaleMrpFlow(test_sale_mrp_flow.TestSaleMrpFlowCommon):
         self.assertEqual(so.picking_ids.state, 'done')
         self.assertRecordValues(so.order_line, [{'purchase_price': 600, 'qty_delivered': 3.0}])
         self.assertEqual(so.order_line.purchase_price, 600)
+        # create an invoice to check that the cost price on the invoice line is correct
+        inv_1 = so._create_invoices()
+        inv_1.action_post()
+        self.assertEqual(inv_1.state, 'posted', 'invoice should be in posted state')
+        # The cost price on the invoice line should be 600 * 3 = 1800
+        self.assertRecordValues(inv_1.line_ids, [
+            {'debit': 0.0, 'credit': 3.0},
+            {'debit': 0.0, 'credit': 0.45},
+            {'debit': 3.45, 'credit': 0.0},
+            {'debit': 0.0, 'credit': 1800},
+            {'debit': 1800, 'credit': 0.0},
+        ])


### PR DESCRIPTION
Bug introduced by: 341928ca477843d92bf7a084f738cf9dcfd3593a

Steps to reproduce:
- Create a storable product “C1”
  - Cost: $1
- Create a storable product “P1”
  - Type: Kit
  - Category: AVCO
  - BoM:
    - Component: C1 (qty: 20)

- Create a sale order for 1 unit of P1
- Confirm the SO
- Validate the delivery
- Create and post the invoice
- Check the journal items

Problem:
The total COGS posted is $400 instead of $200.

When posting the invoice, `_get_cogs_value` is triggered. It retrieves the price unit of each component based on the stock move quantity of the sale order:

https://github.com/odoo/odoo/blob/963bdc5d8a7cc7d3235a52ac2a2282d95a0da400/addons/sale_mrp/models/account_move.py#L39

However, since commit: https://github.com/odoo/odoo/commit/341928ca477843d92bf7a084f738cf9dcfd3593a#diff-bb93bc1c1d7fd07978c5081adc6dc21dc3eb4c37b5e8f44342fe34b61ee060b5R44

, `_get_price_unit` returns the total cost of the component required to produce one kit (i.e., 20 units * $1 = $20).

Later, `_get_cogs_value` multiplies this value again by the component quantity defined in the BoM (20), resulting in a double multiplication: (20 units * $1) * 20 = $400

opw-5946749
