### PR TITLE
[FIX] mass_mailing: correctly check for isSelectionInEditable

### DIFF
--- a/addons/mass_mailing/static/src/builder/plugins/empty_not_editable_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/empty_not_editable_plugin.js
@@ -23,7 +23,8 @@ export class EmptyNotEditableElementsPlugin extends Plugin {
                 emptyNonEditableBlock.remove();
             }
         });
-        if (!this.dependencies.selection.isSelectionInEditable) {
+        const selection = this.document.getSelection();
+        if (!this.dependencies.selection.isSelectionInEditable(selection)) {
             this.dependencies.selection.resetSelection();
         }
     }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This PR makes sure `isSelectionInEditable` is correctly checked in `EmptyNotEditableElementsPlugin`.
`isSelectionInEditable` is a shared method previous code interpreted it as property.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
