### PR TITLE
[FIX] mrp: update manual consumption when updating MO from BoM

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2668,6 +2668,7 @@ class MrpProduction(models.Model):
                 if move_raw.operation_id != bom_line.operation_id:
                     move_raw.operation_id = bom_line.operation_id
                     move_raw.workorder_id = self.workorder_ids.filtered(lambda wo: wo.operation_id == move_raw.operation_id)
+                move_raw.manual_consumption = move_raw._determine_is_manual_consumption(bom_line)
             elif not bom_line:
                 moves_to_unlink |= move_raw
         # Creates a raw moves for each remaining BoM's lines.

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -2272,12 +2272,25 @@ class TestBoM(TestMrpCommon):
     def test_update_operations(self):
         """Update the operations in BoM which reflects the changes in Manufacturing Order"""
 
+        # consume the first component in the operation
+        self.bom_2.bom_line_ids[0].operation_id = self.bom_2.operation_ids.id
         mo_form = Form(self.env['mrp.production'].with_user(self.user_mrp_user))
         mo_form.product_id = self.product_7_1
         mo_form.product_qty = 1.0
         mo_form.bom_id = self.bom_2
         mo = mo_form.save()
         mo.action_confirm()
+
+        move_consumed_in_op = mo.move_raw_ids.filtered(lambda m: m.bom_line_id == self.bom_2.bom_line_ids[0])
+        self.assertTrue(move_consumed_in_op.manual_consumption)
+        self.bom_2.write({
+            'bom_line_ids': [
+                Command.update(self.bom_2.bom_line_ids[0].id, {'operation_id': self.env['mrp.routing.workcenter'].id}),
+            ]
+        })
+        self.assertTrue(mo.is_outdated_bom)
+        mo.action_update_bom()
+        self.assertFalse(move_consumed_in_op.manual_consumption)
 
         self.bom_2.operation_ids.write({
             'name': 'Painting',


### PR DESCRIPTION
Steps to reproduce the issue:
- Create a storable product P1 with the following BoM:
    - A component consumed in an operation.

- Create a MO to produce one unit of P1 and confirm it.
- Modify the BoM so that the component is no longer consumed in the operation.
- Update the BoM on the MO.
- Start and finish the operation.

Problem:
The MO cannot be closed because the component is not consumed.

The `manual_consumption` field on the stock move is set to True when the move is linked to a BoM line consumed in an operation. However, when the BoM is modified so that the component is no longer consumed in the operation, this field should be updated to False when the MO is updated from the BoM.

https://github.com/odoo/odoo/blob/1305c7262fff762c00159377a9ce1ca09d423625/addons/mrp/models/mrp_production.py#L1193

https://github.com/odoo/odoo/blob/1305c7262fff762c00159377a9ce1ca09d423625/addons/mrp/models/stock_move.py#L611-L612

opw-5993652
