### PR TITLE
[IMP] mrp: add small UX improvements

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -83,7 +83,7 @@ class MrpBom(models.Model):
     batch_size = fields.Float('Batch Size Value', default=1.0, digits='Product Unit', help="All automatically generated manufacturing orders for this product will be of this size.")
     enable_batch_size = fields.Boolean('Batch Size', default=False)
 
-    note = fields.Html(string="Additional Notes", help="Add this note on the manufacturing order to share any additional information")
+    note = fields.Html(string="Additional Notes", help="Additional notes for the manufacturing order. Notes added here will also be displayed in the Shop Floor.")
 
     _qty_positive = models.Constraint(
         'check (product_qty > 0)',

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -294,7 +294,7 @@ class MrpProduction(models.Model):
         search='_search_date_category', readonly=True
     )
     serial_numbers_count = fields.Integer("Count of serial numbers", compute='_compute_serial_numbers_count')
-    note = fields.Html(string="Additional Notes", compute='_compute_note', store=True, help="Add this note on the manufacturing order to share any additional information")
+    note = fields.Html(string="Additional Notes", compute='_compute_note', store=True, help="Additional notes for the manufacturing order. Notes added here will also be displayed in the Shop Floor.")
 
     _name_uniq = models.Constraint(
         'unique(name, company_id)',

--- a/addons/mrp/report/mrp_report_bom_structure.xml
+++ b/addons/mrp/report/mrp_report_bom_structure.xml
@@ -20,7 +20,7 @@
                             <th t-if="data['forecast_mode']" class="text-center">Status</th>
                             <th t-if="data['forecast_mode']" class="text-center">Lead Time</th>
                             <th t-if="data['forecast_mode']">Route</th>
-                            <th class="text-end" t-attf-colspan="{{ 1 if data['forecast_mode'] else 2 }}">Cost</th>
+                            <th class="text-end text-nowrap" t-attf-colspan="{{ 1 if data['forecast_mode'] else 2 }}">Total Cost</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.xml
+++ b/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.xml
@@ -4,7 +4,7 @@
     <t t-name="mrp.BomOverviewControlPanel">
         <ControlPanel display="this.controlPanelDisplay">
             <t t-set-slot="control-panel-buttons">
-                <button t-if="this.props.showOptions.mode == 'forecast'" t-on-click="this.manufactureFromBoM" type="button" class="btn btn-primary">Manufacture</button>
+                <button t-on-click="this.manufactureFromBoM" type="button" class="btn btn-primary">Manufacture</button>
                 <button t-on-click="() => this.props.print()" type="button" class="btn btn-secondary">Print</button>
                 <!-- <t t-if="props.showVariants"> commented, waiting for ui update
                     <button t-on-click="() => this.props.print(true)" type="button" class="btn btn-secondary text-nowrap">Print All Variants</button>
@@ -27,29 +27,25 @@
                     </div>
                 </div>
                 <div class="d-flex gap-1">
-                    <t t-if="this.props.showOptions.mode == 'forecast'">
-                        <div>
-                            <form class="d-flex flex-grow-1 gap-3 flex-column flex-md-row">
-                                <label class="visually-hidden" for="bom_quantity"/>
-                                <div t-attf-class="input-group align-items-center">
-                                    <div class="col-4 col-md-auto px-2 fw-bold">Quantity</div>
-                                    <input id="bom_quantity" type="number" step="any" t-on-change="ev => this.updateQuantity(ev)" t-on-keypress="ev => this.onKeyPress(ev)" t-att-value="this.props.bomQuantity" min="1" size="7" class="o_input form-control rounded-0" t-custom-ref="quantity"/>
-                                    <div t-if="this.props.showOptions.uom" t-out="this.props.uomName" class="d-flex align-items-center text-muted small lh-sm"/>
-                                </div>
-                            </form>
-                        </div>
-                    </t>
+                    <div>
+                        <form class="d-flex flex-grow-1 gap-3 flex-column flex-md-row">
+                            <label class="visually-hidden" for="bom_quantity"/>
+                            <div t-attf-class="input-group align-items-center">
+                                <div class="col-4 col-md-auto px-2 fw-bold">Quantity</div>
+                                <input id="bom_quantity" type="number" step="any" t-on-change="ev => this.updateQuantity(ev)" t-on-keypress="ev => this.onKeyPress(ev)" t-att-value="this.props.bomQuantity" min="1" size="7" class="o_input form-control rounded-0" t-custom-ref="quantity"/>
+                                <div t-if="this.props.showOptions.uom" t-out="this.props.uomName" class="d-flex align-items-center text-muted small lh-sm"/>
+                            </div>
+                        </form>
+                    </div>
                 </div>
             </t>
             <t t-set-slot="control-panel-navigation-additional">
-                <t t-if="this.props.showOptions.mode == 'forecast'">
-                    <t t-if="this.props.warehouses.length > 1" class="btn-group flex-grow-1 flex-md-grow-0">
-                        <Dropdown items="this.warehousesItems">
-                            <button class="btn btn-secondary o-dropdown-caret">
-                                <span class="fa fa-home"/> Warehouse: <t t-out="this.props.currentWarehouse.name"/>
-                            </button>
-                        </Dropdown>
-                    </t>
+                <t t-if="this.props.warehouses.length > 1" class="btn-group flex-grow-1 flex-md-grow-0">
+                    <Dropdown items="this.warehousesItems">
+                        <button class="btn btn-light o-dropdown-caret">
+                            <span class="fa fa-home"/> Warehouse: <t t-out="this.props.currentWarehouse.name"/>
+                        </button>
+                    </Dropdown>
                 </t>
                 <t t-if="this.props.showOptions.mode == 'overview'">
                     <div class="o_row" t-on-click="() => this.props.changeMode('forecast')" >

--- a/addons/mrp/static/src/components/bom_overview_table/mrp_bom_overview_table.xml
+++ b/addons/mrp/static/src/components/bom_overview_table/mrp_bom_overview_table.xml
@@ -15,8 +15,8 @@
                             <th t-if="this.forecastMode" class="text-center" title="Resupply lead time.">Lead Time</th>
                             <th t-if="this.forecastMode">Route</th>
                             <th t-else=""/>
-                            <th class="text-end"
-                                title="This is the cost based on the BoM of the product. It is computed by summing the costs of the components and operations needed to build the product.">Cost</th>
+                            <th class="text-end text-nowrap"
+                                title="This is the cost based on the BoM of the product. It is computed by summing the costs of the components and operations needed to build the product.">Total Cost</th>
                             <th t-if="this.showAttachments" class="text-center" title="Files attached to the product.">Attachments</th>
                         </tr>
                     </thead>

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -55,7 +55,7 @@
                         <group>
                             <field name="active" invisible="1"/>
                             <field name="company_id" invisible="1"/>
-                            <field name="product_tmpl_id" context="{'default_is_storable': True}"/>
+                            <field name="product_tmpl_id" context="{'default_is_storable': True}" placeholder="Product to build..."/>
                             <field name="allow_operation_dependencies" invisible="1"/>
                             <field name="product_id" groups="product.group_product_variant" context="{'default_is_storable': True}"/>
                             <field name="product_id" groups="!product.group_product_variant" invisible="1"/>

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -519,7 +519,7 @@
                         <page string="By-Products" name="finished_products" groups="mrp.group_mrp_byproducts">
                             <field name="move_byproduct_ids"
                                 context="{'default_date': date_finished, 'default_date_deadline': date_deadline, 'default_warehouse_id': warehouse_id, 'default_location_id': production_location_id, 'default_location_dest_id': location_dest_id, 'default_state': 'draft', 'default_production_id': id, 'default_picking_type_id': picking_type_id, 'default_company_id': company_id, 'form_view_ref': 'mrp.view_mrp_stock_move_operations'}"
-                                readonly="state == 'cancel' or (state == 'done' and is_locked)" delete="state == 'draft'">
+                                readonly="state == 'cancel' or (state == 'done' and is_locked)">
                                 <list default_order="sequence, id" decoration-muted="state in ['done', 'cancel']" editable="bottom">
                                     <control>
                                         <create string="Add a line"/>

--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -395,8 +395,9 @@
               <p class="o_view_nocontent_smiling_face">
                 Create a new work center
               </p><p>
-                Manufacturing operations are processed at Work Centers. A Work Center can be composed of
-                workers and/or machines, they are used for costing, scheduling, capacity planning, etc.
+                Manufacturing operations are processed at work centers. A work center can
+                represent workers and/or machines. They are used for costing, scheduling, capacity planning, etc.
+                In the Shop Floor application, you can choose the work centers you want to manage at your work station.
               </p>
             </field>
         </record>
@@ -412,8 +413,9 @@
               <p class="o_view_nocontent_smiling_face">
                 Create a new work center
               </p><p>
-                Manufacturing operations are processed at Work Centers. A Work Center can be composed of
-                workers and/or machines, they are used for costing, scheduling, capacity planning, etc.
+                Manufacturing operations are processed at work centers. A work center can
+                represent workers and/or machines. They are used for costing, scheduling, capacity planning, etc.
+                In the Shop Floor application, you can choose the work centers you want to manage at your work station.
                 They can be defined via the configuration menu.
               </p>
             </field>


### PR DESCRIPTION
A series of small UX improvements:
- improve labels and helpers text
- allow to delete by-products on MO form view always (previously was only possible when it was in 'draft' state)
- always show 'Manufacture' button on BoM Overview (previously was only visible when 'Forecast' was toggled on)

task-5974291
