### PR TITLE
[FIX] hr_recruitment: fix recruitment kanban UI

### DIFF
--- a/addons/hr_recruitment/static/src/scss/hr_applicant.scss
+++ b/addons/hr_recruitment/static/src/scss/hr_applicant.scss
@@ -25,3 +25,11 @@
         margin-right: 0px !important;
     }
 }
+
+.o_user_name_align {
+    .o-mail-Avatar {
+        span {
+            text-align: left !important;
+        }
+    }
+}

--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -74,7 +74,7 @@
                                         </div>
                                         <div groups="hr_recruitment.group_hr_recruitment_interviewer,hr.group_hr_user">
                                             <div groups="!base.group_multi_company">
-                                                    <field name="recruiter_id" widget="many2one_avatar_employee" class="text-muted"
+                                                    <field name="recruiter_id" widget="many2one_avatar_employee" class="text-muted o_user_name_align"
                                                         options="{'display_avatar_name': True}"/>
                                                 </div>
                                                 <div groups="base.group_multi_company">
@@ -177,7 +177,7 @@
                                                     options="{'display_avatar_name': False}"/>
                                             </div>
                                         </div>
-                                        <div class="col align-content-end">
+                                        <div class="col align-content-center">
                                             <div groups="base.group_multi_company">
                                                 <t t-if="record.company_id.raw_value != 0">
                                                     <field name="company_id"/>


### PR DESCRIPTION
Version:
- saas-19.2

Before this commit, the job positions in the Recruitment kanban view looked strange and had UI display issues.

<img width="1085" height="538" alt="image" src="https://github.com/user-attachments/assets/e873665c-b0fb-49e2-bd4a-05e9a81809eb" />



This commit adds a class to fix the layout so the view displays properly.

<img width="1211" height="501" alt="image" src="https://github.com/user-attachments/assets/a593fcba-1390-4bb5-b986-560f9c62be0a" />


task-6007958


