### PR TITLE
[REF] *: run rendering context migration script

### DIFF
--- a/addons/board/static/src/add_to_board/add_to_board.xml
+++ b/addons/board/static/src/add_to_board/add_to_board.xml
@@ -11,8 +11,8 @@
                 <t t-set-slot="content">
                     <div class="px-3 pb-2">
                         <label class="mb-2">Add to my dashboard</label>
-                        <input type="text" class="o_input mb-3" t-custom-ref="autofocus" t-custom-model.trim="state.name" t-on-keydown="onInputKeydown" />
-                        <button type="button" class="btn btn-primary" t-on-click="addToBoard">Add</button>
+                        <input type="text" class="o_input mb-3" t-custom-ref="autofocus" t-custom-model.trim="state.name" t-on-keydown="this.onInputKeydown" />
+                        <button type="button" class="btn btn-primary" t-on-click="this.addToBoard">Add</button>
                     </div>
                 </t>
             </Dropdown>
@@ -20,7 +20,7 @@
     </t>
 
     <t t-name="Dashboard.DashboardIcon">
-        <svg viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg" class="o_ui_app_icon oi-large">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50" class="o_ui_app_icon oi-large">
             <path d="M4 8C4 5.79086 5.79086 4 8 4H25V21C25 23.2091 23.2091 25 21 25H4V8Z" fill="var(--oi-color, #FC868B)"/>
             <path d="M4 35C4 32.7909 5.79086 31 8 31H19V42C19 44.2091 17.2091 46 15 46H4V35Z" fill="var(--oi-color, #F9464C)"/>
             <path d="M25 46H29C31.2091 46 33 44.2091 33 42V31H29C26.7909 31 25 32.7909 25 35V46Z" fill="var(--oi-color, #FBB945)"/>

--- a/addons/board/static/src/board_action.xml
+++ b/addons/board/static/src/board_action.xml
@@ -2,8 +2,8 @@
 <templates xml:space="preserve">
 
     <t t-name="board.BoardAction">
-        <t t-if="isValid">
-            <View t-props="viewProps"/>
+        <t t-if="this.isValid">
+            <View t-props="this.viewProps"/>
         </t>
         <t t-else="">
             <div class="text-center text-warning m-1">Invalid action</div>

