### PR TITLE
[FIX] website: remove console warning

### DIFF
--- a/addons/website/static/src/interactions/anchor_slide.js
+++ b/addons/website/static/src/interactions/anchor_slide.js
@@ -16,7 +16,7 @@ export class AnchorSlide extends Interaction {
          * matches the hash.
          */
         const hash = window.location.hash.substring(1);
-        const anchorEl = document.getElementById(hash);
+        const anchorEl = hash ? document.getElementById(hash) : null;
         if (anchorEl && anchorEl.classList.contains("accordion-item")) {
             this.handleAccordionAnchor(anchorEl);
         }


### PR DESCRIPTION
Since [34df6f8d], a warning `Empty string passed to getElementById().` appears on every website page when there is no hash in the URL. That's not the case anymore after this commit.

[34df6f8d]: https://github.com/odoo/odoo/commit/34df6f8d6efc879bef00228b19df04db6c884089
