### PR TITLE
[PERF] stock: prevent MemoryError when running schedulers.

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -562,9 +562,12 @@ class StockWarehouseOrderpoint(models.Model):
             if use_new_cursor:
                 assert isinstance(self._cr, BaseCursor)
                 cr = registry(self._cr.dbname).cursor()
-                self = self.with_env(self.env(cr=cr))
+                self = self.with_env(self.env(cr=cr, context=self.env.context))  # noqa: PLW0642
             try:
                 orderpoints_batch = self.env['stock.warehouse.orderpoint'].browse(orderpoints_batch_ids)
+                if self.env.context.get('recompute_qty_to_order', False):
+                    # Force the recomputation of qty_to_order as it depends on Datetime.now()
+                    self.env.add_to_compute(self._fields['qty_to_order'], orderpoints_batch)
                 all_orderpoints_exceptions = []
                 while orderpoints_batch:
                     procurements = []

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -643,12 +643,11 @@ class ProcurementGroup(models.Model):
         # Minimum stock rules
         domain = self._get_orderpoint_domain(company_id=company_id)
         orderpoints = self.env['stock.warehouse.orderpoint'].search(domain)
-        # ensure that qty_* which depends on datetime.now() are correctly
-        # recomputed
-        orderpoints.sudo()._compute_qty_to_order()
         if use_new_cursor:
             self._cr.commit()
-        orderpoints.sudo()._procure_orderpoint_confirm(use_new_cursor=use_new_cursor, company_id=company_id, raise_user_error=False)
+        orderpoints.sudo().with_context(recompute_qty_to_order=True)._procure_orderpoint_confirm(
+            use_new_cursor=use_new_cursor, company_id=company_id, raise_user_error=False
+        )
 
         # Search all confirmed stock_moves and try to assign them
         domain = self._get_moves_to_assign_domain(company_id)


### PR DESCRIPTION
When running the procurement crons with a lot of orderpoints in the database, typically tens of thousands, a MemoryError can get triggered in `_run_scheduler_tasks` thanks to the line
`orderpoints_batch._compute_qty_to_order()`. The Orderpoints recordset here is the result of a search in the whole database and can contain thousands of records. This computation puts every prefetched fields and every computed fields into the cache, leading to a MemoryError.

In this commit the explicit compute call is replaced by a context key that is used down the stack to call `add_to_compute`. Thanks to the commit at the end of the `_procure_orderpoint_confirm` the cache gets cleared after 1000 orderpoints so the memory is stable and no MemoryError is thrown.


Before PR: MemoryError (more than 2GB of `self.env.cache._data`)
After PR: Procurement cron terminates without memory error.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
