### PR TITLE
[REF] *: run rendering context migration script

### DIFF
--- a/addons/auth_password_policy/static/src/password_field.xml
+++ b/addons/auth_password_policy/static/src/password_field.xml
@@ -2,14 +2,14 @@
 <templates xml:space="preserve">
 
     <t t-name="auth_password_policy.PasswordField">
-        <span t-if="props.readonly" t-out="props.record.data[props.name] and '*'.repeat(props.record.data[props.name].length)"/>
+        <span t-if="this.props.readonly" t-out="this.props.record.data[this.props.name] and '*'.repeat(this.props.record.data[this.props.name].length)"/>
         <t t-else="">
             <input class="o_input o_field_password" type="password"
-                t-att-id="props.id" t-custom-ref="input" placeholder=" "
+                t-att-id="this.props.id" t-custom-ref="input" placeholder=" "
                 t-on-input="ev => this.state.value = ev.target.value"/>
-            <Meter password="state.value"
-                required="state.required"
-                recommended="recommendations"/>
+            <Meter password="this.state.value"
+                required="this.state.required"
+                recommended="this.recommendations"/>
         </t>
     </t>
 </templates>

--- a/addons/auth_password_policy_signup/static/src/public/components/password_meter/password_meter.xml
+++ b/addons/auth_password_policy_signup/static/src/public/components/password_meter/password_meter.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="auth_password_policy_signup.PasswordMeter">
-        <Meter t-if="state.password and hasMinlength"
-            password="state.password"
-            required="required"
-            recommended="recommended"/>
+        <Meter t-if="this.state.password and this.hasMinlength"
+            password="this.state.password"
+            required="this.required"
+            recommended="this.recommended"/>
     </t>
 </templates>

--- a/addons/auth_signup/static/src/components/signup.xml
+++ b/addons/auth_signup/static/src/components/signup.xml
@@ -3,7 +3,7 @@
 <templates>
 
    <t t-name="auth_signup.reset_password_link_button">
-        <button t-on-click="copyResetPasswordLink" class="btn btn-secondary">
+        <button t-on-click="this.copyResetPasswordLink" class="btn btn-secondary">
             Copy Reset Password Link
         </button>
    </t>

--- a/addons/barcodes/static/src/components/barcode_scanner.xml
+++ b/addons/barcodes/static/src/components/barcode_scanner.xml
@@ -3,7 +3,7 @@
 
     <t t-name="barcodes.BarcodeScanner">
         <div class="o_barcode_mobile_container">
-            <a t-if="isBarcodeScannerSupported" role="button" class="btn btn-primary o_mobile_barcode" t-on-click="openMobileScanner">
+            <a t-if="this.isBarcodeScannerSupported" role="button" class="btn btn-primary o_mobile_barcode" t-on-click="this.openMobileScanner">
                 <i class="fa fa-camera fa-2x o_barcode_mobile_camera"/>
                 Tap to scan
             </a>

--- a/addons/barcodes/static/src/components/manual_barcode.xml
+++ b/addons/barcodes/static/src/components/manual_barcode.xml
@@ -2,11 +2,11 @@
 <templates xml:space="preserve">
     <t t-name="barcodes.BarcodeInput">
         <div class="input-group">
-            <input id="manual_barcode" t-custom-model="state.barcode" type="text" name="barcode"
+            <input id="manual_barcode" t-custom-model="this.state.barcode" type="text" name="barcode"
                     class="form-control" t-custom-ref="manualBarcode"
-                    t-att-placeholder="props.placeholder" t-on-keydown="_onKeydown"/>
-            <button class="input-group-text" t-att-disabled="!state.barcode"
-                    t-on-click.prevent="(ev) => this.props.onSubmit(state.barcode)">
+                    t-att-placeholder="this.props.placeholder" t-on-keydown="this._onKeydown"/>
+            <button class="input-group-text" t-att-disabled="!this.state.barcode"
+                    t-on-click.prevent="(ev) => this.props.onSubmit(this.state.barcode)">
                 Apply
             </button>
         </div>

--- a/addons/base_automation/static/src/base_automation_actions_one2many_field.xml
+++ b/addons/base_automation/static/src/base_automation_actions_one2many_field.xml
@@ -3,10 +3,10 @@
 <templates>
     <t t-name="base_automation.ActionsOne2ManyField">
         <div class="d-flex align-items-center" t-custom-ref="root">
-            <t t-if="currentActions.length === 0">
+            <t t-if="this.currentActions.length === 0">
                 <span class="text-muted">no action defined...</span>
             </t>
-            <t t-foreach="currentActions" t-as="action" t-key="action.id">
+            <t t-foreach="this.currentActions" t-as="action" t-key="action.id">
                 <div style="min-width: fit-content;" t-att-data-action-id="action.id">
                     <div class="fs-5 d-flex align-items-center">
                         <i
