### PR TITLE
[FIX] pos_restaurant: update order name when changing partner

### DIFF
--- a/addons/pos_restaurant/static/src/app/models/pos_order.js
+++ b/addons/pos_restaurant/static/src/app/models/pos_order.js
@@ -62,21 +62,26 @@ patch(PosOrder.prototype, {
         }
         return super.getName(...arguments);
     },
-    get isDirectSale() {
+    get isDirectSaleCandidate() {
         return Boolean(
             this.config.module_pos_restaurant &&
                 !this.table_id &&
-                !this.floating_order_name &&
-                this.state == "draft" &&
+                this.state === "draft" &&
                 !this.isRefund
         );
+    },
+    get isDirectSale() {
+        return this.isDirectSaleCandidate && !this.floating_order_name;
     },
     get isFilledDirectSale() {
         return this.isDirectSale && !this.isEmpty();
     },
-    setPartner(partner) {
-        if (this.config.module_pos_restaurant && this.isDirectSale) {
-            this.floating_order_name = partner.name;
+    setPartner(newPartner) {
+        const partner = this.getPartner();
+        const isPreviouslyPartnerName = partner && this.floating_order_name === partner.name;
+
+        if (this.isDirectSaleCandidate && (this.isDirectSale || isPreviouslyPartnerName)) {
+            this.floating_order_name = newPartner ? newPartner.name : "";
         }
         return super.setPartner(...arguments);
     },

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -1252,3 +1252,45 @@ registry.category("web_tour.tours").add("test_futur_orders_are_not_cancelled", {
             Dialog.confirm("Cancel Orders", ".btn-secondary"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_floating_order_name_change_partner", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickNewOrder(),
+
+            ProductScreen.selectPreset("Eat in", "Delivery"),
+            ProductScreen.clickCustomer("Abigael"),
+            ProductScreen.customerIsSelected("Abigael"),
+
+            // Check that order name is Abigael in the ticket screen/order list
+            Chrome.clickOrders(),
+            TicketScreen.nthRowContains(1, "Abigael"),
+            Chrome.clickRegister(),
+
+            // Change partner
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Deco Addict"),
+            ProductScreen.customerIsSelected("Deco Addict"),
+
+            // Check that order name updated to Deco Addict
+            Chrome.clickOrders(),
+            TicketScreen.nthRowContains(1, "Deco Addict"),
+            Chrome.clickRegister(),
+
+            // Clear partner
+            ProductScreen.clickPartnerButton(),
+            {
+                content: "click unselect partner",
+                trigger: ".unselect-tag",
+                run: "click",
+            },
+            ProductScreen.customerIsSelected("Customer"),
+
+            // Check that order name is reset (or just not the old partner)
+            Chrome.clickOrders(),
+            TicketScreen.nthRowNotContains(1, "Deco Addict"),
+            Chrome.clickRegister(),
+        ].flat(),
+});

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -931,3 +931,31 @@ class TestFrontend(TestFrontendCommon):
         self.assertEqual(present_order.state, 'cancel')
         self.assertEqual(future_order.state, 'draft')
         self.assertEqual(future_order.session_id.id, False)
+
+    def test_floating_order_name_change_partner(self):
+        # Create partners
+        self.env['res.partner'].create([
+            {'name': 'Abigael', 'street': '123 Fake St'},
+            {'name': 'Deco Addict', 'street': '456 Real St'},
+        ])
+
+        # Create presets
+        self.preset_eat_in = self.env['pos.preset'].create({
+            'name': 'Eat in',
+        })
+        self.preset_delivery = self.env['pos.preset'].create({
+            'name': 'Delivery',
+            'identification': 'address',
+        })
+
+        self.main_pos_config.write({
+            'use_presets': True,
+            'default_preset_id': self.preset_eat_in.id,
+            'available_preset_ids': [(6, 0, [
+                self.preset_eat_in.id,
+                self.preset_delivery.id,
+            ])],
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_floating_order_name_change_partner', login="pos_user")


### PR DESCRIPTION
When a partner is changed on an order that was previously named after another partner (e.g. in a Delivery/Eat In preset scenario), the order name was not updated.
This was because once `floating_order_name` is set, the order is no longer considered a "direct sale", and the logic to update the name from the partner was bypassed.
This commit updates `setPartner` to check if the current name matches the name of the previous partner. If so, it updates the name to the new partner's name.

task-id: 6000287

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
