### PR TITLE
[FIX] account, pos_sale: fixed tax downpayment

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -3978,8 +3978,7 @@ class AccountTax(models.Model):
         def dispatch_exclude_function(base_line, tax_data):
             return not tax_data['tax']._can_be_discounted() or (exclude_function and exclude_function(base_line, tax_data))
 
-        new_base_lines = self._dispatch_taxes_into_new_base_lines(base_lines, company, dispatch_exclude_function)
-        return new_base_lines + self._turn_removed_taxes_into_new_base_lines(new_base_lines, company)
+        return self._dispatch_taxes_into_new_base_lines(base_lines, company, dispatch_exclude_function)
 
     @api.model
     def _prepare_down_payment_lines(

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -2522,14 +2522,10 @@ export const accountTaxHelpers = {
                 (exclude_function && exclude_function(base_line, tax_data))
             );
         }
-
-        const new_base_lines = this.dispatch_taxes_into_new_base_lines(
+        return this.dispatch_taxes_into_new_base_lines(
             base_lines,
             company,
             dispatch_exclude_function.bind(this)
-        );
-        return new_base_lines.concat(
-            this.turn_removed_taxes_into_new_base_lines(new_base_lines, company)
         );
     },
 

--- a/addons/account/tests/test_taxes_downpayment.py
+++ b/addons/account/tests/test_taxes_downpayment.py
@@ -1688,32 +1688,38 @@ class TestTaxesDownPayment(TestTaxCommon):
             })
 
             # Down payment 2%
