### PR TITLE
[FIX] web: restore correct width behavior for `o_field_widget`

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -447,8 +447,13 @@
         }
     }
 
-    
-    .o_form_sheet .o_field_widget:not(.o_input_box_overlay_start, .o_input_box_overlay_end), .o_input_box:not(.o_input_box .o_input_box) {
+    .o_group, .o_inner_group {
+    .o_field_widget:not(.o_input_box_overlay_start, .o_input_box_overlay_end) {
+            width: 100%;
+        }
+    }
+
+    .o_input_box:not(.o_input_box .o_input_box) {
         width: 100%;
     }
 


### PR DESCRIPTION
**Before this PR:**
Width of the element where `o_field_widget` is used was stretched unexpectedly and shifted the fields beside it.

**Technical reason:**
Introduced in https://github.com/odoo/odoo/commit/dc8f38b1054664a0e382530bb4fc73983e2085cb
Here, 100% width is applied to `.o_field_widget` inside `.o_form_sheet` instead of scoping it to `.o_group` and `.o_inner_group`. This overrode some widgets that rely on automatic width.

**After this PR:**
Width is scoped back to its previous behavior, while preserving the input box behavior.

Task-6007715