### PR TITLE
[REF] *: run rendering context migration script

### DIFF
--- a/addons/crm_livechat/static/src/core/web/livechat_channel_info_list_patch.xml
+++ b/addons/crm_livechat/static/src/core/web/livechat_channel_info_list_patch.xml
@@ -2,12 +2,12 @@
 <templates xml:space="preserve">
     <t t-name="website_livechat.LivechatChannelInfoList" t-inherit="im_livechat.LivechatChannelInfoList" t-inherit-mode="extension">
         <xpath expr="//t[@t-name='extra_infos']" position="inside">
-            <t t-if="props.thread.livechatVisitorMember?.partner_id?.opportunity_ids?.length" t-call="im_livechat.LivechatChannelInfoList.info_links">
+            <t t-if="this.props.thread.livechatVisitorMember?.partner_id?.opportunity_ids?.length" t-call="im_livechat.LivechatChannelInfoList.info_links">
                 <t t-set="title">Open leads</t>
                 <t t-set="templateParams"
                     t-value="{
                         title,
-                        'info_records': props.thread.livechatVisitorMember?.partner_id?.opportunity_ids,
+                        'info_records': this.props.thread.livechatVisitorMember?.partner_id?.opportunity_ids,
                         'model': 'crm.lead'
                     }"
                 />

--- a/addons/hr/static/src/components/avatar_card/avatar_card_popover_patch.xml
+++ b/addons/hr/static/src/components/avatar_card/avatar_card_popover_patch.xml
@@ -12,7 +12,7 @@
     </t>
 
     <t t-name="hr.avatarCardUserInfos">
-        <small class="text-muted text-truncate" t-if="employee?.job_title" t-att-title="employee.job_title" t-out="employee.job_title"/>
-        <span class="text-muted text-truncate" t-if="employee?.department_id" data-tooltip="Department" t-att-title="employee.department_id.name" t-out="employee.department_id.name"/>
+        <small class="text-muted text-truncate" t-if="this.employee?.job_title" t-att-title="this.employee.job_title" t-out="this.employee.job_title"/>
+        <span class="text-muted text-truncate" t-if="this.employee?.department_id" data-tooltip="Department" t-att-title="this.employee.department_id.name" t-out="this.employee.department_id.name"/>
     </t>
 </templates>

--- a/addons/hr/static/src/components/background_image/background_image.xml
+++ b/addons/hr/static/src/components/background_image/background_image.xml
@@ -3,10 +3,10 @@
     <t t-name="hr.BackgroundImage">
         <img
             loading="lazy"
-            t-att-data-tooltip-template="hasTooltip and tooltipAttributes.template"
-            t-att-data-tooltip-info="hasTooltip and tooltipAttributes.info"
-            t-att-data-tooltip-delay="hasTooltip and props.zoomDelay"
-            t-attf-src="#{getUrl(props.previewImage or props.name)}"
+            t-att-data-tooltip-template="this.hasTooltip and this.tooltipAttributes.template"
+            t-att-data-tooltip-info="this.hasTooltip and this.tooltipAttributes.info"
+            t-att-data-tooltip-delay="this.hasTooltip and this.props.zoomDelay"
+            t-attf-src="#{this.getUrl(this.props.previewImage or this.props.name)}"
             alt="Binary file"
            />
     </t>

--- a/addons/hr/static/src/components/button_new_contract/button_new_contract.xml
+++ b/addons/hr/static/src/components/button_new_contract/button_new_contract.xml
@@ -2,8 +2,8 @@
 <template>
     <t t-name="hr.ButtonNewContract">
         <span class="w-100 d-flex justify-content-end">
-            <button class="btn btn-link p-0 o_field_widget text-end w-auto" t-on-click="onClickNewContractBtn"
-                    t-custom-ref="datetime-picker-target-new-contract" t-if="props.record.resId and props.record.data.contract_date_start">New Contract</button>
+            <button class="btn btn-link p-0 o_field_widget text-end w-auto" t-on-click="this.onClickNewContractBtn"
+                    t-custom-ref="datetime-picker-target-new-contract" t-if="this.props.record.resId and this.props.record.data.contract_date_start">New Contract</button>
         </span>
     </t>
 </template>

--- a/addons/hr/static/src/components/department_chart/department_chart.xml
+++ b/addons/hr/static/src/components/department_chart/department_chart.xml
@@ -3,23 +3,23 @@
     <t t-name="hr.DepartmentChart">
         <div class="o_hr_department_chart w-100">
             <div class="o_horizontal_separator mb-3 text-uppercase fw-bolder small">Department Organization</div>
-            <t t-if="state.hierarchy.self">
+            <t t-if="this.state.hierarchy.self">
                 <div class="o_hr_department_chart_parent">
-                    <t t-set="dept" t-value="state.hierarchy.parent"/>
+                    <t t-set="dept" t-value="this.state.hierarchy.parent"/>
                     <t t-set="hideTree" t-value="true"/>
                     <t t-call="hr.DepartmentChart.Department"/>
                 </div>
 
-                <div t-att-class="state.hierarchy.parent?'ms-4':''">
+                <div t-att-class="this.state.hierarchy.parent?'ms-4':''">
                     <div class="o_hr_department_chart_self">
-                        <t t-set="dept" t-value="state.hierarchy.self"/>
-                        <t t-set="hideTree" t-value="!state.hierarchy.parent"/>
+                        <t t-set="dept" t-value="this.state.hierarchy.self"/>
+                        <t t-set="hideTree" t-value="!this.state.hierarchy.parent"/>
                         <t t-call="hr.DepartmentChart.Department"/>
                     </div>
 
                     <t t-set="hideTree" t-value="false"/>
                     <div class="o_hr_department_chart_children ms-4">
-                        <t t-foreach="state.hierarchy.children" t-as="dept" t-key="dept.name">
+                        <t t-foreach="this.state.hierarchy.children" t-as="dept" t-key="dept.name">
                             <t t-call="hr.DepartmentChart.Department"/>
                         </t>
                     </div>

--- a/addons/hr/static/src/components/employee_chat/employee_chat.xml
+++ b/addons/hr/static/src/components/employee_chat/employee_chat.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="hr.OpenChat">
-        <a t-if="props.record.data.user_id and props.record.resId"
+        <a t-if="this.props.record.data.user_id and this.props.record.resId"
             title="Chat"
             icon="fa-comments"
-            t-on-click.prevent="() => openChat(props.record.resId)"
+            t-on-click.prevent="() => this.openChat(this.props.record.resId)"
             href="#"
             class="ml8 o_employee_chat_btn"
             role="button">

--- a/addons/hr/static/src/components/hr_presence_status/hr_presence_status.xml
+++ b/addons/hr/static/src/components/hr_presence_status/hr_presence_status.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="hr.HrPresenceStatus">
-        <span role="img" t-att-class="classNames" t-att-aria-label="label" t-att-title="label"/>
+        <span role="img" t-att-class="this.classNames" t-att-aria-label="this.label" t-att-title="this.label"/>
     </t>
 
 </templates>

--- a/addons/hr/static/src/fields/hr_org_chart.xml
+++ b/addons/hr/static/src/fields/hr_org_chart.xml
@@ -2,10 +2,10 @@
 <templates id="template" xml:space="preserve">
 
 <t t-name="hr.hr_org_chart_employee">
-    <t t-set="is_self" t-value="employee.id == view_employee_id"/>
+    <t t-set="is_self" t-value="employee.id == this.view_employee_id"/>
 
-    <section t-if="employee_type == 'self'" t-attf-class="o_org_chart_entry_self_container #{managers.length &gt; 0 ? 'o_org_chart_has_managers' : ''}">
-        <div t-attf-class="o_org_chart_entry o_org_chart_entry_#{employee_type} position-relative d-flex align-items-center overflow-visible #{managers.length &gt; 0 ? 'o_treeEntry' : ''}">
+    <section t-if="employee_type == 'self'" t-attf-class="o_org_chart_entry_self_container #{this.managers.length &gt; 0 ? 'o_org_chart_has_managers' : ''}">
+        <div t-attf-class="o_org_chart_entry o_org_chart_entry_#{employee_type} position-relative d-flex align-items-center overflow-visible #{this.managers.length &gt; 0 ? 'o_treeEntry' : ''}">
             <t t-call="hr.hr_org_chart_employee_content">
                 <t t-set="is_self" t-value="is_self"/>
             </t>
@@ -70,14 +70,14 @@
 
         -->
     <t t-set="emp_count" t-value="0"/>
-    <div t-if='managers.length &gt; 0' class="o_org_chart_group_up position-relative">
-        <div t-if='managers_more' class="o_org_chart_more pe-3" t-attf-class="{{max_level !== null ? 'invisible' : ''}}">
-            <a href="#" t-att-data-employee-id="managers[0].id" class="o_employee_more_managers d-block bg-100 px-2" t-on-click.prevent="() => this._onEmployeeMoreManager(managers[0].id)">
+    <div t-if='this.managers.length &gt; 0' class="o_org_chart_group_up position-relative">
+        <div t-if='this.managers_more' class="o_org_chart_more pe-3" t-attf-class="{{this.max_level !== null ? 'invisible' : ''}}">
+            <a href="#" t-att-data-employee-id="this.managers[0].id" class="o_employee_more_managers d-block bg-100 px-2" t-on-click.prevent="() => this._onEmployeeMoreManager(this.managers[0].id)">
                 <i class="fa fa-angle-double-up" role="img" aria-label="More managers" title="More managers"/>
             </a>
         </div>
 
-        <t t-foreach="managers" t-as="employee" t-key="employee_index">
+        <t t-foreach="this.managers" t-as="employee" t-key="employee_index">
             <t t-set="emp_count" t-value="emp_count + 1"/>
             <t t-call="hr.hr_org_chart_employee">
                 <t t-set="employee_type" t-value="'manager'"/>
@@ -85,12 +85,12 @@
         </t>
     </div>
 
-    <t t-if="children.length || managers.length" t-call="hr.hr_org_chart_employee">
+    <t t-if="this.children.length || this.managers.length" t-call="hr.hr_org_chart_employee">
         <t t-set="employee_type" t-value="'self'"/>
-        <t t-set="employee" t-value="self"/>
+        <t t-set="employee" t-value="this.self"/>
     </t>
 
-    <t t-if="!children.length &amp;&amp; !managers.length">
+    <t t-if="!this.children.length &amp;&amp; !this.managers.length">
         <p class="mb-3 text-muted fst-italic">Set a manager or reports to show in org chart.</p>
         <div class="o_org_chart_entry_self_container opacity-50">
             <div class="o_org_chart_entry o_org_chart_entry_self d-flex py-2 pe-none">
@@ -131,8 +131,8 @@
         </section>
     </t>
 
-    <div t-if="children.length" t-attf-class="o_org_chart_group_down position-relative #{managers.length &gt; 0 ? 'o_org_chart_has_managers' : ''}">
-        <t t-foreach="children" t-as="employee" t-key="employee_index">
+    <div t-if="this.children.length" t-attf-class="o_org_chart_group_down position-relative #{this.managers.length &gt; 0 ? 'o_org_chart_has_managers' : ''}">
+        <t t-foreach="this.children" t-as="employee" t-key="employee_index">
             <t t-set="emp_count" t-value="emp_count + 1"/>
             <t t-if="emp_count &lt; 20">
                 <t t-call="hr.hr_org_chart_employee">
@@ -141,14 +141,14 @@
             </t>
         </t>
 
-        <t t-if="(children.length + managers.length) &gt; 19">
+        <t t-if="(this.children.length + this.managers.length) &gt; 19">
             <div class="o_org_chart_entry o_org_chart_more d-flex overflow-visible">
                 <div class="o_media_left position-relative">
                     <a href="#"
-                        t-att-data-employee-id="self.id"
-                        t-att-data-employee-name="self.name"
+                        t-att-data-employee-id="this.self.id"
+                        t-att-data-employee-name="this.self.name"
                         class="o_org_chart_show_more o_employee_sub_redirect btn btn-link ps-2"
-                        t-on-click.prevent="_onEmployeeSubRedirect">See All</a>
+                        t-on-click.prevent="this._onEmployeeSubRedirect">See All</a>
                 </div>
             </div>
         </t>
@@ -160,40 +160,40 @@
         <div class="tooltip-arrow"/>
         <h3 class="popover-header">
             <div class="d-flex align-items-center">
-                <span class="o_media_object flex-shrink-0 rounded me-1" t-att-style='"background-image:url(\"/web/image/hr.employee.public/" + props.employee.id + "/avatar_1024/\")"'/>
-                <b class="flex-grow-1 fw-medium"><t t-out="props.employee.name"/></b>
-                <a href="#" class="o_employee_redirect btn btn-link" t-att-data-employee-id="props.employee.id" t-on-click.prevent="() => this._onEmployeeRedirect(props.employee.id)"><i class="fa fa-user" role="img" aria-label='View employee' title="View employee"/></a>
+                <span class="o_media_object flex-shrink-0 rounded me-1" t-att-style='"background-image:url(\"/web/image/hr.employee.public/" + this.props.employee.id + "/avatar_1024/\")"'/>
+                <b class="flex-grow-1 fw-medium"><t t-out="this.props.employee.name"/></b>
+                <a href="#" class="o_employee_redirect btn btn-link" t-att-data-employee-id="this.props.employee.id" t-on-click.prevent="() => this._onEmployeeRedirect(this.props.employee.id)"><i class="fa fa-user" role="img" aria-label='View employee' title="View employee"/></a>
             </div>
         </h3>
         <div class="popover-body">
             <table class="table table-sm table-borderless mb-0">
                 <tbody>
                     <tr>
-                        <td class="text-end"><b t-out="props.employee.direct_sub_count"/></td>
+                        <td class="text-end"><b t-out="this.props.employee.direct_sub_count"/></td>
                         <td>
                             <a href="#" class="o_employee_sub_redirect" data-type='direct'
-                                    t-att-data-employee-name="props.employee.name" t-att-data-employee-id="props.employee.id"
-                                    t-on-click.prevent="_onEmployeeSubRedirect">
+                                    t-att-data-employee-name="this.props.employee.name" t-att-data-employee-id="this.props.employee.id"
+                                    t-on-click.prevent="this._onEmployeeSubRedirect">
                                 <b>Direct subordinates</b></a>
                         </td>
                     </tr>
                     <tr>
                         <td class="text-end">
-                            <b t-out="props.employee.indirect_sub_count - props.employee.direct_sub_count"/>
+                            <b t-out="this.props.employee.indirect_sub_count - this.props.employee.direct_sub_count"/>
                         </td>
                         <td>
                             <a href="#" class="o_employee_sub_redirect" data-type='indirect'
-                                    t-att-data-employee-name="props.employee.name" t-att-data-employee-id="props.employee.id"
-                                    t-on-click.prevent="_onEmployeeSubRedirect">
+                                    t-att-data-employee-name="this.props.employee.name" t-att-data-employee-id="this.props.employee.id"
+                                    t-on-click.prevent="this._onEmployeeSubRedirect">
                                 Indirect subordinates</a>
                         </td>
                     </tr>
                     <tr>
-                        <td class="text-end"><b t-out="props.employee.indirect_sub_count"/></td>
+                        <td class="text-end"><b t-out="this.props.employee.indirect_sub_count"/></td>
                         <td>
                             <a href="#" class="o_employee_sub_redirect" data-type='total'
-                                    t-att-data-employee-name="props.employee.name" t-att-data-employee-id="props.employee.id"
-                                    t-on-click.prevent="_onEmployeeSubRedirect">
+                                    t-att-data-employee-name="this.props.employee.name" t-att-data-employee-id="this.props.employee.id"
+                                    t-on-click.prevent="this._onEmployeeSubRedirect">
                                 Total</a>
                         </td>
                     </tr>

--- a/addons/hr/static/src/fields/optional_float_field.xml
+++ b/addons/hr/static/src/fields/optional_float_field.xml
@@ -2,19 +2,19 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="hr.OptionalFloatField">
-        <span t-if="props.readonly" t-out="formattedValue" />
+        <span t-if="this.props.readonly" t-out="this.formattedValue" />
         <input 
             t-else="" 
-            t-on-focusin="onFocusIn" 
-            t-on-focusout="onFocusOut" 
-            t-att-id="props.id" 
+            t-on-focusin="this.onFocusIn" 
+            t-on-focusout="this.onFocusOut" 
+            t-att-id="this.props.id" 
             t-custom-ref="numpadDecimal"  
-            t-att-type="props.inputType" 
+            t-att-type="this.props.inputType" 
             inputmode="decimal" 
             class="o_input" 
             autocomplete="off"
-            t-att-step="props.step" 
-            t-att-placeholder="props.placeholder"/>
+            t-att-step="this.props.step" 
+            t-att-placeholder="this.props.placeholder"/>
     </t>
 
 </templates>

--- a/addons/hr/static/src/views/fields/many2one_avatar_employee_field/kanban_many2one_avatar_employee_field.xml
+++ b/addons/hr/static/src/views/fields/many2one_avatar_employee_field/kanban_many2one_avatar_employee_field.xml
@@ -2,13 +2,13 @@
 <templates xml:space="preserve">
 
     <t t-name="hr.KanbanMany2OneAvatarEmployeeField">
-        <KanbanMany2One t-props="m2oProps">
+        <KanbanMany2One t-props="this.m2oProps">
             <t t-set-slot="avatar">
-                <AvatarEmployee cssClass="'o_m2o_avatar'" resModel="relation" resId="value.id" noSpacing="true" displayName="displayName" uniqueId="uniqueId"/>
+                <AvatarEmployee cssClass="'o_m2o_avatar'" resModel="this.relation" resId="this.value.id" noSpacing="true" displayName="this.displayName" uniqueId="this.uniqueId"/>
             </t>
             <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                 <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
-                    <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.record.id}}/avatar_128"/>
+                    <img class="rounded me-1" t-attf-src="/web/image/{{this.relation}}/{{autoCompleteItemScope.record.id}}/avatar_128"/>
                     <span t-out="autoCompleteItemScope.label"/>
                 </span>
             </t>

--- a/addons/hr/static/src/views/fields/many2one_avatar_employee_field/many2one_avatar_employee_field.xml
+++ b/addons/hr/static/src/views/fields/many2one_avatar_employee_field/many2one_avatar_employee_field.xml
@@ -2,15 +2,15 @@
 <templates xml:space="preserve">
 
     <t t-name="hr.Many2OneAvatarEmployeeField">
-        <t t-set="value" t-value="props.record.data[props.name]"/>
+        <t t-set="value" t-value="this.props.record.data[this.props.name]"/>
         <div class="o_input_box">
             <t t-if="value !== false">
-                <AvatarEmployee cssClass="'o_m2o_avatar o_input_box_overlay_start'" resModel="relation" resId="value.id" noSpacing="true" uniqueId="uniqueId"/>
+                <AvatarEmployee cssClass="'o_m2o_avatar o_input_box_overlay_start'" resModel="this.relation" resId="value.id" noSpacing="true" uniqueId="this.uniqueId"/>
             </t>
-            <Many2One t-props="m2oProps">
+            <Many2One t-props="this.m2oProps">
                 <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                     <div class="o_avatar_many2x_autocomplete d-flex align-items-center">
-                        <AvatarEmployee resModel="relation" resId="autoCompleteItemScope.record.id" canOpenPopover="false"/>
+                        <AvatarEmployee resModel="this.relation" resId="autoCompleteItemScope.record.id" canOpenPopover="false"/>
                         <span t-out="autoCompleteItemScope.label"/>
                     </div>
                 </t>

--- a/addons/hr/static/src/xml/contract_template_button.xml
+++ b/addons/hr/static/src/xml/contract_template_button.xml
@@ -4,7 +4,7 @@
         <button 
             type="button" 
             class="btn btn-link p-0 text-start"
-            t-on-click="onSelectTemplate"
+            t-on-click="this.onSelectTemplate"
             t-custom-ref="templateButton"
             title="Load Contract Template"
         >
