### PR TITLE
[IMP] html_editor: appropriate table picker cell background

### DIFF
--- a/addons/html_editor/static/src/main/table/table_picker.scss
+++ b/addons/html_editor/static/src/main/table/table_picker.scss
@@ -11,7 +11,7 @@
         height: 19px;
         margin-right: 3px;
         margin-bottom: 3px;
-        background-color: #e9ecef;
+        background-color: $o-gray-200;
         &.active {
             background-color: #71639e;
         }


### PR DESCRIPTION
Currently in dark mode, we don't display the right bg color for (non active) cells in table picker. This PR uses the right variable for the bg color of non active cell that is more suitable for both light and dark mode.

task-6009282





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
