### PR TITLE
[IMP] mail: add internal field option to Store fields

### DIFF
--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -367,6 +367,5 @@ class ResUsers(models.Model):
 
     def _store_im_status_fields(self, res: Store.FieldList):
         super()._store_im_status_fields(res)
-        if res.is_for_internal_users():
-            # sudo: res.users - internal users can access employee information for the IM status
-            res.many("employee_ids", "_store_im_status_fields", sudo=True)
+        # sudo: res.users - internal users can access employee information for the IM status
+        res.many("employee_ids", "_store_im_status_fields", sudo=True)

--- a/addons/hr_holidays/models/res_users.py
+++ b/addons/hr_holidays/models/res_users.py
@@ -46,5 +46,4 @@ class ResUsers(models.Model):
 
     def _store_main_user_fields(self, res: Store.FieldList):
         super()._store_main_user_fields(res)
-        if res.is_for_internal_users():
-            res.many("employee_ids", ["leave_date_to"])
+        res.many("employee_ids", ["leave_date_to"], internal=True)

--- a/addons/im_livechat/controllers/webclient.py
+++ b/addons/im_livechat/controllers/webclient.py
@@ -63,7 +63,14 @@ class WebClient(WebclientController):
                 value=user,
             )
         if guest:
-            res.one("self_guest", "_store_guest_fields", value=guest)
+            res.one(
+                "self_guest",
+                lambda res: (
+                    res.from_method("_store_avatar_fields"),
+                    res.from_method("_store_im_status_fields"),
+                ),
+                value=guest,
+            )
         # sudo - im_livechat.channel: allow access to live chat channel to
         # check if operators are available.
         channel = request.env["im_livechat.channel"].sudo().search([("id", "=", params)])

--- a/addons/im_livechat/models/discuss_channel_member.py
+++ b/addons/im_livechat/models/discuss_channel_member.py
@@ -181,8 +181,7 @@ class DiscussChannelMember(models.Model):
         partner_res.from_method("_store_mention_fields")
         if self.livechat_member_type == "visitor":
             partner_res.extend(["offline_since", "email"])
-        if partner_res.is_for_internal_users():
-            partner_res.from_method("_store_im_status_fields")
+        partner_res.from_method("_store_im_status_fields", internal=True)
 
     def _store_guest_dynamic_fields(self, guest_res: Store.FieldList):
         super()._store_guest_dynamic_fields(guest_res)
@@ -191,7 +190,8 @@ class DiscussChannelMember(models.Model):
         guest_res.clear()
         guest_res.one("country_id", ["code", "name"])
         guest_res.attr("offline_since")
-        guest_res.from_method("_store_guest_fields")
+        guest_res.from_method("_store_avatar_fields")
+        guest_res.from_method("_store_im_status_fields", internal=True)
 
     def _get_rtc_invite_members_domain(self, *a, **kw):
         domain = super()._get_rtc_invite_members_domain(*a, **kw)

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -365,6 +365,27 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                     },
                 ),
                 BusResult(
+                    (discuss_channel, "internal_users"),
+                    "mail.record/insert",
+                    {
+                        "res.partner": self._filter_partners_fields(
+                            {
+                                "email": "e.e@example.com",
+                                "id": self.partner_employee.id,
+                                "im_status": "offline",
+                                "im_status_access_token": self.partner_employee._get_im_status_access_token(),
+                                "main_user_id": self.user_employee.id,
+                                "tz": False,
+                            },
+                        ),
+                        "res.users": self._filter_users_fields({
+                            "employee_ids": [],
+                            "id": self.user_employee.id,
+                            "partner_id": self.partner_employee.id,
+                        }),
+                    },
+                ),
+                BusResult(
                     discuss_channel,
                     "mail.record/insert",
                     {

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -69,8 +69,6 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                     "active": False,
                     "avatar_128_access_token": self.partner_root._get_avatar_128_access_token(),
                     "id": self.user_root.partner_id.id,
-                    "im_status": "bot",
-                    "im_status_access_token": self.partner_root._get_im_status_access_token(),
                     "is_company": False,
                     "main_user_id": self.user_root.id,
                     "name": "OdooBot",

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -375,10 +375,13 @@ class DiscussChannelMember(models.Model):
             partner_fields=lambda res: (
                 res.attr("name"),
                 res.from_method("_store_avatar_fields"),
-                res.from_method("_store_im_status_fields"),
+                res.from_method("_store_im_status_fields", internal=True),
                 res.from_method("_store_mention_fields"),
             ),
-            guest_fields="_store_guest_fields",
+            guest_fields=lambda res: (
+                res.from_method("_store_avatar_fields"),
+                res.from_method("_store_im_status_fields", internal=True),
+            ),
         )
 
     def _store_guest_dynamic_fields(self, res: Store.FieldList):
@@ -395,7 +398,10 @@ class DiscussChannelMember(models.Model):
                 res.from_method("_store_partner_fields"),
                 res.from_method("_store_mention_fields"),
             ),
-            guest_fields="_store_guest_fields",
+            guest_fields=lambda res: (
+                res.from_method("_store_avatar_fields"),
+                res.from_method("_store_im_status_fields", internal=True),
+            ),
         )
 
     def _store_identifying_fields(self, res: Store.FieldList):

