### PR TITLE
[FIX] mail: fix race-condition test auto-focus speaker in call (2)

### DIFF
--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -19,6 +19,7 @@ import {
     dropFiles,
 } from "@mail/../tests/mail_test_helpers";
 import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
+import { SoundEffects } from "@mail/core/common/sound_effects_service";
 import {
     CROSS_TAB_CLIENT_MESSAGE,
     CROSS_TAB_HOST_MESSAGE,
@@ -1212,17 +1213,25 @@ test("auto-focus participant video in one-to-one call in chat window", async () 
         partner_id: pyEnv["res.partner"].create({ name: "Batman" }),
     });
     setupChatHub({ opened: [channelId] });
+    patchWithCleanup(SoundEffects.prototype, {
+        play(name) {
+            expect.step(`play - ${name}`);
+        },
+    });
     const env = await start();
     const network = await makeMockRtcNetwork({ env, channelId });
     const mockedRemote = network.makeMockRemote(channelMemberId);
     await click("[title='Join Call']");
     await contains(".o-discuss-CallParticipantCard", { count: 2 });
+    await expect.waitForSteps(["play - call-join"]);
     await mockedRemote.updateConnectionState("connected");
     await mockedRemote.updateUpload("camera", createVideoStream().getVideoTracks()[0]);
-    await contains(".o-discuss-CallParticipantCard[aria-label='Batman'] video");
+    await contains(".o-discuss-CallParticipantCard[aria-label='Batman']:has(video)");
     await contains(".o-discuss-CallParticipantCard");
     await mockedRemote.updateUpload("camera", null);
+    await contains(".o-discuss-CallParticipantCard[aria-label='Batman']:not(:has(video))");
     await click(".o-discuss-CallParticipantCard[aria-label='Batman']");
+    await contains(".o-discuss-CallParticipantCard", { count: 2 });
     await click("[title='Fullscreen']");
     await contains(".o-mail-Meeting[data-active]");
     await mockedRemote.updateUpload("camera", createVideoStream().getVideoTracks()[0]);


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/250174

PR above attempts to solve race condition of the following test:

```
@mail/discuss/call/call/auto-focus participant video in one-to-one call in chat window
```

Where the meeting view may not have been considered as open and thus mistakenly trigger the speaker auto-focus feature.

However the test is still failing non-deterministically at the same step. While the previous fix sounds good in theory, this is insufficient. We couldn't reproduce the problem, but there are a few theories on what may cause the problem:

"Join Call" has side-effect to auto-focus speaker, which might mistakenly be triggered later in test if executing very fast. To make sure this doesn't happen, test now asserts playing of call-join sound, which happens close to the initial auto-focus of the speaker.

This commit also adds more intermediate assertions that should help awaiting proper time (thus avoiding race conditions) or help with further hints at what's wrong with this test:

- properly check video stream is off visually when other participant stops the camera feed
- click on active card should return to showing of 2 cards, before the other participant re-enables the camera feed in the meeting view
- make use of `card:has(video)` in earlier assertions, instead of `card video`, to more easily distinct which step is problematic. The last one is very likely the issue, therefore we keep the original `card video` as this is more likely to hit with the same runbot error entry, in case the problem is still ongoing.

Fixes runbot error 240554