### PR TITLE
[PERF] l10n_sa_edi: Optimize the sanity check of a journal for onboarding on ZATCA

### DIFF
--- a/addons/l10n_sa_edi/models/account_journal.py
+++ b/addons/l10n_sa_edi/models/account_journal.py
@@ -108,14 +108,13 @@ class AccountJournal(models.Model):
 
         # If the invoice wasn't sent to ZATCA because of a timeout, it will retain its existing chain index
         # Make sure there are no opened invoices with the journal's existing sequence
-        move_ids = self.env['account.move'].search(
-            [
-                ('journal_id', '=', self.id),
-                ('l10n_sa_chain_index', '!=', 0)
-            ]
-        )
-        stuck_moves = [move for move in move_ids if not move._l10n_sa_is_in_chain()]
-        if stuck_moves:
+        has_stuck_moves = self.env['account.edi.document'].search([
+            ('move_id.journal_id', '=', self.id),
+            ('move_id.l10n_sa_chain_index', '!=', 0),
+            ('edi_format_id.code', '=', 'sa_zatca'),
+            ('state', '=', 'to_send'),
+        ], limit=1)
+        if has_stuck_moves:
             raise UserError(_("Oops! The journal is stuck. Please submit the pending invoices to ZATCA and try again."))
 
     def _l10n_sa_edi_set_csr_fields(self):


### PR DESCRIPTION
Behavior before:
Sanity check looped over all account moves of the journal, filtering in Python for ZATCA documents. This caused memory errors when the journal had hundreds of thousands of moves.

Behavior after:
The check now searches directly on l10n_sa.edi.document with a domain that filters only relevant moves with state 'to_send', reducing memory usage and avoiding Python-level loops.

Root cause:
Loading all moves and their One2many edi_document_ids in memory for filtering caused excessive memory usage and MemoryError on large journals.

OPW-5972073

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
