### PR TITLE
[FIX] account: search archived accounts for available codes

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -518,7 +518,7 @@ class AccountAccount(models.Model):
             """
             return (
                 new_code not in cache
-                and not self.sudo().search_count([
+                and not self.sudo().with_context(active_test=False).search_count([
                     ('code', '=', new_code),
                     '|',
                     ('company_ids', 'parent_of', self.env.company.id),


### PR DESCRIPTION
The logic of `code_is_available` should match that of `_ensure_code_is_unique`. However the latter was modified by https://github.com/odoo/odoo/commit/cd8d9718427e48aaa79be21f9a08e89b79b573f9 to also search archived accounts without matching the former. With the current logic, new accounts could generate a code used by an archived account and fail the validation.

Found in failing upgrades.