### PR TITLE
[IMP] website: preserve user edits when changing form action

### DIFF
--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -33,6 +33,8 @@ import {
     setVisibilityDependency,
     rerenderField,
     getFormCacheKey,
+    isFieldRequired,
+    getFieldFillWith,
 } from "./utils";
 import { SyncCache } from "@html_builder/utils/sync_cache";
 import { _t } from "@web/core/l10n/translation";
@@ -340,6 +342,42 @@ export class FormOptionPlugin extends Plugin {
         }
     }
     /**
+     * Checks if a form element conforms to its default configuration.
+     *
+     * @param {HTMLElement} formEl The form element.
+     * @param {Object[]} formInfo The default config.
+     */
+    isDefaultFormConfig(formEl, formInfo) {
+        const DOMFields = [
+            ...formEl.querySelectorAll(".s_website_form_field:not(.s_website_form_dnone)"),
+        ].toSorted((a, b) => getFieldName(a).localeCompare(getFieldName(b)));
+        if (DOMFields.length !== formInfo.formFields.length) {
+            return false;
+        }
+        const fieldFormatID = (field) => JSON.stringify(getFieldFormat(field)).replaceAll(" ", "");
+        const fieldLabelText = (field) =>
+            field.querySelector(".s_website_form_label_content")?.textContent;
+        // We use sorted fields here since changing fields order is not
+        // considered as significant.
+        for (const [i, field] of formInfo.formFields
+            .toSorted((a, b) => a.name.localeCompare(b.name))
+            .entries()) {
+            const fieldEl = renderField(field);
+            if (
+                isFieldCustom(fieldEl) != isFieldCustom(DOMFields[i]) ||
+                getFieldName(fieldEl) !== getFieldName(DOMFields[i]) ||
+                getFieldType(fieldEl) !== getFieldType(DOMFields[i]) ||
+                isFieldRequired(fieldEl) != isFieldRequired(DOMFields[i]) ||
+                fieldLabelText(fieldEl) !== fieldLabelText(DOMFields[i]) ||
+                getFieldFillWith(fieldEl) !== getFieldFillWith(DOMFields[i]) ||
+                fieldFormatID(fieldEl) !== fieldFormatID(DOMFields[i])
+            ) {
+                return false;
+            }
+        }
+        return true;
+    }
+    /**
      * Apply the model on the form changing its fields
      *
      * @param {HTMLElement} el
@@ -349,6 +387,7 @@ export class FormOptionPlugin extends Plugin {
      */
     applyFormModel(el, activeForm, modelId, formInfo) {
         let oldFormInfo;
+        let newFormFields = formInfo?.formFields;
         if (modelId) {
             const oldFormKey = activeForm.website_form_key;
             if (oldFormKey) {
@@ -356,8 +395,42 @@ export class FormOptionPlugin extends Plugin {
                     .category("website.form_editor_actions")
                     .get(oldFormKey, null);
             }
-            for (const fieldEl of el.querySelectorAll(".s_website_form_field")) {
-                fieldEl.remove();
+            // TO apply the new model on the current form:
+            // 1. We check if the form was edited.
+            if (this.isDefaultFormConfig(el, oldFormInfo) || !newFormFields) {
+                // 2. The form hasn't been edited yet > We allow to replace
+                // the whole form with the one from the new model.
+                for (const fieldEl of el.querySelectorAll(".s_website_form_field")) {
+                    fieldEl.remove();
+                }
+            } else {
+                // 3. Otherwise, we remove all the fields that are linked to
+                // the current model.
+                for (const fieldData of oldFormInfo.fields) {
+                    const fieldEl = el.querySelector(
+                        `.s_website_form_field:has([name="${fieldData.name}"])`
+                    );
+                    fieldEl?.remove();
+                }
+                // 4. "Model required fields" will be removed too (Otherwise,
+                // they will be handled as "required" for the new action).
+                for (const fieldEl of el.querySelectorAll(
+                    ".s_website_form_field.s_website_form_model_required"
+                )) {
+                    fieldEl.remove();
+                }
+                // 5. If a field from the new form refers the same information
+                // as a current one, it won't be added.
+                // 6. The rest of the fields will be automatically added to
+                // the form DOM.
+                newFormFields = formInfo.formFields.filter(
+                    (newField) =>
+                        ![...el.querySelectorAll(".s_website_form_field")].some(
+                            (oldFieldEl) =>
+                                getFieldName(oldFieldEl) === newField.name ||
+                                getFieldFillWith(oldFieldEl) === newField.fillWith
+                        )
+                );
             }
             activeForm = this.getModelsCache(el).find((model) => model.id === modelId);
         }
@@ -383,7 +456,7 @@ export class FormOptionPlugin extends Plugin {
         // Load template
         if (formInfo) {
             const formatInfo = getDefaultFormat(el);
-            formInfo.formFields.forEach((field) => {
+            newFormFields.forEach((field) => {
                 // Create a shallow copy of field to prevent unintended
                 // mutations to the original field stored in the registry
                 const _field = { ...field };
@@ -925,12 +998,14 @@ export class SelectAction extends BuilderAction {
         const models = this.dependencies.websiteFormOption.getModelsCache(el);
         const targetModelName = getModelName(el);
         const activeForm = models.find((m) => m.model === targetModelName);
-        this.dependencies.websiteFormOption.applyFormModel(
-            el,
-            activeForm,
-            parseInt(modelId),
-            loadResult.formInfo
-        );
+        if (models.find((model) => model.id === parseInt(modelId)).model !== targetModelName) {
+            this.dependencies.websiteFormOption.applyFormModel(
+                el,
+                activeForm,
+                parseInt(modelId),
+                loadResult.formInfo
+            );
+        }
     }
     isApplied({ editingElement: el, value: modelId }) {
         const models = this.dependencies.websiteFormOption.getModelsCache(el);

--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -425,11 +425,21 @@ export class FormOptionPlugin extends Plugin {
                 // the form DOM.
                 newFormFields = formInfo.formFields.filter(
                     (newField) =>
-                        ![...el.querySelectorAll(".s_website_form_field")].some(
-                            (oldFieldEl) =>
-                                getFieldName(oldFieldEl) === newField.name ||
-                                getFieldFillWith(oldFieldEl) === newField.fillWith
-                        )
+                        ![...el.querySelectorAll(".s_website_form_field")].some((oldFieldEl) => {
+                            const sameFieldsName = getFieldName(oldFieldEl) === newField.name;
+                            const sameFieldsFillWith =
+                                getFieldFillWith(oldFieldEl) === newField.fillWith;
+                            const setFieldName = (fieldEl, name) => {
+                                const inputEls = fieldEl.querySelectorAll(".s_website_form_input");
+                                inputEls.forEach((el) => (el.name = name));
+                                return true;
+                            };
+                            if (sameFieldsName || sameFieldsFillWith) {
+                                return !sameFieldsName
+                                    ? setFieldName(oldFieldEl, newField.name)
+                                    : true;
+                            }
+                        })
                 );
             }
             activeForm = this.getModelsCache(el).find((model) => model.id === modelId);

--- a/addons/website/static/src/builder/plugins/form/utils.js
+++ b/addons/website/static/src/builder/plugins/form/utils.js
@@ -238,6 +238,16 @@ export function getFieldType(fieldEl) {
 }
 
 /**
+ * Returns the "fillWith" value of the field input (if it exists).
+ *
+ * @param {HTMLElement} fieldEl
+ * @returns {string}
+ */
+export function getFieldFillWith(fieldEl) {
+    return `${fieldEl.querySelector("[data-fill-with]")?.dataset.fillWith}`;
+}
+
+/**
  * Set the active field properties on the field Object
  *
  * @param {HTMLElement} fieldEl

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -120,13 +120,22 @@ const addField = function (
             run: `edit ${display.condition} && press Tab`,
         });
     }
-    if (required) {
-        testText += ".s_website_form_required";
+    const addToggleRequiredStep = (required = true) =>
         ret.push({
-            content: "Mark the field as required",
+            content: `Mark the field as ${required ? "" : "non-"}required`,
             trigger: ".o_customize_tab div[data-action-id='toggleRequired'] input[type='checkbox']",
             run: "click",
         });
+    if (required) {
+        testText += ".s_website_form_required";
+        if (name !== "boolean") {
+            addToggleRequiredStep();
+        }
+    } else {
+        if (name === "boolean") {
+            // Checkbox fields are "required" by default.
+            addToggleRequiredStep(false);
+        }
     }
     if (label) {
         testText += `:has(label:contains(${label}))`;
@@ -809,7 +818,7 @@ registerWebsitePreviewTour(
         ...unfoldOptionsGroup("Form"),
         {
             content: "Change the Recipient Email",
-            trigger: '[data-label="Recipient Email"] input',
+            trigger: '[data-label="Emails"] input',
             run: "edit test@test.test",
         },
         // Test a field visibility when it's tied to another Date [Time] field
@@ -886,7 +895,7 @@ registerWebsitePreviewTour(
 
         // Ensure that the description option is working as wanted.
         ...addCustomField("char", "text", "Check description option", false),
-        changeOption("Field", "[data-action-id='toggleDescription'] input"),
+        changeOption("Field", "[data-action-id='setDescription'] input"),
         {
             content: "Ensure that the description has correctly been added on the field",
             trigger:
@@ -927,7 +936,7 @@ registerWebsitePreviewTour(
             ...unfoldOptionsGroup("Form"),
             {
                 content: "Change the Recipient Email",
-                trigger: "div[data-label='Recipient Email'] input",
+                trigger: "div[data-label='Emails'] input",
                 run: "edit test@test.test",
             },
         ])
@@ -948,7 +957,7 @@ registerWebsitePreviewTour(
             {
                 content: "Check that the recipient email is correct",
                 trigger:
-                    "div[data-label='Recipient Email'] input:value('website_form_contactus_edition_no_email@mail.com')",
+                    "div[data-label='Emails'] input:value('website_form_contactus_edition_no_email@mail.com')",
             },
         ])
 );

--- a/addons/website/static/tests/tours/website_form_editor_frontend.js
+++ b/addons/website/static/tests/tours/website_form_editor_frontend.js
@@ -9,7 +9,7 @@ registry.category("web_tour.tours").add("website_form_editor_tour_submit", {
                 "[data-success-page='/contactus-thank-you']" +
                 ":has(.s_website_form_field:has(label:contains('Your Name')):has(input[type='text'][name='name'][required]))" +
                 ":has(.s_website_form_field:has(label:contains('Your Email')):has(input[type='email'][name='email_from'][required]))" +
-                ":has(.s_website_form_field:has(label:contains('Your Question')):has(textarea[name='description'][required]))" +
+                ":has(.s_website_form_field:has(label:contains('Renamed')):has(textarea[name='Renamed'][required]))" +
                 ":has(.s_website_form_field:has(label:contains('Subject')):has(input[type='text'][name='subject'][required]))" +
                 ":has(.s_website_form_field:has(label:contains('Test Date')):has(input[type='text'][name='date'][required]))" +
                 ":has(.s_website_form_field:has(label:contains('Your Message')):has(textarea[name='body_html'][required]))" +
@@ -38,7 +38,7 @@ registry.category("web_tour.tours").add("website_form_editor_tour_submit", {
                 "form:has(#s_website_form_result.text-danger)" +
                 ":has(.s_website_form_field:has(label:contains('Your Name')):not(.o_has_error))" +
                 ":has(.s_website_form_field:has(label:contains('Email')).o_has_error)" +
-                ":has(.s_website_form_field:has(label:contains('Your Question')).o_has_error)" +
+                ":has(.s_website_form_field:has(label:contains('Renamed')).o_has_error)" +
                 ":has(.s_website_form_field:has(label:contains('Subject')).o_has_error)" +
                 ":has(.s_website_form_field:has(label:contains('Test Date')).o_has_error)" +
                 ":has(.s_website_form_field:has(label:contains('Your Message')).o_has_error)" +
@@ -62,7 +62,7 @@ registry.category("web_tour.tours").add("website_form_editor_tour_submit", {
                 "form:has(#s_website_form_result.text-danger)" +
                 ":has(.s_website_form_field:has(label:contains('Your Name')):not(.o_has_error))" +
                 ":has(.s_website_form_field:has(label:contains('Email')).o_has_error)" +
-                ":has(.s_website_form_field:has(label:contains('Your Question')).o_has_error)" +
+                ":has(.s_website_form_field:has(label:contains('Renamed')).o_has_error)" +
                 ":has(.s_website_form_field:has(label:contains('Subject')):not(.o_has_error))" +
                 ":has(.s_website_form_field:has(label:contains('Test Date')).o_has_error)" +
                 ":has(.s_website_form_field:has(label:contains('Your Message')).o_has_error)" +
@@ -86,7 +86,7 @@ registry.category("web_tour.tours").add("website_form_editor_tour_submit", {
                 "form:has(#s_website_form_result.text-danger)" +
                 ":has(.s_website_form_field:has(label:contains('Your Name')):not(.o_has_error))" +
                 ":has(.s_website_form_field:has(label:contains('Email')).o_has_error)" +
-                ":has(.s_website_form_field:has(label:contains('Your Question')).o_has_error)" +
+                ":has(.s_website_form_field:has(label:contains('Renamed')).o_has_error)" +
                 ":has(.s_website_form_field:has(label:contains('Subject')):not(.o_has_error))" +
                 ":has(.s_website_form_field:has(label:contains('Test Date')).o_has_error)" +
                 ":has(.s_website_form_field:has(label:contains('Your Message')):not(.o_has_error))" +
@@ -142,8 +142,8 @@ registry.category("web_tour.tours").add("website_form_editor_tour_submit", {
             run: "edit subject",
         },
         {
-            content: "Complete Your Question field",
-            trigger: "textarea[name='description']",
+            content: "Complete Renamed field",
+            trigger: "textarea[name='Renamed']",
             run: "edit magan",
         },
         {


### PR DESCRIPTION
Switching a form’s action could cause the entire form (and all user
edits) to be lost.

The goal of this commit is to improve this behavior, so when applying
a new model to an existing form:

1. If the current form still matches its initial configuration, it will
be fully replaced by the new model.

2. If the form has been edited, only fields linked to the current model
are replaced. New fields from the incoming model are added without
removing unrelated user edits.

Note: This behavior is experimental (final spec not yet confirmed).

task-3675302