### PR TITLE
[FIX] account_edi_ubl_cii, l10n_ro_edi: Fix non-VAT tax schemes for the HU and RO localizations

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -1335,6 +1335,8 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
             vat = commercial_partner.vat
             if country_code in GST_COUNTRY_CODES:
                 tax_scheme_id = 'GST'
+            elif country_code == 'HU' and not vat.upper().startswith('HU'):
+                tax_scheme_id = 'HU_TAX_NUMBER'
             else:
                 tax_scheme_id = 'VAT'
 

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -1328,16 +1328,18 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
         nodes = vals['party_node']['cac:PartyTaxScheme']
         partner = vals['party_vals']['partner']
         commercial_partner = partner.commercial_partner_id
+        country_code = commercial_partner.country_id.code
+        vat = None
 
         if commercial_partner.vat and commercial_partner.vat != '/':
-            country_code = commercial_partner.country_id.code
+            vat = commercial_partner.vat
             if country_code in GST_COUNTRY_CODES:
                 tax_scheme_id = 'GST'
             else:
                 tax_scheme_id = 'VAT'
 
             nodes.append({
-                'cbc:CompanyID': {'_text': commercial_partner.vat},
+                'cbc:CompanyID': {'_text': vat},
                 'cac:TaxScheme': {
                     'cbc:ID': {'_text': tax_scheme_id},
                 },
@@ -1350,6 +1352,29 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
                     'cbc:ID': {'_text': commercial_partner.peppol_eas},
                 },
             })
+
+        if country_code == 'RO':
+            # Every company has a CIF in Romania.
+            # Only VAT-registered companies have a VAT number.
+            # The VAT number is simply the CIF activated for VAT purposes.
+            # To distinguish both, we just check if the number starts with RO or not.
+            nodes = vals['party_node']['cac:PartyTaxScheme'] = []  # Clear the party nodes
+            vat = vat or commercial_partner.company_registry
+            if vat:
+                if vat.upper().startswith('RO'):
+                    nodes.append({
+                        'cbc:CompanyID': {'_text': vat},
+                        'cac:TaxScheme': {
+                            'cbc:ID': {'_text': 'VAT'},
+                        },
+                    })
+                else:
+                    nodes.append({
+                        'cbc:CompanyID': {'_text': vat},
+                        'cac:TaxScheme': {
+                            'cbc:ID': {'_text': 'CIF'},
+                        },
+                    })
 
     def _ubl_add_party_legal_entity_nodes(self, vals):
         # EXTENDS account.edi.ubl

--- a/addons/l10n_ro_cpv_code/tests/test_files/from_odoo/ciusro_out_invoice_cpv_code.xml
+++ b/addons/l10n_ro_cpv_code/tests/test_files/from_odoo/ciusro_out_invoice_cpv_code.xml
@@ -51,7 +51,7 @@
 	</cac:AccountingSupplierParty>
 	<cac:AccountingCustomerParty>
 		<cac:Party>
-			<cbc:EndpointID schemeID="9947">RO1234567897</cbc:EndpointID>
+			<cbc:EndpointID schemeID="9947">RO136619220</cbc:EndpointID>
 			<cac:PartyIdentification>
 				<cbc:ID>ref_partner_a</cbc:ID>
 			</cac:PartyIdentification>
@@ -68,14 +68,14 @@
 				</cac:Country>
 			</cac:PostalAddress>
 			<cac:PartyTaxScheme>
-				<cbc:CompanyID>RO1234567897</cbc:CompanyID>
+				<cbc:CompanyID>RO136619220</cbc:CompanyID>
 				<cac:TaxScheme>
 					<cbc:ID>VAT</cbc:ID>
 				</cac:TaxScheme>
 			</cac:PartyTaxScheme>
 			<cac:PartyLegalEntity>
 				<cbc:RegistrationName>Roasted Romanian Roller</cbc:RegistrationName>
-				<cbc:CompanyID>RO1234567897</cbc:CompanyID>
+				<cbc:CompanyID>RO136619220</cbc:CompanyID>
 			</cac:PartyLegalEntity>
 			<cac:Contact>
 				<cbc:Name>Roasted Romanian Roller</cbc:Name>