--- a/addons/board/static/src/board_controller.js
+++ b/addons/board/static/src/board_controller.js
@@ -117,7 +117,9 @@ export class BoardController extends Component {
 
     saveBoard() {
         const templateFn = renderToString.app.getTemplate("board.arch");
-        const bdom = templateFn(this.board, {});
+        const ctx = Object.create(this.board);
+        ctx.this = this.board;
+        const bdom = templateFn(ctx, {});
         const root = document.createElement("rendertostring");
         blockDom.mount(bdom, root);
         const result = xmlSerializer.serializeToString(root);

--- a/addons/board/static/src/board_controller.xml
+++ b/addons/board/static/src/board_controller.xml
@@ -3,7 +3,7 @@
 
     <t t-name="board.BoardView">
         <div class="o_dashboard d-flex flex-column">
-            <t t-if="board.isEmpty">
+            <t t-if="this.board.isEmpty">
                 <t t-call="board.NoContent"/>
             </t>
             <t t-else="">
@@ -13,32 +13,32 @@
     </t>
 
     <t t-name="board.Content">
-        <div t-if="!env.isSmall" class="o-dashboard-header d-flex justify-content-end">
+        <div t-if="!this.env.isSmall" class="o-dashboard-header d-flex justify-content-end">
             <Dropdown>
                 <button class="btn btn-secondary m-2 p-2">
-                    <img t-attf-src="/board/static/img/layout_{{board.layout}}.png" width="16" height="16" alt=""/>
+                    <img t-attf-src="/board/static/img/layout_{{this.board.layout}}.png" width="16" height="16" alt=""/>
                     Change Layout
                 </button>
                 <t t-set-slot="content">
                     <t t-foreach="'1 1-1 1-1-1 1-2 2-1'.split(' ')" t-as="layout" t-key="layout">
                         <DropdownItem onSelected="() => this.selectLayout(layout)">
                             <img t-attf-src="/board/static/img/layout_{{layout}}.png" alt=""/>
-                            <i t-if="layout == board.layout" class="fa fa-check fa-lg text-success" aria-label='Layout' role="img" title="Layout"/>
+                            <i t-if="layout == this.board.layout" class="fa fa-check fa-lg text-success" aria-label='Layout' role="img" title="Layout"/>
                         </DropdownItem>
                     </t>
                 </t>
             </Dropdown>
         </div>
-        <div class="o-dashboard-layout flex-grow-1" t-attf-class="o-dashboard-layout-{{board.layout}}" t-custom-ref="main">
-            <t t-foreach="board.columns" t-as="column" t-key="column_index">
-                <div t-if="column_index lt board.colNumber" class="o-dashboard-column h-100" t-att-data-idx="column_index">
+        <div class="o-dashboard-layout flex-grow-1" t-attf-class="o-dashboard-layout-{{this.board.layout}}" t-custom-ref="main">
+            <t t-foreach="this.board.columns" t-as="column" t-key="column_index">
+                <div t-if="column_index lt this.board.colNumber" class="o-dashboard-column h-100" t-att-data-idx="column_index">
                     <t t-foreach="column.actions" t-as="action" t-key="action.id">
                         <div class="o-dashboard-action mx-3 my-1 bg-view border" t-att-data-idx="action_index">
                             <h3 t-attf-class="o-dashboard-action-header {{action.title ? '' : 'oe_header_empty'}} p-2 m-2">
                                 <span> <t t-out="action.title"/> </span>
-                                <span t-if="!env.isSmall" class="btn float-end p-1 text-muted" t-on-click="() => this.closeAction(column, action)"><i class="fa fa-close"/></span>
-                                <span class="btn float-end p-1 text-muted" t-if="!action.isFolded" t-on-click="() => this.toggleAction(action, !env.isSmall)"><i class="fa fa-window-minimize"/></span>
-                                <span class="btn float-end p-1 text-muted" t-if="action.isFolded"  t-on-click="() => this.toggleAction(action, !env.isSmall)"><i class="fa fa-window-maximize"/></span>
+                                <span t-if="!this.env.isSmall" class="btn float-end p-1 text-muted" t-on-click="() => this.closeAction(column, action)"><i class="fa fa-close"/></span>
+                                <span class="btn float-end p-1 text-muted" t-if="!action.isFolded" t-on-click="() => this.toggleAction(action, !this.env.isSmall)"><i class="fa fa-window-minimize"/></span>
+                                <span class="btn float-end p-1 text-muted" t-if="action.isFolded"  t-on-click="() => this.toggleAction(action, !this.env.isSmall)"><i class="fa fa-window-maximize"/></span>
                             </h3>
                             <BoardAction t-if="!action.isFolded" action="action" />
                         </div>
@@ -68,9 +68,9 @@
     </t>
 
     <t t-name="board.arch">
-        <form t-att-string="title">
-            <board t-att-style="layout">
-                <column t-foreach="columns" t-as="column" t-key="column_index">
+        <form t-att-string="this.title">
+            <board t-att-style="this.layout">
+                <column t-foreach="this.columns" t-as="column" t-key="column_index">
                     <t t-foreach="column.actions" t-as="action" t-key="action_index">
                         <action
                             t-att-name="action.actionId"

--- a/addons/bus/static/src/debug/bus_logs_menu_item.xml
+++ b/addons/bus/static/src/debug/bus_logs_menu_item.xml
@@ -4,11 +4,11 @@
         <DropdownItem>
             <div class="d-flex align-items-center justify-content-between" style="padding-left: 12px;">
                 <div class="form-check form-switch">
-                    <label class="form-check-label" t-on-click.prevent.stop="busLogsService.enabled ? busLogsService.disableLogging : busLogsService.enableLogging">
-                        Enable Bus Logging <input class="form-check-input" t-att-checked="busLogsService.enabled" type="checkbox"/>
+                    <label class="form-check-label" t-on-click.prevent.stop="this.busLogsService.enabled ? this.busLogsService.disableLogging : this.busLogsService.enableLogging">
+                        Enable Bus Logging <input class="form-check-input" t-att-checked="this.busLogsService.enabled" type="checkbox"/>
                     </label>
                 </div>
-                <button class="btn btn-light text-muted ms-2" title="Download logs" t-custom-ref="downloadButton" t-on-click="onClickDownload"><i class="fa fa-download"/></button>
+                <button class="btn btn-light text-muted ms-2" title="Download logs" t-custom-ref="downloadButton" t-on-click="this.onClickDownload"><i class="fa fa-download"/></button>
             </div>
         </DropdownItem>
     </t>

--- a/addons/calendar/static/src/components/calendar_provider_config/calendar_connect_provider.xml
+++ b/addons/calendar/static/src/components/calendar_provider_config/calendar_connect_provider.xml
@@ -2,6 +2,6 @@
 <templates id="template" xml:space="preserve">
     <t t-name="calendar.CalendarConnectProvider">
         <a role="button" title="Connect" class="o_calendar_activate_external_cal btn btn-primary"
-            t-on-click="onConnect">Connect</a>
+            t-on-click="this.onConnect">Connect</a>
     </t>
 </templates>

--- a/addons/calendar/static/src/views/ask_recurrence_update_policy_dialog.xml
+++ b/addons/calendar/static/src/views/ask_recurrence_update_policy_dialog.xml
@@ -2,7 +2,7 @@
 <templates>
     <t t-name="calendar.AskRecurrenceUpdatePolicyDialog">
         <Dialog size="'sm'" title.translate="Edit Recurrent event">
-            <t t-foreach="Object.entries(possibleValues)" t-as="value" t-key="value[0]">
+            <t t-foreach="Object.entries(this.possibleValues)" t-as="value" t-key="value[0]">
                 <t t-set="name" t-value="value[0]"/>
                 <t t-set="state" t-value="value[1]"/>
                 <div class="form-check o_radio_item">
@@ -11,7 +11,7 @@
                 </div>
             </t>
             <t t-set-slot="footer">
-                <button class="btn btn-primary" t-on-click="confirm">
+                <button class="btn btn-primary" t-on-click="this.confirm">
                     Confirm
                 </button>
             </t>

--- a/addons/calendar/static/src/views/widgets/calendar_week_days.xml
+++ b/addons/calendar/static/src/views/widgets/calendar_week_days.xml
@@ -2,10 +2,10 @@
 <templates>
     <t t-name="calendar.WeekDays">
         <div class="o_recurrent_weekdays mb-2 d-flex">
-        <t t-foreach="weekdays" t-as="day" t-key="day">
-                <div t-attf-class="o_calendar_week_days_rounded {{data[day] ? 'text-bg-action' : 'btn-secondary'}}"
+        <t t-foreach="this.weekdays" t-as="day" t-key="day">
+                <div t-attf-class="o_calendar_week_days_rounded {{this.data[day] ? 'text-bg-action' : 'btn-secondary'}}"
                     t-on-click="this.props.readonly? () => {} : () => this.onChange(day)">
-                    <t t-out="props.record.fields[day].string[0]"/>
+                    <t t-out="this.props.record.fields[day].string[0]"/>
                 </div>
             </t>
         </div>

--- a/addons/mass_mailing/static/src/builder/components/company_update_dialog.xml
+++ b/addons/mass_mailing/static/src/builder/components/company_update_dialog.xml
@@ -2,7 +2,7 @@
     <t t-name="mass_mailing.CompanyUpdateDialog">
         <Dialog size="'xl'" title="this.dialogTitle">
             <div class="o_inner_group d-flex flex-column">
-                <t t-foreach="fieldNames" t-as="fieldName" t-key="fieldName_index">
+                <t t-foreach="this.fieldNames" t-as="fieldName" t-key="fieldName_index">
                     <div class="row mb-1">
                         <div class="o_cell o_wrap_label text-break text-900 col-2 pe-0">
                             <label class="o_form_label fw-bolder" t-out="fieldName.displayName"/>

--- a/addons/mass_mailing/static/src/builder/fontfamily_picker.xml
+++ b/addons/mass_mailing/static/src/builder/fontfamily_picker.xml
@@ -1,6 +1,6 @@
 <templates>
     <t t-name="mass_mailing.FontFamilyPicker">
-        <BuilderSelect className="props.extraClass" action="this.props.action" actionParam="this.props.actionParam">
+        <BuilderSelect className="this.props.extraClass" action="this.props.action" actionParam="this.props.actionParam">
             <t t-foreach="this.FONT_FAMILIES" t-as="fontFamily" t-key="fontFamily">
                 <BuilderSelectItem t-out="fontFamily" actionValue="fontFamily_value"/>
             </t>

--- a/addons/mass_mailing/static/src/builder/mass_mailing_builder.xml
+++ b/addons/mass_mailing/static/src/builder/mass_mailing_builder.xml
@@ -3,9 +3,9 @@
 <t t-name="mass_mailing.MassMailingBuilder">
     <Builder t-props="this.builderProps">
         <t t-set-slot="extraActions">
-            <button t-if="props.toggleCodeView" t-on-click="props.toggleCodeView"
+            <button t-if="this.props.toggleCodeView" t-on-click="this.props.toggleCodeView"
                 class="o-hb-btn btn d-flex align-items-center o_codeview_btn" title="Code View" accesskey="d"><i class="fa fa-code"/></button>
-            <button t-on-click="props.toggleFullScreen"
+            <button t-on-click="this.props.toggleFullScreen"
                 class="o-hb-btn btn btn-primary d-flex align-items-center" title="Fullscreen" accesskey="f">
                 <span t-attf-class="fa fa-expand"/>
             </button>

--- a/addons/mass_mailing/static/src/builder/options/record_snapshot_option.xml
+++ b/addons/mass_mailing/static/src/builder/options/record_snapshot_option.xml
@@ -1,14 +1,14 @@
 <templates>
     <t t-name="mass_mailing.recordSnapshotOption">
-        <BuilderRow label="getModelDisplayName()">
+        <BuilderRow label="this.getModelDisplayName()">
             <BuilderMany2One
                 action="'selectRecordAction'"
-                model="getElementDataModel()"
+                model="this.getElementDataModel()"
                 preview="false"
                 allowUnselect="false"
                 actionParam="{
-                    model: getElementDataModel(),
-                    fragmentKey: getElementFragmentKey(),
+                    model: this.getElementDataModel(),
+                    fragmentKey: this.getElementFragmentKey(),
                 }"/>
         </BuilderRow>
     </t>

--- a/addons/mass_mailing/static/src/builder/options/social_media_option.xml
+++ b/addons/mass_mailing/static/src/builder/options/social_media_option.xml
@@ -31,7 +31,7 @@
         <BuilderCheckbox classAction="'no_icon_color'" id="'no_icon_color_opt'" inverseAction="true"/>
     </BuilderRow>
 
-    <BuilderRow label.translate="Custom Color" t-if="!isActiveItem('no_icon_color_opt')">
+    <BuilderRow label.translate="Custom Color" t-if="!this.isActiveItem('no_icon_color_opt')">
         <BuilderColorPicker styleAction="'color'" noTransparency="true" enabledTabs="['solid', 'custom']" applyTo="'.fa'"/>
     </BuilderRow>
     <BuilderRow label.translate="Background Color">

--- a/addons/mass_mailing/static/src/builder/tabs/design_tab.xml
+++ b/addons/mass_mailing/static/src/builder/tabs/design_tab.xml
@@ -3,7 +3,7 @@
 <t t-name="mass_mailing.DesignTab">
     <div class="o_design_tab h-100">
         <div t-custom-ref="content" class="d-flex flex-column h-100">
-            <t t-foreach="optionsContainers" t-as="optionsContainer" t-key="optionsContainer.id">
+            <t t-foreach="this.optionsContainers" t-as="optionsContainer" t-key="optionsContainer.id">
                 <!-- TODO EGGMAIL (check theme_tab.xml todo) Define a more basic kind of options container -->
                 <OptionsContainer
                     snippetModel="optionsContainer.snippetModel"

--- a/addons/mass_mailing/static/src/components/mailing_preview_iframe/mailing_preview_iframe.xml
+++ b/addons/mass_mailing/static/src/components/mailing_preview_iframe/mailing_preview_iframe.xml
@@ -4,8 +4,8 @@
 
     <t t-name="mass_mailing.MailingPreviewIframe">
         <div class="o_mass_mailing_iframe_wrapper">
-            <div t-att-class="{'o_is_mobile': state.isMobileMode}"
-                 t-attf-style="overflow: hidden;#{!state.isMobileMode? 'height:60vh;' : ''}">
+            <div t-att-class="{'o_is_mobile': this.state.isMobileMode}"
+                 t-attf-style="overflow: hidden;#{!this.state.isMobileMode? 'height:60vh;' : ''}">
                 <iframe t-custom-ref="iframeRef" t-att-sandbox="this.isBrowserSafari ? 'allow-same-origin allow-scripts' : 'allow-same-origin'"/>
             </div>
         </div>

--- a/addons/mass_mailing/static/src/components/mailing_preview_mode_toggle/mailing_preview_mode_toggle.xml
+++ b/addons/mass_mailing/static/src/components/mailing_preview_mode_toggle/mailing_preview_mode_toggle.xml
@@ -2,13 +2,13 @@
 <templates xml:space="preserve">
 
     <t t-name="mass_mailing.MailingPreviewModeToggle">
-        <div class="d-flex gap-1 pb-1" t-if="!state.isSmall">
+        <div class="d-flex gap-1 pb-1" t-if="!this.state.isSmall">
             <button type="button" class="btn py-0 px-1" t-on-click="() => this.onTogglePreviewMode(false)"
-                    t-att-class="!state.isMobileMode? 'btn-primary' : 'btn-secondary'">
+                    t-att-class="!this.state.isMobileMode? 'btn-primary' : 'btn-secondary'">
                 <i class="fa fa-desktop" title="Desktop Preview"/>
             </button>
             <button type="button" class="btn py-0 px-2" t-on-click="() => this.onTogglePreviewMode(true)"
-                    t-att-class="state.isMobileMode? 'btn-primary' : 'btn-secondary'">
+                    t-att-class="this.state.isMobileMode? 'btn-primary' : 'btn-secondary'">
                 <i class="fa fa-lg fa-mobile" title="Mobile Preview"/>
             </button>
         </div>

--- a/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.xml
+++ b/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.xml
@@ -1,20 +1,20 @@
 <templates>
     <t t-name="mass_mailing.HtmlField">
-        <t t-if="state.showThemeSelector">
+        <t t-if="this.state.showThemeSelector">
             <ThemeSelectorIframe config="this.getThemeSelectorConfig()"/>
         </t>
-        <t t-if="state.showCodeView">
+        <t t-if="this.state.showCodeView">
             <div class="d-flex">
                 <textarea name="codeView" t-custom-ref="codeView" class="o_codeview" t-att-value="this.value"
-                    t-on-input="onTextareaInput"/>
-                <div t-if="state.showCodeView" t-custom-ref="codeViewButtonRef"
+                    t-on-input="this.onTextareaInput"/>
+                <div t-if="this.state.showCodeView" t-custom-ref="codeViewButtonRef"
                     class="btn-group o_mass_mailing_code_view">
-                    <button class="o_codeview_btn btn btn-primary" t-on-click="toggleCodeView" accesskey="d">
+                    <button class="o_codeview_btn btn btn-primary" t-on-click="this.toggleCodeView" accesskey="d">
                         <i class="fa fa-code" />
                     </button>
                 </div>
             </div>
         </t>
-        <MassMailingIframe t-key="state.key" t-props="this.getMassMailingIframeProps()"/>
+        <MassMailingIframe t-key="this.state.key" t-props="this.getMassMailingIframeProps()"/>
     </t>
 </templates>

--- a/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.xml
+++ b/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.xml
@@ -2,23 +2,23 @@
     <t t-name="mass_mailing.MassMailingIframe">
         <div class="o_mass_mailing_iframe_wrapper"
             t-att-class="{
-                'o_mass_mailing_fullscreen': state.showFullscreen,
-                [props.extraClass]: props.extraClass,
+                'o_mass_mailing_fullscreen': this.state.showFullscreen,
+                [this.props.extraClass]: this.props.extraClass,
             }">
             <div class="d-flex w-100 h-100">
                 <div class="flex-grow-1" t-att-class="{'align-self-center': this.state.isMobile}">
