### PR TITLE
[IMP] requirements.txt: upgrade cryptography package to 46.0.5 to address security vulnerabilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ cbor2==5.6.2 ; python_version >= '3.12'
 chardet==4.0.0 ; python_version < '3.11'  # (Jammy)
 chardet==5.2.0 ; python_version >= '3.11'
 cryptography==3.4.8; python_version < '3.12'  # incompatibility between pyopenssl 19.0.0 and cryptography>=37.0.0
-cryptography==42.0.8 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 42.0.8 for security fixes
+cryptography==46.0.5 ; python_version >= '3.12'  # (Noble) min 41.0.7, pinning 46.0.5 for security fixes
 decorator==4.4.2  ; python_version < '3.11'  # (Jammy)
 decorator==5.1.1  ; python_version >= '3.11'
 docutils==0.17 ; python_version < '3.11'  # (Jammy)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

cryptography Vulnerable to a Subgroup Attack Due to Missing Subgroup Validation for SECT Curves

The public_key_from_numbers (or EllipticCurvePublicNumbers.public_key()), EllipticCurvePublicNumbers.public_key(), load_der_public_key() and load_pem_public_key() functions do not verify that the point belongs to the expected prime-order subgroup of the curve.

This missing validation allows an attacker to provide a public key point P from a small-order subgroup. This can lead to security issues in various situations, such as the most commonly used signature verification (ECDSA) and shared key negotiation (ECDH). When the victim computes the shared secret as S = [victim_private_key]P via ECDH, this leaks information about victim_private_key mod (small_subgroup_order). For curves with cofactor > 1, this reveals the least significant bits of the private key. When these weak public keys are used in ECDSA , it's easy to forge signatures on the small subgroup.

Current behavior before PR:

Desired behavior after PR is merged:



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
