### PR TITLE
[FIX] website_sale: prevent description following lines to be inversed

### DIFF
--- a/addons/website_sale/models/sale_order_line.py
+++ b/addons/website_sale/models/sale_order_line.py
@@ -23,7 +23,7 @@ class SaleOrderLine(models.Model):
     #=== BUSINESS METHODS ===#
 
     def get_description_following_lines(self):
-        return reversed(self.name.splitlines()[1:])
+        return self.name.splitlines()[1:]
 
     def _get_combination_name(self):
         return self.product_id.product_template_attribute_value_ids._get_combination_name()


### PR DESCRIPTION
Issue:
---
Due to this issue, the description following lines are inversed.

Steps to reproduce:
---
1- In product page in backend, add a multiline "Short Description" to
   a product.
2- Navigate to website and add the product to the cart.
3- Open the cart.

Outcome: The description after lines are shown inversed.

Cause:
---
This is introduced by https://github.com/odoo/odoo/pull/223433. It was done to ensure some information
such as rental date and variant description are shown at the beginning.
However, it didn't consider that the product description itself might
have multilines.

Fix:
---
There is no clean way to reliably extract structured information from
the computed name. To avoid reversing the product description lines, we
no longer reverse the description. As a limitation, variant
descriptions and rental dates may no longer always appear first.

opw-5976614