### PR TITLE
[FIX] stock_account: avoid unnecessary AVCO recomputation for periodic valuation

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -203,7 +203,9 @@ class ProductProduct(models.Model):
             if cost_method == 'standard':
                 std_prices, total_values = products._run_standard_batch(at_date=at_date)
             elif cost_method == 'average':
-                std_prices, total_values = products._run_average_batch(at_date=at_date, force_recompute=True)
+                # Force recompute only for historical valuation or automated valuation.
+                force = bool(at_date) or ('real_time' in set(products.mapped('categ_id.property_valuation')))
+                std_prices, total_values = products._run_average_batch(at_date=at_date, force_recompute=force)
             else:
                 std_prices, total_values = products._run_fifo_batch(at_date=at_date)
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- For AVCO products, _compute_value() was always forcing _run_average_batch() to recompute valuation history, even when no at_date was provided, creating inconsistencies as you can see in that example:

<img width="398" height="164" alt="image" src="https://github.com/user-attachments/assets/ff2f12e8-8ede-4e9e-88ab-9441d136c40d" />

Desired behavior after PR is merged:

_run_average_batch() is now called with force_recompute=bool(at_date), which keeps the historical valuation logic when at_date is True, and when it's False simply returns the standard value (qty_available * standard_price):

<img width="376" height="162" alt="image" src="https://github.com/user-attachments/assets/385d0c60-a201-4e87-9855-ca66a732a706" />

opw-5959337
opw-5967113
opw-5966563
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
