### PR TITLE
[FIX] point_of_sale: remove `paymentMethodId``prop from FeedbackScreen

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/feedback_screen/feedback_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/feedback_screen/feedback_screen.js
@@ -12,7 +12,6 @@ export class FeedbackScreen extends Component {
     static props = {
         orderUuid: String,
         waitFor: { type: Object, optional: true },
-        paymentMethodId: { type: Number, optional: true, default: null },
     };
 
     setup() {

--- a/addons/point_of_sale/static/src/app/utils/order_payment_validation.js
+++ b/addons/point_of_sale/static/src/app/utils/order_payment_validation.js
@@ -38,16 +38,11 @@ export default class OrderPaymentValidation {
     }
 
     get nextPage() {
-        if (
-            this.pos.config.iface_print_auto &&
-            this.pos.config.iface_print_skip_screen &&
-            this.order.payment_ids[0]?.payment_method_id
-        ) {
+        if (this.pos.config.iface_print_auto && this.pos.config.iface_print_skip_screen) {
             return {
                 page: "FeedbackScreen",
                 params: {
                     orderUuid: this.order.uuid,
-                    paymentMethodId: this.order.payment_ids[0]?.payment_method_id.id,
                 },
             };
         }


### PR DESCRIPTION
- Remove unused `paymentMethodId` prop from FeedbackScreen which caused incorrect redirect to receipt screen instead of feedback screen when using eWallet with "Automatic Receipt Printing" and "Skip Preview Screen" enabled.
- The prop `paymentMethodId` is already removed in versions > `19.0`.

task-id: 6008245



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
