### PR TITLE
[IMP] website, html_builder: add theme colors palette preview

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -53,6 +53,7 @@ export class Builder extends Component {
         overlayRef: { type: Function },
         iframeLoaded: { type: Object },
         isMobile: { type: Boolean },
+        mobileBtnDisabled: { type: Boolean, optional: true },
         Plugins: { type: Array, optional: true },
         // This fragment of config will be passed to the Editor and be
         // available to the plugins in `config`
@@ -70,6 +71,7 @@ export class Builder extends Component {
         themeTabDisplayName: _t("Theme"),
         initialTab: "blocks",
         onlyCustomizeTab: false,
+        mobileBtnDisabled: false,
     };
 
     setup() {

--- a/addons/html_builder/static/src/builder.xml
+++ b/addons/html_builder/static/src/builder.xml
@@ -9,7 +9,11 @@
                 <button type="button"  t-on-click="() => this.redo()" class="o-hb-btn btn fa fa-repeat" t-att-disabled="!this.state.canRedo"/>
             </div>
             <div class="d-flex gap-1">
-                <button t-on-click="this.onMobilePreviewClick" type="button" class="o-hb-btn btn btn-success-color-active d-flex align-items-center" t-att-class="{ active: this.props.isMobile }" data-action="mobile" title="Mobile Preview" accesskey="m" style="--btn-font-size: 20px"><span class="fa fa-mobile" role="img"/></button>
+                <button t-on-click="this.onMobilePreviewClick" type="button" class="o-hb-btn btn btn-success-color-active d-flex align-items-center"
+                    t-att-class="{ active: this.props.isMobile }" t-att-disabled="this.props.mobileBtnDisabled" data-action="mobile"
+                    title="Mobile Preview" accesskey="m" style="--btn-font-size: 20px">
+                    <span class="fa fa-mobile" role="img"/>
+                </button>
                 <t t-if="this.props.slots?.extraActions" t-slot="extraActions"/>
             </div>
         </div>

--- a/addons/html_builder/static/src/core/building_blocks/builder_sliding_panel.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_sliding_panel.js
@@ -16,6 +16,7 @@ export class BuilderSlidingPanel extends Component {
         fullHeight: { type: Boolean, optional: true },
         darkBackground: { type: Boolean, optional: true },
         openByDefault: { type: Boolean, optional: true },
+        onClose: { type: Function, optional: true },
         slots: { type: Object, optional: true },
     };
     static defaultProps = {
@@ -77,6 +78,7 @@ export class BuilderSlidingPanel extends Component {
         this.updateDisplayTimeout = setTimeout(() => {
             this.updateDisplay("d-none");
             this.openButtonRef.el.focus();
+            this.props.onClose?.();
         }, 180);
     }
 

--- a/addons/html_builder/static/src/core/building_blocks/builder_sliding_panel.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_sliding_panel.scss
@@ -8,9 +8,6 @@
 
         .hb-sliding-panel-label .btn {
             font-size: inherit !important;
-            &:focus:not(:hover) {
-                background-color: transparent;
-            }
         }
     }
 

--- a/addons/html_builder/static/src/core/building_blocks/builder_sliding_panel.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_sliding_panel.xml
@@ -16,11 +16,12 @@
     >
         <div class="hb-sliding-panel-content d-flex flex-column" t-att-class="this.props.fullHeight ? 'h-100' : 'pb-3'">
             <div class="hb-sliding-panel-header">
-                <div class="hb-sliding-panel-label d-flex align-items-center p-2">
+                <div class="hb-sliding-panel-label d-flex align-items-stretch p-2">
                     <button class="btn p-1" t-on-click="this.hideSlidingPanel" aria-label="close" tabindex="0" >
                         <i class="oi oi-chevron-left me-1" role="presentation"/>
                         <t t-out="this.state.optionContainerName + ' / ' + this.props.label"/>
                     </button>
+                    <t t-slot="topOptions"/>
                 </div>
             </div>
             <t t-slot="content" close="this.hideSlidingPanel.bind(this)"/>

--- a/addons/html_builder/static/src/core/operation.js
+++ b/addons/html_builder/static/src/core/operation.js
@@ -48,9 +48,10 @@ export class OperationMutex extends Mutex {
 }
 
 export class Operation {
-    constructor(editableDocument = document) {
+    constructor(editableDocument = document, config = {}) {
         this.mutex = new OperationMutex();
         this.editableDocument = editableDocument;
+        this.config = config;
     }
 
     /**
@@ -165,21 +166,26 @@ export class Operation {
      * @returns {Function}
      */
     addLoadingElement(withLoadingEffect, loadingEffectDelay, shouldInterceptClick) {
-        this.loadingScreenEl = document.createElement("div");
+        const getOperationLoadingDocument = this.config.getOperationLoadingDocument;
+        const customLoadingDocument = getOperationLoadingDocument?.();
+        const loadingDocument =
+            customLoadingDocument === undefined ? this.editableDocument : customLoadingDocument;
+        if (!loadingDocument?.body) {
+            return () => {};
+        }
+
+        this.loadingScreenEl = loadingDocument.createElement("div");
         this.loadingScreenEl.classList.add(
             ...["o_loading_screen", "d-flex", "justify-content-center", "align-items-center"]
         );
-        const spinnerEl = document.createElement("img");
+        const spinnerEl = loadingDocument.createElement("img");
         spinnerEl.setAttribute("src", "/web/static/img/spin.svg");
         this.loadingScreenEl.appendChild(spinnerEl);
 
         let removeClickListener = () => {};
         if (shouldInterceptClick) {
             const onClick = (ev) => {
-                const trueTargetEls = this.editableDocument.elementsFromPoint(
-                    ev.clientX,
-                    ev.clientY
-                );
+                const trueTargetEls = loadingDocument.elementsFromPoint(ev.clientX, ev.clientY);
                 this.next(() => {
                     for (const trueTargetEl of trueTargetEls) {
                         if (trueTargetEl.isConnected) {
@@ -189,14 +195,14 @@ export class Operation {
                     }
                 });
             };
-            this.editableDocument.addEventListener("click", onClick);
-            removeClickListener = () => this.editableDocument.removeEventListener("click", onClick);
+            loadingDocument.addEventListener("click", onClick);
+            removeClickListener = () => loadingDocument.removeEventListener("click", onClick);
         }
         if (this.isUIBlocked) {
             this.loadingScreenEl.classList.add("d-none");
         }
 
-        this.editableDocument.body.appendChild(this.loadingScreenEl);
+        loadingDocument.body.appendChild(this.loadingScreenEl);
 
         // If specified, add a loading effect on that element after a delay.
         let loadingTimeout;

--- a/addons/html_builder/static/src/core/operation_plugin.js
+++ b/addons/html_builder/static/src/core/operation_plugin.js
@@ -17,7 +17,7 @@ export class OperationPlugin extends Plugin {
 
     setup() {
         this._hasTimedOut = false;
-        this.operation = new Operation(this.document);
+        this.operation = new Operation(this.document, this.config);
 
         // Revert any potential preview as soon as the user does anything, to
         // avoid losing what the user will have done when they ends the preview.

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -39,6 +39,7 @@
         'data/digest_data.xml',
         'views/website_technical_views.xml',
         'views/website_templates.xml',
+        'views/theme_colors_preview.xml',
         'views/snippets/snippets.xml',
         'views/snippets/s_announcement_scroll.xml',
         'views/snippets/s_framed_intro.xml',
@@ -408,6 +409,10 @@
             'website/static/src/xml/website_form_editor.xml',
             'website/static/src/xml/website.cookies_bar.xml',
             'website/static/src/mail/core/common/**/*',
+        ],
+        'website.assets_theme_colors_preview': [
+            ('include', 'web._assets_helpers'),
+            'html_builder/static/src/core/operation.edit.scss',
         ],
         'html_editor.assets_media_dialog': [
             'website/static/src/components/media_dialog/*',

--- a/addons/website/controllers/backend.py
+++ b/addons/website/controllers/backend.py
@@ -35,6 +35,10 @@ class WebsiteBackend(http.Controller):
     def get_iframe_fallback(self):
         return request.render('website.iframefallback')
 
+    @http.route('/website/theme_colors_preview', type="http", auth='user', website=True, readonly=True)
+    def get_theme_colors_preview(self):
+        return request.render('website.ThemeColorsPreview')
+
     @http.route('/website/track_installing_modules', type='jsonrpc', auth='user', readonly=True)
     def website_track_installing_modules(self, selected_features, total_features=None):
         """

--- a/addons/website/static/src/builder/plugins/customize_website_plugin.js
+++ b/addons/website/static/src/builder/plugins/customize_website_plugin.js
@@ -227,12 +227,15 @@ export class CustomizeWebsitePlugin extends Plugin {
     reloadBundles = debounce(this._reloadBundles.bind(this), 0);
     async _reloadBundles() {
         const bundles = await rpc("/website/theme_customize_bundle_reload");
+        const documents = [this.document, this.config.getThemeColorsPreviewDocument()].filter(
+            Boolean
+        );
         const allLinksIframeEls = [];
         const proms = [];
         const createLinksProms = (bundleURLs, insertionEl) => {
             const newLinkEls = [];
             for (const url of bundleURLs) {
-                const linkEl = this.document.createElement("link");
+                const linkEl = insertionEl.ownerDocument.createElement("link");
                 linkEl.setAttribute("type", "text/css");
                 linkEl.setAttribute("rel", "stylesheet");
                 linkEl.setAttribute("href", `${url}#t=${new Date().getTime()}`); // Ensures that the css will be reloaded.
@@ -248,12 +251,14 @@ export class CustomizeWebsitePlugin extends Plugin {
                 insertionEl.insertAdjacentElement("afterend", el);
             }
         };
-        for (const [bundleName, bundleURLs] of Object.entries(bundles)) {
-            const selector = `link[href*="${bundleName}"]`;
-            const linksIframeEls = this.document.querySelectorAll(selector);
-            if (linksIframeEls.length) {
-                allLinksIframeEls.push(...linksIframeEls);
-                createLinksProms(bundleURLs, linksIframeEls[linksIframeEls.length - 1]);
+        for (const document of documents) {
+            for (const [bundleName, bundleURLs] of Object.entries(bundles)) {
+                const selector = `link[href*="${bundleName}"]`;
+                const linksIframeEls = document.querySelectorAll(selector);
+                if (linksIframeEls.length) {
+                    allLinksIframeEls.push(...linksIframeEls);
+                    createLinksProms(bundleURLs, linksIframeEls[linksIframeEls.length - 1]);
+                }
             }
         }
         await Promise.all(proms).then(() => {

--- a/addons/website/static/src/builder/plugins/theme/theme_colors_option.js
+++ b/addons/website/static/src/builder/plugins/theme/theme_colors_option.js
@@ -1,25 +1,33 @@
-import { onMounted } from "@odoo/owl";
+import { onMounted, onWillUnmount } from "@odoo/owl";
 import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 import { useDomState } from "@html_builder/core/utils";
 import { getCSSVariableValue } from "@html_editor/utils/formatting";
 import { _t } from "@web/core/l10n/translation";
+import { useBus } from "@web/core/utils/hooks";
+import { useState } from "@web/owl2/utils";
 
 export class ThemeColorsOption extends BaseOptionComponent {
     static template = "website.ThemeColorsOption";
     static dependencies = ["themeTab"];
     setup() {
         super.setup();
+        this.isMobileBeforeThemeColorsPreview = null;
         this.palettes = this.getPalettes();
         this.colorPresetToShow = this.env.colorPresetToShow;
         this.grays = this.dependencies.themeTab.getGrays();
         this.state = useDomState(() => ({
             presets: this.getPresets(),
         }));
+        this.websiteContext = useState(this.services.website.context);
+        useBus(this.services.website.bus, "CLOSE-THEME-COLORS-PREVIEW", () =>
+            this.closeThemeColorsPreview()
+        );
         onMounted(() => {
             this.iframeDocument = document.querySelector("iframe").contentWindow.document;
             this.state.presets = this.getPresets();
             this.colorPresetToShow = null;
         });
+        onWillUnmount(() => this.closeThemeColorsPreview());
     }
 
     getPalettes() {
@@ -83,5 +91,32 @@ export class ThemeColorsOption extends BaseOptionComponent {
             );
         }
         return getCSSVariableValue(color, this.iframeStyle);
+    }
+
+    get showThemeColorsPreview() {
+        return this.websiteContext.showThemeColorsPreview;
+    }
+
+    openThemeColorsPreview() {
+        const { context } = this.services.website;
+        if (context.showThemeColorsPreview) {
+            this.closeThemeColorsPreview();
+            return;
+        }
+        this.isMobileBeforeThemeColorsPreview = context.isMobile;
+        context.showThemeColorsPreview = true;
+        context.isMobile = false;
+    }
+
+    closeThemeColorsPreview() {
+        const { context } = this.services.website;
+        if (!context.showThemeColorsPreview) {
+            return;
+        }
+        context.showThemeColorsPreview = false;
+        if (this.isMobileBeforeThemeColorsPreview !== null) {
+            context.isMobile = this.isMobileBeforeThemeColorsPreview;
+            this.isMobileBeforeThemeColorsPreview = null;
+        }
     }
 }

--- a/addons/website/static/src/builder/plugins/theme/theme_colors_option.xml
+++ b/addons/website/static/src/builder/plugins/theme/theme_colors_option.xml
@@ -6,7 +6,8 @@
                     label.translate="Colors"
                     extraClasses="'btn-secondary p-0 d-flex o-hb-theme-color-slider-btn'"
                     darkBackground="true"
-                    openByDefault="!!this.colorPresetToShow">
+                    openByDefault="!!this.colorPresetToShow"
+                    onClose="() => this.closeThemeColorsPreview()">
                     <div class="d-flex w-100">
                         <t t-foreach="[1,2,3,4,5]" t-as="i" t-key="i">
                             <span class="flex-grow-1 o_preview_alpha_background"
@@ -14,6 +15,12 @@
                             </span>
                         </t>
                     </div>
+                    <t t-set-slot="topOptions">
+                        <button class="o-hb-btn btn btn-primary ms-auto fa fa-fw" t-on-click="this.openThemeColorsPreview"
+                            t-att-class="this.showThemeColorsPreview ? 'fa-eye-slash' : 'fa-eye'"
+                            title="Colors preview" aria-label="Colors preview" type="button">
+                        </button>
+                    </t>
                     <t t-set-slot="content">
                         <BuilderContext preview="false">
                             <!-- TODO
@@ -25,7 +32,7 @@
                             </we-alert>-->
                             <BuilderOptionsSection>
                                 <BuilderRow>
-                                    <div class="d-flex flex-row gap-3 w-100 justify-content-between ps-2" style="height: 50px">
+                                    <div class="d-flex flex-row gap-3 w-100 justify-content-between ps-2 mt-1" style="height: 50px">
                                         <div class="d-flex flex-column h-100 justify-content-between">
                                             <span class="fst-italic">Main</span>
                                             <div class="d-flex flex-row gap-1">

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -4,6 +4,7 @@ import { Component, onMounted, onWillDestroy, onWillStart, onWillUnmount, status
 import { loadBundle } from "@web/core/assets";
 import { LazyComponent } from "@web/core/lazy_component";
 import { browser } from "@web/core/browser/browser";
+import { Dialog } from "@web/core/dialog/dialog";
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
@@ -26,6 +27,20 @@ import { CreatePageMessage } from "./create_page_message";
 import { post } from "@web/core/network/http_service";
 
 const websiteSystrayRegistry = registry.category("website_systray");
+
+class ThemeColorsPreviewDialog extends Component {
+    static template = "website.ThemeColorsPreviewDialog";
+    static components = { Dialog };
+    static props = {
+        close: { type: Function },
+        iframeSrc: { type: String },
+        onIframeLoad: { type: Function, optional: true },
+    };
+
+    onIframeLoad(ev) {
+        this.props.onIframeLoad?.(ev.target.contentDocument);
+    }
+}
 
 export class WebsiteBuilderClientAction extends Component {
     static template = "website.WebsiteBuilderClientAction";
@@ -66,6 +81,9 @@ export class WebsiteBuilderClientAction extends Component {
         this.iframeFallbackUrl = "/website/iframefallback";
         this.iframefallback = useRef("iframefallback");
         this.newInstalledModule = router.current.module_installed;
+        this.themeColorsPreviewUrl = "/website/theme_colors_preview";
+        this.themeColorsPreviewDialogClose = null;
+        this.themeColorsPreviewDocument = null;
 
         this.websiteContent = useRef("iframe");
         this.builderSidebarRef = useRef("builder_sidebar");
@@ -97,6 +115,12 @@ export class WebsiteBuilderClientAction extends Component {
                         return;
                     }
                     this.toggleIsMobile(websiteContext.isMobile);
+                    if (websiteContext.showThemeColorsPreview) {
+                        this.openThemeColorsPreviewDialog();
+                    } else {
+                        this.closeThemeColorsPreviewDialog();
+                        this.themeColorsPreviewDocument = null;
+                    }
                 },
                 [this.websiteContext]
             );
@@ -159,6 +183,7 @@ export class WebsiteBuilderClientAction extends Component {
         this.setIframeLoaded();
         this.addSystrayItems();
         onWillDestroy(() => {
+            this.closeThemeColorsPreviewDialog();
             websiteSystrayRegistry.remove("website.WebsiteSystrayItem");
             this.websiteService.currentWebsiteId = null;
             websiteSystrayRegistry.trigger("EDIT-WEBSITE");
@@ -214,11 +239,19 @@ export class WebsiteBuilderClientAction extends Component {
             overlayRef: this.overlayRef,
             iframeLoaded: iframeLoaded,
             isMobile: this.websiteContext.isMobile,
+            mobileBtnDisabled: this.websiteContext.showThemeColorsPreview,
             initialTab: this.reloadContext?.initialTab,
             onlyCustomizeTab: this.translation,
             newInstalledModule: this.newInstalledModule,
             config: {
                 reloadContext: this.reloadContext,
+                getThemeColorsPreviewDocument: () => this.themeColorsPreviewDocument,
+                getOperationLoadingDocument: () => {
+                    if (!this.websiteContext.showThemeColorsPreview) {
+                        return undefined;
+                    }
+                    return this.themeColorsPreviewDocument;
+                },
                 builderSidebar: {
                     withHiddenSidebar: async (cb) => {
                         try {
@@ -677,6 +710,46 @@ export class WebsiteBuilderClientAction extends Component {
         // Adding the mobile class directly, to not wait for the component
         // re-rendering.
         this.websiteService.context.isMobile = !this.websiteService.context.isMobile;
+    }
+
+    closeThemeColorsPreview() {
+        this.websiteService.bus.trigger("CLOSE-THEME-COLORS-PREVIEW");
+    }
+
+    openThemeColorsPreviewDialog() {
+        if (this.themeColorsPreviewDialogClose) {
+            return;
+        }
+        this.themeColorsPreviewDialogClose = this.dialog.add(
+            ThemeColorsPreviewDialog,
+            {
+                iframeSrc: this.themeColorsPreviewUrl,
+                onIframeLoad: (document) => {
+                    this.themeColorsPreviewDocument = document;
+                },
+            },
+            {
+                onClose: () => {
+                    this.themeColorsPreviewDialogClose = null;
+                    this.themeColorsPreviewDocument = null;
+                    if (this.websiteContext.showThemeColorsPreview) {
+                        this.closeThemeColorsPreview();
+                        if (this.websiteContext.showThemeColorsPreview) {
+                            this.websiteContext.showThemeColorsPreview = false;
+                        }
+                    }
+                },
+            }
+        );
+    }
+
+    closeThemeColorsPreviewDialog() {
+        if (!this.themeColorsPreviewDialogClose) {
+            return;
+        }
+        const closeDialog = this.themeColorsPreviewDialogClose;
+        this.themeColorsPreviewDialogClose = null;
+        closeDialog();
     }
 
     toggleIsMobile(isMobile) {

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.scss
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.scss
@@ -92,6 +92,23 @@
     }
 }
 
+.o_dialog:has(.o_theme_colors_preview_dialog) {
+    .modal {
+        width: calc(100% - #{$o-we-sidebar-width});
+        background-color: rgba($modal-backdrop-bg, 0.75);
+
+        .modal-dialog {
+            max-width: 100%;
+            padding: calc(var(--modal-margin) / 2);
+
+            .modal-content {
+                // Handle dark body backgrounds
+                border: 1px solid rgba(white, .175);
+            }
+        }
+    }
+}
+
 .o_builder_disabled {
     opacity: 0.5;
     cursor: wait;

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.xml
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.xml
@@ -27,6 +27,14 @@
     </div>
 </t>
 
+<t t-name="website.ThemeColorsPreviewDialog">
+    <Dialog title.translate="Colors Preview" footer="false" withBodyPadding="false"
+        contentClass="'o_theme_colors_preview_dialog h-100'">
+        <iframe class="d-block h-100 w-100" t-att-src="this.props.iframeSrc"
+            t-on-load="this.onIframeLoad"/>
+    </Dialog>
+</t>
+
 <t t-name="website.homepage_editor_welcome_message">
     <div class="container o_homepage_editor_welcome_message text-center pt128 pb128 h-100">
         <h2 class="mt0">Welcome to your <b>Homepage</b>!</h2>

--- a/addons/website/static/src/services/website_service.js
+++ b/addons/website/static/src/services/website_service.js
@@ -53,6 +53,7 @@ export const websiteService = {
             isPublicRootReady: false,
             snippetsLoaded: false,
             isMobile: false,
+            showThemeColorsPreview: false,
         });
         const bus = new EventBus();
 

--- a/addons/website/static/tests/builder/theme_tab/theme_colors_preview.test.js
+++ b/addons/website/static/tests/builder/theme_tab/theme_colors_preview.test.js
@@ -1,0 +1,46 @@
+import { expect, test } from "@odoo/hoot";
+import { animationFrame, waitForNone } from "@odoo/hoot-dom";
+import {
+    defineWebsiteModels,
+    setupWebsiteBuilder,
+} from "@website/../tests/builder/website_helpers";
+import { contains } from "@web/../tests/web_test_helpers";
+
+defineWebsiteModels();
+
+test("theme colors preview modal", async () => {
+    await setupWebsiteBuilder("");
+
+    await contains("button[data-action='mobile']").click();
+    expect(".o_website_preview.o_is_mobile").toHaveCount(1);
+
+    await contains(".o-snippets-tabs button[data-name=theme]").click();
+    await contains(".o-tab-content .o-hb-theme-color-slider-btn").click();
+    await contains(".o_theme_tab button[title='Colors preview']").click();
+    await animationFrame();
+
+    expect(".o_theme_colors_preview_dialog iframe").toHaveCount(1);
+    expect("button[data-action='mobile']").toHaveAttribute("disabled");
+    expect(".o_website_preview.o_is_mobile").toHaveCount(0);
+    expect(".o_theme_tab button[title='Colors preview']").toHaveClass("fa-eye-slash");
+
+    await contains(".o_theme_tab button[title='Colors preview']").click();
+    await waitForNone(".o_theme_colors_preview_dialog");
+
+    expect("button[data-action='mobile']").not.toHaveAttribute("disabled");
+    expect(".o_website_preview.o_is_mobile").toHaveCount(1);
+    expect(".o_theme_tab button[title='Colors preview']").toHaveClass("fa-eye");
+
+    await contains(".o_theme_tab button[title='Colors preview']").click();
+    await animationFrame();
+
+    expect(".o_theme_colors_preview_dialog iframe").toHaveCount(1);
+    expect("button[data-action='mobile']").toHaveAttribute("disabled");
+    expect(".o_website_preview.o_is_mobile").toHaveCount(0);
+
+    await contains(".o-snippets-tabs button[data-name=blocks]").click();
+    await waitForNone(".o_theme_colors_preview_dialog");
+
+    expect("button[data-action='mobile']").not.toHaveAttribute("disabled");
+    expect(".o_website_preview.o_is_mobile").toHaveCount(1);
+});

--- a/addons/website/views/theme_colors_preview.xml
+++ b/addons/website/views/theme_colors_preview.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="ThemeColorsPreview" inherit_id="web.layout" primary="True">
+    <xpath expr="//head/link[last()]" position="after">
+        <t t-call-assets="web.assets_frontend" t-js="false"/>
+        <t t-call-assets="website.assets_wysiwyg" t-js="false"/>
+        <t t-call-assets="website.assets_theme_colors_preview"/>
+    </xpath>
+    <xpath expr="//body" position="inside">
+        <section class="o_colored_level d-flex align-items-center min-vh-100">
+            <div class="container pb-5">
+                <div class="row g-3">
+                    <t t-foreach="range(1, 6)" t-as="preset_id">
+                        <div class="col-lg-4">
+                            <small>
+                                <span class="badge mb-2" style="--badge-border-color: #cccccc; --badge-bg: white; --badge-color: black;">
+                                    Preset #<t t-out="preset_id"/>
+                                </span>
+                            </small>
+                            <div t-attf-class="o_colored_level o_cc o_cc#{preset_id} shadow-sm border p-4 pb-2 rounded-1">
+                                <h4>Title</h4>
+                                <p>Nihil hic munitissimus <a href="#">habendi</a> senatus locus, nihil horum.</p>
+                                <p class="mb-0">
+                                    <a class="btn btn-primary mb-2" href="#">Primary</a>
+                                    <a class="btn btn-secondary mb-2" href="#">Secondary</a>
+                                </p>
+                                <p class="mb-0">
+                                    <a class="btn btn-outline-primary mb-2" href="#">Primary</a>
+                                    <a class="btn btn-outline-secondary mb-2" href="#">Secondary</a>
+                                </p>
+                            </div>
+                        </div>
+                    </t>
+                    <div class="col-lg-4 d-flex flex-column">
+                        <small>
+                            <span class="badge mb-2" style="--badge-border-color: #cccccc; --badge-bg: white; --badge-color: black;">
+                                UI elements
+                            </span>
+                        </small>
+                        <div class="shadow-sm border p-4 pb-2 rounded-1 d-flex flex-column align-items-center h-100">
+                            <div class="d-flex w-100 gap-2 mb-3 justify-content-center align-items-center">
+                                <a class="btn btn-light fa fa-home h-100 align-content-center" href="#"/>
+                                <div class="input-group">
+                                    <input type="search" name="search" class="form-control border-0 bg-light" placeholder="Search..."/>
+                                    <button type="submit" aria-label="Search" title="Search" class="btn btn-light">
+                                        <i class="oi oi-search"></i>
+                                    </button>
+                                </div>
+                            </div>
+                            <input type="text" class="form-control mb-3" placeholder="Text Input"/>
+                            <div class="d-flex w-100">
+                                <div style="flex: 1;">
+                                    <div class="d-flex gap-1">
+                                        <div class="form-check form-switch">
+                                            <input class="form-check-input" type="checkbox" role="switch"/>
+                                        </div>
+                                        <div class="form-check">
+                                            <input class="form-check-input" type="checkbox"/>
+                                        </div>
+                                        <div class="form-check">
+                                            <input class="form-check-input" type="radio" name="demo_radio"/>
+                                        </div>
+                                    </div>
+                                    <div class="d-flex gap-1">
+                                        <div class="form-check form-switch">
+                                            <input class="form-check-input" type="checkbox" role="switch" checked=""/>
+                                        </div>
+                                        <div class="form-check">
+                                            <input class="form-check-input" type="checkbox" checked=""/>
+                                        </div>
+                                        <div class="form-check">
+                                            <input class="form-check-input" type="radio" name="demo_radio" checked=""/>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="d-flex flex-wrap gap-2 justify-content-end align-self-start" style="flex: 1;">
+                                    <span class="badge text-bg-success">Success</span>
+                                    <span class="badge text-bg-info">Info</span>
+                                    <span class="badge text-bg-warning">Warning</span>
+                                    <span class="badge text-bg-danger">Danger</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </xpath>
+</template>
+
+</odoo>


### PR DESCRIPTION
Steps to reproduce:
- Open the website builder.
- Go to Theme > Colors.
- Change theme colors.
- Try to evaluate the impact on UI elements.

Before this commit, it was hard to understand how theme colors affected
typical components while editing.

After this commit, users can open a dedicated colors preview dialog (see image), and
theme CSS updates are reloaded in both the page iframe and the preview
iframe.

task-5960098

<img width="1550" height="925" alt="image" src="https://github.com/user-attachments/assets/f80dca4f-5223-4f9f-acaf-cb9e03541cae" />
