### PR TITLE
[IMP] digest, *: improve digest KPI actions to open relevant views

### DIFF
--- a/addons/account/models/digest.py
+++ b/addons/account/models/digest.py
@@ -33,6 +33,6 @@ class DigestDigest(models.Model):
     def _get_kpi_custom_settings(self, company, user):
         res = super()._get_kpi_custom_settings(company, user)
         menu_id = self.env.ref('account.menu_finance').id
-        res['kpi_action']['kpi_account_total_revenue'] = f'account.action_move_out_invoice_type?menu_id={menu_id}'
+        res['kpi_action']['kpi_account_total_revenue'] = f'account.action_account_invoice_report_all_digest?menu_id={menu_id}'
         res['kpi_sequence']['kpi_account_total_revenue'] = 5500
         return res

--- a/addons/account/models/digest.py
+++ b/addons/account/models/digest.py
@@ -33,6 +33,8 @@ class DigestDigest(models.Model):
     def _get_kpi_custom_settings(self, company, user):
         res = super()._get_kpi_custom_settings(company, user)
         menu_id = self.env.ref('account.menu_finance').id
-        res['kpi_action']['kpi_account_total_revenue'] = f'account.action_move_out_invoice_type?menu_id={menu_id}'
+        res['kpi_action']['kpi_account_total_revenue'] = (
+            f'account.action_account_invoice_report_all?menu_id={menu_id}'
+        )
         res['kpi_sequence']['kpi_account_total_revenue'] = 5500
         return res

--- a/addons/account/report/account_invoice_report_view.xml
+++ b/addons/account/report/account_invoice_report_view.xml
@@ -110,6 +110,7 @@
                 <filter string="Credit Notes" name="creditnote" domain="['|', ('move_type','=','out_refund'),('move_type','=','in_refund')]"/>
                 <separator/>
                 <filter name="filter_invoice_date" date="invoice_date"/>
+                <filter name="filter_last_30_days" string="Last 30 Days" domain="[('move_id.date', '&gt;=', 'today -30d'), ('move_id.date', '&lt;=', 'today')]" invisible="1"/>
                 <filter name="invoice_date_due" date="invoice_date_due"/>
                 <field name="partner_id" operator="child_of"/>
                 <field name="invoice_user_id" />
@@ -147,6 +148,21 @@
         <field name="path">customer-invoices-analysis</field>
         <field name="view_mode">graph,pivot</field>
         <field name="context">{'search_default_current':1, 'search_default_customer': 1, 'group_by':['invoice_date:month']}</field>
+        <field name="search_view_id" ref="view_account_invoice_report_search"/>
+        <field name="help">From this report, you can have an overview of the amount invoiced to your customers. The search tool can also be used to personalise your Invoices reports and so, match this analysis to your needs.</field>
+    </record>
+
+    <record id="action_account_invoice_report_all_digest" model="ir.actions.act_window">
+        <field name="name">Revenue</field>
+        <field name="res_model">account.invoice.report</field>
+        <field name="view_mode">graph,pivot</field>
+        <field name="domain">[('state', '=', 'posted'), ('account_id.internal_group', '=', 'income')]</field>
+        <field name="context">{
+            'search_default_filter_last_30_days': 1,
+            'group_by': ['invoice_date:day'],
+            'graph_measure': 'price_total',
+            'pivot_measures': ['price_total']
+        }</field>
         <field name="search_view_id" ref="view_account_invoice_report_search"/>
         <field name="help">From this report, you can have an overview of the amount invoiced to your customers. The search tool can also be used to personalise your Invoices reports and so, match this analysis to your needs.</field>
     </record>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -372,6 +372,7 @@
                     <filter string="No Bank Transaction" domain="[('statement_line_id', '=', False), ('payment_id', '=', False)]" name="no_st_line_id" invisible="1"/>
                     <separator/>
                     <filter string="Date" name="date" date="date"/>
+                    <filter string="Last Month" name="last_month" domain="[('date', '&gt;=', 'today -1m'), ('date', '&lt;=', 'today')]" invisible="1"/>
                     <filter string="Invoice Date" name="invoice_date" date="invoice_date"/>
                     <filter string="Report Dates" name="date_between" domain="[('date', '&gt;=', context.get('date_from')), ('date', '&lt;=', context.get('date_to'))]" invisible="1"/>
                     <filter string="Report Dates" name="date_before" domain="[('date', '&lt;=', context.get('date_to'))]" invisible="1"/>

--- a/addons/crm/models/digest.py
+++ b/addons/crm/models/digest.py
@@ -29,11 +29,8 @@ class DigestDigest(models.Model):
     def _get_kpi_custom_settings(self, company, user):
         res = super()._get_kpi_custom_settings(company, user)
         menu_id = self.env.ref('crm.crm_menu_root').id
-        res['kpi_action']['kpi_crm_opportunities_won'] = f'crm.crm_lead_action_pipeline?menu_id={menu_id}'
-        if user.has_group('crm.group_use_lead'):
-            res['kpi_action']['kpi_crm_lead_created'] = f'crm.crm_lead_all_leads?menu_id={menu_id}'
-        else:
-            res['kpi_action']['kpi_crm_lead_created'] = f'crm.crm_lead_action_pipeline?menu_id={menu_id}'
+        res['kpi_action']['kpi_crm_opportunities_won'] = f'crm.action_crm_opportunity_report_won?menu_id={menu_id}'
+        res['kpi_action']['kpi_crm_lead_created'] = f'crm.action_crm_lead_report_active_leads?menu_id={menu_id}'
         res['kpi_sequence']['kpi_crm_lead_created'] = 4550
         res['kpi_sequence']['kpi_crm_opportunities_won'] = 4555
         return res

--- a/addons/crm/report/crm_opportunity_report_views.xml
+++ b/addons/crm/report/crm_opportunity_report_views.xml
@@ -120,8 +120,10 @@
                     <field name="user_id" string="Salesperson"/>
                     <separator/>
                     <filter name="filter_create_date" date="create_date" default_period="year"/>
+                    <filter string="Last 30 Days" name="filter_create_date_last_30_days" domain="[('create_date', '&gt;=', '-30d')]" invisible="1"/>
                     <filter string="Expected Closing" name="filter_date_deadline" date="date_deadline"/>
                     <filter string="Date Closed" name="date_closed_filter" date="date_closed"/>
+                    <filter string="Last 30 Days" name="filter_date_closed_last_30_days" domain="[('date_closed', '&gt;=', '-30d'), ('date_closed', '&lt;', 'now')]" invisible="1"/>
                     <group>
                         <field name="partner_id" filter_domain="[('partner_id','child_of',self)]"/>
                         <field name="stage_id" domain="['|', ('team_ids', '=', False), ('team_ids', 'in', 'team_id')]"/>
@@ -201,6 +203,35 @@
             </field>
         </record>
 
