### PR TITLE
[IMP] pos_restaurant: Fix fast production creation in POS

### DIFF
--- a/addons/pos_restaurant/models/__init__.py
+++ b/addons/pos_restaurant/models/__init__.py
@@ -10,3 +10,4 @@ from . import pos_preset
 from . import restaurant_order_course
 from . import pos_category
 from . import pos_course
+from . import product_template

--- a/addons/pos_restaurant/models/product_template.py
+++ b/addons/pos_restaurant/models/product_template.py
@@ -1,0 +1,18 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    @api.model
+    def default_get(self, fields):
+        defaults = super().default_get(fields)
+        if "is_storable" in fields:
+            session_id = self.env.context.get("pos_session_id")
+            if session_id:
+                session = self.env["pos.session"].browse(session_id)
+                if session.config_id.module_pos_restaurant:
+                    defaults["is_storable"] = False
+        return defaults


### PR DESCRIPTION
When creating a new product in fast creation from the frontend in the POS, the product is now created as non-storable by default only for Bar/Restaurant.

task: 5980278

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
