### PR TITLE
[IMP] point_of_sale, pos_restaurant: show preset popup for direct sale orders

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1330,10 +1330,14 @@ export class PosStore extends WithLazyGetterTrap {
         order.setPricelist(this.config.pricelist_id);
 
         if (this.config.use_presets && !data["preset_id"]) {
-            this.selectPreset(this.config.default_preset_id, order);
+            this.selectPreset(this.config.default_preset_id, order, this.shouldSelectPreset(order));
         }
 
         return order;
+    }
+    // Meant to be overridden by pos_restaurant.
+    shouldSelectPreset(order) {
+        return false;
     }
     addNewOrder(data = {}) {
         if (this.getOrder()) {
@@ -2045,8 +2049,8 @@ export class PosStore extends WithLazyGetterTrap {
             }
         }
     }
-    async selectPreset(preset = false, order = this.getOrder()) {
-        if (!preset) {
+    async selectPreset(preset = false, order = this.getOrder(), presetSelection = false) {
+        if (!preset || presetSelection) {
             const selectionList = this.config.available_preset_ids.map((preset) => ({
                 id: preset.id,
                 label: preset.name,
@@ -2059,7 +2063,7 @@ export class PosStore extends WithLazyGetterTrap {
             }
 
             preset =
-                selectionList.length === 2
+                selectionList.length === 2 && !presetSelection
                     ? selectionList.find((preset) => !preset.isSelected).item
                     : await makeAwaitable(this.dialog, SelectionPopup, {
                           title: _t("Select preset"),

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -72,6 +72,9 @@ patch(PosStore.prototype, {
 
         return order;
     },
+    shouldSelectPreset(order) {
+        return order.isDirectSale && this.config.available_preset_ids.length > 1;
+    },
     async preSyncAllOrders(orders) {
         if (this.config.module_pos_restaurant) {
             for (const order of orders) {

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -697,7 +697,7 @@ registry.category("web_tour.tours").add("test_preset_timing_restaurant", {
         [
             Chrome.freezeDateTime(1749981600000), // June 15, 2025 - 10:00
             Chrome.startPoS(),
-            FloorScreen.clickNewOrder(),
+            FloorScreen.clickNewOrder(true),
             ProductScreen.clickDisplayedProduct("Coca-Cola"),
             ProductScreen.selectPreset("Eat in", "Takeaway"),
             TextInputPopup.inputText("John"),
@@ -759,7 +759,7 @@ registry.category("web_tour.tours").add("test_cancel_future_order", {
             Chrome.freezeDateTime(1739370000000),
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
-            FloorScreen.clickNewOrder(),
+            FloorScreen.clickNewOrder(true),
             ProductScreen.clickDisplayedProduct("Coca-Cola"),
             ProductScreen.selectPreset("Eat in", "Takeaway", false),
             TextInputPopup.inputText("John"),

--- a/addons/pos_restaurant/static/tests/tours/utils/floor_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/floor_screen_util.js
@@ -276,8 +276,21 @@ export function isChildTable(child) {
         trigger: table({ name: child }).trigger + ` .opacity-50`,
     };
 }
-export function clickNewOrder() {
-    return { trigger: ".new-order", run: "click" };
+export function clickNewOrder(presetSelection = false) {
+    const steps = [
+        {
+            trigger: ".new-order",
+            run: "click",
+        },
+    ];
+    if (presetSelection) {
+        steps.push({
+            content: `click preset 'Eat in' from preset modal`,
+            trigger: `.modal-body button:contains("Eat in")`,
+            run: "click",
+        });
+    }
+    return steps;
 }
 
 export function clickEditPlan() {

--- a/addons/pos_restaurant/static/tests/unit/models/pos_order.test.js
+++ b/addons/pos_restaurant/static/tests/unit/models/pos_order.test.js
@@ -8,7 +8,8 @@ definePosModels();
 describe("pos.order restaurant patches", () => {
     test("customer count and amount per guest", async () => {
         const store = await setupPosEnv();
-        const order = await getFilledOrder(store);
+        const table = store.models["restaurant.table"].get(2);
+        const order = await getFilledOrder(store, { table_id: table });
         order.setCustomerCount(3);
         expect(order.getCustomerCount()).toBe(3);
         order.setCustomerCount(4);


### PR DESCRIPTION
In this commit:
=================
When presets are configured and a user creates a new order from a direct sale (floating order) in pos_restaurant, the preset selection popup is now automatically displayed on the Product Screen.

This ensures the preset is selected at the start of the order flow for direct sale orders.

Task-5980627