-                    <LocalOverlayContainer localOverlay="overlayRef" identifier="env.localOverlayContainerKey"/>
+                    <LocalOverlayContainer localOverlay="this.overlayRef" identifier="this.env.localOverlayContainerKey"/>
                     <div t-att-class="{ 'o_is_mobile': this.state.isMobile, 'h-100': !this.state.isMobile }">
                         <iframe t-att-sandbox="this.isBrowserSafari ? 'allow-same-origin allow-scripts' : 'allow-same-origin'"
                             t-att-scrolling="this.state.isMobile ? '' : 'no'"
-                            t-att-class="{ 'd-none': props.showThemeSelector or props.showCodeView }"
+                            t-att-class="{ 'd-none': this.props.showThemeSelector or this.props.showCodeView }"
                             t-custom-ref="iframeRef"/>
                     </div>
                 </div>
-                <div t-if="!props.readonly and props.withBuilder and !props.showThemeSelector and !props.showCodeView">
+                <div t-if="!this.props.readonly and this.props.withBuilder and !this.props.showThemeSelector and !this.props.showCodeView">
                     <div class="position-sticky o_mass_mailing-builder_sidebar o_builder_sidebar_open"
                         t-att-class="{ 'd-none': this.env.isSmall }" t-custom-ref="sidebarRef">