@@ -15,21 +15,21 @@
     <t t-name="hr.TemplateSelectionPopover">
         <div class="p-3" style="min-width: 350px;">
             <div class="mb-3">
-                <Many2One t-props="many2oneProps"/>
+                <Many2One t-props="this.many2oneProps"/>
             </div>
             <div class="d-flex gap-2">
                 <button 
                     type="button" 
                     class="btn btn-primary btn-sm" 
-                    t-on-click="onConfirm" 
-                    t-att-disabled="!state.selectedTemplate"
+                    t-on-click="this.onConfirm" 
+                    t-att-disabled="!this.state.selectedTemplate"
                 >
                     Load Template
                 </button>
                 <button 
                     type="button" 
                     class="btn btn-secondary btn-sm" 
-                    t-on-click="props.close"
+                    t-on-click="this.props.close"
                 >
                     Discard
                 </button>

--- a/addons/hr_attendance/static/src/components/attendance_calendar/attendance_calendar_overview.xml
+++ b/addons/hr_attendance/static/src/components/attendance_calendar/attendance_calendar_overview.xml
@@ -5,15 +5,15 @@
             <div class="o_attendance_info_card">
                 <strong class="o_attendance_info_label">Worked Time</strong>
                 <div class="o_attendance_info_value text-primary">
-                    <span class="o_attendance_info_number"><t t-out="floatTime(state.workedHours)"/></span>
+                    <span class="o_attendance_info_number"><t t-out="this.floatTime(this.state.workedHours)"/></span>
                     <span class="o_attendance_info_unit">Hours</span>
                 </div>
             </div>
 
-            <div t-if="displayExtraHours" class="o_attendance_info_card">
+            <div t-if="this.displayExtraHours" class="o_attendance_info_card">
                 <strong class="o_attendance_info_label">Extra Time</strong>
                 <div class="o_attendance_info_value text-primary">
-                    <span class="o_attendance_info_number"><t t-out="floatTime(state.extraHours)"/></span>
+                    <span class="o_attendance_info_number"><t t-out="this.floatTime(this.state.extraHours)"/></span>
                     <span class="o_attendance_info_unit">Hours</span>
                 </div>
             </div>

--- a/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.xml
+++ b/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.xml
@@ -4,9 +4,9 @@
 <t t-name="hr_attendance.attendance_menu">
     <t t-if="this.state.isDisplayed">
         <Dropdown position="'bottom-end'"
-                  beforeOpen.bind="searchReadEmployee"
+                  beforeOpen.bind="this.searchReadEmployee"
                   menuClass="'p-0'"
-                  state="dropdown">
+                  state="this.dropdown">
             <button>
                 <i class="fa fa-circle"
                    t-attf-class="text-{{ this.state.checkedIn ? 'success' : 'danger' }}"

--- a/addons/hr_attendance/static/src/components/card_layout/card_layout.xml
+++ b/addons/hr_attendance/static/src/components/card_layout/card_layout.xml
@@ -3,10 +3,10 @@
 
 <t t-name="hr_attendance.CardLayout">
     <div class="o_attendance_background d-flex flex-column h-100">
-        <t t-if="env.isSmall">
+        <t t-if="this.env.isSmall">
             <div class="p-2 d-flex justify-content-between">
                 <button
-                    t-on-click="props.kioskReturn"
+                    t-on-click="this.props.kioskReturn"
                     class="o_hr_attendance_back_button btn btn-secondary rounded-pill"
                     t-if="this.props.fromTrialMode">
                     <i class="oi oi-chevron-left" role="img" aria-label="Go back" title="Go back"/>
@@ -18,10 +18,10 @@
             </div>
             <div class="o_hr_kiosk_mode_top d-flex flex-column-reverse flex-sm-row justify-content-between mx-4 my-3" t-if="this.props.activeDisplay != 'settings'">
                 <div class="o_hr_kiosk_mode_top_time d-flex flex-column-reverse flex-sm-row align-items-center justify-content-center mt-2 mt-sm-0">
-                    <span class="me-0 me-sm-2 display-6" t-out="state.time"/>
+                    <span class="me-0 me-sm-2 display-6" t-out="this.state.time"/>
                     <div class="d-flex flex-sm-column gap-1 gap-sm-0 small">
-                        <span t-out="state.dayOfWeek"/>
-                        <span t-out="state.date"/>
+                        <span t-out="this.state.dayOfWeek"/>
+                        <span t-out="this.state.date"/>
                     </div>
                 </div>
             </div>
@@ -30,7 +30,7 @@
             <div class="p-2 d-flex justify-content-between">
                 <div class="m-2">
                     <button
-                        t-on-click="props.kioskReturn"
+                        t-on-click="this.props.kioskReturn"
                         class="o_hr_attendance_back_button btn btn-secondary rounded-pill"
                         t-if="this.props.fromTrialMode">
                         <i class="oi oi-chevron-left" role="img" aria-label="Go back" title="Go back"/>
@@ -38,10 +38,10 @@
                 </div>
                 <div class="o_hr_kiosk_mode_top d-flex flex-column-reverse flex-sm-row justify-content-between mx-4 my-3" t-if="this.props.activeDisplay != 'settings'">
                     <div class="o_hr_kiosk_mode_top_time d-flex flex-column-reverse flex-sm-row align-items-center justify-content-center mt-2 mt-sm-0">
-                        <span class="me-0 me-sm-2 display-6" t-out="state.time"/>
+                        <span class="me-0 me-sm-2 display-6" t-out="this.state.time"/>
                         <div class="d-flex flex-sm-column gap-1 gap-sm-0 small">
-                            <span t-out="state.dayOfWeek"/>
-                            <span t-out="state.date"/>
+                            <span t-out="this.state.dayOfWeek"/>
+                            <span t-out="this.state.date"/>
                         </div>
                     </div>
                 </div>
@@ -51,7 +51,7 @@
                 </t>
             </div>
         </t>
-        <div t-attf-class="o_hr_attendance_kiosk_mode d-flex flex-column w-100 h-100 {{props.kioskModeClasses}} overflow-auto px-3">
+        <div t-attf-class="o_hr_attendance_kiosk_mode d-flex flex-column w-100 h-100 {{this.props.kioskModeClasses}} overflow-auto px-3">
             <t t-slot="default" />
         </div>
     </div>

--- a/addons/hr_attendance/static/src/components/check_in_out/check_in_out.xml
+++ b/addons/hr_attendance/static/src/components/check_in_out/check_in_out.xml
@@ -3,10 +3,10 @@
 
 <t t-name="hr_attendance.CheckInOut">
     <div class="flex-grow-1">
-        <button t-on-click="() => this.onClickSignInOut()" t-attf-class="o_hr_attendance_sign_in_out_icon btn btn-{{ props.checkedIn ? 'warning' : 'success' }} align-self-center px-5 py-3 mt-4 mb-2">
-            <span class="align-middle fs-2 me-3 text-white" t-if="!props.checkedIn">Check IN</span>
-            <i t-attf-class="fa fa-4x fa-sign-{{ props.checkedIn ? 'out' : 'in' }} align-middle"/>
-            <span class="align-middle fs-2 ms-3" t-if="props.checkedIn">Check OUT</span>
+        <button t-on-click="() => this.onClickSignInOut()" t-attf-class="o_hr_attendance_sign_in_out_icon btn btn-{{ this.props.checkedIn ? 'warning' : 'success' }} align-self-center px-5 py-3 mt-4 mb-2">
+            <span class="align-middle fs-2 me-3 text-white" t-if="!this.props.checkedIn">Check IN</span>
+            <i t-attf-class="fa fa-4x fa-sign-{{ this.props.checkedIn ? 'out' : 'in' }} align-middle"/>
+            <span class="align-middle fs-2 ms-3" t-if="this.props.checkedIn">Check OUT</span>
         </button>
     </div>
 </t>

--- a/addons/hr_attendance/static/src/components/greetings/greetings.xml
+++ b/addons/hr_attendance/static/src/components/greetings/greetings.xml
@@ -21,14 +21,14 @@
                                     <t t-set="employeeAvatar" t-value="this.employeeAvatar"/>
                                 </t>
                                 <h5 class="text-muted mt-2 mb-0">
-                                    <t t-if="attendance.check_out" >Goodbye</t>
+                                    <t t-if="this.attendance.check_out" >Goodbye</t>
                                     <t t-else="">Welcome</t>
                                 </h5>
                                 <h2><t t-out="this.employeeName"/></h2>
                             </div>
                             <div class="o_hr_attendance_kiosk_card_bottom d-flex flex-column w-100">
                                 <div class="alert alert-info text-center p-3" role="status">
-                                    <t t-if="attendance.check_out">
+                                    <t t-if="this.attendance.check_out">
                                         Checked out at <strong><t t-out="this.check_out_time"/></strong>
                                     </t>
                                     <t t-else="">
@@ -40,14 +40,14 @@
                                         class="alert alert-info text-center p-3"
                                         t-if="this.hoursToday != '00:00'"
                                         role="status">
-                                        <t t-if="attendance.check_out">
+                                        <t t-if="this.attendance.check_out">
                                             Hours Today: <strong><t t-out="this.hoursToday"/></strong>
                                         </t>
                                         <t t-else="">
                                             Hours Previously Today: <strong><t t-out="this.hoursToday"/></strong>
                                         </t>
                                     </div>
-                                    <div t-if="attendance.check_out and this.overtimeToday" class="alert alert-warning d-flex flex-column gap-2 mb-0 p-2 p-xl-3 border border-warning text-center">
+                                    <div t-if="this.attendance.check_out and this.overtimeToday" class="alert alert-warning d-flex flex-column gap-2 mb-0 p-2 p-xl-3 border border-warning text-center">
                                         <div class="small fw-bolder text-uppercase">
                                             Extra hours
                                         </div>

--- a/addons/hr_attendance/static/src/components/manual_selection/manual_selection.xml
+++ b/addons/hr_attendance/static/src/components/manual_selection/manual_selection.xml
@@ -15,22 +15,22 @@
                         <div class="d-flex flex-row align-items-center rounded-pill border flex-grow-1">
                             <i class="o_searchview_icon d-print-none oi oi-search m-2" aria-label="Search..." title="Search..."/>
                             <div class="o_searchview_input_container position-relative w-100">
-                                <input t-on-input="onSearchInput" type="text" class="d-print-none border-0" style="width: 95%;" placeholder="Search..."/>
+                                <input t-on-input="this.onSearchInput" type="text" class="d-print-none border-0" style="width: 95%;" placeholder="Search..."/>
                             </div>
                         </div>
                     </div>
                     <div class="p-2">
                         <Pager
-                            t-if="state.employeesData.count > state.limit"
-                            total="state.employeesData.count"
-                            offset="state.offset"
-                            limit="state.limit"
-                            onUpdate.bind="_onPagerChanged"/>
+                            t-if="this.state.employeesData.count > this.state.limit"
+                            total="this.state.employeesData.count"
+                            offset="this.state.offset"
+                            limit="this.state.limit"
+                            onUpdate.bind="this._onPagerChanged"/>
                     </div>
                 </div>
             </div>
             <div class="d-flex h-100 flex-column flex-md-row bg-300">
-                <t t-if="!env.isSmall">
+                <t t-if="!this.env.isSmall">
                     <div class="o_hr_kiosk_sidebar ps-2 py-2 overflow-auto">
                         <div class="list-group">
                             <a t-on-click="() => this.onDepartmentClick()" class="list-group-item py-3 list-group-item-action text-start">
@@ -48,7 +48,7 @@
                 <t t-else="">
                     <Dropdown>
                         <button class="btn btn-light m-2 me-auto align-self-start">
-                            <span id="departmentButton" ><i class="fa fa-users me-2"/><t t-out="departmentName"/></span>
+                            <span id="departmentButton" ><i class="fa fa-users me-2"/><t t-out="this.departmentName"/></span>
                             <i class="fa fa-caret-down ms-2"/>
                         </button>
                         <t t-set-slot="content">

--- a/addons/hr_attendance/static/src/components/new_employee_dialog/many2one/many2one.xml
+++ b/addons/hr_attendance/static/src/components/new_employee_dialog/many2one/many2one.xml
@@ -3,10 +3,10 @@
 <templates xml:space="preserve">
     <t t-name="hr_attendance.Many2One">
         <AutoComplete
-            value="props.value"
-            placeholder="props.placeholder || 'Select an employee'"
-            sources="sources"
-            onInput="props.update"
+            value="this.props.value"
+            placeholder="this.props.placeholder || 'Select an employee'"
+            sources="this.sources"
+            onInput="this.props.update"
             dropdown="true"
             autofocus="true">
             <t t-set-slot="option" t-slot-scope="optionScope">

--- a/addons/hr_attendance/static/src/components/new_employee_dialog/new_employee_dialog.xml
+++ b/addons/hr_attendance/static/src/components/new_employee_dialog/new_employee_dialog.xml
@@ -1,38 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="hr_attendance.NewEmployeeDialog" owl="1">
-        <Dialog title="props.title" footer="props.footer" bodyClass="'overflow-visible'" contentClass="'overflow-visible'">
+        <Dialog title="this.props.title" footer="this.props.footer" bodyClass="'overflow-visible'" contentClass="'overflow-visible'">
             <div class="p-3">
                 <div class="mb-3">
                     <label class="form-label">Create the name of the new employee below</label>
                     <div class="d-flex">
                         <input type="text" t-custom-model="state.employeeName" class="form-control me-2" placeholder="e.g. John Doe"/>
-                        <button class="btn btn-primary" t-on-click="onCreate">Confirm</button>
+                        <button class="btn btn-primary" t-on-click="this.onCreate">Confirm</button>
                     </div>
                 </div>
                 <div class="mb-3">
                     <label class="form-label">Select Employee Without Badge</label>
                     <div class="o_select_employee align-items-start">
                         <div class="o_select_employee_display form-control">
-                            <img t-if="state.value" class="d-flex rounded" t-attf-src="/web/image/hr.employee.public/{{state.value.id}}/avatar_128"/>
+                            <img t-if="this.state.value" class="d-flex rounded" t-attf-src="/web/image/hr.employee.public/{{this.state.value.id}}/avatar_128"/>
                             <div class="o_select_employee_option p-0">
-                                <Many2One value="state.searchName" update.bind="onSelectEmployee" token="props.token"/>
+                                <Many2One value="this.state.searchName" update.bind="this.onSelectEmployee" token="this.props.token"/>
                             </div>
                         </div>
                         <input type="text" t-custom-model="state.badgeId" class="form-control" placeholder="Enter Badge Number"/>
                         <div class="d-flex flex-column gap-2">
                             <button class="btn btn-primary"
                                 style="min-width: max-content;"
-                                t-on-click="onSetBadge">
+                                t-on-click="this.onSetBadge">
                                 Set the Badge
                             </button>                            
                             <a
                                 title="Print"
                                 role="button"
                                 class="btn btn-secondary w-100"
-                                t-att-href="`/hr_attendance/print_badge?employee_id=${state.value?.id}&amp;token=${props.token}`"
+                                t-att-href="`/hr_attendance/print_badge?employee_id=${this.state.value?.id}&amp;token=${this.props.token}`"
                                 target="_self"
-                                t-if="state.value and state.employeeHasBadge"
+                                t-if="this.state.value and this.state.employeeHasBadge"
                             >
                                 Print It
                             </a>

--- a/addons/hr_attendance/static/src/components/pin_code/pin_code.xml
+++ b/addons/hr_attendance/static/src/components/pin_code/pin_code.xml
@@ -13,17 +13,17 @@
                     <h3 class="mt-2 mb-1"><t t-out="this.props.employeeData.employee_name"/></h3>
                     <h5 class="text-muted my-0">
                         Please enter your PIN to
-                        <t t-if="checkedIn">check out</t>
+                        <t t-if="this.checkedIn">check out</t>
                         <t t-else="">check in</t>
                     </h5>
                     <div class="o_hr_kiosk_mode_code mb-2">
                         <div class="row">
                             <div class="col-md-8 offset-md-2 o_hr_attendance_pin_pad">
                                 <div class="row g-0 my-2" >
-                                    <input t-att-value="state.codePin" class="o_hr_attendance_PINbox py-0 border-0 bg-white text-center fs-3" type="password" disabled="true"/>
+                                    <input t-att-value="this.state.codePin" class="o_hr_attendance_PINbox py-0 border-0 bg-white text-center fs-3" type="password" disabled="true"/>
                                 </div>
                                 <div class="row g-2">
-                                    <div class="col-4" t-foreach="padButtons" t-as="btn" t-key="btn[0]">
+                                    <div class="col-4" t-foreach="this.padButtons" t-as="btn" t-key="btn[0]">
                                         <a href="#" t-on-click="() => this.onClickPadButton(btn[0])" t-attf-class="o_hr_attendance_PINbox_button btn {{btn[1]? btn[1] : 'btn-secondary'}} d-flex align-items-center justify-content-center py-2 py-xl-3 rounded-1">
                                             <t t-out="btn[0]"/>
                                         </a>

--- a/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.xml
+++ b/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.xml
@@ -20,19 +20,19 @@
 </t>
 
 <t t-name="hr_attendance.PublicKiosksSettingScreen">
-    <div class="align-self-center" t-att-class="{'h2 mt-5': !env.isSmall, 'my-3 text-center h5': env.isSmall}">
+    <div class="align-self-center" t-att-class="{'h2 mt-5': !this.env.isSmall, 'my-3 text-center h5': this.env.isSmall}">
         Choose how to record attendances
     </div>
-    <div class="o_hr_kiosk_mode_main d-flex m-auto" t-att-class="{'gap-5': !env.isSmall, 'gap-3 flex-column': env.isSmall}">
-        <div class="d-flex flex-column align-items-center text-center gap-2" t-att-style="!env.isSmall ? 'max-width: min-content;' : ''">
+    <div class="o_hr_kiosk_mode_main d-flex m-auto" t-att-class="{'gap-5': !this.env.isSmall, 'gap-3 flex-column': this.env.isSmall}">
+        <div class="d-flex flex-column align-items-center text-center gap-2" t-att-style="!this.env.isSmall ? 'max-width: min-content;' : ''">
             <button
                 t-on-click="() => this.setSetting('manual')"
                 class="btn btn-light"
                 t-att-class="{
-                    'd-flex flex-row rounded-2 ps-2 align-items-center gap-2' : env.isSmall,
-                    'btn-lg rounded-3': !env.isSmall
+                    'd-flex flex-row rounded-2 ps-2 align-items-center gap-2' : this.env.isSmall,
+                    'btn-lg rounded-3': !this.env.isSmall
                 }">
-                <t t-if="env.isSmall">
+                <t t-if="this.env.isSmall">
                     <img src="/hr_attendance/static/img/tablet-pin.svg" alt="Manual Attendance" width="40%"/>
                     <h6 class="m-0">Manually (optional PIN)</h6>
                 </t>
@@ -40,20 +40,20 @@
                     <img src="/hr_attendance/static/img/tablet-pin.svg" height="170px" alt="Manual Attendance"/>
                 </t>
             </button>
-            <t t-if="!env.isSmall">
+            <t t-if="!this.env.isSmall">
                 <h5 class="m-0">Select on Tablet</h5>
                 <em>with optional PIN code</em>
             </t>
         </div>
-        <div class="d-flex flex-column align-items-center text-center gap-2" t-att-style="!env.isSmall ? 'max-width: min-content;' : ''">
+        <div class="d-flex flex-column align-items-center text-center gap-2" t-att-style="!this.env.isSmall ? 'max-width: min-content;' : ''">
             <button
                 t-on-click="() => this.setSetting('barcode')"
                 class="btn btn-light"
                 t-att-class="{
-                    'flex-row d-flex rounded-2 ps-2 align-items-center gap-2' : env.isSmall,
-                    'btn-lg rounded-3': !env.isSmall
+                    'flex-row d-flex rounded-2 ps-2 align-items-center gap-2' : this.env.isSmall,
+                    'btn-lg rounded-3': !this.env.isSmall
                 }">