--- a/addons/l10n_ro_edi/models/account_edi_xml_ubl_ciusro.py
+++ b/addons/l10n_ro_edi/models/account_edi_xml_ubl_ciusro.py
@@ -58,19 +58,20 @@ class AccountEdiXmlUBLRO(models.AbstractModel):
         # Old helper not used by default (see _export_invoice override in account.edi.xml.ubl_bis3)
         # If you change this method, please change the corresponding new helper (at the end of this file).
         vals_list = super()._get_partner_party_tax_scheme_vals_list(partner, role)
+        tax_scheme_id = None
 
-        if not _has_vat(partner.vat):
-            if (
-                role == 'supplier'
-                and partner.company_registry
-            ):
-                # Use company_registry (Company ID) as the VAT replacement
-                for vals in vals_list:
-                    tax_scheme_id = 'VAT' if partner.company_registry[:2].isalpha() else 'NOT_EU_VAT'
-                    vals.update({'company_id': partner.company_registry, 'tax_scheme_vals': {'id': tax_scheme_id}})
-            elif role == 'customer':
-                for vals in vals_list:
-                    vals.update({'company_id': DEFAULT_VAT, 'tax_scheme_vals': {'id': 'NOT_EU_VAT'}})
+        # Use company_registry (CIF) as the VAT replacement
+        company_id = partner.vat if _has_vat(partner.vat) else partner.company_registry
+        if company_id:
+            tax_scheme_id = 'VAT' if company_id[:2].isalpha() else 'CIF'
+        elif role == 'customer':
+            # For customers with no VAT nor CIF, use the default RO VAT
+            company_id = DEFAULT_VAT
+            tax_scheme_id = 'DEFAULT_RO_VAT'
+
+        if company_id and tax_scheme_id:
+            for vals in vals_list:
+                vals.update({'company_id': company_id, 'tax_scheme_vals': {'id': tax_scheme_id}})
 
         return vals_list
 
@@ -90,7 +91,7 @@ class AccountEdiXmlUBLRO(models.AbstractModel):
             for legal_entity_vals in vals['vals'][f'accounting_{role}_party_vals']['party_vals']['party_legal_entity_vals']:
                 partner = legal_entity_vals['commercial_partner']
                 if not _has_vat(partner.vat):
-                    legal_entity_vals['company_id'] = partner.company_registry if role == 'supplier' else DEFAULT_VAT
+                    legal_entity_vals['company_id'] = partner.company_registry if role == 'supplier' else partner.company_registry or DEFAULT_VAT
 
         return vals
 
@@ -172,26 +173,6 @@ class AccountEdiXmlUBLRO(models.AbstractModel):
 
         return node
 
-    def _ubl_add_accounting_supplier_party_tax_scheme_nodes(self, vals):
-        # EXTENDS account.edi.xml.ubl_bis3
-        super()._ubl_add_accounting_supplier_party_tax_scheme_nodes(vals)
-        partner = vals['party_vals']['partner']
-        commercial_partner = partner.commercial_partner_id
-        company_id = None
-
-        if not _has_vat(commercial_partner.vat):
-            if commercial_partner.company_registry:
-                company_id = commercial_partner.company_registry
-        else:
-            company_id = commercial_partner.vat
-
-        vals['party_node']['cac:PartyTaxScheme'] = [{
-            'cbc:CompanyID': {'_text': company_id},
-            'cac:TaxScheme': {
-                'cbc:ID': {'_text': 'VAT' if company_id[:2].isalpha() else 'NOT_EU_VAT'},
-            },
-        }] if company_id else []
-
     def _ubl_add_accounting_supplier_party_legal_entity_nodes(self, vals):
         # EXTENDS account.edi.xml.ubl_bis3
         super()._ubl_add_accounting_supplier_party_legal_entity_nodes(vals)
@@ -210,25 +191,6 @@ class AccountEdiXmlUBLRO(models.AbstractModel):
             else:
                 vals['party_node']['cac:PartyLegalEntity'] = []
 
-    def _ubl_add_accounting_customer_party_tax_scheme_nodes(self, vals):
-        # EXTENDS account.edi.xml.ubl_bis3
-        super()._ubl_add_accounting_customer_party_tax_scheme_nodes(vals)
-        partner = vals['party_vals']['partner']
-        commercial_partner = partner.commercial_partner_id
-        company_id = None
-
-        if not _has_vat(commercial_partner.vat):
-            company_id = DEFAULT_VAT
-        else:
-            company_id = commercial_partner.vat
-
-        vals['party_node']['cac:PartyTaxScheme'] = [{
-            'cbc:CompanyID': {'_text': company_id},
-            'cac:TaxScheme': {
-                'cbc:ID': {'_text': 'VAT' if company_id[:2].isalpha() else 'NOT_EU_VAT'},
-            },
-        }] if company_id else []
-
     def _ubl_add_accounting_customer_party_legal_entity_nodes(self, vals):
         # EXTENDS account.edi.xml.ubl_bis3
         super()._ubl_add_accounting_customer_party_legal_entity_nodes(vals)
