### PR TITLE
[IMP] l10n_tr_nilvera_edispatch: allow flexible sequence codes and compute GIB prefix

### DIFF
--- a/addons/l10n_tr_nilvera_edispatch/models/stock_picking.py
+++ b/addons/l10n_tr_nilvera_edispatch/models/stock_picking.py
@@ -355,14 +355,14 @@ class StockPicking(models.Model):
         self.message_post(body=_("The dispatch has been successfully sent to Nilvera."))
 
     def _l10n_tr_nilvera_post_series(self, client):
-        if not self.picking_type_id.sequence_code:
+        if not self.picking_type_id.l10n_tr_nilvera_gib_sequence_code:
             return
 
         client.request(
             "POST",
             endpoint="/edespatch/Series",
             json={
-                'Name': self.picking_type_id.sequence_code.upper(),
+                'Name': self.picking_type_id.l10n_tr_nilvera_gib_sequence_code.upper(),
                 'IsActive': True,
                 'IsDefault': False,
             },
@@ -689,4 +689,4 @@ class StockPicking(models.Model):
         Example: 'OUT2025123456789'
         """
         sequence_number = self.name.removeprefix(self.picking_type_id.sequence_id.prefix or '').removesuffix(self.picking_type_id.sequence_id.suffix or '')
-        return f"{self.picking_type_id.sequence_code.upper()}{self.scheduled_date.year}{sequence_number.zfill(9)}"
+        return f"{self.picking_type_id.l10n_tr_nilvera_gib_sequence_code.upper()}{self.scheduled_date.year}{sequence_number.zfill(9)}"

--- a/addons/l10n_tr_nilvera_edispatch/models/stock_picking_type.py
+++ b/addons/l10n_tr_nilvera_edispatch/models/stock_picking_type.py
@@ -1,19 +1,59 @@
-from odoo import _, api, models
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 
 class StockPickingType(models.Model):
     _inherit = 'stock.picking.type'
+    l10n_tr_nilvera_gib_sequence_code = fields.Char('GIB Sequence Prefix', compute="_compute_l10n_tr_nilvera_gib_sequence_code")
+
+    @api.model
+    def _get_gib_sequence_prefix_from_sequence_code(self, sequence_code):
+        """Return the 3-char GIB prefix parsed from the sequence code for NILVERA.
+
+        Rules:
+        - Prefix must be exactly 3 alphanumeric characters.
+        - A single trailing non-alphanumeric character is allowed and ignored.
+        """
+        if not sequence_code or len(sequence_code) < 3:
+            return False
+
+        if sequence_code[-1].isalnum():
+            gib_prefix = sequence_code[-3:]
+        else:
+            if len(sequence_code) < 4:
+                return False
+            gib_prefix = sequence_code[-4:-1]
+
+        return gib_prefix if gib_prefix.isalnum() else False
+
+    @api.depends('sequence_code', 'company_id.account_fiscal_country_id.code', 'code')
+    def _compute_l10n_tr_nilvera_gib_sequence_code(self):
+        for picking_type in self:
+            is_tr = (picking_type.company_id.account_fiscal_country_id.code == 'TR')
+            is_outgoing = (picking_type.code == 'outgoing')
+            picking_type.l10n_tr_nilvera_gib_sequence_code = (
+                picking_type._get_gib_sequence_prefix_from_sequence_code(picking_type.sequence_code)
+                if is_tr and is_outgoing
+                else False
+            )
 
     @api.onchange('sequence_code')
     def _onchange_sequence_code(self):
+        gib_prefix = self._get_gib_sequence_prefix_from_sequence_code(self.sequence_code)
         if (
             self.company_id.account_fiscal_country_id.code == 'TR'
             and self.code == 'outgoing'
             and self.sequence_code
-            and len(self.sequence_code) != 3
+            and not gib_prefix
         ):
-            raise UserError(_("Only 3 characters are allowed in the Sequence Prefix by GİB"))
+            raise UserError(_("Odoo extracts the last 3 letters of the Sequence Prefix as the GIB prefix for e-Dispatch orders."
+                              "\n\nValid examples:"
+                              "\nOUT/"
+                              "\nOUT-"
+                              "\nWH/OUT"
+                              "\nWH-OUT"
+                              "\nWH/OUT/"
+                              "\n\nPlease update the Sequence Code so the last 3 characters form a valid prefix."))
         return super()._onchange_sequence_code()
 
     def _get_action(self, action_xmlid):

--- a/addons/l10n_tr_nilvera_edispatch/tests/test_files/invoice_with_edispatches.xml
+++ b/addons/l10n_tr_nilvera_edispatch/tests/test_files/invoice_with_edispatches.xml
@@ -17,12 +17,12 @@
         <cbc:IssueDate>2025-03-03</cbc:IssueDate>
     </cac:OrderReference>
     <cac:DespatchDocumentReference>
-        <cbc:ID>TRW/OUT/2025000000001</cbc:ID>
+        <cbc:ID>NIL2025000000001</cbc:ID>
         <cbc:IssueDate>2025-03-05</cbc:IssueDate>
         <cbc:DocumentTypeCode>SEVK</cbc:DocumentTypeCode>
     </cac:DespatchDocumentReference>
     <cac:DespatchDocumentReference>
-        <cbc:ID>TRW/OUT/2025000000002</cbc:ID>
+        <cbc:ID>NIL2025000000002</cbc:ID>
         <cbc:IssueDate>2025-03-05</cbc:IssueDate>
         <cbc:DocumentTypeCode>SEVK</cbc:DocumentTypeCode>
     </cac:DespatchDocumentReference>

--- a/addons/l10n_tr_nilvera_edispatch/tests/test_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_edispatch/tests/test_xml_ubl_tr.py
@@ -18,6 +18,7 @@ class TestEdispatchUBLTr(TestUBLTRCommon):
             'code': 'TRW',
             'sequence': 5,
         })
+        cls.warehouse_1.out_type_id.sequence_code = "WH/NIL/"
 
     def test_xml_invoice_with_edispatches(self):
         with freeze_time('2025-03-05'):

--- a/addons/l10n_tr_nilvera_edispatch/views/stock_picking_views.xml
+++ b/addons/l10n_tr_nilvera_edispatch/views/stock_picking_views.xml
@@ -43,17 +43,19 @@
                 <div name="nilvera_div"
                      class="o_row o_align_center"
                      invisible="country_code != 'TR' or state == 'draft' or picking_type_code != 'outgoing'">
-                    <field name="l10n_tr_nilvera_send_status" class="oe_inline"/>
-                    <button
-                        name="l10n_tr_nilvera_get_dispatch_status"
-                        type="object"
-                        class="o_icon_button text-primary"
-                        invisible="l10n_tr_nilvera_send_status not in ['sent', 'waiting']"
-                        title="Synchronize with Nilvera"
-                        icon="fa-refresh"/>
+                     <div class="d-flex align-items-center gap-2">
+                        <field name="l10n_tr_nilvera_send_status" class="w-auto"/>
+                        <button
+                            name="l10n_tr_nilvera_get_dispatch_status"
+                            type="object"
+                            class="o_icon_button text-primary"
+                            invisible="l10n_tr_nilvera_send_status not in ['sent', 'waiting']"
+                            title="Synchronize with Nilvera"
+                            icon="fa-refresh"/>
+                    </div>
                 </div>
             </field>
-            <xpath expr="//notebook" position="inside">
+            <xpath expr="//notebook/page[@name='operations']" position="after">
                 <page name="l10n_tr_edispatch" string="e-Dispatch" invisible="country_code != 'TR' or picking_type_code == 'internal' or not partner_id">
                     <group>
                         <group name="l10n_tr_delivery_details" string="General Information">
@@ -84,6 +86,24 @@
                 <field name="l10n_tr_nilvera_edispatch_warnings" invisible="1"/>
                 <div class="m-0" name="warnings" invisible="not l10n_tr_nilvera_edispatch_warnings or (state == 'done' and not partner_id)">
                     <field name="l10n_tr_nilvera_edispatch_warnings" class="o_field_html" widget="actionable_errors"/>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_picking_type_form_inherit_l10n_tr_nilvera_edispatch" model="ir.ui.view">
+        <field name="name">view.picking.type.form.inherit.l10n.tr.nilvera.edispatch</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_picking_type_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//sheet" position="before">
+                <div class="alert alert-info" role="alert" invisible="country_code != 'TR' or code != 'outgoing' or not l10n_tr_nilvera_gib_sequence_code">
+                    <span>The system detected the E-Dispatch GIB prefix as <b><field name="l10n_tr_nilvera_gib_sequence_code"/></b>.
+                        <br/>The system will send <b><field name="l10n_tr_nilvera_gib_sequence_code"/></b> to Nilvera instead of <b><field readonly="True" name="sequence_code"/></b>.
+                        <br/>Please verify that the prefix is correct.</span>
+                </div>
+                <div class="alert alert-danger" role="alert" invisible="country_code != 'TR' or code != 'outgoing' or l10n_tr_nilvera_gib_sequence_code">
+                        <span>Odoo could not detect a GIB e-Dispatch prefix. Please update the Sequence Prefix.</span>
                 </div>
             </xpath>
         </field>


### PR DESCRIPTION
# Description of the issue/feature this PR addresses:
Previously, the `sequence_code` of `stock.picking.type` was restricted to exactly 3 characters for outgoing pickings of Turkish companies. This was introduced because Nilvera requires a 3-character prefix when sending e-Dispatch documents.

However, enforcing a 3-character sequence code prevents users from including warehouse identifiers in the prefix (e.g. `WH/OUT`). Odoo normally relies on this structure to help users filter and distinguish warehouses. With the restriction in place, this functionality was lost.

# Desired behavior after PR is merged:
This commit removes the 3-character restriction on the sequence code and introduces a computed field that extracts the required 3-character GIB prefix from the sequence code. The computed prefix is used when sending documents to Nilvera, while users can keep meaningful sequence codes for operational use.

Additional improvements:
- Move the e-Dispatch tab next to "Operations" in `view_picking_form`
- Reduce the spacing between the text and reload button for the "Nilvera Status" field in `view_picking_form`

task-5964505
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