@@ -34,9 +34,9 @@
                     <i class="fa fa-lg fa-plus text-primary"></i>
                 </div>
             </t>
-            <t t-if="hiddenActionsCount">
+            <t t-if="this.hiddenActionsCount">
                 <div class="fs-3 align-self-center text-muted text-nowrap">
-                    <t t-out="moreText"/>
+                    <t t-out="this.moreText"/>
                 </div>
             </t>
         </div>

--- a/addons/base_import/static/src/import_action/import_action.xml
+++ b/addons/base_import/static/src/import_action/import_action.xml
@@ -2,16 +2,16 @@
 <templates xml:space="preserve">
     <t t-name="ImportAction">
         <div t-custom-ref="root" class="h-100 d-flex flex-column">
-            <Layout className="'o_import_action d-flex h-100 overflow-auto'" display="display">
+            <Layout className="'o_import_action d-flex h-100 overflow-auto'" display="this.display">
                 <t t-set-slot="control-panel-buttons">
-                    <t t-if="isPreviewing">
-                        <t t-if="!state.isTested">
+                    <t t-if="this.isPreviewing">
+                        <t t-if="!this.state.isTested">
                             <button type="button" class="btn btn-primary" t-on-click="() => this.handleImport(true)">Test</button>
-                            <button t-if="!state.isPaused" type="button" class="btn btn-secondary" t-on-click="() => this.handleImport(false)">Import</button>
+                            <button t-if="!this.state.isPaused" type="button" class="btn btn-secondary" t-on-click="() => this.handleImport(false)">Import</button>
                             <button t-else="" type="button" class="btn btn-secondary" t-on-click="() => this.handleImport(false)">Resume</button>
                         </t>
                         <t t-else="">
-                            <button t-if="!state.isPaused" type="button" class="btn btn-primary" t-on-click="() => this.handleImport(false)">Import</button>
+                            <button t-if="!this.state.isPaused" type="button" class="btn btn-primary" t-on-click="() => this.handleImport(false)">Import</button>
                             <button t-else="" type="button" class="btn btn-primary" t-on-click="() => this.handleImport(false)">Resume</button>
                             <button type="button" class="btn btn-secondary" t-on-click="() => this.handleImport(true)">Test</button>
                         </t>
@@ -19,34 +19,34 @@
                     <FileInput
                         acceptedFileExtensions="'.csv, .xls, .xlsx, .xlsm, .ods'"
                         onUpload.bind="(data, files) => this.handleFilesUpload(files)"
-                        resId="model.id"
+                        resId="this.model.id"
                         resModel="this.resModel"
                         route="this.uploadFilesRoute"
                     >
-                        <button t-if="isPreviewing" type="button" class="btn btn-secondary">Re-Upload</button>
+                        <button t-if="this.isPreviewing" type="button" class="btn btn-secondary">Re-Upload</button>
                         <button t-else="" type="button" class="btn btn-primary o_import_file">Upload</button>
                     </FileInput>
                 </t>
-                <t t-if="isPreviewing">
+                <t t-if="this.isPreviewing">
                     <ImportDataSidepanel
-                        filename="state.filename"
-                        options="importOptions"
-                        formattingOptions="formattingOptions"
-                        importTemplates="importTemplates"
-                        isBatched="isBatched"
-                        onOptionChanged.bind="onOptionChanged"
-                        hasBinaryFields="hasBinaryFields"
-                        binaryFilesParams="model.binaryFilesParams"
-                        onBinaryFilesParamsChanged.bind="(name, value) => model.onBinaryFilesParamsChanged(name, value)"
+                        filename="this.state.filename"
+                        options="this.importOptions"
+                        formattingOptions="this.formattingOptions"
+                        importTemplates="this.importTemplates"
+                        isBatched="this.isBatched"
+                        onOptionChanged.bind="this.onOptionChanged"
+                        hasBinaryFields="this.hasBinaryFields"
+                        binaryFilesParams="this.model.binaryFilesParams"
+                        onBinaryFilesParamsChanged.bind="(name, value) => this.model.onBinaryFilesParamsChanged(name, value)"
                     />
                     <ImportDataContent
-                        columns="model.columns"
-                        onFieldChanged.bind="onFieldChanged"
-                        onOptionChanged.bind="onOptionChanged"
-                        options="importOptions"
-                        isFieldSet.bind="isFieldSet"
-                        previewError="state.previewError"
-                        importMessages="model.importMessages"
+                        columns="this.model.columns"
+                        onFieldChanged.bind="this.onFieldChanged"
+                        onOptionChanged.bind="this.onOptionChanged"
+                        options="this.importOptions"
+                        isFieldSet.bind="this.isFieldSet"
+                        previewError="this.state.previewError"
+                        importMessages="this.model.importMessages"
                     />
                 </t>
                 <div t-else="" class="o_view_nocontent">
