### PR TITLE
[FIX] mrp: prevent division by zero error in split wizard

### DIFF
--- a/addons/mrp/tests/test_backorder.py
+++ b/addons/mrp/tests/test_backorder.py
@@ -918,6 +918,16 @@ class TestMrpProductionBackorder(TestMrpCommon):
         mo.procurement_group_id.mrp_production_ids[-1].action_cancel()
         self.assertFalse(mo.picking_ids.filtered(lambda p: p.state == 'cancel' and p.product_id == self.product_6))
 
+    def test_zero_batch_size_on_split(self):
+        mo = self.generate_mo()[0]
+        action = mo.action_split()
+        wizard = Form(self.env[action['res_model']].with_context(action['context']))
+        wizard.max_batch_size = 0
+
+        self.assertFalse(wizard.max_batch_size)
+        self.assertFalse(wizard.valid_details)
+        self.assertEqual(wizard.production_id, mo)
+
 
 class TestMrpWorkorderBackorder(TransactionCase):
     @classmethod

--- a/addons/mrp/wizard/mrp_production_split.py
+++ b/addons/mrp/wizard/mrp_production_split.py
@@ -26,7 +26,7 @@ class MrpProductionSplit(models.TransientModel):
         'mrp.production.split.line', 'mrp_production_split_id',
         'Split Details', compute="_compute_details", store=True, readonly=False)
     valid_details = fields.Boolean("Valid", compute="_compute_valid_details")
-    max_batch_size = fields.Float("Max Batch Size", compute="_compute_max_batch_size", readonly=False)
+    max_batch_size = fields.Float("Max Batch Size", compute="_compute_max_batch_size", digits='Product Unit', readonly=False)
     num_splits = fields.Integer("# Splits", compute="_compute_num_splits", readonly=True)
 
     @api.depends('production_id')
@@ -36,11 +36,13 @@ class MrpProductionSplit(models.TransientModel):
 
     @api.depends('max_batch_size')
     def _compute_num_splits(self):
+        self.num_splits = 0
         for wizard in self:
-            wizard.num_splits = float_round(
-                wizard.product_qty / wizard.max_batch_size,
-                precision_digits=0,
-                rounding_method='UP')
+            if float_compare(wizard.max_batch_size, 0, precision_rounding=wizard.product_uom_id.rounding) > 0:
+                wizard.num_splits = float_round(
+                    wizard.product_qty / wizard.max_batch_size,
+                    precision_digits=0,
+                    rounding_method='UP')
 
     @api.depends('num_splits')
     def _compute_details(self):

--- a/addons/mrp/wizard/mrp_production_split.xml
+++ b/addons/mrp/wizard/mrp_production_split.xml
@@ -59,7 +59,7 @@
                     </field>
                     <field name="production_split_multi_id" invisible="1"/>
                     <field name="valid_details" invisible="1"/>
-                    <div class="alert alert-danger" role="alert" invisible="valid_details or max_batch_size &lt;= 0">
+                    <div class="alert alert-danger" role="alert" invisible="valid_details and max_batch_size &gt; 0">
                         The total should be equal to the quantity to produce.
                     </div>
                     <footer>


### PR DESCRIPTION
Steps to reproduce:
- Install `mrp` module
- Create a Manufacturing order
- Server Action > Open the `Split` wizard
- Set the `Max Batch Size` to `0`

Traceback:
`ZeroDivisionError: float division by zero`

Backporting this [commit], as the error still exists in older versions.

[commit]: https://github.com/odoo/odoo/pull/208275/changes/5546689200b7349754cf77bf4dbe7151315a3bfa




