### PR TITLE
[FIX] account_edi_ubl_cii: add fallback for partner info

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -1064,10 +1064,12 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         """ Returns a dict of values that will be used to retrieve the partner """
         return {
             'vat': self._find_value(f'.//cac:{role}Party//cbc:CompanyID[string-length(text()) > 5]', tree),
-            'phone': self._find_value(f'.//cac:{role}Party//cac:Contact//cbc:Telephone', tree),
-            'email': self._find_value(f'.//cac:{role}Party//cac:Contact//cbc:ElectronicMail', tree),
-            'name': self._find_value(f'.//cac:{role}Party//cbc:RegistrationName', tree) or
-                    self._find_value(f'.//cac:{role}Party//cac:Contact//cbc:Name', tree),
+            'phone': self._find_value(f'.//cac:{role}Party//cac:Contact/cbc:Telephone', tree),
+            'email': self._find_value(f'.//cac:{role}Party//cac:Contact/cbc:ElectronicMail', tree),
+            'name': self._find_value(f'.//cac:{role}Party//cac:PartyTaxScheme/cbc:RegistrationName', tree) or
+                    self._find_value(f'.//cac:{role}Party//cac:PartyLegalEntity/cbc:RegistrationName', tree) or
+                    self._find_value(f'.//cac:{role}Party//cac:PartyName/cbc:Name', tree) or
+                    self._find_value(f'.//cac:{role}Party//cac:Contact/cbc:Name', tree),
             'postal_address': self._get_postal_address(tree, role),
         }
 

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -293,6 +293,40 @@ class TestAccountEdiUblCii(TestUblCiiCommon, HttpCase):
         imported_invoice = self._import_as_attachment_on(attachment=xml_attachment, journal=self.company_data["default_journal_sale"])
         self.assertEqual(imported_invoice.partner_id, self.partner_be)
 
+    def test_import_partner_peppol_fields_2(self):
+        """ Test that UBL files missing the <cac:Contact> wrapper still correctly map partner info """
+        xml_content = '''<?xml version="1.0" encoding="UTF-8"?>
+            <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2 http://docs.oasis-open.org/ubl/os-UBL-2.1/xsd/maindoc/UBL-Invoice-2.1.xsd">
+                <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+                <cbc:CustomizationID>urn:www.cenbii.eu:transaction:biitrns010:ver2.0:extended:urn:www.peppol.eu:bis:peppol4a:ver2.0</cbc:CustomizationID>
+                <cbc:ProfileID>urn:www.cenbii.eu:profile:bii04:ver2.0</cbc:ProfileID>
+                <cbc:ID>INV-1234</cbc:ID>
+                <cbc:IssueDate>2023-01-01</cbc:IssueDate>
+                <cac:AccountingCustomerParty>
+                    <cac:Party>
+                        <cac:PartyName>
+                            <cbc:Name>My Test Partner</cbc:Name>
+                        </cac:PartyName>
+                    </cac:Party>
+                </cac:AccountingCustomerParty>
+                <cac:LegalMonetaryTotal>
+                    <cbc:PayableAmount currencyID="USD">100.00</cbc:PayableAmount>
+                </cac:LegalMonetaryTotal>
+            </Invoice>
+        '''
+
+        xml_attachment = self.env['ir.attachment'].create({
+            'raw': xml_content,
+            'name': 'test_invoice.xml',
+        })
+        partner = self.env['res.partner'].create({
+            'name': "My Test Partner",
+            'email': "test@example.com",
+        })
+        # The partner should be retrieved based on the peppol fields
+        imported_invoice = self._import_as_attachment_on(attachment=xml_attachment, journal=self.company_data["default_journal_sale"])
+        self.assertEqual(imported_invoice.partner_id, partner)
+
     def test_import_partner_postal_address(self):
         " Test importing postal address when creating new partner from UBL xml."
         file_path = "bis3_bill_example.xml"


### PR DESCRIPTION
Currently, invoices created by uploading an e-invoice xml
may not have the partner correctly filled in.

Steps to reproduce:
- Upload a customer invoice XML in format PEPPOL BIS 4a

Issue:
Partner is not set on the newly created record.
On the chatter can be observed the message
"Could not retrieve partner with details: Name: None, Vat: None, Phone: None, Email: None"

Analysis:
After https://github.com/odoo/odoo/commit/b4da4a77da3e0dc18707b935786b1924ca473796
we look for partner information under AccountingSupplierParty/Contact
However older format may still be used to encode partner info under
AccountingSupplierParty/Party

opw-5970610