### PR TITLE
[FIX] html_builder, website: show hover overlay on ancestors of target

### DIFF
--- a/addons/html_builder/static/src/core/builder_overlay/builder_overlay_plugin.js
+++ b/addons/html_builder/static/src/core/builder_overlay/builder_overlay_plugin.js
@@ -216,6 +216,8 @@ export class BuilderOverlayPlugin extends Plugin {
         this.hoverOverlay = overlay;
         this.overlayContainer.append(overlay.overlayElement);
         this.resizeObserver.observe(overlay.overlayTarget, { box: "border-box" });
+        // `refreshPosition` won't be called by the resize observer if the element was already observed
+        this.hoverOverlay.refreshPosition();
     }
 
     showOverlayPreview(el) {

--- a/addons/website/static/tests/builder/builder_overlay.test.js
+++ b/addons/website/static/tests/builder/builder_overlay.test.js
@@ -55,6 +55,8 @@ test("Do not show the hover overlay for an element with another overlay", async 
 
     await contains(":iframe section").hover();
     expect(".oe_overlay.o_hover_overlay").toHaveCount(1);
+    // The size and position is given in the `style` attribute
+    expect(".oe_overlay.o_hover_overlay").toHaveAttribute("style");
     await contains(":iframe .col-lg-3").hover();
     expect(".oe_overlay.o_hover_overlay").toHaveCount(0);
 });


### PR DESCRIPTION
Commit 53ae0a9f646808632ca1ca396466e1c0bb5a73c7 adds a temporary overlay on hover of elements with options. But the overlay was not shown on over of an ancestor of the target. This is because it relied on the resize observer to call the `refreshPosition`, which does not happen if the element on which the hover overlay should appear was already observed.

This commit adds an explicit call to `refreshPosition` after the creation of the hover overlay.

Steps to reproduce:
- Open website builder
- Click on a column in a section
- Hover the section outside of the column
- Bug: no hover overlay is shown on the section element

task-6013371