### PR TITLE
[IMP] web: Radio Field: adapt style on small screen.

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -60,7 +60,7 @@
                                 <field name="is_favorite" widget="boolean_favorite" nolabel="1" class="o_input_box_overlay_start"/>
                                 <field class="text-break" name="name" options="{'line_breaks': False}" widget="text" placeholder="e.g. Cheese Burger"/>
                             </h1>
-                            <div name="options">
+                            <div name="options" class="d-flex flex-column flex-md-row" colspan="2">
                                <span name="sale_option" class="d-inline-flex">
                                     <field name="sale_ok" class="w-auto"/>
                                     <label for="sale_ok"/>

--- a/addons/web/static/src/views/fields/radio/radio_field.js
+++ b/addons/web/static/src/views/fields/radio/radio_field.js
@@ -5,6 +5,7 @@ import { getFieldDomain } from "@web/model/relational_model/utils";
 import { useSpecialData } from "@web/views/fields/relational_utils";
 import { standardFieldProps } from "../standard_field_props";
 import { ConnectionLostError } from "@web/core/network/rpc";
+import { hasTouch } from "@web/core/browser/feature_detection";
 
 let nextId = 0;
 export class RadioField extends Component {
@@ -21,6 +22,7 @@ export class RadioField extends Component {
 
     setup() {
         this.id = `radio_field_${nextId++}`;
+        this.hasTouch = hasTouch();
         this.type = this.props.record.fields[this.props.name].type;
         if (this.type === "many2one") {
             this.specialData = useSpecialData(async (orm, props) => {

--- a/addons/web/static/src/views/fields/radio/radio_field.scss
+++ b/addons/web/static/src/views/fields/radio/radio_field.scss
@@ -29,3 +29,7 @@
         }
     }
 }
+
+.o_touch_device .o_radio_item {
+    padding-block: var(--inputbox-spacing-unit);
+}

--- a/addons/web/static/src/views/fields/radio/radio_field.xml
+++ b/addons/web/static/src/views/fields/radio/radio_field.xml
@@ -4,11 +4,11 @@
     <t t-name="web.RadioField">
         <div
             role="radiogroup"
-            t-attf-class="o_{{ props.orientation }}"
+            t-attf-class="{{ this.hasTouch ? 'o_input' : '' }} o_{{ props.orientation }}"
             t-att-aria-label="props.label"
         >
             <t t-foreach="items" t-as="item" t-key="item[0]">
-                <div class="form-check o_radio_item" aria-atomic="true">
+                <div t-attf-class="form-check o_radio_item {{ this.hasTouch ? 'w-100' : '' }}" aria-atomic="true">
                     <input
                         type="radio"
                         class="form-check-input o_radio_input"

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -1153,7 +1153,7 @@
     gap: map-get($spacers, 2);
 
     .o_form_header_details {
-        width: 100%;
+        flex-grow: 1;
     }
 
     > .o_field_widget:has(img) {
@@ -1174,10 +1174,6 @@
         flex-direction: row;
         gap: map-get($spacers, 3);
         margin-bottom: map-get($spacers, 3);
-
-        &:has(> .o_field_widget img) .o_form_header_details {
-            width: 50%;
-        }
     }
 
     @include media-breakpoint-down(md) {

--- a/addons/web/static/tests/views/fields/radio_field.test.js
+++ b/addons/web/static/tests/views/fields/radio_field.test.js
@@ -184,6 +184,7 @@ test("two radio field with same selection", async () => {
     expect("[name='color_2'] input.o_radio_input[data-value=red]").toBeChecked();
 });
 
+test.tags("desktop");
 test("radio field has o_horizontal or o_vertical class", async () => {
     Partner._fields.color2 = Partner._fields.color;
 


### PR DESCRIPTION
On small screen, the color used by the radio box label is the same as label, this is confusing and the user can't understand the possibility to change the value of the radio fields.

task-5359803

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
