### PR TITLE
[FIX] l10_in_hr_holiday: fixed sandwich leave with public holiday

### DIFF
--- a/addons/l10n_in_hr_holidays/models/hr_leave.py
+++ b/addons/l10n_in_hr_holidays/models/hr_leave.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import pytz
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from odoo import api, fields, models
 
@@ -57,6 +57,10 @@ class HolidaysRequest(models.Model):
             - Filters Indian, full-day, sandwich-enabled leaves.
             - Prepares dicts for sibling employee leaves and company public holidays.
         """
+        def _to_local_date(datetime, tz):
+            datetime = pytz.utc.localize(datetime, is_dst=False)
+            return datetime.astimezone(tz).date()
+
         indian_leaves = self.filtered(
             lambda leave: leave.company_id.country_id.code == "IN"
             and leave.holiday_status_id.l10n_in_is_sandwich_leave
@@ -87,22 +91,23 @@ class HolidaysRequest(models.Model):
         }
 
         tz = pytz.timezone(self.env.context.get("tz") or self.env.user.tz or "UTC")
-        public_holidays_dates_by_company = {
-            company_id: {
-                (datetime.date(holiday.date_from.astimezone(tz)) + timedelta(days=offset)): holiday
-                for holiday in recs
-                for offset in range((holiday.date_to.date() - holiday.date_from.date()).days + 1)
-            }
-            for company_id, recs in self.env['resource.calendar.leaves']._read_group(
-                domain=[
-                    ('resource_id', '=', False),
-                    ('company_id', 'in', indian_leaves.company_id.ids),
-                ],
-                groupby=['company_id'],
-                aggregates=['id:recordset'],
-            )
-        }
-
+        public_holidays_dates_by_company = {}
+        for company_id, recs in self.env['resource.calendar.leaves']._read_group(
+            domain=[
+                ('resource_id', '=', False),
+                ('company_id', 'in', indian_leaves.company_id.ids),
+            ],
+            groupby=['company_id'],
+            aggregates=['id:recordset'],
+        ):
+            company_dates = {}
+            tz = pytz.timezone(company_id.resource_calendar_id.tz or self.env.context.get("tz") or self.env.user.tz or "UTC")
+            for holiday in recs:
+                local_start = _to_local_date(holiday.date_from, tz)
+                local_end = _to_local_date(holiday.date_to, tz)
+                for offset in range((local_end - local_start).days + 1):
+                    company_dates[local_start + timedelta(days=offset)] = holiday
+            public_holidays_dates_by_company[company_id] = company_dates
         return indian_leaves, leaves_dates_by_employee, public_holidays_dates_by_company
 
     def _l10n_in_apply_sandwich_rule(self, public_holidays_date_by_company, leaves_dates_by_employee):

--- a/addons/l10n_in_hr_holidays/tests/test_sandwich_leave.py
+++ b/addons/l10n_in_hr_holidays/tests/test_sandwich_leave.py
@@ -13,6 +13,7 @@ class TestSandwichLeave(TransactionCase):
             'name': 'Test Indian Company',
             'country_id': self.env.ref('base.in').id
         })
+        self.indian_company.resource_calendar_id.tz = 'UTC'
         self.env = self.env(context=dict(self.env.context, allowed_company_ids=self.indian_company.ids))
         self.demo_user = self.env['res.users'].with_company(self.indian_company).create({
             'name': 'Piyush User',
@@ -59,6 +60,7 @@ class TestSandwichLeave(TransactionCase):
             'date_from': '2025-01-29 00:00:00',
             'date_to': '2025-01-29 23:59:59',
             'resource_id': False,
+            'company_id': self.indian_company.id,
         })
 
     def test_approved_leave_does_not_raise_access_error(self):
@@ -204,6 +206,41 @@ class TestSandwichLeave(TransactionCase):
         })
         self.assertTrue(holiday_leave.l10n_in_contains_sandwich_leaves)
         self.assertEqual(holiday_leave.number_of_days, 3)
+
+    @freeze_time('2025-03-01')
+    def test_sandwich_leave_with_utc_full_day_public_holiday(self):
+        """
+            Public holiday for one full local day in IST:
+            - local day: 12-Mar-2025 12:00 AM to 11:59:59 PM
+            - UTC value: 11-Mar-2025 18:30:00 to 12-Mar-2025 18:29:59
+        """
+        self.env['resource.calendar.leaves'].create({
+            'name': 'IST Full Day Public Holiday',
+            'date_from': '2025-03-11 18:30:00',
+            'date_to': '2025-03-12 18:29:59',
+            'resource_id': False,
+            'company_id': self.indian_company.id,
+        })
+        self.indian_company.resource_calendar_id.tz = 'Asia/Kolkata'
+        before_holiday_leave = self.env['hr.leave'].create({
+            'name': 'Before Public Holiday',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': '2025-03-11',
+            'request_date_to': '2025-03-11',
+        })
+        after_holiday_leave = self.env['hr.leave'].create({
+            'name': 'After Public Holiday',
+            'employee_id': self.rahul_emp.id,
+            'holiday_status_id': self.leave_type_day.id,
+            'request_date_from': '2025-03-13',
+            'request_date_to': '2025-03-13',
+        })
+
+        self.assertFalse(before_holiday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(before_holiday_leave.number_of_days, 1)
+        self.assertTrue(after_holiday_leave.l10n_in_contains_sandwich_leaves)
+        self.assertEqual(after_holiday_leave.number_of_days, 2)
 
     @freeze_time('2025-01-15')
     def test_sandwich_leave_2days_stop_with_public_holidays(self):


### PR DESCRIPTION
Steps to Reproduce:

1. Install the `l10n_in_hr_holidays` module.
2. Enable the "sandwich leave" option for the time off type.
3. Create public holidays that last the entire day, for example from 00:00 to 23:59.
4. Create a leave around the public holiday
5. Duration should be 3 days instead of 1

Cause:

When creating a dictionary for company-specific public holidays, the dates from and to are not converted to the company's timezone when calculating the days between public holidays.

Fix:

To resolve this, the first step is to localize the `date_from` and `date_to` to the company's timezone before counting the days between the public holidays.

Task-6012992