### PR TITLE
[FIX] project: adapt subtask count and subtask view for task templates

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -56,7 +56,10 @@ class ProjectProject(models.Model):
     def _compute_open_task_count(self):
         self.__compute_task_count(
             count_field='open_task_count',
-            additional_domain=[('state', 'in', self.env['project.task'].OPEN_STATES)],
+            additional_domain=AND([
+                [('state', 'in', self.env['project.task'].OPEN_STATES)],
+                ['|', ('parent_id.is_template', '=', False), ('parent_id', '=', False)],
+            ]),
         )
 
     def _compute_closed_task_count(self):

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -234,7 +234,7 @@ class ProjectTask(models.Model):
     displayed_image_id = fields.Many2one('ir.attachment', domain="[('res_model', '=', 'project.task'), ('res_id', '=', id), ('mimetype', 'ilike', 'image')]", string='Cover Image')
 
     parent_id = fields.Many2one('project.task', string='Parent Task', inverse="_inverse_parent_id", index=True, domain="['!', ('id', 'child_of', id), ('project_id', '!=', False)]", tracking=True)
-    child_ids = fields.One2many('project.task', 'parent_id', string="Sub-tasks", domain="[('recurring_task', '=', False)]", export_string_translation=False)
+    child_ids = fields.One2many('project.task', 'parent_id', string="Sub-tasks", domain=[('recurring_task', '=', False), '|', ('parent_id.is_template', '=', True), ('is_template', '=', False)], export_string_translation=False)
     subtask_count = fields.Integer("Sub-task Count", compute='_compute_subtask_count', export_string_translation=False)
     closed_subtask_count = fields.Integer("Closed Sub-tasks Count", compute='_compute_subtask_count', export_string_translation=False)
     project_privacy_visibility = fields.Selection(related='project_id.privacy_visibility', string="Project Visibility", tracking=False)
@@ -637,7 +637,12 @@ class ProjectTask(models.Model):
         total_and_closed_subtask_count_per_parent_id = {
             parent.id: (count, sum(s in CLOSED_STATES for s in states))
             for parent, states, count in self.env['project.task']._read_group(
-                [('parent_id', 'in', self.ids)],
+                [
+                    ('parent_id', 'in', self.ids),
+                    '|',
+                    ('parent_id.is_template', '=', True),
+                    ('is_template', '=', False),
+                ],
                 ['parent_id'],
                 ['state:array_agg', '__count'],
             )
@@ -1832,6 +1837,14 @@ class ProjectTask(models.Model):
             'type': 'ir.actions.act_window',
             'context': self._context
         }
+
+    def action_open_subtasks(self):
+        self.ensure_one()
+        action = self.env['ir.actions.act_window']._for_xml_id('project.project_task_action_sub_task')
+        action['domain'] = [('id', 'child_of', self.id), ('id', '!=', self.id)]
+        if not self.is_template:
+            action['domain'].append(('is_template', '=', False))
+        return action
 
     def action_project_sharing_open_task(self):
         action = self.action_open_task()

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -628,12 +628,13 @@ class ProjectTask(models.Model):
     def _compute_subtask_count(self):
         if not any(self._ids):
             for task in self:
-                task.subtask_count, task.closed_subtask_count = len(task.child_ids), len(task.child_ids.filtered(lambda r: r.state in CLOSED_STATES))
+                subtasks = task.child_ids.filtered(lambda r: not r.is_template)
+                task.subtask_count, task.closed_subtask_count = len(subtasks), len(subtasks.filtered(lambda r: r.state in CLOSED_STATES))
             return
         total_and_closed_subtask_count_per_parent_id = {
             parent.id: (count, sum(s in CLOSED_STATES for s in states))
             for parent, states, count in self.env['project.task']._read_group(
-                [('parent_id', 'in', self.ids)],
+                [('parent_id', 'in', self.ids), ('is_template', '=', False)],
                 ['parent_id'],
                 ['state:array_agg', '__count'],
             )

--- a/addons/project/tests/test_project_subtasks.py
+++ b/addons/project/tests/test_project_subtasks.py
@@ -470,7 +470,7 @@ class TestProjectSubtasks(TestProjectCommon):
                 }),
             ],
         })
-        child_1, child_2, child_3, child_4 = parent_task.child_ids
+        child_1, child_2, child_3, child_4 = parent_task.child_ids.sorted('id')
         self.assertEqual(9, len(parent_task._get_all_subtasks()), "Should have 9 subtasks")
         parent_task.action_archive()
         self.assertFalse(all((parent_task + child_1._get_all_subtasks() + child_2).mapped('active')),
@@ -562,7 +562,7 @@ class TestProjectSubtasks(TestProjectCommon):
                 Command.create({'name': 'Sub-task 1', 'project_id': self.project_pigs.id}),
             ],
         })
-        subtask_1, subtask_2 = task.child_ids
+        subtask_1, subtask_2 = task.child_ids.sorted('id')
 
         self.assertFalse(subtask_1.display_in_project)
         self.assertTrue(subtask_2.display_in_project)

