### PR TITLE
[FIX] point_of_sale: assign config_id for trusted PoS orders asap

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -60,6 +60,10 @@ export class PosOrder extends PosOrderAccounting {
         if (!this.user_id && this.models["res.users"]) {
             this.user_id = this.user;
         }
+
+        if (!this.config_id) {
+            this.config_id = this.config;
+        }
     }
 
     initState() {


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Create 2 PoS and make them mutually trusted.
2. From PoS 1, make an order, save it, and go to backend.
3. Open PoS 2, and navigate to ticket screen

-> Crash: cannot read property `iface_tax_included` of undefined.

Reason:
-------
When first loaded, in the `loadServerOrders` method, the "trusted" order coming from PoS 1 has the `config_id` of PoS 1; then in `_loadData`, its `config_id` is set to `undefined` since the config record of PoS 1 is not loaded.

Note that we are also explicitly assigning `order.config_id` to the current config in `loadServerOrders` after `callRelated`, but before doing that, we are trying to read from `config_id` in `sendOrderToCustomerDisplay` of `Chrome`, which causes the crash.

The fix:
--------
In the `setup` of the `Order` model, assign the default (current) `config` to `config_id` if it's undefined.

This fix was backported from 6d81f669915408dbd35973fd7a83308134c42547.

opw-5946365
