### PR TITLE
FIX calendar: issue where a calendar event's recurrence rule (rrule) contains an RSCALE parameter (RFC 7529, non-Gregorian calendars) that python-dateutil doesn't support

### DIFF
--- a/addons/calendar/models/calendar.py
+++ b/addons/calendar/models/calendar.py
@@ -624,7 +624,9 @@ class Meeting(models.Model):
         # The start date is naive
         # the timezone will be applied, if necessary, at the very end of the process
         # to allow for DST timezone reevaluation
-        rset1 = rrule.rrulestr(str(self.rrule), dtstart=event_date.replace(tzinfo=None), forceset=True, ignoretz=True)
+        # Strip RFC 7529 parameters (RSCALE, SKIP) not supported by python-dateutil
+        rule_str = re.sub(r';?(?:RSCALE|SKIP)=[^;:\s]+', '', str(self.rrule))
+        rset1 = rrule.rrulestr(rule_str, dtstart=event_date.replace(tzinfo=None), forceset=True, ignoretz=True)
 
         recurring_meetings_ids = self.env.context.get('recurrent_siblings_cache', {}).get(self.id)
         if recurring_meetings_ids is not None:


### PR DESCRIPTION

This usually happens when events are synced from Google Calendar or Apple Calendar.

The events are correctly saved in the database — the rrule field on calendar_event stores the full original rrule string including RSCALE and SKIP. Our patch doesn't touch the stored data; it
  only strips those parameters at runtime when python-dateutil needs to parse the rrule to compute recurrence dates.

  That said, there's a nuance:

  - RSCALE=GREGORIAN (the most common case, typically from Google/Apple Calendar sync) — stripping it is completely safe, since Gregorian is the default calendar system anyway. No behavior change.
  - RSCALE=ISLAMIC-CIVIL, RSCALE=HEBREW, etc. — stripping it means recurrence dates will be computed using the Gregorian calendar instead of the intended non-Gregorian one. The dates would be wrong, but python-dateutil doesn't support non-Gregorian calendars at all, so there's no fix for this in Odoo 12 regardless.
  - SKIP=OMIT/BACKWARD/FORWARD — controls what happens when a recurrence date doesn't exist in the target calendar (e.g., Feb 30). Stripping it falls back to the default behavior, which is generally fine for Gregorian calendars.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
