### PR TITLE
[FIX] base_vat: switch VIES to IAP

### DIFF
--- a/addons/base_vat/__init__.py
+++ b/addons/base_vat/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import controllers
 from . import models

--- a/addons/base_vat/__manifest__.py
+++ b/addons/base_vat/__manifest__.py
@@ -36,6 +36,7 @@ only the country code will be validated.
     """,
     'depends': ['account'],
     'data': [
+        'data/ir_cron.xml',
         'views/res_config_settings_views.xml',
         'views/res_partner_views.xml',
     ],

--- a/addons/base_vat/controllers/__init__.py
+++ b/addons/base_vat/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import webhook

--- a/addons/base_vat/controllers/webhook.py
+++ b/addons/base_vat/controllers/webhook.py
@@ -1,0 +1,23 @@
+import logging
+
+from odoo import http, SUPERUSER_ID
+from odoo.http import request
+from odoo.tools import verify_hash_signed
+
+_logger = logging.getLogger(__name__)
+
+
+class BaseVatWebhookController(http.Controller):
+    @http.route('/base_vat/1/webhook_update_vies', type='http', csrf=False, save_session=False, auth='public')
+    def webhook_update_vies(self, webhook_token, status):
+        """
+        Webhook called by IAP when it updates a status from the pending state.
+        The webhook_token is computed by the Odoo db (in _compute_vies_valid) and stored
+        on IAP such that only IAP can call this webhook.
+        """
+        if not (vat := verify_hash_signed(request.env(su=True), 'vies_check', webhook_token)):
+            _logger.warning("VIES update failed: webhook_token does not match.")
+            return
+
+        partners = request.env["res.partner"].with_user(SUPERUSER_ID).search([("vat", "=", vat)])
+        partners._update_vies_status(status)

--- a/addons/base_vat/data/ir_cron.xml
+++ b/addons/base_vat/data/ir_cron.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <!-- Cron to check if IAP VIES has any update on a previously requested VAT -->
+        <record id="vies_iap_check_update" model="ir.cron">
+            <field name="name">Base VAT: Sync updates from IAP VIES</field>
+            <field name="model_id" ref="account.model_res_partner"/>
+            <field name="state">code</field>
+            <field name="code">model._cron_check_vies_iap()</field>
+            <field name="active" eval="True"/>
+            <field name="user_id" ref="base.user_root"/>
+            <field name="interval_number">3</field>
+            <field name="interval_type">hours</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/base_vat/data/neutralize.sql
+++ b/addons/base_vat/data/neutralize.sql
@@ -1,0 +1,7 @@
+UPDATE ir_config_parameter
+SET value = 'dummy_token'
+WHERE key = 'vies_iap.client_token';
+
+UPDATE ir_config_parameter
+SET value = 'dummy_identifier'
+WHERE key = 'vies_iap.client_identifier';

--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -1,17 +1,20 @@
 import logging
 import datetime
 import re
+import requests
+import secrets
+import uuid
 
 import stdnum
 from stdnum import luhn
-from stdnum.eu.vat import check_vies
-from stdnum.exceptions import InvalidComponent, InvalidChecksum, InvalidFormat
+from stdnum.exceptions import InvalidChecksum, InvalidFormat
 from stdnum.util import clean
 
 from odoo import api, models, fields
-from odoo.tools import _, LazyTranslate
-from odoo.exceptions import ValidationError
+from odoo.tools import _, LazyTranslate, hash_sign
+from odoo.exceptions import ValidationError, UserError
 from odoo.addons.base.models.res_partner import EU_EXTRA_VAT_CODES
+
 
 _lt = LazyTranslate(__name__)
 _logger = logging.getLogger(__name__)
@@ -193,28 +196,112 @@ class ResPartner(models.Model):
             if partner.parent_id and partner.parent_id.vat == partner.vat:
                 partner.vies_valid = partner.parent_id.vies_valid
                 continue
-            from odoo.tools import zeep  # noqa: PLC0415
-            try:
-                vies_valid = check_vies(partner.vat, timeout=10)
-                partner.vies_valid = vies_valid['valid']
-            except (OSError, InvalidComponent, zeep.exceptions.Error) as e:
-                if partner._origin.id:
-                    msg = ""
-                    if isinstance(e, OSError):
-                        msg = _("Connection with the VIES server failed. The VAT number %s could not be validated.", partner.vat)
-                    elif isinstance(e, InvalidComponent):
-                        msg = _("The VAT number %s could not be interpreted by the VIES server.", partner.vat)
-                    elif isinstance(e, zeep.exceptions.Error):
-                        msg = _('The request for VAT validation was not processed. VIES service has responded with the following error: %s', e.message)
-                    partner._origin.message_post(body=msg)
-                _logger.warning("The VAT number %s failed VIES check.", partner.vat)
-                partner.vies_valid = False
+            status = partner._check_vies_iap()
+            partner._update_vies_status(status)
 
     def _split_vat(self, vat):
         vat_prefix, vat_number = vat[:2].upper(), vat[2:].replace(' ', '')
         if not vat_prefix.isalpha():
             return '', vat
         return vat_prefix, vat_number
+
+    @api.model
+    def _get_iap_vies_credentials(self):
+        """
+        Return a couple (identifier, token) that is going to identify this db to IAP such that only
+        this one can request updates on a previously asked VIES check.
+        If they exist, we simply return them. If they don't, we create them in another cursor to
+        avoid the current transaction to be rolled back after the record has been created on IAP.
+        """
+        IrConfigParam = self.env['ir.config_parameter'].sudo()
+        identifier = IrConfigParam.get_param('iap_vies.client_identifier')
+        token = IrConfigParam.get_param('iap_vies.client_token')
+        if identifier and token:
+            return identifier, token
+
+        identifier = str(uuid.uuid4())
+        token = secrets.token_urlsafe()
+        with self.env.registry.cursor() as new_cursor:
+            IrConfigParamNewCursor = self.env(cr=new_cursor)['ir.config_parameter'].sudo()
+            IrConfigParamNewCursor.set_param('iap_vies.client_identifier', identifier)
+            IrConfigParamNewCursor.set_param('iap_vies.client_token', token)
+
+        return identifier, token
+
+    @api.model
+    def _get_iap_vies_endpoint(self):
+        prod, test = 'https://vies.api.odoo.com', 'https://vies.test.odoo.com'
+        default_endpoint = test if self.env.ref('base.module_base_vat').demo else prod
+        endpoint = self.env['ir.config_parameter'].sudo().get_param('iap_vies.endpoint', default_endpoint)
+        if endpoint not in (prod, test):
+            raise UserError(_('Invalid IAP VIES endpoint'))
+        return endpoint
+
+    def _check_vies_iap(self):
+        """Called when VAT is manually edited"""
+        self.ensure_one()
+        endpoint = self._get_iap_vies_endpoint()
+        client_identifier, client_token = self._get_iap_vies_credentials()
+        try:
+            req = requests.post(
+                endpoint + '/api/vies/1/check_validity',
+                data={
+                    "vat": self.vat,
+                    "db_uuid": self.env['ir.config_parameter'].sudo().get_param('database.uuid'),
+                    "client_identifier": client_identifier,
+                    "client_token": client_token,
+                    "webhook_url": self.get_base_url() + '/base_vat/1/webhook_update_vies',
+                    "webhook_token": hash_sign(self.sudo().env, "vies_check", self.vat, expiration_hours=24),  # See BaseVatWebhookController
+                },
+                timeout=20,
+            )
+            req.raise_for_status()
+        except requests.exceptions.RequestException:
+            _logger.exception("VIES check: call to IAP failed")
+            return "fault"
+        resp = req.json()
+        if not resp.get("status"):
+            _logger.error("VIES check: no status returned. Response: %s", resp)
+            return "fault"
+        return resp["status"]
+
+    @api.model
+    def _cron_check_vies_iap(self):
+        """Called by cron to check if IAP has any update on a previously requested VAT that was pending"""
+        endpoint = self._get_iap_vies_endpoint()
+        client_identifier, client_token = self._get_iap_vies_credentials()
+        try:
+            req = requests.post(
+                endpoint + '/api/vies/1/check_update',
+                data={
+                    "db_uuid": self.env['ir.config_parameter'].sudo().get_param('database.uuid'),
+                    "client_identifier": client_identifier,
+                    "client_token": client_token,
+                },
+                timeout=10,
+            )
+            req.raise_for_status()
+        except requests.exceptions.RequestException:
+            _logger.exception("Error while contacting IAP VIES")
+            return
+        resp = req.json()
+        _logger.info("IAP VIES check response: %s", resp)
+        for company_vat, company_status in resp.items():
+            partner = self.search([("vat", "=", company_vat)])
+            partner._update_vies_status(company_status)
+
+    def _update_vies_status(self, status):
+        self.vies_valid = status == "valid"
+        _logger.info("VIES status updated to %s for partner ids: %s", status, self.ids)
+        msg = None
+        if status == "pending":
+            msg = _("The VIES check is pending. The status will be updated soon.")
+        elif status == "fault":
+            msg = _("The VIES check failed. Please check the Tax ID manually.")
+        elif status in ("valid", "unassigned"):
+            msg = _("The Intra-Community validity has been updated.")
+        if msg:
+            self._message_log_batch(bodies={p._origin.id: msg for p in self if p._origin.id})
 
     @api.model
     def _check_vat_number(self, country_code, vat_number):

--- a/addons/base_vat/tests/test_vat_numbers.py
+++ b/addons/base_vat/tests/test_vat_numbers.py
@@ -13,12 +13,12 @@ from zeep.wsdl import Document
 class TestStructure(TransactionCase):
     @classmethod
     def setUpClass(cls):
-        def check_vies(vat_number, timeout=10):
-            return {'valid': vat_number == 'BE0477472701'}
+        def _check_vies_iap(record):
+            return "valid" if record.vat == 'BE0477472701' else "unassigned"
 
         super().setUpClass()
         cls.env.user.company_id.vat_check_vies = False
-        cls._vies_check_func = check_vies
+        cls._check_vies_iap = _check_vies_iap
 
     def test_peru_ruc_format(self):
         """Only values that has the length of 11 will be checked as RUC, that's what we are proving. The second part
