### PR TITLE
[FIX] account_edi_ubl_cii: handles recycling contribution on negative lines

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_ubl.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_ubl.py
@@ -1111,7 +1111,7 @@ class AccountEdiUBL(models.AbstractModel):
         return {
             '_currency': currency,
             'cbc:ChargeIndicator': {'_text': 'true' if is_charge else 'false'},
-            'cbc:AllowanceChargeReasonCode': {'_text': charge_reason_code},
+            'cbc:AllowanceChargeReasonCode': {'_text': charge_reason_code if is_charge else '95'},
             'cbc:AllowanceChargeReason': {'_text': tax.name},
             'cbc:Amount': {
                 '_text': FloatFmt(abs(amount), max_dp=currency.decimal_places),


### PR DESCRIPTION
**PROBLEM**
If you set a recycling contribution (using a fixed tax, affecting the base, tax_included), and use it on a negative line, the generated xml will not pass validation.

**STEP TO REPRODUCE**
1. Setup peppol.
2. Create a RECUPEL tax (fixed tax, affecting the base, tax_included).
3. Create an invoice with a negative line with a VAT and the recupel tax.
4. Send the invoice using peppol, and validate the xml.
5. Notice the xml doesn't pass validation.

**CAUSE**
The allowanceCharge generated for the recupel tax is a allowance (because of the negative quantity). This is fine, but the AllowanceChargeReasonCode used is a code ChargeReasonCode and not a code for allowance.

opw-5955289