### PR TITLE
[IMP] stock: sort move lines by date in 'Moves History'

### DIFF
--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -4,7 +4,7 @@
         <field name="name">stock.move.line.list</field>
         <field name="model">stock.move.line</field>
         <field name="arch" type="xml">
-            <list string="Move Lines" create="0" default_order="id desc" action="action_open_reference" type="object" duplicate="0" >
+            <list string="Move Lines" create="0" default_order="date desc, id desc" action="action_open_reference" type="object" duplicate="0">
                 <field name="location_usage" column_invisible="True"/>
                 <field name="location_dest_usage" column_invisible="True"/>
                 <field name="date"/>


### PR DESCRIPTION
Default sort move lines by date then id (instead of just id), to show moves in chronological order in 'Moves History' report.

task-5481618
