### PR TITLE
[FIX] l10n_vn_edi_viettel: fix line type handling

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -3687,3 +3687,7 @@ class AccountMoveLine(models.Model):
         This method is overridden in the sale order module.
         '''
         return self.env['account.move.line']
+
+    def _get_discount_lines(self):
+        ''' Return the discount move lines associated with the move line.'''
+        return self.filtered(lambda line: line.display_type == 'discount')

--- a/addons/l10n_vn/models/template_vn.py
+++ b/addons/l10n_vn/models/template_vn.py
@@ -37,7 +37,7 @@ class AccountChartTemplate(models.AbstractModel):
                 'transfer_account_id': 'chart1131',
                 'deferred_expense_account_id': 'chart2421',
                 'deferred_revenue_account_id': 'chart33871',
-                'account_production_wip_account_id': 'chart154',
+                'account_production_wip_account_id': 'chart1541',
                 'default_cash_difference_income_account_id': 'chart711',
                 'default_cash_difference_expense_account_id': 'chart811',
                 'account_journal_suspense_account_id': 'chart1121',

--- a/addons/l10n_vn_edi_viettel/models/account_move.py
+++ b/addons/l10n_vn_edi_viettel/models/account_move.py
@@ -692,7 +692,9 @@ class AccountMove(models.Model):
             'line_note': 2,
             'discount': 3,
         }
-        for line in self.invoice_line_ids.filtered(lambda ln: ln.display_type == 'product'):
+        discount_lines = self.invoice_line_ids._get_discount_lines()
+        downpayment_lines = self.invoice_line_ids._get_downpayment_lines()
+        for line in self.invoice_line_ids.filtered(lambda ln: ln.display_type in code_map):
             # For credit notes amount, we send negative values (reduces the amount of the original invoice)
             sign = 1 if self.move_type == 'out_invoice' else -1
             item_name = line.name.replace('\n', ' ')
@@ -712,16 +714,28 @@ class AccountMove(models.Model):
                 'discount': line.discount,
                 'itemTotalAmountAfterDiscount': line.price_subtotal,
                 'itemTotalAmountWithTax': line.price_total,
+                'selection': code_map[line.display_type],
             }
-            if line.display_type in code_map:
-                item_information['selection'] = code_map[line.display_type]
-            if line.display_type == 'discount':
-                item_information['isIncreaseItem'] = False
+            if (
+                line in discount_lines
+                or line in downpayment_lines  # Downpayment lines are considered the same as discount lines
+            ):
+                item_information.update({
+                    'selection': code_map['discount'],
+                    'isIncreaseItem': False,
+                    'unitPrice': abs(item_information['unitPrice']),
+                    'quantity': abs(item_information['quantity']),
+                    'itemTotalAmountWithoutTax': abs(item_information['itemTotalAmountWithoutTax']),
+                    'itemTotalAmountAfterDiscount': abs(item_information['itemTotalAmountAfterDiscount']),
+                    'itemTotalAmountWithTax': abs(item_information['itemTotalAmountWithTax']),
+                })
             if self.move_type == 'out_refund':
                 item_information.update({
                     'adjustmentTaxAmount': item_information['taxAmount'],
                     'isIncreaseItem': False,
                 })
+            if line.display_type == 'line_note':
+                item_information = {'selection': item_information['selection'], 'itemName': item_information['itemName']}
             items_information.append(item_information)
 
         json_values['itemInfo'] = items_information

--- a/addons/l10n_vn_edi_viettel/tests/test_edi.py
+++ b/addons/l10n_vn_edi_viettel/tests/test_edi.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from freezegun import freeze_time
 
-from odoo import fields
+from odoo import Command, fields
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import tagged
 
@@ -453,6 +453,226 @@ class TestVNEDI(AccountTestInvoicingCommon):
              patch('odoo.addons.l10n_vn_edi_viettel.models.account_move.AccountMove._l10n_vn_edi_fetch_invoice_xml_file_data', return_value=xml_response), \
              patch('odoo.addons.l10n_vn_edi_viettel.models.account_move._l10n_vn_edi_send_request', return_value=(request_response, None)):
             self.env['account.move.send.wizard'].with_context(active_model=invoice._name, active_ids=invoice.ids).create({}).action_send_and_print()
+
+    @freeze_time('2024-01-01')
+    def test_line_note_in_json(self):
+        """
+        Test that a line_note display_type line generates a stripped-down itemInfo entry
+        containing only 'selection' (=2) and 'itemName', with no price/quantity fields.
+        """
+        invoice = self.init_invoice(
+            move_type='out_invoice',
+            products=self.product_a,
+            taxes=self.tax_sale_a,
+            post=False,
+        )
+        invoice.write({
+            'invoice_line_ids': [Command.create({
+                'display_type': 'line_note',
+                'name': 'This is a note line',
+            })]
+        })
+        invoice.action_post()
+        json_data = invoice._l10n_vn_edi_generate_invoice_json()
+
+        note_items = [item for item in json_data['itemInfo'] if item.get('selection') == 2]
+        self.assertEqual(len(note_items), 1, "Expected exactly one note line in itemInfo.")
+        note_item = note_items[0]
+        # Should only have 'selection' and 'itemName' — all price/quantity fields must be stripped
+        self.assertEqual(set(note_item.keys()), {'selection', 'itemName'})
+        self.assertEqual(note_item['itemName'], 'This is a note line')
+
+    @freeze_time('2024-01-01')
+    def test_sale_discount_product_in_json(self):
+        """
+        When a line's product matches the company's sale_discount_product_id, it should be
+        treated as a discount line: selection=3, isIncreaseItem=False, all amounts absolute.
+        Requires the 'sale' module to be installed.
+        """
+        self.ensure_installed('sale')
+        discount_product = self.env['product.product'].create({
+            'name': 'Test Discount Product',
+            'type': 'service',
+        })
+        self.env.company.sale_discount_product_id = discount_product
+
+        invoice = self.init_invoice(
+            move_type='out_invoice',
+            products=self.product_a,
+            taxes=self.tax_sale_a,
+            post=False,
+        )
+        invoice.write({
+            'invoice_line_ids': [Command.create({
+                'product_id': discount_product.id,
+                'name': 'Discount',
+                'price_unit': -200.0,
+                'quantity': 1.0,
+                'tax_ids': [],
+            })]
+        })
+        invoice.action_post()
+        json_data = invoice._l10n_vn_edi_generate_invoice_json()
+
+        discount_items = [item for item in json_data['itemInfo'] if item.get('selection') == 3]
+        self.assertEqual(len(discount_items), 1, "Expected exactly one discount item in itemInfo.")
+        discount_item = discount_items[0]
+        self.assertFalse(discount_item['isIncreaseItem'])
+        self.assertGreaterEqual(discount_item['unitPrice'], 0, "unitPrice must be non-negative (abs value).")
+        self.assertGreaterEqual(discount_item['quantity'], 0, "quantity must be non-negative (abs value).")
+        self.assertGreaterEqual(discount_item['itemTotalAmountWithoutTax'], 0)
+        self.assertGreaterEqual(discount_item['itemTotalAmountAfterDiscount'], 0)
+        self.assertGreaterEqual(discount_item['itemTotalAmountWithTax'], 0)
+
+    @freeze_time('2024-01-01')
+    def test_pos_discount_product_in_json(self):
+        """
+        When a line's product matches the POS config's discount_product_id, it should be
+        treated as a discount line: selection=3, isIncreaseItem=False, all amounts absolute.
+        Requires the 'point_of_sale' module to be installed.
+        """
+        self.ensure_installed('pos_discount')
+        discount_product = self.env['product.product'].create({
+            'name': 'POS Discount Product',
+            'type': 'service',
+        })
+        pos_config = self.env['pos.config'].create({
+            'name': 'Test POS',
+            'discount_product_id': discount_product.id,
+        })
+
+        invoice = self.init_invoice(
+            move_type='out_invoice',
+            products=self.product_a,
+            taxes=self.tax_sale_a,
+            post=False,
+        )
+        invoice.write({
+            'invoice_line_ids': [Command.create({
+                'product_id': discount_product.id,
+                'name': 'POS Discount',
+                'price_unit': -100.0,
+                'quantity': 1.0,
+                'tax_ids': [],
+            })]
+        })
+        pos_session = self.env['pos.session'].create({'config_id': pos_config.id})
+        self.env['pos.order'].create({
+            'session_id': pos_session.id,
+            'account_move': invoice.id,
+            'lines': [],
+            'amount_tax': 0,
+            'amount_total': 0,
+            'amount_paid': 0,
+            'amount_return': 0,
+        })
+        invoice.action_post()
+        json_data = invoice._l10n_vn_edi_generate_invoice_json()
+
+        discount_items = [item for item in json_data['itemInfo'] if item.get('selection') == 3]
+        self.assertEqual(len(discount_items), 1, "Expected exactly one POS discount item in itemInfo.")
+        discount_item = discount_items[0]
+        self.assertFalse(discount_item['isIncreaseItem'])
+        self.assertGreaterEqual(discount_item['unitPrice'], 0, "unitPrice must be non-negative (abs value).")
+        self.assertGreaterEqual(discount_item['quantity'], 0, "quantity must be non-negative (abs value).")
+        self.assertGreaterEqual(discount_item['itemTotalAmountWithoutTax'], 0)
+        self.assertGreaterEqual(discount_item['itemTotalAmountAfterDiscount'], 0)
+        self.assertGreaterEqual(discount_item['itemTotalAmountWithTax'], 0)
+
+    @freeze_time('2024-01-01')
+    def test_downpayment_line_in_json(self):
+        """
+        A downpayment line (is_downpayment=True) should be treated as a discount line:
+        selection=3, isIncreaseItem=False, all amounts absolute.
+        Requires the 'sale' module to be installed.
+        """
+        self.ensure_installed('sale')
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'product_id': self.product_a.id,
+                'product_uom_qty': 1,
+                'price_unit': 1000.0,
+            })],
+        })
+        sale_order.action_confirm()
+
+        downpayment_wizard = self.env['sale.advance.payment.inv'].with_context(
+            active_ids=sale_order.ids,
+            active_model='sale.order',
+        ).create({
+            'advance_payment_method': 'fixed',
+            'fixed_amount': 150.0,
+        })
+        downpayment_wizard.create_invoices()
+
+        invoice = sale_order.invoice_ids
+        self.assertEqual(len(invoice), 1)
+        invoice.action_post()
+        json_data = invoice._l10n_vn_edi_generate_invoice_json()
+
+        downpayment_items = [item for item in json_data['itemInfo'] if item.get('selection') == 3]
+        self.assertEqual(len(downpayment_items), 1, "Expected exactly one downpayment item treated as discount.")
+        dp_item = downpayment_items[0]
+        self.assertFalse(dp_item['isIncreaseItem'])
+        self.assertGreaterEqual(dp_item['unitPrice'], 0, "unitPrice must be non-negative (abs value).")
+        self.assertGreaterEqual(dp_item['quantity'], 0, "quantity must be non-negative (abs value).")
+        self.assertGreaterEqual(dp_item['itemTotalAmountWithoutTax'], 0)
+        self.assertGreaterEqual(dp_item['itemTotalAmountAfterDiscount'], 0)
+        self.assertGreaterEqual(dp_item['itemTotalAmountWithTax'], 0)
+
+    @freeze_time('2024-01-01')
+    def test_loyalty_discount_in_json(self):
+        """
+        When a loyalty program applies a discount reward to a sale order, the
+        reward line on the invoice should be treated as a discount line:
+        selection=3, isIncreaseItem=False, all amounts absolute.
+        Requires the 'sale_loyalty' module.
+        """
+        self.ensure_installed('sale_loyalty')
+        program = self.env['loyalty.program'].create({
+            'name': '10% Discount',
+            'program_type': 'coupons',
+            'applies_on': 'current',
+            'trigger': 'auto',
+            'rule_ids': [Command.create({})],
+            'reward_ids': [Command.create({
+                'reward_type': 'discount',
+                'discount': 10,
+                'discount_mode': 'percent',
+                'discount_applicability': 'order',
+            })],
+        })
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'product_id': self.product_a.id,
+                'product_uom_qty': 1,
+                'price_unit': 1000.0,
+                'tax_id': [Command.set(self.tax_sale_a.ids)],
+            })],
+        })
+
+        sale_order._update_programs_and_rewards()
+        coupon = sale_order.coupon_point_ids.coupon_id
+        sale_order._apply_program_reward(program.reward_ids, coupon)
+
+        sale_order.action_confirm()
+        invoice = sale_order._create_invoices()
+        invoice.action_post()
+
+        json_data = invoice._l10n_vn_edi_generate_invoice_json()
+
+        discount_items = [item for item in json_data['itemInfo'] if item.get('selection') == 3]
+        self.assertEqual(len(discount_items), 1, "Expected exactly one loyalty discount item in itemInfo.")
+        discount_item = discount_items[0]
+        self.assertFalse(discount_item['isIncreaseItem'])
+        self.assertGreaterEqual(discount_item['unitPrice'], 0, "unitPrice must be non-negative (abs value).")
+        self.assertGreaterEqual(discount_item['quantity'], 0, "quantity must be non-negative (abs value).")
+        self.assertGreaterEqual(discount_item['itemTotalAmountWithoutTax'], 0)
+        self.assertGreaterEqual(discount_item['itemTotalAmountAfterDiscount'], 0)
+        self.assertGreaterEqual(discount_item['itemTotalAmountWithTax'], 0)
 
     @freeze_time('2024-01-01')
     def test_decimal_rounding(self):

--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -118,3 +118,14 @@ class AccountMoveLine(models.Model):
     def _compute_name(self):
         amls = self.filtered(lambda l: not l.move_id.pos_session_ids)
         super(AccountMoveLine, amls)._compute_name()
+
+    def _get_discount_lines(self):
+        lines = super()._get_discount_lines()
+        discount_line_ids = []
+        for line in self - lines:
+            pos_orders = line.move_id.sudo().pos_order_ids
+            if pos_orders and line.product_id in pos_orders.config_id.discount_product_id:
+                discount_line_ids.append(line.id)
+        if discount_line_ids:
+            lines |= self.browse(discount_line_ids)
+        return lines

--- a/addons/pos_loyalty/models/__init__.py
+++ b/addons/pos_loyalty/models/__init__.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import account_move_line
 from . import barcode_rule
 from . import loyalty_card
 from . import loyalty_mail

--- a/addons/pos_loyalty/models/account_move_line.py
+++ b/addons/pos_loyalty/models/account_move_line.py
@@ -1,0 +1,23 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = 'account.move.line'
+
+    def _get_discount_lines(self):
+        lines = super()._get_discount_lines()
+        discount_line_ids = []
+        for line in self - lines:
+            pos_orders = line.move_id.sudo().pos_order_ids
+            if not pos_orders:
+                continue
+            reward_discount_products = pos_orders.lines.filtered(
+                lambda pol: pol.is_reward_line and pol.reward_id.reward_type == 'discount'
+            ).product_id
+            if line.product_id in reward_discount_products:
+                discount_line_ids.append(line.id)
+        if discount_line_ids:
+            lines |= self.browse(discount_line_ids)
+        return lines

--- a/addons/sale/models/account_move_line.py
+++ b/addons/sale/models/account_move_line.py
@@ -213,3 +213,14 @@ class AccountMoveLine(models.Model):
     def _get_downpayment_lines(self):
         # OVERRIDE
         return self.sale_line_ids.filtered('is_downpayment').invoice_lines.filtered(lambda line: line.move_id._is_downpayment())
+
+    def _get_discount_lines(self):
+        lines = super()._get_discount_lines()
+        discount_line_ids = []
+        for company, company_lines in self.grouped('company_id').items():
+            discount_product = company.sudo().sale_discount_product_id
+            if discount_product:
+                discount_line_ids.extend(company_lines.filtered(lambda line: line.product_id == discount_product).ids)
+        if discount_line_ids:
+            lines |= self.browse(discount_line_ids)
+        return lines

--- a/addons/sale_loyalty/models/__init__.py
+++ b/addons/sale_loyalty/models/__init__.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import account_move_line
 from . import loyalty_card
 from . import loyalty_history
 from . import loyalty_program

--- a/addons/sale_loyalty/models/account_move_line.py
+++ b/addons/sale_loyalty/models/account_move_line.py
@@ -1,0 +1,14 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = 'account.move.line'
+
+    def _get_discount_lines(self):
+        lines = super()._get_discount_lines()
+        lines |= self.filtered(lambda line: any(
+            sl._is_discount_line() for sl in line.sale_line_ids
+        ))
+        return lines


### PR DESCRIPTION
Previously, the invoice logic did not properly handle the following scenarios:

- Global discount: when a global discount was applied, negative values were sent to Sinvoice, resulting in a BAD_REQUEST_ITEM_VALUES_NEGATIVE error.
- Down payment: when an invoice included a down payment to deduct the amount, negative values were sent to Sinvoice, triggering the same BAD_REQUEST_ITEM_VALUES_NEGATIVE error.
- Note lines: note lines on the invoice were not being uploaded/included in the invoice submission.

This commit fixes the handling of global discounts and down payments by ensuring negative values are properly transformed before being sent to Sinvoice, and adds support for uploading note lines in the invoice.

task-5875158