### PR TITLE
[FIX] l10n_dk_nemhandel: Uses parent partner identifier

### DIFF
--- a/addons/l10n_dk_nemhandel/models/account_edi_xml_oioubl_21.py
+++ b/addons/l10n_dk_nemhandel/models/account_edi_xml_oioubl_21.py
@@ -133,7 +133,7 @@ class AccountEdiXmlOIOUBL21(models.AbstractModel):
     def _get_party_node(self, vals):
         # EXTENDS account.edi.xml.ubl_20
         party_node = super()._get_party_node(vals)
-        partner = vals['partner']
+        partner = vals['partner'].commercial_partner_id
         vat = format_vat_number(partner, partner.vat)
         cvr = format_vat_number(partner, partner.company_registry) or vat
         party_node['cac:PartyLegalEntity'].update({

--- a/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_invoice_child_partner.xml
+++ b/addons/l10n_dk_nemhandel/tests/test_files/from_odoo/oioubl_out_invoice_child_partner.xml
@@ -1,0 +1,289 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+    xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+    <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+    <cbc:CustomizationID>OIOUBL-2.1</cbc:CustomizationID>
+    <cbc:ProfileID schemeID="urn:oioubl:id:profileid-1.6" schemeAgencyID="320">Procurement-BilSim-1.0</cbc:ProfileID>
+    <cbc:ID>INV/2017/00001</cbc:ID>
+    <cbc:IssueDate>2017-01-01</cbc:IssueDate>
+    <cbc:DueDate>2017-02-28</cbc:DueDate>
+    <cbc:InvoiceTypeCode listID="urn:oioubl:codelist:invoicetypecode-1.2" listAgencyID="320">380</cbc:InvoiceTypeCode>
+    <cbc:Note>test narration</cbc:Note>
+    <cbc:DocumentCurrencyCode>DKK</cbc:DocumentCurrencyCode>
+    <cac:OrderReference>
+        <cbc:ID>ref_move</cbc:ID>
+    </cac:OrderReference>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>INV_2017_00001.pdf</cbc:ID>
+        <cbc:DocumentTypeCode listAgencyID="6" listID="UN/ECE 1001">380</cbc:DocumentTypeCode>
+        <cac:Attachment>
+            <cbc:EmbeddedDocumentBinaryObject mimeCode="application/pdf" filename="INV_2017_00001.pdf">___ignore___</cbc:EmbeddedDocumentBinaryObject>
+        </cac:Attachment>
+    </cac:AdditionalDocumentReference>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cbc:EndpointID schemeID="DK:CVR">DK12345674</cbc:EndpointID>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="DK:CVR">DK12345674</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>company_1_data</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:AddressFormatCode listAgencyID="320" listID="urn:oioubl:codelist:addressformatcode-1.1">StructuredDK</cbc:AddressFormatCode>
+                <cbc:StreetName>Paradisæblevej,</cbc:StreetName>
+                <cbc:BuildingNumber>10</cbc:BuildingNumber>
+                <cbc:CityName>Aalborg</cbc:CityName>
+                <cbc:PostalZone>9430</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>DK</cbc:IdentificationCode>
+                    <cbc:Name>Denmark</cbc:Name>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+                <cbc:CompanyID schemeID="DK:SE">DK12345674</cbc:CompanyID>
+                <cac:RegistrationAddress>
+                    <cbc:AddressFormatCode listAgencyID="320" listID="urn:oioubl:codelist:addressformatcode-1.1">StructuredDK</cbc:AddressFormatCode>
+                    <cbc:StreetName>Paradisæblevej,</cbc:StreetName>
+                    <cbc:BuildingNumber>10</cbc:BuildingNumber>
+                    <cbc:CityName>Aalborg</cbc:CityName>
+                    <cbc:PostalZone>9430</cbc:PostalZone>
+                    <cac:Country>
+                        <cbc:IdentificationCode>DK</cbc:IdentificationCode>
+                        <cbc:Name>Denmark</cbc:Name>
+                    </cac:Country>
+                </cac:RegistrationAddress>
+                <cac:TaxScheme>
+                    <cbc:ID schemeID="urn:oioubl:id:taxschemeid-1.5">63</cbc:ID>
+                    <cbc:Name>Moms</cbc:Name>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+                <cbc:CompanyID schemeID="DK:CVR">DK12345674</cbc:CompanyID>
+                <cac:RegistrationAddress>
+                    <cbc:AddressFormatCode listAgencyID="320" listID="urn:oioubl:codelist:addressformatcode-1.1">StructuredDK</cbc:AddressFormatCode>
+                    <cbc:StreetName>Paradisæblevej,</cbc:StreetName>
+                    <cbc:BuildingNumber>10</cbc:BuildingNumber>
+                    <cbc:CityName>Aalborg</cbc:CityName>
+                    <cbc:PostalZone>9430</cbc:PostalZone>
+                    <cac:Country>
+                        <cbc:IdentificationCode>DK</cbc:IdentificationCode>
+                        <cbc:Name>Denmark</cbc:Name>
+                    </cac:Country>
+                </cac:RegistrationAddress>
+            </cac:PartyLegalEntity>
+            <cac:Contact>
+                <cbc:ID>___ignore___</cbc:ID>
+                <cbc:Name>company_1_data</cbc:Name>
+                <cbc:Telephone>+45 32 12 34 56</cbc:Telephone>
+            </cac:Contact>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cbc:EndpointID schemeID="GLN">5798009811512</cbc:EndpointID>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="GLN">5798009811512</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PartyName>
+                <cbc:Name>SUPER BELGIAN PARTNER, Jean-Michel</cbc:Name>
+            </cac:PartyName>
+            <cac:PostalAddress>
+                <cbc:AddressFormatCode listAgencyID="320" listID="urn:oioubl:codelist:addressformatcode-1.1">StructuredDK</cbc:AddressFormatCode>
+                <cbc:StreetName>Rue du Paradis,</cbc:StreetName>
+                <cbc:BuildingNumber>10</cbc:BuildingNumber>
+                <cbc:CityName>Eghezee</cbc:CityName>
+                <cbc:PostalZone>6870</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+                    <cbc:Name>Belgium</cbc:Name>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:RegistrationName>SUPER BELGIAN PARTNER</cbc:RegistrationName>
+                <cbc:CompanyID schemeID="ZZZ">BE0897223670</cbc:CompanyID>
+                <cac:RegistrationAddress>
+                    <cbc:AddressFormatCode listAgencyID="320" listID="urn:oioubl:codelist:addressformatcode-1.1">StructuredDK</cbc:AddressFormatCode>
+                    <cbc:StreetName>Rue du Paradis,</cbc:StreetName>
+                    <cbc:BuildingNumber>10</cbc:BuildingNumber>
+                    <cbc:CityName>Eghezee</cbc:CityName>
+                    <cbc:PostalZone>6870</cbc:PostalZone>
+                    <cac:Country>
+                        <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+                        <cbc:Name>Belgium</cbc:Name>
+                    </cac:Country>
+                </cac:RegistrationAddress>
+                <cac:TaxScheme>
+                    <cbc:ID schemeID="urn:oioubl:id:taxschemeid-1.5">63</cbc:ID>
+                    <cbc:Name>Moms</cbc:Name>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>SUPER BELGIAN PARTNER</cbc:RegistrationName>
+                <cbc:CompanyID schemeID="ZZZ">BE0897223670</cbc:CompanyID>
+                <cac:RegistrationAddress>
+                    <cbc:AddressFormatCode listAgencyID="320" listID="urn:oioubl:codelist:addressformatcode-1.1">StructuredDK</cbc:AddressFormatCode>
+                    <cbc:StreetName>Rue du Paradis,</cbc:StreetName>
+                    <cbc:BuildingNumber>10</cbc:BuildingNumber>
+                    <cbc:CityName>Eghezee</cbc:CityName>
+                    <cbc:PostalZone>6870</cbc:PostalZone>
+                    <cac:Country>
+                        <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+                        <cbc:Name>Belgium</cbc:Name>
+                    </cac:Country>
+                </cac:RegistrationAddress>
+            </cac:PartyLegalEntity>
+            <cac:Contact>
+                <cbc:ID>___ignore___</cbc:ID>
+                <cbc:Name>Jean-Michel</cbc:Name>
+            </cac:Contact>
+        </cac:Party>
+    </cac:AccountingCustomerParty>
+    <cac:Delivery>
+        <cac:DeliveryLocation>
+            <cac:Address>
+                <cbc:AddressFormatCode listAgencyID="320" listID="urn:oioubl:codelist:addressformatcode-1.1">StructuredDK</cbc:AddressFormatCode>
+                <cbc:StreetName>Rue du Paradis,</cbc:StreetName>
+                <cbc:BuildingNumber>10</cbc:BuildingNumber>
+                <cbc:CityName>Eghezee</cbc:CityName>
+                <cbc:PostalZone>6870</cbc:PostalZone>
+                <cac:Country>
+                    <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+                    <cbc:Name>Belgium</cbc:Name>
+                </cac:Country>
+            </cac:Address>
+        </cac:DeliveryLocation>
+    </cac:Delivery>
+    <cac:PaymentMeans>
+        <cbc:PaymentMeansCode name="unknown">1</cbc:PaymentMeansCode>
+        <cbc:PaymentDueDate>2017-02-28</cbc:PaymentDueDate>
+        <cbc:InstructionID>+71&lt;000002017000015+40116243&lt;</cbc:InstructionID>
+        <cbc:PaymentID>+71&lt;000002017000015+40116243&lt;</cbc:PaymentID>
+        <cac:PayeeFinancialAccount>
+            <cbc:ID>DK5000400440116243</cbc:ID>
+        </cac:PayeeFinancialAccount>
+    </cac:PaymentMeans>
+    <cac:PaymentTerms>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Note>Payment terms: 30% Advance End of Following Month</cbc:Note>
+        <cbc:Amount currencyID="DKK">450.00</cbc:Amount>
+        <cac:SettlementPeriod>
+            <cbc:StartDate>2017-01-01</cbc:StartDate>
+            <cbc:EndDate>2017-01-01</cbc:EndDate>
+        </cac:SettlementPeriod>
+    </cac:PaymentTerms>
+    <cac:PaymentTerms>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Note>Payment terms: 30% Advance End of Following Month</cbc:Note>
+        <cbc:Amount currencyID="DKK">1050.00</cbc:Amount>
+        <cac:SettlementPeriod>
+            <cbc:StartDate>2017-01-01</cbc:StartDate>
+            <cbc:EndDate>2017-02-28</cbc:EndDate>
+        </cac:SettlementPeriod>
+    </cac:PaymentTerms>
+    <cac:TaxTotal>
+        <cbc:TaxAmount currencyID="DKK">0.00</cbc:TaxAmount>
+        <cac:TaxSubtotal>
+            <cbc:TaxableAmount currencyID="DKK">1500.00</cbc:TaxableAmount>
+            <cbc:TaxAmount currencyID="DKK">0.00</cbc:TaxAmount>
+            <cac:TaxCategory>
+                <cbc:ID schemeID="urn:oioubl:id:taxcategoryid-1.3" schemeAgencyID="320">ReverseCharge</cbc:ID>
+                <cbc:Percent>0.0</cbc:Percent>
+                <cbc:TaxExemptionReasonCode>VATEX-EU-IC</cbc:TaxExemptionReasonCode>
+                <cbc:TaxExemptionReason>Intra-Community supply</cbc:TaxExemptionReason>
+                <cac:TaxScheme>
+                    <cbc:ID schemeID="urn:oioubl:id:taxschemeid-1.5">63</cbc:ID>
+                    <cbc:Name>Moms</cbc:Name>
+                </cac:TaxScheme>
+            </cac:TaxCategory>
+        </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:LegalMonetaryTotal>
+        <cbc:LineExtensionAmount currencyID="DKK">1500.00</cbc:LineExtensionAmount>
+        <cbc:TaxExclusiveAmount currencyID="DKK">0.00</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="DKK">1500.00</cbc:TaxInclusiveAmount>
+        <cbc:PayableAmount currencyID="DKK">1500.00</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="DKK">500.00</cbc:LineExtensionAmount>
+        <cac:TaxTotal>
+            <cbc:TaxAmount currencyID="DKK">0.00</cbc:TaxAmount>
+            <cac:TaxSubtotal>
+                <cbc:TaxableAmount currencyID="DKK">500.00</cbc:TaxableAmount>
+                <cbc:TaxAmount currencyID="DKK">0.00</cbc:TaxAmount>
+                <cac:TaxCategory>
+                    <cbc:ID schemeID="urn:oioubl:id:taxcategoryid-1.3" schemeAgencyID="320">ReverseCharge</cbc:ID>
+                    <cbc:Percent>0.0</cbc:Percent>
+                    <cbc:TaxExemptionReasonCode>VATEX-EU-IC</cbc:TaxExemptionReasonCode>
+                    <cbc:TaxExemptionReason>Intra-Community supply</cbc:TaxExemptionReason>
+                    <cac:TaxScheme>
+                        <cbc:ID schemeID="urn:oioubl:id:taxschemeid-1.5">63</cbc:ID>
+                        <cbc:Name>Moms</cbc:Name>
+                    </cac:TaxScheme>
+                </cac:TaxCategory>
+            </cac:TaxSubtotal>
+        </cac:TaxTotal>
+        <cac:Item>
+            <cbc:Description>product_a</cbc:Description>
+            <cbc:Name>product_a</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID schemeID="urn:oioubl:id:taxcategoryid-1.3" schemeAgencyID="320">ReverseCharge</cbc:ID>
+                <cbc:Percent>0.0</cbc:Percent>
+                <cbc:TaxExemptionReasonCode>VATEX-EU-IC</cbc:TaxExemptionReasonCode>
+                <cbc:TaxExemptionReason>Intra-Community supply</cbc:TaxExemptionReason>
+                <cac:TaxScheme>
+                    <cbc:ID schemeID="urn:oioubl:id:taxschemeid-1.5">63</cbc:ID>
+                    <cbc:Name>Moms</cbc:Name>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="DKK">500.0</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+    <cac:InvoiceLine>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="DZN">1.0</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="DKK">1000.00</cbc:LineExtensionAmount>
+        <cac:TaxTotal>
+            <cbc:TaxAmount currencyID="DKK">0.00</cbc:TaxAmount>
+            <cac:TaxSubtotal>
+                <cbc:TaxableAmount currencyID="DKK">1000.00</cbc:TaxableAmount>
+                <cbc:TaxAmount currencyID="DKK">0.00</cbc:TaxAmount>
+                <cac:TaxCategory>
+                    <cbc:ID schemeID="urn:oioubl:id:taxcategoryid-1.3" schemeAgencyID="320">ReverseCharge</cbc:ID>
+                    <cbc:Percent>0.0</cbc:Percent>
+                    <cbc:TaxExemptionReasonCode>VATEX-EU-IC</cbc:TaxExemptionReasonCode>
+                    <cbc:TaxExemptionReason>Intra-Community supply</cbc:TaxExemptionReason>
+                    <cac:TaxScheme>
+                        <cbc:ID schemeID="urn:oioubl:id:taxschemeid-1.5">63</cbc:ID>
+                        <cbc:Name>Moms</cbc:Name>
+                    </cac:TaxScheme>
+                </cac:TaxCategory>
+            </cac:TaxSubtotal>
+        </cac:TaxTotal>
+        <cac:Item>
+            <cbc:Description>product_b</cbc:Description>
+            <cbc:Name>product_b</cbc:Name>
+            <cac:ClassifiedTaxCategory>
+                <cbc:ID schemeID="urn:oioubl:id:taxcategoryid-1.3" schemeAgencyID="320">ReverseCharge</cbc:ID>
+                <cbc:Percent>0.0</cbc:Percent>
+                <cbc:TaxExemptionReasonCode>VATEX-EU-IC</cbc:TaxExemptionReasonCode>
+                <cbc:TaxExemptionReason>Intra-Community supply</cbc:TaxExemptionReason>
+                <cac:TaxScheme>
+                    <cbc:ID schemeID="urn:oioubl:id:taxschemeid-1.5">63</cbc:ID>
+                    <cbc:Name>Moms</cbc:Name>
+                </cac:TaxScheme>
+            </cac:ClassifiedTaxCategory>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="DKK">1000.0</cbc:PriceAmount>
+        </cac:Price>
+    </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_dk_nemhandel/tests/test_xml_oioubl_21.py
+++ b/addons/l10n_dk_nemhandel/tests/test_xml_oioubl_21.py
@@ -198,6 +198,19 @@ class TestUBLDKOIOUBL21(TestUBLCommon, TestAccountMoveSendCommon):
         self._assert_invoice_attachment(invoice.ubl_cii_xml_id, xpaths=None, expected_file_path="from_odoo/oioubl_out_invoice_partner_dk.xml")
 
     @freeze_time('2017-01-01')
+    def test_oioubl_export_with_partner_child(self):
+        """ This test verifies that when creating a OIOUBL file for a individual partner,
+            linked to a company partner, that we use the GLN from the company partner.
+        """
+        individual_partner = self.env['res.partner'].create({
+                'name': 'Jean-Michel',
+                'parent_id': self.partner_b.id,
+        })
+        invoice = self.create_post_and_send_invoice(partner=individual_partner)
+        self.assertTrue(invoice.ubl_cii_xml_id)
+        self._assert_invoice_attachment(invoice.ubl_cii_xml_id, xpaths=None, expected_file_path="from_odoo/oioubl_out_invoice_child_partner.xml")
+
+    @freeze_time('2017-01-01')
     def test_oioubl_export_import_with_discount(self):
         """ Tests that the discount on a line is well exported, then taken into account when imported """
         line_vals = {


### PR DESCRIPTION
**STEP TO REPRODUCE**
1. install l10n_dk_nemhandel, and activate nemhandel.
2. Create a company partner, with a EAN/GLN as the nemhandel id.
3. Create an individual partner linked to the company partner.
4. Create an invoice with this individual partner.
5. Send the invoice with nemhandel.
6. open the xml file, and notice that the EndpointID doesn't use the EAN/GLN of the company partner. (It falls back to the VAT instead).

opw-5945440