### PR TITLE
[FIX] project: add empty python_method for burndown chart

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -249,6 +249,7 @@
         <field name="name">Burndown Chart</field>
         <field name="parent_action_id" ref="project.act_project_project_2_project_task_all"/>
         <field name="action_id" ref="project.action_project_task_burndown_chart_report"/>
+        <field name="python_method" eval="False"/>
         <field name="groups_ids" eval="[(4, ref('project.group_project_manager'))]" />
     </record>
 
@@ -258,6 +259,7 @@
         <field name="name">Burndown Chart</field>
         <field name="parent_action_id" ref="project.project_update_all_action"/>
         <field name="action_id" ref="project.action_project_task_burndown_chart_report"/>
+         <field name="python_method" eval="False"/>
         <field name="groups_ids" eval="[(4, ref('project.group_project_manager'))]" />
     </record>
 


### PR DESCRIPTION
Add an empty `python_method` field to the burndown chart embedded actions as a preparatory change for a safe upgrade path.

Without this, replacing `action_id` with `python_method` in master would temporarily violate the SQL constraint on `ir.embedded.actions` that prevents both from being set simultaneously.

references: #239000

task-5347524

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
