### PR TITLE
[FIX] account: `user_has_groups` badly forward ported

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5237,7 +5237,7 @@ class AccountMove(models.Model):
                     "So you cannot confirm the invoice."
                 ))
             if invoice.partner_bank_id and invoice.is_inbound() and not invoice.partner_bank_id.allow_out_payment:
-                if self.env.user.id == SUPERUSER_ID or self.user_has_groups('base.group_public') or self.user_has_groups('base.group_portal'):
+                if self.env.user.id == SUPERUSER_ID or self.env.user.has_groups('base.group_public') or self.env.user.has_groups('base.group_portal'):
                     # Do not block in case of automated flows, simply remove the information
                     invoice.partner_bank_id = False
                 elif invoice.partner_bank_id._user_can_trust():


### PR DESCRIPTION
Bad fix during the forward port of [1]. Was good in saas-18.3[^2] and in 19.0[^3].

[1]: a2b3ca73fd63108fc70a5cec8ef328c150f85554
[^2]: 4816dc594edbd4158b2b071eb5a2eec3c862c8df
[^3]: eddc0694b2b3b01f459122bc622876ad82ace039
