### PR TITLE
[FIX] web: prevent ZeroDivisionError during Kanban export

### DIFF
--- a/addons/test_import_export/tests/test_export.py
+++ b/addons/test_import_export/tests/test_export.py
@@ -731,3 +731,36 @@ class TestGroupedExport(XlsxCreatorCase):
             ['10', "{'date': '2025-11-09'}"],
             ['10', "{'date': '2025-11-12'}"],
         ])
+
+    def test_groupby_avg_empty_group(self):
+        """
+        Test that exporting a grouped view does not crash
+        when encountering an empty group.
+        """
+        self.make({'date_max': '2026-01-01', 'float_avg': 100.0})
+
+        # Sepcify min_groups which sets the number of groups in the view
+        export = self.export(
+            fields=['float_avg'],
+            params={
+                'groupby': ['date_max:month'],
+                'context': {
+                    'fill_temporal': {
+                        'min_groups': 4,
+                        'fill_from': '2026-01-01',
+                    }
+                }
+            }
+        )
+
+        self.assertExportEqual(
+            export,
+            [
+                ['Float Avg'],
+                ['January 2026 (1)'],
+                ['100.00'],
+                ['February 2026 (0)'],
+                ['March 2026 (0)'],
+                ['April 2026 (0)'],
+            ],
+        )

--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -90,6 +90,8 @@ class GroupsTreeNode:
 
     def _get_avg_aggregate(self, field_name, data):
         aggregate_func = OPERATOR_MAPPING.get('sum')
+        if not self.count:
+            return None
         if self.data:
             return aggregate_func(data) / self.count
         children_sums = (child.aggregated_values.get(field_name) * child.count for child in self.children.values())


### PR DESCRIPTION
Steps to reproduce:
1- Install CRM
2- Go to [CRM -> Reporting -> Forecast]
3- Export the data from Kanban view

Description of issue:
Traceback: ZeroDivisionError

Expected behavior:
Should export into excel sheet without error

Why this happens:
When exporting from a Kanban view, all month columns are processed even if they contain no records. In these cases:
1. `self.data` is empty, causing the logic to skip the if condition
2. Since `self.count` is 0, the final division fails with a ZeroDivisionError.

opw-5962440