+        <record id="action_crm_opportunity_report_won" model="ir.actions.act_window">
+            <field name="name">Opportunities Won</field>
+            <field name="res_model">crm.lead</field>
+            <field name="view_mode">pivot,graph,list,form</field>
+            <field name="search_view_id" ref="crm.crm_opportunity_report_view_search"/>
+            <field name="context">{
+                'search_default_filter_opportunity': 1,
+                'search_default_filter_won_status_won': 1,
+                'search_default_filter_date_closed_last_30_days': 1,
+                'graph_measure': '__count__',
+                'pivot_measures': ['__count'],
+                'graph_groupbys': ['date_closed:day'],
+                'group_by': ['date_closed:day'],
+                'show_lead_gen_button': 1,
+            }</field>
+            <field name="view_ids"
+                   eval="[(5, 0, 0),
+                          (0, 0, {'view_mode': 'pivot', 'view_id': ref('crm_opportunity_report_view_pivot')}),
+                          (0, 0, {'view_mode': 'graph', 'view_id': ref('crm_opportunity_report_view_graph')}),
+                          (0, 0, {'view_mode': 'list', 'view_id': ref('crm_lead_view_tree_opportunity_reporting')})]"/>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    No data found!
+                </p><p>
+                    Use this menu to have an overview of your Pipeline.
+                </p>
+            </field>
+        </record>
+
         <record id="crm_opportunity_report_action_lead" model="ir.actions.act_window">
             <field name="name">Leads Analysis</field>
             <field name="res_model">crm.lead</field>
@@ -210,6 +241,35 @@
                 'search_default_filter_active': 1,
                 'search_default_filter_inactive': 1,
                 'search_default_filter_create_date': 1,
+            }</field>
+            <field name="view_ids"
+                   eval="[(5, 0, 0),
+                          (0, 0, {'view_mode': 'graph', 'view_id': ref('crm_opportunity_report_view_graph_lead')}),
+                          (0, 0, {'view_mode': 'pivot', 'view_id': ref('crm_opportunity_report_view_pivot_lead')}),
+                          (0, 0, {'view_mode': 'form', 'view_id': ref('crm_lead_view_form')}),
+                          (0, 0, {'view_mode': 'list', 'view_id': ref('crm_lead_view_tree_reporting')}),
+                         ]"/>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    No data found!
+                </p><p>
+                    This analysis shows you how many leads have been created per month.
+                </p>
+            </field>
+        </record>
+
+        <record id="action_crm_lead_report_active_leads" model="ir.actions.act_window">
+            <field name="name">New Leads</field>
+            <field name="res_model">crm.lead</field>
+            <field name="view_mode">graph,pivot,list</field>
+            <field name="search_view_id" ref="crm.crm_opportunity_report_view_search"/>
+            <field name="domain">[('company_id', 'in', allowed_company_ids)]</field>
+            <field name="context">{
+                'search_default_filter_create_date_last_30_days': 1,
+                'graph_measure': '__count__',
+                'pivot_measures': ['__count'],
+                'graph_groupbys': ['create_date:day'],
+                'group_by': ['create_date:day'],
             }</field>
             <field name="view_ids"
                    eval="[(5, 0, 0),

--- a/addons/crm/report/crm_opportunity_report_views.xml
+++ b/addons/crm/report/crm_opportunity_report_views.xml
@@ -202,6 +202,31 @@
             </field>
         </record>
 
+        <record id="action_crm_opportunity_report_won" model="ir.actions.act_window">
+            <field name="name">Pipeline Analysis</field>
+            <field name="res_model">crm.lead</field>
+            <field name="view_mode">graph,pivot,list,form</field>
+            <field name="search_view_id" ref="crm.crm_opportunity_report_view_search"/>
+            <field name="context">{
+                'search_default_filter_opportunity': 1,
+                'search_default_current': 1,
+                'search_default_filter_won_status_won': 1,
+                'show_lead_gen_button': 1,
+            }</field>
+            <field name="view_ids"
+                   eval="[(5, 0, 0),
+                          (0, 0, {'view_mode': 'graph', 'view_id': ref('crm_opportunity_report_view_graph')}),
+                          (0, 0, {'view_mode': 'pivot', 'view_id': ref('crm_opportunity_report_view_pivot')}),
+                          (0, 0, {'view_mode': 'list', 'view_id': ref('crm_lead_view_tree_opportunity_reporting')})]"/>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    No data found!
+                </p><p>
+                    Use this menu to have an overview of your Pipeline.
+                </p>
+            </field>
+        </record>
+
         <record id="crm_opportunity_report_action_lead" model="ir.actions.act_window">
             <field name="name">Leads Analysis</field>
             <field name="res_model">crm.lead</field>
@@ -212,6 +237,28 @@
                 'search_default_filter_inactive': 1,
                 'search_default_filter_create_date': 1,
             }</field>
+            <field name="view_ids"
+                   eval="[(5, 0, 0),
+                          (0, 0, {'view_mode': 'graph', 'view_id': ref('crm_opportunity_report_view_graph_lead')}),
+                          (0, 0, {'view_mode': 'pivot', 'view_id': ref('crm_opportunity_report_view_pivot_lead')}),
+                          (0, 0, {'view_mode': 'form', 'view_id': ref('crm_lead_view_form')}),
+                          (0, 0, {'view_mode': 'list', 'view_id': ref('crm_lead_view_tree_reporting')}),
+                         ]"/>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    No data found!
+                </p><p>
+                    This analysis shows you how many leads have been created per month.
+                </p>
+            </field>
+        </record>
+
+        <record id="action_crm_lead_report_active_leads" model="ir.actions.act_window">
+            <field name="name">Leads Analysis</field>
+            <field name="res_model">crm.lead</field>
+            <field name="view_mode">graph,pivot,list</field>
+            <field name="search_view_id" ref="crm.crm_opportunity_report_view_search"/>
+            <field name="context">{'search_default_filter_create_date': 1}</field>
             <field name="view_ids"
                    eval="[(5, 0, 0),
                           (0, 0, {'view_mode': 'graph', 'view_id': ref('crm_opportunity_report_view_graph_lead')}),