--- a/addons/mail/models/discuss/mail_guest.py
+++ b/addons/mail/models/discuss/mail_guest.py
@@ -117,12 +117,10 @@ class MailGuest(models.Model):
         return limited_field_access_token(self, "im_status", scope="mail.presence")
 
     def _store_avatar_fields(self, res: Store.FieldList):
-        """Same as _store_guest_fields but without im_status fields to reduce queries when im_status is not needed."""
         res.attr("avatar_128_access_token", lambda g: g._get_avatar_128_access_token())
         res.extend(["name", "write_date"])
 
-    def _store_guest_fields(self, res: Store.FieldList):
-        self._store_avatar_fields(res)
+    def _store_im_status_fields(self, res: Store.FieldList):
         res.attr("im_status")
         res.attr("im_status_access_token", lambda g: g._get_im_status_access_token())
 

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -262,7 +262,7 @@ class ResPartner(models.Model):
     def _store_avatar_card_fields(self, res: Store.FieldList):
         res.extend(["name", "partner_share"])
         self._store_avatar_fields(res)
-        self._store_im_status_fields(res)
+        res.from_method("_store_im_status_fields", internal=True)
         # sudo: can access avatar card fields of user of accessible partner
         res.one("main_user_id", "_store_avatar_card_fields", sudo=True)
         if res.is_for_internal_users():
@@ -271,11 +271,10 @@ class ResPartner(models.Model):
     def _store_partner_fields(self, res: Store.FieldList):
         res.extend(["active", "is_company", "name"])
         self._store_avatar_fields(res)
-        self._store_im_status_fields(res)
+        res.from_method("_store_im_status_fields", internal=True)
         # sudo: to access portal user of another company in chatter
         res.one("main_user_id", "_store_main_user_fields", sudo=True)
-        if res.is_for_internal_users():
-            res.extend(["email", "tz"])
+        res.extend(["email", "tz"], internal=True)
 
     @api.readonly
     @api.model

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -391,8 +391,15 @@ class ResUsers(models.Model):
             res.one("self_user", "_store_init_fields", value=self)
             res.attr("settings", settings._res_users_settings_format())
         if guest := self.env["mail.guest"]._get_guest_from_context():
-            # sudo: mail.guest - guest can read its own init fields
-            res.one("self_guest", "_store_avatar_fields", value=guest.sudo())
+            res.one(
+                "self_guest",
+                lambda res: (
+                    res.from_method("_store_avatar_fields"),
+                    res.from_method("_store_im_status_fields"),
+                ),
+                # sudo: mail.guest - guest can read its own init fields
+                value=guest.sudo(),
+            )
 
     def _store_init_fields(self, res: Store.FieldList):
         res.one(

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -82,6 +82,7 @@ class TestChannelInternals(MailCommon, HttpCase):
             member = self.env["discuss.channel.member"].search([], order="id desc", limit=1)
             return [
                 BusResult(test_group),
+                BusResult((test_group, "internal_users")),
                 BusResult(self.test_user),
                 BusResult(self.user_employee),
                 BusResult(
@@ -180,8 +181,6 @@ class TestChannelInternals(MailCommon, HttpCase):
                                 "active": True,
                                 "avatar_128_access_token": self.test_partner._get_avatar_128_access_token(),
                                 "id": self.test_partner.id,
-                                "im_status": "offline",
-                                "im_status_access_token": self.test_partner._get_im_status_access_token(),
                                 "is_company": False,
                                 "main_user_id": self.test_user.id,
                                 "mention_token": self.test_partner._get_mention_token(),
@@ -195,6 +194,29 @@ class TestChannelInternals(MailCommon, HttpCase):
                                 "id": self.test_user.id,
                                 "partner_id": self.test_partner.id,
                                 "share": False,
+                            },
+                        ),
+                    },
+                ),
+                BusResult(
+                    (test_group, "internal_users"),
+                    "mail.record/insert",
+                    {
+                        "res.partner": self._filter_partners_fields(
+                            {
+                                "email": "test_customer@example.com",
+                                "id": self.test_partner.id,
+                                "im_status": "offline",
+                                "im_status_access_token": self.test_partner._get_im_status_access_token(),
+                                "main_user_id": self.test_user.id,
+                                "tz": False,
+                            },
+                        ),
+                        "res.users": self._filter_users_fields(
+                            {
+                                "employee_ids": [],
+                                "id": self.test_user.id,
+                                "partner_id": self.test_partner.id,
                             },
                         ),
                     },
@@ -449,13 +471,75 @@ class TestChannelInternals(MailCommon, HttpCase):
         member = chat.channel_member_ids.filtered(lambda m: m.partner_id == self.test_user.partner_id)
         member.seen_message_id = read_message
 
-        def get_mark_as_read_notifs(for_internal_user):
-            user_data = {"id": self.test_user.id, "partner_id": self.test_partner.id}
-            if for_internal_user:
-                user_data["employee_ids"] = []
-            return [
+        with self.assertBus(
+            [
                 BusResult(
-                    self.test_user if for_internal_user else chat,
+                    chat,
+                    "mail.record/insert",
+                    {
+                        "discuss.channel.member": [
+                            {
+                                "id": member.id,
+                                "partner_id": self.test_partner.id,
+                                "seen_message_id": msg_1.id,
+                                "channel_id": chat.id,
+                            },
+                        ],
+                        "res.partner": self._filter_partners_fields(
+                            {
+                                "avatar_128_access_token": self.test_partner._get_avatar_128_access_token(),
+                                "id": self.test_partner.id,
+                                "mention_token": self.test_partner._get_mention_token(),
+                                "name": self.test_partner.name,
+                                "write_date": fields.Datetime.to_string(self.test_partner.write_date),
+                            },
+                        ),
+                    },
+                ),
+                BusResult(
+                    (chat, "internal_users"),
+                    "mail.record/insert",
+                    {
+                        "res.partner": self._filter_partners_fields(
+                            {
+                                "id": self.test_partner.id,
+                                "im_status": self.test_partner.im_status,
+                                "im_status_access_token": self.test_partner._get_im_status_access_token(),
+                                "main_user_id": self.test_user.id,
+                            },
+                        ),
+                        "res.users": self._filter_users_fields(
+                            {
+                                "employee_ids": [],
+                                "id": self.test_user.id,
+                                "partner_id": self.test_partner.id,
+                            },
+                        ),
+                    },
+                ),
+                BusResult(
+                    self.test_user,
+                    "mail.record/insert",
+                    {
+                        "discuss.channel.member": [
+                            {
+                                "channel_id": chat.id,
+                                "id": member.id,
+                                "message_unread_counter": 0,
+                                "message_unread_counter_bus_id": 0,
+                                "new_message_separator": msg_1.id + 1,
+                                "partner_id": self.test_partner.id,
+                            },
+                        ],
+                    },
+                ),
+            ],
+        ):
+            member._mark_as_read(msg_1.id)
+        with self.assertBus(
+            [
+                BusResult(
+                    self.test_user,
                     "mail.record/insert",
                     {
                         "discuss.channel.member": [
@@ -478,7 +562,13 @@ class TestChannelInternals(MailCommon, HttpCase):
                                 "write_date": fields.Datetime.to_string(self.test_partner.write_date),
                             },
                         ),
-                        "res.users": self._filter_users_fields(user_data),
+                        "res.users": self._filter_users_fields(
+                            {
+                                "employee_ids": [],
+                                "id": self.test_user.id,
+                                "partner_id": self.test_partner.id,
+                            },
+                        ),
                     },
                 ),
                 BusResult(
@@ -497,11 +587,8 @@ class TestChannelInternals(MailCommon, HttpCase):
                         ],
                     },
                 ),
-            ]
-
-        with self.assertBus(get_mark_as_read_notifs(for_internal_user=False)):
-            member._mark_as_read(msg_1.id)
-        with self.assertBus(get_mark_as_read_notifs(for_internal_user=True)):
+            ],
+        ):
             member._mark_as_read(msg_1.id)
 
     def test_channel_message_post_should_not_allow_adding_wrong_parent(self):

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -228,9 +228,6 @@ class TestChannelRTC(MailCommon, HttpCase):
                             {
                                 "avatar_128_access_token": channel_member.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member.partner_id.id,
-                                "im_status": channel_member.partner_id.im_status,
-                                "im_status_access_token": channel_member.partner_id._get_im_status_access_token(),
-                                "main_user_id": self.user_employee.id,
                                 "mention_token": channel_member.partner_id._get_mention_token(),
                                 "name": channel_member.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
@@ -238,8 +235,23 @@ class TestChannelRTC(MailCommon, HttpCase):
                                 ),
                             },
                         ),
