### PR TITLE
[FIX] account: prevent concurrent update on portal token during OCR flow

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4801,6 +4801,11 @@ class AccountMove(models.Model):
                     _logger.exception("Failed to link bill to purchase order")
 
         if new:
+            # we force an early access token write to prevent edge-cases where the notification
+            # email will fail because the OCR/IAP (async) callback triggers a concurrent update on the same
+            # account move
+            self._portal_ensure_token()
+            self.flush_recordset(['access_token'])
             try:
                 attachments = set(self.attachment_ids + self._from_files_data(files_data + self._unwrap_attachments(files_data)))
                 self.journal_id._notify_invoice_subscribers(


### PR DESCRIPTION
When a PDF is received by a journal email alias, a race condition occurs between the notification email process and the OCR (IAP) callback.

The notification email template generates a portal URL. Accessing this URL triggers a lazy-generation of the 'access_token' on the account.move record. If the OCR callback (which is asynchronous) updates the same record while the main thread is busy communicating with the SMTP server, the main thread fails with a SerializationError (Concurrent Update) when it finally tries to commit the new token.

This results in a "bouncing email" error for the user, even though the invoice was created and the OCR worked correctly.

This commit forces the generation and flush of the 'access_token' immediately before the notification process begins. By ensuring the write happens early and is flushed to the DB, we avoid a conflicting lazy-write during the post-SMTP commit phase.

Traceback example (simplified):
```
# Thread A (Alias) starts parsing
INFO: iap jsonrpc .../invoice/2/parse
# Thread B (OCR Callback) finishes and updates the record
 INFO: POST /account_invoice_extract/request_done/... HTTP/1.0" 200 
# Thread A finishes SMTP and tries to flush the lazy-generated access_token 
ERROR: bad query: UPDATE "account_move" SET "access_token" = ... 
ERROR: could not serialize access due to concurrent update psycopg2.errors.SerializationFailure: could not serialize access due to concurrent update
```

OPW-5887922

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
