### PR TITLE
[FIX] stock: Prevent RuntimeError on Transit from sublocation

### DIFF
--- a/addons/stock/report/stock_forecasted.py
+++ b/addons/stock/report/stock_forecasted.py
@@ -349,15 +349,6 @@ class StockForecasted(models.AbstractModel):
             for out in out_moves:
                 data = _get_out_move_taken_from_stock_data(out, currents, moves_data[out])
                 moves_data[out].update(data)
-
-        # The out reserved moves may have removed quantities on a sublocation;
-        # any sublocation qties will be added to the main stock location qty
-        for product_id, location_id in currents:
-            qties = currents[product_id, location_id]
-            if location_id in wh_stock_sub_location_ids and location_id != wh_stock_location.id:
-                currents[product_id, location_id] -= qties
-                currents[product_id, wh_stock_location.id] += qties
-
         product_sum = defaultdict(float)
         for product_loc, quantity in currents.items():
             product_sum[product_loc[0]] += quantity

--- a/addons/stock/tests/test_report.py
+++ b/addons/stock/tests/test_report.py
@@ -1342,12 +1342,6 @@ class TestReports(TestReportsCommon):
             }
         ])
 
-        # Ensure that a move from a sublocation doesn't create a negative 'in_transit' line.
-        delivery.action_assign()
-        _, _, lines = self.get_report_forecast(product_template_ids=self.product_template.ids)
-        self.assertFalse(any(line['in_transit'] for line in lines))
-        self.assertEqual(len(lines), 2)
-
     def test_report_reception_1_one_receipt(self):
         """ Create 2 deliveries and 1 receipt where some of the products being received
         can be reserved for the deliveries. Check that the reception report correctly


### PR DESCRIPTION
This reverts commit 2b2d73df420baee4fec1c51c28250666d80b48b8.

## How to reproduce (in runbot):
- Create Product P
- Create Delivery transfer from 'WH/Stock/Shelf 1'
- Open Forecast report:
=> RuntimeError: dictionary changed size during iteration

The original fix will be redone in another commit.

---

## Traceback:
```
  File "/data/build/odoo/addons/stock/report/stock_forecasted.py", line 21, in get_report_values
    'docs': self._get_report_data(product_ids=docids),
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/addons/stock/report/stock_forecasted.py", line 128, in _get_report_data
    res['lines'] = self._get_report_lines(product_template_ids, product_ids, wh_location_ids, wh_stock_location)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/build/odoo/addons/stock/report/stock_forecasted.py", line 359, in _get_report_lines
    for product_id, location_id in currents:
RuntimeError: dictionary changed size during iteration
```

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
