### PR TITLE
[FIX] website_sale : reorder cart line description

### DIFF
--- a/addons/website_sale/models/sale_order_line.py
+++ b/addons/website_sale/models/sale_order_line.py
@@ -23,7 +23,19 @@ class SaleOrderLine(models.Model):
     #=== BUSINESS METHODS ===#
 
     def get_description_following_lines(self):
-        return reversed(self.name.splitlines()[1:])
+        lang = self.order_id._get_lang()
+        sale_desc = self.product_id.with_context(lang=lang).description_sale
+
+        pattern = f'\n{sale_desc}' if sale_desc else None
+
+        if not pattern or pattern not in self.name:
+            return reversed(self.name.splitlines()[1:])
+
+        before, after = self.name.split(pattern, 1)
+
+        return (list(reversed(after[1:].splitlines())) +
+                sale_desc.splitlines() +
+                list(reversed(before.splitlines()[1:])))
 
     def _get_combination_name(self):
         return self.product_id.product_template_attribute_value_ids._get_combination_name()

--- a/addons/website_sale/tests/__init__.py
+++ b/addons/website_sale/tests/__init__.py
@@ -11,6 +11,7 @@ from . import test_express_checkout_flows
 from . import test_fuzzy
 from . import test_main_controller
 from . import test_product_public_category
+from . import test_sale_order_line
 from . import test_sale_order
 from . import test_sale_process
 from . import test_sitemap

--- a/addons/website_sale/tests/test_sale_order_line.py
+++ b/addons/website_sale/tests/test_sale_order_line.py
@@ -1,0 +1,68 @@
+from odoo import Command
+from odoo.tests import tagged
+
+from odoo.addons.sale.tests.common import SaleCommon
+
+
+@tagged('post_install', '-at_install')
+class TestSaleOrderLine(SaleCommon):
+
+    def test_get_description_following_lines(self):
+        desc = "First line\nSecond line\nThird line"
+        product_2 = self._create_product(name="Test product 2", description_sale=desc)
+        sale_order = self._create_so(company_id=self.company.id, order_line=[
+            Command.create({'product_id': self.product.id}),
+            Command.create({'product_id': self.product.id}),
+            Command.create({'product_id': product_2.id}),
+            Command.create({'product_id': product_2.id}),
+            Command.create({'product_id': product_2.id}),
+            Command.create({'product_id': product_2.id}),
+        ])
+
+        added_desc = "Some important description that should be at the top"
+        added_desc_2 = "Some even more important description"
+        added_desc_3 = "The most important description"
+        added_desc_before = "Some less important description that should be at the bottom"
+
+        sale_order.order_line[1].name += "\n" + added_desc
+        sale_order.order_line[3].name += "\n" + added_desc
+        sale_order.order_line[4].name += "\n" + added_desc + "\n" + added_desc_2 + "\n" + added_desc_3
+        first_newline = sale_order.order_line[5].name.find("\n", 1)
+        sale_order.order_line[5].name = (
+            sale_order.order_line[5].name[:first_newline] +
+            "\n" + added_desc_before +
+            sale_order.order_line[5].name[first_newline:]
+            + "\n" + added_desc
+        )
+
+        split_desc = desc.splitlines()
+        cases = [
+            (0, []),
+            (1, [added_desc]),
+            (2, split_desc),
+            (3, [added_desc, *split_desc]),
+            (4, [added_desc_3, added_desc_2, added_desc, *split_desc]),
+            (5, [added_desc, *split_desc, added_desc_before]),
+        ]
+        for line_index, expected in cases:
+            line = sale_order.order_line[line_index]
+            with self.subTest(product=line.name.splitlines()[0]):
+                self.assertListEqual(list(line.get_description_following_lines()), expected)
+
+    def test_get_other_lang_description_following_lines(self):
+        self.env['res.lang']._activate_lang('fr_BE')
+        desc_fr = "Première ligne\nDeuxième ligne\nTroisième ligne"
+        self.product.with_context(lang="fr_BE").description_sale = desc_fr
+        self.partner.lang = "fr_BE"
+
+        sale_order_fr = self._create_so(partner_id=self.partner.id, company_id=self.company.id,
+            order_line=[Command.create({'product_id': self.product.id})])
+
+        added_desc = "Some important description that should be at the top"
+        added_desc_2 = "Some even more important description"
+        added_desc_3 = "The most important description"
+        sale_order_fr.order_line[0].name += "\n" + added_desc + "\n" + added_desc_2 + "\n" + added_desc_3
+
+        following_lines = list(sale_order_fr.order_line[0].get_description_following_lines())
+        split_desc = desc_fr.splitlines()
+        self.assertListEqual(following_lines, [added_desc_3, added_desc_2, added_desc, *split_desc])


### PR DESCRIPTION
# How to reproduce
- On any published product, set the quotation description to something with multiple lines
- Go to the website and that product to the cart
- Go to the cart

# The problem
The lines of the description are reversed

# Why
This commit (https://github.com/odoo/odoo/commit/5505cab4d0398aa72de4d00e59c92e71483bbb44) reversed the lines of the description of a cart line. It is explained here (https://github.com/odoo/odoo/pull/223433) that because some module (like rental) add important informations at the end of the description, the lines are reversed to show those informations near the product name.

The way it was implement though just split the description of the sale_order_line in different lines and then reverse it. This sadly does not work with multi-lines description because it divides them before reversing. We need to first split the description in "blocks" then divide those blocks into lines and reverse them.

opw-5943206

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