-                        <LazyComponent t-if="state.ready" Component="'mass_mailing.MassMailingBuilder'"
+                        <LazyComponent t-if="this.state.ready" Component="'mass_mailing.MassMailingBuilder'"
                             props="() => ({
                                 builderProps: this.getBuilderProps(),
                                 toggleCodeView: this.props.toggleCodeView,

--- a/addons/mass_mailing/static/src/themes/theme_selector/theme_selector.xml
+++ b/addons/mass_mailing/static/src/themes/theme_selector/theme_selector.xml
@@ -2,13 +2,13 @@
     <div t-name="mass_mailing.ThemeSelector" class="o_mail_theme_selector">
         <div t-custom-ref="themeSelectorWrapper" class="o_mailing_template_preview_wrapper d-inline-block w-100">
             <div class="o_mail_templates_grid w-100">
-                <div t-foreach="simpleThemes.values()" t-as="theme" t-key="theme_index" role="menuitem" class="cursor-pointer dropdown-item px-4"
+                <div t-foreach="this.simpleThemes.values()" t-as="theme" t-key="theme_index" role="menuitem" class="cursor-pointer dropdown-item px-4"
                     t-on-click="() => this.onSelectTheme(theme)" t-att-data-name="theme.name">
                     <div class="o_thumb small mb-2" t-attf-style="background-image: url(#{theme.imgPath}_small.png)"/>
                     <div class="o_thumb large mb-2" t-attf-style="background-image: url(#{theme.imgPath}_large.png)"/>
                     <h5 class="text-capitalize text-truncate" t-out="theme.title"/>
                 </div>