-                <t t-if="env.isSmall">
+                <t t-if="this.env.isSmall">
                     <img src="/hr_attendance/static/img/tablet-cam.svg" alt="Attendance with barcode" width="40%"/>
                     <h6 class="m-0">Badge with Barcode</h6>
                 </t>
@@ -61,19 +61,19 @@
                     <img src="/hr_attendance/static/img/tablet-cam.svg" height="170px" alt="Attendance with barcode"/>
                 </t>
             </button>
-            <t t-if="!env.isSmall">
+            <t t-if="!this.env.isSmall">
                 <h5 class="m-0 w-75">Badge with Barcode on Tablet</h5>
             </t>
         </div>
-        <div class="d-flex flex-column align-items-center text-center gap-2" t-att-style="!env.isSmall ? 'max-width: min-content;' : ''">
+        <div class="d-flex flex-column align-items-center text-center gap-2" t-att-style="!this.env.isSmall ? 'max-width: min-content;' : ''">
             <button
                 t-on-click="() => this.setSetting('barcode_manual')"
                 class="btn btn-light"
                 t-att-class="{
-                    'flex-row d-flex rounded-2 ps-2 align-items-center gap-2' : env.isSmall,
-                    'btn-lg rounded-3': !env.isSmall
+                    'flex-row d-flex rounded-2 ps-2 align-items-center gap-2' : this.env.isSmall,
+                    'btn-lg rounded-3': !this.env.isSmall
                 }">
-                <t t-if="env.isSmall">
+                <t t-if="this.env.isSmall">
                     <img src="/hr_attendance/static/img/tablet-rfid.svg" alt="Manual Attendance or with barcode" width="40%"/>
                     <h6 class="m-0">RFID Token with reader</h6>
                 </t>
@@ -82,7 +82,7 @@
                     alt="Manual Attendance or with barcode"/>
                 </t>
             </button>
-            <t t-if="!env.isSmall">
+            <t t-if="!this.env.isSmall">
                 <h5 class="m-0 w-75">RFID Token with reader on tablet</h5>
             </t>
         </div>
@@ -91,22 +91,23 @@
 
 <t t-name="hr_attendance.public_kiosk_app">
     <MainComponentsContainer/>
-    <CardLayout fromTrialMode="this.props.fromTrialMode" companyImageUrl="this.companyImageUrl" kioskReturn.bind="kioskReturn" activeDisplay = "this.state.active_display">
+    <CardLayout fromTrialMode="this.props.fromTrialMode" companyImageUrl="this.companyImageUrl" kioskReturn.bind="this.kioskReturn"
+        activeDisplay="this.state.active_display" >
         <t t-if="this.state.active_display === 'settings'">
             <t t-call="hr_attendance.PublicKiosksSettingScreen"/>
         </t>
         <t t-if="this.state.active_display === 'main'">
-            <t t-if="state.displayDemoMessage">
+            <t t-if="this.state.displayDemoMessage">
                 <div
                     class="alert alert-info flex-row justify-content-between d-flex"
-                    t-att-class="{'align-self-center col-6': !env.isSmall}"
-                    t-att-style="!env.isSmall? 'min-width: fit-content;' : ''">
+                    t-att-class="{'align-self-center col-6': !this.env.isSmall}"
+                    t-att-style="!this.env.isSmall? 'min-width: fit-content;' : ''">
                         <div>
                             Connect an RFID reader, and scan a token.
                             <DocumentationLink path="'/applications/hr/attendances/hardware.html'" label.translate="'Read the Documentation'" alertLink="true"/>/
                             <DocumentationLink path="'https://duckduckgo.com/?q=rfid+reader'" label.translate="'Buy an RFID Device'" alertLink="true"/>
                         </div>
-                        <button t-on-click="removeDemoMessage" type="button" class="btn-close float-end ms-2" title="Close"/>
+                        <button t-on-click="this.removeDemoMessage" type="button" class="btn-close float-end ms-2" title="Close"/>
                 </div>
             </t>
             <div class="o_hr_kiosk_mode_main d-flex flex-column gap-3 m-auto">

--- a/addons/hr_attendance/static/src/views/attendance_helper_view.xml
+++ b/addons/hr_attendance/static/src/views/attendance_helper_view.xml
@@ -3,8 +3,8 @@
     <t t-name="hr_attendance.AttendanceActionHelper">
         <div class="o_view_nocontent">
             <div class="o_nocontent_help">
-                <t t-if="hasAttendanceRight and isHrUser">
-                    <t t-if="env.isSmall">
+                <t t-if="this.hasAttendanceRight and this.isHrUser">
+                    <t t-if="this.env.isSmall">
                         <t t-call="hr_attendance.AttendanceActionHelperMobileScreen"/>
                     </t>
                     <t t-else="">
@@ -45,7 +45,7 @@
                     </em>
                 </h3>
             </div>
-            <t t-if="!state.hasDemoData">
+            <t t-if="!this.state.hasDemoData">
                 <div class="d-flex gap-3 align-items-center or-separator">
                     <hr class="flex-grow-1"/>
                     or
@@ -86,7 +86,7 @@
                     icon (e.g for work from home)</em></h3>
                 </div>
             </div>
-            <t t-if="!state.hasDemoData">
+            <t t-if="!this.state.hasDemoData">
                     <div class="d-flex gap-3 align-items-center or-separator">
                         <hr class="flex-grow-1"/>
                         or

--- a/addons/hr_attendance/static/src/views/badge_scanner/badge_scanner.xml
+++ b/addons/hr_attendance/static/src/views/badge_scanner/badge_scanner.xml
@@ -13,8 +13,8 @@
                     <BarcodeScanner onBarcodeScanned="(barcode) => this.onBarcodeScanned(barcode)" />
                     <div class="my-5 text-center">
                         <h5 class="mt8 text-muted">Scan or Tap your badge</h5>
-                        <t t-if="employee">
-                            <h4 class="text-primary mt-3">For <t t-out="employee[0].name"/></h4>
+                        <t t-if="this.employee">
+                            <h4 class="text-primary mt-3">For <t t-out="this.employee[0].name"/></h4>
                         </t>
                     </div>
                 </div>

--- a/addons/hr_attendance/static/src/views/calendar/attendance_calendar_renderer.xml
+++ b/addons/hr_attendance/static/src/views/calendar/attendance_calendar_renderer.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="hr_attendance.AttendanceCalendarRenderer">
         <div class="o_attendance_calendar d-flex flex-column">
-            <AttendanceCalendarOverview dateRange="dateRange"/>
+            <AttendanceCalendarOverview dateRange="this.dateRange"/>
             <t t-call="web.CalendarRenderer"/>
         </div>
     </t>

--- a/addons/hr_calendar/static/src/calendar/common/calendar_common_renderer.xml
+++ b/addons/hr_calendar/static/src/calendar/common/calendar_common_renderer.xml
@@ -17,59 +17,59 @@
     </t>
 
     <div t-name="hr_calendar.MultiCalendarButtonWorkLocation" class="o_worklocation_btn my-2 opacity-75 w-100 d-flex align-items-center cursor-default">
-        <div t-if="Object.keys(worklocation).length &gt; 0" class="d-flex gap-1 ms-1 flex-wrap w-75">
+        <div t-if="Object.keys(this.worklocation).length &gt; 0" class="d-flex gap-1 ms-1 flex-wrap w-75">
             <t t-set="iconClass" t-value="`o_homework_content d-flex align-items-center justify-content-center flex-wrap border border-1 rounded-circle me-0 fa`"/>
-            <t t-if="scale === 'month'">
+            <t t-if="this.scale === 'month'">
                 <div class="o_homework_multi d-flex align-items-center gap-1 ms-1 w-100 overflow-hidden">
-                    <t t-foreach="Object.keys(worklocation)" t-as="location" t-key="location">
-                        <t t-foreach="worklocation[location]" t-as="wl" t-key="wl.id">
+                    <t t-foreach="Object.keys(this.worklocation)" t-as="location" t-key="location">
+                        <t t-foreach="this.worklocation[location]" t-as="wl" t-key="wl.id">
                             <div class="o_homeworking_content o_worklocation_action cursor-pointer" t-att-data-location="location" t-att-data-id="wl.id" t-att-data-employee="wl.employeeId">
-                                <i t-att-title="wl.title" t-attf-class="{{iconClass}} {{iconMap[wl.icon] || 'fa-map-marker'}} o_worklocation_color_{{wl.colorIndex}} o_worklocation_outline_{{wl.colorIndex}}"/>
+                                <i t-att-title="wl.title" t-attf-class="{{iconClass}} {{this.iconMap[wl.icon] || 'fa-map-marker'}} o_worklocation_color_{{wl.colorIndex}} o_worklocation_outline_{{wl.colorIndex}}"/>
                             </div>
                         </t>
-                        <span t-if="worklocation[location].length === 1 &amp;&amp; location.length === 1" class="fw-bolder me-3 text-truncate" t-out="worklocation[location][0].title"/>
+                        <span t-if="this.worklocation[location].length === 1 &amp;&amp; location.length === 1" class="fw-bolder me-3 text-truncate" t-out="this.worklocation[location][0].title"/>
                     </t>
                 </div>
             </t>
             <t t-else="">
-                <div t-foreach="Object.keys(worklocation)" t-as="location" t-key="location" class="o_homework_multi d-flex gap-1 ms-1 w-100">
-                    <t t-foreach="worklocation[location]" t-as="wl" t-key="wl.id">
+                <div t-foreach="Object.keys(this.worklocation)" t-as="location" t-key="location" class="o_homework_multi d-flex gap-1 ms-1 w-100">
+                    <t t-foreach="this.worklocation[location]" t-as="wl" t-key="wl.id">
                         <div class="o_homeworking_content o_worklocation_action cursor-pointer" t-att-data-location="location" t-att-data-id="wl.id" t-att-data-employee="wl.employeeId">
-                            <i t-att-title="wl.title" t-attf-class="{{iconClass}} {{iconMap[wl.icon] || 'fa-map-marker'}} o_worklocation_color_{{wl.colorIndex}} o_worklocation_outline_{{wl.colorIndex}}"/>
+                            <i t-att-title="wl.title" t-attf-class="{{iconClass}} {{this.iconMap[wl.icon] || 'fa-map-marker'}} o_worklocation_color_{{wl.colorIndex}} o_worklocation_outline_{{wl.colorIndex}}"/>
                         </div>
                     </t>
-                    <span class="fw-bolder me-3 text-truncate" t-out="worklocation[location][0].title"/>
+                    <span class="fw-bolder me-3 text-truncate" t-out="this.worklocation[location][0].title"/>
                 </div>
             </t>
         </div>
-        <div t-if="userFilterActive and !workLocationSetForCurrentUser" class="w-100 d-flex align-items-center opacity-0 opacity-100-hover o_worklocation_action cursor-pointer" data-create="1">
+        <div t-if="this.userFilterActive and !this.workLocationSetForCurrentUser" class="w-100 d-flex align-items-center opacity-0 opacity-100-hover o_worklocation_action cursor-pointer" data-create="1">
             <button class="o_worklocation_text d-flex justify-content-center align-items-center bg-info bg-opacity-25 border-0 rounded-pill px-lg-2 py-0 text-nowrap mw-100">
                 <i class="add_wl fa fa-map-marker" title="Set location" aria-hidden="true"></i>
-                <span t-if="Object.keys(worklocation).length &lt; 1" class="d-lg-inline fw-bold location_xs_hide ms-lg-1">Set<span class="d-none d-xl-inline"> Location</span></span>
+                <span t-if="Object.keys(this.worklocation).length &lt; 1" class="d-lg-inline fw-bold location_xs_hide ms-lg-1">Set<span class="d-none d-xl-inline"> Location</span></span>
             </button>
-            <button t-if="Object.keys(worklocation).length &lt; 1" class="o_worklocation_line d-lg-block w-100 bg-info bg-opacity-25 border-0 p-0"/>
+            <button t-if="Object.keys(this.worklocation).length &lt; 1" class="o_worklocation_line d-lg-block w-100 bg-info bg-opacity-25 border-0 p-0"/>
         </div>
     </div>
 
     <div t-name="hr_calendar.SingleCalendarButtonWorkLocation" class="o_worklocation_btn my-2 opacity-75 w-100 d-flex align-items-center">
-        <div t-if="workLocationSetForCurrentUser" class="w-100 d-flex align-items-center o_worklocation_action cursor-pointer o_homework_single">
-            <t t-if="worklocation.display">
-                <button t-attf-class='o_worklocation_text mw-100 d-flex justify-content-center align-items-center align-items-center border-0 rounded-pill px-lg-2 py-0 text-nowrap o_worklocation_color_{{worklocation.colorIndex}} o_worklocation_outline_{{worklocation.colorIndex}}'>
-                    <i t-attf-class="fa {{iconMap[worklocation.icon] || 'fa-map-marker'}} me-lg-1" aria-hidden="true"></i>
-                    <span class="d-none d-lg-inline-block fw-bold text-truncate me-3" t-out="worklocation.title"/>
+        <div t-if="this.workLocationSetForCurrentUser" class="w-100 d-flex align-items-center o_worklocation_action cursor-pointer o_homework_single">
+            <t t-if="this.worklocation.display">
+                <button t-attf-class='o_worklocation_text mw-100 d-flex justify-content-center align-items-center align-items-center border-0 rounded-pill px-lg-2 py-0 text-nowrap o_worklocation_color_{{this.worklocation.colorIndex}} o_worklocation_outline_{{this.worklocation.colorIndex}}'>
+                    <i t-attf-class="fa {{this.iconMap[this.worklocation.icon] || 'fa-map-marker'}} me-lg-1" aria-hidden="true"></i>
+                    <span class="d-none d-lg-inline-block fw-bold text-truncate me-3" t-out="this.worklocation.title"/>
                 </button>
-                <button t-if="showLine" t-attf-class="o_worklocation_line d-lg-block w-100 border-0 p-0 o_worklocation_color_{{worklocation.colorIndex}}"/>
+                <button t-if="this.showLine" t-attf-class="o_worklocation_line d-lg-block w-100 border-0 p-0 o_worklocation_color_{{this.worklocation.colorIndex}}"/>
             </t>
             <t t-else="">
-                <button t-if="showLine" t-attf-class="o_worklocation_line d-lg-block w-100 border-0 p-0 o_worklocation_color_{{worklocation.colorIndex}}"/>
+                <button t-if="this.showLine" t-attf-class="o_worklocation_line d-lg-block w-100 border-0 p-0 o_worklocation_color_{{this.worklocation.colorIndex}}"/>
             </t>
         </div>
-        <div t-elif="userFilterActive" class="w-100 d-flex align-items-center opacity-0 opacity-100-hover o_worklocation_action cursor-pointer" data-create="1">
+        <div t-elif="this.userFilterActive" class="w-100 d-flex align-items-center opacity-0 opacity-100-hover o_worklocation_action cursor-pointer" data-create="1">
             <button class="o_worklocation_text d-flex justify-content-center align-items-center align-items-center bg-info bg-opacity-25 border-0 rounded-pill px-lg-2 py-0 text-nowrap">
                 <i class="fa fa-map-marker me-1" aria-hidden="true"></i>
                 <span class="d-lg-inline fw-bold">Set<span class="location_xs_hide"> Location</span></span>
             </button>
-            <button t-if="showLine" class="o_worklocation_line d-lg-block w-100 bg-info bg-opacity-25 border-0 p-0"/>
+            <button t-if="this.showLine" class="o_worklocation_line d-lg-block w-100 bg-info bg-opacity-25 border-0 p-0"/>
         </div>
     </div>
 </templates>

--- a/addons/hr_calendar/static/src/calendar/common/popover/calendar_common_popover.xml
+++ b/addons/hr_calendar/static/src/calendar/common/popover/calendar_common_popover.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates>
     <t t-name="hr_calendar.AttendeeCalendarCommonPopover">
-        <t t-if="isWorkLocationEvent()">
-        <Record resModel="'hr.employee.location'" fieldNames="fieldNames" fields="fields" activeFields="fields" values="values" mode="'readonly'" t-slot-scope="slot">
-            <Dialog t-if="env.isSmall" title="props.record.title" contentClass="'o_calendar_color_'+ props.record.colorIndex">
-                <t t-call="{{ constructor.subTemplates.body }}"/>
+        <t t-if="this.isWorkLocationEvent()">
+        <Record resModel="'hr.employee.location'" fieldNames="this.fieldNames" fields="this.fields" activeFields="this.fields" values="this.values" mode="'readonly'" t-slot-scope="slot">
+            <Dialog t-if="this.env.isSmall" title="this.props.record.title" contentClass="'o_calendar_color_'+ this.props.record.colorIndex">
+                <t t-call="{{ this.constructor.subTemplates.body }}"/>
                 <t t-set-slot="footer">
                     <t t-call="calendar.AttendeeCalendarCommonPopover.footer"/>
                 </t>
@@ -12,24 +12,24 @@
             <div t-else="" class="card-header d-flex justify-content-between py-2 pe-2">
                 <span class="popover-header border-0">
                     <t t-if="slot.record.data.work_location_type === 'office'">
-                        <i class="fa fa-fw fa-building me-2" role="img" t-att-class="`o_worklocation_color_${props.record.colorIndex}`"/>
+                        <i class="fa fa-fw fa-building me-2" role="img" t-att-class="`o_worklocation_color_${this.props.record.colorIndex}`"/>
                     </t>
                     <t t-elif="slot.record.data.work_location_type === 'home'">
                         <i class="fa fa-fw fa-home me-2" role="img" />
                     </t>
                     <t t-else="">
-                    <i class="fa fa-fw fa-map-marker me-2" t-att-class="`o_worklocation_color_${props.record.colorIndex}`" role="img"/>
+                    <i class="fa fa-fw fa-map-marker me-2" t-att-class="`o_worklocation_color_${this.props.record.colorIndex}`" role="img"/>
                     </t>
-                    <t t-out="props.record.title"/>
+                    <t t-out="this.props.record.title"/>
                 </span>
-                <span class="o_cw_popover_close ms-4 mt-2 me-2" t-on-click.stop="() => props.close()">
+                <span class="o_cw_popover_close ms-4 mt-2 me-2" t-on-click.stop="() => this.props.close()">
                     <i class="fc-close fc-icon fc-icon-x" />
                 </span>
             </div>
             <div class="o_cw_body">
-                <t t-call="{{ constructor.subTemplates.body }}" />
-                <div t-if="hasFooter" class="card-footer border-top d-flex gap-1">
-                    <t t-call="{{ constructor.subTemplates.footer }}" />
+                <t t-call="{{ this.constructor.subTemplates.body }}" />
+                <div t-if="this.hasFooter" class="card-footer border-top d-flex gap-1">
+                    <t t-call="{{ this.constructor.subTemplates.footer }}" />
                 </div>
             </div>
         </Record>
@@ -39,20 +39,20 @@
         </t>
     </t>
     <t t-name="hr_calendar.AttendeeCalendarCommonPopover.body">
-        <t t-if="isWorkLocationEvent()">
+        <t t-if="this.isWorkLocationEvent()">
                 <ul class="list-group list-group-flush">
                     <div class="list-group-item">
-                        <i class="fa fa-fw fa-calendar me-2" t-att-class="`o_worklocation_color_${props.record.colorIndex}`"/>
-                        <t t-if="props.record.start.ts != props.record.end.ts">
-                            <t t-out="props.record.start.toFormat('d MMMM')" t-options="{'widget': 'date'}"/>
+                        <i class="fa fa-fw fa-calendar me-2" t-att-class="`o_worklocation_color_${this.props.record.colorIndex}`"/>
+                        <t t-if="this.props.record.start.ts != this.props.record.end.ts">
+                            <t t-out="this.props.record.start.toFormat('d MMMM')" t-options="{'widget': 'date'}"/>
                         </t>
                         <t t-else="">
