### PR TITLE
[FIX] hr_attendance: update weekly overtime rules

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -270,8 +270,8 @@ class HrAttendance(models.Model):
             return Domain.FALSE
         domain_list = [Domain.AND([
             Domain('employee_id', '=', employee.id),
-            Domain('date', '<=', max(attendances.mapped('check_out')).date() + relativedelta(SU)),
-            Domain('date', '>=', min(attendances.mapped('check_in')).date() + relativedelta(MO(-1))),
+            Domain('date', '<=', max(attendances.mapped('check_out')).date() + relativedelta(weekday=SU)),
+            Domain('date', '>=', min(attendances.mapped('check_in')).date() + relativedelta(weekday=MO(-1))),
         ]) for employee, attendances in self.filtered(lambda att: att.check_out).grouped('employee_id').items()]
         if not domain_list:
             return Domain.FALSE

--- a/addons/hr_attendance/tests/test_hr_attendance_rulesets.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_rulesets.py
@@ -120,7 +120,18 @@ class TestHrAttendanceOvertime(TransactionCase):
                     'check_out': datetime(2021, 1, day, 18, 0)
                 }) for day in range(4, 9)  # Monday to Friday
             ]
-            self.assertAlmostEqual(self.employee.total_overtime, 10, 2, msg="He should work from 8-16h so each day he did 2 hours of overtime")
+
+            # Daily rule: 8 hours/day (1)
+            # Weekly rule: 40 hours/week (2)
+            #
+            # Generated overtimes:
+            #   - Monday: 2h from (1)
+            #   - Tuesday: 2h from (1)
+            #   - Wednesday: 2h from (1)
+            #   - Thursday: 2h from (1)
+            #   - Friday: 8h from (2) and 2h from (1, 2)
+            # Total: 18h
+            self.assertAlmostEqual(self.employee.total_overtime, 18, 2)
 
     def test_multiple_attendances_same_day(self):
         """ Test multiple attendances in one day """


### PR DESCRIPTION
### Steps to reproduce:
- Have an employee with a 8h/day, 40h/week calendar
- Create 2 overtime rules for this employee:
    - One for days, based on contract
    - One for weeks, based on contract
- Create 5 attendances of 10h each day of the same week
- The overtimes are only for days, even if the employee worked 50h/40h during the week

### Cause:
The method `_get_overtimes_to_update_domain()` uses ` + relativedelta(SU)` to offset the dates of the attendance and take into account the whole week. ` + relativedelta(SU)` doesn't work. So the other attendances were not included in the weekly overtime recomputation.

### Solution:
We need to use this synthax ` + relativedelta(weekday=SU)`