### PR TITLE
[IMP] payment(_*): Only validate amount data for successful transactions

### DIFF
--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -786,13 +786,14 @@ class PaymentTransaction(models.Model):
         tx = self or self._search_by_reference(provider_code, payment_data)
         if tx:
             tx.ensure_one()
-            previous_state = tx.state
-            tx._validate_amount(payment_data)
-            if tx.state == "error" and tx.state != previous_state:
-                return tx
             tx._apply_updates(payment_data)
-            if tx.tokenize and tx.state in {"authorized", "done"}:
-                tx._tokenize(payment_data)
+            if tx.state in {"authorized", "done"}:
+                tx._validate_amount(payment_data)  # Only validate amount data for successful states
+                if tx.state == "error":  # Amount data validation failed
+                    return tx
+
+                if tx.tokenize:
+                    tx._tokenize(payment_data)
         return tx
 
     @api.model
@@ -831,6 +832,24 @@ class PaymentTransaction(models.Model):
         """
         return payment_data.get("reference")
 
+    def _apply_updates(self, payment_data):  # noqa: ARG002
+        """Update the transaction based on the payment data received from the provider.
+
+        The updates typically include the payment's state, the provider reference, and the selected
+        payment method.
+
+        This method should not be called directly; payment data should go through :meth:`_process`.
+
+        This method must be overridden by providers to update the transaction based on the payment
+        data.
+
+        Note: `self.ensure_one()` from :meth:`_process`
+
+        :param dict payment_data: The payment data sent by the provider.
+        :return: None
+        """
+        return
+
     def _validate_amount(self, payment_data):
         """Ensure that the transaction's amount and currency match the ones from the payment data.
 
@@ -855,7 +874,7 @@ class PaymentTransaction(models.Model):
 
         if not amount or not currency_code:
             error_message = _("The amount or currency is missing from the payment data.")
-            self._set_error(error_message)
+            self._set_error(error_message, extra_allowed_states=("done",))
             return
 
         # Negate the amount for refunds, as refunds have a negative amount in Odoo, but all
@@ -873,14 +892,14 @@ class PaymentTransaction(models.Model):
             error_message = _(
                 "The amount from the payment data doesn't match the one from the transaction."
             )
-            self._set_error(error_message)
+            self._set_error(error_message, extra_allowed_states=("done",))
             return
 
         if currency_code != self.currency_id.name:
             error_message = _(
                 "The currency from the payment data doesn't match the one from the transaction."
             )
-            self._set_error(error_message)
+            self._set_error(error_message, extra_allowed_states=("done",))
 
     def _extract_amount_data(self, payment_data):  # noqa: ARG002
         """Extract the amount, currency and rounding precision from the payment data.
@@ -894,24 +913,6 @@ class PaymentTransaction(models.Model):
         :rtype: dict|None
         """
         return {}
