### PR TITLE
[FIX] pos_self_order: allow order edits after payment cancellation

### DIFF
--- a/addons/pos_self_order/static/src/app/components/order_widget/order_widget.js
+++ b/addons/pos_self_order/static/src/app/components/order_widget/order_widget.js
@@ -39,7 +39,9 @@ export class OrderWidget extends Component {
 
         if (currentPage === "product_list") {
             label = _t("Checkout");
-            disabled = isNoLine || hasNotAllLinesSent.length === 0;
+            disabled =
+                isNoLine ||
+                (this.selfOrder.isSyncedOrderRestricted && hasNotAllLinesSent.length === 0);
         } else if (
             payAfter === "meal" &&
             Object.keys(this.selfOrder.currentOrder.changes).length > 0
@@ -55,6 +57,18 @@ export class OrderWidget extends Component {
 
     // TODO: remove in master
     get lineNotSend() {
+        const order = this.selfOrder.currentOrder;
+        const payAfter = this.selfOrder.config.self_ordering_pay_after;
+
+        if (payAfter === "each" && order.isSynced && !this.selfOrder.isSyncedOrderRestricted) {
+            return {
+                priceWithTax: order.priceIncl,
+                priceWithoutTax: order.priceExcl,
+                count: order.totalQuantity,
+                tax: order.amountTaxes,
+            };
+        }
+
         return this.selfOrder.orderLineNotSend;
     }
 

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
@@ -32,11 +32,7 @@ export class CartPage extends Component {
     }
 
     get showCancelButton() {
-        return (
-            this.selfOrder.config.self_ordering_mode === "mobile" &&
-            this.selfOrder.config.self_ordering_pay_after === "each" &&
-            this.selfOrder.currentOrder.isSynced
-        );
+        return this.selfOrder.isSyncedOrderRestricted;
     }
 
     get lines() {
@@ -52,11 +48,20 @@ export class CartPage extends Component {
     }
 
     get totalPriceAndTax() {
-        const { amountTaxes, priceIncl } = this.selfOrder.currentOrder;
-        const { priceWithTax, tax, count } = this.selfOrder.orderLineNotSend;
+        const order = this.selfOrder.currentOrder;
+        const payAfter = this.selfOrder.config.self_ordering_pay_after;
+
+        if (payAfter === "each" && order.isSynced && !this.selfOrder.isSyncedOrderRestricted) {
+            return {
+                priceWithTax: order.priceIncl,
+                tax: order.amountTaxes,
+            };
+        }
+
+        const { priceWithTax, tax } = this.selfOrder.orderLineNotSend;
         return {
-            priceWithTax: count > 0 ? priceWithTax : priceIncl,
-            tax: count > 0 ? tax : amountTaxes,
+            priceWithTax: priceWithTax || order.priceIncl,
+            tax: tax || order.amountTaxes,
         };
     }
 
@@ -82,9 +87,12 @@ export class CartPage extends Component {
     }
 
     getLineChangeQty(line) {
-        const currentQty = line.qty;
+        if (!this.selfOrder.isSyncedOrderRestricted) {
+            return line.qty;
+        }
+
         const lastChange = this.selfOrder.currentOrder.uiState.lineChanges[line.uuid];
-        return !lastChange ? currentQty : currentQty - lastChange.qty;
+        return !lastChange ? line.qty : line.qty - lastChange.qty;
     }
 
     async pay() {
@@ -193,6 +201,10 @@ export class CartPage extends Component {
     }
 
     getPrice(line) {
+        if (!this.selfOrder.isSyncedOrderRestricted) {
+            return line.displayPrice;
+        }
+
         const childLines = line.combo_line_ids;
         if (childLines.length === 0) {
             const qty = this.getLineChangeQty(line) || line.qty;
@@ -208,6 +220,10 @@ export class CartPage extends Component {
     }
 
     canChangeQuantity(line) {
+        if (!this.selfOrder.isSyncedOrderRestricted) {
+            return true;
+        }
+
         const order = this.selfOrder.currentOrder;
         const lastChange = order.uiState.lineChanges[line.uuid];
         if (!lastChange) {
@@ -217,6 +233,10 @@ export class CartPage extends Component {
     }
 
     canDeleteLine(line) {
+        if (!this.selfOrder.isSyncedOrderRestricted) {
+            return true;
+        }
+
         const lastChange = this.selfOrder.currentOrder.uiState.lineChanges[line.uuid];
         return !lastChange ? true : lastChange.qty !== line.qty;
     }
@@ -225,8 +245,9 @@ export class CartPage extends Component {
         if (!this.canDeleteLine(line)) {
             return;
         }
+
         const lastChange = this.selfOrder.currentOrder.uiState.lineChanges[line.uuid];
-        if (lastChange) {
+        if (lastChange && this.selfOrder.isSyncedOrderRestricted) {
             line.qty = lastChange.qty;
             return;
         }

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml
@@ -12,7 +12,7 @@
                     <h1 class="ms-3 ms-sm-0 mb-3 ">Your Order</h1>
                     <div class="order_box d-flex flex-column bg-white px-3 px-kiosk-p-4 rounded-4 border border-light shadow-sm">
                         <t t-foreach="lines" t-as="line" t-key="line.uuid">
-                            <t t-set="display_change_quantity" t-value="Object.keys(selfOrder.currentOrder.changes).length &gt; 0"/>
+                            <t t-set="display_change_quantity" t-value="!selfOrder.isSyncedOrderRestricted"/>
                             <div t-attf-class="product-cart-item d-flex align-items-center py-3 py-kiosk-p-4 {{!line_last ? 'border-bottom border-medium' : ''}}">
                                 <t t-set="product" t-value="line.product_id"/>
                                 <div class="product_img w-25 me-3 me-kiosk-p-4 ratio ratio-1x1 align-self-start">

--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.js
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.js
@@ -1,4 +1,4 @@
-import { Component, useRef, onMounted, onWillUnmount, useEffect, useState } from "@odoo/owl";
+import { Component, useRef, onMounted, onWillUnmount, useState } from "@odoo/owl";
 import { useSelfOrder } from "@pos_self_order/app/services/self_order_service";
 import { useService } from "@web/core/utils/hooks";
 
@@ -62,21 +62,6 @@ export class ProductListPage extends Component {
         useHorizontalScrollShadow(this.categoryListRef, useRef("category_container"));
         useDraggableScroll(this.subCategoryListRef);
 
-        useEffect(
-            (lines) => {
-                this.state.quantityByProductTmplId = lines
-                    .filter((line) => !line.combo_parent_id)
-                    .reduce((acc, { product_id, changes: { qty } }) => {
-                        const tmplId = product_id.product_tmpl_id.id;
-                        if (tmplId != null) {
-                            acc[tmplId] = (acc[tmplId] || 0) + qty;
-                        }
-                        return acc;
-                    }, {});
-            },
-            () => [this.selfOrder.currentOrder.lines]
-        );
-
         onMounted(() => {
             this.toggleSubCategoryPanel();
             this.ensureCategoryVisible();
@@ -89,6 +74,24 @@ export class ProductListPage extends Component {
             this.selfOrder.currentCategory = this.state.selectedCategory;
             savedScrollTop = this.productListRef.el?.scrollTop || 0;
         });
+    }
+
+    get quantityByProductTmplId() {
+        return this.selfOrder.currentOrder.lines
+            .filter((line) => !line.combo_parent_id)
+            .reduce((acc, line) => {
+                const tmplId = line.product_id.product_tmpl_id.id;
+                if (tmplId != null) {
+                    const qty = this.selfOrder.isSyncedOrderRestricted
+                        ? line.changes.qty
+                        : line.qty;
+
+                    if (qty) {
+                        acc[tmplId] = (acc[tmplId] || 0) + qty;
+                    }
+                }
+                return acc;
+            }, {});
     }
 
     selectCategory(category) {

--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
@@ -71,7 +71,7 @@
                                         <span t-esc="selfOrder.formatMonetary(selfOrder.getProductDisplayPrice(product))" class="o-so-tabular-nums fs-4 fw-bold text-primary"/>
                                         <div class="product_descr d-lg-none mt-1 text-ellipsis text-muted small" t-if="product.public_description" t-out="product.productDescriptionMarkup"/>
                                     </div>
-                                    <t t-set="qty" t-value="state.quantityByProductTmplId[product.id]" />
+                                    <t t-set="qty" t-value="quantityByProductTmplId[product.id]" />
                                     <span t-if="qty" t-esc="qty" class="badge position-absolute top-0 end-0 m-0 m-lg-2 rounded-4 fs-5 text-bg-primary fw-bold"/>
                                 </article>
                             </div>

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -430,6 +430,19 @@ export class SelfOrder extends Reactive {
         return this.config.self_ordering_mode === "kiosk";
     }
 
+    get isSyncedOrderRestricted() {
+        if (
+            this.config.self_ordering_mode === "mobile" &&
+            this.config.self_ordering_pay_after === "each" &&
+            this.currentOrder.isSynced &&
+            !this.hasPaymentMethod()
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
     markupDescriptions() {
         for (const product of this.models["product.template"].getAll()) {
             product.public_description = product.public_description
@@ -710,8 +723,12 @@ export class SelfOrder extends Reactive {
     }
 
     async sendDraftOrderToServer() {
+        const hasDeletedLines = Object.keys(this.currentOrder.uiState.lineChanges).some(
+            (uuid) => !this.currentOrder.lines.find((l) => l.uuid === uuid)
+        );
+
         if (
-            Object.keys(this.currentOrder.changes).length === 0 ||
+            (Object.keys(this.currentOrder.changes).length === 0 && !hasDeletedLines) ||
             this.currentOrder.lines.length === 0
         ) {
             return this.currentOrder;
@@ -773,7 +790,7 @@ export class SelfOrder extends Reactive {
         }));
 
         const accessTokens = [...dbAccessToken, ...argTokens];
-        if (Object.keys(accessTokens).length === 0 && !tableIdentifier) {
+        if (accessTokens.length === 0 && !tableIdentifier) {
             return;
         }
 
@@ -789,17 +806,19 @@ export class SelfOrder extends Reactive {
                 this.selectedOrderUuid = openOrder.uuid;
 
                 // Remove all other open orders in draft and add orderline in the current order
-                const lineCmd = [];
-                for (const order of this.models["pos.order"].filter((o) => o.state === "draft")) {
-                    if (order.uuid !== openOrder.uuid) {
-                        lineCmd.push(...order.lines);
+                const otherOrders = this.models["pos.order"].filter(
+                    (o) => o.state === "draft" && o.uuid !== openOrder.uuid
+                );
+
+                if (otherOrders.length > 0) {
+                    const linesToMerge = otherOrders.flatMap((o) => o.lines);
+                    for (const order of otherOrders) {
                         order.delete();
                     }
+                    openOrder.update({
+                        lines: [["link", linesToMerge]],
+                    });
                 }
-
-                openOrder.update({
-                    lines: [["link", lineCmd]],
-                });
                 openOrder.recomputeChanges();
             }
             this.data.debouncedSynchronizeLocalDataInIndexedDB();

--- a/addons/pos_self_order/static/tests/unit/pages/cart_page.test.js
+++ b/addons/pos_self_order/static/tests/unit/pages/cart_page.test.js
@@ -52,6 +52,17 @@ test("canChangeQuantity", async () => {
 
     expect(comp.canChangeQuantity(line)).toBe(true);
     await comp.pay();
+    expect(comp.canChangeQuantity(line)).toBe(true);
+});
+
+test("canChangeQuantity restricted", async () => {
+    const store = await setupSelfPosEnv("mobile", "counter", "each");
+    const order = await getFilledSelfOrder(store);
+    const line = order.lines[0];
+    const comp = await mountWithCleanup(CartPage, {});
+
+    expect(comp.canChangeQuantity(line)).toBe(true);
+    await comp.pay();
     expect(comp.canChangeQuantity(line)).toBe(false);
 });
 


### PR DESCRIPTION
Currently, in "Pay After Each" mode, once an order is synced to the server, it becomes read-only. If a customer cancels their payment, they are unable to adjust their order (add, remove, or modify items). This commit allows editing synced orders provided that at least one online payment method is configured.

task-id: 5999396

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
