### PR TITLE
[IMP] project_mrp_account: add analytic costs toggle on manufacturing operation types

### DIFF
--- a/addons/mrp_account/models/mrp_workorder.py
+++ b/addons/mrp_account/models/mrp_workorder.py
@@ -49,7 +49,7 @@ class MrpWorkorder(models.Model):
 
     def _create_or_update_analytic_entry_for_record(self, value, hours):
         self.ensure_one()
-        if self.workcenter_id.analytic_distribution or self.wc_analytic_account_line_ids or self.mo_analytic_account_line_ids:
+        if self.workcenter_id.analytic_distribution or self.wc_analytic_account_line_ids:
             wc_analytic_line_vals = self.env['account.analytic.account']._perform_analytic_distribution(self.workcenter_id.analytic_distribution, value, hours, self.wc_analytic_account_line_ids, self)
             if wc_analytic_line_vals:
                 self.sudo().wc_analytic_account_line_ids += self.env['account.analytic.line'].sudo().create(wc_analytic_line_vals)

--- a/addons/project_mrp_account/__manifest__.py
+++ b/addons/project_mrp_account/__manifest__.py
@@ -4,7 +4,11 @@
     'name': "MRP Account Project",
     'summary': "Monitor MRP account using project",
     'category': 'Services/Project',
-    'depends': ['mrp_account', 'project_mrp'],
+    'depends': ['mrp_account', 'project_mrp', 'project_stock_account'],
+    'data': [
+        'data/project_mrp_account_data.xml',
+        'views/stock_picking_type_views.xml',
+    ],
     'demo': [
         'data/project_mrp_account_demo.xml',
     ],

--- a/addons/project_mrp_account/__manifest__.py
+++ b/addons/project_mrp_account/__manifest__.py
@@ -5,6 +5,9 @@
     'summary': "Monitor MRP account using project",
     'category': 'Services/Project',
     'depends': ['mrp_account', 'project_mrp'],
+    'data': [
+        'views/stock_picking_type_views.xml',
+    ],
     'demo': [
         'data/project_mrp_account_demo.xml',
     ],

--- a/addons/project_mrp_account/data/project_mrp_account_data.xml
+++ b/addons/project_mrp_account/data/project_mrp_account_data.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <function model="stock.picking.type" name="write">
+            <value model="stock.picking.type" eval="obj().search([('code', '=', 'mrp_operation')]).ids"/>
+            <value eval="{'analytic_costs': True}"/>
+        </function>
+    </data>
+</odoo>

--- a/addons/project_mrp_account/models/__init__.py
+++ b/addons/project_mrp_account/models/__init__.py
@@ -3,4 +3,5 @@
 from . import mrp_production
 from . import mrp_workorder
 from . import stock_move
+from . import stock_picking_type
 from . import stock_rule

--- a/addons/project_mrp_account/models/mrp_workorder.py
+++ b/addons/project_mrp_account/models/mrp_workorder.py
@@ -9,6 +9,7 @@ class MrpWorkorder(models.Model):
     def _create_or_update_analytic_entry_for_record(self, value, hours):
         super()._create_or_update_analytic_entry_for_record(value, hours)
         project = self.production_id.project_id
-        mo_analytic_line_vals = self.env['account.analytic.account']._perform_analytic_distribution(project._get_analytic_distribution(), value, hours, self.mo_analytic_account_line_ids, self)
+        distribution = project._get_analytic_distribution() if project and self.production_id.picking_type_id.analytic_costs else {}
+        mo_analytic_line_vals = self.env['account.analytic.account']._perform_analytic_distribution(distribution, value, hours, self.mo_analytic_account_line_ids, self)
         if mo_analytic_line_vals:
             self.sudo().mo_analytic_account_line_ids = [Command.create(line_val) for line_val in mo_analytic_line_vals]

--- a/addons/project_mrp_account/models/stock_move.py
+++ b/addons/project_mrp_account/models/stock_move.py
@@ -8,7 +8,10 @@ class StockMove(models.Model):
     _inherit = 'stock.move'
 
     def _get_analytic_distribution(self):
