### PR TITLE
[FIX] point_of_sale: fix check status on missing modules

### DIFF
--- a/addons/point_of_sale/models/pos_payment_method.py
+++ b/addons/point_of_sale/models/pos_payment_method.py
@@ -87,7 +87,7 @@ class PosPaymentMethod(models.Model):
         providers = self.get_payment_providers()
         module_names = [provider["module"] for provider in providers]
         module_states = {m['name']: {'state': m['state'], 'id': m['id']} for m in self.env['ir.module.module'].search_read([('name', 'in', module_names)], ['name', 'state'])}
-        return [{**p, 'state': module_states[p['module']]['state'], 'id': module_states[p['module']]['id']} for p in providers]
+        return [{**p, 'state': module_states[p['module']]['state'], 'id': module_states[p['module']]['id']} for p in providers if p['module'] in module_states]
 
     @api.model
     def get_payment_providers(self):
@@ -105,7 +105,6 @@ class PosPaymentMethod(models.Model):
             {"type": "terminal", "provider": "qfpay", "module": "pos_qfpay", "name": "QFPay"},
             {"type": "terminal", "provider": "dpopay", "module": "pos_dpopay", "name": "DPO Pay"},
             {"type": "terminal", "provider": "mollie", "module": "pos_mollie", "name": "Mollie"},
-
             {"type": "external_qr", "provider": "bancontact_pay", "module": "pos_bancontact_pay", "name": "Bancontact Pay"},
         ]
 


### PR DESCRIPTION
We want to check in the payment method form view all the possible providers and their status (installed/uninstalled). Since we're checking for uninstalled modules, the list is coded in the base point_of_sale payment_method class. But on databases which don't have the modules loaded it would throw a KeyError for the missing modules.

This fix will completely remove the missing modules from the list since users would not be able to install the providers anyway.

Runbot Error-[241155](https://runbot.odoo.com/odoo/runbot.build.error/241155/runbot.build.error/241155)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
