### PR TITLE
[FIX] mail: show company name for nameless partners in notifications

### DIFF
--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -241,7 +241,7 @@ class Partner(models.Model):
             if "country" in fields:
                 c = partner.country_id
                 data["country"] = {"code": c.code, "id": c.id, "name": c.name} if c else False
-            if "display_name" in fields:
+            if "display_name" in fields or ("name" in fields and not data.get("name")):
                 data["displayName"] = partner.display_name
             if 'user' in fields:
                 main_user = main_user_by_partner and main_user_by_partner.get(partner)

--- a/addons/mail/static/src/core/common/message_notification_popover.xml
+++ b/addons/mail/static/src/core/common/message_notification_popover.xml
@@ -5,7 +5,7 @@
         <div class="o-mail-MessageNotificationPopover m-2">
             <div t-foreach="props.message.notifications" t-as="notification" t-key="notification.id">
                 <i class="me-2" t-att-class="notification.statusIcon" t-att-title="notification.statusTitle" role="img"/>
-                <span t-if="notification.persona" t-esc="notification.persona.name"/>
+                <span t-if="notification.persona" t-esc="notification.persona.name or notification.persona.displayName"/>
             </div>
         </div>
     </t>

--- a/doc/cla/individual/trisdoan.md
+++ b/doc/cla/individual/trisdoan.md
@@ -1,0 +1,11 @@
+Vietnam, 2026-03-04
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Doan Minh Tri doanminhtri8183@gmail.com https://github.com/trisdoan


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Partners used as billing/delivery addresses may have no name set. In the message notification popover, their persona name was rendered directly, producing "false" instead of a meaningful label.

Steps to reproduce:
  1. Create a company contact (e.g. "Acme Corp")
  2. Add a billing address with no name, with an email address
  3. Create a Sale Order with this billing address as customer
  4. Send the quotation by email from the chatter
  5. Click the envelope icon on the sent message



Current behavior before PR:
- The notification popover shows "false" as the recipient name

Desired behavior after PR is merged:
- The recipient's company name (or display_name) is shown instead




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
