### PR TITLE
[FIX] hr_work_entry: remove work entry types duplicates

### DIFF
--- a/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_model.js
+++ b/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_model.js
@@ -42,9 +42,13 @@ export class WorkEntryCalendarModel extends CalendarModel {
             }
         );
         if (userFavoritesWorkEntriesIds.length) {
+            const typeIds = userFavoritesWorkEntriesIds
+                .map((r) => r.work_entry_type_id?.[0])
+                .filter(Boolean);
+            const uniqueTypeIds = [...new Set(typeIds)];
             this.userFavoritesWorkEntries = await this.orm.read(
                 "hr.work.entry.type",
-                userFavoritesWorkEntriesIds.map((r) => r.work_entry_type_id?.[0]).filter(Boolean),
+                uniqueTypeIds,
                 ["display_name", "display_code", "color"]
             );
             this.userFavoritesWorkEntries = this.userFavoritesWorkEntries.sort((a, b) =>

--- a/addons/hr_work_entry/static/tests/work_entry_calendar_view.test.js
+++ b/addons/hr_work_entry/static/tests/work_entry_calendar_view.test.js
@@ -77,3 +77,39 @@ test("should use default_employee_id from context in work entry", async () => {
         work_entry_type_id: workEntryTypeId,
     });
 });
+
+test("calendar multi-selection quick buttons deduplicate favorites", async () => {
+    const { env } = await makeMockServer();
+    const [type] = env["hr.work.entry.type"].create([
+        {
+            name: "MyType",
+        },
+    ]);
+    env["hr.work.entry"].create([
+        {
+            name: "e1",
+            employee_id: 100,
+            work_entry_type_id: type,
+            date: "2025-01-01",
+            create_date: "2025-01-01",
+        },
+        {
+            name: "e2",
+            employee_id: 100,
+            work_entry_type_id: type,
+            date: "2025-01-02",
+            create_date: "2025-01-02",
+        },
+    ]);
+
+    const calendar = await mountView({
+        type: "calendar",
+        resModel: "hr.work.entry",
+    });
+    const controller = getCalendarController(calendar);
+    await controller.model._fetchUserFavoritesWorkEntries();
+    //ensure favorites deduplication happened
+    expect(controller.model.userFavoritesWorkEntries).toHaveLength(1, {
+        message: "calendar model favorites list must contain just one type",
+    });
+});


### PR DESCRIPTION
### Steps to reproduce:
- Download Payroll app
- From the top bar 'Employees' > 'Employees', create a new employee
- Select the created employee > click 'Work Entries' smart button, add 2 Attendance work entries on different days, with different creation days (either wait 24h between creations, or adjust one create_date in DB)
- Click on any day, you'll find the "Replace by Attendance" smart button replicated

> If you activate debug mode and click on any cell > **UncaughtPromiseError > OwlError**

### Cause of issue:
https://github.com/odoo/odoo/blob/72be98d705e225f663b65e289e11d0b8642ec6f8/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_calendar_model.js#L30-L58 `formattedReadGroup` is called with both `work_entry_type_id` and `create_date:day`. If the user has created several work entries of the same type on different days, we would get multiple group results having the same `work_entry_type_id`. These duplicated records later produce an Owl crash because the button list uses `t-key="workEntry.id"`. https://github.com/odoo/odoo/blob/72be98d705e225f663b65e289e11d0b8642ec6f8/addons/hr_work_entry/static/src/views/work_entry_calendar/work_entry_multi_selection_buttons.xml#L16-L17

### Fix:
Since the goal of the above method is to extract the favorite work entries to later use in smart buttons and `userFavoritesWorkEntriesIds.map((r) => r.work_entry_type_id?.[0]).filter(Boolean)` extracts all the entries' `work_entry_type_id` (including duplicates), the easiest way to get rid of these duplicates is to create a `Set`.

opw-5953671