### PR TITLE
[REF] mrp,*: run rendering context migration script

### DIFF
--- a/addons/mrp/static/src/components/bom_overview/mrp_bom_overview.xml
+++ b/addons/mrp/static/src/components/bom_overview/mrp_bom_overview.xml
@@ -4,32 +4,32 @@
     <div t-name="mrp.BomOverviewComponent" class="o_action o_mrp_overview">
 
         <BomOverviewControlPanel
-            bomQuantity="state.bomQuantity"
-            uomName="uomName"
-            variants="variants"
-            data="state.bomData"
-            showOptions="state.showOptions"
-            showVariants="showVariants"
-            currentWarehouse="state.currentWarehouse"
-            warehouses="warehouses"
-            print.bind="onClickPrint"
-            changeWarehouse.bind="onChangeWarehouse"
-            changeVariant.bind="onChangeVariant"
-            changeBomQuantity.bind="onChangeBomQuantity"
-            changeMode.bind="onChangeMode"
-            precision="state.precision"
-            foldable="state.foldable"
-            allFolded="state.allFolded"
+            bomQuantity="this.state.bomQuantity"
+            uomName="this.uomName"
+            variants="this.variants"
+            data="this.state.bomData"
+            showOptions="this.state.showOptions"
+            showVariants="this.showVariants"
+            currentWarehouse="this.state.currentWarehouse"
+            warehouses="this.warehouses"
+            print.bind="this.onClickPrint"
+            changeWarehouse.bind="this.onChangeWarehouse"
+            changeVariant.bind="this.onChangeVariant"
+            changeBomQuantity.bind="this.onChangeBomQuantity"
+            changeMode.bind="this.onChangeMode"
+            precision="this.state.precision"
+            foldable="this.state.foldable"
+            allFolded="this.state.allFolded"
             />
 
         <BomOverviewTable
-            uomName="uomName"
-            showOptions="state.showOptions"
-            currentWarehouseId="state.currentWarehouse.id"
-            data="state.bomData"
-            precision="state.precision"
-            bomQuantity="state.bomQuantity"
-            changeFolded.bind="onChangeFolded"/>
+            uomName="this.uomName"
+            showOptions="this.state.showOptions"
+            currentWarehouseId="this.state.currentWarehouse.id"
+            data="this.state.bomData"
+            precision="this.state.precision"
+            bomQuantity="this.state.bomQuantity"
+            changeFolded.bind="this.onChangeFolded"/>
     </div>
 
 </templates>

--- a/addons/mrp/static/src/components/bom_overview_components_block/mrp_bom_overview_components_block.xml
+++ b/addons/mrp/static/src/components/bom_overview_components_block/mrp_bom_overview_components_block.xml
@@ -2,43 +2,43 @@
 <templates xml:space="preserve">
 
     <t t-name="mrp.BomOverviewComponentsBlock">
-        <t name="components" t-if="hasComponents">
-            <t t-foreach="data.components" t-as="line" t-key="line.index">
+        <t name="components" t-if="this.hasComponents">
+            <t t-foreach="this.data.components" t-as="line" t-key="line.index">
                 <BomOverviewLine
-                    isFolded="state[getIdentifier(line)]"
-                    showOptions="props.showOptions"
+                    isFolded="this.state[this.getIdentifier(line)]"
+                    showOptions="this.props.showOptions"
                     data="line"
-                    precision="props.precision"
-                    toggleFolded.bind="onToggleFolded"/>
+                    precision="this.props.precision"
+                    toggleFolded.bind="this.onToggleFolded"/>
 
-                <t t-if="!state[getIdentifier(line)] &amp;&amp; hasComponents">
+                <t t-if="!this.state[this.getIdentifier(line)] &amp;&amp; this.hasComponents">
                     <BomOverviewComponentsBlock
-                        unfoldAll="state.unfoldAll"
-                        showOptions="props.showOptions"
-                        currentWarehouseId="props.currentWarehouseId"
+                        unfoldAll="this.state.unfoldAll"
+                        showOptions="this.props.showOptions"
+                        currentWarehouseId="this.props.currentWarehouseId"
                         data="line"
-                        precision="props.precision"
-                        changeFolded.bind="props.changeFolded"/>
+                        precision="this.props.precision"
+                        changeFolded.bind="this.props.changeFolded"/>
                 </t>
             </t>
         </t>
-        <t name="operations" t-if="!!data.operations &amp;&amp; data.operations.length > 0">
+        <t name="operations" t-if="!!this.data.operations &amp;&amp; this.data.operations.length > 0">
             <BomOverviewExtraBlock
-                unfoldAll="state.unfoldAll"
+                unfoldAll="this.state.unfoldAll"
                 type="'operations'"
-                showOptions="props.showOptions"
-                data="data"
-                precision="props.precision"
-                changeFolded.bind="props.changeFolded"/>
+                showOptions="this.props.showOptions"
+                data="this.data"
+                precision="this.props.precision"
+                changeFolded.bind="this.props.changeFolded"/>
         </t>
-        <t name="byproducts" t-if="!!data.byproducts &amp;&amp; data.byproducts.length > 0">
+        <t name="byproducts" t-if="!!this.data.byproducts &amp;&amp; this.data.byproducts.length > 0">
             <BomOverviewExtraBlock
-                unfoldAll="state.unfoldAll"
+                unfoldAll="this.state.unfoldAll"
                 type="'byproducts'"
-                showOptions="props.showOptions"
-                data="data"
-                precision="props.precision"
-                changeFolded.bind="props.changeFolded"/>
+                showOptions="this.props.showOptions"
+                data="this.data"
+                precision="this.props.precision"
+                changeFolded.bind="this.props.changeFolded"/>
         </t>
     </t>
 

--- a/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.xml
+++ b/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.xml
@@ -2,39 +2,39 @@
 <templates xml:space="preserve">
 
     <t t-name="mrp.BomOverviewControlPanel">
-        <ControlPanel display="controlPanelDisplay">
+        <ControlPanel display="this.controlPanelDisplay">
             <t t-set-slot="control-panel-buttons">
-                <button t-if="props.showOptions.mode == 'forecast'" t-on-click="manufactureFromBoM" type="button" class="btn btn-primary">Manufacture</button>
+                <button t-if="this.props.showOptions.mode == 'forecast'" t-on-click="this.manufactureFromBoM" type="button" class="btn btn-primary">Manufacture</button>
                 <button t-on-click="() => this.props.print()" type="button" class="btn btn-secondary">Print</button>
                 <!-- <t t-if="props.showVariants"> commented, waiting for ui update
                     <button t-on-click="() => this.props.print(true)" type="button" class="btn btn-secondary text-nowrap">Print All Variants</button>
                 </t>
                 </t> -->
-                <button t-if="props.foldable" t-on-click="clickTogglefold" type="button" class="btn btn-secondary" t-out="foldButtonText"/>
+                <button t-if="this.props.foldable" t-on-click="this.clickTogglefold" type="button" class="btn btn-secondary" t-out="this.foldButtonText"/>
             </t>
             <t t-set-slot="control-panel-actions">
-                <div t-if="props.showVariants" class="input-group align-items-center">
+                <div t-if="this.props.showVariants" class="input-group align-items-center">
                     <div class="col-4 col-md-auto pe-2 fw-bold">Variant</div>
                     <div class="col">
                         <Many2XAutocomplete
-                            value="props.data.name"
-                            getDomain.bind="getDomain"
+                            value="this.props.data.name"
+                            getDomain.bind="this.getDomain"
                             resModel="'product.product'"
-                            fieldString="props.data.name"
+                            fieldString="this.props.data.name"
                             activeActions="{}"
                             update.bind="(ev) => this.props.changeVariant(ev[0]?.id)"
                         />
                     </div>
                 </div>
                 <div class="d-flex gap-1">
-                    <t t-if="props.showOptions.mode == 'forecast'">
+                    <t t-if="this.props.showOptions.mode == 'forecast'">
                         <div>
                             <form class="d-flex flex-grow-1 gap-3 flex-column flex-md-row">
                                 <label class="visually-hidden" for="bom_quantity"/>
                                 <div t-attf-class="input-group align-items-center">
                                     <div class="col-4 col-md-auto px-2 fw-bold">Quantity</div>
-                                    <input id="bom_quantity" type="number" step="any" t-on-change="ev => this.updateQuantity(ev)" t-on-keypress="ev => this.onKeyPress(ev)" t-att-value="props.bomQuantity" min="1" size="7" class="o_input form-control rounded-0" t-custom-ref="quantity"/>
-                                    <div t-if="props.showOptions.uom" t-out="props.uomName" class="d-flex align-items-center text-muted small lh-sm"/>
+                                    <input id="bom_quantity" type="number" step="any" t-on-change="ev => this.updateQuantity(ev)" t-on-keypress="ev => this.onKeyPress(ev)" t-att-value="this.props.bomQuantity" min="1" size="7" class="o_input form-control rounded-0" t-custom-ref="quantity"/>
+                                    <div t-if="this.props.showOptions.uom" t-out="this.props.uomName" class="d-flex align-items-center text-muted small lh-sm"/>
                                 </div>
                             </form>
                         </div>
