### PR TITLE
[FIX] website : display image on popup

### DIFF
--- a/addons/website/static/src/snippets/s_image_gallery/gallery_slider.js
+++ b/addons/website/static/src/snippets/s_image_gallery/gallery_slider.js
@@ -107,7 +107,7 @@ export class GallerySlider extends Interaction {
     }
 
     hide() {
-        for (let i = 0; i < this.liEls.length; i++) {
+        for (let i = 0; i < this.liEls?.length; i++) {
             this.liEls[i].classList.toggle("d-none", i < this.page * this.nbPerPage || i >= (this.page + 1) * this.nbPerPage);
         }
         if (this.prevEl) {

--- a/addons/website/static/tests/interactions/snippets/gallery_slider.test.js
+++ b/addons/website/static/tests/interactions/snippets/gallery_slider.test.js
@@ -101,6 +101,33 @@ const defaultLightbox = `
     </main>
 `;
 
+const defaultLightboxWithoutIndicators = `
+    <main class="modal-body o_slideshow bg-transparent">
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close" style="position: absolute; right: 10px; top: 10px;">
+        </button>
+        <div style="margin: 0 12px;" id="slideshow_3" class="carousel slide undefined" data-bs-ride="false" data-bs-interval="0">
+            <div class="carousel-inner">
+                <div class="carousel-item active">
+                    <img class="img img-fluid d-block" data-name="Image" src="/web/image/website.library_image_03" alt="">
+                </div>
+                <div class="carousel-item undefined">
+                    <img class="img img-fluid d-block" data-name="Image" src="/web/image/website.library_image_10" alt="">
+                </div>
+            </div>
+        </div>
+        <div class="o_carousel_controllers">
+                <button class="carousel-control-prev o_we_no_overlay o_not_editable" contenteditable="false" data-bs-slide="prev" aria-label="Previous" title="Previous" data-bs-target="#slideshow_3">
+                    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                    <span class="visually-hidden">Previous</span>
+                </button>
+                <button class="carousel-control-next o_we_no_overlay o_not_editable" contenteditable="false" data-bs-slide="next" aria-label="Next" title="Next" data-bs-target="#slideshow_3">
+                    <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                    <span class="visually-hidden">Next</span>
+                </button>
+            </div>
+    </main>
+`;
+
 // TODO Obtain rendering from `website.gallery.slideshow` template.
 const defaultOldLightbox = `
     <main class="modal-body o_slideshow bg-transparent">
@@ -187,6 +214,20 @@ test("gallery_slider interaction on lightbox", async () => {
     const img3El = queryOne(".carousel-item.active img");
     expect(imgEl).not.toBe(img3El);
     expect(img2El).not.toBe(img3El);
+});
+
+test("gallery_slider interaction on lightbox without indicators", async () => {
+    const { core } = await startInteractions(defaultLightboxWithoutIndicators);
+    expect(core.interactions).toHaveLength(1);
+    await onceAllImagesLoaded(getFixture());
+    await advanceTime(SLIDE_DURATION);
+    const imgEl = queryOne(".carousel-item.active img");
+    await click(".carousel-control-next");
+    await animationFrame();
+    await onceAllImagesLoaded(getFixture());
+    await advanceTime(SLIDE_DURATION);
+    const img2El = queryOne(".carousel-item.active img");
+    expect(imgEl).not.toBe(img2El);
 });
 
 test("gallery_slider interaction on old lightbox", async () => {


### PR DESCRIPTION
# How to reproduce
- Note: this only possible in 19.1+
- Activate the pop un on click option on an image
- Click on the image

# The problem
A traceback is shown

# Why
This commit (https://github.com/odoo/odoo/commit/ca2231346b6d90f64ce2b511244d35c22c0860ff) removed this null check :
```js
for (let i = 0; i < this.liEls?.length; i++) {
```
But this.liEls can be null when the carousel indicators are not found in the setup method
```js
this.carouselEl = this.el.classList.contains("carousel") ? this.el : this.el.querySelector(".carousel");
this.indicatorEl = this.carouselEl?.querySelector(".carousel-indicators");
if (this.indicatorEl) {
    this.prevEl = this.indicatorEl.querySelector("li.o_indicators_left");
    this.nextEl = this.indicatorEl.querySelector("li.o_indicators_right");
    if (this.prevEl) {
        this.prevEl.style.visibility = ""; // force visibility as some databases have it hidden
    }
    if (this.nextEl) {
        this.nextEl.style.visibility = "";
    }
    this.liEls = this.indicatorEl.querySelectorAll("li[data-bs-slide-to]");
```

This is the case starting in saas-19.1, where they use a slideshow in a lightbox to display an image with the Popup on click option. The indicators are below a condition :

```xml
<t t-if="shouldShowControls">
    <div class="o_carousel_controllers">
        <button class="carousel-control-prev o_we_no_overlay o_not_editable" contenteditable="false" t-attf-data-bs-target="##{id}" data-bs-slide="prev" aria-label="Previous" title="Previous">
            <span class="carousel-control-prev-icon" aria-hidden="true"/>
            <span class="visually-hidden">Previous</span>
        </button>
        <div class="carousel-indicators s_image_gallery_indicators_bars">
            <t t-foreach="images" t-as="image" t-key="image_index">
                <button type="button" aria-label="Carousel indicator" t-attf-data-bs-target="##{id}" t-att-data-bs-slide-to="image_index" t-att-class="image_index == index and 'active' or None" t-attf-style="background-image: url(#{image.getAttribute('src')})"/>
            </t>
        </div>
```

opw-5963294

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
