### PR TITLE
[IMP] account_edi_ubl_cii: Identify the correct tax at import

### DIFF
--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -215,6 +215,17 @@ class TestAccountEdiUblCii(AccountTestInvoicingCommon):
         bill = self.import_attachment(xml_attachment, self.company_data["default_journal_purchase"])
         self.assertEqual(bill.invoice_line_ids.tax_ids, new_tax_2)
 
+        wrong_tax = self.env["account.tax"].create({
+            'name': 'Tax incorrectly predicted based on product and account',
+            'amount_type': 'percent',
+            'type_tax_use': 'purchase',
+            'amount': 21.0,
+        })
+
+        with patch.object(type(self.env['account.move.line']), '_predict_taxes', return_value=wrong_tax.ids):
+            bill = self.import_attachment(xml_attachment, self.company_data["default_journal_purchase"])
+            self.assertEqual(bill.invoice_line_ids.tax_ids, new_tax_2)
+
     def test_peppol_eas_endpoint_compute(self):
         partner = self.partner_a
         partner.vat = 'DE123456788'


### PR DESCRIPTION
Context:
When importing an XML invoice or vendor bill, the tax prediction was based on the customer’s invoice history.

Example: if the imported invoice contains an item found in the history with two taxes (6% and 21%), the prediction would return both taxes (6% and 21%), even though only one tax is present in the XML file.

The actual tax data present in the imported XML was not taken into account.

After this commit, the prediction is more rigorous and correctly relies on the tax information provided in the XML (restricted search domain)

task-5503126

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
