### PR TITLE
[FIX] stock,mrp{,_account}: skip price update when scrapping kit

### DIFF
--- a/addons/mrp/models/stock_scrap.py
+++ b/addons/mrp/models/stock_scrap.py
@@ -89,6 +89,12 @@ class StockScrap(models.Model):
     def _should_check_available_qty(self):
         return super()._should_check_available_qty() or self.product_is_kit
 
+    def _create_scrap_move(self):
+        move = super()._create_scrap_move()
+        if self.product_id.is_kits:
+            move = move.with_context(is_scrap=True).action_explode()
+        return move
+
     def do_replenish(self, values=False):
         self.ensure_one()
         values = values or {}

--- a/addons/mrp_account/tests/test_valuation_operation.py
+++ b/addons/mrp_account/tests/test_valuation_operation.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 """ Implementation of "INVENTORY VALUATION TESTS (With valuation layers)" spreadsheet. """
+from odoo import Command
 
 from odoo.addons.mrp_account.tests.common import TestBomPriceOperationCommon
 from odoo.tests import Form
@@ -75,3 +76,58 @@ class TestMrpValuationOperationStandard(TestBomPriceOperationCommon):
     #         {'product_id': self.scrap_wood.id, 'value': (PRICE + 10) * byproduct_cost_share},
     #         {'product_id': self.glass.id, 'value': 10},
     #     ])
+
+    def test_fifo_cost_scrap_kit_product(self):
+        """Verify that scrapping a Kit correctly propagates FIFO valuation to the exploded component moves.
+        """
+        kit_product_tmpl = self.env['product.template'].create({
+            'name': 'kit',
+            'is_storable': True,
+            'standard_price': 0,
+            'qty_available': 0,
+        })
+        kit_product = kit_product_tmpl.product_variant_id
+        self.screw.categ_id = self.category_fifo
+        self.bolt.categ_id = self.category_fifo
+        self.env['mrp.bom'].create({
+            'product_id': kit_product.id,
+            'product_tmpl_id': kit_product_tmpl.id,
+            'product_qty': 1,
+            'type': 'phantom',
+            'company_id': False,
+            'bom_line_ids': [
+                Command.create({
+                    'product_id': self.screw.id,
+                    'product_qty': 1,
+                }),
+                Command.create({
+                    'product_id': self.bolt.id,
+                    'product_qty': 2,
+                }),
+                ],
+            })
+        # Screw: (100*10)/100 = 10.0
+        # Bolt: (100*10)/100 = 10.0
+        self.assertEqual(self.screw.standard_price, 10.0)
+        self.assertEqual(self.bolt.standard_price, 10.0)
+        self._make_in_move(self.screw, 100, 20)
+        self._make_in_move(self.bolt, 200, 40)
+        # Screw: (100*10 + 100*20)/200 = 15.0
+        # Bolt: (100*10 + 200*40)/300 = 30.0
+        self.assertEqual(self.screw.standard_price, 15.0)
+        self.assertEqual(self.bolt.standard_price, 30.0)
+        scrap = self.env['stock.scrap'].create({
+            'product_id': kit_product.id,
+            'product_uom_id': kit_product.uom_id.id,
+            'scrap_qty': 100.0,
+        })
+        scrap.do_scrap()
+        # Screw: 100*10 = 1000
+        # Bolt: (100*10 + 100*40) = 5000
+        self.assertRecordValues(scrap.move_ids,
+            [{'product_id': self.screw.id, 'value': 1000.0},
+            {'product_id': self.bolt.id, 'value': 5000.0}])
+        # Screw: (100*20)/100 = 20.0
+        # Bolt: (100*40)/100 = 40.0
+        self.assertEqual(self.screw.standard_price, 20.0)
+        self.assertEqual(self.bolt.standard_price, 40.0)

--- a/addons/stock/models/stock_scrap.py
+++ b/addons/stock/models/stock_scrap.py
@@ -153,7 +153,7 @@ class StockScrap(models.Model):
         self._check_company()
         for scrap in self:
             scrap.name = self.env['ir.sequence'].next_by_code('stock.scrap') or _('New')
-            move = self.env['stock.move'].create(scrap._prepare_move_values())
+            move = scrap._create_scrap_move()
             # master: replace context by cancel_backorder
             move.with_context(is_scrap=True)._action_done()
             scrap.write({'state': 'done'})
@@ -161,6 +161,10 @@ class StockScrap(models.Model):
             if scrap.should_replenish:
                 scrap.do_replenish()
         return True
+
+    def _create_scrap_move(self):
+        self.ensure_one()
+        return self.env['stock.move'].create(self._prepare_move_values())
 
     def do_replenish(self, values=False):
         self.ensure_one()


### PR DESCRIPTION
When scrapping a kit product, an error would pop if account is installed

Steps to reproduce:
-------------------
* Install stock, mrp, account
* Create a product
* Create a bom of type kit for that product
* Put some quantity of the component in stock
* Mrp>Operantion>Scrap
* Scrap the kit product
-> Missing record error

Observation:
-------------
When a product is scrapped, the ```do_scrap``` method triggers ```_action_done``` on the new kit ```stock.move```
https://github.com/odoo/odoo/blob/89e5038c224d58a2f6be8f3001fd0a2932733cbc/addons/stock/models/stock_scrap.py#L156-L158

In the ```stock_account``` module, ```_action_done``` is overridden to handle inventory valuation and update the standard price.

For products using the FIFO costing method, the move value (for move out) must be calculated before the move is processed to ensure the correct cost are considered. The sequence in ```stock_account/models/stock_move.py``` is as follows:

The move out value is calculated before processing it, to have the correct value in fifo case:
https://github.com/odoo/odoo/blob/e43f6040a6aa9e8f8c10d720a760f9c92606eab5/addons/stock_account/models/stock_move.py#L165-L166
https://github.com/odoo/odoo/blob/e43f6040a6aa9e8f8c10d720a760f9c92606eab5/addons/stock_account/models/stock_move.py#L307
The move is executed:
https://github.com/odoo/odoo/blob/e43f6040a6aa9e8f8c10d720a760f9c92606eab5/addons/stock_account/models/stock_move.py#L167
The product's standard price is updated for the outgoing move
https://github.com/odoo/odoo/blob/e43f6040a6aa9e8f8c10d720a760f9c92606eab5/addons/stock_account/models/stock_move.py#L172

When scrapping a Kit, this logic breaks due to the move being exploted 
- The value calculation and standard price update are mistakenly applied to the Kit move itself, rather than the individual component moves
- During processing, the Kit move is "exploded" into its components (and [unlinked](https://github.com/odoo/odoo/blob/e4d7b400c556344ca0eaab17956efce3ea0ae04e/addons/mrp/models/stock_move.py#L398), because of this when updating the standard price it will raise and error.)

opw-5970674

