### PR TITLE
[IMP] mail: separate error messages for deleting attachments

### DIFF
--- a/addons/mail/controllers/attachment.py
+++ b/addons/mail/controllers/attachment.py
@@ -89,9 +89,12 @@ class AttachmentController(ThreadController):
     @add_guest_to_context
     def mail_attachment_delete(self, attachment_id, access_token=None):
         attachment = request.env["ir.attachment"].browse(int(attachment_id)).exists()
-        if not attachment or not attachment._has_attachments_ownership([access_token]):
+        if not attachment:
             request.env.user._bus_send("ir.attachment/delete", {"id": attachment_id})
             raise NotFound()
+        elif not attachment._has_attachments_ownership([access_token]):
+            request.env.user._bus_send("ir.attachment/delete", {"id": attachment_id})
+            raise UserError(request.env._("You do not have the necessary permissions to perform this action."))
         message = request.env["mail.message"].sudo().search(
             [("attachment_ids", "in", attachment.ids)], limit=1)
         if message:


### PR DESCRIPTION
Description:
Previously, attempting to delete an attachment without the proper access rights would result in a generic NotFound error. To improve usability, this commit separates the error handling: users will now see a specific access error when they lack permissions, and a NotFound error only when the document truly does not exist.

task-6012717