### PR TITLE
[IMP] resource: clean up resource calendar names

### DIFF
--- a/addons/hr/data/hr_demo.xml
+++ b/addons/hr/data/hr_demo.xml
@@ -24,7 +24,7 @@
 
         <!-- Resource Calendar -->
         <record id="resource_calendar_std_20h" model="resource.calendar">
-            <field name="name">Standard 20 hours/week</field>
+            <field name="name">20 hours/week</field>
             <field name="company_id" eval="False"/>
             <field name="hours_per_day">4.0</field>
             <field name="attendance_ids"
@@ -235,7 +235,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="wage">7540.00</field>
             <field name="job_id" ref="hr.job_cto"/>
             <field name="department_id" ref="dep_management"/>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
+            <field name="resource_calendar_id" ref="resource.resource_calendar_std_40h"/>
             <field name="private_street">215 Vine St</field>
             <field name="private_city">Scranton</field>
             <field name="private_zip">18503</field>
@@ -260,7 +260,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="parent_id" ref="employee_admin"/>
             <field name="job_id" ref="hr.job_marketing"/>
             <field name="category_ids" eval="[Command.set([ref('employee_category_4'), ref('employee_category_2')])]"/>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
+            <field name="resource_calendar_id" ref="resource.resource_calendar_std_40h"/>
             <field name="work_location_id" ref="work_location_1"/>
             <field name="work_contact_id" ref="hr.work_contact_ngh"/>
             <field name="image_1920" type="bytes" file="hr/static/img/employee_ngh-image.jpg"/>
@@ -289,7 +289,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="job_id" ref="hr.job_developer"/>
             <field name="department_id" ref="dep_rd"/>
             <field name="parent_id" ref="employee_admin"/>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
+            <field name="resource_calendar_id" ref="resource.resource_calendar_std_40h"/>
             <field name="private_street">361-7936 Feugiat St.</field>
             <field name="private_zip">58521</field>
             <field name="private_city">Williston</field>
@@ -324,7 +324,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="job_id" ref="hr.job_cto"/>
             <field name="department_id" ref="dep_rd"/>
             <field name="parent_id" ref="employee_qdp"/>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
+            <field name="resource_calendar_id" ref="resource.resource_calendar_std_40h"/>
             <field name="work_location_id" ref="work_location_1"/>
             <field name="hr_responsible_id" ref="base.user_admin"/>
             <field name="sex">male</field>
@@ -353,7 +353,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="job_id" ref="hr.job_hrm"/>
             <field name="department_id" ref="dep_administration"/>
             <field name="parent_id" ref="employee_admin"/>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
+            <field name="resource_calendar_id" ref="resource.resource_calendar_std_40h"/>
             <field name="work_location_id" ref="work_location_1"/>
             <field name="hr_responsible_id" ref="base.user_admin"/>
             <field name="sex">female</field>
@@ -375,7 +375,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="job_title">Consultant</field>
             <field name="private_country_id" ref="base.us"/>
             <field name="private_email">abigail.peterson33@example.com</field>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
+            <field name="resource_calendar_id" ref="resource.resource_calendar_std_40h"/>
             <field name="work_location_id" ref="work_location_1"/>
             <field name="work_contact_id" ref="hr.work_contact_hne"/>
             <field name="image_1920" type="bytes" file="hr/static/img/employee_hne-image.jpg"/>
@@ -419,7 +419,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="job_id" ref="hr.job_consultant"/>
             <field name="department_id" ref="dep_ps"/>
             <field name="parent_id" ref="employee_ngh"/>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
+            <field name="resource_calendar_id" ref="resource.resource_calendar_std_40h"/>
             <field name="work_location_id" ref="work_location_1"/>
             <field name="hr_responsible_id" ref="base.user_admin"/>
             <field name="hourly_cost">50</field>
@@ -448,7 +448,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="parent_id" ref="employee_ngh"/>
             <field name="job_id" ref="hr.job_marketing"/>
             <field name="job_title">Marketing and Community Manager</field>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
