### PR TITLE
[FIX] l10n_cz: correct vat 24 23 tax grid

### DIFF
--- a/addons/l10n_cz/data/tax_report.xml
+++ b/addons/l10n_cz/data/tax_report.xml
@@ -363,7 +363,7 @@
                             <record id="l10n_cz_vat_declaration_line_25_value" model="account.report.expression">
                                 <field name="label">value</field>
                                 <field name="engine">tax_tags</field>
-                                <field name="formula">VAT 23</field>
+                                <field name="formula">-VAT 23</field>
                             </record>
                         </field>
                     </record>
@@ -375,7 +375,7 @@
                             <record id="l10n_cz_vat_declaration_line_26_value" model="account.report.expression">
                                 <field name="label">value</field>
                                 <field name="engine">tax_tags</field>
-                                <field name="formula">VAT 24</field>
+                                <field name="formula">-VAT 24</field>
                             </record>
                         </field>
                     </record>


### PR DESCRIPTION
With l10n_cz company:
1. Create some invoices using the VAT 24 or VAT 23 tax grid on an invoice line containing an amount in credit.
2. Go to the VAT Return (CZ) report
3. The amount shown will be negative instead of positive, which goes against what the report should show.

Missed by 17a6117ed88c29b5bc4db0c872bcdbc109a7d98b

opw-5978183

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
