### PR TITLE
[FIX] point_of_sale: Fix archive product with open restaurant order

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1561,7 +1561,7 @@ class PosOrderLine(models.Model):
 
     @api.model
     def _load_pos_data_domain(self, data, config):
-        return [('order_id', 'in', [order['id'] for order in data['pos.order']])]
+        return [('order_id', 'in', [order['id'] for order in data['pos.order']]), ('product_id.active', '=', True)]
 
     @api.model
     def _load_pos_data_fields(self, config):

--- a/addons/point_of_sale/models/product_template.py
+++ b/addons/point_of_sale/models/product_template.py
@@ -307,9 +307,7 @@ class ProductTemplate(models.Model):
         self._check_is_special_product()
 
     def _ensure_unused_in_pos(self):
-        open_pos_sessions = self.env['pos.session'].sudo().search([('state', '!=', 'closed')])
-        used_products = open_pos_sessions.order_ids.filtered(lambda o: o.state == "draft").lines.product_id.product_tmpl_id
-        if used_products & self:
+        if any(self.mapped('available_in_pos')) and self.env['pos.session'].sudo().search_count([('state', '!=', 'closed')]):
             raise UserError(_(
                 "Hold up! Archiving products while POS sessions are active is like pulling a plate mid-meal.\n"
                 "Make sure to close all sessions first to avoid any issues.",

--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -269,6 +269,14 @@ export class PosData {
 
         const preLoadData = await this.preLoadData(data);
         const missing = await this.missingRecursive(preLoadData);
+
+        const serverProductIds = this.models["product.product"].map((p) => p.id);
+        const databaseProductIds = missing["product.product"]?.map((p) => p.id) ?? [];
+        const loadedProductIds = new Set([...databaseProductIds, ...serverProductIds]);
+        missing["pos.order.line"] = missing["pos.order.line"]?.filter((line) =>
+            loadedProductIds.has(line.product_id)
+        );
+
         const results = this.models.loadConnectedData(missing, []);
 
         await this.checkAndDeleteMissingOrders(results);

--- a/addons/point_of_sale/tests/test_report_session.py
+++ b/addons/point_of_sale/tests/test_report_session.py
@@ -22,9 +22,7 @@ class TestReportSession(TestPoSCommon):
         product_to_archive = self.create_product('Product to archive', self.categ_basic, 100, self.tax1.id)
 
         self.config.open_ui()
-        # check that an unsed product can be archived by any user with archive rights
         self.res_users_stock_user.group_ids |= self.env.ref('product.group_product_manager')
-        product_to_archive.with_user(self.res_users_stock_user).action_archive()
 
         session_id = self.config.current_session_id.id
         order = self.env['pos.order'].create({

--- a/addons/pos_restaurant/tests/test_pos_restaurant_flow.py
+++ b/addons/pos_restaurant/tests/test_pos_restaurant_flow.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.exceptions import UserError
 from odoo.tests import tagged
 from odoo.addons.pos_restaurant.tests.test_frontend import TestFrontendCommon
 
@@ -12,3 +13,57 @@ class TestPosRestaurantFlow(TestFrontendCommon):
         floors.action_archive()
         # All floors should be archived successfully
         self.assertTrue(all(floor.active is False for floor in floors), "All floors should be archived")
+
+    def test_archive_product_with_open_restaurant_order(self):
+        """
+        1. Open a POS session (restaurant).
+        2. Place a draft order on a table with.
+        3. Check that no paid/validated order exists for this product in the backend.
+        4. Trying to archive the product must raise a UserError (session is still open).
+        """
+        self.pos_config.open_ui()
+        session = self.pos_config.current_session_id
+
+        product_variant = self.coca_cola_test
+        product = product_variant.product_tmpl_id
+
+        order_data = {
+            'amount_paid': 0,
+            'amount_return': 0,
+            'amount_tax': 0,
+            'amount_total': product_variant.lst_price,
+            'date_order': '2024-01-01 10:00:00',
+            'fiscal_position_id': False,
+            'pricelist_id': session.config_id.pricelist_id.id,
+            'name': 'Order 00001-001-0001',
+            'last_order_preparation_change': '{}',
+            'lines': [(0, 0, {
+                'id': 1,
+                'pack_lot_ids': [],
+                'price_unit': product_variant.lst_price,
+                'product_id': product_variant.id,
+                'price_subtotal': product_variant.lst_price,
+                'price_subtotal_incl': product_variant.lst_price,
+                'qty': 1,
+                'tax_ids': [],
+            })],
+            'partner_id': False,
+            'session_id': session.id,
+            'payment_ids': [],
+            'uuid': 'test-archive-0001',
+            'user_id': self.env.uid,
+            'to_invoice': False,
+            'state': 'draft',
+            'table_id': self.main_floor_table_5.id,
+        }
+        self.env['pos.order'].sync_from_ui([order_data])
+
+        draft_order = self.env['pos.order'].search([
+            ('session_id', '=', session.id),
+            ('table_id', '=', self.main_floor_table_5.id),
+        ])
+        self.assertTrue(draft_order, "A draft order should exist for the table")
+        self.assertEqual(draft_order.state, 'draft', "The order should be in draft state, not yet paid")
+
+        with self.assertRaises(UserError):
+            product.action_archive()


### PR DESCRIPTION
When we archived a product which was in a open order not already synced with the backend, when we went back to the POS, a TB appeared. In the same way, if we had an order in the future with a product and we closed the POS, archive the product and went back to the POS, the same TB appeared.

task: 6002762

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
