### PR TITLE
[FIX] web: add max-width to the o_company_logo_small

### DIFF
--- a/addons/web/static/src/webclient/actions/reports/report.scss
+++ b/addons/web/static/src/webclient/actions/reports/report.scss
@@ -113,6 +113,7 @@ li.oe-nested {
 
     &_small {
         max-height: 4rem;
+        max-width: 11rem;
     }
 
     &_big {


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Similar issue described in: https://github.com/odoo/odoo/pull/249432
Since there is no `max-width` defined for `o_company_logo_small`, if a user uploads a large logo, the customer address overlaps with the company details.

This can be tested by previewing the document with a large logo.
<img width="684" height="449" alt="image" src="https://github.com/user-attachments/assets/aa2ac10b-cb0f-448a-ade3-6e7bb8b1fcff" />


**Current behavior before PR:**
<img width="681" height="383" alt="image" src="https://github.com/user-attachments/assets/cf7d5740-db51-43e3-b8f6-70325e9e28c0" />

**Desired behavior after PR is merged:**

<img width="505" height="307" alt="image" src="https://github.com/user-attachments/assets/b175a06a-cde0-4808-a1fb-276fd96272c3" />



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
cc @ForgeFlow