@@ -42,16 +42,16 @@
                 </div>
             </t>
             <t t-set-slot="control-panel-navigation-additional">
-                <t t-if="props.showOptions.mode == 'forecast'">
-                    <t t-if="props.warehouses.length > 1" class="btn-group flex-grow-1 flex-md-grow-0">
-                        <Dropdown items="warehousesItems">
+                <t t-if="this.props.showOptions.mode == 'forecast'">
+                    <t t-if="this.props.warehouses.length > 1" class="btn-group flex-grow-1 flex-md-grow-0">
+                        <Dropdown items="this.warehousesItems">
                             <button class="btn btn-secondary o-dropdown-caret">
-                                <span class="fa fa-home"/> Warehouse: <t t-out="props.currentWarehouse.name"/>
+                                <span class="fa fa-home"/> Warehouse: <t t-out="this.props.currentWarehouse.name"/>
                             </button>
                         </Dropdown>
                     </t>
                 </t>
-                <t t-if="props.showOptions.mode == 'overview'">
+                <t t-if="this.props.showOptions.mode == 'overview'">
                     <div class="o_row" t-on-click="() => this.props.changeMode('forecast')" >
                         <i class="btn fa fa-toggle-off fa-lg pe-1"/>
                         <span>Forecast</span>

--- a/addons/mrp/static/src/components/bom_overview_display_filter/mrp_bom_overview_display_filter.xml
+++ b/addons/mrp/static/src/components/bom_overview_display_filter/mrp_bom_overview_display_filter.xml
@@ -3,7 +3,7 @@
 
     <t t-name="mrp.BomOverviewDisplayFilter">
         <div class="btn-group flex-grow-1 flex-md-grow-0'">
-            <Dropdown  items="displayableOptions">
+            <Dropdown  items="this.displayableOptions">
                 <button class="btn btn-secondary o-dropdown-caret">
                     <span class="fa fa-filter"/>
                     Display

--- a/addons/mrp/static/src/components/bom_overview_extra_block/mrp_bom_overview_extra_block.xml
+++ b/addons/mrp/static/src/components/bom_overview_extra_block/mrp_bom_overview_extra_block.xml
@@ -3,18 +3,18 @@
 
     <t t-name="mrp.BomOverviewExtraBlock">
         <BomOverviewSpecialLine
-            type="props.type"
-            isFolded="state.isFolded"
-            showOptions="props.showOptions"
-            data="props.data"
-            precision="props.precision"
-            toggleFolded.bind="onToggleFolded"/>
+            type="this.props.type"
+            isFolded="this.state.isFolded"
+            showOptions="this.props.showOptions"
+            data="this.props.data"
+            precision="this.props.precision"
+            toggleFolded.bind="this.onToggleFolded"/>
 
-        <t t-if="!state.isFolded" t-foreach="props.type == 'operations' ? props.data.operations : props.data.byproducts" t-as="extra_data" t-key="extra_data.index">
+        <t t-if="!this.state.isFolded" t-foreach="this.props.type == 'operations' ? this.props.data.operations : this.props.data.byproducts" t-as="extra_data" t-key="extra_data.index">
             <BomOverviewLine
-                showOptions="props.showOptions"
+                showOptions="this.props.showOptions"
                 data="extra_data"
-                precision="props.precision"
+                precision="this.props.precision"
                 />
         </t>
     </t>

--- a/addons/mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.xml
+++ b/addons/mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.xml
@@ -1,57 +1,57 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <tr t-name="mrp.BomOverviewLine" t-on-click="() => this.props.toggleFolded(identifier)">
+    <tr t-name="mrp.BomOverviewLine" t-on-click="() => this.props.toggleFolded(this.identifier)">
         <td name="td_mrp_bom">
-            <div class="text-truncate" t-attf-style="margin-left: {{ marginMultiplicator * 20 }}px">
-                <t t-if="hasFoldButton">
+            <div class="text-truncate" t-attf-style="margin-left: {{ this.marginMultiplicator * 20 }}px">
+                <t t-if="this.hasFoldButton">
                     <t t-set="title_fold">Fold</t>
                     <t t-set="title_unfold">Unfold</t>
-                    <span class="o_mrp_bom_unfoldable btn btn-light p-0" t-att-aria-label="props.isFolded ? title_unfold : title_fold" t-att-title="props.isFolded ? title_unfold : title_fold" style="margin-right: 1px">
-                        <i t-attf-class="fa fa-fw fa-caret-{{ props.isFolded ? 'right' : 'down' }}" role="img"/>
+                    <span class="o_mrp_bom_unfoldable btn btn-light p-0" t-att-aria-label="this.props.isFolded ? title_unfold : title_fold" t-att-title="this.props.isFolded ? title_unfold : title_fold" style="margin-right: 1px">
+                        <i t-attf-class="fa fa-fw fa-caret-{{ this.props.isFolded ? 'right' : 'down' }}" role="img"/>
                     </span>
                 </t>
-                <a href="#" t-on-click.prevent="() => this.goToAction(data.link_id, data.link_model)" t-out="data.name"/>
-                <t t-if="data.phantom_bom">
+                <a href="#" t-on-click.prevent="() => this.goToAction(this.data.link_id, this.data.link_model)" t-out="this.data.name"/>
+                <t t-if="this.data.phantom_bom">
                     <div class="fa fa-dropbox" title="This is a BoM of type Kit!" role="img" aria-label="This is a BoM of type Kit!"/>
                 </t>
             </div>
         </td>
         <td class="text-end" name="quantity">
-            <t t-if="data.type == 'operation'" t-esc="formatFloatTime(data.quantity, {'unit': 'minutes'})"/>
-            <t t-else="" t-esc="formatFloat(data.quantity, {'digits': [false, precision]})"/>
+            <t t-if="this.data.type == 'operation'" t-esc="this.formatFloatTime(this.data.quantity, {'unit': 'minutes'})"/>
+            <t t-else="" t-esc="this.formatFloat(this.data.quantity, {'digits': [false, this.precision]})"/>
         </td>
-         <td t-if="showUom" class="text-start" t-out="data.uom_name"/>
-         <td t-if="forecastMode" class="text-center">
-            <t t-if="hasQuantity">
-                <t t-out="formatFloat(data.quantity_available, {'digits': [false, precision]})"/> /
-                <t t-out="formatFloat(data.quantity_on_hand, {'digits': [false, precision]})"/>
+         <td t-if="this.showUom" class="text-start" t-out="this.data.uom_name"/>
+         <td t-if="this.forecastMode" class="text-center">
+            <t t-if="this.hasQuantity">
+                <t t-out="this.formatFloat(this.data.quantity_available, {'digits': [false, this.precision]})"/> /
+                <t t-out="this.formatFloat(this.data.quantity_on_hand, {'digits': [false, this.precision]})"/>
             </t>
         </td>
-        <td t-if="forecastMode" class="text-center">
-            <div t-if="data.hasOwnProperty('status')" class="o_field_badge">
+        <td t-if="this.forecastMode" class="text-center">
+            <div t-if="this.data.hasOwnProperty('status')" class="o_field_badge">
                 <span
-                    t-on-click.prevent="goToForecast"
+                    t-on-click.prevent="this.goToForecast"
                     title="Forecast Report"
-                    t-attf-class="badge rounded-pill o_mrp_overview_badge {{statusBackgroundClass}}"
-                    t-att-role="data.type != 'operation' ? 'button' : undefined"
-                    t-out="data.status"
+                    t-attf-class="badge rounded-pill o_mrp_overview_badge {{this.statusBackgroundClass}}"
+                    t-att-role="this.data.type != 'operation' ? 'button' : undefined"
+                    t-out="this.data.status"
                 />
             </div>
         </td>
-        <td t-if="forecastMode" class="text-center">
-            <span t-if="hasLeadTime"><t t-out="data.lead_time"/> Days</span>
+        <td t-if="this.forecastMode" class="text-center">
+            <span t-if="this.hasLeadTime"><t t-out="this.data.lead_time"/> Days</span>
         </td>
-        <td t-if="forecastMode">
-            <div t-if="data.route_name &amp;&amp; data.route_detail">
-                <span t-attf-class="{{ data.route_alert ? 'text-danger' : '' }}"><t t-out="data.route_name"/>: </span>
-                <a href="#" t-on-click.prevent="() => this.goToRoute(data.route_type)" t-out="data.route_detail"/>
+        <td t-if="this.forecastMode">
+            <div t-if="this.data.route_name &amp;&amp; this.data.route_detail">
+                <span t-attf-class="{{ this.data.route_alert ? 'text-danger' : '' }}"><t t-out="this.data.route_name"/>: </span>
+                <a href="#" t-on-click.prevent="() => this.goToRoute(this.data.route_type)" t-out="this.data.route_detail"/>
             </div>
         </td>
