### PR TITLE
[FIX] {purchase_,}mrp: round kit layer values at creation

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -243,7 +243,7 @@ class StockMove(models.Model):
     order_finished_lot_id = fields.Many2one('stock.lot', string="Finished Lot/Serial Number", related="raw_material_production_id.lot_producing_id", store=True, index='btree_not_null')
     should_consume_qty = fields.Float('Quantity To Consume', compute='_compute_should_consume_qty', digits='Product Unit of Measure')
     cost_share = fields.Float(
-        "Cost Share (%)", digits=(5, 2),  # decimal = 2 is important for rounding calculations!!
+        "Cost Share (%)", digits=0,
         help="The percentage of the final production cost for this by-product. The total of all by-products' cost share must be smaller or equal to 100.")
     product_qty_available = fields.Float('Product On Hand Quantity', related='product_id.qty_available', depends=['product_id'])
     product_virtual_available = fields.Float('Product Forecasted Quantity', related='product_id.virtual_available', depends=['product_id'])

--- a/addons/purchase_mrp/models/mrp_bom.py
+++ b/addons/purchase_mrp/models/mrp_bom.py
@@ -27,7 +27,7 @@ class MrpBom(models.Model):
     def _round_last_line_done(self, lines_done):
         result = super()._round_last_line_done(lines_done)
         if result:
-            result[-1][1]['line_cost_share'] = float_round(100.0 - sum(vals.get('line_cost_share', 0.0) for _, vals in result[:-1]), precision_digits=2)
+            result[-1][1]['line_cost_share'] = 100 - sum(vals.get('line_cost_share', 0.0) for _, vals in result[:-1])
         return result
 
 
@@ -35,7 +35,7 @@ class MrpBomLine(models.Model):
     _inherit = 'mrp.bom.line'
 
     cost_share = fields.Float(
-        "Cost Share (%)", digits=(5, 2),  # decimal = 2 is important for rounding calculations!!
+        "Cost Share (%)", digits=0,
         help="The percentage of the component repartition cost when purchasing a kit."
              "The total of all components' cost have to be equal to 100.")
 
@@ -54,7 +54,7 @@ class MrpBomLine(models.Model):
 
     def _prepare_line_done_values(self, quantity, product, original_quantity, parent_line, boms_done):
         result = super()._prepare_line_done_values(quantity, product, original_quantity, parent_line, boms_done)
-        result['line_cost_share'] = float_round(self._get_line_cost_share(product, boms_done), precision_digits=2)
+        result['line_cost_share'] = self._get_line_cost_share(product, boms_done)
         return result
 
     def _get_line_cost_share(self, product, boms_done):

--- a/addons/purchase_mrp/models/stock_move.py
+++ b/addons/purchase_mrp/models/stock_move.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, models, fields
+from collections import defaultdict
+
+from odoo import _, api, models, fields
 from odoo.tools.float_utils import float_is_zero, float_round
 from odoo.exceptions import UserError
 
@@ -64,3 +66,26 @@ class StockMove(models.Model):
             if kit_bom:
                 return line._compute_kit_quantities_from_moves(line.move_ids - self, kit_bom)
         return super()._get_qty_received_without_self()
+
+    @api.model
+    def _round_in_svl_value(self, svl_vals_list):
+        moves = self.env['stock.move'].browse({val['stock_move_id'] for val in svl_vals_list})
+        move_kit_pol_mapping = {move.id: move.purchase_line_id for move in moves if move.purchase_line_id and move.purchase_line_id.product_id != move.product_id}
+        if not move_kit_pol_mapping:
+            return svl_vals_list
+        vals_per_kit_line = defaultdict(list)
+        for val in svl_vals_list:
+            if pol := move_kit_pol_mapping.get(val['stock_move_id']):
+                vals_per_kit_line[pol].append(val)
+        company_id = self.env.context.get('force_company', self.env.company.id)
+        currency = self.env['res.company'].browse(company_id).currency_id
+        for vals in vals_per_kit_line.values():
+            total_value = sum(val['unit_cost'] * val['quantity'] for val in vals)
+            total_rounded_value = sum(val['value'] for val in vals)
+            total_rounding_error = currency.round(total_value - total_rounded_value)
+            nber_rounding_steps = int(abs(total_rounding_error / currency.rounding))
+            rounding_error = float_round(nber_rounding_steps and total_rounding_error / nber_rounding_steps or 0.0, precision_rounding=currency.rounding)
+            for val in vals[:nber_rounding_steps]:
+                val['value'] = currency.round(val['value'] + rounding_error)
+                val['remaining_value'] = val['value']
+        return svl_vals_list

