### PR TITLE
[FIX] mail: ensure proper layout of `Permission Needed` label on public page

### DIFF
--- a/addons/mail/static/src/discuss/call/common/device_select.xml
+++ b/addons/mail/static/src/discuss/call/common/device_select.xml
@@ -19,18 +19,16 @@
             </button>
             <button
                 t-else=""
-                t-attf-class="o-mail-DeviceSelect-button btn btn-secondary {{ env.inDialog ? 'w-50' : 'w-100' }}"
+                t-attf-class="o-mail-DeviceSelect-button btn btn-secondary d-flex align-items-center {{ env.inDialog ? 'w-50' : 'w-100' }}"
                 t-att-data-kind="props.kind"
                 t-on-pointerdown.prevent="() => this.showPermissionDialog(props.kind)"
                 t-on-keydown.prevent="() => this.showPermissionDialog(props.kind)"
             >
                 <i t-if="props.icon" t-att-class="props.icon"/>
                 <span
-                    class="text-start"
+                    class="text-truncate flex-grow-1"
                     t-attf-class="{{ props.icon ? 'ps-2' : '' }}"
-                >
-                    <t t-esc="PERMISSION_NEEDED"/>
-                </span>
+                    t-out="PERMISSION_NEEDED"/>
             </button>
             <t t-set-slot="content">
                 <DropdownItem t-if="!isBrowserChrome or props.kind === 'videoinput'" class="{ 'active': isSelected() }" onSelected="onSelectAudioDevice.bind(this)">


### PR DESCRIPTION
**Description of the issue this PR addresses:**
Ensure the `Permission Needed` label in the device selector on the discuss 
public page displays correctly and remains properly aligned when device
permissions are not granted.

**Current behavior before PR:**
- Since this [PR](https://github.com/odoo/odoo/pull/247838), the label could appear misaligned or overflow the button 
on smaller screens, causing UI inconsistencies on both desktop and mobile.

**Desired behavior after PR is merged:**
- The label stays properly aligned and adapts correctly to the available space, 
preventing UI glitches across screen sizes.

task-[6007860](https://www.odoo.com/odoo/project/1519/tasks/6007860)

Before [Larger and Smaller Devices]: 
<img width="639" height="49" alt="image" src="https://github.com/user-attachments/assets/1cd1e240-0f40-42f9-bf93-823add81878f" /> 
<img width="343" height="39" alt="image" src="https://github.com/user-attachments/assets/a7a0f920-39e3-4bb3-a647-461c94cab395" />

After [Larger and Smaller Devices]: 
<img width="638" height="47" alt="image" src="https://github.com/user-attachments/assets/16aa419b-2190-4fd1-a459-8a376d90c349" />
<img width="425" height="41" alt="image" src="https://github.com/user-attachments/assets/fb245378-c04b-4dd8-8c5b-39ad4adefadf" />

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
