### PR TITLE
[IMP] sale: reintroduce amount_total in Orders to Invoice view

### DIFF
--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -223,27 +223,6 @@
         </field>
     </record>
 
-    <record id="view_orders_to_invoice_tree" model="ir.ui.view">
-        <field name="name">sale.order.list (To Invoice)</field>
-        <field name="model">sale.order</field>
-        <field name="inherit_id" ref="sale_order_tree"/>
-        <field name="mode">primary</field>
-        <field name="priority">32</field>
-        <field name="arch" type="xml">
-            <field name="amount_total" position="before">
-                <field name="amount_to_invoice"
-                       sum="Amount to invoice"
-                       widget="monetary"
-                       decoration-bf="1"
-                       decoration-info="invoice_status == 'to invoice'"
-                       optional="show"/>
-            </field>
-            <field name="amount_total" position="attributes">
-                <attribute name="optional">hide</attribute>
-            </field>
-        </field>
-    </record>
-
     <record id="sale_order_list_upload" model="ir.ui.view">
         <field name="name">sale.order.tree.upload (orders)</field>
         <field name="model">sale.order</field>
@@ -1282,13 +1261,6 @@
             or check every order and invoice them one by one.
             </p>
         </field>
-    </record>
-
-    <record id="action_orders_to_invoice_tree" model="ir.actions.act_window.view">
-        <field name="sequence" eval="1"/>
-        <field name="view_mode">list</field>
-        <field name="view_id" ref="sale.view_orders_to_invoice_tree"/>
-        <field name="act_window_id" ref="action_orders_to_invoice"/>
     </record>
 
     <record id="action_orders_upselling" model="ir.actions.act_window">


### PR DESCRIPTION
Remove the specialized view_orders_to_invoice_tree that displayed
amount_to_invoice. The Orders to Invoice action will now use the
standard sale_order_tree view with amount_total.

Task-5438566
