### PR TITLE
[FIX] spreadsheet_account: handle absence of fiscal year

### DIFF
--- a/addons/spreadsheet_account/static/src/fiscal_year_global_filter.js
+++ b/addons/spreadsheet_account/static/src/fiscal_year_global_filter.js
@@ -8,7 +8,8 @@ globalFilterDateRegistry
         canOnlyBeDefault: true,
         getDefaultValue: (now) => ({ type: "fiscal_year", offset: 0 }),
         category: "fiscal_year",
-        shouldBeHidden: (getters) => isFiscalYearSameAsStandardYear(getters),
+        shouldBeHidden: (getters) =>
+            !isFiscalYearAvailable(getters) || isFiscalYearSameAsStandardYear(getters),
     })
     .add("fiscal_year", {
         sequence: 156,
@@ -30,8 +31,15 @@ globalFilterDateRegistry
         isFixedPeriod: true,
         getCurrentFixedPeriod: (now) => ({ type: "fiscal_year", offset: 0 }),
         category: "fiscal_year",
-        shouldBeHidden: (getters) => isFiscalYearSameAsStandardYear(getters),
+        shouldBeHidden: (getters) =>
+            !isFiscalYearAvailable(getters) || isFiscalYearSameAsStandardYear(getters),
     });
+
+function isFiscalYearAvailable(getters) {
+    const fiscalYearStart = getters.getCurrentFiscalYearStart();
+    const fiscalYearEnd = getters.getCurrentFiscalYearEnd();
+    return fiscalYearStart && fiscalYearEnd;
+}
 
 function getFiscalYearFromTo(offset, getters) {
     const currentFiscalYearStart = getters.getCurrentFiscalYearStart();


### PR DESCRIPTION
Steps to reproduce:
- Install Spreadsheet and Accounting
- If `spreadsheet_edition_account` is installed, uninstall it
- Go to Spreadsheets, create a new one and add a "Date" global filter => Traceback

This commit fixes the issue by handling the case where no fiscal year is not installed.

Task: 6002612
