### PR TITLE
[FIX] l10n_jo_edi: Fix credit notes lines ids matching algorithm

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -611,6 +611,10 @@ class AccountEdiXmlUBL20(models.AbstractModel):
 
         return fixed_taxes_charge_list, emptying_taxes_lines_list
 
+    def _enumerate_invoice_lines(self, invoice, start=0):
+        invoice_lines = invoice.invoice_line_ids.filtered(lambda line: line.display_type not in ('line_note', 'line_section') and line._check_edi_line_tax_required())
+        return enumerate(invoice_lines, start=start)
+
     def _export_invoice_vals(self, invoice):
         def grouping_key_generator(base_line, tax_values):
             tax = tax_values['tax_repartition_line'].tax_id
@@ -643,11 +647,10 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         # Compute values for invoice lines.
         line_extension_amount = 0.0
 
-        invoice_lines = invoice.invoice_line_ids.filtered(lambda line: line.display_type not in ('line_note', 'line_section') and line._check_edi_line_tax_required())
         document_allowance_charge_vals_list = self._get_document_allowance_charge_vals_list(invoice)
         invoice_line_vals_list = []
         # actual invoice lines are added to invoice_line_vals_list
-        for line_id, line in enumerate(invoice_lines):
+        for line_id, line in self._enumerate_invoice_lines(invoice):
             line_taxes_vals = taxes_vals['tax_details_per_record'][line]
             line_vals = self._get_invoice_line_vals(line, line_id, {**line_taxes_vals, 'invoice_line': line})
             invoice_line_vals_list.append(line_vals)

--- a/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
+++ b/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
@@ -55,26 +55,8 @@ class AccountEdiXmlUBL21JO(models.AbstractModel):
         return invoice._get_invoice_scope_code() + invoice._get_invoice_payment_method_code() + invoice._get_invoice_tax_payer_type_code()
 
     def _get_line_edi_id(self, line, default_id):
