### PR TITLE
[FIX] sale_stock_margin: incorrect company on _compute_average_price

### DIFF
--- a/addons/sale_stock_margin/models/sale_order_line.py
+++ b/addons/sale_stock_margin/models/sale_order_line.py
@@ -11,13 +11,14 @@ class SaleOrderLine(models.Model):
     def _compute_purchase_price(self):
         line_ids_to_pass = set()
         for line in self:
-            product = line.product_id.with_company(line.company_id)
+            line = line.with_company(line.company_id)
+            product = line.product_id
             if not line.has_valued_move_ids():
                 line_ids_to_pass.add(line.id)
             elif line.product_id and line.product_id.categ_id.property_cost_method != 'standard':
                 # don't overwrite any existing value unless non-standard cost method
                 qty_from_delivery = line.qty_delivered if line.product_id.invoice_policy == 'order' else line.qty_to_invoice
-                purch_price = product._compute_average_price(0, line.product_uom_qty or qty_from_delivery, line.move_ids.with_company(line.company_id))
+                purch_price = product._compute_average_price(0, line.product_uom_qty or qty_from_delivery, line.move_ids)
                 if line.product_uom != product.uom_id:
                     purch_price = product.uom_id._compute_price(purch_price, line.product_uom)
                 line.purchase_price = line._convert_to_sol_currency(


### PR DESCRIPTION
Steps to reproduce:
- Have 2 companies:
	- Company A with a property_cost_method 'average'
	- Company B with a property_cost_method 'standard'
- Create a sales order in B
- Set the default company of the user to A.
- Under certain scenarios, when we confirm the sales order, there will be a `flush_all`.
- When that's the case, margins are recomputed with `line.product_id.categ_id.property_cost_method` as `average` instead of `standard`.
In other words, it will take the property_cost_method from the `user.company_id` (A), instead of the property_cost_method from the `line.company_id` (B).

This fix ensures the `property_cost_method` considered is the one related to the company of the sale order line.

A similar issue was fixed on https://github.com/odoo/odoo/pull/192890

OPW-5939464