### PR TITLE
[FIX] l10n_tw_edi_ecpay_*: check fiscal country instead of company country

### DIFF
--- a/addons/l10n_tw_edi_ecpay/models/account_move_send.py
+++ b/addons/l10n_tw_edi_ecpay/models/account_move_send.py
@@ -14,7 +14,7 @@ class AccountMoveSend(models.AbstractModel):
         return (move.move_type == 'out_invoice'
                 and ('debit_origin_id' not in self.env['account.move']._fields or not move.debit_origin_id)
                 and move.state == 'posted'
-                and move.company_id.country_id.code == 'TW'
+                and move.company_id.account_fiscal_country_id.code == 'TW'
                 and not move.l10n_tw_edi_state
                 and move.company_id._is_ecpay_enabled())
 
@@ -22,7 +22,7 @@ class AccountMoveSend(models.AbstractModel):
     def _is_tw_edi_issue_allowance_applicable(self, move):
         return (move.move_type == 'out_refund'
                 and move.state == 'posted'
-                and move.company_id.country_id.code == 'TW'
+                and move.company_id.account_fiscal_country_id.code == 'TW'
                 and move.reversed_entry_id
                 and move.reversed_entry_id.l10n_tw_edi_ecpay_invoice_id
                 and not move.l10n_tw_edi_refund_invoice_number

--- a/addons/l10n_tw_edi_ecpay_website_sale/controllers/main.py
+++ b/addons/l10n_tw_edi_ecpay_website_sale/controllers/main.py
@@ -151,7 +151,7 @@ class WebsiteSaleL10nTW(WebsiteSale):
             address_values, partner_sudo, address_type, *args, **kwargs
         )
 
-        if address_type == 'billing' and request.website.company_id.country_id.code == 'TW' and request.website.company_id._is_ecpay_enabled():
+        if address_type == 'billing' and request.website.company_id.account_fiscal_country_id.code == 'TW' and request.website.company_id._is_ecpay_enabled():
             phone = address_values.get('phone')
             if phone:
                 formatted_phone = request.env['account.move']._reformat_phone_number(phone)
@@ -169,7 +169,7 @@ class WebsiteSaleL10nTW(WebsiteSale):
     def _handle_extra_form_data(self, extra_form_data, address_values):
         super()._handle_extra_form_data(extra_form_data, address_values)
 
-        if request.website.company_id.country_id.code == 'TW' and request.website.company_id._is_ecpay_enabled():
+        if request.website.company_id.account_fiscal_country_id.code == 'TW' and request.website.company_id._is_ecpay_enabled():
             order = request.website.sale_get_order()
             if address_values.get('company_name'):
                 l10n_tw_edi_is_print = True

--- a/addons/l10n_tw_edi_ecpay_website_sale/models/sale_order.py
+++ b/addons/l10n_tw_edi_ecpay_website_sale/models/sale_order.py
@@ -23,7 +23,7 @@ class SaleOrder(models.Model):
 
     def _prepare_invoice(self):
         res = super()._prepare_invoice()
-        if self.company_id.country_id.code == 'TW' and self.company_id._is_ecpay_enabled():
+        if self.company_id.account_fiscal_country_id.code == 'TW' and self.company_id._is_ecpay_enabled():
             res.update(
                 {
                     "l10n_tw_edi_is_print": self.l10n_tw_edi_is_print,


### PR DESCRIPTION
Previously, the module checked `company_id.country_id.code == 'TW'` to determine if Taiwan's ECPay logic should be applied. However, `country_id` only represents the physical address of the company.

This commit replaces `country_id` with `account_fiscal_country_id` across the sale order model and website controllers. This ensures that the ECPay integration correctly triggers for any company using the Taiwan fiscal localization.

Task-6002433

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
