### PR TITLE
[FIX] hr_holidays: prevent accesserror when approving leaves from overview

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report_calendar.py
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.py
@@ -36,7 +36,7 @@ class LeaveReportCalendar(models.Model):
 
     is_absent = fields.Boolean(related='employee_id.is_absent')
     leave_manager_id = fields.Many2one(related='employee_id.leave_manager_id')
-    leave_id = fields.Many2one(comodel_name='hr.leave', readonly=True, groups='hr_holidays.group_hr_holidays_user')
+    leave_id = fields.Many2one(comodel_name='hr.leave', readonly=True)
     is_manager = fields.Boolean("Manager", compute="_compute_is_manager")
 
     def init(self):

--- a/addons/hr_holidays/security/hr_holidays_security.xml
+++ b/addons/hr_holidays/security/hr_holidays_security.xml
@@ -262,6 +262,30 @@
         <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
     </record>
 
+    <record id="hr_leave_report_calendar_rule_responsible_read" model="ir.rule">
+        <field name="name">Time Off Report Calendar: Responsible Read</field>
+        <field name="model_id" ref="model_hr_leave_report_calendar"/>
+        <field name="domain_force">[
+            '|',
+                ('employee_id.user_id', '=', user.id),
+                ('leave_manager_id', '=', user.id)
+        ]</field>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+        <field name="groups" eval="[(4, ref('hr_holidays.group_hr_holidays_responsible'))]"/>
+    </record>
+
+    <record id="hr_leave_report_calendar_rule_officer_read" model="ir.rule">
+        <field name="name">Time Off Report Calendar: Officer read all</field>
+        <field name="model_id" ref="model_hr_leave_report_calendar"/>
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+        <field name="groups" eval="[(4, ref('hr_holidays.group_hr_holidays_user'))]"/>
+    </record>
+
     <record id="hr_leave_report_rule_multi_company" model="ir.rule">
         <field name="name">Time Off Report: multi company global rule</field>
         <field name="model_id" ref="model_hr_leave_report"/>


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Install Time Off.
2. Create a user and employee without Time Off access rights.
3. Create another employee and set the first employee as the manager.
(This automatically sets them as the Time Off approver.)
4. Create a time off request for the second employee from Time Off > Management.
5. Ensure that "Employee's Manager" is set as the approver in the corresponding Time Off type.
6. Log in with the first user, go to Overview and try to approve the leave.

Issue:
------
An AccessError occurs when approving the leave from the overview:

```python
You do not have enough rights to access the fields 'leave_id'
on Time Off Calendar (hr.leave.report.calendar)
```

Cause:
------
In `hr_leave_report_calendar`, the `leave_id` field is restricted to `hr_holidays.group_hr_holidays_user`.
When a leave manager without Time Off user rights tries to approve a leave from the overview,
the field access restriction triggers an AccessError.

related commit: https://github.com/odoo/odoo/commit/b5c9420543bdaae52b191e518c5e0f31ba925e46

Solution:
---------
Remove the group restriction on the `leave_id` field and introduce record rules
on `hr.leave.report.calendar` to control access.

- Leave managers can read records related to their employees.
- Time Off officers retain full read access.

This prevents the AccessError while still restricting the visibility of leave information for unauthorized users.

opw-5921263



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
