### PR TITLE
[FIX] web: clear caches on lang_install

### DIFF
--- a/addons/web/static/src/core/l10n/localization_service.js
+++ b/addons/web/static/src/core/l10n/localization_service.js
@@ -5,6 +5,7 @@ import { browser } from "../browser/browser";
 import { registry } from "../registry";
 import { strftimeToLuxonFormat } from "./dates";
 import { localization } from "./localization";
+import { rpcBus } from "../network/rpc";
 import {
     translatedTerms,
     translatedTermsGlobal,
@@ -34,6 +35,13 @@ export const localizationService = {
         const localizationDB = new IndexedDB("localization", session.registry_hash);
         const translationURL = session.translationURL || "/web/webclient/translations";
         const lang = jsToPyLocale(user.lang || document.documentElement.getAttribute("lang"));
+
+        rpcBus.addEventListener("RPC:RESPONSE", (ev) => {
+            const { method, model } = ev.detail.data.params || {};
+            if (method === "lang_install" && model === "base.language.install") {
+                rpcBus.trigger("CLEAR-CACHES");
+            }
+        });
 
         const fetchTranslations = async (hash) => {
             let queryString = objectToUrlEncodedString({ hash, lang });


### PR DESCRIPTION
Before this commit, after installing a new language, that language wasn't directly available in the selection field of the user preference form view. An extra reload was necessary to see the new language, which could confuse the user. This was due to the cache.

As installing a language isn't a frequent operation, we simply clear all caches when this happens.

task~5895416

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
