### PR TITLE
[FIX] web: fix XPath for invalid locators alert

### DIFF
--- a/addons/web/views/ir_ui_view_views.xml
+++ b/addons/web/views/ir_ui_view_views.xml
@@ -5,7 +5,7 @@
         <field name="model">ir.ui.view</field>
         <field name="inherit_id" ref="base.view_view_form"/>
         <field name="arch" type="xml">
-        	<xpath expr="//div[hasclass('alert-info')]" position="after">
+        	<xpath expr="//sheet/div[hasclass('alert-info')]" position="after">
                 <div class="alert alert-danger" role="alert" invisible="not invalid_locators">
                     Please note that your view includes invalid locators.<br/>
                     These nodes could not be anchored to the parent view and have no effect.<br/>


### PR DESCRIPTION
The XPath `//div[hasclass('alert-info')]` used to insert the invalid locators warning matches multiple elements since the website module has another `alert-info` div inside the visibility field: https://github.com/odoo/odoo/blob/31c199f3d19b8f9c54d582b6a5c4684e1ed38d0a/addons/website/views/website_pages_views.xml#L221

<img width="1065" height="633" alt="image" src="https://github.com/user-attachments/assets/dab8955c-d01b-4682-871a-b7499ed99297" />

<img width="1427" height="986" alt="image" src="https://github.com/user-attachments/assets/a05efb5d-254b-4e3a-ad14-530ae6718be6" />


On databases created before the invalid locators feature was added, the website inherited view has a lower ID than the web one, so it is applied first. This causes the XPath to match the wrong element and places the warning in the middle of the form fields instead of after the "Be aware" alert. This is not reproducible on runbot since fresh databases always have the correct ID ordering.

<img width="2291" height="956" alt="image" src="https://github.com/user-attachments/assets/fc7eee11-c66e-4d84-b827-f2ed61c76a97" />


We now target the correct alert div that is a direct child of the sheet element. Hence, the inheriting order no longer affect the location of the warning. 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
