### PR TITLE
[FIX] web: rounding errors for large decimals

### DIFF
--- a/addons/web/static/src/core/utils/numbers.js
+++ b/addons/web/static/src/core/utils/numbers.js
@@ -63,7 +63,7 @@ export function roundPrecision(value, precision, method = "HALF-UP") {
     const normalizedValue = normalize(value);
     const sign = Math.sign(normalizedValue);
     const epsilonMagnitude = Math.log2(Math.abs(normalizedValue));
-    const epsilon = Math.pow(2, epsilonMagnitude - 50);
+    const epsilon = Math.pow(2, Math.min(epsilonMagnitude, 48) - 50);
     let roundedValue;
 
     switch (method) {

--- a/addons/web/static/tests/core/utils/numbers.test.js
+++ b/addons/web/static/tests/core/utils/numbers.test.js
@@ -174,6 +174,9 @@ test("roundDecimals", () => {
     expect(roundDecimals(-357.4555, 3)).toBe(-357.456);
     expect(roundDecimals(457.4554, 3)).toBe(457.455);
     expect(roundDecimals(-457.4554, 3)).toBe(-457.455);
+    // Value >= 566 gives an epsilon >= 0.5
+    expect(roundDecimals(566, 12)).toBe(566.000000000000);
+    expect(roundDecimals(700.0, 12)).toBe(700.000000000000);
 });
 
 test("floatIsZero", () => {


### PR DESCRIPTION
Steps to reproduce:
- activate a second currency
- define the currency rate at 700

Issue:
You will get 700.000000000001

Cause:
In 18.0 we used to use toFixed, it changed https://github.com/odoo/odoo/commit/5c51a3f0d5569a53c050cf515e4d19eaf409faec

For digits="[12,12]" such as defined in the [ `res_currency_views`](https://github.com/odoo/odoo/blob/0d489940ed0da4c8fdcf0b18446ec3beab8933cd/odoo/addons/base/views/res_currency_views.xml#L21-L22), for values above a certain threshold ( >=563)* the epsilon becomes higher than 0.5
> Math.log2(Math.abs(562000000000000))

48.99756345886927
> Math.log2(Math.abs(563000000000000))

49.00012825072858

Solution:
Make sure the epsilonMagnitude always stays <=48 so it's not unintentionally rounded up

Note:
Actually there is a rounding issue on the python side due to the double inversion https://github.com/odoo/odoo/blob/a641275f162778aaaff7b21074915bd700296a39/odoo/addons/base/models/res_currency.py#L444

Which is why the client is complaining about the 500 threshold. Python small float error + JS amplifying it => 0.0....01
But we won't correct this on the python side as we want to keep this value as precise as possible and round it at the latest stage of the business flow

opw-5966597
