### PR TITLE
[FIX] html_editor: restrict link popover size on preview

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.scss
+++ b/addons/html_editor/static/src/main/link/link_popover.scss
@@ -33,7 +33,7 @@
     }
 
     .o_we_link_preview {
-        min-width: 274px;
+        width: 300px;
     }
 }
 

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -178,7 +178,7 @@
                             <span t-elif="state.previewIcon.type === 'mimetype'" class="o_image" t-att-data-mimetype="state.previewIcon.value"/>
                             <i t-else="" t-attf-class="fa fa-fw {{state.previewIcon.value}}"></i>
                         </span>
-                        <div class="ms-1 w-100">
+                        <div class="ms-1" style="width: 264px;">
                             <div class="d-flex">
                                 <a
                                     href="#"


### PR DESCRIPTION
Before this commit: the link popover is oversize when the preview has long title.

After this commit: the link popover retains its size.

task-6000052


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
