### PR TITLE
[FIX] stock_landed_costs:  set correct default account partial landed costs

### DIFF
--- a/addons/stock_landed_costs/models/account_move.py
+++ b/addons/stock_landed_costs/models/account_move.py
@@ -31,7 +31,7 @@ class AccountMove(models.Model):
             'cost_lines': [(0, 0, {
                 'product_id': l.product_id.id,
                 'name': l.product_id.name,
-                'account_id': l.product_id.product_tmpl_id.get_product_accounts()['stock_valuation'].id,
+                'account_id': l.product_id.product_tmpl_id.get_product_accounts()['expense'].id,
                 'price_unit': sign * l.currency_id._convert(l.price_subtotal, l.company_currency_id, l.company_id, self.invoice_date or fields.Date.context_today(l)),
                 'split_method': l.product_id.split_method_landed_cost or 'equal',
             }) for l in landed_costs_lines],
@@ -74,10 +74,3 @@ class AccountMoveLine(models.Model):
     def _onchange_is_landed_costs_line(self):
         if self.is_landed_costs_line and self.product_id and self.product_type != 'service':
             self.is_landed_costs_line = False
-
-    def _eligible_for_stock_account(self):
-        return super()._eligible_for_stock_account() or (
-            self.product_id.type == "service"
-            and self.product_id.landed_cost_ok
-            and self.product_id.valuation == "real_time"
-        )

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
@@ -858,3 +858,78 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
         # Check total value in SVL:
         # 120 * 110 + 95 + 70 * 110 = 20995
         self.assertAlmostEqual(self.product1.value_svl, 20995)
+
+    def test_landed_cost_partial_cogs(self):
+        """ Check that when billing a landed cost product and then creating the associate
+        landed cost, the default accounts are correct
+        """
+        self.landed_cost.landed_cost_ok = True
+        self.landed_cost.categ_id.property_cost_method = 'average'
+        self.landed_cost.categ_id.property_valuation = 'real_time'
+        self.product_a.categ_id = self.landed_cost.categ_id
+        self.product_a.is_storable = True
+        lc_stock_valuation_account = self.landed_cost.categ_id.property_stock_valuation_account_id
+        lc_expense_account = self.landed_cost.categ_id.property_account_expense_categ_id
+
+        po = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'currency_id': self.company_data['currency'].id,
+            'order_line': [
+                Command.create({
+                    'name': self.product_a.name,
+                    'product_id': self.product_a.id,
+                    'product_qty': 10.0,
+                    'product_uom_id': self.product_a.uom_id.id,
+                    'price_unit': 100.0,
+                    'tax_ids': False,
+                }),
+                Command.create({
+                    'name': self.landed_cost.name,
+                    'product_id': self.landed_cost.id,
+                    'product_qty': 1.0,
+                    'price_unit': 100.0,
+                    'tax_ids': False
+                }),
+            ],
+        })
+        po.button_confirm()
+        receipt = po.picking_ids
+        receipt.button_validate()
+
+        move = self.env['stock.move'].create({
+            'product_id': self.product_a.id,
+            'location_id': self.warehouse.lot_stock_id.id,
+            'location_dest_id': self.env.ref('stock.stock_location_customers').id,
+            'product_uom_qty': 3,
+            'picking_type_id': self.warehouse.out_type_id.id,
+            'move_line_ids': [Command.create({
+                'quantity': 3,
+                'product_id': self.product_a.id,
+            })]
+        })
+        move.picked = True
+        move._action_done()
+
+        # bill the product and the landed cost
+        po.action_create_invoice()
+        bill = po.invoice_ids
+        bill.invoice_date = fields.Date.today()
+        bill.action_post()
+
+        # create and validate the landed cost
+        action = bill.button_create_landed_costs()
+        lc_form = Form(self.env[action['res_model']].browse(action['res_id']))
+        lc_form.picking_ids.add(receipt)
+        landed_cost = lc_form.save()
+        landed_cost.button_validate()
+
+        # check the amls
+        bill_landed_cost_amls = bill.line_ids.filtered(lambda l: l.product_id == self.landed_cost)
+        self.assertRecordValues(bill_landed_cost_amls, [
+            {'account_id': lc_expense_account.id, 'debit': 100.0, 'credit': 0.0},
+        ])
+        landed_cost_amls = landed_cost.account_move_id.line_ids.sorted('credit')
+        self.assertRecordValues(landed_cost_amls, [
+            {'account_id': lc_stock_valuation_account.id, 'debit':  70.0,   'credit':  0.0},
+            {'account_id': lc_expense_account.id,         'debit':   0.0,   'credit': 70.0},
+        ])


