### PR TITLE
[FIX] sale_management, purchase: await product to be added in tours

### DIFF
--- a/addons/purchase/static/tests/tours/purchase_flow_tour.js
+++ b/addons/purchase/static/tests/tours/purchase_flow_tour.js
@@ -36,6 +36,10 @@ registry.category("web_tour.tours").add("test_basic_purchase_flow_with_minimal_a
             run: "click",
         },
         {
+            content: "Wait for the tax to be set by the onchange",
+            trigger: ".o_field_many2many_tags[name=tax_ids] .o_tag",
+        },
+        {
             trigger: ".o_data_cell[name=price_unit]",
             run: "click",
         },

--- a/addons/sale_management/static/tests/tours/sale_flow_tour.js
+++ b/addons/sale_management/static/tests/tours/sale_flow_tour.js
@@ -12,7 +12,10 @@ registry.category("web_tour.tours").add("test_basic_sale_flow_with_minimal_acces
         ...tourUtils.createNewSalesOrder(),
         ...tourUtils.selectCustomer("partner_a"),
         ...tourUtils.addProduct("Test Product"),
-        tourUtils.checkSOLDescriptionContains("Test Product"),
+        {
+            content: "Wait for the tax to be set by the onchange",
+            trigger: ".o_field_many2many_tags[name=tax_ids] .o_tag",
+        },
         {
             trigger: "button[name=action_confirm]",
             run: "click",


### PR DESCRIPTION
There is an inaccuracy in the steps of the tour:
- test_basic_sale_flow_with_minimal_access_rights Indeed, in this test a new line is added on the order and a product is selected but the next step confirms the order without waiting for all the associated onchanges to be taken into accounts: https://github.com/odoo/odoo/blob/b5511e5ebb919c2c506131bf9e2a4196dac25f79/addons/sale_management/static/tests/tours/sale_flow_tour.js#L14-L20 https://github.com/odoo/odoo/blob/b5511e5ebb919c2c506131bf9e2a4196dac25f79/addons/sale/static/src/js/tours/tour_utils.js#L27-L47

In the case where the confirmation happends before the product edition is taken into account, the order fails to confirm and stays in draft which makes the rest of the tour fails.

Note:

The same issue could happen at some point on the equivalent purchase test, so that we also modify the test:
- test_basic_purchase_flow_with_minimal_access_rights

runbot-241198

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
