### PR TITLE
[FIX] payment: fix token display name computation access error

### DIFF
--- a/addons/payment/models/payment_token.py
+++ b/addons/payment/models/payment_token.py
@@ -41,7 +41,9 @@ class PaymentToken(models.Model):
     @api.depends('payment_details', 'create_date')
     def _compute_display_name(self):
         for token in self:
-            token.display_name = token._build_display_name()
+            # Need to compute it as sudo, in case some provider's override need info.
+            # that are restricted to normal user (for ex. any payment.provider field)
+            token.display_name = token.sudo()._build_display_name()
 
     # === CRUD METHODS === #
 


### PR DESCRIPTION
Use case:
- install `payment_sepa_direct_debit` module.
- As salesman go to a subscription and try to change/reset the payment token field.

When trying to get the values of the `payment_token_id` fields [`name_search()` call] an `AccessError` is raised saying that we don't have access to `payment.provider` model.

  Since odoo/odoo@a3eef91230e0, fetch() do compute fields, so for
payment token this means that `display_name` will be computed without su=True flag, thus it may raise an `AccessError` if accessing some payment provider fields.

So this commit force building token display name as sudo, to ensure it can be correctly computed.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
