### PR TITLE
[IMP] mail:  redirect new channel members to the latest message

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -661,6 +661,7 @@ class DiscussChannel(models.Model):
         guests = guests or self.env["mail.guest"]
         current_user, current_guest = self.env["res.users"]._get_current_persona()
         all_new_members = self.env["discuss.channel.member"]
+        last_message_by_channel = self._get_last_messages().grouped("channel_id")
         for channel in self:
             members_to_create = []
             existing_members = self.env['discuss.channel.member'].search(
@@ -677,6 +678,9 @@ class DiscussChannel(models.Model):
                 'guest_id': guest.id,
                 'channel_id': channel.id,
             } for guest in guests - existing_members.guest_id]
+            if last_message := last_message_by_channel.get(channel):
+                for member_vals in members_to_create:
+                    member_vals.setdefault("new_message_separator", last_message.id + 1)
             if channel.parent_channel_id and channel.parent_channel_id.has_access("write"):
                 new_members = self.env["discuss.channel.member"].sudo().create(members_to_create)
             else:

--- a/addons/mail/static/tests/core/new_message_separator.test.js
+++ b/addons/mail/static/tests/core/new_message_separator.test.js
@@ -13,10 +13,16 @@ import {
     triggerHotkey,
     waitStoreFetch,
 } from "@mail/../tests/mail_test_helpers";
-import { describe, test } from "@odoo/hoot";
+import { describe, expect, test } from "@odoo/hoot";
 import { click as hootClick, press, queryFirst } from "@odoo/hoot-dom";
 import { mockDate } from "@odoo/hoot-mock";
-import { Command, serverState, withUser } from "@web/../tests/web_test_helpers";
+import {
+    Command,
+    getService,
+    makeKwArgs,
+    serverState,
+    withUser,
+} from "@web/../tests/web_test_helpers";
 
 import { rpc } from "@web/core/network/rpc";
 
@@ -377,4 +383,32 @@ test("only show new message separator in its thread", async () => {
     await contains(".o-mail-Thread-newMessage ~ .o-mail-Message:has(:text('@Mitchell Admin'))", {
         count: 0,
     });
+});
+
+test("new member's separator should be at the bottom of existing messages after being invited", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    pyEnv["mail.message"].create({
+        author_id: serverState.partnerId,
+        body: "Hello",
+        message_type: "comment",
+        model: "discuss.channel",
+        res_id: channelId,
+    });
+    const demoPartnerId = pyEnv["res.partner"].create({ name: "Newbie" });
+    await start();
+    const newMemberIds = await getService("orm").call(
+        "discuss.channel",
+        "add_members",
+        [[channelId]],
+        { partner_ids: [demoPartnerId] }
+    );
+    const [lastMessageId = 0] = pyEnv["mail.message"].search(
+        [
+            ["model", "=", "discuss.channel"],
+            ["res_id", "=", channelId],
+        ],
+        makeKwArgs({ limit: 1, order: "id DESC" })
+    );
+    expect(newMemberIds[0].new_message_separator).toBe(lastMessageId + 1);
 });

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -131,6 +131,8 @@ export class DiscussChannel extends models.ServerModel {
         const BusBus = this.env["bus.bus"];
         /** @type {import("mock_models").DiscussChannelMember} */
         const DiscussChannelMember = this.env["discuss.channel.member"];
+        /** @type {import("mock_models").MailMessage} */
+        const MailMessage = this.env["mail.message"];
         /** @type {import("mock_models").ResPartner} */
         const ResPartner = this.env["res.partner"];
 
@@ -145,12 +147,20 @@ export class DiscussChannel extends models.ServerModel {
             const subtype_xmlid = "mail.mt_comment";
             this.message_post(channel.id, makeKwArgs({ body, message_type, subtype_xmlid }));
         }
+        const [lastMessageId = 0] = MailMessage.search(
+            [
+                ["model", "=", "discuss.channel"],
+                ["res_id", "=", channel.id],
+            ],
+            makeKwArgs({ limit: 1, order: "id DESC" })
+        );
         const insertedChannelMembers = [];
         for (const partner of partners) {
             const channelMember = DiscussChannelMember.create({
                 channel_id: channel.id,
                 partner_id: partner.id,
                 create_uid: this.env.uid,
+                new_message_separator: lastMessageId + 1,
             });
             insertedChannelMembers.push(channelMember);
             BusBus._sendone(partner, "discuss.channel/joined", {

--- a/addons/mail/tests/discuss/test_discuss_channel_member.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_member.py
@@ -121,3 +121,9 @@ class TestDiscussChannelMember(MailCommon):
             1,  # channel 2 user 1: received 1 message (from message post)
             1,  # channel 2 user 3: received 1 message (from message post)
         ])
+
+    def test_new_member_lands_at_latest_message(self):
+        channel = self.env['discuss.channel'].with_user(self.user_1)._create_channel(group_id=None, name='wololo channel')
+        last_message_id = channel.message_ids[0].id
+        new_members = channel.with_user(self.user_1)._add_members(users=self.user_2)
+        self.assertEqual(new_members.new_message_separator, last_message_id + 1)

--- a/addons/website_livechat/tests/test_chatbot_ui.py
+++ b/addons/website_livechat/tests/test_chatbot_ui.py
@@ -135,8 +135,8 @@ class TestLivechatChatbotUI(TestLivechatChatbotUICommon):
         ]
 
         self.assertEqual(len(conversation_messages), len(expected_messages))
-        # "invited" notification is not taken into account in unread counter contribution.
-        self.assertEqual(len(conversation_messages) - 1, operator_member.message_unread_counter)
+        # New members land at latest message, so operator unread counter is 0.
+        self.assertEqual(operator_member.message_unread_counter, 0)
 
         # check that the whole conversation is correctly saved
         # including welcome steps: see chatbot.script#_post_welcome_steps


### PR DESCRIPTION
Previously, newly invited channel members were redirected to the beginning of the conversation, which could be irrelevant for long-running channels with a large message history.

This PR improves the user experience by redirecting new channel members to the latest message when they join a channel, allowing them to immediately see the most recent context while still being able to scroll up if needed.

task-5954486




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