-        <td t-attf-class="text-end {{ data.type == 'component' ? 'opacity-50' : '' }}" t-attf-colspan="{{ forecastMode ? 1 : 2 }}" t-out="formatMonetary(data.bom_cost)"/>
-        <td t-if="showAttachments" class="text-center">
-            <span t-if="data.has_attachments">
-                <a href="#" role="button" t-on-click.prevent="goToAttachment" class="fa fa-fw o_button_icon fa-files-o"/>
+        <td t-attf-class="text-end {{ this.data.type == 'component' ? 'opacity-50' : '' }}" t-attf-colspan="{{ this.forecastMode ? 1 : 2 }}" t-out="this.formatMonetary(this.data.bom_cost)"/>
+        <td t-if="this.showAttachments" class="text-center">
+            <span t-if="this.data.has_attachments">
+                <a href="#" role="button" t-on-click.prevent="this.goToAttachment" class="fa fa-fw o_button_icon fa-files-o"/>
             </span>
         </td>
     </tr>

--- a/addons/mrp/static/src/components/bom_overview_special_line/mrp_bom_overview_special_line.xml
+++ b/addons/mrp/static/src/components/bom_overview_special_line/mrp_bom_overview_special_line.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <tr t-name="mrp.BomOverviewSpecialLine" t-on-click="props.toggleFolded" >
+    <tr t-name="mrp.BomOverviewSpecialLine" t-on-click="this.props.toggleFolded" >
         <td name="td_mrp_bom">
-            <span t-attf-style="margin-left: {{ data.level * 20 }}px"/>
+            <span t-attf-style="margin-left: {{ this.data.level * 20 }}px"/>
             <t t-set="title_fold">Fold</t>
             <t t-set="title_unfold">Unfold</t>
-            <span t-if="hasFoldButton" t-attf-class="o_mrp_bom_{{ props.isFolded ? 'unfoldable' : 'foldable' }} btn btn-light ps-0 py-0" t-att-aria-label="props.isFolded ? title_unfold : title_fold" t-att-title="props.isFolded ? title_unfold : title_fold">
-                <i t-attf-class="fa fa-fw fa-caret-{{ props.isFolded ? 'right' : 'down' }}" role="img"/>
-                <t t-if="props.type == 'operations'">Operations</t>
-                <t t-elif="props.type == 'byproducts'">By-Products</t>
+            <span t-if="this.hasFoldButton" t-attf-class="o_mrp_bom_{{ this.props.isFolded ? 'unfoldable' : 'foldable' }} btn btn-light ps-0 py-0" t-att-aria-label="this.props.isFolded ? title_unfold : title_fold" t-att-title="this.props.isFolded ? title_unfold : title_fold">
+                <i t-attf-class="fa fa-fw fa-caret-{{ this.props.isFolded ? 'right' : 'down' }}" role="img"/>
+                <t t-if="this.props.type == 'operations'">Operations</t>
+                <t t-elif="this.props.type == 'byproducts'">By-Products</t>
             </span>
         </td>
         <td name="quantity" class="text-end">
-            <span t-if="props.type == 'operations'" t-esc="formatFloatTime(data.operations_time, {'unit': 'minutes'})"/>
-            <span t-elif="props.type == 'byproducts'" t-esc="formatFloat(data.byproducts_total, {'digits': [false, precision]})"/>
+            <span t-if="this.props.type == 'operations'" t-esc="this.formatFloatTime(this.data.operations_time, {'unit': 'minutes'})"/>
+            <span t-elif="this.props.type == 'byproducts'" t-esc="this.formatFloat(this.data.byproducts_total, {'digits': [false, this.precision]})"/>
         </td>
-        <td name="uom" t-if="showUom" class="text-start"/>
-        <td name="free_to_use" t-if="forecastMode"/>
-        <td name="status" t-if="forecastMode"/>
-        <td name="lead_time" t-if="forecastMode"/>
-        <td name="route" t-if="forecastMode"/>
-        <td name="bom_cost" class="text-end" t-attf-colspan="{{ forecastMode ? 1 : 2 }}">
-            <span t-if="props.type == 'operations'" t-out="formatMonetary(data.operations_cost)"/>
-            <span t-elif="props.type == 'byproducts'" t-out="formatMonetary(data.byproducts_cost)"/>
+        <td name="uom" t-if="this.showUom" class="text-start"/>
+        <td name="free_to_use" t-if="this.forecastMode"/>
+        <td name="status" t-if="this.forecastMode"/>
+        <td name="lead_time" t-if="this.forecastMode"/>
+        <td name="route" t-if="this.forecastMode"/>
+        <td name="bom_cost" class="text-end" t-attf-colspan="{{ this.forecastMode ? 1 : 2 }}">
+            <span t-if="this.props.type == 'operations'" t-out="this.formatMonetary(this.data.operations_cost)"/>
+            <span t-elif="this.props.type == 'byproducts'" t-out="this.formatMonetary(this.data.byproducts_cost)"/>
         </td>
-        <td t-if="showAttachments"/>
+        <td t-if="this.showAttachments"/>
     </tr>
 
 </templates>

--- a/addons/mrp/static/src/components/bom_overview_table/mrp_bom_overview_table.xml
+++ b/addons/mrp/static/src/components/bom_overview_table/mrp_bom_overview_table.xml
@@ -3,63 +3,63 @@
 
     <div t-name="mrp.BomOverviewTable" class="o_content">
         <div class="o_mrp_bom_report_page px-0 overflow-auto border-bottom bg-view">
-            <div t-if="!!data.components || !!data.lines || !!data.operations" class="container-fluid">
+            <div t-if="!!this.data.components || !!this.data.lines || !!this.data.operations" class="container-fluid">
                 <table class="o_mrp_bom_expandable table">
                     <thead>
                         <tr>
                             <th name="th_mrp_bom_h">Product</th>
-                            <th t-attf-class="{{ showUom ? 'text-center' : 'text-end' }}" t-attf-style="text-indent:{{ showUom ? (forecastMode ? -10 : -50) : 0 }}px"
-                                t-attf-colspan="{{ showUom ? 2 : 1 }}">Quantity</th>
-                            <th t-if="forecastMode" class="text-center" title="Availabilities on products.">Free to Use / On Hand</th>
-                            <th t-if="forecastMode" class="text-center">Status</th>
-                            <th t-if="forecastMode" class="text-center" title="Resupply lead time.">Lead Time</th>
-                            <th t-if="forecastMode">Route</th>
+                            <th t-attf-class="{{ this.showUom ? 'text-center' : 'text-end' }}" t-attf-style="text-indent:{{ this.showUom ? (this.forecastMode ? -10 : -50) : 0 }}px"
+                                t-attf-colspan="{{ this.showUom ? 2 : 1 }}">Quantity</th>
+                            <th t-if="this.forecastMode" class="text-center" title="Availabilities on products.">Free to Use / On Hand</th>
+                            <th t-if="this.forecastMode" class="text-center">Status</th>
+                            <th t-if="this.forecastMode" class="text-center" title="Resupply lead time.">Lead Time</th>
+                            <th t-if="this.forecastMode">Route</th>
                             <th t-else=""/>
                             <th class="text-end"
                                 title="This is the cost based on the BoM of the product. It is computed by summing the costs of the components and operations needed to build the product.">Cost</th>
-                            <th t-if="showAttachments" class="text-center" title="Files attached to the product.">Attachments</th>
+                            <th t-if="this.showAttachments" class="text-center" title="Files attached to the product.">Attachments</th>
                         </tr>
                     </thead>
                     <tbody>
                         <BomOverviewLine
-                            showOptions="props.showOptions"
-                            currentWarehouseId="props.currentWarehouseId"
-                            data="data"
-                            precision="props.precision"
+                            showOptions="this.props.showOptions"
+                            currentWarehouseId="this.props.currentWarehouseId"
+                            data="this.data"
+                            precision="this.props.precision"
                             />
 
                         <BomOverviewComponentsBlock
-                            showOptions="props.showOptions"
-                            currentWarehouseId="props.currentWarehouseId"
-                            data="data"
-                            precision="props.precision"
-                            changeFolded.bind="props.changeFolded"/>
+                            showOptions="this.props.showOptions"
+                            currentWarehouseId="this.props.currentWarehouseId"
+                            data="this.data"
+                            precision="this.props.precision"
+                            changeFolded.bind="this.props.changeFolded"/>
                     </tbody>
