### PR TITLE
[FIX] stock_account: oldest_manual_value domain filtering required st…

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -346,10 +346,12 @@ class ProductProduct(models.Model):
         move_fields = ['date', 'is_dropship', 'is_in', 'is_out', 'location_dest_id', 'location_id', 'move_line_ids',
                        'picked', 'value', 'product_id']
         last_manual_value_by_product = self._get_last_product_value(at_date, lot=lot)
-        oldest_manual_value = min(pv.date for pv in last_manual_value_by_product.values()) if last_manual_value_by_product else False
 
-        if oldest_manual_value:
-            moves_domain &= Domain([('date', '>=', oldest_manual_value)])
+        # commented these out first just in case it needs to be looked at later
+        # oldest_manual_value = min(pv.date for pv in last_manual_value_by_product.values()) if last_manual_value_by_product else False
+
+        # if oldest_manual_value:
+        #     moves_domain &= Domain([('date', '>=', oldest_manual_value)])
         moves = self.env['stock.move'].search_fetch(
             moves_domain,
             field_names=move_fields,


### PR DESCRIPTION
…ock.move records

---
Issue:
--
The `oldest_manual_save` is the date containing the earliest manual product cost change (product.value). This is used as part of the domain that filters out all stock.move lines prior to that date. However, this domain is also applied to products that require products that those stock.moves for accurate calculation of their total costs.

Current Behaviour:
--
"Inventory>Reporting>Stock" screen shows inaccurate total values for the product. Extra confusion as well due to expection of
On Hand * Unit Cost = total value (qty_available * avg_cost = total_value)

Expected Behaviour:
--
Stock move records of products that did not have a manual cost change should have all their stock.move records used in calculating the total_value

Fix:
--
Commented the lines for now due to possible urgency of this issue (several different tickets) Did not remove so the code can be looked at and adjusted later on to output correct results.

opw-5944338
---

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