-
-    def _apply_updates(self, payment_data):  # noqa: ARG002
-        """Update the transaction based on the payment data received from the provider.
-
-        The updates typically include the payment's state, the provider reference, and the selected
-        payment method.
-
-        This method should not be called directly; payment data should go through :meth:`_process`.
-
-        This method must be overridden by providers to update the transaction based on the payment
-        data.
-
-        Note: `self.ensure_one()` from :meth:`_process`
-
-        :param dict payment_data: The payment data sent by the provider.
-        :return: None
-        """
-        return
 
     def _tokenize(self, payment_data):
         """Create a new token based on the payment data.

--- a/addons/payment/tests/test_payment_transaction.py
+++ b/addons/payment/tests/test_payment_transaction.py
@@ -278,21 +278,31 @@ class TestPaymentTransaction(PaymentCommon):
             tx._process("test", {})
         self.assertEqual(apply_updates_mock.call_count, 1)
 
-    def test_processing_does_not_apply_updates_when_amount_data_is_invalid(self):
-        tx = self._create_transaction("redirect", state="draft", amount=100)
-        with (
-            patch(
+    def test_processing_sets_authorized_and_done_tx_to_error_on_invalid_amount(self):
+        self.provider.support_manual_capture = "full_only"
+        for state in ["authorized", "done"]:
+            tx = self._create_transaction(
+                "redirect", reference=f"Test {state}", state=state, amount=100
+            )
+            with (
+                patch(
+                    "odoo.addons.payment.models.payment_transaction.PaymentTransaction"
+                    "._extract_amount_data",
+                    return_value={"amount": 10, "currency_code": "USD"},
+                ),
+            ):
+                tx._process("test", {})
+            self.assertEqual(tx.state, "error")
+
+    def test_processing_skips_amount_validation_for_non_authorized_and_done_states(self):
+        for state in ["draft", "pending", "error", "cancel"]:
+            tx = self._create_transaction("redirect", reference=f"Test {state}", state=state)
+            with patch(
                 "odoo.addons.payment.models.payment_transaction.PaymentTransaction"
-                "._extract_amount_data",
-                return_value={"amount": 10, "currency_code": "USD"},
-            ),
-            patch(
-                "odoo.addons.payment.models.payment_transaction.PaymentTransaction._apply_updates"
-            ) as apply_updates_mock,
-        ):
-            tx._process("test", {})
-        self.assertEqual(tx.state, "error")
-        self.assertEqual(apply_updates_mock.call_count, 0)
+                "._validate_amount",
+            ) as validate_amount_mock:
+                tx._process("test", {})
+            self.assertEqual(validate_amount_mock.call_count, 0)
 
     def test_processing_tokenizes_validated_transaction(self):
         """Test that `_process` tokenizes 'authorized' and 'done' transactions when possible."""

--- a/addons/payment_adyen/models/payment_transaction.py
+++ b/addons/payment_adyen/models/payment_transaction.py
@@ -310,33 +310,6 @@ class PaymentTransaction(models.Model):
             converted_amount, is_refund=is_refund, provider_reference=provider_reference
         )
 
-    def _extract_amount_data(self, payment_data):
-        """Override of `payment` to extract the amount and currency from the payment data."""
-        if self.provider_code != "adyen":
-            return super()._extract_amount_data(payment_data)
-
-        # Redirection payments and 3DS challenges don't have the amount or currency in their
-        # payment_data, but processing them results in a pending transaction anyway, neither
-        # does payment refusal response which will result in an error transaction.
-        if (
-            payment_data.get("action", {}).get("type") in ["redirect", "threeDS2"]
-            or payment_data.get("resultCode") in const.RESULT_CODES_MAPPING["refused"]
-        ):
-            return None  # Skip the validation
-
-        amount_data = payment_data.get("amount", {})
-        amount = payment_utils.to_major_currency_units(
-            amount_data.get("value", 0),
-            self.currency_id,
-            arbitrary_decimal_number=const.CURRENCY_DECIMALS.get(self.currency_id.name),
-        )
-        currency_code = amount_data.get("currency")
-        return {
-            "amount": amount,
-            "currency_code": currency_code,
-            "precision_digits": const.CURRENCY_DECIMALS.get(self.currency_id.name),
-        }
-
     def _apply_updates(self, payment_data):
         """Override of payment to update the transaction based on the payment data."""
         if self.provider_code != "adyen":
@@ -439,6 +412,24 @@ class PaymentTransaction(models.Model):
             self._set_error(
                 "Adyen: " + _("Received data with invalid payment state: %s", payment_state)
             )
+
+    def _extract_amount_data(self, payment_data):
+        """Override of `payment` to extract the amount and currency from the payment data."""
+        if self.provider_code != "adyen":
+            return super()._extract_amount_data(payment_data)
+
+        amount_data = payment_data.get("amount", {})
+        amount = payment_utils.to_major_currency_units(
+            amount_data.get("value", 0),
+            self.currency_id,
+            arbitrary_decimal_number=const.CURRENCY_DECIMALS.get(self.currency_id.name),
+        )
+        currency_code = amount_data.get("currency")
+        return {
+            "amount": amount,
+            "currency_code": currency_code,
+            "precision_digits": const.CURRENCY_DECIMALS.get(self.currency_id.name),
+        }
 
     def _extract_token_values(self, payment_data):
         """Override of `payment` to extract the token values from the payment data."""

--- a/addons/payment_aps/models/payment_transaction.py
+++ b/addons/payment_aps/models/payment_transaction.py
@@ -78,16 +78,6 @@ class PaymentTransaction(models.Model):
             return super()._extract_reference(provider_code, payment_data)
         return payment_data.get("merchant_reference")
 
-    def _extract_amount_data(self, payment_data):
-        """Override of `payment` to extract the amount and currency from the payment data."""
-        if self.provider_code != "aps":
-            return super()._extract_amount_data(payment_data)
-
-        amount = payment_utils.to_major_currency_units(
-            float(payment_data.get("amount", 0)), self.currency_id
-        )
-        return {"amount": amount, "currency_code": payment_data.get("currency")}
-
     def _apply_updates(self, payment_data):
         """Override of `payment' to update the transaction based on the payment data."""
         if self.provider_code != "aps":
@@ -123,3 +113,13 @@ class PaymentTransaction(models.Model):
                     reason=status_description,
                 )
             )
+
+    def _extract_amount_data(self, payment_data):
+        """Override of `payment` to extract the amount and currency from the payment data."""
+        if self.provider_code != "aps":
+            return super()._extract_amount_data(payment_data)
+
+        amount = payment_utils.to_major_currency_units(
+            float(payment_data.get("amount", 0)), self.currency_id
+        )
+        return {"amount": amount, "currency_code": payment_data.get("currency")}

--- a/addons/payment_asiapay/models/payment_transaction.py
+++ b/addons/payment_asiapay/models/payment_transaction.py
@@ -107,16 +107,6 @@ class PaymentTransaction(models.Model):
             return super()._extract_reference(provider_code, payment_data)
         return payment_data.get("Ref")
 
-    def _extract_amount_data(self, payment_data):
-        """Override of `payment` to extract the amount and currency from the payment data."""
-        if self.provider_code != "asiapay":
-            return super()._extract_amount_data(payment_data)
-
-        amount = payment_data.get("Amt")
-        # AsiaPay supports only one currency per account.
-        currency = self.provider_id.available_currency_ids  # The currency is still linked.
-        return {"amount": float(amount), "currency_code": currency.name}
-
     def _apply_updates(self, payment_data):
         """Override of `payment' to update the transaction based on the payment data."""
         if self.provider_code != "asiapay":
