### PR TITLE
[FIX] stock: allow reverting a scrapped move

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -1200,7 +1200,7 @@ class StockMoveLine(models.Model):
         self = self.with_context(inventory_mode=False)
         processed_move_line = self.env['stock.move.line']
         for move_line in self:
-            if move_line.is_inventory and not move_line.uom_id.is_zero(move_line.quantity):
+            if (move_line.is_inventory or move_line.is_scrap) and not move_line.uom_id.is_zero(move_line.quantity):
                 processed_move_line += move_line
                 move_vals.append(move_line._get_revert_inventory_move_values())
         if not processed_move_line:

--- a/addons/stock/tests/test_quant_inventory_mode.py
+++ b/addons/stock/tests/test_quant_inventory_mode.py
@@ -325,6 +325,36 @@ class TestEditableQuant(TransactionCase):
         move_lines.action_revert()
         self.assertEqual(self.product.qty_available, 0, "After revert multi inventory adjustment qty is not zero")
 
+    def test_revert_scrap_move(self):
+        """Try to revert a scrapped move"""
+        default_wh = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        default_stock_location = default_wh.lot_stock_id
+        scrap_location = default_wh.company_id.scrap_location_id
+        # Put 1 unit in stock
+        quant = self.Quant.create({
+            'product_id': self.product.id,
+            'location_id': default_stock_location.id,
+            'inventory_quantity': 1,
+        })
+        quant.action_apply_inventory()
+        self.assertEqual(self.product.qty_available, 1)
+        # Scrap the product
+        scrap = self.env['stock.move'].create({
+            'is_scrap': True,
+            'product_id': self.product.id,
+            'location_id': default_stock_location.id,
+            'location_dest_id': scrap_location.id,
+            'quantity': 1,
+            'company_id': self.env.company.id,
+        })
+        scrap._action_scrap()
+        self.assertEqual(self.product.qty_available, 0, "After scrapping, qty should be 0")
+        # Revert the scrap move
+        scrap_move_line = scrap.move_line_ids
+        self.assertEqual(len(scrap_move_line), 1)
+        scrap_move_line.action_revert()
+        self.assertEqual(self.product.qty_available, 1, "After reverting scrap, qty should be restored to 1")
+
     def test_set_inventory_quant_to_zero(self):
         """Try to set inventory quantity to zero and check that the quant is deleted after unlinking zero quants"""
         default_wh = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)


### PR DESCRIPTION
This commit enables reverting a scrapped move. Previously, it was only
possible to revert inventory adjustment moves and commit
https://github.com/odoo/odoo/commit/1c7d80a10b5d7db1c4163166bf52b3f3c77044ba was supposed to add the ability in.

Task: 6001058