### PR TITLE
[FIX] mail, hr_holidays, portal: send `partner_id` of `main_user_id`

### DIFF
--- a/addons/hr_holidays/models/res_partner.py
+++ b/addons/hr_holidays/models/res_partner.py
@@ -38,6 +38,9 @@ class ResPartner(models.Model):
         return super()._to_store_defaults(target) + [
             Store.One(
                 "main_user_id",
-                [Store.Attr("leave_date_to", lambda u: u.leave_date_to if u.active else False)],
+                [
+                    "partner_id",
+                    Store.Attr("leave_date_to", lambda u: u.leave_date_to if u.active else False),
+                ],
             ),
         ]

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -93,7 +93,12 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
         self.assertEqual(
             data["res.users"],
             self._filter_users_fields(
-                {"id": self.user_root.id, "leave_date_to": False, "share": False},
+                {
+                    "id": self.user_root.id,
+                    "leave_date_to": False,
+                    "partner_id": self.partner_root.id,
+                    "share": False,
+                },
             ),
         )
         # ensure visitor info are correct with real user
@@ -163,11 +168,17 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
         self.assertEqual(
             data["res.users"],
             self._filter_users_fields(
-                {"id": self.user_root.id, "leave_date_to": False, "share": False},
+                {
+                    "id": self.user_root.id,
+                    "leave_date_to": False,
+                    "partner_id": self.partner_root.id,
+                    "share": False,
+                },
                 {
                     "id": test_user.id,
                     "is_admin": False,
                     "notification_type": "email",
+                    "partner_id": test_user.partner_id.id,
                     "signature": ["markup", str(test_user.signature)],
                     "share": False,
                 },
@@ -278,11 +289,17 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
         self.assertEqual(
             data["res.users"],
             self._filter_users_fields(
-                {"id": self.user_root.id, "leave_date_to": False, "share": False},
+                {
+                    "id": self.user_root.id,
+                    "leave_date_to": False,
+                    "partner_id": self.partner_root.id,
+                    "share": False,
+                },
                 {
                     "id": operator.id,
                     "is_admin": False,
                     "notification_type": "email",
+                    "partner_id": operator.partner_id.id,
                     "share": False,
                     "signature": ["markup", str(operator.signature)],
                 },

--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -224,7 +224,11 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
                     },
                 ),
                 "res.users": self._filter_users_fields(
-                    {"id": self.users[1].id, "share": False},
+                    {
+                        "id": self.users[1].id,
+                        "partner_id": self.users[1].partner_id.id,
+                        "share": False,
+                    },
                 ),
             },
         )
@@ -340,7 +344,11 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
                                     },
                                 ),
                                 "res.users": self._filter_users_fields(
-                                    {"id": self.env.user.id, "share": True},
+                                    {
+                                        "id": self.env.user.id,
+                                        "partner_id": self.env.user.partner_id.id,
+                                        "share": True,
+                                    },
                                 ),
                             },
                             "id": channel.id,

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1004,7 +1004,7 @@ class MailMessage(models.Model):
             # sudo: mail.message: access to author_id is allowed
             Store.One(
                 "author_id",
-                ["avatar_128", "is_company", Store.One("main_user_id", "share")],
+                ["avatar_128", "is_company", Store.One("main_user_id", ["partner_id", "share"])],
                 dynamic_fields=lambda m: m._get_store_partner_name_fields(),
                 sudo=True,
             ),

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -264,7 +264,8 @@ class ResPartner(models.Model):
             "avatar_128",
             "im_status",
             "is_company",
-            Store.One("main_user_id", ["share"], sudo=True),  # sudo: to access portal user of another company in chatter
+            # sudo: res.partner - to access portal user of another company in chatter
+            Store.One("main_user_id", ["partner_id", "share"], sudo=True),
             "name",
         ]
         if target.is_internal(self.env):

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -346,6 +346,7 @@ class ResUsers(models.Model):
                             [
                                 Store.Attr("is_admin", lambda u: u._is_admin()),
                                 "notification_type",
+                                "partner_id",
                                 "share",
                                 "signature",
                             ],

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -147,7 +147,11 @@ class TestChannelInternals(MailCommon, HttpCase):
                                     },
                                 ),
                                 "res.users": self._filter_users_fields(
-                                    {"id": self.env.user.id, "share": False},
+                                    {
+                                        "id": self.env.user.id,
+                                        "partner_id": self.env.user.partner_id.id,
+                                        "share": False,
+                                    },
                                 ),
                             },
                             "id": channel.id,
@@ -182,7 +186,12 @@ class TestChannelInternals(MailCommon, HttpCase):
                                 },
                             ),
                             "res.users": self._filter_users_fields(
-                                {"id": self.test_user.id, "leave_date_to": False, "share": False},
+                                {
+                                    "id": self.test_user.id,
+                                    "partner_id": self.test_partner.id,
+                                    "leave_date_to": False,
+                                    "share": False,
+                                },
                             ),
                         },
                     },
@@ -229,7 +238,12 @@ class TestChannelInternals(MailCommon, HttpCase):
                                 },
                             ),
                             "res.users": self._filter_users_fields(
-                                {"id": self.test_user.id, "leave_date_to": False, "share": False},
+                                {
+                                    "id": self.test_user.id,
+                                    "leave_date_to": False,
+                                    "partner_id": self.test_partner.id,
+                                    "share": False,
+                                },
                             ),
                         },
                     },