@@ -158,3 +148,13 @@ class PaymentTransaction(models.Model):
                 self.reference,
             )
             self._set_error(_("Unknown success code: %s", success_code))
+
+    def _extract_amount_data(self, payment_data):
+        """Override of `payment` to extract the amount and currency from the payment data."""
+        if self.provider_code != "asiapay":
+            return super()._extract_amount_data(payment_data)
+
+        amount = payment_data.get("Amt")
+        # AsiaPay supports only one currency per account.
+        currency = self.provider_id.available_currency_ids  # The currency is still linked.
+        return {"amount": float(amount), "currency_code": currency.name}

--- a/addons/payment_authorize/models/payment_transaction.py
+++ b/addons/payment_authorize/models/payment_transaction.py
@@ -163,22 +163,6 @@ class PaymentTransaction(models.Model):
         )
         self._process("authorize", {"response": res_content})
 
-    def _extract_amount_data(self, payment_data):
-        """Override of `payment` to extract the amount and currency from the payment data."""
-        if self.provider_code != "authorize":
-            return super()._extract_amount_data(payment_data)
-
-        tx_details = AuthorizeAPI(self.provider_id).get_transaction_details(
-            payment_data.get("response", {}).get("x_trans_id")
-        )
-        if "err_code" in tx_details:  # Transaction details are missing when an API error occurs.
-            return None  # Skip the validation
-
-        amount = tx_details.get("transaction", {}).get("authAmount")
-        # Authorize supports only one currency per account.
-        currency = self.provider_id.available_currency_ids  # The currency is still linked.
-        return {"amount": float(amount), "currency_code": currency.name}
-
     @api.model
     def _extract_reference(self, provider_code, payment_data):
         """Override of `payment` to extract the reference from the payment data.
@@ -251,6 +235,22 @@ class PaymentTransaction(models.Model):
                     error=error_code,
                 )
             )
+
+    def _extract_amount_data(self, payment_data):
+        """Override of `payment` to extract the amount and currency from the payment data."""
+        if self.provider_code != "authorize":
+            return super()._extract_amount_data(payment_data)
+
+        tx_details = AuthorizeAPI(self.provider_id).get_transaction_details(
+            payment_data.get("response", {}).get("x_trans_id")
+        )
+        if "err_code" in tx_details:  # Transaction details are missing when an API error occurs.
+            return None  # Skip the validation
+
+        amount = tx_details.get("transaction", {}).get("authAmount")
+        # Authorize supports only one currency per account.
+        currency = self.provider_id.available_currency_ids  # The currency is still linked.
+        return {"amount": float(amount), "currency_code": currency.name}
 
     def _extract_token_values(self, payment_data):
         """Override of `payment` to extract the token values from the payment data."""

--- a/addons/payment_buckaroo/models/payment_transaction.py
+++ b/addons/payment_buckaroo/models/payment_transaction.py
@@ -51,15 +51,6 @@ class PaymentTransaction(models.Model):
             return super()._extract_reference(provider_code, payment_data)
         return payment_data.get("brq_invoicenumber")
 
-    def _extract_amount_data(self, payment_data):
-        """Override of `payment` to extract the amount and currency from the payment data."""
-        if self.provider_code != "buckaroo":
-            return super()._extract_amount_data(payment_data)
-
-        amount = payment_data.get("brq_amount")
-        currency_code = payment_data.get("brq_currency")
-        return {"amount": float(amount), "currency_code": currency_code}
-
     def _apply_updates(self, payment_data):
         """Override of `payment` to update the transaction based on the payment data."""
         if self.provider_code != "buckaroo":
@@ -107,3 +98,12 @@ class PaymentTransaction(models.Model):
                 self.reference,
             )
             self._set_error(_("Unknown status code: %s.", status_code))
+
+    def _extract_amount_data(self, payment_data):
+        """Override of `payment` to extract the amount and currency from the payment data."""
+        if self.provider_code != "buckaroo":
+            return super()._extract_amount_data(payment_data)
+
+        amount = payment_data.get("brq_amount")
+        currency_code = payment_data.get("brq_currency")
+        return {"amount": float(amount), "currency_code": currency_code}

--- a/addons/payment_custom/models/payment_transaction.py
+++ b/addons/payment_custom/models/payment_transaction.py
@@ -46,12 +46,6 @@ class PaymentTransaction(models.Model):
             communication = self.sale_order_ids[0].reference
         return communication or self.reference
 
-    def _extract_amount_data(self, payment_data):
-        """Override of `payment` to skip the amount validation for custom flows."""
-        if self.provider_code != "custom":
-            return super()._extract_amount_data(payment_data)
-        return None
-
     def _apply_updates(self, payment_data):
         """Override of `payment` to update the transaction based on the payment data."""
         if self.provider_code != "custom":
@@ -59,6 +53,12 @@ class PaymentTransaction(models.Model):
 
         _logger.info("Validated custom payment for transaction %s: set as pending.", self.reference)
         self._set_pending()
+
+    def _extract_amount_data(self, payment_data):
+        """Override of `payment` to skip the amount validation for custom flows."""
+        if self.provider_code != "custom":
+            return super()._extract_amount_data(payment_data)
+        return None
 
     def _log_received_message(self):
         """Override of `payment` to remove custom providers from the recordset.

