### PR TITLE
[FIX] l10n_in_edi: error hide for second EDI

### DIFF
--- a/addons/l10n_in_edi/models/account_move.py
+++ b/addons/l10n_in_edi/models/account_move.py
@@ -34,9 +34,8 @@ class AccountMove(models.Model):
         for move in self:
             if (
                 move.country_code == "IN"
-                and any(move.edi_document_ids.filtered(
-                    lambda d: d.edi_format_id.code in ["in_einvoice_1_03", "in_ewaybill_1_03"] and d.state in ("to_send", "sent") and not d.blocking_level
-                ))
+                and move.edi_document_ids
+                and all(d.state in ("to_send", "sent") and not d.blocking_level for d in move.edi_document_ids)
                 and self.env["ir.config_parameter"].sudo().get_param("l10n_in.gsp_provider", "tera") == "tera"
             ):
                 move.edi_error_count = 1
@@ -46,9 +45,8 @@ class AccountMove(models.Model):
         for move in self:
             if (
                 move.country_code == "IN"
-                and any(move.edi_document_ids.filtered(
-                    lambda d: d.edi_format_id.code in ["in_einvoice_1_03", "in_ewaybill_1_03"] and d.state in ("to_send", "sent") and not d.blocking_level
-                ))
+                and move.edi_document_ids
+                and all(d.state in ("to_send", "sent") and not d.blocking_level for d in move.edi_document_ids)
                 and self.env["ir.config_parameter"].sudo().get_param("l10n_in.gsp_provider", "tera") == "tera"
             ):
                 edi_error_message = _(


### PR DESCRIPTION
If user do E-invoice and after E-waybill then error of E-waybill is overwrite by by one wrong condition So in this commit fix that wrong condition

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
