### PR TITLE
[FIX] mass_mailing,web_tour: fix broken tour

### DIFF
--- a/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.scss
+++ b/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.scss
@@ -1,3 +1,8 @@
+body:has(.o_mass_mailing_fullscreen) {
+    .o_tour_pointer {
+        display: none;
+    }
+}
 .o_mass_mailing_iframe_wrapper {
     &.o_mass_mailing_fullscreen {
         display: block !important;

--- a/addons/mass_mailing/static/src/iframe_assets/iframe_style.scss
+++ b/addons/mass_mailing/static/src/iframe_assets/iframe_style.scss
@@ -37,6 +37,9 @@ html:has(.o_layout, .o_basic_theme) {
             padding: 0;
             border: none;
         }
+        .o_mass_mailing_value {
+            overflow-wrap: break-word !important;
+        }
         .o_mass_mailing_value ~ .o_loading_screen {
             display: none !important;
         }

--- a/addons/mass_mailing/static/src/js/tours/mass_mailing_tour.js
+++ b/addons/mass_mailing/static/src/js/tours/mass_mailing_tour.js
@@ -30,7 +30,7 @@
         trigger: 'div[name="subject"]',
         content: markup(_t('Pick the <b>email subject</b>.')),
         tooltipPosition: 'bottom',
-        run: 'click',
+        run: "edit",
     }, {
         isActive: ["auto"],
         trigger: 'div[name="contact_list_ids"] > .o_input_dropdown > input[type="text"]',
@@ -53,13 +53,13 @@
         run: 'click',
     }, {
         isActive: ["enterprise"],
-        trigger: 'div[name="body_arch"] :iframe div.theme_selection_done div.s_text_block',
+        trigger: 'div[name="body_arch"] :iframe section.s_text_block',
         content: _t('Click on this paragraph to edit it.'),
         tooltipPosition: 'top',
         run: 'click',
     }, {
         isActive: ["community"],
-        trigger: 'div[name="body_arch"] :iframe div.o_mail_block_title_text',
+        trigger: 'div[name="body_arch"] :iframe section.s_text_block',
         content: _t('Click on this paragraph to edit it.'),
         tooltipPosition: 'top',
         run: 'click',


### PR DESCRIPTION
## [FIX] mass_mailing: fix broken tour

This commit fixes issues with the mass_mailing onboarding tour. The resolved
issues are:
 * Subject tour step not properly handled: changed "click" to "edit"
 * Tour steps when theme is selected not shown: updated the trigger so that they
   are displayed.

## [FIX] mass_mailing: fix overlow-wrap

This commit fixes an issue with the overflow-wrap behavior in the mass_mailing
builder. By default the editor removes the overflow-wrap which sets its value to
`normal`. This value makes it so that the text isn't wrapped if a word overflows
the box its in.

Now, the editable in the mass_mailing builder has the property set to
`break-word` which is the wanted behavior.
 

task-5974184
