### PR TITLE
[FIX] account_edi{_ubl_cii}: fix UoM to UNECE code

### DIFF
--- a/addons/account_edi/models/uom.py
+++ b/addons/account_edi/models/uom.py
@@ -8,7 +8,8 @@ class UoM(models.Model):
 
     def _get_unece_code(self):
         """ Returns the UNECE code used for international trading for corresponding to the UoM as per
-        https://unece.org/fileadmin/DAM/cefact/recommendations/rec20/rec20_rev3_Annex2e.pdf"""
+        https://docs.peppol.eu/poacc/billing/3.0/codelist/UNECERec20/
+        """
         mapping = {
             'uom.product_uom_unit': 'C62',
             'uom.product_uom_dozen': 'DZN',
@@ -27,7 +28,7 @@ class UoM(models.Model):
             'uom.product_uom_foot': 'FOT',
             'uom.product_uom_mile': 'SMI',
             'uom.product_uom_floz': 'OZA',
-            'uom.product_uom_qt': 'QT',
+            'uom.product_uom_qt': 'QTL',
             'uom.product_uom_gal': 'GLL',
             'uom.product_uom_cubic_meter': 'MTQ',
             'uom.product_uom_cubic_inch': 'INQ',

--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -31,7 +31,7 @@ UOM_TO_UNECE_CODE = {
     'uom.product_uom_foot': 'FOT',
     'uom.product_uom_mile': 'SMI',
     'uom.product_uom_floz': 'OZA',
-    'uom.product_uom_qt': 'QT',
+    'uom.product_uom_qt': 'QTL',
     'uom.product_uom_gal': 'GLL',
     'uom.product_uom_cubic_inch': 'INQ',
     'uom.product_uom_cubic_foot': 'FTQ',
@@ -103,8 +103,7 @@ class AccountEdiCommon(models.AbstractModel):
 
     def _get_uom_unece_code(self, line):
         """
-        list of codes: https://docs.peppol.eu/poacc/billing/3.0/codelist/UNECERec20/
-        or https://unece.org/fileadmin/DAM/cefact/recommendations/bkup_htm/add2c.htm (sorted by letter)
+        list of codes: https://docs.peppol.eu/poacc/billing/3.0/codelist/UNECERec20/ (sorted by letter)
         """
         xmlid = line.product_uom_id.get_external_id()
         if xmlid and line.product_uom_id.id in xmlid:


### PR DESCRIPTION
Currently, the Odoo UoM 'qt (US)' is converted to 'QT', which is not valid anymore.

Based on investigation, this was originally set to QT following this link: https://unece.org/fileadmin/DAM/cefact/recommendations/rec20/rec20_rev3_Annex2e.pdf But this document seems dated from 2005.

Step to reproduce:
- Create an invoice with a line with 'qt (US)' as UoM
- Try to send the invoice to Peppol
- You will get a validation error: "[BR-CL-23]-Unit code MUST be coded according to the UN/ECE Recommendation 20 with Rec 21"

Also removed the link to unece.org since the link is no longer valid.

opw-5961476