### PR TITLE
[IMP] delivery, (*_)sale: remove carrier-specific settings

### DIFF
--- a/addons/delivery/wizard/__init__.py
+++ b/addons/delivery/wizard/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import choose_delivery_carrier
+from . import res_config_settings

--- a/addons/delivery/wizard/res_config_settings.py
+++ b/addons/delivery/wizard/res_config_settings.py
@@ -1,0 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    def action_install_more_provider(self):
+        return self.env['delivery.carrier'].install_more_provider()

--- a/addons/delivery/wizard/res_config_settings_views.xml
+++ b/addons/delivery/wizard/res_config_settings_views.xml
@@ -9,11 +9,19 @@
             <setting id="delivery" position="inside">
                 <div class="content-group">
                     <div class="mt8" invisible="not module_delivery">
-                        <button name="%(delivery.action_delivery_carrier_form)d"
-                                type="action"
-                                class="btn-link"
-                                icon="oi-arrow-right"
-                                string="Delivery Methods"/>
+                        <button
+                            name="%(delivery.action_delivery_carrier_form)d"
+                            type="action"
+                            class="btn btn-primary"
+                            string="Configure Methods"
+                        />
+                        <button
+                            string="Find a Delivery Provider"
+                            type="object"
+                            name="action_install_more_provider"
+                            class="btn btn-link"
+                            icon="oi-arrow-right"
+                        />
                     </div>
                  </div>
             </setting>

--- a/addons/sale/wizard/res_config_settings.py
+++ b/addons/sale/wizard/res_config_settings.py
@@ -64,16 +64,6 @@ class ResConfigSettings(models.TransientModel):
 
     # Modules
     module_delivery = fields.Boolean("Delivery Methods")
-    module_delivery_bpost = fields.Boolean("bpost Connector")
-    module_delivery_dhl = fields.Boolean("DHL Express Connector")
-    module_delivery_easypost = fields.Boolean("Easypost Connector")
-    module_delivery_envia = fields.Boolean("Envia.com Connector")
-    module_delivery_fedex_rest = fields.Boolean("FedEx Connector")
-    module_delivery_sendcloud = fields.Boolean("Sendcloud Connector")
-    module_delivery_shiprocket = fields.Boolean("Shiprocket Connector")
-    module_delivery_starshipit = fields.Boolean("Starshipit Connector")
-    module_delivery_ups_rest = fields.Boolean("UPS Connector")
-    module_delivery_usps_rest = fields.Boolean("USPS Connector")
 
     module_product_email_template = fields.Boolean("Specific Email")
     module_sale_amazon = fields.Boolean("Amazon Sync")

--- a/addons/sale/wizard/res_config_settings_views.xml
+++ b/addons/sale/wizard/res_config_settings_views.xml
@@ -29,9 +29,6 @@
                                 </div>
                             </div>
                         </setting>
-                        <setting id="email_template" title="Sending an email is useful if you need to share specific information or content about a product (instructions, rules, links, media, etc.). Create and set the email template from the product detail form (in Accounting tab)." string="Deliver Content by Email" help="Send a product-specific email once the invoice is validated">
-                            <field name="module_product_email_template"/>
-                        </setting>
                     </block>
                     <block title="Pricing" id="pricing_setting_container">
                       <setting id="discount_sale_order_lines" title="Apply manual discounts on sales order lines or display discounts computed from pricelists (option to activate in the pricelist configuration)." help="Grant discounts on sales order lines">
@@ -158,64 +155,13 @@
                         </setting>
                     </block>
                     <block title="Shipping" name="sale_shipping_setting_container">
-                        <setting id="delivery" help="Compute shipping costs on orders">
+                        <setting
+                            string="Configure Delivery Methods"
+                            id="delivery"
+                            help="Configure delivery methods or work with delivery providers using existing integrations."
+                            documentation="/applications/inventory_and_mrp/inventory/shipping_receiving/setup_configuration.html"
+                        >
                             <field name="module_delivery"/>
