### PR TITLE
[IMP] core: emit a warning on untracked model setattr

### DIFF
--- a/odoo/_monkeypatches/werkzeug_urls.py
+++ b/odoo/_monkeypatches/werkzeug_urls.py
@@ -7,7 +7,6 @@ import os
 import re
 import sys
 import typing as t
-import warnings
 from shutil import copyfileobj
 from types import CodeType
 
@@ -382,15 +381,13 @@ class URL(BaseURL):
         """Encodes the URL to a tuple made out of bytes.  The charset is
         only being used for the path, query and fragment.
         """
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", "'werkzeug", DeprecationWarning)
-            return BytesURL(
-                self.scheme.encode("ascii"),
-                self.encode_netloc(),
-                self.path.encode(charset, errors),
-                self.query.encode(charset, errors),
-                self.fragment.encode(charset, errors),
-            )
+        return BytesURL(
+            self.scheme.encode("ascii"),
+            self.encode_netloc(),
+            self.path.encode(charset, errors),
+            self.query.encode(charset, errors),
+            self.fragment.encode(charset, errors),
+        )
 
 
 class BytesURL(BaseURL):
@@ -417,15 +414,13 @@ class BytesURL(BaseURL):
         """Decodes the URL to a tuple made out of strings.  The charset is
         only being used for the path, query and fragment.
         """
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", "'werkzeug", DeprecationWarning)
-            return URL(
-                self.scheme.decode("ascii"),  # type: ignore
-                self.decode_netloc(),
-                self.path.decode(charset, errors),  # type: ignore
-                self.query.decode(charset, errors),  # type: ignore
-                self.fragment.decode(charset, errors),  # type: ignore
-            )
+        return URL(
+            self.scheme.decode("ascii"),  # type: ignore
+            self.decode_netloc(),
+            self.path.decode(charset, errors),  # type: ignore
+            self.query.decode(charset, errors),  # type: ignore
+            self.fragment.decode(charset, errors),  # type: ignore
+        )
 
 
 _unquote_maps: dict[frozenset[int], dict[bytes, int]] = {frozenset(): _hextobyte}
@@ -551,9 +546,7 @@ def url_parse(
 
     result_type = URL if is_text_based else BytesURL
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", "'werkzeug", DeprecationWarning)
-        return result_type(scheme, netloc, url, query, fragment)
+    return result_type(scheme, netloc, url, query, fragment)
 
 
 def _make_fast_url_quote(
@@ -648,9 +641,7 @@ def url_quote_plus(
         Will be removed in Werkzeug 2.4. Use ``urllib.parse.quote_plus`` instead.
     """
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", "'werkzeug", DeprecationWarning)
-        return url_quote(string, charset, errors, safe + " ", "+").replace(" ", "+")
+    return url_quote(string, charset, errors, safe + " ", "+").replace(" ", "+")
 
 
 def url_unparse(components: tuple[str, str, str, str, str]) -> str:
@@ -734,9 +725,7 @@ def url_unquote_plus(
     else:
         s = s.replace(b"+", b" ")
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", "'werkzeug", DeprecationWarning)
-        return url_unquote(s, charset, errors)
+    return url_unquote(s, charset, errors)
 
 
 def url_fix(s: str, charset: str = "utf-8") -> str:
@@ -765,13 +754,11 @@ def url_fix(s: str, charset: str = "utf-8") -> str:
     if s.startswith("file://") and s[7:8].isalpha() and s[8:10] in (":/", "|/"):
         s = f"file:///{s[7:]}"
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", "'werkzeug", DeprecationWarning)
-        url = url_parse(s)
-        path = url_quote(url.path, charset, safe="/%+$!*'(),")
-        qs = url_quote_plus(url.query, charset, safe=":&%=+$!*'(),")
-        anchor = url_quote_plus(url.fragment, charset, safe=":&%=+$!*'(),")
-        return url_unparse((url.scheme, url.encode_netloc(), path, qs, anchor))
+    url = url_parse(s)
+    path = url_quote(url.path, charset, safe="/%+$!*'(),")
+    qs = url_quote_plus(url.query, charset, safe=":&%=+$!*'(),")
+    anchor = url_quote_plus(url.fragment, charset, safe=":&%=+$!*'(),")
+    return url_unparse((url.scheme, url.encode_netloc(), path, qs, anchor))
 
 
 def url_decode(
@@ -867,9 +854,7 @@ def url_decode_stream(
 
         cls = MultiDict
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", "'make_chunk_iter", DeprecationWarning)
-        return cls(decoder)
+    return cls(decoder)
 
 
 def _url_decode_impl(

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -980,19 +980,20 @@ class TransactionCase(BaseCase):
                 actual_setattr(model, key, value)
                 return
 
-            valid_paths = SETATTR_SOURCES.get(caller.f_code.co_name)
+            valid_paths = ()  # SETATTR_SOURCES.get(caller.f_code.co_name)
             if not (valid_paths and filename.endswith(valid_paths)):
-                _logger.runbot(
-                    "%s:%s:%s setting %s.%s to %s",
-                    filename,
-                    caller.f_lineno,
-                    caller.f_code.co_name,
-                    model.__name__,
-                    key,
-                    value,
-                    stack_info=True,
+                warnings.warn(
+                    f"{model.__name__}.{key} set to {value!r} while testing"
+                    " without using `patch` or whitelisted methods. This is"
+                    " generally a bad idea as it's harder to track and"
+                    " cleanup, and without cleanup can affect other tests"
+                    " (either through unstated dependencies or the opposite).",
+                    stacklevel=2,
                 )
-            cls.setattrs.setdefault(model._name, []).append((key, value, "".join(traceback.format_stack())))
+            stacks = cls.setattrs.setdefault(model._name, [])
+            k = (key, value, "".join(traceback.format_stack()))
+            if k not in stacks:
+                stacks.append(k)
             actual_setattr(model, key, value)
         cls.classPatch(odoo.models.MetaModel, '__setattr__', metamodel_setattr)
         cls.addClassCleanup(cls.setattrs.clear)


### PR DESCRIPTION
Followup to #247151 again: `_logger.runbot` was a convenience but a mistake to keep:

1. because it doesn't mark the build as failed it's harder to notice
2. because it does not dedup, it creates massive logs when it triggers

`warnings` loses the logger information, but since we log the entire warning stack hopefully that's not too much of an issue.

This is not quite ideal as the stack will point to whatever method ultimately triggers the attribute setting, rather than the "userland" method which calls it (directly or indirectly).