@@ -55,7 +55,7 @@
                             <FileInput
                                 acceptedFileExtensions="'.csv, .xls, .xlsx, .xlsm, .ods'"
                                 onUpload.bind="(data, files) => this.handleFilesUpload(files)"
-                                resId="model.id"
+                                resId="this.model.id"
                                 resModel="this.resModel"
                                 route="this.uploadFilesRoute"
                             >
@@ -63,7 +63,7 @@
                             </FileInput>
                             <span class="text-muted fw-normal"> or drag a file</span>
                         </p>
-                        <div class="mb-2" t-foreach="importTemplates" t-as="template" t-key="template.template">
+                        <div class="mb-2" t-foreach="this.importTemplates" t-as="template" t-key="template.template">
                             <a t-att-href="template.template" aria-label="Download" data-tooltip="Download">
                                 <i class="fa fa-download pe-1"/>
                                 <span><t t-out="template.label"/></span>

--- a/addons/base_import/static/src/import_block_ui.xml
+++ b/addons/base_import/static/src/import_block_ui.xml
@@ -7,9 +7,9 @@
             <div class="o_spinner mb-4">
                 <img src="/web/static/img/spin.svg" alt="Loading..."/>
             </div>
-            <div t-if="props.message or props.blockComponent">
-                <div class="o_message text-center px-4" t-out="props.message" />
-                <t t-if="props.blockComponent" t-component="props.blockComponent.class" t-props="props.blockComponent.props"/>
+            <div t-if="this.props.message or this.props.blockComponent">
+                <div class="o_message text-center px-4" t-out="this.props.message" />
+                <t t-if="this.props.blockComponent" t-component="this.props.blockComponent.class" t-props="this.props.blockComponent.props"/>
             </div>
         </div>
     </t>

--- a/addons/base_import/static/src/import_data_column_error/import_data_column_error.xml
+++ b/addons/base_import/static/src/import_data_column_error/import_data_column_error.xml
@@ -2,22 +2,22 @@
 <templates xml:space="preserve">
     <t t-name="ImportDataColumnError">
         <div class="o_import_report alert alert-danger mb-2">
-            <t t-if="props.errors.length > 1">
+            <t t-if="this.props.errors.length > 1">
                 <p>
-                    <t t-if="props.errors[0].value">No matching records found for the following name </t>
+                    <t t-if="this.props.errors[0].value">No matching records found for the following name </t>
                     <t t-else="">Multiple errors occurred </t>
-                      in field <b t-out="props.fieldInfo.label"/>:
+                      in field <b t-out="this.props.fieldInfo.label"/>:
                 </p>
                 <ul>
-                    <t t-foreach="props.errors" t-as="error" t-key="error_index">
+                    <t t-foreach="this.props.errors" t-as="error" t-key="error_index">
                         <a t-if="error_index === 3" href="#" class="o_import_report_count" t-on-click="() => this.state.isExpanded = !this.state.isExpanded">
-                            <i t-attf-class="fa fa-chevron-{{state.isExpanded ? 'up' : 'down'}}"></i> <t t-out="props.errors.length - error_index"/> more
+                            <i t-attf-class="fa fa-chevron-{{this.state.isExpanded ? 'up' : 'down'}}"></i> <t t-out="this.props.errors.length - error_index"/> more
                         </a>
-                        <li t-if="isErrorVisible(error_index)" t-attf-class="o_import_report_more p-0 text-{{error.priority}} {{error_index > 2 ? 'list-unstyled' : ''}}">
+                        <li t-if="this.isErrorVisible(error_index)" t-attf-class="o_import_report_more p-0 text-{{error.priority}} {{error_index > 2 ? 'list-unstyled' : ''}}">
                             <t t-if="error.rows.from === error.rows.to">
                                 <b t-out="error.value"/> at row <t t-out="error.rows.from + 1"/>
-                                <t t-if="props.resultNames and props.resultNames.length > error.rows.from and props.resultNames[error.rows.from] !== ''">
-                                    (<t t-out="props.resultNames[error.rows.from]"/>)
+                                <t t-if="this.props.resultNames and this.props.resultNames.length > error.rows.from and this.props.resultNames[error.rows.from] !== ''">
+                                    (<t t-out="this.props.resultNames[error.rows.from]"/>)
                                 </t>
                             </t>
                             <t t-else=""><b t-out="error.value || error.message"/> at multiple rows</t>
@@ -25,16 +25,16 @@
                     </t>
                 </ul>
             </t>
