### PR TITLE
[IMP] crm, hr_recruitment, mail: limit number of badges in wizards

### DIFF
--- a/addons/crm/wizard/crm_lead_lost_views.xml
+++ b/addons/crm/wizard/crm_lead_lost_views.xml
@@ -6,7 +6,7 @@
             <field name="arch" type="xml">
                 <form string="Lost Lead">
                     <field name="lead_ids" invisible="1"></field>
-                    <field name="lost_reason_id" placeholder="Select a Lost Reason..." widget="badges_many2one" />
+                    <field name="lost_reason_id" placeholder="Select a Lost Reason..." widget="badges_many2one" options="{'badge_limit': 8}" />
                     <group>
                         <label for="lost_feedback" class="o_form_label">Closing Note</label>
                         <field name="lost_feedback" placeholder="What went wrong?" nolabel="1" colspan="2"/>

--- a/addons/hr_recruitment/wizard/applicant_refuse_reason_views.xml
+++ b/addons/hr_recruitment/wizard/applicant_refuse_reason_views.xml
@@ -6,7 +6,7 @@
             <field name="arch" type="xml">
                 <form string="Refuse Reason" disable_autofocus="true">
                     <group col="1">
-                        <field name="refuse_reason_id" string="Reason" widget="badges_many2one" class="mb-3"/>
+                        <field name="refuse_reason_id" string="Reason" widget="badges_many2one" class="mb-3" options="{'badge_limit' : 8}"/>
                         <group invisible="not refuse_reason_id">
                             <field name="duplicates"
                                 widget="boolean_toggle"

--- a/addons/mail/wizard/mail_activity_schedule_views.xml
+++ b/addons/mail/wizard/mail_activity_schedule_views.xml
@@ -23,7 +23,7 @@
                             domain="[('id', 'in', activity_type_available_ids)]"
                             required="not plan_id"
                             widget="badges_many2one"
-                            options="{'related_icon_field': 'icon'}"
+                            options="{'related_icon_field': 'icon', 'badge_limit': 8}"
                             nolabel="1"/>
                         <group invisible="not plan_id">
                             <group>


### PR DESCRIPTION
Limit the `badges_many2one` widget to **8** items in the CRM Lost, Recruitment Refuse, and Mail Activity wizards.

**Task~5270283**
**Related Enterprise PR: odoo/enterprise#109834**