### PR TITLE
[FIX] website_sale_stock : set default email in tests

### DIFF
--- a/addons/website_sale_stock/models/product_product.py
+++ b/addons/website_sale_stock/models/product_product.py
@@ -70,7 +70,10 @@ class ProductProduct(models.Model):
                 context = {'lang': partner.lang}  # Use partner lang to translate mail subject below
                 mail_values = {
                     "subject": _("The product '%(product_name)s' is now available", product_name=product_ctxt.name),
-                    "email_from": (website.company_id.partner_id or self_ctxt.env.user).email_formatted,
+                    "email_from": (
+                        website.company_id.partner_id.email_formatted
+                        or website.salesperson_id.email_formatted
+                    ),
                     "email_to": partner.email_formatted,
                     "body_html": full_mail,
                 }

--- a/addons/website_sale_stock/tests/test_website_sale_stock_stock_notification.py
+++ b/addons/website_sale_stock/tests/test_website_sale_stock_stock_notification.py
@@ -55,6 +55,7 @@ class TestStockNotificationProduct(HttpCase):
         quants.action_apply_inventory()
 
         website = self.env['website'].get_current_website()
+        website.company_id.partner_id.email = "test@test.com"
 
         ProductProduct._send_availability_email()
         emails = self.env['mail.mail'].search([('email_to', '=', partner.email_formatted)])

--- a/addons/website_sale_stock_wishlist/tests/test_website_sale_stock_wishlist_stock_notification.py
+++ b/addons/website_sale_stock_wishlist/tests/test_website_sale_stock_wishlist_stock_notification.py
@@ -60,6 +60,9 @@ class TestStockNotificationWishlist(HttpCase):
         })
         quants.action_apply_inventory()
 
+        website = self.env['website'].get_current_website()
+        website.company_id.partner_id.email = "test@test.com"
+
         ProductProduct._send_availability_email()
         emails = self.env['mail.mail'].search([('email_to', '=', partner.email_formatted)])
         self.assertEqual(emails[0].subject, "The product 'Macbook Pro' is now available")


### PR DESCRIPTION
This commit (https://github.com/odoo/odoo/pull/249299/changes) backported some changes concerning stock availability mails. The mail is now sent from the partner associated to the website.

However, in nightly runbots, the partner associated to the website does not have any email, so an error is thrown

This fix does two things :
- Make sure the website's partner has an email when running the tests
- Prevent the mails being sent with the current user's email as a last ressort, and let an error be thrown instead

runbot-102934954

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
