### PR TITLE
[FIX] mrp{,_subcontracting}: group resupply pickings after PO confirm

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -641,8 +641,11 @@ class StockMove(models.Model):
 
     def _search_picking_for_assignation_domain(self):
         domain = super()._search_picking_for_assignation_domain()
-        domain += [('production_group_id', '=', self.production_group_id.id)]
+        domain += self._get_production_assignation_domain()
         return domain
+
+    def _get_production_assignation_domain(self):
+        return [('production_group_id', '=', self.production_group_id.id)]
 
     def action_open_reference(self):
         res = super().action_open_reference()

--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -299,3 +299,8 @@ class StockMove(models.Model):
             if route and self.rule_id.route_id == route:
                 return self.raw_material_production_id.subcontractor_id.id
         return super()._get_partner_id()
+
+    def _get_production_assignation_domain(self):
+        if self.move_dest_ids.raw_material_production_id.subcontractor_id:
+            return []
+        return super()._get_production_assignation_domain()

--- a/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
+++ b/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
@@ -43,6 +43,24 @@ class MrpSubcontractingPurchaseTest(TestAccountSubcontractingFlows):
             })],
         })
 
+        self.finished3, self.comp4 = self.env['product.product'].create([{
+            'name': 'Finished 3',
+            'is_storable': True,
+        }, {
+            'name': 'Component 4',
+            'type': 'consu',
+        }])
+
+        self.bom_finished3 = self.env['mrp.bom'].create({
+            'product_tmpl_id': self.finished3.product_tmpl_id.id,
+            'type': 'subcontract',
+            'subcontractor_ids': [(6, 0, self.subcontractor_partner1.ids)],
+            'bom_line_ids': [(0, 0, {
+                'product_id': self.comp4.id,
+                'product_qty': 1,
+            })],
+        })
+
     def test_bom_overview_availability(self):
         # Create routes for components and the main product
         self.comp2.bom_ids.unlink()
@@ -1026,3 +1044,46 @@ class MrpSubcontractingPurchaseTest(TestAccountSubcontractingFlows):
         po.action_create_invoice()
         invoice = po.invoice_ids
         self.assertTrue(invoice)
+
+    def test_subcontracted_products_single_resupply_picking(self):
+        """ Test that two subcontracted products in the same PO
+        result in ONE resupply picking to the subcontractor.
+
+        Additionally, adding a product after the PO is confirmed
+        should group its component with the existing resupply picking.
+        """
+
+        resupply_sub_on_order_route = self.env['stock.route'].search([('name', '=', 'Resupply Subcontractor on Order')])
+        (self.comp1 + self.comp2 + self.comp3 + self.comp4).write({'route_ids': [Command.link(resupply_sub_on_order_route.id)]})
+
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.subcontractor_partner1.id,
+            'order_line': [
+                Command.create({'product_id': self.finished.id}),
+                Command.create({'product_id': self.finished2.id}),
+            ],
+        })
+        purchase_order.button_confirm()
+
+        resupply_pickings = purchase_order._get_subcontracting_resupplies()
+
+        self.assertEqual(len(resupply_pickings), 1, "Should have grouped both products' components into one picking.")
+        self.assertRecordValues(resupply_pickings.move_ids, [
+            {'product_id': self.comp1.id, 'product_uom_qty': 1.0},
+            {'product_id': self.comp2.id, 'product_uom_qty': 1.0},
+            {'product_id': self.comp3.id, 'product_uom_qty': 1.0},
+        ])
+
+        purchase_order.write({
+            'order_line': [Command.create({'product_id': self.finished3.id})],
+        })
+
+        resupply_pickings = purchase_order._get_subcontracting_resupplies()
+
+        self.assertEqual(len(resupply_pickings), 1, "Should have grouped new product's component with the existing picking.")
+        self.assertRecordValues(resupply_pickings.move_ids, [
+            {'product_id': self.comp1.id, 'product_uom_qty': 1.0},
+            {'product_id': self.comp2.id, 'product_uom_qty': 1.0},
+            {'product_id': self.comp3.id, 'product_uom_qty': 1.0},
+            {'product_id': self.comp4.id, 'product_uom_qty': 1.0},
+        ])


### PR DESCRIPTION
Steps to reproduce:
1- Install Inventory, Purchase and Manufacturing
2- Enable 'multi-step routes' in the settings
3- Create Product A and create a Bill of Materials (BoM type: subcontracting,  Component A)
4- Repeat the same for Products [B,C] with components [B,C] correspondingly.
5- Assign the same subcontractor to all of them
6- Create a Purchase Order for both Product A and Product B with vendor as the subcontractor and confirm it
7- Add a new order line with Product C and save

Description of issue:
A second resupply picking is created

Expected behavior:
Should group the new product's component with the existing picking

Why this happens:
When assigning the resupply picking for the new product's component, the search domain for the existing picking includes production_group_id, which is different for the added product.
This prevents merging of components into a single resupply picking despite sharing the same destination and purchase order

Fix:
We ignore production_group_id since it is not necessary in the resupply stock moves domain.

opw-5906451