### PR TITLE
[FIX] web: wrong table styling for optional product table

### DIFF
--- a/addons/web/static/src/webclient/actions/reports/report_tables.scss
+++ b/addons/web/static/src/webclient/actions/reports/report_tables.scss
@@ -212,3 +212,82 @@ div#total {
         }
     }
 }
+
+// Stable fix for sale_management 18 up to 18.4
+
+// The table styling is not applied due to the table missing the
+// table-borderless and the thead using td instead of th.
+
+// Applied here to avoid having to update the module and keep it close to the
+// table styling. Everything stays scoped under the table with
+// table_optional_products name so it doesn't affect other tables.
+
+table[name="table_optional_products"] {
+    // Copy of the table-borderless class
+    > :not(caption) > * > * {
+        border-bottom-width: 0;
+    }
+
+    > :not(:first-child) {
+        border-top-style: none;
+        border-top-width: 0;
+    }
+
+    tbody, thead, tfoot, tr, td, th {
+        border: 0 none;
+    }
+
+    > :not(:first-child) {
+        border-top-style: none;
+    }
+
+    // Overrides the table-sm class
+    td {
+        padding: $table-cell-padding-y $table-cell-padding-x;
+    }
+
+    td[name="td_option_price_unit"] strong, thead {
+        font-weight: normal !important;
+    }
+}
+
+.o_table_boxed, .o_table_boxed-rounded {
+    table[name="table_optional_products"] {
+        thead {
+            text-transform: uppercase;
+
+            td:not(:last-child) {
+                border-right: $border-width solid $gray-700;
+            }
+
+            td {
+                border-bottom: $border-width solid $border-color;
+            }
+        }
+    }
+}
+
+.o_table_bold {
+    table[name="table_optional_products"] {
+        thead td {
+            border-top: $border-width * 3 solid $o-default-report-secondary-color;
+            text-transform: uppercase;
+        }
+    }
+}
+
+.o_table_boxed-rounded {
+    table[name="table_optional_products"] thead {
+        td:first-child {
+            border-radius: $border-radius-lg 0 0 0;
+        }
+
+        td:last-child {
+            border-radius: 0 $border-radius-lg 0 0;
+        }
+
+        td {
+            border-color: $gray-300 !important;
+        }
+    }
+}

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -984,7 +984,7 @@
                         background-color: mix(white, <t t-esc='secondary'/>, 92%);
                     }
 
-                    thead th, #total .o_total td {
+                    thead th, #total .o_total td, thead td {
                         background-color: <t t-esc='primary'/>;
                         color: preview-color-contrast(<t t-esc='primary'/>);
 


### PR DESCRIPTION
Issue:
In sale_management the optional product table doesn't get the report
table styling.

This is due to a different DOM and missing classes. This fix applies the
styling to match the optional product table structure. While the table
is in `sale_management` the change is applied in `web` to avoid having
to update the module for customers.

Note: the color applied in `report_templates.xml` requires that the user
change is layout in the document layout configurator then save again for
it to apply.

task-6009941
opw-5960426

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
