### PR TITLE
[FIX] website: fix header templates' navbar alignment

### DIFF
--- a/addons/website/static/src/builder/plugins/options/header/header_navigation_option.xml
+++ b/addons/website/static/src/builder/plugins/options/header/header_navigation_option.xml
@@ -7,6 +7,8 @@
     </div>
 
     <t t-set="align_left_views" t-value="[
+        'website.template_header_sales_three_align_left',
+        'website.template_header_vertical_align_left',
     ]"/>
 
     <t t-set="align_center_views" t-value="[
@@ -20,7 +22,6 @@
         'website.template_header_sales_three_align_center',
         'website.template_header_sales_four_align_center',
         'website.template_header_sidebar_align_center',
-        'website.template_header_vertical_align_center',
     ]"/>
 
     <t t-set="align_right_views" t-value="[
@@ -31,7 +32,6 @@
         'website.template_header_search_align_right',
         'website.template_header_sales_one_align_right',
         'website.template_header_sales_two_align_right',
-        'website.template_header_sales_three_align_right',
         'website.template_header_sales_four_align_right',
         'website.template_header_sidebar_align_right',
         'website.template_header_vertical_align_right',

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -915,7 +915,7 @@
                         <t t-call="website.placeholder_header_call_to_action"/>
                     </ul>
                 </div>
-                <t t-call="website.navbar_nav_wrapper" _wrapper_class.f="justify-content-start">
+                <t t-call="website.navbar_nav_wrapper" _wrapper_class.f="justify-content-center">
                     <!-- Navbar -->
                     <t t-call="website.navbar_nav"
                         _nav_class.f="pb-0">
@@ -933,9 +933,9 @@
     </xpath>
 </template>
 
-<template id="template_header_vertical_align_center" inherit_id="website.template_header_vertical" active="False">
+<template id="template_header_vertical_align_left" inherit_id="website.template_header_vertical" active="False">
     <xpath expr="//t[@t-call='website.navbar_nav_wrapper']" position="attributes">
-        <attribute name="_wrapper_class.f">justify-content-center</attribute>
+        <attribute name="_wrapper_class.f">justify-content-start</attribute>
     </xpath>
 </template>
 
@@ -1262,7 +1262,7 @@
                                 _dropdown_menu_class.f="dropdown-menu-end"/>
                         </ul>
                         <!-- Navbar -->
-                        <t t-call="website.navbar_nav" _nav_class.f="justify-content-start">
+                        <t t-call="website.navbar_nav" _nav_class.f="justify-content-end">
                             <!-- Menu -->
                             <t t-foreach="website.menu_id.child_id" t-as="submenu">
                                 <t t-call="website.submenu"
@@ -1286,9 +1286,9 @@
     </xpath>
 </template>
 
-<template id="template_header_sales_three_align_right" inherit_id="website.template_header_sales_three" active="False">
+<template id="template_header_sales_three_align_left" inherit_id="website.template_header_sales_three" active="False">
     <xpath expr="//t[@t-call='website.navbar_nav']" position="attributes">
-        <attribute name="_nav_class.f">justify-content-end</attribute>
+        <attribute name="_nav_class.f">justify-content-start</attribute>
     </xpath>
 </template>
 


### PR DESCRIPTION
Since changes in commit 950a5286562ca583a139a14abbaa0851adf6f3b2, the alignment of the navbar in "Vertical" and "Menu Sale 3" templates is wrong.

To reproduce:
- Go in the web editor
- Select the header
- Change the template to Vertical or Menu Sale 3 

To fix this we've changed the classes and updated the header navigation options to correspond with the alignments.

### `template_header_vertical_align_center` 
| <img width="1021" height="226" alt="Screenshot 2026-03-05 at 12 53 29" src="https://github.com/user-attachments/assets/e5abd9db-8dc3-4fc6-8807-9f41dc21a529" /> |
 | ------------- |
|**Before** <img width="1201" height="120" alt="Screenshot 2026-03-05 at 12 52 56" src="https://github.com/user-attachments/assets/853ee42b-40b1-49e4-bbce-baae5cc2e8e5" />|
|**After** <img width="1201" height="117" alt="Screenshot 2026-03-05 at 12 57 44" src="https://github.com/user-attachments/assets/8aae2796-ce9b-40c3-a78d-ba6aad04666d" />|

### `template_header_sales_three_align_right` 
| <img width="1087" height="229" alt="Screenshot 2026-03-05 at 12 54 05" src="https://github.com/user-attachments/assets/74310303-e33d-45bd-9b69-743e17d2ecd4" />|
 | ------------- |
|**Before** <img width="1195" height="86" alt="Screenshot 2026-03-05 at 12 54 22" src="https://github.com/user-attachments/assets/536d51b7-4ed9-4fc6-a8a7-ac709976c611" />|
|**After** <img width="1201" height="86" alt="Screenshot 2026-03-05 at 12 57 31" src="https://github.com/user-attachments/assets/dddc993d-8947-4a5c-8ea4-b563bb587e62" />|


task-5900220


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
