### PR TITLE
[FIX] l10n_din5008_sale: correctly align columns when hiding composition

### DIFF
--- a/addons/l10n_din5008_sale/report/din5008_sale_templates.xml
+++ b/addons/l10n_din5008_sale/report/din5008_sale_templates.xml
@@ -110,6 +110,9 @@
                <td/>
             </t>
         </xpath>
+        <td name="td_section_group_name" position="attributes">
+            <attribute name="t-att-colspan">2 if doc.company_id.has_position_column else 1</attribute>
+        </td>
         <xpath expr="//table/tbody" position="before">
             <t t-if="doc.company_id.has_position_column">
                 <t t-set="line_number" t-value="1"/>


### PR DESCRIPTION
Steps to reproduce
==================

- Install website_sale,accountant,l10n_de
- Select the DE company
- In the accounting settings, enable the "Show Position Column in Reports"
- Go to Sales
- Create a new Quotation
- Select a customer
- Add a product
- Add a section
- Click on the three dots
- Click on Hide Composition
- Add another section
- Click on the cog menu
- Click on Print > PDF Quote

=> The background of the first section ends before the end of the line => The columns are also not aligned

Solution
========

Add a colspan of 2 to the section names

opw-5427590

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
