### PR TITLE
[FIX] hr_expense: require vendor for company-paid expenses using SEPA

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1180,6 +1180,19 @@ class HrExpense(models.Model):
         if len(employee_expenses.company_id) > 1:
             raise UserError(_("You can't post simultaneously employee-paid expenses belonging to different companies"))
 
+        # For company-paid expenses using SEPA Credit Transfer, the vendor must be set
+        # because SEPA XML generation requires a creditor name (partner).
+        expenses_missing_vendor = company_expenses.filtered(
+            lambda exp: exp.payment_method_line_id.code == 'sepa_ct' and not exp.vendor_id
+        )
+        if expenses_missing_vendor:
+            expense_names = ', '.join(expenses_missing_vendor.mapped('name'))
+            raise UserError(_(
+                "The vendor is required for expenses using SEPA Credit Transfer as the payment method."
+                "\nPlease set a vendor on the following expenses: %s",
+                expense_names
+            ))
+
         if company_expenses:
             company_expenses._create_company_paid_moves()
             # Post the company-paid expense through the payment, to post both at the same time

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -1047,6 +1047,7 @@ class TestExpenses(TestExpenseCommon):
             'payment_method_line_id': sepa_ct_line.id,
             'total_amount_currency': 100.00,
             'currency_id': self.env.ref('base.EUR').id,
+            'vendor_id': self.partner_a.id,
         })
 
         expense.action_submit()


### PR DESCRIPTION
**Steps to reproduce:**
* Install `account_iso20022` and `hr_expense`  module.
* Create an expense with `Paid by Company` and `SEPA credit transfer` as the payment method.
* Leave the `Vendor` field empty.
* Submit, approve, and post the expense.

**Observed behavior:**
* The expense is posted successfully without a vendor, creating a payment with `partner_id = False`.
* The payment cannot be reset to draft due to the missing vendor, and SEPA XML generation fails because the creditor name (`<Cdtr><Nm>`) requires a partner.

**Cause:**
* The `hr_expense` module overrides `_compute_show_require_partner_bank`. to set `require_partner_bank_account = False` for expense payments, bypassing the partner bank validation in `account.payment.action_post`.
* `_prepare_payments_vals` uses `self.vendor_id.id` for `partner_id`, which evaluates to `False` when no vendor is set.
* The `_post` method on `account.move` only validates partner presence for invoices (sale/purchase documents), not for `entry` type moves, which payments use.

**Fix:**
* Add a validation in `hr.expense.action_post` that checks whether the payment method is `sepa_ct`. If so, `vendor_id` must be set before posting.
* This catches the issue early in the expense flow, before the payment and journal entry are created.

opw-5930687
