### PR TITLE
[IMP] pos_self_order_bancontact_pay: enable Bancontact Pay in kiosk mode

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -190,7 +190,8 @@ class PosOrder(models.Model):
         self.payment_ids.unlink()
 
     def _compute_amount_paid(self):
-        return sum(self.payment_ids.mapped('amount'))
+        paid_payment_ids = self.payment_ids.filtered(lambda p: not p.payment_status or p.payment_status == "done")
+        return sum(paid_payment_ids.mapped('amount'))
 
     def _process_payment_lines(self, pos_order, order, pos_session, draft):
         """Create account.bank.statement.lines from the dictionary given to the parent function.

--- a/addons/pos_bancontact_pay/__manifest__.py
+++ b/addons/pos_bancontact_pay/__manifest__.py
@@ -9,6 +9,11 @@
         "point_of_sale._assets_pos": [
             "pos_bancontact_pay/static/src/**/*",
         ],
+        'point_of_sale.payment_terminals': [
+            'pos_bancontact_pay/static/src/app/payment_bancontact.js',
+            'pos_bancontact_pay/static/src/app/pos_payment_method.js',
+            'pos_bancontact_pay/static/src/app/pos_payment.js',
+        ],
         "web.assets_tests": [
             "pos_bancontact_pay/static/tests/tours/**/*",
         ],

--- a/addons/pos_bancontact_pay/controllers/signature.py
+++ b/addons/pos_bancontact_pay/controllers/signature.py
@@ -25,7 +25,7 @@ class BancontactSignatureValidation:
         self.test_mode = test_mode
         self.bancontact_api_urls = const.API_URLS["preprod" if test_mode else "production"]
 
-    def verify_signature(self):
+    def verify_signature(self, ppid):
         """Verify the JWS signature and mandatory protected headers of the request."""
         if self.test_mode:
             return
@@ -34,20 +34,10 @@ class BancontactSignatureValidation:
             protected_b64, signature_b64, kid, protected = self._extract_jws_parts()
             jwk = self._get_jwk_by_kid(kid)
             self._verify_jws_signature(jwk, protected_b64, signature_b64)
-            self._validate_critical_headers(protected)
+            self._validate_critical_headers(protected, ppid)
         except BancontactSignatureValidationError as e:
             _logger.warning("Bancontact signature verification failed:\n%s", e)
             raise
-
-    def verify_subject(self, expected_subject):
-        """Ensure the JWS subject matches the expected payment profile identifier."""
-        if self.test_mode:
-            return
-
-        if self.subject != expected_subject:
-            e = f"Invalid subject: {self.subject}"
-            _logger.warning("Bancontact signature subject verification failed:\n%s", e)
-            raise BancontactSignatureValidationError(e)
 
     # ----- Private Methods ----- #
     def _extract_jws_parts(self):
@@ -171,7 +161,7 @@ class BancontactSignatureValidation:
         else:
             raise BancontactSignatureValidationError(f"Unsupported JWK algorithm: {alg}")
 
-    def _validate_critical_headers(self, protected):
+    def _validate_critical_headers(self, protected, ppid):
         """Validate critical protected headers and extract the subject for later checks."""
         # -- crit
         crits = set(protected.get("crit", []))
@@ -222,7 +212,9 @@ class BancontactSignatureValidation:
             raise BancontactSignatureValidationError(f"Path mismatch: {jws_path} != {expected_path}")
 
         # -- sub
-        self.subject = protected.get(const.SUB_KEY)
+        subject = protected.get(const.SUB_KEY)
+        if not ppid or subject != ppid:
+            raise BancontactSignatureValidationError(f"Invalid subject: {subject}")
 
     def _b64url_decode(self, data: str) -> bytes:
         try:

--- a/addons/pos_bancontact_pay/controllers/webhook.py
+++ b/addons/pos_bancontact_pay/controllers/webhook.py
@@ -1,59 +1,48 @@
 from odoo import http
 from odoo.http import request
 
-from odoo.addons.pos_bancontact_pay.controllers.signature import BancontactSignatureValidation
-from odoo.addons.pos_bancontact_pay.errors.exceptions import BancontactSignatureValidationError
+from odoo.addons.pos_bancontact_pay.controllers.signature import (
+    BancontactSignatureValidation,
+)
+from odoo.addons.pos_bancontact_pay.errors.exceptions import (
+    BancontactSignatureValidationError,
+)
 
 
 class BancontactPayController(http.Controller):
 
     @http.route(["/bancontact_pay/webhook"], type="http", auth="public", methods=["POST"], csrf=False)
-    def bancontact_pay_webhook(self, mode=None):
+    def bancontact_pay_webhook(self, config_id=None, ppid=None, mode=None):
         bancontact_signature_validation = BancontactSignatureValidation(request.httprequest, mode == "test")
         try:
-            bancontact_signature_validation.verify_signature()
+            bancontact_signature_validation.verify_signature(ppid)
         except BancontactSignatureValidationError as e:
             return http.Response(str(e), status=403)
-
-        data = request.get_json_data()
-        bancontact_payment_id = data.get("paymentId")
-
-        pos_payment = None
-        if bancontact_payment_id:
-            pos_payment = self.env["pos.payment"].sudo().search([("bancontact_id", "=", bancontact_payment_id)], limit=1)
-        if not pos_payment or not pos_payment.exists():
-            return http.Response("Payment not found.", status=404)
 
         try:
-            bancontact_signature_validation.verify_subject(pos_payment.payment_method_id.bancontact_ppid)
-        except BancontactSignatureValidationError as e:
-            return http.Response(str(e), status=403)
+            config_id = int(config_id)
+        except (TypeError, ValueError):
+            return http.Response("Invalid or missing config_id parameter", status=400)
 
+        pos_config = self.env['pos.config'].sudo().browse(config_id)
+        if not pos_config.exists():
+            return http.Response("Invalid POS configuration ID", status=400)
+
+        data = request.get_json_data()
+        bancontact_id = data.get("paymentId")
         bancontact_status = data.get("status")
+        if bancontact_status not in ["SUCCEEDED", "AUTHORIZATION_FAILED", "FAILED", "EXPIRED", "CANCELLED"]:
+            return http.Response(status=204)
 
-        def _notify_pos():
-            pos_order = pos_payment.pos_order_id
-            pos_order.config_id._notify(
-                "BANCONTACT_PAY_PAYMENTS_NOTIFICATION",
-                {
-                    "order_id": pos_order.id,
-                    "payment_id": pos_payment.id,
-                    "bancontact_status": bancontact_status,
-                },
-            )
-
-        if pos_payment.payment_status != "done":
-            if bancontact_status == "SUCCEEDED":
-                pos_payment.payment_status = "done"
-                pos_payment.qr_code = False
-                _notify_pos()
-            elif bancontact_status in ("AUTHORIZATION_FAILED", "FAILED", "EXPIRED", "CANCELLED") and pos_payment.payment_status != "retry":
-                pos_payment.payment_status = "retry"
-                pos_payment.qr_code = False
-                pos_payment.bancontact_id = False
-                _notify_pos()
-
-            # PENDING, IDENTIFIED, AUTHORIZED, PENDING_MERCHANT_ACKNOWLEDGEMENT, VOIDED --> no action
-            # https://docs.payconiq.be/guides/general/callback052025
+        self._notify_pos(pos_config, bancontact_id, bancontact_status)
 
         return http.Response(status=200)
+
+    def _notify_pos(self, pos_config, bancontact_id, bancontact_status):
+        pos_config._notify(
+            "BANCONTACT_PAY_PAYMENTS_NOTIFICATION",
+            {
+                "bancontact_id": bancontact_id,
+                "bancontact_status": bancontact_status,
+            },
+        )

--- a/addons/pos_bancontact_pay/models/pos_payment_method.py
+++ b/addons/pos_bancontact_pay/models/pos_payment_method.py
@@ -114,104 +114,81 @@ class PosPaymentMethod(models.Model):
         }
 
     # ----- Bancontact Integration ----- #
-    def create_bancontact_payment(self, **kwargs):
-        """Create (or reuse) a Bancontact Pay payment and return updated PoS payment data."""
-        payment_id = kwargs.get("payment_id")
-        pos_payment = self.env["pos.payment"].search([("id", "=", payment_id)], limit=1)
+    def create_bancontact_payment(self, data):
+        self.ensure_one()
+        if self.payment_provider != "bancontact_pay":
+            raise ValidationError(_("Bancontact payments can only be created for payment methods using Bancontact Pay as provider."))
 
-        if not pos_payment.exists():
-            raise ValidationError(_("Bancontact payment not found."))
-
-        if not pos_payment.bancontact_id or pos_payment.payment_status not in ["waiting", "waitingScan", "waitingCancel"]:
-            headers = {
-                "Authorization": f"Bearer {self.bancontact_api_key}",
-                "Content-Type": "application/json",
-            }
-            url, payload = self._prepare_bancontact_payment_request(**kwargs)
-            response = requests.post(url, json=payload, headers=headers, timeout=5)
-            self._assert_bancontact_http_success(response)
-            bancontact_data = response.json()
-
-            pos_payment.bancontact_id = bancontact_data["paymentId"]
-            pos_payment.qr_code = bancontact_data.get("_links", {}).get("qrcode", {}).get("href", "")
+        headers = {
+            "Authorization": f"Bearer {self.bancontact_api_key}",
+            "Content-Type": "application/json",
+        }
+        url, payload = self._prepare_bancontact_payment_request(data)
+        response = requests.post(url, json=payload, headers=headers, timeout=5)
+        self._assert_bancontact_http_success(response)
+        bancontact_data = response.json()
 
         return {
-            "pos.payment": pos_payment._load_pos_data_read(
-                pos_payment,
-                pos_payment.pos_order_id.config_id,
-            ),
+            "bancontact_id": bancontact_data["paymentId"],
+            "qr_code": bancontact_data.get("_links", {}).get("qrcode", {}).get("href", ""),
         }
 
-    def cancel_bancontact_payment(self, **kwargs):
-        """Cancel a Bancontact Pay payment when possible and return updated PoS payment data."""
-        payment_id = kwargs.get("payment_id")
-        pos_payment = self.env["pos.payment"].search([("id", "=", payment_id)], limit=1)
-        if not pos_payment.exists():
-            raise ValidationError(_("Bancontact payment not found."))
+    def cancel_bancontact_payment(self, bancontact_id):
+        self.ensure_one()
+        if self.payment_provider != "bancontact_pay":
+            raise ValidationError(_("Bancontact payments can only be cancelled for payment methods using Bancontact Pay as provider."))
 
-        bancontact_id = pos_payment.bancontact_id
-        if bancontact_id:
-            url = f"{self._get_bancontact_api_url('merchant')}/v3/payments/{bancontact_id}"
-            headers = {
-                "Authorization": f"Bearer {self.bancontact_api_key}",
-                "Content-Type": "application/json",
-            }
-            response = requests.delete(url, headers=headers, timeout=5)
-            self._assert_bancontact_http_success(response,
-                {422: (_("Unable to cancel payment. The payment may not be in a cancellable state."), ValidationError)},
-            )
-
-            pos_payment.bancontact_id = False
-            pos_payment.qr_code = False
-
-        return {
-            "pos.payment": pos_payment._load_pos_data_read(
-                pos_payment,
-                pos_payment.pos_order_id.config_id,
-            ),
+        url = f"{self._get_bancontact_api_url('merchant')}/v3/payments/{bancontact_id}"
+        headers = {
+            "Authorization": f"Bearer {self.bancontact_api_key}",
+            "Content-Type": "application/json",
         }
+        response = requests.delete(url, headers=headers, timeout=5)
+        self._assert_bancontact_http_success(response,
+            {422: (_("Unable to cancel payment. The payment may not be in a cancellable state."), ValidationError)},
+        )
 
     # ----- Helpers ----- #
-    def _get_callback_url(self):
+    def _get_callback_url(self, data):
         """Build the callback URL used by Bancontact Pay to notify payment status."""
-        url = f"{self.get_base_url()}/bancontact_pay/webhook"
+        config_id = data.get("configId")
+        url = f"{self.get_base_url()}/bancontact_pay/webhook?config_id={config_id}&ppid={self.bancontact_ppid}"
         if self.bancontact_test_mode:
-            url += "?mode=test"
+            url += "&mode=test"
         return url
 
-    def _prepare_bancontact_payment_request(self, **kwargs):
+    def _prepare_bancontact_payment_request(self, data):
         """Prepare the endpoint and JSON payload for a Bancontact payment creation call."""
-        usage = kwargs.get("usage")
-        if usage == "sticker":
-            return self._prepare_sticker_payment_request(**kwargs)
-        return self._prepare_display_payment_request(**kwargs)
+        if self.bancontact_usage == "sticker":
+            return self._prepare_sticker_payment_request(data)
+        return self._prepare_display_payment_request(data)
 
-    def _prepare_display_payment_request(self, **kwargs):
+    def _prepare_display_payment_request(self, data):
         """Prepare the request data for a dynamic on-screen QR payment."""
-        callback_url = self._get_callback_url()
+        callback_url = self._get_callback_url(data)
         return [
             f"{self._get_bancontact_api_url('merchant')}/v3/payments",
             {
-                "amount": round(kwargs.get("amount", 0.0) * 100),
-                "currency": kwargs.get("currency", "EUR"),
-                "description": kwargs.get("description", "")[:140],
+                "amount": round(data.get("amount", 0.0) * 100),
+                "currency": data.get("currency", "EUR"),
+                "description": data.get("description", "")[:140],
                 "identifyCallbackUrl": callback_url,
                 "callbackUrl": callback_url,
             },
         ]
 
-    def _prepare_sticker_payment_request(self, **kwargs):
+    def _prepare_sticker_payment_request(self, data):
         """Prepare the request data for a static sticker-based QR payment."""
-        callback_url = self._get_callback_url()
+        callback_url = self._get_callback_url(data)
         return [
             f"{self._get_bancontact_api_url('merchant')}/v3/payments/pos",
             {
-                "amount": round(kwargs.get("amount", 0.0) * 100),
-                "currency": kwargs.get("currency", "EUR"),
-                "description": kwargs.get("description", "")[:140],
-                "posId": f'pm{kwargs.get("paymentMethodId", "")}'[:36],
-                "shopId": f'pos{kwargs.get("posId", "")}'[:36],
-                "shopName": kwargs.get("shopName", "")[:36],
+                "amount": round(data.get("amount", 0.0) * 100),
+                "currency": data.get("currency", "EUR"),
+                "description": data.get("description", "")[:140],
+                "posId": f'pm{self.id}'[:36],
+                "shopId": f'pos{data.get("configId", "")}'[:36],
+                "shopName": data.get("shopName", "")[:36],
                 "identifyCallbackUrl": callback_url,
                 "callbackUrl": callback_url,
             },

--- a/addons/pos_bancontact_pay/static/src/app/payment_bancontact.js
+++ b/addons/pos_bancontact_pay/static/src/app/payment_bancontact.js
@@ -10,28 +10,31 @@ export class PaymentBancontact extends PaymentInterface {
     }
 
     async sendPaymentRequest(line) {
-        await super.sendPaymentRequest(...arguments);
-
-        await this.pos.syncAllOrders({ orders: [line.pos_order_id] });
-        await this.pos.data.callRelated(
-            "pos.payment.method",
-            "create_bancontact_payment",
-            [line.payment_method_id.id],
-            {
-                payment_id: line.id,
-                amount: line.amount,
-                currency: this.pos.currency.name,
-                posId: this.pos.config.id,
-                shopName: this.pos.config.name,
-                paymentMethodId: line.payment_method_id.id,
-                description: _t(
-                    "Payment at %s\nPOS %s",
-                    this.pos.company.name,
-                    this.pos.config.name
-                ),
-                usage: line.payment_method_id.bancontact_usage,
-            }
-        );
+        if (
+            !line.bancontact_id ||
+            !line.qr_code ||
+            !["waiting", "waitingScan", "waitingCancel"].includes(line.payment_status)
+        ) {
+            const { bancontact_id, qr_code } = await this.callPaymentMethod(
+                "create_bancontact_payment",
+                [
+                    line.payment_method_id.id,
+                    {
+                        amount: line.amount,
+                        currency: this.pos.currency.name,
+                        configId: this.pos.config.id,
+                        shopName: this.pos.config.name,
+                        description: _t(
+                            "Payment at %s\nPOS %s",
+                            this.pos.company.name,
+                            this.pos.config.name
+                        ),
+                    },
+                ]
+            );
+            line.bancontact_id = bancontact_id;
+            line.qr_code = qr_code;
+        }
 
         if (line.payment_method_id.bancontact_usage === "display") {
             this.pos.displayQrCode(line);
@@ -40,8 +43,6 @@ export class PaymentBancontact extends PaymentInterface {
     }
 
     async sendPaymentCancel(line) {
-        await super.sendPaymentCancel(...arguments);
-
         const blockingErrorCodes = [422];
         const askForceCancel = async (errorCode) => {
             let message = _t(
@@ -67,13 +68,12 @@ export class PaymentBancontact extends PaymentInterface {
         };
 
         try {
-            await this.pos.syncAllOrders({ orders: [line.pos_order_id] });
-            await this.pos.data.callRelated(
-                "pos.payment.method",
-                "cancel_bancontact_payment",
-                [line.payment_method_id.id],
-                { payment_id: line.id }
-            );
+            await this.callPaymentMethod("cancel_bancontact_payment", [
+                line.payment_method_id.id,
+                line.bancontact_id,
+            ]);
+            line.bancontact_id = null;
+            line.qr_code = null;
             return true;
         } catch (error) {
             const message = error.data?.message || "";

--- a/addons/pos_bancontact_pay/static/src/app/pos_store.js
+++ b/addons/pos_bancontact_pay/static/src/app/pos_store.js
@@ -12,20 +12,26 @@ patch(PosStore.prototype, {
         );
     },
 
-    async handleBancontactPayNotification({ payment_id, bancontact_status }) {
-        const paymentLine = this.models["pos.payment"].get(payment_id);
-        if (!paymentLine) {
+    async handleBancontactPayNotification({ bancontact_id, bancontact_status }) {
+        const paymentline = this.models["pos.payment"].find(
+            (line) => line.bancontact_id === bancontact_id
+        );
+        if (!paymentline || paymentline.payment_status === "done") {
             return;
         }
-        // refresh payment line to get the latest data
-        await this.data.read("pos.payment", [paymentLine.id]);
 
-        const order = paymentLine.pos_order_id;
+        const order = paymentline.pos_order_id;
+        if (!order || order.finalized) {
+            return;
+        }
+
         const currentOrder = this.getOrder();
 
         // --- SUCCEEDED ---
         if (bancontact_status === "SUCCEEDED") {
-            paymentLine.updateCustomerDisplayQrCode(null);
+            paymentline.updateCustomerDisplayQrCode(null);
+            paymentline.setPaymentStatus("done");
+            paymentline.qr_code = null;
 
             // Other order selected
             if (order !== currentOrder) {
@@ -37,27 +43,33 @@ patch(PosStore.prototype, {
             }
 
             // Close QR code if currently displayed
-            if (paymentLine.uuid === this.qrCode?.paymentline.uuid) {
+            if (paymentline.uuid === this.qrCode?.paymentline.uuid) {
                 this.closeQrCode();
             }
 
             // Notify only if another payment line is selected
-            if (paymentLine.uuid !== currentOrder.getSelectedPaymentline()?.uuid) {
+            if (paymentline.uuid !== currentOrder.getSelectedPaymentline()?.uuid) {
                 this.notification.add(_t("Payment received"), { type: "success" });
             }
             await this.autoValidateOrder({ order });
+            return;
         }
 
         // --- FAILED ---
-        else if (
+        if (
+            paymentline.payment_status !== "retry" &&
             ["AUTHORIZATION_FAILED", "FAILED", "EXPIRED", "CANCELLED"].includes(bancontact_status)
         ) {
-            paymentLine.updateCustomerDisplayQrCode(null);
+            paymentline.updateCustomerDisplayQrCode(null);
+            paymentline.setPaymentStatus("retry");
+            paymentline.bancontact_id = null;
+            paymentline.qr_code = null;
+
             const message = this.getBancontactErrorMessage(bancontact_status, order);
             this.notification.add(message, { type: "warning" });
 
             // Close QR code if currently displayed
-            if (paymentLine.uuid === this.qrCode?.paymentline.uuid) {
+            if (paymentline.uuid === this.qrCode?.paymentline.uuid) {
                 this.closeQrCode();
             }
 

--- a/addons/pos_bancontact_pay/static/tests/tours/bancontact_pay_tours.js
+++ b/addons/pos_bancontact_pay/static/tests/tours/bancontact_pay_tours.js
@@ -122,7 +122,7 @@ registry.category("web_tour.tours").add("bancontact_pay_show_qr_code", {
             initOrder(),
 
             // Display waiting
-            PaymentScreen.clickPaymentMethod("Bancontact - Display"),
+            PaymentScreen.clickPaymentMethod("Bancontact - Display"), // bancontact_show_qr_code_0
             PaymentScreen.selectedPaymentlineHas("Bancontact - Display", "10.00"),
             PaymentScreen.qrPopupIsShown("10.00"),
             PaymentScreen.closeQrPopup(),
@@ -137,7 +137,7 @@ registry.category("web_tour.tours").add("bancontact_pay_show_qr_code", {
             // Display retry
             PaymentScreen.enterPaymentLineAmount("Bancontact - Display", "2"),
             PaymentScreen.selectedPaymentlineHas("Bancontact - Display", "2.00"),
-            PaymentScreen.clickRetryButton(),
+            PaymentScreen.clickRetryButton(), // **bancontact_show_qr_code_1**
             PaymentScreen.qrPopupIsShown("2.00"),
             PaymentScreen.closeQrPopup(),
             PaymentScreen.showQrPopup({ selected: true }),
@@ -145,7 +145,7 @@ registry.category("web_tour.tours").add("bancontact_pay_show_qr_code", {
             PaymentScreen.closeQrPopup(),
 
             // Sticker waiting
-            PaymentScreen.clickPaymentMethod("Bancontact - Sticker 1"),
+            PaymentScreen.clickPaymentMethod("Bancontact - Sticker 1"), // bancontact_show_qr_code_2
             PaymentScreen.selectedPaymentlineHas("Bancontact - Sticker 1", "10.00"),
             PaymentScreen.qrPopupIsNotShown(),
             PaymentScreen.showQrPopup({ selected: true }),
@@ -159,7 +159,7 @@ registry.category("web_tour.tours").add("bancontact_pay_show_qr_code", {
             // Sticker retry
             PaymentScreen.enterPaymentLineAmount("Bancontact - Sticker 1", "3"),
             PaymentScreen.selectedPaymentlineHas("Bancontact - Sticker 1", "3.00"),
-            PaymentScreen.clickRetryButton(),
+            PaymentScreen.clickRetryButton(), // **bancontact_show_qr_code_3**
             PaymentScreen.qrPopupIsNotShown(),
             PaymentScreen.showQrPopup({ selected: true }),
             PaymentScreen.qrPopupIsShown("3.00"),
@@ -168,18 +168,18 @@ registry.category("web_tour.tours").add("bancontact_pay_show_qr_code", {
             // Open display sticker without selecting it and pay for the sticker
             PaymentScreen.showQrPopup({ name: "Bancontact - Display" }),
             PaymentScreen.qrPopupIsShown("2.00"),
-            Bancontact.mockCallbackBancontactPay("SUCCEEDED"),
+            Bancontact.mockCallbackBancontactPay("bancontact_show_qr_code_3", "SUCCEEDED"),
             PaymentScreen.qrPopupIsShown("2.00"),
 
             // Pay now for the display
-            Bancontact.mockCallbackBancontactPay("SUCCEEDED", 2),
+            Bancontact.mockCallbackBancontactPay("bancontact_show_qr_code_1", "SUCCEEDED"),
             PaymentScreen.qrPopupIsNotShown(),
 
             // Payment failed close qr
-            PaymentScreen.clickPaymentMethod("Bancontact - Display"),
+            PaymentScreen.clickPaymentMethod("Bancontact - Display"), // **bancontact_show_qr_code_4**
             PaymentScreen.selectedPaymentlineHas("Bancontact - Display", "5.00"),
             PaymentScreen.qrPopupIsShown("5.00"),
-            Bancontact.mockCallbackBancontactPay("FAILED"),
+            Bancontact.mockCallbackBancontactPay("bancontact_show_qr_code_4", "FAILED"),
             PaymentScreen.qrPopupIsNotShown(),
         ].flat(),
 });
@@ -192,31 +192,31 @@ registry.category("web_tour.tours").add("bancontact_pay_success_payment", {
             initOrder(),
 
             // Order 1001 - Display 5€ [A]
-            PaymentScreen.clickPaymentMethod("Bancontact - Display"),
+            PaymentScreen.clickPaymentMethod("Bancontact - Display"), // bancontact_success_0
             PaymentScreen.selectedPaymentlineHas("Bancontact - Display", "10.00"),
             PaymentScreen.closeQrPopup(),
             PaymentScreen.clickCancelButton(),
             PaymentScreen.hasActionState("retry"),
             PaymentScreen.enterPaymentLineAmount("Bancontact - Display", "5"),
             PaymentScreen.selectedPaymentlineHas("Bancontact - Display", "5.00"),
-            PaymentScreen.clickRetryButton(),
+            PaymentScreen.clickRetryButton(), // **bancontact_success_1**
             PaymentScreen.closeQrPopup(),
             PaymentScreen.hasActionState("waiting_scan"),
 
             // Order 1001 - Display 2€ [B]
-            PaymentScreen.clickPaymentMethod("Bancontact - Display"),
+            PaymentScreen.clickPaymentMethod("Bancontact - Display"), // bancontact_success_2
             PaymentScreen.selectedPaymentlineHas("Bancontact - Display", "10.00"),
             PaymentScreen.closeQrPopup(),
             PaymentScreen.clickCancelButton(),
             PaymentScreen.hasActionState("retry"),
             PaymentScreen.enterPaymentLineAmount("Bancontact - Display", "2"),
             PaymentScreen.selectedPaymentlineHas("Bancontact - Display", "2.00"),
-            PaymentScreen.clickRetryButton(),
+            PaymentScreen.clickRetryButton(), // **bancontact_success_3**
             PaymentScreen.closeQrPopup(),
             PaymentScreen.hasActionState("waiting_scan"),
 
             // Pay payment line A while being on another payment line - notified
-            Bancontact.mockCallbackBancontactPay("SUCCEEDED", 2),
+            Bancontact.mockCallbackBancontactPay("bancontact_success_1", "SUCCEEDED"),
             Bancontact.notifiedPaymentReceived(),
             PaymentScreen.clickPaymentline("Bancontact - Display", "5"),
             PaymentScreen.hasActionState("paid"),
@@ -224,47 +224,47 @@ registry.category("web_tour.tours").add("bancontact_pay_success_payment", {
             PaymentScreen.hasActionState("waiting_scan"),
 
             // Pay payment line B
-            Bancontact.mockCallbackBancontactPay("SUCCEEDED", 1),
+            Bancontact.mockCallbackBancontactPay("bancontact_success_3", "SUCCEEDED"),
             PaymentScreen.hasActionState("paid"),
 
             // Order 1001 - Display 3€ (fully paid) [C]
-            PaymentScreen.clickPaymentMethod("Bancontact - Display"),
+            PaymentScreen.clickPaymentMethod("Bancontact - Display"), // **bancontact_success_4**
             PaymentScreen.selectedPaymentlineHas("Bancontact - Display", "3.00"),
             PaymentScreen.hasActionState("waiting_scan"),
 
             // Pay payment line C - Autovalidate order
-            Bancontact.mockCallbackBancontactPay("SUCCEEDED"),
+            Bancontact.mockCallbackBancontactPay("bancontact_success_4", "SUCCEEDED"),
             FeedbackScreen.isShown(),
             FeedbackScreen.clickNextOrder(),
 
             // Order 1002 - Display 5€ [D]
             initOrder(),
-            PaymentScreen.clickPaymentMethod("Bancontact - Display"),
+            PaymentScreen.clickPaymentMethod("Bancontact - Display"), // bancontact_success_5
             PaymentScreen.selectedPaymentlineHas("Bancontact - Display", "10.00"),
             PaymentScreen.closeQrPopup(),
             PaymentScreen.clickCancelButton(),
             PaymentScreen.hasActionState("retry"),
             PaymentScreen.enterPaymentLineAmount("Bancontact - Display", "5"),
             PaymentScreen.selectedPaymentlineHas("Bancontact - Display", "5.00"),
-            PaymentScreen.clickRetryButton(),
+            PaymentScreen.clickRetryButton(), // **bancontact_success_6**
             PaymentScreen.closeQrPopup(),
             PaymentScreen.hasActionState("waiting_scan"),
 
             // Pay payment line D while on another order - notified
             Chrome.createFloatingOrder(),
-            Bancontact.mockCallbackBancontactPay("SUCCEEDED"),
+            Bancontact.mockCallbackBancontactPay("bancontact_success_6", "SUCCEEDED"),
             Bancontact.notifiedOrderPartiallyPaid("1002"),
 
             // Order 1002 - Display 5€ (fully paid) [E]
             Chrome.clickFloatingOrder("1002"),
-            PaymentScreen.clickPaymentMethod("Bancontact - Display"),
+            PaymentScreen.clickPaymentMethod("Bancontact - Display"), // **bancontact_success_7**
             PaymentScreen.selectedPaymentlineHas("Bancontact - Display", "5.00"),
             PaymentScreen.closeQrPopup(),
             PaymentScreen.hasActionState("waiting_scan"),
 
             // Pay payment line E while on another order - notified + NOT autovalidate
             Chrome.clickFloatingOrder("1003"),
-            Bancontact.mockCallbackBancontactPay("SUCCEEDED"),
+            Bancontact.mockCallbackBancontactPay("bancontact_success_7", "SUCCEEDED"),
             Bancontact.notifiedOrderFullyPaid("1002"),
             Chrome.clickFloatingOrder("1002"),
             PaymentScreen.clickValidate(),
@@ -273,7 +273,7 @@ registry.category("web_tour.tours").add("bancontact_pay_success_payment", {
             // Order 1003 - Force done payment [F] - autovalidate
             FeedbackScreen.clickNextOrder(),
             initOrder(),
-            PaymentScreen.clickPaymentMethod("Bancontact - Display"),
+            PaymentScreen.clickPaymentMethod("Bancontact - Display"), // **bancontact_success_8**
             PaymentScreen.selectedPaymentlineHas("Bancontact - Display", "10.00"),
             PaymentScreen.closeQrPopup(),
             PaymentScreen.hasActionState("waiting_scan"),
@@ -290,38 +290,38 @@ registry.category("web_tour.tours").add("bancontact_pay_failed_payment", {
             initOrder(),
 
             // Simulate a AUTHORIZATION_FAILED payment from Bancontact side
-            PaymentScreen.clickPaymentMethod("Bancontact - Display"),
+            PaymentScreen.clickPaymentMethod("Bancontact - Display"), // **bancontact_failed_0**
             PaymentScreen.hasActionState("waiting_scan"),
-            Bancontact.mockCallbackBancontactPay("AUTHORIZATION_FAILED"),
+            Bancontact.mockCallbackBancontactPay("bancontact_failed_0", "AUTHORIZATION_FAILED"),
             PaymentScreen.hasActionState("retry"),
             Bancontact.notifiedPaymentError("Payment failed"),
 
             // Simulate a FAILED payment from Bancontact side
-            PaymentScreen.clickPaymentMethod("Bancontact - Display"),
+            PaymentScreen.clickPaymentMethod("Bancontact - Display"), // **bancontact_failed_1**
             PaymentScreen.hasActionState("waiting_scan"),
-            Bancontact.mockCallbackBancontactPay("FAILED"),
+            Bancontact.mockCallbackBancontactPay("bancontact_failed_1", "FAILED"),
             PaymentScreen.hasActionState("retry"),
             Bancontact.notifiedPaymentError("Payment failed"),
 
             // Simulate a EXPIRED payment from Bancontact side
-            PaymentScreen.clickPaymentMethod("Bancontact - Display"),
+            PaymentScreen.clickPaymentMethod("Bancontact - Display"), // **bancontact_failed_2**
             PaymentScreen.hasActionState("waiting_scan"),
-            Bancontact.mockCallbackBancontactPay("EXPIRED"),
+            Bancontact.mockCallbackBancontactPay("bancontact_failed_2", "EXPIRED"),
             PaymentScreen.hasActionState("retry"),
             Bancontact.notifiedPaymentError("Payment expired"),
 
             // Simulate a CANCELLED payment from Bancontact side
-            PaymentScreen.clickPaymentMethod("Bancontact - Display"),
+            PaymentScreen.clickPaymentMethod("Bancontact - Display"), // **bancontact_failed_3**
             PaymentScreen.hasActionState("waiting_scan"),
-            Bancontact.mockCallbackBancontactPay("CANCELLED"),
+            Bancontact.mockCallbackBancontactPay("bancontact_failed_3", "CANCELLED"),
             PaymentScreen.hasActionState("retry"),
             Bancontact.notifiedPaymentError("Payment cancelled"),
 
             // Failed while not current order
-            PaymentScreen.clickPaymentMethod("Bancontact - Display"),
+            PaymentScreen.clickPaymentMethod("Bancontact - Display"), // **bancontact_failed_4**
             PaymentScreen.closeQrPopup(),
             Chrome.createFloatingOrder(),
-            Bancontact.mockCallbackBancontactPay("FAILED"),
+            Bancontact.mockCallbackBancontactPay("bancontact_failed_4", "FAILED"),
             Bancontact.notifiedPaymentError("A payment for order 1001 has failed."),
         ].flat(),
 });

--- a/addons/pos_bancontact_pay/static/tests/tours/utils/bancontact_pay_utils.js
+++ b/addons/pos_bancontact_pay/static/tests/tours/utils/bancontact_pay_utils.js
@@ -91,7 +91,7 @@ export function notifiedPaymentError(message) {
 // -------------------------------
 // Bancontact payment callbacks
 // -------------------------------
-export function mockCallbackBancontactPay(status, fromEnd = 1) {
+export function mockCallbackBancontactPay(bancontact_id, status) {
     const delay = 200; // ms
     return [
         {
@@ -105,24 +105,11 @@ export function mockCallbackBancontactPay(status, fromEnd = 1) {
             content: "mock scan QR code",
             trigger: "body",
             run: async () => {
-                const orm = posmodel.env.services.orm;
-                const response = await orm.searchRead("pos.payment", [], ["bancontact_id"], {
-                    limit: fromEnd,
-                    order: "id desc",
-                });
-                if (!response || response.length < fromEnd) {
-                    throw new Error("Not enough Bancontact payments found to mock scan QR code");
-                }
-
-                fetch("/bancontact_pay/webhook?mode=test", {
+                const configId = posmodel.config.id;
+                fetch(`/bancontact_pay/webhook?config_id=${configId}&mode=test`, {
                     method: "POST",
-                    headers: {
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify({
-                        paymentId: response[fromEnd - 1].bancontact_id,
-                        status: status,
-                    }),
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ paymentId: bancontact_id, status: status }),
                 });
             },
         },

--- a/addons/pos_bancontact_pay/static/tests/unit/app/payment_bancontact.test.js
+++ b/addons/pos_bancontact_pay/static/tests/unit/app/payment_bancontact.test.js
@@ -17,7 +17,7 @@ describe("sendPaymentRequest", () => {
         const display = store.models["pos.payment.method"].get(4);
         const sticker = store.models["pos.payment.method"].get(5);
 
-        const opts = { amount: -1, payment_status: "waiting" };
+        const opts = { amount: -403, payment_status: "waiting" };
         const paymentlineDisplay = createPaymentLine(store, order, display, opts);
         const paymentlineSticker = createPaymentLine(store, order, sticker, opts);
         const paymentlines = [paymentlineDisplay, paymentlineSticker];
@@ -56,12 +56,10 @@ describe("sendPaymentRequest", () => {
         };
         for (const paymentline of paymentlines) {
             const result = await paymentline.payment_interface.sendPaymentRequest(paymentline);
-            const bancontactId = "bancontact_" + paymentline.id;
-            const qrCodeUrl = `https://example.com/qrcode/${bancontactId}`;
 
             expect(result).toBe(true);
-            expect(paymentline.bancontact_id).toBe(bancontactId);
-            expect(paymentline.qr_code).toBe(qrCodeUrl);
+            expect(paymentline.bancontact_id).toBe("bancontact_id");
+            expect(paymentline.qr_code).toBe("bancontact_qr_code");
 
             expect.verifySteps(
                 paymentline.payment_method_id.bancontact_usage === "display"
@@ -73,6 +71,78 @@ describe("sendPaymentRequest", () => {
             expect(paymentline.payment_status).toBe("waiting");
         }
     });
+
+    test("already has bancontact id + waitingScan status", async () => {
+        const store = await setupPosEnv();
+        const order = await getFilledOrder(store);
+        const display = store.models["pos.payment.method"].get(4);
+        const sticker = store.models["pos.payment.method"].get(5);
+
+        const opts = {
+            bancontact_id: "origin_bancontact_id",
+            qr_code: "origin_bancontact_qr_code",
+            payment_status: "waitingScan",
+        };
+        const paymentlineDisplay = createPaymentLine(store, order, display, opts);
+        const paymentlineSticker = createPaymentLine(store, order, sticker, opts);
+        const paymentlines = [paymentlineDisplay, paymentlineSticker];
+
+        store.displayQrCode = () => {
+            expect.step("store.displayQrCode");
+        };
+        for (const paymentline of paymentlines) {
+            const result = await paymentline.payment_interface.sendPaymentRequest(paymentline);
+
+            expect(result).toBe(true);
+            expect(paymentline.bancontact_id).toBe("origin_bancontact_id");
+            expect(paymentline.qr_code).toBe("origin_bancontact_qr_code");
+
+            expect.verifySteps(
+                paymentline.payment_method_id.bancontact_usage === "display"
+                    ? ["store.displayQrCode"]
+                    : []
+            );
+
+            // The payment status will be updated by `handlePaymentResponse`
+            expect(paymentline.payment_status).toBe("waitingScan");
+        }
+    });
+
+    test("already has bancontact id + retry status", async () => {
+        const store = await setupPosEnv();
+        const order = await getFilledOrder(store);
+        const display = store.models["pos.payment.method"].get(4);
+        const sticker = store.models["pos.payment.method"].get(5);
+
+        const opts = {
+            bancontact_id: "origin_bancontact_id",
+            qr_code: "origin_bancontact_qr_code",
+            payment_status: "retry",
+        };
+        const paymentlineDisplay = createPaymentLine(store, order, display, opts);
+        const paymentlineSticker = createPaymentLine(store, order, sticker, opts);
+        const paymentlines = [paymentlineDisplay, paymentlineSticker];
+
+        store.displayQrCode = () => {
+            expect.step("store.displayQrCode");
+        };
+        for (const paymentline of paymentlines) {
+            const result = await paymentline.payment_interface.sendPaymentRequest(paymentline);
+
+            expect(result).toBe(true);
+            expect(paymentline.bancontact_id).toBe("bancontact_id");
+            expect(paymentline.qr_code).toBe("bancontact_qr_code");
+
+            expect.verifySteps(
+                paymentline.payment_method_id.bancontact_usage === "display"
+                    ? ["store.displayQrCode"]
+                    : []
+            );
+
+            // The payment status will be updated by `handlePaymentResponse`
+            expect(paymentline.payment_status).toBe("retry");
+        }
+    });
 });
 
 describe("sendPaymentCancel", () => {
@@ -82,16 +152,13 @@ describe("sendPaymentCancel", () => {
         const display = store.models["pos.payment.method"].get(4);
         const sticker = store.models["pos.payment.method"].get(5);
 
-        const opts = (bancontact_id) => ({
-            amount: -400, // To trigger ERR: 400
+        const opts = {
+            bancontact_id: -400,
             payment_status: "waitingCancel",
-            bancontact_id: bancontact_id,
-            qr_code: `https://example.com/qrcode/${bancontact_id}`,
-        });
-        const displayTestId = "bancontact_1";
-        const stickerTestId = "bancontact_2";
-        const paymentlineDisplay = createPaymentLine(store, order, display, opts(displayTestId));
-        const paymentlineSticker = createPaymentLine(store, order, sticker, opts(stickerTestId));
+            qr_code: "bancontact_qr_code",
+        };
+        const paymentlineDisplay = createPaymentLine(store, order, display, opts);
+        const paymentlineSticker = createPaymentLine(store, order, sticker, opts);
         const paymentlines = [paymentlineDisplay, paymentlineSticker];
 
         for (const paymentline of paymentlines) {
@@ -111,27 +178,19 @@ describe("sendPaymentCancel", () => {
         const display = store.models["pos.payment.method"].get(4);
         const sticker = store.models["pos.payment.method"].get(5);
 
-        const opts = (bancontact_id) => ({
-            amount: -422, // To trigger ERR: 422
+        const opts = {
+            bancontact_id: -422,
             payment_status: "waitingCancel",
-            bancontact_id: bancontact_id,
-            qr_code: `https://example.com/qrcode/${bancontact_id}`,
-        });
-        const displayTestId = "bancontact_1";
-        const stickerTestId = "bancontact_2";
-        const paymentlineDisplay = createPaymentLine(store, order, display, opts(displayTestId));
-        const paymentlineSticker = createPaymentLine(store, order, sticker, opts(stickerTestId));
+            qr_code: "bancontact_qr_code",
+        };
+        const paymentlineDisplay = createPaymentLine(store, order, display, opts);
+        const paymentlineSticker = createPaymentLine(store, order, sticker, opts);
         const paymentlines = [paymentlineDisplay, paymentlineSticker];
-        const getBancontactId = (pl) =>
-            pl.id === paymentlineDisplay.id ? displayTestId : stickerTestId;
-        const qrCodeUrl = (pl) =>
-            pl.id === paymentlineDisplay.id
-                ? `https://example.com/qrcode/${displayTestId}`
-                : `https://example.com/qrcode/${stickerTestId}`;
 
         await activateMountingDialogs(store.env);
         for (const paymentline of paymentlines) {
             // ---- Click on 'Close' button ----
+
             const promiseResultClose = paymentline.payment_interface.sendPaymentCancel(paymentline);
 
             await animationFrame();
@@ -139,8 +198,8 @@ describe("sendPaymentCancel", () => {
 
             const resultClose = await promiseResultClose;
             expect(resultClose).toBe(false);
-            expect(paymentline.bancontact_id).toBe(getBancontactId(paymentline));
-            expect(paymentline.qr_code).toBe(qrCodeUrl(paymentline));
+            expect(paymentline.bancontact_id).toBe(-422);
+            expect(paymentline.qr_code).toBe("bancontact_qr_code");
 
             // The payment status will be updated by `handlePaymentResponse`
             expect(paymentline.payment_status).toBe("waitingCancel");
@@ -167,15 +226,13 @@ describe("sendPaymentCancel", () => {
         const display = store.models["pos.payment.method"].get(4);
         const sticker = store.models["pos.payment.method"].get(5);
 
-        const opts = (bancontact_id) => ({
+        const opts = {
+            bancontact_id: "bancontact_id",
             payment_status: "waitingCancel",
-            bancontact_id: bancontact_id,
-            qr_code: `https://example.com/qrcode/${bancontact_id}`,
-        });
-        const displayTestId = "bancontact_1";
-        const stickerTestId = "bancontact_2";
-        const paymentlineDisplay = createPaymentLine(store, order, display, opts(displayTestId));
-        const paymentlineSticker = createPaymentLine(store, order, sticker, opts(stickerTestId));
+            qr_code: "bancontact_qr_code",
+        };
+        const paymentlineDisplay = createPaymentLine(store, order, display, opts);
+        const paymentlineSticker = createPaymentLine(store, order, sticker, opts);
         const paymentlines = [paymentlineDisplay, paymentlineSticker];
 
         for (const paymentline of paymentlines) {

--- a/addons/pos_bancontact_pay/static/tests/unit/app/pos_store.test.js
+++ b/addons/pos_bancontact_pay/static/tests/unit/app/pos_store.test.js
@@ -57,9 +57,7 @@ describe("handleBancontactPayNotification", () => {
         const store = await setupPosEnv();
         const order = await getFilledOrder(store);
         const display = store.models["pos.payment.method"].get(4);
-
-        const data = { payment_status: "waitingScan" };
-        const paymentline = createPaymentLine(store, order, display, data);
+        const paymentline = createPaymentLine(store, order, display);
 
         // Prepare asserts
         order.floating_order_name = "test_order_1";
@@ -76,6 +74,9 @@ describe("handleBancontactPayNotification", () => {
         });
 
         const reset = (orderSelected, paymentlineSelected, id) => {
+            paymentline.payment_status = "waitingScan";
+            paymentline.qr_code = "bancontact_qr_code";
+            paymentline.bancontact_id = "bancontact_id";
             notificationMessage = null;
             paymentline.uiState.qrCode = "test_qr_code";
             store.setOrder(orderSelected);
@@ -94,24 +95,30 @@ describe("handleBancontactPayNotification", () => {
         // Current order + current qr code displayed + current payment line
         reset(order, paymentline, 1);
         await store.handleBancontactPayNotification({
-            payment_id: paymentline.id,
+            bancontact_id: "bancontact_id",
             bancontact_status: "SUCCEEDED",
         });
 
+        expect(paymentline.payment_status).toBe("done");
+        expect(paymentline.bancontact_id).toBe("bancontact_id");
+        expect(paymentline.qr_code).toBe(null);
         expect(notificationMessage).toBe(null);
         expect(store.qrCode).toBe(null);
         expect(paymentline.uiState.qrCode).toBe(null);
         expect.verifySteps(["store.qrCode.closer.1", "store.autoValidateOrder.1"]);
 
         // Current order + current qr code displayed + different payment line
-        const paymentline2 = createPaymentLine(store, order, display, data);
+        const paymentline2 = createPaymentLine(store, order, display);
         reset(order, paymentline2, 2);
         store.qrCode.paymentline = paymentline;
         await store.handleBancontactPayNotification({
-            payment_id: paymentline.id,
+            bancontact_id: "bancontact_id",
             bancontact_status: "SUCCEEDED",
         });
 
+        expect(paymentline.payment_status).toBe("done");
+        expect(paymentline.bancontact_id).toBe("bancontact_id");
+        expect(paymentline.qr_code).toBe(null);
         expect(notificationMessage).toBe("Payment received");
         expect(store.qrCode).toBe(null);
         expect(paymentline.uiState.qrCode).toBe(null);
@@ -121,10 +128,13 @@ describe("handleBancontactPayNotification", () => {
         reset(order, paymentline, 3);
         store.qrCode.paymentline = paymentline2;
         await store.handleBancontactPayNotification({
-            payment_id: paymentline.id,
+            bancontact_id: "bancontact_id",
             bancontact_status: "SUCCEEDED",
         });
 
+        expect(paymentline.payment_status).toBe("done");
+        expect(paymentline.bancontact_id).toBe("bancontact_id");
+        expect(paymentline.qr_code).toBe(null);
         expect(notificationMessage).toBe(null);
         expect(store.qrCode).not.toBe(null);
         expect(paymentline.uiState.qrCode).toBe(null);
@@ -133,10 +143,13 @@ describe("handleBancontactPayNotification", () => {
         // Current order + different qr code displayed + different payment line
         reset(order, paymentline2, 4);
         await store.handleBancontactPayNotification({
-            payment_id: paymentline.id,
+            bancontact_id: "bancontact_id",
             bancontact_status: "SUCCEEDED",
         });
 
+        expect(paymentline.payment_status).toBe("done");
+        expect(paymentline.bancontact_id).toBe("bancontact_id");
+        expect(paymentline.qr_code).toBe(null);
         expect(notificationMessage).toBe("Payment received");
         expect(store.qrCode).not.toBe(null);
         expect(paymentline.uiState.qrCode).toBe(null);
@@ -145,13 +158,16 @@ describe("handleBancontactPayNotification", () => {
         // Other order selected - Fully paid
         order.toBeValidate = () => true;
         const order2 = await getFilledOrder(store);
-        const paymentline3 = createPaymentLine(store, order2, display, data);
+        const paymentline3 = createPaymentLine(store, order2, display);
         reset(order2, paymentline3, 5);
         await store.handleBancontactPayNotification({
-            payment_id: paymentline.id,
+            bancontact_id: "bancontact_id",
             bancontact_status: "SUCCEEDED",
         });
 
+        expect(paymentline.payment_status).toBe("done");
+        expect(paymentline.bancontact_id).toBe("bancontact_id");
+        expect(paymentline.qr_code).toBe(null);
         expect(notificationMessage).toInclude(`The order test_order_1 has been fully paid.`);
         expect(store.qrCode).not.toBe(null);
         expect(paymentline.uiState.qrCode).toBe(null);
@@ -161,10 +177,13 @@ describe("handleBancontactPayNotification", () => {
         order.toBeValidate = () => false;
         reset(order2, paymentline3, 6);
         await store.handleBancontactPayNotification({
-            payment_id: paymentline.id,
+            bancontact_id: "bancontact_id",
             bancontact_status: "SUCCEEDED",
         });
 
+        expect(paymentline.payment_status).toBe("done");
+        expect(paymentline.bancontact_id).toBe("bancontact_id");
+        expect(paymentline.qr_code).toBe(null);
         expect(notificationMessage).toInclude(`The order test_order_1 has been partially paid.`);
         expect(store.qrCode).not.toBe(null);
         expect(paymentline.uiState.qrCode).toBe(null);
@@ -175,9 +194,7 @@ describe("handleBancontactPayNotification", () => {
         const store = await setupPosEnv();
         const order = await getFilledOrder(store);
         const display = store.models["pos.payment.method"].get(4);
-
-        const data = { payment_status: "waitingScan" };
-        const paymentline = createPaymentLine(store, order, display, data);
+        const paymentline = createPaymentLine(store, order, display);
 
         // Prepare asserts
         order.floating_order_name = "test_order_1";
@@ -194,6 +211,9 @@ describe("handleBancontactPayNotification", () => {
         });
 
         const reset = (orderSelected, paymentlineSelected, id) => {
+            paymentline.payment_status = "waitingScan";
+            paymentline.qr_code = "bancontact_qr_code";
+            paymentline.bancontact_id = "bancontact_id";
             notificationMessage = null;
             paymentline.uiState.qrCode = "test_qr_code";
             store.setOrder(orderSelected);
@@ -208,23 +228,29 @@ describe("handleBancontactPayNotification", () => {
         // Current order and current payment line
         reset(order, paymentline, 1);
         await store.handleBancontactPayNotification({
-            payment_id: paymentline.id,
+            bancontact_id: "bancontact_id",
             bancontact_status: "FAILED",
         });
 
+        expect(paymentline.payment_status).toBe("retry");
+        expect(paymentline.bancontact_id).toBe(null);
+        expect(paymentline.qr_code).toBe(null);
         expect(notificationMessage).toBe("Payment failed");
         expect(store.qrCode).toBe(null);
         expect(paymentline.uiState.qrCode).toBe(null);
         expect.verifySteps(["store.qrCode.closer.1"]);
 
         // Current order but different payment line selected
-        const paymentline2 = createPaymentLine(store, order, display, data);
+        const paymentline2 = createPaymentLine(store, order, display);
         reset(order, paymentline2, 2);
         await store.handleBancontactPayNotification({
-            payment_id: paymentline.id,
+            bancontact_id: "bancontact_id",
             bancontact_status: "FAILED",
         });
 
+        expect(paymentline.payment_status).toBe("retry");
+        expect(paymentline.bancontact_id).toBe(null);
+        expect(paymentline.qr_code).toBe(null);
         expect(notificationMessage).toBe("Payment failed");
         expect(store.qrCode).not.toBe(null);
         expect(paymentline.uiState.qrCode).toBe(null);
@@ -232,16 +258,78 @@ describe("handleBancontactPayNotification", () => {
 
         // Other order selected
         const order2 = await getFilledOrder(store);
-        const paymentline3 = createPaymentLine(store, order2, display, data);
+        const paymentline3 = createPaymentLine(store, order2, display);
         reset(order2, paymentline3, 3);
         await store.handleBancontactPayNotification({
-            payment_id: paymentline.id,
+            bancontact_id: "bancontact_id",
             bancontact_status: "FAILED",
         });
 
+        expect(paymentline.payment_status).toBe("retry");
+        expect(paymentline.bancontact_id).toBe(null);
+        expect(paymentline.qr_code).toBe(null);
         expect(notificationMessage).toBe(`A payment for order test_order_1 has failed.`);
         expect(store.qrCode).not.toBe(null);
         expect(paymentline.uiState.qrCode).toBe(null);
         expect.verifySteps([]);
+
+        // Already retry
+        reset(order, paymentline, 4);
+        paymentline.payment_status = "retry";
+        await store.handleBancontactPayNotification({
+            bancontact_id: "bancontact_id",
+            bancontact_status: "FAILED",
+        });
+
+        expect(paymentline.payment_status).toBe("retry");
+        expect(paymentline.bancontact_id).toBe("bancontact_id");
+        expect(paymentline.qr_code).toBe("bancontact_qr_code");
+        expect(notificationMessage).toBe(null);
+        expect(store.qrCode).not.toBe(null);
+        expect(paymentline.uiState.qrCode).toBe("test_qr_code");
+        expect.verifySteps([]);
+    });
+
+    test("skip", async () => {
+        const store = await setupPosEnv();
+        const order = await getFilledOrder(store);
+        const display = store.models["pos.payment.method"].get(4);
+        const paymentline = createPaymentLine(store, order, display);
+        paymentline.setPaymentStatus = () => {
+            expect.step("paymentline.setPaymentStatus");
+        };
+
+        // not found
+        await store.handleBancontactPayNotification({
+            bancontact_id: "not_found_bancontact_id",
+            bancontact_status: "SUCCEEDED",
+        });
+        expect.verifySteps([]);
+
+        // already done
+        paymentline.bancontact_id = "bancontact_id";
+        paymentline.payment_status = "done";
+        await store.handleBancontactPayNotification({
+            bancontact_id: "bancontact_id",
+            bancontact_status: "SUCCEEDED",
+        });
+        expect.verifySteps([]);
+
+        // order finalized
+        paymentline.payment_status = "waitingScan";
+        order.state = "done";
+        await store.handleBancontactPayNotification({
+            bancontact_id: "bancontact_id",
+            bancontact_status: "SUCCEEDED",
+        });
+        expect.verifySteps([]);
+
+        // success
+        order.state = "draft";
+        await store.handleBancontactPayNotification({
+            bancontact_id: "bancontact_id",
+            bancontact_status: "SUCCEEDED",
+        });
+        expect.verifySteps(["paymentline.setPaymentStatus"]);
     });
 });

--- a/addons/pos_bancontact_pay/static/tests/unit/data/pos_payment_method.data.js
+++ b/addons/pos_bancontact_pay/static/tests/unit/data/pos_payment_method.data.js
@@ -6,45 +6,29 @@ patch(PosPaymentMethod.prototype, {
         return [...super._load_pos_data_fields(), "bancontact_usage"];
     },
 
-    create_bancontact_payment(id, ...args) {
-        const { amount, payment_id } = args[0];
-        if (amount <= 0) {
-            throw new Error("Failed to create payment");
+    create_bancontact_payment(id, data) {
+        if (this[id].payment_provider !== "bancontact_pay") {
+            throw new Error("Error Server: Wrong Provider");
         }
-        const PosPayment = this.env["pos.payment"];
-        const pos_payment_id = PosPayment.search([["id", "=", payment_id]])[0];
-        const pos_payment = PosPayment.read(
-            [pos_payment_id],
-            PosPayment._load_pos_data_fields(),
-            false
-        )[0];
-        pos_payment.bancontact_id = "bancontact_" + pos_payment_id;
-        pos_payment.qr_code = "https://example.com/qrcode/bancontact_" + pos_payment_id;
+
+        if (data.amount < 0) {
+            throw new Error(`Failed to create payment (ERR: ${-data.amount})`);
+        }
 
         return {
-            "pos.payment": [pos_payment],
+            bancontact_id: "bancontact_id",
+            qr_code: "bancontact_qr_code",
         };
     },
 
-    cancel_bancontact_payment(id, ...args) {
-        const { payment_id, force_cancel } = args[0];
-        const PosPayment = this.env["pos.payment"];
-        const pos_payment_id = PosPayment.search([["id", "=", payment_id]])[0];
-        const pos_payment = PosPayment.read(
-            [pos_payment_id],
-            PosPayment._load_pos_data_fields(),
-            false
-        )[0];
-
-        if (!force_cancel && pos_payment.amount < 0) {
-            throw new Error(`Failed to cancel payment (ERR: ${-pos_payment.amount})`);
+    cancel_bancontact_payment(id, bancontact_id) {
+        if (this[id].payment_provider !== "bancontact_pay") {
+            throw new Error("Error Server: Wrong Provider");
         }
-        pos_payment.bancontact_id = null;
-        pos_payment.qr_code = null;
 
-        return {
-            "pos.payment": [pos_payment],
-        };
+        if (typeof bancontact_id === "number" && bancontact_id < 0) {
+            throw new Error(`Failed to cancel payment (ERR: ${-bancontact_id})`);
+        }
     },
 });
 
@@ -65,6 +49,7 @@ PosPaymentMethod._records.push(
         image: false,
         sequence: 3,
         default_qr: false,
+        config_ids: [1],
     },
     {
         id: 5,
@@ -82,6 +67,7 @@ PosPaymentMethod._records.push(
         image: false,
         sequence: 4,
         default_qr: false,
+        config_ids: [1],
     },
     {
         id: 6,
@@ -99,5 +85,6 @@ PosPaymentMethod._records.push(
         image: false,
         sequence: 5,
         default_qr: false,
+        config_ids: [1],
     }
 );

--- a/addons/pos_bancontact_pay/tests/test_frontend.py
+++ b/addons/pos_bancontact_pay/tests/test_frontend.py
@@ -1,5 +1,4 @@
 import json
-import uuid
 from contextlib import contextmanager
 from unittest.mock import patch
 
@@ -34,17 +33,17 @@ class TestFrontend(TestBancontactPay):
 
     def test_bancontact_show_qr_code(self):
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        with self.mock_bancontact_call():
+        with self.mock_bancontact_call(prefix="bancontact_show_qr_code_"):
             self.start_pos_tour("bancontact_pay_show_qr_code")
 
     def test_bancontact_success_payment(self):
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        with self.mock_bancontact_call():
+        with self.mock_bancontact_call(prefix="bancontact_success_"):
             self.start_pos_tour("bancontact_pay_success_payment")
 
     def test_bancontact_failed_payment(self):
         self.main_pos_config.with_user(self.pos_user).open_ui()
-        with self.mock_bancontact_call():
+        with self.mock_bancontact_call(prefix="bancontact_failed_"):
             self.start_pos_tour("bancontact_pay_failed_payment")
 
     @mute_logger("odoo.http")
@@ -61,20 +60,21 @@ class TestFrontend(TestBancontactPay):
             self.start_pos_tour("bancontact_pay_failed_to_cancel_payment_error_429")
 
     @contextmanager
-    def mock_bancontact_call(self, is_sticker=False, post_status_code=200, delete_status_code=200):
+    def mock_bancontact_call(self, prefix="bancontact_", post_status_code=200, delete_status_code=200):
+        counter = {"post": -1}
+
         def mock_post(url, **kwargs):
+            counter["post"] += 1
             response = Response()
 
-            if (not is_sticker and "merchant.api.preprod.bancontact.net/v3/payments" not in url) or \
-               (is_sticker and "merchant.api.preprod.bancontact.net/v3/payments/pos" not in url):
+            if "merchant.api.preprod.bancontact.net/v3/payments" not in url:
                 response.status_code = 404
                 return response
 
             if 200 <= post_status_code < 300:
-                payment_id = "bancontact_" + str(uuid.uuid4())
                 response._content = json.dumps(
                     {
-                        "paymentId": payment_id,
+                        "paymentId": prefix + str(counter["post"]),
                         "_links": {"qrcode": {"href": "https://example.com/bancontact_qrcode"}},
                     },
                 ).encode()
@@ -84,7 +84,7 @@ class TestFrontend(TestBancontactPay):
 
         def mock_delete(url, **kwargs):
             response = Response()
-            if "merchant.api.preprod.bancontact.net/v3/payments/" not in url:
+            if "merchant.api.preprod.bancontact.net/v3/payments" not in url:
                 response.status_code = 404
                 return response
 

--- a/addons/pos_bancontact_pay/tests/test_models.py
+++ b/addons/pos_bancontact_pay/tests/test_models.py
@@ -132,157 +132,87 @@ class TestModels(TestBancontactPay, CommonPosTest):
     # --------------------------------------
     # Create Bancontact Payment
     # --------------------------------------
-
-    def test_create_bancontact_payment_not_found(self):
+    def test_create_bancontact_payment_wrong_provider(self):
         with (self.assertRaises(ValidationError)):
-            self.payment_method_display.create_bancontact_payment(payment_id=9999)
+            self.bank_payment_method.create_bancontact_payment({})
 
     def test_create_bancontact_payment_success(self):
-        payment = self._init_bancontact_pos_payment()
         generated_bancontact_id = self._generate_bancontact_id()
         generated_qr_code = self._generate_qr_code()
 
         with self.mock_bancontact_call(bancontact_id=generated_bancontact_id, qr_code=generated_qr_code):
-            result = payment.payment_method_id.create_bancontact_payment(payment_id=payment.id)
-
-            self.assertEqual(len(result["pos.payment"]), 1)
-            self.assertEqual(result["pos.payment"][0]["id"], payment.id)
-            self.assertEqual(payment.bancontact_id, generated_bancontact_id)
-            self.assertEqual(payment.qr_code, generated_qr_code)
-
-    def test_create_bancontact_payment_already_exists_not_processing(self):
-        existing_bancontact_id = "__bancontact_existing_id__"
-        existing_qr_code = "__bancontact_existing_qr_code__"
-        payment = self._init_bancontact_pos_payment(
-            bancontact_id=existing_bancontact_id,
-            qr_code=existing_qr_code,
-            payment_status="retry",
-        )
-
-        generated_bancontact_id = self._generate_bancontact_id()
-        generated_qr_code = self._generate_qr_code()
-
-        with self.mock_bancontact_call(bancontact_id=generated_bancontact_id, qr_code=generated_qr_code):
-            result = payment.payment_method_id.create_bancontact_payment(payment_id=payment.id)
-
-            self.assertEqual(len(result["pos.payment"]), 1)
-            self.assertEqual(result["pos.payment"][0]["id"], payment.id)
-            self.assertEqual(payment.bancontact_id, generated_bancontact_id)
-            self.assertEqual(payment.qr_code, generated_qr_code)
-
-    def test_create_bancontact_payment_already_exists_processing(self):
-        existing_bancontact_id = "__bancontact_existing_id__"
-        existing_qr_code = "__bancontact_existing_qr_code__"
-        payment = self._init_bancontact_pos_payment(
-            bancontact_id=existing_bancontact_id,
-            qr_code=existing_qr_code,
-            payment_status="waitingScan",
-        )
-
-        generated_bancontact_id = self._generate_bancontact_id()
-        generated_qr_code = self._generate_qr_code()
-
-        with self.mock_bancontact_call(bancontact_id=generated_bancontact_id, qr_code=generated_qr_code):
-            result = payment.payment_method_id.create_bancontact_payment(payment_id=payment.id)
-
-            self.assertEqual(len(result["pos.payment"]), 1)
-            self.assertEqual(result["pos.payment"][0]["id"], payment.id)
-            self.assertEqual(payment.bancontact_id, existing_bancontact_id)
-            self.assertEqual(payment.qr_code, existing_qr_code)
+            result = self.payment_method_display.create_bancontact_payment({})
+            self.assertEqual(result, {"bancontact_id": generated_bancontact_id, "qr_code": generated_qr_code})
 
     def test_create_bancontact_payment_api_error(self):
         codes = [(400, MissingError), (401, AccessDenied), (403, AccessDenied),
                  (404, UserError), (422, ValidationError), (429, AccessDenied),
                  (500, AccessError), (503, AccessError)]
 
-        payment = self._init_bancontact_pos_payment()
         for status_code, expected_exception in codes:
             with self.mock_bancontact_call(post_status_code=status_code), self.assertRaises(expected_exception):
-                payment.payment_method_id.create_bancontact_payment(payment_id=payment.id)
+                self.payment_method_display.create_bancontact_payment({})
 
     # --------------------------------------
     # Cancel Bancontact Payment
     # --------------------------------------
-
-    def test_cancel_bancontact_payment_not_found(self):
+    def test_cancel_bancontact_payment_wrong_provider(self):
         with (self.assertRaises(ValidationError)):
-            self.payment_method_display.cancel_bancontact_payment(payment_id=9999)
+            self.bank_payment_method.cancel_bancontact_payment("bancontact_id")
 
     def test_cancel_bancontact_payment_success(self):
-        bancontact_id = self._generate_bancontact_id()
-        qr_code = self._generate_qr_code()
-        payment = self._init_bancontact_pos_payment(bancontact_id=bancontact_id, qr_code=qr_code, payment_status="waitingScan")
         with self.mock_bancontact_call():
-            result = payment.payment_method_id.cancel_bancontact_payment(payment_id=payment.id)
-
-            self.assertEqual(len(result["pos.payment"]), 1)
-            self.assertEqual(result["pos.payment"][0]["id"], payment.id)
-            self.assertFalse(payment.bancontact_id)
-            self.assertFalse(payment.qr_code)
-
-    def test_cancel_bancontact_payment_no_bancontact_id(self):
-        payment = self._init_bancontact_pos_payment(payment_status="waitingScan", qr_code="some_qr_code")
-        with self.mock_bancontact_call():
-            result = payment.payment_method_id.cancel_bancontact_payment(payment_id=payment.id)
-
-            self.assertEqual(len(result["pos.payment"]), 1)
-            self.assertEqual(result["pos.payment"][0]["id"], payment.id)
-            self.assertFalse(payment.bancontact_id)
-            self.assertEqual(payment.qr_code, "some_qr_code")
+            self.payment_method_display.cancel_bancontact_payment("bancontact_id")
 
     def test_cancel_bancontact_payment_api_error(self):
         codes = [(400, MissingError), (401, AccessDenied), (403, AccessDenied),
                  (404, UserError), (422, ValidationError), (429, AccessDenied),
                  (500, AccessError), (503, AccessError)]
 
-        bancontact_id = self._generate_bancontact_id()
-        qr_code = self._generate_qr_code()
-        payment = self._init_bancontact_pos_payment(bancontact_id=bancontact_id, qr_code=qr_code, payment_status="waitingScan")
-
         for status_code, expected_exception in codes:
             with self.mock_bancontact_call(delete_status_code=status_code), self.assertRaises(expected_exception):
-                payment.payment_method_id.cancel_bancontact_payment(payment_id=payment.id)
+                self.payment_method_display.cancel_bancontact_payment("bancontact_id")
 
     # --------------------------------------
     # Prepare Bancontact Payment Request
     # --------------------------------------
     def test_prepare_display_payment_request(self):
-        actual = self.payment_method_display._prepare_display_payment_request(
-            amount=10.00,
-            currency="EUR",
-            description="sample description",
-        )
+        actual = self.payment_method_display._prepare_display_payment_request({
+            "configId": 1,
+            "amount": 10.00,
+            "currency": "EUR",
+            "description": "sample description",
+        })
         expected = [
             f"{const.API_URLS['preprod']['merchant']}/v3/payments",
             {
                 "amount": 1000,
                 "currency": "EUR",
                 "description": "sample description",
-                "identifyCallbackUrl": f"{self.payment_method_sticker_1.get_base_url()}/bancontact_pay/webhook?mode=test",
-                "callbackUrl": f"{self.payment_method_sticker_1.get_base_url()}/bancontact_pay/webhook?mode=test",
+                "identifyCallbackUrl": f"{self.payment_method_display.get_base_url()}/bancontact_pay/webhook?config_id=1&ppid={self.payment_method_display.bancontact_ppid}&mode=test",
+                "callbackUrl": f"{self.payment_method_display.get_base_url()}/bancontact_pay/webhook?config_id=1&ppid={self.payment_method_display.bancontact_ppid}&mode=test",
             },
         ]
         self.assertEqual(actual, expected)
 
     def test_prepare_sticker_payment_request(self):
-        actual = self.payment_method_sticker_1._prepare_sticker_payment_request(
-            amount=10.00,
-            currency="EUR",
-            description="sample description",
-            paymentMethodId=1,
-            posId=2,
-            shopName="Shop Name",
-        )
+        actual = self.payment_method_sticker_1._prepare_sticker_payment_request({
+            "configId": 1,
+            "amount": 10.00,
+            "currency": "EUR",
+            "description": "sample description",
+            "shopName": "Shop Name",
+        })
         expected = [
             f"{const.API_URLS['preprod']['merchant']}/v3/payments/pos",
             {
                 "amount": 1000,
                 "currency": "EUR",
                 "description": "sample description",
-                "identifyCallbackUrl": f"{self.payment_method_sticker_1.get_base_url()}/bancontact_pay/webhook?mode=test",
-                "callbackUrl": f"{self.payment_method_sticker_1.get_base_url()}/bancontact_pay/webhook?mode=test",
-                "posId": "pm1",
-                "shopId": "pos2",
+                "identifyCallbackUrl": f"{self.payment_method_sticker_1.get_base_url()}/bancontact_pay/webhook?config_id=1&ppid={self.payment_method_sticker_1.bancontact_ppid}&mode=test",
+                "callbackUrl": f"{self.payment_method_sticker_1.get_base_url()}/bancontact_pay/webhook?config_id=1&ppid={self.payment_method_sticker_1.bancontact_ppid}&mode=test",
+                "posId": f"pm{self.payment_method_sticker_1.id}",
+                "shopId": "pos1",
                 "shopName": "Shop Name",
             },
         ]
@@ -323,22 +253,3 @@ class TestModels(TestBancontactPay, CommonPosTest):
 
     def _generate_qr_code(self):
         return "https://example.com/bancontact_qrcode/" + str(uuid.uuid4())
-
-    def _init_bancontact_pos_payment(self, **kwargs):
-        order, _ = self.create_backend_pos_order(
-            {
-                "pos_config": self.main_pos_config,
-                "line_data": [
-                    {"product_id": self.ten_dollars_no_tax.product_variant_id.id},
-                ],
-            },
-        )
-        return self.env["pos.payment"].create(
-            {
-                "amount": 100,
-                "payment_status": "pending",
-                "payment_method_id": self.payment_method_display.id,
-                "pos_order_id": order.id,
-                **kwargs,
-            },
-        )

--- a/addons/pos_bancontact_pay/tests/test_signature.py
+++ b/addons/pos_bancontact_pay/tests/test_signature.py
@@ -1,7 +1,7 @@
 import base64
 import json
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from unittest.mock import MagicMock, patch
 
 from cryptography.hazmat.backends import default_backend
@@ -292,17 +292,18 @@ class TestSignature(CommonPosTest, TestPointOfSaleHttpCommon):
     @freeze_time("2026-02-12 12:00:00")
     def test_validate_critical_headers_missing_unexpected_crit(self):
         protected = {
-            "crit": [const.IAT_KEY, const.PATH_KEY, const.SUB_KEY, "unexpected-crit"],
+            "crit": [const.ISS_KEY, const.IAT_KEY, const.PATH_KEY, const.SUB_KEY, "unexpected-crit"],
+            const.ISS_KEY: const.ISS_VALUE,
             const.IAT_KEY: "2026-02-12T12:00:00.000Z",
             const.PATH_KEY: "https://example.com/webhook",
             const.SUB_KEY: "dummy-ppid",
             "unexpected-crit": "value",
         }
         validation = BancontactSignatureValidation(MockRequest())
-        missing = {const.ISS_KEY, const.JTI_KEY}
+        missing = {const.JTI_KEY}
         unexpected = {"unexpected-crit"}
         with self.bancontact_signature_raise(f"Invalid crit header: missing {missing}, unexpected {unexpected}"):
-            validation._validate_critical_headers(protected)
+            validation._validate_critical_headers(protected, "dummy-ppid")
 
     @freeze_time("2026-02-12 12:00:00")
     def test_validate_critical_headers_wrong_iss(self):
@@ -316,11 +317,11 @@ class TestSignature(CommonPosTest, TestPointOfSaleHttpCommon):
         }
         validation = BancontactSignatureValidation(MockRequest())
         with self.bancontact_signature_raise("Invalid issuer: dummy"):
-            validation._validate_critical_headers(protected)
+            validation._validate_critical_headers(protected, "dummy-ppid")
 
         protected.pop(const.ISS_KEY)
         with self.bancontact_signature_raise(f"Missing required protected header(s): ['{const.ISS_KEY}']"):
-            validation._validate_critical_headers(protected)
+            validation._validate_critical_headers(protected, "dummy-ppid")
 
     @freeze_time("2026-02-12 12:00:00")
     def test_validate_critical_headers_wrong_iat(self):
@@ -334,19 +335,19 @@ class TestSignature(CommonPosTest, TestPointOfSaleHttpCommon):
         }
         validation = BancontactSignatureValidation(MockRequest())
         with self.bancontact_signature_raise(f"Invalid iat: outside allowed skew ({const.MAX_SKEW_SECONDS}s)"):
-            validation._validate_critical_headers(protected)
+            validation._validate_critical_headers(protected, "dummy-ppid")
 
         protected.update({const.IAT_KEY: "2026-02-12T13:00:00.000Z"})
         with self.bancontact_signature_raise(f"Invalid iat: outside allowed skew ({const.MAX_SKEW_SECONDS}s)"):
-            validation._validate_critical_headers(protected)
+            validation._validate_critical_headers(protected, "dummy-ppid")
 
         protected.update({const.IAT_KEY: "invalid-format"})
         with self.bancontact_signature_raise("Invalid iat format: invalid-format"):
-            validation._validate_critical_headers(protected)
+            validation._validate_critical_headers(protected, "dummy-ppid")
 
         protected.pop(const.IAT_KEY)
         with self.bancontact_signature_raise(f"Missing required protected header(s): ['{const.IAT_KEY}']"):
-            validation._validate_critical_headers(protected)
+            validation._validate_critical_headers(protected, "dummy-ppid")
 
     @freeze_time("2026-02-12 12:00:00")
     def test_validate_critical_headers_wrong_path(self):
@@ -360,7 +361,22 @@ class TestSignature(CommonPosTest, TestPointOfSaleHttpCommon):
         }
         validation = BancontactSignatureValidation(MockRequest())
         with self.bancontact_signature_raise("Path mismatch: https://example.com/error != https://example.com/webhook"):
-            validation._validate_critical_headers(protected)
+            validation._validate_critical_headers(protected, "dummy-ppid")
+
+    @freeze_time("2026-02-12 12:00:00")
+    def test_validate_critical_headers_wrong_subject(self):
+        protected = {
+            "crit": [const.ISS_KEY, const.IAT_KEY, const.JTI_KEY, const.PATH_KEY, const.SUB_KEY],
+            const.ISS_KEY: const.ISS_VALUE,
+            const.IAT_KEY: "2026-02-12T12:00:00.000Z",
+            const.JTI_KEY: "unique-jti-12345",
+            const.PATH_KEY: "https://example.com/webhook",
+            const.SUB_KEY: "wrong-ppid",
+        }
+
+        validation = BancontactSignatureValidation(MockRequest())
+        with self.bancontact_signature_raise("Invalid subject: wrong-ppid"):
+            validation._validate_critical_headers(protected, "dummy-ppid")
 
     @freeze_time("2026-02-12 12:00:00")
     def test_validate_critical_headers_success(self):
@@ -370,25 +386,10 @@ class TestSignature(CommonPosTest, TestPointOfSaleHttpCommon):
             const.IAT_KEY: "2026-02-12T12:00:00.000Z",
             const.JTI_KEY: "unique-jti-12345",
             const.PATH_KEY: "http://example.com/webhook",  # Allow http vs https mismatch
-            const.SUB_KEY: "save-subject",
+            const.SUB_KEY: "dummy-ppid",
         }
         validation = BancontactSignatureValidation(MockRequest())
-        validation._validate_critical_headers(protected)
-        self.assertEqual(validation.subject, "save-subject")
-
-    # ----- verify_subject ----- #
-    @mute_logger("odoo.addons.pos_bancontact_pay.controllers.signature")
-    def test_verify_subject_mismatch(self):
-        validation = BancontactSignatureValidation(MockRequest())
-        validation.subject = "dummy-ppid"
-        validation.verify_subject("dummy-ppid")
-
-        validation.subject = "wrong-ppid"
-        with self.bancontact_signature_raise("Invalid subject: wrong-ppid"):
-            validation.verify_subject("dummy-ppid")
-
-        validation.test_mode = True
-        validation.verify_subject("dummy-ppid")  # Should not raise in test mode
+        validation._validate_critical_headers(protected, "dummy-ppid")
 
     # ----- verify_signature ----- #
     @mute_logger("odoo.addons.pos_bancontact_pay.controllers.signature")
@@ -408,19 +409,19 @@ class TestSignature(CommonPosTest, TestPointOfSaleHttpCommon):
         }
         with self.mock_jwk_fetch([jwk], called=False, cache=cache) as get_cache:
             validation = BancontactSignatureValidation(MockRequest(data=payload, headers={"Signature": signature}))
-            validation.verify_signature()
+            validation.verify_signature("dummy-ppid")
         self.assertEqual(get_cache(), cache)
 
         tampered_payload = b"tampered payload"
         validation.request.data = tampered_payload
         with self.mock_jwk_fetch([jwk], called=False, cache=cache) as get_cache, \
             self.bancontact_signature_raise("ECDSA signature verification failed."):
-            validation.verify_signature()
+            validation.verify_signature("dummy-ppid")
         self.assertEqual(get_cache(), cache)
 
         validation.test_mode = True
         with self.mock_jwk_fetch([jwk], called=False, cache=cache) as get_cache:
-            validation.verify_signature()  # Should not raise in test mode
+            validation.verify_signature("dummy-ppid")  # Should not raise in test mode
         self.assertEqual(get_cache(), cache)
 
     # ----- Context Manager ----- #
@@ -551,7 +552,7 @@ class BancontactTestUtils:
     @staticmethod
     def create_protected_header(kid: str, url: str, ppid: str, **overrides) -> dict:
         """Create valid protected header with optional overrides."""
-        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+        now = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
         header = {
             "alg": "ES256",
             "kid": kid,

--- a/addons/pos_bancontact_pay/tests/test_webhook.py
+++ b/addons/pos_bancontact_pay/tests/test_webhook.py
@@ -11,148 +11,71 @@ from odoo.addons.pos_bancontact_pay.errors.exceptions import BancontactSignature
 
 @tagged("post_install", "-at_install")
 class TestWebhook(CommonPosTest, TestPointOfSaleHttpCommon):
-
-    def setUp(self):
-        super().setUp()
-        self.test_ppid = "test_bancontact_ppid"
-        self.web_hook_payload_base = {"transferAmount": 100, "amount": 100, "currency": "EUR"}
-
-        self.bancontact_payment_method = self.env['pos.payment.method'].create({
-            'name': 'Bancontact Pay',
-            'bancontact_ppid': self.test_ppid,
-            'journal_id': self.company_data['default_journal_bank'].id,
-            'receivable_account_id': self.company_data['default_account_receivable'].id,
-        })
-
-        self.pos_config_usd.write({
-            'payment_method_ids': [(4, self.bancontact_payment_method.id, 0)],
-        })
-
     # ----- Payment Status ----- #
-    def test_bancontact_webhook_payment_status_done(self):
-        pos_payment, payload = self._make_payment_and_payload("succeeded_id", "waitingScan", "succeeded_qr_code")
+    def test_bancontact_webhook(self):
+        payload = self._make_payload("any_id", "any_status")
 
-        with self._notify_patcher(pos_payment) as mock_notify:
-            self._post_status(payload, "SUCCEEDED")
-            self.assertEqual(pos_payment.payment_status, "done")
-            self.assertFalse(pos_payment.qr_code)
-            self.assertEqual(pos_payment.bancontact_id, "succeeded_id")
-            self._assert_notify_called_once(mock_notify, pos_payment, "SUCCEEDED")
+        response = self._post_bancontact_webhook("string_config_id", payload)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.text, "Invalid or missing config_id parameter")
 
-    def test_bancontact_webhook_payment_status_done_ignore(self):
-        pos_payment, payload = self._make_payment_and_payload("not_updated", "done", "not_updated_qr_code")
+        response = self._post_bancontact_webhook(999, payload)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.text, "Invalid POS configuration ID")
 
-        with self._notify_patcher(pos_payment) as mock_notify:
-            for status in ("SUCCEEDED", "CANCELLED"):
-                self._post_status(payload, status)
-                self.assertEqual(pos_payment.payment_status, "done")
-                self.assertEqual(pos_payment.qr_code, "not_updated_qr_code")
-                self.assertEqual(pos_payment.bancontact_id, "not_updated")
-
-            mock_notify.assert_not_called()
-
-    def test_bancontact_webhook_payment_status_error(self):
-        for bancontact_status in ("AUTHORIZATION_FAILED", "FAILED", "EXPIRED", "CANCELLED"):
-            pos_payment, payload = self._make_payment_and_payload("error_id", "waitingScan", "error_qr_code")
-
-            with self._notify_patcher(pos_payment) as mock_notify:
-                self._post_status(payload, bancontact_status)
-                self.assertEqual(pos_payment.payment_status, "retry")
-                self.assertFalse(pos_payment.qr_code)
-                self.assertFalse(pos_payment.bancontact_id)
-                self._assert_notify_called_once(mock_notify, pos_payment, bancontact_status)
-
-    def test_bancontact_webhook_payment_status_error_ignore(self):
-        pos_payment, payload = self._make_payment_and_payload("not_updated", "retry", "not_updated_qr_code")
-
-        with self._notify_patcher(pos_payment) as mock_notify:
-            for status in ("AUTHORIZATION_FAILED", "FAILED", "EXPIRED", "CANCELLED"):
-                self._post_status(payload, status)
-                self.assertEqual(pos_payment.payment_status, "retry")
-                self.assertEqual(pos_payment.qr_code, "not_updated_qr_code")
-                self.assertEqual(pos_payment.bancontact_id, "not_updated")
-
-            mock_notify.assert_not_called()
-
-    # ----- Errors ----- #
-    def test_bancontact_webhook_payment_not_found(self):
-        response = self._post_bancontact_webhook({"paymentId": "not_found_id"})
-        self.assertEqual(response.status_code, 404)
-        self.assertEqual(response.text, "Payment not found.")
-
-    def test_bancontact_webhook_invalid_signature(self):
         with self.mock_bancontact_signature_validation_error(verify_signature=True):
-            response = self._post_bancontact_webhook({"paymentId": "any_id"})
+            response = self._post_bancontact_webhook(self.main_pos_config.id, payload)
             self.assertEqual(response.status_code, 403)
             self.assertEqual(response.text, "MOCK: Invalid signature")
 
-    def test_bancontact_webhook_subject_mismatch(self):
-        _pos_payment, payload = self._make_payment_and_payload("subject_mismatch_id", "waitingScan", "subject_mismatch_qr_code")
+        with self._notify_patcher() as mock_notify:
+            response = self._post_bancontact_webhook(self.main_pos_config.id, payload)
+            self.assertEqual(response.status_code, 204)
+            self._assert_notify_count(mock_notify, "BANCONTACT_PAY_PAYMENTS_NOTIFICATION", 0)
 
-        with self.mock_bancontact_signature_validation_error(verify_subject=True):
-            response = self._post_bancontact_webhook(payload)
-            self.assertEqual(response.status_code, 403)
-            self.assertEqual(response.text, "MOCK: Subject mismatch")
+        for bancontact_status in ("SUCCEEDED", "AUTHORIZATION_FAILED", "FAILED", "EXPIRED", "CANCELLED"):
+            payload["status"] = bancontact_status
+            with self._notify_patcher() as mock_notify:
+                response = self._post_bancontact_webhook(self.main_pos_config.id, payload)
+                self.assertEqual(response.status_code, 200)
+                self._assert_notify_count(mock_notify, "BANCONTACT_PAY_PAYMENTS_NOTIFICATION", 1)
+                self._assert_notify_bancontact_pay_payments_notification(mock_notify, "any_id", bancontact_status)
 
     # ----- Helpers ----- #
-    def _make_payment_and_payload(self, bancontact_id, payment_status, qr_code):
-        pos_payment = self._init_bancontact_pos_payment(bancontact_id, payment_status, qr_code)
-        payload = dict(self.web_hook_payload_base, paymentId=bancontact_id)
-        return pos_payment, payload
+    def _make_payload(self, bancontact_id, payment_status):
+        return {"transferAmount": 100, "amount": 100, "currency": "EUR", "paymentId": bancontact_id, "status": payment_status}
 
-    def _notify_patcher(self, pos_payment):
-        return patch.object(pos_payment.pos_order_id.config_id.__class__, "_notify")
+    def _notify_patcher(self):
+        return patch.object(self.env["pos.config"].__class__, "_notify")
 
-    def _assert_notify_called_once(self, mock_notify, pos_payment, bancontact_status):
-        mock_notify.assert_called_once_with(
-            "BANCONTACT_PAY_PAYMENTS_NOTIFICATION",
-            {
-                "order_id": pos_payment.pos_order_id.id,
-                "payment_id": pos_payment.id,
-                "bancontact_status": bancontact_status,
-            },
-        )
+    def _assert_notify_count(self, mock_notify, name, expected_count):
+        calls = [call for call in mock_notify.mock_calls if call.args and call.args[0] == name]
+        self.assertEqual(len(calls), expected_count, f"Expected {expected_count} calls to _notify with name '{name}', but got {len(calls)} calls.")
 
-    def _init_bancontact_pos_payment(self, bancontact_id, payment_status, qr_code):
-        order, _ = self.create_backend_pos_order(
-            {
-                "line_data": [
-                    {"product_id": self.ten_dollars_no_tax.product_variant_id.id},
-                ],
-            },
-        )
-        return self.env["pos.payment"].create(
-            {
-                "amount": 100,
-                "payment_status": payment_status,
-                "bancontact_id": bancontact_id,
-                "payment_method_id": self.bancontact_payment_method.id,
-                "pos_order_id": order.id,
-                "qr_code": qr_code,
-            },
-        )
+    def _assert_notify_with(self, mock_notify, name, expected_payload):
+        args_list = [call.args for call in mock_notify.mock_calls]
+        actual = [args == (name, expected_payload) for args in args_list]
+        self.assertTrue(any(actual), f"Notification not found\nExpected: {(name, expected_payload)}\nActual: {args_list}")
 
-    def _post_bancontact_webhook(self, payload):
+    def _assert_notify_bancontact_pay_payments_notification(self, mock_notify, bancontact_id, bancontact_status):
+        expected_payload = {
+            "bancontact_id": bancontact_id,
+            "bancontact_status": bancontact_status,
+        }
+        self._assert_notify_with(mock_notify, "BANCONTACT_PAY_PAYMENTS_NOTIFICATION", expected_payload)
+
+    def _post_bancontact_webhook(self, config_id, payload):
         return self.url_open(
-            "/bancontact_pay/webhook?mode=test",
+            f"/bancontact_pay/webhook?config_id={config_id}&mode=test",
             data=json.dumps(payload),
             headers={"content-type": "application/json"},
             method="POST",
         )
 
-    def _post_status(self, payload, status):
-        payload["status"] = status
-        response = self._post_bancontact_webhook(payload)
-        self.assertEqual(response.status_code, 200)
-        return response
-
     # ----- Context Manager ----- #
     @contextmanager
-    def mock_bancontact_signature_validation_error(self, verify_signature=None, verify_subject=None):
-        with patch("odoo.addons.pos_bancontact_pay.controllers.signature.BancontactSignatureValidation.verify_signature") as verify_signature_mock, \
-             patch("odoo.addons.pos_bancontact_pay.controllers.signature.BancontactSignatureValidation.verify_subject") as verify_subject_mock:
+    def mock_bancontact_signature_validation_error(self, verify_signature=None):
+        with patch("odoo.addons.pos_bancontact_pay.controllers.signature.BancontactSignatureValidation.verify_signature") as verify_signature_mock:
             if verify_signature:
                 verify_signature_mock.side_effect = BancontactSignatureValidationError("MOCK: Invalid signature")
-            if verify_subject:
-                verify_subject_mock.side_effect = BancontactSignatureValidationError("MOCK: Subject mismatch")
             yield

--- a/addons/pos_online_payment_self_order/static/src/app/pages/payment_page/payment_page.js
+++ b/addons/pos_online_payment_self_order/static/src/app/pages/payment_page/payment_page.js
@@ -4,6 +4,12 @@ import { _t } from "@web/core/l10n/translation";
 import { generateQRCodeDataUrl } from "@point_of_sale/utils";
 
 patch(PaymentPage.prototype, {
+    get showQrCode() {
+        return (
+            super.showQrCode ||
+            (this.selectedPaymentIsOnline && this.selfOrder.config.self_ordering_mode === "kiosk")
+        );
+    },
     async startPayment() {
         let order = this.selfOrder.currentOrder;
         const pm = this.selectedPaymentMethod;
@@ -27,7 +33,7 @@ patch(PaymentPage.prototype, {
         return paymentMethods && paymentMethods.is_online_payment;
     },
     generateQrcodeImg(url) {
-        this.state.qrImage = generateQRCodeDataUrl(url);
+        this.state.qrCode = generateQRCodeDataUrl(url);
     },
     async checkAndOpenPaymentPage(order) {
         if (order.state === "draft") {

--- a/addons/pos_online_payment_self_order/static/src/app/pages/payment_page/payment_page.scss
+++ b/addons/pos_online_payment_self_order/static/src/app/pages/payment_page/payment_page.scss
@@ -1,7 +1,0 @@
-.o_self_payment_screen {
-
-    .qr-code {
-        width: 50vw;
-        max-width: 400px;
-    }
-}

--- a/addons/pos_online_payment_self_order/static/src/app/pages/payment_page/payment_page.xml
+++ b/addons/pos_online_payment_self_order/static/src/app/pages/payment_page/payment_page.xml
@@ -1,17 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_online_payment_self_order.PaymentPage" t-inherit="pos_self_order.PaymentPage" t-inherit-mode="extension">
-        <xpath expr="//div[hasclass('payment-state-container')]" position="after">
-            <div t-if="this.selectedPaymentIsOnline and !this.state.selection and this.selfOrder.config.self_ordering_mode === 'kiosk'" class="o_self_payment_screen d-flex justify-content-center align-items-center flex-column h-100 px-3 text-center o_self_fade">
-                <h1 class="fw-bolder mb-4">Scan the QR code to pay</h1>
-                <div class="qr-code d-inline-flex flex-column border rounded-4 p-0 bg-view mb-3">
-                    <img class="p-5" t-att-src="this.state.qrImage" />
-                </div>
-                <h3 t-if="this.selfOrder.onlinePaymentStatus === 'progress'">Payment in progress</h3>
-            </div>
-        </xpath>
-        <xpath expr="//div[hasclass('payment-state-container')]" position="attributes">
-            <attribute name="t-if">!this.selectedPaymentIsOnline and !this.state.selection</attribute>
+        <xpath expr="//t[@name='external_qr']" position="inside">
+            <h3 class="position-absolute"
+                style="top: 110%"
+                t-if="this.selectedPaymentIsOnline and this.selfOrder.config.self_ordering_mode === 'kiosk' and this.selfOrder.onlinePaymentStatus === 'progress'">
+                Payment in progress
+            </h3>
         </xpath>
     </t>
 </templates>

--- a/addons/pos_online_payment_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_online_payment_self_order/static/src/app/services/self_order_service.js
@@ -25,6 +25,12 @@ patch(SelfOrder.prototype, {
             }
         });
     },
+    createNewOrder() {
+        if (this.onlinePaymentStatus === "progress") {
+            this.onlinePaymentStatus = null;
+        }
+        return super.createNewOrder(...arguments);
+    },
     hasPaymentMethod() {
         if (
             this.config.self_ordering_mode === "mobile" &&

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -90,7 +90,8 @@ class PosOrder(models.Model):
             'data': {
                 'pos.order': self.read(self._load_pos_self_data_fields(self.config_id), load=False),
                 'pos.order.line': self.lines.read(self.lines._load_pos_self_data_fields(self.config_id), load=False),
-            }
+                'pos.payment': self.payment_ids.read(self.payment_ids._load_pos_self_data_fields(self.config_id), load=False),
+            },
         })
         if payment_result == 'Success':
             self._send_self_order_receipt()
@@ -117,7 +118,7 @@ class PosOrder(models.Model):
             product = pos_config.env['product.product'].browse(line_data.get('product_id'))
             tax_ids = fiscal_position_id.map_tax(product.taxes_id)
 
-            return [Command.CREATE, 0, {
+            return [line[0], 0 if line[0] == Command.CREATE else line[1], {
                 'combo_id': line_data.get('combo_id'),
                 'product_id': line_data.get('product_id'),
                 'tax_ids': tax_ids.ids,
@@ -131,11 +132,45 @@ class PosOrder(models.Model):
                 'full_product_name': line_data.get('full_product_name'),
                 'customer_note': line_data.get('customer_note'),
                 'uuid': line_data.get('uuid'),
-                'id': line_data.get('id'),
                 'order_id': existing_order.id if existing_order.exists() else None,
                 'combo_parent_id': line_data.get('combo_parent_id'),
                 'combo_item_id': line_data.get('combo_item_id'),
                 'combo_line_ids': [id for id in line_data.get('combo_line_ids', []) if isinstance(id, int)],
+            }]
+        return []
+
+    @api.model
+    def _check_pos_order_payments(self, pos_config, order, payment):
+        existing_order = pos_config.env['pos.order'].browse(order.get('id'))
+        existing_payments = existing_order.payment_ids if existing_order.exists() else pos_config.env['pos.payment']
+
+        if payment[0] == Command.DELETE and payment[1] in existing_payments.ids:
+            return [Command.DELETE, payment[1]]
+        if payment[0] == Command.UNLINK and payment[1] in existing_payments.ids:
+            return [Command.UNLINK, payment[1]]
+        if payment[0] == Command.CREATE or payment[0] == Command.UPDATE:
+            payment_data = payment[2]
+
+            return [payment[0], 0 if payment[0] == Command.CREATE else payment[1], {
+                'amount': payment_data.get('amount'),
+                'card_brand': payment_data.get('card_brand'),
+                'card_no': payment_data.get('card_no'),
+                'card_type': payment_data.get('card_type'),
+                'cardholder_name': payment_data.get('cardholder_name'),
+                'is_change': payment_data.get('is_change'),
+                'name': payment_data.get('name'),
+                'payment_date': payment_data.get('payment_date'),
+                'payment_method_authcode': payment_data.get('payment_method_authcode'),
+                'payment_method_id': payment_data.get('payment_method_id'),
+                'payment_method_issuer_bank': payment_data.get('payment_method_issuer_bank'),
+                'payment_method_payment_mode': payment_data.get('payment_method_payment_mode'),
+                'payment_ref_no': payment_data.get('payment_ref_no'),
+                'payment_status': payment_data.get('payment_status'),
+                'pos_order_id': existing_order.id if existing_order.exists() else None,
+                'qr_code': payment_data.get('qr_code'),
+                'ticket': payment_data.get('ticket'),
+                'transaction_id': payment_data.get('transaction_id'),
+                'uuid': payment_data.get('uuid'),
             }]
         return []
 
@@ -154,6 +189,7 @@ class PosOrder(models.Model):
         fiscal_position_id = preset_id.fiscal_position_id if preset_id else pos_config.default_fiscal_position_id
         pricelist_id = preset_id.pricelist_id if preset_id else pos_config.pricelist_id
         lines = [self._check_pos_order_lines(pos_config, order, line, fiscal_position_id) for line in order.get('lines', [])]
+        payments = [self._check_pos_order_payments(pos_config, order, payment) for payment in order.get('payment_ids', [])]
         partner_id = order.get('partner_id')
         partner = pos_config.env['res.partner'].browse(partner_id) if partner_id else None
 
@@ -201,6 +237,7 @@ class PosOrder(models.Model):
             'uuid': order.get('uuid'),
             'has_deleted_line': order.get('has_deleted_line'),
             'lines': lines,
+            'payment_ids': payments,
             'relations_uuid_mapping': order.get('relations_uuid_mapping', {}),
         }
 

--- a/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.js
+++ b/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.js
@@ -16,6 +16,9 @@ export class PaymentPage extends Component {
         this.state = useState({
             selection: true,
             paymentMethodId: null,
+            qrCode: null,
+            fadeOut: false,
+            paymentMethodType: null,
         });
 
         onMounted(() => {
@@ -34,9 +37,14 @@ export class PaymentPage extends Component {
         this.router.back();
     }
 
+    get showQrCode() {
+        return this.state.paymentMethodType === "external_qr" && this.state.qrCode;
+    }
+
     selectMethod(methodId) {
         this.state.selection = false;
         this.state.paymentMethodId = methodId;
+        this.state.paymentMethodType = this.selectedPaymentMethod.payment_method_type;
         this.startPayment();
     }
 
@@ -49,6 +57,7 @@ export class PaymentPage extends Component {
     // this function will be override by pos_online_payment_self_order module
     // in mobile is the only available payment method
     async startPayment() {
+        this.state.qrCode = null;
         this.selfOrder.paymentError = false;
         try {
             if (this.selectedPaymentMethod.payment_interface) {
@@ -62,7 +71,16 @@ export class PaymentPage extends Component {
                 try {
                     const paymentSuccessful = await newPaymentLine.pay();
                     if (!paymentSuccessful) {
-                        throw new Error("Payment terminal payment failed");
+                        if (newPaymentLine.useQr && newPaymentLine.qr_code) {
+                            this.state.fadeOut = true;
+                            setTimeout(() => {
+                                this.state.qrCode = newPaymentLine.qr_code;
+                                this.state.fadeOut = false;
+                            }, 300);
+                            return;
+                        }
+
+                        throw new Error("Payment failed");
                     }
                 } catch (err) {
                     this.selfOrder.currentOrder.removePaymentline(newPaymentLine);

--- a/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.scss
+++ b/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.scss
@@ -1,0 +1,103 @@
+.payment-state-container {
+    min-width: 200px;
+    opacity: 0;
+    animation: fadeIn 300ms forwards;
+    &.fade-out {
+        animation: fadeOut 300ms forwards;
+    }
+    .qr-code {
+        width: 50vw;
+        max-width: 400px;
+    }
+}
+
+@keyframes fadeOut {
+    from {
+        opacity: 1;
+    }
+    to {
+        opacity: 0;
+    }
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+.lds-grid,
+.lds-grid div {
+    box-sizing: border-box;
+}
+.lds-grid {
+    display: inline-block;
+    position: relative;
+    width: 80px;
+    height: 80px;
+}
+.lds-grid div {
+    position: absolute;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: currentColor;
+    animation: lds-grid 1.2s linear infinite;
+}
+.lds-grid div:nth-child(1) {
+    top: 8px;
+    left: 8px;
+    animation-delay: 0s;
+}
+.lds-grid div:nth-child(2) {
+    top: 8px;
+    left: 32px;
+    animation-delay: -0.4s;
+}
+.lds-grid div:nth-child(3) {
+    top: 8px;
+    left: 56px;
+    animation-delay: -0.8s;
+}
+.lds-grid div:nth-child(4) {
+    top: 32px;
+    left: 8px;
+    animation-delay: -0.4s;
+}
+.lds-grid div:nth-child(5) {
+    top: 32px;
+    left: 32px;
+    animation-delay: -0.8s;
+}
+.lds-grid div:nth-child(6) {
+    top: 32px;
+    left: 56px;
+    animation-delay: -1.2s;
+}
+.lds-grid div:nth-child(7) {
+    top: 56px;
+    left: 8px;
+    animation-delay: -0.8s;
+}
+.lds-grid div:nth-child(8) {
+    top: 56px;
+    left: 32px;
+    animation-delay: -1.2s;
+}
+.lds-grid div:nth-child(9) {
+    top: 56px;
+    left: 56px;
+    animation-delay: -1.6s;
+}
+@keyframes lds-grid {
+    0%,
+    100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.5;
+    }
+}

--- a/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.xml
@@ -17,17 +17,32 @@
                             <span t-out="payment_method.name" />
                         </button>
                     </div>
-                    <div class="payment-state-container d-flex flex-column gap-4 align-items-center justify-content-center w-50 mx-auto p-3">
-                        <h1 class="mb-3 text-center">Follow instructions on the terminal</h1>
-                        <div class="btn btn-light btn-lg w-100 py-5 border border-light shadow-sm">
-                            <i class="fa fa-credit-card-alt fa-3x" aria-hidden="true"></i>
-                        </div>
+                    <div t-else="" class="payment-state-container d-flex flex-column gap-4 align-items-center justify-content-center w-sm-75 w-50-md mx-auto"
+                        t-att-class="{'fade-out': state.fadeOut}">
+                        <t name="terminal" t-if="state.paymentMethodType === 'terminal'">
+                            <h1 class="text-center">Follow instructions on the terminal</h1>
+                            <div class="btn btn-light btn-lg w-100 py-5 border border-light shadow-sm">
+                                <i class="fa fa-credit-card-alt fa-3x" aria-hidden="true"></i>
+                            </div>
+                        </t>
+                        <t name="external_qr" t-elif="this.showQrCode">
+                            <h1 class="text-center">Scan the QR code to pay</h1>
+                            <div class="qr-code border rounded-4 p-4 bg-view">
+                                <img class="w-100" t-att-src="state.qrCode" />
+                            </div>
+                        </t>
+                        <t t-else="">
+                            <h1 class="text-center">Processing your payment...</h1>
+                            <div class="btn btn-light btn-lg w-100 py-5 border border-light shadow-sm">
+                                <div class="lds-grid"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+                            </div>
+                        </t>
                     </div>
                </div>
             </div>
 
             <div class="o_self_footer container o_self_container d-flex justify-content-between align-items-center position-relative py-3">
-                <button class="btn btn-secondary btn-lg" t-if="this.state.selection || this.selectedPaymentMethod.is_online_payment || this.selfOrder.paymentError" t-on-click="this.back">Back</button>
+                <button class="btn btn-secondary btn-lg" t-if="this.state.selection || this.state.paymentMethodType !== 'terminal' || this.selfOrder.paymentError" t-on-click="this.back">Back</button>
                 <button class="btn btn-primary btn-lg" t-if="!this.state.selection and this.selfOrder.paymentError" t-on-click="this.startPayment">Retry</button>
             </div>
 

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -142,6 +142,11 @@ export class SelfOrder extends Reactive {
                     this.paymentError = true;
                 }
             });
+
+            this.data.connectWebSocket(
+                "FINALIZE_KIOSK_PAYMENT",
+                this._onFinalizeKiokPayment.bind(this)
+            );
         }
         this.data.connectWebSocket("REMOVE_ORDERS", (data) => {
             this.removeOrdersByAccessTokens(data.deleted_order_tokens);
@@ -176,6 +181,36 @@ export class SelfOrder extends Reactive {
             this.addToCart(productTemplate, 1, "", {}, {});
             this.router.navigate("cart");
         });
+    }
+
+    _onFinalizeKiokPayment(args) {
+        const payment = this.currentOrder?.payment_ids.at(-1);
+        const order_id = args.order_id || payment?.pos_order_id?.id;
+        if (
+            !this.currentOrder ||
+            this.currentOrder.id !== order_id ||
+            payment?.pos_order_id?.id !== order_id
+        ) {
+            return;
+        }
+
+        if (args.status === "success" && payment) {
+            payment.setPaymentStatus("done");
+            rpc(`/kiosk/payment/${this.config.id}/kiosk`, {
+                order: this.currentOrder.serializeForORM(),
+                access_token: this.access_token,
+                payment_method_id: payment.payment_method_id.id,
+            });
+        } else {
+            for (const p of this.currentOrder.payment_ids) {
+                this.currentOrder.removePaymentline(p);
+            }
+            this.paymentError = true;
+            this.notification.add(_t("Please try again or select another payment method"), {
+                title: args.error || _t("Payment failed"),
+                type: "danger",
+            });
+        }
     }
 
     /**
@@ -489,9 +524,7 @@ export class SelfOrder extends Reactive {
             const PaymentInterface = registry
                 .category("pos_payment_providers")
                 .get(pm.payment_provider, null);
-            if (PaymentInterface) {
-                pm.payment_interface = new PaymentInterface(this, pm);
-            }
+            pm.payment_interface = PaymentInterface ? new PaymentInterface(this, pm) : null;
         }
 
         if (this.ticketPrinter.useLna) {

--- a/addons/pos_self_order/static/tests/unit/pages/payment_page.test.js
+++ b/addons/pos_self_order/static/tests/unit/pages/payment_page.test.js
@@ -4,6 +4,7 @@ import { PaymentPage } from "@pos_self_order/app/pages/payment_page/payment_page
 import { setupSelfPosEnv, getFilledSelfOrder } from "../utils";
 import { definePosSelfModels } from "../data/generate_model_definitions";
 import { PaymentInterface } from "@point_of_sale/app/utils/payment/payment_interface";
+import { advanceTime } from "@odoo/hoot-mock";
 
 definePosSelfModels();
 
@@ -11,15 +12,22 @@ class MockPaymentInterface extends PaymentInterface {
     setup() {
         this.hasBeenCalled = false;
     }
-    sendPaymentRequest() {
+    sendPaymentRequest(line) {
         this.hasBeenCalled = true;
+        if (line.useQr) {
+            line.qr_code = "mock_qr_code";
+            return false;
+        }
         return true;
     }
 }
 
 class MockPaymentInterfaceWithError extends MockPaymentInterface {
-    sendPaymentRequest() {
+    sendPaymentRequest(line) {
         this.hasBeenCalled = true;
+        if (line.useQr) {
+            throw new Error("Payment failed");
+        }
         return false;
     }
 }
@@ -27,28 +35,53 @@ class MockPaymentInterfaceWithError extends MockPaymentInterface {
 const setupPaymentPage = async () => {
     const store = await setupSelfPosEnv();
 
-    const nonPaymentTerminal = store.models["pos.payment.method"].create({
+    const paymentNoProvider = store.models["pos.payment.method"].create({
         payment_provider: null,
+        payment_method_type: "none",
     });
+
     const paymentTerminal = store.models["pos.payment.method"].create({
         payment_provider: "mock_terminal",
+        payment_method_type: "terminal",
     });
     paymentTerminal.payment_interface = new MockPaymentInterface();
+
     const paymentTerminalWithError = store.models["pos.payment.method"].create({
         payment_provider: "mock_terminal",
+        payment_method_type: "terminal",
     });
     paymentTerminalWithError.payment_interface = new MockPaymentInterfaceWithError();
-    await getFilledSelfOrder(store);
 
+    const paymentExternalQr = store.models["pos.payment.method"].create({
+        payment_provider: "mock_qr",
+        payment_method_type: "external_qr",
+    });
+    paymentExternalQr.payment_interface = new MockPaymentInterface();
+
+    const paymentExternalQrWithError = store.models["pos.payment.method"].create({
+        payment_provider: "mock_qr",
+        payment_method_type: "external_qr",
+    });
+    paymentExternalQrWithError.payment_interface = new MockPaymentInterfaceWithError();
+
+    await getFilledSelfOrder(store);
     const paymentPage = await mountWithCleanup(PaymentPage, {});
 
-    return { paymentPage, store, nonPaymentTerminal, paymentTerminal, paymentTerminalWithError };
+    return {
+        paymentPage,
+        store,
+        paymentNoProvider,
+        paymentTerminal,
+        paymentTerminalWithError,
+        paymentExternalQr,
+        paymentExternalQrWithError,
+    };
 };
 
 describe("startPayment", () => {
     test("succeeds if the backend returns no error", async () => {
-        const { paymentPage, store, nonPaymentTerminal } = await setupPaymentPage();
-        paymentPage.state.paymentMethodId = nonPaymentTerminal.id;
+        const { paymentPage, store, paymentNoProvider } = await setupPaymentPage();
+        paymentPage.state.paymentMethodId = paymentNoProvider.id;
 
         onRpc("/kiosk/payment/1/kiosk", () => true);
         await paymentPage.startPayment();
@@ -57,8 +90,8 @@ describe("startPayment", () => {
     });
 
     test("fails if the backend returns an error", async () => {
-        const { paymentPage, store, nonPaymentTerminal } = await setupPaymentPage();
-        paymentPage.state.paymentMethodId = nonPaymentTerminal.id;
+        const { paymentPage, store, paymentNoProvider } = await setupPaymentPage();
+        paymentPage.state.paymentMethodId = paymentNoProvider.id;
 
         onRpc("/kiosk/payment/1/kiosk", () => {
             throw new Error();
@@ -100,6 +133,28 @@ describe("startPayment", () => {
         await paymentPage.startPayment();
 
         expect(paymentTerminal.payment_interface.hasBeenCalled).toBe(true);
+        expect(store.paymentError).toBe(true);
+    });
+
+    test("succeeds if the external QR code payment interface succeeds and backend returns no error", async () => {
+        const { paymentPage, store, paymentExternalQr } = await setupPaymentPage();
+        paymentPage.state.paymentMethodId = paymentExternalQr.id;
+
+        await paymentPage.startPayment();
+
+        expect(paymentExternalQr.payment_interface.hasBeenCalled).toBe(true);
+        expect(store.paymentError).toBe(false);
+        await advanceTime(500); // Wait timeout fade out
+        expect(paymentPage.state.qrCode).toBe("mock_qr_code");
+    });
+
+    test("fails if the external QR code payment interface fails", async () => {
+        const { paymentPage, store, paymentExternalQrWithError } = await setupPaymentPage();
+        paymentPage.state.paymentMethodId = paymentExternalQrWithError.id;
+
+        await paymentPage.startPayment();
+
+        expect(paymentExternalQrWithError.payment_interface.hasBeenCalled).toBe(true);
         expect(store.paymentError).toBe(true);
     });
 });

--- a/addons/pos_self_order/static/tests/unit/utils.js
+++ b/addons/pos_self_order/static/tests/unit/utils.js
@@ -29,10 +29,32 @@ export function initMockRpc() {
         return Object.fromEntries(Object.entries(response).filter(([key]) => models.includes(key)));
     };
 
+    const mockSyncOrder = async (request) => {
+        const { params } = await request.json();
+        const { order } = params;
+        const configId = order.config_id;
+
+        const response = MockServer.env["pos.order"].sync_from_ui([order]);
+
+        const partnerFields = MockServer.env["res.partner"]._load_pos_data_fields(configId);
+        const partnerIds = response["pos.order"]
+            .map((o) => o.partner_id)
+            .flat()
+            .filter((p) => !!p);
+        return {
+            "pos.order": response["pos.order"],
+            "pos.order.line": response["pos.order.line"],
+            "product.attribute.custom.value": response["product.attribute.custom.value"],
+            "pos.payment": response["pos.payment"],
+            "res.partner": MockServer.env["res.partner"].read(partnerIds, partnerFields, false),
+        };
+    };
+
     onRpc("/pos-self-order/process-order/kiosk", mockProcssOrder);
     onRpc("/pos-self-order/process-order/mobile", mockProcssOrder);
     onRpc("/pos-self-order/get-slots/", () => ({ usage_utc: {} }));
     onRpc("/pos-self-order/remove-order", () => ({}));
+    onRpc("/pos-self-order/sync-from-ui", mockSyncOrder);
 }
 
 export const setupPoSEnvForSelfOrder = async () => {

--- a/addons/pos_self_order_bancontact_pay/__init__.py
+++ b/addons/pos_self_order_bancontact_pay/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import controllers

--- a/addons/pos_self_order_bancontact_pay/__manifest__.py
+++ b/addons/pos_self_order_bancontact_pay/__manifest__.py
@@ -5,6 +5,21 @@
     "summary": "Disable Bancontact Pay payment methods for the kiosk",
     "auto_install": True,
     "depends": ["pos_self_order", "pos_bancontact_pay"],
+    "assets": {
+        "point_of_sale.payment_terminals": [
+            "pos_self_order_bancontact_pay/static/src/app/payment_bancontact.js",
+        ],
+        "pos_self_order.assets": [
+            "pos_self_order_bancontact_pay/static/src/app/payment_page.js",
+        ],
+        "pos_self_order.assets_tests": [
+            "pos_bancontact_pay/static/tests/tours/utils/*",
+            "pos_self_order_bancontact_pay/static/tests/tours/**/*",
+        ],
+        "web.assets_unit_tests": [
+            "pos_self_order_bancontact_pay/static/tests/unit/**/*",
+        ],
+    },
     "author": "Odoo S.A.",
     "license": "LGPL-3",
 }

--- a/addons/pos_self_order_bancontact_pay/controllers/__init__.py
+++ b/addons/pos_self_order_bancontact_pay/controllers/__init__.py
@@ -1,0 +1,2 @@
+from . import webhook
+from . import kiosk

--- a/addons/pos_self_order_bancontact_pay/controllers/kiosk.py
+++ b/addons/pos_self_order_bancontact_pay/controllers/kiosk.py
@@ -1,0 +1,23 @@
+from werkzeug.exceptions import Unauthorized
+
+from odoo import _, http
+
+from odoo.addons.pos_self_order.controllers.orders import PosSelfOrderController
+
+
+class PosSelfOrderControllerBancontactPay(PosSelfOrderController):
+    @http.route("/pos-self-order/create-bancontact-pay-payment", auth="public", type="jsonrpc", website=True)
+    def bancontact_pay_create_payment_from_kiosk(self, access_token, payment_method_id, order_uuid):
+        pos_config = self._verify_pos_config(access_token)
+        order = pos_config.env["pos.order"].search([["uuid", "=", order_uuid]], limit=1)
+        payment_method = pos_config.env["pos.payment.method"].browse(payment_method_id)
+
+        if not order.exists or not payment_method.exists() or payment_method.payment_provider != 'bancontact_pay' or pos_config.id not in payment_method.config_ids.ids:
+            raise Unauthorized()
+
+        return payment_method.sudo().create_bancontact_payment({
+            "configId": pos_config.id,
+            "amount": order.amount_total,
+            "currency": order.currency_id.name,
+            "description": _("Payment at %(company)s\nKiosk: %(config)s", company=pos_config.company_id.name, config=pos_config.name),
+        })

--- a/addons/pos_self_order_bancontact_pay/controllers/webhook.py
+++ b/addons/pos_self_order_bancontact_pay/controllers/webhook.py
@@ -1,0 +1,24 @@
+from odoo.addons.pos_bancontact_pay.controllers.webhook import BancontactPayController
+
+
+class SelfOrderBancontactPayController(BancontactPayController):
+    def _notify_pos(self, pos_config, bancontact_id, bancontact_status):
+        super()._notify_pos(pos_config, bancontact_id, bancontact_status)
+
+        if pos_config.self_ordering_mode == "kiosk":
+            error = self._get_bancontact_error_message(bancontact_status)
+            pos_config._notify(
+                "FINALIZE_KIOSK_PAYMENT",
+                {
+                    "status": "success" if bancontact_status == "SUCCEEDED" else "fail",
+                    "error": error,
+                    "bancontact_id": bancontact_id,
+                },
+            )
+
+    def _get_bancontact_error_message(self, bancontact_status):
+        if bancontact_status == "CANCELLED":
+            return "Payment cancelled"
+        if bancontact_status == "EXPIRED":
+            return "Payment expired"
+        return None

--- a/addons/pos_self_order_bancontact_pay/models/__init__.py
+++ b/addons/pos_self_order_bancontact_pay/models/__init__.py
@@ -1,2 +1,3 @@
 from . import pos_config
+from . import pos_order
 from . import pos_payment_method

--- a/addons/pos_self_order_bancontact_pay/models/pos_config.py
+++ b/addons/pos_self_order_bancontact_pay/models/pos_config.py
@@ -8,5 +8,5 @@ class PosConfig(models.Model):
     @api.constrains("payment_method_ids")
     def _check_unsupported_kiosks(self):
         for config in self:
-            if config.self_ordering_mode == "kiosk" and any(method.payment_provider == "bancontact_pay" for method in config.payment_method_ids):
-                raise ValidationError(_("Bancontact Pay payment methods are not supported in kiosk (self-ordering) mode."))
+            if config.self_ordering_mode == "kiosk" and any(method.payment_provider == "bancontact_pay" and method.bancontact_usage == "sticker" for method in config.payment_method_ids):
+                raise ValidationError(_("Bancontact Pay stickers are not supported for kiosks."))

--- a/addons/pos_self_order_bancontact_pay/models/pos_order.py
+++ b/addons/pos_self_order_bancontact_pay/models/pos_order.py
@@ -1,0 +1,12 @@
+from odoo import Command, api, models
+
+
+class PosOrder(models.Model):
+    _inherit = "pos.order"
+
+    @api.model
+    def _check_pos_order_payments(self, pos_config, order, payment):
+        result = super()._check_pos_order_payments(pos_config, order, payment)
+        if payment[0] in [Command.CREATE, Command.UPDATE]:
+            result[2]["bancontact_id"] = payment[2].get("bancontact_id")
+        return result

--- a/addons/pos_self_order_bancontact_pay/models/pos_payment_method.py
+++ b/addons/pos_self_order_bancontact_pay/models/pos_payment_method.py
@@ -8,5 +8,5 @@ class PosPaymentMethod(models.Model):
     @api.constrains("payment_provider", "config_ids")
     def _check_unsupported_kiosks(self):
         for record in self:
-            if record.payment_provider == "bancontact_pay" and any(config.self_ordering_mode == "kiosk" for config in record.config_ids):
-                raise ValidationError(_("Bancontact Pay is not supported in kiosk (self-ordering) mode."))
+            if record.payment_provider == "bancontact_pay" and record.bancontact_usage == "sticker" and any(config.self_ordering_mode == "kiosk" for config in record.config_ids):
+                raise ValidationError(_("Bancontact Pay stickers are not supported for kiosks."))

--- a/addons/pos_self_order_bancontact_pay/static/src/app/payment_bancontact.js
+++ b/addons/pos_self_order_bancontact_pay/static/src/app/payment_bancontact.js
@@ -1,0 +1,39 @@
+import { _t } from "@web/core/l10n/translation";
+import { patch } from "@web/core/utils/patch";
+import { PaymentBancontact } from "@pos_bancontact_pay/app/payment_bancontact";
+import { rpc } from "@web/core/network/rpc";
+import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+
+patch(PaymentBancontact.prototype, {
+    async sendPaymentRequest(line) {
+        if (this.pos.kioskMode) {
+            try {
+                const order = await this.pos.sendDraftOrderToServer();
+                const { bancontact_id, qr_code } = await rpc(
+                    `/pos-self-order/create-bancontact-pay-payment`,
+                    {
+                        access_token: this.pos.access_token,
+                        payment_method_id: line.payment_method_id.id,
+                        order_uuid: order.uuid,
+                    }
+                );
+                line.bancontact_id = bancontact_id;
+                line.qr_code = qr_code;
+            } catch (error) {
+                this._showError(error);
+                throw error;
+            }
+            return true;
+        }
+        return await super.sendPaymentRequest(...arguments);
+    },
+
+    _showError(error) {
+        if (error?.data?.message) {
+            this.dialog.add(AlertDialog, {
+                title: _t("Bancontact Payment Error"),
+                body: error.data.message,
+            });
+        }
+    },
+});

--- a/addons/pos_self_order_bancontact_pay/static/src/app/payment_page.js
+++ b/addons/pos_self_order_bancontact_pay/static/src/app/payment_page.js
@@ -1,0 +1,25 @@
+import { patch } from "@web/core/utils/patch";
+import { PaymentPage } from "@pos_self_order/app/pages/payment_page/payment_page";
+
+patch(PaymentPage.prototype, {
+    async startPayment() {
+        // Already waiting bancontact payment, do not start another one
+        const payments = this.selfOrder.currentOrder.payment_ids;
+        const waitingBancontactPayment = payments.find(
+            (p) =>
+                p.payment_method_id.id === this.state.paymentMethodId &&
+                p.payment_method_id.payment_provider === "bancontact_pay" &&
+                p.bancontact_id &&
+                p.qr_code &&
+                ["waiting", "waitingScan", "waitingCancel"].includes(p.payment_status)
+        );
+        if (waitingBancontactPayment) {
+            if (waitingBancontactPayment.amount === this.selfOrder.currentOrder.amount_total) {
+                this.state.qrCode = waitingBancontactPayment.qr_code;
+                return;
+            }
+            this.selfOrder.currentOrder.removePaymentline(waitingBancontactPayment);
+        }
+        await super.startPayment(...arguments);
+    },
+});

--- a/addons/pos_self_order_bancontact_pay/static/tests/tours/kiosk_bancontact_pay_tours.js
+++ b/addons/pos_self_order_bancontact_pay/static/tests/tours/kiosk_bancontact_pay_tours.js
@@ -1,0 +1,68 @@
+import { registry } from "@web/core/registry";
+import * as Utils from "@pos_self_order/../tests/tours/utils/common";
+import * as CartPage from "@pos_self_order/../tests/tours/utils/cart_page_util";
+import * as ConfirmationPage from "@pos_self_order/../tests/tours/utils/confirmation_page_util";
+import * as ProductPage from "@pos_self_order/../tests/tours/utils/product_page_util";
+import * as PosBancontactPay from "@pos_bancontact_pay/../tests/tours/utils/bancontact_pay_utils";
+import * as KioskBancontactPay from "@pos_self_order_bancontact_pay/../tests/tours/utils/kiosk_bancontact_pay_utils";
+const BancontactPay = { ...PosBancontactPay, ...KioskBancontactPay };
+
+registry.category("web_tour.tours").add("kiosk_bancontact_pay_success", {
+    steps: () =>
+        [
+            Utils.clickBtn("Order Now"),
+            ProductPage.clickProduct("Letter Tray"),
+            Utils.clickBtn("Checkout"),
+            CartPage.checkProduct("Letter Tray", "5.28"),
+            Utils.clickBtn("Pay"), // **kiosk_bancontact_success_0**
+            BancontactPay.processingPaymentStep(),
+            BancontactPay.scanQrCodeStep(),
+            BancontactPay.mockCallbackBancontactPay("kiosk_bancontact_success_0", "SUCCEEDED"),
+            ConfirmationPage.isShown(),
+            Utils.clickBtn("Close"),
+            Utils.checkIsNoBtn("My Order"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("kiosk_bancontact_pay_failed", {
+    steps: () =>
+        [
+            Utils.clickBtn("Order Now"),
+            ProductPage.clickProduct("Letter Tray"),
+            Utils.clickBtn("Checkout"),
+            CartPage.checkProduct("Letter Tray", "5.28"),
+            Utils.clickBtn("Pay"), // **kiosk_bancontact_failed_0**
+            BancontactPay.processingPaymentStep(),
+            BancontactPay.scanQrCodeStep(),
+            BancontactPay.mockCallbackBancontactPay("kiosk_bancontact_failed_0", "FAILED"),
+            BancontactPay.scanQrCodeStep(),
+            BancontactPay.notifiedDanger("Payment failed"),
+            Utils.clickBtn("Retry"), // **kiosk_bancontact_failed_1**
+            BancontactPay.processingPaymentStep(),
+            BancontactPay.scanQrCodeStep(),
+            BancontactPay.mockCallbackBancontactPay("kiosk_bancontact_failed_1", "SUCCEEDED"),
+            ConfirmationPage.isShown(),
+            Utils.clickBtn("Close"),
+            Utils.checkIsNoBtn("My Order"),
+        ].flat(),
+});
+
+const memo = {};
+registry.category("web_tour.tours").add("kiosk_bancontact_pay_failed_create_payment", {
+    steps: () =>
+        [
+            BancontactPay.setupBancontactErrorHttp(memo),
+            Utils.clickBtn("Order Now"),
+            ProductPage.clickProduct("Letter Tray"),
+            Utils.clickBtn("Checkout"),
+            CartPage.checkProduct("Letter Tray", "5.28"),
+            Utils.clickBtn("Pay"),
+            BancontactPay.processingPaymentStep(),
+            BancontactPay.notifiedDanger("An error has occurred"),
+            BancontactPay.bancontactDialogError(),
+            Utils.clickBtn("Retry"),
+            BancontactPay.teardownBancontactErrorHttp(memo),
+            BancontactPay.processingPaymentStep(),
+            BancontactPay.notifiedDanger("An error has occurred"),
+        ].flat(),
+});

--- a/addons/pos_self_order_bancontact_pay/static/tests/tours/utils/kiosk_bancontact_pay_utils.js
+++ b/addons/pos_self_order_bancontact_pay/static/tests/tours/utils/kiosk_bancontact_pay_utils.js
@@ -1,0 +1,32 @@
+export const followInstructionsTerminalStep = () => ({
+    content: "Check that the payment page shows the terminal instructions container",
+    trigger: ".payment-state-container h1:contains('Follow instructions on the terminal')",
+});
+export const scanQrCodeStep = () => ({
+    content: "Check that the payment page shows the QR code to pay",
+    trigger: ".payment-state-container h1:contains('Scan the QR code to pay')",
+});
+export const processingPaymentStep = () => ({
+    content: "Check that the payment page shows the processing payment message",
+    trigger: ".payment-state-container h1:contains('Processing your payment...')",
+});
+export function notifiedDanger(message) {
+    return {
+        content: "close the notification",
+        trigger: `.o_notification:has(.o_notification_bar.bg-danger):has(.o_notification_content:contains('${message}')) .o_notification_close`,
+        run: "click",
+    };
+}
+export function bancontactDialogError() {
+    return [
+        {
+            content: "Check that the Bancontact Pay dialog shows an error message",
+            trigger: ".o_dialog .modal-title:contains('Bancontact Payment Error')",
+        },
+        {
+            content: "Close the Bancontact Pay dialog",
+            trigger: ".o_dialog .modal-footer .btn:contains('Ok')",
+            run: "click",
+        },
+    ];
+}

--- a/addons/pos_self_order_bancontact_pay/static/tests/unit/app/payment_bancontact.test.js
+++ b/addons/pos_self_order_bancontact_pay/static/tests/unit/app/payment_bancontact.test.js
@@ -1,0 +1,97 @@
+import { test, expect, describe, beforeEach, animationFrame } from "@odoo/hoot";
+import { waitFor } from "@odoo/hoot-dom";
+import { createPaymentLine } from "@point_of_sale/../tests/unit/utils";
+import { setupSelfPosEnv, getFilledSelfOrder } from "@pos_self_order/../tests/unit/utils";
+import { definePosSelfModels } from "@pos_self_order/../tests/unit/data/generate_model_definitions";
+import { MockServer, onRpc } from "@web/../tests/web_test_helpers";
+import { registry } from "@web/core/registry";
+
+definePosSelfModels();
+
+beforeEach(async () => {
+    const mockCreateBancontactPayment = async (request) => {
+        const { params } = await request.json();
+        const { payment_method_id, order_uuid } = params;
+
+        // Should normally use the `access_token` from params
+        // But we override `odoo.access_token` in `setupPosEnvForSelfOrder`
+        const access_token = "test_access_token";
+        const config = MockServer.env["pos.config"].find((c) => c.access_token == access_token);
+        const order = MockServer.env["pos.order"].find((o) => o.uuid === order_uuid);
+        const paymentMethod = MockServer.env["pos.payment.method"].browse(payment_method_id)[0];
+
+        if (
+            !config ||
+            !order ||
+            !paymentMethod ||
+            paymentMethod.payment_provider !== "bancontact_pay" ||
+            paymentMethod.config_ids.every((id) => id !== config.id)
+        ) {
+            throw new Error("Payment method not found");
+        }
+
+        return MockServer.env["pos.payment.method"].create_bancontact_payment(payment_method_id, {
+            configId: config.id,
+            amount: -window.__test_error__ || order.amount_total,
+            currency: order.currency_id.name,
+            description: "Test Bancontact Payment",
+        });
+    };
+
+    onRpc("/pos-self-order/create-bancontact-pay-payment", mockCreateBancontactPayment);
+});
+
+describe("sendPaymentRequest", () => {
+    test("failed to create bancontact payment", async () => {
+        const store = await setupSelfPosEnv();
+        const order = await getFilledSelfOrder(store);
+        const display = store.models["pos.payment.method"].get(4);
+
+        const opts = { payment_status: "waiting" };
+        const paymentline = createPaymentLine(store, order, display, opts);
+
+        // Force the creation of the pos service for the test. The file
+        // point_of_sale/static/src/app/components/popups/confirmation_dialog/confirmation_dialog.js
+        // calls this service. In production, this file is not loaded for self-order,
+        // so the pos service is never started and no error occurs.
+        registry.category("services").add("pos", {
+            start() {
+                return {};
+            },
+        });
+
+        let failed = false;
+        try {
+            window.__test_error__ = 400;
+            await paymentline.payment_interface.sendPaymentRequest(paymentline);
+        } catch {
+            failed = true;
+        }
+        delete window.__test_error__;
+
+        expect(failed).toBe(true);
+        expect(paymentline.bancontact_id).toBeEmpty();
+        expect(paymentline.qr_code).toBeEmpty();
+        expect(paymentline.payment_status).toBe("waiting");
+
+        await animationFrame();
+        await waitFor(".o_alert_dialog");
+        expect(".o_alert_dialog .modal-body").toHaveText("Failed to create payment (ERR: 400)");
+    });
+
+    test("success to create bancontact payment", async () => {
+        const store = await setupSelfPosEnv();
+        const order = await getFilledSelfOrder(store);
+        const display = store.models["pos.payment.method"].get(4);
+
+        const opts = { payment_status: "waiting" };
+        const paymentline = createPaymentLine(store, order, display, opts);
+
+        const result = await paymentline.payment_interface.sendPaymentRequest(paymentline);
+
+        expect(result).toBe(true);
+        expect(paymentline.bancontact_id).toBe("bancontact_id");
+        expect(paymentline.qr_code).toBe("bancontact_qr_code");
+        expect(paymentline.payment_status).toBe("waiting");
+    });
+});

--- a/addons/pos_self_order_bancontact_pay/tests/__init__.py
+++ b/addons/pos_self_order_bancontact_pay/tests/__init__.py
@@ -1,1 +1,3 @@
 from . import test_models
+from . import test_webhook
+from . import test_kiosk

--- a/addons/pos_self_order_bancontact_pay/tests/test_kiosk.py
+++ b/addons/pos_self_order_bancontact_pay/tests/test_kiosk.py
@@ -1,0 +1,43 @@
+from odoo import Command
+from odoo.tests.common import tagged
+from odoo.tools import mute_logger
+
+from odoo.addons.pos_bancontact_pay.tests.test_frontend import (
+    TestFrontend,
+    error_checker_bancontact_failed_rpc_request,
+)
+
+
+@tagged("post_install", "-at_install")
+class TestKioskFrontend(TestFrontend):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.bancontact_kiosk = cls.env['pos.config'].create({
+            'name': 'Bancontact Kiosk',
+            'currency_id': cls.eur_currency.id,
+            'self_ordering_mode': 'kiosk',
+            'self_ordering_pay_after': 'each',
+            'payment_method_ids': [Command.clear(), Command.link(cls.payment_method_display.id)],
+        })
+
+    def start_kiosk_tour(self, tour_name, **kwargs):
+        self.bancontact_kiosk.with_user(self.pos_admin).open_ui()
+        self.bancontact_kiosk.current_session_id.set_opening_control(0, "")
+        self_route = self.bancontact_kiosk._get_self_order_route()
+        self.start_tour(self_route, tour_name, **kwargs)
+
+    def test_kiosk_bancontact_pay_success(self):
+        with self.mock_bancontact_call(prefix="kiosk_bancontact_success_"):
+            self.start_kiosk_tour("kiosk_bancontact_pay_success")
+
+    def test_kiosk_bancontact_pay_failed(self):
+        with self.mock_bancontact_call(prefix="kiosk_bancontact_failed_"):
+            self.start_kiosk_tour("kiosk_bancontact_pay_failed")
+
+    @mute_logger("odoo.http")
+    def test_kiosk_bancontact_pay_failed_create_payment(self):
+        with self.mock_bancontact_call(post_status_code=401):
+            self.start_kiosk_tour("kiosk_bancontact_pay_failed_create_payment", error_checker=error_checker_bancontact_failed_rpc_request)

--- a/addons/pos_self_order_bancontact_pay/tests/test_models.py
+++ b/addons/pos_self_order_bancontact_pay/tests/test_models.py
@@ -17,6 +17,8 @@ class TestModels(TestBancontactPay):
             },
         )
         with self.assertRaises(ValidationError):
-            kiosk_config.payment_method_ids = [Command.link(self.payment_method_display.id)]
+            kiosk_config.payment_method_ids = [Command.link(self.payment_method_sticker_1.id)]
+        kiosk_config.payment_method_ids = [Command.link(self.payment_method_display.id)]
         with self.assertRaises(ValidationError):
-            self.payment_method_display.config_ids = [Command.link(kiosk_config.id)]
+            self.payment_method_sticker_1.config_ids = [Command.link(kiosk_config.id)]
+        self.payment_method_display.config_ids = [Command.link(kiosk_config.id)]

--- a/addons/pos_self_order_bancontact_pay/tests/test_webhook.py
+++ b/addons/pos_self_order_bancontact_pay/tests/test_webhook.py
@@ -1,0 +1,51 @@
+from odoo.tests.common import tagged
+
+from odoo.addons.pos_bancontact_pay.tests.test_webhook import TestWebhook
+
+
+@tagged("post_install", "-at_install")
+class TestSelfOrderWebhook(TestWebhook):
+    def setUp(self):
+        super().setUp()
+        self.kiosk = self.env["pos.config"].create(
+            {
+                "name": "Kiosk Test",
+                "self_ordering_default_user_id": self.pos_user.id,
+                "self_ordering_mode": "kiosk",
+                "self_ordering_pay_after": "each",
+                "payment_method_ids": [(4, self.bank_payment_method.id)],
+            },
+        )
+
+    def test_bancontact_webhook_success(self):
+        payload = self._make_payload("any_id", "SUCCEEDED")
+
+        with self._notify_patcher() as mock_notify:
+            response = self._post_bancontact_webhook(self.kiosk.id, payload)
+            self.assertEqual(response.status_code, 200)
+            self._assert_notify_count(mock_notify, "FINALIZE_KIOSK_PAYMENT", 1)
+            self._assert_notify_finalize_kiosk_payment(mock_notify, "any_id", "SUCCEEDED")
+
+    def test_bancontact_webhook_error(self):
+        for bancontact_status in ("AUTHORIZATION_FAILED", "FAILED", "EXPIRED", "CANCELLED"):
+            payload = self._make_payload("any_id", bancontact_status)
+
+            with self._notify_patcher() as mock_notify:
+                response = self._post_bancontact_webhook(self.kiosk.id, payload)
+                self.assertEqual(response.status_code, 200)
+                self._assert_notify_count(mock_notify, "FINALIZE_KIOSK_PAYMENT", 1)
+                self._assert_notify_finalize_kiosk_payment(mock_notify, "any_id", bancontact_status)
+
+    def _assert_notify_finalize_kiosk_payment(self, mock_notify, bancontact_id, bancontact_status):
+        error = None
+        if bancontact_status == "CANCELLED":
+            error = "Payment cancelled"
+        elif bancontact_status == "EXPIRED":
+            error = "Payment expired"
+
+        expected_payload = {
+            "status": "success" if bancontact_status == "SUCCEEDED" else "fail",
+            "error": error,
+            "bancontact_id": bancontact_id,
+        }
+        self._assert_notify_with(mock_notify, "FINALIZE_KIOSK_PAYMENT", expected_payload)


### PR DESCRIPTION
..., pos_bancontact_pay, pos_online_payment_self_order, pos_self_order

---

Bancontact Pay was previously available in POS but not supported in kiosk mode.

This commit extends the existing Bancontact Pay integration to kiosk by introducing the required frontend and backend adaptations, ensuring a consistent payment flow across standard POS and kiosk environments.

---

Task: https://www.odoo.com/odoo/project/1737/tasks/4875917
