### PR TITLE
[IMP] stock: apply route for all warehouses on empty

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -255,3 +255,8 @@ class StockRoute(models.Model):
         if any(rule.action == 'manufacture' for rule in self.rule_ids):
             return any(bom.type == 'normal' for bom in product.bom_ids)
         return super()._is_valid_resupply_route_for_product(product)
+
+    def _get_non_push_pull_rule_actions(self):
+        rule_actions = super()._get_non_push_pull_rule_actions()
+        rule_actions.append('manufacture')
+        return rule_actions

--- a/addons/mrp/models/stock_warehouse.py
+++ b/addons/mrp/models/stock_warehouse.py
@@ -45,7 +45,8 @@ class StockWarehouse(models.Model):
     def _compute_manufacture_to_resupply(self):
         for warehouse in self:
             manufacture_route = warehouse.manufacture_pull_id.route_id
-            warehouse.manufacture_to_resupply = warehouse.id in manufacture_route.warehouse_ids.ids
+            warehouse.manufacture_to_resupply = warehouse.id in manufacture_route.warehouse_ids.ids or \
+                                                (manufacture_route.warehouse_selectable and not manufacture_route.warehouse_ids)
 
     def _inverse_manufacture_to_resupply(self):
         for warehouse in self:

--- a/addons/mrp/tests/test_stock.py
+++ b/addons/mrp/tests/test_stock.py
@@ -342,6 +342,17 @@ class TestWarehouseMrp(common.TestMrpCommon):
         self.assertFalse(self.warehouse_1.pbm_mto_pull_id.location_dest_id.active)
         self.assertNotIn(self.warehouse_1.pbm_mto_pull_id, self.route_mto.rule_ids)
 
+    def test_default_manufacture_route_with_no_warehouse(self):
+        route_domain = [
+            ('warehouse_selectable', '=', True),
+            ('rule_ids.action', '=', 'manufacture'),
+            ('company_id', 'in', [False, self.env.company.id]),
+        ]
+        routes = self.env['stock.route'].search(route_domain)
+        routes.warehouse_ids = False
+        orderpoint = self.env['stock.warehouse.orderpoint'].create({'product_id': self.laptop.id})
+        self.assertEqual(routes[0].name, orderpoint.route_id_placeholder)
+
 
 class TestKitPicking(common.TestMrpCommon):
     @classmethod

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -81,7 +81,7 @@ class StockWarehouse(models.Model):
     def _compute_buy_to_resupply(self):
         for warehouse in self:
             buy_route = warehouse.buy_pull_id.route_id
-            warehouse.buy_to_resupply = warehouse.id in buy_route.warehouse_ids.ids
+            warehouse.buy_to_resupply = warehouse.id in buy_route.warehouse_ids.ids or (buy_route.warehouse_selectable and not buy_route.warehouse_ids)
 
     def _inverse_buy_to_resupply(self):
         for warehouse in self:

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -415,3 +415,8 @@ class StockRoute(models.Model):
         if any(rule.action == 'buy' for rule in self.rule_ids):
             return bool(product.seller_ids)
         return super()._is_valid_resupply_route_for_product(product)
+
+    def _get_non_push_pull_rule_actions(self):
+        rule_actions = super()._get_non_push_pull_rule_actions()
+        rule_actions.append('buy')
+        return rule_actions

--- a/addons/purchase_stock/tests/test_routes.py
+++ b/addons/purchase_stock/tests/test_routes.py
@@ -75,5 +75,7 @@ class TestRoutes(TransactionCase):
         wh.buy_to_resupply = False
         # Invalidate recordset to avoid cached `buy_to_resupply`
         wh.invalidate_recordset(["buy_to_resupply"])
+        # Creating a new warehouse because if buy_route.warehouse_ids is empty and warehouse_selectable = True, it applies to all warehouses
+        self.env['stock.warehouse'].create({'name': 'WH 2', 'code': 'WH2'})
         self.assertFalse(wh.buy_to_resupply)
         self.assertNotIn(wh, buy_route.warehouse_ids)

--- a/addons/purchase_stock/tests/test_stock_orderpoint.py
+++ b/addons/purchase_stock/tests/test_stock_orderpoint.py
@@ -4,16 +4,43 @@ from odoo.tests.common import HttpCase, tagged
 @tagged("-at_install", "post_install")
 class TestStockWarehouseOrderpoint(HttpCase):
 