--- a/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
+++ b/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
@@ -474,7 +474,7 @@ class TestAngloSaxonValuationPurchaseMRP(AccountTestInvoicingCommon):
                     - C03, cost share 0% (Last line should round to reach 100%)
         Buy and receive 1 kit Giga Kit @ 1000
         """
-        components = component01, component02, component03, component04, component05 = self.env['product.product'].create([{
+        component01, component02, component03, component04, component05 = self.env['product.product'].create([{
             'name': 'Component %s' % name,
             'categ_id': self.avco_category.id,
         } for name in ('01', '02 ', '03', '04', '05')])
@@ -556,38 +556,20 @@ class TestAngloSaxonValuationPurchaseMRP(AccountTestInvoicingCommon):
         #   1.0 * 0.6 * 0.5 * 0.5 (0%) = 0.15 -> 15%
         #   1.0 * 0.2 * 0.5 (0%) = 0.1 -> 10%
         #   1.0 * 0.0 * 1.0 = 0.0 -> 0%
-        self.assertEqual(sum(purchase_order.order_line.move_ids.mapped('cost_share')), 100.0)
-        self.assertRecordValues(purchase_order.order_line.move_ids.sorted(lambda m: m.product_id.id), [
-            {'product_id': component01.id, 'cost_share': 3.33},
-            {'product_id': component02.id, 'cost_share': 10.0},
-            {'product_id': component02.id, 'cost_share': 15.0},
-            {'product_id': component02.id, 'cost_share': 3.33},
-            {'product_id': component03.id, 'cost_share': 15.0},
-            {'product_id': component03.id, 'cost_share': 3.34},
-            {'product_id': component04.id, 'cost_share': 15.0},
-            {'product_id': component04.id, 'cost_share': 10.0},
-            {'product_id': component05.id, 'cost_share': 15.0},
-            {'product_id': component05.id, 'cost_share': 10.0},
-            {'product_id': component05.id, 'cost_share': 0.0},
-        ])
+        moves = purchase_order.order_line.move_ids.sorted('cost_share')
+        cost_share_values = moves.mapped('cost_share')
+        self.assertEqual(sum(cost_share_values), 100.0)
+        expected_values = [0.0, 3.3333333333333, 3.3333333333333, 3.3333333333333, 10.0, 10.0, 10.0, 15.0, 15.0, 15.0, 15.0]
+        for actual, expected in zip(cost_share_values, expected_values):
+            self.assertAlmostEqual(actual, expected)
         receipt = purchase_order.picking_ids
         receipt.button_validate()
-        svls_ordered = components.stock_valuation_layer_ids.sorted(lambda l: l.product_id.id)
-        self.assertRecordValues(svls_ordered, [
-            {'product_id': component01.id},
-            {'product_id': component02.id},
-            {'product_id': component02.id},
-            {'product_id': component02.id},
-            {'product_id': component03.id},
-            {'product_id': component03.id},
-            {'product_id': component04.id},
-            {'product_id': component04.id},
-            {'product_id': component05.id},
-            {'product_id': component05.id},
-            {'product_id': component05.id},
+
+        layers = receipt.move_ids.stock_valuation_layer_ids.sorted('value')
+        self.assertEqual(sum(layers.mapped('value')), 1000.0)
+        self.assertRecordValues(layers, [
+            {'value': val} for val in (0.0, 33.33, 33.33, 33.33, 100.0, 100.0, 100.01, 150.0, 150.0, 150.0, 150.0)
         ])
-        for svl, expected_unit_cost in zip(svls_ordered, [33.3, 100.0, 150.0, 33.3, 150.0, 33.4, 150.0, 100.0, 150.0, 100.0, 0.0]):
-            self.assertAlmostEqual(svl.unit_cost, expected_unit_cost)
 
     def test_kit_bom_cost_share_constraint_with_variants(self):
         """
@@ -783,4 +765,40 @@ class TestAngloSaxonValuationPurchaseMRP(AccountTestInvoicingCommon):
             # L attribute - Cost share 0% automatically splitted
             {'product_id': c4.id, 'unit_cost':  500.0},
             {'product_id': c5.id, 'unit_cost':  500.0},
+        ])
+
+    def test_kit_components_cost_distribution(self):
+        """
+        Test the cost share rounding when purchasing a kit with several lines without cost_share
+        """
+        kit, *components = self.env['product.product'].create([{
+            'name': 'Product %s' % i,
+            'is_storable': True,
+            'categ_id': self.avco_category.id,
+        } for i in range(7)])
+        self.env['mrp.bom'].create([{
+            'product_tmpl_id': kit.product_tmpl_id.id,
+            'type': 'phantom',
+            'bom_line_ids': [
+                *[Command.create({'product_id': p.id}) for p in components],
+            ],
+        }])
+
+        kit_price = 1000
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'product_id': kit.id,
+                'product_qty': 1,
+                'price_unit': kit_price,
+            })],
+        })
+        purchase_order.button_confirm()
+        receipt = purchase_order.picking_ids
+        receipt.button_validate()
+
+        layers = receipt.move_ids.stock_valuation_layer_ids.sorted('value')
+        self.assertAlmostEqual(sum(layers.mapped('value')), kit_price)
+        self.assertRecordValues(layers, [
+            {'value': val} for val in (166.66, 166.66, 166.67, 166.67, 166.67, 166.67)
         ])