-        if not line.is_refund:  # in case it's invoice not credit note
-            return default_id
-
-        refund_move = line.move_id
-        invoice_move = refund_move.reversed_entry_id
-        invoice_lines = invoice_move.invoice_line_ids.filtered(lambda line: line.display_type not in ('line_note', 'line_section'))
-        n = len(invoice_lines)
-
-        line_id = -1
-        for invoice_line_id, invoice_line in enumerate(invoice_lines, 1):
-            if line.product_id == invoice_line.product_id \
-                    and line.name == invoice_line.name \
-                    and line.price_unit == invoice_line.price_unit \
-                    and line.discount == invoice_line.discount:
-                line_id = invoice_line_id
-                break
-        if line_id == -1:
-            line_id = n + default_id
-
-        return line_id
+        # only kept for stable policy, would be removed in FWs
+        return default_id
 
     def _aggregate_totals(self, vals):
         """
@@ -283,7 +265,7 @@ class AccountEdiXmlUBL21JO(models.AbstractModel):
         return {
             'currency': JO_CURRENCY,
             'currency_dp': self._get_currency_decimal_places(),
-            'id': self._get_line_edi_id(line, default_id=line_id + 1),
+            'id': line_id,
             'line_quantity': line.quantity,
             'line_quantity_attrs': {'unitCode': self._get_uom_unece_code()},
             'line_extension_amount': self._get_line_taxable_amount(line),
@@ -381,6 +363,34 @@ class AccountEdiXmlUBL21JO(models.AbstractModel):
     ####################################################
     # export methods
     ####################################################
+
+    def _enumerate_invoice_lines(self, invoice, start=0):
+        if invoice.move_type == 'out_refund':
+            invoice_edi_id_x_line = dict(self._enumerate_invoice_lines(invoice.reversed_entry_id, start=start))
+            overflow_edi_id = len(invoice_edi_id_x_line) + 1
+
+            refund_edi_id_x_line = {}
+            refund_lines = invoice.invoice_line_ids.filtered(lambda line: line.display_type not in ('line_note', 'line_section'))
+            for refund_line in refund_lines:
+                matching_edi_ids = [
+                    line_id for line_id, line in invoice_edi_id_x_line.items()
+                    if line.product_id == refund_line.product_id
+                    and line.price_unit == refund_line.price_unit
+                    and line.discount == refund_line.discount
+                    and line.quantity >= refund_line.quantity
+                ]
+
+                if matching_edi_ids:
+                    edi_id = min(matching_edi_ids, key=lambda line_id: invoice_edi_id_x_line[line_id].quantity)
+                    refund_edi_id_x_line[edi_id] = refund_line
+                    invoice_edi_id_x_line.pop(edi_id)
+                else:
+                    refund_edi_id_x_line[overflow_edi_id] = refund_line
+                    overflow_edi_id += 1
+
+            return refund_edi_id_x_line.items()
+        else:
+            return super()._enumerate_invoice_lines(invoice, 1)
 
     def _export_invoice_vals(self, invoice):
         vals = super()._export_invoice_vals(invoice)

--- a/addons/l10n_jo_edi/tests/test_jo_edi_types.py
+++ b/addons/l10n_jo_edi/tests/test_jo_edi_types.py
@@ -304,3 +304,58 @@ class TestJoEdiTypes(JoEdiCommon):
             self.assertEqual(int(xml_line.findtext('{*}ID')), expected_line_id)
 
         self.assertGreater(int(xml_tree.findall('./{*}InvoiceLine')[-1].findtext('{*}ID')), 4)
+
+    def test_credit_notes_lines_matching_2(self):
+        self.company.l10n_jo_edi_taxpayer_type = 'income'
+        self.company.l10n_jo_edi_sequence_income_source = '4419618'
+
+        invoice_vals = {
+            'name': 'EIN00017',
+            'invoice_line_ids': [
+                Command.create({  # id = 1
+                    'product_id': self.product_a.id,
+                    'price_unit': 10,
+                    'quantity': 1,
+                }),
+                Command.create({  # id = 2
+                    'product_id': self.product_a.id,
+                    'price_unit': 10,
+                    'quantity': 3,
+                }),
+                Command.create({  # id = 3
+                    'product_id': self.product_a.id,
+                    'price_unit': 10,
+                    'quantity': 2,
+                }),
+            ],
+        }
+        refund_vals = {
+            'name': 'EIN998833',
+            'invoice_date': '2022-09-27',
+            'narration': 'ملاحظات 2',
+            'invoice_line_ids': [
+                Command.create({  # id = 3
+                    'product_id': self.product_a.id,
+                    'price_unit': 10,
+                    'quantity': 2,
+                    'name': '3',  # label should not affect matching
+                }),
+                Command.create({  # id = 1
+                    'product_id': self.product_a.id,
+                    'price_unit': 10,
+                    'quantity': 1,
+                    'name': '1',
+                }),
+                Command.create({  # id = 2
+                    'product_id': self.product_a.id,
+                    'price_unit': 10,
+                    'quantity': 2,
+                    'name': '2',
+                }),
+            ],
+        }
+        refund = self._l10n_jo_create_refund(invoice_vals, 'change price', refund_vals)
+        xml_string = self.env['account.edi.xml.ubl_21.jo']._export_invoice(refund)[0]
+        xml_tree = self.get_xml_tree_from_string(xml_string)
+        for xml_line, expected_line_id in zip(xml_tree.findall('./{*}InvoiceLine'), [3, 1, 2]):
+            self.assertEqual(int(xml_line.findtext('{*}ID')), expected_line_id)


### PR DESCRIPTION
In some cases, the users may have invoices with the same product, price unit, and discount on multiple lines. When they create refunds from such invoices, the lines ids matching algorithm would fail because it would match the first matching line over and over again. Also, lines should not match based on line label, as it can be modified in the refund.

This commit solves these 2 issues by
1) Preventing matching an invoice line more than once with refund lines
2) Preventing matching based on line label

The new algorithm finds the best match for a refund line from the invoice lines with the following criteria:
1) same product
2) same unit price
3) same discount
4) invoiced quantity should be at least equal to the refunded quantity 5) invoice line should not be matched before
6) from the lines that match previous criteria, we pick the one with the minium quantity

task-6004207
