### PR TITLE
Saas 18.4 fix images loco

### DIFF
--- a/addons/html_builder/static/src/plugins/image/image_filter_option.js
+++ b/addons/html_builder/static/src/plugins/image/image_filter_option.js
@@ -1,6 +1,7 @@
 import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
-import { shouldPreventGifTransformation } from "@html_editor/main/media/image_post_process_plugin";
-import { loadImageInfo, isWebGLEnabled } from "@html_editor/utils/image_processing";
+import { getMimetypeBeforeShape } from "@html_builder/utils/image";
+import { isImageSupportedForProcessing } from "@html_editor/main/media/image_post_process_plugin";
+import { isWebGLEnabled } from "@html_editor/utils/image_processing";
 import { _t } from "@web/core/l10n/translation";
 
 export class ImageFilterOption extends BaseOptionComponent {
@@ -14,14 +15,12 @@ export class ImageFilterOption extends BaseOptionComponent {
     setup() {
         super.setup();
         this.state = useDomState(async (editingElement) => {
-            const data = await loadImageInfo(editingElement).then((data) => ({
-                ...editingElement.dataset,
-                ...data,
-            }));
             const canUseGlFilter = isWebGLEnabled();
+            const mimetype = await getMimetypeBeforeShape(editingElement);
+            const showFilter = await isImageSupportedForProcessing(editingElement, mimetype);
             return {
                 isCustomFilter: editingElement.dataset.glFilter === "custom",
-                showFilter: data.mimetypeBeforeConversion && !shouldPreventGifTransformation(data),
+                showFilter,
                 disableFilter: !canUseGlFilter,
                 tooltip: !canUseGlFilter ? _t("WebGL is not enabled on your browser.") : undefined,
             };

--- a/addons/html_builder/static/src/plugins/image/image_format_option.js
+++ b/addons/html_builder/static/src/plugins/image/image_format_option.js
@@ -1,5 +1,7 @@
 import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
-import { getImageSrc, getFetchedMimetype } from "@html_editor/utils/image";
+import { getMimetypeBeforeShape } from "@html_builder/utils/image";
+import { isImageSupportedForProcessing } from "@html_editor/main/media/image_post_process_plugin";
+import { getImageSrc } from "@html_editor/utils/image";
 import { clamp } from "@web/core/utils/numbers";
 
 export class ImageFormatOption extends BaseOptionComponent {
@@ -22,15 +24,14 @@ export class ImageFormatOption extends BaseOptionComponent {
                 this.computeMaxDisplayWidth.bind(this)
             );
             const hasSrc = !!getImageSrc(editingElement);
-            const mimetype =
-                editingElement.dataset.formatMimetype ||
-                editingElement.dataset.mimetypeBeforeConversion ||
-                (await getFetchedMimetype(editingElement));
+            const mimetype = await getMimetypeBeforeShape(editingElement);
             const compressionUnsupported =
                 mimetype === "image/webp" && this.webpCompressionUnuspported();
+            const showFormat = await isImageSupportedForProcessing(editingElement, mimetype);
             return {
                 showQuality: ["image/jpeg", "image/webp"].includes(mimetype),
                 compressionUnsupported: compressionUnsupported,
+                showFormat,
                 formats: hasSrc ? formats : [],
             };
         });

--- a/addons/html_builder/static/src/plugins/image/image_format_option.js
+++ b/addons/html_builder/static/src/plugins/image/image_format_option.js
@@ -1,5 +1,5 @@
 import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
-import { getImageSrc, getMimetype } from "@html_editor/utils/image";
+import { getImageSrc, getFetchedMimetype } from "@html_editor/utils/image";
 import { clamp } from "@web/core/utils/numbers";
 
 export class ImageFormatOption extends BaseOptionComponent {
@@ -25,7 +25,7 @@ export class ImageFormatOption extends BaseOptionComponent {
             const mimetype =
                 editingElement.dataset.formatMimetype ||
                 editingElement.dataset.mimetypeBeforeConversion ||
-                getMimetype(editingElement);
+                (await getFetchedMimetype(editingElement));
             const compressionUnsupported =
                 mimetype === "image/webp" && this.webpCompressionUnuspported();
             return {

--- a/addons/html_builder/static/src/plugins/image/image_format_option.xml
+++ b/addons/html_builder/static/src/plugins/image/image_format_option.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="html_builder.ImageFormat">
-    <BuilderRow label.translate="Format" level="this.props.level">
+    <BuilderRow label.translate="Format" level="this.props.level" t-if="this.state.showFormat">
         <BuilderSelect>
             <t t-foreach="state.formats" t-as="format" t-key="format.id">
                 <BuilderSelectItem className="'o_we_badge_at_end'" action="'setImageFormat'" actionParam="format">

--- a/addons/html_builder/static/src/plugins/image/image_shape_option.js
+++ b/addons/html_builder/static/src/plugins/image/image_shape_option.js
@@ -3,6 +3,7 @@ import { toRatio } from "@html_builder/utils/utils";
 import { _t } from "@web/core/l10n/translation";
 import { ShapeSelector } from "@html_builder/plugins/shape/shape_selector";
 import { deepCopy } from "@web/core/utils/objects";
+import { loadImageInfo } from "@html_editor/utils/image_processing";
 
 export class ImageShapeOption extends BaseOptionComponent {
     static template = "html_builder.ImageShapeOption";
@@ -18,7 +19,10 @@ export class ImageShapeOption extends BaseOptionComponent {
         this.customizeTabPlugin = this.dependencies.customizeTab;
         this.imageShapeOption = this.dependencies.imageShapeOption;
         this.toRatio = toRatio;
-        this.state = useDomState((editingElement) => {
+        this.state = useDomState(async (editingElement) => {
+            const { originalSrc } = editingElement.dataset.originalSrc
+                ? editingElement.dataset
+                : await loadImageInfo(editingElement);
             const shape = editingElement.dataset.shape;
             return {
                 hasShape: !!shape && !this.imageShapeOption.isTechnicalShape(shape),
@@ -34,6 +38,7 @@ export class ImageShapeOption extends BaseOptionComponent {
                 hasShapeTransformation:
                     !!editingElement.dataset.shapeFlip ||
                     !!parseInt(editingElement.dataset.shapeRotate),
+                isShapeSupported: !!originalSrc,
             };
         });
     }

--- a/addons/html_builder/static/src/plugins/image/image_shape_option.js
+++ b/addons/html_builder/static/src/plugins/image/image_shape_option.js
@@ -4,6 +4,8 @@ import { _t } from "@web/core/l10n/translation";
 import { ShapeSelector } from "@html_builder/plugins/shape/shape_selector";
 import { deepCopy } from "@web/core/utils/objects";
 import { loadImageInfo } from "@html_editor/utils/image_processing";
+import { isImageSupportedForProcessing } from "@html_editor/main/media/image_post_process_plugin";
+import { getMimetypeBeforeShape } from "@html_builder/utils/image";
 
 export class ImageShapeOption extends BaseOptionComponent {
     static template = "html_builder.ImageShapeOption";
@@ -24,6 +26,11 @@ export class ImageShapeOption extends BaseOptionComponent {
                 ? editingElement.dataset
                 : await loadImageInfo(editingElement);
             const shape = editingElement.dataset.shape;
+            const mimetype = await getMimetypeBeforeShape(editingElement);
+            const isImgSupportedForProcessing = await isImageSupportedForProcessing(
+                editingElement,
+                mimetype
+            );
             return {
                 hasShape: !!shape && !this.imageShapeOption.isTechnicalShape(shape),
                 shapeLabel: this.imageShapeOption.getShapeLabel(shape),
@@ -34,7 +41,9 @@ export class ImageShapeOption extends BaseOptionComponent {
                 showImageShape4: this.isShapeVisible(editingElement, 4),
                 showImageShapeTransform: this.imageShapeOption.isTransformableShape(shape),
                 showImageShapeAnimation: this.imageShapeOption.isAnimableShape(shape),
-                togglableRatio: this.imageShapeOption.isTogglableRatioShape(shape),
+                togglableRatio:
+                    this.imageShapeOption.isTogglableRatioShape(shape) &&
+                    isImgSupportedForProcessing,
                 hasShapeTransformation:
                     !!editingElement.dataset.shapeFlip ||
                     !!parseInt(editingElement.dataset.shapeRotate),

--- a/addons/html_builder/static/src/plugins/image/image_shape_option.xml
+++ b/addons/html_builder/static/src/plugins/image/image_shape_option.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="html_builder.ImageShapeOption">
-    <BuilderRow label.translate="Shape">
+    <BuilderRow label.translate="Shape" t-if="this.state.isShapeSupported">
         <div class="btn-group o-hb-button-group">
             <div
                 class="o-hb-btn btn btn-secondary o-dropdown dropdown-toggle dropdown"

--- a/addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js
@@ -18,7 +18,7 @@ import {
 } from "@html_editor/main/media/image_post_process_plugin";
 import { _t } from "@web/core/l10n/translation";
 import { BuilderAction } from "@html_builder/core/builder_action";
-import { getMimetype } from "@html_editor/utils/image";
+import { getFetchedMimetype, getMimetype } from "@html_editor/utils/image";
 
 /**
  * @typedef {((dataset: DOMStringMap) => string)[]} default_shape_handlers
@@ -86,11 +86,12 @@ export class ImageShapeOptionPlugin extends Plugin {
     }
     async canHaveHoverEffect(imgEl) {
         const dataset = Object.assign({}, imgEl.dataset, await loadImageInfo(imgEl));
+        const isImageSupportedForShapes = await this.asyncIsImageSupportedForShapes(imgEl, dataset);
         return (
             imgEl.tagName === "IMG" &&
             !this.isDeviceShape(imgEl) &&
             !this.isAnimableShape(dataset.shape) &&
-            this.isImageSupportedForShapes(imgEl, dataset)
+            isImageSupportedForShapes
         );
     }
     isDeviceShape(img) {
@@ -110,6 +111,17 @@ export class ImageShapeOptionPlugin extends Plugin {
             return false;
         }
         return isImageSupportedForProcessing(getMimetype(img, dataset));
+    }
+    // TODO: this has been introduced for stable policy. In master, remove it
+    // and adapt 'isImageSupportedForShapes'.
+    async asyncIsImageSupportedForShapes(img, dataset = img.dataset) {
+        if (!!dataset.hoverEffect || !!dataset.shape) {
+            return true;
+        }
+        if (!dataset.originalId) {
+            return false;
+        }
+        return isImageSupportedForProcessing(await getFetchedMimetype(img, dataset));
     }
     async getShapeSvgText(shapeName) {
         // Compatibility with old shapes.

--- a/addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_shape_option_plugin.js
@@ -19,6 +19,8 @@ import {
 import { _t } from "@web/core/l10n/translation";
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { getFetchedMimetype, getMimetype } from "@html_editor/utils/image";
+import { withSequence } from "@html_editor/utils/resource";
+import { handleImagesIfDataset } from "@html_builder/utils/image";
 
 /**
  * @typedef {((dataset: DOMStringMap) => string)[]} default_shape_handlers
@@ -74,6 +76,7 @@ export class ImageShapeOptionPlugin extends Plugin {
         process_image_warmup_handlers: this.processImageWarmup.bind(this),
         process_image_post_handlers: this.processImagePost.bind(this),
         hover_effect_allowed_predicates: (el) => this.canHaveHoverEffect(el),
+        on_media_dialog_saved_handlers: withSequence(5, this.onMediaDialogSavedHandlers.bind(this)),
     };
     setup() {
         this.shapeSvgTextCache = {};
@@ -83,6 +86,21 @@ export class ImageShapeOptionPlugin extends Plugin {
             const oldShapeId = shapeId.replace("html_builder", "web_editor");
             this.imageShapes[oldShapeId] = this.imageShapes[shapeId];
         }
+    }
+    async onMediaDialogSavedHandlers(elements, { node }) {
+        const callback = async function (toProcessEl, nodeEl) {
+            const data = await loadImageInfo(toProcessEl);
+            if (!data.originalSrc) {
+                return;
+            }
+            toProcessEl.dataset.shape = nodeEl.dataset.shape;
+            for (const shapeInfo of ["shapeColors", "shapeFlip", "shapeRotate"]) {
+                if (nodeEl.dataset[shapeInfo]) {
+                    toProcessEl.dataset[shapeInfo] = nodeEl.dataset[shapeInfo];
+                }
+            }
+        };
+        await handleImagesIfDataset(elements, node, "shape", callback);
     }
     async canHaveHoverEffect(imgEl) {
         const dataset = Object.assign({}, imgEl.dataset, await loadImageInfo(imgEl));

--- a/addons/html_builder/static/src/plugins/image/image_size.js
+++ b/addons/html_builder/static/src/plugins/image/image_size.js
@@ -1,5 +1,5 @@
 import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
-import { getImageSrc } from "@html_editor/utils/image";
+import { getImageSrc, isImageCorsProtected } from "@html_editor/utils/image";
 import { getDataURLBinarySize } from "@html_editor/utils/image_processing";
 
 const imageCacheSize = new Map();
@@ -26,6 +26,9 @@ export class ImageSize extends BaseOptionComponent {
             if (imageCacheSize.has(src)) {
                 size = imageCacheSize.get(src);
             } else {
+                if (await isImageCorsProtected(el)) {
+                    return;
+                }
                 size = await this.imagePostProcess.getProcessedImageSize(el);
                 imageCacheSize.set(src, size);
             }

--- a/addons/html_builder/static/src/plugins/image/image_tool_option.js
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option.js
@@ -4,6 +4,8 @@ import { ImageFilterOption } from "@html_builder/plugins/image/image_filter_opti
 import { ImageFormatOption } from "@html_builder/plugins/image/image_format_option";
 import { ImageTransformOption } from "./image_transform_option";
 import { dynamicSVGSelector } from "../utils";
+import { getMimetypeBeforeShape } from "@html_builder/utils/image";
+import { isImageSupportedForProcessing } from "@html_editor/main/media/image_post_process_plugin";
 
 export class ImageToolOption extends BaseOptionComponent {
     static template = "html_builder.ImageToolOption";
@@ -18,10 +20,15 @@ export class ImageToolOption extends BaseOptionComponent {
     static name = "imageToolOption";
     setup() {
         super.setup();
-        this.state = useDomState((editingElement) => ({
-            isImageAnimated: editingElement.classList.contains("o_animate"),
-            isDynamicSVG: editingElement.matches(dynamicSVGSelector),
-            isImageBinaryField: editingElement.parentElement.matches("[data-oe-type=image]"),
-        }));
+        this.state = useDomState(async (editingElement) => {
+            const mimetype = await getMimetypeBeforeShape(editingElement);
+            const showCropTool = await isImageSupportedForProcessing(editingElement, mimetype);
+            return {
+                isImageAnimated: editingElement.classList.contains("o_animate"),
+                isDynamicSVG: editingElement.matches(dynamicSVGSelector),
+                isImageBinaryField: editingElement.parentElement.matches("[data-oe-type=image]"),
+                showCropTool,
+            };
+        });
     }
 }

--- a/addons/html_builder/static/src/plugins/image/image_tool_option.xml
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option.xml
@@ -19,8 +19,8 @@
             placeholder.translate="Title tag" />
     </BuilderRow>
     <BuilderRow label.translate="Transform" preview="false">
-        <BuilderButton title.translate="Crop image" action="'cropImage'" icon="'fa-crop'" id="'cropImage'" />
-        <BuilderButton title.translate="Reset crop" action="'resetCrop'" t-if="this.isActiveItem('cropImage')">Reset</BuilderButton>
+        <BuilderButton t-if="state.showCropTool" title.translate="Crop image" action="'cropImage'" icon="'fa-crop'" id="'cropImage'" />
+        <BuilderButton title.translate="Reset crop" action="'resetCrop'" t-if="this.state.showCropTool and this.isActiveItem('cropImage')">Reset</BuilderButton>
         <ImageTransformOption t-if="!state.isImageAnimated and !state.isImageBinaryField" />
     </BuilderRow>
     <ImageFilterOption />

--- a/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/image/image_tool_option_plugin.js
@@ -1,8 +1,12 @@
-import { cropperDataFieldsWithAspectRatio, loadImage } from "@html_editor/utils/image_processing";
+import {
+    cropperDataFieldsWithAspectRatio,
+    loadImage,
+    loadImageInfo,
+} from "@html_editor/utils/image_processing";
 import { registry } from "@web/core/registry";
 import { Plugin } from "@html_editor/plugin";
 import { ImageToolOption } from "./image_tool_option";
-import { isImageCorsProtected } from "@html_editor/utils/image";
+import { getFetchedMimetype, isImageCorsProtected } from "@html_editor/utils/image";
 import { withSequence } from "@html_editor/utils/resource";
 import {
     REPLACE_MEDIA,
@@ -17,6 +21,7 @@ import { selectElements } from "@html_editor/utils/dom_traversal";
 import { isCSSColor } from "@web/core/utils/colors";
 import { getCSSVariableValue, getHtmlStyle } from "@html_editor/utils/formatting";
 import { BaseOptionComponent } from "@html_builder/core/utils";
+import { isImageSupportedForProcessing } from "@html_editor/main/media/image_post_process_plugin";
 
 const IMAGE_LINK_ALIGN_CLASSES = ["mx-auto", "ms-auto", "me-auto"];
 
@@ -57,44 +62,31 @@ class ImageToolOptionPlugin extends Plugin {
         on_media_dialog_saved_handlers: async (elements, { node }) => {
             for (const image of elements) {
                 if (image && image.tagName === "IMG") {
+                    const imgInfo = await loadImageInfo(image);
+                    if (!imgInfo.originalSrc || !imgInfo.originalId) {
+                        return;
+                    }
+                    const isImgSupportedForProcessing = await isImageSupportedForProcessing(
+                        image,
+                        await getFetchedMimetype(image, imgInfo)
+                    );
+                    const newDataset = {};
+                    if (isImgSupportedForProcessing) {
+                        newDataset.formatMimetype = "image/webp";
+                        const original = await loadImage(imgInfo.originalSrc);
+                        const maxWidth = image.dataset.width
+                            ? image.naturalWidth
+                            : original.naturalWidth;
+                        const optimizedWidth = Math.min(
+                            maxWidth,
+                            computeMaxDisplayWidth(node || this.editable)
+                        );
+                        newDataset.resizeWidth = optimizedWidth;
+                    }
                     const updateImageAttributes =
                         await this.dependencies.imagePostProcess.processImage({
                             img: image,
-                            newDataset: {
-                                formatMimetype: "image/webp",
-                            },
-                            // TODO Using a callback is currently needed to avoid
-                            // the extra RPC that would occur if loadImageInfo was
-                            // called before processImage as well. This flow can be
-                            // simplified if image infos are somehow cached.
-                            onImageInfoLoaded: async (dataset) => {
-                                if (!dataset.originalSrc || !dataset.originalId) {
-                                    return true;
-                                }
-                                const original = await loadImage(dataset.originalSrc);
-                                const maxWidth = dataset.width
-                                    ? image.naturalWidth
-                                    : original.naturalWidth;
-                                const optimizedWidth = Math.min(
-                                    maxWidth,
-                                    computeMaxDisplayWidth(node || this.editable)
-                                );
-                                if (
-                                    !["image/gif", "image/svg+xml"].includes(
-                                        dataset.mimetypeBeforeConversion
-                                    )
-                                ) {
-                                    // Convert to recommended format and width.
-                                    dataset.resizeWidth = optimizedWidth;
-                                } else if (
-                                    dataset.shape &&
-                                    dataset.mimetypeBeforeConversion !== "image/gif"
-                                ) {
-                                    dataset.resizeWidth = optimizedWidth;
-                                } else {
-                                    return true;
-                                }
-                            },
+                            newDataset,
                         });
                     updateImageAttributes();
                 }

--- a/addons/html_builder/static/src/utils/image.js
+++ b/addons/html_builder/static/src/utils/image.js
@@ -1,0 +1,10 @@
+import { loadImageInfo } from "@html_editor/utils/image_processing";
+import { getFetchedMimetype } from "@html_editor/utils/image";
+
+export async function getMimetypeBeforeShape(imageEl) {
+    const data = imageEl.dataset;
+    const { formatMimetype, mimetypeBeforeConversion } = data.mimetypeBeforeConversion
+        ? data
+        : await loadImageInfo(imageEl);
+    return formatMimetype || mimetypeBeforeConversion || getFetchedMimetype(imageEl, data);
+}

--- a/addons/html_builder/static/src/utils/image.js
+++ b/addons/html_builder/static/src/utils/image.js
@@ -8,3 +8,23 @@ export async function getMimetypeBeforeShape(imageEl) {
         : await loadImageInfo(imageEl);
     return formatMimetype || mimetypeBeforeConversion || getFetchedMimetype(imageEl, data);
 }
+
+/**
+ * Executes a callback for each <img> element in a collection if the given node
+ * contains a specific data-* attribute.
+ * @param {Array<HTMLElement>} toProcessEls
+ * @param {HTMLElement} nodeEl
+ * @param {String} dataInfo
+ * @param {Function} callback
+ */
+export async function handleImagesIfDataset(toProcessEls, nodeEl, dataInfo, callback) {
+    if (!nodeEl || !nodeEl.dataset[dataInfo]) {
+        return;
+    }
+    for (const toProcessEl of toProcessEls) {
+        if (!toProcessEl || !toProcessEl.tagName === "IMG") {
+            continue;
+        }
+        await callback(toProcessEl, nodeEl);
+    }
+}

--- a/addons/html_builder/static/src/utils/utils_css.js
+++ b/addons/html_builder/static/src/utils/utils_css.js
@@ -357,6 +357,7 @@ export function forwardToThumbnail(imgEl) {
     }
 }
 
+// TODO: to remove in master (use the one of html_editor instead)
 /**
  * @param {HTMLImageElement} img
  * @returns {Promise<Boolean>}

--- a/addons/html_builder/static/tests/helpers.js
+++ b/addons/html_builder/static/tests/helpers.js
@@ -500,7 +500,7 @@ export async function confirmAddSnippet(snippetName) {
 }
 
 export const dummyBase64Img =
-    "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUA\n        AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO\n            9TXL0Y4OHwAAAABJRU5ErkJggg==";
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==";
 
 export const exampleContent = '<h1 class="title">Hello</h1>';
 

--- a/addons/html_builder/static/tests/helpers.js
+++ b/addons/html_builder/static/tests/helpers.js
@@ -17,6 +17,7 @@ import {
     defineModels,
     models,
     mountWithCleanup,
+    onRpc,
     patchWithCleanup,
     waitUntilIdle,
 } from "@web/../tests/web_test_helpers";
@@ -542,4 +543,18 @@ export async function editBuilderRangeValue(selector, newValue) {
     await delay();
     input.dispatchEvent(new Event("change"));
     await delay();
+}
+export const dummyCORSSrc = "/web/image/0-redirect/foo.jpg";
+
+export function setupCORSProtectedImg() {
+    onRpc("/html_editor/get_image_info", () => ({
+        original: {
+            id: 1,
+            image_src: dummyCORSSrc,
+            mimetype: "image/jpeg",
+        },
+    }));
+    onRpc(dummyCORSSrc, () => {
+        throw new Error("simulated cors error");
+    });
 }

--- a/addons/html_builder/static/tests/image.test.js
+++ b/addons/html_builder/static/tests/image.test.js
@@ -1,0 +1,27 @@
+import { expect, test, describe } from "@odoo/hoot";
+import { contains, dataURItoBlob, onRpc } from "@web/../tests/web_test_helpers";
+import { dummyBase64Img, setupHTMLBuilder } from "./helpers";
+
+describe.current.tags("desktop");
+
+test("Size should not be displayed on CORS protected images", async () => {
+    onRpc("/html_editor/get_image_info", () => ({
+        original: {
+            id: 1,
+            image_src: "/web/image/0-redirect/foo.jpg",
+            mimetype: "image/jpeg",
+        },
+    }));
+    onRpc("/web/image/0-redirect/foo.jpg", () => {
+        throw new Error("simulated cors error");
+    });
+    // The next line is needed in order to correctly run the test without the
+    // fix.
+    onRpc("/web/image/__odoo__unknown__src__/", () => dataURItoBlob(dummyBase64Img));
+    const { waitSidebarUpdated } = await setupHTMLBuilder(
+        `<img src='/web/image/0-redirect/foo.jpg'>`
+    );
+    await contains(":iframe img").click();
+    await waitSidebarUpdated();
+    expect(".o-hb-image-size-info").toHaveCount(0);
+});

--- a/addons/html_builder/static/tests/image.test.js
+++ b/addons/html_builder/static/tests/image.test.js
@@ -1,26 +1,15 @@
 import { expect, test, describe } from "@odoo/hoot";
 import { contains, dataURItoBlob, onRpc } from "@web/../tests/web_test_helpers";
-import { dummyBase64Img, setupHTMLBuilder } from "./helpers";
+import { dummyBase64Img, dummyCORSSrc, setupCORSProtectedImg, setupHTMLBuilder } from "./helpers";
 
 describe.current.tags("desktop");
 
 test("Size should not be displayed on CORS protected images", async () => {
-    onRpc("/html_editor/get_image_info", () => ({
-        original: {
-            id: 1,
-            image_src: "/web/image/0-redirect/foo.jpg",
-            mimetype: "image/jpeg",
-        },
-    }));
-    onRpc("/web/image/0-redirect/foo.jpg", () => {
-        throw new Error("simulated cors error");
-    });
+    setupCORSProtectedImg();
     // The next line is needed in order to correctly run the test without the
     // fix.
     onRpc("/web/image/__odoo__unknown__src__/", () => dataURItoBlob(dummyBase64Img));
-    const { waitSidebarUpdated } = await setupHTMLBuilder(
-        `<img src='/web/image/0-redirect/foo.jpg'>`
-    );
+    const { waitSidebarUpdated } = await setupHTMLBuilder(`<img src="${dummyCORSSrc}">`);
     await contains(":iframe img").click();
     await waitSidebarUpdated();
     expect(".o-hb-image-size-info").toHaveCount(0);

--- a/addons/html_builder/static/tests/image_field.test.js
+++ b/addons/html_builder/static/tests/image_field.test.js
@@ -19,6 +19,7 @@ test("replacing an image should display the image tool options", async () => {
     onRpc("/html_editor/get_image_info", () => ({
         original: {
             image_src: dummyBase64Img,
+            mimetype: "image/png",
         },
     }));
     onRpc("ir.attachment", "search_read", () => [

--- a/addons/html_editor/static/src/main/media/image_post_process_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_post_process_plugin.js
@@ -98,7 +98,9 @@ export class ImagePostProcessPlugin extends Plugin {
         const originalImg = await loadImage(data.originalSrc);
         const originalSrc = originalImg.getAttribute("src");
 
-        if (shouldPreventGifTransformation(data)) {
+        if (
+            !(await isImageSupportedForProcessing(img, formatMimetype || mimetypeBeforeConversion))
+        ) {
             const [postUrl, postDataset] = await this.postProcessImage(
                 await loadImageDataURL(originalSrc),
                 newDataset,
@@ -337,6 +339,13 @@ export const defaultImageFilterOptions = {
     brightness: "0",
     sepia: "0",
 };
+
+export async function isImageSupportedForProcessing(imgEl, originalImgMimetype) {
+    if (!["image/jpeg", "image/png", "image/webp"].includes(originalImgMimetype)) {
+        return false;
+    }
+    return !!(imgEl.dataset.originalSrc || (await loadImageInfo(imgEl)).originalSrc);
+}
 
 // webgl color filters
 const _applyAll = (result, filter, filters) => {

--- a/addons/html_editor/static/src/main/media/media_dialog/media_dialog.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/media_dialog.js
@@ -198,35 +198,6 @@ export class MediaDialog extends Component {
                 if (style) {
                     element.setAttribute("style", style);
                 }
-                if (this.state.activeTab === this.tabs.IMAGES.id) {
-                    if (this.props.media.dataset.shape) {
-                        element.dataset.shape = this.props.media.dataset.shape;
-                    }
-                    if (this.props.media.dataset.shapeColors) {
-                        element.dataset.shapeColors = this.props.media.dataset.shapeColors;
-                    }
-                    if (this.props.media.dataset.shapeFlip) {
-                        element.dataset.shapeFlip = this.props.media.dataset.shapeFlip;
-                    }
-                    if (this.props.media.dataset.shapeRotate) {
-                        element.dataset.shapeRotate = this.props.media.dataset.shapeRotate;
-                    }
-                    if (this.props.media.dataset.hoverEffect) {
-                        element.dataset.hoverEffect = this.props.media.dataset.hoverEffect;
-                    }
-                    if (this.props.media.dataset.hoverEffectColor) {
-                        element.dataset.hoverEffectColor =
-                            this.props.media.dataset.hoverEffectColor;
-                    }
-                    if (this.props.media.dataset.hoverEffectStrokeWidth) {
-                        element.dataset.hoverEffectStrokeWidth =
-                            this.props.media.dataset.hoverEffectStrokeWidth;
-                    }
-                    if (this.props.media.dataset.hoverEffectIntensity) {
-                        element.dataset.hoverEffectIntensity =
-                            this.props.media.dataset.hoverEffectIntensity;
-                    }
-                }
             }
             for (const otherTab of Object.keys(this.tabs).filter(
                 (key) => key !== this.state.activeTab

--- a/addons/html_editor/static/src/utils/image.js
+++ b/addons/html_editor/static/src/utils/image.js
@@ -1,4 +1,10 @@
+import { Cache } from "@web/core/utils/cache";
 import { isColorGradient } from "@web/core/utils/colors";
+
+const headResponseCache = new Cache(
+    async (src) => await fetch(src, { method: "HEAD" }),
+    JSON.stringify
+);
 
 /**
  * Extracts url and gradient parts from the background-image CSS property.
@@ -68,7 +74,8 @@ export async function isImageCorsProtected(img) {
         //    same database behind.
         // 2. A "attachment-url" which is just a redirect to the real image
         //    which could be hosted on another website.
-        isCorsProtected = await fetch(src, { method: "HEAD" })
+        isCorsProtected = await headResponseCache
+            .read(src)
             .then(() => false)
             .catch(() => true);
     }

--- a/addons/html_editor/static/src/utils/image.js
+++ b/addons/html_editor/static/src/utils/image.js
@@ -1,6 +1,16 @@
 import { Cache } from "@web/core/utils/cache";
 import { isColorGradient } from "@web/core/utils/colors";
 
+const SUPPORTED_MIMETYPES = [
+    "image/gif",
+    "image/jpe",
+    "image/jpeg",
+    "image/jpg",
+    "image/png",
+    "image/svg+xml",
+    "image/webp",
+];
+
 const headResponseCache = new Cache(
     async (src) => await fetch(src, { method: "HEAD" }),
     JSON.stringify
@@ -53,6 +63,37 @@ export function getMimetype(image, data = image.dataset) {
                 (src.endsWith(".jpeg") && "image/jpeg"))) ||
         null
     );
+}
+
+// TODO: in master, remove getFetchedMimetype and modify getMimetype
+/**
+ * @param {HTMLImageElement} image
+ * @param {Object} data
+ * @returns {string|null} The mimetype of the image.
+ */
+export async function getFetchedMimetype(image, data = image.dataset) {
+    const mimetypeOnData = data.mimetype || data.mimetypeBeforeConversion;
+    if (mimetypeOnData) {
+        return mimetypeOnData;
+    }
+    const src = getImageSrc(image);
+    try {
+        const response = await headResponseCache.read(src);
+        if (!response.ok) {
+            return null;
+        }
+        const contentType = response.headers.get("content-type");
+        if (!SUPPORTED_MIMETYPES.some((mimetype) => contentType.startsWith(mimetype))) {
+            return null;
+        }
+        if (contentType.startsWith("image/svg+xml")) {
+            return "image/svg+xml";
+        }
+        return contentType;
+    } catch {
+        // Typically a CORS image
+        return null;
+    }
 }
 
 /**

--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -1,4 +1,4 @@
-import { expect, test } from "@odoo/hoot";
+import { expect, mockFetch, test } from "@odoo/hoot";
 import {
     click,
     dblclick,
@@ -15,6 +15,7 @@ import { base64Img, setupEditor } from "./_helpers/editor";
 import { getContent, moveSelectionOutsideEditor, setContent } from "./_helpers/selection";
 import { insertText, undo } from "./_helpers/user_actions";
 import { expectElementCount } from "./_helpers/ui_expectations";
+import { getFetchedMimetype } from "@html_editor/utils/image";
 
 test("image can be selected", async () => {
     const { plugins } = await setupEditor(`
@@ -608,4 +609,17 @@ test("should select image on pointerdown", async () => {
     const selectedNode = selectionPlugin.getTargetedNodes()[0];
 
     expect(selectedNode.tagName).toBe("IMG");
+});
+
+test("Correctly determine the mimetype of an image with wrong extension", async () => {
+    const imgSrc = "/web/image/wrongExtension.jpeg";
+    mockFetch((url) => {
+        if (url === imgSrc) {
+            return new Response("", { headers: new Headers([["content-Type", "image/png"]]) });
+        }
+    });
+    const imageEl = document.createElement("img");
+    imageEl.setAttribute("src", imgSrc);
+    const mimetype = await getFetchedMimetype(imageEl);
+    expect(mimetype).toBe("image/png");
 });

--- a/addons/website/static/src/builder/plugins/options/animate_option.js
+++ b/addons/website/static/src/builder/plugins/options/animate_option.js
@@ -1,10 +1,6 @@
 import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
 import { isImageSupportedForStyle } from "@html_builder/plugins/image/replace_media_option";
 
-/**
- * @typedef {((el: HTMLElement) => Promise<boolean>)[]} hover_effect_allowed_predicates
- */
-
 export class AnimateOption extends BaseOptionComponent {
     static template = "website.AnimateOption";
     static dependencies = ["animateOption"];
@@ -77,9 +73,9 @@ export class AnimateOption extends BaseOptionComponent {
 
         return hasDirection;
     }
+    // This is done as a stable fix
+    // TODO: remove in master
     async canHaveHoverEffect(el) {
-        const proms = this.getResource("hover_effect_allowed_predicates").map((p) => p(el));
-        const settledProms = await Promise.all(proms);
-        return settledProms.length && settledProms.every(Boolean);
+        return this.dependencies.animateOption.canHaveHoverEffect(el);
     }
 }

--- a/addons/website/static/src/builder/plugins/options/animate_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/animate_option_plugin.js
@@ -11,6 +11,7 @@ import { ancestors, closestElement, findFurthest } from "@html_editor/utils/dom_
 import { childNodeIndex, DIRECTIONS, nodeSize } from "@html_editor/utils/position";
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { EmphasizeAnimatedText } from "./emphasize_animated_text";
+import { handleImagesIfDataset } from "@html_builder/utils/image";
 
 /**
  * @typedef { Object } AnimateOptionShared
@@ -24,6 +25,10 @@ import { EmphasizeAnimatedText } from "./emphasize_animated_text";
  * @typedef {((editingElement: HTMLElement) => Promise<void>)[]} set_hover_effect_handlers
  */
 
+/**
+ * @typedef {((el: HTMLElement) => Promise<boolean>)[]} hover_effect_allowed_predicates
+ */
+
 export class AnimateOptionPlugin extends Plugin {
     static id = "animateOption";
     static dependencies = ["history", "selection", "split"];
@@ -32,6 +37,7 @@ export class AnimateOptionPlugin extends Plugin {
         "getDirectionsItems",
         "getEffectsItems",
         "hasAnimationEffect",
+        "canHaveHoverEffect",
     ];
     /** @type {import("plugins").WebsiteResources} */
     resources = {
@@ -68,10 +74,37 @@ export class AnimateOptionPlugin extends Plugin {
                 ".o_animated_text"
             ),
         lower_panel_entries: withSequence(10, { Component: EmphasizeAnimatedText }),
+        on_media_dialog_saved_handlers: withSequence(5, this.onMediaDialogSavedHandlers.bind(this)),
     };
 
     setup() {
         this.scrollingElement = getScrollingElement(this.document);
+    }
+
+    async canHaveHoverEffect(el) {
+        const proms = this.getResource("hover_effect_allowed_predicates").map((p) => p(el));
+        const settledProms = await Promise.all(proms);
+        return settledProms.length && settledProms.every(Boolean);
+    }
+
+    async onMediaDialogSavedHandlers(elements, { node }) {
+        const callback = async (toProcessEl, nodeEl) => {
+            const canImgHaveHoverEffect = await this.canHaveHoverEffect(toProcessEl);
+            if (!canImgHaveHoverEffect) {
+                return;
+            }
+            toProcessEl.dataset.hoverEffect = nodeEl.dataset.hoverEffect;
+            for (const hoverEffectInfo of [
+                "hoverEffectColor",
+                "hoverEffectStrokeWidth",
+                "hoverEffectIntensity",
+            ]) {
+                if (nodeEl.dataset[hoverEffectInfo]) {
+                    toProcessEl.dataset[hoverEffectInfo] = nodeEl.dataset[hoverEffectInfo];
+                }
+            }
+        };
+        await handleImagesIfDataset(elements, node, "hoverEffect", callback);
     }
 
     getEffectsItems(isActiveItem) {

--- a/addons/website/static/tests/builder/image_shape.test.js
+++ b/addons/website/static/tests/builder/image_shape.test.js
@@ -2,7 +2,7 @@ import { describe, expect, test } from "@odoo/hoot";
 import { queryFirst, setInputRange } from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 import { defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
-import { testImg } from "./image_test_helpers";
+import { testImg, testSvgImg } from "./image_test_helpers";
 import { dummyCORSSrc, setupCORSProtectedImg } from "@html_builder/../tests/helpers";
 
 defineWebsiteModels();
@@ -53,12 +53,11 @@ test("Should set a shape on a GIF", async () => {
     >`;
 
     // Set up the website builder with the test GIF.
-    const { getEditor, waitSidebarUpdated } = await setupWebsiteBuilder(`
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`
         <div class="test-options-target">
             ${testGif}
         </div>
         `);
-    const editor = getEditor();
 
     // Click the GIF to activate the image options in the sidebar.
     await contains(":iframe .test-options-target img").click();
@@ -67,8 +66,7 @@ test("Should set a shape on a GIF", async () => {
     // Select and apply a shape.
     await contains("[data-label='Shape'] .dropdown").click();
     await contains("[data-action-value='html_builder/geometric/geo_shuriken']").click();
-    // Wait for the editor to process the change.
-    await editor.shared.operation.next(() => {});
+    await waitSidebarUpdated();
 
     const gif = queryFirst(":iframe .test-options-target img");
 
@@ -97,6 +95,10 @@ test("Should set a shape on a GIF", async () => {
         "data-shape",
         "html_builder/geometric/geo_shuriken"
     );
+
+    // 6. The stretch option should not be visible as it works with a canvas
+    // transformation that is not compatible with a gif.
+    expect("[data-action-id='toggleImageShapeRatio']").not.toHaveCount();
 });
 
 test("Should change the shape color of an image", async () => {
@@ -646,4 +648,26 @@ test("Don't display the shape option on image that do not have an original src",
     await contains(":iframe .test-options-target img").click();
     await waitSidebarUpdated();
     expect("[data-label='Shape']").toHaveCount(0);
+});
+
+test("Check that the stretch option does not appear when applying a shape on a svg image", async () => {
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(
+        `<div class="test-options-target">
+            ${testSvgImg}
+        </div>`,
+        {
+            loadIframeBundles: true,
+        }
+    );
+
+    // Select image and apply shape
+    await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
+
+    await contains("[data-label='Shape'] .dropdown").click();
+    await contains("[data-action-value='html_builder/geometric/geo_shuriken']").click();
+    await waitSidebarUpdated();
+    // The stretch option should not be visible as it works with a canvas
+    // transformation that is not compatible with a svg.
+    expect("[data-action-id='toggleImageShapeRatio']").not.toHaveCount();
 });

--- a/addons/website/static/tests/builder/image_shape.test.js
+++ b/addons/website/static/tests/builder/image_shape.test.js
@@ -3,6 +3,7 @@ import { queryFirst, setInputRange } from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 import { defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
 import { testImg } from "./image_test_helpers";
+import { dummyCORSSrc, setupCORSProtectedImg } from "@html_builder/../tests/helpers";
 
 defineWebsiteModels();
 
@@ -632,4 +633,17 @@ test("Should reset shape transformation with reset button and when switching sha
     expect(imgSelector).toHaveAttribute("data-shape", "html_builder/geometric/geo_shuriken");
     expect(imgSelector).not.toHaveAttribute("data-shape-flip");
     expect(imgSelector).not.toHaveAttribute("data-shape-rotate");
+});
+
+test("Don't display the shape option on image that do not have an original src", async () => {
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`
+        <div class="test-options-target">
+            <img src="${dummyCORSSrc}">
+        </div>
+    `);
+    setupCORSProtectedImg();
+
+    await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
+    expect("[data-label='Shape']").toHaveCount(0);
 });

--- a/addons/website/static/tests/builder/image_shape.test.js
+++ b/addons/website/static/tests/builder/image_shape.test.js
@@ -705,3 +705,30 @@ test("Replacing a shaped image by an svg should also apply the shape on the svg"
         "html_builder/geometric/geo_shuriken"
     );
 });
+
+test("Shape should not be applied on replaced CORS-protected image", async () => {
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(
+        `<div class="test-options-target">
+            <img src='${testSvgImgSrc}' data-mimetype="image/svg+xml" data-shape="html_builder/geometric/geo_shuriken" data-original-id="1665" data-original-src="/website/static/src/img/snippets_demo/s_text_image.jpg" data-mimetype-before-conversion="image/jpeg" data-shape-colors=";;;;" data-aspect-ratio="1/1" data-file-name="s_text_image.svg" data-attachment-id="1665">
+        </div>`
+    );
+    setupCORSProtectedImg();
+    onRpc("ir.attachment", "search_read", () => [
+        {
+            id: 1,
+            name: "logo",
+            mimetype: "image/jpeg",
+            image_src: dummyCORSSrc,
+            access_token: false,
+            public: true,
+        },
+    ]);
+    await contains(":iframe img").click();
+    await contains("[data-action-id=replaceMedia]").click();
+    await contains("img.o_we_attachment_highlight").click();
+    await waitSidebarUpdated();
+    const imgEl = queryFirst(":iframe .test-options-target img");
+    expect(imgEl).toHaveAttribute("src", dummyCORSSrc);
+    expect(imgEl).not.toHaveAttribute("data-shape");
+    expect(imgEl).not.toHaveAttribute("data-shape-colors");
+});

--- a/addons/website/static/tests/builder/image_shape.test.js
+++ b/addons/website/static/tests/builder/image_shape.test.js
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "@odoo/hoot";
 import { queryFirst, setInputRange } from "@odoo/hoot-dom";
-import { contains } from "@web/../tests/web_test_helpers";
+import { contains, onRpc } from "@web/../tests/web_test_helpers";
 import { defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
-import { testImg, testSvgImg } from "./image_test_helpers";
+import { testImg, testSvgImg, testSvgImgSrc } from "./image_test_helpers";
 import { dummyCORSSrc, setupCORSProtectedImg } from "@html_builder/../tests/helpers";
 
 defineWebsiteModels();
@@ -670,4 +670,38 @@ test("Check that the stretch option does not appear when applying a shape on a s
     // The stretch option should not be visible as it works with a canvas
     // transformation that is not compatible with a svg.
     expect("[data-action-id='toggleImageShapeRatio']").not.toHaveCount();
+});
+
+test("Replacing a shaped image by an svg should also apply the shape on the svg", async () => {
+    onRpc("ir.attachment", "search_read", () => [
+        {
+            id: 1,
+            name: "logo",
+            mimetype: "image/svg+xml",
+            image_src: testSvgImgSrc,
+            access_token: false,
+            public: true,
+        },
+    ]);
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(
+        `<div class="test-options-target">
+            ${testImg}
+        </div>`
+    );
+    await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
+
+    await contains("[data-label='Shape'] .dropdown").click();
+    await contains("[data-action-value='html_builder/geometric/geo_shuriken']").click();
+    await waitSidebarUpdated();
+
+    await contains("[data-action-id=replaceMedia]").click();
+    await contains("img.o_we_attachment_highlight").click();
+    await waitSidebarUpdated();
+    const imgEl = queryFirst(":iframe .test-options-target img");
+    expect(imgEl.src.startsWith("data:image/svg+xml;base64,")).toBe(true);
+    expect(`:iframe .test-options-target img`).toHaveAttribute(
+        "data-shape",
+        "html_builder/geometric/geo_shuriken"
+    );
 });

--- a/addons/website/static/tests/builder/image_test_helpers.js
+++ b/addons/website/static/tests/builder/image_test_helpers.js
@@ -26,33 +26,50 @@ export const testGifImg = `
     <img src='/web/image/456-test/test.gif'>
     `;
 
+export const testSvgImgSrc = "/web/image/457-test/test.svg";
+
+export const testSvgImg = `
+    <img src='${testSvgImgSrc}'>
+    `;
+
+const imageData = {
+    [testGifImgSrc]: {
+        attachment: {
+            id: 456,
+        },
+        original: {
+            id: 456,
+            image_src: "/website/static/src/img/snippets_options/header_effect_fade_out.gif",
+            mimetype: "image/gif",
+        },
+    },
+    [testSvgImgSrc]: {
+        attachment: {
+            id: 457,
+        },
+        original: {
+            id: 457,
+            image_src: "/website/static/src/img/website_logo.svg",
+            mimetype: "image/svg+xml",
+        },
+    },
+    default: {
+        attachment: {
+            id: 1,
+        },
+        original: {
+            id: 1,
+            image_src: "/website/static/src/img/snippets_demo/s_text_image.jpg",
+            mimetype: "image/jpeg",
+        },
+    },
+};
+
 export function mockImageRequests() {
     before(() => {
         onRpc("/html_editor/get_image_info", async (data) => {
             const { params } = await data.json();
-            if (params.src === testGifImgSrc) {
-                return {
-                    attachment: {
-                        id: 456,
-                    },
-                    original: {
-                        id: 456,
-                        image_src:
-                            "/website/static/src/img/snippets_options/header_effect_fade_out.gif",
-                        mimetype: "image/gif",
-                    },
-                };
-            }
-            return {
-                attachment: {
-                    id: 1,
-                },
-                original: {
-                    id: 1,
-                    image_src: "/website/static/src/img/snippets_demo/s_text_image.jpg",
-                    mimetype: "image/jpeg",
-                },
-            };
+            return imageData[params.src] || imageData.default;
         });
         onRpcImg("/html_builder/static/image_shapes/geometric/geo_shuriken.svg");
         onRpcImg("/html_builder/static/image_shapes/pattern/pattern_wave_4.svg");
@@ -63,5 +80,6 @@ export function mockImageRequests() {
         onRpcImg("/web/image/123/transparent.png");
         onRpcImg("/website/static/src/svg/hover_effects.svg");
         onRpcImg("/html_builder/static/image_shapes/geometric/geo_square.svg");
+        onRpcImg("/website/static/src/img/website_logo.svg");
     });
 }

--- a/addons/website/static/tests/builder/images.test.js
+++ b/addons/website/static/tests/builder/images.test.js
@@ -284,6 +284,63 @@ describe("Image format/optimize", () => {
 
         expect(img.dataset.quality).toBe("50");
     });
+    test("Quality option does not disappear when a shape is applied on the image", async () => {
+        onRpc("/html_editor/get_image_info", () => ({
+            attachment: { id: 1 },
+            original: {
+                id: 1,
+                image_src: "/website/static/src/img/snippets_demo/s_text_image.webp",
+                mimetype: "image/webp",
+            },
+        }));
+        // The first img corresponds to a default image on which a shape has
+        // been applied. The second one corresponds to a modified image on which
+        // a shape has been applied. The last one corresponds to a case where
+        // the mimetype information is not present (this case should not appear
+        // in practice but the system should be robust to this case as the
+        // backend has all the information needed to work correctly).
+        const { waitSidebarUpdated } = await setupWebsiteBuilder(`
+        <div class="test-options-target">
+            <img src='${dummyBase64Img}'
+                data-attachment-id="1" data-original-id="1"
+                data-original-src="/website/static/src/img/snippets_demo/s_text_image.webp"
+                data-mimetype="image/svg+xml"
+                data-shape="html_builder/devices/iphone_front_portrait"
+                data-mimetype-before-conversion="image/webp"
+                class="first"
+            >
+        </div>
+        <div class="test-options-target">
+            <img src='${dummyBase64Img}'
+                data-attachment-id="1" data-original-id="1"
+                data-original-src="/website/static/src/img/snippets_demo/s_text_image.webp"
+                data-mimetype="image/svg+xml"
+                data-shape="html_builder/devices/iphone_front_portrait"
+                data-mimetype-before-conversion="image/webp"
+                data-format-mimetype="image/webp"
+                class="second"
+            >
+        </div>
+        <div class="test-options-target">
+            <img src='${dummyBase64Img}'
+                data-attachment-id="1" data-original-id="1"
+                data-original-src="/website/static/src/img/snippets_demo/s_text_image.webp"
+                data-mimetype="image/svg+xml"
+                data-shape="html_builder/devices/iphone_front_portrait"
+                class="third"
+            >
+        </div>
+    `);
+        await contains(":iframe .test-options-target img.first").click();
+        await waitSidebarUpdated();
+        expect(`[data-action-id="setImageQuality"]`).toBeVisible();
+        await contains(":iframe .test-options-target img.second").click();
+        await waitSidebarUpdated();
+        expect(`[data-action-id="setImageQuality"]`).toBeVisible();
+        await contains(":iframe .test-options-target img.third").click();
+        await waitSidebarUpdated();
+        expect(`[data-action-id="setImageQuality"]`).toBeVisible();
+    });
 });
 
 test("Save image with correct parameter", async () => {

--- a/addons/website/static/tests/builder/images.test.js
+++ b/addons/website/static/tests/builder/images.test.js
@@ -20,7 +20,7 @@ import {
     setupWebsiteBuilderOeId,
 } from "./website_helpers";
 import { dummyBase64Img } from "@html_builder/../tests/helpers";
-import { testImg } from "./image_test_helpers";
+import { testGifImg, testImg, testSvgImg } from "./image_test_helpers";
 import { expectElementCount } from "@html_editor/../tests/_helpers/ui_expectations";
 
 defineWebsiteModels();
@@ -369,3 +369,25 @@ test("Save image with correct parameter", async () => {
     await contains(".o-snippets-top-actions button:contains(Save)").click();
     await expect.waitForSteps(["modify_image"]);
 });
+
+test("Correct options appear when clicking on a gif image", async () => {
+    await clickOnImgAndCheckOptions(testGifImg);
+});
+
+test("Correct options appear when clicking on a svg image", async () => {
+    await clickOnImgAndCheckOptions(testSvgImg);
+});
+
+async function clickOnImgAndCheckOptions(imgEl) {
+    const { waitSidebarUpdated } = await setupWebsiteBuilder(`
+        <div class="test-options-target">
+            ${imgEl}
+        </div>
+    `);
+    await contains(":iframe .test-options-target img").click();
+    await waitSidebarUpdated();
+    // Check that the options that need a canvas to work are not displayed
+    expect("[data-action-id='cropImage']").not.toHaveCount();
+    expect("[data-action-id='setImageFormat']").not.toHaveCount();
+    expect("[data-action-id='setImageQuality']").not.toHaveCount();
+}


### PR DESCRIPTION
[FIX] html_builder, *: hide the size of CORS-protected images
*: html_editor

Steps to reproduce:
- Add an image on the website.
- Replace it with a CORS-protected image.

-> The image options display a size, but it is incorrect.

The problem is that it is not the real size of the image but the size of
a default image (due to it, if you replace the image by another CORS
protected one, you'll see that the size of the image remains the same).
Indeed, the size of an image (in bytes) is computed from the length of
the raw b64 content of the image, on which a ratio of 3/4 is applied.
Because the image is CORS protected, we can not retrieve the raw b64 of
the image so the image size should not be displayed.
This commit hides the size of CORS protected image as it is impossible
to retrieve.

Note: example of a CORS protected image:
https://tinyjpg.com/images/social/website.jpg 

task-5405262

---------------------------------------------------------------------------------------------------------------------------------------------

[FIX] html_builder, *: correctly determine image mimetype
*: html_editor

The goal of this commit is to improve the way the mimetype of an image
is determined if the information is not in the DOM. Before this commit,
the system relied on the extension of the image source to determine its
mimetype. This is not really robust and it is easily trickable. For
example, in `html_editor`, if an image in a html field comes from an
attachment, its `src` attribute will end by the attachment name. If a
user changes the attachment name extension, the next time the image is
added on the DOM, the extension is changed but the mimetype of the image
is unchanged.
To solve the problem, the mimetype of the image is determined thanks to
the headers of the http request to the `src` of the image. That way, the
information comes from the server hosting the image.

task-5405262

---------------------------------------------------------------------------------------------------------------------------------------------

[FIX] html_builder, website: enable the quality change on shaped img

This commit improves [this one] by adding a test (this commit was
created before [this one] was merged).

[this one]: https://github.com/odoo/odoo/commit/738d5fb5ae2154e1f6993817fab5471d2d4384fa

task-5405262

---------------------------------------------------------------------------------------------------------------------------------------------

[FIX] html_builder, *: hide shape option for CORS-protected images
*: website

Steps to reproduce the problem:
- Add an image on the page.
- Replace the image by a CORS protected one.
- Try to apply a shape on the image.

-> Traceback

The goal of this commit is to hide the "Shape" option if the "original
image" of an image is not retrievable. Indeed, in this case, the option
will fail to apply correctly.

task-5405262

---------------------------------------------------------------------------------------------------------------------------------------------

[FIX] html_builder, *: avoid displaying options that are not compatible
*: html_editor, website

Few options like filter, quality, format and cropping rely on canvas to
work. The problem is that it does not work correctly for mimetypes like
`svg` or `gif`. Indeed, if an image modification is done on such images,
it will automatically be transformed into a `png` by default. To avoid
it, this commit hides the options that rely on a canvas manipulation
when clicking on a `svg` or `gif` image. The process image function has
also been adapted to not try to transform an image if its mimetype is
not compatible with a canvas transformation. Instead, those images are
directly transformed into `b64` images without any transformation.
Thanks to it, a shape can be applied on a `svg` or a `gif`.

task-5405262

---------------------------------------------------------------------------------------------------------------------------------------------

[FIX] html_builder, *: apply shape on replaced svg and gif images
*: website

Steps to reproduce the problem:
- Add a "Text-Image" snippet on the page and add a shape on the image.
- Replace the image by a svg or a gif.

-> A shape is displayed on the image options but the shape is not
applied on the image.

task-5405262

---------------------------------------------------------------------------------------------------------------------------------------------

[FIX] html_builder, *: avoid copying options on new incompatible images
*: html_editor, website

Steps to reproduce:
- Add an image on the website.
- Add a shape on the image.
- Replace the image by a CORS-protected one.

-> The image still has the shape data attributes on its HTML element
while it should not as it does not have the prerequisites to have a
shape (it does not have an original source). The same problem exists
with the hover effect.

This commit moves the logic that transfers the shape and hover effect on
replaced images from `html_editor` to the responsible plugins in
`html_builder` and `website`. It also adds a check to verify that the
replaced image is eligible to have a particular option before
transferring its data information.

task-5405262
