### PR TITLE
[FIX] hr: allow open users form view

### DIFF
--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -224,9 +224,6 @@
                         <field name="mobile_phone" widget="phone" placeholder="Work Mobile" string="Work Mobile" class="w-75"/>
                     </h5>
                 </xpath>
-                <xpath expr="//group[@name='other_preferences']" position="inside">
-                    <field name="pin" string="Attendance PIN" invisible="not employee_id"/>
-                </xpath>
                 <xpath expr="//group[@name='other_calendar_preferences']" position="inside">
                     <field name="work_location_id" string="Main Work Location" invisible="not employee_id or share"/>
                 </xpath>


### PR DESCRIPTION
If a person having rights to edit users is not HR officer, he gets a traceback when he tries to open the user form.

As the information of PIN is not really related to the user, we left it on the employee and the "Preference" view, but remove it from the main user view


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