--- a/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
+++ b/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
@@ -1271,8 +1271,8 @@ class TestPurchaseMrpFlow(AccountTestInvoicingCommon):
         # The standard price of the component is updated to $10 because the kit cost
         # is $60, there are 6 units of different components used in this BoM, and since
         # the cost_share is equal, 60/6 = $10.
-        self.assertAlmostEqual(self.component_a.standard_price, 9.99899999)
-        self.assertAlmostEqual(lot_a.standard_price, 9.99899999)
+        self.assertAlmostEqual(self.component_a.standard_price, 10)
+        self.assertAlmostEqual(lot_a.standard_price, 10)
         self.assertEqual(lot_a.quantity_svl, 4)
         self.assertEqual(lot_a.value_svl, 40)
 

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -526,6 +526,11 @@ class StockMove(models.Model):
                 if forced_quantity:
                     val['description'] = _('Correction of %s (modification of past move)', move.picking_id.name or move.name)
             svl_vals_list += vals
+        self._round_in_svl_value(svl_vals_list)
+        return svl_vals_list
+
+    @api.model
+    def _round_in_svl_value(self, svl_vals_list):
         return svl_vals_list
 
     def _get_src_account(self, accounts_data):


### PR DESCRIPTION
### Steps to reproduce:

- Create a kit product with 6 bom lines (with a `cost_share` of `0.0%`)
- Create + confirm a purchase order for 1 unit of the kit product at 60
- Validate the delivery

#### > 6 layers were created with values 9.99, 10, 10, 10, 10 and 10

There are two issues with purchased kit valuation addressed in this PR:

### Issue 1:

Since 8c199f7783527735b35c9fbda334cbdcd55a004f, the product price unit is not supposed to be rounded anymore. However, kit products rely on the rounded `cost_share` field of the `mrp.bom.line` to determine which part of the price of the kit product is handled by which component: https://github.com/odoo/odoo/blob/591102ff37fef1f0b9a946fee3f9d85789653e65/addons/mrp/models/stock_move.py#L245-L246 https://github.com/odoo/odoo/blob/591102ff37fef1f0b9a946fee3f9d85789653e65/addons/purchase_mrp/models/stock_move.py#L28 https://github.com/odoo/odoo/blob/591102ff37fef1f0b9a946fee3f9d85789653e65/addons/purchase_mrp/models/stock_move.py#L38

This leads to inevitable rounding issues where `60/6` does not match `10`: https://github.com/odoo/odoo/blob/591102ff37fef1f0b9a946fee3f9d85789653e65/addons/purchase_mrp/tests/test_purchase_mrp_flow.py#L1273-L1275 simply because 1/6 is represented  as `16.67%` and not by `16.66666666666666%`. However, values such as 1/6 can be obtained if you do not set any `cost_share`, since the kit explosion will equidistribute its cost share:
https://github.com/odoo/odoo/blob/591102ff37fef1f0b9a946fee3f9d85789653e65/addons/purchase_mrp/models/mrp_bom.py#L42-L48

### Fix of this issue:

We set the digits to `False` for stability reason as the columns have 
been initiallised as "numeric" values and needs to stay numeric:
https://github.com/odoo/odoo/blob/b007b0a4f7e56f6dc44df3154e13745c9981eae3/odoo/fields.py#L1627-L1650

Note that when the digit is Falsy on the field, the field value is formatted to the second digit by the front end:
https://github.com/odoo/odoo/blob/3542c542eac5b204e69a8dd6ae1907cfcef60af3/addons/web/static/src/views/fields/float/float_field.js#L58-L76
https://github.com/odoo/odoo/blob/12e453302a950df4d9ee45954f54bdf610888eda/addons/web/static/src/core/utils/numbers.js#L214-L227

In particular, when we create the bom and set the `cost_share`, all possible values will be rounded to the second decimal just as before. This change will therefore only alter the rounding behavior in the DB for equidistributed values such as `16.66666666666666%`.

### Issue 2:

While the value of the kit product is exploded and distributed among components, the values of each individual `stock.valuation.layer` are themselves rounded before creation based on the company currency: https://github.com/odoo/odoo/blob/4188436a9e800b062bf9f3b0055cad86acc47e19/addons/stock_account/models/product.py#L240-L255 https://github.com/odoo/odoo/blob/4188436a9e800b062bf9f3b0055cad86acc47e19/addons/stock_account/models/stock_valuation_layer.py#L30

Now, this is problematic since the sum of the values of the layers is expected to match the total value of the purchase order line (that is, the non-rounded value of the components of the purchased kit).

### Fix of this issue:

We compute and distribute the rounding error among layers corresponding to the purchased kit product before creation (since layer values are not expected to be modified afterwards), based on the non-rounded computation, since this value should now be exact (as the unit cost is not rounded anymore).

opw-5085457
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