--- a/addons/payment_demo/models/payment_transaction.py
+++ b/addons/payment_demo/models/payment_transaction.py
@@ -95,12 +95,6 @@ class PaymentTransaction(models.Model):
         payment_data = {"reference": self.reference, "simulated_state": "done"}
         self._process("demo", payment_data)
 
-    def _extract_amount_data(self, payment_data):
-        """Override of `payment` to skip the amount validation for demo flows."""
-        if self.provider_code != "demo":
-            return super()._extract_amount_data(payment_data)
-        return None
-
     def _apply_updates(self, payment_data):
         """Override of `payment` to update the transaction based on the payment data."""
         if self.provider_code != "demo":
@@ -134,6 +128,12 @@ class PaymentTransaction(models.Model):
             self._set_canceled()
         else:  # Simulate an error state.
             self._set_error(_("You selected the following demo payment status: %s", state))
+
+    def _extract_amount_data(self, payment_data):
+        """Override of `payment` to skip the amount validation for demo flows."""
+        if self.provider_code != "demo":
+            return super()._extract_amount_data(payment_data)
+        return None
 
     def _extract_token_values(self, payment_data):
         """Override of `payment` to extract the token values from the payment data."""

--- a/addons/payment_dpo/models/payment_transaction.py
+++ b/addons/payment_dpo/models/payment_transaction.py
@@ -88,15 +88,6 @@ class PaymentTransaction(models.Model):
             return super()._extract_reference(provider_code, payment_data)
         return payment_data.get("CompanyRef")
 
-    def _extract_amount_data(self, payment_data):
-        """Override of `payment` to extract the amount and currency from the payment data."""
-        if self.provider_code != "dpo":
-            return super()._extract_amount_data(payment_data)
-
-        amount = payment_data.get("TransactionAmount")
-        currency_code = payment_data.get("TransactionCurrency")
-        return {"amount": float(amount), "currency_code": currency_code}
-
     def _apply_updates(self, payment_data):
         """Override of `payment` to update the transaction based on the payment data."""
         if self.provider_code != "dpo":
@@ -131,3 +122,12 @@ class PaymentTransaction(models.Model):
                 self.reference,
             )
             self._set_error(_("Unknown status code: %s", status_code))
+
+    def _extract_amount_data(self, payment_data):
+        """Override of `payment` to extract the amount and currency from the payment data."""
+        if self.provider_code != "dpo":
+            return super()._extract_amount_data(payment_data)
+
+        amount = payment_data.get("TransactionAmount")
+        currency_code = payment_data.get("TransactionCurrency")
+        return {"amount": float(amount), "currency_code": currency_code}

--- a/addons/payment_flutterwave/models/payment_transaction.py
+++ b/addons/payment_flutterwave/models/payment_transaction.py
@@ -139,15 +139,6 @@ class PaymentTransaction(models.Model):
             return super()._extract_reference(provider_code, payment_data)
         return payment_data.get("tx_ref") or payment_data.get("txRef")
 
-    def _extract_amount_data(self, payment_data):
-        """Override of `payment` to extract the amount and currency from the payment data."""
-        if self.provider_code != "flutterwave":
-            return super()._extract_amount_data(payment_data)
-
-        amount = payment_data.get("amount")
-        currency_code = payment_data.get("currency")
-        return {"amount": float(amount), "currency_code": currency_code}
-
     def _apply_updates(self, payment_data):
         """Override of `payment` to update the transaction based on the payment data."""
         if self.provider_code != "flutterwave":
@@ -192,6 +183,15 @@ class PaymentTransaction(models.Model):
                 self.reference,
             )
             self._set_error(_("Unknown payment status: %s", payment_status))
+
+    def _extract_amount_data(self, payment_data):
+        """Override of `payment` to extract the amount and currency from the payment data."""
+        if self.provider_code != "flutterwave":
+            return super()._extract_amount_data(payment_data)
+
+        amount = payment_data.get("amount")
+        currency_code = payment_data.get("currency")
+        return {"amount": float(amount), "currency_code": currency_code}
 
     def _extract_token_values(self, payment_data):
         """Override of `payment` to extract the token values from the payment data."""

--- a/addons/payment_iyzico/models/payment_transaction.py
+++ b/addons/payment_iyzico/models/payment_transaction.py
@@ -96,13 +96,6 @@ class PaymentTransaction(models.Model):
 
     # === BUSINESS METHODS - PROCESSING === #
 
-    def _extract_amount_data(self, payment_data):
-        """Override of `payment` to extract the amount and currency from the payment data."""
-        if self.provider_code != "iyzico":
-            return super()._extract_amount_data(payment_data)
-
-        return {"amount": payment_data.get("price"), "currency_code": payment_data.get("currency")}
-
     def _apply_updates(self, payment_data):
         """Override of payment to update the transaction based on the payment data."""
         if self.provider_code != "iyzico":