-            <p t-else="" t-attf-class="mb-0 p-2 alert-{{props.errors[0].type}}" t-out="props.errors[0].message" />
-            <t t-if="moreInfo">
-                <t t-if="typeof moreInfo === 'string'" t-out="moreInfo"/>
-                <div t-else="" class="o_import_moreinfo" t-on-click="onMoreInfoClicked">
+            <p t-else="" t-attf-class="mb-0 p-2 alert-{{this.props.errors[0].type}}" t-out="this.props.errors[0].message" />
+            <t t-if="this.moreInfo">
+                <t t-if="typeof this.moreInfo === 'string'" t-out="this.moreInfo"/>
+                <div t-else="" class="o_import_moreinfo" t-on-click="this.onMoreInfoClicked">
                     <a href="#" class="o_import_see_all">
                         <i class="oi oi-arrow-right"></i> See possible values
                     </a>
                 </div>
-                <ul t-if="state.moreInfoContent" class="o_import_report_more">
-                    <li t-foreach="state.moreInfoContent" t-as="msg" t-key="msg_index"><t t-out="msg"/></li>
+                <ul t-if="this.state.moreInfoContent" class="o_import_report_more">
+                    <li t-foreach="this.state.moreInfoContent" t-as="msg" t-key="msg_index"><t t-out="msg"/></li>
                 </ul>
             </t>
         </div>

--- a/addons/base_import/static/src/import_data_content/import_data_content.xml
+++ b/addons/base_import/static/src/import_data_content/import_data_content.xml
@@ -2,18 +2,18 @@
 <templates xml:space="preserve">
     <t t-name="ImportDataContent">
         <div class="o_import_data_content flex-grow-1 overflow-auto border-start">
-            <div t-if="props.previewError" class="border-bottom p-2">
+            <div t-if="this.props.previewError" class="border-bottom p-2">
                 <div class="alert alert-danger mb-0">
                     <p>
                         Import preview failed due to: "
-                        <t t-out="props.previewError" />
+                        <t t-out="this.props.previewError" />
                         ".
                     </p>
                     <p>For CSV files, you may need to select the correct separator.</p>
-                    <p t-if="props.columns.length > 0">Here is the start of the file we could not import:</p>
+                    <p t-if="this.props.columns.length > 0">Here is the start of the file we could not import:</p>
                 </div>
             </div>
-            <div t-if="!props.options.has_headers" class="border-bottom p-2">
+            <div t-if="!this.props.options.has_headers" class="border-bottom p-2">
                 <p class="alert alert-info mb-0">
                     If the file contains
                     the column names, Odoo can try auto-detecting the
@@ -21,16 +21,16 @@
                     simpler especially when the file has many columns.
                 </p>
             </div>
-            <div t-if="props.importMessages.length > 0" class="border-bottom p-2">
-                <t t-foreach="props.importMessages" t-as="message" t-key="`${message.lines[0]}-${message_index}`">
-                    <p t-att-class="getErrorMessageClass(props.importMessages, message.type, message_index)">
+            <div t-if="this.props.importMessages.length > 0" class="border-bottom p-2">
+                <t t-foreach="this.props.importMessages" t-as="message" t-key="`${message.lines[0]}-${message_index}`">
+                    <p t-att-class="this.getErrorMessageClass(this.props.importMessages, message.type, message_index)">
                         <t t-foreach="message.lines" t-as="line" t-key="`${line}-${line_index}`">
                             <b t-out="line" /><br/>
                         </t>
                     </p>
                 </t>
             </div>
-            <table t-if="!props.previewError" class="table table-borderless w-100 bg-view">
+            <table t-if="!this.props.previewError" class="table table-borderless w-100 bg-view">
                 <thead class="bg-100 sticky-top">
                     <tr>
                         <th scope="col">File Column</th>
@@ -39,7 +39,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <t t-foreach="props.columns" t-as="column" t-key="`${column_index}-${column.id}`">
+                    <t t-foreach="this.props.columns" t-as="column" t-key="`${column_index}-${column.id}`">
                         <tr class="border-bottom align-middle">
                             <td>
                                 <div class="o_import_file_column_cell d-flex flex-column user-select-none">
@@ -48,10 +48,10 @@
                                         <span t-else="">Untitled</span>
                                     </span>
                                     <span
-                                        t-if="props.options.has_headers"
+                                        t-if="this.props.options.has_headers"
                                         class="o_import_preview fst-italic small pe-2"
                                         data-tooltip-template="ImportDataContent.tooltip"
-                                        t-att-data-tooltip-info="getTooltip(column)"
+                                        t-att-data-tooltip-info="this.getTooltip(column)"
                                         data-tooltip-position="right"
                                     >
                                         <t t-out="column.preview" />
