### PR TITLE
[FIX] html_editor: fix unexpected selection move when pressing space in Safari

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -1,5 +1,5 @@
 import { Plugin } from "@html_editor/plugin";
-import { cleanTrailingBR, unwrapContents } from "@html_editor/utils/dom";
+import { cleanTrailingBR, mergeAdjacentTextNodes, unwrapContents } from "@html_editor/utils/dom";
 import {
     childNodes,
     closestElement,
@@ -903,7 +903,9 @@ export class LinkPlugin extends Plugin {
             selection.anchorNode.nodeType === Node.TEXT_NODE
         ) {
             // Merge adjacent text nodes.
-            selection.anchorNode.parentNode.normalize();
+            const cursor = this.dependencies.selection.preserveSelection();
+            mergeAdjacentTextNodes(selection.anchorNode.parentNode, cursor);
+            cursor.restore();
             selection = this.dependencies.selection.getEditableSelection();
             const textSliced = selection.anchorNode.textContent.slice(0, selection.anchorOffset);
             const textNodeSplitted = textSliced.split(/\s/);

--- a/addons/html_editor/static/src/utils/dom.js
+++ b/addons/html_editor/static/src/utils/dom.js
@@ -1,5 +1,12 @@
 import { closestBlock, isBlock } from "./blocks";
-import { isEmptyTextNode, isParagraphRelatedElement, isShrunkBlock, isVisible } from "./dom_info";
+import {
+    isElement,
+    isEmptyTextNode,
+    isParagraphRelatedElement,
+    isShrunkBlock,
+    isTextNode,
+    isVisible,
+} from "./dom_info";
 import { callbacksForCursorUpdate } from "./selection";
 import { isEmptyBlock, isPhrasingContent } from "../utils/dom_info";
 import { childNodes } from "./dom_traversal";
@@ -323,4 +330,37 @@ export function splitTextNode(textNode, offset, originalNodeSide = DIRECTIONS.RI
         }
     }
     return parentOffset;
+}
+
+/**
+ * This is used as a replacement for `node.normalize()` which in Safari
+ * incorrectly moves the selection to the parent element instead of
+ * restoring it to the correct offset in the merged text node.
+ *
+ * @param {HTMLElement} node
+ * @param {Cursors} cursor
+ */
+export function mergeAdjacentTextNodes(node, cursor) {
+    let child = node.firstChild;
+    while (child) {
+        if (isElement(child)) {
+            mergeAdjacentTextNodes(child, cursor);
+        }
+
+        const next = child.nextSibling;
+        if (isTextNode(child) && next && isTextNode(next)) {
+            if (cursor.anchor.node === next) {
+                cursor.anchor.node = child;
+                cursor.anchor.offset = child.textContent.length + cursor.anchor.offset;
+            }
+            if (cursor.focus.node === next) {
+                cursor.focus.node = child;
+                cursor.focus.offset = child.textContent.length + cursor.focus.offset;
+            }
+            child.textContent += next.textContent;
+            next.remove();
+        } else {
+            child = next;
+        }
+    }
 }


### PR DESCRIPTION
Problem:
In Safari, pressing space sometimes can move the selection unexpectedly.

Cause:
`node.normalize()` in Safari doesn't work in the same way as in Chrome or Firefox.
When the selection is on a text node adjacent to another and we normalize, the two text nodes will be merged but the selection will move to the parent element instead of the correct position inside the new merged text node.

Example:
before normalize: `<span>"ab""c[]d"</span>`
after normalize:  `<span>"ab[]cd"</span>` (expected) vs `<span[]>"abcd"</span>` (Safari)

Solution:
Instead of using `normalize`, we manually merge adjacent text nodes and properly restore the selection by computing the absolute offset before the merge and restoring it to the correct position in the merged text node.

Steps to reproduce:
- Have two adjacent text nodes inside a `span`.
- Put the selection on the second text node in the middle.
- Press space.
- The selection will move to the end of the text.

opw-5956709

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
