### PR TITLE
[FIX] iot_drivers: wifi AP can't be connected to

### DIFF
--- a/addons/iot_drivers/tools/wifi.py
+++ b/addons/iot_drivers/tools/wifi.py
@@ -240,7 +240,7 @@ def _configure_access_point(on=True):
     if on:
         _logger.info("Starting access point with SSID %s", ssid)
         with open('/etc/hostapd/hostapd.conf', 'w', encoding='utf-8') as f:
-            f.write(f"interface=wlan0\nssid={ssid}\nchannel=1\n")
+            f.write(f"interface=wlan0\nssid={ssid}\nchannel=36\nhw_mode=a\n")
     mode = 'add' if on else 'del'
     return (
         subprocess.run(


### PR DESCRIPTION
Before this commit, the `hostapd` Wi-Fi access point that is started to allow configuring the Wi-Fi network on the IoT box could not be connected to when using the latest images. The exact cause is unknown, but the Odoo code has not changed so it seems to be due to an OS or driver update.

After this commit, we set the Wi-Fi mode to 802.11a, which enables modern Wi-Fi standards on the AP, whereas before it defaulted to 802.11b which is the oldest Wi-Fi standard. This change makes the network visible and able to be connected to.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
