### PR TITLE
[FIX] hr: fix job title search access error

### DIFF
--- a/addons/hr/models/hr_employee_public.py
+++ b/addons/hr/models/hr_employee_public.py
@@ -22,7 +22,7 @@ class HrEmployeePublic(models.Model):
     department_id = fields.Many2one('hr.department', readonly=True)
     member_of_department = fields.Boolean(compute='_compute_member_of_department', search='_search_part_of_department')
     job_id = fields.Many2one('hr.job', readonly=True)
-    job_title = fields.Char(related='employee_id.job_title')
+    job_title = fields.Char(readonly=True)
     company_id = fields.Many2one('res.company', readonly=True)
     address_id = fields.Many2one('res.partner', readonly=True)
     mobile_phone = fields.Char(readonly=True)

--- a/addons/hr_skills/views/hr_views.xml
+++ b/addons/hr_skills/views/hr_views.xml
@@ -10,7 +10,7 @@
                 <field name="employee_skill_ids"/>
                 <field name="resume_line_ids" string="Resume" filter_domain="
                     ['|',
-                        ('version_ids.job_title', 'ilike', self),
+                        ('job_title', 'ilike', self),
                         '|',
                             ('resume_line_ids.name', 'ilike', self),
                             ('resume_line_ids.description', 'ilike', self),
@@ -28,7 +28,7 @@
                 <field name="employee_skill_ids"/>
                 <field name="resume_line_ids" string="Resume" filter_domain="
                     ['|',
-                        ('version_ids.job_title', 'ilike', self),
+                        ('job_title', 'ilike', self),
                         '|',
                             ('resume_line_ids.name', 'ilike', self),
                             ('resume_line_ids.description', 'ilike', self),


### PR DESCRIPTION
[FIX] hr: fix job title search access error

Bug reproduction: Select marc demo -> employee app -> try to search something for job title -> Access error appears for no hr ones
Bug cause: Only users/managers can access to hr_version model and since marc demo has not, it receives this error.
Bug solution: I put store=True and compute_sudo for job_title and by that way everyone can search for job_title without access.

In the task [MOHF] showed another traceback about job title search. I fixed that in this commit as well.

Bug 2 reproduction: employee app -> try to search something for resume -> it will give error (there is no version_ids)
Bug 2 cause: There is no version_ids in the employee.public model, in the search version_ids.job_title is used but job_title can be used directly.
Bug 2 solution: I used job_title in the search instead of using version_ids.job_title.

task - 6000488

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