-                            <t t-out="props.record.start.toFormat('d MMMM yyyy')" t-options="{'widget': 'date'}"/>
+                            <t t-out="this.props.record.start.toFormat('d MMMM yyyy')" t-options="{'widget': 'date'}"/>
                         </t>
                     </div>
                     <div class="list-group-item">
-                        <i class="fa fa-fw fa-user me-2" t-att-class="`o_worklocation_color_${props.record.colorIndex}`"/>
-                        <Field name="'employee_name'" record="slot.record" readonly="true"/>
+                        <i class="fa fa-fw fa-user me-2" t-att-class="`o_worklocation_color_${this.props.record.colorIndex}`"/>
+                        <Field name="'employee_name'" record="this.slot.record" readonly="true"/>
                     </div>
                 </ul>
         </t>
@@ -62,8 +62,8 @@
     </t>
 
     <t t-name="hr_calendar.AttendeeCalendarCommonPopover.footer">
-        <t t-if="isWorkLocationEvent()">
-            <t t-if="isCurrentUserIsOwnerWorklocation()">
+        <t t-if="this.isWorkLocationEvent()">
+            <t t-if="this.isCurrentUserIsOwnerWorklocation()">
                 <t t-call="calendar.AttendeeCalendarCommonPopover.footer" />
             </t>
         </t>

--- a/addons/hr_calendar/static/src/calendar/common/popover/calendar_common_popover.xml
+++ b/addons/hr_calendar/static/src/calendar/common/popover/calendar_common_popover.xml
@@ -52,7 +52,7 @@
                     </div>
                     <div class="list-group-item">
                         <i class="fa fa-fw fa-user me-2" t-att-class="`o_worklocation_color_${this.props.record.colorIndex}`"/>
-                        <Field name="'employee_name'" record="this.slot.record" readonly="true"/>
+                        <Field name="'employee_name'" record="slot.record" readonly="true"/>
                     </div>
                 </ul>
         </t>

--- a/addons/hr_expense/static/src/components/expense_dashboard.xml
+++ b/addons/hr_expense/static/src/components/expense_dashboard.xml
@@ -2,19 +2,19 @@
 <templates xml:space="preserve">
     <t t-name="hr_expense.ExpenseDashboard">
         <div class="d-none d-md-flex o_expense_container position-sticky start-0 d-flex o_form_statusbar">
-            <t t-foreach="Object.entries(state.expenses)" t-as="expense" t-key="expense[0]">
+            <t t-foreach="Object.entries(this.state.expenses)" t-as="expense" t-key="expense[0]">
                 <t t-set="name" t-value="expense[0]"/>
                 <t t-set="data" t-value="expense[1]"/>
                 <div t-attf-class="o_expense_card o_arrow_button flex-grow-1 d-flex flex-column p-3 border-bottom text-center cursor-pointer"
                      t-att-data-tooltip="data['tooltip']" t-on-click="() => this.applyFilter(name)">
-                    <span t-out="renderMonetaryField(data['amount'], data['currency'])" class="h2 m-0 text-primary"/>
+                    <span t-out="this.renderMonetaryField(data['amount'], data['currency'])" class="h2 m-0 text-primary"/>
                     <b class="mx-2" t-out="data['description']"/>
                 </div>
                 <div t-if="name !== 'approved'" t-attf-class="o_expense_card o_arrow_button flex-grow-1 d-flex flex-column p-3 border-bottom text-center">
                     <i class="fa fa-angle-right fa-3x"/>
                 </div>
             </t>
-            <div class="fa fa-question-circle-o flex-grow-0.5 d-flex flex-column p-3 border-bottom text-center" t-if="env.debug" data-tooltip="Numbers computed from your personal expenses."/>
+            <div class="fa fa-question-circle-o flex-grow-0.5 d-flex flex-column p-3 border-bottom text-center" t-if="this.env.debug" data-tooltip="Numbers computed from your personal expenses."/>
         </div>
     </t>
 </templates>

--- a/addons/hr_expense/static/src/components/nb_attachment.xml
+++ b/addons/hr_expense/static/src/components/nb_attachment.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates>
-    <t t-if="nb_attachment > 0" t-name="hr_expense.AttachmentNumber" >
+    <t t-if="this.nb_attachment > 0" t-name="hr_expense.AttachmentNumber" >
         <div>
             <span class="fa fa-paperclip pe-1 align-middle"/>
-            <sup><t class="text-center" t-out="nb_attachment"/></sup>
+            <sup><t class="text-center" t-out="this.nb_attachment"/></sup>
         </div>
     </t>
 </templates>

--- a/addons/hr_holidays/static/src/components/accrual_level/accrual_levels.xml
+++ b/addons/hr_holidays/static/src/components/accrual_level/accrual_levels.xml
@@ -9,11 +9,11 @@
                 </h3>
             </div>
         </div>
-        <t t-foreach="milestones" t-as="level" t-key="level.id">
+        <t t-foreach="this.milestones" t-as="level" t-key="level.id">
             <div class="o_accrual_level w-100 d-flex vertical-align-middle" t-if="level.data">
                 <div class="time d-flex flex-column align-items-end mx-2" style="width: 150px; min-width: 150px; align-self: center;">
-                    <span class="o_accrual_bg border w-100 position-relative text-center px-3 py-1 rounded-3" role="button" t-on-click="editMilestone.bind(this, level.data.id)">
-                        <span class="new-text position-absolute fw-bold" t-if="getNewMilestoneClass(level.data.id)">New !</span>
+                    <span class="o_accrual_bg border w-100 position-relative text-center px-3 py-1 rounded-3" role="button" t-on-click="this.editMilestone.bind(this, level.data.id)">
+                        <span class="new-text position-absolute fw-bold" t-if="this.getNewMilestoneClass(level.data.id)">New !</span>
                         <span class="text">
                             <t t-if="level.data.milestone_date == 'creation'">
                                 Immediately
@@ -26,11 +26,11 @@
                 </div>
                 <span class="timeline d-flex align-items-center flex-column" style="pointer-events: none;">
                     <span class="flex-grow-1 rounded border" style="width: 0;"/>
-                    <span class="circle position-relative border rounded-circle border" style="z-index: 0; height: 15px; width: 15px;" t-att-class="getNewMilestoneClass(level.data.id)"/>
+                    <span class="circle position-relative border rounded-circle border" style="z-index: 0; height: 15px; width: 15px;" t-att-class="this.getNewMilestoneClass(level.data.id)"/>
                     <span class="flex-grow-1 rounded border" style="width: 0;"/>
                     <i class="arrow down"/>
                 </span>
-                <div class="content o_accrual_bg align-self-center w-100 h-100 px-3 py-2 my-3 ms-2 border rounded-3" role="button" t-on-click="editMilestone.bind(this, level.data.id)">
+                <div class="content o_accrual_bg align-self-center w-100 h-100 px-3 py-2 my-3 ms-2 border rounded-3" role="button" t-on-click="this.editMilestone.bind(this, level.data.id)">
                     <span class="text">
                         <h4 class="header m-0" name="header">
                             Accrual frequency : <t t-out="level.data.added_value"/> <t t-out="level.data.added_value_type"/>(s)
@@ -43,7 +43,7 @@
                                 <br/>
                             </t>
                             <t t-elif="level.data.frequency == 'weekly'">
-                                every week on <t t-out="getFullDay(level.data.week_day)"/>.
+                                every week on <t t-out="this.getFullDay(level.data.week_day)"/>.
                                 <br/>
                             </t>
                             <t t-elif="level.data.frequency == 'bimonthly'">
@@ -61,15 +61,15 @@
                             <t t-elif="level.data.frequency == 'biyearly'">
                                 twice a year on the <t t-out="level.data.first_month_day"/>
                                 of
-                                <t t-out="getFullMonth(level.data.first_month)"/>
+                                <t t-out="this.getFullMonth(level.data.first_month)"/>
                                 and the
                                 <t t-out="level.data.second_month_day"/>
-                                of <t t-out="getFullMonth(level.data.second_month)"/>.
+                                of <t t-out="this.getFullMonth(level.data.second_month)"/>.
                                 <br/>
                             </t>
                             <t t-elif="level.data.frequency == 'yearly'">
                                 every year on the <t t-out="level.data.yearly_day"/>
-                                of <t t-out="getFullMonth(level.data.yearly_month)"/>.
+                                of <t t-out="this.getFullMonth(level.data.yearly_month)"/>.
                                 <br/>
                             </t>
                         </h4>
@@ -79,12 +79,12 @@
                                     Unused days will be reset.<br/>
                                 </t>
                                 <t t-elif="level.data.carryover_options == 'unlimited'">
-                                    Unused days will be transferred totally on each <t t-out="state.carryOverDate"/>.
+                                    Unused days will be transferred totally on each <t t-out="this.state.carryOverDate"/>.
                                     <br/>
                                 </t>
                                 <t t-else="">
                                     Unused days will be transferred with a max of <t t-out="level.data.postpone_max_days"/> <t t-out="level.data.added_value_type"/>
-                                    on each <t t-out="state.carryOverDate"/>.
+                                    on each <t t-out="this.state.carryOverDate"/>.
                                     <br/>
                                 </t>
                             </t>
@@ -113,7 +113,7 @@
         <div class="o_accrual_level w-100 d-flex vertical-align-middle">
             <div class="d-flex flex-column align-items-end mx-2" style="width: 150px; min-width: 150px; align-self: center;"/>
             <div class="timeline d-flex align-items-center flex-column" style="pointer-events: all;">
-                <button class="btn btn-secondary my-2" style="margin-left: -85%;" t-on-click="editMilestone.bind(this, false)">
+                <button class="btn btn-secondary my-2" style="margin-left: -85%;" t-on-click="this.editMilestone.bind(this, false)">
                     Add a milestone
                 </button>
             </div>

--- a/addons/hr_holidays/static/src/components/float_time_selection/float_time_selection_popover.xml
+++ b/addons/hr_holidays/static/src/components/float_time_selection/float_time_selection_popover.xml
@@ -2,15 +2,15 @@
 <templates xml:space="preserve">
     <t t-name="hr_holidays.FloatTimeSelectionPopover">
         <div class="position-relative d-flex align-items-center flex-sm-row gap-1 gap-md-1 p-2">
-            <select class="o_hour_selection form-control form-control-sm w-auto" t-on-change="onTimeChange" t-custom-model="state.selectedHours">
-                <t t-foreach="availableHours" t-as="unit" t-key="unit[0]">
-                    <option class="text-center" t-att-value="unit[0]" t-out="unit[1]" t-att-selected="unit[0] == state.selectedHours"/>
+            <select class="o_hour_selection form-control form-control-sm w-auto" t-on-change="this.onTimeChange" t-custom-model="state.selectedHours">
+                <t t-foreach="this.availableHours" t-as="unit" t-key="unit[0]">
+                    <option class="text-center" t-att-value="unit[0]" t-out="unit[1]" t-att-selected="unit[0] == this.state.selectedHours"/>
                 </t>
             </select>
             <span>:</span>
-            <select class="o_hour_selection form-control form-control-sm w-auto" t-on-change="onTimeChange" t-custom-model="state.selectedMinutes">
-                <t t-foreach="availableMinutes" t-as="unit" t-key="unit[0]">
-                    <option class="text-center" t-att-value="unit[0]" t-out="unit[1]" t-att-selected="unit[0] == state.selectedMinutes"/>
+            <select class="o_hour_selection form-control form-control-sm w-auto" t-on-change="this.onTimeChange" t-custom-model="state.selectedMinutes">
+                <t t-foreach="this.availableMinutes" t-as="unit" t-key="unit[0]">
+                    <option class="text-center" t-att-value="unit[0]" t-out="unit[1]" t-att-selected="unit[0] == this.state.selectedMinutes"/>
                 </t>
             </select>
         </div>

--- a/addons/hr_holidays/static/src/dashboard/time_off_card.xml
+++ b/addons/hr_holidays/static/src/dashboard/time_off_card.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <div t-name="hr_holidays.TimeOffCard" class="o_timeoff_card py-3 text-primary">
-        <t t-set="data" t-value="props.data"/>
-        <t t-set="duration" t-value="props.requires_allocation ? data.virtual_remaining_leaves : data.virtual_leaves_taken"/>
-        <t t-set="parsed_duration" t-value="formatDuration(duration)"/>
+        <t t-set="data" t-value="this.props.data"/>
+        <t t-set="duration" t-value="this.props.requires_allocation ? data.virtual_remaining_leaves : data.virtual_leaves_taken"/>
+        <t t-set="parsed_duration" t-value="this.formatDuration(duration)"/>
         <t t-set="show_popover" t-value="true"/>
 
-        <strong class="o_timeoff_name cursor-pointer btn-link" t-on-click="navigateTimeOffType"><t t-out="props.name"/></strong>
+        <strong class="o_timeoff_name cursor-pointer btn-link" t-on-click="this.navigateTimeOffType"><t t-out="this.props.name"/></strong>
         <span class="o_timeoff_duration">
             <span t-att-style="data.holds_changes ? 'color: #B6D369;' : ''">
                 <t t-out="parsed_duration"/>
             </span>
         </span>
         <span
-            t-att-class="'text-uppercase o_timeoff_details p-1' + (warning ? ' alert alert-warning' : '')"
+            t-att-class="'text-uppercase o_timeoff_details p-1' + (this.warning ? ' alert alert-warning' : '')"
             t-on-click.stop="(ev) => (show_popover &amp;&amp; this.onClickInfo(ev))">
             <t t-if="data.unit_of_measure == 'hour'" name="duration_unit">hours</t>
             <t t-else="">days</t>
-            <t t-if="props.requires_allocation" name="duration_type">
+            <t t-if="this.props.requires_allocation" name="duration_type">
                 available
             </t>
             <t t-else="">
                 taken
             </t>
             <span t-if="show_popover"
-                t-att-class="'o_timeoff_info fa' + (warning ? ' fa-exclamation-triangle' : ' fa-question-circle-o')"
+                t-att-class="'o_timeoff_info fa' + (this.warning ? ' fa-exclamation-triangle' : ' fa-question-circle-o')"
             />
         </span>
-        <span t-if="props.requires_allocation and data.closest_allocation_expire !== false" class="text-uppercase o_timeoff_validity">
+        <span t-if="this.props.requires_allocation and data.closest_allocation_expire !== false" class="text-uppercase o_timeoff_validity">
             <t t-if="data.closest_allocation_remaining != data.virtual_remaining_leaves">
                 (<t t-out="data.closest_allocation_remaining"/> <t t-if="data.unit_of_measure == 'hour'">hours</t><t t-else="">days</t>
                 valid until <span t-out="data.closest_allocation_expire"/>)
@@ -39,11 +39,11 @@
     </div>
 
     <t t-name="hr_holidays.TimeOffCardMobile">
-        <t t-set="data" t-value="props.data"/>
-        <t t-set="duration" t-value="props.requires_allocation ? data.virtual_remaining_leaves : data.virtual_leaves_taken" />
+        <t t-set="data" t-value="this.props.data"/>
+        <t t-set="duration" t-value="this.props.requires_allocation ? data.virtual_remaining_leaves : data.virtual_leaves_taken" />
 
         <span class="float-end o_timeoff_card_mobile">
-            <t t-if="props.requires_allocation" name="duration_type">
+            <t t-if="this.props.requires_allocation" name="duration_type">
                 <strong t-out="duration" class="o_timeoff_green text-success"/> / <span t-out="data.max_leaves"/> <t t-if="data.unit_of_measure == 'hour'">Hours</t><t t-else="">Days</t> <span class="o_timeoff_green text-success">Available</span>
             </t>
             <t t-else="">
@@ -55,31 +55,31 @@
     <t t-name="hr_holidays.TimeOffCardPopover">
         <ul class="list-unstyled p-3 mb-0">
             <li class="d-flex justify-content-between">
-                <span><span class="btn-link p-0 cursor-pointer" t-on-click="allocatedLeaves">Allocated</span> (<span class="btn-link p-0 cursor-pointer" t-on-click="props.onClickNewAllocationRequest">new request</span>):</span>
-                <span class="ps-1" t-out="props.allocated"/>
+                <span><span class="btn-link p-0 cursor-pointer" t-on-click="this.allocatedLeaves">Allocated</span> (<span class="btn-link p-0 cursor-pointer" t-on-click="this.props.onClickNewAllocationRequest">new request</span>):</span>
+                <span class="ps-1" t-out="this.props.allocated"/>
             </li>
-            <li class="d-flex justify-content-between" t-if="props.accrual_bonus != 0">
-                Accrual (Future): <span class="ps-1" t-out="props.accrual_bonus"/>
+            <li class="d-flex justify-content-between" t-if="this.props.accrual_bonus != 0">
+                Accrual (Future): <span class="ps-1" t-out="this.props.accrual_bonus"/>
             </li>
-            <li class="d-flex justify-content-between btn-link cursor-pointer" t-on-click="() => this.navigateInfo(['validate'])">Approved: <span class="ps-1" t-out="props.approved"/></li>
-            <li class="d-flex justify-content-between border-bottom btn-link cursor-pointer" t-on-click="() => this.navigateInfo(['confirm','validate1'])">Planned: <span class="ps-1" t-out="props.planned"/></li>
-            <li class="d-flex justify-content-between">Available: <span class="ps-1" t-out="props.left"/></li>
+            <li class="d-flex justify-content-between btn-link cursor-pointer" t-on-click="() => this.navigateInfo(['validate'])">Approved: <span class="ps-1" t-out="this.props.approved"/></li>
+            <li class="d-flex justify-content-between border-bottom btn-link cursor-pointer" t-on-click="() => this.navigateInfo(['confirm','validate1'])">Planned: <span class="ps-1" t-out="this.props.planned"/></li>
+            <li class="d-flex justify-content-between">Available: <span class="ps-1" t-out="this.props.left"/></li>
         </ul>
-        <div t-if="props.warning" class="alert alert-warning mb-0 pb-0 o_time_off_card_popover_warning">
+        <div t-if="this.props.warning" class="alert alert-warning mb-0 pb-0 o_time_off_card_popover_warning">
             <span class="d-inline-block m-0 mb-3"
-                t-if="props.errorLeaves.length">
+                t-if="this.props.errorLeaves.length">
                 Some leaves cannot be linked to any allocation. To see those leaves, 
                 <a t-on-click="() => this.openLeaves()" class="cursor-pointer">click here</a>.
             </span>
             <span class="d-inline-block m-0 mb-3"
-                t-if="props.closest &amp;&amp; props.closest &lt; props.left">
-                <i class="fa fa-warning"/> Only <t t-out="props.closest"/>
-                <t t-if="props.unit_of_measure == 'hour'"> hours</t>
+                t-if="this.props.closest &amp;&amp; this.props.closest &lt; this.props.left">
+                <i class="fa fa-warning"/> Only <t t-out="this.props.closest"/>
+                <t t-if="this.props.unit_of_measure == 'hour'"> hours</t>
                 <t t-else=""> days</t>
                 can be used before the allocation expires.
             </span>
             <span class="d-inline-block m-0 mb-3"
-                t-if="props.accrualExcess">
+                t-if="this.props.accrualExcess">
                 The leaves planned in the future are exceeding the maximum value of the allocation.
                 It will not be possible to take all of them.
             </span>

--- a/addons/hr_holidays/static/src/dashboard/time_off_dashboard.xml
+++ b/addons/hr_holidays/static/src/dashboard/time_off_dashboard.xml
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <div t-name="hr_holidays.TimeOffDashboard" class="o_timeoff_dashboard">
-        <t t-foreach="state.holidays" t-as="holiday" t-key="holiday[3]">
+        <t t-foreach="this.state.holidays" t-as="holiday" t-key="holiday[3]">
             <TimeOffCard
                 name="holiday[0]"
                 data="holiday[1]"
                 requires_allocation="holiday[2]"
                 holidayStatusId="holiday[3]"
