### PR TITLE
[FIX] project: AccessError when project user sets partner on task

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -649,8 +649,8 @@ class ProjectTask(models.Model):
 
     def _inverse_partner_phone(self):
         for task in self:
-            if task.partner_id:
-                task.partner_id.phone = task.partner_phone
+            if task.partner_id and task.partner_phone != task.partner_id.phone:
+                task.partner_id.sudo().phone = task.partner_phone
 
     @api.onchange('company_id')
     def _onchange_task_company(self):

--- a/addons/project/tests/test_project_task_quick_create.py
+++ b/addons/project/tests/test_project_task_quick_create.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
 from odoo.addons.project.tests.test_project_base import TestProjectCommon
 from odoo.tests import Form
 
@@ -80,3 +81,20 @@ class TestProjectTaskQuickCreate(TestProjectCommon):
         field_specs = {'project_id': {}, 'company_id': {'fields': {}}}
         task_values = self.env['project.task'].onchange({}, [], field_specs)['value']
         self.assertEqual(task_values['project_id'], self.project_pigs.id, "The task project_id should be set")
+
+    def test_project_user_task_creation_without_access_error_updates_partner_mobile(self):
+        """
+        Verify that creating a task with a customer as project user
+        raises AccessError due to restricted res.partner rights.
+        """
+        self.user_projectuser.group_ids = [Command.set([self.env.ref('project.group_project_user').id])]
+        self.assertFalse(self.user_projectuser.partner_id.phone)
+        test_task = self.env['project.task'].with_user(self.user_projectuser).create({
+            'name': 'Test task',
+            'project_id': self.project_pigs.id,
+            'partner_id': self.user_projectuser.partner_id.id,
+            'partner_phone': '1234'
+        })
+
+        self.assertTrue(test_task.partner_id, "Customer should be set when creating a task with a partner.")
+        self.assertEqual(self.user_projectuser.partner_id.phone, '1234', "Partner phone number should be updated according to the partner_phone field.")


### PR DESCRIPTION
Steps to Reproduce:
-
1. Log in with a user having only Project > User access.
2. Create a new task in project.
3. Add a customer on the task.
4. Access error is raised.

Issue:
-
- Project users could not create a task with a customer.
- An access error appeared during task creation.

Cause:
-
- When a customer was added to the task, the partner_phone inverse method was triggered.
- This method attempted to write on the partner record.

Solution:
-
- Added a check before writing to avoid unnecessary writes.
- Used sudo() to update the partner phone securely.
- Added view-level restriction using base.group_partner_manager to control
  who can edit the phone number.

task-5039657
