### PR TITLE
[FIX] l10n_in_pos: avoid tb on qr generation

### DIFF
--- a/addons/l10n_in_pos/models/res_partner_bank.py
+++ b/addons/l10n_in_pos/models/res_partner_bank.py
@@ -12,3 +12,9 @@ class ResPartnerBank(models.Model):
         if self.env.company.country_code == 'IN':
             rslt.append(('upi', _("UPI"), 10))
         return rslt
+
+    def _get_qr_code_generation_params(self, qr_method, amount, currency, debtor_partner, free_communication, structured_communication):
+        # Nothing to do with the 'upi' method, we return None to avoid raising a NotImplementedError
+        if qr_method == 'upi':
+            return None
+        return super()._get_qr_code_generation_params(qr_method, amount, currency, debtor_partner, free_communication, structured_communication)

--- a/addons/l10n_in_pos/tests/__init__.py
+++ b/addons/l10n_in_pos/tests/__init__.py
@@ -6,3 +6,4 @@ from . import common
 from . import test_pos_flow
 from . import test_gstr_section
 from . import test_product_screen
+from . import test_standard_flows

--- a/addons/l10n_in_pos/tests/test_standard_flows.py
+++ b/addons/l10n_in_pos/tests/test_standard_flows.py
@@ -1,0 +1,20 @@
+from odoo.addons.l10n_in.tests.common import L10nInTestInvoicingCommon
+from odoo.tests import Form, tagged
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestStandardFlows(L10nInTestInvoicingCommon):
+    """ Tests for standard flows not related to PoS but that can be impacted by it """
+
+    def test_open_payment_register_with_upi_qr_method(self):
+        self.env.company.l10n_in_upi_id = 12345
+        self.env['res.partner.bank'].create({
+            'acc_number': '0144748555',
+            'partner_id': self.partner_a.id,
+            'allow_out_payment': True,
+        })
+        bill = self._create_invoice('in_invoice', post=True)
+
+        # the wizard should be created without error
+        Form(self.env['account.payment.register'].with_context(
+            active_model='account.move', active_ids=bill.ids))


### PR DESCRIPTION
With the 'upi' qr method, we get a `NotImplementedError` raised by
`ResPartnerBank._get_qr_code_generation_params`
when trying to open the payment register wizard from a vendor bill.

With this commit, we override the method to return None for the 'upi'
method case, that way we keep the correct way of using `NotImplementedError`
which expects us to always implement `_get_qr_code_generation_params`
when we add `_get_available_qr_methods`, to make it explicit that there is
nothing to do and that we didn't forget to implement.

opw-5978048
