### PR TITLE
[FIX] mail: sending email templates with no record

### DIFF
--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -680,7 +680,7 @@ class MailTemplate(models.Model):
         """ Generates a new mail.mail. Template is rendered on record given by
         res_id and model coming from template.
 
-        :param int res_id: id of the record to render the template
+        :param int res_id: id of the record to render the template (may be ``False`` if no record)
         :param bool force_send: send email immediately; otherwise use the mail
             queue (recommended);
         :param dict email_values: update generated mail with those values to further
@@ -709,7 +709,7 @@ class MailTemplate(models.Model):
         """
         # Grant access to send_mail only if access to related document
         self.ensure_one()
-        self._send_check_access(res_ids)
+        self._send_check_access([res_id for res_id in res_ids if res_id])
         sending_email_layout_xmlid = email_layout_xmlid or self.email_layout_xmlid
 
         mails_sudo = self.env['mail.mail'].sudo()
@@ -739,7 +739,8 @@ class MailTemplate(models.Model):
             values_list = [res_ids_values[res_id] for res_id in res_ids_chunk]
 
             # get record in batch to use the prefetch
-            records = RecordModel.browse(res_ids_chunk)
+            prefetch_ids = [res_id for res_id in res_ids_chunk if res_id]  # avoid browsing False
+            records = RecordModel.browse(prefetch_ids)
             attachments_list = []
 
             # lang and company is used for rendering layout
@@ -749,7 +750,9 @@ class MailTemplate(models.Model):
                     res_ids_langs = self._render_lang(res_ids_chunk)
                 res_ids_companies = records._mail_get_companies(default=self.env.company)
 
-            for record in records:
+            for res_id in res_ids_chunk:
+                # special case: use empty record when res_id is False
+                record = RecordModel.browse(res_id).with_prefetch(prefetch_ids)
                 values = res_ids_values[record.id]
                 values['recipient_ids'] = [(4, pid) for pid in (values.get('partner_ids') or [])]
                 values['attachment_ids'] = [(4, aid) for aid in (values.get('attachment_ids') or [])]

--- a/addons/test_mail/tests/test_mail_template.py
+++ b/addons/test_mail/tests/test_mail_template.py
@@ -153,6 +153,17 @@ class TestMailTemplate(TestMailTemplateCommon):
         self.assertEqual(mail.body_html, body_result)
         self.assertEqual(mail.body, body_result)
 
+    @mute_logger('odoo.addons.mail.models.mail_mail')
+    def test_template_send_mail_body_empty_record(self):
+        """ Test that the body and body_html is set correctly in 'mail.mail'
+        when sending an email from mail.template """
+        mail_id = self.test_template.send_mail(False)
+        mail = self.env['mail.mail'].sudo().browse(mail_id)
+        body_result = '<p>EnglishBody for </p>'
+
+        self.assertEqual(mail.body_html, body_result)
+        self.assertEqual(mail.body, body_result)
+
 
 @tagged('mail_template', 'multi_lang', 'mail_performance', 'post_install', '-at_install')
 class TestMailTemplateLanguages(TestMailTemplateCommon):


### PR DESCRIPTION
Add explicit support for sending an email template with no actual record, i.e., calling `template.send_mail(False)`.

This used to work but now fails since https://github.com/odoo/odoo/pull/227477.

task-6000637