### PR TITLE
[IMP] mail: show end datetime of poll on mouse-hover time remaining

### DIFF
--- a/addons/mail/static/src/core/common/poll.js
+++ b/addons/mail/static/src/core/common/poll.js
@@ -3,6 +3,8 @@ import { Component, useState } from "@odoo/owl";
 
 import { _t } from "@web/core/l10n/translation";
 
+const { DateTime } = luxon;
+
 /**
  * @typedef {Object} Props
  * @property {import("models").MailPollModel} poll
@@ -45,6 +47,12 @@ export class Poll extends Component {
             },
             () => [this.props.poll.poll_end_dt]
         );
+    }
+
+    get remainingTimeTextTitle() {
+        return _t("Poll ends on %(date)s", {
+            date: this.props.poll.poll_end_dt.toLocaleString(DateTime.DATETIME_MED),
+        });
     }
 
     showResults() {

--- a/addons/mail/static/src/core/common/poll.xml
+++ b/addons/mail/static/src/core/common/poll.xml
@@ -27,7 +27,7 @@
                         <t t-esc="voteCountText(props.poll.numberOfVotes)"/>
                         &#8729;
                         <t t-if="props.poll.end_message_id">Poll closed</t>
-                        <t t-else="" t-esc="state.remainingTimeText"/>
+                        <span t-else="" t-att-title="remainingTimeTextTitle" t-esc="state.remainingTimeText"/>
                     </p>
                     <span class="flex-grow-1"/>
                     <t t-if="!props.poll.end_message_id">


### PR DESCRIPTION
This commit adds showing of datetime when the poll will end when mouse-hovering on the Remaining time text of the poll. This is useful to put a reminder for later just before the poll ends, let's say to see if involvement is fine or we need to push pressure for people to vote.

<img width="555" height="255" alt="Screenshot 2026-03-04 at 12 55 44" src="https://github.com/user-attachments/assets/19ef91a1-ea52-475a-86e1-acc16e18fe98" />