+            <field name="resource_calendar_id" ref="resource.resource_calendar_std_40h"/>
             <field name="work_location_id" ref="work_location_1"/>
             <field name="work_contact_id" ref="hr.work_contact_lur"/>
             <field name="image_1920" type="bytes" file="hr/static/img/employee_lur-image.jpg"/>
@@ -472,7 +472,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="parent_id" ref="employee_ngh"/>
             <field name="job_id" ref="hr.job_marketing"/>
             <field name="job_title">Marketing and Community Manager</field>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
+            <field name="resource_calendar_id" ref="resource.resource_calendar_std_40h"/>
             <field name="work_location_id" ref="work_location_1"/>
             <field name="work_contact_id" ref="hr.work_contact_jod"/>
             <field name="image_1920" type="bytes" file="hr/static/img/employee_jod-image.jpg"/>
@@ -505,7 +505,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="job_id" ref="hr.job_developer"/>
             <field name="department_id" ref="dep_rd"/>
             <field name="parent_id" ref="employee_al"/>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
+            <field name="resource_calendar_id" ref="resource.resource_calendar_std_40h"/>
             <field name="work_location_id" ref="work_location_1"/>
             <field name="hr_responsible_id" ref="base.user_admin"/>
             <field name="sex">male</field>
@@ -527,7 +527,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="job_title">Consultant</field>
             <field name="private_country_id" ref="base.us"/>
             <field name="private_email">Doris.cole.LoveSong@example.com</field>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
+            <field name="resource_calendar_id" ref="resource.resource_calendar_std_40h"/>
             <field name="work_location_id" ref="work_location_1"/>
             <field name="work_contact_id" ref="hr.work_contact_jep"/>
             <field name="image_1920" type="bytes" file="hr/static/img/employee_jep-image.jpg"/>
@@ -553,7 +553,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="job_id" ref="hr.job_consultant"/>
             <field name="job_title">Consultant</field>
             <field name="work_location_id" ref="work_location_1"/>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
+            <field name="resource_calendar_id" ref="resource.resource_calendar_std_40h"/>
             <field name="work_contact_id" ref="hr.work_contact_jgo"/>
             <field name="image_1920" type="bytes" file="hr/static/img/employee_jgo-image.jpg"/>
             <field name="date_version" eval="'2010-01-01'"/>
@@ -614,7 +614,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="job_id" ref="hr.job_developer"/>
             <field name="department_id" ref="dep_rd"/>
             <field name="parent_id" ref="employee_fme"/>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
+            <field name="resource_calendar_id" ref="resource.resource_calendar_std_40h"/>
             <field name="private_country_id" ref="base.us"/>
             <field name="private_phone">(538)-672-3185</field>
             <field name="private_email">anita.oliver00@example.com</field>
@@ -646,7 +646,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="job_id" ref="hr.job_developer"/>
             <field name="department_id" ref="dep_management"/>
             <field name="parent_id" ref="employee_qdp"/>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
+            <field name="resource_calendar_id" ref="resource.resource_calendar_std_40h"/>
             <field name="work_location_id" ref="work_location_1"/>
             <field name="hr_responsible_id" ref="base.user_admin"/>
             <field name="sex">female</field>
@@ -675,7 +675,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="job_id" ref="hr.job_developer"/>
             <field name="department_id" ref="dep_rd"/>
             <field name="parent_id" ref="employee_qdp"/>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
+            <field name="resource_calendar_id" ref="resource.resource_calendar_std_40h"/>
             <field name="work_location_id" ref="work_location_1"/>
             <field name="hr_responsible_id" ref="base.user_admin"/>
             <field name="sex">male</field>
@@ -704,7 +704,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="job_id" ref="hr.job_developer"/>
             <field name="department_id" ref="dep_rd"/>
             <field name="parent_id" ref="employee_fme"/>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
