### PR TITLE
[FIX] project_account_budget: Project Budget Follow‑Up Improvements

### DIFF
--- a/addons/account/views/account_analytic_line_views.xml
+++ b/addons/account/views/account_analytic_line_views.xml
@@ -56,6 +56,9 @@
                     <xpath expr="//filter[@name='month']" position="after">
                         <filter name="fiscal_date" string="From last fiscal year" domain="[('fiscal_year_search', '=', True)]" invisible="1"/>
                     </xpath>
+                    <xpath expr="//filter[@name='month']" position="inside">
+                        <filter string="For the Last 365 Days" name="last_365_days" domain="[('date', '&gt;=', 'today -365d')]"/>
+                    </xpath>
                     <xpath expr="//group" position="inside">
                         <separator/>
                         <filter name="account_id" context="{'group_by': 'account_id'}"/>

--- a/addons/hr_timesheet/views/project_project_views.xml
+++ b/addons/hr_timesheet/views/project_project_views.xml
@@ -41,7 +41,7 @@
                         <field name="allow_timesheets"/>
                     </setting>
                 </xpath>
-                <xpath expr="//div[@name='button_box']" position="inside">
+                <xpath expr="//button[@name='project_update_all_action']" position="after">
                     <button name="action_project_timesheets" type="object" class="oe_stat_button" icon="" groups="hr_timesheet.group_hr_timesheet_user" invisible="not allow_timesheets">
                         <i class="fa fa-fw o_button_icon fa-clock-o" title="Timesheets" invisible="stat_success_rate"/>
                         <i class="fa fa-fw o_button_icon fa-clock-o text-success" title="On Due" invisible="not stat_success_rate or stat_success_rate &gt;= 80"/>

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -209,7 +209,12 @@ class ProjectProject(models.Model):
     def _compute_next_milestone_info(self):
         for project in self:
             if milestone := project.next_milestone_id:
-                project.next_milestone_status = 'off_track' if milestone.is_deadline_exceeded else 'on_track'
+                if milestone.is_deadline_exceeded:
+                    project.next_milestone_status = 'off_track'
+                elif milestone.can_be_marked_as_done:
+                    project.next_milestone_status = 'next_track'
+                else:
+                    project.next_milestone_status = 'on_track'
             else:
                 project.next_milestone_status = False
 
@@ -1017,7 +1022,8 @@ class ProjectProject(models.Model):
     def action_open_project_form(self):
         self.ensure_one()
         return {
-            'type': 'ir.actions.act_window',
+            'tag': "project_top_menu_overview",
+            'type': 'ir.actions.client',
             'name': self.env._('Project Overview'),
             'res_model': 'project.project',
             'view_mode': 'form',

--- a/addons/project/static/src/actions/client_actions.js
+++ b/addons/project/static/src/actions/client_actions.js
@@ -81,6 +81,14 @@ export async function showTemplateFormView(
     });
     await env.services.action.doAction(action);
 }
+export async function showProjectForm(env, { model, recordId }) {
+    await env.services.action.doAction({
+        type: "ir.actions.act_window",
+        res_model: model,
+        views: [[false, "form"]],
+        res_id: recordId,
+    });
+}
 
 // Task → Template Notification
 registry.category("actions").add("project_show_template_notification", (env, action) => {
@@ -145,3 +153,14 @@ registry
         });
         return params.next;
     });
+
+// Top Menu → Project Form  Make Breadcrumbs
+registry.category("actions").add("project_top_menu_overview", (env, action) => {
+    const params = action || {};
+    console.log(params);
+    showProjectForm(env, {
+        model: "project.project",
+        recordId: action.res_id,
+    });
+    return params.next;
+});

--- a/addons/project/static/src/components/project_status_with_color_selection/project_status_with_color_selection_field.js
+++ b/addons/project/static/src/components/project_status_with_color_selection/project_status_with_color_selection_field.js
@@ -1,12 +1,14 @@
-import { SelectionField, selectionField } from '@web/views/fields/selection/selection_field';
-import { registry } from '@web/core/registry';
+import { SelectionField, selectionField } from "@web/views/fields/selection/selection_field";
+import { registry } from "@web/core/registry";
 
