### PR TITLE
[PERF] html_editor: reduce style recalculations in updateHooks

### DIFF
--- a/addons/html_editor/static/src/main/movenode_plugin.js
+++ b/addons/html_editor/static/src/main/movenode_plugin.js
@@ -161,16 +161,22 @@ export class MoveNodePlugin extends Plugin {
         }
 
         const visibleElements = [...this.visibleMovableElements];
-        // Prevent layout thrashing by computing all the rects in advance.
+        // Prevent layout thrashing by computing all the rects and styles in
+        // advance.
         const elementRects = visibleElements.map((element) => element.getBoundingClientRect());
+        const elementStyles = visibleElements.map((element) => {
+            const style = getComputedStyle(element);
+            return {
+                marginTop: parseInt(style.marginTop, 10) || 0,
+                marginBottom: parseInt(style.marginBottom, 10) || 0,
+            };
+        });
         for (const index in visibleElements) {
             const element = visibleElements[index];
             const elementRect = elementRects[index];
             const hookElement = this.elementHookMap.get(element);
 
-            const style = getComputedStyle(element);
-            const marginTop = parseInt(style.marginTop, 10) || 0;
-            const marginBottom = parseInt(style.marginBottom, 10) || 0;
+            const { marginTop, marginBottom } = elementStyles[index];
             let hookBox;
             if (element.tagName === "HR") {
                 hookBox = new DOMRect(


### PR DESCRIPTION
Description of the issue this PR addresses:

Before this PR, updateHooks retrieved the computed style for each visible element and accessed marginTop and marginBottom inside the loop. Accessing properties of CSSStyleDeclaration may trigger style resolution, causing repeated 'Recalculate Style' work during hook updates.

This PR extracts marginTop and marginBottom after getComputedStyle outside the loop, which reduces style reads during hook updates and avoids unnecessary style recalculations.

Before:
<img width="1522" height="360" alt="image" src="https://github.com/user-attachments/assets/c35cd866-09ac-4520-8828-3a787538aed9" />

After:
<img width="967" height="360" alt="image" src="https://github.com/user-attachments/assets/ce43ea50-0766-446d-ba3f-f2cb571089d2" />


task-6009463

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