-                    <tfoot t-if="showUnitCosts">
+                    <tfoot t-if="this.showUnitCosts">
                         <tr>
                             <td name="td_mrp_bom_f" class="text-end" colspan="2">
-                                <span t-if="!!data.byproducts &amp;&amp; data.byproducts.length > 0" t-out="data.name"/>
+                                <span t-if="!!this.data.byproducts &amp;&amp; this.data.byproducts.length > 0" t-out="this.data.name"/>
                             </td>
-                            <td t-if="showUom &amp;&amp; (data.byproducts.length || data.product_uom_name != data.uom_name)">
-                                <t t-out="data.product_uom_name"/>
+                            <td t-if="this.showUom &amp;&amp; (this.data.byproducts.length || this.data.product_uom_name != this.data.uom_name)">
+                                <t t-out="this.data.product_uom_name"/>
                             </td>
-                            <td name="free_to_use" t-if="forecastMode"/>
-                            <td name="status" t-if="forecastMode"/>
-                            <td name="lead_time" t-if="forecastMode"/>
-                            <td name="route_column" class="text-end" t-attf-colspan="{{ data.byproducts.length || showUom &amp;&amp; data.product_uom_name != data.uom_name || !showUom ? 1 : 2 }}"><strong>Unit Cost</strong></td>
-                            <td name="cost" class="text-end" width="5rem"><t t-out="formatMonetary(data.bom_unit_cost / data.quantity)"/></td>
-                            <td t-if="showAttachments"/>
+                            <td name="free_to_use" t-if="this.forecastMode"/>
+                            <td name="status" t-if="this.forecastMode"/>
+                            <td name="lead_time" t-if="this.forecastMode"/>
+                            <td name="route_column" class="text-end" t-attf-colspan="{{ this.data.byproducts.length || this.showUom &amp;&amp; this.data.product_uom_name != this.data.uom_name || !this.showUom ? 1 : 2 }}"><strong>Unit Cost</strong></td>
+                            <td name="cost" class="text-end" width="5rem"><t t-out="this.formatMonetary(this.data.bom_unit_cost / this.data.quantity)"/></td>
+                            <td t-if="this.showAttachments"/>
                         </tr>
-                        <t t-if="data.byproducts &amp;&amp; data.byproducts.length > 0" t-foreach="data.byproducts" t-as="byproduct" t-key="byproduct.id">
+                        <t t-if="this.data.byproducts &amp;&amp; this.data.byproducts.length > 0" t-foreach="this.data.byproducts" t-as="byproduct" t-key="byproduct.id">
                             <tr>
                                 <td name="td_mrp_bom_b" class="text-end" colspan="2" t-out="byproduct.name"/>
-                                <td t-if="showUom"><t t-out="byproduct['product_uom_name']"/></td>
-                                <td name="free_to_use" t-if="forecastMode"/>
-                                <td name="status" t-if="forecastMode"/>
-                                <td name="lead_time" t-if="forecastMode"/>
+                                <td t-if="this.showUom"><t t-out="byproduct['product_uom_name']"/></td>
+                                <td name="free_to_use" t-if="this.forecastMode"/>
+                                <td name="status" t-if="this.forecastMode"/>
+                                <td name="lead_time" t-if="this.forecastMode"/>
                                 <td name="route_column" class="text-end"><strong>Unit Cost</strong></td>
-                                <td name="cost" class="text-end" width="5rem"><t t-out="formatMonetary(byproduct.bom_cost / byproduct.quantity)"/></td>
-                                <td t-if="showAttachments"/>
+                                <td name="cost" class="text-end" width="5rem"><t t-out="this.formatMonetary(byproduct.bom_cost / byproduct.quantity)"/></td>
+                                <td t-if="this.showAttachments"/>
                             </tr>
                         </t>
                     </tfoot>

--- a/addons/mrp/static/src/components/mo_overview/mrp_mo_overview.xml
+++ b/addons/mrp/static/src/components/mo_overview/mrp_mo_overview.xml
@@ -4,12 +4,12 @@
     <div t-name="mrp.MoOverview" class="o_action">
         <Layout display="{ controlPanel: {} }">
             <t t-set-slot="control-panel-actions">
-                <MoOverviewDisplayFilter showOptions="state.showOptions" limited="isProductionDone" changeDisplay.bind="onChangeDisplay" isProductionDraft="isProductionDraft"/>
+                <MoOverviewDisplayFilter showOptions="this.state.showOptions" limited="this.isProductionDone" changeDisplay.bind="this.onChangeDisplay" isProductionDraft="this.isProductionDraft"/>
             </t>
 
             <t t-set-slot="control-panel-buttons">
-                <button class="btn btn-primary" t-on-click="onPrint">Print</button>
-                <button class="btn btn-primary" t-on-click="onUnfold">Unfold</button>
+                <button class="btn btn-primary" t-on-click="this.onPrint">Print</button>
+                <button class="btn btn-primary" t-on-click="this.onUnfold">Unfold</button>
             </t>
 
             <div class="overflow-auto border-bottom bg-view container-fluid">
@@ -17,74 +17,74 @@
                     <thead class="o_mrp_mo_overview_thead">
                         <tr>
                             <th class="text-start"/>
-                            <th class="text-center" t-if="showReplenishments">Status</th>
-                            <th t-attf-class="{{ showUom ? 'text-center' : 'text-end' }}" t-attf-colspan="{{ showUom ? 2 : 1 }}">Quantity</th>
-                            <th class="text-end" t-if="showAvailabilities">Free to use / On Hand</th>
-                            <th class="text-end" t-if="showAvailabilities">Reserved</th>
-                            <th class="text-end" t-if="showReceipts">Receipt</th>
-                            <th class="text-end" t-if="showUnitCosts">Unit Cost</th>
-                            <th class="text-end" t-if="showMoCosts" title="Cost based on related replenishments. Otherwise cost from product form">MO Cost</th>
-                            <th class="text-end" t-if="showBomCosts" title="Cost based on the BoM">BoM Cost</th>
-                            <th class="text-end" t-if="showRealCosts and realInDraft" title="Cost based on cost projection">Real Cost</th>
-                            <th class="text-end" t-elif="showRealCosts" title="Cost as it is currently accumulated">Real Cost</th>
+                            <th class="text-center" t-if="this.showReplenishments">Status</th>
+                            <th t-attf-class="{{ this.showUom ? 'text-center' : 'text-end' }}" t-attf-colspan="{{ this.showUom ? 2 : 1 }}">Quantity</th>
+                            <th class="text-end" t-if="this.showAvailabilities">Free to use / On Hand</th>
+                            <th class="text-end" t-if="this.showAvailabilities">Reserved</th>
+                            <th class="text-end" t-if="this.showReceipts">Receipt</th>
+                            <th class="text-end" t-if="this.showUnitCosts">Unit Cost</th>
+                            <th class="text-end" t-if="this.showMoCosts" title="Cost based on related replenishments. Otherwise cost from product form">MO Cost</th>
+                            <th class="text-end" t-if="this.showBomCosts" title="Cost based on the BoM">BoM Cost</th>
+                            <th class="text-end" t-if="this.showRealCosts and this.realInDraft" title="Cost based on cost projection">Real Cost</th>
+                            <th class="text-end" t-elif="this.showRealCosts" title="Cost as it is currently accumulated">Real Cost</th>
                         </tr>
                     </thead>
                     <tbody>
-                        <MoOverviewLine data="state.data.summary" showOptions="state.showOptions"/>
+                        <MoOverviewLine data="this.state.data.summary" showOptions="this.state.showOptions"/>
                         <MoOverviewComponentsBlock
-                            components="state.data.components"
-                            operations="state.data.operations"
-                            byproducts="state.data.byproducts"
-                            showOptions="state.showOptions"/>
+                            components="this.state.data.components"
+                            operations="this.state.data.operations"
+                            byproducts="this.state.data.byproducts"
+                            showOptions="this.state.showOptions"/>
                     </tbody>
-                    <tfoot t-if="showMoCosts or showRealCosts">
+                    <tfoot t-if="this.showMoCosts or this.showRealCosts">
                         <tr name="unitCost">
-                            <td class="text-end" t-att-colspan="totalColspan">Unit Cost</td>
-                            <td t-attf-class="text-end" t-if="showMoCosts" t-out="formatCost(state.data.extras.unit_mo_cost)"/>
-                            <td class="text-end" t-if="showBomCosts" t-out="formatCost(state.data.extras.unit_bom_cost)"/>
-                            <td t-attf-class="text-end" t-if="showRealCosts" t-out="formatCost(state.data.extras.unit_real_cost)"/>
+                            <td class="text-end" t-att-colspan="this.totalColspan">Unit Cost</td>
+                            <td t-attf-class="text-end" t-if="this.showMoCosts" t-out="this.formatCost(this.state.data.extras.unit_mo_cost)"/>
+                            <td class="text-end" t-if="this.showBomCosts" t-out="this.formatCost(this.state.data.extras.unit_bom_cost)"/>
+                            <td t-attf-class="text-end" t-if="this.showRealCosts" t-out="this.formatCost(this.state.data.extras.unit_real_cost)"/>
                         </tr>
