### PR TITLE
[FIX] sale_timesheet: make label of "Billable" project setting more visible (non-muted)

### DIFF
--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -104,8 +104,8 @@
                 </page>
             </xpath>
             <xpath expr="//page[@name='settings']//field[@name='allow_billable']" position="after">
-                <div invisible="not allow_billable or not allow_timesheets" class="text-muted">
-                    Timesheets without a sales order item are reported as
+                <div invisible="not allow_billable or not allow_timesheets">
+                    <span class="text-muted">Timesheets without a sales order item are reported as</span>
                     <field name="billing_type" nolabel="1" class="w-auto"/>
                 </div>
             </xpath>


### PR DESCRIPTION
Before this commit, when the project is billable, the user can also
alter Billing type. However, that field is in muted and displayed inside
the description of billable feature and so the user could miss he could
alter a field inside that description.

This commit makes sure billing type field is no longer in muted to
correctly show the field can be edited.

task-5994180