### PR TITLE
[IMP] web: Add this to dynamic templates

### DIFF
--- a/addons/web/static/src/core/utils/render.js
+++ b/addons/web/static/src/core/utils/render.js
@@ -51,7 +51,9 @@ Object.defineProperty(renderToString, "app", {
 function render(template, context = {}) {
     const app = renderToString.app;
     const templateFn = app.getTemplate(template);
-    const bdom = templateFn(context, {});
+    const ctx = Object.create(context);
+    ctx.this = context;
+    const bdom = templateFn(ctx, {});
     const div = document.createElement("div");
     blockDom.mount(bdom, div);
     return div;


### PR DESCRIPTION
As part of the OWL3 preparation phase, we have a task to add `.this` in front of all component variables in templates. To also follow the same syntax in dynamic (eg rederToMarkup ..) we patch the render context to also work with `this`

task - OWL3 premigration

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
