### PR TITLE
[FIX] website_{blog,cover}: use record cover as social media


### DIFF
--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -335,7 +335,7 @@ class BlogPost(models.Model):
         res['default_opengraph']['article:modified_time'] = self.write_date
         res['default_opengraph']['article:tag'] = self.tag_ids.mapped('name')
         # background-image might contain single quotes eg `url('/my/url')`
-        res['default_opengraph']['og:image'] = res['default_twitter']['twitter:image'] = json_scriptsafe.loads(self.cover_properties).get('background-image', 'none')[4:-1].strip("'")
+        res['default_opengraph']['og:image'] = res['default_twitter']['twitter:image'] = json_scriptsafe.loads(self.cover_properties).get('background-image', 'none')[4:-1].strip("\"'")
         res['default_opengraph']['og:title'] = res['default_twitter']['twitter:title'] = self.name
         res['default_meta_description'] = self.subtitle
         return res

--- a/addons/website_blog/tests/test_ui.py
+++ b/addons/website_blog/tests/test_ui.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import odoo.tests
 import re
-from odoo.addons.website_blog.tests.common import TestWebsiteBlogCommon
 from datetime import datetime
+
+import odoo.tests
+from odoo.addons.http_routing.tests.common import MockRequest
+from odoo.addons.website_blog.tests.common import TestWebsiteBlogCommon
 
 
 @odoo.tests.tagged('post_install', '-at_install')
@@ -21,7 +23,7 @@ class TestWebsiteBlogUi(odoo.tests.HttpCase, TestWebsiteBlogCommon):
         blog_tag = cls.env.ref('website_blog.blog_tag_2', raise_if_not_found=False)
         if not blog_tag:
             blog_tag = cls.env['blog.tag'].create({'name': 'adventure'})
-        cls.env['blog.post'].create({
+        cls.blog_post = cls.env['blog.post'].create({
             "name": "Post Test",
             "subtitle": "Subtitle Test",
             "blog_id": blog.id,
@@ -70,6 +72,20 @@ class TestWebsiteBlogUi(odoo.tests.HttpCase, TestWebsiteBlogCommon):
         })
         self.env.ref('website_blog.opt_blog_sidebar_show').active = True
         self.start_tour("/blog", "blog_context_and_social_media", login="admin")
+
+    def test_blog_social_image(self):
+        with MockRequest(self.env, website=self.env.ref('website.default_website'), url_root='http://example.com'):
+            meta = self.blog_post.get_website_meta()
+            self.assertEqual(meta['opengraph_meta']['og:image'], 'http://example.com/website_blog/static/src/img/cover_1.jpg')
+            self.assertEqual(meta['twitter_meta']['twitter:image'], 'http://example.com/website_blog/static/src/img/cover_1.jpg')
+            self.blog_post.cover_properties = """{"background-image": "url(\\"/2.jpg\\")"}"""
+            meta = self.blog_post.get_website_meta()
+            self.assertEqual(meta['opengraph_meta']['og:image'], 'http://example.com/2.jpg')
+            self.assertEqual(meta['twitter_meta']['twitter:image'], 'http://example.com/2.jpg')
+            self.blog_post.cover_properties = """{"background-image": "url(/3.jpg)"}"""
+            meta = self.blog_post.get_website_meta()
+            self.assertEqual(meta['opengraph_meta']['og:image'], 'http://example.com/3.jpg')
+            self.assertEqual(meta['twitter_meta']['twitter:image'], 'http://example.com/3.jpg')
 
     def test_avatar_comment(self):
         mail_message = self.env['mail.message'].create({

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -504,7 +504,7 @@ class EventEvent(models.Model):
         res = super()._default_website_meta()
         event_cover_properties = json.loads(self.cover_properties)
         # background-image might contain single quotes eg `url('/my/url')`
-        res['default_opengraph']['og:image'] = res['default_twitter']['twitter:image'] = event_cover_properties.get('background-image', 'none')[4:-1].strip("'")
+        res['default_opengraph']['og:image'] = res['default_twitter']['twitter:image'] = event_cover_properties.get('background-image', 'none')[4:-1].strip("\"'")
         res['default_opengraph']['og:title'] = res['default_twitter']['twitter:title'] = self.name
         res['default_opengraph']['og:description'] = res['default_twitter']['twitter:description'] = self.subtitle
         res['default_twitter']['twitter:card'] = 'summary'

--- a/addons/website_event/tests/test_website_event.py
+++ b/addons/website_event/tests/test_website_event.py
@@ -6,6 +6,7 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import fields, http
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo, HttpCaseWithUserPortal
+from odoo.addons.http_routing.tests.common import MockRequest
 from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.website_event.tests.common import TestEventOnlineCommon, OnlineEventCase
 from odoo.exceptions import AccessError
@@ -195,6 +196,27 @@ class TestUi(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
         ])
 
         self.start_tour('/event', 'test_website_event_search', login='admin')
+
+    def test_website_event_social_image(self):
+        website = self.env['website'].get_current_website()
+        event = self.env['event.event'].create({
+            'name': 'Event With Menu',
+            'website_menu': True,
+            'website_id': website.id,
+        })
+        with MockRequest(self.env, website=website, url_root='http://example.com'):
+            event.cover_properties = """{"background-image": "url('/1.jpg')"}"""
+            meta = event.get_website_meta()
+            self.assertEqual(meta['opengraph_meta']['og:image'], 'http://example.com/1.jpg')
+            self.assertEqual(meta['twitter_meta']['twitter:image'], 'http://example.com/1.jpg')
+            event.cover_properties = """{"background-image": "url(\\"/2.jpg\\")"}"""
+            meta = event.get_website_meta()
+            self.assertEqual(meta['opengraph_meta']['og:image'], 'http://example.com/2.jpg')
+            self.assertEqual(meta['twitter_meta']['twitter:image'], 'http://example.com/2.jpg')
+            event.cover_properties = """{"background-image": "url(/3.jpg)"}"""
+            meta = event.get_website_meta()
+            self.assertEqual(meta['opengraph_meta']['og:image'], 'http://example.com/3.jpg')
+            self.assertEqual(meta['twitter_meta']['twitter:image'], 'http://example.com/3.jpg')
 
 
 @tagged('post_install', '-at_install')


### PR DESCRIPTION
Scenario:

- set cover image of a blog post
- post blog post on social media (or check og:image/twitter:image tags)

Result: the social media is a dead image like:

http://site/blog/1/&#34;/web/image/3198-3915f222/cover%20image.webp&#34;

Cause: the code setting social image expected it to be in the
cover_properties background-image in url('{image}') or url({image})
format, but since 1b0852948c070d4d936bd00b3dd1c0e5501a1300 the format is
url("{image}") so it was gotten incorrectly.

Fix: also strip doubles quote and have the code working with
cover_properties background image with:

- no quote: for cover_properties before 18.4
- single quote: not sure in what situation this can happen
- double quote: for cover_properties since 18.4

opw-5471804