### PR TITLE
[FIX] account{_edi_ubl_cii}: Add Åland island (AX) for PEPPOL

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -46,8 +46,9 @@ PEPPOL_MAILING_COUNTRIES = [
 
 # List of countries where Peppol is accessible.
 PEPPOL_LIST = PEPPOL_DEFAULT_COUNTRIES + [
-    'AD', 'AL', 'BA', 'BG', 'BL', 'GB', 'GF', 'GP', 'HR', 'HU', 'LI', 'MC', 'ME', 'MF',
-    'MK', 'MQ', 'NC', 'PF', 'PM', 'RE', 'RS', 'SK', 'SM', 'TF', 'TR', 'VA', 'WF', 'YT',
+    'AD', 'AL', 'AX', 'BA', 'BG', 'BL', 'GB', 'GF', 'GP', 'HR', 'HU', 'LI', 'MC', 'ME',
+    'MF', 'MK', 'MQ', 'NC', 'PF', 'PM', 'RE', 'RS', 'SK', 'SM', 'TF', 'TR', 'VA', 'WF',
+    'YT',
 ]
 
 INTEGRITY_HASH_BATCH_SIZE = 1000

--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -62,7 +62,7 @@ EAS_MAPPING = {
     'DK': {'0184': 'vat', '0198': 'vat'},
     'EE': {'9931': 'vat'},
     'ES': {'9920': 'vat'},
-    'FI': {'0216': None, '0213': 'vat'},
+    'FI': {'0216': None},
     'FR': {'0009': 'company_registry', '9957': 'vat', '0002': None},
     'SG': {'0195': 'l10n_sg_unique_entity_number'},
     'GB': {'9932': 'vat'},
@@ -111,6 +111,8 @@ EAS_MAPPING = {
     'TF': {'0009': 'siret', '9957': 'vat', '0002': None},  # French Southern and Antarctic Lands
     'WF': {'0009': 'siret', '9957': 'vat', '0002': None},  # Wallis and Futuna
     'YT': {'0009': 'siret', '9957': 'vat', '0002': None},  # Mayotte
+
+    'AX': {'0216': None},  # Åland Islands
 }
 
 # -------------------------------------------------------------------------


### PR DESCRIPTION
Before this commit, invoice to a partner in Åland Island can't be sent via Peppol.
XML and PDF are generated, linked to the account.move, but are not sent and don't appear in the chatter.

Steps to reproduce:
- Create a partner in Åland Island
- Create an invoice
- Send to Peppol

Current behavior:
- Invoice is not sent, appear in the attachment, but doesn't appear in the chatter.

Expected behavior:
- invoice is sent and attachments are in the chatter

This also allow activating Peppol for companies in Åland Island.

Ticket [link](https://www.odoo.com/odoo/project.task/5949439)
opw-5949439