### PR TITLE
[IMP] base: get specific model reports from a dedicated method

### DIFF
--- a/odoo/addons/base/tests/test_reports.py
+++ b/odoo/addons/base/tests/test_reports.py
@@ -24,14 +24,18 @@ _logger = logging.getLogger(__name__)
 
 @odoo.tests.tagged('post_install', '-at_install', 'post_install_l10n')
 class TestReports(odoo.tests.TransactionCase):
-    def test_reports(self):
-        invoice_domain = [('move_type', 'in', ('out_invoice', 'out_refund', 'out_receipt', 'in_invoice', 'in_refund', 'in_receipt'))]
-        specific_model_domains = {
+
+    def _get_specific_model_domains(self, invoice_domain):
+        return {
             'account.report_original_vendor_bill': [('move_type', 'in', ('in_invoice', 'in_receipt'))],
             'account.report_invoice_with_payments': invoice_domain,
             'account.report_invoice': invoice_domain,
             'l10n_th.report_commercial_invoice': invoice_domain,
         }
+
+    def test_reports(self):
+        invoice_domain = [('move_type', 'in', ('out_invoice', 'out_refund', 'out_receipt', 'in_invoice', 'in_refund', 'in_receipt'))]
+        specific_model_domains = self._get_specific_model_domains(invoice_domain)
         Report = self.env['ir.actions.report']
         for report in Report.search([('report_type', 'like', 'qweb')]):
             report_model = 'report.%s' % report.report_name


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The specific_model_domains dictionary is hard-coded inside test_reports method.
Custom modules needing extra domain rules currently have to override the whole test method.

Current behavior before PR:
There isn't possibility to extend this dictionary.
To add or adjust report-specific domains, inherited test classes must replace the whole test_reports method.

Desired behavior after PR is merged:
The mapping is extracted to a dedicated internal method:
_get_specific_model_domains.
Inherited test classes can override this method to extend domains without overriding the full test_reports logic.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