@@ -61,7 +61,7 @@
                             <td>
                                 <SelectMenu
                                     value="column.fieldInfo ? column.fieldInfo.fieldPath : undefined"
-                                    groups="getGroups(column)"
+                                    groups="this.getGroups(column)"
                                     onSelect="(fieldPath) => this.onFieldChanged(column, fieldPath)"
                                     searchPlaceholder.translate="Search a field..."
                                 >
@@ -70,7 +70,7 @@
                                             class="o_import_field_icon"
                                             t-att-class="'position-absolute d-inline-block o_import_field_icon_' + column.fieldInfo.type"
                                             data-tooltip-template="web.FieldTooltip"
-                                            t-att-data-tooltip-info="getTooltipDetails(column.fieldInfo)"
+                                            t-att-data-tooltip-info="this.getTooltipDetails(column.fieldInfo)"
                                         ></i>
                                         <span class="ms-1 ps-4">
                                             <t t-out="column.fieldInfo.label" />
@@ -89,10 +89,10 @@
                             </td>
                             <td>
                                 <t t-foreach="column.comments" t-as="comment" t-key="comment_index">
-                                    <p class="m-0 p-2 alert" t-att-class="getCommentClass(column, comment, comment_index)"><t t-out="comment.content" /> <b t-if="comment.fieldName" t-out="comment.fieldName"/></p>
+                                    <p class="m-0 p-2 alert" t-att-class="this.getCommentClass(column, comment, comment_index)"><t t-out="comment.content" /> <b t-if="comment.fieldName" t-out="comment.fieldName"/></p>
                                 </t>
                                 <ImportDataColumnError t-if="column.errors.length" errors="column.errors" resultNames="column.resultNames" fieldInfo="column.fieldInfo" />
-                                <ImportDataOptions t-if="column.errors.length or column.importOptions" importOptions="column.importOptions" fieldInfo="column.fieldInfo" onOptionChanged="props.onOptionChanged" />
+                                <ImportDataOptions t-if="column.errors.length or column.importOptions" importOptions="column.importOptions" fieldInfo="column.fieldInfo" onOptionChanged="this.props.onOptionChanged" />
                             </td>
                         </tr>
                     </t>
@@ -106,7 +106,7 @@
         <hr class="m-0"/>
         <div class="p-2 pe-3">
             <p
-                t-foreach="lines"
+                t-foreach="this.lines"
                 t-as="line"
                 t-key="line_index"
                 t-out="line"

--- a/addons/base_import/static/src/import_data_options/import_data_options.xml
+++ b/addons/base_import/static/src/import_data_options/import_data_options.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="ImportDataOptions">
-        <div t-if="isVisible and state.options.length > 1" t-attf-class="o_import_dropdown o_import_field_#{props.fieldInfo.type} alert alert-danger mb-2">
+        <div t-if="this.isVisible and this.state.options.length > 1" t-attf-class="o_import_dropdown o_import_field_#{this.props.fieldInfo.type} alert alert-danger mb-2">
             <b>When a value cannot be matched:</b>
-            <select class="o_import_create_option form-select w-auto bg-light" t-att-type="props.fieldInfo.type" t-on-change="onSelectionChanged">
-                <option t-foreach="state.options" t-as="option" t-key="option" t-att-value="option[0]">
+            <select class="o_import_create_option form-select w-auto bg-light" t-att-type="this.props.fieldInfo.type" t-on-change="this.onSelectionChanged">
+                <option t-foreach="this.state.options" t-as="option" t-key="option" t-att-value="option[0]">
                     <t t-out="option[1]"/>
                 </option>
             </select>

--- a/addons/base_import/static/src/import_data_progress/import_data_progress.xml
+++ b/addons/base_import/static/src/import_data_progress/import_data_progress.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="ImportDataProgress">
-        <div t-if="props.importProgress.step > 1" class="o_import_data_progress d-flex align-items-center flex-column">
+        <div t-if="this.props.importProgress.step > 1" class="o_import_data_progress d-flex align-items-center flex-column">
             <div class="o_import_progress_dialog_batch text-center">
-                Batch <span class="o_import_progress_dialog_batch_count"><t t-out="props.importProgress.step"/></span> out of <span t-out="props.totalSteps"/>...
-                <div t-if="props.importProgress.value and state.timeLeft and !state.isInterrupted" class="o_import_progress_dialog_time_left">
+                Batch <span class="o_import_progress_dialog_batch_count"><t t-out="this.props.importProgress.step"/></span> out of <span t-out="this.props.totalSteps"/>...
+                <div t-if="this.props.importProgress.value and this.state.timeLeft and !this.state.isInterrupted" class="o_import_progress_dialog_time_left">
                     <span>Estimated time left:</span>
