### PR TITLE
[FIX] stock: prevent error when creating scrap order without scrap location

### DIFF
--- a/addons/stock/models/stock_scrap.py
+++ b/addons/stock/models/stock_scrap.py
@@ -90,7 +90,7 @@ class StockScrap(models.Model):
         }
         for scrap in self:
             if scrap.company_id:
-                scrap.scrap_location_id = locations_per_company[scrap.company_id.id]
+                scrap.scrap_location_id = locations_per_company.get(scrap.company_id.id, False)
 
     @api.depends('move_ids', 'move_ids.move_line_ids.quantity', 'product_id')
     def _compute_scrap_qty(self):


### PR DESCRIPTION
When user tries to create a scrap order without scrap location, A traceback is raised.

Steps to reproduce the error:
- Install ``stock`` module
- Go to Inventory > Configuration > Settings > Enable Storage Locations > Save
- Go to Configuration > Locations > Delete Virtual Locations/Scrap > Delete
- Go to Operations > Scrap > New

Traceback:
```py
KeyError: 1
```

https://github.com/odoo/odoo/blob/7d89c092ac25ffe149fb38fb52863fdaa3b6ed5f/addons/stock/models/stock_scrap.py#L93 When the Scrap location is deleted,
``locations_per_company`` becomes an empty dictionary.
Accessing a key from this empty dictionary lead to the above traceback.

sentry-7307394327

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
