### PR TITLE
[FIX] html_editor: prevent traceback with invalid nested list html

### DIFF
--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -1,6 +1,7 @@
 import { Plugin } from "@html_editor/plugin";
 import { closestBlock, isBlock } from "@html_editor/utils/blocks";
 import {
+    fillEmpty,
     removeClass,
     removeStyle,
     toggleClass,
@@ -318,6 +319,9 @@ export class ListPlugin extends Plugin {
             root = closestNestedLI.parentElement;
         }
         for (let element of selectElements(root, "ul, ol, li")) {
+            if (element.nodeName === "LI" && !element.hasChildNodes()) {
+                fillEmpty(element);
+            }
             if (isProtected(element) || isProtecting(element)) {
                 continue;
             }

--- a/addons/html_editor/static/tests/list/delete_backward.test.js
+++ b/addons/html_editor/static/tests/list/delete_backward.test.js
@@ -960,9 +960,9 @@ describe("Selection collapsed", () => {
 
             test("should remove the checkmark when the list item marker is deleted", async () => {
                 await testEditor({
-                    contentBefore: '<ul class="o_checklist"><li class="o_checked">[]</li></ul>',
+                    contentBefore: '<ul class="o_checklist"><li class="o_checked">[]<br></li></ul>',
                     stepFunction: deleteBackward,
-                    contentAfter: '<ul class="o_checklist"><li class="oe-nested">[]</li></ul>',
+                    contentAfter: '<ul class="o_checklist"><li class="oe-nested">[]<br></li></ul>',
                 });
             });
 

--- a/addons/html_editor/static/tests/list/indent.test.js
+++ b/addons/html_editor/static/tests/list/indent.test.js
@@ -272,7 +272,7 @@ describe("Regular list", () => {
             contentBefore: unformat(`
                     <ul>
                         <li>abc</li>
-                        <li>[]</li>
+                        <li>[]<br></li>
                     </ul>
                     <p>def</p>`),
             stepFunction: keydownTab,
@@ -280,7 +280,7 @@ describe("Regular list", () => {
                     <ul>
                         <li><p>abc</p>
                             <ul>
-                                <li>[]</li>
+                                <li>[]<br></li>
                             </ul>
                         </li>
                     </ul>

--- a/addons/html_editor/static/tests/list/normalization.test.js
+++ b/addons/html_editor/static/tests/list/normalization.test.js
@@ -312,3 +312,24 @@ describe("Merge similar lists", () => {
         });
     });
 });
+
+describe("Nested lists with oe-nested class", () => {
+    test("should allow an oe-nested list item without any children", async () => {
+        await testEditor({
+            contentBefore: unformat(`
+                <ul>
+                    <li>1</li>
+                    <li>2</li>
+                    <li class="oe-nested"></li>
+                </ul>
+            `),
+            contentAfter: unformat(`
+                <ul>
+                    <li>1</li>
+                    <li>2</li>
+                    <li class="oe-nested"><br></li>
+                </ul>
+            `),
+        });
+    });
+});


### PR DESCRIPTION
Steps to reproduce:
- Open a record containing the following invalid HTML: 
```html
<ul>
    <li>1</li>
    <li class=oe-nested></li>
</ul>
```

Description of the issue:
- A traceback occurs when opening a record with this html.

Cause:
- The provided HTML is invalid because an `<li>` element must contain at least one child node. In this case, the `<li>` element has no children. As a result, when `isListElement` tries to access the `nodeName` of its child, a traceback occurs because the `<li>` has no child node.

Solution:

During normalization. If an `<li>` element has no children, call `fillEmpty` so that a `<br>` element is inserted. This ensures the `<li>` contains at least one child and is no longer invalid.

task-6012663