-import { STATUS_COLORS, STATUS_COLOR_PREFIX } from '../../utils/project_utils';
+import { STATUS_COLORS, STATUS_COLOR_PREFIX } from "../../utils/project_utils";
 
 export class ProjectStatusWithColorSelectionField extends SelectionField {
     static props = {
         ...SelectionField.props,
         statusLabel: { type: String, optional: true },
+        hideIcon: { type: Boolean, optional: true },
+        hideValue: { type: Boolean, optional: true },
     };
 
     static template = "project.ProjectStatusWithColorSelectionField";
@@ -32,6 +34,8 @@ export const projectStatusWithColorSelectionField = {
     extractProps: (fieldInfo, dynamicInfo) => {
         const props = selectionField.extractProps(fieldInfo, dynamicInfo);
         props.statusLabel = fieldInfo.attrs.status_label;
+        props.hideIcon = Boolean(fieldInfo.attrs.hide_icon);
+        props.hideValue = Boolean(fieldInfo.attrs.hide_value);
         return props;
     },
 };

--- a/addons/project/static/src/components/project_status_with_color_selection/project_status_with_color_selection_field.xml
+++ b/addons/project/static/src/components/project_status_with_color_selection/project_status_with_color_selection_field.xml
@@ -4,10 +4,10 @@
     <t t-name="project.ProjectStatusWithColorSelectionField" t-inherit="web.SelectionField" t-inherit-mode="primary">
         <xpath expr="//t[@t-if='props.readonly']/span" position="replace">
             <div class="d-flex align-items-center">
-                <span t-attf-class="o_status {{ statusColor(currentValue) }} d-inline-block"/>
+                <span t-if="!this.props.hideIcon" t-attf-class="o_status {{ statusColor(currentValue) }} d-inline-block"/>
                 <div class="ps-2">
                     <div class="o_stat_text" t-if="this.props.statusLabel" t-out="this.props.statusLabel"/>
-                    <div class="o_stat_value" t-out="string" t-att-raw-value="value"/>
+                    <div class="o_stat_value" t-if="!this.props.hideValue" t-out="string" t-att-raw-value="value"/>
                 </div>
             </div>
         </xpath>

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -43,38 +43,50 @@
                     <div class="oe_button_box" name="button_box" groups="base.group_user">
                         <button class="oe_stat_button" type="object" name="action_view_tasks" icon="fa-check">
                             <div class="o_field_widget o_stat_info">
-                                <field name="label_tasks" readonly="1"/>
+                                <field class="o_stat_text" name="label_tasks" readonly="1"/>
                                 <span class="o_stat_value">
-                                    <field name="closed_task_count"/> / <field name="task_count"/>
-                                    (<field name="task_completion_percentage" widget="percentage" options="{'digits': [1, 0]}"/>)
+                                    <field name="closed_task_count"/><span class="o_field_widget"> / </span><field name="task_count"/> 
+                                    <span class="o_field_widget ps-1" invisible="closed_task_count == 0">(</span>
+                                    <field name="task_completion_percentage" invisible="closed_task_count == 0" widget="percentage" options="{'digits': [1, 0]}"/>
+                                    <span class="o_field_widget" invisible="closed_task_count == 0"> ) </span>
                                 </span>
                             </div>
                         </button>
                         <button class="oe_stat_button" name="action_get_list_view" type="object" groups="project.group_project_milestone" invisible="not allow_milestones or milestone_count &lt;= 0 or is_template">
-                            <i class="fa o_button_icon fa-check text-success" invisible="next_milestone_status == 'off_track'" title="On Track"/>
-                            <i class="fa o_button_icon fa-check text-danger" invisible="next_milestone_status == 'on_track'" title="Off Track"/>
+                            <i class="fa o_button_icon fa-check" invisible="next_milestone_status == False or next_milestone_status != 'on_track'" title="On Track"/>
+                            <i class="fa o_button_icon fa-check text-success" invisible="next_milestone_status != 'next_track'" title="On Track"/>
+                            <i class="fa o_button_icon fa-check text-danger" invisible="next_milestone_status != 'off_track'" title="Off Track"/>
                             <div class="o_field_widget o_stat_info">
                                 <span class="o_stat_text">Milestones</span>
                                 <span class="o_stat_value">
-                                    <field name="milestone_count_reached"/> / <field name="milestone_count"/>
-                                    (<field name="milestone_progress" options="{'digits': [1, 0]}"/>%)
+                                    <field name="milestone_count_reached"/><span class="o_field_widget"> / </span><field name="milestone_count"/>  
+                                       <span class="o_field_widget ps-1">(</span>
+                                       <field name="milestone_progress" options="{'digits': [1, 0]}"/>
+                                       <span class="o_field_widget">%)</span>
                                 </span>
                             </div>
                         </button>
                         <button class="oe_stat_button" name="project_update_all_action" type="object" groups="project.group_project_user" context="{'active_id': id}" invisible="is_template">
-                            <field name="last_update_status" class="o_stat_info" readonly="1" widget="status_with_color" status_label="Status"/>
+                            <field name="last_update_status" class="o_stat_info ps-1" readonly="1" status_label="Status" widget="status_with_color" hide_value="1" hide_icon=""/>
+                            <span class="o_field_widget ps-1">(</span>
+                            <field name="last_update_status" class="o_stat_info" readonly="1" widget="status_with_color" hide_value="" hide_icon="1"/>
+                            <span class="o_field_widget ps-2">)</span>
                         </button>
                         <button class="oe_stat_button" type="object" name="action_project_task_burndown_chart_report"
-                            icon="fa-area-chart" string="Burndown Chart" groups="project.group_project_user"/>
+                            icon="fa-area-chart" groups="project.group_project_user">
+                            <div class="o_stat_info">
+                                <span class="o_stat_text">Burndown<br/> Chart</span>
+                            </div>
+                        </button>
                         <button name="action_view_all_rating" type="object" class="oe_stat_button" icon="" invisible="rating_count == 0">
                             <i class="fa fa-fw o_button_icon fa-smile-o text-success" invisible="rating_avg &lt; 3.66" title="Happy"/>
                             <i class="fa fa-fw o_button_icon fa-meh-o text-warning" invisible="rating_avg &lt; 2.33 or rating_avg &gt;= 3.66" title="Neutral"/>
                             <i class="fa fa-fw o_button_icon fa-frown-o text-danger" invisible="rating_avg &gt;= 2.33" title="Unhappy"/>
                             <div class="o_field_widget o_stat_info">
                                 <span class="o_stat_value">
-                                    <field name="rating_avg" nolabel="1" widget="float" digits="[1, 1]"/> / 5
+                                    <field name="rating_avg" nolabel="1" widget="float" digits="[1, 1]"/><span class="o_field_widget"> / 5 </span>
                                 </span>
-                                <span class="o_stat_text">Average Rating</span>
+                                <span class="o_stat_text">Rating</span>
                             </div>
                         </button>
                     </div>

--- a/addons/project/views/project_update_templates.xml
+++ b/addons/project/views/project_update_templates.xml
@@ -15,7 +15,7 @@
     <template id="project_update_default_description" name="Project Update Description">
 <!--As this template is rendered in an html field, the spaces may be interpreted as nbsp while editing. -->
 <div name="summary">
-<br/><h1 style="font-weight: bolder;">Summary</h1>
+<h1 style="font-weight: bolder;">Summary</h1>
 <br/><p>How’s this project going?</p><br/><br/>
 </div>
 

--- a/addons/project/views/project_update_views.xml
+++ b/addons/project/views/project_update_views.xml
@@ -45,7 +45,6 @@
                             <field name="date"/>
                         </group>
                     </group>
-                    <separator/>
                     <notebook>
                         <page string="Description" name="description">
                             <field name="description" nolabel="1" class="o_project_update_description" options="{'resizable': false, 'collaborative': true}"/>
@@ -113,12 +112,23 @@
             </list>
         </field>
     </record>
+    
+    <record id="project_update_view_graph" model="ir.ui.view">
+        <field name="name">project.update.view.graph</field>
+        <field name="model">project.update</field>
+        <field name="arch" type="xml">
+            <graph>
+                <field name="date" type="row"/>
+                <field name="progress" type="measure"/>
+            </graph>
+        </field>
+    </record>
 
     <record id="project_update_all_action" model="ir.actions.act_window">
         <field name="name">Updates</field>
         <field name="res_model">project.update</field>
         <field name="path">project-dashboard</field>
-        <field name="view_mode">list,kanban,form</field>
+        <field name="view_mode">list,kanban,graph,form</field>
         <field name="domain">[('project_id', '=', active_id)]</field>
         <field name="search_view_id" ref="project_update_view_search"/>
         <field name="help" type="html">

--- a/addons/sale_margin/report/sale_report_views.xml
+++ b/addons/sale_margin/report/sale_report_views.xml
@@ -18,12 +18,30 @@
         </field>
     </record>
 
+    <record id="sale_report_projected_margins_kanban" model="ir.ui.view">
+        <field name="name">sale.report.view.kanban</field>
+         <field name="model">sale.report</field>
+        <field name="arch" type="xml">
+            <kanban>
+                 <templates>
+                    <t t-name="card">
+                        <div>
+                           <field name="name" class="fw-bold"/>-<field name="partner_id"/><br/>
+                           <field name="product_id"/><br/>
+                           <field name="currency_id" invisible="1"/>
+                           <field name="margin" widget="monetary" options="{'currency_field': 'currency_id'}"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
     <record id="action_order_report_projected_margins" model="ir.actions.act_window">
         <field name="name">Projected Margins</field>
         <field name="res_model">sale.report</field>
         <field name="path">project-projected-margins</field>
         <field name="view_mode">list,kanban</field>
-        <field name="view_id" ref="sale_report_projected_margins_list" />
         <field name="search_view_id" ref="sale.view_order_product_search" />
         <field name="context">{'search_default_Customer': 1, 'search_default_filter_order_date': 1}</field>
         <field name="help" type="html">

--- a/addons/sale_project/models/account_analytic_line.py
+++ b/addons/sale_project/models/account_analytic_line.py
@@ -3,9 +3,9 @@
 from odoo import api, fields, models
 
 BILLABLE_TYPES = [
-    ('01_revenues_fixed', 'Revenues Fixed Price'),
-    ('05_revenues_milestones', 'Revenues Milestones'),
-    ('07_revenues_manual', 'Revenues Manual'),
+    ('01_revenues_fixed', 'Revenues (Fixed Price)'),
+    ('05_revenues_milestones', 'Revenues (Milestones)'),
+    ('07_revenues_manual', 'Revenues (Manual)'),
     ('10_service_revenues', 'Service Revenues'),
     ('11_other_revenues', 'Other Revenues'),
     ('12_other_costs', 'Other Costs'),
@@ -40,3 +40,19 @@ class AccountAnalyticLine(models.Model):
                     line.billable_type = invoice_type
             else:
                 line.billable_type = '12_other_costs'
+
+    def action_open_account_analytic_line_origine(self):
+        self.ensure_one()
+        if (self.so_line):
+            return {
+                'res_model': self.so_line,
+                'type': 'ir.actions.act_window',
+                'views': [[False, "form"]],
+                'res_id': self.so_line.id,
+            }
+        return {
+            'res_model': self,
+            'type': 'ir.actions.act_window',
+            'views': [[False, "form"]],
+            'res_id': self.id,
+        }

--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -151,7 +151,7 @@ class ProjectProject(models.Model):
             aggregates=['amount:sum'],
         ))
         for project in self:
-            project.actual_margin = margin_per_account.get(project.account_id.id, 0.0)
+            project.actual_margin = margin_per_account.get(project.account_id, 0.0)
 
     def action_customer_preview(self):
         self.ensure_one()
@@ -517,6 +517,5 @@ class ProjectProject(models.Model):
         self.ensure_one()
         action = self.env['ir.actions.act_window']._for_xml_id('sale_project.action_analytic_reporting_inherit_sale_project')
         action['display_name'] = self.env._("%(name)s's Actual Margins", name=self.name)
-        action['context'] = {'search_default_fiscal_date': 1, 'search_default_group_date': 1}
         action['domain'] = [('account_id', 'in', self.account_id.ids)]
         return action

--- a/addons/sale_project/report/account_analytic_line_views.xml
+++ b/addons/sale_project/report/account_analytic_line_views.xml
@@ -20,6 +20,12 @@
         <field name="model">account.analytic.line</field>
         <field name="inherit_id" ref="account.view_account_analytic_line_tree_inherit_account"/>
         <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <xpath expr="//list" position='attributes'>
+                <attribute name="action">action_open_account_analytic_line_origine</attribute>
+                <attribute name="type">object</attribute>
+            </xpath>
+        </field>
     </record>
 
     <record id="action_analytic_reporting_inherit_sale_project" model="ir.actions.act_window">