+                    },
+                ),
+                BusResult(
+                    (channel, "internal_users"),
+                    "mail.record/insert",
+                    {
+                        "res.partner": self._filter_partners_fields(
+                            {
+                                "id": channel_member.partner_id.id,
+                                "im_status": channel_member.partner_id.im_status,
+                                "im_status_access_token": channel_member.partner_id._get_im_status_access_token(),
+                                "main_user_id": self.user_employee.id,
+                            },
+                        ),
                         "res.users": self._filter_users_fields(
                             {
+                                "employee_ids": [],
                                 "id": self.user_employee.id,
                                 "partner_id": self.partner_employee.id,
                             },
@@ -318,9 +330,6 @@ class TestChannelRTC(MailCommon, HttpCase):
                             {
                                 "avatar_128_access_token": channel_member_test_user.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_user.partner_id.id,
-                                "im_status": channel_member_test_user.partner_id.im_status,
-                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
-                                "main_user_id": test_user.id,
                                 "mention_token": channel_member_test_user.partner_id._get_mention_token(),
                                 "name": channel_member_test_user.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
@@ -328,8 +337,23 @@ class TestChannelRTC(MailCommon, HttpCase):
                                 ),
                             },
                         ),
+                    },
+                ),
+                BusResult(
+                    (channel, "internal_users"),
+                    "mail.record/insert",
+                    {
+                        "res.partner": self._filter_partners_fields(
+                            {
+                                "id": channel_member_test_user.partner_id.id,
+                                "im_status": channel_member_test_user.partner_id.im_status,
+                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
+                                "main_user_id": test_user.id,
+                            },
+                        ),
                         "res.users": self._filter_users_fields(
                             {
+                                "employee_ids": [],
                                 "id": test_user.id,
                                 "partner_id": test_user.partner_id.id,
                             },
@@ -418,9 +442,6 @@ class TestChannelRTC(MailCommon, HttpCase):
                             {
                                 "avatar_128_access_token": channel_member.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member.partner_id.id,
-                                "im_status": channel_member.partner_id.im_status,
-                                "im_status_access_token": channel_member.partner_id._get_im_status_access_token(),
-                                "main_user_id": self.user_employee.id,
                                 "mention_token": channel_member.partner_id._get_mention_token(),
                                 "name": channel_member.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
@@ -428,8 +449,23 @@ class TestChannelRTC(MailCommon, HttpCase):
                                 ),
                             },
                         ),
+                    },
+                ),
+                BusResult(
+                    (channel, "internal_users"),
+                    "mail.record/insert",
+                    {
+                        "res.partner": self._filter_partners_fields(
+                            {
+                                "id": channel_member.partner_id.id,
+                                "im_status": channel_member.partner_id.im_status,
+                                "im_status_access_token": channel_member.partner_id._get_im_status_access_token(),
+                                "main_user_id": self.user_employee.id,
+                            },
+                        ),
                         "res.users": self._filter_users_fields(
                             {
+                                "employee_ids": [],
                                 "id": self.user_employee.id,
                                 "partner_id": self.partner_employee.id,
                             },
@@ -519,20 +555,11 @@ class TestChannelRTC(MailCommon, HttpCase):
                             {
                                 "avatar_128_access_token": channel_member.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member.partner_id.id,
-                                "im_status": channel_member.partner_id.im_status,
-                                "im_status_access_token": channel_member.partner_id._get_im_status_access_token(),
-                                "main_user_id": self.user_employee.id,
                                 "mention_token": channel_member.partner_id._get_mention_token(),
                                 "name": channel_member.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member.partner_id.write_date
                                 ),
-                            },
-                        ),
-                        "res.users": self._filter_users_fields(
-                            {
-                                "id": self.user_employee.id,
-                                "partner_id": self.user_employee.partner_id.id,
                             },
                         ),
                     },
