### PR TITLE
[FIX] web, website: country flags on Visitors page, size change in Studio

### DIFF
--- a/addons/web/static/src/views/fields/image_url/image_url_field.js
+++ b/addons/web/static/src/views/fields/image_url/image_url_field.js
@@ -29,15 +29,14 @@ export class ImageUrlField extends Component {
 
     get sizeStyle() {
         let style = "";
-        if (this.props.width) {
-            style += `max-width: ${this.props.width}px;`;
-        }
-        if (this.props.height) {
-            style += `max-height: ${this.props.height}px;`;
-        }
+        const width = this.props.width;
+        const height = this.props.height;
+        style = width ? `max-width: ${width}px;` : `width: auto;`;
+        style += height ? `max-height: ${height}px` : `height: auto`;
+        
         return style;
     }
-
+    
     onLoadFailed() {
         this.state.src = this.constructor.fallbackSrc;
     }

--- a/addons/web/static/tests/views/fields/image_url_field.test.js
+++ b/addons/web/static/tests/views/fields/image_url_field.test.js
@@ -224,3 +224,19 @@ test("onchange update image fields", async () => {
         message: "the image should have the onchange src",
     });
 });
+
+test("ImageUrlField with width attribute is auto when Studio is set", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: /* xml */ `
+            <form>
+                <field name="foo" widget="image_url" options="{'size': [0, 270]}" /> 
+            </form>
+        `,
+        resId: 1,
+
+    });
+
+    expect(`.o_field_widget[name=foo] img`).toHaveAttribute("style", "width: auto;max-height: 270px");
+});

--- a/addons/website/static/src/scss/website_visitor_views.scss
+++ b/addons/website/static/src/scss/website_visitor_views.scss
@@ -32,3 +32,8 @@
         margin-right: 0.25rem;
     }
 }
+
+.o_country_flag {
+    width: 24px;
+    height: 16px;
+}


### PR DESCRIPTION
The website.visitor.view.kanban view uses the o_country_flag class which is not defined anywhere besides livechat_channel_info_list.scss. This causes unintended behavior where the flag size for the kanban view on ' Website > Reporting > Visitors ' changes when installing the livechat app.
Additionally, the image_url_field.js file does not address cases when height/width are not set. This results in the flags (or any other image using 'widget="image_url"' disappearing (being set to a 'width: 0px') whenever their Size is set via Studio. This change makes it so that the flags don't disappear when altered in Studio (but does not make them actually respond to size changes)

Related tickets: opw-5962151, opw-5995004