### PR TITLE
[FIX] web_tour: wait for tour registration before execution

### DIFF
--- a/addons/web_tour/static/src/js/tour_service.js
+++ b/addons/web_tour/static/src/js/tour_service.js
@@ -162,6 +162,9 @@ export class TourService {
      * @param {string} name The name of the tour
      */
     async getTour(name, options) {
+        if (options.mode !== "manual") {
+            await this.waitUntilTourRegistered(name);
+        }
         let tour = tourRegistry.get(name, null);
         if (options.mode === "manual" && options.fromDB) {
             tour = await this.orm.call("web_tour.tour", "get_tour_json_by_name", [name]);
@@ -192,16 +195,31 @@ export class TourService {
     }
 
     /**
-     * Wait the tour is ready (only for automatic tour)
+     * Waits up to 5 seconds for a tour to be registered in the client-side
+     * tour registry.
+     *
+     * This is required because after a browser refresh, the tour definition
+     * may not yet be loaded when execution starts. Without this guard,
+     * the tour could abort if it is triggered before being registered.
+     *
+     * @param {string} name - The tour name.
+     * @returns {Promise<boolean>} Resolves to `true` if the tour is found
+     *   within the timeout, otherwise `false`.
+     */
+    async waitUntilTourRegistered(name) {
+        const start = Date.now();
+        while (!tourRegistry.contains(name) && Date.now() - start <= 5000) {
+            await new Promise((r) => setTimeout(r, 50));
+        }
+        return tourRegistry.contains(name);
+    }
+
+    /**
+     * Check that the registry contains the tour (only for automatic tour)
      * @param {string} name The name of the tour
      */
-    async isTourReady(name) {
-        if (!tourRegistry.contains(name)) {
-            return false;
-        }
-        const tour = tourRegistry.get(name);
-        await (tour.wait_for || Promise.resolve());
-        return true;
+    isTourReady(name) {
+        return tourRegistry.contains(name);
     }
 
     async resumeTour() {


### PR DESCRIPTION
Add a `waitUntilTourRegistered` helper to ensure a tour is present in the client-side registry before starting it.

After a browser refresh, the tour definition may not yet be loaded when execution resumes. This could cause the tour to abort because it is triggered before being registered.

The new helper waits up to 5 seconds for the tour to be available, preventing race conditions and improving test stability.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