### PR DESCRIPTION
**Problem:**
the default account suggested for landed cost (with 
real time category) are not the good ones.

**Steps to reproduce:**
- create a storable product with perpetual average category
- create a landed cost (a service product with 'is a 
landed cost' checked in the purchase tab)
- create a category for the landed cost with perpetual valuation
- confirm a purchase order for 10 quantity of the product with a 
unit price of 10
- validate the receipt
- confirm quotation for 3 of the product, validate the delivery and 
confirm the invoice
- create a bill for the purchase order
- on the invoice lines, unhide the product column
- add an invoice line with the landed cost product, for a quantity 
of 1 and a price of 10
- confirm the bill
- click on create landed cost 
- select the receipt in the transfers field
- validate
- click on the journal entry on the landed cost form

**Current behavior:**
On the bill, for the landed cost : 
- stock valuation is debited of 10
- account payable is credited of 10 (which makes the total 
credit 110 for account payable)

On the journal entry linked to the landed cost: 
- stock valuation is debited of 7 
- stock valuation is credited of 7

So in total there is a debit of 10 in stock valuation and 
a credit of 10 in account payable.
Which does not reflect that part of the products are out 
of stock. 

**Expected behavior:**
If the expense account was used, both on the bill and on 
the landed cost, (which is already the case for landed cost
with periodic category) the account move lines would be: 

On the bill : 
- Expense is debited of 10
- account payable is credited of 10 (which makes the total 
credit 110 for account payable)

On the journal entry linked to the landed cost: 
- stock valuation is debited of 7 
- Expense is credited of 7

So in the total there is : 
- a credit of 10 in account payable
- a debit of 7 in stock valuation
- a debit of 3 in expense

This is what we want, because the debit of 7 in stock valuation 
reflect that we only increase the valuation by 7 because only 7 
products are still in stock. 
The debit of 3 in expenses compensate for the cogs. Indeed 
when we invoiced the SO, the cogs where of 30 but, after the landed
cost, valuation wise, the products actually exited the stock with a 
value of 33 total (11 each).

**Cause of the issue:**
For the bill: 
when you create the new account move line and enter the product, 
_compute_account_id is called to compute the default account 
for the line. 
In the stock override, _eligible_for_stock_account is called on the line
https://github.com/odoo/odoo/blob/3542c542eac5b204e69a8dd6ae1907cfcef60af3/addons/stock_account/models/account_move_line.py#L18-L19
Because of the stock_landed_costs override, the return value is true
https://github.com/odoo/odoo/blob/3542c542eac5b204e69a8dd6ae1907cfcef60af3/addons/stock_landed_costs/models/account_move.py#L78-L82
So the account is changed to stock valuation
https://github.com/odoo/odoo/blob/3542c542eac5b204e69a8dd6ae1907cfcef60af3/addons/stock_account/models/account_move_line.py#L23-L24

For the landed cost: 
- if we create it by selecting 'create landed cost' on the bill : 
the account id is set in button_create_landed_cost
https://github.com/odoo/odoo/blob/3542c542eac5b204e69a8dd6ae1907cfcef60af3/addons/stock_landed_costs/models/account_move.py#L34
-if we create the landed cost, from adjustment/landed cost and 
selecting new : the expense account is already selected


**fix:**
In both cases, the client can already manually set the 
accounts they want, the fix is about having the right 
default accounts. 

opw-5941753
