### PR TITLE
[REF] mail, hr: prevent infinite loops in store.add()

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -2122,10 +2122,8 @@ class HrEmployee(models.Model):
             "user_id",
             lambda res: (
                 res.attr("share"),
-                res.one(
-                    "partner_id",
-                    lambda res: (res.from_method("_store_im_status_fields"), res.attr("tz")),
-                ),
+                res.one("partner_id", ["tz"]),
+                res.from_method("_store_im_status_fields"),
             ),
         )
         res.one("work_location_id", ["location_type", "name"])
@@ -2133,6 +2131,7 @@ class HrEmployee(models.Model):
         res.extend(["work_email", "work_phone"])
 
     def _store_im_status_fields(self, res: Store.FieldList):
+        res.one("user_id", "_store_im_status_fields")
         res.attr("work_location_type")
 
     @api.depends('bank_account_ids')

--- a/addons/hr/models/hr_employee_public.py
+++ b/addons/hr/models/hr_employee_public.py
@@ -240,10 +240,8 @@ class HrEmployeePublic(models.Model):
             "user_id",
             lambda res: (
                 res.attr("share"),
-                res.one(
-                    "partner_id",
-                    lambda res: (res.from_method("_store_im_status_fields"), res.attr("tz")),
-                ),
+                res.one("partner_id", ["tz"]),
+                res.from_method("_store_im_status_fields"),
             ),
         )
         res.one("work_location_id", ["location_type", "name"])

--- a/addons/mail/controllers/poll.py
+++ b/addons/mail/controllers/poll.py
@@ -110,5 +110,8 @@ class PollController(ThreadController):
         )
         store = Store(**thread._store_target())
         store.add(poll_sudo.option_ids, ["number_of_votes", "vote_percentage"])
-        store.add(options_sudo, [Store.Many("vote_ids", [], mode="DELETE", value=votes_sudo)])
+        store.add(
+            options_sudo,
+            lambda res: res.many("vote_ids", [], mode="DELETE", value=votes_sudo),
+        )
         store.bus_send()

--- a/addons/mail/models/discuss/bus_sync_mixin.py
+++ b/addons/mail/models/discuss/bus_sync_mixin.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from collections import defaultdict
+import copy
+
 from odoo import models
 from odoo.addons.web.models.models import lazymapping
 from odoo.addons.mail.tools.discuss import Store
