### PR TITLE
[IMP] mrp{,_account}: set tests as post-install

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -281,17 +281,6 @@ class StockMove(models.Model):
         return super().create(vals_list)
 
     def write(self, vals):
-        if 'product_id' in vals:
-            move_to_unlink = self.filtered(lambda m: m.product_id.id != vals.get('product_id'))
-            other_move = self - move_to_unlink
-            if move_to_unlink.production_id and move_to_unlink.state not in ['draft', 'cancel', 'done']:
-                moves_data = move_to_unlink.copy_data()
-                for move_data in moves_data:
-                    move_data.update({'product_id': vals.get('product_id')})
-                updated_product_move = self.create(moves_data)
-                updated_product_move._action_confirm()
-                move_to_unlink.unlink()
-                self = other_move + updated_product_move
         if self.env.context.get('force_manual_consumption') and 'quantity' in vals:
             moves_to_update = self.filtered(lambda move: move.product_uom_qty != vals['quantity'])
             if moves_to_update:

--- a/addons/mrp/tests/test_backorder.py
+++ b/addons/mrp/tests/test_backorder.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from datetime import datetime, timedelta
 
 from odoo import Command
 from odoo.addons.mrp.tests.common import TestMrpCommon
-from odoo.tests import tagged, Form
+from odoo.tests import Form
 from odoo.tests.common import TransactionCase, freeze_time
 
 
@@ -967,11 +966,10 @@ class TestMrpProductionBackorder(TestMrpCommon):
         self.assertFalse(mo.picking_ids.filtered(lambda p: p.state == 'cancel' and p.product_id == self.product_6))
 
 
-@tagged('-post_install', 'at_install')  # test_mrp_backorder_operations breaks post install
 class TestMrpWorkorderBackorder(TransactionCase):
     @classmethod
     def setUpClass(cls):
-        super(TestMrpWorkorderBackorder, cls).setUpClass()
+        super().setUpClass()
         cls.uom_unit = cls.env.ref('uom.product_uom_unit')
         cls.finished1 = cls.env['product.product'].create({
             'name': 'finished1',
@@ -1010,8 +1008,6 @@ class TestMrpWorkorderBackorder(TransactionCase):
                 Command.create({'sequence': 2, 'name': 'finished operation 2', 'workcenter_id': cls.workcenter2.id}),
             ],
         })
-        cls.bom_finished1.bom_line_ids[0].operation_id = cls.bom_finished1.operation_ids[0].id
-        cls.bom_finished1.bom_line_ids[1].operation_id = cls.bom_finished1.operation_ids[1].id
 
     @freeze_time('2025-10-27 12:00:00')
     def test_mrp_backorder_operations(self):
@@ -1039,11 +1035,6 @@ class TestMrpWorkorderBackorder(TransactionCase):
         op_2.button_start()
         op_2.button_finish()
         action = mo.button_mark_done()
-        warning = Form(self.env['mrp.consumption.warning'].with_context(**action['context'])).save()
-        self.assertRecordValues(warning.mrp_consumption_warning_line_ids, [
-            {'product_consumed_qty_uom': 10, 'product_expected_qty_uom': 4},
-        ])
-        action = warning.action_confirm()
         backorder_1 = Form(self.env['mrp.production.backorder'].with_context(**action['context']))
         backorder_1.save().action_backorder()
         bo_1 = mo.production_group_id.production_ids - mo

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -4,14 +4,13 @@ from datetime import timedelta
 from odoo import exceptions, fields
 from odoo.exceptions import UserError
 from odoo.fields import Command
-from odoo.tests import Form, HttpCase, freeze_time, tagged
+from odoo.tests import Form, HttpCase, freeze_time
 from odoo.tools import float_compare, float_repr, float_round, format_date
 
 from odoo.addons.mrp.tests.common import TestMrpCommon
 
 
 @freeze_time(fields.Date.today())
-@tagged('at_install', '-post_install')  # LEGACY at_install Access error in post install
 class TestBoM(TestMrpCommon):
 
     @classmethod
@@ -2881,7 +2880,6 @@ class TestBoM(TestMrpCommon):
         self.assertFalse(self.bom_1.show_copy_operations_button, "The copy operations button should be visible even if the current BoM is empty.")
 
 