+            <field name="resource_calendar_id" ref="resource.resource_calendar_std_40h"/>
             <field name="work_location_id" ref="work_location_1"/>
             <field name="hr_responsible_id" ref="base.user_admin"/>
             <field name="sex">female</field>
@@ -732,7 +732,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="job_id" ref="hr.job_developer"/>
             <field name="department_id" ref="dep_rd_ltp"/>
             <field name="parent_id" ref="employee_qdp"/>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
+            <field name="resource_calendar_id" ref="resource.resource_calendar_std_40h"/>
             <field name="work_location_id" ref="work_location_1"/>
             <field name="hr_responsible_id" ref="base.user_admin"/>
             <field name="sex">male</field>
@@ -759,7 +759,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="job_id" ref="hr.job_developer"/>
             <field name="department_id" ref="dep_rd"/>
             <field name="parent_id" ref="employee_jve"/>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
+            <field name="resource_calendar_id" ref="resource.resource_calendar_std_40h"/>
             <field name="work_location_id" ref="work_location_1"/>
             <field name="hr_responsible_id" ref="base.user_admin"/>
             <field name="sex">male</field>
@@ -781,7 +781,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="job_title">Experienced Developer</field>
             <field name="private_country_id" ref="base.us"/>
             <field name="private_email">beth.evans@example.com</field>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
+            <field name="resource_calendar_id" ref="resource.resource_calendar_std_40h"/>
             <field name="work_location_id" ref="work_location_1"/>
             <field name="work_contact_id" ref="hr.work_contact_jog"/>
             <field name="image_1920" type="bytes" file="hr/static/img/employee_jog-image.jpg"/>
@@ -807,7 +807,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="contract_date_end">1885-09-07</field>
             <field name="employee_type_id" ref="contract_type_employee"/>
             <field name="structure_type_id" ref="structure_type_employee"/>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
+            <field name="resource_calendar_id" ref="resource.resource_calendar_std_40h"/>
             <field name="wage">15.00</field>
             <field name="job_id" ref="hr.job_consultant"/>
             <field name="department_id" ref="dep_administration"/>
@@ -854,7 +854,7 @@ If you have development competencies, we can propose you specific traineeships</
             <field name="wage">2000.00</field>
             <field name="job_id" ref="hr.job_hrm"/>
             <field name="department_id" ref="hr.dep_administration"/>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
+            <field name="resource_calendar_id" ref="resource.resource_calendar_std_40h"/>
         </record>
 
         <!-- Assign manager for each department -->
@@ -884,11 +884,11 @@ If you have development competencies, we can propose you specific traineeships</
 
         <!-- Structure Types -->
         <record id="structure_type_employee_cp200_pfi" model="hr.payroll.structure.type">
-            <field name="default_resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
+            <field name="default_resource_calendar_id" ref="resource.resource_calendar_std_40h"/>
         </record>
 
         <record id="structure_type_employee_cp200" model="hr.payroll.structure.type">
-            <field name="default_resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
+            <field name="default_resource_calendar_id" ref="resource.resource_calendar_std_40h"/>
         </record>
     </data>
 </odoo>

