### PR TITLE
[FIX] web: formatter extract option get unit

### DIFF
--- a/addons/web/static/src/views/fields/formatters.js
+++ b/addons/web/static/src/views/fields/formatters.js
@@ -286,6 +286,7 @@ export function formatFloatTime(value, options = {}) {
 formatFloatTime.extractOptions = ({ options }) => ({
     showSeconds: Boolean(options.show_seconds),
     numeric: Boolean(options.numeric),
+    unit: options.unit,
 });
 
 /**

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -4997,6 +4997,22 @@ test(`aggregates are formatted according to field widget`, async () => {
     });
 });
 
+test(`aggregates are formatted according to field widget with options`, async () => {
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <list>
+                <field name="foo"/>
+                <field name="qux" widget="float_time" sum="Sum" options="{'unit': 'minutes', 'show_seconds': true}"/>
+            </list>
+        `,
+    });
+    expect(`tfoot`).toHaveText("19m 24s", {
+        message: "total should be formatted as a float_time",
+    });
+});
+
 test(`aggregates of monetary widget with no currency data in grouped list`, async () => {
     await mountView({
         resModel: "foo",


### PR DESCRIPTION
Before this commit, the float_time formatter didn't extract
the options "unit" and the field widget was. So, the list view
footer, that was using the formatter and not the field widget, wasn't
formatted in the same way that the column.

Now, the formatter and the field widget float_time time behaviour with
the options are the same.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
