### PR TITLE
[FIX] account: avoid crash when uploading empty PDF file

### DIFF
--- a/addons/account/models/account_document_import_mixin.py
+++ b/addons/account/models/account_document_import_mixin.py
@@ -501,7 +501,7 @@ class AccountDocumentImportMixin(models.AbstractModel):
         :return: a `files_data` list representation of the embedded attachements.
         """
         embedded = []
-        if file_data['import_file_type'] == 'pdf':
+        if file_data['import_file_type'] == 'pdf' and file_data['raw']:
             for filename, content in extract_pdf_embedded_files(file_data['name'], file_data['raw']):
                 embedded_file_data = {
                     'name': filename,

--- a/addons/account/tests/test_account_move_attachment.py
+++ b/addons/account/tests/test_account_move_attachment.py
@@ -23,3 +23,12 @@ class TestAccountMoveAttachment(HttpCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertTrue(invoice.attachment_ids)
+
+    def test_create_records_from_empty_pdf_attachment(self):
+        """Ensure importing an empty PDF attachment does not crash and still returns created records."""
+        attachment = self.env['ir.attachment'].create({
+            'name': 'invoice.pdf',
+            'mimetype': 'application/pdf',
+        })
+        records = self.env['account.move']._create_records_from_attachments(attachment)
+        self.assertTrue(records)


### PR DESCRIPTION
Issue:
- Uploading an empty PDF triggered a stack trace.
- The uploaded file content sometimes returned False instead of bytes.
- Passing this value to io.BytesIO() raised a TypeError.

Fix:
- Added a check to ensure the content is valid.

Impact:
- Prevents crashes when users upload empty or invalid PDF files.

TaskID-6004471