### PR TITLE
[FIX] l10n_my_edi: correct prepaid and payable amounts for specific document types

### DIFF
--- a/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
+++ b/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
@@ -138,6 +138,14 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
         ]
         vals['vals']['accounting_customer_party_vals']['party_vals']['party_identification_vals'] = customer_identification_vals
 
+        vals['vals'].update({
+            'prepaid_payment_vals': {
+                'currency': invoice.currency_id,
+                'currency_dp': self._get_currency_decimal_places(invoice.currency_id),
+                'amount': invoice.amount_total - invoice.amount_residual,
+            },
+        })
+
         # Debit/Credit note original invoice ref.
         # Applies to credit notes, debit notes, refunds for both invoices and self-billed invoices.
         # The original document is mandatory; but in some specific cases it will be empty (sending a credit note for an invoice
@@ -160,13 +168,11 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
                 },
             })
 
-        vals['vals'].update({
-            'prepaid_payment_vals': {
-                'currency': invoice.currency_id,
-                'currency_dp': self._get_currency_decimal_places(invoice.currency_id),
-                'amount': invoice.amount_total - invoice.amount_residual,
-            },
-        })
+            # For credit, debit, refund notes, and their self-billed variants,
+            # the PrepaidPayment amount must be set to 0. This ensures the PayableAmount reflects the full refund/adjustment
+            # amount without being reduced by the prepayment, as per MyInvois specifications.
+            vals['vals'].get('monetary_total_vals', {})['payable_amount'] = invoice.amount_total
+            vals['vals']['prepaid_payment_vals']['amount'] = 0
 
         return vals
 

--- a/addons/l10n_my_edi/tests/test_file_generation.py
+++ b/addons/l10n_my_edi/tests/test_file_generation.py
@@ -452,6 +452,40 @@ class L10nMyEDITestFileGeneration(AccountTestInvoicingCommon):
             'Initial Reference',
         )
 
+    def test_12_prepaid_amount_on_debit_credit_refund_notes(self):
+        """
+        Ensure that the prepaid amount is 0 and payable_amount is invoice.amount_total
+        """
+        basic_invoice = self.init_invoice('out_invoice', currency=self.currency_data['currency'], amounts=[2000],
+                                          post=True)
+
+        action = basic_invoice.action_reverse()
+        reversal_wizard = self.env[action['res_model']].with_context(
+            active_ids=basic_invoice.ids,
+            active_model='account.move',
+            default_journal_id=basic_invoice.journal_id.id,
+        ).create({})
+        action = reversal_wizard.reverse_moves()
+        credit_note = self.env['account.move'].browse(action['res_id'])
+        credit_note.action_post()
+
+        file, _errors = credit_note._l10n_my_edi_generate_invoice_xml()
+        root = etree.fromstring(file)
+
+        # Check that the prepaid amount is 0
+        self._assert_node_values(
+            root,
+            'cac:PrepaidPayment/cbc:PaidAmount',
+            '0.000',
+        )
+
+        # Check that the payable amount is the total amount of the invoice
+        self._assert_node_values(
+            root,
+            'cac:LegalMonetaryTotal/cbc:PayableAmount',
+            '2000.000',
+        )
+
     def _assert_node_values(self, root, node_path, text, attributes=None):
         node = root.xpath(node_path, namespaces=NS_MAP)
 


### PR DESCRIPTION
Currently, the `prepaid_amount` in the UBL export is calculated as `amount_total - amount_residual` for all document types. However, for credit notes, debit notes, and refund notes (both standard and self-billed, corresponding to document type codes 02, 03, 04, 12, 13, and 14), this amount should be 0 to comply with Malaysian e-Invoicing (MyInvois) API requirements.

This commit introduces the following fixes:
- Sets the `prepaid_amount` to 0 for document types '02', '03', '04', '12', '13', and '14'.
- Update the `payable_amount` to the full `invoice.amount_total`.

Task-5971843

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
