### PR TITLE
[FIX] mail, account: attachment delete access handling

### DIFF
--- a/addons/account/tests/test_portal_attachment.py
+++ b/addons/account/tests/test_portal_attachment.py
@@ -121,12 +121,13 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
                 'params': {
                     'attachment_id': create_res['id'],
                     'access_token': "wrong",
+                    "raw_access_token": create_res["raw_access_token"],
                 },
             },
         )
         self.assertEqual(res.status_code, 200)
         self.assertTrue(self.env['ir.attachment'].sudo().search([('id', '=', create_res['id'])]))
-        self.assertIn("The requested URL was not found on the server.", res.text)
+        self.assertEqual("odoo.exceptions.AccessError", res.json()["error"]["data"]["name"])
 
         # Test attachment can be removed with token if "pending" state
         res = self.url_open(
@@ -135,6 +136,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
                 'params': {
                     'attachment_id': create_res['id'],
                     "access_token": create_res["ownership_token"],
+                    "raw_access_token": create_res["raw_access_token"],
                 },
             },
         )
@@ -151,6 +153,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
                 'params': {
                     'attachment_id': attachment.id,
                     "access_token": attachment._get_ownership_token(),
+                    "raw_access_token": attachment._get_raw_access_token(),
                 },
             },
         )
@@ -173,6 +176,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
                 'params': {
                     'attachment_id': attachment.id,
                     "access_token": attachment._get_ownership_token(),
+                    "raw_access_token": attachment._get_raw_access_token(),
                 },
             },
         )

--- a/addons/account/tests/test_portal_attachment.py
+++ b/addons/account/tests/test_portal_attachment.py
@@ -126,7 +126,7 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
         )
         self.assertEqual(res.status_code, 200)
         self.assertTrue(self.env['ir.attachment'].sudo().search([('id', '=', create_res['id'])]))