-                        </setting>
-                        <setting id="ups">
-                            <div class="o_form_label">UPS Connector</div>
-                                <a href="https://www.odoo.com/documentation/latest/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                <div class="text-muted">
-                                    Compute shipping costs and ship with UPS<br/>
-                                    <strong>(please go to Home>Apps to install)</strong>
-                                </div>
-                        </setting>
-                        <setting id="shipping_costs_dhl">
-                            <div class="o_form_label">DHL Connector</div>
-                                <a href="https://www.odoo.com/documentation/latest/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                <div class="text-muted">
-                                    Compute shipping costs and ship with DHL<br/>
-                                    <strong>(please go to Home>Apps to install)</strong>
-                                </div>
-                        </setting>
-                        <setting id="shipping_costs_fedex">
-                            <div class="o_form_label">FedEx Connector</div>
-                                <a href="https://www.odoo.com/documentation/latest/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                <div class="text-muted">
-                                    Compute shipping costs and ship with FedEx<br/>
-                                    <strong>(please go to Home>Apps to install)</strong>
-                                </div>
-                        </setting>
-                        <setting id="shipping_costs_usps">
-                            <div class="o_form_label">USPS Connector</div>
-                                <a href="https://www.odoo.com/documentation/latest/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html" title="Documentation" class="o_doc_link" target="_blank"></a>
-                                <div class="text-muted">
-                                    Compute shipping costs and ship with USPS<br/>
-                                    <strong>(please go to Home>Apps to install)</strong>
-                                </div>
-                        </setting>
-                        <setting id="shipping_costs_bpost" help="Compute shipping costs and ship with bpost"
-                                 documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
-                            <field name="module_delivery_bpost" widget="upgrade_boolean"/>
-                        </setting>
-                        <setting id="shipping_costs_easypost" help="Compute shipping costs and ship with Easypost"
-                                 documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
-                            <field name="module_delivery_easypost" widget="upgrade_boolean"/>
-                        </setting>
-                        <setting id="shipping_costs_sendcloud" help="Compute shipping costs and ship with Sendcloud"
-                                 documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
-                            <field name="module_delivery_sendcloud" widget="upgrade_boolean"/>
-                        </setting>
-                        <setting id="shipping_costs_shiprocket" help="Compute shipping costs and ship with Shiprocket"
-                                 documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
-                            <field name="module_delivery_shiprocket" widget="upgrade_boolean"/>
-                        </setting>
-                        <setting id="shipping_costs_starshipit" help="Compute shipping costs and ship with Starshipit"
-                                 documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
-                            <field name="module_delivery_starshipit" widget="upgrade_boolean"/>
-                        </setting>
-                        <setting id="shipping_costs_envia" help="Compute shipping costs and ship with Envia.com"
-                                 documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html">
-                            <field name="module_delivery_envia" widget="upgrade_boolean"/>
                         </setting>
                     </block>
                     <block title="Invoicing" name="invoicing_setting_container">

--- a/addons/website_sale/models/res_config_settings.py
+++ b/addons/website_sale/models/res_config_settings.py
@@ -109,9 +109,6 @@ class ResConfigSettings(models.TransientModel):
 
     # === ACTION METHODS === #
 
-    def action_view_delivery_provider_modules(self):
-        return self.env["delivery.carrier"].install_more_provider()
-
     @api.readonly
     def action_open_abandoned_cart_mail_template(self):
         return {

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -36,7 +36,7 @@
                     string="Configure Delivery Methods"
                     id="website_delivery_setting"
                     help="Configure delivery methods or work with delivery providers using existing integrations."
-                    documentation="/applications/inventory_and_mrp/inventory/shipping/setup/third_party_shipper.html"
+                    documentation="/applications/inventory_and_mrp/inventory/shipping_receiving/setup_configuration.html"
                 >
                     <button
                         string="Configure Methods"
@@ -47,7 +47,7 @@
                     <button
                         string="Find a Delivery Provider"
                         type="object"
-                        name="action_view_delivery_provider_modules"
+                        name="action_install_more_provider"
                         class="btn btn-link"
                         icon="oi-arrow-right"
                     />


### PR DESCRIPTION
In this commit, we remove carrier-specific settings from the Sale module settings to avoid duplication (as they are already available in the Inventory one) and simplify the view.

See enterprise PR: https://github.com/odoo/enterprise/pull/109626

task-5887918