-                employeeId="props.employeeId"/>
+                employeeId="this.props.employeeId"/>
         </t>
         <div class="o_timeoff_card p-0 d-flex justify-content-around">
-            <div class="row justify-content-center align-items-center border-bottom h-25 w-100 p-0" t-if="hasAccrualAllocation">
+            <div class="row justify-content-center align-items-center border-bottom h-25 w-100 p-0" t-if="this.hasAccrualAllocation">
                 Balance at the
                 <div class="p-1" style="max-width: 100px!important">
                     <DateTimeInput
                         type="'date'"
-                        value="state.date"
+                        value="this.state.date"
                         onChange="(date) => this.loadDashboardData(date)"
-                        minDate="state.today"
+                        minDate="this.state.today"
                         placeholder.translate="Today"/>
                 </div>
-                <button class="o_timeoff_today_button btn btn-secondary" t-on-click="resetDate">Today</button>
+                <button class="o_timeoff_today_button btn btn-secondary" t-on-click="this.resetDate">Today</button>
             </div>
             <div class="d-flex flex-column justify-content-center align-items-center w-100">
                 <strong class="o_timeoff_name">Pending Requests</strong>
-                <span t-on-click="openPendingRequests"
-                    t-att-class="'o_timeoff_duration' + (state.allocationRequests ? ' cursor-pointer' : '')">
-                    <t t-out="state.allocationRequests"/>
+                <span t-on-click="this.openPendingRequests"
+                    t-att-class="'o_timeoff_duration' + (this.state.allocationRequests ? ' cursor-pointer' : '')">
+                    <t t-out="this.state.allocationRequests"/>
                 </span>
-                <a class="text-uppercase o_timeoff_details p-1" t-on-click="newAllocationRequest">
-                    <t t-if="employeeId">Grant Time</t>
+                <a class="text-uppercase o_timeoff_details p-1" t-on-click="this.newAllocationRequest">
+                    <t t-if="this.employeeId">Grant Time</t>
                     <t t-else="">New Allocation Request</t>
                 </a>
             </div>

--- a/addons/hr_holidays/static/src/leave_stats/leave_stats.xml
+++ b/addons/hr_holidays/static/src/leave_stats/leave_stats.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <div t-name="hr_holidays.LeaveStatsComponent" class="o_leave_stats">
-        <div t-if="state.employee and state.leaves.length !== 0" id="o_leave_stats_employee" class="sub_table px-3 py-2 mb-3">
+        <div t-if="this.state.employee and this.state.leaves.length !== 0" id="o_leave_stats_employee" class="sub_table px-3 py-2 mb-3">
             <div>
                 <div class="d-flex align-items-end">
                     <div class="mx-1">
@@ -11,12 +11,12 @@
                         />
                     </div>
                     <div class="o_hr_leave_subtitle">
-                        <t t-out="state.employee.display_name"/>'s summary (<t t-out="thisYear"/>)
+                        <t t-out="this.state.employee.display_name"/>'s summary (<t t-out="this.thisYear"/>)
                     </div>
                 </div>
             </div>
             <div class="d-flex flex-column mb-1">
-                <div t-foreach="state.leaves" t-as="leave" t-key="leave.id" class="d-flex mb-2 gap-1 o_employee_leave">
+                <div t-foreach="this.state.leaves" t-as="leave" t-key="leave.id" class="d-flex mb-2 gap-1 o_employee_leave">
                     <span class="col-3 fw-bold" t-out="leave.work_entry_type_id.display_name"/>
                     <div t-if="leave.work_entry_type_request_unit == 'hour'" class="d-flex gap-2 col-6 flex-wrap">
                         <span t-out="leave.date_from"/>
@@ -38,16 +38,16 @@
                 </div>
             </div>
         </div>
-        <div t-if="state.department and state.departmentLeaves.length !== 0" id="o_leave_stats_department" class="sub_table px-3 py-2">
+        <div t-if="this.state.department and this.state.departmentLeaves.length !== 0" id="o_leave_stats_department" class="sub_table px-3 py-2">
             <div class="o_horizontal_separator o_hr_leave_subtitle d-flex align-items-center justify-content-between">
                 <div>
-                    <span t-if="state.has_parent_department" class="mx-1">.../</span>
-                    <span t-out="state.department_name"/>
+                    <span t-if="this.state.has_parent_department" class="mx-1">.../</span>
+                    <span t-out="this.state.department_name"/>
                     <span>'s summary in this period</span>
                 </div>
             </div>
             <div class="d-flex flex-column mb-1">
-                <div t-foreach="state.departmentLeaves" t-as="leave" t-key="leave.id" class="d-flex flex-column mb-2">
+                <div t-foreach="this.state.departmentLeaves" t-as="leave" t-key="leave.id" class="d-flex flex-column mb-2">
                     <div class=" d-flex my-1 gap-1">
                         <div class="col-3 d-flex">
                             <KanbanMany2OneAvatarEmployeeField

--- a/addons/hr_holidays/static/src/views/calendar/calendar_controller.xml
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_controller.xml
@@ -16,7 +16,7 @@
     </t>
 
     <t t-name="hr_holidays.CalendarView.Buttons">
-        <button t-if="canCreateGroupTimeOff" class="btn btn-secondary" t-on-click="onNewGroupTimeOff">
+        <button t-if="this.canCreateGroupTimeOff" class="btn btn-secondary" t-on-click="this.onNewGroupTimeOff">
             New Group Time Off
         </button>
     </t>

--- a/addons/hr_holidays/static/src/views/calendar/calendar_renderer.xml
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_renderer.xml
@@ -3,7 +3,7 @@
 
     <t t-name="hr_holidays.CalendarRenderer">
         <div class="o_timeoff_calendar d-flex flex-column">
-            <TimeOffDashboard t-if="showDashboard" employeeId="employeeId"/>
+            <TimeOffDashboard t-if="this.showDashboard" employeeId="this.employeeId"/>
             <t t-call="web.CalendarRenderer"/>
         </div>
     </t>

--- a/addons/hr_holidays/static/src/views/calendar/year/calendar_year_popover.xml
+++ b/addons/hr_holidays/static/src/views/calendar/year/calendar_year_popover.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="hr_holidays.MandatoryDayCalendarYearPopover.body">
-        <t t-foreach="recordGroups" t-as="recordGroup" t-key="recordGroup.title">
+        <t t-foreach="this.recordGroups" t-as="recordGroup" t-key="recordGroup.title">
             <div class="fw-bold mt-2" t-out="recordGroup.title" />
             <t t-foreach="recordGroup.records" t-as="record" t-key="record.id">
                 <t t-if="record.id &lt; 0">
@@ -11,7 +11,7 @@
                     </p>
                 </t>
                 <t t-else="">
-                    <t t-call="{{ constructor.subTemplates.record }}" />
+                    <t t-call="{{ this.constructor.subTemplates.record }}" />
                 </t>
             </t>
         </t>

--- a/addons/hr_holidays/static/src/views/kanban/kanban_renderer.xml
+++ b/addons/hr_holidays/static/src/views/kanban/kanban_renderer.xml
@@ -3,7 +3,7 @@
     <t t-name="hr_holidays.KanbanRenderer">
         <div class="d-flex flex-column h-100">
             <div class="o_timeoff_calendar">
-                <TimeOffDashboard t-if="showDashboard" employeeId="employeeId"/>
+                <TimeOffDashboard t-if="this.showDashboard" employeeId="this.employeeId"/>
             </div>
             <t t-call="web.KanbanRenderer"/>
         </div>

--- a/addons/hr_holidays_attendance/static/src/views/calendar/attendance_calendar_overview.xml
+++ b/addons/hr_holidays_attendance/static/src/views/calendar/attendance_calendar_overview.xml
@@ -3,17 +3,17 @@
     <t t-name="hr_holidays_attendance.A" t-inherit="hr_attendance.AttendanceCalendarOverview"
         t-inherit-mode="extension">
         <xpath expr="//div[@class='o_attendance_info_bar']" position="inside">
-            <div t-if="displayExtraHours" class="o_attendance_info_card">
+            <div t-if="this.displayExtraHours" class="o_attendance_info_card">
                 <strong class="o_attendance_info_label">Left</strong>
                 <div class="o_attendance_info_value text-primary">
                     <span class="o_attendance_info_number text-primary">
-                        <t t-out="floatTime(state.remainingExtraHours)"/>
+                        <t t-out="this.floatTime(this.state.remainingExtraHours)"/>
                     </span>
                     <span class="o_attendance_info_unit">Hours</span>
                 </div>
-                <div t-if="state.remainingExtraHours > 0">
+                <div t-if="this.state.remainingExtraHours > 0">
                     <a class="o_attendance_info_link"
-                       t-on-click="newTimeOffRequest">
+                       t-on-click="this.newTimeOffRequest">
                         NEW TIMEOFF REQUEST
                     </a>
                 </div>

--- a/addons/hr_holidays_attendance/static/src/xml/time_off_calendar.xml
+++ b/addons/hr_holidays_attendance/static/src/xml/time_off_calendar.xml
@@ -3,31 +3,31 @@
 <templates id="template" xml:space="preserve">
     <t t-name="hr_holidays_attendance.TimeOffCard" t-inherit="hr_holidays.TimeOffCard" t-inherit-mode="extension">
         <xpath expr="//t[@t-set='duration']" position="replace">
-            <t t-set="duration" t-value="props.requires_allocation || props.data['overtime_deductible']?props.data['virtual_remaining_leaves']:props.data['virtual_leaves_taken']" />
+            <t t-set="duration" t-value="this.props.requires_allocation || this.props.data['overtime_deductible']?this.props.data['virtual_remaining_leaves']:this.props.data['virtual_leaves_taken']" />
         </xpath>
         <xpath expr="//t[@t-set='show_popover']" position="replace">
-            <t t-set="show_popover" t-value="!props.data['overtime_deductible']"/>
+            <t t-set="show_popover" t-value="!this.props.data['overtime_deductible']"/>
         </xpath>
         <xpath expr="//t[@name='duration_unit']" position="attributes">
-            <attribute name="t-if">props.data.unit_of_measure == 'hour' || props.data['overtime_deductible']</attribute>
+            <attribute name="t-if">this.props.data.unit_of_measure == 'hour' || this.props.data['overtime_deductible']</attribute>
         </xpath>
         <xpath expr="//t[@name='duration_type']" position="attributes">
-            <attribute name="t-if">props.requires_allocation || props.data['overtime_deductible']</attribute>
+            <attribute name="t-if">this.props.requires_allocation || this.props.data['overtime_deductible']</attribute>
         </xpath>
     </t>
 
     <t t-name="hr_holidays_attendance.TimeOffCardMobile" t-inherit="hr_holidays.TimeOffCardMobile" t-inherit-mode="extension">
         <xpath expr="//t[@t-set='duration']" position="replace">
-            <t t-set="duration" t-value="props.requires_allocation || props.data['overtime_deductible']?props.data['virtual_remaining_leaves']:props.data['virtual_leaves_taken']" />
+            <t t-set="duration" t-value="this.props.requires_allocation || this.props.data['overtime_deductible']?this.props.data['virtual_remaining_leaves']:this.props.data['virtual_leaves_taken']" />
         </xpath>
         <xpath expr="//t[@name='duration_type']" position="before">
-            <t t-if="props.data['overtime_deductible'] == true &amp;&amp; !props.requires_allocation">
-                <strong t-out="duration" class="o_timeoff_green"/> <t t-if="props.data['unit_of_measure'] == 'hour'">Hours</t><t t-else="">Days</t> <span class="o_timeoff_green">Available</span>
+            <t t-if="this.props.data['overtime_deductible'] == true &amp;&amp; !this.props.requires_allocation">
+                <strong t-out="duration" class="o_timeoff_green"/> <t t-if="this.props.data['unit_of_measure'] == 'hour'">Hours</t><t t-else="">Days</t> <span class="o_timeoff_green">Available</span>
             </t>
         </xpath>
         <xpath expr="//t[@name='duration_type']" position="attributes">
             <attribute name="t-if"/>
-            <attribute name="t-elif">props.requires_allocation</attribute>
+            <attribute name="t-elif">this.props.requires_allocation</attribute>
         </xpath>
     </t>
 </templates>

--- a/addons/hr_presence/static/src/search/hr_presence_cog_menu/hr_presence_cog_menu.xml
+++ b/addons/hr_presence/static/src/search/hr_presence_cog_menu/hr_presence_cog_menu.xml
@@ -18,7 +18,7 @@
                 <span class="o_dropdown_title">Presence Control</span>
             </button>
             <t t-set-slot="content">
-                <t t-foreach="PresenceActionItems" t-as="item" t-key="item.key">
+                <t t-foreach="this.PresenceActionItems" t-as="item" t-key="item.key">
                     <t t-if="currentGroup !== null and currentGroup !== item.groupNumber">
                         <div role="separator" class="dropdown-divider"/>
                     </t>

--- a/addons/hr_recruitment/static/src/js/fields/recruitment_copy_clipboard_char_field/recruitment_copy_clipboard_char_field.xml
+++ b/addons/hr_recruitment/static/src/js/fields/recruitment_copy_clipboard_char_field/recruitment_copy_clipboard_char_field.xml
@@ -3,9 +3,9 @@
 
     <t t-name="hr_recruitment.RecruitmentCopyClipboardCharField">
         <div class="d-flex">
-            <span t-out="props.displayedValue"></span>
-            <GenerateContentAndCopyButton t-if="props.contentGenerationFunctionName" className="copyButtonClassName" disabled="props.record.isNew" contentGenerationFunction="contentGenerationFunction" icon="copyButtonIcon" successText="successText"/>
-            <GenerateContentAndCopyButton t-else="" className="copyButtonClassName" content="props.record.data[props.name]" icon="copyButtonIcon" successText="successText"/>
+            <span t-out="this.props.displayedValue"></span>
+            <GenerateContentAndCopyButton t-if="this.props.contentGenerationFunctionName" className="this.copyButtonClassName" disabled="this.props.record.isNew" contentGenerationFunction="this.contentGenerationFunction" icon="this.copyButtonIcon" successText="this.successText"/>
+            <GenerateContentAndCopyButton t-else="" className="this.copyButtonClassName" content="this.props.record.data[this.props.name]" icon="this.copyButtonIcon" successText="this.successText"/>
         </div>
     </t>
 </templates>

--- a/addons/hr_recruitment/static/src/views/recruitment_helper_view.xml
+++ b/addons/hr_recruitment/static/src/views/recruitment_helper_view.xml
@@ -12,7 +12,7 @@
                         Let's create a job position.
                     </a>
                 </p>
-                <t t-if="!state.hasDemoData and isRecruitmentUser">
+                <t t-if="!this.state.hasDemoData and this.isRecruitmentUser">
                     <div class="d-flex gap-3 align-items-center or-separator">
                         <hr class="flex-grow-1" /> or <hr class="flex-grow-1" />
                     </div>

--- a/addons/hr_recruitment_skills/static/src/components/search_job_applicant_menu/search_job_applicant_menu.xml
+++ b/addons/hr_recruitment_skills/static/src/components/search_job_applicant_menu/search_job_applicant_menu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <templates id="template" xml:space="preserve">
     <t t-name="hr_recruitment_skills.SearchJobApplicant">
-        <DropdownItem onSelected.bind="openMatchingJobApplicants">
+        <DropdownItem onSelected.bind="this.openMatchingJobApplicants">
             <i class="fa fa-fw fa-search me-1" aria-hidden="true"></i>Matching Talents
         </DropdownItem>
     </t>

--- a/addons/hr_skills/static/src/components/internal_resume_lines/internal_resume_one2many.xml
+++ b/addons/hr_skills/static/src/components/internal_resume_lines/internal_resume_one2many.xml
@@ -11,26 +11,26 @@
                     </tr>
                 </thead>
                 <tbody class="ui-sortable">
-                    <t t-if="internalResumeLines.length">
+                    <t t-if="this.internalResumeLines.length">
                         <tr class="o_group_has_content o_group_header o_resume_group_header">
                             <th tabindex="-1" class="o_group_name" colspan="2">
                                 <div class="d-flex align-items-center">
-                                    Experience - <t t-out="companyId"/>
+                                    Experience - <t t-out="this.companyId"/>
                                 </div>
                             </th>
                         </tr>
                     </t>
-                    <t t-foreach="internalResumeLines" t-as="record" t-key="record.id">
+                    <t t-foreach="this.internalResumeLines" t-as="record" t-key="record.id">
                         <tr class="o_data_row">
                             <td class="o_resume_timeline_cell position-relative pe-lg-2">
                                 <div class="rounded-circle bg-info position-relative"/>
                             </td>
                             <td class="o_data_cell pt-0">
-                                <div t-attf-class="o_resume_line" t-att-data-id="id">
+                                <div t-attf-class="o_resume_line" t-att-data-id="this.id">
                                     <small class="o_resume_line_dates fw-bold">
-                                        <t t-out="formatDate(record.date_start)"/>
+                                        <t t-out="this.formatDate(record.date_start)"/>
                                         -
-                                        <t t-if="record.date_end" t-out="formatDate(record.date_end)"/>
+                                        <t t-if="record.date_end" t-out="this.formatDate(record.date_end)"/>
                                         <t t-else="">
                                             Current
                                         </t>
@@ -42,7 +42,7 @@
                     </t>
                 </tbody>
             </table>
-            <t t-if="!haveResumeLines">
+            <t t-if="!this.haveResumeLines">
                 <div name="no_resume_line" class="ms-4 mt-3 text-muted fst-italic oe_inline">
                     <p>
                         There are no resume lines on this employee.

--- a/addons/hr_skills/static/src/fields/one2many_tags_skills/one2many_tags_skills.xml
+++ b/addons/hr_skills/static/src/fields/one2many_tags_skills/one2many_tags_skills.xml
@@ -3,13 +3,13 @@
 
     <t t-name="hr_recruitment_skills.One2ManyTagsSkillsField">
         <div class="d-flex align-items-baseline"
-            t-attf-class="{{ tags.length &amp;&amp; 'gap-1'}}">
+            t-attf-class="{{ this.tags.length &amp;&amp; 'gap-1'}}">
             <div class=" d-inline-flex flex-wrap gap-1 mw-100">
                 <t t-foreach="this.tags" t-as="tag" t-key="tag.id">
                     <BadgeTag color="tag.color" text="tag.text" onClick="tag.onClick" onDelete="tag.onDelete"/>
                 </t>
             </div>
-            <button t-on-click="onAdd"
+            <button t-on-click="this.onAdd"
                 class="btn btn-link text-action"
                 style="padding: 0; line-height: 0; height: min-content;">
                 <i class="fa fa-plus text-info" />

--- a/addons/hr_skills/static/src/fields/resume_one2many/resume_one2many.xml
+++ b/addons/hr_skills/static/src/fields/resume_one2many/resume_one2many.xml
@@ -30,7 +30,7 @@
             <th></th>
         </xpath>
         <xpath expr="//button[@id='add_button']" position="attributes">
-            <attribute name="t-on-click">() => props.onAdd({ context: { default_line_type_id: skill_group[1].id }})</attribute>
+            <attribute name="t-on-click">() => this.props.onAdd({ context: { default_line_type_id: skill_group[1].id }})</attribute>
         </xpath>
     </t>
 

--- a/addons/hr_skills/static/src/fields/skills_one2many/skills_one2many.xml
+++ b/addons/hr_skills/static/src/fields/skills_one2many/skills_one2many.xml
@@ -44,7 +44,7 @@
     </t>
 
     <t t-name="hr_skills.SkillsListRenderer.Rows">
-        <t t-foreach="Object.entries(this.groupedList)" t-as="skill_group" t-key="skill_group[0]">
+        <t t-foreach="Object.entries(this.groupedList(list))" t-as="skill_group" t-key="skill_group[0]">
             <tr class="o_group_has_content o_group_header">
                 <th tabindex="-1" class="o_group_name" t-att-colspan="this.colspan">
                     <div class="d-flex justify-content-between align-items-center">