@@ -568,8 +595,6 @@ class TestChannelRTC(MailCommon, HttpCase):
                             {
                                 "avatar_128_access_token": channel_member_test_guest.guest_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_guest.guest_id.id,
-                                "im_status": channel_member_test_guest.guest_id.im_status,
-                                "im_status_access_token": channel_member_test_guest.guest_id._get_im_status_access_token(),
                                 "name": channel_member_test_guest.guest_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_guest.guest_id.write_date
@@ -580,9 +605,6 @@ class TestChannelRTC(MailCommon, HttpCase):
                             {
                                 "avatar_128_access_token": channel_member_test_user.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_user.partner_id.id,
-                                "im_status": channel_member_test_user.partner_id.im_status,
-                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
-                                "main_user_id": test_user.id,
                                 "mention_token": channel_member_test_user.partner_id._get_mention_token(),
                                 "name": channel_member_test_user.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
@@ -590,8 +612,30 @@ class TestChannelRTC(MailCommon, HttpCase):
                                 ),
                             },
                         ),
+                    },
+                ),
+                BusResult(
+                    (channel, "internal_users"),
+                    "mail.record/insert",
+                    {
+                        "mail.guest": [
+                            {
+                                "id": channel_member_test_guest.guest_id.id,
+                                "im_status": channel_member_test_guest.guest_id.im_status,
+                                "im_status_access_token": channel_member_test_guest.guest_id._get_im_status_access_token(),
+                            },
+                        ],
+                        "res.partner": self._filter_partners_fields(
+                            {
+                                "id": channel_member_test_user.partner_id.id,
+                                "im_status": channel_member_test_user.partner_id.im_status,
+                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
+                                "main_user_id": test_user.id,
+                            },
+                        ),
                         "res.users": self._filter_users_fields(
                             {
+                                "employee_ids": [],
                                 "id": test_user.id,
                                 "partner_id": test_user.partner_id.id,
                             },
@@ -654,9 +698,6 @@ class TestChannelRTC(MailCommon, HttpCase):
                             {
                                 "avatar_128_access_token": channel_member_test_user.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_user.partner_id.id,
-                                "im_status": channel_member_test_user.partner_id.im_status,
-                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
-                                "main_user_id": test_user.id,
                                 "mention_token": channel_member_test_user.partner_id._get_mention_token(),
                                 "name": channel_member_test_user.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
@@ -664,8 +705,23 @@ class TestChannelRTC(MailCommon, HttpCase):
                                 ),
                             },
                         ),
+                    },
+                ),
+                BusResult(
+                    (channel, "internal_users"),
+                    "mail.record/insert",
+                    {
+                        "res.partner": self._filter_partners_fields(
+                            {
+                                "id": channel_member_test_user.partner_id.id,
+                                "im_status": channel_member_test_user.partner_id.im_status,
+                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
+                                "main_user_id": test_user.id,
+                            },
+                        ),
                         "res.users": self._filter_users_fields(
                             {
+                                "employee_ids": [],
                                 "id": test_user.id,
                                 "partner_id": test_user.partner_id.id,
                             },
@@ -699,9 +755,6 @@ class TestChannelRTC(MailCommon, HttpCase):
                             {
                                 "avatar_128_access_token": channel_member_test_user.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_user.partner_id.id,
-                                "im_status": channel_member_test_user.partner_id.im_status,
-                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
-                                "main_user_id": test_user.id,
                                 "mention_token": channel_member_test_user.partner_id._get_mention_token(),
                                 "name": channel_member_test_user.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
@@ -709,8 +762,23 @@ class TestChannelRTC(MailCommon, HttpCase):
                                 ),
                             },
                         ),
+                    },
+                ),
+                BusResult(
+                    (channel, "internal_users"),
+                    "mail.record/insert",
+                    {
+                        "res.partner": self._filter_partners_fields(
+                            {
+                                "id": channel_member_test_user.partner_id.id,
+                                "im_status": channel_member_test_user.partner_id.im_status,
+                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
+                                "main_user_id": test_user.id,
+                            },
+                        ),
                         "res.users": self._filter_users_fields(
                             {
+                                "employee_ids": [],
                                 "id": test_user.id,
                                 "partner_id": test_user.partner_id.id,
                             },
@@ -759,12 +827,23 @@ class TestChannelRTC(MailCommon, HttpCase):
                             {
                                 "avatar_128_access_token": channel_member_test_guest.guest_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_guest.guest_id.id,
-                                "im_status": channel_member_test_guest.guest_id.im_status,
-                                "im_status_access_token": channel_member_test_guest.guest_id._get_im_status_access_token(),
                                 "name": channel_member_test_guest.guest_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_guest.guest_id.write_date
                                 ),
+                            },
+                        ],
+                    },
+                ),
+                BusResult(
+                    (channel, "internal_users"),
+                    "mail.record/insert",
+                    {
+                        "mail.guest": [
+                            {
+                                "id": channel_member_test_guest.guest_id.id,
+                                "im_status": channel_member_test_guest.guest_id.im_status,
+                                "im_status_access_token": channel_member_test_guest.guest_id._get_im_status_access_token(),
                             },
                         ],
                     },
@@ -796,12 +875,23 @@ class TestChannelRTC(MailCommon, HttpCase):
                             {
                                 "avatar_128_access_token": channel_member_test_guest.guest_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_guest.guest_id.id,
-                                "im_status": channel_member_test_guest.guest_id.im_status,
-                                "im_status_access_token": channel_member_test_guest.guest_id._get_im_status_access_token(),
                                 "name": channel_member_test_guest.guest_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_guest.guest_id.write_date
                                 ),
+                            },
+                        ],
+                    },
+                ),
+                BusResult(
+                    (channel, "internal_users"),
+                    "mail.record/insert",
+                    {
+                        "mail.guest": [
+                            {
+                                "id": channel_member_test_guest.guest_id.id,
+                                "im_status": channel_member_test_guest.guest_id.im_status,
+                                "im_status_access_token": channel_member_test_guest.guest_id._get_im_status_access_token(),
                             },
                         ],
                     },
@@ -859,9 +949,6 @@ class TestChannelRTC(MailCommon, HttpCase):
                             {
                                 "avatar_128_access_token": channel_member_test_user.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_user.partner_id.id,
-                                "im_status": channel_member_test_user.partner_id.im_status,
-                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
-                                "main_user_id": test_user.id,
                                 "mention_token": channel_member_test_user.partner_id._get_mention_token(),
                                 "name": channel_member_test_user.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
@@ -869,8 +956,23 @@ class TestChannelRTC(MailCommon, HttpCase):
                                 ),
                             },
                         ),
