### PR TITLE
[FIX] website: allow manual file upload in website form

### DIFF
--- a/addons/website/models/website_form.py
+++ b/addons/website/models/website_form.py
@@ -56,6 +56,7 @@ class IrModel(models.Model):
         fields_get = model.fields_get(attributes=[
             'required', 'domain', 'readonly', 'type', 'relation',
             'definition_record', 'definition_record_field', 'string', 'selection',
+            'manual',
         ])
 
         for val in model._inherits.values():


### PR DESCRIPTION
Steps to reproduce:
===================
1. In CRM, use Studio to add a new File field to the lead form.
2. Go to website & Create a contact form that creates an opportunity
3. Add the studio field to the contact form created
4. Fill the form, upload the file and submit.

-> An error has occured, the form has not been sent.

Cause:
======
After this commit [1], `get_authorized_fields` calls `fields_get` with an explicit attributes list; 'manual' was not included in that list, so it was never returned, which causes the form submission to fail here:
https://github.com/odoo/odoo/blob/242afb9ca3a76e3628260ac81a9f5ddcd5d445dd/addons/website/controllers/form.py#L194

Solution:
=========
Add 'manual' to the attributes list in fields_get in website_form.py

[1]: https://github.com/odoo/odoo/commit/bfae7140d3951bec93fb7f2e49018649045edd40

opw-5933992

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