--- a/addons/hr_skills/static/src/fields/skills_one2many/skills_one2many.xml
+++ b/addons/hr_skills/static/src/fields/skills_one2many/skills_one2many.xml
@@ -44,20 +44,20 @@
     </t>
 
     <t t-name="hr_skills.SkillsListRenderer.Rows">
-        <t t-foreach="Object.entries(groupedList)" t-as="skill_group" t-key="skill_group[0]">
+        <t t-foreach="Object.entries(this.groupedList)" t-as="skill_group" t-key="skill_group[0]">
             <tr class="o_group_has_content o_group_header">
-                <th tabindex="-1" class="o_group_name" t-att-colspan="colspan">
+                <th tabindex="-1" class="o_group_name" t-att-colspan="this.colspan">
                     <div class="d-flex justify-content-between align-items-center">
                         <span t-out="skill_group[1].name"/>
                         <button id="add_button" class="btn btn-secondary btn-sm"
-                            t-if="isEditable"
-                            t-on-click="() => props.onAdd({ context: { default_skill_type_id: skill_group[1].id }})">ADD</button>
+                            t-if="this.isEditable"
+                            t-on-click="() => this.props.onAdd({ context: { default_skill_type_id: skill_group[1].id }})">ADD</button>
                     </div>
                 </th>
             </tr>
             <t t-foreach="skill_group[1].list.records" t-as="record" t-key="record.id">
                 <t t-set="group" t-value="skill_group[1]"/>
-                <t t-call="{{ constructor.recordRowTemplate }}"/>
+                <t t-call="{{ this.constructor.recordRowTemplate }}"/>
             </t>
         </t>
     </t>

--- a/addons/hr_skills/static/src/views/skills_list_renderer.js
+++ b/addons/hr_skills/static/src/views/skills_list_renderer.js
@@ -15,10 +15,10 @@ export class CommonSkillsListRenderer extends ListRenderer {
         return '';
     }
 
-    get groupedList() {
+    groupedList(list) {
         const grouped = {};
 
-        for (const record of this.list.records) {
+        for (const record of list.records) {
             const data = record.data;
             const group = data[this.groupBy];
 

--- a/addons/hr_timesheet/static/src/components/task_with_hours/task_with_hours.xml
+++ b/addons/hr_timesheet/static/src/components/task_with_hours/task_with_hours.xml
@@ -2,7 +2,7 @@
 <templates>
 
     <t t-name="hr_timesheet.TaskWithHours">
-        <Many2One t-props="m2oProps"/>
+        <Many2One t-props="this.m2oProps"/>
     </t>
 
 </templates>

--- a/addons/hr_timesheet/static/src/components/timesheet_uom/timesheet_uom.xml
+++ b/addons/hr_timesheet/static/src/components/timesheet_uom/timesheet_uom.xml
@@ -2,7 +2,7 @@
 <templates>
 
     <t t-name="hr_timesheet.TimesheetUOM">
-        <t t-component="timesheetComponent" t-props="timesheetComponentProps"/>
+        <t t-component="this.timesheetComponent" t-props="this.timesheetComponentProps"/>
     </t>
 
 </templates>

--- a/addons/iap/static/src/action_buttons_widget/action_buttons_widget.xml
+++ b/addons/iap/static/src/action_buttons_widget/action_buttons_widget.xml
@@ -4,8 +4,8 @@
     <t t-name="iap.ActionButtonsWidget">
         <div class="row">
             <div class="col-sm">
-                <button t-on-click="onManageServiceLinkClicked" class="btn btn-link px-0 o-hidden-ios text-nowrap"><i class="oi oi-arrow-right"/> Manage Service &amp; Buy Credits</button><br/>
-                <button t-if="props.showServiceButtons" t-on-click="onViewServicesClicked" class="btn btn-link px-0 o-hidden-ios text-nowrap"><i class="oi oi-arrow-right"/> View My Services</button>
+                <button t-on-click="this.onManageServiceLinkClicked" class="btn btn-link px-0 o-hidden-ios text-nowrap"><i class="oi oi-arrow-right"/> Manage Service &amp; Buy Credits</button><br/>
+                <button t-if="this.props.showServiceButtons" t-on-click="this.onViewServicesClicked" class="btn btn-link px-0 o-hidden-ios text-nowrap"><i class="oi oi-arrow-right"/> View My Services</button>
             </div>
         </div>
     </t>

--- a/addons/im_livechat/static/src/core/common/close_confirmation.xml
+++ b/addons/im_livechat/static/src/core/common/close_confirmation.xml
@@ -7,8 +7,8 @@
                 <div class="position-absolute top-0 end-0 p-1 o-xsmaller">
                     <button class="o-livechat-CloseConfirmation-close btn-close" t-on-click.stop="() => this.props.onCloseConfirmationDialog()"/>
                 </div>
-                <span class="pt-2 pb-3" t-out="confirmationMessage"/>
-                <button class="o-livechat-CloseConfirmation-leave btn btn-danger p-2 gap-1" t-on-keydown.stop.prevent="onKeydown" t-on-click.stop="() => this.props.onClickLeaveConversation()" t-custom-ref="confirm"><i class="fa fa-fw fa-sign-out"/>Yes, leave conversation</button>
+                <span class="pt-2 pb-3" t-out="this.confirmationMessage"/>
+                <button class="o-livechat-CloseConfirmation-leave btn btn-danger p-2 gap-1" t-on-keydown.stop.prevent="this.onKeydown" t-on-click.stop="() => this.props.onClickLeaveConversation()" t-custom-ref="confirm"><i class="fa fa-fw fa-sign-out"/>Yes, leave conversation</button>
             </div>
         </div>
     </t>

--- a/addons/im_livechat/static/src/core/common/livechat_command_dialog.xml
+++ b/addons/im_livechat/static/src/core/common/livechat_command_dialog.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="im_livechat.LivechatCommandDialog">
-        <ActionPanel title="props.title" icon="props.icon" resizable="false">
+        <ActionPanel title="this.props.title" icon="this.props.icon" resizable="false">
             <div class="input-group my-2 shadow-sm">
                 <div class="o-livechat-LivechatCommandDialog-form form-control bg-view p-0" aria-autocomplete="list">
-                    <input type="text" class="border-0 h-100 rounded px-2 form-control" accesskey="Q" t-att-placeholder="props.placeholderText" t-on-keydown="onKeydown" t-custom-ref="autofocus" t-custom-model="state.inputText"/>
+                    <input type="text" class="border-0 h-100 rounded px-2 form-control" accesskey="Q" t-att-placeholder="this.props.placeholderText" t-on-keydown="this.onKeydown" t-custom-ref="autofocus" t-custom-model="state.inputText"/>
                 </div>
-                <button class="btn btn-primary" t-on-click="executeCommand" t-att-disabled="!state.inputText" t-out="props.title"/>
+                <button class="btn btn-primary" t-on-click="this.executeCommand" t-att-disabled="!this.state.inputText" t-out="this.props.title"/>
             </div>
         </ActionPanel>
     </t>

--- a/addons/im_livechat/static/src/core/common/transcript_sender.xml
+++ b/addons/im_livechat/static/src/core/common/transcript_sender.xml
@@ -3,19 +3,19 @@
     <t t-name="im_livechat.TranscriptSender">
         <div class="o-livechat-TranscriptSender">
             <div class="input-group">
-                <input t-custom-ref="input" t-on-keydown="onKeydown" t-custom-model="state.email" t-att-disabled="isInputDisabled" type="text" class="form-control" t-att-class="{'bg-view': !isInputDisabled}" placeholder="mail@example.com" />
-                <button class="btn btn-primary" type="button" data-action="sendTranscript" t-att-disabled="isButtonDisabled" t-on-click="onClickSend">
+                <input t-custom-ref="input" t-on-keydown="this.onKeydown" t-custom-model="state.email" t-att-disabled="this.isInputDisabled" type="text" class="form-control" t-att-class="{'bg-view': !this.isInputDisabled}" placeholder="mail@example.com" />
+                <button class="btn btn-primary" type="button" data-action="sendTranscript" t-att-disabled="this.isButtonDisabled" t-on-click="this.onClickSend">
                     <i class="fa" t-att-class="{
-                        'fa-circle-o-notch fa-spin': state.status === STATUS.SENDING,
-                        'fa-check': state.status === STATUS.SENT,
-                        'fa-paper-plane': state.status === STATUS.IDLE,
-                        'fa-repeat': state.status === STATUS.FAILED,
+                        'fa-circle-o-notch fa-spin': this.state.status === this.STATUS.SENDING,
+                        'fa-check': this.state.status === this.STATUS.SENT,
+                        'fa-paper-plane': this.state.status === this.STATUS.IDLE,
+                        'fa-repeat': this.state.status === this.STATUS.FAILED,
                     }" />
                 </button>
             </div>
             <div class="form-text ms-1">
-                <t t-if="state.status === STATUS.SENT">The conversation was sent.</t>
-                <t t-elif="state.status === STATUS.FAILED">An error occurred. Please try again.</t>
+                <t t-if="this.state.status === this.STATUS.SENT">The conversation was sent.</t>
+                <t t-elif="this.state.status === this.STATUS.FAILED">An error occurred. Please try again.</t>
             </div>
         </div>
     </t>

--- a/addons/im_livechat/static/src/core/public_web/livechat_leave_dialog.xml
+++ b/addons/im_livechat/static/src/core/public_web/livechat_leave_dialog.xml
@@ -2,17 +2,17 @@
 <templates xml:space="preserve">
 
 <t t-name="im_livechat.LivechatLeaveDialog">
-    <Dialog size="'md'" title="title" contentClass="'o-bg-body'">
+    <Dialog size="'md'" title="this.title" contentClass="'o-bg-body'">
         <p class="mx-3">Here's the most recent message:</p>
         <blockquote class="mx-3 fst-normal pe-none">
-            <t t-component="messageComponent" message="props.channel.newestPersistentOfAllMessage" isReadOnly="true" hasActions="false"/>
+            <t t-component="this.messageComponent" message="this.props.channel.newestPersistentOfAllMessage" isReadOnly="true" hasActions="false"/>
         </blockquote>
         <t t-set-slot="footer">
-            <button class="btn btn-danger me-2" t-on-click="onClickConfirm">
+            <button class="btn btn-danger me-2" t-on-click="this.onClickConfirm">
                 <i class="fa fa-sign-out me-1 opacity-50"/>
                 Leave Conversation
             </button>
-            <button class="btn btn-secondary me-2" t-on-click="props.close">
+            <button class="btn btn-secondary me-2" t-on-click="this.props.close">
                 <i class="oi oi-close me-1 opacity-50"/>
                 Discard
             </button>

--- a/addons/im_livechat/static/src/core/web/command_palette.xml
+++ b/addons/im_livechat/static/src/core/web/command_palette.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="im_livechat.LivechatChannelCommand">
         <div class="o_command_default d-flex align-items-center justify-content-between px-4 py-2">
-            <i class="me-2" t-att-class="props.iconClass"/>
+            <i class="me-2" t-att-class="this.props.iconClass"/>
             <span class="flex-grow-1 text-ellipsis">
                 <t t-slot="name"/>
             </span>

--- a/addons/im_livechat/static/src/core/web/discuss_app/sidebar/category_patch.xml
+++ b/addons/im_livechat/static/src/core/web/discuss_app/sidebar/category_patch.xml
@@ -32,20 +32,20 @@
         <t t-set="livechatThread" t-value="templateParams.livechatThread"/>
         <t t-set="small" t-value="templateParams.small"/>
         <span t-if="livechatThread.channel?.channel_type === 'livechat' and (livechatThread.channel.livechat_status === 'need_help' or livechatThread.livechat_end_dt)" class="o-livechat-LivechatStatusLabel" t-att-title="livechatThread.channel.livechatStatusLabel" t-att-class="{
-            'position-absolute top-0 start-0': env.inDiscussSidebar or env.inChatBubble or env.inNotificationItem,
-            'o-livechat-LivechatStatusLabel-Sidebar end-0 bottom-0 rounded-2 border': env.inDiscussSidebar,
-            'd-flex z-1 bg-opacity-100': env.inChatBubble or env.inNotificationItem,
-            'mx-n1': env.inChatBubble,
-            'mx-n2 my-n1': env.inNotificationItem,
+            'position-absolute top-0 start-0': this.env.inDiscussSidebar or this.env.inChatBubble or this.env.inNotificationItem,
+            'o-livechat-LivechatStatusLabel-Sidebar end-0 bottom-0 rounded-2 border': this.env.inDiscussSidebar,
+            'd-flex z-1 bg-opacity-100': this.env.inChatBubble or this.env.inNotificationItem,
+            'mx-n1': this.env.inChatBubble,
+            'mx-n2 my-n1': this.env.inNotificationItem,
             'o-selfMember': livechatThread.channel.self_member_id,
             'o-help': livechatThread.channel.livechat_status === 'need_help',
-            'bg-info': env.inDiscussSidebar and livechatThread.channel.livechat_status === 'need_help' and !livechatThread.channel.self_member_id,
+            'bg-info': this.env.inDiscussSidebar and livechatThread.channel.livechat_status === 'need_help' and !livechatThread.channel.self_member_id,
         }">
-            <t t-set="livechatStatusButton" t-value="store.livechatStatusButtons.find(btn => btn.status === livechatThread.channel.livechat_status)"/>
+            <t t-set="livechatStatusButton" t-value="this.store.livechatStatusButtons.find(btn => btn.status === livechatThread.channel.livechat_status)"/>
             <i class="o-livechat-LivechatStatusLabel-icon" t-attf-class="{{ livechatThread.livechat_end_dt ? ('fa fa-flag-checkered' + (small ? ' o-xsmaller' : '')) : small ? livechatStatusButton?.iconSmall : livechatStatusButton?.icon }}" t-att-class="{
                 'o-white': livechatThread.livechat_end_dt,
-                'position-absolute start-0 top-0 z-1 o-inDiscussSidebar rounded-circle o-px-0_5': env.inDiscussSidebar,
-                'fa-fw': !env.inDiscussSidebar,
+                'position-absolute start-0 top-0 z-1 o-inDiscussSidebar rounded-circle o-px-0_5': this.env.inDiscussSidebar,
+                'fa-fw': !this.env.inDiscussSidebar,
             }"/>
         </span>
     </t>
@@ -53,7 +53,7 @@
     <t t-name="im_livechat.LivechatStatusSelection">
     <t t-set="livechatThread" t-value="templateParams.livechatThread"/>
         <div class="o-livechat-LivechatStatusSelection list-group" t-custom-ref="livechat-status-selection">
-            <t t-foreach="store.livechatStatusButtons" t-as="btn" t-key="btn.status">
+            <t t-foreach="this.store.livechatStatusButtons" t-as="btn" t-key="btn.status">
                 <t t-set="isBtnActive" t-value="livechatThread.channel.livechat_status === btn.status"/>
                 <button
                     class="list-group-item list-group-item-action d-flex align-items-center gap-2"
@@ -63,7 +63,7 @@
                         'bg-view': isBtnActive and btn.status === 'in_progress',
                         'o-need-help': isBtnActive and btn.status === 'need_help',
                     }"
-                    t-att-disabled="!store.has_access_livechat"
+                    t-att-disabled="!this.store.has_access_livechat"
                     t-on-click="() => livechatThread.channel.updateLivechatStatus(btn.status)"
                 >
                     <input

--- a/addons/im_livechat/static/src/core/web/expertise_tags_autocomplete.xml
+++ b/addons/im_livechat/static/src/core/web/expertise_tags_autocomplete.xml
@@ -3,25 +3,25 @@
     <t t-name="im_livechat.ExpertiseTagsAutocomplete">
         <div
             class="o-livechat-ExpertiseTagsAutocomplete d-inline-flex o_tags_input flex-wrap gap-1 mb-3"
-            t-att-class="{'o_input': !props.disabled, 'o-disabled': props.disabled}"
+            t-att-class="{'o_input': !this.props.disabled, 'o-disabled': this.props.disabled}"
             t-custom-ref="root"
         >
             <div class="d-flex flex-wrap gap-1">
-                <BadgeTag t-foreach="props.channel.livechat_expertise_ids" t-as="expertise" t-key="expertise.id" text="expertise.name" color="expertise.color" onDelete="props.disabled ? null : () => this.unlinkExpertise(expertise)"/>
+                <BadgeTag t-foreach="this.props.channel.livechat_expertise_ids" t-as="expertise" t-key="expertise.id" text="expertise.name" color="expertise.color" onDelete="this.props.disabled ? null : () => this.unlinkExpertise(expertise)"/>
             </div>
-            <div t-if="!props.disabled" class="flex-grow-1 d-inline-flex w-100" style="flex-basis: 0;">
+            <div t-if="!this.props.disabled" class="flex-grow-1 d-inline-flex w-100" style="flex-basis: 0;">
                 <Many2XAutocomplete
-                    placeholder="placeholder"
+                    placeholder="this.placeholder"
                     resModel="'im_livechat.expertise'"
                     activeActions="{'link': true}"
                     isToMany="true"
                     fieldString.translate="Expertise"
-                    update.bind="addExpertises"
-                    quickCreate="store.self_user?.is_livechat_manager ? (name) => this.createAndLinkExpertise(name) : null"
+                    update.bind="this.addExpertises"
+                    quickCreate="this.store.self_user?.is_livechat_manager ? (name) => this.createAndLinkExpertise(name) : null"
                     getDomain="() => []"
                 >
                     <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
-                        <span t-att-class="{ 'fw-bold': isSelected(autoCompleteItemScope.record.id) }">
+                        <span t-att-class="{ 'fw-bold': this.isSelected(autoCompleteItemScope.record.id) }">
                             <span t-out="autoCompleteItemScope.label"/>
                         </span>
                     </t>

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="im_livechat.LivechatChannelInfoList">
-        <ActionPanel title.translate="Information" minWidth="200" initialWidth="env.inMeetingView ? 400 : 300" icon="'fa fa-info'">
-            <a t-if="visitorProfileURL" class="btn btn-primary mt-1 d-flex align-items-center justify-content-between" t-on-click.prevent="openVisitorProfile" t-att-href="visitorProfileURL" title="View Contact">
+        <ActionPanel title.translate="Information" minWidth="200" initialWidth="this.env.inMeetingView ? 400 : 300" icon="'fa fa-info'">
+            <a t-if="this.visitorProfileURL" class="btn btn-primary mt-1 d-flex align-items-center justify-content-between" t-on-click.prevent="this.openVisitorProfile" t-att-href="this.visitorProfileURL" title="View Contact">
                 <span class="flex-grow-1 text-center">
                     <i class="fa fa-address-book-o opacity-50 me-1"/>
                     View Contact
                 </span>
                 <i class="oi oi-chevron-right opacity-50 small"/>
             </a>
-            <div t-if="!props.thread.livechat_end_dt" class="o-livechat-LivechatChannelInfoList d-flex flex-column bg-inherit gap-1">
+            <div t-if="!this.props.thread.livechat_end_dt" class="o-livechat-LivechatChannelInfoList d-flex flex-column bg-inherit gap-1">
                 <h6 class="pt-3 mb-1">Status</h6>
                 <t t-call="im_livechat.LivechatStatusSelection">
-                    <t t-set="templateParams" t-value="{ livechatThread: props.thread }"/>
+                    <t t-set="templateParams" t-value="{ livechatThread: this.props.thread }"/>
                 </t>
             </div>
-            <div t-if="props.thread.livechat_end_dt" class="o-livechat-LivechatChannelInfoList d-flex flex-column bg-inherit gap-1">
+            <div t-if="this.props.thread.livechat_end_dt" class="o-livechat-LivechatChannelInfoList d-flex flex-column bg-inherit gap-1">
                 <h6 class="pt-3 mb-1">Outcome</h6>
                 <div class="d-flex text-truncate">