@@ -145,3 +138,10 @@ class PaymentTransaction(models.Model):
                 self.reference,
             )
             self._set_error(self.env._("Unknown status code: %s", status))
+
+    def _extract_amount_data(self, payment_data):
+        """Override of `payment` to extract the amount and currency from the payment data."""
+        if self.provider_code != "iyzico":
+            return super()._extract_amount_data(payment_data)
+
+        return {"amount": payment_data.get("price"), "currency_code": payment_data.get("currency")}

--- a/addons/payment_mercado_pago/models/payment_transaction.py
+++ b/addons/payment_mercado_pago/models/payment_transaction.py
@@ -184,22 +184,6 @@ class PaymentTransaction(models.Model):
             return super()._extract_reference(provider_code, payment_data)
         return payment_data.get("external_reference")
 
-    def _extract_amount_data(self, payment_data):
-        """Override of payment to extract the amount and currency from the payment data."""
-        if self.provider_code != "mercado_pago":
-            return super()._extract_amount_data(payment_data)
-
-        if self.operation in ("online_redirect", "online_direct"):
-            amount = payment_data.get("additional_info", {}).get("items", [{}])[0].get("unit_price")
-        else:  # 'online_token', 'offline'
-            amount = payment_data.get("transaction_amount")
-        currency_code = payment_data.get("currency_id")
-        return {
-            "amount": float(amount),
-            "currency_code": currency_code,
-            "precision_digits": const.CURRENCY_DECIMALS.get(currency_code),
-        }
-
     def _apply_updates(self, payment_data):
         """Override of `payment` to update the transaction based on the payment data."""
         if self.provider_code != "mercado_pago":
@@ -261,6 +245,22 @@ class PaymentTransaction(models.Model):
                 payment_status,
             )
             self._set_error(_("Received data with invalid status: %s.", payment_status))
+
+    def _extract_amount_data(self, payment_data):
+        """Override of payment to extract the amount and currency from the payment data."""
+        if self.provider_code != "mercado_pago":
+            return super()._extract_amount_data(payment_data)
+
+        if self.operation in ("online_redirect", "online_direct"):
+            amount = payment_data.get("additional_info", {}).get("items", [{}])[0].get("unit_price")
+        else:  # 'online_token', 'offline'
+            amount = payment_data.get("transaction_amount")
+        currency_code = payment_data.get("currency_id")
+        return {
+            "amount": float(amount),
+            "currency_code": currency_code,
+            "precision_digits": const.CURRENCY_DECIMALS.get(currency_code),
+        }
 
     def _extract_token_values(self, payment_data):
         """Override of `payment` to return token data based on payment data."""

--- a/addons/payment_mollie/models/payment_transaction.py
+++ b/addons/payment_mollie/models/payment_transaction.py
@@ -117,16 +117,6 @@ class PaymentTransaction(models.Model):
             return super()._extract_reference(provider_code, payment_data)
         return payment_data.get("ref")
 
-    def _extract_amount_data(self, payment_data):
-        """Override of `payment` to extract the amount and currency from the payment data."""
-        if self.provider_code != "mollie":
-            return super()._extract_amount_data(payment_data)
-
-        amount_data = payment_data.get("amount", {})
-        amount = amount_data.get("value")
-        currency_code = amount_data.get("currency")
-        return {"amount": float(amount), "currency_code": currency_code}
-
     def _apply_updates(self, payment_data):
         """Override of `payment` to update the transaction based on the payment data."""
         if self.provider_code != "mollie":
@@ -159,3 +149,13 @@ class PaymentTransaction(models.Model):
                 self.reference,
             )
             self._set_error(_("Received data with invalid payment status: %s.", payment_status))
+
+    def _extract_amount_data(self, payment_data):
+        """Override of `payment` to extract the amount and currency from the payment data."""
+        if self.provider_code != "mollie":
+            return super()._extract_amount_data(payment_data)
+
+        amount_data = payment_data.get("amount", {})
+        amount = amount_data.get("value")
+        currency_code = amount_data.get("currency")
+        return {"amount": float(amount), "currency_code": currency_code}

--- a/addons/payment_nuvei/models/payment_transaction.py
+++ b/addons/payment_nuvei/models/payment_transaction.py
@@ -105,29 +105,6 @@ class PaymentTransaction(models.Model):
             return super()._extract_reference(provider_code, payment_data)
         return payment_data.get("invoice_id")
 
-    def _extract_amount_data(self, payment_data):
-        """Override of `payment` to extract the amount and currency from the payment data."""
-        if self.provider_code != "nuvei":
-            return super()._extract_amount_data(payment_data)
-
-        # When a user declines to pay and leaves the payment page, no information
-        # is sent back to odoo via the endpoint. As such there is no currency or
-        # amount set so we return early. This only occurs in the leaving flow so
-        # no issue should arise leaving early.
-        if not payment_data:
-            return None
-
-        is_mandatory_integer_pm = self.payment_method_code in const.INTEGER_METHODS
-        rounding = 0 if is_mandatory_integer_pm else self.currency_id.decimal_places
-
-        amount = payment_data.get("totalAmount")
-        currency_code = payment_data.get("currency")
-        return {
-            "amount": float(amount),
-            "currency_code": currency_code,
-            "precision_digits": rounding,
-        }
-
     def _apply_updates(self, payment_data):
         """Override of `payment` to update the transaction based on the payment data."""
         if self.provider_code != "nuvei":