@@ -239,10 +201,22 @@ class AccountEdiXmlUBLRO(models.AbstractModel):
             vals['party_node']['cac:PartyLegalEntity'] = [{
                 'cbc:RegistrationName': {'_text': commercial_partner.name},
                 'cbc:CompanyID': {
-                    '_text': DEFAULT_VAT,
+                    '_text': commercial_partner.company_registry or DEFAULT_VAT,
                     'schemeID': None,
                 },
             }]
+
+    def _ubl_add_accounting_customer_party_tax_scheme_nodes(self, vals):
+        # EXTENDS account.edi.xml.ubl_bis3
+        super()._ubl_add_accounting_customer_party_tax_scheme_nodes(vals)
+        nodes = vals['party_node']['cac:PartyTaxScheme']
+        if not nodes:
+            nodes.append({
+                'cbc:CompanyID': {'_text': DEFAULT_VAT},
+                'cac:TaxScheme': {
+                    'cbc:ID': {'_text': 'DEFAULT_RO_VAT'},
+                },
+            })
 
     def _export_invoice_constraints_new(self, invoice, vals):
         # OVERRIDE 'account.edi.xml.ubl_bis3': don't apply Peppol rules

--- a/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice.xml
+++ b/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice.xml
@@ -52,7 +52,7 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="9947">RO1234567897</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9947">RO136619220</cbc:EndpointID>
       <cac:PartyIdentification>
         <cbc:ID>ref_partner_a</cbc:ID>
       </cac:PartyIdentification>
@@ -69,14 +69,14 @@
         </cac:Country>
       </cac:PostalAddress>
       <cac:PartyTaxScheme>
-        <cbc:CompanyID>RO1234567897</cbc:CompanyID>
+        <cbc:CompanyID>RO136619220</cbc:CompanyID>
         <cac:TaxScheme>
           <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>Roasted Romanian Roller</cbc:RegistrationName>
-        <cbc:CompanyID>RO1234567897</cbc:CompanyID>
+        <cbc:CompanyID>RO136619220</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:Name>Roasted Romanian Roller</cbc:Name>

--- a/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_defaults.xml
+++ b/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_defaults.xml
@@ -21,7 +21,7 @@
   </cac:AdditionalDocumentReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="9947">1234567897</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9947">___ignore___</cbc:EndpointID>
       <cac:PartyName>
         <cbc:Name>Hudson Construction</cbc:Name>
       </cac:PartyName>
@@ -35,14 +35,14 @@
         </cac:Country>
       </cac:PostalAddress>
       <cac:PartyTaxScheme>
-        <cbc:CompanyID>___ignore___</cbc:CompanyID>
+        <cbc:CompanyID>RO1234567897</cbc:CompanyID>
         <cac:TaxScheme>
-          <cbc:ID>NOT_EU_VAT</cbc:ID>
+          <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>Hudson Construction</cbc:RegistrationName>
-        <cbc:CompanyID>___ignore___</cbc:CompanyID>
+        <cbc:CompanyID>RO1234567897</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:Name>Hudson Construction</cbc:Name>
@@ -52,7 +52,7 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="9947">RO1234567897</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9947">___ignore___</cbc:EndpointID>
       <cac:PartyIdentification>
         <cbc:ID>ref_partner_a</cbc:ID>
       </cac:PartyIdentification>
@@ -71,7 +71,7 @@
       <cac:PartyTaxScheme>
         <cbc:CompanyID>0000000000000</cbc:CompanyID>
         <cac:TaxScheme>
-          <cbc:ID>NOT_EU_VAT</cbc:ID>
+          <cbc:ID>DEFAULT_RO_VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>

--- a/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_different_currency.xml
+++ b/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_different_currency.xml
@@ -52,7 +52,7 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="9947">RO1234567897</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9947">RO136619220</cbc:EndpointID>
       <cac:PartyIdentification>
         <cbc:ID>ref_partner_a</cbc:ID>
       </cac:PartyIdentification>