-                <div t-foreach="state.favoriteTemplates" t-as="template" t-key="template_index"
+                <div t-foreach="this.state.favoriteTemplates" t-as="template" t-key="template_index"
                     class="cursor-pointer dropdown-item px-4 o_mail_template_preview d-flex flex-column justify-content-between" role="menuitem"
                     t-on-click="() => this.onSelectFavorite(template.bodyArch)">
                     <!-- Template HTML preview -->
@@ -30,7 +30,7 @@
                         </div> 
                     </div>
                 </div>
-                <div t-foreach="commonThemes.values()" t-as="theme" t-key="theme_index" role="menuitem" class="cursor-pointer dropdown-item px-4"
+                <div t-foreach="this.commonThemes.values()" t-as="theme" t-key="theme_index" role="menuitem" class="cursor-pointer dropdown-item px-4"
                     t-on-click="() => this.onSelectTheme(theme)" t-att-data-name="theme.name">
                     <div class="o_thumb small mb-2" t-attf-style="background-image: url(#{theme.imgPath}_small.png)"/>
                     <div class="o_thumb large mb-2" t-attf-style="background-image: url(#{theme.imgPath}_large.png)"/>

--- a/addons/mass_mailing/static/src/themes/theme_selector/theme_selector_iframe.xml
+++ b/addons/mass_mailing/static/src/themes/theme_selector/theme_selector_iframe.xml
@@ -3,7 +3,7 @@
     <div class="o_mass_mailing_theme_selector_iframe_wrapper">
         <div class="d-flex w-100 h-100">
             <div class="flex-grow-1 o_mass_mailing_theme_selector_iframe_container">