+            # The total of the document will be 43.06.
+            # However, only the percentage tax is considered in the discount. So the discount will be based on:
+            # 2 * 16.79 * 1.21 = 40.6318 ~= 40.63
+            # For a discount of 2%,
+            # 40.63 * 0.02 = 0.81 is the discount amount.
+            # 43.06 - 0.81 = 42.25 is the total amount after discount.
             expected_values = {
                 'same_tax_base': True,
                 'currency_id': self.foreign_currency.id,
                 'company_currency_id': self.currency.id,
-                'base_amount_currency': 0.71,
-                'base_amount': 1.42,
-                'tax_amount_currency': 0.15,
-                'tax_amount': 0.3,
-                'total_amount_currency': 0.86,
-                'total_amount': 1.72,
+                'base_amount_currency': 0.67,
+                'base_amount': 1.35,
+                'tax_amount_currency': 0.14,
+                'tax_amount': 0.28,
+                'total_amount_currency': 0.81,
+                'total_amount': 1.63,
                 'subtotals': [
                     {
                         'name': "Untaxed Amount",
-                        'base_amount_currency': 0.71,
-                        'base_amount': 1.42,
-                        'tax_amount_currency': 0.15,
-                        'tax_amount': 0.3,
+                        'base_amount_currency': 0.67,
+                        'base_amount': 1.35,
+                        'tax_amount_currency': 0.14,
+                        'tax_amount': 0.28,
                         'tax_groups': [
                             {
                                 'id': self.tax_groups[1].id,
-                                'base_amount_currency': 0.71,
-                                'base_amount': 1.42,
-                                'tax_amount_currency': 0.15,
-                                'tax_amount': 0.3,
-                                'display_base_amount_currency': 0.71,
-                                'display_base_amount': 1.42,
+                                'base_amount_currency': 0.67,
+                                'base_amount': 1.34,
+                                'tax_amount_currency': 0.14,
+                                'tax_amount': 0.28,
+                                'display_base_amount_currency': 0.67,
+                                'display_base_amount': 1.34,
                             },
                         ],
                     },
@@ -1723,7 +1729,7 @@ class TestTaxesDownPayment(TestTaxCommon):
 
             # Down Payment 3-20%
             for percent in range(3, 21):
-                expected_values = {'total_amount_currency': self.foreign_currency.round(43.06 * percent / 100.0)}
+                expected_values = {'total_amount_currency': self.foreign_currency.round(40.64 * percent / 100.0)}
                 yield "round_per_line, price_excluded", document, True, 'percent', percent, expected_values
 
         with self.with_tax_calculation_rounding_method('round_globally'):
@@ -1774,28 +1780,28 @@ class TestTaxesDownPayment(TestTaxCommon):
                 'same_tax_base': True,
                 'currency_id': self.foreign_currency.id,
                 'company_currency_id': self.currency.id,
-                'base_amount_currency': 0.71,
-                'base_amount': 1.42,
-                'tax_amount_currency': 0.15,
-                'tax_amount': 0.3,
-                'total_amount_currency': 0.86,
-                'total_amount': 1.72,
+                'base_amount_currency': 0.67,
+                'base_amount': 1.35,
+                'tax_amount_currency': 0.14,
+                'tax_amount': 0.28,
+                'total_amount_currency': 0.81,
+                'total_amount': 1.63,
                 'subtotals': [
                     {
                         'name': "Untaxed Amount",
-                        'base_amount_currency': 0.71,
-                        'base_amount': 1.42,
-                        'tax_amount_currency': 0.15,
-                        'tax_amount': 0.3,
+                        'base_amount_currency': 0.67,
+                        'base_amount': 1.35,
+                        'tax_amount_currency': 0.14,
+                        'tax_amount': 0.28,
                         'tax_groups': [
                             {
                                 'id': self.tax_groups[1].id,
-                                'base_amount_currency': 0.71,
-                                'base_amount': 1.42,
-                                'tax_amount_currency': 0.15,
-                                'tax_amount': 0.3,
-                                'display_base_amount_currency': 0.71,
-                                'display_base_amount': 1.42,
+                                'base_amount_currency': 0.67,
+                                'base_amount': 1.34,
+                                'tax_amount_currency': 0.14,
+                                'tax_amount': 0.28,
+                                'display_base_amount_currency': 0.67,
+                                'display_base_amount': 1.34,
                             },
                         ],
                     },
@@ -1805,7 +1811,7 @@ class TestTaxesDownPayment(TestTaxCommon):
 
             # Down Payment 3-20%
             for percent in range(3, 21):
-                expected_values = {'total_amount_currency': self.foreign_currency.round(43.05 * percent / 100.0)}
+                expected_values = {'total_amount_currency': self.foreign_currency.round(40.63 * percent / 100.0)}
                 yield "round_globally, price_excluded", document, True, 'percent', percent, expected_values
 
         taxes.price_include_override = 'tax_included'
@@ -1866,28 +1872,28 @@ class TestTaxesDownPayment(TestTaxCommon):
                 'same_tax_base': True,
                 'currency_id': self.foreign_currency.id,
                 'company_currency_id': self.currency.id,
-                'base_amount_currency': 0.71,
-                'base_amount': 1.42,
-                'tax_amount_currency': 0.15,
-                'tax_amount': 0.3,
-                'total_amount_currency': 0.86,
-                'total_amount': 1.72,
+                'base_amount_currency': 0.67,
+                'base_amount': 1.35,
+                'tax_amount_currency': 0.14,
+                'tax_amount': 0.28,
+                'total_amount_currency': 0.81,
+                'total_amount': 1.63,
                 'subtotals': [
                     {
                         'name': "Untaxed Amount",
-                        'base_amount_currency': 0.71,
-                        'base_amount': 1.42,
-                        'tax_amount_currency': 0.15,
-                        'tax_amount': 0.3,
+                        'base_amount_currency': 0.67,
+                        'base_amount': 1.35,
+                        'tax_amount_currency': 0.14,
+                        'tax_amount': 0.28,
                         'tax_groups': [
                             {
                                 'id': self.tax_groups[1].id,
-                                'base_amount_currency': 0.71,
-                                'base_amount': 1.42,
-                                'tax_amount_currency': 0.15,
-                                'tax_amount': 0.3,
-                                'display_base_amount_currency': 0.71,
-                                'display_base_amount': 1.42,
+                                'base_amount_currency': 0.67,
+                                'base_amount': 1.34,
+                                'tax_amount_currency': 0.14,
+                                'tax_amount': 0.28,
+                                'display_base_amount_currency': 0.67,
+                                'display_base_amount': 1.34,
                             },
                         ],
                     },
@@ -1897,7 +1903,7 @@ class TestTaxesDownPayment(TestTaxCommon):
 
             # Down Payment 3-20%
             for percent in range(3, 21):
-                expected_values = {'total_amount_currency': self.foreign_currency.round(43.06 * percent / 100.0)}
+                expected_values = {'total_amount_currency': self.foreign_currency.round(40.64 * percent / 100.0)}
                 yield "round_per_line, price_included", document, True, 'percent', percent, expected_values
 
         with self.with_tax_calculation_rounding_method('round_globally'):
@@ -1948,28 +1954,28 @@ class TestTaxesDownPayment(TestTaxCommon):
                 'same_tax_base': True,
                 'currency_id': self.foreign_currency.id,
                 'company_currency_id': self.currency.id,
-                'base_amount_currency': 0.71,
-                'base_amount': 1.42,
-                'tax_amount_currency': 0.15,
-                'tax_amount': 0.3,
-                'total_amount_currency': 0.86,
-                'total_amount': 1.72,
+                'base_amount_currency': 0.67,
+                'base_amount': 1.35,
+                'tax_amount_currency': 0.14,
+                'tax_amount': 0.28,
+                'total_amount_currency': 0.81,
+                'total_amount': 1.63,
                 'subtotals': [
                     {
                         'name': "Untaxed Amount",
-                        'base_amount_currency': 0.71,
-                        'base_amount': 1.42,
-                        'tax_amount_currency': 0.15,
-                        'tax_amount': 0.3,
+                        'base_amount_currency': 0.67,
+                        'base_amount': 1.35,
+                        'tax_amount_currency': 0.14,
+                        'tax_amount': 0.28,
                         'tax_groups': [
                             {
                                 'id': self.tax_groups[1].id,
-                                'base_amount_currency': 0.71,
-                                'base_amount': 1.42,
-                                'tax_amount_currency': 0.15,
-                                'tax_amount': 0.3,
-                                'display_base_amount_currency': 0.71,
-                                'display_base_amount': 1.42,
+                                'base_amount_currency': 0.67,
+                                'base_amount': 1.34,
+                                'tax_amount_currency': 0.14,
+                                'tax_amount': 0.28,
+                                'display_base_amount_currency': 0.67,
+                                'display_base_amount': 1.34,
                             },
                         ],
                     },
@@ -1979,7 +1985,7 @@ class TestTaxesDownPayment(TestTaxCommon):
 
             # Down Payment 3-20%
             for percent in range(3, 21):
-                expected_values = {'total_amount_currency': self.foreign_currency.round(43.06 * percent / 100.0)}
+                expected_values = {'total_amount_currency': self.foreign_currency.round(40.64 * percent / 100.0)}
                 yield "round_globally, price_included", document, True, 'percent', percent, expected_values
 
     def test_taxes_l10n_be_generic_helpers(self):
@@ -1997,15 +2003,15 @@ class TestTaxesDownPayment(TestTaxCommon):
         document = self.populate_document(document_params)
 
         expected_values = {
-            'same_tax_base': False,
+            'same_tax_base': True,
             'currency_id': self.currency.id,
-            'base_amount_currency': 55.0,
+            'base_amount_currency': 50.0,
             'tax_amount_currency': 10.0,
-            'total_amount_currency': 65.0,
+            'total_amount_currency': 60.0,
             'subtotals': [
                 {
                     'name': "Untaxed Amount",
-                    'base_amount_currency': 55.0,
+                    'base_amount_currency': 50.0,
                     'tax_amount_currency': 10.0,
                     'tax_groups': [
                         {

--- a/addons/pos_sale/static/src/app/services/pos_store.js
+++ b/addons/pos_sale/static/src/app/services/pos_store.js
@@ -293,7 +293,22 @@ patch(PosStore.prototype, {
 
         if (isPercentage) {
             const percentage = amount / 100.0;
-            amount = baseLines.length ? saleOrder.amount_unpaid * percentage : 0.0;
+            amount = baseLines.length ? saleOrder.amount_unpaid : 0.0;
+            const fixedBaseLines = accountTaxHelpers.dispatch_taxes_into_new_base_lines(
+                baseLines,
+                this.company,
+                (baseLine, taxData) => !accountTaxHelpers.can_be_discounted(taxData.tax)
+            );
+            const baseLinesAggregatedValues = accountTaxHelpers.aggregate_base_lines_tax_details(
+                fixedBaseLines,
+                (baseLine, taxData) => true
+            );
+            const valuesPerGroupingKey =
+                accountTaxHelpers.aggregate_base_lines_aggregated_values(baseLinesAggregatedValues);
+            const fixedBaseLinesTotal = Object.values(valuesPerGroupingKey).map(
+                (v) => v.base_amount_currency + v.tax_amount_currency
+            );
+            amount = fixedBaseLinesTotal * percentage;
         }
 
         const downPaymentProduct = this.config.down_payment_product_id;

--- a/addons/pos_sale/static/tests/tours/test_taxes_downpayment.js
+++ b/addons/pos_sale/static/tests/tours/test_taxes_downpayment.js
@@ -272,9 +272,9 @@ registry
                 Dialog.confirm("Open Register"),
 
                 ...addDownPayment("2", 1, "percent"),
-                ProductScreen.checkTotalAmount("0.86"),
-                ProductScreen.checkTaxAmount("0.15"),
-                ...payAndInvoice("0.86"),
+                ProductScreen.checkTotalAmount("0.81"),
+                ProductScreen.checkTaxAmount("0.14"),
+                ...payAndInvoice("0.81"),
             ].flat(),
     });
 
@@ -287,9 +287,9 @@ registry
                 Dialog.confirm("Open Register"),
 
                 ...addDownPayment("2", 1, "percent"),
-                ProductScreen.checkTotalAmount("0.86"),
-                ProductScreen.checkTaxAmount("0.15"),
-                ...payAndInvoice("0.86"),
+                ProductScreen.checkTotalAmount("0.81"),
+                ProductScreen.checkTaxAmount("0.14"),
+                ...payAndInvoice("0.81"),
             ].flat(),
     });
 
@@ -302,9 +302,9 @@ registry
                 Dialog.confirm("Open Register"),
 
                 ...addDownPayment("2", 1, "percent"),
-                ProductScreen.checkTotalAmount("0.86"),
-                ProductScreen.checkTaxAmount("0.15"),
-                ...payAndInvoice("0.86"),
+                ProductScreen.checkTotalAmount("0.81"),
+                ProductScreen.checkTaxAmount("0.14"),
+                ...payAndInvoice("0.81"),
             ].flat(),
     });
 
@@ -317,8 +317,8 @@ registry
                 Dialog.confirm("Open Register"),
 
                 ...addDownPayment("2", 1, "percent"),
-                ProductScreen.checkTotalAmount("0.86"),
-                ProductScreen.checkTaxAmount("0.15"),
-                ...payAndInvoice("0.86"),
+                ProductScreen.checkTotalAmount("0.81"),
+                ProductScreen.checkTaxAmount("0.14"),
+                ...payAndInvoice("0.81"),
             ].flat(),
     });


### PR DESCRIPTION

When making a downpayment for an order containing product using fixed
taxes, the downpayment invoice would contain line without tax associated
This is an issue when sending these invoices to Peppol.

Steps to reproduce:
-------------------
* Create a fixed tax of 5€
* Set this tax on any product along another tax
* Create a sale order for this product
* Make a downpayment of 10%
* The invoice created has a line without any tax set
> Observation: When sending to Peppol we get an error

Why the fix:
------------
We remove the downpayment part that concerns fixed tax to avoid having
lines without tax set.

opw-5853070