### PR TITLE
[IMP] maintenance: modernize request form and support multiple assignees

### DIFF
--- a/addons/hr_maintenance/views/maintenance_views.xml
+++ b/addons/hr_maintenance/views/maintenance_views.xml
@@ -7,7 +7,7 @@
         <field name="model">maintenance.request</field>
         <field name="inherit_id" ref="maintenance.hr_equipment_request_view_search"/>
         <field name="arch" type="xml">
-            <xpath expr="field[@name='user_id']" position="after">
+            <xpath expr="field[@name='user_ids']" position="after">
                 <field name="employee_id"/>
             </xpath>
             <xpath expr="//filter[@name='my_maintenances']" position="replace">

--- a/addons/maintenance/data/maintenance_demo.xml
+++ b/addons/maintenance/data/maintenance_demo.xml
@@ -106,7 +106,7 @@
 
     <record id="m_request_3" model="maintenance.request">
         <field name="name">Resolution is bad</field>
-        <field name="user_id" ref="base.user_demo"/>
+        <field name="user_ids" eval="[Command.link(ref('base.user_demo'))]"/>
         <field name="owner_user_id" ref="base.user_admin"/>
         <field name="equipment_id" ref="equipment_monitor6"/>
         <field name="color">7</field>
@@ -115,7 +115,7 @@
     </record>
     <record id="m_request_4" model="maintenance.request">
         <field name="name">Some keys are not working</field>
-        <field name="user_id" ref="base.user_admin"/>
+        <field name="user_ids" eval="[Command.link(ref('base.user_admin'))]"/>
         <field name="owner_user_id" ref="base.user_admin"/>
         <field name="equipment_id" ref="equipment_computer3"/>
         <field name="stage_id" ref="stage_0"/>
@@ -123,7 +123,7 @@
     </record>
     <record id="m_request_6" model="maintenance.request">
         <field name="name">Motherboard failed</field>
-        <field name="user_id" ref="base.user_demo"/>
+        <field name="user_ids" eval="[Command.link(ref('base.user_demo'))]"/>
         <field name="owner_user_id" ref="base.user_admin"/>
         <field name="equipment_id" ref="equipment_computer5"/>
          <field name="stage_id" ref="stage_4"/>
@@ -131,7 +131,7 @@
     </record>
     <record id="m_request_7" model="maintenance.request">
         <field name="name">Battery drains fast</field>
-        <field name="user_id" ref="base.user_demo"/>
+        <field name="user_ids" eval="[Command.link(ref('base.user_demo'))]"/>
         <field name="owner_user_id" ref="base.user_demo"/>
         <field name="equipment_id" ref="equipment_computer9"/>
         <field name="stage_id" ref="stage_1"/>
@@ -139,7 +139,7 @@
     </record>
     <record id="m_request_8" model="maintenance.request">
         <field name="name">Touchpad not working</field>
-        <field name="user_id" ref="base.user_demo"/>
+        <field name="user_ids" eval="[Command.link(ref('base.user_demo'))]"/>
         <field name="owner_user_id" ref="base.user_demo"/>
         <field name="equipment_id" ref="equipment_computer11"/>
         <field name="stage_id" ref="stage_1"/>

--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -298,7 +298,7 @@ class MaintenanceRequest(models.Model):
         ('cancelled', 'Cancelled'),
     ], string='State', required=True, default='normal', tracking=True, copy=False)
     maintenance_type = fields.Selection([('corrective', 'Corrective'), ('preventive', 'Preventive')], string='Maintenance Type', default="corrective")
