### PR TITLE
[FIX] website_hr_recruitment: filter with office and country

### DIFF
--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -810,7 +810,7 @@
                 <t t-else="">All Offices</t>
             </button>
             <div class="dropdown-menu w-100 w-md-auto" aria-labelledby="officesDropdown">
-                <a t-attf-href="/jobs?#{'all_countries=1' if is_remote else current_country_path}#{non_location_params}"
+                <a t-attf-href="/jobs?#{'all_countries=1' if is_remote else current_country_param}#{non_location_params}"
                     t-attf-class="dropdown-item d-flex align-items-center justify-content-between nav-link#{'' if office_id or is_remote else ' active'}">
                     All Offices
                     <span t-attf-class="badge text-bg-primary ms-2" t-out="count_per_office.get('all', '0')"/>


### PR DESCRIPTION
Steps to reproduce:
===================
1. Navigate to the Jobs page.
2. Filter a specific country
3. Select all offices

-> The country filter will be removed

Cause:
======
the "All Offices" link inside job_filter_by_offices, the href uses 'all_countries=1' if is_remote else current_country_path but current_country_path is not defined anywhere

Solution:
=========
Switch to current_country_param

Note:
=====
The fix will be adapted in later versions

opw-5947819

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
