### PR TITLE
[IMP] l10n_pl_edi: set default KSeF mode to test and improve settings UX

### DIFF
--- a/addons/l10n_pl_edi/models/res_config_settings.py
+++ b/addons/l10n_pl_edi/models/res_config_settings.py
@@ -29,6 +29,17 @@ class ResConfigSettings(models.TransientModel):
         readonly=False,
     )
 
+    l10n_pl_edi_ksef_mode = fields.Selection(
+        selection=[
+            ('test', 'TEST'),
+            ('prod', 'PRODUCTION')
+        ],
+        string="KSeF Environment",
+        config_parameter='l10n_pl_edi_ksef.mode',
+        default='test',
+        readonly=True,
+    )
+
     @api.depends('company_id')
     def _compute_l10n_pl_edi_certificate(self):
         for config in self:

--- a/addons/l10n_pl_edi/tools/ksef_api_service.py
+++ b/addons/l10n_pl_edi/tools/ksef_api_service.py
@@ -24,7 +24,7 @@ class KsefApiService:
     def __init__(self, company):
         self.company = company
         self.env = company.env
-        self.mode = self.env['ir.config_parameter'].sudo().get_param('l10n_pl_edi_ksef.mode') or 'prod'
+        self.mode = self.env['ir.config_parameter'].sudo().get_param('l10n_pl_edi_ksef.mode') or 'test'
         self.refresh_token = company.l10n_pl_edi_refresh_token
         self.api_url = self._get_api_url()
         self.raw_symmetric_key = base64.b64decode(company.l10n_pl_edi_session_key) if company.l10n_pl_edi_session_key else None

--- a/addons/l10n_pl_edi/views/res_config_settings_views.xml
+++ b/addons/l10n_pl_edi/views/res_config_settings_views.xml
@@ -19,6 +19,19 @@
                                 placeholder="certificate.pem"
                             />
                         </div>
+                        <div class="row mt-3" invisible="not l10n_pl_edi_register">
+                            <div class="col-12">
+                                <div class="text-success fw-bold" invisible="not l10n_pl_edi_access_token">
+                                    <i class="fa fa-check-circle"/> Connected and Authenticated to KSeF
+                                    (<field name="l10n_pl_edi_ksef_mode" class="oe_inline"/>)
+                                </div>
+                                <div class="text-warning fw-bold" invisible="l10n_pl_edi_access_token">
+                                    <i class="fa fa-exclamation-triangle"/> Not Authenticated. Will connect to KSeF
+                                    (<field name="l10n_pl_edi_ksef_mode" class="oe_inline"/>) upon saving.
+                                </div>
+
+                            </div>
+                        </div>
                     </div>
                 </setting>
             </xpath>


### PR DESCRIPTION
- Ensure the KSeF integration defaults to the 'test' environment if the `l10n_pl_edi_ksef.mode` system parameter is not set.

- Enhance the settings view to dynamically display the active environment mode and provide clear visual feedback on the authentication status (Connected vs. Not Authenticated) based on the access token.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
