### PR TITLE
[FIX] website_sale: ensure product search works properly in mobile view

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2171,6 +2171,7 @@
                                 <t t-set="_classes" t-valuef="input-group rounded o_cc o_cc1 mb-1"/>
                                 <t t-set="_input_classes" t-valuef="border-0 p-3"/>
                                 <t t-set="_submit_classes" t-valuef="px-4"/>
+                                <t t-set="action" t-value="keep(search=0)"/>
                                 <t t-if="category" t-set="placeholder">Search in <t t-out="category.name"/></t>
                             </t>
                         </div>


### PR DESCRIPTION
Steps to produce:
---
- Install `website_sale` module.
- Go to `website > shop`.
- Open the `Customizable Desk` product page.
- From the website editor, `enable the search bar` for the product page.
- Switch to `mobile view`.
- Now search for `drawer` in product search.

Issue:
---
- In mobile view, the search does not work. When performing a search, nothing happens, and the request is not executed.

Root cause:
---
- At [1], in the search template definition, the action attribute is missing in the search form.

Solution:
---
- Set the form action using keep(search=0) instead of leaving it undefined.
- This ensures that the search behaves correctly depending on the context (global or category-scoped).

[1]https://github.com/odoo/odoo/blob/51f59a293de1e86f66f30257f8fc0c419463d18c/addons/website_sale/views/templates.xml#L2239-L2259

opw-5992052

---


I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
