### PR TITLE
[FIX] sale_stock: add a field for placeholder widget

### DIFF
--- a/addons/sale_stock/views/sale_order_views.xml
+++ b/addons/sale_stock/views/sale_order_views.xml
@@ -29,6 +29,7 @@
             </field>
             <div name="commitment_date_div" position="after">
                 <field name="effective_date" invisible="not effective_date"/>
+                <field name="expected_date" invisible="1"/>  <!-- Needed for the placeholder widget -->
             </div>
             <field name="commitment_date" position="attributes">
                 <attribute name="options">{'placeholder_field': 'expected_date'}</attribute>


### PR DESCRIPTION
In commit 3854d4c5aba234dbcc59793b2cf4aad01ce34b59 the field was mistakenly removed even though it is necessary for the widget.

