### PR TITLE
[FIX] hr: allow correct visualization of blacklist status after removal

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -262,6 +262,7 @@ class HrEmployeePrivate(models.Model):
             'type': 'ir.actions.act_window',
             'res_model': 'res.partner',
             'view_mode': 'form',
+            'context': dict(self.env.context, active_test=True),
         }
         if len(related_partners) > 1:
             action['view_mode'] = 'kanban,list,form'


### PR DESCRIPTION
### Issue before this commit:
When removing an email address from the blacklist, the contact could still appear as blacklisted when accessed through the Employee>Contacts smart button.

### Steps to reproduce the issue:
1. Install email marketing
2. Go to Blacklisted email addresses
3. Add a new email (ex. mark.brown23@example.com that is already an user and an employee for My Company (San Francisco))
4. Check contact cart to see that email is blocked
5. Remove email from blacklist
6. Go through users > employee (with smart button) > contact (with smart button)
7. See that the email continues to be blocked even if it was removed
8. If you refresh it will temporarily fix the problem and also going from home page to contact direclty will display correctly the email that is not blocked

### Cause of the issue:
The action opening the related contact inherited a context with active_test=False. As a result, archived records in mail.blacklist (i.e., entries with active=False created after unblacklisting) were still considered during the computation of is_blacklisted, causing the contact to incorrectly appear as blacklisted until the page was refreshed or the contact was opened through another navigation path.

### Reason to introduce the fix:
This inconsistent behavior can confuse users and lead them to believe that a non-blacklisted contact is still blacklisted. The change guarantees that the displayed status accurately reflects the actual blacklist state.

opw-5952301

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