--- a/addons/portal/controllers/portal_thread.py
+++ b/addons/portal/controllers/portal_thread.py
@@ -51,7 +51,7 @@ class PortalChatter(ThreadController):
                                 fields=[
                                     "active",
                                     "avatar_128",
-                                    Store.One("main_user_id", "share"),
+                                    Store.One("main_user_id", ["partner_id", "share"]),
                                     "name",
                                 ],
                             )

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -380,7 +380,8 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         The point of having a separate getter is to allow it to be overriden.
         """
         xmlid_to_res_id = self.env["ir.model.data"]._xmlid_to_res_id
-        partner_0 = self.users[0].partner_id
+        user_0 = self.users[0]
+        partner_0 = user_0.partner_id
         return {
             "res.partner": self._filter_partners_fields(
                 {
@@ -398,22 +399,28 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 {
                     "active": True,
                     "avatar_128_access_token": partner_0._get_avatar_128_access_token(),
-                    "id": self.users[0].partner_id.id,
-                    "im_status": 'online',
-                    "im_status_access_token": self.users[0].partner_id._get_im_status_access_token(),
-                    "main_user_id": self.users[0].id,
+                    "id": partner_0.id,
+                    "im_status": "online",
+                    "im_status_access_token": partner_0._get_im_status_access_token(),
+                    "main_user_id": user_0.id,
                     "name": "Ernest Employee",
-                    "write_date": fields.Datetime.to_string(self.users[0].partner_id.write_date),
+                    "write_date": fields.Datetime.to_string(partner_0.write_date),
                 },
             ),
             "res.users": self._filter_users_fields(
-                {"id": self.user_root.id, "leave_date_to": False, "share": False},
                 {
-                    "id": self.users[0].id,
+                    "id": self.user_root.id,
+                    "leave_date_to": False,
+                    "partner_id": self.partner_root.id,
+                    "share": False,
+                },
+                {
+                    "id": user_0.id,
                     "is_admin": False,
                     "notification_type": "inbox",
+                    "partner_id": partner_0.id,
                     "share": False,
-                    "signature": ["markup", str(self.users[0].signature)],
+                    "signature": ["markup", str(user_0.signature)],
                 },
             ),
             "Store": {
@@ -1826,20 +1833,59 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         return {}
 
     def _res_for_user(self, user):
+        partner = user.partner_id
         if user == self.users[0]:
-            return {"id": user.id, "leave_date_to": False, "share": False}
+            return {
+                "id": user.id,
+                "leave_date_to": False,
+                "partner_id": partner.id,
+                "share": False,
+            }
         if user == self.users[1]:
-            return {"id": user.id, "share": False}
+            return {
+                "id": user.id,
+                "partner_id": partner.id,
+                "share": False,
+            }
         if user == self.users[2]:
-            return {"id": user.id, "leave_date_to": False, "share": False}
+            return {
+                "id": user.id,
+                "leave_date_to": False,
+                "partner_id": partner.id,
+                "share": False,
+            }
         if user == self.users[3]:
-            return {"id": user.id, "leave_date_to": False, "share": False}
+            return {
+                "id": user.id,
+                "leave_date_to": False,
+                "partner_id": partner.id,
+                "share": False,
+            }
         if user == self.users[12]:
-            return {"id": user.id, "leave_date_to": False, "share": False}
+            return {
+                "id": user.id,
+                "leave_date_to": False,
+                "partner_id": partner.id,
+                "share": False,
+            }
         if user == self.users[14]:
-            return {"id": user.id, "leave_date_to": False, "share": False}
+            return {
+                "id": user.id,
+                "leave_date_to": False,
+                "partner_id": partner.id,
+                "share": False,
+            }
         if user == self.users[15]:
-            return {"id": user.id, "leave_date_to": False, "share": False}
+            return {
+                "id": user.id,
+                "leave_date_to": False,
+                "partner_id": partner.id,
+                "share": False,
+            }
         if user == self.user_root:
-            return {"id": user.id, "share": False}
+            return {
+                "id": user.id,
+                "partner_id": partner.id,
+                "share": False,
+            }
         return {}

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1723,7 +1723,11 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                 },
                             ),
                             "res.users": self._filter_users_fields(
-                                {"id": self.env.user.id, "share": False},
+                                {
+                                    "id": self.env.user.id,
+                                    "partner_id": self.env.user.partner_id.id,
+                                    "share": False,
+                                },
                             ),
                         },
                     },
@@ -1838,7 +1842,11 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                 },
                             ),
                             "res.users": self._filter_users_fields(
-                                {"id": self.env.user.id, "share": False},
+                                {
+                                    "id": self.env.user.id,
+                                    "partner_id": self.env.user.partner_id.id,
+                                    "share": False,
+                                },
                             ),
                         },
                     },


### PR DESCRIPTION
`main_user_id` should always be sent with its `partner_id` to avoid subtle issues.

Indeed the `partner_id` inverse is on `user_ids` not on `main_user_id`.

It is indirectly assumed `partner_id` should be set on `res.users`, in particular when using `partner.main_user_id.partner_id`.

https://github.com/odoo/enterprise/pull/109364