### PR TITLE
[FIX] mass_mailing: use shared wrapInlinesInBlocks in icon plugin

### DIFF
--- a/addons/mass_mailing/static/src/builder/plugins/icon_snippet_option_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/icon_snippet_option_plugin.js
@@ -1,10 +1,9 @@
 import { Plugin } from "@html_editor/plugin";
-import { wrapInlinesInBlocks } from "@html_editor/utils/dom";
 import { registry } from "@web/core/registry";
 
 export class MassMailingIconSnippetOptionPlugin extends Plugin {
     static id = "mass_mailing.iconSnippetOption";
-    static dependencies = ["media"];
+    static dependencies = ["media", "dom"];
     resources = {
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
     };
@@ -20,7 +19,7 @@ export class MassMailingIconSnippetOptionPlugin extends Plugin {
                 iconInserted = true;
                 snippetEl.insertAdjacentElement("afterend", selectedIconEl);
                 snippetEl.remove();
-                wrapInlinesInBlocks(selectedIconEl.parentElement);
+                this.dependencies.dom.wrapInlinesInBlocks(selectedIconEl.parentElement);
             },
         });
         return !iconInserted;


### PR DESCRIPTION
Prior to this commit, `MassMailingIconSnippetOptionPlugin` still used the `wrapInlinesInBlocks` util, which was removed in a prior [commit].

Now `wrapInlinesInBlocks` is a shared function from the `dom` plugin.

[commit]: https://github.com/odoo/odoo/commit/5324aba70c8dccab8ff83a06885ce1ce0704509c

task-6004455