### PR TITLE
[FIX] hr_holidays: fix work entry type error in demo data

### DIFF
--- a/addons/hr_holidays/data/hr_holidays_demo.xml
+++ b/addons/hr_holidays/data/hr_holidays_demo.xml
@@ -14,9 +14,7 @@
     </record>
 
     <!--Time Off Type-->
-    <record id="hr_work_entry_type_dv" model="hr.work.entry.type">
-        <field name="name">Parental Leaves</field>
-        <field name="code">Parental Leaves</field>
+    <record id="hr_work_entry.hr_work_entry_type_dv" model="hr.work.entry.type">
         <field name="requires_allocation">yes</field>
         <field name="employee_requests">False</field>
         <field name="leave_validation_type">both</field>
@@ -25,9 +23,7 @@
         <field name="unit_of_measure">day</field>
     </record>
 
-    <record id="work_entry_type_training" model="hr.work.entry.type">
-        <field name="name">Training Time Off</field>
-        <field name="code">Training Time Off</field>
+    <record id="hr_work_entry.work_entry_type_training" model="hr.work.entry.type">
         <field name="requires_allocation">yes</field>
         <field name="employee_requests">False</field>
         <field name="leave_validation_type">both</field>
@@ -102,7 +98,7 @@
 
     <record id="hr_holidays_vc" model="hr.leave.allocation">
         <field name="name">Functional Training</field>
-        <field name="work_entry_type_id" ref="work_entry_type_training"/>
+        <field name="work_entry_type_id" ref="hr_work_entry.work_entry_type_training"/>
         <field name="number_of_days">7</field>
         <field name="state">confirm</field>
         <field name="employee_id" ref="hr.employee_admin"/>
@@ -178,7 +174,7 @@
 
     <record id="hr_holidays_allocation_pl_al" model="hr.leave.allocation">
         <field name="name">Parental Leaves</field>
-        <field name="work_entry_type_id" ref="hr_work_entry_type_dv"/>
+        <field name="work_entry_type_id" ref="hr_work_entry.hr_work_entry_type_dv"/>
         <field name="number_of_days">10</field>
         <field name="employee_id" ref="hr.employee_al"/>
         <field name="state">confirm</field>
@@ -188,7 +184,7 @@
 
     <record id="hr_holidays_vc_al" model="hr.leave.allocation">
         <field name="name">Soft Skills Training</field>
-        <field name="work_entry_type_id" ref="work_entry_type_training"/>
+        <field name="work_entry_type_id" ref="hr_work_entry.work_entry_type_training"/>
         <field name="number_of_days">12</field>
         <field name="employee_id" ref="hr.employee_al"/>
         <field name="state">confirm</field>
@@ -240,7 +236,7 @@
 
     <record id="hr_holidays_vc_mit" model="hr.leave.allocation">
         <field name="name">Compliance Training</field>
-        <field name="work_entry_type_id" ref="work_entry_type_training"/>
+        <field name="work_entry_type_id" ref="hr_work_entry.work_entry_type_training"/>
         <field name="number_of_days">7</field>
         <field name="state">confirm</field>
         <field name="employee_id" ref="hr.employee_mit"/>
@@ -294,7 +290,7 @@
 
     <record id="hr_holidays_vc_qdp" model="hr.leave.allocation">
         <field name="name">Time Management Training</field>
-        <field name="work_entry_type_id" ref="work_entry_type_training"/>
+        <field name="work_entry_type_id" ref="hr_work_entry.work_entry_type_training"/>
         <field name="number_of_days">7</field>
         <field name="employee_id" ref="hr.employee_qdp"/>
         <field name="state">confirm</field>
@@ -347,7 +343,7 @@
 
     <record id="hr_holidays_vc_fpi" model="hr.leave.allocation">
         <field name="name">Consulting Training</field>
-        <field name="work_entry_type_id" ref="work_entry_type_training"/>
+        <field name="work_entry_type_id" ref="hr_work_entry.work_entry_type_training"/>
         <field name="number_of_days">7</field>
         <field name="employee_id" ref="hr.employee_fpi"/>
         <field name="state">confirm</field>
@@ -369,7 +365,7 @@
 
     <record id="hr_holidays_vc_vad" model="hr.leave.allocation">
         <field name="name">Software Development Training</field>
-        <field name="work_entry_type_id" ref="work_entry_type_training"/>
+        <field name="work_entry_type_id" ref="hr_work_entry.work_entry_type_training"/>
         <field name="number_of_days">5</field>
         <field name="employee_id" ref="hr.employee_niv"/>
         <field name="state">confirm</field>
@@ -418,7 +414,7 @@
 
     <record id="hr_holidays_vc_kim" model="hr.leave.allocation">
         <field name="name">Onboarding Training</field>
-        <field name="work_entry_type_id" ref="work_entry_type_training"/>
+        <field name="work_entry_type_id" ref="hr_work_entry.work_entry_type_training"/>
         <field name="number_of_days">5</field>
         <field name="state">confirm</field>
         <field name="employee_id" ref="hr.employee_jve"/>

--- a/addons/hr_work_entry/data/hr_work_entry_demo.xml
+++ b/addons/hr_work_entry/data/hr_work_entry_demo.xml
@@ -11,4 +11,14 @@
         <field name="code">LEAVE200</field>
         <field name="color">4</field>
     </record>
+
+    <record id="hr_work_entry_type_dv" model="hr.work.entry.type">
+        <field name="name">Parental Leaves</field>
+        <field name="code">Parental Leaves</field>
+    </record>
+
+    <record id="work_entry_type_training" model="hr.work.entry.type">
+        <field name="name">Training Time Off</field>
+        <field name="code">Training Time Off</field>
+    </record>
 </odoo>


### PR DESCRIPTION
Two demo work entry types were wrongly defined in hr_holidays, when they should be defined in hr_work_entry. This commit moves the two work entry types to hr_work_entry.

Task-6004338

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