-                <iframe t-custom-ref="iframe" t-att-hidden="!state.show ? '' : false"
+                <iframe t-custom-ref="iframe" t-att-hidden="!this.state.show ? '' : false"
                     t-att-sandbox="this.isBrowserSafari ? 'allow-same-origin allow-scripts' : 'allow-same-origin'"
                     scrolling="no"/>
             </div>

--- a/addons/mass_mailing/static/src/themes/theme_wrapper.xml
+++ b/addons/mass_mailing/static/src/themes/theme_wrapper.xml
@@ -1,19 +1,19 @@
 <templates id="template">
     <t t-name="mass_mailing.ThemeLayout">
         <div data-name="Mailing" class="o_layout oe_unremovable oe_unmovable"
-            t-att-class="className" t-att-style="layoutStyles">
-            <t t-if="nowrap" t-call="mass_mailing.ThemeStructure"/>
+            t-att-class="this.className" t-att-style="this.layoutStyles">
+            <t t-if="this.nowrap" t-call="mass_mailing.ThemeStructure"/>
             <t t-else="" t-call="mass_mailing.ThemeWrapper"/>
         </div>
     </t>
     <t t-name="mass_mailing.ThemeWrapper">
         <div class="container o_mail_wrapper o_mail_regular oe_unremovable">
             <div class="row mw-100 mx-0">
