### PR TITLE
[FIX] stock_account: fix avco report and added value computation

### DIFF
--- a/addons/stock_account/report/stock_avco_audit_report.py
+++ b/addons/stock_account/report/stock_avco_audit_report.py
@@ -100,25 +100,26 @@ WHERE
             total_quantity = 0.0
             avco = 0.0
             for record in total_records:
-                in_qty = record.quantity
-                in_value = record.value
+                qty = record.quantity
                 if record.res_model_name == 'stock.move':
                     previous_qty = total_quantity
-                    total_quantity += in_qty
-
-                    # Regular case, value from accumulation
-                    if previous_qty > 0:
-                        total_value += in_value
-                        avco = total_value / total_quantity if not float_is_zero(total_quantity, precision_digits=self.env['decimal.precision'].precision_get('Product Unit')) else avco
-                    # From negative quantity case, value from last_in
-                    elif previous_qty <= 0:
-                        avco = in_value / in_qty if in_qty else avco
-                        total_value = avco * total_quantity
-
-                    added_value = avco * in_qty
+                    total_quantity += qty
+                    if qty > 0:
+                        added_value = record.value
+                        # Regular case, value from accumulation
+                        if previous_qty > 0:
+                            total_value += added_value
+                            avco = total_value / total_quantity if not float_is_zero(total_quantity, precision_digits=self.env['decimal.precision'].precision_get('Product Unit')) else avco
+                        # From negative quantity case, value from last_in
+                        elif previous_qty <= 0:
+                            avco = added_value / qty if qty else avco
+                            total_value = avco * total_quantity
+                    else:
+                        added_value = avco * qty
+                        total_value += added_value
 
                 elif record.res_model_name == 'product.value':
-                    avco = in_value
+                    avco = record.value
                     added_value = (avco * total_quantity) - total_value
                     total_value = avco * total_quantity
 

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -3122,3 +3122,36 @@ class TestStockValuation(TestStockValuationCommon):
         recs[-2:]._compute_cumulative_fields()
         self.assertEqual(recs[-1].total_quantity, 3)
         self.assertEqual(recs[-1].total_value, 30)
+
+    def test_avco_report_after_cost_method_change(self):
+        """Ensure that the AVCO justification report for a product is accurate at all steps, even if
+        the cost method changed after some moves.
+        """
+
+        product_avco = self.env['product.product'].create({
+            'uom_id': self.uom.id,
+            'is_storable': True,
+            'name': "AVCO product",
+            'standard_price': 10,
+        })
+
+        self._make_in_move(product_avco, quantity=10, unit_cost=10)
+        self._make_out_move(product_avco, quantity=5)
+        self._make_in_move(product_avco, quantity=10, unit_cost=25)
+        self._make_out_move(product_avco, quantity=5)
+
+        product_avco.write({'categ_id': self.category_avco.id})
+
+        report_lines = self.env['stock.avco.report'].search([('product_id', '=', product_avco.id)]).sorted('date, id')[1:]
+
+        self.assertEqual(report_lines[-1].avco_value, product_avco.standard_price)
+
+        self.assertRecordValues(
+            report_lines,
+            [
+                {'added_value': 100, 'total_quantity': 10, 'total_value': 100, 'avco_value': 10},
+                {'added_value': -50, 'total_quantity': 5, 'total_value': 50, 'avco_value': 10},
+                {'added_value': 250, 'total_quantity': 15, 'total_value': 300, 'avco_value': 20},
+                {'added_value': -100, 'total_quantity': 10, 'total_value': 200, 'avco_value': 20},
+            ]
+        )


### PR DESCRIPTION
The AVCO audit report currently recalculates the AVCO value on outgoing moves. Based on the logic in `run_average_batch()`, it should instead use the AVCO value computed on the last ingoing move to recalculate the
`added_value`.                                                         

On the other hand, the `added_value` should not be recomputed from the AVCO value on ingoing moves.

Source of those changes: [245141](https://github.com/odoo/odoo/pull/245141)

Steps to reproduce the issue:
1. Create a new product. Do not assign it to a category yet.
2. Set the cost (standard_price) to 10$ on the product form.
3. Add 10 units to inventory.
4. Sell and deliver 5 units to a customer.
5. Purchase 10 units at 25$/ea and validate the receipt.
6. Sell and deliver 5 units to a customer.
7. Assign the product to category with AVCO cost method.
8. Go to the AVCO justification report:
    - The added value on the purchase is incorrect: 200$ instead of 250$.
    - On the last delivery: the added value is -125$ and the AVCO increases from 20$ to 25$.

Ticket: opw-5921104
