### PR TITLE
[FIX] website_sale: make product search global instead of category specific

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -793,10 +793,8 @@ class WebsiteSale(payment_portal.PaymentPortal):
     def _prepare_product_values(self, product, category, **kwargs):
         ProductCategory = request.env['product.public.category']
         product_markup_data = [product._to_markup_data(request.website)]
-        category = (
-            (category and ProductCategory.browse(int(category)).exists())
-            or product.public_categ_ids[:1]
-        )
+        original_category = category
+        category = category or product.public_categ_ids[:1]
         if category:
             # Add breadcrumb's SEO data.
             product_markup_data.append(self._prepare_breadcrumb_markup_data(
@@ -805,11 +803,11 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
         if (last_attributes_search := request.session.get('attribute_values', [])):
             keep = QueryURL(
-                self._get_shop_path(category),
+                self._get_shop_path(original_category),
                 attribute_values=last_attributes_search
             )
         else:
-            keep = QueryURL(self._get_shop_path(category))
+            keep = QueryURL(self._get_shop_path(original_category))
 
         if attribute_values := kwargs.get('attribute_values', ''):
             attribute_value_ids = {int(i) for i in attribute_values.split(',')}
@@ -835,6 +833,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         return {
             'categories': ProductCategory.search([('parent_id', '=', False)]),
             'category': category,
+            'original_category': original_category,
             'combination_info': combination_info,
             'keep': keep,
             'main_object': product,

--- a/addons/website_sale/tests/test_website_sale_product_configurator.py
+++ b/addons/website_sale/tests/test_website_sale_product_configurator.py
@@ -486,3 +486,30 @@ class TestWebsiteSaleProductConfigurator(HttpCase, WebsiteSaleCommon):
         combination_product_id = product_values['combination_info']['product_id']
         self.assertTrue(is_combination_possible)
         self.assertTrue(self.env['product.product'].browse(combination_product_id).active)
+
+    def test_product_page_search_scope_respects_navigation_context(self):
+        """
+        Ensure that search scope depends on how the user accessed the product page.
+
+        - Direct access to a product → search must be global (/shop)
+        - Access via category → search must be category-scoped
+        """
+        product_tmpl = self.product.product_tmpl_id
+        public_category = self.env['product.public.category'].create({
+            'name': 'Test Public Category',
+        })
+        product_tmpl.public_categ_ids = [Command.set([public_category.id])]
+
+        with MockRequest(self.env, website=self.website):
+            values = self.pc_controller._prepare_product_values(
+                product_tmpl,
+                category=None,
+            )
+        self.assertNotIn('/category', values['keep'].path)
+
+        with MockRequest(self.env, website=self.website):
+            values = self.pc_controller._prepare_product_values(
+                product_tmpl,
+                category=public_category,
+            )
+        self.assertIn('/category', values['keep'].path)

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2259,7 +2259,7 @@
                                 <t t-set="_input_classes" t-valuef="border-0 p-3"/>
                                 <t t-set="_submit_classes" t-valuef="px-4"/>
                                 <t t-set="action" t-value="keep(search=0)"/>
-                                <t t-if="category" t-set="placeholder">Search in <t t-out="category.name"/></t>
+                                <t t-if="original_category" t-set="placeholder">Search in <t t-out="original_category.name"/></t>
                             </t>
                         </div>
                     </div>
@@ -2432,7 +2432,8 @@
         name="Searchbar On Product Page"
     >
         <xpath expr="//div[hasclass('o_wsale_product_top_bar_desktop')]" position="inside">
-            <t t-call="website_sale.search">
+            <t t-if="original_category" t-set="placeholder">Search in <t t-out="original_category.name"/></t>
+            <t t-call="website_sale.search" placeholder="placeholder">
                 <t t-set="search" t-value="False"/>
                 <t t-set="_classes" t-value="'me-sm-2'"/>
             </t>


### PR DESCRIPTION
Steps to produce:
---
- Install `website_sale` module.
- Go to `website > shop`.
- Open the `Customizable Desk` product page.
- From the website editor, `enable the search bar` for the product page.
- Now search for `drawer`.

Issue:
---
- Searching from a product page always scopes results to the product's category, even when the user navigated directly to the product without selecting any category.

Root cause:
---
- The issue occurs because `_prepare_product_values()`[1] always assigns a category using the fallback `product.public_categ_ids[:1]` when no category is explicitly provided. As a result, the `keep` object is generated with `_get_shop_path(category)`[2], which produces a category-based shop URL. Since the search form action is defined as `keep(search=0)` [3] in the template, the generated search URL always includes `/shop/category/<slug>`, even when the user accessed the product page directly. This unintentionally scopes all searches to the product’s first public category instead of performing a global `/shop` search.

Solution:
---
- Separate the breadcrumb logic from the search context logic. Before automatically assigning a default category for breadcrumb display, store the originally requested category (which is None when navigating directly to a product).
- Use the auto-assigned category only for breadcrumb display.
- Use the originally requested category to build the keep QueryURL

[1]https://github.com/odoo/odoo/blob/242afb9ca3a76e3628260ac81a9f5ddcd5d445dd/addons/website_sale/controllers/main.py#L796-L799 
[2]https://github.com/odoo/odoo/blob/242afb9ca3a76e3628260ac81a9f5ddcd5d445dd/addons/website_sale/controllers/main.py#L806-L812
[3]https://github.com/odoo/odoo/blob/242afb9ca3a76e3628260ac81a9f5ddcd5d445dd/addons/website_sale/views/templates.xml#L360-L372

opw-5969662
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