-                    <t t-if="state.timeLeft >= 1">
-                        <span class="o_import_progress_dialog_time_left_text mx-1" t-out="minutesLeft"/><span>minutes</span>
+                    <t t-if="this.state.timeLeft >= 1">
+                        <span class="o_import_progress_dialog_time_left_text mx-1" t-out="this.minutesLeft"/><span>minutes</span>
                     </t>
                     <t t-else="">
-                        <span class="o_import_progress_dialog_time_left_text mx-1" t-out="secondsLeft"/><span>seconds</span>
+                        <span class="o_import_progress_dialog_time_left_text mx-1" t-out="this.secondsLeft"/><span>seconds</span>
                     </t>
                 </div>
             </div>
-            <span t-if="state.isInterrupted" class="o_import_progress_dialog_stop">
+            <span t-if="this.state.isInterrupted" class="o_import_progress_dialog_stop">
                 Finalizing current batch before interrupting...
             </span>
             <div t-else="" class="d-flex align-items-center mt-2">
                 <div class="progress flex-grow-1 rounded-3">
                     <div class="progress-bar progress-bar-striped" role="progressbar"
                          aria-valuenow="props.importProgress" aria-valuemin="0" aria-valuemax="100" aria-label="Progress bar"
-                         t-att-style="'width: ' + props.importProgress.value + '%'">
-                        <span class="fs-4"><t t-out="props.importProgress.value" />%</span>
+                         t-att-style="'width: ' + this.props.importProgress.value + '%'">
+                        <span class="fs-4"><t t-out="this.props.importProgress.value" />%</span>
                     </div>
                 </div>
-                <a class="o_progress_stop_import ms-2" role="button" t-on-click="interrupt"><i class="fa fa-close fs-2 text-danger" aria-label="Stop Import" title="Stop Import"/></a>
+                <a class="o_progress_stop_import ms-2" role="button" t-on-click="this.interrupt"><i class="fa fa-close fs-2 text-danger" aria-label="Stop Import" title="Stop Import"/></a>
             </div>
         </div>
     </t>

--- a/addons/base_import/static/src/import_data_sidepanel/import_data_sidepanel.xml
+++ b/addons/base_import/static/src/import_data_sidepanel/import_data_sidepanel.xml
@@ -3,38 +3,38 @@
     <t t-name="ImportDataSidepanel">
         <div class="o_import_data_sidepanel p-3 bg-view flex-shrink-0">
             <div class="pb-3">
-                <div t-if="props.options.sheets.length > 1" class="flex-row my-2">
+                <div t-if="this.props.options.sheets.length > 1" class="flex-row my-2">
                     <label for="o_import_sheet">Sheet:</label>
                     <select
                         class="o_select o_import_sheet w-100 mb-3 form-select"
                         name="o_import_sheet"
                         t-on-change="ev => this.props.onOptionChanged('sheet', ev.target.value)"
-                        t-att-value="props.options.sheet"
+                        t-att-value="this.props.options.sheet"
                     >
-                        <option t-foreach="props.options.sheets" t-as="sheet" t-key="sheet" t-att-value="sheet" t-att-selected="sheet === props.options.sheet">
+                        <option t-foreach="this.props.options.sheets" t-as="sheet" t-key="sheet" t-att-value="sheet" t-att-selected="sheet === this.props.options.sheet">
                             <t t-out="sheet" />
                         </option>
                     </select>
                 </div>
-                <CheckBox value="props.options.has_headers" onChange.bind="isChecked => this.props.onOptionChanged('has_headers', isChecked)">
-                    Use first row as header<sup class="text-info p-1 cursor-default" t-att-data-tooltip="headersTooltip" t-out="'?'" />
+                <CheckBox value="this.props.options.has_headers" onChange.bind="isChecked => this.props.onOptionChanged('has_headers', isChecked)">
+                    Use first row as header<sup class="text-info p-1 cursor-default" t-att-data-tooltip="this.headersTooltip" t-out="'?'" />
                 </CheckBox>
-                <CheckBox value="!props.options.tracking_disable" onChange.bind="(isChecked) => this.props.onOptionChanged('tracking_disable', !isChecked)">
-                    Track changes in chatter<sup class="text-info p-1 cursor-default" t-att-data-tooltip="trackingTooltip" t-out="'?'" />
+                <CheckBox value="!this.props.options.tracking_disable" onChange.bind="(isChecked) => this.props.onOptionChanged('tracking_disable', !isChecked)">
+                    Track changes in chatter<sup class="text-info p-1 cursor-default" t-att-data-tooltip="this.trackingTooltip" t-out="'?'" />
                 </CheckBox>
