### PR TITLE
[FIX] account_edi_ubl_cii: skip PartyIdentification for Danish

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -986,15 +986,15 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
         nodes = vals['party_node']['cac:PartyIdentification']
         partner = vals['party_vals']['partner']
         commercial_partner = partner.commercial_partner_id
-
-        if commercial_partner.country_code == 'BE' and commercial_partner.company_registry:
+        country_code = commercial_partner.country_code
+        if country_code == 'BE' and commercial_partner.company_registry:
             nodes.append({
                 'cbc:ID': {
                     '_text': be_vat.compact(commercial_partner.company_registry),
                     'schemeID': '0208',
                 },
             })
-        elif commercial_partner.ref:
+        elif commercial_partner.ref and country_code != 'DK':  # DK-R-013
             nodes.append({
                 'cbc:ID': {
                     '_text': commercial_partner.ref,


### PR DESCRIPTION
Currently, if a Danish partner has a reference set, Odoo adds it under PartyIdentification. This violates Peppol `DK-R-013`, which mandates using schemeID when PartyIdentification is used.

Adding the Danish schemeID would also trigger another error, `PEPPOL-COMMON-R042`, as the organization number (CVR) must be included in the `_text`. Including schemeID seem therefore unnecessary since it will appear in CompanyID.

Steps to reproduce:
- Create a Danish company and enable Peppol
- Create a Danish customer with a reference
- Create an invoice and submit to Peppol, `DK-R-013` error occurs

opw-5921602