### PR TITLE
[FIX] base_vat: ensure valid NRI GSTINs are accepted

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -715,6 +715,7 @@ class ResPartner(models.Model):
             all_gstin_re = [
                 r'[0-9]{2}[a-zA-Z]{5}[0-9]{4}[a-zA-Z]{1}[1-9A-Za-z]{1}[Zz1-9A-Ja-j]{1}[0-9a-zA-Z]{1}', # Normal, Composite, Casual GSTIN
                 r'[0-9]{4}[A-Z]{3}[0-9]{5}[UO]{1}[N][A-Z0-9]{1}', #UN/ON Body GSTIN
+                r'[0-9]{4}[A-Z]{3}[0-9]{5}[A-Z]{3}',  # Revised NRI GSTIN
                 r'[0-9]{4}[a-zA-Z]{3}[0-9]{5}[N][R][0-9a-zA-Z]{1}', #NRI GSTIN
                 r'[0-9]{2}[a-zA-Z]{4}[a-zA-Z0-9]{1}[0-9]{4}[a-zA-Z]{1}[1-9A-Za-z]{1}[DK]{1}[0-9a-zA-Z]{1}', #TDS GSTIN
                 r'[0-9]{2}[a-zA-Z]{5}[0-9]{4}[a-zA-Z]{1}[1-9A-Za-z]{1}[C]{1}[0-9a-zA-Z]{1}' #TCS GSTIN

--- a/addons/base_vat/tests/test_validate_ruc.py
+++ b/addons/base_vat/tests/test_validate_ruc.py
@@ -185,6 +185,11 @@ class TestStructure(TransactionCase):
             with self.assertRaises(ValidationError):
                 test_partner.vat = ubn
 
+    def test_revised_nri_gstin_format(self):
+        """Test valid NRI GSTIN number is accepted"""
+        in_partner = self.env["res.partner"].create({"name": "IN Company", "country_id": self.env.ref("base.in").id})
+        in_partner.vat = "9922JPN29001OSU"
+
 
 @tagged('-standard', 'external')
 class TestStructureVIES(TestStructure):


### PR DESCRIPTION
Currently, valid GSTINs for certain Non-Resident taxpayers are rejected.

**Steps to reproduce:**
- Install the `l10n_in` module.
- Navigate to Settings > Users & Companies > Companies.
- Open `IN Company` and set `Tax ID` to `9922JPN29001OSU` and try to `save`.

**Error:**
`The VAT number [9922JPN29001OSU] for partner [IN Company] does not seem to be valid.` 
`Note: the expected format is 12AAAAA1234AAZA`

The system rejects the GSTIN, although it is valid and verifiable on the 
official GST portal: https://services.gst.gov.in/services/searchtp

**Root cause:**
At [2], the GSTIN validation regex for NRI taxpayers only supports formats 
ending with `NRX` (X = any alphanumeric character). However, certain valid 
GSTINs follow a different structure and are not matched by the existing regex.

**Fix:**
This commit ensures that valid NRI GSTIN formats are accepted during validation.

Confirm with IN PO.

[1]:
https://services.gst.gov.in/services/searchtp

[2]:
https://github.com/odoo/odoo/blob/5e59f4b3def44aa84c06ba4c2ed34bf2e8da928f/addons/base_vat/models/res_partner.py#L712-L723

opw-5956299