### PR TITLE
[FIX] mail: properly upgrade localStorage on 'saas~' versions

### DIFF
--- a/addons/mail/static/src/core/common/upgrade/upgrade_19_1.js
+++ b/addons/mail/static/src/core/common/upgrade/upgrade_19_1.js
@@ -10,7 +10,7 @@ export const upgrade_19_1 = {
      * @returns {UpgradeFnReturn}
      */
     add(key, upgrade) {
-        return addUpgrade({ key, version: "19.1", upgrade });
+        return addUpgrade({ key, version: "19.1.0", upgrade });
     },
 };
 

--- a/addons/mail/static/src/utils/common/local_storage.js
+++ b/addons/mail/static/src/utils/common/local_storage.js
@@ -1,7 +1,7 @@
 import { browser } from "@web/core/browser/browser";
 import { session } from "@web/session";
 
-const LOCAL_STORAGE_SUBVERSION = 0;
+const LOCAL_STORAGE_SUBVERSION = 1;
 
 /**
  * @typedef {Object} LocalStorageValue

--- a/addons/mail/static/src/utils/common/misc.js
+++ b/addons/mail/static/src/utils/common/misc.js
@@ -148,8 +148,16 @@ function compareVersion(v1, v2) {
     const parts2 = v2.split(".");
 
     for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
-        const num1 = parseInt(parts1[i]) || 0;
-        const num2 = parseInt(parts2[i]) || 0;
+        let rawPart1 = parts1[i];
+        let rawPart2 = parts2[i];
+        if (typeof rawPart1 === "string" && rawPart1.startsWith("saas~")) {
+            rawPart1 = rawPart1.substring("saas~".length);
+        }
+        if (typeof rawPart2 === "string" && rawPart2.startsWith("saas~")) {
+            rawPart2 = rawPart2.substring("saas~".length);
+        }
+        const num1 = parseInt(rawPart1) || 0;
+        const num2 = parseInt(rawPart2) || 0;
         if (num1 < num2) {
             return -1;
         }

--- a/addons/mail/static/tests/core/common/upgrade_19_1.test.js
+++ b/addons/mail/static/tests/core/common/upgrade_19_1.test.js
@@ -15,7 +15,7 @@ import { toRawValue } from "@mail/utils/common/local_storage";
 import { Settings } from "@mail/core/common/settings_model";
 import { DiscussApp } from "@mail/core/public_web/discuss_app/discuss_app_model";
 import { DiscussAppCategory } from "@mail/discuss/core/public_web/discuss_app/discuss_app_category_model";
-import { getService, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { getService, patchWithCleanup, serverState } from "@web/../tests/web_test_helpers";
 import { browser } from "@web/core/browser/browser";
 
 describe.current.tags("desktop");
@@ -24,6 +24,22 @@ defineMailModels();
 test("message sound is 'off'", async () => {
     localStorage.setItem("mail.user_setting.message_sound", "false");
     await start();
+    expect(serverState.serverVersion).toEqual([99, 9]);
+    getService("action").doAction({
+        tag: "mail.discuss_notification_settings_action",
+        type: "ir.actions.client",
+    });
+    await contains("label:has(h5:contains('Message sound')) input:not(:checked)");
+    const messageSoundKey = makeRecordFieldLocalId(Settings.localId(), "messageSound");
+    expect(localStorage.getItem(messageSoundKey)).toBe(toRawValue(false));
+    expect(localStorage.getItem("mail.user_setting.message_sound")).toBe(null);
+});
+
+test("message sound is 'off' (serverVersion with 'saas~' prefix)", async () => {
+    // same test as above but testing with server version with `saas~` prefix that should be ignored and upgrade as expected.
+    localStorage.setItem("mail.user_setting.message_sound", "false");
+    await start({ serverVersion: ["saas~99", "9"] });
+    expect(serverState.serverVersion).toEqual(["saas~99", "9"]);
     getService("action").doAction({
         tag: "mail.discuss_notification_settings_action",
         type: "ir.actions.client",

--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -347,9 +347,7 @@ export async function start(options) {
             after(() => this.clear());
         },
     });
-    if (!options?.serverVersion) {
-        serverState.serverVersion = [99, 9]; // so local storage entries upgrade to latest version. HOOT sets 1.0 otherwise, ignoring all upgrades...
-    }
+    serverState.serverVersion = options?.serverVersion ?? [99, 9]; // so local storage entries upgrade to latest version. HOOT sets 1.0 otherwise, ignoring all upgrades...
     if (!MockServer.current) {
         await startServer();
     }


### PR DESCRIPTION
Before this commit, upgrade of local storage from 19.0 to 19.1 were not working.

Steps to reproduce:
- have DB in 19.0 with message sound "off" in Discuss Notifications settings
- upgrade to 19.1 DB (or make a fresh 19.1 DB on same sub-domain)
- log on this new DB => "message sound" settings is "on" when it should be "off".

This happens because the server version is "saas~19.1" and the prefix `saas~` was not taken into account. As a result, the version `saas~19.1` was mistakenly considered as lower than `19.0`.

This commit fixes the issue by omitting the prefix `saas~` in the utils function of version comparison, which is what is used by the local storage internal code to compare versions.

Upgrade version has been bumped to `19.1.1` and upgrade scripts have their sub-version explicitly set to `19.1.0`, so that these scripts are run for versions equal or lower than `19.1.0`, meaning they re-run also for `19.1.0`.

Task-6008166