### PR TITLE
[FIX] account_peppol: avoid cron loop and token race condition

### DIFF
--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -93,6 +93,7 @@ class Account_Edi_Proxy_ClientUser(models.Model):
             'is_token_out_of_sync': True,
             'refresh_token': None,
         })
+        self.env.cr.flush()  # if token refreshed & commited in another transaction, crash before doing API call
         try:
             self._make_request(
                 f'{self._get_server_url()}/api/peppol/1/mark_connection_out_of_sync',
@@ -372,7 +373,9 @@ class Account_Edi_Proxy_ClientUser(models.Model):
             )
 
         if need_retrigger:
-            self.env.ref('account_peppol.ir_cron_peppol_get_message_status')._trigger()
+            self.env.ref('account_peppol.ir_cron_peppol_get_message_status')._trigger(
+                fields.Datetime.add(fields.Datetime.now(), minutes=5),
+            )
 
     def _peppol_get_participant_status(self):
         for edi_user in self:


### PR DESCRIPTION
Fix two issues observed on Odoo production.

1) When more than 50 messages from this odoo db/client are queued to be sent on peppol-ap, all client-side messages remain in `processing` If the send queue stays saturated, the retrigger logic repeatedly schedules the cron, causing an infinite `ir_cron_peppol_get_message_status` loop.

2) Each cron refreshes the authentication token, which allows concurrent threads to refresh it in parallel. Due to the `REPEATABLE READ` isolation level, a long-running cron may continue using the old token while another thread has already refreshed it. This leads to `invalid-signature` responses and incorrectly marks the connection as out of sync on one thread, even through the long-running transaction fails on trying to commit. Thus, simply flushing the cursor will block the transaction in such a situation

no-task