-                        <t t-if="isProductionDone">
+                        <t t-if="this.isProductionDone">
                             <tr>
-                                <td class="text-end" t-att-colspan="totalColspan">Total Cost of Components</td>
-                                <td t-attf-class="text-end" t-if="showMoCosts" t-out="formatCost(state.data.extras.total_mo_cost_components)"/>
-                                <td class="text-end" t-if="showBomCosts" t-out="formatCost(state.data.extras.total_bom_cost_components)"/>
-                                <td t-attf-class="text-end {{ getColorClass(state.data.extras.total_real_cost_components_decorator) }}" t-if="showRealCosts" t-out="formatCost(state.data.extras.total_real_cost_components)"/>
+                                <td class="text-end" t-att-colspan="this.totalColspan">Total Cost of Components</td>
+                                <td t-attf-class="text-end" t-if="this.showMoCosts" t-out="this.formatCost(this.state.data.extras.total_mo_cost_components)"/>
+                                <td class="text-end" t-if="this.showBomCosts" t-out="this.formatCost(this.state.data.extras.total_bom_cost_components)"/>
+                                <td t-attf-class="text-end {{ this.getColorClass(this.state.data.extras.total_real_cost_components_decorator) }}" t-if="this.showRealCosts" t-out="this.formatCost(this.state.data.extras.total_real_cost_components)"/>
                             </tr>
-                            <tr t-if="state.data.summary.quantity != 1">
-                                <td class="text-end" t-att-colspan="totalColspan">
+                            <tr t-if="this.state.data.summary.quantity != 1">
+                                <td class="text-end" t-att-colspan="this.totalColspan">
                                     Cost of Components per unit
-                                    <t t-if="showUom">(in <t t-out='state.data.summary.uom_name'/>)</t>
+                                    <t t-if="this.showUom">(in <t t-out='this.state.data.summary.uom_name'/>)</t>
                                 </td>
-                                <td t-attf-class="text-end" t-if="showMoCosts" t-out="formatCost(state.data.extras.unit_mo_cost_components)"/>
-                                <td class="text-end" t-if="showBomCosts" t-out="formatCost(state.data.extras.unit_bom_cost_components)"/>
-                                <td t-attf-class="text-end {{ getColorClass(state.data.extras.total_real_cost_components_decorator) }}" t-if="showRealCosts" t-out="formatCost(state.data.extras.unit_real_cost_components)"/>
+                                <td t-attf-class="text-end" t-if="this.showMoCosts" t-out="this.formatCost(this.state.data.extras.unit_mo_cost_components)"/>
+                                <td class="text-end" t-if="this.showBomCosts" t-out="this.formatCost(this.state.data.extras.unit_bom_cost_components)"/>
+                                <td t-attf-class="text-end {{ this.getColorClass(this.state.data.extras.total_real_cost_components_decorator) }}" t-if="this.showRealCosts" t-out="this.formatCost(this.state.data.extras.unit_real_cost_components)"/>
                             </tr>
-                            <tr t-if="hasOperations">
-                                <td class="text-end" t-att-colspan="totalColspan">Total Cost of Operations</td>
-                                <td t-attf-class="text-end {{ getColorClass(state.data.extras.total_mo_cost_operations_decorator) }}" t-if="showMoCosts" t-out="formatCost(state.data.extras.total_mo_cost_operations)"/>
-                                <td class="text-end" t-if="showBomCosts" t-out="formatCost(state.data.extras.total_bom_cost_operations)"/>
-                                <td t-attf-class="text-end" t-if="showRealCosts" t-out="formatCost(state.data.extras.total_real_cost_operations)"/>
+                            <tr t-if="this.hasOperations">
+                                <td class="text-end" t-att-colspan="this.totalColspan">Total Cost of Operations</td>
+                                <td t-attf-class="text-end {{ this.getColorClass(this.state.data.extras.total_mo_cost_operations_decorator) }}" t-if="this.showMoCosts" t-out="this.formatCost(this.state.data.extras.total_mo_cost_operations)"/>
+                                <td class="text-end" t-if="this.showBomCosts" t-out="this.formatCost(this.state.data.extras.total_bom_cost_operations)"/>
+                                <td t-attf-class="text-end" t-if="this.showRealCosts" t-out="this.formatCost(this.state.data.extras.total_real_cost_operations)"/>
                             </tr>
-                            <tr t-if="hasOperations and state.data.summary.quantity != 1">
-                                <td class="text-end" t-att-colspan="totalColspan">
+                            <tr t-if="this.hasOperations and this.state.data.summary.quantity != 1">
+                                <td class="text-end" t-att-colspan="this.totalColspan">
                                     Cost of Operations per unit
-                                    <t t-if="showUom">(in <t t-out='state.data.summary.uom_name'/>)</t>
+                                    <t t-if="this.showUom">(in <t t-out='this.state.data.summary.uom_name'/>)</t>
                                 </td>
-                                <td t-attf-class="text-end {{ getColorClass(state.data.extras.total_mo_cost_operations_decorator) }}" t-if="showMoCosts" t-out="formatCost(state.data.extras.unit_mo_cost_operations)"/>
-                                <td class="text-end" t-if="showBomCosts" t-out="formatCost(state.data.extras.unit_bom_cost_operations)"/>
-                                <td t-attf-class="text-end" t-if="showRealCosts" t-out="formatCost(state.data.extras.unit_real_cost_operations)"/>
+                                <td t-attf-class="text-end {{ this.getColorClass(this.state.data.extras.total_mo_cost_operations_decorator) }}" t-if="this.showMoCosts" t-out="this.formatCost(this.state.data.extras.unit_mo_cost_operations)"/>
+                                <td class="text-end" t-if="this.showBomCosts" t-out="this.formatCost(this.state.data.extras.unit_bom_cost_operations)"/>
+                                <td t-attf-class="text-end" t-if="this.showRealCosts" t-out="this.formatCost(this.state.data.extras.unit_real_cost_operations)"/>
                             </tr>
-                            <tr t-if="hasBreakdown and hasOperations">
-                                <td class="text-end" t-att-colspan="totalColspan">Total Cost of Production</td>
-                                <td t-attf-class="text-end" t-if="showMoCosts" t-out="formatCost(state.data.extras.total_mo_cost)"/>
-                                <td class="text-end" t-if="showBomCosts" t-out="formatCost(state.data.extras.total_bom_cost)"/>
-                                <td t-attf-class="text-end" t-if="showRealCosts" t-out="formatCost(state.data.extras.total_real_cost)"/>
+                            <tr t-if="this.hasBreakdown and this.hasOperations">
+                                <td class="text-end" t-att-colspan="this.totalColspan">Total Cost of Production</td>
+                                <td t-attf-class="text-end" t-if="this.showMoCosts" t-out="this.formatCost(this.state.data.extras.total_mo_cost)"/>
+                                <td class="text-end" t-if="this.showBomCosts" t-out="this.formatCost(this.state.data.extras.total_bom_cost)"/>
+                                <td t-attf-class="text-end" t-if="this.showRealCosts" t-out="this.formatCost(this.state.data.extras.total_real_cost)"/>
                             </tr>
                         </t>
                     </tfoot>
                 </table>
-                <t t-if="hasBreakdown">
+                <t t-if="this.hasBreakdown">
                     <hr/>
                     <h2 class="pt-3">Cost Breakdown of Products</h2>
                     <table name="breakdown" class="table">
@@ -92,18 +92,18 @@
                             <tr>
                                 <th class="text-start">Product</th>
                                 <th class="text-end">Avg Cost of Components per Unit</th>
-                                <th t-if="hasOperations" class="text-end">Avg Cost of Operations per Unit</th>
+                                <th t-if="this.hasOperations" class="text-end">Avg Cost of Operations per Unit</th>
                                 <th class="text-end">Avg Total Cost per Unit</th>
-                                <th t-if="showUom" class="text-end">Unit of Measure</th>
+                                <th t-if="this.showUom" class="text-end">Unit of Measure</th>
                             </tr>
                         </thead>
                         <tbody>
-                            <tr t-foreach="state.data.cost_breakdown" t-as="line" t-key="line.index">
+                            <tr t-foreach="this.state.data.cost_breakdown" t-as="line" t-key="line.index">
                                 <td class="text-start" t-out="line.name"/>