-        distribution = self.raw_material_production_id.project_id._get_analytic_distribution()
+        production = self.raw_material_production_id
+        if not (production.project_id and production.picking_type_id.analytic_costs):
+            return super()._get_analytic_distribution()
+        distribution = production.project_id._get_analytic_distribution()
         return distribution or super()._get_analytic_distribution()
 
     def _prepare_analytic_line_values(self, account_field_values, amount, unit_amount):

--- a/addons/project_mrp_account/models/stock_picking_type.py
+++ b/addons/project_mrp_account/models/stock_picking_type.py
@@ -1,0 +1,14 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models
+
+
+class StockPickingType(models.Model):
+    _inherit = 'stock.picking.type'
+
+    @api.depends('code')
+    def _compute_analytic_costs(self):
+        super()._compute_analytic_costs()
+        for picking_type in self:
+            if picking_type.code == 'mrp_operation':
+                picking_type.analytic_costs = True

--- a/addons/project_mrp_account/tests/test_analytic_account.py
+++ b/addons/project_mrp_account/tests/test_analytic_account.py
@@ -107,6 +107,41 @@ class TestAnalyticAccount(TestMrpAnalyticAccount):
         self.assertEqual(mo.state, 'done')
         self.assertEqual(mo.move_raw_ids.analytic_account_line_ids.amount, -100.0)
 
+    def test_mo_analytic_disabled(self):
+        """Test no analytic line is created when analytic costs are disabled.
+        """
+        # create a mo
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.product_id = self.product
+        mo_form.bom_id = self.bom
+        mo_form.product_qty = 10.0
+        mo_form.project_id = self.project
+        mo = mo_form.save()
+        mo.picking_type_id.analytic_costs = False
+        mo.action_confirm()
+        self.assertEqual(mo.state, 'confirmed')
+        self.assertFalse(mo.move_raw_ids.analytic_account_line_ids)
+
+        # increase qty_producing to 5.0
+        mo_form = Form(mo)
+        mo_form.qty_producing = 5.0
+        mo_form.save()
+        self.assertEqual(mo.state, 'progress')
+        self.assertFalse(mo.move_raw_ids.analytic_account_line_ids)
+
+        # increase qty_producing to 10.0
+        mo_form = Form(mo)
+        mo_form.qty_producing = 10.0
+        mo_form.save()
+        mo.workorder_ids.button_finish()
+        self.assertEqual(mo.state, 'to_close')
+        self.assertFalse(mo.move_raw_ids.analytic_account_line_ids)
+
+        # mark as done
+        mo.button_mark_done()
+        self.assertEqual(mo.state, 'done')
+        self.assertFalse(mo.move_raw_ids.analytic_account_line_ids)
+
     def test_mo_analytic_backorder(self):
         """Test the analytic lines are correctly posted when backorder.
         """

--- a/addons/project_mrp_account/tests/test_analytic_account.py
+++ b/addons/project_mrp_account/tests/test_analytic_account.py
@@ -99,6 +99,42 @@ class TestAnalyticAccount(TestMrpAnalyticAccount):
         self.assertEqual(mo.state, 'done')
         self.assertEqual(mo.move_raw_ids.analytic_account_line_ids.amount, -100.0)
 
+    def test_mo_analytic_disabled(self):
+        """Test the amount on analytic line will change when consumed qty of the
+        component changed.
+        """
+        # create a mo
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.product_id = self.product
+        mo_form.bom_id = self.bom
+        mo_form.product_qty = 10.0
+        mo_form.project_id = self.project
+        mo = mo_form.save()
+        mo.picking_type_id.analytic_costs = False
+        mo.action_confirm()
+        self.assertEqual(mo.state, 'confirmed')
+        self.assertEqual(len(mo.move_raw_ids.analytic_account_line_ids), 0)
+
+        # increase qty_producing to 5.0
+        mo_form = Form(mo)
+        mo_form.qty_producing = 5.0
+        mo_form.save()
+        self.assertEqual(mo.state, 'progress')
+        self.assertEqual(mo.move_raw_ids.analytic_account_line_ids.amount, 0.0)
+
+        # increase qty_producing to 10.0
+        mo_form = Form(mo)
+        mo_form.qty_producing = 10.0
+        mo_form.save()
+        mo.workorder_ids.button_finish()
+        self.assertEqual(mo.state, 'to_close')
+        self.assertEqual(mo.move_raw_ids.analytic_account_line_ids.amount, 0.0)
+
+        # mark as done
+        mo.button_mark_done()
+        self.assertEqual(mo.state, 'done')
+        self.assertEqual(mo.move_raw_ids.analytic_account_line_ids.amount, 0.0)
+
     def test_mo_analytic_backorder(self):
         """Test the analytic lines are correctly posted when backorder.
         """