@@ -181,3 +158,19 @@ class PaymentTransaction(models.Model):
                     reason=status_description,
                 )
             )
+
+    def _extract_amount_data(self, payment_data):
+        """Override of `payment` to extract the amount and currency from the payment data."""
+        if self.provider_code != "nuvei":
+            return super()._extract_amount_data(payment_data)
+
+        is_mandatory_integer_pm = self.payment_method_code in const.INTEGER_METHODS
+        rounding = 0 if is_mandatory_integer_pm else self.currency_id.decimal_places
+
+        amount = payment_data.get("totalAmount")
+        currency_code = payment_data.get("currency")
+        return {
+            "amount": float(amount),
+            "currency_code": currency_code,
+            "precision_digits": rounding,
+        }

--- a/addons/payment_paymob/models/payment_transaction.py
+++ b/addons/payment_paymob/models/payment_transaction.py
@@ -122,16 +122,6 @@ class PaymentTransaction(models.Model):
             return super()._extract_reference(provider_code, payment_data)
         return payment_data.get("merchant_order_id")
 
-    def _extract_amount_data(self, payment_data):
-        """Override of payment to extract the amount and currency from the payment data."""
-        if self.provider_code != "paymob":
-            return super()._extract_amount_data(payment_data)
-
-        amount_cents = float(payment_data.get("amount_cents"))
-        amount = payment_utils.to_major_currency_units(amount_cents, self.currency_id)
-        currency_code = payment_data.get("currency")
-        return {"amount": amount, "currency_code": currency_code}
-
     def _apply_updates(self, payment_data):
         """Override of `payment` to update the transaction based on the payment data."""
         if self.provider_code != "paymob":
@@ -154,3 +144,13 @@ class PaymentTransaction(models.Model):
                     msg=message,
                 )
             )
+
+    def _extract_amount_data(self, payment_data):
+        """Override of payment to extract the amount and currency from the payment data."""
+        if self.provider_code != "paymob":
+            return super()._extract_amount_data(payment_data)
+
+        amount_cents = float(payment_data.get("amount_cents"))
+        amount = payment_utils.to_major_currency_units(amount_cents, self.currency_id)
+        currency_code = payment_data.get("currency")
+        return {"amount": amount, "currency_code": currency_code}

--- a/addons/payment_paypal/models/payment_transaction.py
+++ b/addons/payment_paypal/models/payment_transaction.py
@@ -98,16 +98,6 @@ class PaymentTransaction(models.Model):
             return super()._extract_reference(provider_code, payment_data)
         return payment_data.get("reference_id")
 
-    def _extract_amount_data(self, payment_data):
-        """Override of payment to extract the amount and currency from the payment data."""
-        if self.provider_code != "paypal":
-            return super()._extract_amount_data(payment_data)
-
-        amount_data = payment_data.get("amount", {})
-        amount = amount_data.get("value")
-        currency_code = amount_data.get("currency_code")
-        return {"amount": float(amount), "currency_code": currency_code}
-
     def _apply_updates(self, payment_data):
         """Override of `payment` to update the transaction based on the payment data."""
         if self.provider_code != "paypal":
@@ -156,3 +146,13 @@ class PaymentTransaction(models.Model):
                 self.reference,
             )
             self._set_error(_("Received data with invalid payment status: %s", payment_status))
+
+    def _extract_amount_data(self, payment_data):
+        """Override of payment to extract the amount and currency from the payment data."""
+        if self.provider_code != "paypal":
+            return super()._extract_amount_data(payment_data)
+
+        amount_data = payment_data.get("amount", {})
+        amount = amount_data.get("value")
+        currency_code = amount_data.get("currency_code")
+        return {"amount": float(amount), "currency_code": currency_code}

--- a/addons/payment_razorpay/models/payment_transaction.py
+++ b/addons/payment_razorpay/models/payment_transaction.py
@@ -354,18 +354,6 @@ class PaymentTransaction(models.Model):
             converted_amount, is_refund=True, provider_reference=refund_provider_reference
         )
 
-    def _extract_amount_data(self, payment_data):
-        """Override of payment to extract the amount and currency from the payment data."""
-        if self.provider_code != "razorpay":
-            return super()._extract_amount_data(payment_data)
-
-        # Amount and currency are not sent in the payment data when redirecting to the return route.
-        if "amount" not in payment_data or "currency" not in payment_data:
-            return None
-
-        amount = payment_utils.to_major_currency_units(payment_data["amount"], self.currency_id)
-        return {"amount": amount, "currency_code": payment_data["currency"]}
-
     def _apply_updates(self, payment_data):
         """Override of `payment` to update the transaction based on the payment data."""
         if self.provider_code != "razorpay":
@@ -448,6 +436,14 @@ class PaymentTransaction(models.Model):
             self._set_error(
                 "Razorpay: " + _("Received data with invalid status: %s", entity_status)
             )
