### PR TITLE
[REF] web,*: remove wrong usage of ExprToBoolean in fields

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -358,7 +358,7 @@
                                     widget="daterange"
                                     readonly="state != 'confirm'"
                                     required="not date_from or not date_to"
-                                    options="{'end_date_field': 'request_date_to', 'always_range': '1'}"/>
+                                    options="{'end_date_field': 'request_date_to', 'always_range': True}"/>
                                 <field name="request_date_to" required="not date_from or not date_to" invisible="1"/> <!-- For Form view test-->
                                 <div>
                                     ( <field name="duration_display" readonly="1" class="w-auto"/> )

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -108,7 +108,7 @@
                         <group>
                             <field name="active" invisible="1"/>
                             <field name="user_id" string="Project Manager" widget="many2one_avatar_user" readonly="not active" domain="[('share', '=', False)]"/>
-                            <field name="date_start" string="Planned Date" widget="daterange" options='{"end_date_field": "date", "always_range": "1"}' required="date_start or date" />
+                            <field name="date_start" string="Planned Date" widget="daterange" options='{"end_date_field": "date", "always_range": True}' required="date_start or date" />
                             <field name="date" invisible="1" required="date_start"/>
                         </group>
                     </group>
@@ -257,7 +257,7 @@
                     <field name="partner_id" optional="show" string="Customer" invisible="is_template"/>
                     <field name="company_id" optional="show" groups="base.group_multi_company" options="{'no_create': True, 'no_open': True}"/>
                     <field name="company_id" column_invisible="True"/>
-                    <field name="date_start" string="Planned Date" widget="daterange" options="{'end_date_field': 'date', 'always_range': '1'}" optional="hide"/>
+                    <field name="date_start" string="Planned Date" widget="daterange" options="{'end_date_field': 'date', 'always_range': True}" optional="hide"/>
                     <field name="date" column_invisible="True" />
                     <field name="milestone_progress" widget="progressbar"
                         invisible="milestone_progress == 0 or not allow_milestones or is_template"

--- a/addons/project/wizard/project_template_create_wizard.xml
+++ b/addons/project/wizard/project_template_create_wizard.xml
@@ -15,7 +15,7 @@
                 <group>
                     <group>
                         <field name="date" required="not template_has_dates and date_start" invisible="1"/>
-                        <field name="date_start" required="not template_has_dates and date" string="Planned Date" widget="daterange" options='{"end_date_field": "date", "always_range": "1"}'/>
+                        <field name="date_start" required="not template_has_dates and date" string="Planned Date" widget="daterange" options='{"end_date_field": "date", "always_range": True}'/>
                         <label for="alias_name" string="Project's Email"/>
                         <div class="o_row">
                             <field name="alias_name" placeholder="e.g. office-party"/>

--- a/addons/sale_timesheet/wizard/sale_make_invoice_advance_views.xml
+++ b/addons/sale_timesheet/wizard/sale_make_invoice_advance_views.xml
@@ -20,7 +20,7 @@
                         string="Timesheets Period"
                         widget="daterange"
                         required="date_start_invoice_timesheet or date_end_invoice_timesheet"
-                        options="{'end_date_field': 'date_end_invoice_timesheet', 'always_range': 'true'}"
+                        options="{'end_date_field': 'date_end_invoice_timesheet', 'always_range': True}"
                         title="Only timesheets not yet invoiced (and validated, if applicable) from this period will be invoiced. If the period is not indicated, all timesheets not yet invoiced (and validated, if applicable) will be invoiced without distinction."
                     />
                     <field name="date_end_invoice_timesheet" required="date_start_invoice_timesheet or date_end_invoice_timesheet" invisible="1" />

--- a/addons/web/static/src/views/fields/color/color_field.js
+++ b/addons/web/static/src/views/fields/color/color_field.js
@@ -1,7 +1,6 @@
 import { Component } from "@odoo/owl";
 import { registry } from "@web/core/registry";
 import { standardFieldProps } from "../standard_field_props";
