### PR TITLE
[FIX] mail: no crash on close AI chat window

### DIFF
--- a/addons/mail/static/src/model/record_list.js
+++ b/addons/mail/static/src/model/record_list.js
@@ -173,10 +173,8 @@ export class RecordListInternal {
                 function recordList_DeleteNoInv_Insert(record) {
                     const index = recordList.data.indexOf(record.localId);
                     if (index !== -1) {
-                        const old = recordList._proxy.at(-1);
                         recordList.splice.call(recordList._proxy, index, 1);
                         self.syncLength(recordList);
-                        old._.uses.delete(recordList);
                     }
                 },
                 { inv: false }
@@ -479,10 +477,9 @@ export class RecordList extends Array {
         const recordListFullProxy = recordList._.downgradeProxy(recordList, this);
         const store = recordList._store;
         return store.MAKE_UPDATE(function recordListSplice() {
-            const oldRecordsProxy = recordList._proxyInternal.slice.call(
-                recordListFullProxy,
-                start,
-                start + deleteCount
+            const oldRecordLocalIds = recordList.data.slice(start, start + deleteCount);
+            const oldRecords = oldRecordLocalIds.map(
+                (localId) => toRaw(toRaw(recordList._store.recordByLocalId).get(localId))._raw
             );
             const list = recordListFullProxy.data.slice(); // splice on copy of list so that reactive observers not triggered while splicing
             list.splice(
@@ -501,8 +498,7 @@ export class RecordList extends Array {
                 recordList._proxy.data = list;
             }
             recordList._.syncLength(recordList);
-            for (const oldRecordProxy of oldRecordsProxy) {
-                const oldRecord = toRaw(oldRecordProxy)._raw;
+            for (const oldRecord of oldRecords) {
                 oldRecord._.uses.delete(recordList);
                 store._.ADD_QUEUE("onDelete", recordList._.owner, recordList._.name, oldRecord);
                 const inverse = getInverse(recordList);

--- a/addons/mail/static/tests/core/record.test.js
+++ b/addons/mail/static/tests/core/record.test.js
@@ -1412,3 +1412,54 @@ test("Record exists is reactive", async () => {
     thread.delete();
     await expect.waitForSteps(["thread does not exist"]);
 });
+
+test("record.delete() while used in a 'on-sort' sorted field should properly delete this record from relation", async () => {
+    // 'on-sort' flag marks the lazy relational field to sort-on-the-fly when 'in-need', i.e. when next accessed.
+    // When a record is deleted, internal code also deletes the records from relational fields.
+    // Internal code should make sure to avoid re-triggering a sort-on-the-fly while deleting the record from relation.
+    // For example, finding index of record and splice / internal slice should mistakenly delete the wrong records!
+    // Let's say relational fields is [1, 2, 3], 'sort-on-need' to become [3, 1, 2]
+    // We wouldn't want 2 step deletion of 3 as:
+    // - index: 2
+    // - internal array.slice() => sort-on-the-fly to [3, 1, 2]
+    // - delete record at index 2 => resulting list is [3, 1] instead of [1, 2]!
+    (class Message extends Record {
+        static id = "id";
+        id;
+        sequence;
+        thread_name;
+    }).register(localRegistry);
+    (class Thread extends Record {
+        static id = "name";
+        name;
+        description;
+        messages = fields.Many("Message", {
+            // intentional combine of `compute` and `sort` so that the `compute` sets the `on-sort` flag
+            compute() {
+                return Object.values(this.store.Message.records).filter(
+                    (msg) => msg.thread_name === this.name
+                );
+            },
+            sort: (m1, m2) => (m1.sequence ?? 0) - (m2.sequence ?? 0),
+        });
+    }).register(localRegistry);
+    const store = await start();
+    const thread = store.Thread.insert("General");
+    store.Message.insert([
+        { id: 1, sequence: 10, thread_name: "General" },
+        { id: 2, sequence: 20, thread_name: "General" },
+    ]);
+    void thread.messages; // intentional read to have computed and sorted list
+    expect(toRaw(thread)._raw.messages.data).toEqual(["Message,1", "Message,2"]);
+    store.insert({
+        Thread: { name: "General", description: "This is the general channel" },
+        Message: { id: 3, sequence: 30, thread_name: "General" },
+    });
+    expect(toRaw(thread)._raw.messages.data).toEqual(["Message,1", "Message,2", "Message,3"]);
+    store.Message.get(3).sequence = 5; // intentional sequence change to trigger sort again, as the 'in-need' flag persists at least once
+    expect(toRaw(thread)._raw.messages.data).toEqual(["Message,3", "Message,1", "Message,2"]);
+    store.Message.get(3).sequence = 15;
+    expect(toRaw(thread)._raw.messages.data).toEqual(["Message,3", "Message,1", "Message,2"]); // still hasn't re-sorted yet
+    store.Message.get(3).delete();
+    expect(toRaw(thread)._raw.messages.data).toEqual(["Message,1", "Message,2"]);
+});


### PR DESCRIPTION
Before this commit, closing an AI chat window could lead to the following crash:

```js
TypeError: Cannot read properties of undefined (reading '_raw')
```

Steps to reproduce:
- have no chat windows open, cache cleared.
- open DM with demo in chat window from messaging menu, in home menu.
- open AI chat, from systray.
- close the AI chat window. => crash

This happens because when closing the AI chat window, it deletes the AI conversation. By deleting the AI conversation, it removes the conversation from `store.menuThreads`, which is the list of conversations to display in messaging menu. Removal of this conversation in `menuThreads` is done internally through

```js
const index = recordList.indexOf(record);
recordList.splice(index, 1);
```

This is done that way as to reuse custom methods of `RecordList`, especially the `splice()` that is used by many methods that mutate the record list. Internal code of the custom `splice` method does `slice()`, which is used to retrieve some records without mutating the record list.

In practice, these `.slice()` were accidentally mutating the list, because they invoke the `Proxy.getter` of the `RecordList`, and when the list is flagged for `computeOnNeed` / `sortOnNeed`, invoking this `Proxy.getter` would mistakenly enable the `computeInNeed` / `sortInNeed` flags and thus mutate the list, e.g. with a sort, which may change the order of items and mess up the `index` computed in `indexOf()` step.

This is what happens with the chat window. The `menuThreads` looked something like this:

```js
menuThread = ["thread_1", "thread_2", "thread_3"];
```

With the removal of `thread_2`, the `.indexOf()` is `1`, but due to `.slice()` triggering the sort, the list was changed to:

```js
menuThread = ["thread_2", "thread_1", "thread_3"];
```

... And it instead removed `thread_1` but kept `thread_2` in list. This introduce 2 problems:
- `thread_1` is mistakenly removed from relation when it shouldn't
- `thread_2` is kept, but since this is a local id with no actual record in store, `recordList[index]` would return `undefined` as there's no existing record matching this local id.

This commit fixes the issue by improving internal code of record list
methods to avoid accidental triggering of lazy re-compute and
re-sort. The accidental re-compute and re-sort come from invoking
non-implemented array methods on the proxy of record, such as:

- `recordProxy.at()`
- `recordProxy.slice()`

These methods were just used meant to retrieve records from the record list, and they did so by using accessing through `recordProxy`. This approach has the benefit to look good as this is exactly the same as the external API, but it has the unintended side-effect of the re-compute / re-sort of lazy fields. Instead of using these methods, records are retrieved with:

- raw access to get local ids in relation
- convert local ids to raw records through raw access in `store.recordByLocalId`

This approach, while uglier, has the benefit to not accidentally trigger the re-compute / re-sort.

opw-5761279