### PR TITLE
[IMP] project: extend customer follower subscription logic

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -711,7 +711,7 @@ class ProjectProject(models.Model):
                 })
             vals.pop('last_update_status')
         if vals.get('privacy_visibility'):
-            self._change_privacy_visibility(vals['privacy_visibility'])
+            self._change_privacy_visibility(vals['privacy_visibility'], [vals['partner_id']] if vals.get('partner_id') else [])
 
         if vals.get('partner_id'):
             projects = self.filtered(lambda p: (vals.get('privacy_visibility') or p.privacy_visibility) in ['invited_users', 'portal'])
@@ -1111,7 +1111,7 @@ class ProjectProject(models.Model):
     # Privacy
     # ---------------------------------------------------
 
-    def _change_privacy_visibility(self, new_visibility):
+    def _change_privacy_visibility(self, new_visibility, partner_ids=[]):
         """
         Unsubscribe non-internal users from the project and tasks if the project privacy visibility
         goes from 'portal' to a different value.
@@ -1121,7 +1121,7 @@ class ProjectProject(models.Model):
             if project.privacy_visibility == new_visibility:
                 continue
             if new_visibility in ['invited_users', 'portal']:
-                project.message_subscribe(partner_ids=project.partner_id.ids)
+                project.message_subscribe(partner_ids=partner_ids or project.partner_id.ids)
                 for task in project.task_ids.filtered('partner_id'):
                     task.message_subscribe(partner_ids=task.partner_id.ids)
             elif project.privacy_visibility in ['invited_users', 'portal']:

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -666,8 +666,8 @@ class ProjectProject(models.Model):
                 vals['favorite_user_ids'] = [self.env.uid]
         projects = super().create(vals_list)
         for project in projects:
-            if project.privacy_visibility == 'portal':
-                project.message_subscribe(partner_ids=[project.partner_id.id])
+            if project.privacy_visibility in ['invited_users', 'portal'] and project.partner_id:
+                project.message_subscribe(partner_ids=project.partner_id.ids)
         return projects
 
     def write(self, vals):
@@ -712,6 +712,10 @@ class ProjectProject(models.Model):
             vals.pop('last_update_status')
         if vals.get('privacy_visibility'):
             self._change_privacy_visibility(vals['privacy_visibility'])
+
+        if vals.get('partner_id'):
+            projects = self.filtered(lambda p: (vals.get('privacy_visibility') or p.privacy_visibility) in ['invited_users', 'portal'])
+            projects.message_subscribe(partner_ids=[vals.get('partner_id')])
 
         date_start = vals.get('date_start', True)
         date_end = vals.get('date', True)

--- a/addons/project/tests/test_project_flow.py
+++ b/addons/project/tests/test_project_flow.py
@@ -490,3 +490,9 @@ class TestProjectFlow(TestProjectCommon, MailCase):
             self.partner_1, project.message_partner_ids,
             "Customer should be automatically subscribed to the project when visibility is set to 'public'."
         )
+
+        project.partner_id = self.partner_2.id
+        self.assertIn(
+            self.partner_2, project.message_partner_ids,
+            "New customer should be automatically subscribed when partner changes on a public project."
+        )

--- a/addons/sale_timesheet/tests/test_performance.py
+++ b/addons/sale_timesheet/tests/test_performance.py
@@ -19,7 +19,7 @@ class TestPerformanceTimesheet(TestSaleTimesheet):
         })
         self.assertFalse(project.task_ids.sale_line_id)
         self.env.invalidate_all()
-        with self.assertQueryCount(165):
+        with self.assertQueryCount(172):
             project.write({
                 'allow_billable': True,
                 'partner_id': self.partner_b.id,
@@ -34,7 +34,7 @@ class TestPerformanceTimesheet(TestSaleTimesheet):
             'project_id': project.id,
         } for i in range(50, 100)])
         self.env.invalidate_all()
-        with self.assertQueryCount(236):
+        with self.assertQueryCount(239):
             project.write({
                 'allow_billable': True,
                 'partner_id': self.partner_b.id,


### PR DESCRIPTION
Before this commit:
-

 - Customer was added as follower only when project visibility was set to 'portal'.
 - Changing the customer did not automatically add the new customer as a follower.

After this commit:
-

 - Customer is automatically added as follower when project visibility is follower-based ('portal', 'invited_users').
 - Changing the customer now also updates follower subscription to keep access consistent.

task-5966602

