### PR TITLE
[18.0][FIX] stock: Avoid Serialization Failure when unlinking zero quants

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -1133,10 +1133,11 @@ class StockQuant(models.Model):
         """
         precision_digits = max(6, self.sudo().env.ref('product.decimal_product_uom').digits * 2)
         # Use a select instead of ORM search for UoM robustness.
+        self.flush_model(["quantity", "reserved_quantity", "inventory_quantity", "user_id"])
         query = """SELECT id FROM stock_quant WHERE (round(quantity::numeric, %s) = 0 OR quantity IS NULL)
                                                      AND round(reserved_quantity::numeric, %s) = 0
                                                      AND (round(inventory_quantity::numeric, %s) = 0 OR inventory_quantity IS NULL)
-                                                     AND user_id IS NULL;"""
+                                                     AND user_id IS NULL FOR NO KEY UPDATE SKIP LOCKED;"""
         params = (precision_digits, precision_digits, precision_digits)
         self.env.cr.execute(query, params)
         quants = self.env['stock.quant'].browse([quant['id'] for quant in self.env.cr.dictfetchall()])


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

As stock.move._action_done will call stock.quant._unlink_zero_quants when processing complete packs,in case we have multiple concurrent transaction calling this same code, we risk having serialization errors between the time when zero quants are selected and the time the DELETE statement is executed on the database.

By adding an explicit locking `FOR UPDATE` that will avoid selecting rows already locked `SKIP LOCKED`, we ensure zero quants can only be selected by a single transaction that is going to delete it, and avoid having the serialization error in the concurrent transaction.

Also, add a flush model for fields used in the SQL bypassing the ORM to select zero quants.

Current behavior before PR:

Serialization error raised

Desired behavior after PR is merged:

No serialization error raised


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
