### PR TITLE
[FIX] mail: prevent type error

### DIFF
--- a/addons/mail/static/src/model/record.js
+++ b/addons/mail/static/src/model/record.js
@@ -338,7 +338,7 @@ export class Record {
         if (!collection) {
             return false;
         }
-        return collection.some((record) => toRaw(record)._raw.eq(this));
+        return collection.some((record) => record && toRaw(record)._raw.eq(this));
     }
 
     /** @param {Record[]|RecordList} collection */

--- a/addons/mail/static/src/model/record_list.js
+++ b/addons/mail/static/src/model/record_list.js
@@ -132,7 +132,7 @@ export class RecordListInternal {
             const vals = [...collection];
             const oldRecords = recordList._proxyInternal.slice
                 .call(recordList._proxy)
-                .map((recordProxy) => toRaw(recordProxy)._raw);
+                .map((recordProxy) => recordProxy && toRaw(recordProxy)._raw);
             const newRecords = vals.map((val) =>
                 self.insert(recordList, val, function recordListAssignInsert(record) {
                     if (record.notIn(oldRecords)) {
@@ -143,7 +143,7 @@ export class RecordListInternal {
             );
             const inverse = getInverse(recordList);
             for (const oldRecord of oldRecords) {
-                if (oldRecord.notIn(newRecords)) {
+                if (oldRecord && oldRecord.notIn(newRecords)) {
                     oldRecord._.uses.delete(recordList);
                     store._.ADD_QUEUE("onDelete", self.owner, self.name, oldRecord);
                     if (inverse) {

--- a/addons/mail/static/src/model/store_internal.js
+++ b/addons/mail/static/src/model/store_internal.js
@@ -139,7 +139,7 @@ export class StoreInternal extends RecordInternal {
             recordListFullProxy._store.recordByLocalId.get(localId)
         );
         recordsFullProxy.sort(func);
-        const data = recordsFullProxy.map((recordFullProxy) => toRaw(recordFullProxy)._raw.localId);
+        const data = recordsFullProxy.map((recordFullProxy) => recordFullProxy && toRaw(recordFullProxy)._raw.localId);
         const hasChanged = recordList.data.some((localId, i) => localId !== data[i]);
         if (hasChanged) {
             recordListFullProxy.data = data;


### PR DESCRIPTION
- while closing AI chat which opens after mail chat raising an type error
- Uncaught Promise > Cannot read properties of undefined (reading '_raw')
- traceback:
```py
TypeError: Cannot read properties of undefined (reading '_raw')
at https://test_ai.odoo.com/web/assets/1/d857df7/web.assets_web.min.js:15663:305
at Array.map (<anonymous>)
at recordListAssign (https://test_ai.odoo.com/web/assets/1/d857df7/web.assets_web.min.js:15663:268)
at Store.MAKE_UPDATE (https://test_ai.odoo.com/web/assets/1/d857df7/web.assets_web.min.js:15724:65)
at RecordListInternal.assign (https://test_ai.odoo.com/web/assets/1/d857df7/web.assets_web.min.js:15663:84)
at StoreInternal.updateRelationMany (https://test_ai.odoo.com/web/assets/1/d857df7/web.assets_web.min.js:15781:741)
at StoreInternal.updateRelation (https://test_ai.odoo.com/web/assets/1/d857df7/web.assets_web.min.js:15780:115)
at StoreInternal.updateFields (https://test_ai.odoo.com/web/assets/1/d857df7/web.assets_web.min.js:15779:316)
at StoreInternal.compute (https://test_ai.odoo.com/web/assets/1/d857df7/web.assets_web.min.js:15636:9)
at StoreInternal.requestCompute (https://test_ai.odoo.com/web/assets/1/d857df7/web.assets_web.min.js:15631:198)
```

- steps to reproduce:
   - open chat
   - without closing open AI chat
   - close the AI chat
For more clearing: https://github.com/user-attachments/assets/16be2598-7b34-4f92-9ee2-c03420f049d0


- Current behavior before PR:
   - raising an error while closing the AI chat if it's open without closing mail chat
   - After more deep check found if we lastly close the AI chat then message
     it's raising an error

- Desired behavior after PR is merged:
   - it'll work smoothly without any error


- OPW:5761279

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
