### PR TITLE
[FIX] html_builder: make async useDomState robust to destroyed context

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -249,7 +249,7 @@ export class Builder extends Component {
         const getStatePromises = [];
         const { promise: updatePromise, resolve } = Promise.withResolvers();
         this.editorBus.trigger("DOM_UPDATED", { getStatePromises, updatePromise });
-        await Promise.all(getStatePromises);
+        await Promise.allSettled(getStatePromises);
         const isLastTriggerId = this.lastTrigerUpdateId === currentTriggerId;
         resolve(isLastTriggerId);
     }

--- a/addons/html_builder/static/src/core/utils.js
+++ b/addons/html_builder/static/src/core/utils.js
@@ -6,6 +6,7 @@ import {
     onWillStart,
     onWillUpdateProps,
     reactive,
+    status,
     toRaw,
     useComponent,
     useEffect,
@@ -27,21 +28,29 @@ function isConnectedElement(el) {
 }
 
 export function useDomState(getState, { checkEditingElement = true } = {}) {
+    const component = useComponent();
     const env = useEnv();
     const isValid = (el) => (!el && !checkEditingElement) || isConnectedElement(el);
     const handler = async (ev) => {
         const editingElement = env.getEditingElement();
         if (isValid(editingElement)) {
-            const newStatePromise = getState(editingElement);
-            if (ev) {
-                ev.detail.getStatePromises.push(newStatePromise);
-                const newState = await newStatePromise;
-                const shouldApply = await ev.detail.updatePromise;
-                if (shouldApply) {
-                    Object.assign(state, newState);
+            try {
+                const newStatePromise = getState(editingElement);
+                if (ev) {
+                    ev.detail.getStatePromises.push(newStatePromise);
+                    const newState = await newStatePromise;
+                    const shouldApply = await ev.detail.updatePromise;
+                    if (shouldApply) {
+                        Object.assign(state, newState);
+                    }
+                } else {
+                    Object.assign(state, await newStatePromise);
                 }
-            } else {
-                Object.assign(state, await newStatePromise);
+            } catch (e) {
+                if (!isValid(editingElement) || status(component) === "destroyed") {
+                    return;
+                }
+                throw e;
             }
         }
     };

--- a/addons/html_builder/static/tests/utils.test.js
+++ b/addons/html_builder/static/tests/utils.test.js
@@ -6,7 +6,7 @@ import {
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
 import { describe, expect, test } from "@odoo/hoot";
-import { animationFrame, Deferred, delay } from "@odoo/hoot-dom";
+import { animationFrame, Deferred, delay, queryOne } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
 import { contains, onRpc } from "@web/../tests/web_test_helpers";
 
@@ -188,4 +188,33 @@ test("UI is blocked when doing the reloadable operation", async () => {
     expect(".o_blockUI").toHaveCount(1);
     await waitSidebarUpdated();
     expect(".o_blockUI").toHaveCount(0);
+});
+
+test("System should not crash if an asynchronous useDomState is working with removed editing element", async () => {
+    let useDomStateStarted;
+    let editingElRemoved;
+    class TestOptionComponent extends BaseOptionComponent {
+        static template = xml`<BuilderButton t-if="state.showOption" classAction="'y'">Click</BuilderButton>`;
+        static selector = "div.test";
+        setup() {
+            super.setup();
+            this.state = useDomState(async (el) => {
+                if (useDomStateStarted) {
+                    useDomStateStarted.resolve();
+                }
+                await editingElRemoved;
+                return { showOption: !!el.parentElement.ownerDocument.defaultView };
+            });
+        }
+    }
+    addBuilderOption(TestOptionComponent);
+    const { waitSidebarUpdated } = await setupHTMLBuilder(`<div class="test">a</div>`);
+    await contains(":iframe .test").click();
+    await waitSidebarUpdated();
+    useDomStateStarted = new Deferred();
+    editingElRemoved = new Deferred();
+    await contains("[data-class-action='y']").click();
+    await useDomStateStarted;
+    queryOne(":iframe .test").remove();
+    editingElRemoved.resolve();
 });


### PR DESCRIPTION
[FIX] html_builder: make async useDomState robust to destroyed context

Option components may define an asynchronous `useDomState`. When the
asynchronous part of the callback resolves, the execution context may no
longer be valid. For example, the editing element, iframe, or even the
component itself may have been destroyed in the meantime.

This change ensures that async `useDomState` handlers safely abort when
their context is no longer available, preventing unnecessary errors
from being thrown.

task-6003213

