### PR TITLE
[FIX] mass_mailing: fix text-muted colors

### DIFF
--- a/addons/mass_mailing/static/src/iframe_assets/snippets_style.scss
+++ b/addons/mass_mailing/static/src/iframe_assets/snippets_style.scss
@@ -23,4 +23,7 @@
             color: unset !important;
         }
     }
+    .text-muted {
+        color: rgb(99, 99, 99) !important;
+    }
 }


### PR DESCRIPTION
This commit fixes an issue with the `text-muted` class that gives a specific color to the text based on a background-color.
Since the mass_mailing builder is a special case for background colors. The class now gives a specific color no matter what the background color is set when used inside the mass_mailing builder.

task-5993139