### PR TITLE
[FIX] l10n_ro_edi: Don't check for customer company registry

### DIFF
--- a/addons/l10n_ro_edi/models/account_edi_xml_ubl_ciusro.py
+++ b/addons/l10n_ro_edi/models/account_edi_xml_ubl_ciusro.py
@@ -218,8 +218,7 @@ class AccountEdiXmlUBLRO(models.AbstractModel):
         company_id = None
 
         if not _has_vat(commercial_partner.vat):
-            if commercial_partner.company_registry:
-                company_id = DEFAULT_VAT
+            company_id = DEFAULT_VAT
         else:
             company_id = commercial_partner.vat
 


### PR DESCRIPTION
Problem
---------
In a recent fix, in the Tax Scheme customer node, the scheme type was recomputed correctly depending on the companyID node. However, during the fix, a condition was wrongly introduced. This will lead to some issue: when a customer has no VAT, he should be given the default VAT. However, due to condition, the customer gets given the Default VAT only when he does not have a vat NOR A COMPANY REGISTRY.

Solution
---------
Remove the condition

no-task

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