--- a/addons/project_mrp_account/views/stock_picking_type_views.xml
+++ b/addons/project_mrp_account/views/stock_picking_type_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_picking_type_form_inherit_project_mrp_account" model="ir.ui.view">
+        <field name="name">stock.picking.type.inherit.project_mrp_account</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_picking_type_form"/>
+        <field name="arch" type="xml">
+            <field name="create_backorder" position="after">
+                <field name="analytic_costs" invisible="code != 'mrp_operation'" groups="analytic.group_analytic_accounting"
+                    help="Analytical entries will be generated in real time for components and labour consumption."/>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/addons/project_stock_account/models/stock_move.py
+++ b/addons/project_stock_account/models/stock_move.py
@@ -7,9 +7,11 @@ from odoo.exceptions import ValidationError
 class StockMove(models.Model):
     _inherit = 'stock.move'
 
+    def _create_analytic_move(self):
+        moves = self.filtered(lambda move: move.picking_type_id.analytic_costs)
+        return super(StockMove, moves)._create_analytic_move()
+
     def _get_analytic_distribution(self):
-        if not self.picking_type_id.analytic_costs:
-            return super()._get_analytic_distribution()
         distribution = self.picking_id.project_id._get_analytic_distribution()
         return distribution or super()._get_analytic_distribution()
 

--- a/addons/project_stock_account/models/stock_picking_type.py
+++ b/addons/project_stock_account/models/stock_picking_type.py
@@ -1,9 +1,19 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class StockPickingType(models.Model):
     _inherit = 'stock.picking.type'
 
-    analytic_costs = fields.Boolean(help="Validating stock pickings will generate analytic entries for the selected project. Products set for re-invoicing will also be billed to the customer.")
+    analytic_costs = fields.Boolean(
+        compute="_compute_analytic_costs",
+        store=True,
+        readonly=False,
+        help="Validating stock pickings will generate analytic entries for the selected project. Products set for re-invoicing will also be billed to the customer."
+    )
+
+    @api.depends('code')
+    def _compute_analytic_costs(self):
+        for picking_type in self:
+            picking_type.analytic_costs = False

--- a/addons/project_stock_account/models/stock_picking_type.py
+++ b/addons/project_stock_account/models/stock_picking_type.py
@@ -6,4 +6,14 @@ from odoo import fields, models
 class StockPickingType(models.Model):
     _inherit = 'stock.picking.type'
 
-    analytic_costs = fields.Boolean(help="Validating stock pickings will generate analytic entries for the selected project. Products set for re-invoicing will also be billed to the customer.")
+    analytic_costs = fields.Boolean(
+        compute="_compute_analytic_costs",
+        store=True,
+        readonly=False,
+        precompute=True,
+        help="Validating stock pickings will generate analytic entries for the selected project. Products set for re-invoicing will also be billed to the customer."
+        )
+
+    def _compute_analytic_costs(self):
+        for picking_type in self:
+            picking_type.analytic_costs = picking_type.code == 'mrp_operation'


### PR DESCRIPTION
Manufacturing orders linked to a project could generate duplicate analytic entries when costs were already posted through another flow, such as sale COGS or purchase costs linked to the same project.

This adds an "Analytic Costs" toggle on manufacturing operation picking types, reusing the stock picking type setting already available for receipts and deliveries.

This commit's changes:
- makes analytic_costs a stored editable computed field on picking types
- enables it by default for mrp_operation picking types in project_mrp_account
- skips stock move analytic entry creation when analytic costs are disabled
- skips MO and workorder project analytic distributions when the setting is disabled, while keeping cleanup behavior
- adds a test covering disabled analytic costs on manufacturing orders.

task-5130915

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
