### PR TITLE
[FIX] pos_hr: make sure employey is correct

### DIFF
--- a/addons/pos_hr/models/pos_config.py
+++ b/addons/pos_hr/models/pos_config.py
@@ -21,7 +21,17 @@ class PosConfig(models.Model):
     def write(self, vals):
         if 'advanced_employee_ids' not in vals:
             vals['advanced_employee_ids'] = []
-        vals['advanced_employee_ids'] += [(4, emp_id) for emp_id in self._get_group_pos_manager().user_ids.employee_id.ids]
+        group_users = self.sudo()._get_group_pos_manager().with_company(self.company_id).user_ids.filtered(
+            lambda u: self.company_id in u.company_ids
+        )
+        allowed_employees = group_users.sudo().mapped('employee_id')
+        if not allowed_employees and group_users:
+            target_user = group_users.sudo().with_company(self.company_id).filtered(lambda user: not user.employee_id)[0]
+            target_user.action_create_employee()
+            allowed_employees = target_user.employee_id
+
+        # Update the vals list
+        vals['advanced_employee_ids'] += [(4, emp.id) for emp in allowed_employees]
 
         # write employees in sudo, because we have no access to these corecords
         sudo_vals = {

--- a/addons/pos_hr/tests/test_frontend.py
+++ b/addons/pos_hr/tests/test_frontend.py
@@ -12,16 +12,11 @@ class TestPosHrHttpCommon(TestPointOfSaleHttpCommon):
 
         cls.env.user.group_ids += cls.env.ref('hr.group_hr_user')
 
-        cls.main_pos_config.write({"module_pos_hr": True})
-
         # Admin employee
-        cls.admin = cls.env.ref("hr.employee_admin").sudo().copy({
-            "date_version": '2000-01-01',
-            "company_id": cls.env.company.id,
-            "user_id": cls.pos_admin.id,
-            "name": "Mitchell Admin",
-            "pin": False,
-        })
+        cls.pos_admin.employee_id.name = "Mitchell Admin"
+        cls.admin = cls.pos_admin.employee_id
+
+        cls.main_pos_config.write({"module_pos_hr": True})
 
         # Managers
         cls.manager_user = new_test_user(

--- a/addons/pos_hr/tests/test_res_config_settings.py
+++ b/addons/pos_hr/tests/test_res_config_settings.py
@@ -20,3 +20,25 @@ class TestConfigureShopsPoSHR(TestPosHrHttpCommon, TestConfigureShops):
 
         self.assertListEqual(self.main_pos_config.basic_employee_ids.ids, [])
         self.assertListEqual(self.main_pos_config.minimal_employee_ids.ids, [])
+
+    def test_write_create_employee_if_none(self):
+        """This test make sure that the employee set on advanced_employee_ids is from
+           the current company. And if none exists it create one for the user."""
+
+        # First test that an employee is created if none exists
+        self.env['hr.employee'].search([]).unlink()
+        self.main_pos_config.with_context(from_settings_view=True).write({
+            'basic_employee_ids': [],
+        })
+
+        self.assertEqual(len(self.main_pos_config.advanced_employee_ids), 1)
+        self.assertEqual(self.main_pos_config.advanced_employee_ids.company_id, self.main_pos_config.company_id)
+        advanced_employee = self.main_pos_config.advanced_employee_ids
+
+        # Test that the previously employee is used
+        self.main_pos_config.with_context(from_settings_view=True).write({
+            'advanced_employee_ids': [],
+        })
+        self.assertEqual(len(self.main_pos_config.advanced_employee_ids), 1)
+        self.assertEqual(self.main_pos_config.advanced_employee_ids.company_id, self.main_pos_config.company_id)
+        self.assertEqual(self.main_pos_config.advanced_employee_ids, advanced_employee)


### PR DESCRIPTION

When writing to a PoS config, it will automatically set an
`advanced_employee_ids` if none is set. But it will take any employee
that is part of `point_of_sale.group_pos_manager`. If the employee
selected is not part of the same company as the PoS config, and the
current user doesn't have HR employee access it will trigger an ir.rule
that block the user from opening the settings.

Steps to reproduce:
-------------------
* Create a new company
* Create a new user that only have access to this company and no HR
  access
* Create a PoS in the new company
* Login as the new user
* Try to open the settings
> Observation: You will get an access error because the employee set in
  `advanced_employee_ids` is from the other company

Why the fix:
------------
We make sure that when automatically setting the advanced_employee_ids
we filter out the ones that are not from the correct company. If no
employee exist that satisfies the requirements, we take a user from the
`group_pos_manager` and create an employee for him.

opw-5885417