-                <div class="col o_mail_no_options o_mail_wrapper_td bg-white oe_structure" t-out="html"/>
+                <div class="col o_mail_no_options o_mail_wrapper_td bg-white oe_structure" t-out="this.html"/>
             </div>
         </div>
     </t>
     <t t-name="mass_mailing.ThemeStructure">
-        <div class="oe_structure" t-out="html"/>
+        <div class="oe_structure" t-out="this.html"/>
     </t>
 </templates>

--- a/addons/mass_mailing/static/src/xml/mailing_filter_widget.xml
+++ b/addons/mass_mailing/static/src/xml/mailing_filter_widget.xml
@@ -4,8 +4,8 @@
     <!-- Template for 'mailing_filter' widget, specific for mailing form view -->
     <t t-name="mass_mailing.MailingFilter">
         <div class="d-flex align-items-center gap-1">
-            <Many2One t-props="m2oProps" cssClass="'w-100'"/>
-            <t t-if="!props.readonly">
+            <Many2One t-props="this.m2oProps" cssClass="'w-100'"/>
+            <t t-if="!this.props.readonly">
                 <div class="o_mass_mailing_filter_container">
                     <div t-attf-class="o_mass_mailing_save_filter_container pt-1 {{ !this.filter.canSaveFilter ? 'd-none': '' }}">
                         <div class="o_mass_mailing_filter_dropdown">
