### PR TITLE
[FIX] mail: hide empty activity description

### DIFF
--- a/addons/mail/static/src/core/web/activity.xml
+++ b/addons/mail/static/src/core/web/activity.xml
@@ -41,7 +41,7 @@
                     </tbody>
                 </table>
             </div>
-            <div t-if="props.activity.note" class="o-mail-Activity-note text-break" t-out="props.activity.note"/>
+            <div t-if="!props.activity.isNoteEmpty" class="o-mail-Activity-note text-break" t-out="props.activity.note"/>
             <div t-if="props.activity.mail_template_ids?.length > 0" class="o-mail-Activity-mailTemplates">
                 <ActivityMailTemplate activity="props.activity" onActivityChanged="props.onActivityChanged"/>
             </div>

--- a/addons/mail/static/src/core/web/activity_model.js
+++ b/addons/mail/static/src/core/web/activity_model.js
@@ -1,7 +1,11 @@
 import { Record } from "@mail/core/common/record";
 import { assignDefined } from "@mail/utils/common/misc";
+
+import { isEmptyBlock } from "@html_editor/utils/dom_info";
+
 import { _t } from "@web/core/l10n/translation";
 import { formatDate, formatDateTime } from "@web/core/l10n/dates";
+import { setElementContent } from "@web/core/utils/html";
 
 /**
  * @typedef Data
@@ -105,6 +109,18 @@ export class Activity extends Record {
     icon = "fa-tasks";
     /** @type {number} */
     id;
+    /** @type {boolean} */
+    isNoteEmpty = Record.attr(true, {
+        /** @this {import("models").Activity} */
+        compute() {
+            if (!this.note) {
+                return true;
+            }
+            const element = document.createElement("div");
+            setElementContent(element, this.note);
+            return isEmptyBlock(element);
+        },
+    });
     /** @type {Object[]} */
     mail_template_ids;
     note = Record.attr("", { html: true });


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
When an activity description is cleared, the stored value may still contain empty HTML content. The UI was still rendering this as a note, resulting in unnecessary blank space in the activity card.

**Current behavior before PR:**
Even when the activity description is cleared and contains only empty HTML, the activity note container is still rendered, leaving visible empty space in the UI.

**Desired behavior after PR is merged:**
The activity note is rendered only when it contains meaningful content. Empty HTML descriptions are ignored, preventing blank space from appearing in the activity card UI.

Before
<img width="445" height="84" alt="image" src="https://github.com/user-attachments/assets/f6648bb0-78d9-4063-a347-fe664370106e" />

After
<img width="459" height="72" alt="image" src="https://github.com/user-attachments/assets/84c2063a-7c68-4dfe-b729-566ca4b5dcd1" />

task-[4752613](https://www.odoo.com/odoo/project/1519/tasks/4752613)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