-                    <t t-if="props.thread.livechat_outcome === 'no_answer'">Never Answered</t>
-                    <t t-elif="props.thread.livechat_outcome === 'no_agent'">No one Available</t>
-                    <t t-elif="props.thread.livechat_outcome === 'no_failure'">Success</t>
-                    <t t-elif="props.thread.livechat_outcome === 'escalated'">Escalated</t>
+                    <t t-if="this.props.thread.livechat_outcome === 'no_answer'">Never Answered</t>
+                    <t t-elif="this.props.thread.livechat_outcome === 'no_agent'">No one Available</t>
+                    <t t-elif="this.props.thread.livechat_outcome === 'no_failure'">Success</t>
+                    <t t-elif="this.props.thread.livechat_outcome === 'escalated'">Escalated</t>
                 </div>
             </div>
             <div class="d-flex flex-column bg-inherit gap-1">
                 <h6 class="pt-3 mb-0">Notes</h6>
-                <textarea class="form-control" t-att-disabled="!store.has_access_livechat"  rows="3" placeholder="Add your notes here..." t-custom-model="props.thread.livechatNoteText" t-on-blur="onBlurNote"></textarea>
+                <textarea class="form-control" t-att-disabled="!this.store.has_access_livechat"  rows="3" placeholder="Add your notes here..." t-custom-model="props.thread.livechatNoteText" t-on-blur="this.onBlurNote"></textarea>
             </div>
-            <div t-if="expectAnswerSteps.length" class="d-flex flex-column bg-inherit gap-1">
+            <div t-if="this.expectAnswerSteps.length" class="d-flex flex-column bg-inherit gap-1">
                 <h6 class="pt-3 mb-0">Chatbot answers</h6>
-                <t t-foreach="expectAnswerSteps" t-as="step" t-key="step.id">
+                <t t-foreach="this.expectAnswerSteps" t-as="step" t-key="step.id">
                     <div class="d-flex align-items-center gap-1 bg-inherit rounded-3">
                         <i class="fa fa-comment-o me-1"/>
                         <span class="text-truncate" t-out="step.answer"/>
@@ -39,20 +39,20 @@
             </div>
             <div class="d-flex flex-column bg-inherit gap-1">
                 <h6 class="pt-3 mb-1">Expertise</h6>
-                <ExpertiseTagsAutocomplete channel="props.thread.channel" disabled="!store.has_access_livechat"/>
+                <ExpertiseTagsAutocomplete channel="this.props.thread.channel" disabled="!this.store.has_access_livechat"/>
             </div>
-            <div t-if="props.thread.channel.correspondentCountry or props.thread.channel.livechat_lang_id">
+            <div t-if="this.props.thread.channel.correspondentCountry or this.props.thread.channel.livechat_lang_id">
                 <h6 class="pt-3">Country &amp; Language</h6>
                 <div class="d-flex bg-inherit align-items-center gap-1">
-                    <img t-if="props.thread.channel.correspondentCountry" class="o_country_flag" t-att-src="props.thread.channel.correspondentCountry.flagUrl" t-att-title="props.thread.channel.correspondentCountry.code or props.thread.channel.correspondentCountry.name" aria-label="Country"/>
-                    <span t-if="props.thread.channel.livechat_lang_id" title="Language" t-out="props.thread.channel.livechat_lang_id.name"/>
+                    <img t-if="this.props.thread.channel.correspondentCountry" class="o_country_flag" t-att-src="this.props.thread.channel.correspondentCountry.flagUrl" t-att-title="this.props.thread.channel.correspondentCountry.code or this.props.thread.channel.correspondentCountry.name" aria-label="Country"/>
+                    <span t-if="this.props.thread.channel.livechat_lang_id" title="Language" t-out="this.props.thread.channel.livechat_lang_id.name"/>
                 </div>
             </div>
             <t t-name="extra_infos"/>
-            <div t-if="props.thread.livechat_end_dt" class="d-flex flex-column bg-inherit gap-1">
+            <div t-if="this.props.thread.livechat_end_dt" class="d-flex flex-column bg-inherit gap-1">
                 <h6 class="pt-3 mb-0">Send conversation</h6>
-                <TranscriptSender thread="props.thread"/>
-                <a class="btn btn-outline-secondary" title="Download a copy of this conversation" target="_blank" t-att-href="props.thread.transcriptUrl"><i class="pe-2 fa fa-download"/>Download</a>
+                <TranscriptSender thread="this.props.thread"/>
+                <a class="btn btn-outline-secondary" title="Download a copy of this conversation" target="_blank" t-att-href="this.props.thread.transcriptUrl"><i class="pe-2 fa fa-download"/>Download</a>
             </div>
         </ActionPanel>
     </t>

--- a/addons/im_livechat/static/src/embed/common/feedback_panel/feedback_panel.xml
+++ b/addons/im_livechat/static/src/embed/common/feedback_panel/feedback_panel.xml
@@ -5,30 +5,30 @@
 <div class="d-flex flex-column bg-view flex-grow-1 p-3">
     <div class="p-2">
         <div class="mb-5">
-            <t t-if="state.step === STEP.RATING">
+            <t t-if="this.state.step === this.STEP.RATING">
                 <p class="text-center fs-6 mb-4">Did we correctly answer your question?</p>
                 <div class="d-flex justify-content-center">
-                    <img role="button" class="mx-3 opacity-50 opacity-100-hover" t-att-class="{ 'opacity-100': state.rating === RATING.GOOD }" t-att-src="url(`/rating/static/src/img/rating_${RATING.GOOD}.png`)" t-att-alt="RATING.GOOD" t-on-click="() => this.select(RATING.GOOD)"/>
-                    <img role="button" class="mx-3 opacity-50 opacity-100-hover" t-att-class="{ 'opacity-100': state.rating === RATING.OK }" t-att-src="url(`/rating/static/src/img/rating_${RATING.OK}.png`)" t-att-alt="RATING.OK"  t-on-click="() => this.select(RATING.OK)"/>
-                    <img role="button" class="mx-3 opacity-50 opacity-100-hover" t-att-class="{ 'opacity-100': state.rating === RATING.BAD }" t-att-src="url(`/rating/static/src/img/rating_${RATING.BAD}.png`)" t-att-alt="RATING.BAD" t-on-click="() => this.select(RATING.BAD)"/>
+                    <img role="button" class="mx-3 opacity-50 opacity-100-hover" t-att-class="{ 'opacity-100': this.state.rating === this.RATING.GOOD }" t-att-src="this.url(`/rating/static/src/img/rating_${this.RATING.GOOD}.png`)" t-att-alt="this.RATING.GOOD" t-on-click="() => this.select(this.RATING.GOOD)"/>
+                    <img role="button" class="mx-3 opacity-50 opacity-100-hover" t-att-class="{ 'opacity-100': this.state.rating === this.RATING.OK }" t-att-src="this.url(`/rating/static/src/img/rating_${this.RATING.OK}.png`)" t-att-alt="this.RATING.OK"  t-on-click="() => this.select(this.RATING.OK)"/>
+                    <img role="button" class="mx-3 opacity-50 opacity-100-hover" t-att-class="{ 'opacity-100': this.state.rating === this.RATING.BAD }" t-att-src="this.url(`/rating/static/src/img/rating_${this.RATING.BAD}.png`)" t-att-alt="this.RATING.BAD" t-on-click="() => this.select(this.RATING.BAD)"/>
                 </div>
             </t>
             <t t-else="">
                 <p class="text-center fs-5 fw-bold mb-4">Thank you for your feedback</p>
             </t>
         </div>
-        <div t-if="state.rating and state.step === STEP.RATING" class="d-flex flex-column mb-5">
+        <div t-if="this.state.rating and this.state.step === this.STEP.RATING" class="d-flex flex-column mb-5">
             <textarea t-custom-model="state.feedback" class="form-control my-2" placeholder="Explain your note"/>
-            <button class="btn btn-primary align-self-end" t-on-click="onClickSendFeedback">Send</button>
+            <button class="btn btn-primary align-self-end" t-on-click="this.onClickSendFeedback">Send</button>
         </div>
-        <label class="mb-5 w-100" t-if="store.self_user?.share === false">
+        <label class="mb-5 w-100" t-if="this.store.self_user?.share === false">
             Receive a copy of this conversation
-            <TranscriptSender thread="props.thread" disableOnSend="true"/>
+            <TranscriptSender thread="this.props.thread" disableOnSend="true"/>
         </label>
         <div class="d-flex gap-2 justify-content-center">
-            <button class="btn btn-outline-secondary" t-on-click="props.onClickClose">Close</button>
-            <button t-if="allowNewSession" class="btn btn-outline-secondary" t-on-click="props.onClickNewSession">New Session</button>
-            <a t-if="store.can_download_transcript" class="btn btn-outline-secondary" title="Download a copy of this conversation" target="_blank" t-att-href="props.thread.transcriptUrl"><i class="fa fa-download"/></a>
+            <button class="btn btn-outline-secondary" t-on-click="this.props.onClickClose">Close</button>
+            <button t-if="this.allowNewSession" class="btn btn-outline-secondary" t-on-click="this.props.onClickNewSession">New Session</button>
+            <a t-if="this.store.can_download_transcript" class="btn btn-outline-secondary" title="Download a copy of this conversation" target="_blank" t-att-href="this.props.thread.transcriptUrl"><i class="fa fa-download"/></a>
         </div>
     </div>
 </div>

--- a/addons/im_livechat/static/src/embed/common/livechat_button.xml
+++ b/addons/im_livechat/static/src/embed/common/livechat_button.xml
@@ -4,16 +4,16 @@
 <t t-name="im_livechat.LivechatButton">
     <button
         part="openChatButton"
-        t-if="isShown"
+        t-if="this.isShown"
         class="btn o-livechat-LivechatButton p-3 d-flex justify-content-center align-items-center shadow rounded-circle "
-        t-attf-style="color: {{livechatService.options.button_text_color}}; background-color: {{livechatService.options.button_background_color}};"
+        t-attf-style="color: {{this.livechatService.options.button_text_color}}; background-color: {{this.livechatService.options.button_background_color}};"
         t-custom-ref="button"
-        t-on-click="onClick"
+        t-on-click="this.onClick"
         title="Chat with us"
     >
         <i class="fa fa-commenting" style="font-size: 22px;"/>
-        <div t-if="store.livechat_rule?.action === 'display_button_and_text'" class="o-livechat-LivechatButton-notification text-nowrap position-absolute bg-100 py-2 px-3 rounded" style="max-width: 75vw;" t-att-class="{'o-livechat-LivechatButton-animate': state.animateNotification}">
-            <p class="m-0 text-dark text-truncate" t-out="livechatService.options.button_text"/>
+        <div t-if="this.store.livechat_rule?.action === 'display_button_and_text'" class="o-livechat-LivechatButton-notification text-nowrap position-absolute bg-100 py-2 px-3 rounded" style="max-width: 75vw;" t-att-class="{'o-livechat-LivechatButton-animate': this.state.animateNotification}">
+            <p class="m-0 text-dark text-truncate" t-out="this.livechatService.options.button_text"/>
         </div>
     </button>
 </t>

--- a/addons/im_livechat/static/src/js/colors_reset_button/colors_reset_button.xml
+++ b/addons/im_livechat/static/src/js/colors_reset_button/colors_reset_button.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="im_livechat.ColorsResetButton">
-        <button class="btn btn-link oe_edit_only" t-on-click="onColorsResetButtonClick" aria-label="Reset to default colors" title="Reset to default colors">
+        <button class="btn btn-link oe_edit_only" t-on-click="this.onColorsResetButtonClick" aria-label="Reset to default colors" title="Reset to default colors">
             <span class="fa fa-refresh mb-4"/>
         </button>
     </t>

--- a/addons/im_livechat/static/src/views/boolean_phone/boolean_phone.xml
+++ b/addons/im_livechat/static/src/views/boolean_phone/boolean_phone.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="im_livechat.BooleanPhoneField">
-        <i t-if="state.value" class="fa fa-fw fa-phone" role="img" title="In a Call"/>
+        <i t-if="this.state.value" class="fa fa-fw fa-phone" role="img" title="In a Call"/>
     </t>
 </templates>

--- a/addons/im_livechat/static/src/views/discuss_template.xml
+++ b/addons/im_livechat/static/src/views/discuss_template.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="im_livechat.LivechatDiscuss">
-        <t t-if="thread">
-            <Discuss hasSidebar="false" thread="thread"/>
+        <t t-if="this.thread">
+            <Discuss hasSidebar="false" thread="this.thread"/>
         </t>
         <t t-else="">
             <div class="d-flex h-100 flex-column justify-content-center align-items-center">
                 <span class="fs-1">No conversation found</span>
-                <button type="button" class="btn btn-primary" t-on-click="redirectToSessions">
+                <button type="button" class="btn btn-primary" t-on-click="this.redirectToSessions">
                     Go to Sessions
                 </button>
             </div>

--- a/addons/loyalty/static/src/js/portal/loyalty_card_dialog/loyalty_card_dialog.xml
+++ b/addons/loyalty/static/src/js/portal/loyalty_card_dialog/loyalty_card_dialog.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="loyalty.portal_loyalty_card_dialog">
-        <Dialog size="'md'" header="false" footer="false" t-on-click="props.close">
+        <Dialog size="'md'" header="false" footer="false" t-on-click="this.props.close">
             <div class="d-flex align-items-center" t-on-click.stop="">
                 <div class="d-flex justify-content-between w-100 align-items-center">
                     <div class="d-flex align-items-center gap-2">
                         <img
                             class="img-fluid"
-                            t-att-src="props.img_path"
+                            t-att-src="this.props.img_path"
                             width="40"
                         />
-                        <div class="fs-5"><t t-out="props.program.program_name"/></div>
+                        <div class="fs-5"><t t-out="this.props.program.program_name"/></div>
                     </div>
                     <div class="d-flex flex-column align-items-end">
-                        <span class="fs-5" t-out="props.card.points_display"/>
-                        <i class="text-secondary fs-6" t-if="props.card.expiration_date">
-                            Valid until <t t-out="props.card.expiration_date"/>
+                        <span class="fs-5" t-out="this.props.card.points_display"/>
+                        <i class="text-secondary fs-6" t-if="this.props.card.expiration_date">
+                            Valid until <t t-out="this.props.card.expiration_date"/>
                         </i>
                     </div>
                 </div>
                 <div
                     type="button"
                     class="d-sm-block btn-close p-0 p-md-2"
-                    t-on-click="props.close"
+                    t-on-click="this.props.close"
                 />
             </div>
             <hr/>
             <div class="mt-0 pt-0" t-on-click.stop="">
                 <div name="history_lines">
-                    <t t-if="props.history_lines.length">
+                    <t t-if="this.props.history_lines.length">
                         <strong>Last Transactions</strong>
                         <div
-                            t-foreach="props.history_lines"
+                            t-foreach="this.props.history_lines"
                             t-as="line"
                             t-key="line_index"
                             class="row px-2"
@@ -49,8 +49,8 @@
                             <div t-out="line.points" class="text-end col-5"/>
                         </div>
                         <div class="mt-1 mb-1">
-                            <a t-attf-href="/my/loyalty_card/{{props.card.id}}/history/">
-                                -> View History
+                            <a t-attf-href="/my/loyalty_card/{{this.props.card.id}}/history/">
+                                -&gt; View History
                             </a>
                         </div>
                     </t>

--- a/addons/loyalty/static/src/xml/loyalty_templates.xml
+++ b/addons/loyalty/static/src/xml/loyalty_templates.xml
@@ -11,9 +11,9 @@
     <t t-name="loyalty.LoyaltyActionHelper">
         <div class="o_view_nocontent">
             <div class="o_nocontent_help container mt-5 my-lg-auto">
-                <t t-out="props.noContentHelp"/>
+                <t t-out="this.props.noContentHelp"/>
                 <div class="row g-2 g-md-3 mx-auto mt-2 justify-content-center">
-                    <div class="col-12 col-md-4 col-xl-3" t-foreach="Object.entries(loyaltyTemplateData)" t-as="data" t-key="data[0]">
+                    <div class="col-12 col-md-4 col-xl-3" t-foreach="Object.entries(this.loyaltyTemplateData)" t-as="data" t-key="data[0]">
                         <t t-set="loyalty_el_icon" t-value="data[1].icon"/>
                         <t t-set="loyalty_el_title" t-value="data[1].title"/>
                         <button type="button" class="loyalty-template card flex-row flex-md-column align-items-center w-100 h-100 gap-4 gap-md-3 p-3 border rounded" t-on-click.stop.prevent="() => this.onTemplateClick(data[0])" t-attf-aria-label="Select {{loyalty_el_title}} template">

--- a/addons/lunch/static/src/components/lunch_dashboard.xml
+++ b/addons/lunch/static/src/components/lunch_dashboard.xml
@@ -2,9 +2,9 @@
 <templates id="template" xml:space="preserve">
     <t t-name="lunch.LunchCurrency">
         <span>
-            <t t-if="props.currency.position == 'before'" t-out="props.currency.symbol"/>
-            <t t-out="amount"/>
-            <t t-if="props.currency.position == 'after'" t-out="props.currency.symbol"/>
+            <t t-if="this.props.currency.position == 'before'" t-out="this.props.currency.symbol"/>
+            <t t-out="this.amount"/>
+            <t t-if="this.props.currency.position == 'after'" t-out="this.props.currency.symbol"/>
         </span>
     </t>
 
@@ -12,36 +12,36 @@
         <li
             class="d-flex flex-column gap-2 border rounded p-2 w-100 mb-2"
             name="o_lunch_order_line"
-            t-attf-aria-label="{{line.quantity}} {{line.product[1]}} - {{line.state}}"
+            t-attf-aria-label="{{this.line.quantity}} {{this.line.product[1]}} - {{this.line.state}}"
             tabindex="0"
         >
             <div class="d-flex justify-content-between align-items-start gap-2">
                 <h6 class="mb-0">
-                    <span t-if="!props.isToOrder"><t t-out="line.quantity"/> x </span>
-                    <t t-out="line.product[1]"/>
-                    <span t-if="!props.isToOrder"> &#8226; <LunchCurrency currency="props.currency" amount="line.product[2]"/></span>
+                    <span t-if="!this.props.isToOrder"><t t-out="this.line.quantity"/> x </span>
+                    <t t-out="this.line.product[1]"/>
+                    <span t-if="!this.props.isToOrder"> &#8226; <LunchCurrency currency="this.props.currency" amount="this.line.product[2]"/></span>
                 </h6>
-                <span t-out="line.state" t-attf-class="badge flex-shrink-0 rounded-pill text-bg-#{badgeClass}"/>
+                <span t-out="this.line.state" t-attf-class="badge flex-shrink-0 rounded-pill text-bg-#{this.badgeClass}"/>
             </div>
-            <div t-if="line.note" class="p-2 rounded bg-100 text-muted">
+            <div t-if="this.line.note" class="p-2 rounded bg-100 text-muted">
                 <i class="fa fa-fw fa-sticky-note pe-2"/>
-                <t t-out="line.note"/>
+                <t t-out="this.line.note"/>
             </div>
             <div class="d-flex justify-content-between">
-                <span class="text-nowrap" t-out="line.location"/>
-                <span class="text-nowrap" t-out="line.date"/>
+                <span class="text-nowrap" t-out="this.line.location"/>
+                <span class="text-nowrap" t-out="this.line.date"/>
             </div>
-            <ul t-if="hasToppings" class="list-group list-group-flush" t-foreach="line.toppings" t-as="topping" t-key="topping">
+            <ul t-if="this.hasToppings" class="list-group list-group-flush" t-foreach="this.line.toppings" t-as="topping" t-key="topping">
                 <li class="list-group-item d-flex justify-content-between ps-2 pe-0 py-1">
                     <span>+ <t t-out="topping[0]"/></span>
