### PR TITLE
[FIX] resource: use `hours_per_week` as max weekly hours for flexible calendar

### DIFF
--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -116,6 +116,7 @@ class TestHrAttendanceOvertime(HttpCase):
             'name': 'Flexible 40 hours/week',
             'company_id': cls.company.id,
             'hours_per_day': 8,
+            'hours_per_week': 40,
             'flexible_hours': True,
             'full_time_required_hours': 40,
         })

--- a/addons/hr_attendance/tests/test_hr_attendance_undertime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_undertime.py
@@ -124,6 +124,7 @@ class TestHrAttendanceUndertime(HttpCase):
             'name': 'Flexible 40 hours/week',
             'company_id': cls.company.id,
             'hours_per_day': 8,
+            'hours_per_week': 40,
             'flexible_hours': True,
             'full_time_required_hours': 40,
         })

--- a/addons/hr_holidays/tests/test_expiring_leaves.py
+++ b/addons/hr_holidays/tests/test_expiring_leaves.py
@@ -557,6 +557,7 @@ class TestExpiringLeaves(HttpCase, TestHrHolidaysCommon):
             'name': 'Flexible 40h/week',
             'tz': 'UTC',
             'hours_per_day': 8.0,
+            'hours_per_week': 80.0,
             'full_time_required_hours': 80.0,
             'flexible_hours': True,
         })

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -335,6 +335,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             'flexible_hours': True,
             'full_time_required_hours': 21,
             'hours_per_day': 3,