@@ -30,8 +36,7 @@
         <field name="view_id" ref="view_account_analytic_line_inherit_sale_project_pivot"/>
         <field name="view_mode">pivot,list,kanban,graph,grid</field>
         <field name="context">{
-            'search_default_fiscal_date': 1,
-            'group_by': 'account_id'
+            'search_default_month': 'custom_last_365_days',
         }</field>
     </record>
 

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -78,7 +78,7 @@
                     class="oe_stat_button"
                     type="object"
                     name="action_view_sos"
-                    icon="fa-dollar"
+                    icon="fa-id-card-o"
                     invisible="not display_sales_stat_buttons or sale_order_count != 0 or is_template"
                     groups="sales_team.group_sale_salesman_all_leads"
                     context="{
@@ -104,24 +104,27 @@
                     <field string="Vendor Bills" name="vendor_bill_count" widget="statinfo"/>
                 </button>
             </xpath>
-            <xpath expr="//button[@name='action_project_task_burndown_chart_report']" position="after">
+            <xpath expr="//button[@name='action_view_tasks']" position="before">
                 <button class="oe_stat_button" name="action_actual_margin" type="object" groups="project.group_project_manager" context="{'active_id': id}" invisible="is_template or not allow_billable">
                     <i class="fa fa-fw o_button_icon fa-dollar text-success" invisible="actual_margin &lt; 0" title="On Track"/>
                     <i class="fa fa-fw o_button_icon fa-dollar text-danger" invisible="actual_margin &gt;= 0" title="Off Track"/>
                     <div class="o_stat_info">
                         <span class="o_stat_text">Actual Margin</span>
