### PR TITLE
[FIX] account,purchase_stock: fix error when opening accrued expense entry

### DIFF
--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -215,9 +215,7 @@ class AccountAccruedOrdersWizard(models.TransientModel):
                         )
 
                         # Generate price diff account move lines if needed.
-                        price_diff_account = False
-                        if product.cost_method == 'standard':
-                            price_diff_account = product.categ_id.property_price_difference_account_id
+                        price_diff_account = self._get_price_diff_account(product)
                         if price_diff_account:
                             qty_to_invoice = order_line.qty_received_at_date - order_line.qty_invoiced_at_date
                             diff_label = _('%(order)s - %(order_line)s; price difference for %(product)s',
@@ -379,3 +377,7 @@ class AccountAccruedOrdersWizard(models.TransientModel):
     @api.model
     def _get_product_expense_and_stock_var_accounts(self, product):
         return (False, False)
+
+    @api.model
+    def _get_price_diff_account(self, product):
+        return False

--- a/addons/purchase_stock/wizard/__init__.py
+++ b/addons/purchase_stock/wizard/__init__.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import accrued_orders
 from . import stock_replenishment_info
 from . import product_replenish

--- a/addons/purchase_stock/wizard/accrued_orders.py
+++ b/addons/purchase_stock/wizard/accrued_orders.py
@@ -1,0 +1,11 @@
+from odoo import models, api
+
+
+class AccountAccruedOrdersWizard(models.TransientModel):
+    _inherit = 'account.accrued.orders.wizard'
+
+    @api.model
+    def _get_price_diff_account(self, product):
+        if product.cost_method == 'standard':
+            return product.categ_id.property_price_difference_account_id
+        return super()._get_price_diff_account(product)


### PR DESCRIPTION
When a user tries to open accrued expense entry from purchase order,
A traceback will appear.

Steps to reproduce the error:
- Install ``purchase`` and ``accountant`` module with demo data
- Create a Purchase Order > Add product Office Chair Black > Add quantity >
  Confirm Order > Set received quantity > Save
- Actions > Accrued Expense Entry

Traceback:
```
AttributeError: 'product.product' object has no attribute 'cost_method'
```

https://github.com/odoo/odoo/blob/242afb9ca3a76e3628260ac81a9f5ddcd5d445dd/addons/account/wizard/accrued_orders.py#L219
Here, ``cost_method`` field is accessed.
However, the ``cost_method`` field is defined in the ``stock_account`` module.
If ``stock_account`` is not installed, the field does not exist,
which leads to the traceback when opening the accrued expense entry.

sentry-7303032922

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
