### PR TITLE
[IMP] website*_sale*: simplify cart totals display for tax-included prices

### DIFF
--- a/addons/website_event_booth_sale/static/tests/tours/website_event_booth.js
+++ b/addons/website_event_booth_sale/static/tests/tours/website_event_booth.js
@@ -44,7 +44,6 @@ registry.category("web_tour.tours").add('website_event_booth_tour', {
 },
 ...wsTourUtils.assertCartAmounts({
     taxes: '20.00',
-    untaxed: '200.00',
     total: '220.00',
 }),
 wsTourUtils.goToCheckout(),
@@ -54,7 +53,6 @@ wsTourUtils.goToCheckout(),
 },
 ...wsTourUtils.assertCartAmounts({
     taxes: '20.00',
-    untaxed: '200.00',
     total: '220.00',
 }),
 ]});

--- a/addons/website_sale/static/src/interactions/checkout.js
+++ b/addons/website_sale/static/src/interactions/checkout.js
@@ -5,6 +5,8 @@ import { rpc } from '@web/core/network/rpc';
 import {
     LocationSelectorDialog
 } from '@delivery/js/location_selector/location_selector_dialog/location_selector_dialog';
+import { setElementContent } from '@web/core/utils/html';
+import { markup } from '@odoo/owl';
 
 export class Checkout extends Interaction {
     static selector = '#shop_checkout';
@@ -381,10 +383,10 @@ export class Checkout extends Interaction {
             amountDelivery.querySelector('span[name="o_message_no_dm_set"]')?.classList.add('d-none');
             amountDelivery.classList.remove('d-none');
         }
-
         amountDelivery.innerHTML = result.amount_delivery;
-        amountUntaxed.innerHTML = result.amount_untaxed;
-
+        if (amountUntaxed) {
+            setElementContent(amountUntaxed, markup(result.amount_untaxed));
+        }
         amountTax.outerHTML = result.amount_tax_lines;
         amountTotal.forEach(total => total.innerHTML = result.amount_total);
     }

--- a/addons/website_sale/static/tests/tours/combo_configurator.js
+++ b/addons/website_sale/static/tests/tours/combo_configurator.js
@@ -44,10 +44,6 @@ registry
                 content: "Verify the combo product's price (tax included)",
                 trigger: 'h6[name=website_sale_cart_line_price]:contains(106.95)',
             },
