### PR TITLE
[FIX] web: form: show empty readonly fields

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -616,10 +616,6 @@
         }
     }
 
-    .o_field_widget.o_field_empty.o_readonly_modifier {
-        display: none;
-    }
-
     .o_form_renderer:not(.o_field_highlight):not(.o_touch_device .o_field_highlight) {
         .o_field_widget {
             .o_dropdown_button {


### PR DESCRIPTION
Before this commit, empty readonly fields were hidden.
This was probably because they caused layout issues during the dev of
The "Input Box Design".
But we finally decided to display readonly fields with a grey background,
so they can now be shown without any issues.

Hiding content should not be automatic. It should be done explicitly
using the `invisible` attribute.

Steps to reproduce:
- Go to contact
- Set "Job position" as readonly
=> The field will disappear

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
