### PR TITLE
[FIX] mail: better position of star icon in member list

### DIFF
--- a/addons/mail/static/src/discuss/core/common/channel_member.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member.xml
@@ -9,8 +9,8 @@
             <div t-ref="displayName" class="d-flex overflow-hidden flex-column lh-sm">
                 <span class="ms-2 text-truncate text-muted fw-bold" t-esc="member.name" t-att-title="member.name"/>
             </div>
-            <i t-if="member.channel_role === 'owner'" class="ms-2 fa fa-star text-warning" role="img" title="Channel Owner" aria-label="Channel Owner"/>
-            <i t-if="member.channel_role === 'admin'" class="ms-2 fa fa-star text-primary" role="img" title="Channel Admin" aria-label="Channel Admin"/>
+            <i t-if="member.channel_role === 'owner'" class="ms-1 fa fa-star text-warning lh-sm" role="img" title="Channel Owner" aria-label="Channel Owner"/>
+            <i t-if="member.channel_role === 'admin'" class="ms-1 fa fa-star text-primary lh-sm" role="img" title="Channel Admin" aria-label="Channel Admin"/>
             <span class="ms-auto">
                 <span t-if="member.in(member.channel_id.invited_member_ids)" class="p-1 oi oi-user-plus opacity-75"/>
                 <span t-if="member.rtcSession?.is_muted and !member.rtcSession?.is_deaf" class="p-1 fa fa-microphone-slash opacity-75"/>
@@ -22,7 +22,7 @@
                 'd-flex': showingActions.isOpen or store.useMobileView,
             }">
                 <Dropdown state="showingActions" position="'bottom-end'" menuClass="'my-1 ' + store.discussDropdownMenuClass(this)">
-                    <button class="btn btn-light rounded-circle d-flex o-p-0_5 align-items-center justify-content-center o-mail-discussSidebarBgColor border" t-att-class="{ 'o-showingActions': showingActions.isOpen }" title="Member Actions">
+                    <button class="btn btn-light rounded-circle d-flex o-p-0_5 ms-1 align-items-center justify-content-center o-mail-discussSidebarBgColor border" t-att-class="{ 'o-showingActions': showingActions.isOpen }" title="Member Actions">
                         <i role="img" class="oi oi-fw oi-lg oi-ellipsis-h"/>
                     </button>
                     <t t-set-slot="content">


### PR DESCRIPTION
- reduced spacing with the member name
- better vertical alignment of name and star icon
- some spacing with the "..." button when member name is long

Before / After
<img width="241" height="205" alt="Screenshot 2026-03-06 at 15 16 44" src="https://github.com/user-attachments/assets/448a8d5c-36a4-4018-89f3-cf89dabdac8a" /> <img width="237" height="195" alt="Screenshot 2026-03-06 at 15 15 47" src="https://github.com/user-attachments/assets/29968c76-51f8-498e-ac9a-98861d3360a2" />

Before / After
<img width="241" height="206" alt="Screenshot 2026-03-06 at 15 16 56" src="https://github.com/user-attachments/assets/96a0ee34-ec87-418f-8ecd-0025dfe79387" /> <img width="244" height="197" alt="Screenshot 2026-03-06 at 15 16 10" src="https://github.com/user-attachments/assets/9a4dc28c-8ba3-4992-8230-0aa4f8af382c" />
