### PR TITLE
[FIX] html_builder: keep intentionally unfolded containers unfolded

### DIFF
--- a/addons/html_builder/static/src/core/builder_options_plugin.js
+++ b/addons/html_builder/static/src/core/builder_options_plugin.js
@@ -152,6 +152,7 @@ export class BuilderOptionsPlugin extends Plugin {
                     i++
                 ) {
                     this.lastContainers[i].folded &&= this.config.initialFolded[i];
+                    this.lastContainers[i].foldedIntent &&= this.config.initialFolded[i];
                 }
             }
         },
@@ -381,17 +382,18 @@ export class BuilderOptionsPlugin extends Plugin {
         }
 
         const previousElementToIdAndStateMap = new Map(
-            this.lastContainers.map((c) => [c.element, { id: c.id, folded: c.folded }])
+            this.lastContainers.map((c) => [
+                c.element,
+                { id: c.id, folded: c.folded, foldedIntent: c.foldedIntent },
+            ])
         );
-        const keepUnfolded = this.lastContainers.some((c) => c.element === element);
         let containers = reactive(
             [...elementToOptions]
                 .sort(([a], [b]) => (b.contains(a) ? 1 : -1))
                 .map(([element, Options]) => ({
                     id: previousElementToIdAndStateMap.get(element)?.id || uniqueId(),
-                    folded: keepUnfolded
-                        ? previousElementToIdAndStateMap.get(element)?.folded ?? true
-                        : true,
+                    folded: previousElementToIdAndStateMap.get(element)?.foldedIntent ?? true,
+                    foldedIntent: previousElementToIdAndStateMap.get(element)?.foldedIntent,
                     element,
                     options: Options,
                     optionTitleComponents: elementToOptionTitleComponents.get(element) || [],
@@ -426,7 +428,7 @@ export class BuilderOptionsPlugin extends Plugin {
                 if (lastContainerWithOptions.element.matches(selector)) {
                     const ancestorContainer = containers.findLast((c) => c.element.matches(target));
                     if (ancestorContainer) {
-                        ancestorContainer.folded = false;
+                        ancestorContainer.folded = ancestorContainer.foldedIntent ?? false;
                     }
                 }
             }
@@ -499,6 +501,18 @@ export class BuilderOptionsPlugin extends Plugin {
     setNextTarget(targetEl) {
         if (this.dependencies.history.getIsPreviewing()) {
             return;
+        }
+        // In the case an option changes the target, keep its group unfolded.
+        // We don't know which one it is, so we keep all the opened ones.
+        // Only the last group may be "temporarily" unfolded, or one opened
+        // with `auto_unfold_container_providers`. In case an option call
+        // `setNextTarget`, it will always either be an option in the last
+        // group, or the last group will disappear in favor of the one with
+        // the new target.
+        for (const container of this.lastContainers) {
+            if (!container.folded) {
+                container.foldedIntent = false;
+            }
         }
         // Store the next target to activate in the current step.
         this.dependencies.history.setStepExtra("nextTarget", targetEl);

--- a/addons/html_builder/static/src/sidebar/customize_tab.xml
+++ b/addons/html_builder/static/src/sidebar/customize_tab.xml
@@ -19,7 +19,10 @@
                     <OptionsContainer
                         snippetModel="props.snippetModel"
                         folded="optionsContainer.folded"
-                        toggleFold="() => optionsContainer.folded = !optionsContainer.folded"
+                        toggleFold="() => {
+                            optionsContainer.folded = !optionsContainer.folded;
+                            optionsContainer.foldedIntent = optionsContainer.folded;
+                        }"
                         editingElement="optionsContainer.element"
                         options="optionsContainer.options"
                         containerTitle="optionsContainer.containerTitle"

--- a/addons/html_builder/static/tests/custom_tab/misc.test.js
+++ b/addons/html_builder/static/tests/custom_tab/misc.test.js
@@ -352,6 +352,51 @@ test("option with groups restriction not available to user", async () => {
     expect(".options-container").toHaveCount(0);
 });
 
+test("unfolded-by-click option group stay unfolded when changing target", async () => {
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static selector = ".test-options-target";
+            static template = xml`<BuilderRow label="'Row 1'">A</BuilderRow>`;
+        }
+    );
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static selector = ".test-options-child";
+            static template = xml`<BuilderRow label="'Row 2'">B</BuilderRow>`;
+        }
+    );
+    await setupHTMLBuilder(
+        `<section class="test-options-target first-section" data-name="Target">
+            <div class="test-options-child first-child" data-name="Child">
+                Text
+            </div>
+            <div class="test-options-child second-child" data-name="Child 2">
+                Text
+            </div>
+        </section>
+        <section class="test-options-target second-section">
+            Text
+        </section>`
+    );
+    await contains(":iframe .test-options-child.first-child").click();
+    expect(".options-container-header i.fa-caret-right").toHaveCount(1);
+    expect(".options-container-header i.fa-caret-down").toHaveCount(1);
+    await contains(".options-container-header:contains('Target') i.fa-caret-right").click();
+    expect(".options-container-header i.fa-caret-right").toHaveCount(0);
+    expect(".options-container-header i.fa-caret-down").toHaveCount(2);
+    await contains(":iframe .test-options-child.second-child").click();
+    expect(".options-container-header i.fa-caret-right").toHaveCount(0);
+    expect(".options-container-header i.fa-caret-down").toHaveCount(2);
+
+    // Moving away then back does not reopen the parent
+    await contains(":iframe .second-section").click();
+    expect(".options-container-header i.fa-caret-right").toHaveCount(0);
+    expect(".options-container-header i.fa-caret-down").toHaveCount(1);
+    await contains(":iframe .test-options-child.first-child").click();
+    expect(".options-container-header i.fa-caret-right").toHaveCount(1);
+    expect(".options-container-header i.fa-caret-down").toHaveCount(1);
+});
+
 test("option that matches several elements", async () => {
     addBuilderOption(
         class extends BaseOptionComponent {

--- a/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/social_media_option_plugin.js
@@ -172,7 +172,7 @@ class SocialMediaOptionPlugin extends Plugin {
             ".s_social_media .s_social_media_title",
         ],
         auto_unfold_container_providers: {
-            selector: ".s_social_media > a > i",
+            selector: ".s_social_media > a > *",
             target: ".s_social_media",
         },
     };

--- a/addons/website/static/tests/tours/snippet_editor_panel_options.js
+++ b/addons/website/static/tests/tours/snippet_editor_panel_options.js
@@ -122,7 +122,6 @@ registerWebsitePreviewTour(
         checkIfParagraphSelected(":iframe .s_text_block p:not([data-selection-placeholder])"),
         // Test keeping the text selection when removing all columns of a
         // snippet.
-        ...unfoldOptionsGroup("Text"),
         ...changeOptionInPopover("Text", "Layout", "[data-action-value='0']"),
         {
             content: "The snippet should have the correct number of columns.",

--- a/addons/website/static/tests/tours/snippet_social_media.js
+++ b/addons/website/static/tests/tours/snippet_social_media.js
@@ -4,7 +4,6 @@ import {
     clickOnSnippet,
     insertSnippet,
     registerWebsitePreviewTour,
-    unfoldOptionsGroup,
 } from "@website/js/tours/tour_utils";
 
 // TODO: Remove following steps once fix of task-3212519 is done.
@@ -60,7 +59,7 @@ const replaceIconByImage = function (url) {
 
 const addNewSocialNetwork = function (optionIndex, linkIndex, url, replaceIcon = false) {
     const replaceIconByImageSteps = replaceIcon
-        ? [...replaceIconByImage("https://www.example.com"), ...unfoldOptionsGroup("Social Media")]
+        ? [...replaceIconByImage("https://www.example.com")]
         : [];
     return [
         {
@@ -227,7 +226,6 @@ registerWebsitePreviewTour(
         ...addNewSocialNetwork(10, 10, "https://google.com", true),
         // Create a social network after replacing the first icon by an image.
         ...replaceIconByImage("/website/social/twitter"),
-        ...unfoldOptionsGroup("Social Media"),
         ...addNewSocialNetwork(11, 11, "https://facebook.com"),
         {
             content: "Check if the result is correct after adding images",


### PR DESCRIPTION
Commit 64d35ccd6fade9e0473686b8484f561b5f4215ce added folding of groups of options. On every target change, all groups were folded, except the last one. But this leads to friction in some cases where the user wants another groups than the last one to stay unfolded.

With this commit, a group that stays in the sidebar stays unfolded if the user clicked to unfold it, or if they used an option that changed the target to a descendant.

Steps to reproduce:
- Open website builder
- Drag and drop a banner snippet
- Click "add elements/text"
- Bug: Banner options folds for no reason

####
- Open website builder
- Click on a column in the footer
- Unfold the options of the footer
- Click on another column of the footer
- Bug: the options of the footer closes

task-5999383
