### PR TITLE
[FIX] web: Use a readable highlight color in dark mode

### DIFF
--- a/addons/web/static/src/webclient/settings_form_view/settings_form_view.scss
+++ b/addons/web/static/src/webclient/settings_form_view/settings_form_view.scss
@@ -164,6 +164,7 @@ body:not(.o_touch_device) .o_settings_container .o_field_selection {
 
            .highlighter {
                background: yellow;
+               color: black;
                font-weight: bold;
            }
 


### PR DESCRIPTION
Before this commit, highlights were not readable when searching on the settings in dark mode.

Now, we force the text color to black to improuve the contrast and redability.

task-id 6003446