### PR TITLE
[FIX] payment_razorpay: fix name with comma and long name issue

### DIFF
--- a/addons/payment_razorpay/models/payment_transaction.py
+++ b/addons/payment_razorpay/models/payment_transaction.py
@@ -54,7 +54,7 @@ class PaymentTransaction(models.Model):
         :rtype: dict
         """
         payload = {
-            'name': self.partner_name,
+            'name': self.partner_name.replace(',', ' ')[:50],
             'email': self.partner_email or '',
             'contact': self.partner_phone and self._validate_phone_number(self.partner_phone) or '',
             'fail_existing': '0',  # Don't throw an error if the customer already exists.


### PR DESCRIPTION
Steps:
- Install and set up Razropay.
- Create order and set customer with long name or name with comma.
- Try to pay with Razorpay.

Issue:
- Error name is invalid.

Cause:
- Razorpay only take name without comma and upto 50 character, so having longer name or name with comma would cause an issue.

Fix:
- Replace comma with empty space and only take first 50 character of name while creating customer in Razorpay.