### PR TITLE
[FIX] l10n_in_withholding: display "TDS on" label for TDS entries

### DIFF
--- a/addons/l10n_in_withholding/__manifest__.py
+++ b/addons/l10n_in_withholding/__manifest__.py
@@ -21,6 +21,11 @@
         'views/account_tax_views.xml',
         'views/res_config_settings_views.xml',
     ],
+    'assets': {
+        'web.assets_backend': [
+            'l10n_in_withholding/static/src/components/account_payment.xml',
+        ],
+    },
     'post_init_hook': '_l10n_in_withholding_post_init',
     'license': 'LGPL-3',
 }

--- a/addons/l10n_in_withholding/models/account_move.py
+++ b/addons/l10n_in_withholding/models/account_move.py
@@ -225,3 +225,18 @@ class AccountMove(models.Model):
                     move.l10n_in_tcs_tds_warning = False
             else:
                 move.l10n_in_tcs_tds_warning = False
+
+    @api.depends('move_type', 'line_ids.amount_residual')
+    def _compute_payments_widget_reconciled_info(self):
+        super()._compute_payments_widget_reconciled_info()
+
+        for move in self:
+            widget = move.invoice_payments_widget
+            if not widget or not isinstance(widget, dict):
+                continue
+
+            for line in widget.get('content', []):
+                mid = line.get('move_id')
+                line['is_tds'] = bool(self.env['account.move'].browse(mid).l10n_in_is_withholding) if mid else False
+
+            move.invoice_payments_widget = widget

--- a/addons/l10n_in_withholding/static/src/components/account_payment.xml
+++ b/addons/l10n_in_withholding/static/src/components/account_payment.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<templates xml:space='preserve'>
+    <t t-inherit='account.AccountPaymentField' t-inherit-mode='extension'>
+        <xpath expr='//i[contains(@class, "o_payment_label")]/t[@t-if="line.is_refund"]' position='after'>
+            <t t-elif='line.is_tds'>TDS on </t>
+        </xpath>
+    </t>
+</templates>

--- a/addons/l10n_in_withholding/tests/test_tds_tcs_alert.py
+++ b/addons/l10n_in_withholding/tests/test_tds_tcs_alert.py
@@ -606,3 +606,22 @@ class TestTdsTcsAlert(L10nInTestInvoicingCommon):
         )
 
         self.assertEqual(move.l10n_in_tcs_tds_warning, "It's advisable to collect TCS u/s 206C(1G) Remittance on this transaction.")
+
+    def test_invoice_payments_widget_has_tds_flag(self):
+        '''
+        Test the is_tds is correctly set to True if a TDS entry is created.
+        '''
+        move = self.create_invoice(
+            partner=self.partner_a,
+            invoice_date='2024-06-05',
+            amounts=[31000],
+            company=self.branch_a,
+            accounts=[self.internet_account],
+            quantities=[1],
+        )
+        self.tds_wizard_entry(move=move, lines=[(self.tax_194c, 31000)])
+        move._compute_payments_widget_reconciled_info()
+        tds_move = move.l10n_in_withhold_move_ids.filtered(lambda m: m.state == 'posted')[:1]
+        lines = (move.invoice_payments_widget or {}).get('content', [])
+        tds_line = next((l for l in lines if l.get('move_id') == tds_move.id), False)
+        self.assertTrue(tds_line.get('is_tds'))


### PR DESCRIPTION
### Issue before this commit:
When generating a TDS entry for an Indian company, the payment widget
on the invoice incorrectly displays the label "Paid on" instead of
"TDS on," failing to distinguish tax withholdings from standard payments.

### Steps to reproduce the issue:
1. Install l10n_in and switch to IN company
2. Go to settings and activate TDS and TCS
3. Create an invoice setting a certain price and confirm it
4. Click on the 'TDS entry' button
5. Set a random TDS tax and the base amount equal the one of the invoice
6. Confirm it and see there is the label "Paid on" and not "TDS on"

### Cause of the issue:
The invoice payments widget determines the label displayed for each reconciled entry based on predefined flags. However, entries created for TDS withholding were not explicitly identified in the widget data. As a result, these entries were treated as regular payments and the label "Paid on" was displayed instead of a more appropriate label indicating that the entry corresponds to a TDS withholding transaction.

### Reason to introduce the fix:
The label "Paid on" is conceptually incorrect for TDS transactions because no actual payment or cash outflow has occurred since TDS is a tax withholding rather than a monetary settlement. Using "Paid on" creates confusion for the user, as it implies a transfer of funds that does not exist in this context.

opw-5952700

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
