### PR TITLE
[FIX] web: tooltip: domain t-out-ed as string

### DIFF
--- a/addons/web/static/src/views/fields/field_tooltip.js
+++ b/addons/web/static/src/views/fields/field_tooltip.js
@@ -3,6 +3,14 @@ export function getTooltipInfo(params) {
     if (params.fieldInfo.widget) {
         widgetDescription = params.fieldInfo.field.displayName;
     }
+    let domain = params.fieldInfo.domain || params.field.domain;
+    let context = params.fieldInfo.context;
+    if (domain && typeof domain !== "string") {
+        domain = JSON.stringify(domain);
+    }
+    if (context && typeof context !== "string") {
+        context = JSON.stringify(context);
+    }
 
     const info = {
         viewMode: params.viewMode,
@@ -15,8 +23,8 @@ export function getTooltipInfo(params) {
             type: params.field.type,
             widget: params.fieldInfo.widget,
             widgetDescription,
-            context: params.fieldInfo.context,
-            domain: params.fieldInfo.domain || params.field.domain,
+            context,
+            domain,
             invisible: params.fieldInfo.invisible,
             column_invisible: params.fieldInfo.column_invisible,
             readonly: params.fieldInfo.readonly,


### PR DESCRIPTION
Because of the conversion of all t-esc to t-out, sometimes objects are used verbatim and make the interface crash.

This happened in FieldTooltip in debug mode with the domain.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