-import { exprToBoolean } from "@web/core/utils/strings";
 
 export class ColorField extends Component {
     static template = "web.ColorField";
@@ -28,7 +27,7 @@ export const colorField = {
     extractProps({ viewType, options }, dynamicInfo) {
         let autosave = false;
         if ("autosave" in options) {
-            autosave = exprToBoolean(options.autosave);
+            autosave = Boolean(options.autosave);
         } else if (["list", "kanban"].includes(viewType)) {
             autosave = true;
         }

--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -14,13 +14,6 @@ import { DateTimeOperation } from "@web/model/relational_model/operation";
 
 const { DateTime } = luxon;
 
-function getFormattedPlaceholder(value, type, options) {
-    if (value instanceof luxon.DateTime) {
-        return type === "date" ? formatDate(value, options) : formatDateTime(value, options);
-    }
-    return value || "";
-}
-
 /**
  * @typedef {luxon.DateTime} DateTime
  *
@@ -442,12 +435,12 @@ export const dateField = {
         },
     ],
     supportedTypes: ["date"],
-    extractProps: ({ options, placeholder, type }, dynamicInfo) => ({
+    extractProps: ({ options, placeholder }, dynamicInfo) => ({
         endDateField: options[END_DATE_FIELD_OPTION],
         maxDate: options.max_date,
         minDate: options.min_date,
         alwaysRange: exprToBoolean(options.always_range),
-        placeholder: getFormattedPlaceholder(placeholder, type, { numeric: options.numeric }),
+        placeholder,
         required: dynamicInfo.required,
         rounding: options.rounding && parseInt(options.rounding, 10),
         startDateField: options[START_DATE_FIELD_OPTION],
@@ -519,22 +512,11 @@ export const dateTimeField = {
             availableTypes: ["datetime", "char"],
         },
     ],
-    extractProps: ({ attrs, options, placeholder, type }, dynamicInfo) => {
-        const showSeconds = exprToBoolean(options.show_seconds ?? false);
-        const showTime = exprToBoolean(options.show_time ?? true);
-        const numeric = exprToBoolean(options.numeric ?? false);
-        return {
-            ...dateField.extractProps({ attrs, options, placeholder, type }, dynamicInfo),
-            placeholder: getFormattedPlaceholder(placeholder, type, {
-                numeric,
-                showSeconds,
-                showTime,
-            }),
-            numeric,
-            showSeconds,
-            showTime,
-        };
-    },
+    extractProps: (fieldInfo, dynamicInfo) => ({
+        ...dateField.extractProps(fieldInfo, dynamicInfo),
+        showSeconds: exprToBoolean(fieldInfo.options.show_seconds ?? false),
+        showTime: exprToBoolean(fieldInfo.options.show_time ?? true),
+    }),
     supportedTypes: ["datetime"],
     listViewWidth: ({ options }) => {
         if (!exprToBoolean(options.show_time ?? true)) {

--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -6,7 +6,6 @@ import { _t } from "@web/core/l10n/translation";
 import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { registry } from "@web/core/registry";
 import { ensureArray } from "@web/core/utils/arrays";
-import { exprToBoolean } from "@web/core/utils/strings";
 import { FIELD_WIDTHS } from "@web/views/list/column_width_hook";
 import { formatDate, formatDateTime } from "../formatters";
 import { standardFieldProps } from "../standard_field_props";
@@ -439,13 +438,13 @@ export const dateField = {
         endDateField: options[END_DATE_FIELD_OPTION],
         maxDate: options.max_date,
         minDate: options.min_date,
-        alwaysRange: exprToBoolean(options.always_range),
+        alwaysRange: Boolean(options.always_range),
         placeholder,
         required: dynamicInfo.required,
         rounding: options.rounding && parseInt(options.rounding, 10),
         startDateField: options[START_DATE_FIELD_OPTION],
         numeric: options.numeric,
-        warnFuture: exprToBoolean(options.warn_future),
+        warnFuture: Boolean(options.warn_future),
         minPrecision: options.min_precision,
         maxPrecision: options.max_precision,
     }),
@@ -514,12 +513,12 @@ export const dateTimeField = {
     ],
     extractProps: (fieldInfo, dynamicInfo) => ({
         ...dateField.extractProps(fieldInfo, dynamicInfo),
-        showSeconds: exprToBoolean(fieldInfo.options.show_seconds ?? false),
-        showTime: exprToBoolean(fieldInfo.options.show_time ?? true),
+        showSeconds: fieldInfo.options.show_seconds ?? false,
+        showTime: fieldInfo.options.show_time ?? true,
     }),
     supportedTypes: ["datetime"],
     listViewWidth: ({ options }) => {
-        if (!exprToBoolean(options.show_time ?? true)) {
+        if (!(options.show_time ?? true)) {
             return dateField.listViewWidth({ options });
         }
         return options.numeric ? FIELD_WIDTHS.numeric_datetime : FIELD_WIDTHS.datetime;

--- a/addons/web/static/src/views/fields/field.js
+++ b/addons/web/static/src/views/fields/field.js
@@ -16,6 +16,7 @@ import { useService } from "@web/core/utils/hooks";
 
 const isSmall = utils.isSmall;
 
+const formatterRegistry = registry.category("formatters");
 const viewRegistry = registry.category("views");
 const fieldRegistry = registry.category("fields");
 
@@ -373,26 +374,32 @@ export class Field extends Component {
             this.field = getFieldFromRegistry(fieldType, this.props.type);
         }
 
-        useLayoutEffect(() => {
-            this.debouncedOverlayPositioning();
-        }, () => [this.props.record.data]);
+        useLayoutEffect(
+            () => {
+                this.debouncedOverlayPositioning();
+            },
+            () => [this.props.record.data]
+        );
 
-        useLayoutEffect((fieldEl) => {
-            if (!fieldEl) {
-                return;
-            }
-            positionInputBoxOverlay(fieldEl);
-            if (hasTouch() && this.props.fieldInfo?.viewType === "form") {
-                const focusIn = () => this.onFieldFocus(true);
-                const focusOut = () => this.onFieldFocus(false);
-                fieldEl.addEventListener("focusin", focusIn);
-                fieldEl.addEventListener("focusout", focusOut);
-                return () => {
-                    fieldEl.removeEventListener("focusin", focusIn);
-                    fieldEl.removeEventListener("focusout", focusOut);
+        useLayoutEffect(
+            (fieldEl) => {
+                if (!fieldEl) {
+                    return;
                 }
-            }
-        }, () => [this.fieldRef.el]);
+                positionInputBoxOverlay(fieldEl);
+                if (hasTouch() && this.props.fieldInfo?.viewType === "form") {
+                    const focusIn = () => this.onFieldFocus(true);
+                    const focusOut = () => this.onFieldFocus(false);
+                    fieldEl.addEventListener("focusin", focusIn);
+                    fieldEl.addEventListener("focusout", focusOut);
+                    return () => {
+                        fieldEl.removeEventListener("focusin", focusIn);
+                        fieldEl.removeEventListener("focusout", focusOut);
+                    };
+                }
+            },
+            () => [this.fieldRef.el]
+        );
     }
 
     get classNames() {
@@ -463,10 +470,12 @@ export class Field extends Component {
                         attrs: { ...fieldInfo.attrs, ...this.props.attrs },
                     };
                 }
-                if (fieldInfo.attrs.placeholder || fieldInfo.options.placeholder_field) {
-                    fieldInfo.placeholder =
-                        record.data[fieldInfo.options.placeholder_field] ||
-                        fieldInfo.attrs.placeholder;
+                if (fieldInfo.options.placeholder_field) {
+                    const placeholderField = fieldInfo.options.placeholder_field;
+                    const formatter = formatterRegistry.get(record.fields[placeholderField].type);
+                    fieldInfo.placeholder = formatter(record.data[placeholderField]);
+                } else if (fieldInfo.attrs.placeholder) {
+                    fieldInfo.placeholder = fieldInfo.attrs.placeholder;
                 }
 
                 const dynamicInfo = {
@@ -519,6 +528,8 @@ export class Field extends Component {
     }
     onFieldFocus(isActive) {
         const formLabelSelector = `.o_cell:has(+ .o_cell .o_field_widget[name=${this.props.name}]) .o_form_label`;
-        document.querySelector(`label[for=${this.fieldComponentProps.id}], ${formLabelSelector}`)?.classList.toggle("o_label_active", isActive);
+        document
+            .querySelector(`label[for=${this.fieldComponentProps.id}], ${formLabelSelector}`)
+            ?.classList.toggle("o_label_active", isActive);
     }
 }

--- a/addons/web/static/src/views/fields/field_selector/field_selector_field.js
+++ b/addons/web/static/src/views/fields/field_selector/field_selector_field.js
@@ -2,7 +2,6 @@ import { Component } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { ModelFieldSelector } from "@web/core/model_field_selector/model_field_selector";
 import { registry } from "@web/core/registry";
-import { exprToBoolean } from "@web/core/utils/strings";
 import { standardFieldProps } from "../standard_field_props";
 import { formatChar } from "../formatters";
 
@@ -12,7 +11,6 @@ export class FieldSelectorField extends Component {
     static props = {
         ...standardFieldProps,
         resModel: { type: String, optional: true },
-        onlySearchable: { type: Boolean, optional: true },
         allowProperties: { type: Boolean, optional: true },
         followRelations: { type: Boolean, optional: true },
     };
@@ -25,7 +23,7 @@ export class FieldSelectorField extends Component {
         if (!this.props.allowProperties && fieldDef.type === "properties") {
             return false;
         }
-        return !this.props.onlySearchable || fieldDef.searchable;
+        return true;
     }
 
     async update(value) {
@@ -71,17 +69,11 @@ export const fieldSelectorField = {
             name: "model",
             type: "string",
         },
-        {
-            label: _t("Only searchable"),
-            name: "only_searchable",
-            type: "string",
-        },
     ],
-    extractProps({ options }, dynamicInfo) {
+    extractProps({ options }) {
         return {
             allowProperties: options.allow_properties ?? true,
             followRelations: options.follow_relations ?? true,
-            onlySearchable: exprToBoolean(options.only_searchable),
             resModel: options.model,
         };
     },

--- a/addons/web/static/src/views/fields/formatters.js
+++ b/addons/web/static/src/views/fields/formatters.js
@@ -92,7 +92,7 @@ export function formatDate(value, options = {}) {
     }
 }
 formatDate.extractOptions = ({ options }) => ({
-    numeric: exprToBoolean(options.numeric ?? false),
+    numeric: options.numeric ?? false,
 });
 
 export function formatDateTime(value, options = {}) {
@@ -107,9 +107,8 @@ export function formatDateTime(value, options = {}) {
 }
 formatDateTime.extractOptions = ({ attrs, options }) => ({
     ...formatDate.extractOptions({ attrs, options }),
-    showSeconds: exprToBoolean(options.show_seconds ?? false),
-    showTime: exprToBoolean(options.show_time ?? true),
-    showDate: exprToBoolean(options.show_date ?? true),
+    showSeconds: options.show_seconds ?? false,
+    showTime: options.show_time ?? true,
 });
 
 /**
@@ -280,7 +279,7 @@ export function formatFloatTime(value, options = {}) {
         {
             [options.unit]: value,
         },
-        options,
+        options
     );
 }
 formatFloatTime.extractOptions = ({ options }) => ({

--- a/addons/web/static/tests/views/fields/daterange_field.test.js
+++ b/addons/web/static/tests/views/fields/daterange_field.test.js
@@ -1181,7 +1181,7 @@ test("always range: related end date, both start date and end date empty", async
         resModel: "partner",
         arch: /* xml */ `
         <form>
-            <field name="datetime" widget="daterange" options="{'end_date_field': 'datetime_end', 'always_range': '1'}"/>
+            <field name="datetime" widget="daterange" options="{'end_date_field': 'datetime_end', 'always_range': True}"/>
         </form>`,
         resId: 1,
     });
@@ -1226,8 +1226,8 @@ test("there is no arrow between the dates with option always_range if nothing is
         resModel: "partner",
         arch: /* xml */ `
         <form>
-            <field name="datetime" widget="daterange" options="{'end_date_field': 'datetime_end', 'always_range': 'true'}" />
-            <field name="datetime" widget="daterange" options="{'end_date_field': 'datetime_end', 'always_range': 'true'}" readonly="true" />
+            <field name="datetime" widget="daterange" options="{'end_date_field': 'datetime_end', 'always_range': True}" />
+            <field name="datetime" widget="daterange" options="{'end_date_field': 'datetime_end', 'always_range': True}" readonly="true" />
         </form>`,
     });
 
