### PR TITLE
[IMP] web: prevent cache clearing on failed RPCs

### DIFF
--- a/addons/web/static/src/core/l10n/localization_service.js
+++ b/addons/web/static/src/core/l10n/localization_service.js
@@ -38,7 +38,11 @@ export const localizationService = {
 
         rpcBus.addEventListener("RPC:RESPONSE", (ev) => {
             const { method, model } = ev.detail.data.params || {};
-            if (method === "lang_install" && model === "base.language.install") {
+            if (
+                method === "lang_install" &&
+                model === "base.language.install" &&
+                !ev.detail.error
+            ) {
                 rpcBus.trigger("CLEAR-CACHES");
             }
         });

--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -108,7 +108,7 @@ const DEFAULT_HOOKS = {
 };
 
 rpcBus.addEventListener("RPC:RESPONSE", (ev) => {
-    if (ev.detail.data.params?.method === "unlink") {
+    if (ev.detail.data.params?.method === "unlink" && !ev.detail.error) {
         rpcBus.trigger("CLEAR-CACHES", ["web_read", "web_search_read", "web_read_group"]);
     }
 });

--- a/addons/web/static/src/views/view_service.js
+++ b/addons/web/static/src/views/view_service.js
@@ -46,7 +46,7 @@ export const viewService = {
     start(env, { orm }) {
         rpcBus.addEventListener("RPC:RESPONSE", (ev) => {
             const { model, method } = ev.detail.data.params;
-            if (["ir.ui.view", "ir.filters"].includes(model)) {
+            if (["ir.ui.view", "ir.filters"].includes(model) && !ev.detail.error) {
                 if (UPDATE_METHODS.includes(method)) {
                     rpcBus.trigger("CLEAR-CACHES", "get_views");
                 }

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -17,15 +17,7 @@ import { CallbackRecorder } from "@web/search/action_hook";
 import { ControlPanel } from "@web/search/control_panel/control_panel";
 import { PATH_KEYS, router as _router } from "@web/core/browser/router";
 
-import {
-    Component,
-    markup,
-    onMounted,
-    onWillUnmount,
-    onError,
-    xml,
-    status,
-} from "@odoo/owl";
+import { Component, markup, onMounted, onWillUnmount, onError, xml, status } from "@odoo/owl";
 import { downloadReport, getReportUrl } from "./reports/utils";
 import { zip } from "@web/core/utils/arrays";
 import { isHtmlEmpty } from "@web/core/utils/html";
@@ -143,7 +135,11 @@ export function makeActionManager(env, router = _router) {
 
     rpcBus.addEventListener("RPC:RESPONSE", async (ev) => {
         const { model, method } = ev.detail.data.params;
-        if (model === "ir.actions.act_window" && UPDATE_METHODS.includes(method)) {
+        if (
+            model === "ir.actions.act_window" &&
+            UPDATE_METHODS.includes(method) &&
+            !ev.detail.error
+        ) {
             rpcBus.trigger("CLEAR-CACHES", "/web/action/load");
             const virtualStack = await _controllersFromState(router.current);
             const nextStack = [...virtualStack, controllerStack[controllerStack.length - 1]];


### PR DESCRIPTION
Currently, when listening to the `RPC:RESPONSE` event, the cache is conditionally cleared based on the RPC parameters (e.g., clearing the cache after an `unlink` call). However, this logic does not verify whether the RPC was actually successful.

If the RPC fails (for example, throwing a `ConnectionLostError` when the user goes offline), the cache is still cleared unnecessarily. This leads to a degraded user experience, as it prevents further navigation in offline mode.

This commit ensures that caches are only cleared if the RPC response does not contain an error.

task-id: 6007829