-                <div t-if="props.isBatched and env.debug" class="o_import_grid gap-1">
+                <div t-if="this.props.isBatched and this.env.debug" class="o_import_grid gap-1">
                     <div class="o_import_grid_col">
                         <label for="o_import_batch_limit">Batch size</label>
-                        <sup class="text-info p-1 cursor-default" t-att-data-tooltip="batchLimitTooltip" t-out="'?'"/>
+                        <sup class="text-info p-1 cursor-default" t-att-data-tooltip="this.batchLimitTooltip" t-out="'?'"/>
                     </div>
                     <div class="o_import_grid_col">
-                        <input class="w-100 border rounded-2" type="number" id="o_import_batch_limit" t-att-value="getOptionValue('limit')" t-on-change="(ev) => this.setOptionValue('limit', ev.target.value || 1)" />
+                        <input class="w-100 border rounded-2" type="number" id="o_import_batch_limit" t-att-value="this.getOptionValue('limit')" t-on-change="(ev) => this.setOptionValue('limit', ev.target.value || 1)" />
                     </div>
                 </div>
             </div>
-            <div t-if="fileExtension.toLowerCase() === '.csv'" class="o_import_formatting pt-3 border-top">
+            <div t-if="this.fileExtension.toLowerCase() === '.csv'" class="o_import_formatting pt-3 border-top">
                 <h4>Formatting</h4>
-                <div t-foreach="Object.entries(props.formattingOptions)" t-as="option" t-key="`${option[0]}-${option_index}`" class="o_import_options">
+                <div t-foreach="Object.entries(this.props.formattingOptions)" t-as="option" t-key="`${option[0]}-${option_index}`" class="o_import_options">
                     <label t-att-for="`${option[0]}-${option_index}`">
                         <t t-out="option[1].label" />
                         <sup t-if="option[1].help" class="text-info p-1" t-att-data-tooltip="option[1].help" t-out="'?'" />
@@ -72,8 +72,8 @@
                     />
                 </div>
             </div>
-            <div t-if="props.hasBinaryFields" class="py-3 border-top o_import_file">
-                <h4>Attachments<sup class="text-info p-1" t-att-data-tooltip="attachmentsTooltip" t-out="'?'" /></h4>
+            <div t-if="this.props.hasBinaryFields" class="py-3 border-top o_import_file">
+                <h4>Attachments<sup class="text-info p-1" t-att-data-tooltip="this.attachmentsTooltip" t-out="'?'" /></h4>
                 <div class="o_import_grid gap-1">
                     <!-- First row-->
                     <div class="o_import_grid_col">
@@ -84,23 +84,23 @@
                         </label>
                     </div>
                     <div class="o_import_grid_col o_grid_span_2 align-content-center">
-                        <t t-out="binaryFilesLabel"/>
+                        <t t-out="this.binaryFilesLabel"/>
                     </div>
 
                     <!-- Second row-->
-                    <t t-if="env.debug">
+                    <t t-if="this.env.debug">
                         <div class="o_import_grid_col">
                             <label for="o_input_maxSizePerBatch">Batch max size</label>
-                            <sup t-if="props.binaryFilesParams.maxSizePerBatch.help" class="text-info p-1 cursor-default" t-att-data-tooltip="props.binaryFilesParams.maxSizePerBatch.help" t-out="'?'"/>
+                            <sup t-if="this.props.binaryFilesParams.maxSizePerBatch.help" class="text-info p-1 cursor-default" t-att-data-tooltip="this.props.binaryFilesParams.maxSizePerBatch.help" t-out="'?'"/>
                         </div>
                         <div class="o_import_grid_col">
                                 <input
                                     type="number"
                                     id="o_input_maxSizePerBatch"
                                     class="border rounded-2"
-                                    t-att-value="props.binaryFilesParams.maxSizePerBatch.value"
-                                    t-att-max="props.binaryFilesParams.maxSizePerBatch.max"
-                                    t-att-min="props.binaryFilesParams.maxSizePerBatch.min"
+                                    t-att-value="this.props.binaryFilesParams.maxSizePerBatch.value"
+                                    t-att-max="this.props.binaryFilesParams.maxSizePerBatch.max"
+                                    t-att-min="this.props.binaryFilesParams.maxSizePerBatch.min"
                                     t-on-change="(event) => this.props.onBinaryFilesParamsChanged('maxSizePerBatch', event.target.value)"
                                 />
                         </div>
@@ -111,15 +111,15 @@
                         <!-- Third row-->
                         <div class="o_import_grid_col">
                             <label for="o_input_delayAfterEachBatch">Batch interval</label>