+
+    def _extract_amount_data(self, payment_data):
+        """Override of payment to extract the amount and currency from the payment data."""
+        if self.provider_code != "razorpay":
+            return super()._extract_amount_data(payment_data)
+
+        amount = payment_utils.to_major_currency_units(payment_data["amount"], self.currency_id)
+        return {"amount": amount, "currency_code": payment_data["currency"]}
 
     def _extract_token_values(self, payment_data):
         """Override of `payment` to return token data based on Razorpay data.

--- a/addons/payment_redsys/models/payment_transaction.py
+++ b/addons/payment_redsys/models/payment_transaction.py
@@ -151,22 +151,6 @@ class PaymentTransaction(models.Model):
             return super()._extract_reference(provider_code, payment_data)
         return payment_data.get("Ds_Order")
 
-    def _extract_amount_data(self, payment_data):
-        """Override of `payment` to extract the amount and currency from the payment data."""
-        if self.provider_code != "redsys":
-            return super()._extract_amount_data(payment_data)
-
-        amount = payment_utils.to_major_currency_units(
-            float(payment_data.get("Ds_Amount", 0)), self.currency_id
-        )
-        currency = (
-            self
-            .env["res.currency"]
-            .search([("iso_numeric", "=", payment_data.get("Ds_Currency"))], limit=1)
-            .name
-        )
-        return {"amount": amount, "currency_code": currency}
-
     def _apply_updates(self, payment_data):
         """Override of `payment' to update the transaction based on the payment data."""
         if self.provider_code != "redsys":
@@ -196,6 +180,22 @@ class PaymentTransaction(models.Model):
         else:
             _logger.warning("Received invalid payment status (%s).", status_code)
             self._set_error(_("Unknown status code: %s", status_code))
+
+    def _extract_amount_data(self, payment_data):
+        """Override of `payment` to extract the amount and currency from the payment data."""
+        if self.provider_code != "redsys":
+            return super()._extract_amount_data(payment_data)
+
+        amount = payment_utils.to_major_currency_units(
+            float(payment_data.get("Ds_Amount", 0)), self.currency_id
+        )
+        currency = (
+            self
+            .env["res.currency"]
+            .search([("iso_numeric", "=", payment_data.get("Ds_Currency"))], limit=1)
+            .name
+        )
+        return {"amount": amount, "currency_code": currency}
 
     def _extract_token_values(self, payment_data):
         """Override of `payment` to return token data based on Redsys payment data."""

--- a/addons/payment_stripe/models/payment_transaction.py
+++ b/addons/payment_stripe/models/payment_transaction.py
@@ -305,27 +305,6 @@ class PaymentTransaction(models.Model):
 
         return tx
 
-    def _extract_amount_data(self, payment_data):
-        """Override of payment to extract the amount and currency from the payment data."""
-        if self.provider_code != "stripe":
-            return super()._extract_amount_data(payment_data)
-
-        if self.operation == "refund":
-            payment_data = payment_data["refund"]
-        else:  # 'online_direct', 'online_token', 'offline'
-            payment_data = payment_data["payment_intent"]
-        amount = payment_utils.to_major_currency_units(
-            payment_data.get("amount", 0),
-            self.currency_id,
-            arbitrary_decimal_number=const.CURRENCY_DECIMALS.get(self.currency_id.name),
-        )
-        currency_code = payment_data.get("currency", "").upper()
-        return {
-            "amount": amount,
-            "currency_code": currency_code,
-            "precision_digits": const.CURRENCY_DECIMALS.get(self.currency_id.name),
-        }
-
     def _apply_updates(self, payment_data):
         """Override of `payment` to update the transaction based on the payment data."""
         if self.provider_code != "stripe":
@@ -393,6 +372,27 @@ class PaymentTransaction(models.Model):
                 "Received invalid payment status (%s) for transaction %s.", status, self.reference
             )
             self._set_error(_("Received data with invalid intent status: %s.", status))
+
+    def _extract_amount_data(self, payment_data):
+        """Override of payment to extract the amount and currency from the payment data."""
+        if self.provider_code != "stripe":
+            return super()._extract_amount_data(payment_data)
+
+        if self.operation == "refund":
+            payment_data = payment_data["refund"]
+        else:  # 'online_direct', 'online_token', 'offline'
+            payment_data = payment_data["payment_intent"]
+        amount = payment_utils.to_major_currency_units(
+            payment_data.get("amount", 0),
+            self.currency_id,
+            arbitrary_decimal_number=const.CURRENCY_DECIMALS.get(self.currency_id.name),
+        )
+        currency_code = payment_data.get("currency", "").upper()
+        return {
+            "amount": amount,
+            "currency_code": currency_code,
+            "precision_digits": const.CURRENCY_DECIMALS.get(self.currency_id.name),
+        }
 
     def _extract_token_values(self, payment_data):
         """Override of `payment` to return token data based on Stripe data.

--- a/addons/payment_toss_payments/models/payment_transaction.py
+++ b/addons/payment_toss_payments/models/payment_transaction.py
@@ -72,16 +72,6 @@ class PaymentTransaction(models.Model):
 
         return payment_data["orderId"]
 
-    def _extract_amount_data(self, payment_data):
-        """Override of `payment` to extract the amount from the payment data."""
-        if self.provider_code != "toss_payments":
-            return super()._extract_amount_data(payment_data)
-
-        return {
-            "amount": float(payment_data.get("totalAmount")),
-            "currency_code": const.SUPPORTED_CURRENCY,
-        }
-
     def _apply_updates(self, payment_data):
         """Override of `payment` to update the transaction based on the payment data."""
         if self.provider_code != "toss_payments":
@@ -105,3 +95,13 @@ class PaymentTransaction(models.Model):
             pass
         else:
             self._set_error(self.env._("Received data with invalid payment status: %s", status))
+
+    def _extract_amount_data(self, payment_data):
+        """Override of `payment` to extract the amount from the payment data."""
+        if self.provider_code != "toss_payments":
+            return super()._extract_amount_data(payment_data)
+
+        return {
+            "amount": float(payment_data.get("totalAmount")),
+            "currency_code": const.SUPPORTED_CURRENCY,
+        }

--- a/addons/payment_worldline/models/payment_transaction.py
+++ b/addons/payment_worldline/models/payment_transaction.py
@@ -194,22 +194,6 @@ class PaymentTransaction(models.Model):
         payment_output = payment_result.get("payment", {}).get("paymentOutput", {})
         return payment_output.get("references", {}).get("merchantReference", "")
 
-    def _extract_amount_data(self, payment_data):
-        """Override of payment to extract the amount and currency from the payment data."""
-        if self.provider_code != "worldline":
-            return super()._extract_amount_data(payment_data)
-
-        # In case of failed payment, paymentResult could be given as a separate key
-        payment_result = payment_data.get("paymentResult", payment_data)
-        amount_of_money = (
-            payment_result.get("payment", {}).get("paymentOutput", {}).get("amountOfMoney", {})
-        )
-        amount = payment_utils.to_major_currency_units(
-            amount_of_money.get("amount", 0), self.currency_id
-        )
-        currency_code = amount_of_money.get("currencyCode")
-        return {"amount": amount, "currency_code": currency_code}
-
     def _apply_updates(self, payment_data):
         """Override of `payment' to process the transaction based on Worldline data.
 