@@ -1247,7 +1247,7 @@ test("invalid empty date with optional end date", async () => {
         arch: /* xml */ `
         <form>
             <label for="date" string="Daterange" />
-            <field name="date" widget="daterange" options="{'end_date_field': 'date_end','always_range': '1'}"  string="Planned Date" required="date_end"/>
+            <field name="date" widget="daterange" options="{'end_date_field': 'date_end','always_range': True}"  string="Planned Date" required="date_end"/>
             <field name="date_end" invisible="1" required="date"/>
         </form>`,
         resId: 1,
@@ -1272,7 +1272,7 @@ test("invalid empty date with optional start date", async () => {
         <form>
             <label for="date_end" string="Daterange" />
             <field name="date" invisible="1" required="date_end"/>
-            <field name="date_end" widget="daterange" options="{'start_date_field': 'date','always_range': '1'}" string="Planned Date" required="date"/>
+            <field name="date_end" widget="daterange" options="{'start_date_field': 'date','always_range': True}" string="Planned Date" required="date"/>
         </form>`,
         resId: 1,
     });

--- a/addons/web/static/tests/views/fields/field_selector_field.test.js
+++ b/addons/web/static/tests/views/fields/field_selector_field.test.js
@@ -71,23 +71,6 @@ test("no specified options", async () => {
     );
 });
 
-test("only_searchable option", async () => {
-    await mountView({
-        type: "form",
-        resModel: "update.record.action",
-        arch: /* xml */ `
-            <form>
-                <field name="update_path" widget="field_selector" options="{'only_searchable': true}"/>
-            </form>
-        `,
-    });
-    await contains(".o_field_widget[name='update_path'] .o_input").click();
-    expect(queryAllTexts(".o_model_field_selector_popover_item")).toEqual(
-        ["Created on", "Display name", "Id", "Last Modified on", "Model", "Update path"],
-        { message: "should not display non searchable fields" }
-    );
-});
-
 test("model option", async () => {
     await mountView({
         type: "form",

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -11423,7 +11423,7 @@ test(`list daterange in form: open/close picker`, async () => {
                 <sheet>
                     <field name="foo_o2m">
                         <list editable="bottom">
-                            <field name="date" widget="daterange" options="{'end_date_field': 'date_end', 'always_range': '1'}"/>
+                            <field name="date" widget="daterange" options="{'end_date_field': 'date_end', 'always_range': True}"/>
                         </list>
                     </field>
                 </sheet>


### PR DESCRIPTION
Before this commit, some widgets and formatters used `exprToBoolean`
to evaluate their boolean options from the arch. This was a
mistake as those options are supposed to already be boolean values
in the arch. As a consequence, one had to wrap them into strings,
which was confusing.

This PR removes the wrong usages of `exprToBoolean` and adapts
the impacted archs.

Impacted widgets:
- `color` (`autosave` option, not used)
- `field_selector` (`only_searchable` option, not used => removed)
- `date` (options `numeric`, `always_range` and `warn_future` => few archs had to be adapted)
- `datetime` (options `show_seconds` and `show_time` + option `show_date`, only in formatter, unused, removed)

This PR also moved the logic of formatting dynamic placeholders (`placeholder_field` option)
into the Field component for convenience. More details in the dedicated commit.

Task~6012182