### PR TITLE
[FIX] hr_attendance: prevent duplication of overtime lines

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -19,6 +19,7 @@ from odoo.http import request
 from odoo.tools import convert, format_duration, format_time, format_datetime
 from odoo.tools.date_utils import sum_intervals
 from odoo.tools.intervals import Intervals
+from odoo.tools.float_utils import float_compare
 
 def get_google_maps_url(latitude, longitude):
     return "https://maps.google.com?q=%s,%s" % (latitude, longitude)
@@ -270,8 +271,8 @@ class HrAttendance(models.Model):
             return Domain.FALSE
         domain_list = [Domain.AND([
             Domain('employee_id', '=', employee.id),
-            Domain('date', '<=', max(attendances.mapped('check_out')).date() + relativedelta(SU)),
-            Domain('date', '>=', min(attendances.mapped('check_in')).date() + relativedelta(MO(-1))),
+            Domain('date', '<=', max(attendances.mapped('check_out')).date() + relativedelta(weekday=SU)),
+            Domain('date', '>=', min(attendances.mapped('check_in')).date() + relativedelta(weekday=MO(-1))),
         ]) for employee, attendances in self.filtered(lambda att: att.check_out).grouped('employee_id').items()]
         if not domain_list:
             return Domain.FALSE
@@ -309,9 +310,14 @@ class HrAttendance(models.Model):
                 ruleset_sudo.rule_ids._generate_overtime_vals_v2(min(attendances_dates), max(attendances_dates), ruleset_attendances, schedules_intervals_by_employee)
             )
         self.env['hr.attendance.overtime.line'].create(overtime_vals_list)
-        self.env.add_to_compute(self._fields['overtime_hours'], all_attendances)
-        self.env.add_to_compute(self._fields['validated_overtime_hours'], all_attendances)
-        self.env.add_to_compute(self._fields['overtime_status'], all_attendances)
+        to_recompute = self.search([('employee_id', 'in', employees.ids)])
+
+        # for automatically validated attendances, avoid recomputing extra hours if user has changed its value
+        validated_modified = to_recompute.filtered(lambda att: att.employee_id.company_id.attendance_overtime_validation == 'no_validation'
+                                                               and float_compare(att.overtime_hours, att.validated_overtime_hours, precision_digits=2))
+        self.env.add_to_compute(self._fields['overtime_hours'], to_recompute)
+        self.env.add_to_compute(self._fields['validated_overtime_hours'], to_recompute - validated_modified)
+        self.env.add_to_compute(self._fields['expected_hours'], to_recompute)
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -1280,3 +1280,19 @@ class TestHrAttendanceOvertime(HttpCase):
         ruleset_1.action_regenerate_overtimes()
         self.assertEqual(attendance_1.overtime_hours, 1)
         self.assertEqual(attendance_2.overtime_hours, 0.5)
+
+    def test_regenerate_overtime_with_different_work_schedule_tz(self):
+        """Checks that overtime lines get unlinked correctly when regenerating overtimes with a timezone that would
+        set the overtime (pacific) to the day after the checkin/checkout (UTC) date"""
+        self.ruleset.rule_ids.write({'expected_hours': 8.0})
+        self.employee.resource_calendar_id.write({'tz': 'Pacific/Fiji'})
+        self.env['hr.attendance'].create({
+            'employee_id': self.employee.id,
+            'check_in': datetime(2020, 3, 2, 3, 0),
+            'check_out': datetime(2020, 3, 2, 15, 0)
+        })
+        overtime_lines_before_regeneration = self.env['hr.attendance.overtime.line'].search([('employee_id', '=', self.employee.id)])
+        self.ruleset.action_regenerate_overtimes()
+        overtime_lines_after_regeneration = self.env['hr.attendance.overtime.line'].search([('employee_id', '=', self.employee.id)])
+        self.assertEqual(len(overtime_lines_after_regeneration), 2)
+        self.assertNotEqual(overtime_lines_before_regeneration[-1], overtime_lines_after_regeneration[0])

--- a/addons/hr_attendance/tests/test_hr_attendance_rulesets.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_rulesets.py
@@ -111,6 +111,11 @@ class TestHrAttendanceOvertime(TransactionCase):
 
     def test_weekly_overtime(self):
         """ Test weekly overtime for the 40-hour rule """
+        weekly_ruleset = self.env['hr.attendance.overtime.ruleset'].create({
+            'name': 'weekly Ruleset',
+            'rule_ids': [self.ruleset.rule_ids[2].id]
+        })
+        self.employee.write({'ruleset_id': weekly_ruleset.id})
         with freeze_time("2021-01-04"):
             # Week: Mon-Fri, 10 hours/day = 50 hours total (40 expected + 10 overtime at 200%)
             [


### PR DESCRIPTION
__

## Short functional explanation of the error
When creating overtimes for an employee who has a
different time zone than the one indicated on the work schedule. If the overtimes overlap on 2 days based on the work schedule time zone, 2 different
overtime lines will be created: one for overtimes on the first day, and one for overtimes on the second day. When regenerating overtimes, the overtime line of the second day will always be duplicated, leading to wrong overtimes.

## Reproduction Steps
1. Create an employee. The time zone of the employee should be different from the one on his work schedule. To be sure to replicate the bug, set the time zone of the work schedule to Pacific/Fiji (GMT +12).
Set his Work Entry Source to Attendances, and in
settings, set an overtime ruleset.
2. On this ruleset, select a rule and select 'From a specific duration', and in the field Duration to Exceed, write 8 hours.
3. Go to Attendances. Create an attendance from 3 am to 3 pm, save and close.
With this setting, you are creating an attendance from 3 am to 3 pm on European time (GMT+1). This will be translated to 2 pm -> 2 am on the working schedule tz. As we will have 3 hours overtime, we will have one from 11 pm to 12 am for day 1 and another one from 12 am to 2 pm for day 2.
4. Click on the Configuration tab > Rulesets, click on the ruleset and click on Regenerate overtimes.
5. Go back to the attendance you created.

### Expected behavior
The overtime should be the same before and after
regenerating overtimes.

### Unexpected behavior
The attendance overtime has increased.

## Origin of the issue
When regenerating overtimes, we unlink the previously created overtime lines. However, as the domain to retrieve such lines wasn't set correctly, the overtime line of day 2 wasn't included in the lines to unlink.


Note: reintroducing changes made in commit 
d00e5d6e08550cac836e3d839611ea1c6f313686:
its test used to pass before this fix because the domain wasn't
computed correctly, so the day for which to recompute the overtime
hours wasn't even in the domain anymore, never triggering the
error while it still occurred.

__
opw-5908447
