### PR TITLE
[FIX] point_of_sale: set default preset on orders missing preset_id

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -570,6 +570,8 @@ class PosOrder(models.Model):
         values.setdefault('pricelist_id', session.config_id.pricelist_id.id)
         values.setdefault('fiscal_position_id', session.config_id.default_fiscal_position_id.id)
         values.setdefault('company_id', session.config_id.company_id.id)
+        if session.config_id.use_presets and session.config_id.default_preset_id:
+            values.setdefault('preset_id', session.config_id.default_preset_id.id)
 
         if not values.get('pos_reference'):
             reference, tracking_number = session.config_id._get_next_order_refs()


### PR DESCRIPTION
When a pos.order was created without a preset_id (e.g. frontend order synced before the async preset dialog resolved, or any other path that omits the field), _complete_values_from_session did not fall back to the config's default_preset_id. Apply it the same way pricelist and fiscal position are defaulted, without overriding an explicitly passed value.

opw-5997872

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
