### PR TITLE
[IMP] im_livechat: mark ended livechat conversations as read

### DIFF
--- a/addons/im_livechat/static/src/core/common/thread_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_patch.js
@@ -30,6 +30,20 @@ patch(Thread.prototype, {
             () => [this.props.thread.livechatVisitorMember?.im_status]
         );
     },
+    /** @override */
+    applyScrollContextually(thread) {
+        super.applyScrollContextually(...arguments);
+        if (thread.channel?.composerHidden && this.shouldMarkAsReadOnScroll(thread)) {
+            thread.markAsRead();
+        }
+    },
+    /** @override */
+    shouldMarkAsReadOnScroll(thread) {
+        if (thread.channel?.composerHidden) {
+            return this.isAtBottom && !thread.channel?.markedAsUnread && !thread.markingAsRead;
+        }
+        return super.shouldMarkAsReadOnScroll(...arguments);
+    },
     get showVisitorDisconnected() {
         return (
             this.store.self.notEq(this.props.thread.livechatVisitorMember?.persona) &&

--- a/addons/im_livechat/static/tests/chat_window_patch.test.js
+++ b/addons/im_livechat/static/tests/chat_window_patch.test.js
@@ -2,13 +2,15 @@ import {
     click,
     contains,
     openDiscuss,
+    onRpcBefore,
     openFormView,
     setupChatHub,
+    scroll,
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
 import { withGuest } from "@mail/../tests/mock_server/mail_mock_server";
-import { test } from "@odoo/hoot";
+import { expect, test } from "@odoo/hoot";
 import { animationFrame } from "@odoo/hoot-mock";
 import { Command, serverState } from "@web/../tests/web_test_helpers";
 import { rpc } from "@web/core/network/rpc";
@@ -208,4 +210,56 @@ test("livechat: non-member can close immediately", async () => {
     await contains(".o-mail-ChatWindow");
     await click("[title*='Close Chat Window']");
     await contains(".o-mail-ChatWindow", { count: 0 });
+});
+
+test("Mark closed conversation as read when scrolling to bottom", async () => {
+    const pyEnv = await startServer();
+    const guestId = pyEnv["mail.guest"].create({ name: "Visitor" });
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
+        ],
+        channel_type: "livechat",
+        livechat_end_dt: serializeDate(luxon.DateTime.now()),
+    });
+    for (let i = 0; i <= 5; i++) {
+        pyEnv["mail.message"].create({
+            author_guest_id: guestId,
+            body: "test message".repeat(100),
+            model: "discuss.channel",
+            res_id: channelId,
+        });
+    }
+    onRpcBefore("/discuss/channel/mark_as_read", () => expect.step("mark_as_read"));
+    setupChatHub({ opened: [channelId] });
+    await start();
+    await contains(".o-mail-ChatWindow .o-mail-Message", { count: 6 });
+    await scroll(".o-mail-Thread", "bottom");
+    await contains(".o-mail-Thread", { scroll: "bottom" });
+    await expect.waitForSteps(["mark_as_read"]);
+});
+
+test("Mark auto-open conversation as read when session ends", async () => {
+    const pyEnv = await startServer();
+    const guestId = pyEnv["mail.guest"].create({ name: "Visitor" });
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
+        ],
+        channel_type: "livechat",
+    });
+    pyEnv["mail.message"].create({
+        author_guest_id: guestId,
+        body: "test message",
+        model: "discuss.channel",
+        res_id: channelId,
+    });
+    onRpcBefore("/discuss/channel/mark_as_read", () => expect.step("mark_as_read"));
+    setupChatHub({ opened: [channelId] });
+    await start();
+    await contains(".o-mail-ChatWindow .o-mail-Message:has(:text('test message'))");
+    await withGuest(guestId, () => rpc("/im_livechat/visitor_leave_session", { channel_id: channelId }));
+    await expect.waitForSteps(["mark_as_read"]);
 });


### PR DESCRIPTION
**Description of the issue this PR addresses:**
Previously, when a livechat conversation ended, it was never automatically 
marked as read. The existing `mark_as_read` mechanism depends on the 
composer being focused, but ended livechat conversations hides the composer, 
and the chat window does not focus the thread automatically 
(focus only happens on explicit click).

This made it impossible for the read state to be triggered through the normal 
path, leaving agents with persistent unread indicators on closed livechat 
conversations.

**Desired behavior after PR is merged:**
- Mark ended livechat conversations as read when the agent is not at the bottom, 
only after they scroll to the bottom ensuring the full conversation has been 
seen before clearing the unread indicator.
- Mark ended livechat conversations as read when opened and the agent is 
already at the bottom.
- Mark an ongoing conversation as read automatically when the session ends 
and the chat window was opened via auto-open.

task-[5900038](https://www.odoo.com/odoo/project/1519/tasks/5900038)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
