### PR TITLE
[FIX] website_sale: archive guests only for automatic invoices

### DIFF
--- a/addons/website_sale/models/payment_transaction.py
+++ b/addons/website_sale/models/payment_transaction.py
@@ -6,8 +6,8 @@ from odoo import models
 class PaymentTransaction(models.Model):
     _inherit = "payment.transaction"
 
-    def _check_amount_and_confirm_order(self):
+    def _post_process(self):
         """Override of `sale` to archive guest contacts."""
-        confirmed_orders = super()._check_amount_and_confirm_order()
-        confirmed_orders.filtered("website_id")._archive_partner_if_no_user()
-        return confirmed_orders
+        super()._post_process()
+        if self.env["ir.config_parameter"].sudo().get_bool("sale.automatic_invoice"):
+            self.sale_order_ids.filtered("website_id")._archive_partner_if_no_user()

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -1039,7 +1039,11 @@ class SaleOrder(models.Model):
         partners_to_archive = self.env["res.partner"]
         for order in self:
             if not (commercial_partner := order.partner_id).user_ids:
-                partners_to_archive |= commercial_partner + commercial_partner.child_ids
+                partners_to_archive |= (
+                    commercial_partner
+                    | commercial_partner.child_ids
+                    | commercial_partner.parent_id
+                )
 
         partners_to_archive.active = False
 


### PR DESCRIPTION
Before this fix, when automatic invoicing was disabled, manually sending
an invoice by email resulted in an empty "Send To" field because the
guest contact had already been archived.

To prevent this issue, guest archiving is now triggered only when
automatic invoicing is enabled. Additionally, to avoid problems with
email delivery, the guest is archived only after the invoice has been
successfully sent.