### PR TITLE
[FIX] hr: M2O private city

### DIFF
--- a/addons/hr_address_extended/__init__.py
+++ b/addons/hr_address_extended/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import views

--- a/addons/hr_address_extended/__manifest__.py
+++ b/addons/hr_address_extended/__manifest__.py
@@ -1,0 +1,18 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'HR Address Extended',
+    'category': 'Human Resources/Employees',
+    'sequence': 95,
+    'summary': 'Centralize employee information',
+    'website': 'https://www.odoo.com/app/employees',
+    'depends': [
+        'hr',
+        'base_address_extended'
+    ],
+    'data': [
+        'views/hr_employee_views.xml'
+    ],
+    'author': 'Odoo S.A.',
+    'license': 'LGPL-3',
+}

--- a/addons/hr_address_extended/models/__init__.py
+++ b/addons/hr_address_extended/models/__init__.py
@@ -1,0 +1,1 @@
+from . import hr_version

--- a/addons/hr_address_extended/models/hr_version.py
+++ b/addons/hr_address_extended/models/hr_version.py
@@ -1,0 +1,28 @@
+from odoo import api, fields, models
+
+
+class HrVersion(models.Model):
+    _inherit = 'hr.version'
+
+    private_city_id = fields.Many2one(
+        'res.city',
+        string='Private City ID', groups="hr.group_hr_user", tracking=1,
+        compute="_compute_private_city_id",
+        inverse="_inverse_private_city_id",
+        readonly=False, store=True,
+        domain="[('country_id', '=?', private_country_id), ('state_id', '=?', private_state_id)]")
+    private_country_enforce_cities = fields.Boolean(
+        related='private_country_id.enforce_cities', groups="hr.group_hr_user", readonly=True)
+
+    @api.depends('private_state_id')
+    def _compute_private_city_id(self):
+        for record in self:
+            if record.private_city_id and record.private_state_id and record.private_city_id.state_id != record.private_state_id:
+                record.private_city_id = False
+
+    def _inverse_private_city_id(self):
+        for record in self:
+            if record.private_city_id:
+                record.private_state_id = record.private_city_id.state_id
+                record.private_city = record.private_city_id.name
+                record.private_zip = record.private_city_id.zipcode

--- a/addons/hr_address_extended/views/hr_employee_views.xml
+++ b/addons/hr_address_extended/views/hr_employee_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="view_employee_form_inherit_address" model="ir.ui.view">
+            <field name="name">hr.employee.form.inherit.address</field>
+            <field name="model">hr.employee</field>
+            <field name="inherit_id" ref="hr.view_employee_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='private_city']" position="attributes">
+                    <attribute name="invisible">private_country_enforce_cities</attribute>
+                </xpath>
+                <xpath expr="//field[@name='private_city']" position="after">
+                    <field name="private_city_id" 
+                        placeholder="City" 
+                        class="o_address_city"
+                        invisible="not private_country_enforce_cities"
+                        options='{"no_open": True, "no_create": True}'
+                        domain="[('country_id', '=?', private_country_id), ('state_id', '=?', private_state_id)]"
+                        context="{'show_state': True}"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
. Idea was to make the city field on employee personal address a M2O referring to the list and not something freely editable.
. When we select the City, the state should be automatically selected. ANd if I select the state first, only the cities from this state should be available

Current behavior before PR:

Desired behavior after PR is merged:
. Add new module hr_address_extended to handle M2O private_city field if enforce_cities is enabled . Add Corresponding tests

task-5877610


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