-                            <sup t-if="props.binaryFilesParams.delayAfterEachBatch.help" class="text-info p-1 cursor-default" t-att-data-tooltip="props.binaryFilesParams.delayAfterEachBatch.help" t-out="'?'"/>
+                            <sup t-if="this.props.binaryFilesParams.delayAfterEachBatch.help" class="text-info p-1 cursor-default" t-att-data-tooltip="this.props.binaryFilesParams.delayAfterEachBatch.help" t-out="'?'"/>
                         </div>
                         <div class="o_import_grid_col">
                                 <input
                                     type="number"
                                     id="o_input_delayAfterEachBatch"
                                     class="border rounded-2"
-                                    t-att-value="props.binaryFilesParams.delayAfterEachBatch.value"
-                                    t-att-min="props.binaryFilesParams.delayAfterEachBatch.min"
+                                    t-att-value="this.props.binaryFilesParams.delayAfterEachBatch.value"
+                                    t-att-min="this.props.binaryFilesParams.delayAfterEachBatch.min"
                                     t-on-change="(event) => this.props.onBinaryFilesParamsChanged('delayAfterEachBatch', event.target.value)"
                                 />
                         </div>
@@ -132,7 +132,7 @@
             </div>
             <div class="py-3 border-top">
                 <h4>Help</h4>
-                <t t-foreach="props.importTemplates" t-as="template" t-key="template">
+                <t t-foreach="this.props.importTemplates" t-as="template" t-key="template">
                     <a class="d-block my-2" t-att-href="template.template" aria-label="Download" data-tooltip="Download">
                         <i class="fa fa-download"/> <span><t t-out="template.label"/></span>
                     </a>

--- a/addons/base_import/static/src/import_records/import_records.xml
+++ b/addons/base_import/static/src/import_records/import_records.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="base_import.ImportRecords">
-        <DropdownItem class="'o_import_menu'" onSelected.bind="importRecords">
+        <DropdownItem class="'o_import_menu'" onSelected.bind="this.importRecords">
             <i class="fa fa-fw fa-download me-1"/>Import
         </DropdownItem>
     </t>

--- a/addons/base_setup/static/src/views/module_views.xml
+++ b/addons/base_setup/static/src/views/module_views.xml
@@ -2,7 +2,7 @@
 
 <templates>
     <t t-name="base_setup.ResetModuleStateCogMenu">
-        <DropdownItem onSelected.bind="resetModuleState">
+        <DropdownItem onSelected.bind="this.resetModuleState">
             Reset Updating States
         </DropdownItem>
     </t>

--- a/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.xml
+++ b/addons/hr_attendance/static/src/public_kiosk/public_kiosk_app.xml
@@ -7,14 +7,14 @@
 
 <t t-name="hr_attendance.BarcodeScanner" t-inherit="barcodes.BarcodeScanner" t-inherit-mode="primary">
     <xpath expr="//div[hasclass('o_barcode_mobile_container')]" position="replace">
-        <div class="o_hr_attendance_kiosk d-flex justify-content-around" t-att-class="{'position-relative' : !isDisplayStandalone}">
-            <button t-if="isBarcodeScannerSupported" t-on-click="openMobileScanner" class="o_mobile_barcode btn btn-light btn-lg p-5 rounded-3" t-att-class="{'position-absolute' : !isDisplayStandalone}">
+        <div class="o_hr_attendance_kiosk d-flex justify-content-around" t-att-class="{'position-relative' : !this.isDisplayStandalone}">
+            <button t-if="this.isBarcodeScannerSupported" t-on-click="this.openMobileScanner" class="o_mobile_barcode btn btn-light btn-lg p-5 rounded-3" t-att-class="{'position-absolute' : !this.isDisplayStandalone}">
                 <i class="fa fa-3x fa-barcode mb-3"/>
                 <span class="d-block">Scan your badge</span>
             </button>
-            <a t-if="!isDisplayStandalone" class="o_hr_attendance_install_btn btn btn-secondary d-flex align-items-center justify-content-center fw-bolder position-relative"
-            t-att-style="props.fromTrialMode ? 'left: 25%;' : 'left: 115%;'"
-            t-att-href="installURL" target="_blank">Install</a>
+            <a t-if="!this.isDisplayStandalone" class="o_hr_attendance_install_btn btn btn-secondary d-flex align-items-center justify-content-center fw-bolder position-relative"
+            t-att-style="this.props.fromTrialMode ? 'left: 25%;' : 'left: 115%;'"
+            t-att-href="this.installURL" target="_blank">Install</a>
         </div>
     </xpath>
 </t>


### PR DESCRIPTION
In preparation for OWL3, where template variables will need to use 
`.this` to target component variables, we add `.this` to template 
variables that are targetting the component.

Script PR: https://github.com/odoo/odoo/pull/247965

THIS_TARGETS = ['attachment_indexation', 'auth', 'barcodes', 'base'] 
task: OWL3 prep - add `this.` to template variables

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
