### PR TITLE
[FIX] point_of_sale: use all attributes on product scan

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1202,7 +1202,7 @@ export class PosStore extends WithLazyGetterTrap {
                 values.attribute_value_ids = [];
             }
             values.attribute_value_ids = values.attribute_value_ids.concat(
-                values.product_id.product_template_variant_value_ids.map((attr) => ["link", attr])
+                values.product_id.product_template_attribute_value_ids.map((attr) => ["link", attr])
             );
         }
     };

--- a/addons/point_of_sale/static/tests/pos/tours/barcode_scanning_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/barcode_scanning_tour.js
@@ -1,7 +1,8 @@
 import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
+import * as ProductConfiguratorPopup from "@point_of_sale/../tests/pos/tours/utils/product_configurator_util";
+import * as Order from "@point_of_sale/../tests/generic_helpers/order_widget_util";
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
-import * as ProductConfigurator from "@point_of_sale/../tests/pos/tours/utils/product_configurator_util";
 import { registry } from "@web/core/registry";
 import { scan_barcode } from "@point_of_sale/../tests/generic_helpers/utils";
 
@@ -56,7 +57,7 @@ registry.category("web_tour.tours").add("BarcodeScanningProductPackagingTour", {
 
             // Add Product which has no barcode, but it's packaging has one
             scan_barcode("12345618"),
-            ProductConfigurator.pickMulti("Cushion"),
+            ProductConfiguratorPopup.pickMulti("Cushion"),
             Dialog.confirm(),
             ProductScreen.selectedOrderlineHas("Packaging Product2", 10),
             Chrome.endTour(),
@@ -116,6 +117,29 @@ registry.category("web_tour.tours").add("test_quantity_package_of_non_basic_unit
             Dialog.confirm("Open Register"),
             scan_barcode("555555"),
             ProductScreen.selectedOrderlineHas("Cord", 12),
+            Chrome.endTour(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_variants_merge_line_barcode", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("A variant product"),
+            ProductConfiguratorPopup.pickRadio("S"),
+            Dialog.confirm(),
+            Order.hasLine({
+                productName: "A variant product",
+                quantity: 1,
+                attributeLine: "S, blue",
+            }),
+            scan_barcode("TEST123"),
+            Order.hasLine({
+                productName: "A variant product",
+                quantity: 2,
+                attributeLine: "S, Blue",
+            }),
             Chrome.endTour(),
         ].flat(),
 });

--- a/addons/point_of_sale/tests/test_pos_product_variants.py
+++ b/addons/point_of_sale/tests/test_pos_product_variants.py
@@ -289,3 +289,31 @@ class TestPoSProductVariants(ProductVariantsCommon, TestPointOfSaleHttpCommon):
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_image_variants_displayed', login="pos_user")
+
+    def test_variants_merge_line_barcode(self):
+        """Tests the price of products with always variant when added to cart"""
+        product_template = self.env['product.template'].create({
+            'name': 'A variant product',
+            'uom_id': self.env.ref('uom.product_uom_unit').id,
+            'is_storable': True,
+            'taxes_id': False,
+            'available_in_pos': True,
+            'pos_categ_ids': [Command.set(self.pos_desk_misc_test.ids)],
+        })
+        self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': product_template.id,
+            'attribute_id': self.size_attribute.id,
+            'value_ids': [Command.set([self.size_attribute_s.id, self.size_attribute_m.id])],
+        })
+        self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': product_template.id,
+            'attribute_id': self.color_attribute.id,
+            'value_ids': [Command.set([self.color_attribute_blue.id])],
+        })
+        product_S_blue = self.env["product.product"].search([("product_tmpl_id", "=", product_template.id)])[0]
+        self.assertEqual(len(product_S_blue.product_template_variant_value_ids), 1)  # Size S (only size varies)
+        self.assertEqual(len(product_S_blue.product_template_attribute_value_ids), 2)  # Attributes: S, blue
+        product_S_blue.barcode = "TEST123"
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_variants_merge_line_barcode', login="pos_user")


### PR DESCRIPTION
Currently, when a product has more attribute values then variant values (some attribue can have only one option), the pos behaves differently depending if you select the product or scan it.

Steps to reproduce:
-------------------
* Modify the acoustic bloc screen "Attributes & Variants" tab
* Have one attribute line Color, only White as values
* Have one attribute line Size, S and M as values
* Go to the variants, select the one corresponding to the Size S
> Observe it also has the attribute White
* Set a barcode on this variant
* Open shop
* Select Acoustic Bloc Screens, select Size S, confirm
* Now scan the barcode
> Observation:
  2 Different pos order lines on the order, the first shows S, White as attributes, the second one only shows S.

Why the fix:
------------
We need to use all attribute values, not only the variant values.

opw-5932560