--- a/addons/hr_holidays/static/src/components/float_time_selection/float_time_selection.js
+++ b/addons/hr_holidays/static/src/components/float_time_selection/float_time_selection.js
@@ -98,6 +98,9 @@ export class FloatTimeSelectionField extends FloatTimeField {
     onClose() {
         this.props.record.update({ [this.props.name]: this.timeValues.floatValue });
     }
+
+    // Remove the tooltip that shows up in the float time selection widget
+    openPopover() {}
 }
 
 export const charHours = {

--- a/addons/resource/data/resource_data.xml
+++ b/addons/resource/data/resource_data.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
         <record id="resource_calendar_std" model="resource.calendar">
-            <field name="name">Standard 40 hours/week</field>
+            <field name="name">40 hours/week</field>
             <field name="company_id" ref="base.main_company"/>
             <field name="full_time_required_hours">40</field>
         </record>

--- a/addons/resource/data/resource_demo.xml
+++ b/addons/resource/data/resource_demo.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
         <record id="resource_calendar_std_35h" model="resource.calendar">
-            <field name="name">Standard 35 hours/week</field>
+            <field name="name">35 hours/week</field>
             <field name="company_id" ref="base.main_company"/>
             <field name="attendance_ids"
                 eval="[(5, 0, 0),
@@ -15,20 +15,20 @@
             />
         </record>
 
-        <record id="resource_calendar_std_38h" model="resource.calendar">
-            <field name="name">Standard 38 hours/week</field>
+        <record id="resource_calendar_std_40h" model="resource.calendar">
+            <field name="name">40 hours/week</field>
             <field name="company_id" eval="False"/>
-            <field name="hours_per_day">7.6</field>
+            <field name="hours_per_day">8</field>
             <field name="attendance_ids"
                 eval="[(5, 0, 0),
-                    (0, 0, {'dayofweek': '0', 'duration_hours': 7.6, 'hour_from': 0, 'hour_to': 0}),
-                    (0, 0, {'dayofweek': '1', 'duration_hours': 7.6, 'hour_from': 0, 'hour_to': 0}),
-                    (0, 0, {'dayofweek': '2', 'duration_hours': 7.6, 'hour_from': 0, 'hour_to': 0}),
-                    (0, 0, {'dayofweek': '3', 'duration_hours': 7.6, 'hour_from': 0, 'hour_to': 0}),
-                    (0, 0, {'dayofweek': '4', 'duration_hours': 7.6, 'hour_from': 0, 'hour_to': 0}),
+                    (0, 0, {'dayofweek': '0', 'duration_hours': 8, 'hour_from': 0, 'hour_to': 0}),
+                    (0, 0, {'dayofweek': '1', 'duration_hours': 8, 'hour_from': 0, 'hour_to': 0}),
+                    (0, 0, {'dayofweek': '2', 'duration_hours': 8, 'hour_from': 0, 'hour_to': 0}),
+                    (0, 0, {'dayofweek': '3', 'duration_hours': 8, 'hour_from': 0, 'hour_to': 0}),
+                    (0, 0, {'dayofweek': '4', 'duration_hours': 8, 'hour_from': 0, 'hour_to': 0}),
                 ]"
             />
-            <field name="full_time_required_hours">38</field>
+            <field name="full_time_required_hours">40</field>
         </record>
 
     </data>

--- a/addons/resource/models/res_company.py
+++ b/addons/resource/models/res_company.py
@@ -31,7 +31,7 @@ class ResCompany(models.Model):
     def _prepare_resource_calendar_values(self):
         self.ensure_one()
         return {
-            'name': _('Standard 40 hours/week'),
+            'name': _('40 hours/week'),
             'company_id': self.id,
         }
 

--- a/addons/sale_timesheet/data/sale_service_demo.xml
+++ b/addons/sale_timesheet/data/sale_service_demo.xml
@@ -31,7 +31,7 @@
             <field name="parent_id" ref="hr.employee_al"/>
             <field name="job_id" ref="sale_timesheet.job_engineer"/>
             <field name="category_ids" eval="[(6, 0, [ref('hr.employee_category_4')])]"/>
-            <field name="resource_calendar_id" ref="resource.resource_calendar_std_38h"/>
+            <field name="resource_calendar_id" ref="resource.resource_calendar_std_40h"/>
             <field name="work_location_id" ref="hr.work_location_1"/>
             <field name="work_phone">(535)-495-4164</field>
             <field name="work_contact_id" ref="sale_timesheet.work_contact_jjo"/>


### PR DESCRIPTION
Shorten the names of resource calendar names for working hours by removing "Standard" from the names. Clean up the names of demo data and in the default resource calendar creation.

Task: 5979729

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