-        self.assertIn("The requested URL was not found on the server.", res.text)
+        self.assertEqual("odoo.exceptions.AccessError", res.json()["error"]["data"]["name"])
 
         # Test attachment can be removed with token if "pending" state
         res = self.url_open(

--- a/addons/mail/controllers/attachment.py
+++ b/addons/mail/controllers/attachment.py
@@ -12,7 +12,7 @@ from odoo.addons.mail.controllers.thread import ThreadController
 from odoo.exceptions import AccessError, UserError
 from odoo.http import request, content_disposition
 from odoo.addons.mail.tools.discuss import add_guest_to_context, Store
-from odoo.tools.misc import file_open
+from odoo.tools.misc import file_open, verify_limited_field_access_token
 from odoo.tools.pdf import DependencyError, PdfReadError, extract_page
 
 logger = logging.getLogger(__name__)
@@ -87,11 +87,22 @@ class AttachmentController(ThreadController):
 
     @http.route("/mail/attachment/delete", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
-    def mail_attachment_delete(self, attachment_id, access_token=None):
+    def mail_attachment_delete(self, attachment_id, access_token=None, raw_access_token=None):
+        """
+        Deletes given attachment.
+        :param attachment_id: ID of the attachment to delete.
+        :param access_token: attachment_ownership_token for write access.
+        :param raw_access_token: raw field token for read access.
+        """
         attachment = request.env["ir.attachment"].browse(int(attachment_id)).exists()
-        if not attachment or not attachment._has_attachments_ownership([access_token]):
-            request.env.user._bus_send("ir.attachment/delete", {"id": attachment_id})
+        if not (
+            attachment
+            and raw_access_token
+            and verify_limited_field_access_token(attachment, "raw", raw_access_token, scope="binary")
+        ):
             raise NotFound()
+        if not attachment._has_attachments_ownership([access_token]):
+            raise AccessError(self.env._("You are not allowed to delete this attachment."))
         message = request.env["mail.message"].sudo().search(
             [("attachment_ids", "in", attachment.ids)], limit=1)
         # sudo: ir.attachment: access is validated with _has_attachments_ownership

--- a/addons/mail/controllers/attachment.py
+++ b/addons/mail/controllers/attachment.py
@@ -89,9 +89,10 @@ class AttachmentController(ThreadController):
     @add_guest_to_context
     def mail_attachment_delete(self, attachment_id, access_token=None):
         attachment = request.env["ir.attachment"].browse(int(attachment_id)).exists()
-        if not attachment or not attachment._has_attachments_ownership([access_token]):
-            request.env.user._bus_send("ir.attachment/delete", {"id": attachment_id})
+        if not attachment:
             raise NotFound()
+        if not attachment._has_attachments_ownership([access_token]):
+            raise AccessError(self.env._("You are not allowed to delete this attachment."))
         message = request.env["mail.message"].sudo().search(
             [("attachment_ids", "in", attachment.ids)], limit=1)
         # sudo: ir.attachment: access is validated with _has_attachments_ownership

--- a/addons/mail/static/src/core/common/attachment_model.js
+++ b/addons/mail/static/src/core/common/attachment_model.js
@@ -4,7 +4,7 @@ import { generatePdfThumbnail } from "@mail/utils/common/pdf_thumbnail";
 
 import { FileModelMixin } from "@web/core/file_viewer/file_model";
 import { _t } from "@web/core/l10n/translation";
-import { rpc } from "@web/core/network/rpc";
+import { rpc, RPCError } from "@web/core/network/rpc";
 import { imageUrl, url } from "@web/core/utils/urls";
 
 export class Attachment extends FileModelMixin(Record) {
@@ -73,7 +73,7 @@ export class Attachment extends FileModelMixin(Record) {
         if (this.message && this.store.self.main_user_id?.share !== false) {
             return this.message.editable;
         }
-        return true;
+        return (this.ownership_token || this.hasWriteAccess) ?? true;
     }
 
     get monthYear() {
@@ -101,10 +101,29 @@ export class Attachment extends FileModelMixin(Record) {
      */
     async remove() {
         if (this.id > 0) {
-            await rpc(
-                "/mail/attachment/delete",
-                assignDefined({ attachment_id: this.id }, { access_token: this.ownership_token })
-            );
+            try {
+                await rpc(
+                    "/mail/attachment/delete",
+                    assignDefined(
+                        { attachment_id: this.id },
+                        {
+                            access_token: this.ownership_token,
+                            raw_access_token: this.raw_access_token,
+                        }
+                    )
+                );
+            } catch (error) {
+                if (
+                    error instanceof RPCError &&
+                    error.data.name === "werkzeug.exceptions.NotFound"
+                ) {
+                    this.store.env.services.notification.add(_t("Attachment not found"), {
+                        type: "error",
+                    });
+                } else {
+                    throw error;
+                }
+            }
         }
         this.delete();
     }

--- a/addons/mail/static/src/core/common/attachment_model.js
+++ b/addons/mail/static/src/core/common/attachment_model.js
@@ -73,7 +73,7 @@ export class Attachment extends FileModelMixin(Record) {
         if (this.message && this.store.self.main_user_id?.share !== false) {
             return this.message.editable;
         }
-        return true;
+        return this.thread?.hasWriteAccess ?? true;
     }
 
     get monthYear() {

--- a/addons/mail/tests/common_controllers.py
+++ b/addons/mail/tests/common_controllers.py
@@ -131,8 +131,9 @@ class MailControllerAttachmentCommon(MailControllerCommon):
                     self._delete_attachment(attachment, token)
                     self.assertFalse(attachment.exists())
                 else:
-                    with self.assertRaises(JsonRpcException, msg="Wrong access token"):
+                    with self.assertRaises(JsonRpcException) as e:
                         self._delete_attachment(attachment, token)
+                    self.assertEqual(str(e.exception), "odoo.exceptions.AccessError")
 
     def _upload_attachment(self, document, route_kw):
         with mute_logger("odoo.http"), file_open("addons/web/__init__.py") as file:
@@ -162,6 +163,7 @@ class MailControllerAttachmentCommon(MailControllerCommon):
                 params={
                     "attachment_id": attachment.id,
                     "access_token": attachment._get_ownership_token() if token else None,
+                    "raw_access_token": attachment._get_raw_access_token(),
                 },
             )
 

--- a/addons/mail/tests/common_controllers.py
+++ b/addons/mail/tests/common_controllers.py
@@ -131,8 +131,9 @@ class MailControllerAttachmentCommon(MailControllerCommon):
                     self._delete_attachment(attachment, token)
                     self.assertFalse(attachment.exists())
                 else:
-                    with self.assertRaises(JsonRpcException, msg="Wrong access token"):
+                    with self.assertRaises(JsonRpcException) as e:
                         self._delete_attachment(attachment, token)
+                    self.assertEqual(str(e.exception), "odoo.exceptions.AccessError")
 
     def _upload_attachment(self, document, route_kw):
         with mute_logger("odoo.http"), file_open("addons/web/__init__.py") as file:


### PR DESCRIPTION
Previously, if a user without write access to an attachment attempted to delete it, a NotFound error was raised. Since this error is not handled like other access-related errors, it appeared as a crash in the UI.

Now the server properly distinguishes between:
- NotFound: raised when attachment doesn't exist or user lacks read access
- AccessError: raised when user lacks write access

Additionally, the client-side now disables the delete button for users without write access and handles errors gracefully.

Task-4979444

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
