### PR TITLE
[FIX] sale: prevent small floating point in down payment percentage

### DIFF
--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -246,7 +246,10 @@
                                                     t-options="{'widget': 'monetary', 'display_currency': sale_order.currency_id}"
                                                     class="fw-bold"
                                                 />
-                                                (<b t-esc="sale_order.prepayment_percent * 100"/>%),
+                                                (<b
+                                                    t-esc="sale_order.prepayment_percent * 100"
+                                                    t-options="{'widget': 'float'}"
+                                                />%),
                                             </span>
                                             <span id="o_sale_portal_use_amount_total">
                                                 By paying,


### PR DESCRIPTION
Issue:
---
Due to this issue, a small floating point is shown in down payment percentage of a sale order.

Steps to reproduce:
---
1- Create a sale order with lines.
2- From `other info` tab, uncheck `online signature` and check `online payment`, and set it to 14 percent.
3- Click on preview.
4- Click on `Accept & Pay`.

The percentage shown is `14.000000000000002`, which is unexpected.

Fix:
---
By setting the percentage as `float` widget it will be rounded properly:
https://github.com/odoo/odoo/blob/0fe2023dc57b6cc02bd399d3c8fc5d6c8ed6e833/odoo/addons/base/models/ir_qweb_fields.py#L185-L208

opw-5975047
