### PR TITLE
[FIX] web_tour: pointer disappear from active element

### DIFF
--- a/addons/web_tour/static/src/js/tour_pointer/tour_pointer.js
+++ b/addons/web_tour/static/src/js/tour_pointer/tour_pointer.js
@@ -167,19 +167,23 @@ export class TourPointer extends Component {
             }
         });
         this.state = useState({ triggerBelow: false });
-        const uiService = useService("ui");
+        this.ui = useService("ui");
         const onActiveElementChanged = () => {
-            const activeEl = uiService.activeElement;
+            const activeEl = this.ui.activeElement;
             const pointerAnchor = this.props.pointerState.anchor;
             if (pointerAnchor) {
                 this.state.triggerBelow = !activeEl.contains(pointerAnchor);
             }
         };
-        useBus(uiService.bus, "active-element-changed", onActiveElementChanged);
+        useBus(this.ui.bus, "active-element-changed", onActiveElementChanged);
     }
 
     get isVisible() {
-        return this.props.pointerState.isVisible && !this.state.triggerBelow;
+        return (
+            this.props.pointerState.isVisible &&
+            (this.ui.activeElement.contains(this.props.pointerState.anchor) ||
+                !this.state.triggerBelow)
+        );
     }
 
     get content() {

--- a/addons/web_tour/static/tests/tour_interactive.test.js
+++ b/addons/web_tour/static/tests/tour_interactive.test.js
@@ -56,7 +56,7 @@ defineModels([Partner, Product]);
 
 class Counter extends Component {
     static props = ["*"];
-    static template = xml/*html*/ `
+    static template = xml /*html*/ `
         <div class="counter">
             <div class="interval">
                 <input type="number" t-model.number="state.interval" />
@@ -141,7 +141,7 @@ test("next step with new anchor at same position", async () => {
     class Dummy extends Component {
         static props = ["*"];
         state = useState({ bool: true });
-        static template = xml/*html*/ `
+        static template = xml /*html*/ `
             <button class="foo w-100" t-if="state.bool" t-on-click="() => { state.bool = false; }">Foo</button>
             <button class="bar w-100" t-if="!state.bool">Bar</button>
         `;
@@ -149,7 +149,7 @@ test("next step with new anchor at same position", async () => {
     class Root extends Component {
         static props = ["*"];
         static components = { Dummy };
-        static template = xml/*html*/ `
+        static template = xml /*html*/ `
             <t>
                 <Dummy />
             </t>
@@ -233,7 +233,7 @@ test("registering test tour after service is started doesn't auto-start the tour
     patchWithCleanup(session, { tour_enabled: true });
     class Root extends Component {
         static components = { Counter };
-        static template = xml/*html*/ `
+        static template = xml /*html*/ `
                 <t>
                     <Counter />
                 </t>
@@ -273,7 +273,7 @@ test("hovering to the anchor element should show the content and not when conten
     class Root extends Component {
         static props = ["*"];
         static components = { Counter };
-        static template = xml/*html*/ `
+        static template = xml /*html*/ `
             <t>
                 <Counter />
                 <button class="other">Pogačar</button>
@@ -325,7 +325,7 @@ test("should show only 1 pointer at a time", async () => {
     class Root extends Component {
         static props = ["*"];
         static components = { Counter };
-        static template = xml/*html*/ `
+        static template = xml /*html*/ `
             <t>
                 <Counter />
             </t>
@@ -360,7 +360,7 @@ test("perform edit on next step", async () => {
     class Root extends Component {
         static props = ["*"];
         static components = { Counter };
-        static template = xml/*html*/ `
+        static template = xml /*html*/ `
             <t>
                 <Counter />
             </t>
@@ -395,7 +395,7 @@ test("scrolling to next step should update the pointer's height", async (assert)
     class Root extends Component {
         static props = ["*"];
         static components = { Counter };
-        static template = xml/*html*/ `
+        static template = xml /*html*/ `
             <div class="scrollable-parent" style="overflow-y: scroll; height: 150px;">
                 <Counter />
                 <div class="bottom-filler" style="height: 300px" />
@@ -464,7 +464,7 @@ test("scroller pointer to reach next step", async () => {
     class Root extends Component {
         static props = ["*"];
         static components = { Counter };
-        static template = xml/*html*/ `
+        static template = xml /*html*/ `
             <div class="scrollable-parent" style="overflow-y: scroll; height: 150px;">
                 <button class="test">Test me</button>
                 <div class="top-filler" style="height: 500px" />
@@ -519,7 +519,7 @@ test("scroller pointer to reach next step (X axis)", async () => {
     class Root extends Component {
         static props = ["*"];
         static components = { Counter };
-        static template = xml/*html*/ `
+        static template = xml /*html*/ `
             <div class="scrollable-parent d-flex flex-row" style="overflow-x: scroll; width: 300px;">
                 <button class="test">Test me</button>
                 <div class="left-filler" style="min-width: 500px" />
@@ -601,7 +601,7 @@ test("manual tour with inactive steps", async () => {
     class Root extends Component {
         static props = ["*"];
         static components = { Counter };
-        static template = xml/*html*/ `
+        static template = xml /*html*/ `
             <t>
                 <Counter />
             </t>
@@ -647,7 +647,7 @@ test("manual tour with alternative trigger", async () => {
     });
     class Root extends Component {
         static components = {};
-        static template = xml/*html*/ `
+        static template = xml /*html*/ `
             <t>
                 <div class="container">
                     <button class="button0">0, hello</button>
@@ -854,7 +854,7 @@ test("check tooltip position", async () => {
     });
     class Root extends Component {
         static components = {};
-        static template = xml/*html*/ `
+        static template = xml /*html*/ `
             <t>
                 <div class="container">
                     <div class="p-3"><button class="button0">Button 0</button></div>
@@ -926,7 +926,7 @@ test("check rainbowManMessage", async () => {
     });
     class Root extends Component {
         static components = {};
-        static template = xml/*html*/ `
+        static template = xml /*html*/ `
             <t>
                 <div class="container">
                     <div class="p-3"><button class="button0">Button 0</button></div>
@@ -962,7 +962,7 @@ test("check alternative trigger that appear after the initial trigger", async ()
     });
     class Root extends Component {
         static components = {};
-        static template = xml/*html*/ `
+        static template = xml /*html*/ `
             <t>
                 <div class="container">
                     <div class="p-3"><button class="button0">Button 0</button></div>
@@ -1237,4 +1237,44 @@ test("pointer hidden when trigger is behind overlay", async () => {
     await waitFor(".o_tour_pointer");
     // Finalize the dummy tour to avoid leaving in a dirty state
     await contains("button.foo").click();
+});
+
+test("pointer in active element", async () => {
+    registry.category("web_tour.tours").add("tour1", {
+        steps: () => [
+            { trigger: "button.foo", run: "click" },
+            { trigger: "button.a", run: "click" },
+        ],
+    });
+
+    class DummyDialog extends Component {
+        static props = ["*"];
+        static components = { Dialog };
+        static template = xml`
+            <Dialog>
+                <button class="a">A</button>
+            </Dialog>
+        `;
+    }
+
+    class Dummy extends Component {
+        static props = ["*"];
+        static components = {};
+        static template = xml`
+            <button class="foo w-100" t-on-click="this.click">Foo</button>
+        `;
+
+        click() {
+            getService("dialog").add(DummyDialog, {});
+        }
+    }
+
+    await mountWithCleanup(Dummy);
+    await getService("tour_service").startTour("tour1", { mode: "manual" });
+    await waitFor(".o_tour_pointer");
+    await contains(".foo").click();
+    await waitFor(".modal");
+    await waitFor(".o_tour_pointer");
+    await contains(".modal .a").click();
+    await waitForNone(".o_tour_pointer");
 });


### PR DESCRIPTION
Before this commit, the pointer disappeared when the active element change before the anchor of the tour pointer. So, it was not visible in modals for example.

Now, the check is done when the active element change and when the isVisisble is read.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
