### PR TITLE
[IMP] account: improve product name matching

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -73,6 +73,7 @@ You could use this simplified accounting in case you work with an (external) acc
         'views/bill_preview_template.xml',
         'data/account_reports_data.xml',
         'views/uom_uom_views.xml',
+        'data/ir_config_parameter_data.xml',
     ],
     'demo': [
         'demo/account_demo.xml',

--- a/addons/account/data/ir_config_parameter_data.xml
+++ b/addons/account/data/ir_config_parameter_data.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="product_name_similarity_threshold" model="ir.config_parameter">
+            <field name="key">account.product_name_similarity_threshold</field>
+            <field name="value">0.9</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -1,11 +1,14 @@
 # -*- coding: utf-8 -*-
 
+from difflib import SequenceMatcher
+
 from odoo import api, Command, fields, models, _
 from odoo.exceptions import ValidationError
 from odoo.osv import expression
 from odoo.tools import format_amount
 
 ACCOUNT_DOMAIN = "['&', ('deprecated', '=', False), ('account_type', 'not in', ('asset_receivable','liability_payable','asset_cash','liability_credit_card','off_balance'))]"
+
 
 class ProductCategory(models.Model):
     _inherit = "product.category"
@@ -298,6 +301,30 @@ class ProductProduct(models.Model):
         :param extra_domain:    Any extra domain to add to the search.
         :returns:               A product or an empty recordset if not found.
         '''
+
+        def find_product_by_name_similarity(base_domain):
+            """ Returns the first product whose name similarity ratio with the provided name is at least 90%. """
+
+            # Get similarity threshold from system parameter, fallback to 0.9 if missing, invalid, or out of range (0, 1].
+            try:
+                similarity_threshold = float(
+                    self.env['ir.config_parameter'].sudo().get_param('account.product_name_similarity_threshold', '0.9')
+                )
+                if similarity_threshold <= 0.0 or similarity_threshold > 1.0:
+                    similarity_threshold = 0.9
+            except ValueError:
+                similarity_threshold = 0.9
+
+            products = self.search(
+                expression.AND([
+                    [('name', 'ilike', name)],
+                    base_domain,
+                ]),
+            )
+            for product in products:
+                if SequenceMatcher(None, name.lower(), product.name.lower()).ratio() >= similarity_threshold:
+                    return product
+
         if name and '\n' in name:
             # cut Sales Description from the name
             name = name.split('\n')[0]
@@ -307,23 +334,28 @@ class ProductProduct(models.Model):
         if default_code:
             domains.append([('default_code', '=', default_code)])
         if name:
-            domains += [[('name', '=', name)], [('name', 'ilike', name)]]
+            domains.append([('name', '=ilike', name)])
 
         company = company or self.env.company
         for company_domain in (
             [*self.env['res.partner']._check_company_domain(company), ('company_id', '!=', False)],
             [('company_id', '=', False)],
         ):
+            base_domain = expression.AND([company_domain, extra_domain])
             for domain in domains:
                 product = self.env['product.product'].search(
                     expression.AND([
                         domain,
-                        company_domain,
-                        extra_domain,
+                        base_domain,
                     ]),
                     limit=1,
                 )
                 # We need a single product. Exit early if one is found (implements the priority logic).
                 if product:
                     return product
+
+            # checking length to avoid matching unrelated products whose names merely contain that short string
+            if name and len(name) > 4 and (product := find_product_by_name_similarity(base_domain)):
+                return product
+
         return self.env['product.product']

--- a/addons/account/tests/test_product.py
+++ b/addons/account/tests/test_product.py
@@ -136,3 +136,13 @@ class TestProduct(AccountTestInvoicingCommon):
             "Customer invoice line should use grandparent category's income account")
         self.assertEqual(bill.invoice_line_ids.account_id, child_expense,
             "Vendor bill line should use child category's expense account")
+
+    def test_retrieve_product_by_name(self):
+        Product = self.env['product.product']
+        Product.create({'name': 'Wireless bluetooth speaker battery'})
+        product_A = Product.create({'name': 'Network Cables'})
+
+        # Similar but not similar enough to be considered the same product
+        self.assertFalse(Product._retrieve_product(name='Wireless bluetooth speaker'))
+        self.assertEqual(product_A, Product._retrieve_product(name='Network Cable'))
+        self.assertEqual(product_A, Product._retrieve_product(name='network cables'))  # case insensitive exact match


### PR DESCRIPTION
Before this commit:

- Product retrieval during import relied on exact name match and substring (ilike) search.
- Exact name search was case sensitive, so values like `Network Cable` would not match `Network cable`.
- Substring matching could return unrelated products (e.g. `Wireless bluetooth speaker` gets matched with
  `Wireless bluetooth speaker battery`), leading to unrelated matches.

After this commit:

- Exact name search is now case insensitive, allowing matches such as `Network Cable` and `network cable`.
- Substring based matching has been replaced with a similarity ratio (90%) to reduce false positives and improve matching reliability against customer database product names.

Technical:

- Replaced `=` with `=ilike` in the exact name search domain to make the lookup case insensitive.
- Similarity ratio is computed using Python's `difflib.SequenceMatcher` on product names, with a minimum threshold of 90% to qualify as a match.
- Added system parameter for configurable product name similarity threshold.

task-5951469