-                                <td class="text-end" t-out="formatCost(line.unit_avg_cost_component)"/>
-                                <td t-if="hasOperations" class="text-end" t-out="formatCost(line.unit_avg_cost_operation)"/>
-                                <td class="text-end" t-out="formatCost(line.unit_avg_total_cost)"/>
-                                <td t-if="showUom" class="text-end" t-out="line.uom_name"/>
+                                <td class="text-end" t-out="this.formatCost(line.unit_avg_cost_component)"/>
+                                <td t-if="this.hasOperations" class="text-end" t-out="this.formatCost(line.unit_avg_cost_operation)"/>
+                                <td class="text-end" t-out="this.formatCost(line.unit_avg_total_cost)"/>
+                                <td t-if="this.showUom" class="text-end" t-out="line.uom_name"/>
                             </tr>
                         </tbody>
                     </table>

--- a/addons/mrp/static/src/components/mo_overview_byproducts_block/mrp_mo_overview_byproducts_block.xml
+++ b/addons/mrp/static/src/components/mo_overview_byproducts_block/mrp_mo_overview_byproducts_block.xml
@@ -2,28 +2,28 @@
 <templates xml:space="preserve">
 
     <t t-name="mrp.MoOverviewByproductsBlock">
-        <t t-if="hasByproducts">
+        <t t-if="this.hasByproducts">
             <tr>
                 <td class="text-start">
-                    <span t-attf-style="margin-left: {{ level * 20 }}px"/>
-                    <button t-on-click="toggleFolded" class="btn btn-light ps-0 py-0" t-attf-aria-label="{{ state.isFolded ? 'Unfold' : 'Fold' }}" t-attf-title="{{ state.isFolded ? 'Unfold' : 'Fold' }}">
-                        <i t-attf-class="fa fa-fw fa-caret-{{ state.isFolded ? 'right' : 'down' }}" role="img"/>
+                    <span t-attf-style="margin-left: {{ this.level * 20 }}px"/>
+                    <button t-on-click="this.toggleFolded" class="btn btn-light ps-0 py-0" t-attf-aria-label="{{ this.state.isFolded ? 'Unfold' : 'Fold' }}" t-attf-title="{{ this.state.isFolded ? 'Unfold' : 'Fold' }}">
+                        <i t-attf-class="fa fa-fw fa-caret-{{ this.state.isFolded ? 'right' : 'down' }}" role="img"/>
                         By-Products
                     </button>
                 </td>
-                <td class="text-center" t-if="props.showOptions.replenishments"/>
+                <td class="text-center" t-if="this.props.showOptions.replenishments"/>
                 <td class="text-end"/>
-                <td class="text-start" t-if="props.showOptions.uom"/>
-                <td class="text-end" t-if="props.showOptions.availabilities"/>
-                <td class="text-end" t-if="props.showOptions.availabilities"/>
-                <td class="text-end" t-if="props.showOptions.receipts"/>
-                <td class="text-end" t-if="props.showOptions.unitCosts"/>
-                <td t-attf-class="text-end {{ getColorClass(props.summary.mo_cost_decorator) }}" t-if="props.showOptions.moCosts" t-out="formatMonetary(props.summary.mo_cost)"/>
-                <td class="text-end" t-if="props.showOptions.bomCosts" t-out="formatMonetary(props.summary.bom_cost)"/>
-                <td t-attf-class="text-end {{ getColorClass(props.summary.real_cost_decorator) }}" t-if="props.showOptions.realCosts" t-out="formatMonetary(props.summary.real_cost)"/>
+                <td class="text-start" t-if="this.props.showOptions.uom"/>
+                <td class="text-end" t-if="this.props.showOptions.availabilities"/>
+                <td class="text-end" t-if="this.props.showOptions.availabilities"/>
+                <td class="text-end" t-if="this.props.showOptions.receipts"/>
+                <td class="text-end" t-if="this.props.showOptions.unitCosts"/>
+                <td t-attf-class="text-end {{ this.getColorClass(this.props.summary.mo_cost_decorator) }}" t-if="this.props.showOptions.moCosts" t-out="this.formatMonetary(this.props.summary.mo_cost)"/>
+                <td class="text-end" t-if="this.props.showOptions.bomCosts" t-out="this.formatMonetary(this.props.summary.bom_cost)"/>
+                <td t-attf-class="text-end {{ this.getColorClass(this.props.summary.real_cost_decorator) }}" t-if="this.props.showOptions.realCosts" t-out="this.formatMonetary(this.props.summary.real_cost)"/>
             </tr>
-            <t t-if="!state.isFolded" t-foreach="props.byproducts" t-as="byproduct" t-key="byproduct.index">
-                <MoOverviewLine data="byproduct" showOptions="props.showOptions"/>
+            <t t-if="!this.state.isFolded" t-foreach="this.props.byproducts" t-as="byproduct" t-key="byproduct.index">
+                <MoOverviewLine data="byproduct" showOptions="this.props.showOptions"/>
             </t>
         </t>
     </t>

--- a/addons/mrp/static/src/components/mo_overview_components_block/mrp_mo_overview_components_block.xml
+++ b/addons/mrp/static/src/components/mo_overview_components_block/mrp_mo_overview_components_block.xml
@@ -2,41 +2,41 @@
 <templates xml:space="preserve">
 
     <t t-name="mrp.MoOverviewComponentsBlock">
-        <t t-foreach="props.components" t-as="component" t-key="component.summary.index">
+        <t t-foreach="this.props.components" t-as="component" t-key="component.summary.index">
             <MoOverviewLine
                 data="component.summary"
-                hasFoldButton="hasReplenishments(component)"
-                isFolded="state.fold[component.summary.index]"
-                showOptions="props.showOptions"
-                toggleFolded.bind="onToggleFolded"/>
+                hasFoldButton="this.hasReplenishments(component)"
+                isFolded="this.state.fold[component.summary.index]"
+                showOptions="this.props.showOptions"
+                toggleFolded.bind="this.onToggleFolded"/>
             <!-- Display Replenishment block -->
-            <t t-if="hasReplenishmentsBlock(component)" t-foreach="component.replenishments" t-as="replenishment" t-key="replenishment.summary.index">
+            <t t-if="this.hasReplenishmentsBlock(component)" t-foreach="component.replenishments" t-as="replenishment" t-key="replenishment.summary.index">
                 <MoOverviewLine
                     data="replenishment.summary"
-                    hasFoldButton="hasComponents(replenishment)"
-                    isFolded="state.fold[replenishment.summary.index]"
-                    showOptions="props.showOptions"
-                    toggleFolded.bind="onToggleFolded"/>
-                <t t-if="hasComponentsBlock(replenishment)">
+                    hasFoldButton="this.hasComponents(replenishment)"
+                    isFolded="this.state.fold[replenishment.summary.index]"
+                    showOptions="this.props.showOptions"
+                    toggleFolded.bind="this.onToggleFolded"/>
+                <t t-if="this.hasComponentsBlock(replenishment)">
                     <MoOverviewComponentsBlock
-                        unfoldAll="state.unfoldAll"
+                        unfoldAll="this.state.unfoldAll"
                         components="replenishment.components"
                         operations="replenishment.operations"
                         byproducts="replenishment.byproducts"
-                        showOptions="props.showOptions"/>
+                        showOptions="this.props.showOptions"/>
                 </t>
             </t>
         </t>
         <MoOverviewOperationsBlock
-            unfoldAll="state.unfoldAll"
-            summary="props.operations.summary"
-            operations="props.operations.details"
-            showOptions="props.showOptions"/>
+            unfoldAll="this.state.unfoldAll"
+            summary="this.props.operations.summary"
+            operations="this.props.operations.details"
+            showOptions="this.props.showOptions"/>
         <MoOverviewByproductsBlock
-            unfoldAll="state.unfoldAll"
-            summary="props.byproducts.summary"
-            byproducts="props.byproducts.details"
-            showOptions="props.showOptions"/>
+            unfoldAll="this.state.unfoldAll"
+            summary="this.props.byproducts.summary"
+            byproducts="this.props.byproducts.details"
+            showOptions="this.props.showOptions"/>
     </t>
 
 </templates>

--- a/addons/mrp/static/src/components/mo_overview_line/mrp_mo_overview_line.xml
+++ b/addons/mrp/static/src/components/mo_overview_line/mrp_mo_overview_line.xml
@@ -1,44 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <tr t-name="mrp.MoOverviewLine" t-on-click="() => this.props.hasFoldButton? this.props.toggleFolded(data.index) : false">
+    <tr t-name="mrp.MoOverviewLine" t-on-click="() => this.props.hasFoldButton? this.props.toggleFolded(this.data.index) : false">
         <td class="text-start">
