### PR TITLE
[FIX] stock: prevent access error when validating intercompany receipt

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2088,7 +2088,7 @@ Please change the quantity done or the rounding precision of your unit of measur
         # Break move dest link if move dest and move_dest source are not the same,
         # so that when move_dests._action_assign is called, the move lines are not created with
         # the new location, they should not be created at all.
-        moves_to_push = moves_todo.filtered(lambda m: not m._skip_push())
+        moves_to_push = moves_todo.filtered(lambda m: not m.sudo()._skip_push())
         if moves_to_push:
             moves_to_push._push_apply()
         for move_dest in moves_todo.move_dest_ids:

--- a/addons/stock/tests/test_multicompany.py
+++ b/addons/stock/tests/test_multicompany.py
@@ -432,6 +432,50 @@ class TestMultiCompany(TransactionCase):
         with self.assertRaises(UserError):
             move._action_confirm()
 
+    def test_intercompany_move(self):
+        '''
+        Test that a move from a company A with a dest move from a company B can be validated
+        '''
+        product = self.env['product.product'].create({
+            'name': 'p1',
+            'is_storable': True,
+        })
+        transit_location = self.env['stock.location'].create({
+            'name': 'Intercompany Transit',
+            'usage': 'transit',
+            'company_id': False,
+        })
+
+        move_dest = self.env['stock.move'].with_company(self.company_b).create({
+            'company_id': self.company_b.id,
+            'location_id': transit_location.id,
+            'location_dest_id': self.stock_location_b.id,
+            'name': 'move for company b',
+            'picked': True,
+            'product_id': product.id,
+            'product_uom_qty': 10,
+            'quantity': 10,
+        })
+
+        move = self.env['stock.move'].with_company(self.company_a).create({
+            'company_id': self.company_a.id,
+            'location_id': self.stock_location_a.id,
+            'location_dest_id': transit_location.id,
+            'name': 'move for company a',
+            'move_dest_ids': [move_dest.id],
+            'picked': True,
+            'product_id': product.id,
+            'product_uom_qty': 10,
+            'quantity': 10,
+        })
+
+        move_dest.move_line_ids.invalidate_recordset()
+        move_dest.invalidate_recordset()
+        move.with_user(self.user_a)._action_done()
+
+        self.assertEqual(move.state, 'done')
+        self.assertEqual(move_dest.state, 'assigned')
+
     def test_intercom_lot_push(self):
         """ Create a push rule to transfer products received in inter company
         transit location to company b. Move a lot product from company a to the


### PR DESCRIPTION
**Issue**:
Validating a receipt with intercompany move, can lead to access right issue

**Steps to reproduce**:
- Create two different companies A and B
- Create an inter company route with two 'pull from' action defined:
	- One from Virtual Locations/Inter-company transit to A/Stock with operation type A: Receipts
	- One from B/stock to Virtual Locations/Inter-company transit with operation type B: Delivery Orders
- Create a product P accessible from both company
- Create a MO (while both company activated with company A selected) for a product that consumes 1 unit P as component and confirm it
- Go to the receipt while only company B activated
- Select a quantity of 1 and validate it 
-> A traceback is displayed

**Cause**:
While confirming the receipt (calling `button_validate`): https://github.com/odoo/odoo/blob/e9a8b81d4a972a57a8f46377864874190b04af2c/addons/stock/models/stock_picking.py#L1403 this will eventually runs:
https://github.com/odoo/odoo/blob/e9a8b81d4a972a57a8f46377864874190b04af2c/addons/stock/models/stock_move.py#L2091 https://github.com/odoo/odoo/blob/e9a8b81d4a972a57a8f46377864874190b04af2c/addons/stock/models/stock_move.py#L2036-L2039 Since self.move_dest_ids belongs to another company, accessing the associated location_id triggers an AccessError.

opw-5177369