### PR TITLE
[FIX] account: activate stripe currency

### DIFF
--- a/addons/account/tests/test_transfer_wizard.py
+++ b/addons/account/tests/test_transfer_wizard.py
@@ -17,7 +17,7 @@ class TestTransferWizard(AccountTestInvoicingCommon):
         cls.company = cls.company_data['company']
         cls.receivable_account = cls.company_data['default_account_receivable']
         cls.payable_account = cls.company_data['default_account_payable']
-        cls.accounts = cls.env['account.account'].search([('reconcile', '=', False), ('company_ids', '=', cls.company.id)], limit=5)
+        cls.accounts = cls.env['account.account'].search([('reconcile', '=', False), ('company_ids', '=', cls.company.id), ('name', '!=', 'Stripe Issuing')], limit=5)
         cls.journal = cls.company_data['default_journal_misc']
 
         # Set rate for base currency to 1


### PR DESCRIPTION
https://github.com/odoo/enterprise/pull/108905
Fixes a bug where stripe account is created without currency when the currency that should be used is not activated.
This break the setup of the transfer wizard, because the accounts used in tests can sometime contains the stripe account, which use a different currency than the company, and the move created in the tests doesn't take that into account.
opw-5975238