-            <div t-attf-style="margin-left: {{ marginMultiplicator * 20 }}px" class="d-inline-block">
-                <span t-if="props.hasFoldButton" class="btn btn-light p-0" t-attf-aria-label="{{ foldButtonTitle }}" t-attf-title="{{ foldButtonTitle }}" style="margin-right: 1px">
-                    <i t-attf-class="fa fa-fw fa-caret-{{ props.isFolded ? 'right' : 'down' }}" role="img"/>
+            <div t-attf-style="margin-left: {{ this.marginMultiplicator * 20 }}px" class="d-inline-block">
+                <span t-if="this.props.hasFoldButton" class="btn btn-light p-0" t-attf-aria-label="{{ this.foldButtonTitle }}" t-attf-title="{{ this.foldButtonTitle }}" style="margin-right: 1px">
+                    <i t-attf-class="fa fa-fw fa-caret-{{ this.props.isFolded ? 'right' : 'down' }}" role="img"/>
                 </span>
-                <a t-if="data.id and data.model === 'mrp.workorder'" href="#" t-on-click.prevent="openWorkorder" t-out="data.name"/>
-                <a t-elif="data.id and data.model" href="#" t-on-click.prevent="openForm" t-out="data.name"/>
-                <t t-else="" t-out="data.name"/>
-                <button t-if="data.model === 'to_order'" class="ms-2 py-0 btn btn-secondary" t-on-click="openReplenish">Replenish</button>
+                <a t-if="this.data.id and this.data.model === 'mrp.workorder'" href="#" t-on-click.prevent="this.openWorkorder" t-out="this.data.name"/>
+                <a t-elif="this.data.id and this.data.model" href="#" t-on-click.prevent="this.openForm" t-out="this.data.name"/>
+                <t t-else="" t-out="this.data.name"/>
+                <button t-if="this.data.model === 'to_order'" class="ms-2 py-0 btn btn-secondary" t-on-click="this.openReplenish">Replenish</button>
             </div>
         </td>
-        <td class="text-center" t-if="props.showOptions.replenishments">
+        <td class="text-center" t-if="this.props.showOptions.replenishments">
             <div class="o_field_badge">
-                <span t-attf-class="badge rounded-pill o_mrp_overview_badge {{ stateDecorator }}" t-out="data.formatted_state"/>
+                <span t-attf-class="badge rounded-pill o_mrp_overview_badge {{ this.stateDecorator }}" t-out="this.data.formatted_state"/>
             </div>
         </td>
-        <td t-attf-class="text-end" t-out="formattedQuantity"/>
-        <td t-if="props.showOptions.uom" class="text-start" t-out="data.uom_name"/>
-        <td class="text-end" t-if="props.showOptions.availabilities">
-            <t t-if="hasQuantity('quantity_on_hand')">
-                <t t-out="formatFloat(data.quantity_free)"/> /
-                <t t-out="formatFloat(data.quantity_on_hand)"/>
+        <td t-attf-class="text-end" t-out="this.formattedQuantity"/>
+        <td t-if="this.props.showOptions.uom" class="text-start" t-out="this.data.uom_name"/>
+        <td class="text-end" t-if="this.props.showOptions.availabilities">
+            <t t-if="this.hasQuantity('quantity_on_hand')">
+                <t t-out="this.formatFloat(this.data.quantity_free)"/> /
+                <t t-out="this.formatFloat(this.data.quantity_on_hand)"/>
             </t>
         </td>
-        <td class="text-end" t-if="props.showOptions.availabilities">
-            <t t-if="hasQuantity('quantity_reserved')" t-out="formatFloat(data.quantity_reserved)"/>
+        <td class="text-end" t-if="this.props.showOptions.availabilities">
+            <t t-if="this.hasQuantity('quantity_reserved')" t-out="this.formatFloat(this.data.quantity_reserved)"/>
         </td>
-        <td class="text-end" t-if="props.showOptions.receipts">
-            <t t-if="data.receipt">
-                <span t-attf-class="{{ getColorClass(data.receipt.decorator) }}" t-out="data.receipt.display"/>
-                <a href="#" role="button" t-on-click.prevent="openForecast" title="Forecast Report" t-attf-class="fa fa-fw fa-area-chart ms-1 {{getColorClass(data.receipt.decorator)}}"/>
+        <td class="text-end" t-if="this.props.showOptions.receipts">
+            <t t-if="this.data.receipt">
+                <span t-attf-class="{{ this.getColorClass(this.data.receipt.decorator) }}" t-out="this.data.receipt.display"/>
+                <a href="#" role="button" t-on-click.prevent="this.openForecast" title="Forecast Report" t-attf-class="fa fa-fw fa-area-chart ms-1 {{this.getColorClass(this.data.receipt.decorator)}}"/>
             </t>
         </td>
-        <td class="text-end" t-if="props.showOptions.unitCosts" t-out="formatMonetary(data.unit_cost)"/>
-        <td t-attf-class="text-end {{ getColorClass(data.mo_cost_decorator) }}" t-if="props.showOptions.moCosts" t-out="formatMonetary(data.mo_cost)"/>
-        <td class="text-end" t-if="props.showOptions.bomCosts" t-out="formatMonetary(data.bom_cost)"/>
-        <td t-attf-class="text-end {{ getColorClass(data.real_cost_decorator) }}" t-if="props.showOptions.realCosts" t-out="formatMonetary(data.real_cost)"/>
+        <td class="text-end" t-if="this.props.showOptions.unitCosts" t-out="this.formatMonetary(this.data.unit_cost)"/>
+        <td t-attf-class="text-end {{ this.getColorClass(this.data.mo_cost_decorator) }}" t-if="this.props.showOptions.moCosts" t-out="this.formatMonetary(this.data.mo_cost)"/>
+        <td class="text-end" t-if="this.props.showOptions.bomCosts" t-out="this.formatMonetary(this.data.bom_cost)"/>
+        <td t-attf-class="text-end {{ this.getColorClass(this.data.real_cost_decorator) }}" t-if="this.props.showOptions.realCosts" t-out="this.formatMonetary(this.data.real_cost)"/>
     </tr>
 
 </templates>

--- a/addons/mrp/static/src/components/mo_overview_operations_block/mrp_mo_overview_operations_block.xml
+++ b/addons/mrp/static/src/components/mo_overview_operations_block/mrp_mo_overview_operations_block.xml
@@ -2,28 +2,28 @@
 <templates xml:space="preserve">
 
     <t t-name="mrp.MoOverviewOperationsBlock">
-        <t t-if="hasOperations">
-            <tr t-on-click="toggleFolded">
+        <t t-if="this.hasOperations">
+            <tr t-on-click="this.toggleFolded">
                 <td class="text-start">
-                    <span t-attf-style="margin-left: {{ level * 20 }}px"/>
-                    <span class="btn btn-light ps-0 py-0" t-attf-aria-label="{{ state.isFolded ? 'Unfold' : 'Fold' }}" t-attf-title="{{ state.isFolded ? 'Unfold' : 'Fold' }}">
-                        <i t-attf-class="fa fa-fw fa-caret-{{ state.isFolded ? 'right' : 'down' }}" role="img"/>
+                    <span t-attf-style="margin-left: {{ this.level * 20 }}px"/>
+                    <span class="btn btn-light ps-0 py-0" t-attf-aria-label="{{ this.state.isFolded ? 'Unfold' : 'Fold' }}" t-attf-title="{{ this.state.isFolded ? 'Unfold' : 'Fold' }}">
+                        <i t-attf-class="fa fa-fw fa-caret-{{ this.state.isFolded ? 'right' : 'down' }}" role="img"/>
                         Operations
                     </span>
                 </td>
-                <td class="text-center" t-if="props.showOptions.replenishments"/>
-                <td t-attf-class="text-end" t-out="totalQuantity"/>
-                <td class="text-start" t-if="props.showOptions.uom" t-out="props.summary.uom_name"/>
-                <td class="text-end" t-if="props.showOptions.availabilities"/>
-                <td class="text-end" t-if="props.showOptions.availabilities"/>
-                <td class="text-end" t-if="props.showOptions.receipts"/>
-                <td class="text-end" t-if="props.showOptions.unitCosts"/>
-                <td t-attf-class="text-end {{ getColorClass(props.summary.mo_cost_decorator) }}" t-if="props.showOptions.moCosts" t-out="formatMonetary(props.summary.mo_cost)"/>
-                <td class="text-end" t-if="props.showOptions.bomCosts" t-out="formatMonetary(props.summary.bom_cost)"/>
-                <td t-attf-class="text-end {{ getColorClass(props.summary.real_cost_decorator) }}" t-if="props.showOptions.realCosts" t-out="formatMonetary(props.summary.real_cost)"/>
+                <td class="text-center" t-if="this.props.showOptions.replenishments"/>
+                <td t-attf-class="text-end" t-out="this.totalQuantity"/>
+                <td class="text-start" t-if="this.props.showOptions.uom" t-out="this.props.summary.uom_name"/>
+                <td class="text-end" t-if="this.props.showOptions.availabilities"/>
+                <td class="text-end" t-if="this.props.showOptions.availabilities"/>
+                <td class="text-end" t-if="this.props.showOptions.receipts"/>
+                <td class="text-end" t-if="this.props.showOptions.unitCosts"/>
+                <td t-attf-class="text-end {{ this.getColorClass(this.props.summary.mo_cost_decorator) }}" t-if="this.props.showOptions.moCosts" t-out="this.formatMonetary(this.props.summary.mo_cost)"/>
+                <td class="text-end" t-if="this.props.showOptions.bomCosts" t-out="this.formatMonetary(this.props.summary.bom_cost)"/>
+                <td t-attf-class="text-end {{ this.getColorClass(this.props.summary.real_cost_decorator) }}" t-if="this.props.showOptions.realCosts" t-out="this.formatMonetary(this.props.summary.real_cost)"/>
             </tr>