+            'hours_per_week': 21,
         })
         employee_1, employee_2 = self.env['hr.employee'].sudo().create([
             {
@@ -566,6 +567,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         calendar.write({
             'flexible_hours': True,
             'hours_per_day': 8.0,
+            'hours_per_week': 40,
             'full_time_required_hours': 40
         })
 
@@ -1374,6 +1376,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         calendar = self.env['resource.calendar'].create({
             'name': 'Flexible 40h/week',
             'hours_per_day': 8.0,
+            'hours_per_week': 40,
             'full_time_required_hours': 40,
             'flexible_hours': True,
         })
@@ -1558,6 +1561,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         calendar = self.env['resource.calendar'].create({
             'name': 'Test calendar',
             'hours_per_day': 8,
+            'hours_per_week': 56,
             'full_time_required_hours': 56,
             'flexible_hours': True
         })
@@ -1633,6 +1637,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         calendar = self.env['resource.calendar'].create({
             'name': 'Test calendar',
             'hours_per_day': 8,
+            'hours_per_week': 56,
             'full_time_required_hours': 56,
             'flexible_hours': True
         })
@@ -2132,6 +2137,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             'name': 'Flexible 40h/week',
             'tz': 'UTC',
             'hours_per_day': 8.0,
+            'hours_per_week': 40.0,
             'full_time_required_hours': 40.0,
             'flexible_hours': True,
             'schedule_type': 'flexible',
@@ -2158,6 +2164,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         calendar = self.env['resource.calendar'].create({
             'name': 'Test calendar',
             'hours_per_day': 8,
+            'hours_per_week': 56,
             'full_time_required_hours': 56,
             'flexible_hours': True
         })

--- a/addons/hr_work_entry/tests/test_work_entry.py
+++ b/addons/hr_work_entry/tests/test_work_entry.py
@@ -195,6 +195,7 @@ class TestWorkEntry(TestWorkEntryBase):
             'flexible_hours': True,
             'full_time_required_hours': 21,
             'hours_per_day': 3,
+            'hours_per_week': 21,
         })
         # create 4 employees that have versions corresponding to these 4 cases:
         # flexible calendar then standard calendar

--- a/addons/hr_work_entry_holidays/tests/test_leave.py
+++ b/addons/hr_work_entry_holidays/tests/test_leave.py
@@ -187,6 +187,7 @@ class TestWorkEntryLeave(TestWorkEntryHolidaysBase):
         flex_40h_calendar = self.env['resource.calendar'].create({
             'name': 'Flexible 40h/week',
             'hours_per_day': 8.0,
+            'hours_per_week': 40.0,
             'full_time_required_hours': 40.0,
             'flexible_hours': True,
             'tz': self.jules_emp.tz

--- a/addons/project_timesheet_holidays/tests/test_timesheet_global_time_off.py
+++ b/addons/project_timesheet_holidays/tests/test_timesheet_global_time_off.py
@@ -572,6 +572,7 @@ class TestTimesheetGlobalTimeOff(common.TransactionCase):
         self.flexible_calendar = self.env['resource.calendar'].create({
             'name': 'Flexible Calendar',
             'hours_per_day': 7.0,
+            'hours_per_week': 7.0,
             'full_time_required_hours': 7.0,
             'flexible_hours': True,
         })

--- a/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
+++ b/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
@@ -267,6 +267,7 @@ class TestTimesheetHolidays(TestCommonTimesheet):
         flex_40h_calendar = self.env['resource.calendar'].create({
             'name': 'Flexible 40h/week',
             'hours_per_day': 8.0,
+            'hours_per_week': 40.0,
             'full_time_required_hours': 40.0,
             'flexible_hours': True,
         })
@@ -343,6 +344,7 @@ class TestTimesheetHolidays(TestCommonTimesheet):
         flex_40h_calendar = self.env['resource.calendar'].create({
             'name': 'Flexible 10h/week',
             'hours_per_day': 10,
+            'hours_per_week': 10,
             'full_time_required_hours': 10,
             'flexible_hours': True,
         })

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -421,7 +421,7 @@ class ResourceCalendar(models.Model):
 
                     calendar = resource_calendars[resource] if resource else self
 
-                    full_time_required_hours = calendar.full_time_required_hours
+                    max_hours_per_week = calendar.hours_per_week
                     max_hours_per_day = calendar.hours_per_day
 
                     intervals = []
@@ -435,11 +435,11 @@ class ResourceCalendar(models.Model):
 
                         if current_start_day < start_date:
                             prior_days = (start_date - current_start_day).days
-                            prior_hours = min(full_time_required_hours, max_hours_per_day * prior_days)
+                            prior_hours = min(max_hours_per_week, max_hours_per_day * prior_days)
                         else:
                             prior_hours = 0
 
-                        remaining_hours = max(0, full_time_required_hours - prior_hours)
+                        remaining_hours = max(0, max_hours_per_week - prior_hours)
                         remaining_hours = min(remaining_hours, (end_dt - start_dt).total_seconds() / 3600)
 
                         current_day = week_start

--- a/addons/resource/tests/test_resource_calendar.py
+++ b/addons/resource/tests/test_resource_calendar.py
@@ -51,6 +51,7 @@ class TestResourceCalendar(TransactionCase):
         flexible_calendar = self.env['resource.calendar'].create({
             'name': 'Flexible Calendar',
             'hours_per_day': 7.0,
+            'hours_per_week': 30,
             'full_time_required_hours': 30,
             'flexible_hours': True,
             'tz': 'UTC',

--- a/addons/test_resource/tests/test_timezones.py
+++ b/addons/test_resource/tests/test_timezones.py
@@ -231,6 +231,7 @@ class TestTimezones(TestResourceCommon):
             'flexible_hours': True,
             'full_time_required_hours': 40,
             'hours_per_day': 8,
+            'hours_per_week': 40,
         })
         flex_resource = self.env['resource.resource'].create({
             'name': 'Test FlexResource',


### PR DESCRIPTION
### Issue:
When having a part-time flexible employee (`hours_per_week` < `full_time_required_hours`), some values still show `full_time_required_hours` as the total hours they should work in a week.

### Steps to reproduce:
- Have an employee with a part-time flexible schedule
    - `full_time_required_hours`: 40
    - `hours_per_week`: 24
    - `hours_per_day`: 8
- Go in Attendances
- Hover the employee
- It shows ...h/40h but it should show ...h/24h

### Cause:
In `_attendance_intervals_batch()` we build theoretical attendances for flexible employees. Starting at the start of the week, we add an attendance of `hours_per_day` each day until we reached `full_time_required_hours`.

In the case above, we would return five attendances of 8h, ignoring `hours_per_week`.

Then `_get_attendance_intervals_days_data()` counts the hours to display them in the Gantt view.

### Solution:
In `_attendance_intervals_batch()` we use `hours_per_week` instead of `full_time_required_hours` as the weekly limit of hours per week.

A lot of tests needed to be adapted, as they were specifying `full_time_required_hours` but not `hours_per_week` when creating calendars.

opw-5973117