### PR TITLE
[FIX] hr_recruitment: send mail when candidate is refused

### DIFF
--- a/addons/hr_recruitment/tests/test_recruitment.py
+++ b/addons/hr_recruitment/tests/test_recruitment.py
@@ -466,3 +466,29 @@ class TestRecruitment(TransactionCase):
         self.assertEqual(applicant.partner_id.email, 'applicant_diff@example.com', "Email should have been updated on the partner.")
         applicant.partner_phone = '987654321'
         self.assertEqual(applicant.partner_id.phone, '987654321', "Phone should have been updated on the partner.")
+
+    def test_send_mail_when_refuse_applicant(self):
+        mail_template = self.env['mail.template'].create({
+            'name': 'Test template',
+            'model_id': self.env['ir.model']._get('hr.applicant').id,
+            'subject': 'Application refused: {{ object.partner_name }}',
+        })
+
+        refuse_reason = self.env['hr.applicant.refuse.reason'].create([{
+            'name': 'Not good',
+            'template_id': mail_template.id,
+        }])
+
+        app_1 = self.env['hr.applicant'].create({
+            'partner_name': 'Mario',
+            'email_from': 'super@mario.bros',
+        })
+
+        applicant_get_refuse_reason = self.env['applicant.get.refuse.reason'].create({
+            'refuse_reason_id': refuse_reason.id,
+            'send_mail': True,
+            'applicant_ids': [(6, 0, [app_1.id])],
+        })
+        applicant_get_refuse_reason._prepare_send_refusal_mails()
+        mail = self.env['mail.mail'].search([('subject', '=', 'Application refused: Mario')], limit=1)
+        self.assertEqual(mail.partner_ids, app_1.partner_id)

--- a/addons/hr_recruitment/wizard/applicant_refuse_reason.py
+++ b/addons/hr_recruitment/wizard/applicant_refuse_reason.py
@@ -170,8 +170,7 @@ class ApplicantGetRefuseReason(models.TransientModel):
             'email_from': email_from,
             'subject': subject,
             'author_id': self.env.user.partner_id.id,
-            'incoming_email_to': applicant.email_from or applicant.partner_id.email,
             'scheduled_date': self.scheduled_date,
             'attachment_ids': [(4, att.id) for att in self.attachment_ids],
-            'body_is_html': True,
+            'partner_ids': applicant.partner_id.ids
         }


### PR DESCRIPTION
## Short functional explanation of the error
When a candidate is refused, an email isn't sent to their email address.

## Reproduction Steps
1. Open Mailhog in a separate tab.
2. Go to the Recruitment app and select any job position.
3. Click on new to create a new application. Enter an applicant name and an applicant email.
4. Check Mailhog: a job application has been sent to the applicant.
5. Go back on the Recruitment app and click on Refuse. In the wizard, make sure you toggle Send Email and click on Refuse.

### Expected behavior
In Mailhog, a refusal mail has been sent to the applicant.

### Unexpected behavior
Nothing is sent.

## Origin of the issue
When refusing a candidate, we create a notification in the chatter but an email isn't sent. This is due to the `incoming_email_to` field, which is checked here:

https://github.com/odoo/odoo/blob/bfc1c210eca65de1116aa09cdd62749ed9192407/addons/mail/models/mail_thread.py#L4040-L4053

but because this field is already retrieved here:
https://github.com/odoo/odoo/blob/bfc1c210eca65de1116aa09cdd62749ed9192407/addons/mail/models/mail_thread.py#L4025 the last condition will always be true, preventing the recipient's data to be added to the message, thus preventing the message to be sent correctly.

Note: as of 19.0, the field `outgoing_email_to` can be used to determine the recipient's email address.
Note: we remove `'body_is_html': True` because this field
is misused in this case: when set at true, the field is always
considered as HTML
__
opw-5980079