-            <t t-if="!state.isFolded" t-foreach="props.operations" t-as="operation" t-key="operation.index">
-                <MoOverviewLine data="operation" showOptions="props.showOptions"/>
+            <t t-if="!this.state.isFolded" t-foreach="this.props.operations" t-as="operation" t-key="operation.index">
+                <MoOverviewLine data="operation" showOptions="this.props.showOptions"/>
             </t>
         </t>
     </t>

--- a/addons/mrp/static/src/components/wo_list_view_dropdown/wo_list_view_dropdown.xml
+++ b/addons/mrp/static/src/components/wo_list_view_dropdown/wo_list_view_dropdown.xml
@@ -5,8 +5,8 @@
         <Dropdown t-if="this.props.record.data.state !== 'done'">
             <button t-attf-class="btn btn-link d-flex p-0 {{!this.props.record.resId ? 'invisible': ''}}">
                 <div class="d-flex align-items-center">
-                    <span t-attf-class="o_wo_status {{statusColor}}" t-if="this.props.display === 'bubble'"/>
-                    <span t-out="formattedValue" class="badge rounded-pill" t-attf-class="{{statusColor}}" t-if="this.props.display === 'badge'"/>
+                    <span t-attf-class="o_wo_status {{this.statusColor}}" t-if="this.props.display === 'bubble'"/>
+                    <span t-out="this.formattedValue" class="badge rounded-pill" t-attf-class="{{this.statusColor}}" t-if="this.props.display === 'badge'"/>
                 </div>
             </button>
             <t t-set-slot="content">

--- a/addons/mrp/static/src/widgets/mrp_should_consume.xml
+++ b/addons/mrp/static/src/widgets/mrp_should_consume.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mrp.ShouldConsume">
-        <t t-if="displayShouldConsume">
+        <t t-if="this.displayShouldConsume">
             <span t-attf-class="o_should_consume"> 
-                <span t-if="props.readonly"><t t-out="shouldConsumeQty"/> / </span>
+                <span t-if="this.props.readonly"><t t-out="this.shouldConsumeQty"/> / </span>
                 <t t-call="web.FloatField"/>
             </span>
         </t>

--- a/addons/mrp/static/src/widgets/mrp_workorder_popover.xml
+++ b/addons/mrp/static/src/widgets/mrp_workorder_popover.xml
@@ -3,10 +3,10 @@
 
     <div t-name="mrp.workorderPopover">
         <h6>Scheduling Information</h6>
-        <t t-foreach="props.infos" t-as="info" t-key="info_index">
+        <t t-foreach="this.props.infos" t-as="info" t-key="info_index">
             <i t-attf-class="oi oi-arrow-right me-2 #{ info.color }"></i><t t-out="info.msg"/><br/>
         </t>
-        <button t-if="props.replan" t-on-click="onReplanClick" class="btn btn-sm btn-primary m-1 float-end action_replan_button">Replan</button>
+        <button t-if="this.props.replan" t-on-click="this.onReplanClick" class="btn btn-sm btn-primary m-1 float-end action_replan_button">Replan</button>
     </div>
 
 </templates>

--- a/addons/mrp/static/src/widgets/timer.xml
+++ b/addons/mrp/static/src/widgets/timer.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="mrp.MrpTimer">
-        <span t-out="durationFormatted"/>
+        <span t-out="this.durationFormatted"/>
     </t>
 
     <t t-name="mrp.MrpTimerField">
-        <MrpTimer t-if="props.readonly" value="duration" ongoing="ongoing"/>
-        <input t-else="" t-att-id="props.id" t-custom-ref="numpadDecimal" t-att-placeholder="props.placeholder" inputmode="numeric" class="o_input" />
+        <MrpTimer t-if="this.props.readonly" value="this.duration" ongoing="this.ongoing"/>
+        <input t-else="" t-att-id="this.props.id" t-custom-ref="numpadDecimal" t-att-placeholder="this.props.placeholder" inputmode="numeric" class="o_input" />
     </t>
 </templates>

--- a/addons/mrp_account/static/src/stock_valuation/stock_valuation_report.xml
+++ b/addons/mrp_account/static/src/stock_valuation/stock_valuation_report.xml
@@ -11,9 +11,9 @@
             label.translate="Cost of Production"
             level="0"
             displayDebitCredit="true"
-            onClickMethod.bind="openCostOfProduction"
-            sublines="data.cost_of_production.lines"
-            value="data.cost_of_production.value"/>
+            onClickMethod.bind="this.openCostOfProduction"
+            sublines="this.data.cost_of_production.lines"
+            value="this.data.cost_of_production.value"/>
         <t t-call="stock_account.StockValuationReport.EmptyLine"/>
     </t>
 </templates>

--- a/addons/mrp_subcontracting/static/src/components/bom_overview_components_block/mrp_bom_overview_components_block.xml
+++ b/addons/mrp_subcontracting/static/src/components/bom_overview_components_block/mrp_bom_overview_components_block.xml
@@ -3,12 +3,12 @@
 
     <t t-name="mrp_subcontracting.BomOverviewComponentsBlock" t-inherit="mrp.BomOverviewComponentsBlock" t-inherit-mode="extension">
         <xpath expr="//t[@name='byproducts']" position="after">
-            <t t-if="data.subcontracting">
+            <t t-if="this.data.subcontracting">
                 <BomOverviewSpecialLine
                     type="'subcontracting'"
-                    showOptions="props.showOptions"
-                    data="props.data"
-                    precision="props.precision"
+                    showOptions="this.props.showOptions"
+                    data="this.props.data"
+                    precision="this.props.precision"
                     />
             </t>
         </xpath>

--- a/addons/mrp_subcontracting/static/src/components/bom_overview_special_line/mrp_bom_overview_special_line.xml
+++ b/addons/mrp_subcontracting/static/src/components/bom_overview_special_line/mrp_bom_overview_special_line.xml
@@ -3,19 +3,19 @@
 
     <t t-name="mrp_subcontracting.BomOverviewSpecialLine" t-inherit="mrp.BomOverviewSpecialLine" t-inherit-mode="extension">
         <xpath expr="//td[@name='td_mrp_bom']" position="inside">
-            <t t-if="props.type == 'subcontracting'">Subcontracting: <a href="#" t-on-click.prevent="goToSubcontractor" t-out="subcontracting.name"/></t>
+            <t t-if="this.props.type == 'subcontracting'">Subcontracting: <a href="#" t-on-click.prevent="this.goToSubcontractor" t-out="this.subcontracting.name"/></t>
         </xpath>
 
         <xpath expr="//td[@name='quantity']" position="inside">
-            <span t-if="props.type == 'subcontracting'" t-out="formatFloat(subcontracting.quantity, {'digits': [false, precision]})"/>
+            <span t-if="this.props.type == 'subcontracting'" t-out="this.formatFloat(this.subcontracting.quantity, {'digits': [false, this.precision]})"/>
         </xpath>
 
         <xpath expr="//td[@name='uom']" position="inside">
-            <span t-if="showUom &amp;&amp; props.type == 'subcontracting'" t-out="subcontracting.uom"/>
+            <span t-if="this.showUom &amp;&amp; this.props.type == 'subcontracting'" t-out="this.subcontracting.uom"/>
         </xpath>
 
         <xpath expr="//td[@name='bom_cost']" position="inside">
-            <span t-if="props.type == 'subcontracting'" t-out="formatMonetary(subcontracting.bom_cost)"/>
+            <span t-if="this.props.type == 'subcontracting'" t-out="this.formatMonetary(this.subcontracting.bom_cost)"/>
         </xpath>
     </t>
 


### PR DESCRIPTION
In preparation for OWL3, where template variables will need to use 
`.this` to target component variables, we add `.this` to template 
variables that are targetting the component.

Script PR: https://github.com/odoo/odoo/pull/247965

THIS_TARGETS = ['mrp']
task: OWL3 prep - add `this.` to template variables

Enterprsie PR : https://github.com/odoo/enterprise/pull/109654

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
