### PR TITLE
[FIX] pos_self_order: price with fiscal position

### DIFF
--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -182,24 +182,16 @@ class PosOrder(models.Model):
         self.amount_total = tax_totals['total_amount_currency']
 
     def _compute_line_price(self, line):
-        company = self.company_id
         pricelist = self.pricelist_id
         selected_attributes = line.attribute_value_ids
         product = line.product_id.with_context(line.product_id._get_product_price_context(selected_attributes))
-        tax_domain = self.env['account.tax']._check_company_domain(company)
-
-        price = pricelist._get_product_price(product, line.qty or 1.0, currency=self.currency_id)
-        line.tax_ids = product.taxes_id.filtered_domain(tax_domain)
+        price = pricelist._get_product_price(product, 1.0, currency=self.currency_id)
+        line.price_unit = price
+        line.tax_ids = line.product_id.taxes_id._filter_taxes_by_company(self.company_id)
         tax_ids_after_fiscal_position = self.fiscal_position_id.map_tax(line.tax_ids)
-        new_price = self.env['account.tax']._fix_tax_included_price_company(
-            price, line.tax_ids, tax_ids_after_fiscal_position, self.company_id)
-
-        line.price_unit = new_price
-        base_line = line._prepare_base_line_for_taxes_computation()
-        self.env['account.tax']._add_tax_details_in_base_line(base_line, company)
-        self.env['account.tax']._round_base_lines_tax_details([base_line], company)
-        line.price_subtotal = base_line['tax_details']['total_excluded_currency']
-        line.price_subtotal_incl = base_line['tax_details']['total_included_currency']
+        taxes = tax_ids_after_fiscal_position.compute_all(price, self.currency_id, line.qty, product=product, partner=self.partner_id)
+        line.price_subtotal = taxes['total_excluded']
+        line.price_subtotal_incl = taxes['total_included']
 
     def _compute_combo_price(self, parent_line):
         """

--- a/addons/pos_self_order/static/tests/tours/self_order_prices_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_prices_tour.js
@@ -267,3 +267,23 @@ registry.category("web_tour.tours").add("test_pricelist_should_not_be_changed_fr
         },
     ],
 });
+
+registry.category("web_tour.tours").add("test_fiscal_position_between_frontend_and_backend", {
+    steps: () => [
+        Utils.clickBtn("Order Now"),
+        ...commonStepWithSpecificPrice,
+        {
+            content: "Check that the fiscal position is applied",
+            trigger: "body",
+            run: async () => {
+                const order = posmodel.currentOrder;
+                if (order.fiscal_position_id?.name !== "Take out") {
+                    throw new Error(
+                        `The fiscal position should not be "Take out", but it is ${order.fiscal_position_id?.name}`
+                    );
+                }
+            },
+        },
+        comparePricesWithBackend,
+    ],
+});

--- a/addons/pos_self_order/tests/test_self_order_prices.py
+++ b/addons/pos_self_order/tests/test_self_order_prices.py
@@ -73,7 +73,7 @@ class TestSelfOrderCombo(SelfOrderCommonTest):
             'pos_categ_ids': [(6, 0, [self.combo_category.id])],
         })
 
-        price_extra_product = self.env['product.product'].create({
+        self.price_extra_product = self.env['product.product'].create({
             'name': 'Product with attributes',
             'is_storable': True,
             'available_in_pos': True,
@@ -108,12 +108,12 @@ class TestSelfOrderCombo(SelfOrderCommonTest):
             'attribute_id': no_price_extra.id,
         }])
         self.env['product.template.attribute.line'].create({
-            'product_tmpl_id': price_extra_product.product_tmpl_id.id,
+            'product_tmpl_id': self.price_extra_product.product_tmpl_id.id,
             'attribute_id': price_extra.id,
             'value_ids': [(6, 0, price_extra_values.ids)],
         })
         self.env['product.template.attribute.line'].create({
-            'product_tmpl_id': price_extra_product.product_tmpl_id.id,
+            'product_tmpl_id': self.price_extra_product.product_tmpl_id.id,
             'attribute_id': no_price_extra.id,
             'value_ids': [(6, 0, no_price_extra_values.ids)],
         })
@@ -261,3 +261,30 @@ class TestSelfOrderCombo(SelfOrderCommonTest):
         self.pos_config.current_session_id.set_opening_control(0, '')
         self_route = self.pos_config._get_self_order_route()
         self.start_tour(self_route, 'test_pricelist_should_not_be_changed_from_frontend')
+
+    def test_fiscal_position_between_frontend_and_backend(self):
+        self.tax_21.price_include_override = 'tax_included'
+        self.tax_6.price_include_override = 'tax_included'
+
+        fp = self.env['account.fiscal.position'].create({
+            'name': 'Take out',
+            'tax_ids': [(0, 0, {
+                'tax_src_id': self.tax_21.id,
+                'tax_dest_id': self.tax_6.id,
+            })],
+        })
+        self.pos_config.write({
+            'tax_regime_selection': True,
+            'default_fiscal_position_id': fp.id,
+            'fiscal_position_ids': [Command.set(fp.ids)],
+        })
+
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, '')
+        self_route = self.pos_config._get_self_order_route()
+        self.start_tour(self_route, 'test_fiscal_position_between_frontend_and_backend')
+
+        self.tax_21.price_include_override = 'tax_excluded'
+        self.tax_6.price_include_override = 'tax_excluded'
+
+        self.start_tour(self_route, 'test_fiscal_position_between_frontend_and_backend')


### PR DESCRIPTION
Before this commit, the price of order lines from self was recomputed in the backend but for orders with price included taxes and a fiscal position mapping, the recomputation was not correct. This commit fixes the issue by recomputing the prices using compute_all method from accounting on taxes after fiscal position.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
