### PR TITLE
[FIX] web,orm: raise error for non-stored fields in validation domain

### DIFF
--- a/addons/web/tests/test_domain.py
+++ b/addons/web/tests/test_domain.py
@@ -49,3 +49,10 @@ class DomainTest(HttpCaseWithUserDemo):
             data=json.dumps({'params': {'model': 'res.users', 'domain': [('', '=', 1)]}}),
         )
         self.assertEqual(resp.json()['result'], False)
+
+        resp = self.url_open(
+            '/web/domain/validate',
+            headers={'Content-Type': 'application/json'},
+            data=json.dumps({'params': {'model': 'res.users', 'domain': [('accesses_count', '>', 10)]}}),
+        )
+        self.assertEqual(resp.json()['result'], False)

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -983,6 +983,9 @@ class DomainCondition(Domain):
                 if domain != self:
                     return domain
 
+            if not field.store and not field.compute_sql:
+                self._raise("Field has no SQL representation because it is not stored")
+
         # apply optimizations of the level for operator and type
         optimizations = _OPTIMIZATIONS_FOR[level]
         for opt in optimizations.get(self.operator, ()):


### PR DESCRIPTION
An error is generated in the logs when a user opens a record after saving a computed field used in the domain, as demonstrated in the steps below.

Step1:
- install `crm` and `base_automation`
- Create a new automation rule for the `Activity` module and set the `Apply On` domain as below: `[("res_model", "=", "crm.lead"), ("state","=","done")]`
- An error will occur in the log when you open this record.

Step 2:
- Install `mass_mailing`
- Go to Email Marketing and create a record as below data
    - Recipients: `Contact`
    - Set domain as `[("vat_label", "=", 'test')]`
- An error will occur in the log when user open this record.


This issue occurred because the recently refactored commit [1] used `validate` of Domain for the domain instead of `search_count`. The `validate` method only checks the structure of the domain and does not verify whether the domain is actually executed or not.

This commit fixes the issue by reverting commit [1], restoring the previous behavior where the domain is evaluated using `search_count`.

[1]: https://github.com/odoo/odoo/commit/a1434c32e9f4dd226d512677fd96e3051b908d8b

sentry-7004977102