### PR TITLE
[FIX] account_edi_ubl_cii: fix TypeError

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_move_send.py
+++ b/addons/account_edi_ubl_cii/models/account_move_send.py
@@ -187,7 +187,7 @@ class AccountMoveSend(models.AbstractModel):
 
         # PDF-A.
         if ((invoice_data.get('ubl_cii_xml_options', {}).get('ubl_cii_format') in ('facturx', 'zugferd')
-                or (invoice.commercial_partner_id.country_code in ('FR, DE') and invoice.commercial_partner_id.peppol_eas != '0204'))
+                or (invoice.commercial_partner_id.country_code in ('FR', 'DE') and invoice.commercial_partner_id.peppol_eas != '0204'))
                 and invoice.country_code in ('FR', 'DE')
                 and not writer.is_pdfa
             ):


### PR DESCRIPTION
`('FR, DE')` was a single string instead of a tuple, causing a TypeError when `country_code` is not a string (e.g. falsy value on empty recordset). Changed to `('FR', 'DE')` so membership test is used instead of substring search.

opw-6004910

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
