### PR TITLE
[FIX] mail:  display time correctly in direct messages

### DIFF
--- a/addons/mail/static/src/core/public_web/discuss_content.js
+++ b/addons/mail/static/src/core/public_web/discuss_content.js
@@ -52,7 +52,7 @@ export class DiscussContent extends Component {
                 }
                 return 60000 - (Date.now() % 60000);
             },
-            () => [this.thread?.correspondent?.persona?.tz, this.store.self?.tz]
+            () => [this.thread?.channel?.correspondent?.persona?.tz, this.store.self?.tz]
         );
     }
 

--- a/addons/mail/static/tests/discuss/core/public_web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/public_web/discuss.test.js
@@ -7,7 +7,14 @@ import {
     startServer,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, expect, test } from "@odoo/hoot";
-import { Command, mockService, patchWithCleanup, withUser } from "@web/../tests/web_test_helpers";
+import { mockDate } from "@odoo/hoot-mock";
+import {
+    Command,
+    mockService,
+    patchWithCleanup,
+    serverState,
+    withUser,
+} from "@web/../tests/web_test_helpers";
 
 import { rpc } from "@web/core/network/rpc";
 
@@ -59,4 +66,21 @@ test("notify message to user as non member", async () => {
     );
     await contains(".o-mail-Message:has(:text('Hello!'))");
     expect.verifySteps(["push notification"]);
+});
+
+test("show correspondent local time in DM header when timezones differ", async () => {
+    mockDate("2026-01-01 12:00:00");
+    const pyEnv = await startServer();
+    pyEnv["res.partner"].write([serverState.partnerId], { tz: "Europe/Brussels" });
+    const partnerId = pyEnv["res.partner"].create({ name: "Demo", tz: "Asia/Kolkata" });
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: partnerId }),
+        ],
+        channel_type: "chat",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-DiscussContent-header:has(:text('17:30 local time'))");
 });

--- a/addons/mail/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_partner.js
@@ -329,6 +329,7 @@ export class ResPartner extends webModels.ResPartner {
             "email",
             "active",
             "is_company",
+            "tz",
             mailDataHelpers.Store.one("main_user_id", ["share"]),
             ...this._get_store_im_status_fields(),
         ];


### PR DESCRIPTION
Before this PR:
The time was not displayed in direct message conversations because the
timezone dependency relied on `thread.correspondent`, while the
correspondent is now stored on the `channel` model since https://github.com/odoo/odoo/pull/241072.

After this PR:
The timezone dependency now retrieves the correspondent from
`thread.channel.correspondent`, ensuring the correct timezone is used and
the time is displayed properly in direct messages.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
