### PR TITLE
[FIX] mail: reduce spacing between lang and badge of livechat items

### DIFF
--- a/addons/im_livechat/static/src/core/public_web/discuss_sidebar_channel_patch.xml
+++ b/addons/im_livechat/static/src/core/public_web/discuss_sidebar_channel_patch.xml
@@ -5,7 +5,7 @@
             <CountryFlag t-if="channel.showCorrespondentCountry" country="channel.correspondentCountry" class="'o-mail-DiscussSidebarChannel-country'"/>
         </xpath>
         <xpath expr="//*[@t-ref='displayNameAdditionalContent']" position="inside">
-            <span t-if="channel.livechat_lang_id" class="fw-normal small text-uppercase" t-out="channel.livechat_lang_id.baseCode" t-att-title="channel.livechat_lang_id.name"/>
+            <span t-if="channel.livechat_lang_id" class="fw-normal small text-uppercase text-muted" t-out="channel.livechat_lang_id.baseCode" t-att-title="channel.livechat_lang_id.name"/>
             <t t-if="channel.livechat_status === 'need_help'">
                 <i t-if="channel.matchesSelfExpertise" class="fa fa-star o-mail-favorite" role="image" title="Relevant to your expertise"/>
                 <span t-if="helpState.text" class="o-livechat-LookingForHelp-timer text-muted fw-normal smaller" t-esc="helpState.text"/>

--- a/addons/im_livechat/static/src/core/web/chat_window_patch.xml
+++ b/addons/im_livechat/static/src/core/web/chat_window_patch.xml
@@ -7,7 +7,7 @@
             </t>
         </xpath>
         <xpath expr="//div[hasclass('o-mail-ChatWindow-displayName')]" position="after">
-            <span t-if="channel.livechat_lang_id" class="text-uppercase o-ms-0_5 fs-5 fw-normal" t-out="channel.livechat_lang_id.baseCode" t-att-title="channel.livechat_lang_id.name"/>
+            <span t-if="channel.livechat_lang_id" class="text-uppercase text-muted o-ms-0_5 fs-5 fw-normal" t-out="channel.livechat_lang_id.baseCode" t-att-title="channel.livechat_lang_id.name"/>
         </xpath>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.js
@@ -67,7 +67,7 @@ export class DiscussSidebarChannel extends Component {
             "opacity-50": this.channel.self_member_id?.mute_until_dt,
             "position-relative justify-content-center o-compact mt-0 p-1":
                 this.store.discuss.isSidebarCompact,
-            "px-0": !this.store.discuss.isSidebarCompact,
+            "ps-0": !this.store.discuss.isSidebarCompact,
         };
     }
 

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.xml
@@ -34,7 +34,7 @@
                 <div class="position-relative d-flex flex-shrink-0 o-my-0_5 rounded-2" name="threadAvatar" t-att-class="{ 'ms-2': !store.discuss.isSidebarCompact }">
                     <DiscussAvatar channel="channel" size="26"/>
                 </div>
-                <div t-if="!store.discuss.isSidebarCompact" class="o-mail-DiscussSidebarChannel-itemName overflow-hidden mx-2 text-start flex-grow-1" t-att-class="itemNameAttClass">
+                <div t-if="!store.discuss.isSidebarCompact" class="o-mail-DiscussSidebarChannel-itemName overflow-hidden ms-2 text-start flex-grow-1" t-att-class="itemNameAttClass">
                     <div class="d-flex align-items-baseline o-min-width-0 gap-2">
                         <span class="text-truncate" t-esc="channel.displayName" t-ref="displayName"/>
                         <div class="d-flex gap-2 ms-auto" t-ref="displayNameAdditionalContent"/>
@@ -47,7 +47,7 @@
             <t t-if="channel.self_member_id?.message_unread_counter > 0 and !channel.self_member_id?.mute_until_dt and channel.importantCounter === 0" t-call="mail.DiscussSidebar.unreadIndicator"/>
             <t t-if="channel.importantCounter > 0 and (showingActions.isOpen or store.discuss.isSidebarCompact or !hover.isHover)" t-call="mail.discuss_badge">
                 <t t-set="counter" t-value="channel.importantCounter"/>
-                <t t-set="badgeClass" t-value="'o-mail-DiscussSidebarChannel-badge o-mail-DiscussSidebar-badge shadow-sm flex-shrink-0 fw-bold ' + (channel.self_member_id?.mute_until_dt ? 'o-muted' : '') + ' ' + (store.discuss.isSidebarCompact ? 'position-absolute o-compact' : showingActions.isOpen ? 'ms-1 me-0' : 'ms-1 me-2') + (channel.importantCounter &lt; 10 ? ' o-discuss-badge-circle' : '') "/>
+                <t t-set="badgeClass" t-value="'o-mail-DiscussSidebarChannel-badge o-mail-DiscussSidebar-badge shadow-sm flex-shrink-0 fw-bold ' + (channel.self_member_id?.mute_until_dt ? 'o-muted' : '') + ' ' + (store.discuss.isSidebarCompact ? 'position-absolute o-compact' : 'ms-1 me-0') + (channel.importantCounter &lt; 10 ? ' o-discuss-badge-circle' : '') "/>
                 <t t-set="floating" t-value="store.discuss.isSidebarCompact"/>
             </t>
             <t t-if="!store.discuss.isSidebarCompact" t-call="mail.DiscussSidebarChannel.actions"/>
@@ -61,7 +61,7 @@
             'ms-1': channel.importantCounter > 0,
         }">
             <Dropdown state="showingActions" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu o-discuss-dropdownMenu border-secondary my-0 min-w-0 mx-1 ' + store.discussDropdownMenuClass(this)">
-                <button class="btn btn-light rounded-circle d-flex o-p-0_5 align-items-center justify-content-center o-mail-discussSidebarBgColor border" t-att-class="{ 'o-showingActions': showingActions.isOpen, 'me-1': !channel.parent_channel_id }" t-att-title="actionsTitle">
+                <button class="btn btn-light rounded-circle d-flex o-p-0_5 align-items-center justify-content-center o-mail-discussSidebarBgColor border" t-att-class="{ 'o-showingActions': showingActions.isOpen, 'me-1': channel.parent_channel_id }" t-att-title="actionsTitle">
                     <i role="img" class="oi oi-fw oi-lg oi-ellipsis-h"/>
                 </button>
                 <t t-set-slot="content">


### PR DESCRIPTION
Before this commit, discuss app sidebar items that had both the language and the important badge counter had too much spacing.

This commit adapts spacing to preserve visually the same except reducing the language and counter spacing.

The language code was also too visible compared to conversation name, so this PR improves by putting a `.text-muted` on it.

Before / After
<img width="297" height="945" alt="Screenshot 2026-03-06 at 14 44 59" src="https://github.com/user-attachments/assets/b75fc8ae-7c56-4918-8adb-5a347b740d7e" /> <img width="298" height="949" alt="Screenshot 2026-03-06 at 14 44 45" src="https://github.com/user-attachments/assets/6f3b98ec-4f54-438c-8e8b-bdac9a842a5d" />
