### PR TITLE
[FIX] html_editor: show selected bg color of selected table cells

### DIFF
--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -68,9 +68,14 @@ export class ColorPlugin extends Plugin {
         ],
 
         /** Handlers */
-        selectionchange_handlers: this.updateSelectedColor.bind(this),
+        selectionchange_handlers: withSequence(100, this.updateSelectedColor.bind(this)),
         remove_format_handlers: this.removeAllColor.bind(this),
         normalize_handlers: this.normalize.bind(this),
+        /** Providers */
+        selected_background_color_providers: withSequence(
+            10,
+            this.computeBackgroundColorForTextNode.bind(this)
+        ),
     };
 
     setup() {
@@ -104,7 +109,7 @@ export class ColorPlugin extends Plugin {
         };
     }
 
-    updateSelectedColor() {
+    computeBackgroundColorForTextNode() {
         const nodes = this.dependencies.selection.getTargetedNodes().filter(isTextNode);
         if (nodes.length === 0) {
             return;
@@ -133,10 +138,40 @@ export class ColorPlugin extends Plugin {
             }
         }
 
+        return hasGradient && !hasTextGradientClass ? backgroundImage : rgbaToHex(backgroundColor);
+    }
+
+    updateSelectedColor() {
+        // Compute and update the background color.
+        let backgroundColor;
+        for (const provider of this.getResource("selected_background_color_providers")) {
+            const providedBackgroundColor = provider();
+            if (providedBackgroundColor) {
+                backgroundColor = providedBackgroundColor;
+                break;
+            }
+        }
+
+        this.selectedColors.backgroundColor = backgroundColor || "#00000000";
+
+        // Compute and update the text color.
+        const nodes = this.dependencies.selection.getTargetedNodes().filter(isTextNode);
+        if (nodes.length === 0) {
+            this.selectedColors.color = "";
+            return;
+        }
+        const el = closestElement(nodes[0]);
+        if (!el) {
+            this.selectedColors.color = "";
+            return;
+        }
+        const elStyle = getComputedStyle(el);
+        const backgroundImage = elStyle.backgroundImage;
+        const hasGradient = isColorGradient(backgroundImage);
+        const hasTextGradientClass = el.classList.contains("text-gradient");
+
         this.selectedColors.color =
             hasGradient && hasTextGradientClass ? backgroundImage : rgbaToHex(elStyle.color);
-        this.selectedColors.backgroundColor =
-            hasGradient && !hasTextGradientClass ? backgroundImage : rgbaToHex(backgroundColor);
     }
 
     /**

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -6,8 +6,8 @@ import {
     hasAnyNodesColor,
     TEXT_CLASSES_REGEX,
     BG_CLASSES_REGEX,
-    RGBA_REGEX,
     hasTextColorClass,
+    computeBackgroundColorForElement,
 } from "@html_editor/utils/color";
 import { fillEmpty, unwrapContents } from "@html_editor/utils/dom";
 import {
@@ -28,7 +28,6 @@ import { withSequence } from "@html_editor/utils/resource";
 import { isBlock } from "@html_editor/utils/blocks";
 import { callbacksForCursorUpdate } from "@html_editor/utils/selection";
 
-const RGBA_OPACITY = 0.6;
 const HEX_OPACITY = "99";
 
 /**
@@ -118,27 +117,7 @@ export class ColorPlugin extends Plugin {
         if (!el) {
             return;
         }
-        const elStyle = getComputedStyle(el);
-        const backgroundImage = elStyle.backgroundImage;
-        const hasGradient = isColorGradient(backgroundImage);
-        const hasTextGradientClass = el.classList.contains("text-gradient");
-
-        let backgroundColor = elStyle.backgroundColor;
-        const activeTab = document
-            .querySelector(".o_font_color_selector button.active")
-            ?.innerHTML.trim();
-        if (backgroundColor.startsWith("rgba") && activeTab === "Solid") {
-            // Buttons in the solid tab of color selector have no
-            // opacity, hence to match selected color correctly,
-            // we need to remove applied 0.6 opacity.
-            const values = backgroundColor.match(RGBA_REGEX) || [];
-            const alpha = parseFloat(values.pop()); // Extract alpha value
-            if (alpha === RGBA_OPACITY) {
-                backgroundColor = `rgb(${values.slice(0, 3).join(", ")})`; // Remove alpha
-            }
-        }
-
-        return hasGradient && !hasTextGradientClass ? backgroundImage : rgbaToHex(backgroundColor);
+        return computeBackgroundColorForElement(el);
     }
 
     updateSelectedColor() {

--- a/addons/html_editor/static/src/main/media/icon_plugin.js
+++ b/addons/html_editor/static/src/main/media/icon_plugin.js
@@ -6,6 +6,7 @@ import { isZWS } from "@html_editor/utils/dom_info";
 import { leftPos, rightPos } from "@html_editor/utils/position";
 import { normalizeCursorPosition } from "@html_editor/utils/selection";
 import { closestElement } from "@html_editor/utils/dom_traversal";
+import { computeBackgroundColorForElement } from "@html_editor/utils/color";
 
 export class IconPlugin extends Plugin {
     static id = "icon";
@@ -120,6 +121,11 @@ export class IconPlugin extends Plugin {
         ],
         /** Handlers */
         selectionchange_handlers: this.normalizeIconSelection.bind(this),
+        /** Providers */
+        selected_background_color_providers: withSequence(
+            5,
+            this.computeBackgroundColorForIcon.bind(this)
+        ),
     };
 
     /**
@@ -212,5 +218,19 @@ export class IconPlugin extends Plugin {
             return;
         }
         return selectedIcon.classList.contains("fa-spin");
+    }
+
+    computeBackgroundColorForIcon() {
+        const nodes = this.dependencies.selection
+            .getTargetedNodes()
+            .filter((node) => node.classList?.contains("fa"));
+        if (nodes.length === 0) {
+            return;
+        }
+        const el = closestElement(nodes[0], "font");
+        if (!el) {
+            return;
+        }
+        return computeBackgroundColorForElement(el);
     }
 }

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -15,6 +15,7 @@ import { withSequence } from "@html_editor/utils/resource";
 import { findInSelection } from "@html_editor/utils/selection";
 import { getColumnIndex, getRowIndex } from "@html_editor/utils/table";
 import { isBrowserFirefox } from "@web/core/browser/feature_detection";
+import { rgbaToHex } from "@html_editor/utils/color";
 
 export const BORDER_SENSITIVITY = 5;
 
@@ -77,7 +78,7 @@ export class TablePlugin extends Plugin {
         ],
 
         /** Handlers */
