### PR TITLE
[FIX] base: exclude the retrieve of unsupported timezones

### DIFF
--- a/odoo/addons/base/tests/test_tz.py
+++ b/odoo/addons/base/tests/test_tz.py
@@ -66,3 +66,9 @@ class TestTZ(TransactionCase):
         expected_offset = datetime.datetime.now(ZoneInfo('America/New_York')).strftime('%z')
         # offest will be -0400 in summer, -0500 in winter
         self.assertEqual(partner.tz_offset, expected_offset)
+
+    def test_tz_selection_excludes_special_timezones(self):
+        with self.assertRaises(ValueError):
+            self.env['res.partner'].create({'name': 'test', 'tz': 'localtime'})
+        with self.assertRaises(ValueError):
+            self.env['res.partner'].create({'name': 'test', 'tz': 'Factory'})

--- a/odoo/tools/date_utils.py
+++ b/odoo/tools/date_utils.py
@@ -5,6 +5,8 @@ import math
 import re
 import typing
 import zoneinfo
+import contextlib
+import babel
 from datetime import date, datetime, time, timedelta, tzinfo, UTC
 from operator import methodcaller
 
@@ -14,13 +16,21 @@ from .func import lazy
 from .float_utils import float_round
 
 if typing.TYPE_CHECKING:
-    import babel
     from collections.abc import Callable, Iterable, Iterator
     from odoo.orm.types import Environment
     D = typing.TypeVar('D', date, datetime)
 
+
 # cache `available_timezones` as it's recomputed on every call
-all_timezones = lazy(zoneinfo.available_timezones)
+@lazy
+def all_timezones():
+    tzs = []
+    for tz in zoneinfo.available_timezones():
+        with contextlib.suppress(LookupError):
+            babel.dates.get_timezone(tz)
+            tzs.append(tz)
+    return tzs
+
 
 TRUNCATE_TODAY = relativedelta(microsecond=0, second=0, minute=0, hour=0)
 TRUNCATE_UNIT = {


### PR DESCRIPTION
### Issue before this commit:
When creating an event, the timezone selection dropdown could include values such as localtime or Factory. If one of these values was selected and the event was later displayed on the website, it will led to a traceback error such as: Unknown timezone localtime. As a result, the event page will fail to render correctly or trigger runtime errors related to timezone handling.

### Steps to reproduce the issue:
1. Install Ecommerce and Events apps
2. Go to Ecommerce > Site > Events
3. Create a new test event
4. Activate the Unpublished button
5. Click on the button "Events"
6. Set the display timezone as localtime
7. Click the button "Go to website"
8. Traceback will appear saying: Unknown timezone localtime

### Cause of the issue:
The issue was caused by the way the list of available timezones was generated. Timezones are retrieved using the system-provided timezone database through Python’s zoneinfo module. This list includes certain special or internal entries such as localtime and Factory. These entries are not meant to be used as real timezones but were still included in the selection field used by the event model. Since the code responsible for formatting event dates expects valid IANA timezone identifiers, selecting one of these special entries could cause failures.

### Reason to introduce the fix:
The fix ensures that unsupported or special timezone entries are excluded from the list of selectable timezones. By filtering out values such as localtime and Factory, the system prevents users from selecting timezones that cannot be safely used in event date computations.

opw-5994939

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
