### PR TITLE
[IMP] website_sale: Add weight to product feeds

### DIFF
--- a/addons/website_sale/models/product_feed.py
+++ b/addons/website_sale/models/product_feed.py
@@ -200,6 +200,7 @@ class ProductFeed(models.Model):
                 **self._prepare_gmc_identifier(product),
                 **self._prepare_gmc_image_links(product, base_url),
                 **price_info,
+                **self._prepare_gmc_weight_info(product),
                 **self._prepare_gmc_stock_info(product),
                 **self._prepare_gmc_additional_info(product),
             }
@@ -345,6 +346,19 @@ class ProductFeed(models.Model):
                 price_info["unit_pricing_base_measure"] = f"{base_count}{base_unit}"
 
         return price_info
+
+    def _prepare_gmc_weight_info(self, product):
+        """Prepare weight-related information for Google Merchant Center.
+
+        :return: A dictionary containing:
+            - Weight + Weight UoM
+        :rtype: dict
+        """
+        weight, uom = product.weight, product.weight_uom_name
+        if weight:
+            return {"product_weight": f"{weight} {uom}"}
+
+        return {}
 
     def _prepare_gmc_stock_info(self, _product):  # noqa: PLR6301
         """Intended to be overridden in stock."""

--- a/addons/website_sale/templates/gmc_templates.xml
+++ b/addons/website_sale/templates/gmc_templates.xml
@@ -33,6 +33,10 @@
                             t-if="'unit_pricing_base_measure' in item"
                             t-out="item['unit_pricing_base_measure']"
                         />
+                        <g:product_weight
+                            t-if="'product_weight' in item"
+                            t-out="item['product_weight']"
+                        />
                         <t t-foreach="item['custom_label']" t-as="tag_label">
                             <t t-translation="off">
                                 &lt;g:<t t-out="tag_label[0]"/>&gt;


### PR DESCRIPTION
In odoo/odoo#224889, GMC feed was reintroduced in eCommerce after being disabled due to performance constraints, increasing product visibility for by adding fields such as description, availability, price, etc.

This commit adds, if available, the product weight field to the feed.

task-5376024
