### PR TITLE
[FIX] pos_loyalty: prevent crash when opening orders with rewards in multiple sessions

### DIFF
--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -431,7 +431,7 @@ export class PosData {
 
     async sanitizeData() {
         const order_to_delete = this.models["pos.order"].filter((order) =>
-            order.lines.some((line) => line.is_reward_line && !line.coupon_id && !line.reward_id)
+            order.lines.some((line) => line.is_reward_line && !line.couponId && !line.rewardId)
         );
         for (const order of order_to_delete) {
             for (let i = order.lines.length - 1; i >= 0; i--) {

--- a/addons/pos_loyalty/static/src/app/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/app/models/pos_order.js
@@ -236,9 +236,13 @@ patch(PosOrder.prototype, {
         const otherRewards = [];
         const paymentRewards = []; // Gift card and ewallet rewards are considered payments and must stay at the end
         for (const line of rewardLines) {
+            const reward = line.reward_id || this.models["loyalty.reward"].get(line.rewardId);
+            if (!reward) {
+                continue;
+            }
             const claimedReward = {
-                reward: line.reward_id,
-                coupon_id: line.coupon_id?.id,
+                reward: reward,
+                coupon_id: line.couponId,
                 args: {
                     product: line._reward_product_id,
                     price: line.price_unit,
@@ -291,7 +295,20 @@ patch(PosOrder.prototype, {
                 ) &&
                 !this.uiState.couponPointChanges[claimedReward.coupon_id]
             ) {
-                continue;
+                // The coupon_id from the server may not match local couponPointChanges
+                // (e.g. after cross-session sync). Try to find a matching coupon for the same
+                // program, but only if that match is unambiguous: with more than one active
+                // coupon on the same program we cannot tell which one the reward belongs to.
+                const programId =
+                    claimedReward.reward.program_id?.id ?? claimedReward.reward.program_id;
+                const matchingChanges = Object.values(this.uiState.couponPointChanges).filter(
+                    (pe) => pe.program_id === programId
+                );
+                if (matchingChanges.length === 1) {
+                    claimedReward.coupon_id = matchingChanges[0].coupon_id;
+                } else {
+                    continue;
+                }
             }
             if (
                 claimedReward.reward.program_id.program_type === "coupons" &&
@@ -350,7 +367,7 @@ patch(PosOrder.prototype, {
             won += points - this._getPointsCorrection(program);
             if (coupon_id !== 0) {
                 for (const line of this._get_reward_lines()) {
-                    if (line.coupon_id.id === coupon_id) {
+                    if (line.couponId === coupon_id) {
                         spent += line.points_cost;
                     }
                 }
@@ -456,7 +473,7 @@ patch(PosOrder.prototype, {
             return false;
         });
         for (const line of this.getOrderlines()) {
-            if (line.is_reward_line && line.coupon_id?.id === coupon_id) {
+            if (line.is_reward_line && line.couponId === coupon_id) {
                 points -= line.points_cost;
             }
         }
@@ -1288,29 +1305,33 @@ patch(PosOrder.prototype, {
         let claimed = 0;
         let available = 0;
         let shouldCorrectRemainingPoints = false;
+        const rewardProductIds = reward.reward_product_ids.map((r) => r.id);
+        const hasRewardLines = this._get_reward_lines().length > 0;
         for (const line of this.getOrderlines()) {
-            if (
-                reward.reward_product_ids.map((reward) => reward.id).includes(product.id) &&
-                reward.reward_product_ids.map((reward) => reward.id).includes(line.getProduct().id)
-            ) {
-                if (this._get_reward_lines() == 0) {
-                    if (line.getProduct() === product) {
-                        available += line.getQuantity();
-                    }
-                } else {
-                    available += line.getQuantity();
-                }
-            } else if (
-                reward.reward_product_ids
-                    .map((reward) => reward.id)
-                    .includes(line._reward_product_id?.id)
-            ) {
-                if (line.reward_id.id == reward.id) {
+            // Handle reward lines first: use is_reward_line which is always
+            // available, even for lines loaded from the server (unlike
+            // _reward_product_id which is a local-only field).
+            if (line.is_reward_line) {
+                const lineRewardId = line.rewardId;
+                if (lineRewardId == reward.id && rewardProductIds.includes(line.getProduct().id)) {
                     remainingPoints += line.points_cost;
                     claimed += line.getQuantity();
-                } else {
+                } else if (
+                    rewardProductIds.includes(line._reward_product_id?.id ?? line.getProduct().id)
+                ) {
                     shouldCorrectRemainingPoints = true;
                 }
+                continue;
+            }
+            // Regular (non-reward) lines count as available
+            if (
+                rewardProductIds.includes(product.id) &&
+                rewardProductIds.includes(line.getProduct().id)
+            ) {
+                if (!hasRewardLines && line.getProduct() !== product) {
+                    continue;
+                }
+                available += line.getQuantity();
             }
         }
         let freeQty;
@@ -1465,8 +1486,8 @@ patch(PosOrder.prototype, {
             // Remove any line that is part of that same reward aswell.
             const linesToRemove = this.getOrderlines().filter(
                 (line) =>
-                    line.reward_id === lineToRemove.reward_id &&
-                    line.coupon_id === lineToRemove.coupon_id &&
+                    line.rewardId === lineToRemove.rewardId &&
+                    line.couponId === lineToRemove.couponId &&
                     line.reward_identifier_code === lineToRemove.reward_identifier_code
             );
             for (const line of linesToRemove) {

--- a/addons/pos_loyalty/static/src/app/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/app/models/pos_order.js
@@ -238,7 +238,7 @@ patch(PosOrder.prototype, {
         for (const line of rewardLines) {
             const claimedReward = {
                 reward: line.reward_id,
-                coupon_id: line.coupon_id?.id,
+                coupon_id: line.couponId,
                 args: {
                     product: line._reward_product_id,
                     price: line.price_unit,
@@ -291,7 +291,18 @@ patch(PosOrder.prototype, {
                 ) &&
                 !this.uiState.couponPointChanges[claimedReward.coupon_id]
             ) {
-                continue;
+                // The coupon_id from the server may not match local couponPointChanges
+                // (e.g. after cross-session sync). Try to find a matching coupon for the same program.
+                const programId =
+                    claimedReward.reward.program_id?.id ?? claimedReward.reward.program_id;
+                const matchingChange = Object.values(this.uiState.couponPointChanges).find(
+                    (pe) => pe.program_id === programId
+                );
+                if (matchingChange) {
+                    claimedReward.coupon_id = matchingChange.coupon_id;
+                } else {
+                    continue;
+                }
             }
             if (
                 claimedReward.reward.program_id.program_type === "coupons" &&
@@ -350,7 +361,7 @@ patch(PosOrder.prototype, {
             won += points - this._getPointsCorrection(program);
             if (coupon_id !== 0) {
                 for (const line of this._get_reward_lines()) {
-                    if (line.coupon_id.id === coupon_id) {
+                    if (line.couponId === coupon_id) {
                         spent += line.points_cost;
                     }
                 }
@@ -456,7 +467,7 @@ patch(PosOrder.prototype, {
             return false;
         });
         for (const line of this.getOrderlines()) {
-            if (line.is_reward_line && line.coupon_id?.id === coupon_id) {
+            if (line.is_reward_line && line.couponId === coupon_id) {
                 points -= line.points_cost;
             }
         }
@@ -1251,29 +1262,29 @@ patch(PosOrder.prototype, {
         let claimed = 0;
         let available = 0;
         let shouldCorrectRemainingPoints = false;
+        const rewardProductIds = reward.reward_product_ids.map((r) => r.id);
         for (const line of this.getOrderlines()) {
-            if (
-                reward.reward_product_ids.map((reward) => reward.id).includes(product.id) &&
-                reward.reward_product_ids.map((reward) => reward.id).includes(line.getProduct().id)
-            ) {
-                if (this._get_reward_lines() == 0) {
-                    if (line.getProduct() === product) {
-                        available += line.getQuantity();
-                    }
-                } else {
-                    available += line.getQuantity();
-                }
-            } else if (
-                reward.reward_product_ids
-                    .map((reward) => reward.id)
-                    .includes(line._reward_product_id?.id)
-            ) {
-                if (line.reward_id.id == reward.id) {
+            // Handle reward lines first: use is_reward_line which is always
+            // available, even for lines loaded from the server (unlike
+            // _reward_product_id which is a local-only field).
+            if (line.is_reward_line) {
+                const lineRewardId = line.rewardId;
+                if (lineRewardId == reward.id && rewardProductIds.includes(line.getProduct().id)) {
                     remainingPoints += line.points_cost;
                     claimed += line.getQuantity();
-                } else {
+                } else if (
+                    rewardProductIds.includes(line._reward_product_id?.id ?? line.getProduct().id)
+                ) {
                     shouldCorrectRemainingPoints = true;
                 }
+                continue;
+            }
+            // Regular (non-reward) lines count as available
+            if (
+                rewardProductIds.includes(product.id) &&
+                rewardProductIds.includes(line.getProduct().id)
+            ) {
+                available += line.getQuantity();
             }
         }
         let freeQty;

--- a/addons/pos_loyalty/static/src/app/models/pos_order_line.js
+++ b/addons/pos_loyalty/static/src/app/models/pos_order_line.js
@@ -38,6 +38,33 @@ patch(PosOrderline, {
             type: "many2one",
             local: true,
         },
+        is_reward_line: {
+            model: "pos.order.line",
+            name: "is_reward_line",
+            type: "boolean",
+        },
+        reward_id: {
+            model: "pos.order.line",
+            name: "reward_id",
+            relation: "loyalty.reward",
+            type: "many2one",
+        },
+        coupon_id: {
+            model: "pos.order.line",
+            name: "coupon_id",
+            relation: "loyalty.card",
+            type: "many2one",
+        },
+        reward_identifier_code: {
+            model: "pos.order.line",
+            name: "reward_identifier_code",
+            type: "char",
+        },
+        points_cost: {
+            model: "pos.order.line",
+            name: "points_cost",
+            type: "float",
+        },
     },
 });
 
@@ -106,8 +133,13 @@ patch(PosOrderline.prototype, {
         }
         return res;
     },
-
     isRefund() {
         return super.isRefund(...arguments) && !this.is_reward_line;
+    },
+    get rewardId() {
+        return this.reward_id?.id ?? this.raw.reward_id ?? 0;
+    },
+    get couponId() {
+        return this.coupon_id?.id ?? this.raw.coupon_id ?? 0;
     },
 });

--- a/addons/pos_loyalty/static/src/app/models/pos_order_line.js
+++ b/addons/pos_loyalty/static/src/app/models/pos_order_line.js
@@ -38,6 +38,33 @@ patch(PosOrderline, {
             type: "many2one",
             local: true,
         },
+        is_reward_line: {
+            model: "pos.order.line",
+            name: "is_reward_line",
+            type: "boolean",
+        },
+        reward_id: {
+            model: "pos.order.line",
+            name: "reward_id",
+            relation: "loyalty.reward",
+            type: "many2one",
+        },
+        coupon_id: {
+            model: "pos.order.line",
+            name: "coupon_id",
+            relation: "loyalty.card",
+            type: "many2one",
+        },
+        reward_identifier_code: {
+            model: "pos.order.line",
+            name: "reward_identifier_code",
+            type: "char",
+        },
+        points_cost: {
+            model: "pos.order.line",
+            name: "points_cost",
+            type: "float",
+        },
     },
 });
 
@@ -81,5 +108,11 @@ patch(PosOrderline.prototype, {
             ...super.getDisplayClasses(),
             "fst-italic": this.is_reward_line,
         };
+    },
+    get rewardId() {
+        return this.reward_id?.id ?? this.reward_id;
+    },
+    get couponId() {
+        return this.coupon_id?.id ?? this.coupon_id;
     },
 });

--- a/addons/pos_loyalty/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/pos_loyalty/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -75,11 +75,11 @@ patch(OrderSummary.prototype, {
             return;
         }
         if (selectedLine.is_reward_line && val === "remove") {
-            this.currentOrder.uiState.disabledRewards.add(selectedLine.reward_id.id);
+            this.currentOrder.uiState.disabledRewards.add(selectedLine.rewardId);
             const coupon = selectedLine.coupon_id;
+            const couponId = selectedLine.couponId;
             if (
-                coupon &&
-                coupon.id > 0 &&
+                couponId > 0 &&
                 this.currentOrder._code_activated_coupon_ids.find((c) => c.code === coupon.code)
             ) {
                 coupon.delete();

--- a/addons/pos_loyalty/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/pos_loyalty/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -75,11 +75,12 @@ patch(OrderSummary.prototype, {
             return;
         }
         if (selectedLine.is_reward_line && val === "remove") {
-            this.currentOrder.uiState.disabledRewards.add(selectedLine.reward_id.id);
+            this.currentOrder.uiState.disabledRewards.add(selectedLine.rewardId);
             const coupon = selectedLine.coupon_id;
+            const couponId = selectedLine.couponId;
             if (
                 coupon &&
-                coupon.id > 0 &&
+                couponId > 0 &&
                 this.currentOrder._code_activated_coupon_ids.find((c) => c.code === coupon.code)
             ) {
                 coupon.delete();

--- a/addons/pos_loyalty/static/src/app/services/pos_store.js
+++ b/addons/pos_loyalty/static/src/app/services/pos_store.js
@@ -708,8 +708,9 @@ patch(PosStore.prototype, {
             Object.assign(
                 this.couponByLineUuidCache,
                 order.lines.reduce((agg, line) => {
-                    if (line.coupon_id && line.coupon_id.id < 0) {
-                        return { ...agg, [line.uuid]: line.coupon_id.id };
+                    const lineCouponId = line.couponId;
+                    if (lineCouponId && lineCouponId < 0) {
+                        return { ...agg, [line.uuid]: lineCouponId };
                     } else {
                         return agg;
                     }
@@ -779,7 +780,7 @@ patch(PosStore.prototype, {
         }, {});
         for (const line of rewardLines) {
             const reward = line.reward_id;
-            const couponId = line.coupon_id.id;
+            const couponId = line.couponId;
             if (!couponData[couponId]) {
                 couponData[couponId] = {
                     points: 0,
@@ -849,7 +850,7 @@ patch(PosStore.prototype, {
 
                         // Before deleting the old coupon, update the order lines that use it.
                         for (const line of order.lines) {
-                            if (line.coupon_id?.id == couponUpdate.old_id) {
+                            if (line.couponId == couponUpdate.old_id) {
                                 line.coupon_id = coupon;
                             }
                         }

--- a/addons/pos_loyalty/static/src/app/services/pos_store.js
+++ b/addons/pos_loyalty/static/src/app/services/pos_store.js
@@ -708,8 +708,9 @@ patch(PosStore.prototype, {
             Object.assign(
                 this.couponByLineUuidCache,
                 order.lines.reduce((agg, line) => {
-                    if (line.coupon_id && line.coupon_id.id < 0) {
-                        return { ...agg, [line.uuid]: line.coupon_id.id };
+                    const lineCouponId = line.couponId;
+                    if (lineCouponId && lineCouponId < 0) {
+                        return { ...agg, [line.uuid]: lineCouponId };
                     } else {
                         return agg;
                     }
@@ -774,7 +775,7 @@ patch(PosStore.prototype, {
         }, {});
         for (const line of rewardLines) {
             const reward = line.reward_id;
-            const couponId = line.coupon_id.id;
+            const couponId = line.couponId;
             if (!couponData[couponId]) {
                 couponData[couponId] = {
                     points: 0,
@@ -841,7 +842,7 @@ patch(PosStore.prototype, {
 
                         // Before deleting the old coupon, update the order lines that use it.
                         for (const line of order.lines) {
-                            if (line.coupon_id?.id == couponUpdate.old_id) {
+                            if (line.couponId == couponUpdate.old_id) {
                                 line.coupon_id = coupon;
                             }
                         }

--- a/addons/pos_loyalty/static/src/app/utils/order_payment_validation.js
+++ b/addons/pos_loyalty/static/src/app/utils/order_payment_validation.js
@@ -16,13 +16,14 @@ patch(OrderPaymentValidation.prototype, {
             }
         }
         for (const line of this.order._get_reward_lines()) {
-            if (line.coupon_id.id < 1) {
+            const lineCouponId = line.couponId;
+            if (lineCouponId < 1) {
                 continue;
             }
-            if (!pointChanges[line.coupon_id.id]) {
-                pointChanges[line.coupon_id.id] = -line.points_cost;
+            if (!pointChanges[lineCouponId]) {
+                pointChanges[lineCouponId] = -line.points_cost;
             } else {
-                pointChanges[line.coupon_id.id] -= line.points_cost;
+                pointChanges[lineCouponId] -= line.points_cost;
             }
         }
         if (!(await this.isOrderValid(isForceValidate))) {


### PR DESCRIPTION
Allows users to correctly open or reload a POS order containing loyalty rewards across different browser sessions or windows without the interface crashing.
Previously, resuming an order with loyalty rewards from another session would cause a crash because some loyalty-related data wasn't being properly recognized during the synchronization from the server. This update ensures that all loyalty information is correctly handled when a pending order is loaded.

taks-id: 5454644

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
