### PR TITLE
[FIX] mail: reduce ImStatus size in ChatBubble and Mobile Discuss

### DIFF
--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -7,7 +7,7 @@
             <button t-if="!env.embedLivechat and !isMobileOS" class="o-mail-ChatBubble-close position-absolute shadow rounded-circle fw-bold bg-view" title="Close Chat Bubble" t-on-click.stop="() => this.props.chatWindow.requestClose()"><i class="oi oi-close"/></button>
             <CountryFlag t-if="channel.showCorrespondentCountry" country="channel.correspondentCountry" class="'o-mail-ChatBubble-country position-absolute bottom-0 border shadow-sm'"/>
             <button class="o-mail-ChatHub-bubbleBtn btn shadow">
-                <DiscussAvatar channel="channel" size="42" imgRoundedClass="'rounded-circle'"/>
+                <DiscussAvatar channel="channel" size="42" imgRoundedClass="'rounded-circle'" iconExtraTransform="'scale(.75) translate(3, 3)'"/>
             </button>
         </div>
     </t>

--- a/addons/mail/static/src/core/common/discuss_avatar.js
+++ b/addons/mail/static/src/core/common/discuss_avatar.js
@@ -12,6 +12,7 @@ export class DiscussAvatar extends Component {
         "member?",
         "persona?",
         "thread?",
+        "iconExtraTransform?",
         "size?",
         "typing?",
         "className?",

--- a/addons/mail/static/src/core/common/discuss_avatar.xml
+++ b/addons/mail/static/src/core/common/discuss_avatar.xml
@@ -2,14 +2,14 @@
 <templates xml:space="preserve">
     <t t-name="mail.DiscussAvatar">
         <svg t-att-width="props.size" t-att-height="props.size" viewBox="0 0 32 32" class="overflow-visible" t-att-class="props.className">
-            <mask t-att-id="uniqueId" width="32" height="32">
-                <rect x="0" y="0" height="32" width="32" fill="white"/>
-                <rect t-if="showIcon" color="black" t-att-x="isTyping ? 15 : 19" y="19" t-att-width="isTyping ? 24 : 16" t-att-height="isTyping ? 15 : 16" rx="8" ry="8"/>
+            <mask t-att-id="uniqueId" width="1000" height="1000">
+                <rect x="0" y="0" height="100%" width="100%" fill="white"/>
+                <rect t-if="showIcon" color="black" x="0" y="0" t-att-width="isTyping ? 24 : 16" t-att-height="isTyping ? 15 : 16" rx="8" ry="8" t-att-transform="'translate(' + (isTyping ? 14 : 19) + ', 19) ' + (props.iconExtraTransform ?? '')"/>
             </mask>
             <foreignObject x="0" y="0" width="32" height="32" t-att-mask="'url(#' + uniqueId + ')'">
                 <t t-call="mail.DiscussAvatar.avatarImg"/> <!-- FIXME: owl doesn't like and load immediate <img> below <foreignObject>, hence t-call shenanigans -->
             </foreignObject>
-            <g t-if="showIcon" t-att-transform="'translate(' + (isTyping ? 16 : 21) + ', 20)'">
+            <g t-if="showIcon" t-att-transform="'translate(' + (isTyping ? 16 : 21) + ', 20) ' + (props.iconExtraTransform ?? '')">
                 <svg width="25" height="15" viewBox="0 0 25 15">
                     <foreignObject x="0" y="0" width="25" height="15">
                         <ThreadIcon t-if="thread" thread="thread" typing="props.typing"/>

--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -14,7 +14,7 @@
             'o-active': props.isActive,
         }">
             <div class="o-mail-NotificationItem-avatarContainer position-relative flex-shrink-0 align-self-start" t-att-class="{ 'o-small': ui.isSmall }">
-                <DiscussAvatar t-if="props.thread or props.persona" thread="props.thread" persona="props.persona" size="ui.isSmall ? 52 : undefined"/>
+                <DiscussAvatar t-if="props.thread or props.persona" thread="props.thread" persona="props.persona" size="ui.isSmall ? 52 : undefined" iconExtraTransform="ui.isSmall ? 'scale(.75) translate(3, 3)' : undefined"/>
                 <img t-else="" class="o_avatar w-100 h-100" t-att-class="{ 'rounded-3': ui.isSmall, 'rounded': !ui.isSmall }" alt="Notification Item Image" t-att-src="props.iconSrc"/>
                 <t t-if="props.slots and props.slots.icon" t-slot="icon"/>
             </div>


### PR DESCRIPTION
Before this commit, the size of IM status in ChatBubble and Mobile Discuss were too big.

This happens because the `DiscussAvatar` component, which groups the img and IM status, is made from SVG, so that there's mask of image around the IM status. Size of the IM status is coupled with size of the img, so for example if the IMG is twice as big as the default size, then the IM status is also twice as big, which is roughly what chat bubble and mobile discuss have.

This commit reduces the size of IM status of chat bubble and mobile discuss to 75%, so that this looks better. This is made possible by providing `iconExtraTransform`, some extra `transform` that are applied on the image mask related to icon and the icon itself. This allows the scale down the IM status in addition to the mask, and offset the position with the new scaling.

Before / After
<img width="63" height="393" alt="Screenshot 2026-03-06 at 14 15 40" src="https://github.com/user-attachments/assets/6ef2ae3d-d54c-461e-9688-91c69d5631ff" /> <img width="64" height="401" alt="Screenshot 2026-03-06 at 14 15 12" src="https://github.com/user-attachments/assets/edeb2175-698c-4734-8e98-d0b373e7aabc" />
