### PR TITLE
[FIX] website: single scroll slide in dynamic snippet carousel

### DIFF
--- a/addons/website/static/src/snippets/s_dynamic_snippet_carousel/dynamic_snippet_carousel.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet_carousel/dynamic_snippet_carousel.js
@@ -12,10 +12,13 @@ export class DynamicSnippetCarousel extends DynamicSnippet {
     }
 
     getQWebRenderOptions() {
-        const scrollMode = this.el.classList.contains('o_carousel_multi_items') ? 'single' : 'all';
-        return Object.assign(
-            super.getQWebRenderOptions(...arguments),
-            {
+        const renderOptions = super.getQWebRenderOptions(...arguments);
+        const isSingleScroll = this.el.classList.contains("o_carousel_multi_items");
+        const scrollMode =
+            isSingleScroll && renderOptions.data.length > renderOptions.chunkSize
+                ? "single"
+                : "all";
+        return Object.assign(renderOptions, {
                 interval: parseInt(this.el.dataset.carouselInterval),
                 rowPerSlide: parseInt(uiUtils.isSmall() ? 1 : this.el.dataset.rowPerSlide || 1),
                 arrowPosition: this.el.dataset.arrowPosition || "",

--- a/addons/website/static/tests/interactions/snippets/dynamic_snippet_carousel.test.js
+++ b/addons/website/static/tests/interactions/snippets/dynamic_snippet_carousel.test.js
@@ -32,6 +32,49 @@ beforeEach(() => {
 
 describe.current.tags("interaction_dev");
 
+const singleScrollTemplate = /* xml */ `
+    <div id="wrapwrap">
+        <section data-snippet="s_dynamic_snippet_carousel" class="s_dynamic_snippet_carousel s_dynamic o_carousel_multi_items pt32 pb32 o_colored_level" data-custom-template-data="{}" data-name="Dynamic Carousel"
+                data-filter-id="1"
+                data-template-key="website.dynamic_filter_template_test_item"
+                data-number-of-records="4"
+                data-carousel-interval="1000">
+            <div class="container">
+                <div class="row s_nb_column_fixed">
+                    <section class="s_dynamic_snippet_content oe_unremovable oe_unmovable o_not_editable col o_colored_level">
+                        <div class="css_non_editable_mode_hidden">
+                            <div class="missing_option_warning alert alert-info fade show d-none d-print-none rounded-0">
+                            Your Dynamic Snippet will be displayed here... This message is displayed because you did not provide both a filter and a template to use.
+                                <br/>
+                            </div>
+                        </div>
+                        <div class="dynamic_snippet_template"></div>
+                    </section>
+                </div>
+            </div>
+        </section>
+    </div>;
+`;
+
+test.tags("desktop");
+test("dynamic carousel snippet doesn't slide when number of records is less than chunksize", async () => {
+    onRpc("/website/snippet/filters", async () => [
+        `<div class="s_test_dynamic_carousel_single_item">Test Record 1</div>`,
+        `<div class="s_test_dynamic_carousel_single_item">Test Record 2</div>`,
+        `<div class="s_test_dynamic_carousel_single_item">Test Record 3</div>`,
+        `<div class="s_test_dynamic_carousel_single_item">Test Record 4</div>`,
+    ]);
+    await startInteractions(singleScrollTemplate);
+    expect(".carousel").not.toHaveClass("o_carousel_multi_items");
+    const carouselItemEls = queryAll(".carousel-item");
+    expect(carouselItemEls).toHaveLength(1);
+    expect(carouselItemEls[0]).toHaveClass("active");
+    const itemEls = queryAll(".carousel .s_test_dynamic_carousel_single_item");
+    expect(itemEls).toHaveLength(4);
+    expect(queryAll(".carousel-control-prev")).toHaveLength(0);
+    expect(queryAll(".carousel-control-next")).toHaveLength(0);
+});
+
 const testTemplate = /* xml */ `
     <div id="wrapwrap">
         <section data-snippet="s_dynamic_snippet_carousel" class="s_dynamic_snippet_carousel s_dynamic s_dynamic_empty pt32 pb32 o_colored_level" data-custom-template-data="{}" data-name="Dynamic Carousel"


### PR DESCRIPTION
Steps to reproduce:
1. Add a Dynamic Snippet Carousel(Products).
2. Set the number of records to 4.
3. Enable Single Scroll mode.

Issue:
When a dynamic snippet carousel is in single scroll mode
(`o_carousel_multi_items`) and the number of fetched items is less than
or equal to the visible slots per slide (`chunkSize`,
typically 4 on desktop), the carousel still slides one item at a time.

Cause:
When `scrollMode` is single, the QWeb template generates each data item
in its own `carousel-item` div. So with 3 products and 4 visible slots,
we got 3 separate slides(this is the usual behavior of single scroll
mode). But due to this bootstrap would slide between them one by one.

Fix:
If the number of fetched records is less than or equal to the number of
elements per slide (chunkSize), use "all" scroll mode so that all items
are grouped in a single slide instead of being split into individual
carousel-items (which would cause unwanted sliding).