### PR TITLE
[FIX] website_sale: fix minus button on product and cart pages

### DIFF
--- a/addons/website_sale/static/src/interactions/cart_line.js
+++ b/addons/website_sale/static/src/interactions/cart_line.js
@@ -34,7 +34,7 @@ export class CartLine extends Interaction {
         const input = currentTargetEl.closest('.css_quantity').querySelector('input.js_quantity');
         const maxQuantity = parseFloat(input.dataset.max || Infinity);
         const oldQuantity = parseFloat(input.value || 0);
-        const newQuantity = currentTargetEl.querySelector('i').classList.contains('oi-minus')
+        const newQuantity = currentTargetEl.name === 'minus_button'
             ? Math.min(Math.max(oldQuantity - 1, 0), maxQuantity)
             : Math.min(oldQuantity + 1, maxQuantity);
         if (oldQuantity !== newQuantity) {

--- a/addons/website_sale/static/src/interactions/product_page.js
+++ b/addons/website_sale/static/src/interactions/product_page.js
@@ -58,7 +58,7 @@ export class ProductPage extends Interaction {
         const max = parseFloat(input.dataset.max || Infinity);
         const previousQty = parseFloat(input.value || 0);
         const quantity = (
-            ev.currentTarget.name === 'remove_one' ? -1 : 1
+            ev.currentTarget.name === 'minus_button' ? -1 : 1
         ) + previousQty;
         const newQty = quantity > min ? (quantity < max ? quantity : max) : min;
 

--- a/addons/website_sale/templates/checkout/cart_templates.xml
+++ b/addons/website_sale/templates/checkout/cart_templates.xml
@@ -179,6 +179,7 @@
         >
             <t t-if="should_show_quantity_selector and line._is_sellable()">
                 <button
+                    name="minus_button"
                     class="btn btn-link d-inline-block border-end-0"
                     aria-label="Remove one"
                     title="Remove one"

--- a/addons/website_sale/templates/product_page_templates.xml
+++ b/addons/website_sale/templates/product_page_templates.xml
@@ -850,6 +850,7 @@
                 contenteditable="false"
             >
                 <button
+                    name="minus_button"
                     class="btn btn-link pe-2 border-0"
                     aria-label="Remove one"
                     title="Remove one"


### PR DESCRIPTION
The minus button name was wrongly removed in [1], which made the button
perform an addition instead of a subtraction.

This fix puts the name back. It also makes the minus button on the cart page
use a name instead of relying on the icon (since the icon can be changed via
the website editor).

[1] https://github.com/odoo/odoo/pull/220597