-                        <field name="actual_margin" class="o_stat_value" widget="float" options="{'digits': [1, 0]}"/>
+                        <field name="currency_id" invisible="1"/>
+                        <field name="actual_margin" class="o_stat_value" widget="monetary" options="{'currency_field': 'currency_id'}"/>
                     </div>
                 </button>
+            </xpath>
+            <xpath expr="//button[@name='action_project_task_burndown_chart_report']" position="after">
                 <button class="oe_stat_button" type="object" name="action_view_sols" icon="fa-dollar"
                     groups="sales_team.group_sale_salesman_all_leads" invisible="not display_sales_stat_buttons">
-                    <field string="Sales Order Items" name="sale_order_line_count" widget="statinfo"/>
+                    <field string="Sales Items" name="sale_order_line_count" widget="statinfo"/>
                 </button>
             </xpath>
             <xpath expr="//button[@name='action_view_all_rating']" position="after">
                 <button class="oe_stat_button" type="object" name="action_customer_preview" icon="fa-globe icon" invisible="not partner_id or not allow_billable or privacy_visibility not in ['invited_users', 'portal'] or is_template">
                     <div class="o_field_widget o_stat_info">
-                        <span class="o_stat_text">Preview</span>
+                        <span class="o_stat_text">Customer View</span>
                     </div>
                 </button>
             </xpath>

--- a/addons/sale_project_margin/views/project_task_views.xml
+++ b/addons/sale_project_margin/views/project_task_views.xml
@@ -6,14 +6,15 @@
         <field name="model">project.project</field>
         <field name="inherit_id" ref="sale_project.view_edit_project_inherit_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//button[@name='action_actual_margin']" position="after">
+            <xpath expr="//button[@name='action_view_tasks']" position="before">
                 <t groups="sales_team.group_sale_salesman_all_leads">
                     <button class="oe_stat_button" name="action_projected_margin" type="object" groups="project.group_project_manager" context="{'active_id': id}" invisible="is_template or not allow_billable">
                         <i class="fa fa-fw o_button_icon fa-dollar text-success" invisible="projected_margin &lt; 0" title="On Track"/>
                         <i class="fa fa-fw o_button_icon fa-dollar text-danger" invisible="projected_margin &gt;= 0" title="Off Track"/>
                         <div class="o_stat_info">
                             <span class="o_stat_text">Projected Margin</span>
-                            <field name="projected_margin" class="o_stat_value" widget="float" options="{'digits': [1, 0]}"/>
+                            <field name="currency_id" invisible="1"/> <!-- Needed for widget bellow-->
+                            <field name="projected_margin" class="o_stat_value" widget="monetary" options="{'currency_field': 'currency_id'}"/>
                         </div>
                     </button>
                 </t>

--- a/addons/sale_timesheet/__init__.py
+++ b/addons/sale_timesheet/__init__.py
@@ -21,3 +21,10 @@ def _sale_timesheet_post_init(env):
     for product in products:
         product.service_type = 'timesheet'
         product._compute_service_policy()
