### PR TITLE
[REF] web: migrate array.js:groupBy to native Object.groupBy

### DIFF
--- a/addons/base_import/static/src/import_model.js
+++ b/addons/base_import/static/src/import_model.js
@@ -2,7 +2,7 @@ import { useState } from "@web/owl2/utils";
 import { localization } from "@web/core/l10n/localization";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
-import { groupBy, sortBy } from "@web/core/utils/arrays";
+import { sortBy } from "@web/core/utils/arrays";
 import { checkFileSize, DEFAULT_MAX_FILE_SIZE } from "@web/core/utils/files";
 import { memoize } from "@web/core/utils/functions";
 import { useService } from "@web/core/utils/hooks";
@@ -545,7 +545,7 @@ export class BaseImportModel {
 
     _groupErrorsByField(messages) {
         const groupedErrors = {};
-        const errorsByMessage = groupBy(this._sortErrors(messages), (f) => f.message || "0");
+        const errorsByMessage = Object.groupBy(this._sortErrors(messages), (f) => f.message || "0");
         for (const [message, errors] of Object.entries(errorsByMessage)) {
             if (!message.record) {
                 const foundError = errors.find((e) => e.record === undefined);

--- a/addons/hr_holidays/static/src/views/graph/hr_holidays_graph_renderer.js
+++ b/addons/hr_holidays/static/src/views/graph/hr_holidays_graph_renderer.js
@@ -5,7 +5,6 @@ import { _t } from "@web/core/l10n/translation";
 import { cookie } from "@web/core/browser/cookie";
 import { getColor } from "@web/core/colors/colors";
 import { GraphRenderer } from "@web/views/graph/graph_renderer";
-import { groupBy } from "@web/core/utils/arrays";
 
 const colorScheme = cookie.get("color_scheme");
 
@@ -42,10 +41,16 @@ export class HrHolidaysGraphRenderer extends GraphRenderer {
 
     _computeBalanceDatasets(data) {
         this.balance_label = _t('Balance')
-        const datasetsByLabel = groupBy(data.datasets, 
-            (dataset) => dataset.label.split(this.delimiter)
-            .map(labelPart => labelPart === this.model.allocation_label || labelPart === this.model.timeoff_label ? this.balance_label : labelPart)
-            .join(this.delimiter)
+        const datasetsByLabel = Object.groupBy(data.datasets, (dataset) =>
+            dataset.label
+                .split(this.delimiter)
+                .map((labelPart) =>
+                    labelPart === this.model.allocation_label ||
+                    labelPart === this.model.timeoff_label
+                        ? this.balance_label
+                        : labelPart
+                )
+                .join(this.delimiter)
         );
         this.datasets_offset = data.datasets.length;
         this.datasets_length = this.datasets_offset + Object.keys(datasetsByLabel).length;

--- a/addons/html_builder/static/src/core/save_plugin.js
+++ b/addons/html_builder/static/src/core/save_plugin.js
@@ -1,6 +1,5 @@
 import { Plugin } from "@html_editor/plugin";
 import { withSequence } from "@html_editor/utils/resource";
-import { groupBy } from "@web/core/utils/arrays";
 import { uniqueId } from "@web/core/utils/functions";
 import { isZWS } from "@html_editor/utils/dom_info";
 import { _t } from "@web/core/l10n/translation";
@@ -68,7 +67,7 @@ export class SavePlugin extends Plugin {
     }
 
     groupElements(toGroupEls) {
-        return groupBy(toGroupEls, (toGroupEl) => {
+        return Object.groupBy(toGroupEls, (toGroupEl) => {
             const model = toGroupEl.dataset.oeModel;
             const recordId = toGroupEl.dataset.oeId;
             const field = toGroupEl.dataset.oeField;

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -15,7 +15,6 @@ import {
 import { Domain } from "@web/core/domain";
 import { serializeDateTime } from "@web/core/l10n/dates";
 import { registry } from "@web/core/registry";
-import { groupBy } from "@web/core/utils/arrays";
 import { createDocumentFragmentFromContent } from "@web/core/utils/html";
 
 const mockRpcRegistry = registry.category("mail.mock_rpc");
@@ -1397,7 +1396,10 @@ export class StoreMany extends StoreRelation {
         const res = [];
 
         if (this.records._name === "mail.message.reaction") {
-            const reactionGroups = groupBy(this.records, (r) => [r.message_id, r.content]);
+            const reactionGroups = Object.groupBy(
+                this.records,
+                (r) => `${r.message_id},${r.content}`
+            );
             for (const groupId in reactionGroups) {
                 const { message_id, content } = reactionGroups[groupId][0];
                 res.push({ message: message_id, content: content });

--- a/addons/mail/static/tests/mock_server/mock_models/mail_activity.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_activity.js
@@ -3,7 +3,7 @@ import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
 import { fields, getKwArgs, makeKwArgs, models, serverState } from "@web/../tests/web_test_helpers";
 import { Domain } from "@web/core/domain";
 import { deserializeDate, serializeDate, today } from "@web/core/l10n/dates";
-import { groupBy, sortBy, unique } from "@web/core/utils/arrays";
+import { sortBy, unique } from "@web/core/utils/arrays";
 
 const { DateTime } = luxon;
 
@@ -164,8 +164,14 @@ export class MailActivity extends models.ServerModel {
             attachmentsById = {};
         }
         // 3. Group activities per records and activity type
-        const groupedCompleted = groupBy(allCompleted, (a) => [a.res_id, a.activity_type_id]);
-        const groupedOngoing = groupBy(allOngoing, (a) => [a.res_id, a.activity_type_id]);
+        const groupedCompleted = Object.groupBy(
+            allCompleted,
+            (a) => `${a.res_id},${a.activity_type_id}`
+        );
+        const groupedOngoing = Object.groupBy(
+            allOngoing,
+            (a) => `${a.res_id},${a.activity_type_id}`
+        );
         // 4. Format data
         const resIdToDeadline = {};
         const resIdToDateDone = {};
@@ -227,7 +233,7 @@ export class MailActivity extends models.ServerModel {
                 count_by_state: {
                     ...Object.fromEntries(
                         Object.entries(
-                            groupBy(ongoing, (a) =>
+                            Object.groupBy(ongoing, (a) =>
                                 this._compute_state_from_date(deserializeDate(a.date_deadline))
                             )
                         ).map(([state, activities]) => [state, activities.length])

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message_reaction.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message_reaction.js
@@ -1,5 +1,4 @@
 import { makeKwArgs, models } from "@web/../tests/web_test_helpers";
-import { groupBy } from "@web/core/utils/arrays";
 import { mailDataHelpers } from "../mail_mock_server";
 
 export class MailMessageReaction extends models.ServerModel {
@@ -11,7 +10,7 @@ export class MailMessageReaction extends models.ServerModel {
         /** @type {import("mock_models").ResPartner} */
         const ResPartner = this.env["res.partner"];
 
-        const reactionGroups = groupBy(this, (r) => [r.message_id, r.content]);
+        const reactionGroups = Object.groupBy(this, (r) => `${r.message_id},${r.content}`);
         for (const groupId in reactionGroups) {
             const reactionGroup = reactionGroups[groupId];
             const { message_id, content } = reactionGroups[groupId][0];

--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -151,6 +151,7 @@ This module provides the core of the Odoo Web Client.
             'web/static/src/polyfills/promise.js',
             'web/static/src/module_loader.js',
             'web/static/src/polyfills/set.js',
+            'web/static/src/polyfills/map.js',
             'web/static/src/session.js',
             'web/static/src/core/browser/cookie.js',
             'web/static/src/core/utils/ui.js',

--- a/addons/web/static/src/core/debug/debug_menu_basic.js
+++ b/addons/web/static/src/core/debug/debug_menu_basic.js
@@ -2,7 +2,7 @@ import { useEnvDebugContext } from "./debug_context";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { _t } from "@web/core/l10n/translation";
-import { groupBy, sortBy } from "@web/core/utils/arrays";
+import { sortBy } from "@web/core/utils/arrays";
 
 import { Component } from "@odoo/owl";
 import { registry } from "@web/core/registry";
@@ -31,7 +31,7 @@ export class DebugMenuBasic extends Component {
 
     async loadGroupedItems() {
         const items = await this.debugContext.getItems(this.env);
-        const sections = groupBy(items, (item) => item.section || "");
+        const sections = Object.groupBy(items, (item) => item.section || "");
         this.sectionEntries = sortBy(
             Object.entries(sections),
             ([section]) => debugSectionRegistry.get(section, { sequence: 50 }).sequence

--- a/addons/web/static/src/core/utils/arrays.js
+++ b/addons/web/static/src/core/utils/arrays.js
@@ -95,35 +95,6 @@ export function isIterable(value) {
 }
 
 /**
- * Returns an object holding different groups defined by a given criterion
- * or a default one. Each group is a subset of the original given list.
- * The given criterion can either be:
- * - a string: a property name on the list elements which value will be the
- * group name,
- * - a function: a handler that will return the group name from a given
- * element.
- *
- * @template T
- * @template {string | number | symbol} K
- * @param {Iterable<T>} iterable
- * @param {Criterion<T, K>} [criterion]
- * @returns {Record<K, T[]>}
- */
-export function groupBy(iterable, criterion) {
-    const extract = _getExtractorFrom(criterion);
-    /** @type {Partial<Record<K, T[]>>} */
-    const groups = {};
-    for (const element of iterable) {
-        const group = String(extract(element));
-        if (!(group in groups)) {
-            groups[group] = [];
-        }
-        groups[group].push(element);
-    }
-    return groups;
-}
-
-/**
  * Return a shallow copy of a given array sorted by a given criterion or a default one.
  * The given criterion can either be:
  * - a string: a property name on the array elements returning the sortable primitive

--- a/addons/web/static/src/polyfills/array.js
+++ b/addons/web/static/src/polyfills/array.js
@@ -7,6 +7,6 @@ if (!Array.prototype.at) {
                 return this[index];
             }
             return this[this.length + index];
-        }
+        },
     });
 }

--- a/addons/web/static/src/polyfills/map.js
+++ b/addons/web/static/src/polyfills/map.js
@@ -1,0 +1,23 @@
+/**
+ * Polyfill for Map.groupBy (Baseline 2024)
+ */
+if (!Map.groupBy) {
+    Object.defineProperty(Map, "groupBy", {
+        configurable: true,
+        enumerable: false,
+        writable: true,
+        value: function (items, callbackfn) {
+            const map = new Map();
+            let i = 0;
+            for (const item of items) {
+                const key = callbackfn(item, i++);
+                if (map.has(key)) {
+                    map.get(key).push(item);
+                } else {
+                    map.set(key, [item]);
+                }
+            }
+            return map;
+        },
+    });
+}

--- a/addons/web/static/src/polyfills/object.js
+++ b/addons/web/static/src/polyfills/object.js
@@ -2,3 +2,27 @@
 if (!Object.hasOwn) {
     Object.hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
 }
+
+/**
+ * Polyfill for Object.groupBy (Baseline 2024)
+ */
+if (!Object.groupBy) {
+    Object.defineProperty(Object, "groupBy", {
+        configurable: true,
+        enumerable: false,
+        writable: true,
+        value: function (items, callbackfn) {
+            const obj = Object.create(null);
+            let i = 0;
+            for (const item of items) {
+                const key = callbackfn(item, i++);
+                if (obj[key]) {
+                    obj[key].push(item);
+                } else {
+                    obj[key] = [item];
+                }
+            }
+            return obj;
+        },
+    });
+}

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -8,7 +8,7 @@ import { rpcBus } from "@web/core/network/rpc";
 import { evaluateExpr } from "@web/core/py_js/py";
 import { domainFromTree } from "@web/core/tree_editor/domain_from_tree";
 import { user } from "@web/core/user";
-import { groupBy, sortBy } from "@web/core/utils/arrays";
+import { sortBy } from "@web/core/utils/arrays";
 import { useService } from "@web/core/utils/hooks";
 import { deepCopy } from "@web/core/utils/objects";
 import { router } from "@web/core/browser/router";
@@ -1243,7 +1243,10 @@ export class SearchModel extends EventBus {
             fieldName,
             domain
         );
-        const result = groupBy(Object.values(definitions), (definition) => definition.record_id);
+        const result = Object.groupBy(
+            Object.values(definitions),
+            (definition) => definition.record_id
+        );
         return Object.entries(result).map(([recordId, definitions]) => ({
             definitionRecordId: parseInt(recordId),
             definitionRecordName: definitions[0]?.record_name,

--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -11,7 +11,7 @@ import { localization } from "@web/core/l10n/localization";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { user } from "@web/core/user";
-import { groupBy, intersection } from "@web/core/utils/arrays";
+import { intersection } from "@web/core/utils/arrays";
 import { Cache } from "@web/core/utils/cache";
 import { KeepLast } from "@web/core/utils/concurrency";
 import { formatFloat } from "@web/core/utils/numbers";
@@ -544,7 +544,7 @@ export class CalendarModel extends Model {
     computeAggregatedValues(fieldName, data = this.data) {
         const records = Object.values(data.records);
         const fieldType = this.meta.fields[fieldName].type;
-        const groups = groupBy(records, ({ rawRecord }) => {
+        const groups = Object.groupBy(records, ({ rawRecord }) => {
             const rawValue = rawRecord[fieldName];
             // FIXME: many2many not supported, but not supported for filters either
             return fieldType === "many2one" ? rawValue?.[0] || false : rawValue;

--- a/addons/web/static/src/views/fields/statusbar/statusbar_field.js
+++ b/addons/web/static/src/views/fields/statusbar/statusbar_field.js
@@ -6,7 +6,6 @@ import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
-import { groupBy } from "@web/core/utils/arrays";
 import { throttleForAnimation } from "@web/core/utils/timing";
 import { getFieldDomain } from "@web/model/relational_model/utils";
 import { useSpecialData } from "@web/views/fields/relational_utils";
@@ -322,7 +321,7 @@ export class StatusBarField extends Component {
     getSortedItems() {
         const before = [];
         const after = [];
-        const { true: inline = [], false: folded = [] } = groupBy(
+        const { true: inline = [], false: folded = [] } = Object.groupBy(
             this.getAllItems(),
             (item) => item.isSelected || !item.isFolded
         );

--- a/addons/web/static/src/webclient/debug/debug_items.js
+++ b/addons/web/static/src/webclient/debug/debug_items.js
@@ -5,7 +5,6 @@ import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 import { registry } from "@web/core/registry";
 import { user } from "@web/core/user";
-import { groupBy } from "@web/core/utils/arrays";
 import { useService } from "@web/core/utils/hooks";
 import { SelectCreateDialog } from "@web/views/view_dialogs/select_create_dialog";
 
@@ -80,7 +79,9 @@ class ClocReport extends Component {
 
     groupRecords(_records) {
         const groups = [];
-        for (const [groupName, records] of Object.entries(groupBy(_records, "module"))) {
+        for (const [groupName, records] of Object.entries(
+            Object.groupBy(_records, (r) => r.module)
+        )) {
             const isUserCusto = groupName === "odoo/studio";
             const group = {
                 name: groupName,

--- a/addons/web/static/src/webclient/offline_systray/offline_systray.js
+++ b/addons/web/static/src/webclient/offline_systray/offline_systray.js
@@ -3,7 +3,6 @@ import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
-import { groupBy } from "@web/core/utils/arrays";
 import { _t } from "../../core/l10n/translation";
 import { formatDateTime } from "@web/core/l10n/dates";
 import { useLayoutEffect } from "@web/owl2/utils";
@@ -57,7 +56,7 @@ class OfflineSystray extends Component {
                 });
             }
         }
-        const sections = Object.entries(groupBy(items, (item) => item.actionName || ""));
+        const sections = Object.entries(Object.groupBy(items, (item) => item.actionName || ""));
         sections.forEach(([_name, items]) => {
             items.sort((itemA, itemB) => itemA.timeStamp - itemB.timeStamp);
         });

--- a/addons/web/static/src/webclient/res_user_group_ids_field/res_user_group_ids_popover.js
+++ b/addons/web/static/src/webclient/res_user_group_ids_field/res_user_group_ids_popover.js
@@ -1,6 +1,5 @@
 import { useState } from "@web/owl2/utils";
 import { Component } from "@odoo/owl";
-import { groupBy } from "@web/core/utils/arrays";
 import { useService } from "@web/core/utils/hooks";
 import { omit } from "@web/core/utils/objects";
 
@@ -33,13 +32,15 @@ export class ResUserGroupIdsPopover extends Component {
         // split joint/joint extra/exclusive implies (at most one group by privilege, the one with
         // higher level, and omit groups of same privilege as the current group)
         const implyGroups = this.group.implyIds.map((gid) => this.groups[gid]);
-        const implyGroupsByPrivilege = groupBy(implyGroups, (g) => g.privilege_id);
+        const implyGroupsByPrivilege = Object.groupBy(implyGroups, (g) => g.privilege_id);
         const keysToOmit = this.privilege ? ["false", String(this.privilege.id)] : ["false"];
         const groupsFromOtherPrivileges = omit(implyGroupsByPrivilege, ...keysToOmit);
-        const higherLevelGroups = Object.values(groupsFromOtherPrivileges).map((groups) => groups[groups.length-1]);
+        const higherLevelGroups = Object.values(groupsFromOtherPrivileges).map(
+            (groups) => groups[groups.length - 1]
+        );
         const groupsWithoutPrivilege = implyGroupsByPrivilege[false] || [];
         const implyGroupsToDisplay = groupsWithoutPrivilege.concat(higherLevelGroups);
-        const { exclusive, joint, extra } = groupBy(implyGroupsToDisplay, (g) => {
+        const { exclusive, joint, extra } = Object.groupBy(implyGroupsToDisplay, (g) => {
             if (g.impliedByIds.length > 1) {
                 return g.privilege_id ? "joint" : "extra";
             }

--- a/addons/web/static/tests/core/utils/arrays.test.js
+++ b/addons/web/static/tests/core/utils/arrays.test.js
@@ -3,7 +3,6 @@ import { describe, expect, test } from "@odoo/hoot";
 import {
     cartesian,
     ensureArray,
-    groupBy,
     intersection,
     shallowEqual,
     slidingWindow,
@@ -14,49 +13,6 @@ import {
 } from "@web/core/utils/arrays";
 
 describe.current.tags("headless");
-
-describe("groupby", () => {
-    test("groupBy parameter validations", () => {
-        // Safari: TypeError: undefined is not a function
-        // Other navigator: array is not iterable
-        expect(() => groupBy({})).toThrow(/TypeError: \w+ is not iterable/);
-        expect(() => groupBy([], true)).toThrow(
-            /Expected criterion of type 'string' or 'function' and got 'boolean'/
-        );
-        expect(() => groupBy([], 3)).toThrow(
-            /Expected criterion of type 'string' or 'function' and got 'number'/
-        );
-        expect(() => groupBy([], {})).toThrow(
-            /Expected criterion of type 'string' or 'function' and got 'object'/
-        );
-    });
-
-    test("groupBy (no criterion)", () => {
-        // criterion = default
-        expect(groupBy(["a", "b", 1, true])).toEqual({
-            1: [1],
-            a: ["a"],
-            b: ["b"],
-            true: [true],
-        });
-    });
-
-    test("groupBy by property", () => {
-        expect(groupBy([{ x: "a" }, { x: "a" }, { x: "b" }], "x")).toEqual({
-            a: [{ x: "a" }, { x: "a" }],
-            b: [{ x: "b" }],
-        });
-    });
-
-    test("groupBy", () => {
-        expect(groupBy(["a", "b", 1, true], (x) => `el${x}`)).toEqual({
-            ela: ["a"],
-            elb: ["b"],
-            el1: [1],
-            eltrue: [true],
-        });
-    });
-});
 
 describe("sortby", () => {
     test("sortBy parameter validation", () => {

--- a/addons/website_event/static/src/snippets/s_events/events.js
+++ b/addons/website_event/static/src/snippets/s_events/events.js
@@ -1,7 +1,6 @@
 import { DynamicSnippet } from "@website/snippets/s_dynamic_snippet/dynamic_snippet";
 import { registry } from "@web/core/registry";
 
-import { groupBy } from "@web/core/utils/arrays";
 
 export class Events extends DynamicSnippet {
     // While the selector has 'upcoming_snippet' in its name, it now has a filter
@@ -15,7 +14,10 @@ export class Events extends DynamicSnippet {
         let searchDomain = super.getSearchDomain(...arguments);
         const filterByTagIds = this.el.dataset.filterByTagIds;
         if (filterByTagIds) {
-            let tagGroupedByCategory = groupBy(JSON.parse(filterByTagIds), "category_id");
+            const tagGroupedByCategory = Object.groupBy(
+                JSON.parse(filterByTagIds),
+                (tag) => tag.category_id
+            );
             for (const category in tagGroupedByCategory) {
                 searchDomain = searchDomain.concat(
                     [["tag_ids", "in", tagGroupedByCategory[category].map(e => e.id)]]);


### PR DESCRIPTION
**This PR:**
Removes the `groupBy` utility in favor of the native **`Object.groupBy`** API.

### Key Changes

* **Removal:** Deleted `groupBy` from `@web/core/utils/arrays`.
* **Migration:** Updated all call sites (converted string criteria to callbacks).
* **Polyfills:** Added `Object.groupBy` and `Map.groupBy` for Safari < 17.4 support.

**Task-5477775**