### PR TITLE
[FIX] mail: no spacing above poll result message

### DIFF
--- a/addons/mail/static/src/core/common/poll_result.xml
+++ b/addons/mail/static/src/core/common/poll_result.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="mail.PollResult">
         <div class="w-100">
-            <div class="o-mail-PollResult card border border-secondary rounded shadow-sm my-2 p-2 w-100">
+            <div class="o-mail-PollResult card border border-secondary rounded shadow-sm mb-2 p-2 w-100">
                 <div class="d-flex gap-1 align-items-start fw-bold text-muted text-break card-title small">
                     <i class="oi oi-view-cohort mt-1"/>
                     <span t-out="props.poll.pollClosedText"/>


### PR DESCRIPTION
Before this commit, Poll Result in message list had some unwanted spacing between the message header and the poll result box. The bottom spacing is fine but not the top.

Before / After
<img width="263" height="161" alt="Screenshot 2026-03-04 at 16 44 12" src="https://github.com/user-attachments/assets/b827bc1e-ee67-4f73-bea5-3bfc3ed7ed2d" /> <img width="271" height="150" alt="Screenshot 2026-03-04 at 16 43 57" src="https://github.com/user-attachments/assets/fc816b40-f375-48f3-a283-ea064d2b4cfb" />