+                    },
+                ),
+                BusResult(
+                    (channel, "internal_users"),
+                    "mail.record/insert",
+                    {
+                        "res.partner": self._filter_partners_fields(
+                            {
+                                "id": channel_member_test_user.partner_id.id,
+                                "im_status": channel_member_test_user.partner_id.im_status,
+                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
+                                "main_user_id": test_user.id,
+                            },
+                        ),
                         "res.users": self._filter_users_fields(
                             {
+                                "employee_ids": [],
                                 "id": test_user.id,
                                 "partner_id": test_user.partner_id.id,
                             },
@@ -919,12 +1021,23 @@ class TestChannelRTC(MailCommon, HttpCase):
                             {
                                 "avatar_128_access_token": channel_member_test_guest.guest_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_guest.guest_id.id,
-                                "im_status": channel_member_test_guest.guest_id.im_status,
-                                "im_status_access_token": channel_member_test_guest.guest_id._get_im_status_access_token(),
                                 "name": channel_member_test_guest.guest_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_guest.guest_id.write_date
                                 ),
+                            },
+                        ],
+                    },
+                ),
+                BusResult(
+                    (channel, "internal_users"),
+                    "mail.record/insert",
+                    {
+                        "mail.guest": [
+                            {
+                                "id": channel_member_test_guest.guest_id.id,
+                                "im_status": channel_member_test_guest.guest_id.im_status,
+                                "im_status_access_token": channel_member_test_guest.guest_id._get_im_status_access_token(),
                             },
                         ],
                     },
@@ -1008,8 +1121,6 @@ class TestChannelRTC(MailCommon, HttpCase):
                             {
                                 "avatar_128_access_token": channel_member_test_guest.guest_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_guest.guest_id.id,
-                                "im_status": channel_member_test_guest.guest_id.im_status,
-                                "im_status_access_token": channel_member_test_guest.guest_id._get_im_status_access_token(),
                                 "name": channel_member_test_guest.guest_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_guest.guest_id.write_date
@@ -1020,9 +1131,6 @@ class TestChannelRTC(MailCommon, HttpCase):
                             {
                                 "avatar_128_access_token": channel_member_test_user.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_user.partner_id.id,
-                                "im_status": channel_member_test_user.partner_id.im_status,
-                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
-                                "main_user_id": test_user.id,
                                 "mention_token": channel_member_test_user.partner_id._get_mention_token(),
                                 "name": channel_member_test_user.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
@@ -1030,8 +1138,30 @@ class TestChannelRTC(MailCommon, HttpCase):
                                 ),
                             },
                         ),
