### PR TITLE
[FIX] web: Ghost readonly field

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -611,9 +611,6 @@
             color: $text-muted;
         }
 
-        &.o_form_label_empty.o_form_label_readonly {
-            display: none;
-        }
     }
 
     .o_form_renderer:not(.o_field_highlight):not(.o_touch_device .o_field_highlight) {


### PR DESCRIPTION
[FIX] sales: Ghost readonly field

Before this commit, empty read-only field labels were hidden. 
We restored the display of the field in this commit[1], but we should
also restore the display of the linked label field.


task-6008159

[1]: https://github.com/odoo/odoo/commit/34b2a918bcb1e21b02ac0373ba8f2fa795aacd10