@@ -22,8 +22,8 @@
                                     </div>
                                     <div class="d-inline-flex">
                                         <input t-custom-ref="autofocus" type="text" class="o_mass_mailing_filter_name o_input w-auto ms-2"
-                                            placeholder='e.g. "VIP Customers"' t-on-keydown="onFilterNameInputKeydown"/>
-                                        <button class="btn btn-sm btn-primary o_mass_mailing_btn_save_filter mx-2" t-on-click="onSaveFilter">
+                                            placeholder='e.g. "VIP Customers"' t-on-keydown="this.onFilterNameInputKeydown"/>
+                                        <button class="btn btn-sm btn-primary o_mass_mailing_btn_save_filter mx-2" t-on-click="this.onSaveFilter">
                                             Add
                                         </button>
                                     </div>
@@ -31,7 +31,7 @@
                             </MailingFilterDropdown>
                         </div>
                     </div>
-                    <a t-attf-class="o_mass_mailing_remove_filter btn px-1 pt-1 pb-0 {{ !this.filter.canRemoveFilter ? 'd-none': '' }}" t-on-click="onRemoveFilter">
+                    <a t-attf-class="o_mass_mailing_remove_filter btn px-1 pt-1 pb-0 {{ !this.filter.canRemoveFilter ? 'd-none': '' }}" t-on-click="this.onRemoveFilter">
                         <i class="fa fa-trash px-3 py-1 align-bottom" title="Remove from Favorites"/>
                     </a>
                 </div>

--- a/addons/mass_mailing/static/src/xml/mailing_portal_subscription_blocklist.xml
+++ b/addons/mass_mailing/static/src/xml/mailing_portal_subscription_blocklist.xml
@@ -3,11 +3,11 @@
 <templates xml:space="preserve">
     <t t-name="mass_mailing.portal.blocklist_update_info">
         <span>
-            <t t-if="infoKey == 'blocklist_add'">
+            <t t-if="this.infoKey == 'blocklist_add'">
                 <i class="fa fa-check me-1"/>
                 <span>Email added to our blocklist</span>
             </t>
-            <t t-elif="infoKey == 'blocklist_remove'">
+            <t t-elif="this.infoKey == 'blocklist_remove'">
                 <i class="fa fa-check me-1"/>
                 <span>Email removed from our blocklist</span>
             </t>

--- a/addons/mass_mailing/static/src/xml/mailing_portal_subscription_feedback.xml
+++ b/addons/mass_mailing/static/src/xml/mailing_portal_subscription_feedback.xml
@@ -3,7 +3,7 @@
 <templates xml:space="preserve">
     <t t-name="mass_mailing.portal.feedback_update_info">
         <span>
-            <t t-if="infoKey == 'feedback_sent'">
+            <t t-if="this.infoKey == 'feedback_sent'">
                 <i class="fa fa-check me-1"/>
                 <span>Sent. Thanks you for your feedback!</span>
             </t>

--- a/addons/mass_mailing/static/src/xml/mailing_portal_subscription_form.xml
+++ b/addons/mass_mailing/static/src/xml/mailing_portal_subscription_form.xml
@@ -74,7 +74,7 @@
 
     <!-- Post action informative span -->
     <t t-name="mass_mailing.portal.list_form_update_info">
-        <t t-if="infoKey == 'subscription_updated'">
+        <t t-if="this.infoKey == 'subscription_updated'">
             <i class="fa fa-check me-1"/>
             <span>Membership updated</span>
         </t>


### PR DESCRIPTION
In preparation for OWL3, where template variables will need to use `.this` to target component variables, we add `.this` to template variables that are targetting the component.

Script PR: https://github.com/odoo/odoo/pull/247965

THIS_TARGETS = ["board", "bus", "calendar", "certificate",
                "cloud_storage", "contacts", "crm", "maintenance",
                "marketing_card","mass_mailing", "microsoft_account",
                "microsoft_calendar","microsoft_outlook"]
task: OWL3 prep - add this. to template variables


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