--- a/addons/project/tests/test_task_templates.py
+++ b/addons/project/tests/test_task_templates.py
@@ -106,3 +106,41 @@ class TestTaskTemplates(TestProjectCommon, MailCase):
         task = self.env["project.task"].browse(task_id)
         self.assertEqual(task.message_ids[0].subtype_id, self.env.ref('project.mt_task_new'))
         self.assertEqual(task.message_ids[0].notified_partner_ids, self.user_projectuser.partner_id)
+
+    def test_subtask_count_ignores_template_child_on_normal_parent(self):
+        """Template subtasks should not be counted on a normal parent task."""
+        parent_task = self.env["project.task"].create({
+            "name": "Normal Parent",
+            "project_id": self.project_with_templates.id,
+        })
+        self.env["project.task"].create({
+            "name": "Template Child",
+            "project_id": self.project_with_templates.id,
+            "parent_id": parent_task.id,
+            "is_template": True,
+        })
+
+        self.assertEqual(parent_task.subtask_count, 0, "Template subtasks should not be counted on a normal parent task.")
+
+    def test_open_task_count_on_template_parent(self):
+        """Template parents should not count normal children in project open_task_count."""
+        self.assertEqual(
+            self.project_with_templates.open_task_count,
+            0,
+            "Template parent child tasks should not be counted in project open_task_count.",
+        )
+
+    def test_template_parent_counts_template_subtasks_in_subtask_count(self):
+        """Template parents should still count template subtasks."""
+        self.env["project.task"].create({
+            "name": "Template Child",
+            "project_id": self.project_with_templates.id,
+            "parent_id": self.template_task.id,
+            "is_template": True,
+        })
+
+        self.assertEqual(
+            self.template_task.subtask_count,
+            2,
+            "Template parent tasks should count template subtasks in subtask_count.",
+        )

--- a/addons/project/tests/test_task_templates.py
+++ b/addons/project/tests/test_task_templates.py
@@ -106,3 +106,11 @@ class TestTaskTemplates(TestProjectCommon, MailCase):
         task = self.env["project.task"].browse(task_id)
         self.assertEqual(task.message_ids[0].subtype_id, self.env.ref('project.mt_task_new'))
         self.assertEqual(task.message_ids[0].notified_partner_ids, self.user_projectuser.partner_id)
+
+    def test_subtask_count_excludes_templates(self):
+        self.env['project.task'].create({
+            'name': 'Template Subtask',
+            'parent_id': self.template_task.id,
+            'is_template': True,
+        })
+        self.assertEqual(self.template_task.subtask_count, 1, "Template subtasks should not be included in subtask_count.")

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -366,7 +366,7 @@
                         <button name="action_recurring_tasks" type="object" invisible="not active or not recurrence_id" class="oe_stat_button" icon="fa-repeat" groups="project.group_project_recurring_tasks">
                             <field name="recurring_count" widget="statinfo" string="Recurring Tasks"/>
                         </button>
-                        <button name="%(project_task_action_sub_task)d" type="action" class="oe_stat_button" icon="fa-check"
+                        <button name="action_open_subtasks" type="object" class="oe_stat_button" icon="fa-check"
                             invisible="not id or subtask_count == 0"
                             context="{
                                 'default_project_id': project_id,

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -287,7 +287,7 @@
             <field name="res_model">project.task</field>
             <field name="view_mode">list,kanban,form,calendar,pivot,graph,activity</field>
             <field name="search_view_id" ref="project.view_task_search_form"/>
-            <field name="domain">[('id', 'child_of', active_id), ('id', '!=', active_id)]</field>
+            <field name="domain">[('id', 'child_of', active_id), ('id', '!=', active_id), ('has_template_ancestor', '=', False)]</field>
             <field name="context">{'show_project_update': False, 'default_parent_id': active_id}</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">


### PR DESCRIPTION
Steps to Reproduce
---
- Create a normal parent task with one normal sub-task and one template sub-task.
- Open the parent task form view and observe the Sub-tasks stat button count and
notebook tab, check the subtask view as well.
- Create a template parent task with one normal sub-task and one template sub-task,
then repeat the same checks.

Issue
---
- Task templates are handled like regular subtasks in the subtask count, notebook, and
subtask view, without taking the parent task type into account.

Current Behaviour
---
- For a normal parent task, both the normal sub-task and the template sub-task are
counted and shown in the opened subtask view and notebook.
- For a template parent task, the same filtering is applied, even though template subtasks
should remain accessible in that context.

Expected Behaviour
---
- For a normal parent task, only real sub-tasks should be counted and shown in the subtask
view and notebook, and on the project kanban card.
- For a template parent task, template subtasks should remain available in the subtask
view and notebook according to the parent template context.
- In the project kanban card, tasks must not be counted when their parent task is a template,
 even if the child task itself is not a template.

Fix
---
- Apply template-aware filtering to subtask counting,project kanban task count and subtask view
 behavior, depending on whether the parent task is a normal task or a template task.

task-5966684