-@tagged('-at_install', 'post_install')
 class TestTourBoM(HttpCase):
     @classmethod
     def setUpClass(cls):

--- a/addons/mrp/tests/test_byproduct.py
+++ b/addons/mrp/tests/test_byproduct.py
@@ -1,12 +1,10 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.fields import Command
-from odoo.tests import common, tagged, Form
+from odoo.tests import common, Form
 from odoo.exceptions import ValidationError
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install MissingError in post install
 class TestMrpByProduct(common.TransactionCase):
 
     @classmethod

--- a/addons/mrp/tests/test_byproduct.py
+++ b/addons/mrp/tests/test_byproduct.py
@@ -428,68 +428,6 @@ class TestMrpByProduct(common.TransactionCase):
         mo.button_mark_done()
         self.assertEqual(mo.state, 'done')
 
-    def test_01_check_byproducts_update(self):
-        """
-        Test that check byproducts update in stock move should also reflect in stock move line(Product moves).
-        """
-        # Create new MO
-        mo_form = Form(self.env['mrp.production'])
-        mo_form.product_id = self.product_a
-        mo_form.product_qty = 1.0
-        mo = mo_form.save()
-        mo.action_confirm()
-
-        mo.move_byproduct_ids.write({'product_id': self.product_c_id})
-        mo.button_mark_done()
-        self.assertEqual(mo.move_byproduct_ids.product_id, mo.move_byproduct_ids.move_line_ids.product_id)
-
-    def test_02_check_byproducts_update(self):
-        """
-        Case 2: Update Product From Tracked Product to Non Tracked Product.
-        """
-        self.bom_byproduct.byproduct_ids[0].product_id = self.produced_serial.id
-        self.bom_byproduct.byproduct_ids[0].product_qty = 2
-        mo = self.env["mrp.production"].create({
-            'product_id': self.product_a.id,
-            'product_qty': 1.0,
-            'bom_id': self.bom_byproduct.id,
-        })
-        mo.action_confirm()
-
-        mo.move_byproduct_ids.lot_ids = [(4, self.sn_1.id)]
-        mo.move_byproduct_ids.lot_ids = [(4, self.sn_2.id)]
-
-        self.assertEqual(len(mo.move_byproduct_ids.move_line_ids), 2)
-
-        mo.move_byproduct_ids.write({'product_id': self.product_c_id})
-
-        mo.button_mark_done()
-        self.assertEqual(len(mo.move_byproduct_ids.move_line_ids), 1)
-        self.assertEqual(mo.move_byproduct_ids.product_id, mo.move_byproduct_ids.move_line_ids.product_id)
-
-    def test_03_check_byproducts_update(self):
-        """
-        Case 3: Update Product From Non Tracked Product to Tracked Product.
-        """
-        mo_form = Form(self.env['mrp.production'])
-        mo_form.product_id = self.product_a
-        mo_form.product_qty = 2.0
-        mo = mo_form.save()
-        mo.action_confirm()
-
-        mo.move_byproduct_ids.write({'product_id': self.produced_serial.id})
-
-        mo.move_byproduct_ids.lot_ids = [(4, self.sn_1.id)]
-        mo.move_byproduct_ids.lot_ids = [(4, self.sn_2.id)]
-
-        self.assertFalse(mo.move_byproduct_ids.show_lots_text)
-        self.assertTrue(mo.move_byproduct_ids.show_lots_m2o)
-        self.assertFalse(mo.move_byproduct_ids.show_quant)
-
-        mo.button_mark_done()
-        self.assertEqual(len(mo.move_byproduct_ids.move_line_ids), 2)
-        self.assertEqual(mo.move_byproduct_ids.product_id, mo.move_byproduct_ids.move_line_ids.product_id)
-
     def test_byproduct_qty_update(self):
         """
         Test that byproduct quantity is updated to the quantity set on the Mo when the Mo is marked as done.ee

--- a/addons/mrp/tests/test_cancel_mo.py
+++ b/addons/mrp/tests/test_cancel_mo.py
@@ -1,10 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests import tagged, Form
-from datetime import datetime, timedelta
-
-from odoo.fields import Datetime as Dt
+from odoo.tests import Form
 from odoo.exceptions import UserError
 from odoo.addons.mrp.tests.common import TestMrpCommon
 

--- a/addons/mrp/tests/test_consume_component.py
+++ b/addons/mrp/tests/test_consume_component.py
@@ -1,7 +1,7 @@
 import copy
 
 from odoo.exceptions import UserError
-from odoo.tests import common, tagged, Form
+from odoo.tests import common, Form
 
 
 class TestConsumeComponentCommon(common.TransactionCase):
@@ -219,7 +219,6 @@ class TestConsumeComponentCommon(common.TransactionCase):
             self.assertFalse(error, "Immediate Production shall not raise an error.")
 
 
-@tagged('post_install', '-at_install')
 class TestConsumeComponent(TestConsumeComponentCommon):
     def test_option_enabled_and_qty_available(self):
         """Option enabled, qty available

