### PR TITLE
[FIX] web_editor, mass_mailing: mark field dirty when leaving code view

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -254,7 +254,7 @@ export class MassMailingHtmlField extends HtmlField {
             this.wysiwyg.odooEditor.observerActive();
 
             if ($codeview.hasClass('d-none')) {
-                this.wysiwyg.setValue(this._getCodeViewValue($codeview[0]));
+                this.wysiwyg.setValue(this._getCodeViewValue($codeview[0]), false);
                 this.wysiwyg.odooEditor.sanitize();
                 this.wysiwyg.odooEditor.historyStep(true);
             } else {

--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -327,7 +327,7 @@ export class HtmlField extends Component {
             }
             const lastStep = this.wysiwyg.odooEditor._historySteps.at(-1);
             this.isDirty = true;
-            if (lastStep.isReset) {
+            if (lastStep.isSavePoint) {
                 this.wysiwyg.odooEditor.lastSavePoint = lastStep.id;
                 this.isDirty = false;
             } else if (

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -896,11 +896,11 @@ export class OdooEditor extends EventTarget {
         }
     }
 
-    resetContent(value) {
+    resetContent(value, isSavePoint = true) {
         value = value || '<p><br></p>';
         this.editable.innerHTML = fixInvalidHTML(value);
         this.sanitize(this.editable);
-        this.historyStep(true, { isReset: true });
+        this.historyStep(true, { isSavePoint });
         // The unbreakable protection mechanism detects an anomaly and attempts
         // to trigger a rollback when the content is reset using `innerHTML`.
         // Prevent this rollback as it would otherwise revert the new content.
@@ -1333,7 +1333,7 @@ export class OdooEditor extends EventTarget {
     }
 
     // One step completed: apply to vDOM, setup next history step
-    historyStep(skipRollback = false, { stepId, restoredStepId, isReset } = {}) {
+    historyStep(skipRollback = false, { stepId, restoredStepId, isSavePoint } = {}) {
         if (!this._historyStepsActive) {
             return;
         }
@@ -1354,7 +1354,7 @@ export class OdooEditor extends EventTarget {
         const previousStep = peek(this._historySteps);
         currentStep.clientId = this._collabClientId;
         currentStep.previousStepId = previousStep.id;
-        currentStep.isReset = isReset;
+        currentStep.isSavePoint = isSavePoint;
         currentStep.restoredStepId = restoredStepId;
 
         this._historySteps.push(currentStep);

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1175,8 +1175,8 @@ export class Wysiwyg extends Component {
      * @param {String} value
      * @returns {String}
      */
-    setValue(value) {
-        this.odooEditor.resetContent(value);
+    setValue(value, isSavePoint = true) {
+        this.odooEditor.resetContent(value, isSavePoint);
     }
     /**
      * Undo one step of change in the editor.


### PR DESCRIPTION
Problem:
In Email Marketing, switching to code view, editing the HTML, and then switching back to the editor view does not mark the field as dirty.

As a result, changes cannot be saved unless an additional modification is made directly in the editor.

Solution:
Explicitly mark the field as dirty when switching from code view back to editor view, ensuring HTML changes are properly detected.

Steps to reproduce:
- Create a new Email Marketing record.
- Drop any snippet.
- Switch to code view.
- Modify the HTML.
- Switch back to editor view.
- Observe that the field is not marked as dirty and changes cannot be saved unless further edits are made in the editor.

opw-5999752

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