@@ -70,7 +70,7 @@ class TestStructure(TransactionCase):
         })
 
         # reactivate it and correct the vat number
-        with patch('odoo.addons.base_vat.models.res_partner.check_vies', type(self)._vies_check_func):
+        with patch('odoo.addons.base_vat.models.res_partner.ResPartner._check_vies_iap', TestStructure._check_vies_iap):
             self.env.user.company_id.vat_check_vies = True
             with self.assertRaises(ValidationError):
                 company.vat = "BE0987654321"  # VIES refused, don't fallback on other check
@@ -136,7 +136,7 @@ class TestStructure(TransactionCase):
     def test_no_vies_revalidation_when_creating_company_from_contact(self):
         # Test that we don't revalidate the VAT when create a company from a contact where it's already validated
         self.env.user.company_id.vat_check_vies = True
-        with patch('odoo.addons.base_vat.models.res_partner.check_vies', type(self)._vies_check_func):
+        with patch('odoo.addons.base_vat.models.res_partner.ResPartner._check_vies_iap', TestStructure._check_vies_iap):
             partner = self.env["res.partner"].create({
                 'name': 'Dummy Partner',
                 'company_name': 'My Company',
@@ -145,8 +145,8 @@ class TestStructure(TransactionCase):
             })
             self.assertEqual(partner.vies_valid, True)
 
-        with patch('odoo.addons.base_vat.models.res_partner.check_vies',
-                   side_effect=Exception('should not call check_vies()')):
+        with patch('odoo.addons.base_vat.models.res_partner.ResPartner._check_vies_iap',
+                   side_effect=Exception('should not call _check_vies_iap()')):
             partner.create_company()
             self.assertEqual(partner.vies_valid, True)
             self.assertEqual(partner.parent_id.name, 'My Company')


### PR DESCRIPTION
Currently, when changing the Tax ID of a partner that is another EU country, we perform a VIES check to know whether it is valid (i.e. can do intra-com).
However, it is often the case that the VIES check fails because of an internal error on their side (timeout, max concurrent update, ...), especially for France.

Instead, we will now use the IAP server which stores the validity of a Tax ID for some time. If the IAP server does not have the info (because VIES is down), we will not actively wait. Instead, IAP will perform a push to a webhook on the client database once it has the information.

For security purposes, an HMAC is generated and sent to IAP so that only IAP can contact the db with the up-to-date info, and not anyone on the internet that calls this new webhook.

task-5977584

PR IAP: https://github.com/odoo/iap-apps/pull/1473