### PR TITLE
[REF] tests: merge Cursor and BaseCursor

### DIFF
--- a/odoo/addons/test_orm/tests/test_registry_signaling.py
+++ b/odoo/addons/test_orm/tests/test_registry_signaling.py
@@ -456,8 +456,8 @@ class TestTestCursor(common.TransactionCase):
         a = self.registry.cursor()
         b = self.registry.cursor()
         # This forces the savepoint to be created
-        a._check_savepoint()
-        b._check_savepoint()
+        a.execute("SELECT 1")
+        b.execute("SELECT 1")
         # `a` should warn that it found un-closed cursor `b` when trying to close itself
         with self.assertLogs('odoo.sql_db', level=logging.WARNING) as cm:
             a.close()

--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -21,6 +21,9 @@ import odoo.release as release
 import odoo.tools as tools
 import odoo.upgrade
 
+if typing.TYPE_CHECKING:
+    from unittest import TestCase
+
 try:
     from packaging.requirements import InvalidRequirement, Requirement
 except ImportError:
@@ -106,8 +109,8 @@ TYPED_FIELD_DEFINITION_RE = re.compile(r'''
 
 _logger = logging.getLogger(__name__)
 
-current_test: bool = False
-"""Indicates whteher we are in a test mode"""
+current_test: TestCase | None = None
+"""The current test being run, if any"""
 
 
 class UpgradeHook:

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -7,6 +7,7 @@ the ORM does, in fact.
 """
 from __future__ import annotations
 
+import functools
 import logging
 import os
 import re
@@ -326,7 +327,7 @@ class Cursor(BaseCursor):
             *any* data which may be modified during the life of the cursor.
 
     """
-    def __init__(self, pool: ConnectionPool, dbname: str, dsn: dict):
+    def __init__(self, cnx: PsycoConnection, dbname: str):
         super().__init__()
         self.sql_from_log: dict[str, tuple[int, float]] = {}
         self.sql_into_log: dict[str, tuple[int, float]] = {}
@@ -339,22 +340,14 @@ class Cursor(BaseCursor):
         # is raised by any of the following initializations
         self._closed: bool = True
 
-        self.__pool: ConnectionPool = pool
         self.dbname = dbname
-
-        self._cnx: PsycoConnection = pool.borrow(dsn)
-        self._obj: psycopg2.extensions.cursor = self._cnx.cursor()
+        self._cnx = cnx
+        self._obj: psycopg2.extensions.cursor = cnx.cursor()
         if _logger.isEnabledFor(logging.DEBUG):
             self.__caller: tuple[str, str | int] | None = frame_codeinfo(currentframe(), 2)
         else:
             self.__caller = None
         self._closed = False   # real initialization value
-        self._cnx.set_session(
-            # See the docstring of this class.
-            isolation_level=ISOLATION_LEVEL_REPEATABLE_READ,
-            readonly=pool.readonly,
-            autocommit=False,
-        )
 
         if os.getenv('ODOO_FAKETIME_TEST_MODE') and self.dbname in tools.config['db_name']:
             self.execute("SET search_path = public, pg_catalog;")
@@ -393,7 +386,7 @@ class Cursor(BaseCursor):
             _logger.log(logging.DEBUG if self._cnx.closed else logging.WARNING, msg)
             # Just close the raw connection as other all environments are
             # (being) collected at this time.
-            self.__pool.give_back(self._cnx, keep_in_pool=False)
+            self._cnx.give_back(keep_in_pool=False)
 
     def _format(self, query, params=None) -> str:
         encoding = psycopg2.extensions.encodings[self.connection.encoding]
@@ -541,7 +534,7 @@ class Cursor(BaseCursor):
                 config['db_system'] if config['db_system'] not in config['db_name'] else '',
                 config['db_template'],
             )
-            self.__pool.give_back(self._cnx, keep_in_pool=keep_in_pool)
+            self._cnx.give_back(keep_in_pool=keep_in_pool)
 
     def commit(self) -> None:
         """ Perform an SQL `COMMIT` """
@@ -593,6 +586,9 @@ class PsycoConnection(psycopg2.extensions.connection):
                 def password(self):
                     pass
             return PsycoConnectionInfo(self)
+
+    def give_back(self, keep_in_pool=True):
+        raise RuntimeError('not bound to a pool')
 
 
 class ConnectionPool:
@@ -673,6 +669,7 @@ class ConnectionPool:
             result = psycopg2.connect(
                 connection_factory=PsycoConnection,
                 **connection_info)
+            result.give_back = functools.partial(self.give_back, result)
         except psycopg2.Error:
             _logger.info('Connection to the database failed')
             raise
@@ -757,7 +754,14 @@ class Connection:
 
     def cursor(self) -> Cursor:
         _logger.debug('create cursor to %r', self.dsn)
-        return Cursor(self.__pool, self.__dbname, self.__dsn)
+        cnx = self.__pool.borrow(self.__dsn)
+        cnx.set_session(
+            # See the docstring of this class.
+            isolation_level=ISOLATION_LEVEL_REPEATABLE_READ,
+            readonly=self.__pool.readonly,
+            autocommit=False,
+        )
+        return Cursor(cnx, self.__dbname)
 
     def __bool__(self):
         raise NotImplementedError()

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -41,7 +41,7 @@ from .tools.misc import Callbacks, real_time
 if typing.TYPE_CHECKING:
     from odoo.orm.environments import Transaction
 
-    # when type checking, the BaseCursor exposes methods of the psycopg cursor
+    # when type checking, the Cursor exposes methods of the psycopg cursor
     _CursorProtocol = psycopg2.extensions.cursor
 else:
     _CursorProtocol = object
@@ -90,11 +90,11 @@ MAX_IDLE_TIMEOUT = 60 * 10
 
 
 class Savepoint:
-    """ Reifies an active breakpoint, allows :meth:`BaseCursor.savepoint` users
+    """ Reifies an active breakpoint, allows :meth:`Cursor.savepoint` users
     to internally rollback the savepoint (as many times as they want) without
     having to implement their own savepointing, or triggering exceptions.
 
-    Should normally be created using :meth:`BaseCursor.savepoint` rather than
+    Should normally be created using :meth:`Cursor.savepoint` rather than
     directly.
 
     The savepoint will be rolled back on unsuccessful context exits
@@ -105,7 +105,7 @@ class Savepoint:
     The savepoint can also safely be explicitly closed during context body. This
     will rollback by default.
 
-    :param BaseCursor cr: the cursor to execute the `SAVEPOINT` queries on
+    :param Cursor cr: the cursor to execute the `SAVEPOINT` queries on
     """
 
     def __init__(self, cr: _CursorProtocol):
@@ -135,14 +135,14 @@ class Savepoint:
 
 
 class _FlushingSavepoint(Savepoint):
-    def __init__(self, cr: BaseCursor):
+    def __init__(self, cr: Cursor):
         cr.flush()
         super().__init__(cr)
         self._default_env = cr.transaction.default_env if cr.transaction is not None else None
 
     def rollback(self):
         cr = self._cr
-        assert isinstance(cr, BaseCursor)
+        assert isinstance(cr, Cursor)
         if cr.transaction is not None:
             cr.transaction.default_env = self._default_env
             cr.transaction.clear()
@@ -151,7 +151,7 @@ class _FlushingSavepoint(Savepoint):
         super().rollback()
 
     def _close(self, rollback: bool):
-        assert isinstance(self._cr, BaseCursor)
+        assert isinstance(self._cr, Cursor)
         try:
             if not rollback:
                 self._cr.flush()
@@ -164,106 +164,7 @@ class _FlushingSavepoint(Savepoint):
 
 # _CursorProtocol declares the available methods and type information,
 # at runtime, it is just an `object`
-class BaseCursor(_CursorProtocol):
-    """ Base class for cursors that manage pre/post commit hooks. """
-    IN_MAX = 1000   # decent limit on size of IN queries - guideline = Oracle limit
-
-    transaction: Transaction | None
-    cache: dict[typing.Any, typing.Any]
-    dbname: str
-
-    def __init__(self) -> None:
-        self.precommit = Callbacks()
-        self.postcommit = Callbacks()
-        self.prerollback = Callbacks()
-        self.postrollback = Callbacks()
-        self._now: datetime | None = None
-        self.cache = {}
-        # By default a cursor has no transaction object.  A transaction object
-        # for managing environments is instantiated by registry.cursor().  It
-        # is not done here in order to avoid cyclic module dependencies.
-        self.transaction = None
-
-    def flush(self) -> None:
-        """ Flush the current transaction, and run precommit hooks. """
-        # In case some pre-commit added another pre-commit or triggered changes
-        # in the ORM, we must flush and run it again.
-        for _ in range(10):  # limit number of iterations
-            if self.transaction is not None:
-                self.transaction.flush()
-            if not self.precommit:
-                break
-            self.precommit.run()
-        else:
-            _logger.warning("Too many iterations for flushing the cursor!")
-
-    def execute(self, query, params=None, log_exceptions: bool = True) -> None:
-        """ Execute a query inside the current transaction.
-        """
-        raise NotImplementedError
-
-    def commit(self) -> None:
-        """ Commit the current transaction.
-        """
-        raise NotImplementedError
-
-    def rollback(self) -> None:
-        """ Rollback the current transaction.
-        """
-        raise NotImplementedError
-
-    def savepoint(self, flush: bool = True) -> Savepoint:
-        """context manager entering in a new savepoint
-
-        With ``flush`` (the default), will automatically run (or clear) the
-        relevant hooks.
-        """
-        if flush:
-            return _FlushingSavepoint(self)
-        else:
-            return Savepoint(self)
-
-    def __enter__(self):
-        """ Using the cursor as a contextmanager automatically commits and
-            closes it::
-
-                with cr:
-                    cr.execute(...)
-
-                # cr is committed if no failure occurred
-                # cr is closed in any case
-        """
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        try:
-            if exc_type is None:
-                self.commit()
-        finally:
-            self.close()
-
-    def dictfetchone(self) -> dict[str, typing.Any] | None:
-        """ Return the first row as a dict (column_name -> value) or None if no rows are available. """
-        raise NotImplementedError
-
-    def dictfetchmany(self, size: int) -> list[dict[str, typing.Any]]:
-        raise NotImplementedError
-
-    def dictfetchall(self) -> list[dict[str, typing.Any]]:
-        """ Return all rows as dicts (column_name -> value). """
-        raise NotImplementedError
-
-    def now(self) -> datetime:
-        """ Return the transaction's timestamp ``NOW() AT TIME ZONE 'UTC'``. """
-        if self._now is None:
-            self.execute("SELECT (now() AT TIME ZONE 'UTC')")
-            row = self.fetchone()
-            assert row
-            self._now = row[0]
-        return self._now
-
-
-class Cursor(BaseCursor):
+class Cursor(_CursorProtocol):
     """Represents an open transaction to the PostgreSQL DB backend,
        acting as a lightweight wrapper around psycopg2's
        ``cursor`` objects.
@@ -327,8 +228,22 @@ class Cursor(BaseCursor):
             *any* data which may be modified during the life of the cursor.
 
     """
+    IN_MAX = 1000   # decent limit on size of IN queries - guideline = Oracle limit
+
     def __init__(self, cnx: PsycoConnection, dbname: str):
         super().__init__()
+        self.precommit = Callbacks()
+        self.postcommit = Callbacks()
+        self.prerollback = Callbacks()
+        self.postrollback = Callbacks()
+        self._now: datetime | None = None
+        self.cache: dict[typing.Any, typing.Any] = {}
+
+        # By default a cursor has no transaction object.  A transaction object
+        # for managing environments is instantiated by registry.cursor().  It
+        # is not done here in order to avoid cyclic module dependencies.
+        self.transaction: Transaction | None = None
+
         self.sql_from_log: dict[str, tuple[int, float]] = {}
         self.sql_into_log: dict[str, tuple[int, float]] = {}
 
@@ -353,7 +268,60 @@ class Cursor(BaseCursor):
             self.execute("SET search_path = public, pg_catalog;")
             self.commit()  # ensure that the search_path remains after a rollback
 
+    def flush(self) -> None:
+        """ Flush the current transaction, and run precommit hooks. """
+        # In case some pre-commit added another pre-commit or triggered changes
+        # in the ORM, we must flush and run it again.
+        for _ in range(10):  # limit number of iterations
+            if self.transaction is not None:
+                self.transaction.flush()
+            if not self.precommit:
+                break
+            self.precommit.run()
+        else:
+            _logger.warning("Too many iterations for flushing the cursor!")
+
+    def savepoint(self, flush: bool = True) -> Savepoint:
+        """context manager entering in a new savepoint
+
+        With ``flush`` (the default), will automatically run (or clear) the
+        relevant hooks.
+        """
+        if flush:
+            return _FlushingSavepoint(self)
+        else:
+            return Savepoint(self)
+
+    def __enter__(self):
+        """ Using the cursor as a contextmanager automatically commits and
+            closes it::
+
+                with cr:
+                    cr.execute(...)
+
+                # cr is committed if no failure occurred
+                # cr is closed in any case
+        """
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        try:
+            if exc_type is None:
+                self.commit()
+        finally:
+            self.close()
+
+    def now(self) -> datetime:
+        """ Return the transaction's timestamp ``NOW() AT TIME ZONE 'UTC'``. """
+        if self._now is None:
+            self.execute("SELECT (now() AT TIME ZONE 'UTC')")
+            row = self.fetchone()
+            assert row
+            self._now = row[0]
+        return self._now
+
     def dictfetchone(self) -> dict[str, typing.Any] | None:
+        """ Return the first row as a dict (column_name -> value) or None if no rows are available. """
         description = self._obj.description
         assert description, "Query does not have results"
         row = self._obj.fetchone()
@@ -366,6 +334,7 @@ class Cursor(BaseCursor):
         return [dict(zip(names, row)) for row in self._obj.fetchmany(size)]
 
     def dictfetchall(self) -> list[dict[str, typing.Any]]:
+        """ Return all rows as dicts (column_name -> value). """
         description = self._obj.description
         assert description, "Query does not have results"
         names = [column.name for column in description]
@@ -399,6 +368,7 @@ class Cursor(BaseCursor):
         return self._obj.mogrify(query, params)
 
     def execute(self, query, params=None, log_exceptions: bool = True) -> None:
+        """ Execute a query inside the current transaction. """
         global sql_counter
 
         if isinstance(query, SQL):
@@ -537,7 +507,7 @@ class Cursor(BaseCursor):
             self._cnx.give_back(keep_in_pool=keep_in_pool)
 
     def commit(self) -> None:
-        """ Perform an SQL `COMMIT` """
+        """ Commit the current transaction. """
         self.flush()
         self._cnx.commit()
         if self.transaction is not None:
@@ -548,7 +518,7 @@ class Cursor(BaseCursor):
         self.postcommit.run()
 
     def rollback(self) -> None:
-        """ Perform an SQL `ROLLBACK` """
+        """ Rollback the current transaction. """
         self.precommit.clear()
         self.postcommit.clear()
         self.prerollback.run()
@@ -570,6 +540,9 @@ class Cursor(BaseCursor):
     @property
     def readonly(self) -> bool:
         return bool(self._cnx.readonly)
+
+
+BaseCursor = Cursor  # backward-compatibility
 
 
 class PsycoConnection(psycopg2.extensions.connection):

--- a/odoo/tests/loader.py
+++ b/odoo/tests/loader.py
@@ -109,12 +109,6 @@ def make_suite(module_names, position='at_install'):
 
 
 def run_suite(suite, global_report=None):
-    # avoid dependency hell
-    from ..modules import module
-    module.current_test = True
-
     results = OdooTestResult(global_report=global_report)
     suite(results)
-
-    module.current_test = False
     return results

--- a/odoo/tests/suite.py
+++ b/odoo/tests/suite.py
@@ -16,13 +16,14 @@ to minimise the code to maintain
 import logging
 import sys
 
-import odoo
+import odoo.modules
 from . import case
 from .common import HttpCase
 from .result import stats_logger
 from unittest import util, BaseTestSuite, TestCase
 
 __unittest = True
+
 
 class TestSuite(BaseTestSuite):
     """A test suite is a composite test consisting of a number of TestCases.
@@ -38,8 +39,8 @@ class TestSuite(BaseTestSuite):
             if result.shouldStop:
                 break
             assert isinstance(test, (TestCase))
-            odoo.modules.module.current_test = test
             self._tearDownPreviousClass(test, result)
+            odoo.modules.module.current_test = test
             self._handleClassSetUp(test, result)
             result._previousTestClass = test.__class__
 
@@ -47,6 +48,7 @@ class TestSuite(BaseTestSuite):
                 test(result)
 
         self._tearDownPreviousClass(None, result)
+        odoo.modules.module.current_test = None
         return result
 
     def _handleClassSetUp(self, test, result):

--- a/odoo/tests/test_cursor.py
+++ b/odoo/tests/test_cursor.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import threading
 
 from odoo.sql_db import BaseCursor, Cursor, Savepoint, _logger
-import odoo
+import odoo.modules
 
 
 class TestCursor(BaseCursor):

--- a/odoo/tests/test_cursor.py
+++ b/odoo/tests/test_cursor.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
+import typing
 from datetime import datetime
-import threading
 
-from odoo.sql_db import BaseCursor, Cursor, Savepoint, _logger
 import odoo.modules
+from odoo.sql_db import Cursor, Savepoint, _logger
+
+if typing.TYPE_CHECKING:
+    import threading
+    from odoo.sql_db import PsycoConnection as _base_PsycoConnection
+else:
+    _base_PsycoConnection = object
 
 
-class TestCursor(BaseCursor):
+class TestCursor(Cursor):
     """ A pseudo-cursor to be used for tests, on top of a real cursor. It keeps
         the transaction open across requests, and simulates committing, rolling
         back, and closing:
@@ -29,14 +35,14 @@ class TestCursor(BaseCursor):
         +------------------------+---------------------------------------------------+
     """
     _cursors_stack: list[TestCursor] = []
+    _cnx: MockedPsycoConnection
 
     def __init__(self, cursor: Cursor, lock: threading.RLock, readonly: bool):
-        assert isinstance(cursor, BaseCursor)
-        super().__init__()
+        assert isinstance(cursor, Cursor) and not isinstance(cursor, TestCursor)
+        super().__init__(MockedPsycoConnection(cursor, readonly), cursor.dbname)
+        self._closed = True  # consider closed until acquired
+        self._cnx._obj = self._obj
         self._now = datetime.now()
-        self._closed: bool = False
-        self._cursor = cursor
-        self.readonly = readonly
         # we use a lock to serialize concurrent requests
         self._lock = lock
         current_test = odoo.modules.module.current_test
@@ -49,95 +55,91 @@ class TestCursor(BaseCursor):
             # Check after acquiring in case current_test has changed.
             # This can happen if the request was hanging between two tests.
             current_test.assertCanOpenTestCursor()
-            self._check_cursor_readonly()
+            if (
+                self._cursors_stack
+                and (last_cursor := self._cursors_stack[-1])
+                and last_cursor.readonly
+                and not self._cnx.readonly
+                and last_cursor._cnx._savepoint
+            ):
+                raise Exception('Opening a read/write test cursor from a readonly one')  # noqa: TRY301
         except Exception:
             self._lock.release()
             raise
+        self._closed = False
         self._cursors_stack.append(self)
-        # in order to simulate commit and rollback, the cursor maintains a
-        # savepoint at its last commit, the savepoint is created lazily
-        self._savepoint: Savepoint | None = None
-
-    def _check_cursor_readonly(self):
-        last_cursor = self._cursors_stack and self._cursors_stack[-1]
-        if last_cursor and last_cursor.readonly and not self.readonly and last_cursor._savepoint:
-            raise Exception('Opening a read/write test cursor from a readonly one')
-
-    def _check_savepoint(self) -> None:
-        if not self._savepoint:
-            # we use self._cursor._obj for the savepoint to avoid having the
-            # savepoint queries in the query counts, profiler, ...
-            # Those queries are tests artefacts and should be invisible.
-            self._savepoint = Savepoint(self._cursor._obj)
-            if self.readonly:
-                # this will simulate a readonly connection
-                self._cursor._obj.execute('SET TRANSACTION READ ONLY')  # use _obj to avoid impacting query count and profiler.
 
     def execute(self, *args, **kwargs) -> None:
-        assert not self._closed, "Cannot use a closed cursor"
-        self._check_savepoint()
-        return self._cursor.execute(*args, **kwargs)
+        assert not self.closed, "Cannot use a closed cursor"
+        self._cnx._check_savepoint()
+        return super().execute(*args, **kwargs)
 
-    def close(self) -> None:
-        if not self._closed:
-            try:
-                self.rollback()
-                if self.transaction is not None:
-                    self.transaction.default_env = None  # break the cyclic reference
-                    self.transaction.reset()
-                if self._savepoint:
-                    self._savepoint.close(rollback=False)
-            finally:
-                self._closed = True
-
-                tos = self._cursors_stack.pop()
-                if tos is not self:
-                    _logger.warning("Found different un-closed cursor when trying to close %s: %s", self, tos)
-                self._lock.release()
-
-    @property
-    def closed(self) -> bool:
-        return self._closed
+    def close(self):
+        if self._closed:
+            return
+        try:
+            super().close()
+        finally:
+            tos = self._cursors_stack.pop()
+            if tos is not self:
+                _logger.warning("Found different un-closed cursor when trying to close %s: %s", self, tos)
+            self._lock.release()
 
     def commit(self) -> None:
         """ Perform an SQL `COMMIT` """
-        self.flush()
-        if self._savepoint:
-            self._savepoint.close(rollback=self.readonly)
-            self._savepoint = None
-        if self.transaction is not None:
-            self.transaction.clear()
-        self.prerollback.clear()
-        self.postrollback.clear()
-        self.postcommit.clear()         # TestCursor ignores post-commit hooks by default
-
-    def rollback(self) -> None:
-        """ Perform an SQL `ROLLBACK` """
-        self.precommit.clear()
-        self.postcommit.clear()
-        self.prerollback.run()
-        if self._savepoint:
-            self._savepoint.close(rollback=True)
-            self._savepoint = None
-        if self.transaction is not None:
-            self.transaction.clear()
-        self.postrollback.run()
-
-    def __getattr__(self, name):
-        return getattr(self._cursor, name)
-
-    def dictfetchone(self):
-        """ Return the first row as a dict (column_name -> value) or None if no rows are available. """
-        return self._cursor.dictfetchone()
-
-    def dictfetchmany(self, size):
-        return self._cursor.dictfetchmany(size)
-
-    def dictfetchall(self):
-        return self._cursor.dictfetchall()
+        self.precommit.add(self.postcommit.clear)  # ignore post-commit hooks
+        super().commit()
 
     def now(self) -> datetime:
         """ Return the transaction's timestamp ``datetime.now()``. """
         if self._now is None:
             self._now = datetime.now()
         return self._now
+
+
+class MockedPsycoConnection(_base_PsycoConnection):
+    def __init__(self, cursor: Cursor, readonly: bool):
+        self._cursor = cursor
+        self.readonly = readonly
+        # In order to simulate commit and rollback, the connection maintains a
+        # savepoint at its last commit. This savepoint is created lazily.
+        self._savepoint: Savepoint | None = None
+        self._obj = None
+
+    def set_session(self, *a, **kw):
+        pass  # ignoring
+
+    def give_back(self, keep_in_pool=True):
+        del self._obj
+
+    def _check_savepoint(self) -> None:
+        if self._savepoint:
+            return
+        # We use self._obj for the savepoint to avoid having the savepoint
+        # queries in the query counts, profiler, etc. Those queries are tests
+        # artefacts and should be invisible.
+        obj = self._obj
+        self._savepoint = Savepoint(obj)
+        if self.readonly:
+            # this will simulate a readonly connection
+            obj.execute('SET TRANSACTION READ ONLY')
+
+    def commit(self):
+        if self._savepoint is not None:
+            self._savepoint.close(rollback=False)
+            self._savepoint = None
+
+    def rollback(self):
+        if self._savepoint is not None:
+            self._savepoint.close(rollback=True)
+            self._savepoint = None
+
+    def reset(self):
+        self.rollback()
+
+    @property
+    def closed(self) -> bool:
+        return self._cursor.closed
+
+    def __getattr__(self, name):
+        return getattr(self._cursor._cnx, name)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Avoid duplicating logic in commit/rollback in both Cursor and TestCursor.

Current behavior before PR:
```
class BaseCursor
class Cursor(BaseCursor) uses PsyoConnection
class PsycoConnection
# tests
class TestCursor(BaseCursor) uses Cursor
```

Desired behavior after PR is merged:
```
class Cursor uses PsycoConnection
class PsycoConnection
# tests
class TestCursor(Cursor)
class MockedPsycoConnection uses Cursor
```



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