@@ -286,6 +270,22 @@ class PaymentTransaction(models.Model):
                         error_code=error_code,
                     )
                 )
+
+    def _extract_amount_data(self, payment_data):
+        """Override of payment to extract the amount and currency from the payment data."""
+        if self.provider_code != "worldline":
+            return super()._extract_amount_data(payment_data)
+
+        # In case of failed payment, paymentResult could be given as a separate key
+        payment_result = payment_data.get("paymentResult", payment_data)
+        amount_of_money = (
+            payment_result.get("payment", {}).get("paymentOutput", {}).get("amountOfMoney", {})
+        )
+        amount = payment_utils.to_major_currency_units(
+            amount_of_money.get("amount", 0), self.currency_id
+        )
+        currency_code = amount_of_money.get("currencyCode")
+        return {"amount": amount, "currency_code": currency_code}
 
     @staticmethod
     def _worldline_extract_payment_method_data(payment_data):

--- a/addons/payment_xendit/models/payment_transaction.py
+++ b/addons/payment_xendit/models/payment_transaction.py
@@ -155,19 +155,6 @@ class PaymentTransaction(models.Model):
             return super()._extract_reference(provider_code, payment_data)
         return payment_data.get("external_id")
 
-    def _extract_amount_data(self, payment_data):
-        """Override of payment to extract the amount and currency from the payment data."""
-        if self.provider_code != "xendit":
-            return super()._extract_amount_data(payment_data)
-
-        amount = payment_data.get("amount") or payment_data.get("authorized_amount")
-        currency_code = payment_data.get("currency")
-        return {
-            "amount": float(amount),
-            "currency_code": currency_code,
-            "precision_digits": const.CURRENCY_DECIMALS.get(currency_code),
-        }
-
     def _apply_updates(self, payment_data):
         """Override of `payment` to update the transaction based on the payment data."""
         if self.provider_code != "xendit":
@@ -204,6 +191,19 @@ class PaymentTransaction(models.Model):
                     failure_reason,
                 )
             )
+
+    def _extract_amount_data(self, payment_data):
+        """Override of payment to extract the amount and currency from the payment data."""
+        if self.provider_code != "xendit":
+            return super()._extract_amount_data(payment_data)
+
+        amount = payment_data.get("amount") or payment_data.get("authorized_amount")
+        currency_code = payment_data.get("currency")
+        return {
+            "amount": float(amount),
+            "currency_code": currency_code,
+            "precision_digits": const.CURRENCY_DECIMALS.get(currency_code),
+        }
 
     def _extract_token_values(self, payment_data):
         """Override of `payment` to return token data based on Xendit data.


### PR DESCRIPTION
**Purpose:**
In several legit cases, payment data may be missing the amount and currency. It typically happens when the transaction is not (yet) successful (not authorized/confirmed), and the provider didn't include the amount data.

**Specification:**
Run the amount validation after the processing and only if the state is 'authorized' or 'done'.

Task-5388769

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