@@ -23,55 +24,27 @@ class BusSyncMixin(models.AbstractModel):
         """
 
     def write(self, vals):
-        def get_field_value(record, field_description):
-            """Get the value of a field based on its description."""
-            if isinstance(field_description, Store.Attr):
-                if field_description.predicate and not field_description.predicate(record):
-                    return None
-            if isinstance(field_description, Store.Relation):
-                return field_description._get_value(record).records
-            if isinstance(field_description, Store.Attr):
-                return field_description._get_value(record)
-            return record[field_description]
-
-        def get_vals(record):
-            """Get the current values of the fields to sync."""
-            result = defaultdict(dict)
-            for bus_target, field_descriptions in fields_to_sync.items():
-                target, sub_channel = (
-                    (record[bus_target[0]], bus_target[1])
-                    if isinstance(bus_target, tuple)
-                    else (record, bus_target)
-                )
-                for bus_channel in target._bus_channels():
-                    result[bus_channel, sub_channel] = {
-                        Store.get_field_name(field_description): (
-                            get_field_value(record, field_description),
-                            field_description,
-                        )
-                        for field_description in field_descriptions
-                    }
-            return result
-
-        self._sync_field_names(fields_to_sync := defaultdict(Store.FieldList))
-        old_vals = {record: get_vals(record) for record in self}
-        result = super().write(vals)
         stores = lazymapping(lambda param: Store(bus_channel=param[0], bus_subchannel=param[1]))
+        manager_by_bus_target = lazymapping(
+            lambda bus_target: Store.FieldListManager(stores, self, bus_target),
+        )
+        self._sync_field_names(manager_by_bus_target)
+        get_vals = Store.FieldListManager.get_val_by_field_by_store_by_record
+        old_val_by_field_by_store_by_record = get_vals(manager_by_bus_target.values(), self)
+        result = super().write(vals)
+        new_val_by_field_by_store_by_record = get_vals(manager_by_bus_target.values(), self)
         for record in self:
-            for (channel, subchannel), values in get_vals(record).items():
-                diff = defaultdict(Store.FieldList)
-                for field_name, (value, field_description) in values.items():
-                    if value != old_vals[record][channel, subchannel][field_name][0]:
-                        diff[channel, subchannel].append(field_description)
-                if diff:
-                    for (channel, subchannel), diff_fields in diff.items():
-                        stores[channel, subchannel].add(
-                            record,
-                            lambda res, diff_fields=diff_fields: (
-                                res.extend(diff_fields),
-                                res.from_method("_store_sync_extra_fields"),
-                            ),
-                        )
+            for store, new_vals_by_field in new_val_by_field_by_store_by_record[record].items():
+                field_list = Store.FieldList(store, record)
+                for field, new_value in new_vals_by_field.items():
+                    if new_value != old_val_by_field_by_store_by_record[record][store][field]:
+                        # Copy to avoid sharing the same Store.Attr for multiple stores/records.
+                        # Store.Many for instance mutates self.sort to None after sorting records,
+                        # which would cause incorrect behavior if the same instance is reused.
+                        field_list.append(copy.copy(field))
+                if field_list:
+                    record._store_sync_extra_fields(field_list)
+                    store.add(record, field_list)
         for store in stores.values():
             store.bus_send()
         return result

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -401,17 +401,17 @@ class ResUsers(models.Model):
                 res.extend(["active", "name", "tz"]),
                 res.one("main_user_id", ["partner_id"]),
                 res.from_method("_store_avatar_fields"),
-                res.from_method("_store_im_status_fields"),
             ),
         )
         res.attr("is_admin", lambda u: u._is_admin())
         res.extend(["notification_type", "share", "signature"])
+        res.from_method("_store_im_status_fields")
 
     def _store_main_user_fields(self, res: Store.FieldList):
         res.extend(["partner_id", "share"])
 
     def _store_im_status_fields(self, res: Store.FieldList):
-        res.attr("partner_id")
+        res.one("partner_id", "_store_im_status_fields")
 
     def _store_bookmark_box_global_fields(self, res: Store.FieldList, bus_last_id=None):
         """ Update the bookmark box info in the given store."""

--- a/addons/mail/tests/test_discuss_tools.py
+++ b/addons/mail/tests/test_discuss_tools.py
@@ -251,6 +251,19 @@ class TestDiscussTools(TransactionCase):
         self.assertEqual(data["res.partner"][0]["email"], "test_user_355_a@example.com")
         self.assertNotIn("email", data["res.partner"][1])
 
+    def test_390_add_no_loop(self):
+        """Test that store.add() does not loop indefinitely but it is still allowed to process
+        consecutive calls."""
+        user_a = new_test_user(self.env, "test_user_390@example.com")
+        store = Store()
+        store.add(user_a, "_store_im_status_fields")
+        data = store.get_result()
+        self.assertEqual(data["res.partner"][0]["im_status"], "offline")
+        self.env["mail.presence"]._update_presence(user_a)
+        store.add(user_a, "_store_im_status_fields")
+        data2 = store.get_result()
+        self.assertEqual(data2["res.partner"][0]["im_status"], "online")
+
     # 4xx Tests many command modes
 
     def test_450_replace_clear_existing_data(self):

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -3,7 +3,8 @@
 import os
 from collections import defaultdict, UserList
 from datetime import date, datetime
-from functools import wraps
+from functools import partial, wraps
+from itertools import product
 from markupsafe import Markup
 
 import odoo
@@ -12,6 +13,7 @@ from odoo.exceptions import MissingError
 from odoo.http import request
 from odoo.tools import groupby
 from odoo.addons.bus.websocket import wsrequest
+
 
 def add_guest_to_context(func):
     """ Decorate a function to extract the guest from the request.
