### PR TITLE
[FIX] sale_stock: prevent unlink of sale order from delivery

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -91,7 +91,12 @@ class StockRule(models.Model):
 class StockPicking(models.Model):
     _inherit = 'stock.picking'
 
-    sale_id = fields.Many2one(related="group_id.sale_id", string="Sales Order", store=True, index='btree_not_null')
+    sale_id = fields.Many2one(compute="_compute_sale_id", comodel_name="sale.order", string="Sales Order", store=True, index='btree_not_null')
+
+    @api.depends('group_id')
+    def _compute_sale_id(self):
+        for picking in self:
+            picking.sale_id = picking.group_id.sale_id if picking.group_id else picking.sale_id
 
     def _auto_init(self):
         """

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -1931,6 +1931,18 @@ class TestSaleStock(TestSaleCommon, ValuationReconciliationTestCommon):
         ship02.button_validate()
         self.assertEqual(so.delivery_status, 'full')
 
+    def test_delivery_removed_lines(self):
+        """
+        Tests if removing all lines in delivery unlinks from sale order it originated from.
+        It shouldn't as user has no way of creating new delivery or relinking
+        """
+        so = self._get_new_sale_order(product=self.product_a)
+        so.action_confirm()
+
+        ship = so.picking_ids
+        ship.move_ids.unlink()
+        self.assertEqual(so, ship.sale_id)
+
     def test_return_from_customer_multi_step(self):
         """
         Check that, when using multi-step routes, returned quantities are counted on


### PR DESCRIPTION
Steps to reproduce:
- Create a new sales quote with >=1 products and confirm it
- Click on the delivery smart button
- Remove all products from the delivery and save
- Navigate back to the sales quote

Current behavior:
- The smart button for the delivery is gone in the sales quote form

Expected behavior:
- The smart button for the delivery should always remain

Note:
There is no way for the user to relink the sales order to the delivery or make a new one, hence the necessity of this

opw-5941496