### PR TITLE
[FIX] sale_timesheet_margin: Timesheet cost compute

### DIFF
--- a/addons/sale_timesheet_margin/models/sale_order_line.py
+++ b/addons/sale_timesheet_margin/models/sale_order_line.py
@@ -12,7 +12,8 @@ class SaleOrderLine(models.Model):
         # for which the recomputation was triggered by a depency from another override of _compute_purchase_price
         service_non_timesheet_sols = self.filtered(
             lambda sol: not sol.is_expense and sol.is_service and
-            sol.product_id.service_policy == 'ordered_prepaid' and sol.state == 'sale'
+            sol.product_id.service_policy in ['ordered_prepaid', 'delivered_manual', 'delivered_milestones'] and
+            sol.state == 'sale'
         )
         timesheet_sols = self.filtered(
             lambda sol: sol.qty_delivered_method == 'timesheet' and not sol.product_id.standard_price


### PR DESCRIPTION
Originally, timesheet updates for tasks associated with sale order lines would cause the cost (purchase_price) to be recomputed. However, this was prevented if the invoice policy was 'ordered_prepaid.' This should also apply to 'delivered_manual' and 'delivered_milestones.' Otherwise, any timesheet updates will recompute the sales.order.line purchase_price field.

Steps to reproduce:
  Create a service product that creates a project/tasks
  Create a sales order with the product and manually set the cost
  Assign the timesheets of the task to an employee
  Have the employee update their timesheet for the task
  The cost on the sales order line gets recomputed to the default product price

Duplicate of pr-250495

task-5902688
related-pr-205415

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
