### PR TITLE
[FIX] website_event_sale: hide original price for fixed price rules

### DIFF
--- a/addons/website_event_sale/models/__init__.py
+++ b/addons/website_event_sale/models/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from . import event_ticket
 from . import product
 from . import product_pricelist
 from . import sale_order

--- a/addons/website_event_sale/models/event_ticket.py
+++ b/addons/website_event_sale/models/event_ticket.py
@@ -1,0 +1,23 @@
+from odoo import models
+
+
+class EventTicket(models.Model):
+    _inherit = 'event.event.ticket'
+
+    def _show_discount(self):
+        """Determine if the discount should be shown on the website for this ticket."""
+        self.ensure_one()
+        if not self.price:
+            return False
+
+        website = self.env['website'].get_current_website()
+        pricelist = website.pricelist_id
+        if not pricelist:
+            return False
+
+        rule_id = pricelist._get_product_rule(
+            product=self.product_id,
+            quantity=1.0,
+        )
+        pricelist_item = self.env['product.pricelist.item'].browse(rule_id)
+        return pricelist_item._show_discount_on_shop() and (self.price - self.price_reduce) > 0

--- a/addons/website_event_sale/views/website_event_templates.xml
+++ b/addons/website_event_sale/views/website_event_templates.xml
@@ -13,7 +13,7 @@
     <!-- Add price information on tickets (multi tickets, aka in collapse) -->
     <xpath expr="//div[hasclass('o_wevent_registration_multi_select')]" position="inside">
         <t t-if="ticket.price">
-            <t t-if="(ticket.price - ticket.price_reduce) &gt; 0">
+            <t t-if="ticket._show_discount()">
                 <del t-if="website.show_line_subtotals_tax_selection == 'tax_excluded'"
                      class="text-danger me-1"
                      t-field="ticket.price"
@@ -56,7 +56,7 @@
     <xpath expr="//div[hasclass('o_wevent_registration_single_select')]" position="before">
         <div class="flex-md-grow-1 me-2 text-end">
             <t t-if="tickets.price">
-                <t t-if="(tickets.price - tickets.price_reduce) &gt;0">
+                <t t-if="tickets._show_discount()">
                     <del t-if="website.show_line_subtotals_tax_selection == 'tax_excluded'"
                          class="text-danger me-1"
                          t-field="tickets.price"


### PR DESCRIPTION
Event tickets show a struck-through original price even when a "Fixed Price" pricelist rule is applied, making it incorrectly appear as a discount. This is inconsistent with eCommerce shop behavior.

### Steps to reproduce

1. Create an event with a paid ticket (e.g., 100 EUR).
2. Create a pricelist with a "Fixed Price" rule for that ticket (e.g., 80 EUR).
3. Open the event registration page.
4. The 100 EUR appears struck-through next to 80 EUR.

### Cause

Odoo's website only shows a struck-through original price for discount rules, not fixed price rules. By design, a fixed price replaces the original rather than reducing it. However, the event registration page used a simplified check: it compared the final price to the original and assumed any difference was a discount. This ignored the rule type, incorrectly flagging fixed price rules as discounts.

### Fix Rationale

A new helper method on the event ticket model now queries the applied pricelist rule to determine if it qualifies as a discount.

opw-5993477