-    schedule_date = fields.Datetime('Scheduled Date', help="Date the maintenance team plans the maintenance.  It should not differ much from the Request Date. ")
+    schedule_date = fields.Datetime('Scheduled Date', help="Date the maintenance team plans the maintenance.  It should not differ much from the Request Date. ", default=fields.Datetime.now)
     schedule_end = fields.Datetime(
         string="Scheduled End", compute='_compute_schedule_end',
         help="Expected completion date and time of the maintenance request.",

--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -283,7 +283,7 @@ class MaintenanceRequest(models.Model):
     equipment_id = fields.Many2one('maintenance.equipment', string='Equipment',
                                    ondelete='restrict', index=True, check_company=True,
                                    group_expand='_read_group_equipment_id')
-    user_id = fields.Many2one('res.users', string='Technician', compute='_compute_user_id', store=True, readonly=False, tracking=True)
+    user_ids = fields.Many2many('res.users', string='Technicians', compute='_compute_user_ids', store=True, readonly=False, tracking=True)
     stage_id = fields.Many2one('maintenance.stage', string='Stage', ondelete='restrict', tracking=True,
                                compute='_compute_stage_id', store=True, readonly=False, group_expand='_read_group_stage_ids', copy=False,
                                domain="['|', ('maintenance_team_ids', '=', False), ('maintenance_team_ids', 'in', [maintenance_team_id])]")
@@ -366,12 +366,16 @@ class MaintenanceRequest(models.Model):
                 request.maintenance_team_id = False
 
     @api.depends('company_id', 'equipment_id')
-    def _compute_user_id(self):
+    def _compute_user_ids(self):
         for request in self:
+            users = request.user_ids
             if request.equipment_id:
-                request.user_id = request.equipment_id.technician_user_id or request.equipment_id.category_id.technician_user_id
-            if request.user_id and request.company_id.id not in request.user_id.company_ids.ids:
-                request.user_id = False
+                technician = request.equipment_id.technician_user_id or request.equipment_id.category_id.technician_user_id
+                if technician and technician not in users:
+                    users |= technician
+            if request.company_id:
+                users = users.filtered(lambda u: request.company_id.id in u.company_ids.ids)
+            request.user_ids = users
 
     @api.depends('maintenance_team_id')
     def _compute_stage_id(self):
@@ -426,7 +430,7 @@ class MaintenanceRequest(models.Model):
         # context: no_log, because subtype already handle this
         maintenance_requests = super().create(vals_list)
         for request in maintenance_requests:
-            if request.owner_user_id or request.user_id:
+            if request.owner_user_id or request.user_ids:
                 request._add_followers()
             if request.equipment_id and not request.maintenance_team_id:
                 request.maintenance_team_id = request.maintenance_team_id
@@ -458,15 +462,27 @@ class MaintenanceRequest(models.Model):
             self.close_date = fields.Date.today()
         elif 'state' in vals:
             self.filtered('close_date').close_date = False
+
+        req_to_existing_users = {}
+        if vals.get('owner_user_id') or vals.get('user_ids'):
+            req_to_existing_users = {request.id: (request.owner_user_id.partner_id.ids + request.user_ids.partner_id.ids) for request in self}
+
         res = super(MaintenanceRequest, self).write(vals)
-        if vals.get('owner_user_id') or vals.get('user_id'):
-            self._add_followers()
+
+        if req_to_existing_users:
+            self._add_new_followers(req_to_existing_users)
         return res
 
     def _add_followers(self):
         for request in self:
-            partner_ids = (request.owner_user_id.partner_id + request.user_id.partner_id).ids
+            partner_ids = (request.owner_user_id.partner_id + request.user_ids.partner_id).ids
             request.message_subscribe(partner_ids=partner_ids)
+
+    def _add_new_followers(self, req_to_existing_users):
+        for request in self:
+            new_partner_ids = set((request.owner_user_id.partner_id | request.user_ids.partner_id).ids) - set(req_to_existing_users[request.id])
+            if new_partner_ids:
+                request.message_subscribe(partner_ids=list(new_partner_ids))
 
     @api.model
     def _read_group_stage_ids(self, stages, domain):

--- a/addons/maintenance/security/maintenance.xml
+++ b/addons/maintenance/security/maintenance.xml
@@ -21,7 +21,7 @@
     <record id="equipment_request_rule_user" model="ir.rule">
         <field name="name">Users are allowed to access their own maintenance requests</field>
         <field name="model_id" ref="model_maintenance_request"/>
-        <field name="domain_force">['|', '|', ('owner_user_id', '=', user.id), ('message_partner_ids', 'in', [user.partner_id.id]), ('user_id', '=', user.id)]</field>
+        <field name="domain_force">['|', '|', ('owner_user_id', '=', user.id), ('message_partner_ids', 'in', [user.partner_id.id]), ('user_ids', 'in', user.id)]</field>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
     </record>
 

--- a/addons/maintenance/static/tests/tours/tour_calendar_with_recurrence.js
+++ b/addons/maintenance/static/tests/tours/tour_calendar_with_recurrence.js
@@ -34,11 +34,11 @@ registry.category("web_tour.tours").add("test_dblclick_event_from_calendar", {
         },
         {
             content: "Change Scheduled End",
-            trigger: "button#schedule_end_0",
+            trigger: "button.o_daterange_end",
             run: "click",
         },
         {
-            trigger: "input#schedule_end_0",
+            trigger: 'input[data-field="schedule_end"]',
             async run({ edit, anchor }) {
                 const value = luxon.DateTime.fromFormat(anchor.value, "MM/dd/yyyy hh:mm:ss a")
                     .plus({ hours: 1 })

--- a/addons/maintenance/tests/test_maintenance.py
+++ b/addons/maintenance/tests/test_maintenance.py
@@ -132,17 +132,24 @@ class TestEquipmentPostInstall(TestEquipmentCommon):
         In theory this should never happen, but we should fail gracefully
         in case these dates are forced set to False.
         """
-
         form = Form(self.env['maintenance.equipment'].with_user(self.manager))
         form.name = "brain"
         equipment = form.save()
+
         form = Form(self.env['maintenance.request'].with_user(self.manager))
         form.name = "improve efficiency"
         form.equipment_id = equipment
         form.maintenance_type = 'corrective'
         maintenance = form.save()
-        self.assertFalse(maintenance.schedule_date)
+
+        self.assertTrue(maintenance.schedule_date)
+        self.assertTrue(maintenance.schedule_end)
         self.assertFalse(maintenance.close_date)
+
+        maintenance.write({
+            'schedule_date': False,
+            'schedule_end': False
+        })
 
         maintenance.state = 'done'
         self.assertFalse(maintenance.schedule_date)
@@ -152,7 +159,33 @@ class TestEquipmentPostInstall(TestEquipmentCommon):
         # this shouldn't happen unless it's forced
         maintenance.close_date = False
         form = Form(equipment)
+
         maintenance.close_date = fields.Date.today()
         form = Form(equipment)
+
         maintenance.close_date = False
         form = Form(equipment)
+
+    def test_maintenance_request_default_schedule_dates(self):
+        """
+        Ensure a newly created maintenance request gets valid scheduled dates by default.
+        When a maintenance request is created, `schedule_date` should be set automatically,
+        and `schedule_end` should be set to one hour after `schedule_date`.
+        """
+        form = Form(self.env['maintenance.equipment'].with_user(self.manager))
+        form.name = "brain"
+        equipment = form.save()
+
+        before = fields.Datetime.now()
+        form = Form(self.env['maintenance.request'].with_user(self.manager))
+        form.name = "improve efficiency"
+        form.equipment_id = equipment
+        form.maintenance_type = 'corrective'
+        maintenance = form.save()
+        after = fields.Datetime.now()
+
+        self.assertTrue(maintenance.schedule_date)
+        self.assertTrue(maintenance.schedule_end)
+        self.assertGreaterEqual(maintenance.schedule_date, before)
+        self.assertLessEqual(maintenance.schedule_date, after)
+        self.assertEqual(maintenance.schedule_end, maintenance.schedule_date + timedelta(hours=1))

--- a/addons/maintenance/tests/test_maintenance.py
+++ b/addons/maintenance/tests/test_maintenance.py
@@ -6,6 +6,7 @@ import time
 from odoo.tests import Form
 from odoo.tests.common import tagged, TransactionCase
 from odoo import fields
+from datetime import timedelta
 
 
 class TestEquipmentCommon(TransactionCase):
@@ -64,7 +65,7 @@ class TestEquipment(TestEquipmentCommon):
         # Create new maintenance request
         maintenance_request_01 = self.maintenance_request.with_user(self.user).create({
             'name': 'Resolution is bad',
-            'user_id': self.user.id,
+            'user_ids': [self.user.id],
             'owner_user_id': self.user.id,
             'equipment_id': equipment_01.id,
             'color': 7,

--- a/addons/maintenance/tests/test_maintenance_multicompany.py
+++ b/addons/maintenance/tests/test_maintenance_multicompany.py
@@ -159,7 +159,7 @@ class TestEquipmentMulticompany(TransactionCase):
         MaintenanceRequest.with_user(user).create({
             'name': 'Some keys are not working',
             'company_id': company_b.id,
-            'user_id': user.id,
+            'user_ids': [user.id],
             'owner_user_id': user.id,
         })
 
@@ -167,7 +167,7 @@ class TestEquipmentMulticompany(TransactionCase):
         MaintenanceRequest.with_user(equipment_manager).create({
             'name': 'Battery drains fast',
             'company_id': company_a.id,
-            'user_id': equipment_manager.id,
+            'user_ids': [equipment_manager.id],
             'owner_user_id': equipment_manager.id,
         })
 

--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -9,12 +9,12 @@
             <search string="Maintenance Request Search">
                 <field name="name" string="Request"/>
                 <field name="category_id"/>
-                <field name="user_id"/>
+                <field name="user_ids"/>
                 <field name="equipment_id"/>
                 <field name="owner_user_id"/>
                 <field name="stage_id"/>
                 <field name="maintenance_team_id"/>
-                <filter string="My Maintenances" name="my_maintenances" domain="[('user_id', '=', uid)]"/>
+                <filter string="My Maintenances" name="my_maintenances" domain="[('user_ids', 'in', uid)]"/>
                 <separator/>
                 <filter string="Open" name="todo" domain="[('state', 'not in', ['done', 'cancelled'])]"/>
                 <filter string="Done" name="done" domain="[('state', '=', 'done')]"/>
@@ -41,7 +41,7 @@
                 <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
                     domain="[('my_activity_date_deadline', '&gt;', 'today')]"/>
                 <group>
-                    <filter string='Assigned to' name="assigned" domain="[]" context="{'group_by': 'user_id'}"/>
+                    <filter string='Assigned to' name="assigned" domain="[]" context="{'group_by': 'user_ids'}"/>
                     <filter string='Category' name="category" domain="[]" context="{'group_by' : 'category_id'}"/>
                     <filter string='Stage' name="stages" domain="[]" context="{'group_by' : 'stage_id'}"/>
                     <filter string='Created By' name='created_by' domain="[]" context="{'group_by': 'owner_user_id'}"/>
@@ -55,10 +55,10 @@
         <field name="model">maintenance.request</field>
         <field name="arch" type="xml">
             <activity string="Maintenance Request">
-                <field name="user_id"/>
+                <field name="user_ids"/>
                 <templates>
                     <div t-name="activity-box">
-                        <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
+                        <field name="user_ids" widget="many2many_avatar_user" readonly="1" class="me-2"/>
                         <div class="flex-grow-1 d-block">
                             <div class="d-flex justify-content-between">
                                 <field name="name" display="full" class="o_text_block o_text_bold"/>
@@ -105,7 +105,7 @@
                         </group>
                         <group>
                             <field name="maintenance_team_id" options="{'no_create': True, 'no_open': True}"/>
-                            <field name="user_id" string="Assignee"/>
+                            <field name="user_ids" string="Assignees" widget="many2many_avatar_user"/>
                             <field name="schedule_date" string="Planned Date" widget="daterange" options="{'end_date_field': 'schedule_end', 'always_range': True}"/>
                             <label for="recurring_maintenance" invisible="maintenance_type == 'corrective'"/>
                             <div class="d-inline-flex" invisible="maintenance_type == 'corrective'">
@@ -159,8 +159,8 @@
                                     <field name="activity_ids" widget="kanban_activity" class="ms-3"/>
                                 </div>
                                 <div class="d-flex ms-auto align-items-center">
+                                    <field name="user_ids" widget="many2many_avatar_user" class="me-1"/>
                                     <field name="state" widget="maintenance_request_state_selection"/>
-                                    <field name="user_id" widget="many2one_avatar_user" class="ms-1"/>
                                 </div>
                             </footer>
                         </main>
@@ -178,7 +178,7 @@
                 <field name="message_needaction" column_invisible="True"/>
                 <field name="name"/>
                 <field name="owner_user_id"/>
-                <field name="user_id"/>
+                <field name="user_ids" widget="many2many_avatar_user"/>
                 <field name="category_id" readonly="1" groups="maintenance.group_equipment_manager"/>
                 <field name="stage_id"/>
                 <field name="company_id" readonly="1" groups="base.group_multi_company"/>
@@ -192,7 +192,7 @@
         <field name="model">maintenance.request</field>
         <field name="arch" type="xml">
             <graph string="Maintenance Request" sample="1">
-                <field name="user_id"/>
+                <field name="user_ids"/>
                 <field name="stage_id"/>
                 <field name="duration" type="measure"/>
                 <field name="color" type="measure" invisible="1"/>
@@ -206,7 +206,7 @@
         <field name="model">maintenance.request</field>
         <field name="arch" type="xml">
             <pivot string="Maintenance Request" sample="1">
-                <field name="user_id"/>
+                <field name="user_ids"/>
                 <field name="stage_id"/>
                 <field name="color" invisible="1"/>
             </pivot>
@@ -218,8 +218,8 @@
         <field name="name">equipment.request.calendar</field>
         <field name="model">maintenance.request</field>
         <field name="arch" type="xml">
-            <calendar date_start="schedule_date" date_stop="schedule_end" color="user_id" event_limit="5" js_class="calendar_with_recurrence">
-                <field name="user_id" filters="1"/>
+            <calendar date_start="schedule_date" date_stop="schedule_end" color="user_ids" event_limit="5" js_class="calendar_with_recurrence">
+                <field name="user_ids" filters="1"/>
                 <field name="priority"/>
                 <field name="maintenance_type"/>
                 <field name="recurring_maintenance" invisible="1"/>
@@ -242,7 +242,7 @@
         <field name="view_id" ref="hr_equipment_request_view_kanban"/>
         <field name="context">{
             'search_default_todo': True,
-            'default_user_id': uid,
+            'default_user_ids': [uid],
         }</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">

--- a/addons/maintenance/views/maintenance_views.xml
+++ b/addons/maintenance/views/maintenance_views.xml
@@ -79,17 +79,21 @@
                 <field name="company_id" invisible="1"/>
                 <field name="category_id" invisible="1"/>
                 <header>
-                    <button string="Cancel" name="cancel_equipment_request" type="object" invisible="state == 'cancelled'"/>
+                    <button string="Cancel" name="cancel_equipment_request" type="object" invisible="state == 'cancelled' or not id"/>
                     <button string="Reopen Request" name="reset_equipment_request" type="object" invisible="state != 'cancelled'"/>
                     <field name="stage_id" widget="statusbar" options="{'clickable': '1'}" invisible="state == 'cancelled'"/>
                 </header>
                 <sheet>
-                    <field name="state" widget="maintenance_request_state_selection" class="float-end"/>
-                    <div class="oe_title">
-                        <label for="name" string="Request"/>
-                        <h1>
-                            <field name="name" placeholder="e.g. Screen not working"/>
-                        </h1>
+                    <div class="d-flex">
+                        <div class="oe_title flex-grow-1">
+                            <h1>
+                                <field name="name" placeholder="e.g. Screen not working"/>
+                            </h1>
+                        </div>
+                        <div class="d-flex justify-content-end align-items-center flex-shrink-0 ms-auto">
+                            <field name="priority" widget="priority" class="me-3"/>
+                            <field name="state" widget="maintenance_request_state_selection"/>
+                        </div>
                     </div>
                     <group>
                         <group>
@@ -101,9 +105,8 @@
                         </group>
                         <group>
                             <field name="maintenance_team_id" options="{'no_create': True, 'no_open': True}"/>
-                            <field name="user_id" string="Responsible"/>
-                            <field name="schedule_date"/>
-                            <field name="schedule_end"/>
+                            <field name="user_id" string="Assignee"/>
+                            <field name="schedule_date" string="Planned Date" widget="daterange" options="{'end_date_field': 'schedule_end', 'always_range': True}"/>
                             <label for="recurring_maintenance" invisible="maintenance_type == 'corrective'"/>
                             <div class="d-inline-flex" invisible="maintenance_type == 'corrective'">
                                 <field name="recurring_maintenance" nolabel="1" class="ms-0" style="width: fit-content;"/>
@@ -115,7 +118,6 @@
                                 <field name="repeat_type" required="recurring_maintenance" class="me-2" style="max-width: 15rem !important;" />
                                 <field name="repeat_until" invisible="repeat_type != 'until'" required="repeat_type == 'until'" class="me-2" />
                             </div>
-                            <field name="priority" widget="priority"/>
                             <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
                         </group>
                     </group>


### PR DESCRIPTION
## Overview
This PR improves the Maintenance module UX by modernizing the request form and extending the assignment logic to support multiple technicians. It streamlines the workflow with better defaults and a cleaner interface.

## Key Changes

### 1. Multi-Assignee Support
* **Field Conversion:** Converted the technician field from `user_id` (Many2one) to `user_ids` (Many2many) to support multiple technicians per request.
* **View Updates:** Updated Form, List, Calendar, Graph, and Activity views to handle the new `user_ids` field.
* **Follower Logic Fix:** Refactored the subscription logic to ensure only *newly added* assignees are subscribed. This prevents users who have manually unsubscribed from being automatically re-added during subsequent record updates.

### 2. UI & UX Modernization
* **Daterange Widget:** Combined `schedule_date` and `schedule_end` into a single intuitive `daterange` widget.
* **Kanban Improvements:**
    * Enabled direct assignment editing from kanban cards using the `many2many_avatar_user` widget.
    * Swapped the positions of the status icon and user avatars to align with standard Odoo card layouts.
* **Form Cleanup:**
    * Hid the **Cancel** button on unsaved records.
    * Removed the redundant **Request** label from the header.
    * Grouped **Priority** and **State** in the header for better visual hierarchy.
    * Renamed **Responsible** to **Assignee** for better ecosystem consistency.

**task-5960480**