--- a/addons/mrp/tests/test_consumption_warning.py
+++ b/addons/mrp/tests/test_consumption_warning.py
@@ -1,8 +1,7 @@
 from odoo.fields import Command
-from odoo.tests import tagged, common, Form
+from odoo.tests import common, Form
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
 class TestConsumptionWarning(common.TransactionCase):
     @classmethod
     def setUpClass(cls):

--- a/addons/mrp/tests/test_manual_consumption.py
+++ b/addons/mrp/tests/test_manual_consumption.py
@@ -1,12 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-# -*- coding: utf-8 -*-
 
 from odoo import Command
 from odoo.addons.mrp.tests.common import TestMrpCommon
-from odoo.tests import tagged, Form, HttpCase
+from odoo.tests import Form, HttpCase
 
 
-@tagged('post_install', '-at_install')
 class TestTourManualConsumption(HttpCase):
     def test_mrp_manual_consumption_02(self):
         """

--- a/addons/mrp/tests/test_mrp_reports.py
+++ b/addons/mrp/tests/test_mrp_reports.py
@@ -1,8 +1,7 @@
-from odoo.tests import HttpCase, tagged
+from odoo.tests import HttpCase
 from odoo.fields import Command
 
 
-@tagged('post_install', '-at_install')
 class TestReportBom(HttpCase):
 
     def test_mrp_report_bom_variant_selection(self):

--- a/addons/mrp/tests/test_multicompany.py
+++ b/addons/mrp/tests/test_multicompany.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.fields import Command
-from odoo.tests import tagged, common, Form
+from odoo.tests import common, Form
 from odoo.exceptions import UserError
 
 

--- a/addons/mrp/tests/test_oee.py
+++ b/addons/mrp/tests/test_oee.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import datetime, timedelta, time, UTC
@@ -8,7 +7,7 @@ from freezegun import freeze_time
 
 from odoo import fields
 from odoo.addons.mrp.tests.common import TestMrpCommon
-from odoo.tests import tagged, Form
+from odoo.tests import Form
 
 
 class TestOee(TestMrpCommon):

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import datetime, timedelta
@@ -8,12 +7,11 @@ from odoo import Command, fields
 from odoo.exceptions import UserError
 from odoo.tests import Form, users
 from odoo.tools.misc import format_date
-from odoo.tests.common import HttpCase, tagged
+from odoo.tests.common import HttpCase
 
 from odoo.addons.mrp.tests.common import TestMrpCommon
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install, fails post install
 class TestMrpOrder(TestMrpCommon):
 
     @classmethod
@@ -23,6 +21,15 @@ class TestMrpOrder(TestMrpCommon):
             'product_selectable': True,
         })
         cls.env.ref('base.group_user').write({'implied_ids': [(4, cls.env.ref('stock.group_production_lot').id)]})
+
+    def _handle_workorder_compatibility(self):
+        # Once `mrp_workorder` is installed, an employee is required for a lot of workorder usecases.
+        # To avoid issues when running these tests post-install, we add an employee if that module is installed.
+        if self.env['ir.module.module']._get('mrp_workorder').state == 'installed':
+            self.env['hr.employee'].create({
+                'name': 'Current User Employee',
+                'user_id': self.env.user.id,
+            })
 
     def test_access_rights_manager(self):
         """ Checks an MRP manager can create, confirm and cancel a manufacturing order. """
@@ -2873,18 +2880,18 @@ class TestMrpOrder(TestMrpCommon):
         wo_1.button_start()
         wo_1.qty_producing = 20
         self.assertEqual(mo.state, 'progress')
-        wo_1.button_finish()
         self.assertEqual(duration_expected, wo_1.duration_expected)
+        wo_1.button_finish()
 
         wo_2.button_start()
         wo_2.qty_producing = 10
-        wo_2.button_finish()
         self.assertEqual(wo_2.duration_expected, 12 + 10 * 60)
+        wo_2.button_finish()
 
         wo_3.button_start()
         wo_3.qty_producing = 5
-        wo_3.button_finish()
         self.assertEqual(wo_3.duration_expected, 13 + 5 * 60)
+        wo_3.button_finish()
 
         self.assertEqual(mo.state, 'to_close')
         mo.button_mark_done()
@@ -3036,6 +3043,7 @@ class TestMrpOrder(TestMrpCommon):
         """
             Check that the timers in the workorders are stopped after the cancellation of the MO
         """
+        self._handle_workorder_compatibility()
         mo_form = Form(self.env['mrp.production'])
         mo_form.bom_id = self.bom_2
         mo_form.product_qty = 1
@@ -3071,6 +3079,7 @@ class TestMrpOrder(TestMrpCommon):
         """
             Check that the work order is started only once when clicking the start button several times.
         """
+        self._handle_workorder_compatibility()
         # Required for `workorder_ids` to be visible in the view
         self.env.user.group_ids += self.env.ref('mrp.group_mrp_routings')
         production_form = Form(self.env['mrp.production'])
@@ -3791,6 +3800,7 @@ class TestMrpOrder(TestMrpCommon):
     def test_unlink_update_workcenter_productivity(self):
         """ Test that workcenter_productivity entries for deleted work order has end date set
         """
+        self._handle_workorder_compatibility()
         mo_form = Form(self.env['mrp.production'])
         mo_form.bom_id = self.bom_3
         mo = mo_form.save()
@@ -5260,6 +5270,7 @@ class TestMrpOrder(TestMrpCommon):
         """Test to ensure that `_split_productions` is correctly skipping workorder quantity. when
         `skip_workorder_quantity` param is passed as true.
         """
+        self._handle_workorder_compatibility()
         mo = self.env['mrp.production'].create({
             'bom_id': self.bom_4.id,
             'product_qty': 10,
@@ -5375,7 +5386,6 @@ class TestMrpOrder(TestMrpCommon):
         self.assertEqual(len(mo.workorder_ids), 1)
 
 
-@tagged('-at_install', 'post_install')
 class TestTourMrpOrder(HttpCase):
     def test_mrp_order_product_catalog(self):
         product = self.env['product.product'].create({

--- a/addons/mrp/tests/test_performance.py
+++ b/addons/mrp/tests/test_performance.py
@@ -1,11 +1,10 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import unittest
 import time
 import logging
 
-from odoo.tests import tagged, common, Form
+from odoo.tests import common, Form
 
 _logger = logging.getLogger(__name__)
 

--- a/addons/mrp/tests/test_procurement.py
+++ b/addons/mrp/tests/test_procurement.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from datetime import timedelta
 from json import loads
 
 from odoo import Command, fields
-from odoo.tests import tagged, Form
+from odoo.tests import Form
 from odoo.addons.mrp.tests.common import TestMrpCommon
 from odoo.exceptions import UserError
 

--- a/addons/mrp/tests/test_replenish.py
+++ b/addons/mrp/tests/test_replenish.py
@@ -1,11 +1,10 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import datetime, timedelta
 from freezegun import freeze_time
 from json import loads
 
-from odoo.tests import tagged, Form
+from odoo.tests import Form
 from odoo.addons.mrp.tests.common import TestMrpCommon
 from odoo import fields, Command
 

--- a/addons/mrp/tests/test_stock.py
+++ b/addons/mrp/tests/test_stock.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import common
 from odoo import Command
-from odoo.exceptions import UserError
-from odoo.tests import tagged, Form
+from odoo.tests import Form
 
 
 class TestWarehouseMrp(common.TestMrpCommon):
@@ -345,7 +343,6 @@ class TestWarehouseMrp(common.TestMrpCommon):
         self.assertNotIn(self.warehouse_1.pbm_mto_pull_id, self.route_mto.rule_ids)
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install, fails post install
 class TestKitPicking(common.TestMrpCommon):
     @classmethod
     def setUpClass(cls):

--- a/addons/mrp/tests/test_stock_report.py
+++ b/addons/mrp/tests/test_stock_report.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests import tagged, Form
+from odoo.tests import Form
 from odoo.addons.stock.tests.test_report import TestReportsCommon
 from odoo import Command
 

--- a/addons/mrp/tests/test_traceability.py
+++ b/addons/mrp/tests/test_traceability.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import Command
-from odoo.tests import tagged, Form
+from odoo.tests import Form
 from odoo.addons.mrp.tests.common import TestMrpCommon
 from odoo.exceptions import UserError
 

--- a/addons/mrp/tests/test_unbuild.py
+++ b/addons/mrp/tests/test_unbuild.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import Command
-from odoo.tests import tagged, Form
+from odoo.tests import Form
 from odoo.addons.mrp.tests.common import TestMrpCommon
 from odoo.exceptions import UserError
 

--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -1,11 +1,9 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.tests import Form, tagged
+from odoo.tests import Form
 from odoo.addons.mrp.tests.common import TestMrpCommon
 
 
-@tagged('post_install', '-at_install')
 class TestMultistepManufacturingWarehouse(TestMrpCommon):
 
     @classmethod

--- a/addons/mrp/tests/test_workcenter.py
+++ b/addons/mrp/tests/test_workcenter.py
@@ -4,10 +4,9 @@ from freezegun import freeze_time
 
 from . import common
 from odoo import Command
-from odoo.tests import Form, tagged
+from odoo.tests import Form
 
 
-@tagged('-at_install', 'post_install')
 class TestWorkcenterOverview(common.TestMrpCommon):
 
     @freeze_time('2020-03-13')  # Friday

--- a/addons/mrp_account/models/mrp_production.py
+++ b/addons/mrp_account/models/mrp_production.py
@@ -12,7 +12,7 @@ class MrpProduction(models.Model):
 
     extra_cost = fields.Float(copy=False, string='Extra Unit Cost')
     show_valuation = fields.Boolean(compute='_compute_show_valuation')
-    wip_move_ids = fields.Many2many('account.move', 'wip_move_production_rel', 'production_id', 'move_id')
+    wip_move_ids = fields.Many2many('account.move', 'wip_move_production_rel', 'production_id', 'move_id', copy=False)
     wip_move_count = fields.Integer("WIP Journal Entry Count", compute='_compute_wip_move_count')
 
     def _compute_show_valuation(self):

--- a/addons/mrp_account/models/mrp_workorder.py
+++ b/addons/mrp_account/models/mrp_workorder.py
@@ -21,7 +21,8 @@ class MrpWorkorder(models.Model):
         return res
 
     def action_cancel(self):
-        (self.mo_analytic_account_line_ids | self.wc_analytic_account_line_ids).unlink()
+        sudo_self = self.sudo()
+        (sudo_self.mo_analytic_account_line_ids | sudo_self.wc_analytic_account_line_ids).unlink()
         return super().action_cancel()
 
     def _prepare_analytic_line_values(self, account_field_values, amount, unit_amount):
@@ -54,5 +55,6 @@ class MrpWorkorder(models.Model):
                 self.wc_analytic_account_line_ids += self.env['account.analytic.line'].sudo().create(wc_analytic_line_vals)
 
     def unlink(self):
-        (self.mo_analytic_account_line_ids | self.wc_analytic_account_line_ids).unlink()
+        sudo_self = self.sudo()
+        (sudo_self.mo_analytic_account_line_ids | sudo_self.wc_analytic_account_line_ids).unlink()
         return super().unlink()


### PR DESCRIPTION
The main change is to set `mrp` tests as `post_install`. Other commits are fixes that emerged from trying to run those tests with other modules installed.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