--- a/addons/digest/models/digest.py
+++ b/addons/digest/models/digest.py
@@ -517,7 +517,6 @@ class DigestDigest(models.Model):
         return {
             'kpi_action': {
                 'kpi_res_users_connected': f"base.action_res_users?menu_id={self.env.ref('base.menu_administration').id}",
-                'kpi_mail_message_total': f"mail.action_discuss?menu_id={self.env.ref('mail.menu_root_discuss').id}",
             },
             'kpi_module': {
                 'kpi_mail_message_total': 'mail',

--- a/addons/digest/models/digest.py
+++ b/addons/digest/models/digest.py
@@ -512,7 +512,6 @@ class DigestDigest(models.Model):
         return {
             'kpi_action': {
                 'kpi_res_users_connected': f"base.action_res_users?menu_id={self.env.ref('base.menu_administration').id}",
-                'kpi_mail_message_total': f"mail.action_discuss?menu_id={self.env.ref('mail.menu_root_discuss').id}",
             },
             'kpi_module': {
                 'kpi_mail_message_total': 'mail',

--- a/addons/digest/wizard/digest_test.py
+++ b/addons/digest/wizard/digest_test.py
@@ -9,7 +9,7 @@ class TestDigest(models.TransientModel):
 
     digest_id = fields.Many2one('digest.digest', string='Digest', required=True, ondelete='cascade')
     user_ids = fields.Many2many('res.users', string='Recipients', domain="[('share', '=', False)]",
-                                default=lambda self: self.env.user)
+                                default=lambda self: self.env.user, required=True)
 
     def send_mail_test(self):
         self.ensure_one()

--- a/addons/event/models/digest.py
+++ b/addons/event/models/digest.py
@@ -17,6 +17,7 @@ class Digest(models.Model):
 
     def _get_kpi_custom_settings(self, company, user):
         res = super()._get_kpi_custom_settings(company, user)
-        res['kpi_action']['kpi_nbr_of_registrations'] = 'event.action_registration'
+        menu_id = self.env.ref('event.event_main_menu').id
+        res['kpi_action']['kpi_nbr_of_registrations'] = f'event.action_event_registration?menu_id={menu_id}'
         res['kpi_sequence']['kpi_nbr_of_registrations'] = 10500
         return res

--- a/addons/event/views/event_registration_views.xml
+++ b/addons/event/views/event_registration_views.xml
@@ -236,7 +236,7 @@
                     domain="[('my_activity_date_deadline', '=', 'today')]"/>
                 <filter invisible="1" string="Future Activities" name="activities_upcoming_all"
                     domain="[('my_activity_date_deadline', '&gt;', 'today')]"/>
-                <filter string="Last 30 days" name="filter_last_month_creation" domain="[('create_date', '&gt;=', 'today -30d'), ('create_date', '&lt;', 'today')]"/>
+                <filter string="Last Month" name="filter_last_month_creation" domain="[('create_date', '&gt;=', 'today -1m')]"/>
                 <separator/>
                 <filter string="Archived" name="filter_inactive" domain="[('active', '=', False)]"/>
                 <group>
@@ -372,6 +372,27 @@
             }
         </field>
         <field name="search_view_id" ref="event_registration_view_search_event_specific"/>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No Attendees yet!
+            </p><p>
+                From this dashboard you can report, analyze and detect trends regarding your event registrations.
+            </p>
+        </field>
+    </record>
+
+    <record id="action_event_registration" model="ir.actions.act_window">
+        <field name="name">Registrations</field>
+        <field name="res_model">event.registration</field>
+        <field name="view_mode">graph,pivot,kanban,list,form</field>
+        <field name="search_view_id" ref="view_registration_search"/>
+        <field name="context">{
+                'search_default_filter_last_month_creation': 1,
+                'search_default_taken': 1,
+                'search_default_group_by_create_date_day': 1,
+                'registration_view_hide_group_by_create_date_week': 1,
+            }
+        </field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No Attendees yet!

--- a/addons/event/views/event_registration_views.xml
+++ b/addons/event/views/event_registration_views.xml
@@ -374,6 +374,27 @@
         </field>
     </record>
 
+    <record id="action_event_registration" model="ir.actions.act_window">
+        <field name="name">Attendees</field>
+        <field name="res_model">event.registration</field>
+        <field name="view_mode">graph,pivot,kanban,list,form</field>
+        <field name="context">{
+                'search_default_filter_last_month_creation': 1,
+                'search_default_taken': 1,
+                'search_default_group_by_create_date_day': 1,
+                'registration_view_hide_group_by_create_date_week': 1,
+            }
+        </field>
+        <field name="search_view_id" ref="view_registration_search"/>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No Attendees yet!
+            </p><p>
+                From this dashboard you can report, analyze and detect trends regarding your event registrations.
+            </p>
+        </field>
+    </record>
+
     <menuitem name="Attendees"
         id="menu_action_registration"
         parent="event.menu_reporting_events"

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -62,7 +62,9 @@
                     <separator />
                     <filter string="Contract Start" name="contract_date_start" date="contract_date_start"/>
                     <filter string="Contract End" name="contract_date_end" date="contract_date_end"/>
+                    <filter string="Newly Hired" name="newly_hired" domain="[('newly_hired', '=', True)]" invisible="1"/>
                     <separator />
+                    <filter string="Last 30 Days" name="create_date_last_30_days" domain="[('create_date', '&gt;=', '-1m')]" invisible="1"/>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
                     <group>
                         <filter name="group_manager" string="Manager" domain="[]" context="{'group_by': 'parent_id'}"/>
@@ -841,6 +843,21 @@
             <field name="view_mode">form,list</field>
             <field name="view_id" eval="False"/>
             <field name="search_view_id" ref="view_employee_filter"/>
+        </record>
+
+        <record id="action_employee_newly_hired" model="ir.actions.act_window">
+            <field name="name">New Employees</field>
+            <field name="res_model">hr.employee</field>
+            <field name="view_mode">graph,kanban,list,form,pivot</field>
+            <field name="view_id" eval="False"/>
+            <field name="search_view_id" ref="view_employee_filter"/>
+            <field name="domain">[('company_id', 'in', allowed_company_ids)]</field>
+            <field name="context">{
+                'searchpanel_default_company_id': allowed_company_ids[0],
+                'chat_icon': True,
+                'search_default_newly_hired': 1,
+                'search_default_create_date_last_30_days': 1,
+            }</field>
         </record>
 
         <record id="action_hr_employee_all_activities" model="ir.actions.act_window">

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -52,6 +52,8 @@
                     <separator />
                     <filter string="Contract Start" name="contract_date_start" date="contract_date_start" groups="hr.group_hr_manager"/>
                     <filter string="Contract End" name="contract_date_end" date="contract_date_end" groups="hr.group_hr_manager"/>
+                    <separator invisible="1"/>
+                    <filter string="Newly Hired" name="newly_hired" domain="[('newly_hired', '=', True)]" invisible="1"/>
                     <separator />
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
                     <group>
@@ -965,6 +967,20 @@
             <field name="name">Employees</field>
             <field name="res_model">hr.employee</field>
             <field name="view_mode">form,list</field>
+            <field name="view_id" eval="False"/>
+            <field name="search_view_id" ref="view_employee_filter"/>
+        </record>
+
+        <record id="action_employee_newly_hired" model="ir.actions.act_window">
+            <field name="name">Employees</field>
+            <field name="res_model">hr.employee</field>
+            <field name="view_mode">kanban,list,form,graph,pivot</field>
+            <field name="domain">[('company_id', 'in', allowed_company_ids)]</field>
+            <field name="context">{
+                'searchpanel_default_company_id': allowed_company_ids[0],
+                'chat_icon': True,
+                'search_default_newly_hired': 1,
+            }</field>
             <field name="view_id" eval="False"/>
             <field name="search_view_id" ref="view_employee_filter"/>
         </record>

--- a/addons/hr_recruitment/models/digest.py
+++ b/addons/hr_recruitment/models/digest.py
@@ -20,6 +20,8 @@ class DigestDigest(models.Model):
     def _get_kpi_custom_settings(self, company, user):
         res = super()._get_kpi_custom_settings(company, user)
         menu_id = self.env.ref('hr.menu_hr_root').id
-        res['kpi_action']['kpi_hr_recruitment_new_colleagues'] = f'hr.open_view_employee_list_my?menu_id={menu_id}'
+        res['kpi_action']['kpi_hr_recruitment_new_colleagues'] = (
+            f'hr.action_employee_newly_hired?menu_id={menu_id}'
+        )
         res['kpi_sequence']['kpi_hr_recruitment_new_colleagues'] = 12500
         return res

--- a/addons/hr_recruitment/models/digest.py
+++ b/addons/hr_recruitment/models/digest.py
@@ -20,6 +20,8 @@ class DigestDigest(models.Model):
     def _get_kpi_custom_settings(self, company, user):
         res = super()._get_kpi_custom_settings(company, user)
         menu_id = self.env.ref('hr.menu_hr_root').id
-        res['kpi_action']['kpi_hr_recruitment_new_colleagues'] = f'hr.open_view_employee_list_my?menu_id={menu_id}'
+        res['kpi_action']['kpi_hr_recruitment_new_colleagues'] = (
+            f'hr.action_employee_newly_hired?menu_id={menu_id}&view_type=graph'
+        )
         res['kpi_sequence']['kpi_hr_recruitment_new_colleagues'] = 12500
         return res

--- a/addons/im_livechat/models/digest.py
+++ b/addons/im_livechat/models/digest.py
@@ -11,7 +11,7 @@ class DigestDigest(models.Model):
     kpi_livechat_rating_value = fields.Float(digits=(16, 2), compute='_compute_kpi_livechat_rating_value')
     kpi_livechat_conversations = fields.Boolean('Conversations handled')
     kpi_livechat_conversations_value = fields.Integer(compute='_compute_kpi_livechat_conversations_value')
-    kpi_livechat_response = fields.Boolean('Time to answer (sec)')
+    kpi_livechat_response = fields.Boolean('Response Time')
     kpi_livechat_response_value = fields.Float(digits=(16, 2), compute='_compute_kpi_livechat_response_value')
 
     def _compute_kpi_livechat_rating_value(self):
@@ -59,6 +59,7 @@ class DigestDigest(models.Model):
 
     def _get_kpi_custom_settings(self, company, user):
         res = super()._get_kpi_custom_settings(company, user)
+        res['kpi_action']['kpi_livechat_rating'] = 'im_livechat.im_livechat_report_channel_rating_action'
         res['kpi_action']['kpi_livechat_conversations'] = 'im_livechat.im_livechat_report_channel_action'
         res['kpi_action']['kpi_livechat_response'] = 'im_livechat.im_livechat_report_channel_time_to_answer_action'
         res['is_cross_company'].update(('kpi_livechat_rating', 'kpi_livechat_conversations', 'kpi_livechat_response'))

--- a/addons/im_livechat/models/digest.py
+++ b/addons/im_livechat/models/digest.py
@@ -11,7 +11,7 @@ class DigestDigest(models.Model):
     kpi_livechat_rating_value = fields.Float(digits=(16, 2), compute='_compute_kpi_livechat_rating_value')
     kpi_livechat_conversations = fields.Boolean('Conversations handled')
     kpi_livechat_conversations_value = fields.Integer(compute='_compute_kpi_livechat_conversations_value')
-    kpi_livechat_response = fields.Boolean('Time to answer (sec)')
+    kpi_livechat_response = fields.Boolean('Response Time')
     kpi_livechat_response_value = fields.Float(digits=(16, 2), compute='_compute_kpi_livechat_response_value')
 
     def _compute_kpi_livechat_rating_value(self):
@@ -47,6 +47,7 @@ class DigestDigest(models.Model):
 
     def _get_kpi_custom_settings(self, company, user):
         res = super()._get_kpi_custom_settings(company, user)
+        res['kpi_action']['kpi_livechat_rating'] = 'im_livechat.im_livechat_report_channel_action'
         res['kpi_action']['kpi_livechat_conversations'] = 'im_livechat.im_livechat_report_channel_action'
         res['kpi_action']['kpi_livechat_response'] = 'im_livechat.im_livechat_report_channel_time_to_answer_action'
         res['is_cross_company'].update(('kpi_livechat_rating', 'kpi_livechat_conversations', 'kpi_livechat_response'))

--- a/addons/im_livechat/report/im_livechat_report_channel_views.xml
+++ b/addons/im_livechat/report/im_livechat_report_channel_views.xml
@@ -128,10 +128,25 @@
         </record>
 
         <record id="im_livechat_report_channel_time_to_answer_action" model="ir.actions.act_window">
-            <field name="name">Sessions</field>
+            <field name="name">Response Time</field>
             <field name="res_model">im_livechat.report.channel</field>
             <field name="view_mode">graph,pivot</field>
-            <field name="context">{"graph_measure": "time_to_answer", "search_default_filter_date_last_week":1}</field>
+            <field name="context">{"graph_measure": "time_to_answer", "search_default_filter_date_last_month":1}</field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">No data yet!</p>
+                <p>Track and improve live chat performance with insights on session activity, response times, customer ratings, and call interactions.</p>
+            </field>
+        </record>
+
+        <record id="im_livechat_report_channel_rating_action" model="ir.actions.act_window">
+            <field name="name">Happy Sessions</field>
+            <field name="res_model">im_livechat.report.channel</field>
+            <field name="view_mode">graph,pivot</field>
+            <field name="context">{
+                "graph_measure": "rating_percentage",
+                "search_default_filter_date_last_month": 1,
+                "search_default_group_by_rating": 1,
+            }</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">No data yet!</p>
                 <p>Track and improve live chat performance with insights on session activity, response times, customer ratings, and call interactions.</p>

--- a/addons/link_tracker/views/link_tracker_views.xml
+++ b/addons/link_tracker/views/link_tracker_views.xml
@@ -12,6 +12,8 @@
                     <field name="campaign_id"/>
                     <field name="medium_id"/>
                     <field name="source_id"/>
+                    <filter string="Social Media" name="social_media" invisible="1"
+                            domain="[('utm_reference', 'like', 'social.post,%')]"/>
                     <group>
                         <filter string="Campaign" name="groupby_campaign_id" context="{'group_by': 'campaign_id'}"/>
                         <filter string="Medium" name="groupby_medium_id" context="{'group_by': 'medium_id'}"/>
@@ -104,6 +106,20 @@
             <field name="res_model">link.tracker</field>
             <field name="view_mode">list,form,graph</field>
             <field name="view_id" ref="link_tracker_view_tree"/>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    Create a link tracker
+                </p><p>
+                    Trackers are used to collect count stat about click on links and generate short URLs.
+                </p>
+            </field>
+        </record>
+
+        <record id="action_link_tracker_social_clicks" model="ir.actions.act_window">
+            <field name="name">Link Tracker</field>
+            <field name="res_model">link.tracker</field>
+            <field name="view_mode">graph,list,form</field>
+            <field name="context">{'search_default_social_media': '1'}</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     Create a link tracker

--- a/addons/point_of_sale/models/digest.py
+++ b/addons/point_of_sale/models/digest.py
@@ -23,6 +23,6 @@ class DigestDigest(models.Model):
     def _get_kpi_custom_settings(self, company, user):
         res = super()._get_kpi_custom_settings(company, user)
         menu_id = self.env.ref('point_of_sale.menu_point_root').id
-        res['kpi_action']['kpi_pos_total'] = f'point_of_sale.action_pos_sale_graph?menu_id={menu_id}'
+        res['kpi_action']['kpi_pos_total'] = f'point_of_sale.action_report_pos_sale?menu_id={menu_id}'
         res['kpi_sequence']['kpi_pos_total'] = 1500
         return res

--- a/addons/point_of_sale/views/pos_order_report_view.xml
+++ b/addons/point_of_sale/views/pos_order_report_view.xml
@@ -56,6 +56,7 @@
                     <filter string="Not Cancelled" name="not_cancelled" domain="[('state','!=','cancel')]"/>
                     <separator/>
                     <filter name="filter_date" date="date"/>
+                    <filter string="Last 30 Days" name="last_30_days" domain="[('date', '&gt;=', '-30d'), ('date', '&lt;', 'now')]" invisible="1"/>
                     <field name="config_id"/>
                     <field name="partner_id"/>
                     <field name="product_id"/>
@@ -96,6 +97,23 @@
             </field>
         </record>
 
+        <record id="action_report_pos_sale" model="ir.actions.act_window">
+            <field name="name">POS Sales</field>
+            <field name="res_model">report.pos.order</field>
+            <field name="view_mode">pivot,graph</field>
+            <field name="domain">[('state', 'not in', ['draft', 'cancel'])]</field>
+            <field name="search_view_id" ref="view_report_pos_order_search"/>
+            <field name="context">{
+                'search_default_last_30_days': 1,
+            }</field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    No data yet!
+                </p><p>
+                    Create a new POS order
+                </p>
+            </field>
+        </record>
 
         <record id="action_report_pos_details" model="ir.actions.act_window">
             <field name="name">Sales Details</field>

--- a/addons/point_of_sale/views/pos_order_report_view.xml
+++ b/addons/point_of_sale/views/pos_order_report_view.xml
@@ -95,6 +95,20 @@
             </field>
         </record>
 
+        <record id="action_report_pos_sale" model="ir.actions.act_window">
+            <field name="name">Orders Analysis</field>
+            <field name="res_model">report.pos.order</field>
+            <field name="view_mode">graph,pivot</field>
+            <field name="domain">[('state', 'not in', ['draft', 'cancel'])]</field>
+            <field name="context">{'search_default_not_invoiced': 1}</field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    No data yet!
+                </p><p>
+                    Create a new POS order
+                </p>
+            </field>
+        </record>
 
         <record id="action_report_pos_details" model="ir.actions.act_window">
             <field name="name">Sales Details</field>

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -267,20 +267,6 @@
         </field>
     </record>
 
-    <record id="action_pos_sale_graph" model="ir.actions.act_window">
-        <field name="name">Orders</field>
-        <field name="res_model">pos.order</field>
-        <field name="view_mode">graph,list,form,kanban,pivot</field>
-        <field name="domain">[('state', 'not in', ['draft', 'cancel']), ('account_move', '=', False)]</field>
-        <field name="help" type="html">
-            <p class="o_view_nocontent_smiling_face">
-                No data yet!
-            </p><p>
-                Create a new POS order
-            </p>
-        </field>
-    </record>
-
     <record id="view_pos_order_tree" model="ir.ui.view">
         <field name="name">pos.order.list</field>
         <field name="model">pos.order</field>

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -277,20 +277,6 @@
         </field>
     </record>
 
-    <record id="action_pos_sale_graph" model="ir.actions.act_window">
-        <field name="name">Orders</field>
-        <field name="res_model">pos.order</field>
-        <field name="view_mode">graph,list,form,kanban,pivot</field>
-        <field name="domain">[('state', 'not in', ['draft', 'cancel']), ('account_move', '=', False)]</field>
-        <field name="help" type="html">
-            <p class="o_view_nocontent_smiling_face">
-                No data yet!
-            </p><p>
-                Create a new POS order
-            </p>
-        </field>
-    </record>
-
     <record id="view_pos_order_tree" model="ir.ui.view">
         <field name="name">pos.order.list</field>
         <field name="model">pos.order</field>

--- a/addons/project/models/digest_digest.py
+++ b/addons/project/models/digest_digest.py
@@ -15,12 +15,12 @@ class DigestDigest(models.Model):
         self._calculate_kpi(
             'project.task',
             'kpi_project_task_opened_value',
-            additional_domain=[('stage_id.fold', '=', False), ('project_id', '!=', False)],
+            additional_domain=[('is_closed', '=', False), ('project_id', '!=', False)],
         )
 
     def _get_kpi_custom_settings(self, company, user):
         res = super()._get_kpi_custom_settings(company, user)
         menu_id = self.env.ref('project.menu_main_pm').id
-        res['kpi_action']['kpi_project_task_opened'] = f'project.open_view_project_all?menu_id={menu_id}'
+        res['kpi_action']['kpi_project_task_opened'] = f'project.action_project_task_user_open_tasks?menu_id={menu_id}'
         res['kpi_sequence']['kpi_project_task_opened'] = 7500
         return res

--- a/addons/project/report/project_report_views.xml
+++ b/addons/project/report/project_report_views.xml
@@ -68,6 +68,10 @@
                 <search position="attributes">
                     <attribute name="string">Tasks Analysis</attribute>
                 </search>
+                <search position="inside">
+                    <filter string="Last 30 Days" name="project_report_create_date_last_30_days" invisible="1"
+                        domain="[('create_date', '&gt;=', '-1m'), ('create_date', '&lt;', 'now')]"/>
+                </search>
             </field>
         </record>
 
@@ -79,6 +83,31 @@
             <field name="view_mode">graph,pivot</field>
             <field name="search_view_id" ref="view_task_project_user_search"/>
             <field name="context">{'group_by': [], 'graph_measure': '__count__'}</field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_empty_folder">
+                    No data yet!
+                </p><p>
+                    Analyze the progress of your projects and the performance of your employees.
+                </p>
+            </field>
+        </record>
+
+        <record id="action_project_task_user_open_tasks" model="ir.actions.act_window">
+            <field name="name">Open Tasks</field>
+            <field name="res_model">report.project.task.user</field>
+            <field name="domain">[
+                ('project_id', '!=', False),
+                ('company_id', '=', allowed_company_ids[0]),
+                ('task_id.active', '=', True),
+                ('task_id', 'access', 'read')
+            ]</field>
+            <field name="view_mode">graph,pivot</field>
+            <field name="search_view_id" ref="view_task_project_user_search"/>
+            <field name="context">{
+                'search_default_open_tasks': 1,
+                'search_default_project_report_create_date_last_30_days': 1,
+                'graph_measure': '__count__',
+            }</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_empty_folder">
                     No data yet!

--- a/addons/project/report/project_report_views.xml
+++ b/addons/project/report/project_report_views.xml
@@ -71,7 +71,7 @@
             </field>
         </record>
 
-       <record id="action_project_task_user_tree" model="ir.actions.act_window">
+        <record id="action_project_task_user_tree" model="ir.actions.act_window">
             <field name="name">Tasks Analysis</field>
             <field name="res_model">report.project.task.user</field>
             <field name="path">tasks-analysis</field>
@@ -79,6 +79,22 @@
             <field name="view_mode">graph,pivot</field>
             <field name="search_view_id" ref="view_task_project_user_search"/>
             <field name="context">{'group_by': [], 'graph_measure': '__count__'}</field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_empty_folder">
+                    No data yet!
+                </p><p>
+                    Analyze the progress of your projects and the performance of your employees.
+                </p>
+            </field>
+        </record>
+
+        <record id="action_project_task_user_open_tasks" model="ir.actions.act_window">
+            <field name="name">Tasks Analysis</field>
+            <field name="res_model">report.project.task.user</field>
+            <field name="domain">[('has_template_ancestor', '=', False)]</field>
+            <field name="view_mode">graph,pivot</field>
+            <field name="search_view_id" ref="view_task_project_user_search"/>
+            <field name="context">{'search_default_open_tasks': 1, 'graph_measure': '__count__'}</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_empty_folder">
                     No data yet!

--- a/addons/sale/report/sale_report_views.xml
+++ b/addons/sale/report/sale_report_views.xml
@@ -87,6 +87,7 @@
                 <filter string="Sales Orders" name="Sales" domain="[('state','not in',('draft', 'cancel', 'sent'))]"/>
                 <separator/>
                 <filter name="filter_date" date="date" default_period="month"/>
+                <filter name="filter_last_month" invisible="1" string="Order Date: Last Month"  domain="[('date', '&gt;=', '-1m')]"/>
                 <filter name="filter_order_date" invisible="1" string="Order Date: Last 365 Days" domain="[('date', '&gt;=', '-365d')]"/>
                 <separator/>
                 <field name="user_id"/>
@@ -134,6 +135,22 @@
         <field name="search_view_id" ref="view_order_product_search"/>
         <field name="domain">[('state', '!=', 'cancel')]</field>
         <field name="context">{'search_default_Sales':1,'group_by':[], 'search_default_filter_order_date': 1}</field>
+        <field name="help">This report performs analysis on your quotations and sales orders. Analysis check your sales revenues and sort it by different group criteria (salesman, partner, product, etc.) Use this report to perform analysis on sales not having invoiced yet. If you want to analyse your turnover, you should use the Invoice Analysis report in the Accounting application.</field>
+    </record>
+
+    <record id="action_order_report_all_digest" model="ir.actions.act_window">
+        <field name="name">All Sales</field>
+        <field name="res_model">sale.report</field>
+        <field name="view_mode">pivot,graph,list,form</field>
+        <field name="view_id"></field>
+        <field name="search_view_id" ref="view_order_product_search"/>
+        <field name="domain">[('state', 'not in', ('draft', 'cancel', 'sent'))]</field>
+        <field name="context">{
+            'group_by': ['date:day'],
+            'graph_measure': 'price_total',
+            'pivot_measures': ['price_total'],
+            'search_default_filter_last_month': 1
+        }</field>
         <field name="help">This report performs analysis on your quotations and sales orders. Analysis check your sales revenues and sort it by different group criteria (salesman, partner, product, etc.) Use this report to perform analysis on sales not having invoiced yet. If you want to analyse your turnover, you should use the Invoice Analysis report in the Accounting application.</field>
     </record>
 

--- a/addons/sale_management/models/digest.py
+++ b/addons/sale_management/models/digest.py
@@ -23,7 +23,7 @@ class DigestDigest(models.Model):
         res = super()._get_kpi_custom_settings(company, user)
         menu_id = self.env.ref("sale.sale_menu_root").id
         res["kpi_action"]["kpi_all_sale_total"] = (
-            f"sale.report_all_channels_sales_action?menu_id={menu_id}"
+            f"sale.action_order_report_all_digest?menu_id={menu_id}"
         )
         res["kpi_sequence"]["kpi_all_sale_total"] = 2500
         return res

--- a/addons/stock/models/digest.py
+++ b/addons/stock/models/digest.py
@@ -14,9 +14,9 @@ class Digest(models.Model):
     def _compute_kpi_stock_delivery_count_value(self):
         self._raise_if_not_member_of('stock.group_stock_manager')
         self._calculate_kpi(
-            'stock.picking',
+            'stock.move',
             'kpi_stock_delivery_count_value',
-            date_field='date_done',
+            date_field='picking_id.date_done',
             additional_domain=[('state', '=', 'done'),
                                # view_move_search outgoing filter condition
                                ('location_id.usage', 'in', ('internal', 'transit')),
@@ -26,9 +26,9 @@ class Digest(models.Model):
     def _compute_kpi_stock_receipt_count_value(self):
         self._raise_if_not_member_of('stock.group_stock_manager')
         self._calculate_kpi(
-            'stock.picking',
+            'stock.move',
             'kpi_stock_receipt_count_value',
-            date_field='date_done',
+            date_field='picking_id.date_done',
             additional_domain=[('state', '=', 'done'),
                                # view_move_search incoming filter condition
                                ('location_id.usage', 'not in', ('internal', 'transit')),

--- a/addons/stock/models/digest.py
+++ b/addons/stock/models/digest.py
@@ -38,8 +38,12 @@ class Digest(models.Model):
     def _get_kpi_custom_settings(self, company, user):
         res = super()._get_kpi_custom_settings(company, user)
         menu_id = self.env.ref('stock.menu_stock_root').id
-        res['kpi_action']['kpi_stock_delivery_count'] = f'stock.stock_move_action_outgoing?menu_id={menu_id}'
-        res['kpi_action']['kpi_stock_receipt_count'] = f'stock.stock_move_action_incoming?menu_id={menu_id}'
+        res['kpi_action']['kpi_stock_delivery_count'] = (
+            f'stock.stock_move_action_outgoing?menu_id={menu_id}&view_type=graph'
+        )
+        res['kpi_action']['kpi_stock_receipt_count'] = (
+            f'stock.stock_move_action_incoming?menu_id={menu_id}&view_type=graph'
+        )
         res['kpi_sequence']['kpi_stock_delivery_count'] = 6500
         res['kpi_sequence']['kpi_stock_receipt_count'] = 6505
         return res

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -410,6 +410,7 @@
                     <filter string="Scrapped" name="scrapped" domain="[('is_scrap', '=', True)]" invisible="context.get('from_scrap_menu')"/>
                     <separator/>
                     <filter string="Date" name="today" date="date" help="Scheduled or processing date"/>
+                    <filter string="Last Month" name="filter_last_month" domain="[('picking_id.date_done', '&gt;=', '-1m'), ('picking_id.date_done', '&lt;', 'now')]" invisible="1"/>
                     <group>
                         <filter string="Product" name="by_product" domain="[]"  context="{'group_by': 'product_id'}"/>
                         <filter string="Operation Type" name="groupby_picking_type_id" domain="[]"  context="{'group_by': 'picking_type_id'}"/>
@@ -445,7 +446,7 @@
         </record>
 
         <record id="stock_move_action_incoming" model="ir.actions.act_window">
-            <field name="name">Stock Moves (receipts)</field>
+            <field name="name">Receipts</field>
             <field name="res_model">stock.move</field>
             <field name="type">ir.actions.act_window</field>
             <field name="view_id" ref="view_move_tree"/>
@@ -453,7 +454,8 @@
             <field name="context">{
                 'search_default_done': 1,
                 'search_default_groupby_location_id': 2,
-                'search_default_incoming': 3
+                'search_default_incoming': 3,
+                'search_default_filter_last_month': 1,
             }</field>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">
@@ -467,7 +469,7 @@
         </record>
 
         <record id="stock_move_action_outgoing" model="ir.actions.act_window">
-            <field name="name">Stock Moves (deliveries)</field>
+            <field name="name">Deliveries</field>
             <field name="res_model">stock.move</field>
             <field name="type">ir.actions.act_window</field>
             <field name="view_id" ref="view_move_tree"/>
@@ -475,7 +477,8 @@
             <field name="context">{
                 'search_default_done': 1,
                 'search_default_groupby_location_id': 2,
-                'search_default_outgoing': 3
+                'search_default_outgoing': 3,
+                'search_default_filter_last_month': 1,
             }</field>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">

--- a/addons/survey/models/digest.py
+++ b/addons/survey/models/digest.py
@@ -35,7 +35,9 @@ class Digest(models.Model):
     def _get_kpi_custom_settings(self, company, user):
         res = super()._get_kpi_custom_settings(company, user)
         menu_root_id = self.env.ref('survey.menu_surveys').id
-        res['kpi_action']['kpi_nbr_of_answers'] = f'survey.action_survey_user_input?menu_id={menu_root_id}'
+        res['kpi_action']['kpi_nbr_of_answers'] = (
+            f'survey.action_survey_user_input?menu_id={menu_root_id}&view_type=pivot'
+        )
         res['kpi_action']['kpi_nbr_of_certified_participants'] = (
             f'survey.survey_user_input_action_certified?menu_id={menu_root_id}')
         res['is_cross_company'].update(('kpi_nbr_of_answers', 'kpi_nbr_of_certified_participants'))

--- a/addons/survey/models/digest.py
+++ b/addons/survey/models/digest.py
@@ -35,9 +35,12 @@ class Digest(models.Model):
     def _get_kpi_custom_settings(self, company, user):
         res = super()._get_kpi_custom_settings(company, user)
         menu_root_id = self.env.ref('survey.menu_surveys').id
-        res['kpi_action']['kpi_nbr_of_answers'] = f'survey.action_survey_user_input?menu_id={menu_root_id}'
+        res['kpi_action']['kpi_nbr_of_answers'] = (
+            f'survey.action_survey_user_input?menu_id={menu_root_id}&view_type=pivot'
+        )
         res['kpi_action']['kpi_nbr_of_certified_participants'] = (
-            f'survey.survey_user_input_action_certified?menu_id={menu_root_id}')
+            f'survey.survey_user_input_action_certified?menu_id={menu_root_id}&view_type=pivot'
+        )
         res['is_cross_company'].update(('kpi_nbr_of_answers', 'kpi_nbr_of_certified_participants'))
         res['kpi_sequence']['kpi_nbr_of_answers'] = 11500
         res['kpi_sequence']['kpi_nbr_of_certified_participants'] = 11505

--- a/addons/survey/views/survey_user_views.xml
+++ b/addons/survey/views/survey_user_views.xml
@@ -21,6 +21,11 @@
                 <filter string="Certified" name="certified" invisible="1"
                         domain="[('scoring_success','=', True), ('survey_id.certification','=', True)]"/>
                 <separator/>
+                <filter string="Created Last Month" name="create_date_last_month" invisible="1"
+                        domain="[('create_date', '&gt;=', '-1m'), ('create_date', '&lt;', 'now')]"/>
+                <filter string="Last Month" name="end_datetime_last_month" invisible="1"
+                        domain="[('end_datetime', '&gt;=', '-1m'), ('end_datetime', '&lt;', 'now')]"/>
+                <separator/>
                 <filter string="Tests Only" name="test" domain="[('test_entry','=', True)]"/>
                 <filter string="Exclude Tests" name="not_test" domain="[('test_entry','=', False)]"/>
                 <group>
@@ -153,14 +158,27 @@
         </field>
     </record>
 
+    <record id="survey_user_input_view_pivot" model="ir.ui.view">
+        <field name="name">survey.user_input.view.pivot</field>
+        <field name="model">survey.user_input</field>
+        <field name="arch" type="xml">
+            <pivot string="Participants" sample="1">
+                <field name="survey_id" type="row"/>
+            </pivot>
+        </field>
+    </record>
+
     <record model="ir.actions.act_window" id="action_survey_user_input">
         <field name="name">Participants</field>
         <field name="res_model">survey.user_input</field>
-        <field name="domain">[('survey_id.survey_type', 'in', ('assessment', 'custom', 'live_session', 'survey'))]</field>
-        <field name="view_mode">list,kanban,form</field>
-        <field name="view_id" ref="survey_user_input_view_tree"></field>
+        <field name="view_mode">list,kanban,pivot,form</field>
+        <field name="view_id" ref="survey_user_input_view_tree"/>
         <field name="search_view_id" ref="survey_user_input_view_search"/>
-        <field name="context">{'search_default_group_by_survey': True}</field>
+        <field name="context">{
+            'search_default_group_by_survey': True,
+            'search_default_not_test': True,
+            'search_default_create_date_last_month': True,
+        }</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_empty_folder">
                 No answers yet!
@@ -173,12 +191,14 @@
     <record id="survey_user_input_action_certified" model="ir.actions.act_window">
         <field name="name">Certified Participants</field>
         <field name="res_model">survey.user_input</field>
-        <field name="view_mode">list,kanban,form</field>
+        <field name="view_mode">pivot,list,kanban,form</field>
         <field name="view_id" ref="survey_user_input_view_tree"></field>
         <field name="search_view_id" ref="survey_user_input_view_search"/>
         <field name="context">{
             'search_default_group_by_survey': True,
             'search_default_certified': True,
+            'search_default_not_test': True,
+            'search_default_end_datetime_last_month': True,
         }</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_empty_folder">

--- a/addons/survey/views/survey_user_views.xml
+++ b/addons/survey/views/survey_user_views.xml
@@ -153,11 +153,21 @@
         </field>
     </record>
 
+    <record id="survey_user_input_view_pivot" model="ir.ui.view">
+        <field name="name">survey.user_input.view.pivot</field>
+        <field name="model">survey.user_input</field>
+        <field name="arch" type="xml">
+            <pivot string="Participants" sample="1">
+                <field name="survey_id" type="row"/>
+            </pivot>
+        </field>
+    </record>
+
     <record model="ir.actions.act_window" id="action_survey_user_input">
         <field name="name">Participants</field>
         <field name="res_model">survey.user_input</field>
         <field name="domain">[('survey_id.survey_type', 'in', ('assessment', 'custom', 'live_session', 'survey'))]</field>
-        <field name="view_mode">list,kanban,form</field>
+        <field name="view_mode">list,kanban,pivot,form</field>
         <field name="view_id" ref="survey_user_input_view_tree"></field>
         <field name="search_view_id" ref="survey_user_input_view_search"/>
         <field name="context">{'search_default_group_by_survey': True}</field>
@@ -173,7 +183,7 @@
     <record id="survey_user_input_action_certified" model="ir.actions.act_window">
         <field name="name">Certified Participants</field>
         <field name="res_model">survey.user_input</field>
-        <field name="view_mode">list,kanban,form</field>
+        <field name="view_mode">list,kanban,pivot,form</field>
         <field name="view_id" ref="survey_user_input_view_tree"></field>
         <field name="search_view_id" ref="survey_user_input_view_search"/>
         <field name="context">{

--- a/addons/website/models/digest.py
+++ b/addons/website/models/digest.py
@@ -79,8 +79,12 @@ class Digest(models.Model):
     def _get_kpi_custom_settings(self, company, user):
         res = super()._get_kpi_custom_settings(company, user)
         menu_id = self.env.ref('website.menu_website_configuration').id
-        res['kpi_action']['kpi_website_visitor_count'] = f'website.website_visitors_action?menu_id={menu_id}'
-        res['kpi_action']['kpi_website_track_count'] = f'website.website_visitor_view_action?menu_id={menu_id}'
+        res['kpi_action']['kpi_website_visitor_count'] = (
+            f'website.website_visitors_action?menu_id={menu_id}&view_type=graph'
+        )
+        res['kpi_action']['kpi_website_track_count'] = (
+            f'website.website_visitor_view_action?menu_id={menu_id}&view_type=graph'
+        )
         res['kpi_sequence']['kpi_website_visitor_count'] = 3500
         res['kpi_sequence']['kpi_website_track_count'] = 3505
         return res

--- a/addons/website/views/website_visitor_views.xml
+++ b/addons/website/views/website_visitor_views.xml
@@ -33,6 +33,8 @@
                 <field name="page_id"/>
                 <field name="url"/>
                 <field name="visit_datetime"/>
+                <filter string="Last Month" name="filter_last_month" domain="[('visit_datetime', '&gt;=', '-1m'), ('visit_datetime', '&lt;', 'now')]" invisible="1"/>
+                <separator/>
                 <filter string="Pages" name="type_page" domain="[('page_id', '!=', False)]"/>
                 <filter string="Urls &amp; Pages" name="type_url" domain="[('url', '!=', False)]"/>
                 <group>
@@ -229,6 +231,7 @@
                 <field name="visit_count"/>
                 <field name="page_ids"/>
                 <filter string="Last 7 Days" name="filter_last_7_days" domain="[('last_connection_datetime', '&gt;', '-7d')]"/>
+                <filter string="Last Month" name="filter_last_month" domain="[('last_connection_datetime', '&gt;', '-1m')]" invisible="1"/>
                 <separator/>
                 <filter string="Unregistered" name="filter_type_visitor" domain="[('partner_id', '=', False)]"/>
                 <filter string="Contacts" name="filter_type_customer" domain="[('partner_id', '!=', False)]"/>
@@ -264,7 +267,7 @@
         <field name="res_model">website.visitor</field>
         <field name="path">visitors</field>
         <field name="view_mode">kanban,list,form,graph</field>
-        <field name="context">{'search_default_filter_last_7_days':1}</field>
+        <field name="context">{'search_default_filter_last_month':1}</field>
         <field name="help" type="html">
           <p class="o_view_nocontent_smiling_face">
             No Visitors yet!
@@ -302,7 +305,15 @@
         <field name="res_model">website.track</field>
         <field name="path">website-page-views</field>
         <field name="view_mode">list</field>
-        <field name="context">{'search_default_type_url': 1, 'create': False, 'edit': False, 'copy': False}</field>
+        <field name="search_view_id" ref="website_visitor_page_view_search"/>
+        <field name="context">{
+            'search_default_filter_last_month': 1,
+            'search_default_type_url': 1,
+            'search_default_group_by_page': 1,
+            'create': False,
+            'edit': False,
+            'copy': False
+        }</field>
         <field name="view_ids" eval="[(5, 0, 0),
             (0, 0, {'view_mode': 'list', 'view_id': ref('website_visitor_track_view_tree')}),
             (0, 0, {'view_mode': 'graph', 'view_id': ref('website_visitor_track_view_graph')}),

--- a/addons/website_sale/models/digest.py
+++ b/addons/website_sale/models/digest.py
@@ -25,6 +25,6 @@ class DigestDigest(models.Model):
     def _get_kpi_custom_settings(self, company, user):
         res = super()._get_kpi_custom_settings(company, user)
         menu_id = self.env.ref("website.menu_website_configuration").id
-        res["kpi_action"]["kpi_website_sale_total"] = f"website.backend_dashboard?menu_id={menu_id}"
+        res["kpi_action"]["kpi_website_sale_total"] = f"website_sale.sale_report_action_dashboard?menu_id={menu_id}"
         res["kpi_sequence"]["kpi_website_sale_total"] = 2505
         return res

--- a/addons/website_sale/report/sale_report_views.xml
+++ b/addons/website_sale/report/sale_report_views.xml
@@ -29,9 +29,9 @@
                     <separator orientation="vertical"/>
                     <filter string="Order Date" name="groupby_order_date" context="{'group_by':'date'}"/>
                     <!-- Dashboard filter - used by context -->
-                    <filter string="Last Week" invisible="1" name="week" domain="[('date','&gt;=', 'today -7d'), ('date', '&lt;', 'today')]"/>
-                    <filter string="Last Month" invisible="1" name="month" domain="[('date','&gt;=', 'today -30d'), ('date', '&lt;', 'today')]"/>
-                    <filter string="Last Year" invisible="1"  name="year" domain="[('date','&gt;=', 'today -365d'), ('date', '&lt;', 'today')]"/>
+                    <filter string="Last Week" invisible="1" name="week" domain="[('date','&gt;=', 'today -7d')]"/>
+                    <filter string="Last Month" invisible="1" name="month" domain="[('date','&gt;=', 'today -30d')]"/>
+                    <filter string="Last Year" invisible="1"  name="year" domain="[('date','&gt;=', 'today -365d')]"/>
                 </group>
             </search>
         </field>
@@ -78,7 +78,7 @@
         <field name="path">online-sales-analysis</field>
         <field name="view_mode">pivot,graph</field>
         <field name="domain">[('website_id', '!=', False)]</field>
-        <field name="context">{'search_default_confirmed': 1}</field>
+        <field name="context">{'search_default_confirmed': 1, 'search_default_month': 1}</field>
         <field name="search_view_id" ref="sale_report_view_search_website"/>
         <field name="help" type="html">
             <p class="o_view_nocontent_empty_folder">

--- a/addons/website_slides/views/slide_channel_partner_views.xml
+++ b/addons/website_slides/views/slide_channel_partner_views.xml
@@ -16,9 +16,11 @@
                     <filter string="Joined" name="filter_joined" domain="[('member_status', '=', 'joined')]"/>
                     <filter string="Ongoing" name="filter_ongoing" domain="[('member_status', '=', 'ongoing')]"/>
                     <filter string="Completed" name="filter_completed" domain="[('member_status', '=', 'completed')]"/>
+                    <filter string="Last Month" name="create_date_last_month" invisible="1" domain="[('create_date', '&gt;=', '-1m')]"/>
                     <group>
                         <filter string="Course" name="groupby_channel_id" context="{'group_by': 'channel_id'}"/>
                         <filter string="Status" name="groupby_member_status" context="{'group_by': 'member_status'}"/>
+                        <filter string="Create Date" name="groupby_create_date" context="{'group_by': 'create_date'}"/>
                     </group>
                 </search>
             </field>
@@ -116,7 +118,10 @@
             <field name="res_model">slide.channel.partner</field>
             <field name="view_mode">graph,pivot,list,kanban</field>
             <field name="search_view_id" ref="website_slides.slide_channel_partner_view_search"/>
-            <field name="context">{'search_default_groupby_member_status': 1}</field>
+            <field name="context">{
+                'search_default_groupby_create_date': 1,
+                'search_default_create_date_last_month': 1,
+            }</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     <strong>No Attendees Yet!</strong>
@@ -131,7 +136,10 @@
             <field name="name">Certified attendees</field>
             <field name="res_model">slide.channel.partner</field>
             <field name="view_mode">list,form,kanban</field>
-            <field name="context">{'search_default_filter_completed': 1}</field>
+            <field name="context">{
+                'search_default_filter_completed': 1,
+                'search_default_create_date_last_month': 1,
+            }</field>
             <field name="search_view_id" ref="website_slides.slide_channel_partner_view_search"/>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">


### PR DESCRIPTION
Update several Digest KPI actions across modules to open views that better match the metrics displayed in the Digest email. The actions now redirect to more relevant analytical views (e.g., graph/pivot) so that when users click "Open Report", they see data consistent with the computed Digest KPI.

task-5409170