### PR TITLE
[FIX] account_peppol: skip contact email proxy sync when no peppol user exists.

### DIFF
--- a/addons/account_peppol/models/res_config_settings.py
+++ b/addons/account_peppol/models/res_config_settings.py
@@ -84,6 +84,10 @@ class ResConfigSettings(models.TransientModel):
             # Update company field
             company.account_peppol_contact_email = record.account_peppol_contact_email
 
+            # No Peppol user yet: keep new value but skip proxy sync.
+            if not record.account_peppol_edi_user:
+                continue
+
             # Sync with IAP (Peppol proxy)
             params = {
                 'update_data': {


### PR DESCRIPTION
**[FIX] account_peppol: skip contact email proxy sync when no peppol user exists.**

Before this fix the sync would fail in certain scenarios when there is no proxy user preset in the database. The fix is to simply skip the proxy call if no user is present.

opw-5980696