-            {
-                content: "Verify the order's total price",
-                trigger: 'tr[name="o_order_total_untaxed"]:contains(93.00)',
-            },
             // Assert that the combo quantity can be updated in the cart.
             {
                 content: "Edit the combo quantity",

--- a/addons/website_sale/static/tests/tours/complete_flow.js
+++ b/addons/website_sale/static/tests/tours/complete_flow.js
@@ -208,7 +208,6 @@ registry.category("web_tour.tours").add('website_sale.complete_flow_1', {
         }),
         ...tourUtils.assertCartAmounts({
             taxes: "23.70",
-            untaxed: "158.00",
             total: "181.70",
         }),
         tourUtils.goToCheckout(),

--- a/addons/website_sale/templates/checkout/checkout_templates.xml
+++ b/addons/website_sale/templates/checkout/checkout_templates.xml
@@ -55,7 +55,6 @@
                                    name="csrf_token"
                                    t-att-value="request.csrf_token()"/>
                             <t t-if="not hide_payment_button" t-call="payment.submit_button"/>
-
                         </form>
                     </div>
                     <t t-elif="not hide_payment_button" t-call="payment.submit_button"/>
@@ -412,7 +411,11 @@
             t-if="website_sale_order and website_sale_order.website_order_line"
             t-attf-class="o_cart_total #{_cart_total_classes}"
         >
-            <table class="table mb-0">
+            <t
+                t-set="tax_included"
+                t-value="website_sale_order.website_id.show_line_subtotals_tax_selection == 'tax_included'"
+            />
+            <table name="cart_total_table" class="table mb-0">
                 <tr
                     t-if="website_sale_order._has_deliverable_products()"
                     name="o_order_delivery"
@@ -436,28 +439,44 @@
                         />
                     </td>
                 </tr>
-                <tr name="o_order_total_untaxed">
+                <!-- Tax excluded view -->
+                <tr
+                    t-if="not tax_included"
+                    name="o_order_total_untaxed"
+                >
                     <td
-                        class="border-0 pb-2 ps-0 pt-0 text-start text-muted"
-                        colspan="2">
+                        class="border-0 pb-2 ps-0 pt-0 text-muted"
+                        colspan="2"
+                    >
                         Subtotal
                     </td>
                     <td class="text-end border-0 pb-2 pe-0 pt-0">
-                        <span t-field="website_sale_order.amount_untaxed"
-                              class="monetary_field"
-                              style="white-space: nowrap;"
-                              t-options="{'widget': 'monetary', 'display_currency': website_sale_order.currency_id}"/>
+                        <span
+                            t-field="website_sale_order.amount_untaxed"
+                            class="monetary_field"
+                            t-options="{'widget': 'monetary', 'display_currency': website_sale_order.currency_id}"
+                        />
                     </td>
                 </tr>
-                <t t-call="website_sale.order_tax_lines"/>
+                <t t-if="not tax_included" t-call="website_sale.order_tax_lines"/>
+                <!-- Total -->
                 <tr name="o_order_total" class="border-top">
-                    <td colspan="2" class="border-0 ps-0 pt-2"><strong>Total</strong></td>
-                    <td class="text-end border-0 px-0 pt-2">
-                        <strong t-field="website_sale_order.amount_total"
-                                class="monetary_field text-end p-0"
-                                t-options="{'widget': 'monetary', 'display_currency': website_sale_order.currency_id}"/>
+                    <td
+                        colspan="2"
+                        t-attf-class="border-0 ps-0 pt-2 #{'pb-1' if tax_included else 'pb-2'}"
+                    >
+                        <strong>Total</strong>
+                    </td>
+                    <td t-attf-class="text-end border-0 px-0 pt-2 #{'pb-1' if tax_included else 'pb-2'}">
+                        <strong
+                            t-field="website_sale_order.amount_total"
+                            class="monetary_field"
+                            t-options="{'widget': 'monetary', 'display_currency': website_sale_order.currency_id}"
+                        />
                     </td>
                 </tr>
+                <!-- Tax included view -->
+                <t t-if="tax_included" t-call="website_sale.order_tax_lines"/>
             </table>
         </div>
     </template>
@@ -469,7 +488,7 @@
             - redirect: The route to redirect to when a customer enters a coupon; default: `None`.
             - website_sale_order: The current order.
         -->
-        <xpath expr="//div[contains(@t-attf-class, 'o_cart_total')]//table/tr[last()]" position="after">
+        <table name="cart_total_table" position="inside">
             <tr t-if="not hide_promotions">
                 <td colspan="3" class="text-end text-xl-end border-0 p-0">
                 <span>
@@ -480,25 +499,52 @@
                 </span>
                 </td>
             </tr>
-        </xpath>
+        </table>
     </template>
 
     <template id="order_tax_lines">
         <tbody id="order_tax_lines_container">
+            <t
+                t-set="tax_included"
+                t-value="website_sale_order.website_id.show_line_subtotals_tax_selection == 'tax_included'"
+            />
             <t t-if="website_sale_order.tax_totals and website_sale_order.tax_totals['subtotals']">
                 <t t-foreach="website_sale_order.tax_totals['subtotals']" t-as="line">
                     <t t-foreach="line['tax_groups']" t-as="tax_line">
                         <tr name="o_order_total_taxes">
-                            <td colspan="2" class="text-muted border-0 p-0 pe-3 pb-2">
-                                <t t-out="tax_line['group_name']"/>
+                            <!-- Tax included view -->
+                            <td
+                                t-if="tax_included"
+                                class="border-0 p-0 pb-2 small"
+                                colspan="3"
+                            >
+                                <p class="text-muted mb-0">
+                                    Including
+                                    <span
+                                        t-out="tax_line['tax_amount_currency']"
+                                        class="monetary_field"
+                                        t-options="{'widget': 'monetary', 'display_currency': website_sale_order.currency_id}"
+                                    />
+                                    <t t-out="tax_line['group_name']"/>
+                                </p>
                             </td>
-                            <td class="text-end border-0 p-0 ps-3 pb-2">
-                                <span t-out="tax_line['tax_amount_currency']"
+                            <!-- Tax excluded view -->
+                            <t t-else="">
+                                <td
+                                    class="text-muted border-0 p-0 pe-3 pb-2"
+                                    colspan="2"
+                                >
+                                    <t t-out="tax_line['group_name']"/>
+                                </td>
+                                <td class="text-end border-0 p-0 ps-3 pb-2">
+                                    <span
+                                        t-out="tax_line['tax_amount_currency']"
                                         class="monetary_field"
                                         style="white-space: nowrap;"
                                         t-options="{'widget': 'monetary', 'display_currency': website_sale_order.currency_id}"
-                                />
-                            </td>
+                                    />
+                                </td>
+                            </t>
                         </tr>
                     </t>
                 </t>

--- a/addons/website_sale_loyalty/views/website_sale_templates.xml
+++ b/addons/website_sale_loyalty/views/website_sale_templates.xml
@@ -12,7 +12,7 @@
         inherit_id="website_sale.total"
         name="Loyalty, coupon, gift card"
     >
-        <xpath expr="//div[contains(@t-attf-class, 'o_cart_total')]//table/tr[last()]" position="after">
+        <table name="cart_total_table" position="inside">
             <tr t-if="not hide_promotions" class="oe_website_sale_gift_card">
                 <td colspan="3" class="text-center text-xl-end border-0 p-0">
                     <span class=''>
@@ -153,7 +153,7 @@
                     </span>
                 </td>
             </tr>
-        </xpath>
+        </table>
     </template>
 
     <template id="website_sale_loyalty.layout" inherit_id="website.layout">


### PR DESCRIPTION
When prices are tax-included, the cart summary was hard to understand as Subtotal, Taxes, and Total were all displayed together, causing confusing information for the customer.

Before the commit:
Subtotal, Taxes, and Total were shown even when prices were tax-included, making it unclear how the final amount was calculated.

After the commit:
When tax-included pricing is enabled:
- Subtotal row will be hidden.
- Tax groups will be displayed after the total.

When tax-excluded pricing is enabled:
- Subtotal and Taxes will be displayed as it is currently.

This aligns the cart summary with common eCommerce UX patterns and improves clarity for customers.

task-5887432

See also : https://github.com/odoo/enterprise/pull/111711