### PR TITLE
[FIX] point_of_sale: avoid cash rounding on non-cash consolidation

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -791,7 +791,7 @@ class PosOrder(models.Model):
         amount_total = sum(order.amount_total for order in self)
         payment_total = sum(order.amount_paid for order in self)
 
-        if self.config_id.cash_rounding:
+        if self.config_id.cash_rounding and invoice.invoice_cash_rounding_id:
             line_ids_commands = []
             rate = invoice.invoice_currency_rate
             sign = invoice.direction_sign

--- a/addons/point_of_sale/tests/test_pos_invoice_consolidation.py
+++ b/addons/point_of_sale/tests/test_pos_invoice_consolidation.py
@@ -105,3 +105,40 @@ class TestPosInvoiceConsolidation(TestPoSCommon, CommonPosTest):
 
         self.assertEqual(len(invoice_user2), 1, "User 2 should have one invoice")
         self.assertEqual(sum(orders_user2.mapped('amount_total')), invoice_user2.amount_total)
+
+    def test_consolidation_non_cash_with_cash_rounding_enabled(self):
+        """Cash rounding enabled, consolidate +/- orders paid non-cash; force delta; no crash."""
+        self.open_new_session()
+
+        income_acc = self.env['account.account'].search([('account_type', '=', 'income')], limit=1)
+        expense_acc = self.env['account.account'].search([('account_type', '=', 'expense')], limit=1)
+
+        rounding = self.env['account.cash.rounding'].create({
+            'name': 'Rounding 0.05',
+            'rounding': 0.05,
+            'strategy': 'add_invoice_line',
+            'profit_account_id': income_acc.id,
+            'loss_account_id': expense_acc.id,
+        })
+
+        self.config.write({
+            'cash_rounding': True,
+            'only_round_cash_method': True,
+            'rounding_method': rounding.id,
+        })
+
+        non_cash_pm = self.config.payment_method_ids.filtered(lambda pm: not pm.is_cash_count)[:1]
+        self.assertTrue(non_cash_pm, "Need at least one non-cash payment method on the POS config.")
+
+        with self.with_user(self.user1.login):
+            orders = self._create_orders([
+                {'pos_order_lines_ui_args': [(self.product1, 1)], 'customer': self.customer, 'is_invoiced': False},
+                {'pos_order_lines_ui_args': [(self.product1, -1)], 'customer': self.customer, 'is_invoiced': False},
+            ])
+            orders = sum(orders.values(), self.env['pos.order'])
+
+        orders.payment_ids.write({'payment_method_id': non_cash_pm.id})
+        orders.payment_ids[:1].write({'amount': orders.payment_ids[:1].amount + 1})
+
+        self.env['pos.make.invoice'].create({'consolidated_billing': True}).with_context(active_ids=orders.ids).action_create_invoices()
+        self.assertEqual(len(orders.account_move), 1)


### PR DESCRIPTION
When consolidating POS orders into a single invoice, the cash rounding adjustment logic was triggered whenever cash rounding was enabled on the POS configuration, even if the payment methods were not cash.

In scenarios where only non-cash payment methods (card or customer account) were used, 'invoice.invoice_cash_rounding_id' could legitimately be unset as 'only_round_cash_method' is enabled. However, the rounding adjustment code still attempted to create a rounding line using accounts from this field.

This resulted in a NULL `account_id` on a rounding line ("Missing required account on accountable line")

This fix ensures that the rounding adjustment logic only executes when there is cash payment (meaning that 'invoice_cash_rounding_id' exsists).

Related to opw-5969706