### PR TITLE
[IMP] pos_self_order: make time slot dialog size dynamic

### DIFF
--- a/addons/pos_self_order/static/src/app/components/pills_selection_popup/pills_selection_popup.scss
+++ b/addons/pos_self_order/static/src/app/components/pills_selection_popup/pills_selection_popup.scss
@@ -1,15 +1,24 @@
 .self_order_pills_selection_popup_dialog {
     border-radius: 35px 35px 0 0 !important;
     bottom: 0;
+    top: auto !important;
+    height: auto !important;
+
+    .modal-body {
+        height: auto !important;
+    }
 }
 
 .no-scrollbar {
-    -ms-overflow-style: none;  /* IE and Edge */
-    scrollbar-width: none;  /* Firefox */
+    -ms-overflow-style: none;
+    /* IE and Edge */
+    scrollbar-width: none;
+    /* Firefox */
 }
 
 .no-scrollbar::-webkit-scrollbar {
-    display: none;  /* Chrome, Safari and Opera */
+    display: none;
+    /* Chrome, Safari and Opera */
 }
 
 /* On small screens (576px - 767px) */
@@ -35,3 +44,4 @@
         max-height: 70vh;
     }
 }
+


### PR DESCRIPTION
The o_modal_full class forces height: 100% on modal-content and modal-body, causing the time slot selection popup to stretch to full screen with empty white space below the content.

Override height and top on modal-content and modal-body to let the dialog shrink to fit its content while staying anchored at the bottom of the screen.

task-id: 5952769

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
