### PR TITLE
[FIX] project: Enable auto-deletion for task assignment emails

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1558,7 +1558,7 @@ class ProjectTask(models.Model):
                     partner_ids=user.partner_id.ids,
                     email_layout_xmlid='mail.mail_notification_layout',
                     model_description=task_model_description,
-                    mail_auto_delete=False,
+                    mail_auto_delete=True,
                 )
 
     def _message_auto_subscribe_followers(self, updated_values, default_subtype_ids):


### PR DESCRIPTION
Task assignment notification emails (sent via message_notify when a user is assigned to a project task) were configured with mail_auto_delete=False, causing them to accumulate in the mail.mail table indefinitely. These are transient notifications that don't need to be retained after sending.
