### PR TITLE
[IMP] mail: improve QWeb rendering error clarity

### DIFF
--- a/addons/mail/models/mail_render_mixin.py
+++ b/addons/mail/models/mail_render_mixin.py
@@ -406,12 +406,54 @@ class MailRenderMixin(models.AbstractModel):
                         _('Only members of %(group_name)s group are allowed to edit templates containing sensible placeholders',
                            group_name=group.name)
                     ) from e
-                _logger.info("Failed to render template: %s", template_src, exc_info=True)
+
+                error_details = str(e)
+                error_traceback = traceback.format_exc()
+
+                # Identify the template safely
+                template_label = _("Template name not identified")
+
+                if self._name == 'mail.template' and self.id:
+                    template_label = _("Mail Template: '%(name)s' (ID: %(record_id)s)",
+                                       name=self.name or _("Unnamed Mail Template"),
+                                       record_id=self.id)
+                    is_identified = True
+                elif self._name == 'mail.compose.message' and self.mass_mailing_id:
+                    template_label = _("Mass Mailing Template: '%(name)s' (ID: %(record_id)s)",
+                                       name=self.mass_mailing_id.display_name or _("Unnamed Mailing"),
+                                       record_id=self.mass_mailing_id.id)
+                    is_identified = True
+                else:
+                    # if we can't name the template, we output the full template src, so that we
+                    # can try to find the failing template by it's src
+                    template_label = _("Template name not identified")
+                    is_identified = False
+
+                # Truncation of the source to prevent log bloat
+                truncated_src = template_src
+                if len(template_src) > 1000 and is_identified:
+                    truncated_src = f"{template_src[:500]}\n[...] (content truncated) [...]\n{template_src[-500:]}"
+
+                lang_context = self.env.context.get('lang', _("No language detected in context"))
+                # Log the full technical traceback for the sysadmin/developer
+                _logger.error(
+                    "Failed to render QWeb template for %s - Context language:%s\nTarget Model: %s\nError: %s\n%s",
+                    template_label, lang_context, model, error_details, error_traceback
+                )
+
+                # Raise a cleaner error for the UI
                 raise UserError(
-                    _("Failed to render QWeb template: %(template_src)s\n\n%(template_traceback)s)",
-                      template_src=template_src,
-                      template_traceback=traceback.format_exc())
-                    ) from e
+                    _("Failed to render QWeb template for %(template_label)s\n"
+                    "Target Model: %(model_name)s\n"
+                    "Language context: %(lang_context)s\n"
+                    "Error: %(error_details)s\n\n"
+                    "Template Source Snippet:\n%(template_src)s",
+                    template_label=template_label,
+                    model_name=model,
+                    lang_context=lang_context,
+                    error_details=error_details,
+                    template_src=truncated_src)
+                ) from e
             results[record.id] = render_result
 
         return results
@@ -562,8 +604,10 @@ class MailRenderMixin(models.AbstractModel):
             except Exception as e:
                 _logger.info("Failed to render inline_template: \n%s", str(template_txt), exc_info=True)
                 raise UserError(
-                    _("Failed to render inline_template template: %(template_txt)s",
-                      template_txt=template_txt)
+                    _("Failed to render inline_template template: %(template_txt)s\n"
+                    "Error details: %(error)s",
+                    template_txt=template_txt,
+                    error=str(e))
                 ) from e
 
         return results

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -225,10 +225,15 @@ class MailTemplate(models.Model):
                 try:
                     template._render_field(fname, record.ids, options=render_options)
                 except Exception as e:
-                    _logger.exception("Error while checking if template can be rendered for field %s", fname)
+                    _logger.info("Error while checking if template can be rendered for field %s", fname)
+
+                    error_details = str(e)
+
                     raise ValidationError(
-                        _("Oops! We couldn't save your template due to an issue with this value: %(template_txt)s. Correct it and try again.",
-                        template_txt=template[fname])
+                        _("Oops! We couldn't save your template due to an issue.\n\n"
+                          "Error: %(error_details)s\n\n"
+                          "Correct it and try again.",
+                        error_details=error_details)
                     ) from e
 
     def _get_dynamic_field_names(self):


### PR DESCRIPTION
When a QWeb template fails to render, the current logic logs the entire template source and raises a generic UserError. This leads to significant log bloat and makes it difficult for developers and support staff to identify the specific failing template or the root cause of the error.

This commit improves the error handling in `mail.render.mixin` and `mail.template` by:

- mail.render.mixin: Added logic to identify the failing template's name and ID if it belongs to a `mail.template` or `mail.compose.message` (mass mailing).
- Log Truncation: Implemented truncation for identified templates, showing only a snippet (first and last 500 chars) in logs and UserErrors to prevent log/UI bloat while keeping full source logging as a fallback for unidentified templates.
- mail.template: Improved the `_check_can_be_rendered` constraint to extract and display the specific exception message (e.g., AttributeError) in the ValidationError popup, rather than just showing the field value.
- Explicit Error Context: Replaced generic logging with structured  calls that include the template label, target model, specific error details, and the technical traceback.

OPW-5980295

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