+
+    lines = env['account.analytic.line'].search(['&', '|',
+        ('billable_type', '=', '12_other_costs'),
+        ('billable_type', '=', '11_other_revenues'),
+        ('project_id', '!=', False),
+    ])
+    lines._compute_project_billable_type()

--- a/addons/sale_timesheet/models/hr_timesheet.py
+++ b/addons/sale_timesheet/models/hr_timesheet.py
@@ -9,12 +9,12 @@ from odoo.tools.misc import unquote
 from odoo.addons.sale_project.models.account_analytic_line import BILLABLE_TYPES
 
 TIMESHEET_BILLABLE_TYPES = [
-    ('02_billable_fixed', 'Billed at a Fixed price'),
-    ('03_timesheet_revenues', 'Revenues Timesheets'),
-    ('04_billable_time', 'Billed on Timesheets'),
-    ('06_billable_milestones', 'Billed on Milestones'),
-    ('08_billable_manual', 'Billed Manually'),
-    ('09_non_billable', 'Non-Billable'),
+    ('02_billable_fixed', 'Timesheet (Fixed price)'),
+    ('03_timesheet_revenues', 'Revenues (Time & Material)'),
+    ('04_billable_time', 'Timesheets (Time & Materials)'),
+    ('06_billable_milestones', 'Timesheets (Milestones)'),
+    ('08_billable_manual', 'Timesheets (Manual) '),
+    ('09_non_billable', 'Timesheets (Non-Billable)'),
 ]
 
 BILLABLE_TYPES += TIMESHEET_BILLABLE_TYPES

--- a/addons/sale_timesheet/views/account_analytic_line_views.xml
+++ b/addons/sale_timesheet/views/account_analytic_line_views.xml
@@ -30,4 +30,18 @@
             </filter>
         </field>
     </record>
+    <record id="hr_timesheet_line_search" model="ir.ui.view">
+        <field name="name">sale_timesheet.account.analytic.margins.search</field>
+        <field name="model">account.analytic.line</field>
+        <field name="priority" eval="50"/>
+        <field name="inherit_id" ref="account.view_account_analytic_line_filter_inherit_account"/>
+        <field name="arch" type="xml">
+            <xpath expr="//filter[@name='mine']" position="attributes">
+                <attribute name="string">Mine</attribute>
+            </xpath>
+            <xpath expr="//filter[@name='groupby_parent_task']" position="attributes">
+                <attribute name="invisible">True</attribute>
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
This task provides corrections and follow‑up work related to PR : IMP #236971 .

## Expected Behavior After This Commit
1. Renamed the stat buttons in the Project form view to make their purpose clearer.
2. Corrected breadcrumb generation when accessing the Project form view from the top menu.
3. Adjusted the project update form view to remove excessive padding.
4. Added a graph to the project update view to visualize project progress over time.
5. Updated filters in the margin search view.
6. Improved billable type labels for better user clarity.
7. Ensured billable types are updated correctly when sale_timesheet is installed.
8. Added navigation from analytic lines to their parent record in the margin list view.
9. Added three colors (gray, green, red) to the Milestone stat button.
10. Improved the kanban view of projected margins.

## Additions

### Point 2 — Breadcrumb Fix
When navigating from the top menu to the Project Overview, breadcrumbs were not generated correctly. To resolve this, a multi‑step flow was implemented:

- Clicking the "Overview" button triggers the action `project_embedded_action_project_overview`.
- This action calls the Python method `action_open_project_form`, which then triggers the client action `project_top_menu_overview`.
- The client action uses the `doAction` service to open the Project form view.

This approach is required because:
- Breadcrumbs are generated correctly only when `doAction` is executed inside a client action.
- The "Overview" button cannot directly trigger a client action, making the Python intermediary necessary.

### Point 7 — Billable Type Synchronization
The `sale_project` module defines the `billable_type` field on `account_analytic_line`, including the generic types *Other Revenues* and *Other Costs*. The `hr_timesheet` module adds additional, more specific billable types.

A problem occurs when:
- `sale_project` is installed first, causing analytic lines that should belong to `hr_timesheet` billable types to be incorrectly classified under *Other Revenues* or *Other Costs*.
- When `hr_timesheet` is installed afterward, these analytic lines are not automatically updated.

This fix ensures that potentially misclassified analytic lines are corrected when both `hr_timesheet` and `sale_project` are installed.

## Task
task-[5955934](https://www.odoo.com/odoo/project/4105/tasks/5955934)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
