### PR TITLE
[FIX] sale_stock,stock_dropshipping: avoid negative delivery when not a return

### DIFF
--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -203,7 +203,7 @@ class SaleOrderLine(models.Model):
                         continue
                     qty += move.product_uom._compute_quantity(move.quantity, line.product_uom_id, rounding_method='HALF-UP')
                 for move in incoming_moves:
-                    if move.state != 'done':
+                    if move.state != 'done' or (not move.origin_returned_move_id and line.product_uom_qty > 0 and not move.picking_id.return_id):
                         continue
                     qty -= move.product_uom._compute_quantity(move.quantity, line.product_uom_id, rounding_method='HALF-UP')
                 line.qty_delivered = qty

--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -203,7 +203,7 @@ class SaleOrderLine(models.Model):
                         continue
                     qty += move.product_uom._compute_quantity(move.quantity, line.product_uom_id, rounding_method='HALF-UP')
                 for move in incoming_moves:
-                    if move.state != 'done':
+                    if move.state != 'done' or (not move.origin_returned_move_id and line.product_uom_qty > 0):
                         continue
                     qty -= move.product_uom._compute_quantity(move.quantity, line.product_uom_id, rounding_method='HALF-UP')
                 line.qty_delivered = qty

--- a/addons/stock_dropshipping/tests/test_dropship.py
+++ b/addons/stock_dropshipping/tests/test_dropship.py
@@ -515,3 +515,24 @@ class TestDropshipPostInstall(common.TransactionCase):
         purchase_order.button_confirm()
         sale_order._action_cancel()
         self.assertEqual(len(purchase_order.activity_ids), 1)
+
+    def test_so_line_delivered_qty_for_dropshipping(self):
+        """
+        Ensure that the delivered quantity on a Sale Order line remains 0
+        and does not become -1 when the purchase order picking type (location
+        address) is changed to warehouse during a dropshipping instead of delivering
+        directly to the customer.
+        """
+        so = self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'order_line': [Command.create({
+                'product_id':  self.dropship_product.id,
+                'product_uom_qty': 1,
+            })],
+        })
+        so.action_confirm()
+        po = so._get_purchase_orders()
+        po.picking_type_id = po._default_picking_type()
+        po.button_confirm()
+        po.picking_ids.button_validate()
+        self.assertEqual(so.order_line.qty_delivered, 0)


### PR DESCRIPTION
Currently, an error occurs when the user receives a dropship order instead of delivering it directly to the customer. As a result, the sale order shows a negative delivered quantity.

## Steps to replicate:
- Install Sales, Inventory, and Purchase.
- Enable Dropshipping from Inventory settings.
- Create a test product with the Dropship route enabled and set a vendor for it in the Purchase tab.
- Create and confirm a quotation for a customer.
- Go to Purchase > `Deliver To:` and set it to `My Company: Receipts.`
- Confirm the Purchase Order and validate the receipt.
- Go back to the Sale Order.

## Observed Behavior:
The delivered quantity is -1, which is incorrect because the customer has not returned any products, nor has the user created a sale order line with a negative quantity (which would indicate a return).

## Root cause:
When computing the delivered quantity at [1], the function `_get_outgoing_incoming_moves` [2] is called to retrieve the incoming and outgoing stock moves associated with the sale order lines.

Inside this function, moves are filtered and categorized as incoming or outgoing. At [3], the condition is satisfied because the default value of `to_refund` is `True`, so the move is added to `incoming_move_ids`. Later, during the computation at [1], the code iterates through the incoming moves and subtracts their quantities from the delivered quantity.

Since the initial delivered quantity is 0, including such a move in `incoming_move_ids` causes the delivered quantity to become -1.


<h3> Why did this behavior not occur in lower versions?:</h3>

This issue was introduced by [commit], which added the functionality for users to return products that are not listed in the purchase order. As a result, their quantities appear as negative received quantities on the purchase order.

Before this change (in saas-18.2), the field `move.to_refund` had a default value of `False`. Because of this, the condition at [3] was not satisfied, and the move was not included in `incoming_move_ids`. Therefore, it was not subtracted when iterating through incoming moves, and the delivered quantity did not become negative.

Starting from 18.3, the default value of `to_refund` was changed to `True`. This causes the condition at [3] to be satisfied, the move to be included in `incoming_move_ids`, and its quantity to be subtracted during the computation, resulting in a delivered quantity of -1.

[1]-
https://github.com/odoo/odoo/blob/1256875226436a854558a1334ffdc886fa4767a8/addons/sale_stock/models/sale_order_line.py#L193-L209 
[2]-
https://github.com/odoo/odoo/blob/1256875226436a854558a1334ffdc886fa4767a8/addons/sale_stock/models/sale_order_line.py#L316-L353 
[3]-
https://github.com/odoo/odoo/blob/1256875226436a854558a1334ffdc886fa4767a8/addons/sale_stock/models/sale_order_line.py#L346-L351

## Solution:
We can make the condition stricter by ensuring that only incoming moves that are actual returns are counted as negative in the quantity delivered on a sale order. 

Specifically, if an incoming move has no corresponding originating return move and the customer has not created a sale order line with a negative quantity (which could also indicate a return), it should not be considered when calculating the delivered quantity.

[commit]:
https://github.com/odoo/odoo/pull/209110/changes/c1c86182e4b28e929bf56e79f57f33aaa13e67f1

opw-5933594