### PR TITLE
[FIX] mail: fix 'CallParticipantCard[Batman] video' test for good

### DIFF
--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -1218,6 +1218,7 @@ test("auto-focus participant video in one-to-one call in chat window", async () 
         channel_id: channelId,
         partner_id: pyEnv["res.partner"].create({ name: "Batman" }),
     });
+    listenStoreFetch("channels_as_member");
     setupChatHub({ opened: [channelId] });
     patchWithCleanup(SoundEffects.prototype, {
         play(name) {
@@ -1225,6 +1226,10 @@ test("auto-focus participant video in one-to-one call in chat window", async () 
         },
     });
     const env = await start();
+    // Open messaging menu to force channels_as_member store fetch,
+    // as to not receive wrong outdated rtc_session data that would fail the "Batman video" step at the end
+    await click(".o_menu_systray i[aria-label='Messages']");
+    await waitStoreFetch("channels_as_member");
     const network = await makeMockRtcNetwork({ env, channelId });
     const mockedRemote = network.makeMockRemote(channelMemberId);
     await click("[title='Join Call']");


### PR DESCRIPTION
Test `auto-focus participant video in one-to-one call in chat window` failed non-deterministically at the following step:

```
.o-discuss-CallParticipantCard[aria-label='Batman'] video
```

This issue happens because very late in test there's a debounced store fetch of `channels_as_member` from receiving a new message, a call notification, and these store data contain outdated rtc session data, some of which are on `camera_is_on` being `false` instead of `true` that is simulated just prior to the failing step that expects showing of video stream on UI.

This commit solely fixes the test by forcing a `channels_as_member` fetch at the very beginning of the test, as to prevent risk of such a late fetch of store data that contains the outdated rtc session data.

Note that this test shows a genuine problem and there's ongoing work to solve it (see Task-4966085). This commit merely fixes the test to not show this problem that is out-of-scope of the intent of the test.

Fixes runbot-error-240554