### PR TITLE
[FIX] l10n_ar: allow "Export Invoices" document type for "IVA Sujeto Exento" companies

### DIFF
--- a/addons/l10n_ar/models/account_journal.py
+++ b/addons/l10n_ar/models/account_journal.py
@@ -57,7 +57,7 @@ class AccountJournal(models.Model):
         letters_data = {
             'issued': {
                 '1': ['A', 'B', 'E', 'M'],
-                '4': ['C'],
+                '4': ['C', 'E'],
                 '5': [],
                 '6': ['C', 'E'],
                 '7': ['B', 'C', 'I'],


### PR DESCRIPTION
**Steps to reproduce:**
- Install l10n_ar
- Create a Argentinian company with "AFIP Responsibility Type" set to "IVA Sujeto Exento" (VAT exempt)
- Switch to the created company

- In Accounting settings, set up "AFIP Web Services"
- Create a journal for export invoices

- Create a customer with "AFIP Responsibility Type" set to "Cliente del Exterior"

- Create an invoice
- Select the created customer
- Try to set the document type for export invoices

**Issue:**
It is not possible to select "(19) EXPORT INVOICES" as "Document Type" for companies having "AFIP Responsibility Type" set to "IVA Sujeto Exento". It is not because the company is "VAT exempt" that it should not be able to create an export invoice.

opw-5974268




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
