### PR TITLE
[FIX] mass_mailing: add styles for sized btns

### DIFF
--- a/addons/mail/static/src/views/web/fields/html_mail_field/convert_inline.js
+++ b/addons/mail/static/src/views/web/fields/html_mail_field/convert_inline.js
@@ -642,6 +642,10 @@ export function classToStyle(element, cssRules) {
                         computedStyle.getPropertyValue(prop) ||
                         computedStyle.getPropertyValue(styleName);
                     node.style.setProperty(styleName, value);
+                    if (value.includes("calc(")) {
+                        // If value included a calc(), assign the node's computed style property value for Outlook compatibility
+                        node.style.setProperty(styleName, computedStyle.getPropertyValue(styleName));
+                    }
                 }
             }
         });

--- a/addons/mass_mailing/static/src/builder/plugins/customize_mailing_variables.js
+++ b/addons/mass_mailing/static/src/builder/plugins/customize_mailing_variables.js
@@ -57,6 +57,18 @@ const buttonProperties = [
     "border-color",
 ];
 
+const sizedButtonProperties =  [
+    "font-size",
+    "padding-x",
+    "padding-y",
+];
+
+const outlinedButtonProperties = [
+    "background-color",
+    "color",
+    "border-color",
+];
+
 const separatorProperties = [
     "border-top-width",
     "border-style",
@@ -98,6 +110,36 @@ export const CUSTOMIZE_MAILING_VARIABLES = Object.assign(
         "btn-secondary",
         ["a.btn.btn-fill-secondary", "a.btn.btn-outline-secondary", "a.btn.btn-secondary"],
         buttonProperties
+    ),
+    generateSimpleMailingVariables(
+        "btn-primary-lg",
+        ["a.btn.btn-fill-primary.btn-lg", "a.btn.btn-outline-primary.btn-lg", "a.btn.btn-primary.btn-lg"],
+        sizedButtonProperties
+    ),
+    generateSimpleMailingVariables(
+        "btn-primary-sm",
+        ["a.btn.btn-fill-primary.btn-sm", "a.btn.btn-outline-primary.btn-sm", "a.btn.btn-primary.btn-sm"],
+        sizedButtonProperties
+    ),
+    generateSimpleMailingVariables(
+        "btn-secondary-lg",
+        ["a.btn.btn-fill-secondary.btn-lg", "a.btn.btn-outline-secondary.btn-lg", "a.btn.btn-secondary.btn-lg"],
+        sizedButtonProperties
+    ),
+    generateSimpleMailingVariables(
+        "btn-secondary-sm",
+        ["a.btn.btn-fill-secondary.btn-sm", "a.btn.btn-outline-secondary.btn-sm", "a.btn.btn-secondary.btn-sm"],
+        sizedButtonProperties
+    ),
+    generateSimpleMailingVariables(
+        "btn-primary-outline",
+        ["a.btn.btn-outline-primary"],
+        outlinedButtonProperties
+    ),
+    generateSimpleMailingVariables(
+        "btn-secondary-outline",
+        ["a.btn.btn-outline-secondary"],
+        outlinedButtonProperties
     ),
     generateSimpleMailingVariables("separator", ["hr"], separatorProperties)
 );
@@ -237,6 +279,37 @@ export const CUSTOMIZE_MAILING_VARIABLES_DEFAULTS = {
     "--btn-primary-border-color": {
         "border-color": "rgb(53, 151, 156)",
     },
+    "--btn-primary-lg-font-size": {
+        "font-size": "calc(var(--btn-primary-font-size) * 1.5)",
+    },
+    "--btn-primary-lg-padding-x": {
+        "padding-left": "calc(var(--btn-primary-padding-x) * 2.5)",
+        "padding-right": "calc(var(--btn-primary-padding-x) * 2.5)",
+    },
+    "--btn-primary-lg-padding-y": {
+        "padding-top": "calc(var(--btn-primary-padding-y) * 1.5)",
+        "padding-bottom": "calc(var(--btn-primary-padding-y) * 1.5)",
+    },
+    "--btn-primary-sm-font-size": {
+        "font-size": "calc(var(--btn-primary-font-size) * 0.875)",
+    },
+    "--btn-primary-sm-padding-x": {
+        "padding-left": "calc(var(--btn-primary-padding-x) * 0.3)",
+        "padding-right": "calc(var(--btn-primary-padding-x) * 0.3)",
+    },
+    "--btn-primary-sm-padding-y": {
+        "padding-top": "calc(var(--btn-primary-padding-y) * 0.20)",
+        "padding-bottom": "calc(var(--btn-primary-padding-y) * 0.20)",
+    },
+    "--btn-primary-outline-color": {
+        color: "var(--btn-primary-background-color)",
+    },
+    "--btn-primary-outline-background-color": {
+        "background-color": "transparent",
+    },
+    "--btn-primary-outline-border-color": {
+        "border-color": "var(--btn-primary-background-color)",
+    },
     "--btn-secondary-font-size": {
         "font-size": "12px",
     },
@@ -265,6 +338,37 @@ export const CUSTOMIZE_MAILING_VARIABLES_DEFAULTS = {
     },
     "--btn-secondary-border-color": {
         "border-color": "rgb(104, 85, 99)",
+    },
+    "--btn-secondary-lg-font-size": {
+        "font-size": "calc(var(--btn-secondary-font-size) * 1.5)",
+    },
+    "--btn-secondary-lg-padding-x": {
+        "padding-left": "calc(var(--btn-secondary-padding-x) * 2.5)",
+        "padding-right": "calc(var(--btn-secondary-padding-x) * 2.5)",
+    },
+    "--btn-secondary-lg-padding-y": {
+        "padding-top": "calc(var(--btn-secondary-padding-y) * 1.5)",
+        "padding-bottom": "calc(var(--btn-secondary-padding-y) * 1.5)",
+    },
+    "--btn-secondary-sm-font-size": {
+        "font-size": "calc(var(--btn-secondary-font-size) * 0.875)",
+    },
+    "--btn-secondary-sm-padding-x": {
+        "padding-left": "calc(var(--btn-secondary-padding-x) * 0.3)",
+        "padding-right": "calc(var(--btn-secondary-padding-x) * 0.3)",
+    },
+    "--btn-secondary-sm-padding-y": {
+        "padding-top": "calc(var(--btn-secondary-padding-y) * 0.20)",
+        "padding-bottom": "calc(var(--btn-secondary-padding-y) * 0.20)",
+    },
+    "--btn-secondary-outline-color": {
+        color: "var(--btn-secondary-background-color)",
+    },
+    "--btn-secondary-outline-background-color": {
+        "background-color": "transparent",
+    },
+    "--btn-secondary-outline-border-color": {
+        "border-color": "var(--btn-secondary-background-color)",
     },
     "--separator-border-top-width": {
         "border-top-width": "1px",


### PR DESCRIPTION
Currently, setting a button as Large, Small, or Outlined has no impact
on the appearance of the button, as it instead remains dependent on
mailing-wide set button dimensions and colors.

Steps to reproduce:
- Create a new mailing
- Type /button in the editor to insert a button
- Select the button and set its size as Large/Small or its nature as
  Outlined
- The button's appearance does not change

This commit allows Large, Small and Outlined button attributes to have
an effect on button appearance.

Sizes will scale linearly with mailing-wide button dimensions.

task-5910193
