### PR TITLE
[FIX] pos_sale: remove undeterministicTour key

### DIFF
--- a/addons/pos_sale/static/tests/tours/pos_sale_tour.js
+++ b/addons/pos_sale/static/tests/tours/pos_sale_tour.js
@@ -64,7 +64,6 @@ registry.category("web_tour.tours").add("PosSettleOrder2", {
 });
 
 registry.category("web_tour.tours").add("PosRefundDownpayment", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -267,7 +266,6 @@ registry.category("web_tour.tours").add("test_settle_so_with_non_pos_groupable_u
 });
 
 registry.category("web_tour.tours").add("PoSDownPaymentLinesPerTax", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -297,7 +295,6 @@ registry.category("web_tour.tours").add("PoSDownPaymentLinesPerTax", {
 });
 
 registry.category("web_tour.tours").add("PoSApplyDownpayment", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -310,7 +307,6 @@ registry.category("web_tour.tours").add("PoSApplyDownpayment", {
 });
 
 registry.category("web_tour.tours").add("PoSApplyDownpaymentInvoice", {
-    undeterministicTour_doNotCopy: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -324,7 +320,6 @@ registry.category("web_tour.tours").add("PoSApplyDownpaymentInvoice", {
 });
 
 registry.category("web_tour.tours").add("PoSApplyDownpaymentInvoice2", {
-    undeterministicTour_doNotCopy: true,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -375,7 +370,6 @@ registry.category("web_tour.tours").add("PosOrdersListDifferentCurrency", {
 });
 
 registry.category("web_tour.tours").add("PoSDownPaymentAmount", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -524,7 +518,6 @@ registry.category("web_tour.tours").add("test_settle_order_with_lot", {
 });
 
 registry.category("web_tour.tours").add("test_down_payment_displayed", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_sale/static/tests/tours/utils/pos_sale_utils.js
+++ b/addons/pos_sale/static/tests/tours/utils/pos_sale_utils.js
@@ -58,12 +58,18 @@ export function downPaymentFirstOrder(amount) {
     return [
         ...selectNthOrder(1),
         {
-            content: `click on select the order`,
-            trigger: `.selection-item:contains('Apply a down payment')`,
+            content: `click on select the order (percentage)`,
+            trigger: `.modal:has(.modal-title:contains(what do you want to do?)) .selection-item:contains('Apply a down payment')`,
             run: "click",
         },
+        Dialog.is({ title: "Down payment" }),
         Numpad.click(amount),
-        Dialog.confirm("Apply"),
+        {
+            trigger: `.modal:has(.modal-title:contains(Down payment)) .popup-input:contains(${Number(
+                amount
+            )})`,
+        },
+        Dialog.proceed({ title: "down payment", button: "Apply" }),
     ];
 }
 


### PR DESCRIPTION
Fix undeterministic tours by adding a step that verifies the amount entered on the numpad before closing the dialog.

This ensures the clicked amount is correctly set in the input field before proceeding, preventing random tour failures.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