@@ -81,6 +83,7 @@ ids_by_model.update(
 
 NO_VALUE = object()
 
+
 class Store:
     """Helper to build a dict of data for sending to web client.
     It supports merging of data from multiple sources, either through list extend or dict update.
@@ -88,6 +91,8 @@ class Store:
     format supported by store.insert() method (single dict or list of dict for each model name)."""
 
     def __init__(self, bus_channel=None, bus_subchannel=None):
+        self.add_depth = 0
+        self.already_done = set()
         self.data = {}
         self.data_id = None
         self.target = Store.Target(bus_channel, bus_subchannel)
@@ -110,12 +115,23 @@ class Store:
         if not records:
             return self
         assert isinstance(records, models.Model)
-        field_list = Store._format_fields(fields, self.target, records, fields_params)
-        if not as_thread and hasattr(records, "_to_store"):
-            records._to_store(self, field_list)
-        else:
-            self.add_records_fields(field_list, as_thread=as_thread)
-        return self
+        # call _format_fields before checking identifier to always compare the final shape
+        field_list = self._format_fields(fields, records, fields_params)
+        identifier = Store._deep_freeze((records.env, records, field_list, as_thread))
+        if identifier in self.already_done:
+            return self
+        self.already_done.add(identifier)
+        self.add_depth += 1
+        try:
+            if not as_thread and hasattr(records, "_to_store"):
+                records._to_store(self, field_list)
+            else:
+                self.add_records_fields(field_list, as_thread=as_thread)
+            return self
+        finally:
+            self.add_depth -= 1
+            if self.add_depth == 0:
+                self.already_done.clear()
 
     def add_global_values(self, field_fn=None, /, **values):
         """Add global values to the store. Global values are stored in the Store singleton
@@ -135,7 +151,7 @@ class Store:
         if not values:
             return self
         data_list = []
-        self._add_abstract_fields_value(Store._format_fields(values, self.target), data_list)
+        self._add_abstract_fields_value(self._format_fields(values), data_list)
         index = self._get_record_index(model_name, data_list)
         self._ensure_record_at_index(model_name, index)
         for data in data_list:
@@ -167,7 +183,7 @@ class Store:
         if not values:
             return self
         data_list = []
-        self._add_abstract_fields_value(Store._format_fields(values, self.target), data_list)
+        self._add_abstract_fields_value(self._format_fields(values), data_list)
         ids = ids_by_model[model_name]
         assert not ids
         if model_name not in self.data:
@@ -227,7 +243,7 @@ class Store:
         if not self.data_id:
             return self
         data_list = []
-        self._add_abstract_fields_value(Store._format_fields(values or [{}], self.target), data_list)
+        self._add_abstract_fields_value(self._format_fields(values or [{}]), data_list)
         for data in data_list:
             self.add_model_values("DataResponse", {"id": self.data_id, "_resolve": True, **data})
         return self
@@ -254,18 +270,15 @@ class Store:
         if index not in self.data[model_name]:
             self.data[model_name][index] = {}
 
-    @staticmethod
-    def _format_fields(fields, target, records=None, fields_params=None):
-        field_list = Store.FieldList()
-        field_list.target = target
-        field_list.records = records
+    def _format_fields(self, fields, records=None, fields_params=None):
+        field_list = Store.FieldList(self, records)
         if isinstance(fields, str) and (method := Store._get_fields_method(records, fields)):
             method(field_list, **(fields_params or {}))
         elif callable(fields):
             fields(field_list)
         elif isinstance(fields, dict):
-            field_list.extend(Store.Attr(key, value) for key, value in fields.items())
-        elif isinstance(fields, (list, Store.FieldList)):
+            field_list.extend(Store.Attr(self, key, value) for key, value in fields.items())
+        elif isinstance(fields, (list, tuple, Store.FieldList)):
             field_list.extend(fields)  # prevent mutation of original list
         else:
             raise TypeError(f"unexpected fields format: '{fields}' for records: '{records}'")
@@ -306,7 +319,7 @@ class Store:
             elif not field.predicate or field.predicate(record):
                 try:
                     data_list.append(
-                        {field.field_name: field._get_value(record, target=self.target)},
+                        {field.field_name: field._get_value(record)},
                     )
                 except MissingError:
                     break
@@ -328,11 +341,23 @@ class Store:
         return record.id
 
     @staticmethod
-    def get_field_name(field_description):
-        """Get the field name from a field description."""
-        if isinstance(field_description, Store.Attr):
-            return field_description.field_name
-        return field_description
+    def _deep_freeze(obj):
+        """Recursively convert a data structure into an immutable version that can be hashed and
+        compared for identity."""
+        if isinstance(obj, (Store.FieldList, Store.Attr)):
+            return Store._deep_freeze(obj._identity())
+        if isinstance(obj, dict):
+            return (
+                "__dict__",
+                frozenset((Store._deep_freeze(k), Store._deep_freeze(v)) for k, v in obj.items()),
+            )
+        if isinstance(obj, list):
+            return ("__list__", tuple(Store._deep_freeze(i) for i in obj))
+        if isinstance(obj, tuple):
+            return tuple(Store._deep_freeze(i) for i in obj)
+        if isinstance(obj, set):
+            return frozenset(Store._deep_freeze(i) for i in obj)
+        return obj
 
     class Target:
         """Target of the current store. Useful when information have to be added contextually
@@ -358,13 +383,14 @@ class Store:
         Note: when a static value is given to a recordset, the same value is set on all records.
         """
 
-        def __init__(self, field_name, value=NO_VALUE, *, predicate=None, sudo=False):
+        def __init__(self, store, field_name, value=NO_VALUE, *, predicate=None, sudo=False):
+            self.store = store
             self.field_name = field_name
             self.predicate = predicate
             self.sudo = sudo
             self.value = value
 
-        def _get_value(self, record, *, target=None):
+        def _get_value(self, record):
             if self.value is NO_VALUE and record is not None and self.field_name in record._fields:
                 return (record.sudo() if self.sudo else record)[self.field_name]
             if callable(self.value):
@@ -375,11 +401,21 @@ class Store:
                 return None
             return self.value
 
+        def _identity(self):
+            return (
+                self.__class__.__name__,
+                self.field_name,
+                self.predicate,
+                self.sudo,
+                self.value,
+            )
+
     class Relation(Attr):
         """Flags a record or field name to be added to the store in a relation."""
 
         def __init__(
             self,
+            store,
             records_or_field_name,
             fields,
             /,
@@ -393,7 +429,7 @@ class Store:
             value=NO_VALUE,
         ):
             field_name = records_or_field_name if isinstance(records_or_field_name, str) else None
-            super().__init__(field_name, predicate=predicate, sudo=sudo, value=value)
+            super().__init__(store, field_name, predicate=predicate, sudo=sudo, value=value)
             assert (
                 not records_or_field_name
                 or isinstance(records_or_field_name, (str, models.Model))
@@ -410,22 +446,26 @@ class Store:
             self.fields = fields
             self.fields_params = fields_params
             self.only_data = only_data
+            # format fields early to ensure the final shape is used for identity whenever possible
+            if self.records:
+                self.fields = self.store._format_fields(self.fields, self.records, self.fields_params)
+                self.fields_params = None
 
-        def _get_value(self, record, *, target=None):
-            records = super()._get_value(record, target=target)
+        def _get_value(self, record):
+            records = super()._get_value(record)
             if records is None and self.value is NO_VALUE:
                 res_model_field = "res_model" if "res_model" in record._fields else "model"
                 if self.field_name == "thread" and "thread" not in record._fields:
                     if (res_model := record[res_model_field]) and (res_id := record["res_id"]):
                         records = record.env[res_model].browse(res_id)
-            return self._copy_with_records(records, calling_record=record, target=target)
+            return self._copy_with_records(records, calling_record=record)
 
-        def _copy_with_records(self, records, calling_record, target):
+        def _copy_with_records(self, records, calling_record):
             """Returns a new relation with the given records instead of the field name."""
             assert self.field_name and self.records is None
             assert not self.dynamic_fields or calling_record
             if records:
-                field_list = Store._format_fields(self.fields, target, records, self.fields_params)
+                field_list = self.store._format_fields(self.fields, records, self.fields_params)
                 if self.dynamic_fields:
                     if (
                         isinstance(self.dynamic_fields, str)
@@ -440,6 +480,7 @@ class Store:
             else:
                 field_list = []  # avoid calling field methods (which potentially does queries) on empty records
             return self.__class__(
+                self.store,
                 records,
                 field_list,
                 as_thread=self.as_thread,
@@ -451,11 +492,24 @@ class Store:
             """Add the current relation to the given store at target[key]."""
             store.add(self.records, self.fields, as_thread=self.as_thread)
 
+        def _identity(self):
+            return (
+                *super()._identity(),
+                self.records.env if self.records else None,
+                self.records,
+                self.as_thread,
+                self.dynamic_fields,
+                self.fields,
+                self.fields_params,
+                self.only_data,
+            )
+
     class One(Relation):
         """Flags a record or field name to be added to the store in a One relation."""
 
         def __init__(
             self,
+            store,
             record_or_field_name,
             fields,
             /,
@@ -469,6 +523,7 @@ class Store:
             value=NO_VALUE,
         ):
             super().__init__(
+                store,
                 record_or_field_name,
                 fields,
                 as_thread=as_thread,
@@ -492,6 +547,7 @@ class Store:
 
         def __init__(
             self,
+            store,
             records_or_field_name,
             fields,
             /,
@@ -507,6 +563,7 @@ class Store:
             value=NO_VALUE,
         ):
             super().__init__(
+                store,
                 records_or_field_name,
                 fields,
                 as_thread=as_thread,
@@ -520,16 +577,16 @@ class Store:
             self.mode = mode
             self.sort = sort
 
-        def _copy_with_records(self, records, calling_record, target):
+        def _copy_with_records(self, records, calling_record):
             if records is None:
                 records = []
-            res = super()._copy_with_records(records, calling_record, target)
+            res = super()._copy_with_records(records, calling_record)
             res.mode = self.mode
             res.sort = self.sort
             return res
 
         def _add_to_store(self, store: "Store", target, key):
-            self._sort_recods()
+            self._sort_records()
             super()._add_to_store(store, target, key)
             if not self.only_data and (self.records or self.mode == "REPLACE"):
                 rel_val = self._get_id()
@@ -542,7 +599,7 @@ class Store:
 
         def _get_id(self):
             """Return the ids that can be used to insert the current relation in the store."""
-            self._sort_recods()
+            self._sort_records()
             if self.records._name == "mail.message.reaction":
                 res = [
                     {"message": message.id, "content": content}
@@ -558,25 +615,36 @@ class Store:
                 res = [("DELETE", res)]
             return res
 
-        def _sort_recods(self):
+        def _sort_records(self):
             if self.sort:
                 self.records = self.records.sorted(self.sort)
                 self.sort = None
 
+        def _identity(self):
+            return (*super()._identity(), self.mode, self.sort)
+
     class FieldList(UserList):
         """Helper to provide short syntax for building a list of field definitions for a specific
         store.add call (with given records and target)."""
-        # records for which the field list will apply. Useful to pre-compute values in batch.
-        records = None
-        # Store.Target of the field list. Useful to adapt fields depending on the receivers.
-        target = None
+        def __init__(self, store, records):
+            super().__init__()
+            # records for which the field list will apply. Useful to pre-compute values in batch.
+            self.records = records
+            self.store = store
+
+        @property
+        def target(self):
+            """Store.Target of the field list. Useful to adapt fields depending on the receivers."""
+            return self.store.target
 
         def attr(self, field_name, value=NO_VALUE, *, predicate=None, sudo=False):
             """Add an attribute to the field list."""
             if self.records is not None and value is NO_VALUE and predicate is None and not sudo:
                 self.append(field_name)
             else:
-                self.append(Store.Attr(field_name, value=value, predicate=predicate, sudo=sudo))
+                self.append(
+                    Store.Attr(self.store, field_name, value=value, predicate=predicate, sudo=sudo),
+                )
 
         def from_method(self, method_name, **fields_params):
             """Add fields coming from a method on the records to the field list."""
@@ -589,11 +657,11 @@ class Store:
 
         def one(self, record_or_field_name, fields, /, *args, **kwargs):
             """Add a x2one relation to the field list."""
-            self.append(Store.One(record_or_field_name, fields, *args, **kwargs))
+            self.append(Store.One(self.store, record_or_field_name, fields, *args, **kwargs))
 
         def many(self, records_or_field_name, fields, /, *args, **kwargs):
             """Add a x2many relation to the field list."""
-            self.append(Store.Many(records_or_field_name, fields, *args, **kwargs))
+            self.append(Store.Many(self.store, records_or_field_name, fields, *args, **kwargs))
 
         def is_for_current_user(self):
             """Return whether the current target is the current user or guest of the given env.
@@ -654,3 +722,63 @@ class Store:
             if self.target.channel is None and self.target.subchannel is None:
                 records = env.user
             return records if isinstance(records, env.registry["res.users"]) else env["res.users"]
+
+        def _identity(self):
+            return ("FieldList", self.records.env, self.records, tuple(self))
+
+    class FieldListManager:
+        """Similar API as Store.FieldList but for multiple field lists at once.
+        This is necessary because FieldList is tied to a specific Store, and Store is tied
+        to a specific (bus_channel, sub_channel), and there can be multiple bus_channel for one
+        record depending on the result of _bus_channels()."""
+
+        def __init__(self, stores, records, bus_target):
+            """bus_target is expected in the following format:
+            - single bus_subchannel (which can be None), where bus_channel is implied as being the
+              record on which it is called.
+            - tuple of (field_name, bus_subchannel), where bus_channel is the record pointed by
+              field_name on the record on which it is called"""
+            self._field_lists_by_record = {}
+            if isinstance(bus_target, tuple):
+                field_name, bus_subchannel = bus_target
+            else:
+                field_name, bus_subchannel = None, bus_target
+            for record in records:
+                target = record[field_name] if field_name else record
+                self._field_lists_by_record[record] = [
+                    Store.FieldList(stores[bus_channel, bus_subchannel], record)
+                    for bus_channel in target._bus_channels()
+                ]
+
+        def __getattr__(self, name):
+            return partial(self._forward, name)
+
+        def _forward(self, name, /, *args, **kwargs):
+            if name not in {"attr", "extend", "from_method", "many", "one"}:
+                raise AttributeError(
+                    f"'FieldListManager' object has no attribute '{name}'",
+                )
+            for field_lists in self._field_lists_by_record.values():
+                for field_list in field_lists:
+                    assert isinstance(field_list, Store.FieldList)
+                    # getattr: only allowed methods of Store.FieldList are forwarded
+                    getattr(field_list, name)(*args, **kwargs)
+
+        @staticmethod
+        def get_val_by_field_by_store_by_record(manager_list, records):
+            """Given a list of Store.FieldListManager and records, returns a dict with all the
+            values of the fields in the managers indexed by store and by record."""
+            res = defaultdict(lambda: defaultdict(dict))
+            for record, manager in product(records, manager_list):
+                for field_list in manager._field_lists_by_record[record]:
+                    for field in field_list:
+                        if isinstance(field, Store.Attr) and field.predicate and not field.predicate(record):
+                            result = None
+                        elif isinstance(field, Store.Relation):
+                            result = field._get_value(record).records
+                        elif isinstance(field, Store.Attr):
+                            result = field._get_value(record)
+                        else:
+                            result = record[field]
+                        res[record][field_list.store][field] = result
+            return res

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -395,7 +395,12 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         partner_0 = user_0.partner_id
         return {
             "hr.employee": [
-                {"id": self.employees[0].id, "leave_date_to": False, "work_location_type": False},
+                {
+                    "id": self.employees[0].id,
+                    "leave_date_to": False,
+                    "user_id": self.users[0].id,
+                    "work_location_type": False,
+                },
             ],
             "res.partner": self._filter_partners_fields(
                 {
@@ -1928,5 +1933,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         return {
             "id": employee.id,
             "leave_date_to": False,
+            "user_id": employee.user_id.id,
             "work_location_type": False,
         }


### PR DESCRIPTION
Before this commit, it is not possible for 2 related records to reference each other in store.add() with the exact same fields methods as it would cause an infinite loop.

For example, for `_store_im_status_fields` on `res.partner`, we call `_store_im_status_fields` on the related `res.users` record. This is acceptable as long as `_store_im_status_fields` does not call back `_store_im_status_fields` on the related `res.partner` record. But this is a limitation that forces us to always call the method on partner explicitly even if we are currently working with user records.

There are many situations where depending on which record we are working with, we expect both sides of the relation to be processed accordingly, for example: employee/resource, partner/user, attachment/document, etc.

This commit prevents this kind of infinite loop by keeping track of which exact store.add have already been processed and ignoring subsequent calls in the same stack.

Note: `_store_im_status_fields` is changed in this PR in a way that would create an infinite loop before this PR to illustrate it.