### PR TITLE
[FIX] account: use table-responsive only in web view

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -169,7 +169,7 @@
                         <t t-set="display_taxes" t-value="any(l.tax_ids for l in o.invoice_line_ids)"/>
                         <div class="oe_structure"></div>
                         <t t-set="has_long_desc" t-value="any(line.name and line.name.count('\n') > 30 for line in o.invoice_line_ids if line.name)"/>
-                        <div class="table-responsive-sm">
+                        <div t-att-class="'table-responsive-sm' if report_type == 'html' else ''">
                             <table class="o_has_total_table table o_main_table table-borderless mb-0" name="invoice_line_table">
                                 <thead t-attf-style="#{has_long_desc and 'display: table-row-group;' or ''}">
                                     <tr>


### PR DESCRIPTION
The invoice report table uses 'table-responsive-sm' to improve mobile
readability. However, this class causes rendering artifacts in PDF
generation via wkhtmltopdf.

Steps to reproduce:
- Have an invoice with multiple lines
- Print

Issue:
Depending on the number of lines involved the printed pdf may exhibit
graphical issues:
- The first page may not contain invoice lines at all, with all lines
  pushed to the second page
- The second page may have the header mixed up with the first line

Analysis:
It occurs after refactoring the invoice report for mobile view
https://github.com/odoo-dev/odoo/commit/ad6351c44b7419f2a1c13731e33b111e0b25e633
However, when printing the report we don't actually need the responsible
table. This commit preserve the mobile-friendly web view while ensuring the
PDF engine handles the table as a standard static block.

opw-5909071