### PR TITLE
[FIX] html_editor: traceback when clicking image during transformation

### DIFF
--- a/addons/html_editor/static/src/main/media/image_transformation.js
+++ b/addons/html_editor/static/src/main/media/image_transformation.js
@@ -227,7 +227,6 @@ export class ImageTransformation extends Component {
         if (this.transfo.active) {
             return;
         }
-        this.isCurrentlyTransforming = true;
         let type;
         const target = ev.target.closest("div");
 
@@ -251,6 +250,11 @@ export class ImageTransformation extends Component {
             type = "mr";
         }
 
+        // No transformation handle was clicked.
+        if (!type) {
+            return;
+        }
+        this.isCurrentlyTransforming = true;
         const { pageX, pageY } = this.normalizeCoordinates(ev);
         this.transfo.active = {
             type: type,


### PR DESCRIPTION
### Steps to Reproduce:

- Open the To-Do app.
- Insert an image (e.g. using /media).
- Select the image.
- Click on Image Transformation from the toolbar.
- Click directly on the image instead of a transformation handle.
- A traceback occurs.

### Purpose of this commit:

- Since [commit](https://github.com/odoo/odoo/commit/633267efef54bc6f88d2d6b5517e2dd56ec135f0#diff-7611cc3ab11e330827e96b643deb9605c42512e004f50b1ea12dded7ca6bd63e), the default transformation type value was removed. When clicking directly on the image (instead of a handle), a transformation state could still be created with an undefined type, which later caused a crash in mouseUp.

task-5998153

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
