### PR TITLE
[FIX] html_editor: prevent unintended symbol creation when pressing space

### DIFF
--- a/addons/html_editor/static/src/core/shortcut_plugin.js
+++ b/addons/html_editor/static/src/core/shortcut_plugin.js
@@ -1,5 +1,4 @@
 import { Plugin, isValidTargetForDomListener } from "../plugin";
-import { closestBlock } from "@html_editor/utils/blocks";
 import { fillEmpty } from "@html_editor/utils/dom";
 import { leftLeafOnlyNotBlockPath } from "@html_editor/utils/dom_state";
 import { closestElement } from "@html_editor/utils/dom_traversal";
@@ -114,12 +113,12 @@ export class ShortCutPlugin extends Plugin {
             return;
         }
         const selection = this.dependencies.selection.getEditableSelection();
-        let blockEl = closestBlock(selection.anchorNode);
         const leftDOMPath = leftLeafOnlyNotBlockPath(selection.anchorNode);
         let spaceOffset = selection.anchorOffset;
         let lineBreak;
         let lineOffset = 0;
         let leftLeaf = leftDOMPath.next().value;
+        let textContent = selection.anchorNode.textContent;
         while (leftLeaf) {
             // Calculate spaceOffset by adding lengths of previous text nodes
             // to correctly find offset position for selection within inline
@@ -133,9 +132,10 @@ export class ShortCutPlugin extends Plugin {
             } else if (leftLeaf.nodeName === "BR") {
                 lineBreak = leftLeaf;
             }
+            textContent = leftLeaf.textContent + textContent;
             leftLeaf = leftDOMPath.next().value;
         }
-        const precedingText = blockEl.textContent.substring(lineOffset, spaceOffset - 1);
+        const precedingText = textContent.substring(lineOffset, spaceOffset - 1);
         const matchedShortcut = this.getResource("shorthands").find(({ pattern }) =>
             pattern.test(precedingText.trimStart())
         );
@@ -144,7 +144,6 @@ export class ShortCutPlugin extends Plugin {
             if (command) {
                 if (lineBreak) {
                     this.dependencies.split.splitBlockSegments();
-                    blockEl = closestBlock(selection.anchorNode);
                 }
                 // Set selection to the matched string with space
                 let offset =

--- a/addons/html_editor/static/tests/insert/text.test.js
+++ b/addons/html_editor/static/tests/insert/text.test.js
@@ -120,6 +120,27 @@ describe("collapsed selection", () => {
         execCommand(editor, "historyUndo");
         expect(getContent(el)).toBe("<p>ab=>&nbsp;[]</p>");
     });
+
+    test("should not replace last chars with symbol", async () => {
+        const { editor, el } = await setupEditor(
+            unformat(`
+                <div class="o-paragraph">\ufeff
+                    <span class="o_file_box o-contenteditable-false" contenteditable="false">
+                        <span class="d-flex flex-grow-1 align-items-center alert alert-info">
+                            <span class="o_file_image d-flex o_image user-select-none" contenteditable="false">
+                                <br>
+                            </span>
+                            <span class="o_file_name_container mx-2 d-flex flex-grow-1">
+                                <a class="o_link_readonly w-100" contenteditable="false" href="#">odoo_gmail.png</a>
+                            </span>
+                        </span>
+                    </span>\ufeff&nbsp;--> Document (fr&nbsp;[]
+                </div>
+            `)
+        );
+        await insertSpace(editor);
+        expect(getContent(el).includes("→")).toBe(false);
+    });
 });
 
 describe("not collapsed selection", () => {


### PR DESCRIPTION
Problem:
Sometimes pressing space in content containing a symbol pattern creates the symbol even when the space is not placed directly before it.

Cause:
`leftLeafOnlyNotBlockPath` sums the `spaceOffset` of all non-block leaf nodes, then performs a substring on the whole block containing those leafs.

In this case, the file box contains a `span` with `d-flex`, which is considered a block. Therefore, the file box text content length is not included in the `spaceOffset` calculation.

However, we later call `substring` on the `textContent` of the `closestBlock`, which includes the file box content. This leads to an incorrect `spaceOffset`, effectively skipping the file box text.

This can happen by chance when the `substring` returns the file box text content with `"-->"` immediately after it, making it the last character and triggering symbol creation.

Solution:
When computing the `substring`, consider only the `textContent` of the leaf nodes traversed while calculating `spaceOffset`. This ensures the offset matches the actual traversed content and prevents accidental symbol generation.

Steps to reproduce:
- Use the same HTML structure as in the test.
- Place the selection as in the test case.
- Press space.
- Observe that a symbol is incorrectly created.

task-6004954

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
