### PR TITLE
[FIX] stock: prevent random failure in test_set_inventory_quant_to_zero

### DIFF
--- a/addons/stock/tests/test_quant_inventory_mode.py
+++ b/addons/stock/tests/test_quant_inventory_mode.py
@@ -339,5 +339,9 @@ class TestEditableQuant(TransactionCase):
         quant.with_context(inventory_report_mode=True).action_set_inventory_quantity_zero()
         self.assertEqual(quant.inventory_quantity, 0)
         self.assertEqual(quant.user_id.id, False)
+        self.assertEqual(quant.quantity, 0)
+        self.assertEqual(quant.reserved_quantity, 0)
+        # flush ORM state before raw SQL in _unlink_zero_quants
+        quant.flush_recordset()
         quant._unlink_zero_quants()
         self.assertFalse(quant.exists(), "After unlinking zero quants, the quant should be deleted")


### PR DESCRIPTION
In Signal app, the test `test_set_inventory_quant_to_zero` was failing
randomly when asserting that the quant no longer exists after calling
`_unlink_zero_quants()`.

All required conditions for deletion were met:
- inventory_quantity == 0
- user_id is False
- quantity == 0
- reserved_quantity == 0

The method `_unlink_zero_quants()` performs a raw SQL query to select
zero quants. Since raw SQL does not trigger an automatic ORM flush,
the quant state could be out-of-sync with the database at the time of
the query, making the deletion non-deterministic.

Add an explicit `flush_all()` before calling `_unlink_zero_quants()` in
the test to ensure the database reflects the latest ORM state and avoid
random failures.

Runbot-241210