### PR TITLE
[FIX] mail: no '...' button in members panel for non-owner/admins

### DIFF
--- a/addons/mail/static/src/discuss/core/common/channel_member.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member.xml
@@ -17,7 +17,7 @@
                 <span t-elif="member.rtcSession?.is_deaf" class="p-1 fa fa-deaf opacity-75"/>
                 <span t-if="member.rtcSession?.raisingHand" class="p-1 fa fa-hand-paper-o"/>
             </span>
-            <div class="o-discuss-ChannelMember-actions" t-att-class="{
+            <div t-if="actions.actions.length" class="o-discuss-ChannelMember-actions" t-att-class="{
                 'd-none': !showingActions.isOpen and !store.useMobileView,
                 'd-flex': showingActions.isOpen or store.useMobileView,
             }">


### PR DESCRIPTION
Partial backport of https://github.com/odoo/odoo/pull/246580

Before this commit, the button "..." on channel members was visible even for non-owner / admins. Normal members cannot make any action on members, so there's no point in showing this button: clicking on it shows an empty popover.

This commit prevents the showing of this button when member has no actions.

Before / After
<img width="244" height="223" alt="Screenshot 2026-03-06 at 12 50 59" src="https://github.com/user-attachments/assets/2257e27a-33b3-4c33-94a7-0d81dff3e0a9" /> <img width="244" height="206" alt="Screenshot 2026-03-06 at 12 51 21" src="https://github.com/user-attachments/assets/6da655a3-30b4-430b-bdf6-7c2316674ebc" />