-    def test_product_replenishment(self):
-        product = self.env['product.product'].create({
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product = cls.env['product.product'].create({
             'name': 'Book Shelf',
             'lst_price': 1750.00,
             'is_storable': True,
             'purchase_ok': True,
         })
-        self.assertFalse(product.orderpoint_ids)
+        cls.res_partner_1 = cls.env['res.partner'].create({
+            'name': 'Wood Corner',
+        })
+        cls.env['product.supplierinfo'].create([
+            {
+                'partner_id': cls.res_partner_1.id,
+                'product_id': cls.product.id,
+                'delay': 3,
+                'min_qty': 1,
+                'price': 750,
+            }
+        ])
+
+    def test_product_replenishment(self):
+        self.assertFalse(self.product.orderpoint_ids)
 
         self.start_tour("/odoo/replenishment", "test_product_replenishment", login='admin')
 
-        self.assertEqual(len(product.orderpoint_ids), 1)
-        self.assertEqual(product.orderpoint_ids[0].route_id.name, 'Buy')
+        self.assertEqual(len(self.product.orderpoint_ids), 1)
+        self.assertEqual(self.product.orderpoint_ids[0].route_id.name, 'Buy')
+
+    def test_default_buy_route_with_no_warehouse(self):
+        route_domain = [
+            ('warehouse_selectable', '=', True),
+            ('rule_ids.action', '=', 'buy'),
+            ('company_id', 'in', [False, self.env.company.id]),
+        ]
+        routes = self.env['stock.route'].search(route_domain)
+        routes.warehouse_ids = False
+        orderpoint = self.env['stock.warehouse.orderpoint'].create({'product_id': self.product.id})
+        self.assertEqual(routes[0].name, orderpoint.route_id_placeholder)

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -596,3 +596,19 @@ class StockRoute(models.Model):
 
     def _is_valid_resupply_route_for_product(self, product):
         return False
+
+    def _get_routes_with_no_warehouse(self):
+        rule_actions = self._get_non_push_pull_rule_actions()
+        route_domain = [
+            ('warehouse_selectable', '=', True),
+            ('rule_ids.action', 'in', rule_actions),
+            ('company_id', 'in', [False, self.env.company.id]),
+            '|',
+                ('warehouse_ids', '=', False),
+                ('warehouse_ids', 'not in', self.env['stock.warehouse']._search([
+                    ('company_id', '=', self.env.company.id)]))
+        ]
+        return self.env['stock.route'].search(route_domain)
+
+    def _get_non_push_pull_rule_actions(self):
+        return []

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -537,9 +537,11 @@ class StockRule(models.Model):
         while locations[-1].location_id:
             locations |= locations[-1].location_id
         domain = self._get_rule_domain(locations, values)
+        routes_with_no_warehouse = self.env['stock.route']._get_routes_with_no_warehouse()
+        routes = (values.get('route_ids') or self.env['stock.route']) | routes_with_no_warehouse
         # Get a mapping (location_id, route_id) -> warehouse_id -> rule_id
         rule_dict = self._search_rule_for_warehouses(
-            values.get("route_ids", False),
+            routes,
             values.get("packaging_uom_id", False),
             product_id,
             values.get("warehouse_id", locations.warehouse_id),
@@ -588,7 +590,7 @@ class StockRule(models.Model):
             for candidate_location in candidate_locations:
                 result = get_rule_for_routes(
                     rule_dict,
-                    values.get("route_ids", self.env['stock.route']),
+                    routes,
                     values.get("packaging_uom_id", self.env['uom.uom']),
                     product_id,
                     values.get("warehouse_id", candidate_location.warehouse_id),

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -1110,6 +1110,7 @@ class StockWarehouse(models.Model):
 
     def _get_all_routes(self):
         routes = self.mapped('route_ids') | self.mapped('mto_pull_id').mapped('route_id')
+        routes |= self.env['stock.route']._get_routes_with_no_warehouse()
         routes |= self.env["stock.route"].with_context(active_test=False).search([('supplied_wh_id', 'in', self.ids)])
         return routes
 

--- a/addons/stock/report/report_stock_rule.py
+++ b/addons/stock/report/report_stock_rule.py
@@ -80,7 +80,8 @@ class ReportStockReport_Stock_Rule(models.AbstractModel):
         """
         product = self.env['product.product'].browse(data['product_id'])
         warehouse_ids = self.env['stock.warehouse'].browse(data['warehouse_ids'])
-        return product.route_ids | product.categ_id.total_route_ids | warehouse_ids.mapped('route_ids')
+        routes_with_no_warehouse = self.env['stock.route']._get_routes_with_no_warehouse()
+        return product.route_ids | product.categ_id.total_route_ids | routes_with_no_warehouse | warehouse_ids.mapped('route_ids')
 
     @api.model
     def _get_rule_loc(self, rule, product):

--- a/addons/stock/views/stock_location_views.xml
+++ b/addons/stock/views/stock_location_views.xml
@@ -218,7 +218,7 @@
                             <div class="o_row">
                                 <field name="warehouse_selectable" class="oe_inline" nolabel="1"/>
                                 <field name="warehouse_domain_ids" invisible="1"/>
-                                <field name="warehouse_ids" widget="many2many_tags" class="o_field_highlighted" placeholder="Choose Warehouses" nolabel="1" invisible="not warehouse_selectable"/>
+                                <field name="warehouse_ids" widget="many2many_tags" class="o_field_highlighted" placeholder="All Warehouses" nolabel="1" invisible="not warehouse_selectable"/>
                             </div>
                         </group>
                     </group>


### PR DESCRIPTION
This commit allows the user to leave `warehouse_ids`
empty on `stock.route` to apply on any warehouse, only
if warehouse_selectable is true.

Previously when `warehouse_ids` were false, the route applied
to no warehouse even though its not intuitive to have
`warehouse_selectable` = True and apply to no warehouse.

Additonally on creating new warehouses, the route will no
longer be automatically added to `stock.route`'s
`warehouse_ids`.

For the warehouse's default route, if more than one
route applies to all warehouses and no route is set on the
product, the route with the lowest sequence will be set as
default. Just like it currently is when a warehouse is set
on 2 different routes,

Task: 5868723




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
