### PR TITLE
[FIX] web: restore favorite star heading size in oe_title

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -346,7 +346,7 @@
                 height: max-content;
             }
         }
-        .o_priority > .o_priority_star, .o_favorite i.fa {
+        .o_priority > .o_priority_star, .o_favorite .btn, .o_favorite i.fa {
             font-size: inherit;
         }
         > h1 {


### PR DESCRIPTION
Steps to reproduce:

Open a form with a favorite star in .oe_title (e.g. Product form). The star icon appears at body size (1rem) instead of matching the heading font size.

The <a> -> <button class="btn btn-link btn-link-inline"> refactor broke the size: .btn-link-inline sets --bs-btn-font-size to body size, so the existing .o_favorite i.fa { font-size: inherit } rule inherited 1rem from the button instead of the heading size.

Solution:
Add .o_favorite .btn to the font-size: inherit rule so the heading size cascades through the button to the icon.

opw-5998155