### PR TITLE
[FIX] mrp: prevent error when opening view

### DIFF
--- a/addons/mrp/wizard/mrp_production_split.py
+++ b/addons/mrp/wizard/mrp_production_split.py
@@ -38,6 +38,8 @@ class MrpProductionSplit(models.TransientModel):
     def _compute_num_splits(self):
         self.num_splits = 0
         for wizard in self:
+            if not wizard.product_uom_id:
+                continue
             if float_compare(wizard.max_batch_size, 0, precision_rounding=wizard.product_uom_id.rounding) > 0:
                 wizard.num_splits = float_round(
                     wizard.product_qty / wizard.max_batch_size,


### PR DESCRIPTION
Steps to reproduce:
- Install `mrp` module
- Active debugger > Open view
- Open `Split Production` view

Traceback:
`AssertionError: precision_rounding must be positive, got 0.0 (saas-18.3) `
`ValueError: Expected singleton: uom.uom() (19.0)`

When trying to open the view directly, we do not receive the `product_uom_id` from the wizard in compute method `_compute_num_splits`, which leads to an error.

sentry-7379431482


