### PR TITLE
[FIX] account: handle False country_code in UBL/CII condition

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_move_send.py
+++ b/addons/account_edi_ubl_cii/models/account_move_send.py
@@ -186,11 +186,15 @@ class AccountMoveSend(models.AbstractModel):
         writer.addAttachment(attachment_name, xml_facturx, subtype='text/xml')
 
         # PDF-A.
-        if ((invoice_data.get('ubl_cii_xml_options', {}).get('ubl_cii_format') in ('facturx', 'zugferd')
-                or (invoice.commercial_partner_id.country_code in ('FR', 'DE') and invoice.commercial_partner_id.peppol_eas != '0204'))
-                and invoice.country_code in ('FR', 'DE')
+        invoice_country = invoice.country_code or ''
+        partner_country = invoice.commercial_partner_id.country_code or ''
+
+        if (
+                (invoice_data.get('ubl_cii_xml_options', {}).get('ubl_cii_format') in ('facturx', 'zugferd')
+                 or (partner_country in ('FR', 'DE') and invoice.commercial_partner_id.peppol_eas != '0204'))
+                and invoice_country in ('FR', 'DE')
                 and not writer.is_pdfa
-            ):
+        ):
             try:
                 writer.convert_to_pdfa()
             except Exception:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR fixes an error occurring during the evaluation of the UBL/CII export condition when the country_code field on the invoice or its commercial partner is not set. In Odoo, unset fields may return False, which can lead to type comparison errors when performing membership checks against string values.

Current behavior before PR:
If invoice.country_code or invoice.commercial_partner_id.country_code is False, the condition that checks whether the country code is in ('FR', 'DE') may raise an error because a boolean value is being evaluated where a string is expected.

Desired behavior after PR is merged:
The condition safely handles cases where country_code is not set by normalizing the value before performing the membership check. This prevents type errors and ensures the logic behaves correctly even when the country code is missing.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