@@ -69,14 +69,14 @@
         </cac:Country>
       </cac:PostalAddress>
       <cac:PartyTaxScheme>
-        <cbc:CompanyID>RO1234567897</cbc:CompanyID>
+        <cbc:CompanyID>RO136619220</cbc:CompanyID>
         <cac:TaxScheme>
           <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>Roasted Romanian Roller</cbc:RegistrationName>
-        <cbc:CompanyID>RO1234567897</cbc:CompanyID>
+        <cbc:CompanyID>RO136619220</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:Name>Roasted Romanian Roller</cbc:Name>

--- a/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_no_prefix_vat.xml
+++ b/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_invoice_no_prefix_vat.xml
@@ -37,7 +37,7 @@
       <cac:PartyTaxScheme>
         <cbc:CompanyID>1234567897</cbc:CompanyID>
         <cac:TaxScheme>
-          <cbc:ID>NOT_EU_VAT</cbc:ID>
+          <cbc:ID>CIF</cbc:ID>
         </cac:TaxScheme>
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
@@ -52,6 +52,7 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
+      <cbc:EndpointID schemeID="9947">___ignore___</cbc:EndpointID>
       <cac:PartyIdentification>
         <cbc:ID>ref_partner_a</cbc:ID>
       </cac:PartyIdentification>
@@ -68,14 +69,14 @@
         </cac:Country>
       </cac:PostalAddress>
       <cac:PartyTaxScheme>
-        <cbc:CompanyID>0000000000000</cbc:CompanyID>
+        <cbc:CompanyID>8001011234567</cbc:CompanyID>
         <cac:TaxScheme>
-          <cbc:ID>NOT_EU_VAT</cbc:ID>
+          <cbc:ID>CIF</cbc:ID>
         </cac:TaxScheme>
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>Roasted Romanian Roller</cbc:RegistrationName>
-        <cbc:CompanyID>0000000000000</cbc:CompanyID>
+        <cbc:CompanyID>8001011234567</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:Name>Roasted Romanian Roller</cbc:Name>

--- a/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_refund.xml
+++ b/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_refund.xml
@@ -52,7 +52,7 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="9947">RO1234567897</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9947">RO136619220</cbc:EndpointID>
       <cac:PartyIdentification>
         <cbc:ID>ref_partner_a</cbc:ID>
       </cac:PartyIdentification>
@@ -69,14 +69,14 @@
         </cac:Country>
       </cac:PostalAddress>
       <cac:PartyTaxScheme>
-        <cbc:CompanyID>RO1234567897</cbc:CompanyID>
+        <cbc:CompanyID>RO136619220</cbc:CompanyID>
         <cac:TaxScheme>
           <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>Roasted Romanian Roller</cbc:RegistrationName>
-        <cbc:CompanyID>RO1234567897</cbc:CompanyID>
+        <cbc:CompanyID>RO136619220</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:Name>Roasted Romanian Roller</cbc:Name>

--- a/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_refund_negative_quantity.xml
+++ b/addons/l10n_ro_edi/tests/test_files/from_odoo/ciusro_out_refund_negative_quantity.xml
@@ -52,7 +52,7 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="9947">RO1234567897</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9947">RO136619220</cbc:EndpointID>
       <cac:PartyIdentification>
         <cbc:ID>ref_partner_a</cbc:ID>
       </cac:PartyIdentification>
@@ -69,14 +69,14 @@
         </cac:Country>
       </cac:PostalAddress>
       <cac:PartyTaxScheme>
-        <cbc:CompanyID>RO1234567897</cbc:CompanyID>
+        <cbc:CompanyID>RO136619220</cbc:CompanyID>
         <cac:TaxScheme>
           <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>Roasted Romanian Roller</cbc:RegistrationName>
-        <cbc:CompanyID>RO1234567897</cbc:CompanyID>
+        <cbc:CompanyID>RO136619220</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:Name>Roasted Romanian Roller</cbc:Name>

--- a/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
+++ b/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
@@ -39,13 +39,13 @@ class TestUBLROCommon(TestUBLCommon):
             'allow_out_payment': True,
         })
 
