### PR TITLE
[FIX] base: find or create bank with company contact

### DIFF
--- a/odoo/addons/base/models/res_bank.py
+++ b/odoo/addons/base/models/res_bank.py
@@ -174,7 +174,7 @@ class ResPartnerBank(models.Model):
         """
         bank_account = self.env['res.partner.bank'].sudo().with_context(active_test=False).search([
             ('acc_number', '=', account_number),
-            ('partner_id', 'child_of', partner.id),
+            ('partner_id', 'child_of', partner.commercial_partner_id.id),
         ])
         if not bank_account:
             if not allow_company_account_creation and partner.id in self.env['res.company']._get_company_partner_ids():
@@ -192,4 +192,4 @@ class ResPartnerBank(models.Model):
         return bank_account.filtered_domain([
             *self.env['res.partner.bank']._check_company_domain(company),
             ('active', '=', True),
-        ]).sudo(False)
+        ]).sorted(lambda b: b.partner_id != partner).sudo(False)[:1]

--- a/odoo/addons/base/tests/test_res_partner_bank.py
+++ b/odoo/addons/base/tests/test_res_partner_bank.py
@@ -54,3 +54,107 @@ class TestResPartnerBank(SavepointCaseWithUserDemo):
         # updating the sanitized value will also update the acc_number
         partner_bank.write({'sanitized_acc_number': 'BE001251882303WRONG'})
         self.assertEqual(partner_bank.acc_number, partner_bank.sanitized_acc_number)
+
+    def test_find_or_create_bank_account_create(self):
+        partner = self.env['res.partner'].create({'name': 'partner name'})
+        found_bank = self.env['res.partner.bank']._find_or_create_bank_account(
+            account_number='account number',
+            partner=partner,
+            company=self.env.company,
+        )
+        # The bank didn't exist, we should create it
+        self.assertRecordValues(found_bank, [{
+            'acc_number': 'account number',
+            'partner_id': partner.id,
+            'company_id': False,
+            'active': True,
+        }])
+
+    def test_find_or_create_bank_account_find_active(self):
+        partner = self.env['res.partner'].create({'name': 'partner name'})
+        bank = self.env['res.partner.bank'].create({
+            'acc_number': 'account number',
+            'partner_id': partner.id,
+            'company_id': False,
+            'active': True,
+        })
+        found_bank = self.env['res.partner.bank']._find_or_create_bank_account(
+            account_number='account number',
+            partner=partner,
+            company=self.env.company,
+        )
+        # The bank exists and is active, we should not create a new one
+        self.assertEqual(bank, found_bank)
+
+    def test_find_or_create_bank_account_find_inactive(self):
+        partner = self.env['res.partner'].create({'name': 'partner name'})
+        self.env['res.partner.bank'].create({
+            'acc_number': 'account number',
+            'partner_id': partner.id,
+            'company_id': False,
+            'active': False,
+        })
+        found_bank = self.env['res.partner.bank']._find_or_create_bank_account(
+            account_number='account number',
+            partner=partner,
+            company=self.env.company,
+        )
+        # The bank exists but is inactive, we should neither create a new one, neither return it
+        self.assertFalse(found_bank)
+
+    def test_find_or_create_bank_account_find_parent(self):
+        partner = self.env['res.partner'].create({'name': 'partner name'})
+        contact = self.env['res.partner'].create({'name': 'contact', 'parent_id': partner.id})
+        partner_bank = self.env['res.partner.bank'].create({
+            'acc_number': 'account number',
+            'partner_id': partner.id,
+        })
+        # Only the bank on the commercial partner exists
+        found_bank = self.env['res.partner.bank']._find_or_create_bank_account(
+            account_number='account number',
+            partner=partner,
+            company=self.env.company,
+        )
+        self.assertEqual(partner_bank, found_bank)
+
+        found_bank = self.env['res.partner.bank']._find_or_create_bank_account(
+            account_number='account number',
+            partner=contact,
+            company=self.env.company,
+        )
+        self.assertEqual(partner_bank, found_bank)
+
+        # Now the bank exists on both partners
+        contact_bank = self.env['res.partner.bank'].create({
+            'acc_number': 'account number',
+            'partner_id': contact.id,
+        })
+        found_bank = self.env['res.partner.bank']._find_or_create_bank_account(
+            account_number='account number',
+            partner=partner,
+            company=self.env.company,
+        )
+        self.assertEqual(partner_bank, found_bank)
+
+        found_bank = self.env['res.partner.bank']._find_or_create_bank_account(
+            account_number='account number',
+            partner=contact,
+            company=self.env.company,
+        )
+        self.assertEqual(contact_bank, found_bank)
+
+        # Only the bank on the contact exists
+        partner_bank.unlink()
+        found_bank = self.env['res.partner.bank']._find_or_create_bank_account(
+            account_number='account number',
+            partner=partner,
+            company=self.env.company,
+        )
+        self.assertEqual(contact_bank, found_bank)
+
+        found_bank = self.env['res.partner.bank']._find_or_create_bank_account(
+            account_number='account number',
+            partner=contact,
+            company=self.env.company,
+        )
+        self.assertEqual(contact_bank, found_bank)


### PR DESCRIPTION
The function `_find_or_create_bank_account` is expected to return one or no record at all.
In the case of child contacts, it is possible that the same account number was set on multiple records, leading the function to return multiple banks.
