### PR TITLE
[FIX] hr, *: prevent traceback when starting live chat as internal user

### DIFF
--- a/addons/hr/static/src/core/common/res_partner_model_patch.js
+++ b/addons/hr/static/src/core/common/res_partner_model_patch.js
@@ -16,7 +16,7 @@ patch(ResPartner.prototype, {
             compute() {
                 return (
                     this.employee_ids.find(
-                        (employee) => employee.company_id?.id === user.activeCompany.id
+                        (employee) => employee.company_id?.id === user.activeCompany?.id
                     ) || this.employee_ids[0]
                 );
             },

--- a/addons/hr/static/src/core/common/res_users_model_patch.js
+++ b/addons/hr/static/src/core/common/res_users_model_patch.js
@@ -13,7 +13,7 @@ patch(ResUsers.prototype, {
             compute() {
                 return (
                     this.employee_ids.find(
-                        (employee) => employee.company_id?.id === user.activeCompany.id
+                        (employee) => employee.company_id?.id === user.activeCompany?.id
                     ) || this.employee_ids[0]
                 );
             },


### PR DESCRIPTION
...when the `hr_holidays` module is installed.

Before this commit, starting a live chat conversation as an internal user would produce a traceback.

Steps to reproduce:
- Log in as internal user and navigate to the website.
- Start a live chat by sending a message -> traceback.

This is because since [1] the "back on" banner is loaded in the embed bundle, causing the `employee_id` field to get accessed. The `employee_id` field is computed based on the user active company, which is not present in the frontend session, causing the traceback.

This commit fixes the issue by guarding the access to `user.activeCompany`.

[1]: https://github.com/odoo/odoo/pull/247141

task-6003634