-        cls.partner_a = cls.env['res.partner'].create({
+        cls.partner_a = cls.env['res.partner'].with_context(no_vat_validation=True).create({
             'country_id': cls.env.ref('base.ro').id,
             'state_id': cls.env.ref('base.RO_B').id,
             'name': 'Roasted Romanian Roller',
             'city': 'SECTOR3',
             'zip': '010101',
-            'vat': 'RO1234567897',
+            'vat': 'RO136619220',
             'phone': '+40 123 456 780',
             'street': "Rolling Roast, 88",
             'bank_ids': [(0, 0, {'acc_number': 'RO98RNCB1234567890123456', 'allow_out_payment': True})],
@@ -167,7 +167,8 @@ class TestUBLRO(TestUBLROCommon):
         self.test_export_invoice_different_currency()
 
     def test_export_no_vat_but_have_company_registry(self):
-        self.company_data['company'].write({'vat': False, 'company_registry': 'RO1234567897'})
+        self.company_data['company'].write({'vat': False, 'company_registry': self.company_data['company'].vat})
+        self.partner_a.write({'vat': False, 'company_registry': self.partner_a.vat})
         invoice = self.create_move("out_invoice", currency_id=self.company.currency_id.id)
         attachment = self.get_attachment(invoice)
         self._assert_invoice_attachment(attachment, xpaths=None, expected_file_path='from_odoo/ciusro_out_invoice.xml')
@@ -177,8 +178,8 @@ class TestUBLRO(TestUBLROCommon):
         self.test_export_no_vat_but_have_company_registry()
 
     def test_export_no_vat_but_have_company_registry_without_prefix(self):
-        self.company_data['company'].write({'vat': False, 'company_registry': '1234567897'})
-        self.partner_a.write({'vat': False, 'peppol_eas': False, 'peppol_endpoint': False})
+        self.company_data['company'].write({'vat': False, 'company_registry': self.company_data['company'].vat[2:]})
+        self.partner_a.write({'vat': False, 'company_registry': '8001011234567'})
         invoice = self.create_move("out_invoice", currency_id=self.company.currency_id.id)
         attachment = self.get_attachment(invoice)
         self._assert_invoice_attachment(attachment, xpaths=None, expected_file_path='from_odoo/ciusro_out_invoice_no_prefix_vat.xml')
@@ -189,14 +190,24 @@ class TestUBLRO(TestUBLROCommon):
 
     def test_export_invoice_no_vat_prefix(self):
         self.company_data['company'].vat = self.company_data['company'].vat[2:]
-        no_vat_partner = self.partner_a.copy({'name': 'Roasted Romanian Roller', 'vat': False, 'invoice_edi_format': 'ciusro'})
-        invoice = self.create_move("out_invoice", partner_id=no_vat_partner.id, currency_id=self.company.currency_id.id)
+        self.partner_a.vat = '8001011234567'
+        invoice = self.create_move("out_invoice", currency_id=self.company.currency_id.id)
         attachment = self.get_attachment(invoice)
-        self._assert_invoice_attachment(attachment, xpaths=None, expected_file_path='from_odoo/ciusro_out_invoice_defaults.xml')
+        self._assert_invoice_attachment(attachment, xpaths=None, expected_file_path='from_odoo/ciusro_out_invoice_no_prefix_vat.xml')
 
     def test_export_invoice_defaults_new(self):
         self.env['ir.config_parameter'].set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', 'True')
         self.test_export_invoice_no_vat_prefix()
+
+    def test_export_invoice_customer_default_vat(self):
+        self.partner_a.write({'vat': False, 'company_registry': False})
+        invoice = self.create_move("out_invoice", currency_id=self.company.currency_id.id)
+        attachment = self.get_attachment(invoice)
+        self._assert_invoice_attachment(attachment, xpaths=None, expected_file_path='from_odoo/ciusro_out_invoice_defaults.xml')
+
+    def test_export_invoice_customer_default_vat_new(self):
+        self.env['ir.config_parameter'].set_param('account_edi_ubl_cii.use_new_dict_to_xml_helpers', 'True')
+        self.test_export_invoice_customer_default_vat()
 
     def test_export_no_vat_and_no_company_registry_raises_error(self):
         self.company_data['company'].write({'vat': False, 'company_registry': False})


### PR DESCRIPTION
Problem
---------
Currently, if a customer has no VAT, we use the Romanian default VAT 00..0. This is not correct in every instance since the customer CIF may exist in its company registry.

Solution
---------
Use the company registry if existing and then fallback to the default VAT.

no-task

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