-        selectionchange_handlers: this.updateSelectionTable.bind(this),
+        selectionchange_handlers: withSequence(5, this.updateSelectionTable.bind(this)),
         clean_handlers: this.deselectTable.bind(this),
         clean_for_save_handlers: ({ root }) => this.deselectTable(root),
         before_line_break_handlers: this.resetTableSelection.bind(this),
@@ -94,8 +95,13 @@ export class TablePlugin extends Plugin {
             node.nodeName === "TABLE" || tableInnerComponents.has(node.nodeName),
         fully_selected_node_predicates: (node) => !!closestElement(node, ".o_selected_td"),
         traversed_nodes_processors: this.adjustTraversedNodes.bind(this),
+
         normalize_handlers: this.distributeTableColorsToAllCells.bind(this),
         overlay_selection_target_rect_providers: this.getTableSelectionRangeRect.bind(this),
+        selected_background_color_providers: withSequence(
+            5,
+            this.computeBackgroundColorForTable.bind(this)
+        ),
     };
 
     setup() {
@@ -780,6 +786,33 @@ export class TablePlugin extends Plugin {
                 }
             }
         }
+    }
+
+    computeBackgroundColorForTable() {
+        const selectedTds = Array.from(this.editable.querySelectorAll(".o_selected_td"));
+        if (selectedTds.length === 0) {
+            return null;
+        }
+
+        const firstStyle = getComputedStyle(selectedTds[0]);
+        const backgroundColor = firstStyle.backgroundColor;
+        const backgroundImage = firstStyle.backgroundImage;
+        // If the first selected cell doesn't have any background style, we
+        // consider that there's no common background style.
+        if (backgroundImage === "none" && backgroundColor === "rgba(0, 0, 0, 0)") {
+            return null;
+        }
+
+        const allSameStyle = selectedTds.slice(1).every((td) => {
+            const s = getComputedStyle(td);
+            return s.backgroundColor === backgroundColor && s.backgroundImage === backgroundImage;
+        });
+
+        if (!allSameStyle) {
+            return "#00000000";
+        }
+
+        return backgroundImage !== "none" ? backgroundImage : rgbaToHex(backgroundColor);
     }
 
     /**

--- a/addons/html_editor/static/src/utils/color.js
+++ b/addons/html_editor/static/src/utils/color.js
@@ -15,6 +15,8 @@ export const COLOR_PALETTE_COMPATIBILITY_COLOR_NAMES = [
     "danger",
 ];
 
+export const RGBA_OPACITY = 0.6;
+
 /**
  * Colors of the default palette, used for substitution in shapes/illustrations.
  * key: number of the color in the palette (ie, o-color-<1-5>)
@@ -297,4 +299,28 @@ export function hasAnyNodesColor(nodes, mode) {
         }
     }
     return false;
+}
+
+export function computeBackgroundColorForElement(el) {
+    const elStyle = getComputedStyle(el);
+    const backgroundImage = elStyle.backgroundImage;
+    const hasGradient = isColorGradient(backgroundImage);
+    const hasTextGradientClass = el.classList.contains("text-gradient");
+
+    let backgroundColor = elStyle.backgroundColor;
+    const activeTab = document
+        .querySelector(".o_font_color_selector button.active")
+        ?.innerHTML.trim();
+    if (backgroundColor.startsWith("rgba") && activeTab === "Solid") {
+        // Buttons in the solid tab of color selector have no
+        // opacity, hence to match selected color correctly,
+        // we need to remove applied 0.6 opacity.
+        const values = backgroundColor.match(RGBA_REGEX) || [];
+        const alpha = parseFloat(values.pop()); // Extract alpha value
+        if (alpha === RGBA_OPACITY) {
+            backgroundColor = `rgb(${values.slice(0, 3).join(", ")})`; // Remove alpha
+        }
+    }
+
+    return hasGradient && !hasTextGradientClass ? backgroundImage : rgbaToHex(backgroundColor);
 }

--- a/addons/html_editor/static/tests/table/misc.test.js
+++ b/addons/html_editor/static/tests/table/misc.test.js
@@ -111,3 +111,76 @@ test("can color cells", async () => {
     expect(cells[1]).toHaveStyle({ "background-color": "rgba(107, 173, 222, 0.6)" });
     expect(cells[2]).not.toHaveStyle({ "background-color": "rgba(107, 173, 222, 0.6)" });
 });
+
+describe("selected cell color in toolbar", () => {
+    test("cell's selected color should be shown in toolbar (1)", async () => {
+        await setupEditor(`
+        <table>
+            <tbody>
+                <tr>
+                    <td style="background-color: rgba(255, 0, 0, 0.6);"><div class="o-paragraph">[ab</div></td>
+                    <td style="background-color: rgba(255, 0, 0, 0.6);"><div class="o-paragraph">c]</div></td>
+                    <td>ef</td>
+                    <td>ef</td>
+                </tr>
+            </tbody>
+        </table>`);
+
+        await waitFor(".o-we-toolbar");
+        expect(".fa-paint-brush").toHaveCount(1);
+        expect(".fa-paint-brush").toHaveStyle({
+            "border-bottom": "2px solid rgba(255, 0, 0, 0.6)",
+        });
+    });
+    test("cell's selected color should be shown in toolbar (2)", async () => {
+        await setupEditor(`
+        <table>
+            <tbody>
+                <tr>
+                    <td style="background-color: rgba(255, 0, 0, 0.6);"><div class="o-paragraph">[ab</div></td>
+                    <td style="background-color: rgba(107, 173, 222, 0.6);"><div class="o-paragraph">c]</div></td>
+                    <td>ef</td>
+                </tr>
+            </tbody>
+        </table>`);
+
+        await waitFor(".o-we-toolbar");
+        await animationFrame();
+        expect(".fa-paint-brush").toHaveCount(1);
+        expect(".fa-paint-brush").toHaveStyle({
+            "border-bottom": "2px solid rgba(0, 0, 0, 0)",
+        });
+    });
+    test("cell's selected color should be shown in toolbar (3)", async () => {
+        await setupEditor(`
+        <table>
+            <tbody>
+                <tr>
+                    <td style="background-color: rgba(255, 0, 0, 0.6);"><div class="o-paragraph">[ab</div></td>
+                    <td style="background-color: rgba(255, 0, 0, 0.6);"><div class="o-paragraph">c]</div></td>
+                    <td class="non_styled_1">a</td>
+                    <td class="non_styled_2">c</td>
+                </tr>
+            </tbody>
+        </table>`);
+
+        await waitFor(".o-we-toolbar");
+        expect(".fa-paint-brush").toHaveCount(1);
+        expect(".fa-paint-brush").toHaveStyle({
+            "border-bottom": "2px solid rgba(255, 0, 0, 0.6)",
+        });
+        const nonStyledCellOne = queryFirst(".non_styled_1");
+        const nonStyledCellTwo = queryFirst(".non_styled_2");
+        setSelection({
+            anchorNode: nonStyledCellOne,
+            anchorOffset: 0,
+            focusNode: nonStyledCellTwo,
+            focusOffset: 1,
+        });
+        await animationFrame();
+        expect(".fa-paint-brush").toHaveCount(1);
+        expect(".fa-paint-brush").toHaveStyle({
+            "border-bottom": "2px solid rgba(0, 0, 0, 0)",
+        });
+    });
+});


### PR DESCRIPTION
Before this commit: the background color of selected table cells isn't shown in the toolbar.

After this commit: we have a background color processor in the table plugin to calculate the background color of selected cells. The color and background color are also properly reset to update the selected color when selecting an empty table cell. table_selectionchange_handlers is created to make sure the selected color is updated after it.

task-5976046


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