+                    },
+                ),
+                BusResult(
+                    (channel, "internal_users"),
+                    "mail.record/insert",
+                    {
+                        "mail.guest": [
+                            {
+                                "id": channel_member_test_guest.guest_id.id,
+                                "im_status": channel_member_test_guest.guest_id.im_status,
+                                "im_status_access_token": channel_member_test_guest.guest_id._get_im_status_access_token(),
+                            },
+                        ],
+                        "res.partner": self._filter_partners_fields(
+                            {
+                                "id": channel_member_test_user.partner_id.id,
+                                "im_status": channel_member_test_user.partner_id.im_status,
+                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
+                                "main_user_id": test_user.id,
+                            },
+                        ),
                         "res.users": self._filter_users_fields(
                             {
+                                "employee_ids": [],
                                 "id": test_user.id,
                                 "partner_id": test_user.partner_id.id,
                             },
@@ -1084,6 +1214,7 @@ class TestChannelRTC(MailCommon, HttpCase):
             last_rtc_session_id = channel_member.rtc_session_ids.id
             return [
                 BusResult(channel, "mail.record/insert"),  # discuss.channel (channel_name_member_ids)
+                BusResult((channel, "internal_users"), "mail.record/insert"),
                 BusResult(test_user, "discuss.channel/joined"),
                 BusResult(self.user_employee, "mail.record/insert"),  # discuss.channel.member (message_unread_counter, new_message_separator, …)
                 BusResult(channel, "discuss.channel/new_message"),
@@ -1091,6 +1222,7 @@ class TestChannelRTC(MailCommon, HttpCase):
                 BusResult(self.user_employee, "mail.record/insert"),  # discuss.channel.member (message_unread_counter, new_message_separator, …)
                 BusResult(channel, "discuss.channel/new_message"),
                 BusResult(channel, "mail.record/insert"),  # discuss.channel (member_count), discuss.channel.member
+                BusResult((channel, "internal_users"), "mail.record/insert"),
                 BusResult(
                     test_user,
                     "mail.record/insert",
@@ -1172,20 +1304,11 @@ class TestChannelRTC(MailCommon, HttpCase):
                             {
                                 "avatar_128_access_token": channel_member.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member.partner_id.id,
-                                "im_status": channel_member.partner_id.im_status,
-                                "im_status_access_token": channel_member.partner_id._get_im_status_access_token(),
-                                "main_user_id": self.user_employee.id,
                                 "mention_token": channel_member.partner_id._get_mention_token(),
                                 "name": channel_member.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member.partner_id.write_date
                                 ),
-                            },
-                        ),
-                        "res.users": self._filter_users_fields(
-                            {
-                                "id": self.user_employee.id,
-                                "partner_id": self.user_employee.partner_id.id,
                             },
                         ),
                     },
@@ -1221,8 +1344,6 @@ class TestChannelRTC(MailCommon, HttpCase):
                             {
                                 "avatar_128_access_token": channel_member_test_guest.guest_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_guest.guest_id.id,
-                                "im_status": channel_member_test_guest.guest_id.im_status,
-                                "im_status_access_token": channel_member_test_guest.guest_id._get_im_status_access_token(),
                                 "name": channel_member_test_guest.guest_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_guest.guest_id.write_date
@@ -1233,9 +1354,6 @@ class TestChannelRTC(MailCommon, HttpCase):
                             {
                                 "avatar_128_access_token": channel_member_test_user.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_user.partner_id.id,
-                                "im_status": channel_member_test_user.partner_id.im_status,
-                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
-                                "main_user_id": test_user.id,
                                 "mention_token": channel_member_test_user.partner_id._get_mention_token(),
                                 "name": channel_member_test_user.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
@@ -1243,8 +1361,30 @@ class TestChannelRTC(MailCommon, HttpCase):
                                 ),
                             },
                         ),
+                    },
+                ),
+                BusResult(
+                    (channel, "internal_users"),
+                    "mail.record/insert",
+                    {
+                        "mail.guest": [
+                            {
+                                "id": channel_member_test_guest.guest_id.id,
+                                "im_status": channel_member_test_guest.guest_id.im_status,
+                                "im_status_access_token": channel_member_test_guest.guest_id._get_im_status_access_token(),
+                            },
+                        ],
+                        "res.partner": self._filter_partners_fields(
+                            {
+                                "id": channel_member_test_user.partner_id.id,
+                                "im_status": channel_member_test_user.partner_id.im_status,
+                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
+                                "main_user_id": test_user.id,
+                            },
+                        ),
                         "res.users": self._filter_users_fields(
                             {
+                                "employee_ids": [],
                                 "id": test_user.id,
                                 "partner_id": test_user.partner_id.id,
                             },

--- a/addons/mail/tests/test_discuss_tools.py
+++ b/addons/mail/tests/test_discuss_tools.py
@@ -2,11 +2,12 @@
 
 from odoo.addons.mail.tools.discuss import Store
 from odoo.addons.mail.tests.common import mail_new_test_user
-from odoo.tests import TransactionCase
+from odoo.addons.mail.tests.common import MailCase
 from odoo.tests.common import new_test_user
+from odoo.addons.bus.tests.common import BusResult
 
 
-class TestDiscussTools(TransactionCase):
+class TestDiscussTools(MailCase):
     """Test class for discuss tools."""
 
     # 0xx generic tests (key not in ids_by_model)
@@ -258,6 +259,111 @@ class TestDiscussTools(TransactionCase):
         data = store.get_result()
         self.assertEqual(data["res.partner"][0]["email"], "test_user_355_a@example.com")
         self.assertNotIn("email", data["res.partner"][1])
+
+    def test_360_internal_fields(self):
+        public_category = self.env["discuss.category"].create({"name": "Public Channels"})
+        public_channel = self.env["discuss.channel"].create(
+            {
+                "name": "Public Channel",
+                "description": "secret",
+                "group_public_id": False,
+                "discuss_category_id": public_category.id,
+            },
+        )
+        odoobot_partner = self.env.ref("base.partner_root")
+        odoobot_member = public_channel.channel_member_ids.filtered(
+            lambda m: m.partner_id == odoobot_partner,
+        )
+        bob_user = new_test_user(self.env, "bob_user", name="Bob", email="bob@secret.com")
+        bob_member = public_channel._add_members(users=bob_user)
+        portal_user = new_test_user(self.env, login="portal_user", groups="base.group_portal")
+        test_message = public_channel.message_post(body="Test Message")
+
+        def _get_fields(res):
+            res.attr("name")
+            res.attr("description", internal=True)
+            res.many(
+                "channel_member_ids",
+                lambda res: (
+                    res.one(
+                        "partner_id",
+                        lambda res: (
+                            res.attr("name"),
+                            res.extend(["email", "phone"], internal=True),
+                        ),
+                    ),
+                    res.attr("seen_message_id"),
+                ),
+            )
+            res.many("message_ids", ["author_id"], internal=True)
+            res.one(
+                "discuss_category_id",
+                lambda res: (
+                    res.attr("id"),
+                    res.from_method("_store_category_fields", internal=True),
+                ),
+            )
+
+        non_internal_payload = {
+            "discuss.category": [{"id": public_category.id}],
+            "discuss.channel": [
+                {
+                    "channel_member_ids": public_channel.channel_member_ids.ids,
+                    "discuss_category_id": public_category.id,
+                    "id": public_channel.id,
+                    "name": "Public Channel",
+                },
+            ],
+            "discuss.channel.member": [
+                {
+                    "id": odoobot_member.id,
+                    "partner_id": odoobot_partner.id,
+                    "seen_message_id": test_message.id,
+                },
+                {
+                    "id": bob_member.id,
+                    "partner_id": bob_user.partner_id.id,
+                    "seen_message_id": False,
+                },
+            ],
+            "res.partner": [
+                {"id": odoobot_partner.id, "name": "OdooBot"},
+                {"id": bob_user.partner_id.id, "name": "Bob"},
+            ],
+        }
+        internal_payload = {
+            "discuss.channel": [
+                {
+                    "description": "secret",
+                    "id": public_channel.id,
+                    "message_ids": [test_message.id],
+                },
+            ],
+            "discuss.category": [
+                {
+                    "bus_channel_access_token": public_category._get_bus_channel_access_token(),
+                    "id": public_category.id,
+                    "name": "Public Channels",
+                    "sequence": public_category.sequence,
+                },
+            ],
+            "mail.message": [{"id": test_message.id, "author_id": odoobot_partner.id}],
+            "res.partner": [
+                {"id": odoobot_partner.id, "email": "odoobot@example.com", "phone": False},
+                {"id": bob_user.partner_id.id, "email": "bob@secret.com", "phone": False},
+            ],
+        }
+        with self.assertBus([
+            BusResult(public_channel, "mail.record/insert", non_internal_payload),
+            BusResult((public_channel, "internal_users"), "mail.record/insert", internal_payload),
+        ]):
+            store = Store(bus_channel=public_channel)
+            store.add(public_channel, _get_fields)
+            store.bus_send()
+        with self.assertBus([BusResult(portal_user, "mail.record/insert", non_internal_payload)]):
+            store = Store(bus_channel=portal_user)
+            store.add(public_channel, _get_fields)
+            store.bus_send()
 
     def test_390_add_no_loop(self):
         """Test that store.add() does not loop indefinitely but it is still allowed to process

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -286,6 +286,9 @@ class Store:
         self.is_executing_operation_queue = False
         self.operation_queue = []
         self.target = Store.Target(bus_channel, bus_subchannel)
+        self._internal_store = None
+        if bus_channel and bus_channel._name == "discuss.channel" and bus_subchannel != "internal_users":
+            self._internal_store = Store(bus_channel=bus_channel, bus_subchannel="internal_users")
 
     @store_enqueue
     def add(self, records, fields, *, as_thread=False, fields_params=None):
@@ -360,16 +363,17 @@ class Store:
         Use case: to add fields from inside _to_store() methods to avoid recursive code.
         Note: in all other cases, Store.add() should be called instead.
         """
-        if not field_list or not field_list.records:
-            return self
-        for record, record_data_list in self._get_records_data_list(field_list).items():
-            for record_data in record_data_list:
-                if as_thread:
-                    self.add_model_values(
-                        "mail.thread", {"id": record.id, "model": record._name, **record_data},
-                    )
-                else:
-                    self.add_model_values(record._name, {"id": record.id, **record_data})
+        if field_list and field_list.records:
+            for record, record_data_list in self._get_records_data_list(field_list).items():
+                for record_data in record_data_list:
+                    if as_thread:
+                        self.add_model_values(
+                            "mail.thread", {"id": record.id, "model": record._name, **record_data},
+                        )
+                    else:
+                        self.add_model_values(record._name, {"id": record.id, **record_data})
+        if self._internal_store:
+            self._internal_store.add_records_fields(field_list._internal_field_list, as_thread)
         return self
 
     @store_enqueue
@@ -438,6 +442,8 @@ class Store:
         )
         if res := self.get_result():
             self.target.channel._bus_send(notification_type, res, subchannel=self.target.subchannel)
+        if self._internal_store:
+            self._internal_store.bus_send()
 
     @store_enqueue
     def resolve_data_request(self, values=None, *, data_id=None):
@@ -484,6 +490,8 @@ class Store:
             field_list.extend(Store.Attr(self, key, value) for key, value in fields.items())
         elif isinstance(fields, (list, tuple, Store.FieldList)):
             field_list.extend(fields)  # prevent mutation of original list
+            if isinstance(fields, Store.FieldList) and fields._internal_field_list:
+                field_list.extend(fields._internal_field_list, internal=True)
         else:
             raise TypeError(f"unexpected fields format: '{fields}' for records: '{records}'")
         return field_list
@@ -861,37 +869,62 @@ class Store:
             # records for which the field list will apply. Useful to pre-compute values in batch.
             self.records = records
             self.store = store
+            self._internal_field_list = None
+            if store._internal_store:
+                self._internal_field_list = Store.FieldList(store._internal_store, records)
 
         @property
         def target(self):
             """Store.Target of the field list. Useful to adapt fields depending on the receivers."""
             return self.store.target
 
-        def attr(self, field_name, value=NO_VALUE, *, predicate=None, sudo=False):
+        def append(self, field, *, internal=False):
+            if not internal or self.is_for_internal_users():
+                super().append(field)
+            elif self._internal_field_list is not None:
+                self._internal_field_list.append(field)
+
+        def extend(self, fields, *, internal=False):
+            if not internal or self.is_for_internal_users():
+                super().extend(fields)
+            elif self._internal_field_list is not None:
+                self._internal_field_list.extend(fields)
+
+        def attr(self, field_name, value=NO_VALUE, *, predicate=None, sudo=False, internal=False):
             """Add an attribute to the field list."""
             if self.records is not None and value is NO_VALUE and predicate is None and not sudo:
-                self.append(field_name)
+                self.append(field_name, internal=internal)
             else:
                 self.append(
                     Store.Attr(self.store, field_name, value=value, predicate=predicate, sudo=sudo),
+                    internal=internal,
                 )
 
-        def from_method(self, method_name, **fields_params):
+        def from_method(self, method_name, *, internal=False, **fields_params):
             """Add fields coming from a method on the records to the field list."""
             if (method := Store._get_fields_method(self.records, method_name)):
-                method(self, **fields_params)
+                if not internal or self.is_for_internal_users():
+                    method(self, **fields_params)
+                elif self._internal_field_list is not None:
+                    method(self._internal_field_list, **fields_params)
             else:
                 raise TypeError(
                     f"unexpected method name format: '{method_name}' for records: '{self.records}'",
                 )
 
-        def one(self, record_or_field_name, fields, /, *args, **kwargs):
+        def one(self, record_or_field_name, fields, /, *args, internal=False, **kwargs):
             """Add a x2one relation to the field list."""
-            self.append(Store.One(self.store, record_or_field_name, fields, *args, **kwargs))
+            self.append(
+                Store.One(self.store, record_or_field_name, fields, *args, **kwargs),
+                internal=internal,
+            )
 
-        def many(self, records_or_field_name, fields, /, *args, **kwargs):
+        def many(self, records_or_field_name, fields, /, *args, internal=False, **kwargs):
             """Add a x2many relation to the field list."""
-            self.append(Store.Many(self.store, records_or_field_name, fields, *args, **kwargs))
+            self.append(
+                Store.Many(self.store, records_or_field_name, fields, *args, **kwargs),
+                internal=internal,
+            )
 
         def is_for_current_user(self):
             """Return whether the current target is the current user or guest of the given env.
@@ -954,7 +987,13 @@ class Store:
             return records if isinstance(records, env.registry["res.users"]) else env["res.users"]
 
         def _identity(self):
-            return ("FieldList", self.records.env, self.records, tuple(self))
+            return (
+                "FieldList",
+                self.records.env,
+                self.records,
+                tuple(self),
+                *(self._internal_field_list._identity() if self._internal_field_list is not None else ()),
+            )
 
     class FieldListManager:
         """Similar API as Store.FieldList but for multiple field lists at once.

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -2158,7 +2158,7 @@ class ProjectTask(models.Model):
             self.env["res.partner"].sudo()._search_mention_suggestions(domain, limit),
             lambda res: (
                 res.extend(["email", "name"]),
-                res.from_method("_store_im_status_fields"),
+                res.from_method("_store_im_status_fields", internal=True),
                 res.from_method("_store_mention_fields"),
             ),
         )


### PR DESCRIPTION
This commit allows Store fields to be marked as internal so they are automatically sent to the "internal_users" sub-channel instead of the original sub-channel.
This enables sending sensitive data (like email, livechat notes) only to internal users while keeping them from leaking to external users (ive chat visitors, guests in public channels).
The Store now creates an internal_store when bus_subchannel is not already "internal_users", and automatically splits fields based on their internal flag during bus_send().

task-5945563
