### PR TITLE
[IMP] hr_attendance: empty for now

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -80,6 +80,22 @@ class HrAttendance(models.Model):
     expected_hours = fields.Float(string="Theoretical Hours", compute="_compute_expected_hours", store=True, aggregator="sum")
     device_tracking_enabled = fields.Boolean(related="employee_id.company_id.attendance_device_tracking")
     linked_overtime_ids = fields.Many2many('hr.attendance.overtime.line', compute='_compute_linked_overtime_ids', readonly=False)
+    day_of_date = fields.Selection(
+        compute='_compute_day_of_date',
+        store=True,
+        string="Day",
+        index=True,
+        selection=[('0', "Monday"), ('1', "Tuesday"), ('2', "Wednesday"), ('3', "Thursday"), ('4', "Friday"), ('5', "Saturday"), ('6', "Sunday")],
+    )
+    resource_calendar_id = fields.Many2one(related='employee_id.resource_calendar_id', string="Working Schedule")
+
+    @api.depends('date')
+    def _compute_day_of_date(self):
+        for record in self:
+            if record.date:
+                record.day_of_date = str(record.date.weekday())
+            else:
+                record.day_of_date = False
 
     @api.depends("check_in", "employee_id")
     def _compute_date(self):

--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -103,6 +103,7 @@
                                     groups="hr_attendance.group_hr_attendance_user"/>
                                 <field name="check_in" options="{'rounding': 0}" readonly="not can_edit"/>
                                 <field name="check_out" options="{'rounding': 0}" placeholder="Currently Working" readonly="not can_edit"/>
+                                <field name="resource_calendar_id" groups="base.group_no_one"/>
                             </group>
                             <group col="2" name="group_worked_hours">
                                 <field name="worked_hours" string="Worked Time" widget="float_time"/>
@@ -288,6 +289,8 @@
                     string="Archived Employees"
                     name="archivedemployees"
                     domain="[('employee_id.active', '=', False)]"/>
+                <field name="day_of_date"/>
+                <field name="resource_calendar_id"/>
                 <separator invisible="1"/>
                 <filter string="Last 3 Months" invisible="1" name="last_three_months" domain="[('check_in','&gt;=', '-3m')]"/>
                 <group>


### PR DESCRIPTION
[IMP] hr_attendance: add time-based filters

1 - Day filter is added to attendance
2 - Working schedule is inserted to view of attendance record (appears in debug mode, default is hidden)
    2.1 - Working schedule is usable in the search

task - 5979296

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
