### PR TITLE
[FIX] html_editor: not lose font size on toolbar redraw

### DIFF
--- a/addons/html_editor/static/src/main/font/font_size_selector.js
+++ b/addons/html_editor/static/src/main/font/font_size_selector.js
@@ -39,8 +39,8 @@ export class FontSizeSelector extends Component {
             const initFontSizeInput = () => {
                 const iframeDoc = iframeEl.contentWindow.document;
 
-                // Skip if already initialized.
-                if (this.fontSizeInput || !iframeDoc.body) {
+                // Skip if already/still initialized.
+                if (this.fontSizeInput?.closest("body") === iframeDoc.body || !iframeDoc.body) {
                     return;
                 }
 
@@ -83,17 +83,9 @@ export class FontSizeSelector extends Component {
             };
             if (iframeEl.contentDocument.readyState === "complete") {
                 initFontSizeInput();
-            } else {
-                // in firefox, iframe is not immediately available. we need to wait
-                // for it to be ready before mounting.
-                iframeEl.addEventListener(
-                    "load",
-                    () => {
-                        initFontSizeInput();
-                    },
-                    { once: true }
-                );
             }
+            // If iframe is moved around in DOM, it restarts from scratch and needs to be repopulated.
+            iframeEl.addEventListener("load", initFontSizeInput);
         });
         useEffect(
             () => {


### PR DESCRIPTION
Since [1], the font size in editor's toolbar is a `button` that contains an `iframe`. An `input` is put within this `iframe` so that when it is focused, the selection in the edited document is not lost. Unfortunately, when an `iframe` is moved in the DOM, it is restarted. In this case, the `iframe` has no source, so it becomes empty, and the content that was added into it `onMounted` is lost.

This commit solves this by listening to every `load` events on the `iframe` instead of only the initial one.

Steps to reproduce:
- Go to a "To Do" note
- Create a table with `/table`
- Press Enter to confirm the 3x3 size
- Select the last two cells of the first column
- Move the mouse upwards to the next cell

=> The font size disappeared

[1]: https://github.com/odoo/odoo/commit/a468de9d1099931d8f553c8569359996e7b694f2

task-6003539