-                    <LunchCurrency currency="props.currency" amount="topping[1]"/>
+                    <LunchCurrency currency="this.props.currency" amount="topping[1]"/>
                 </li>
             </ul>
-            <div t-if="props.isToOrder" class="d-flex justify-content-between">
+            <div t-if="this.props.isToOrder" class="d-flex justify-content-between">
                 <div class="o_lunch_order_line_quantity input-group">
                     <button
                         type="button"
-                        t-attf-class="o_lunch_qty_btn btn btn-sm btn-outline-secondary border-end-0 {{canEdit ? '' : 'opacity-100 disabled'}}"
+                        t-attf-class="o_lunch_qty_btn btn btn-sm btn-outline-secondary border-end-0 {{this.canEdit ? '' : 'opacity-100 disabled'}}"
                         t-on-click="() => this.updateQuantity(-1)"
                         aria-label="Decrease quantity"
                     >
@@ -49,13 +49,13 @@
                     </button>
                     <input
                         type="text"
-                        t-attf-class="form-control border border-start-0 border-end-0 text-center bg-view {{canAdd or canEdit ? '' : 'o_lunch_order_line_input_disabled'}}"
-                        t-att-value="line.quantity"
+                        t-attf-class="form-control border border-start-0 border-end-0 text-center bg-view {{this.canAdd or this.canEdit ? '' : 'o_lunch_order_line_input_disabled'}}"
+                        t-att-value="this.line.quantity"
                         disabled="true"
                     />
                     <button
                         type="button"
-                        t-attf-class="o_lunch_qty_btn btn btn-sm btn-outline-secondary border-start-0 {{canAdd ? '' : 'opacity-100 disabled'}}"
+                        t-attf-class="o_lunch_qty_btn btn btn-sm btn-outline-secondary border-start-0 {{this.canAdd ? '' : 'opacity-100 disabled'}}"
                         t-on-click="() => this.updateQuantity(1)"
                         aria-label="Increase quantity"
                     >
@@ -63,15 +63,15 @@
                     </button>
                 </div>
                 <span class="align-content-end fs-3">
-                    <LunchCurrency currency="props.currency" amount="line.product[2]"/>
+                    <LunchCurrency currency="this.props.currency" amount="this.line.product[2]"/>
                 </span>
             </div>
         </li>
     </t>
 
     <t t-name="lunch.LunchAlerts">
-        <div class="alert alert-warning mb-0" t-if="props.alerts.length !== 0" role="alert">
-            <t t-foreach="props.alerts" t-as="alert" t-key="alert.id">
+        <div class="alert alert-warning mb-0" t-if="this.props.alerts.length !== 0" role="alert">
+            <t t-foreach="this.props.alerts" t-as="alert" t-key="alert.id">
                 <LunchAlert message="alert.message" />
             </t>
         </div>
@@ -79,15 +79,15 @@
 
     <t t-name="lunch.LunchUser">
         <div class="lunch_user flex-grow-1">
-            <span t-if="!props.isManager" t-out="props.username"/>
+            <span t-if="!this.props.isManager" t-out="this.props.username"/>
             <div t-else="" class="o_field_widget w-100">
                 <Many2XAutocomplete
-                    value="props.username"
+                    value="this.props.username"
                     resModel="'res.users'"
-                    getDomain="getDomain"
-                    fieldString="props.username"
+                    getDomain="this.getDomain"
+                    fieldString="this.props.username"
                     activeActions="{}"
-                    update.bind="props.onUpdateUser"
+                    update.bind="this.props.onUpdateUser"
                 />
             </div>
         </div>
@@ -95,15 +95,15 @@
 
     <t t-name="lunch.LunchLocation">
         <div class="lunch_location">
-            <t t-if="props.location">
+            <t t-if="this.props.location">
                 <div class="o_field_widget w-100">
                     <Many2XAutocomplete
-                        value="props.location"
+                        value="this.props.location"
                         resModel="'lunch.location'"
-                        fieldString="props.location"
-                        getDomain="getDomain"
+                        fieldString="this.props.location"
+                        getDomain="this.getDomain"
                         activeActions="{}"
-                        update.bind="props.onUpdateLunchLocation"
+                        update.bind="this.props.onUpdateLunchLocation"
                     />
                 </div>
             </t>
@@ -118,29 +118,29 @@
         <div class="o_lunch_banner d-flex flex-column border-start h-100 bg-view">
             <div class="p-3 overflow-y-auto w-100">
                 <div class="d-flex flex-column w-100 gap-2">
-                    <LunchAlerts alerts="state.infos.alerts"/>
+                    <LunchAlerts alerts="this.state.infos.alerts"/>
                     <div class="d-flex gap-2 align-content-center">
-                        <img class="o_image_24_cover rounded" t-att-src="state.infos.userimage"/>
+                        <img class="o_image_24_cover rounded" t-att-src="this.state.infos.userimage"/>
                         <LunchUser
-                            isManager="state.infos.is_manager"
-                            username="state.infos.username"
-                            onUpdateUser.bind="onUpdateUser"/>
+                            isManager="this.state.infos.is_manager"
+                            username="this.state.infos.username"
+                            onUpdateUser.bind="this.onUpdateUser"/>
                     </div>
                     <LunchLocation
-                        location="location"
-                        onUpdateLunchLocation.bind="onUpdateLunchLocation"/>
+                        location="this.location"
+                        onUpdateLunchLocation.bind="this.onUpdateLunchLocation"/>
 
                     <div id="lunch_order_date">
                         <DateTimeInput
                             type="'date'"
                             value="this.state.date"
-                            onChange.bind="onUpdateLunchTime"/>
+                            onChange.bind="this.onUpdateLunchTime"/>
                     </div>
                 </div>
                 <div id="o_lunch_orders" class="o_lunch_widget_line">
-                    <div t-if="hasLines" class="accordion">
+                    <div t-if="this.hasLines" class="accordion">
                         <button
-                            t-if="state.infos.lines.some(line => ['sent', 'confirmed'].includes(line.raw_state))"
+                            t-if="this.state.infos.lines.some(line => ['sent', 'confirmed'].includes(line.raw_state))"
                             class="accordion-button collapsed py-2 px-0 bg-view shadow-none"
                             data-bs-toggle="collapse"
                             href="#o_lunch_passed_orders"
@@ -150,7 +150,7 @@
                             Passed orders
                             <span
                                 class="badge rounded-pill ms-2 text-bg-secondary"
-                                t-out="state.infos.lines.filter(line => ['sent', 'confirmed'].includes(line.raw_state)).length"
+                                t-out="this.state.infos.lines.filter(line => ['sent', 'confirmed'].includes(line.raw_state)).length"
                             />
                         </button>
                         <div
@@ -162,16 +162,16 @@
                             <div class="accordion-body px-0 pt-0">
                                 <ul class="list-unstyled">
                                     <t
-                                        t-foreach="state.infos.lines"
+                                        t-foreach="this.state.infos.lines"
                                         t-as="line" t-key="line.id"
                                         t-if="line.raw_state != 'new' &amp;&amp; line.raw_state != 'ordered'"
                                     >
                                         <LunchOrderLine
                                             line="line"
                                             currency="currency"
-                                            onUpdateQuantity.bind="onUpdateQuantity"
-                                            openOrderLine.bind="props.openOrderLine"
-                                            infos="state.infos"
+                                            onUpdateQuantity.bind="this.onUpdateQuantity"
+                                            openOrderLine.bind="this.props.openOrderLine"
+                                            infos="this.state.infos"
                                             isToOrder="false"
                                         />
                                     </t>
@@ -181,29 +181,29 @@
                     </div>
                     <span
                         class="d-flex justify-content-between p-2 bg-100 rounded"
-                        t-attf-class="{{hasLines and state.infos.lines.some(line => ['sent', 'confirmed'].includes(line.raw_state)) ? '' : 'mt-2'}}"
-                        name="o_lunch_balance" role="status" tabindex="0" t-attf-aria-label="Available Balance {{state.infos.wallet}} {{currency.symbol}}"
+                        t-attf-class="{{this.hasLines and this.state.infos.lines.some(line => ['sent', 'confirmed'].includes(line.raw_state)) ? '' : 'mt-2'}}"
+                        name="o_lunch_balance" role="status" tabindex="0" t-attf-aria-label="Available Balance {{this.state.infos.wallet}} {{currency.symbol}}"
                     >
                         <span><i class="fa fa-money me-2"/>Available Balance</span>
-                        <LunchCurrency currency="currency" amount="state.infos.wallet"/>
+                        <LunchCurrency currency="currency" amount="this.state.infos.wallet"/>
                     </span>
                     <h4 class="mt-3 pt-3 border-top">Your Order</h4>
-                    <p t-if="!(['new', 'ordered'].includes(state.infos.raw_state))" class="text-muted">
+                    <p t-if="!(['new', 'ordered'].includes(this.state.infos.raw_state))" class="text-muted">
                         Nothing to order, add some meals to begin.
                     </p>
-                    <t t-if="hasLines">
+                    <t t-if="this.hasLines">
                         <ul class="list-unstyled">
                             <t
-                                t-foreach="state.infos.lines"
+                                t-foreach="this.state.infos.lines"
                                 t-as="line" t-key="line.id"
                                 t-if="line.raw_state == 'new' || line.raw_state == 'ordered'"
                             >
                                 <LunchOrderLine
                                     line="line"
                                     currency="currency"
-                                    onUpdateQuantity.bind="onUpdateQuantity"
-                                    openOrderLine.bind="props.openOrderLine"
-                                    infos="state.infos"
+                                    onUpdateQuantity.bind="this.onUpdateQuantity"
+                                    openOrderLine.bind="this.props.openOrderLine"
+                                    infos="this.state.infos"
                                     isToOrder="true"
                                 />
                             </t>
@@ -211,34 +211,34 @@
                     </t>
                 </div>
             </div>
-            <div t-if="hasLines" class="mt-auto p-3 border-top">
+            <div t-if="this.hasLines" class="mt-auto p-3 border-top">
                 <span class="d-flex justify-content-between text-muted">
                     Total
-                    <LunchCurrency currency="currency" amount="state.infos.total"/>
+                    <LunchCurrency currency="currency" amount="this.state.infos.total"/>
                 </span>
                 <span class="d-flex justify-content-between text-muted">
                     Already Paid
-                    <LunchCurrency currency="currency" amount="state.infos.paid_subtotal"/>
+                    <LunchCurrency currency="currency" amount="this.state.infos.paid_subtotal"/>
                 </span>
                 <h4 class="d-flex justify-content-between">
                     To Pay
-                    <LunchCurrency currency="currency" amount="state.infos.unpaid_subtotal"/>
+                    <LunchCurrency currency="currency" amount="this.state.infos.unpaid_subtotal"/>
                 </h4>
                 <div class="d-flex flex-column gap-2" name="o_lunch_order_buttons">
                     <button
-                        t-if="canOrder"
+                        t-if="this.canOrder"
                         type="button"
                         class="btn btn-primary"
-                        t-on-click="orderNow"
-                        t-attf-aria-label="Order Now {{state.infos.unpaid_subtotal}}{{currency.symbol}}"
+                        t-on-click="this.orderNow"
+                        t-attf-aria-label="Order Now {{this.state.infos.unpaid_subtotal}}{{currency.symbol}}"
                     >
                         Order Now
                     </button>
                     <button
                         type="button"
-                        t-if="(['new', 'ordered'].includes(state.infos.raw_state))"
+                        t-if="(['new', 'ordered'].includes(this.state.infos.raw_state))"
                         class="btn btn-secondary"
-                        t-on-click.prevent="emptyCart">
+                        t-on-click.prevent="this.emptyCart">
                         Clear Order
                     </button>
                 </div>
@@ -247,8 +247,8 @@
     </t>
 
     <t t-name="lunch.LunchDashboard">
-        <t t-set="currency" t-value="state.infos.currency"/>
-        <t t-if="!env.isSmall">
+        <t t-set="currency" t-value="this.state.infos.currency"/>
+        <t t-if="!this.env.isSmall">
             <t t-call="lunch.LunchDashboardOrder"/>
         </t>
         <t t-else="">
@@ -260,7 +260,7 @@
                     data-bs-target="#lunch_order_mobile"
                     aria-controls="lunch_order_mobile"
                 >
-                    Your Cart (<LunchCurrency currency="currency" amount="state.infos.total || 0"/>)
+                    Your Cart (<LunchCurrency currency="currency" amount="this.state.infos.total || 0"/>)
                 </button>
             </div>
             <div

--- a/addons/lunch/static/src/views/kanban.xml
+++ b/addons/lunch/static/src/views/kanban.xml
@@ -5,7 +5,7 @@
             <div class="o_lunch_content_container flex-grow-1">
                 <t t-call="lunch.WebKanbanRenderer"/>
             </div>
-            <LunchDashboard openOrderLine.bind="openOrderLine"/>
+            <LunchDashboard openOrderLine.bind="this.openOrderLine"/>
         </div>
     </t>
 

--- a/addons/lunch/static/src/views/list.xml
+++ b/addons/lunch/static/src/views/list.xml
@@ -4,7 +4,7 @@
         <div class="o_lunch_content d-flex flex-column flex-md-row h-100 overflow-auto">
             <t t-call="lunch.WebListRenderer"/>
         </div>
-        <LunchDashboard openOrderLine.bind="openOrderLine"/>
+        <LunchDashboard openOrderLine.bind="this.openOrderLine"/>
     </t>
 
     <t t-name="lunch.WebListRenderer" t-inherit="web.ListRenderer" t-inherit-mode="primary" owl="1">

--- a/addons/lunch/static/src/views/no_content_helper.xml
+++ b/addons/lunch/static/src/views/no_content_helper.xml
@@ -4,7 +4,7 @@
     <t t-name="lunch.NoContentHelper" owl="1">
         <t t-set="showNoLocationHelper" t-value="!this.env.searchModel.lunchState.locationId"/>
 
-        <div t-if="showNoLocationHelper and !showNoContentHelper" class="o_view_nocontent" style="pointer-events: all">
+        <div t-if="showNoLocationHelper and !this.showNoContentHelper" class="o_view_nocontent" style="pointer-events: all">
             <div class="o_nocontent_help">
                 <p class="o_view_nocontent_smiling_face">
                     No location found

--- a/addons/pos_loyalty/static/src/portal/loyalty_card_dialog.xml
+++ b/addons/pos_loyalty/static/src/portal/loyalty_card_dialog.xml
@@ -2,14 +2,14 @@
     <t t-inherit="loyalty.portal_loyalty_card_dialog" t-inherit-mode="extension">
         <div name="history_lines" position="before">
             <div
-                t-if="props.program.program_type == 'loyalty'"
+                t-if="this.props.program.program_type == 'loyalty'"
                 class="d-flex align-items-center flex-column"
             >
                 <img
-                    t-att-src="`/report/barcode/Code128/${props.card.code}?&amp;width=350&amp;height=100`"
+                    t-att-src="`/report/barcode/Code128/${this.props.card.code}?&amp;width=350&amp;height=100`"
                     style="width:400px;height:100px"
                 />
-                <span t-out="props.card.code" class="fs-5"/>
+                <span t-out="this.props.card.code" class="fs-5"/>
             </div>
         </div>
     </t>

--- a/addons/website_livechat/static/src/core/web/livechat_channel_info_list_patch.xml
+++ b/addons/website_livechat/static/src/core/web/livechat_channel_info_list_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="website_livechat.LivechatChannelInfoList" t-inherit="im_livechat.LivechatChannelInfoList" t-inherit-mode="extension">
         <xpath expr="//t[@t-name='extra_infos']" position="inside">
-            <t t-set="visitor" t-value="props.thread.livechat_visitor_id"/>
+            <t t-set="visitor" t-value="this.props.thread.livechat_visitor_id"/>
             <div t-if="visitor?.pageVisitHistoryText" class="d-flex flex-column bg-inherit gap-1">
                 <h6 class="pt-3">Recent page views</h6>
                 <div t-if="visitor.website_id">
@@ -11,11 +11,11 @@
                 </div>
                 <span t-out="visitor.pageVisitHistoryText"/>
             </div>
-            <div t-if="!props.thread.livechat_end_dt and recentConversations.length" class="d-flex flex-column bg-inherit gap-1">
+            <div t-if="!this.props.thread.livechat_end_dt and this.recentConversations.length" class="d-flex flex-column bg-inherit gap-1">
                 <h6 class="pt-3">Recent conversations</h6>
                 <div class="btn btn-group o-rounded-bubble d-flex flex-column w-100 p-0 m-0" style="gap: 1px;">
                     <a
-                        t-foreach="recentConversations" t-as="channel" t-key="channel.localId"
+                        t-foreach="this.recentConversations" t-as="channel" t-key="channel.localId"
                         class="o-livechat-LivechatChannelInfoList-recentConversation btn btn-sm btn-secondary btn-group-item d-flex flex-column w-100 m-0 px-3 py-1"
                         t-attf-href="/odoo/discuss?active_id=discuss.channel_{{channel.id}}"
                         target="_blank"
@@ -29,7 +29,7 @@
                         <div class="d-flex align-items-center">
                             <i class="fa fa-external-link me-2 o-mt-0_5 opacity-75"/>
                             <span>
-                                <t t-if="channel.livechat_end_dt" t-out="CLOSED_ON_TEXT(channel)"/>
+                                <t t-if="channel.livechat_end_dt" t-out="this.CLOSED_ON_TEXT(channel)"/>
                                 <t t-else="">Conversation ongoing</t>
                             </span>
                         </div>

--- a/addons/website_sale_loyalty/static/src/js/portal_loyalty_card.xml
+++ b/addons/website_sale_loyalty/static/src/js/portal_loyalty_card.xml
@@ -3,8 +3,8 @@
     <t t-inherit="loyalty.portal_loyalty_card_dialog" t-inherit-mode="extension">
         <div name="history_lines" position="after">
             <div
-                t-if="props.program.program_type == 'loyalty'"
-                t-foreach="props.rewards"
+                t-if="this.props.program.program_type == 'loyalty'"
+                t-foreach="this.props.rewards"
                 t-as="reward"
                 t-key="reward_index"
                 class="mb-2 mt-2"
@@ -16,9 +16,9 @@
                     <span class="text-primary" t-out="reward.points"/>
                 </div>
             </div>
-            <div t-if="props.rewards.length > 0" class="d-flex justify-content-center">
+            <div t-if="this.props.rewards.length > 0" class="d-flex justify-content-center">
                 <a
-                    t-if="props.program.program_type == 'loyalty'"
+                    t-if="this.props.program.program_type == 'loyalty'"
                     type="button"
                     href="/shop"
                     class="btn btn-primary"
@@ -27,18 +27,18 @@
                 </a>
             </div>
             <div
-                t-if="props.program.program_type == 'ewallet'
-                and props.program.trigger_products.length"
+                t-if="this.props.program.program_type == 'ewallet'
+                and this.props.program.trigger_products.length"
             >
                 <form
                     method="post"
                     action="/wallet/top_up"
                     class="d-flex w-75 w-md-50 m-auto gap-1"
                 >
-                    <input type="hidden" name="csrf_token" t-att-value="csrf_token"/>
+                    <input type="hidden" name="csrf_token" t-att-value="this.csrf_token"/>
                     <select name="trigger_product_id" class="form-select">
                         <t
-                            t-foreach="props.program.trigger_products"
+                            t-foreach="this.props.program.trigger_products"
                             t-as="product"
                             t-key="product_index"
                         >


### PR DESCRIPTION
In preparation for OWL3, where template variables will need to use `.this` to target component variables, we add `.this` to template variables that are targetting the component.

Enterprise PR: https://github.com/odoo/enterprise/pull/109249
Script PR: odoo/odoo#247965

THIS_TARGETS: ["hr", "iap", "im_livechat", "iot", "knowledge", "link_tracker", "loyalty", "lunch"]

task: OWL3 prep - add this. to template variables
