### PR TITLE
[IMP] base: res_partner active user

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -845,7 +845,7 @@ class ResPartner(models.Model):
             # This is wrong if the user is not active, as partner.user_ids only returns active users.
             # Hence this temporary hack until the ORM updates inverse fields correctly.
             self.invalidate_recordset(['user_ids'])
-            users = self.env['res.users'].sudo().search([('partner_id', 'in', self.ids)])
+            users = self.env['res.users'].sudo().search([('partner_id', 'in', self.ids), ('active', '=', True)])
             if users:
                 if users.sudo(False).has_access('write'):
                     error_msg = _('You cannot archive contacts linked to an active user.\n'


### PR DESCRIPTION
As the filtering of active records on `_search()` also depends on the
`active_test` argument. This commit forces the use of active records,
whatever the value of `active_test`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
