### PR TITLE
[IMP] web: improve relative datetime in searchModel

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_input.xml
+++ b/addons/web/static/src/core/datetime/datetime_input.xml
@@ -5,6 +5,7 @@
             type="text"
             t-custom-ref="start-date"
             t-att-id="this.props.id"
+            style="field-sizing: content;"
             class="o_datetime_input o_input cursor-pointer user-select-none"
             t-att-class="this.props.class"
             autocomplete="off"

--- a/addons/web/static/src/core/tree_editor/condition_tree.js
+++ b/addons/web/static/src/core/tree_editor/condition_tree.js
@@ -103,6 +103,16 @@ export function condition(path, operator, value, negate = false, isProperty = fa
     return { type: "condition", path, operator, value, negate, isProperty };
 }
 
+/**
+ * Clones a condition and applies updates, preserving all other metadata.
+ * @param {Condition} c
+ * @param {Object} updates
+ * @returns {Condition}
+ */
+export function updateCondition(c, updates) {
+    return { ...c, ...updates, type: "condition" };
+}
+
 export const TRUE_TREE = condition(1, "=", 1);
 export const FALSE_TREE = condition(0, "=", 1);
 
@@ -262,11 +272,7 @@ function normalizeConnector(connector) {
     if (newTree.children.length === 1) {
         const child = newTree.children[0];
         if (newTree.negate) {
-            const newChild = { ...child, negate: !child.negate };
-            if (newChild.type === "condition") {
-                return newChild;
-            }
-            return newChild;
+            return { ...child, negate: !child.negate };
         }
         return child;
     }

--- a/addons/web/static/src/core/tree_editor/tree_editor_components.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_components.js
@@ -36,19 +36,19 @@ export class InRange extends Component {
     static template = "web.TreeEditor.InRange";
     static options = [
         ["today", _t("Today")],
-        ["last 7 days", _t("Last 7 days")],
-        ["last 30 days", _t("Last 30 days")],
-        ["month to date", _t("Month to date")],
-        ["last month", _t("Last month")],
-        ["year to date", _t("Year to date")],
-        ["last 365 days", _t("Last 365 days")],
-        ["custom range", _t("Custom range")],
+        ["last7Days", _t("Last 7 days")],
+        ["last30Days", _t("Last 30 days")],
+        ["monthToDate", _t("Month to date")],
+        ["lastMonth", _t("Last month")],
+        ["yearToDate", _t("Year to date")],
+        ["last365Days", _t("Last 365 days")],
+        ["dateRange", _t("Date range")],
     ];
     updateValueType(newValueType) {
         const [fieldType, currentValueType] = this.props.value;
         if (currentValueType !== newValueType) {
             const values =
-                newValueType === "custom range"
+                newValueType === "dateRange"
                     ? this.props.betweenEditorInfo.defaultValue()
                     : [false, false];
             return this.props.update([fieldType, newValueType, ...values]);

--- a/addons/web/static/src/core/tree_editor/tree_editor_components.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_components.js
@@ -3,8 +3,13 @@ import { BadgeTag } from "@web/core/tags_list/badge_tag";
 import { _t } from "@web/core/l10n/translation";
 
 export class Input extends Component {
-    static props = ["value", "update", "placeholder?", "startEmpty?"];
+    static props = ["value", "update", "type?", "placeholder?", "startEmpty?"];
     static template = "web.TreeEditor.Input";
+
+    update(value) {
+        const newValue = this.props.type === "number" ? Number(value) : value;
+        return this.props.update(newValue);
+    }
 }
 
 export class Select extends Component {
@@ -31,8 +36,32 @@ export class Range extends Component {
     }
 }
 
+export class RelativeRange extends Component {
+    static props = ["value", "update", "relativeInput", "relativeSelect"];
+    static template = "web.TreeEditor.relativeRange";
+
+    static options = [
+        ["day", _t("day")],
+        ["week", _t("week")],
+        ["month", _t("month")],
+        ["year", _t("year")],
+    ];
+
+    update(index, newValue) {
+        const result = [...this.props.value];
+        result[index] = newValue;
+        return this.props.update(result);
+    }
+}
+
 export class InRange extends Component {
-    static props = ["value", "update", "valueTypeEditorInfo", "betweenEditorInfo"];
+    static props = [
+        "value",
+        "update",
+        "valueTypeEditorInfo",
+        "betweenEditorInfo",
+        "relativeEditorInfo",
+    ];
     static template = "web.TreeEditor.InRange";
     static options = [
         ["today", _t("Today")],
@@ -43,14 +72,17 @@ export class InRange extends Component {
         ["yearToDate", _t("Year to date")],
         ["last365Days", _t("Last 365 days")],
         ["dateRange", _t("Date range")],
+        ["relativeRange", _t("Relative range"), { debugOnly: true }],
     ];
     updateValueType(newValueType) {
         const [fieldType, currentValueType] = this.props.value;
         if (currentValueType !== newValueType) {
-            const values =
-                newValueType === "dateRange"
-                    ? this.props.betweenEditorInfo.defaultValue()
-                    : [false, false];
+            let values = [false, false];
+            if (newValueType === "dateRange") {
+                values = this.props.betweenEditorInfo.defaultValue();
+            } else if (newValueType === "relativeRange") {
+                values = this.props.relativeEditorInfo.defaultValue();
+            }
             return this.props.update([fieldType, newValueType, ...values]);
         }
     }

--- a/addons/web/static/src/core/tree_editor/tree_editor_components.xml
+++ b/addons/web/static/src/core/tree_editor/tree_editor_components.xml
@@ -40,7 +40,7 @@
                 <t t-set="value" t-value="this.props.value[1]" />
                 <t t-set="update" t-value="(val) => this.updateValueType(val)" />
             </t>
-            <t t-if="this.props.value[1] === 'custom range'">
+            <t t-if="this.props.value[1] === 'dateRange'">
                 <t t-call="web.TreeEditor.Editor">
                     <t t-set="_classes" t-value="'overflow-hidden flex-grow-1'"/>
                     <t t-set="info" t-value="this.props.betweenEditorInfo" />

--- a/addons/web/static/src/core/tree_editor/tree_editor_components.xml
+++ b/addons/web/static/src/core/tree_editor/tree_editor_components.xml
@@ -17,14 +17,14 @@
     <t t-name="web.TreeEditor.Range">
         <div class="d-flex align-items-center">
             <t t-call="web.TreeEditor.Editor">
-                <t t-set="_classes" t-value="'overflow-hidden flex-grow-1'"/>
+                <t t-set="_classes" t-value="'overflow-hidden'"/>
                 <t t-set="info" t-value="this.props.editorInfo" />
                 <t t-set="value" t-value="this.props.value[0]" />
                 <t t-set="update" t-value="(val) => this.update(0, val)" />
             </t>
             <i class="fa fa-long-arrow-right mx-2" aria-label="Arrow icon" title="Arrow" />
             <t t-call="web.TreeEditor.Editor">
-                <t t-set="_classes" t-value="'overflow-hidden flex-grow-1'"/>
+                <t t-set="_classes" t-value="'overflow-hidden'"/>
                 <t t-set="info" t-value="this.props.editorInfo" />
                 <t t-set="value" t-value="this.props.value[1]" />
                 <t t-set="update" t-value="(val) => this.update(1, val)" />
@@ -33,23 +33,21 @@
     </t>
 
     <t t-name="web.TreeEditor.InRange">
-        <div class="d-flex">
-            <div class="d-flex flex-column gap-2">
+        <div class="d-flex gap-4">
+            <t t-call="web.TreeEditor.Editor">
+                <t t-set="_classes" t-value="'overflow-hidden'"/>
+                <t t-set="info" t-value="this.props.valueTypeEditorInfo" />
+                <t t-set="value" t-value="this.props.value[1]" />
+                <t t-set="update" t-value="(val) => this.updateValueType(val)" />
+            </t>
+            <t t-if="this.props.value[1] === 'dateRange'">
                 <t t-call="web.TreeEditor.Editor">
-                    <t t-set="_classes" t-value="'overflow-hidden flex-grow-1'"/>
-                    <t t-set="info" t-value="this.props.valueTypeEditorInfo" />
-                    <t t-set="value" t-value="this.props.value[1]" />
-                    <t t-set="update" t-value="(val) => this.updateValueType(val)" />
+                    <t t-set="_classes" t-value="'overflow-hidden'"/>
+                    <t t-set="info" t-value="this.props.betweenEditorInfo" />
+                    <t t-set="value" t-value="this.props.value.slice(2)" />
+                    <t t-set="update" t-value="(val) => this.updateValues(val)" />
                 </t>
-                <t t-if="this.props.value[1] === 'dateRange'">
-                    <t t-call="web.TreeEditor.Editor">
-                        <t t-set="_classes" t-value="'overflow-hidden flex-grow-1'"/>
-                        <t t-set="info" t-value="this.props.betweenEditorInfo" />
-                        <t t-set="value" t-value="this.props.value.slice(2)" />
-                        <t t-set="update" t-value="(val) => this.updateValues(val)" />
-                    </t>
-                </t>
-            </div>
+            </t>
             <t t-if="props.value[1] === 'relativeRange'">
                 <t t-call="web.TreeEditor.Editor">
                     <t t-set="_classes" t-value="'overflow-hidden'"/>
@@ -62,7 +60,7 @@
     </t>
 
     <t t-name="web.TreeEditor.relativeRange">
-        <div class="d-flex ms-4 gap-4">
+        <div class="d-flex gap-4">
             <div style="width: 60px;">
                 <t t-call="web.TreeEditor.Editor">
                     <t t-set="info" t-value="this.props.relativeInput" />

--- a/addons/web/static/src/core/tree_editor/tree_editor_components.xml
+++ b/addons/web/static/src/core/tree_editor/tree_editor_components.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.TreeEditor.Input">
-        <input type="text" class="o_input" t-att-value="this.props.startEmpty ? '' : this.props.value" t-att-placeholder="this.props.placeholder" t-on-change="(ev) => this.props.update(ev.target.value)" />
+        <input  t-att-type="this.props.type ?? 'text'" class="o_input" t-att-value="this.props.startEmpty ? '' : this.props.value" t-att-placeholder="this.props.placeholder" t-on-change="(ev) => this.update(ev.target.value)" />
     </t>
 
     <t t-name="web.TreeEditor.Select">
@@ -33,20 +33,48 @@
     </t>
 
     <t t-name="web.TreeEditor.InRange">
-        <div class="d-flex flex-column gap-2">
-            <t t-call="web.TreeEditor.Editor">
-                <t t-set="_classes" t-value="'overflow-hidden flex-grow-1'"/>
-                <t t-set="info" t-value="this.props.valueTypeEditorInfo" />
-                <t t-set="value" t-value="this.props.value[1]" />
-                <t t-set="update" t-value="(val) => this.updateValueType(val)" />
-            </t>
-            <t t-if="this.props.value[1] === 'dateRange'">
+        <div class="d-flex">
+            <div class="d-flex flex-column gap-2">
                 <t t-call="web.TreeEditor.Editor">
                     <t t-set="_classes" t-value="'overflow-hidden flex-grow-1'"/>
-                    <t t-set="info" t-value="this.props.betweenEditorInfo" />
-                    <t t-set="value" t-value="this.props.value.slice(2)" />
+                    <t t-set="info" t-value="this.props.valueTypeEditorInfo" />
+                    <t t-set="value" t-value="this.props.value[1]" />
+                    <t t-set="update" t-value="(val) => this.updateValueType(val)" />
+                </t>
+                <t t-if="this.props.value[1] === 'dateRange'">
+                    <t t-call="web.TreeEditor.Editor">
+                        <t t-set="_classes" t-value="'overflow-hidden flex-grow-1'"/>
+                        <t t-set="info" t-value="this.props.betweenEditorInfo" />
+                        <t t-set="value" t-value="this.props.value.slice(2)" />
+                        <t t-set="update" t-value="(val) => this.updateValues(val)" />
+                    </t>
+                </t>
+            </div>
+            <t t-if="props.value[1] === 'relativeRange'">
+                <t t-call="web.TreeEditor.Editor">
+                    <t t-set="_classes" t-value="'overflow-hidden'"/>
+                    <t t-set="info" t-value="props.relativeEditorInfo" />
+                    <t t-set="value" t-value="props.value.slice(2)" />
                     <t t-set="update" t-value="(val) => this.updateValues(val)" />
                 </t>
+            </t>
+        </div>
+    </t>
+
+    <t t-name="web.TreeEditor.relativeRange">
+        <div class="d-flex ms-4 gap-4">
+            <div style="width: 60px;">
+                <t t-call="web.TreeEditor.Editor">
+                    <t t-set="info" t-value="this.props.relativeInput" />
+                    <t t-set="value" t-value="props.value[0]" />
+                    <t t-set="update" t-value="(val) => this.update(0, val)" />
+                </t>
+            </div>
+            <t t-call="web.TreeEditor.Editor">
+                <t t-set="_classes" t-value="'overflow-hidden'"/>
+                <t t-set="info" t-value="this.props.relativeSelect" />
+                <t t-set="value" t-value="props.value[1]" />
+                <t t-set="update" t-value="(val) => this.update(1, val)" />
             </t>
         </div>
     </t>

--- a/addons/web/static/src/core/tree_editor/tree_editor_value_editors.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_value_editors.js
@@ -13,7 +13,14 @@ import {
     DomainSelectorAutocomplete,
     DomainSelectorSingleAutocomplete,
 } from "@web/core/tree_editor/tree_editor_autocomplete";
-import { Input, InRange, List, Range, Select } from "@web/core/tree_editor/tree_editor_components";
+import {
+    Input,
+    InRange,
+    List,
+    Range,
+    RelativeRange,
+    Select,
+} from "@web/core/tree_editor/tree_editor_components";
 import { disambiguate, getResModel, isId } from "@web/core/tree_editor/utils";
 import { unique } from "@web/core/utils/arrays";
 
@@ -63,28 +70,44 @@ function placeholderForInput(displayPlaceholder) {
     }
 }
 
-const STRING_EDITOR = {
-    component: Input,
-    extractProps: ({ value, update, displayPlaceholder }) => ({
-        value,
-        update,
-        placeholder: placeholderForInput(displayPlaceholder),
-    }),
-    isSupported: (value) => typeof value === "string",
-    defaultValue: () => "",
-};
+/**
+ * Creates an editor definition for a standard HTML input.
+ * @param {"text" | "number"} [type="text"] - The type of input to generate.
+ * @returns {Object} The editor configuration object.
+ */
+function makeInputEditor(type = "text") {
+    if (!["text", "number"].includes(type)) {
+        throw new Error(`Input editor only supports 'text' and 'number' types. Received: ${type}`);
+    }
+    return {
+        component: Input,
+        extractProps: ({ value, update, displayPlaceholder }) => ({
+            value,
+            update,
+            type: type,
+            ...(type === "text" && { placeholder: placeholderForInput(displayPlaceholder) }),
+        }),
+        isSupported: (value) => typeof value === (type === "number" ? "number" : "string"),
+        defaultValue: () => (type === "number" ? 0 : ""),
+    };
+}
 
 function makeSelectEditor(options, params = {}) {
     const getOption = (value) => options.find(([v]) => v === value) || null;
     return {
         component: Select,
-        extractProps: ({ value, update, displayPlaceholder }) => ({
-            value,
-            update,
-            options,
-            addBlankOption: params.addBlankOption,
-            placeholder: placeholderForSelect(displayPlaceholder),
-        }),
+        extractProps: ({ value, update, displayPlaceholder }) => {
+            const visibleOptions = options.filter(
+                (opt) => odoo.debug || !opt[2]?.debugOnly || opt[0] === value
+            );
+            return {
+                value,
+                update,
+                options: visibleOptions,
+                addBlankOption: params.addBlankOption,
+                placeholder: placeholderForSelect(displayPlaceholder),
+            };
+        },
         isSupported: (value) => Boolean(getOption(value)),
         defaultValue: () => options[0]?.[0] ?? false,
         stringify: (value, disambiguate) => {
@@ -145,7 +168,7 @@ function getPartialValueEditorInfo(fieldDef, operator, params = {}) {
         case "not like":
         case "ilike":
         case "not ilike":
-            return STRING_EDITOR;
+            return makeInputEditor("text");
         case "between": {
             const editorInfo = getValueEditorInfo(fieldDef, "=", params);
             const { defaultValue } = getValueEditorInfo(fieldDef, "=", {
@@ -168,6 +191,22 @@ function getPartialValueEditorInfo(fieldDef, operator, params = {}) {
                     !editorInfo.isSupported(value[0]) || !editorInfo.isSupported(value[1]),
             };
         }
+        case "relative": {
+            const relativeInput = makeInputEditor("number");
+            const relativeSelect = makeSelectEditor(RelativeRange.options, params);
+            return {
+                component: RelativeRange,
+                extractProps: ({ value, update }) => ({
+                    value,
+                    update,
+                    relativeInput,
+                    relativeSelect,
+                }),
+                isSupported: (value) => Array.isArray(value) && value.length === 2,
+                defaultValue: () => [-1, "day"],
+                stringify: (value) => `${value[0]} ${value[1]}`,
+            };
+        }
         case "in range": {
             return {
                 component: InRange,
@@ -176,6 +215,7 @@ function getPartialValueEditorInfo(fieldDef, operator, params = {}) {
                     update,
                     valueTypeEditorInfo: makeSelectEditor(InRange.options, params),
                     betweenEditorInfo: getValueEditorInfo(fieldDef, "between", params),
+                    relativeEditorInfo: getValueEditorInfo(fieldDef, "relative", params),
                 }),
                 isSupported: (value) =>
                     Array.isArray(value) &&
@@ -189,7 +229,7 @@ function getPartialValueEditorInfo(fieldDef, operator, params = {}) {
         case "not in": {
             switch (fieldDef.type) {
                 case "tags":
-                    return STRING_EDITOR;
+                    return makeInputEditor("text");
                 case "many2one":
                 case "many2many":
                 case "one2many":
@@ -303,7 +343,7 @@ function getPartialValueEditorInfo(fieldDef, operator, params = {}) {
         case "char":
         case "html":
         case "text":
-            return STRING_EDITOR;
+            return makeInputEditor("text");
         case "many2one": {
             if (["=", "!="].includes(operator)) {
                 return {

--- a/addons/web/static/src/core/tree_editor/tree_processor.js
+++ b/addons/web/static/src/core/tree_editor/tree_processor.js
@@ -2,7 +2,7 @@ import {
     deserializeDate,
     deserializeDateTime,
     formatDate,
-    formatDateTime,
+    toLocaleDateTimeString,
 } from "@web/core/l10n/dates";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
@@ -40,7 +40,7 @@ function formatValue(val, disambiguate, fieldDef, displayNames) {
     }
     if (typeof val === "string") {
         if (fieldDef?.type === "datetime") {
-            return formatDateTime(deserializeDateTime(val));
+            return toLocaleDateTimeString(deserializeDateTime(val));
         }
         if (fieldDef?.type === "date") {
             return formatDate(deserializeDate(val));
@@ -255,13 +255,18 @@ export const treeProcessorService = {
             if (["set", "not set"].includes(operator)) {
                 return description;
             }
-
             const coModeldisplayNames = displayNames[getResModel(fieldDef)];
             const dis = disambiguate(value, coModeldisplayNames);
             let values;
             if (operator === "in range") {
                 const valueType = value[1];
-                values = [InRange.options.find(([t]) => t === valueType)[1].toString()];
+                if (valueType === "relativeRange") {
+                    let [, , range, unit] = value;
+                    unit = Math.abs(range) > 1 ? unit + "s" : unit;
+                    values = [Number(range) > 0 ? "next" : "last", Math.abs(range), unit]; // eg. last 7 months
+                } else {
+                    values = [InRange.options.find(([t]) => t === valueType)[1].toString()];
+                }
             } else {
                 values = (Array.isArray(value) ? value : [value])
                     .slice(0, limit)
@@ -280,7 +285,7 @@ export const treeProcessorService = {
                     addParenthesis = false;
                     break;
                 case "in range":
-                    join = _t(" ");
+                    join = " ";
                     addParenthesis = false;
                     break;
                 case "in":
@@ -330,7 +335,8 @@ export const treeProcessorService = {
             const stringDescription = [pathDescription, operatorDescription];
             if (valueDescription) {
                 const { values, join, addParenthesis } = valueDescription;
-                const jointedValues = values.join(` ${join} `);
+                const joint = ["", " "].includes(join) ? `${join}` : ` ${join} `;
+                const jointedValues = values.join(joint);
                 stringDescription.push(addParenthesis ? `( ${jointedValues} )` : jointedValues);
             } else if (isTree(tree.value)) {
                 const _fieldDef = getFieldDef(tree.path);
@@ -365,7 +371,8 @@ export const treeProcessorService = {
             const stringDescriptions = [pathDescription, operatorDescription];
             if (valueDescription) {
                 const { values, join, addParenthesis } = valueDescription;
-                const jointedValues = values.join(` ${join} `);
+                const joint = ["", " "].includes(join) ? `${join}` : ` ${join} `;
+                const jointedValues = values.join(joint);
                 stringDescriptions.push(addParenthesis ? `( ${jointedValues} )` : jointedValues);
             }
             descr.push(`${tabs}${stringDescriptions.join(" ")}`);

--- a/addons/web/static/src/core/tree_editor/tree_processor.js
+++ b/addons/web/static/src/core/tree_editor/tree_processor.js
@@ -219,7 +219,7 @@ export const treeProcessorService = {
             limit = 5
         ) {
             let { operator, negate, value, path } = node;
-            if (operator === "in range" && value[1] === "custom range") {
+            if (operator === "in range" && value[1] === "dateRange") {
                 operator = "between";
                 value = value.slice(2);
             }

--- a/addons/web/static/src/core/tree_editor/utils.js
+++ b/addons/web/static/src/core/tree_editor/utils.js
@@ -43,3 +43,57 @@ export function getDefaultPath(fieldDefs) {
     }
     throw new Error(`No field found`);
 }
+
+/**
+ * Parses a relative date string or domain expression into a standardized diff, unit, and offset.
+ * - "today - 5d"         --> { diff: -5, unit: "day", offsetDays: 0 }
+ * - "today + 2w + 1d"    --> { diff: 2,  unit: "week", offsetDays: 1 }
+ * - "relativedelta(m=-2)"--> { diff: -2, unit: "month", offsetDays: 0 }
+ * - "today"              --> { diff: 0,  unit: "day", offsetDays: 0 }
+ * @param {string | { _expr: string }} val - The relative date string
+ * @returns {{ diff: number, unit: "day" | "week" | "month" | "year", offsetDays: number } | null}
+ */
+export function parseRelativeValue(val) {
+    if (typeof val === "string") {
+        const trimmed = val.trim();
+        if (trimmed === "today") {
+            return { diff: 0, unit: "day", offsetDays: 0 };
+        }
+        // Regex captures: 1: sign, 2: value, 3: unit, 4: optional day offset (e.g., " + 1d")
+        const match = trimmed.match(/^today\s*([+-])\s*(\d+)\s*([dwmy])(?:\s*\+\s*(\d+)d)?$/);
+        if (match) {
+            const unitMap = { d: "day", w: "week", m: "month", y: "year" };
+            return {
+                diff: Number(match[1] + match[2]),
+                unit: unitMap[match[3]],
+                offsetDays: match[4] ? Number(match[4]) : 0,
+            };
+        }
+    } else if (val?._expr && typeof val._expr === "string") {
+        const expr = val._expr;
+        const matches = [...expr.matchAll(/(days|weeks|months|years)\s*=\s*([+-]?\d+)/g)];
+
+        if (matches.length === 0) {
+            const isToday = expr.includes("context_today()");
+            return isToday ? { diff: 0, unit: "day", offsetDays: 0 } : null;
+        }
+
+        let mainMatch = matches[0];
+        let offsetDays = 0;
+
+        if (matches.length > 1) {
+            const offsetIndex = matches.findIndex((m) => m[1] === "days" && Number(m[2]) > 0);
+            if (offsetIndex !== -1) {
+                offsetDays = Number(matches[offsetIndex][2]);
+                mainMatch = matches[offsetIndex === 0 ? 1 : 0];
+            }
+        }
+
+        return {
+            diff: Number(mainMatch[2]),
+            unit: mainMatch[1].slice(0, -1), // "months" -> "month"
+            offsetDays: offsetDays,
+        };
+    }
+    return null;
+}

--- a/addons/web/static/src/core/tree_editor/utils.js
+++ b/addons/web/static/src/core/tree_editor/utils.js
@@ -1,3 +1,5 @@
+import { expression } from "./condition_tree";
+
 export function disambiguate(value, displayNames) {
     if (!Array.isArray(value)) {
         return value === "";
@@ -42,6 +44,69 @@ export function getDefaultPath(fieldDefs) {
         return name;
     }
     throw new Error(`No field found`);
+}
+
+// --- Date range utils, used by ExpressionEditor --- //
+
+/**
+ * Generates an relativedelta expression string for a date or datetime relative to today.
+ * @param {'date' | 'datetime'} type - The field type determining the string format
+ * @param {string | array} [delta] - Relativedelta arguments (e.g., "days=-2", [weeks=2, "days=1"] ).
+ * @returns {Expression} An expression object containing the formatted Python string. Returns today if delta is null
+ */
+export function getRelativeDateExpr(type, delta) {
+    const isDate = type === "date";
+    const deltaStr = delta ? ` + relativedelta(${delta})` : "";
+
+    if (isDate) {
+        return expression(`(context_today()${deltaStr}).strftime("%Y-%m-%d")`);
+    }
+
+    return expression(
+        `datetime.datetime.combine(context_today()${deltaStr}, datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
+    );
+}
+
+const BOUNDS_SMART_DATES = [
+    ["today", "today", "today +1d"],
+    ["last7Days", "today -7d", "today"],
+    ["last30Days", "today -30d", "today"],
+    ["monthToDate", "today =1d", "today +1d"],
+    ["lastMonth", "today =1d -1m", "today =1d"],
+    ["yearToDate", "today =1m =1d", "today +1d"],
+    ["last365Days", "today -365d", "today"],
+];
+const DELTAS = [
+    ["today", "", "days = 1"],
+    ["last7Days", "days = -7", ""],
+    ["last30Days", "days = -30", ""],
+    ["monthToDate", "day = 1", "days = 1"],
+    ["lastMonth", "day = 1, months = -1", "day = 1"],
+    ["yearToDate", "day = 1, month = 1", "days = 1"],
+    ["last365Days", "days = -365", ""],
+];
+const BOUNDS_DATE = DELTAS.map(([k, l, r]) => [
+    k,
+    getRelativeDateExpr("date", l),
+    getRelativeDateExpr("date", r),
+]);
+const BOUNDS_DATETIME = DELTAS.map(([k, l, r]) => [
+    k,
+    getRelativeDateExpr("datetime", l),
+    getRelativeDateExpr("datetime", r),
+]);
+
+/**
+ * Retrieves the appropriate date range syntax for hardcoded options (last 7 days ..)
+ * @param {boolean} generateSmartDates - Whether to return human-readable odoo syntax (today + 1d)
+ * @param {'date'|'datetime'} fieldType - The data type of the field, used to select the syntax
+ * @returns {Object[]} An array of bound definition (eg. ["last30Days", "today -30d", "today"])
+ */
+export function getBounds(generateSmartDates, fieldType) {
+    if (generateSmartDates) {
+        return BOUNDS_SMART_DATES;
+    }
+    return fieldType === "date" ? BOUNDS_DATE : BOUNDS_DATETIME;
 }
 
 /**

--- a/addons/web/static/src/core/tree_editor/virtual_operators.js
+++ b/addons/web/static/src/core/tree_editor/virtual_operators.js
@@ -14,6 +14,18 @@ import {
 } from "./condition_tree";
 import { getRelativeDateExpr, getBounds, parseRelativeValue } from "./utils";
 
+/** @typedef {import("./condition_tree").AST} AST */
+/** @typedef {import("./condition_tree").Value} Value */
+/** @typedef {import("./condition_tree").Condition} Condition */
+/** @typedef {import("./condition_tree").Connector} Connector */
+/** @typedef {import("./condition_tree").Tree} Tree */
+/** @typedef {import("./condition_tree").Options} Options */
+
+/**
+ * Splits a condition's path into an initial segment and a final segment, handling property paths appropriately.
+ * @param {Condition} c
+ * @returns {{ initialPath: string, lastPart: string }}
+ */
 function splitPath(c) {
     if (typeof c.path !== "string" || c.path === "") {
         return { initialPath: "", lastPart: "" };
@@ -32,10 +44,22 @@ function splitPath(c) {
     return { initialPath, lastPart };
 }
 
+/**
+ * Checks if a condition's path is a field string without dot notation (eg. properties).
+ * @param {Condition} c
+ * @returns {boolean}
+ */
 function isSimplePath(c) {
     return typeof c.path === "string" && !splitPath(c).initialPath;
 }
 
+/**
+ * Wraps a given condition tree in an "any" operator condition using the specified initial path.
+ * @param {Tree} tree
+ * @param {string} initialPath
+ * @param {boolean} [negate]
+ * @returns {Tree}
+ */
 function wrapInAny(tree, initialPath, negate) {
     if (initialPath) {
         return condition(initialPath, "any", cloneTree(tree), negate);
@@ -43,6 +67,12 @@ function wrapInAny(tree, initialPath, negate) {
     return { ...cloneTree(tree), negate };
 }
 
+/**
+ * Transforms `=` and `!=` operators into `set` and `not set` operators
+ * @param {Tree} tree
+ * @param {TreeOperatorOptions} options
+ * @returns {Tree}
+ */
 function introduceSetOperators(tree, options = {}) {
     function _introduceSetOperator(c, options = {}) {
         const fieldType = options.getFieldDef?.(c.path)?.type;
@@ -58,6 +88,11 @@ function introduceSetOperators(tree, options = {}) {
     return operate(_introduceSetOperator, tree, options);
 }
 
+/**
+ * Transforms `set` and `not set` operators into `=` and `!=` operators
+ * @param {Tree} tree
+ * @returns {Tree}
+ */
 function eliminateSetOperators(tree) {
     function _removeSetOperator(c) {
         if (["set", "not set"].includes(c.operator)) {
@@ -68,6 +103,12 @@ function eliminateSetOperators(tree) {
     return operate(_removeSetOperator, tree);
 }
 
+/**
+ * Transforms `ilike` operators into `start with` operators
+ * @param {Tree} tree
+ * @param {TreeOperatorOptions} options
+ * @returns {Tree}
+ */
 function introduceStartsWithOperators(tree, options) {
     function _introduceStartsWithOperator(c, options) {
         const fieldType = options.getFieldDef?.(c.path)?.type;
@@ -84,6 +125,11 @@ function introduceStartsWithOperators(tree, options) {
     return operate(_introduceStartsWithOperator, tree, options);
 }
 
+/**
+ * Transforms `start with` operators into `ilike` operators
+ * @param {Tree} tree
+ * @returns {Tree}
+ */
 function eliminateStartsWithOperators(tree) {
     function _eliminateStartsWithOperator(c) {
         if (c.operator === "starts with") {
@@ -93,6 +139,11 @@ function eliminateStartsWithOperators(tree) {
     return operate(_eliminateStartsWithOperator, tree);
 }
 
+/**
+ * Checks if a condition is a simple (ie. no nesting) domain AND condition.
+ * @param {Condition} c
+ * @returns {boolean}
+ */
 function isSimpleAnd(c) {
     if (
         c.type === "connector" &&
@@ -106,6 +157,11 @@ function isSimpleAnd(c) {
     return false;
 }
 
+/**
+ * Checks if a condition matches the expected syntax of a between
+ * @param {Condition} c The condition to assess
+ * @returns {boolean}
+ */
 function isBetween(c) {
     const [{ path: p1, operator: op1, value: value1 }, { path: p2, operator: op2, value: value2 }] =
         c.children;
@@ -115,6 +171,14 @@ function isBetween(c) {
     return false;
 }
 
+/**
+ * Creates a domain range condition between 2 dates with a syntax that is interpreted as a between.
+ * @param {string} path - Field name.
+ * @param {'date'|'datetime'} value1 - first date
+ * @param {'date'|'datetime'} value2 - second date
+ * @param {boolean} isProperty - True if field is a metadata property.
+ * @returns {Condition} A combined domain condition (AND).
+ */
 function makeBetween(path, value1, value2, isProperty) {
     return connector("&", [
         condition(path, ">=", value1, false, isProperty),
@@ -122,6 +186,11 @@ function makeBetween(path, value1, value2, isProperty) {
     ]);
 }
 
+/**
+ * Checks if a condition matches the expected syntax of a strict between
+ * @param {Condition} c The condition to assess
+ * @returns {boolean}
+ */
 function isStrictBetween(c) {
     const [{ path: p1, operator: op1, value: value1 }, { path: p2, operator: op2, value: value2 }] =
         c.children;
@@ -131,6 +200,14 @@ function isStrictBetween(c) {
     return false;
 }
 
+/**
+ * Creates a domain range condition between 2 dates with a syntax that is interpreted as a strict between.
+ * @param {string} path - Field name.
+ * @param {'date'|'datetime'} value1 - first date
+ * @param {'date'|'datetime'} value2 - second date
+ * @param {boolean} isProperty - True if field is a metadata property.
+ * @returns {Condition} A combined domain condition (AND).
+ */
 function makeStrictBetween(path, value1, value2, isProperty) {
     return connector("&", [
         condition(path, ">=", value1, false, isProperty),
@@ -237,6 +314,12 @@ function makeRelativeBetween(path, diff, unit, isProperty, smartDates, fieldType
     ]);
 }
 
+/**
+ * Check if a tree can be interpreted as an in range operator (as a `strictBetween`, `relativeBetween` or `between`)
+ * @param {Tree} tree
+ * @param {TreeOperatorOptions} options
+ * @returns {boolean}
+ */
 function introduceInRangeOperators(tree, options = {}) {
     function _introduceInRangeOperator(c, options) {
         const path = c.children[0].path;
@@ -282,6 +365,13 @@ function introduceInRangeOperators(tree, options = {}) {
     );
 }
 
+/**
+ * Expands "in range" operators into standard domain bounds, scoping nested paths with
+ * an "any" condition to ensure both bounds apply to the exact same related record.
+ * @param {Tree} tree
+ * @param {TreeOperatorOptions} options
+ * @returns {boolean}
+ */
 function eliminateInRangeOperators(tree, options = {}) {
     function _eliminateInRangeOperator(c, options) {
         if (c.operator !== "in range") {
@@ -305,6 +395,12 @@ function eliminateInRangeOperators(tree, options = {}) {
     return operate(_eliminateInRangeOperator, tree, options);
 }
 
+/**
+ * Transforms standard numeric ranges into "between" virtual operators.
+ * @param {Tree} tree
+ * @param {TreeOperatorOptions} options
+ * @returns {boolean}
+ */
 function introduceBetweenOperators(tree, options = {}) {
     function _introduceBetweenOperator(c, options) {
         const res = isBetween(c);
@@ -326,6 +422,12 @@ function introduceBetweenOperators(tree, options = {}) {
     );
 }
 
+/**
+ * Expands "Between" operators into standard domain bounds, scoping nested paths with
+ * an "any" condition to ensure both bounds apply to the exact same related record.
+ * @param {Tree} tree
+ * @returns {Tree}
+ */
 function eliminateBetweenOperators(tree) {
     function _eliminateBetweenOperator(c) {
         if (c.operator !== "between") {
@@ -341,6 +443,11 @@ function eliminateBetweenOperators(tree) {
     return operate(_eliminateBetweenOperator, tree);
 }
 
+/**
+ * Flattens specific "any" operators containing "between" or "in range" conditions by combining their paths
+ * @param {Tree} tree
+ * @returns {Tree}
+ */
 function eliminateAnyOperators(tree) {
     function _eliminateAnyOperator(c) {
         if (
@@ -359,6 +466,11 @@ function eliminateAnyOperators(tree) {
     return operate(_eliminateAnyOperator, tree);
 }
 
+/**
+ * Removes explicit TRUE or FALSE leaf conditions by replacing them with equivalent empty connectors.
+ * @param {Tree} tree
+ * @returns {Tree}
+ */
 function removeFalseTrueLeaves(tree) {
     function _removeFalseTrueLeave(c) {
         const { path, operator, value, negate, isProperty } = c;
@@ -372,6 +484,12 @@ function removeFalseTrueLeaves(tree) {
     return operate(_removeFalseTrueLeave, tree);
 }
 
+/**
+ * Applies transformations to introduce virtual operators (e.g., set, starts with, between, in range).
+ * @param {Tree} tree
+ * @param {TreeOperatorOptions} options
+ * @returns {boolean}
+ */
 export function introduceVirtualOperators(tree, options = {}) {
     return applyTransformations(
         [
@@ -386,6 +504,12 @@ export function introduceVirtualOperators(tree, options = {}) {
     );
 }
 
+/**
+ * Reverts virtual operators back into their standard domain condition equivalents.
+ * @param {Tree} tree
+ * @param {TreeOperatorOptions} options
+ * @returns {boolean}
+ */
 export function eliminateVirtualOperators(tree, options = {}) {
     return applyTransformations(
         [
@@ -399,6 +523,12 @@ export function eliminateVirtualOperators(tree, options = {}) {
     );
 }
 
+/**
+ * Compares two condition trees for logical equivalence by removing virtual operators and explicit leaves.
+ * @param {Tree} tree
+ * @param {Tree} otherTree
+ * @returns {boolean}
+ */
 export function areEquivalentTrees(tree, otherTree) {
     const simplifiedTree = removeFalseTrueLeaves(eliminateVirtualOperators(tree));
     const otherSimplifiedTree = removeFalseTrueLeaves(eliminateVirtualOperators(otherTree));

--- a/addons/web/static/src/core/tree_editor/virtual_operators.js
+++ b/addons/web/static/src/core/tree_editor/virtual_operators.js
@@ -177,21 +177,21 @@ function boundDatetime(delta) {
 
 const BOUNDS_SMART_DATES = [
     ["today", "today", "today +1d"],
-    ["last 7 days", "today -7d", "today"],
-    ["last 30 days", "today -30d", "today"],
-    ["month to date", "today =1d", "today +1d"],
-    ["last month", "today =1d -1m", "today =1d"],
-    ["year to date", "today =1m =1d", "today +1d"],
-    ["last 365 days", "today -365d", "today"],
+    ["last7Days", "today -7d", "today"],
+    ["last30Days", "today -30d", "today"],
+    ["monthToDate", "today =1d", "today +1d"],
+    ["lastMonth", "today =1d -1m", "today =1d"],
+    ["yearToDate", "today =1m =1d", "today +1d"],
+    ["last365Days", "today -365d", "today"],
 ];
 const DELTAS = [
     ["today", "", "days = 1"],
-    ["last 7 days", "days = -7", ""],
-    ["last 30 days", "days = -30", ""],
-    ["month to date", "day = 1", "days = 1"],
-    ["last month", "day = 1, months = -1", "day = 1"],
-    ["year to date", "day = 1, month = 1", "days = 1"],
-    ["last 365 days", "days = -365", ""],
+    ["last7Days", "days = -7", ""],
+    ["last30Days", "days = -30", ""],
+    ["monthToDate", "day = 1", "days = 1"],
+    ["lastMonth", "day = 1, months = -1", "day = 1"],
+    ["yearToDate", "day = 1, month = 1", "days = 1"],
+    ["last365Days", "days = -365", ""],
 ];
 const BOUNDS_DATE = DELTAS.map(([k, l, r]) => [k, boundDate(l), boundDate(r)]);
 const BOUNDS_DATETIME = DELTAS.map(([k, l, r]) => [k, boundDatetime(l), boundDatetime(r)]);
@@ -247,7 +247,7 @@ function introduceInRangeOperators(tree, options = {}) {
                     "in range",
                     [
                         fieldType,
-                        "custom range",
+                        "dateRange",
                         // @ts-ignore
                         ...normalizeValue([value1, value2]),
                     ],
@@ -275,7 +275,7 @@ function eliminateInRangeOperators(tree, options = {}) {
         const { initialPath, lastPart } = splitPath(path, isProperty);
         const [fieldType, valueType, value1, value2] = value;
         let tree;
-        if (valueType === "custom range") {
+        if (valueType === "dateRange") {
             tree = makeBetween(lastPart, value1, value2, isProperty);
         } else {
             const generateSmartDates =

--- a/addons/web/static/src/core/tree_editor/virtual_operators.js
+++ b/addons/web/static/src/core/tree_editor/virtual_operators.js
@@ -3,24 +3,24 @@ import {
     areEqualTrees,
     cloneTree,
     condition,
+    updateCondition,
     connector,
-    expression,
-    FALSE_TREE,
     isTree,
     normalizeValue,
     operate,
-    rewriteNConsecutiveChildren,
+    FALSE_TREE,
     TRUE_TREE,
+    rewriteNConsecutiveChildren,
 } from "./condition_tree";
-import { parseRelativeValue } from "./utils";
+import { getRelativeDateExpr, getBounds, parseRelativeValue } from "./utils";
 
-function splitPath(path, is_property) {
-    if (typeof path !== "string" || path === "") {
+function splitPath(c) {
+    if (typeof c.path !== "string" || c.path === "") {
         return { initialPath: "", lastPart: "" };
     }
 
-    const pathParts = path.split(".");
-    if (is_property && pathParts.length >= 2) {
+    const pathParts = c.path.split(".");
+    if (c.isProperty && pathParts.length >= 2) {
         return {
             initialPath: pathParts.slice(0, -2).join("."),
             lastPart: pathParts.slice(-2).join("."),
@@ -32,34 +32,27 @@ function splitPath(path, is_property) {
     return { initialPath, lastPart };
 }
 
-function isSimplePath(path, isProperty) {
-    return typeof path === "string" && !splitPath(path, isProperty).initialPath;
+function isSimplePath(c) {
+    return typeof c.path === "string" && !splitPath(c).initialPath;
 }
 
 function wrapInAny(tree, initialPath, negate) {
-    let con = cloneTree(tree);
     if (initialPath) {
-        con = condition(initialPath, "any", con);
+        return condition(initialPath, "any", cloneTree(tree), negate);
     }
-    con.negate = negate;
-    return con;
+    return { ...cloneTree(tree), negate };
 }
 
 function introduceSetOperators(tree, options = {}) {
     function _introduceSetOperator(c, options = {}) {
-        const { negate, path, operator, value } = c;
-        const fieldType = options.getFieldDef?.(path)?.type;
-        if (["=", "!="].includes(operator)) {
-            if (fieldType) {
-                if (fieldType === "boolean" && value === true) {
-                    return condition(path, operator === "=" ? "set" : "not set", value, negate);
-                } else if (
-                    !["many2one", "date", "datetime"].includes(fieldType) &&
-                    value === false
-                ) {
-                    return condition(path, operator === "=" ? "not set" : "set", value, negate);
-                }
-            }
+        const fieldType = options.getFieldDef?.(c.path)?.type;
+        if (!["=", "!="].includes(c.operator) || !fieldType) {
+            return;
+        }
+        if (fieldType === "boolean" && c.value === true) {
+            return updateCondition(c, { operator: c.operator === "=" ? "set" : "not set" });
+        } else if (!["many2one", "date", "datetime"].includes(fieldType) && c.value === false) {
+            return updateCondition(c, { operator: c.operator === "=" ? "not set" : "set" });
         }
     }
     return operate(_introduceSetOperator, tree, options);
@@ -67,12 +60,9 @@ function introduceSetOperators(tree, options = {}) {
 
 function eliminateSetOperators(tree) {
     function _removeSetOperator(c) {
-        const { negate, path, operator, value, isProperty } = c;
-        if (["set", "not set"].includes(operator)) {
-            if (value === true) {
-                return condition(path, operator === "set" ? "=" : "!=", value, negate, isProperty);
-            }
-            return condition(path, operator === "set" ? "!=" : "=", value, negate, isProperty);
+        if (["set", "not set"].includes(c.operator)) {
+            const op = c.operator === "set" ? (c.value ? "=" : "!=") : c.value ? "!=" : "=";
+            return updateCondition(c, { operator: op });
         }
     }
     return operate(_removeSetOperator, tree);
@@ -80,15 +70,14 @@ function eliminateSetOperators(tree) {
 
 function introduceStartsWithOperators(tree, options) {
     function _introduceStartsWithOperator(c, options) {
-        const { negate, path, operator, value, isProperty } = c;
-        const fieldType = options.getFieldDef?.(path)?.type;
+        const fieldType = options.getFieldDef?.(c.path)?.type;
         if (
             ["char", "text", "html"].includes(fieldType) &&
-            operator === "=ilike" &&
-            typeof value === "string"
+            c.operator === "=ilike" &&
+            typeof c.value === "string"
         ) {
-            if (value.endsWith("%")) {
-                return condition(path, "starts with", value.slice(0, -1), negate, isProperty);
+            if (c.value.endsWith("%")) {
+                return updateCondition(c, { operator: "starts with", value: c.value.slice(0, -1) });
             }
         }
     }
@@ -97,9 +86,8 @@ function introduceStartsWithOperators(tree, options) {
 
 function eliminateStartsWithOperators(tree) {
     function _eliminateStartsWithOperator(c) {
-        const { negate, path, operator, value, isProperty } = c;
-        if (operator === "starts with") {
-            return condition(path, "=ilike", `${value}%`, negate, isProperty);
+        if (c.operator === "starts with") {
+            return updateCondition(c, { operator: "=ilike", value: `${c.value}%` });
         }
     }
     return operate(_eliminateStartsWithOperator, tree);
@@ -249,117 +237,41 @@ function makeRelativeBetween(path, diff, unit, isProperty, smartDates, fieldType
     ]);
 }
 
-/**
- * Helper to build the chained relativedelta string
- * e.g. ["months=1", "days=1"] -> "relativedelta(months=1) + relativedelta(days=1)"
- */
-function buildDeltaExpr(deltas) {
-    const arr = Array.isArray(deltas) ? deltas : deltas ? [deltas] : [];
-    if (arr.length === 0) {
-        return null;
-    }
-    return arr.map((d) => `relativedelta(${d})`).join(" + ");
-}
-
-export function boundDate(deltas) {
-    const deltaExpr = buildDeltaExpr(deltas);
-    if (!deltaExpr) {
-        return expression(`context_today().strftime("%Y-%m-%d")`);
-    }
-    return expression(`(context_today() + ${deltaExpr}).strftime('%Y-%m-%d')`);
-}
-
-export function boundDatetime(deltas) {
-    const deltaExpr = buildDeltaExpr(deltas);
-    if (!deltaExpr) {
-        return expression(
-            `datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-        );
-    }
-    return expression(
-        `datetime.datetime.combine(context_today() + ${deltaExpr}, datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
-    );
-}
-
-const BOUNDS_SMART_DATES = [
-    ["today", "today", "today +1d"],
-    ["last7Days", "today -7d", "today"],
-    ["last30Days", "today -30d", "today"],
-    ["monthToDate", "today =1d", "today +1d"],
-    ["lastMonth", "today =1d -1m", "today =1d"],
-    ["yearToDate", "today =1m =1d", "today +1d"],
-    ["last365Days", "today -365d", "today"],
-];
-const DELTAS = [
-    ["today", "", "days = 1"],
-    ["last7Days", "days = -7", ""],
-    ["last30Days", "days = -30", ""],
-    ["monthToDate", "day = 1", "days = 1"],
-    ["lastMonth", "day = 1, months = -1", "day = 1"],
-    ["yearToDate", "day = 1, month = 1", "days = 1"],
-    ["last365Days", "days = -365", ""],
-];
-const BOUNDS_DATE = DELTAS.map(([k, l, r]) => [k, boundDate(l), boundDate(r)]);
-const BOUNDS_DATETIME = DELTAS.map(([k, l, r]) => [k, boundDatetime(l), boundDatetime(r)]);
-
-function getBounds(generateSmartDates, fieldType) {
-    return generateSmartDates
-        ? BOUNDS_SMART_DATES
-        : fieldType === "date"
-        ? BOUNDS_DATE
-        : BOUNDS_DATETIME;
-}
-
 function introduceInRangeOperators(tree, options = {}) {
     function _introduceInRangeOperator(c, options) {
         const path = c.children[0].path;
         const fieldType = options.getFieldDef?.(path)?.type;
         const isProperty = c.children[0].isProperty;
         const isDate = ["date", "datetime"].includes(fieldType);
-        if (!isSimpleAnd(c) || !isDate || !isSimplePath(c.children[0].path, isProperty)) {
+        if (!isSimpleAnd(c) || !isDate || !isSimplePath(c.children[0])) {
             return;
         }
         const generateSmartDates = options.generateSmartDates ?? true;
+        const base = condition(path, "in range", "_replaced_below", false, isProperty);
+
         let res = isStrictBetween(c);
         if (res) {
             const bounds = getBounds(generateSmartDates, fieldType);
-            for (const [valueType, leftBound, rightBound] of bounds) {
-                if (
-                    generateSmartDates
-                        ? res.value1 === leftBound && res.value2 === rightBound
-                        : res.value1._expr === leftBound._expr &&
-                          res.value2._expr === rightBound._expr
-                ) {
-                    return condition(
-                        path,
-                        "in range",
-                        [fieldType, valueType, false, false],
-                        false,
-                        isProperty
-                    );
-                }
+            const match = bounds.find(([, left, right]) =>
+                generateSmartDates
+                    ? res.value1 === left && res.value2 === right
+                    : res.value1._expr === left._expr && res.value2._expr === right._expr
+            );
+            if (match) {
+                return updateCondition(base, { value: [fieldType, match[0], false, false] });
             }
         }
         res = isRelativeBetween(c, fieldType);
         if (res) {
-            const value = [fieldType, "relativeRange", res.diff, res.unit];
-            return condition(path, "in range", value);
+            return updateCondition(base, {
+                value: [fieldType, "relativeRange", res.diff, res.unit],
+            });
         }
         res = isBetween(c);
         if (res) {
-            const { path, value1, value2 } = res;
-            return condition(
-                path,
-                "in range",
-                [
-                    fieldType,
-                    "dateRange",
-                    // @ts-ignore
-                    ...normalizeValue([value1, value2]),
-                ],
-                false,
-                isProperty
-            );
+            return updateCondition(base, {
+                value: [fieldType, "dateRange", ...normalizeValue([res.value1, res.value2])],
+            });
         }
     }
     return operate(
@@ -372,25 +284,23 @@ function introduceInRangeOperators(tree, options = {}) {
 
 function eliminateInRangeOperators(tree, options = {}) {
     function _eliminateInRangeOperator(c, options) {
-        const { negate, path, operator, value, isProperty } = c;
-        // @ts-ignore
-        if (operator !== "in range") {
+        if (c.operator !== "in range") {
             return;
         }
-        const { initialPath, lastPart } = splitPath(path, isProperty);
-        const [fieldType, valueType, value1, value2] = value;
+        const { initialPath, lastPart } = splitPath(c);
+        const [fieldType, valueType, v1, v2] = c.value;
         const smartDates = options.generateSmartDates ?? true;
         let tree;
         if (valueType === "dateRange") {
-            tree = makeBetween(lastPart, value1, value2, isProperty);
+            tree = makeBetween(lastPart, v1, v2, c.isProperty);
         } else if (valueType === "relativeRange") {
-            tree = makeRelativeBetween(lastPart, value1, value2, isProperty, smartDates, fieldType);
+            tree = makeRelativeBetween(lastPart, v1, v2, c.isProperty, smartDates, fieldType);
         } else {
             const bounds = getBounds(smartDates, fieldType);
             const [, leftBound, rightBound] = bounds.find(([v]) => v === valueType);
-            tree = makeStrictBetween(lastPart, leftBound, rightBound, isProperty);
+            tree = makeStrictBetween(lastPart, leftBound, rightBound, c.isProperty);
         }
-        return wrapInAny(tree, initialPath, negate);
+        return wrapInAny(tree, initialPath, c.negate);
     }
     return operate(_eliminateInRangeOperator, tree, options);
 }
@@ -401,11 +311,11 @@ function introduceBetweenOperators(tree, options = {}) {
         if (!res) {
             return;
         }
-        // @ts-ignore
         const { path, value1, value2 } = res;
         const fieldType = options.getFieldDef?.(path)?.type;
-        if (["integer", "float", "monetary"].includes(fieldType) && isSimplePath(path)) {
-            return condition(path, "between", normalizeValue([value1, value2]));
+        const isProperty = c.children[0].isProperty;
+        if (["integer", "float", "monetary"].includes(fieldType) && isSimplePath(c.children[0])) {
+            return condition(path, "between", normalizeValue([value1, value2]), false, isProperty);
         }
     }
     return operate(
@@ -418,44 +328,34 @@ function introduceBetweenOperators(tree, options = {}) {
 
 function eliminateBetweenOperators(tree) {
     function _eliminateBetweenOperator(c) {
-        const { negate, path, operator, value, isProperty } = c;
-        // @ts-ignore
-        if (operator !== "between") {
+        if (c.operator !== "between") {
             return;
         }
-        const { initialPath, lastPart } = splitPath(path, isProperty);
+        const { initialPath, lastPart } = splitPath(c);
         return wrapInAny(
-            makeBetween(lastPart, value[0], value[1], isProperty),
+            makeBetween(lastPart, c.value[0], c.value[1], c.isProperty),
             initialPath,
-            negate
+            c.negate
         );
     }
     return operate(_eliminateBetweenOperator, tree);
 }
 
-function _eliminateAnyOperator(c) {
-    const { path, operator, value, negate } = c;
-    if (
-        operator === "any" &&
-        isTree(value) &&
-        value.type === "condition" &&
-        typeof path === "string" &&
-        typeof value.path === "string" &&
-        !negate &&
-        !value.negate &&
-        ["between", "in range"].includes(value.operator)
-    ) {
-        return condition(
-            `${path}.${value.path}`,
-            value.operator,
-            value.value,
-            false,
-            value.isProperty
-        );
-    }
-}
-
 function eliminateAnyOperators(tree) {
+    function _eliminateAnyOperator(c) {
+        if (
+            c.operator === "any" &&
+            isTree(c.value) &&
+            c.value.type === "condition" &&
+            typeof c.path === "string" &&
+            typeof c.value.path === "string" &&
+            !c.negate &&
+            !c.value.negate &&
+            ["between", "in range"].includes(c.value.operator)
+        ) {
+            return updateCondition(c.value, { path: `${c.path}.${c.value.path}` });
+        }
+    }
     return operate(_eliminateAnyOperator, tree);
 }
 

--- a/addons/web/static/src/core/tree_editor/virtual_operators.js
+++ b/addons/web/static/src/core/tree_editor/virtual_operators.js
@@ -12,6 +12,7 @@ import {
     rewriteNConsecutiveChildren,
     TRUE_TREE,
 } from "./condition_tree";
+import { parseRelativeValue } from "./utils";
 
 function splitPath(path, is_property) {
     if (typeof path !== "string" || path === "") {
@@ -118,14 +119,10 @@ function isSimpleAnd(c) {
 }
 
 function isBetween(c) {
-    if (isSimpleAnd(c)) {
-        const [
-            { path: p1, operator: op1, value: value1 },
-            { path: p2, operator: op2, value: value2 },
-        ] = c.children;
-        if (p1 === p2 && op1 === ">=" && op2 === "<=") {
-            return { path: p1, value1, value2 };
-        }
+    const [{ path: p1, operator: op1, value: value1 }, { path: p2, operator: op2, value: value2 }] =
+        c.children;
+    if (p1 === p2 && op1 === ">=" && op2 === "<=") {
+        return { path: p1, value1, value2 };
     }
     return false;
 }
@@ -138,14 +135,10 @@ function makeBetween(path, value1, value2, isProperty) {
 }
 
 function isStrictBetween(c) {
-    if (isSimpleAnd(c)) {
-        const [
-            { path: p1, operator: op1, value: value1 },
-            { path: p2, operator: op2, value: value2 },
-        ] = c.children;
-        if (p1 === p2 && op1 === ">=" && op2 === "<") {
-            return { path: p1, value1, value2 };
-        }
+    const [{ path: p1, operator: op1, value: value1 }, { path: p2, operator: op2, value: value2 }] =
+        c.children;
+    if (p1 === p2 && op1 === ">=" && op2 === "<") {
+        return { path: p1, value1, value2 };
     }
     return false;
 }
@@ -157,21 +150,134 @@ function makeStrictBetween(path, value1, value2, isProperty) {
     ]);
 }
 
-function boundDate(delta) {
-    if (!delta) {
-        return expression(`context_today().strftime("%Y-%m-%d")`);
+/**
+ * Returns the relative range if a domain syntax matches the relative range syntax (checking if range is today +/- xxx d/w/m/y)
+ * PAST relativity: PATH >= "today -X d/w/y/m" AND < "today" OR Future relativity: PATH > "today" AND <= "today +X d/w/y/m"
+ * For DATETIMEs FUTURE relativity we expect 1 day offset to both side of the equation because today means today at 00:00
+ * --> it takes the form of PATH > "today + 1d" AND <= "today +X w/m/y + 1d"
+ * @param {Condition} c
+ * @param {string} fieldType date and datetime supported for relativeBetween
+ * @returns {boolean|Object} returns false if not a relative range compared to today
+ */
+function isRelativeBetween(c, fieldType) {
+    const [c1, c2] = c.children;
+    const p1 = parseRelativeValue(c1.value);
+    const p2 = parseRelativeValue(c2.value);
+
+    if (c1.path !== c2.path || !p1 || !p2) {
+        return false;
     }
-    return expression(`(context_today() + relativedelta(${delta})).strftime('%Y-%m-%d')`);
+
+    const items = [
+        { operator: c1.operator, diff: p1.diff, unit: p1.unit, offsetDays: p1.offsetDays },
+        { operator: c2.operator, diff: p2.diff, unit: p2.unit, offsetDays: p2.offsetDays },
+    ];
+
+    // Sort by absolute difference. The one closest to 0 (today) becomes the first item.
+    // We want the parser to detect regardless of the order (ie. today can be left or right)
+    items.sort((a, b) => Math.abs(a.diff) - Math.abs(b.diff));
+    const [today, other] = items;
+
+    const pastRelativity = today.operator === "<" && other.operator === ">=" && other.diff < 0;
+    const futureRelativity = today.operator === ">" && other.operator === "<=" && other.diff >= 0;
+
+    if (pastRelativity || (futureRelativity && fieldType === "date")) {
+        const isAnchorToday = today.unit === "day" && today.offsetDays === 0 && today.diff === 0;
+        const isValidDayRange = isAnchorToday && other.offsetDays === 0;
+        return isValidDayRange ? { diff: other.diff, unit: other.unit } : false;
+    } else if (futureRelativity && fieldType === "datetime") {
+        const isAnchorTomorrow = today.diff === 1 && today.unit === "day";
+        if (other.unit === "day") {
+            // e.g., > today + 1d AND <= today + 5d  => range of 4 days
+            const isValidDayRange = isAnchorTomorrow && other.offsetDays === 0;
+            return isValidDayRange ? { diff: other.diff - 1, unit: "day" } : false;
+        } else {
+            // e.g., > today + 1d AND <= today + 1w + 1d => range of 1 week
+            const isValidDayRange = isAnchorTomorrow && other.offsetDays === 1;
+            return isValidDayRange ? { diff: other.diff, unit: other.unit } : false;
+        }
+    }
+    return false;
 }
 
-function boundDatetime(delta) {
-    if (!delta) {
+/**
+ * Creates a domain range condition between today and a relative offset.
+ * @param {string} path - Field name.
+ * @param {number} diff - Magnitude of time shift.
+ * @param {string} unit - 'day', 'week', 'month', or 'year'.
+ * @param {boolean} isProperty - True if field is a metadata property.
+ * @param {boolean} smartDates - Use shorthand keywords instead of expressions.
+ * @param {'date'|'datetime'} fieldType - Field type for formatting/offset logic.
+ * @returns {Condition} A combined domain condition (AND).
+ */
+function makeRelativeBetween(path, diff, unit, isProperty, smartDates, fieldType) {
+    const isFuture = diff > 0;
+    let todayCond, diffCond;
+
+    if (smartDates) {
+        const smartUnit = { week: "w", month: "m", year: "y" }[unit] || "d";
+        todayCond = "today";
+        diffCond = isFuture ? `today +${diff}${smartUnit}` : `today ${diff}${smartUnit}`;
+
+        // Edge cases
+        if (diff === 0) {
+            todayCond = "today +1d"; // To match TODAY smart date format
+            diffCond = "today";
+        } else if (isFuture && fieldType === "datetime") {
+            const futureOffset = smartUnit === "d" ? `${diff + 1}d` : `${diff}${smartUnit} +1d`;
+            todayCond = "today +1d"; // because today == today 00:00 in datetimes
+            diffCond = `today +${futureOffset}`;
+        }
+    } else {
+        todayCond = getRelativeDateExpr(fieldType);
+        diffCond = getRelativeDateExpr(fieldType, [`${unit}s = ${diff}`]);
+
+        // Edge cases
+        if (diff === 0) {
+            todayCond = getRelativeDateExpr(fieldType, ["days=1"]);
+            diffCond = getRelativeDateExpr(fieldType);
+        } else if (isFuture && fieldType === "datetime") {
+            const offset = unit === "day" ? [`days=${diff + 1}`] : [`${unit}s=${diff}`, "days=1"];
+            todayCond = getRelativeDateExpr(fieldType, ["days=1"]);
+            diffCond = getRelativeDateExpr(fieldType, offset);
+        }
+    }
+    // return the lowest date first, makes more sense when reading domain in debug mode
+    return connector("&", [
+        condition(path, isFuture ? ">" : ">=", isFuture ? todayCond : diffCond, false, isProperty),
+        condition(path, isFuture ? "<=" : "<", isFuture ? diffCond : todayCond, false, isProperty),
+    ]);
+}
+
+/**
+ * Helper to build the chained relativedelta string
+ * e.g. ["months=1", "days=1"] -> "relativedelta(months=1) + relativedelta(days=1)"
+ */
+function buildDeltaExpr(deltas) {
+    const arr = Array.isArray(deltas) ? deltas : deltas ? [deltas] : [];
+    if (arr.length === 0) {
+        return null;
+    }
+    return arr.map((d) => `relativedelta(${d})`).join(" + ");
+}
+
+export function boundDate(deltas) {
+    const deltaExpr = buildDeltaExpr(deltas);
+    if (!deltaExpr) {
+        return expression(`context_today().strftime("%Y-%m-%d")`);
+    }
+    return expression(`(context_today() + ${deltaExpr}).strftime('%Y-%m-%d')`);
+}
+
+export function boundDatetime(deltas) {
+    const deltaExpr = buildDeltaExpr(deltas);
+    if (!deltaExpr) {
         return expression(
             `datetime.datetime.combine(context_today(), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
         );
     }
     return expression(
-        `datetime.datetime.combine(context_today() + relativedelta(${delta}), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
+        `datetime.datetime.combine(context_today() + ${deltaExpr}, datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")`
     );
 }
 
@@ -206,55 +312,54 @@ function getBounds(generateSmartDates, fieldType) {
 
 function introduceInRangeOperators(tree, options = {}) {
     function _introduceInRangeOperator(c, options) {
-        const res1 = isStrictBetween(c);
-        if (res1) {
-            const generateSmartDates =
-                "generateSmartDates" in options ? options.generateSmartDates : true;
-            // @ts-ignore
-            const { path, value1, value2 } = res1;
-            const fieldDef = options.getFieldDef?.(path);
-            const fieldType = fieldDef?.type;
-            const isProperty = fieldDef?.is_property;
-            if (["date", "datetime"].includes(fieldType) && isSimplePath(path, isProperty)) {
-                const bounds = getBounds(generateSmartDates, fieldType);
-                for (const [valueType, leftBound, rightBound] of bounds) {
-                    if (
-                        generateSmartDates
-                            ? value1 === leftBound && value2 === rightBound
-                            : value1._expr === leftBound._expr && value2._expr === rightBound._expr
-                    ) {
-                        return condition(
-                            path,
-                            "in range",
-                            [fieldType, valueType, false, false],
-                            false,
-                            isProperty
-                        );
-                    }
+        const path = c.children[0].path;
+        const fieldType = options.getFieldDef?.(path)?.type;
+        const isProperty = c.children[0].isProperty;
+        const isDate = ["date", "datetime"].includes(fieldType);
+        if (!isSimpleAnd(c) || !isDate || !isSimplePath(c.children[0].path, isProperty)) {
+            return;
+        }
+        const generateSmartDates = options.generateSmartDates ?? true;
+        let res = isStrictBetween(c);
+        if (res) {
+            const bounds = getBounds(generateSmartDates, fieldType);
+            for (const [valueType, leftBound, rightBound] of bounds) {
+                if (
+                    generateSmartDates
+                        ? res.value1 === leftBound && res.value2 === rightBound
+                        : res.value1._expr === leftBound._expr &&
+                          res.value2._expr === rightBound._expr
+                ) {
+                    return condition(
+                        path,
+                        "in range",
+                        [fieldType, valueType, false, false],
+                        false,
+                        isProperty
+                    );
                 }
             }
         }
-        const res2 = isBetween(c);
-        if (res2) {
-            // @ts-ignore
-            const { path, value1, value2 } = res2;
-            const fieldDef = options.getFieldDef?.(path);
-            const fieldType = fieldDef?.type;
-            const isProperty = fieldDef?.is_property;
-            if (["date", "datetime"].includes(fieldType) && isSimplePath(path, isProperty)) {
-                return condition(
-                    path,
-                    "in range",
-                    [
-                        fieldType,
-                        "dateRange",
-                        // @ts-ignore
-                        ...normalizeValue([value1, value2]),
-                    ],
-                    false,
-                    isProperty
-                );
-            }
+        res = isRelativeBetween(c, fieldType);
+        if (res) {
+            const value = [fieldType, "relativeRange", res.diff, res.unit];
+            return condition(path, "in range", value);
+        }
+        res = isBetween(c);
+        if (res) {
+            const { path, value1, value2 } = res;
+            return condition(
+                path,
+                "in range",
+                [
+                    fieldType,
+                    "dateRange",
+                    // @ts-ignore
+                    ...normalizeValue([value1, value2]),
+                ],
+                false,
+                isProperty
+            );
         }
     }
     return operate(
@@ -274,13 +379,14 @@ function eliminateInRangeOperators(tree, options = {}) {
         }
         const { initialPath, lastPart } = splitPath(path, isProperty);
         const [fieldType, valueType, value1, value2] = value;
+        const smartDates = options.generateSmartDates ?? true;
         let tree;
         if (valueType === "dateRange") {
             tree = makeBetween(lastPart, value1, value2, isProperty);
+        } else if (valueType === "relativeRange") {
+            tree = makeRelativeBetween(lastPart, value1, value2, isProperty, smartDates, fieldType);
         } else {
-            const generateSmartDates =
-                "generateSmartDates" in options ? options.generateSmartDates : true;
-            const bounds = getBounds(generateSmartDates, fieldType);
+            const bounds = getBounds(smartDates, fieldType);
             const [, leftBound, rightBound] = bounds.find(([v]) => v === valueType);
             tree = makeStrictBetween(lastPart, leftBound, rightBound, isProperty);
         }

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -43,6 +43,7 @@ import {
     models,
     mountWithCleanup,
     onRpc,
+    serverState,
 } from "@web/../tests/web_test_helpers";
 import { SELECTORS } from "./domain_selector_helpers";
 
@@ -2531,6 +2532,7 @@ test("selection: placeholders for in operator", async () => {
 });
 
 test(`datetime: "in range" operator`, async () => {
+    serverState.debug = "1";
     mockDate("2023-04-20 17:00:00", 0);
     await makeDomainSelector({
         domain: `[("id", "=", 1)]`,
@@ -2555,6 +2557,7 @@ test(`datetime: "in range" operator`, async () => {
         "Year to date",
         "Last 365 days",
         "Date range",
+        "Relative range",
     ]);
 
     await selectValue("last7Days");
@@ -2585,6 +2588,22 @@ test(`datetime: "in range" operator`, async () => {
     expect(getCurrentValue()).toBe("Last 365 days");
     expect.verifySteps([`["&", ("datetime", ">=", "today -365d"), ("datetime", "<", "today")]`]);
 
+    await selectValue("relativeRange");
+    expect(`${SELECTORS.valueEditor} select:first`).toHaveValue('"relativeRange"');
+    expect.verifySteps([`["&", ("datetime", ">=", "today -1d"), ("datetime", "<", "today")]`]);
+
+    await contains(`${SELECTORS.valueEditor} input[type="number"]`).edit(-5, { instantly: true });
+    await contains(`${SELECTORS.valueEditor} select:last`).select('"month"');
+    expect.verifySteps([
+        `["&", ("datetime", ">=", "today -5d"), ("datetime", "<", "today")]`,
+        `["&", ("datetime", ">=", "today -5m"), ("datetime", "<", "today")]`,
+    ]);
+
+    // Important that it stays a relative range with 0 to make key nav work on number input
+    await contains(`${SELECTORS.valueEditor} input[type="number"]`).edit("0");
+    await animationFrame();
+    expect.verifySteps([`["&", ("datetime", ">=", "today"), ("datetime", "<", "today +1d")]`]); // When input is 0 the expression should be the same as today smart date
+
     await selectValue("dateRange");
     expect(queryOne(`${SELECTORS.valueEditor} select`).value).toBe('"dateRange"');
     expect.verifySteps([
@@ -2606,6 +2625,7 @@ test(`datetime: "in range" operator`, async () => {
 });
 
 test(`date: "in range" operator`, async () => {
+    serverState.debug = "1";
     mockDate("2023-04-20 17:00:00", 0);
     await makeDomainSelector({
         domain: `[("id", "=", 1)]`,
@@ -2630,6 +2650,7 @@ test(`date: "in range" operator`, async () => {
         "Year to date",
         "Last 365 days",
         "Date range",
+        "Relative range",
     ]);
 
     await selectValue("last7Days");
@@ -2655,6 +2676,22 @@ test(`date: "in range" operator`, async () => {
     await selectValue("last365Days");
     expect(getCurrentValue()).toBe("Last 365 days");
     expect.verifySteps([`["&", ("date", ">=", "today -365d"), ("date", "<", "today")]`]);
+
+    await selectValue("relativeRange");
+    expect(`${SELECTORS.valueEditor} select:first`).toHaveValue('"relativeRange"');
+    expect.verifySteps([`["&", ("date", ">=", "today -1d"), ("date", "<", "today")]`]);
+
+    await contains(`${SELECTORS.valueEditor} input[type="number"]`).edit(-5, { instantly: true });
+    await contains(`${SELECTORS.valueEditor} select:last`).select('"month"');
+    expect.verifySteps([
+        `["&", ("date", ">=", "today -5d"), ("date", "<", "today")]`,
+        `["&", ("date", ">=", "today -5m"), ("date", "<", "today")]`,
+    ]);
+
+    // Important that it stays a relative range with 0 to make key nav work on number input
+    await contains(`${SELECTORS.valueEditor} input[type="number"]`).edit("0");
+    await animationFrame();
+    expect.verifySteps([`["&", ("date", ">=", "today"), ("date", "<", "today +1d")]`]); // When input is 0 the expression should be the same as today smart date
 
     await selectValue("dateRange");
     expect(queryOne(`${SELECTORS.valueEditor} select`).value).toBe('"dateRange"');
@@ -2733,6 +2770,7 @@ test(`swith from [(0, "=", 1)] to other condition`, async () => {
 
 test("properties field: date & datetime", async () => {
     mockDate("2077-01-02 10:00:00", 0);
+    serverState.debug = "1";
     Partner._fields.properties = fields.Properties({
         string: "partner_properties",
         definition_record: "product_id",
@@ -2852,6 +2890,12 @@ test("properties field: date & datetime", async () => {
             operator: "in range",
             treeValue: "yearToDate",
             expectedDomain: `[("product_id", "any", ["&", ("properties.date_properties", ">=", "today =1m =1d"), ("properties.date_properties", "<", "today +1d")])]`,
+        },
+        {
+            fields: ["product", "product_properties", "date_properties"],
+            operator: "in range",
+            treeValue: "relativeRange",
+            expectedDomain: `[("product_id", "any", ["&", ("properties.date_properties", ">=", "today -1d"), ("properties.date_properties", "<", "today")])]`,
         },
     ];
     for (const value of values) {

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -2087,8 +2087,31 @@ test("datetime domain in readonly mode (check localization)", async () => {
         readonly: true,
     });
     expect(".o_tree_editor_condition").toHaveText(
-        `Datetime\nbetween\n11.03.2023 13:41:23\nand\n11.13.2023 11:45:11`
+        `Datetime\nbetween\nNov 3, 2023, 1:41 PM\nand\nNov 13, 2023, 11:45 AM`
     );
+});
+
+test("relative date domain in readonly mode", async () => {
+    await makeDomainSelector({
+        domain: `["&", ("create_date", ">", "today +1d"), ("create_date", "<=", "today +6d")]`,
+        readonly: true,
+    });
+    await makeDomainSelector({
+        domain: `["&", ("create_date", ">=", "today -5d"), ("create_date", "<", "today")]`,
+        readonly: true,
+    });
+    await makeDomainSelector({
+        domain: `["&", ("create_date", "<=", "today +6d"), ("create_date", ">", "today +1d")]`,
+        readonly: true,
+    });
+    await makeDomainSelector({
+        domain: `["&", ("create_date", "<", "today"), ("create_date", ">=", "today -5d")]`,
+        readonly: true,
+    });
+    expect(".o_tree_editor_condition:eq(0)").toHaveText("Created on\nis in\nnext\n5\ndays");
+    expect(".o_tree_editor_condition:eq(1)").toHaveText("Created on\nis in\nlast\n5\ndays");
+    expect(".o_tree_editor_condition:eq(2)").toHaveText("Created on\nis in\nnext\n5\ndays");
+    expect(".o_tree_editor_condition:eq(3)").toHaveText("Created on\nis in\nlast\n5\ndays");
 });
 
 test("date domain in readonly mode (check localization)", async () => {

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -2554,39 +2554,39 @@ test(`datetime: "in range" operator`, async () => {
         "Last month",
         "Year to date",
         "Last 365 days",
-        "Custom range",
+        "Date range",
     ]);
 
-    await selectValue("last 7 days");
+    await selectValue("last7Days");
     expect(getCurrentValue()).toBe("Last 7 days");
     expect.verifySteps([`["&", ("datetime", ">=", "today -7d"), ("datetime", "<", "today")]`]);
 
-    await selectValue("last 30 days");
+    await selectValue("last30Days");
     expect(getCurrentValue()).toBe("Last 30 days");
     expect.verifySteps([`["&", ("datetime", ">=", "today -30d"), ("datetime", "<", "today")]`]);
 
-    await selectValue("month to date");
+    await selectValue("monthToDate");
     expect(getCurrentValue()).toBe("Month to date");
     expect.verifySteps([`["&", ("datetime", ">=", "today =1d"), ("datetime", "<", "today +1d")]`]);
 
-    await selectValue("last month");
+    await selectValue("lastMonth");
     expect(getCurrentValue()).toBe("Last month");
     expect.verifySteps([
         `["&", ("datetime", ">=", "today =1d -1m"), ("datetime", "<", "today =1d")]`,
     ]);
 
-    await selectValue("year to date");
+    await selectValue("yearToDate");
     expect(getCurrentValue()).toBe("Year to date");
     expect.verifySteps([
         `["&", ("datetime", ">=", "today =1m =1d"), ("datetime", "<", "today +1d")]`,
     ]);
 
-    await selectValue("last 365 days");
+    await selectValue("last365Days");
     expect(getCurrentValue()).toBe("Last 365 days");
     expect.verifySteps([`["&", ("datetime", ">=", "today -365d"), ("datetime", "<", "today")]`]);
 
-    await selectValue("custom range");
-    expect(queryOne(`${SELECTORS.valueEditor} select`).value).toBe('"custom range"');
+    await selectValue("dateRange");
+    expect(queryOne(`${SELECTORS.valueEditor} select`).value).toBe('"dateRange"');
     expect.verifySteps([
         `["&", ("datetime", ">=", "2023-04-20 00:00:00"), ("datetime", "<=", "2023-04-20 23:59:59")]`,
     ]);
@@ -2629,35 +2629,35 @@ test(`date: "in range" operator`, async () => {
         "Last month",
         "Year to date",
         "Last 365 days",
-        "Custom range",
+        "Date range",
     ]);
 
-    await selectValue("last 7 days");
+    await selectValue("last7Days");
     expect(getCurrentValue()).toBe("Last 7 days");
     expect.verifySteps([`["&", ("date", ">=", "today -7d"), ("date", "<", "today")]`]);
 
-    await selectValue("last 30 days");
+    await selectValue("last30Days");
     expect(getCurrentValue()).toBe("Last 30 days");
     expect.verifySteps([`["&", ("date", ">=", "today -30d"), ("date", "<", "today")]`]);
 
-    await selectValue("month to date");
+    await selectValue("monthToDate");
     expect(getCurrentValue()).toBe("Month to date");
     expect.verifySteps([`["&", ("date", ">=", "today =1d"), ("date", "<", "today +1d")]`]);
 
-    await selectValue("last month");
+    await selectValue("lastMonth");
     expect(getCurrentValue()).toBe("Last month");
     expect.verifySteps([`["&", ("date", ">=", "today =1d -1m"), ("date", "<", "today =1d")]`]);
 
-    await selectValue("year to date");
+    await selectValue("yearToDate");
     expect(getCurrentValue()).toBe("Year to date");
     expect.verifySteps([`["&", ("date", ">=", "today =1m =1d"), ("date", "<", "today +1d")]`]);
 
-    await selectValue("last 365 days");
+    await selectValue("last365Days");
     expect(getCurrentValue()).toBe("Last 365 days");
     expect.verifySteps([`["&", ("date", ">=", "today -365d"), ("date", "<", "today")]`]);
 
-    await selectValue("custom range");
-    expect(queryOne(`${SELECTORS.valueEditor} select`).value).toBe('"custom range"');
+    await selectValue("dateRange");
+    expect(queryOne(`${SELECTORS.valueEditor} select`).value).toBe('"dateRange"');
     expect.verifySteps([`["&", ("date", ">=", "2023-04-20"), ("date", "<=", "2023-04-20")]`]);
 
     await contains(".o_datetime_input:last").click();
@@ -2843,14 +2843,14 @@ test("properties field: date & datetime", async () => {
         {
             fields: ["product", "product_properties", "datetime_properties"],
             operator: "in range",
-            treeValue: "last 365 days",
+            treeValue: "last365Days",
             expectedDomain:
                 '[("product_id", "any", ["&", ("properties.datetime_properties", ">=", "today -365d"), ("properties.datetime_properties", "<", "today")])]',
         },
         {
             fields: ["product", "product_properties", "date_properties"],
             operator: "in range",
-            treeValue: "year to date",
+            treeValue: "yearToDate",
             expectedDomain: `[("product_id", "any", ["&", ("properties.date_properties", ">=", "today =1m =1d"), ("properties.date_properties", "<", "today +1d")])]`,
         },
     ];

--- a/addons/web/static/tests/core/expression_editor/expression_editor.test.js
+++ b/addons/web/static/tests/core/expression_editor/expression_editor.test.js
@@ -468,6 +468,7 @@ test(`"in range" operator`, async () => {
 });
 
 test(`date: "in range" operator`, async () => {
+    serverState.debug = "1";
     mockDate("2023-04-20 17:00:00", 0);
     await makeExpressionEditor({
         expression: `id`,
@@ -492,6 +493,7 @@ test(`date: "in range" operator`, async () => {
         "Year to date",
         "Last 365 days",
         "Date range",
+        "Relative range",
     ]);
 
     const dateRangeTests = [
@@ -533,6 +535,22 @@ test(`date: "in range" operator`, async () => {
         expect.verifySteps([formatExpr(expr)]);
     }
 
+    await selectValue("relativeRange");
+    expect(`${SELECTORS.valueEditor} select:first`).toHaveValue('"relativeRange"');
+    expect.verifySteps([formatExpr(`date >= ${pyDate("days = -1")} and date < ${pyDate()}`)]);
+
+    await contains(`${SELECTORS.valueEditor} input[type="number"]`).edit(-5, { instantly: true });
+    await contains(`${SELECTORS.valueEditor} select:last`).select('"month"');
+    expect.verifySteps([
+        formatExpr(`date >= ${pyDate("days = -5")} and date < ${pyDate()}`),
+        formatExpr(`date >= ${pyDate("months = -5")} and date < ${pyDate()}`),
+    ]);
+
+    // Important that it stays a relative range with 0 to make key nav work on number input
+    await contains(`${SELECTORS.valueEditor} input[type="number"]`).edit("0");
+    await animationFrame();
+    expect.verifySteps([formatExpr(`date >= ${pyDate()} and date < ${pyDate("days = 1")}`)]); // When input is 0 the expression should be the same as today smart date
+
     await selectValue("dateRange");
     expect(queryOne(`${SELECTORS.valueEditor} select`).value).toBe('"dateRange"');
     expect.verifySteps([formatExpr(`date >= "2023-04-20" and date <= "2023-04-20"`)]);
@@ -546,10 +564,11 @@ test(`date: "in range" operator`, async () => {
     await selectValue("today");
     expect(getCurrentOperator()).toBe(label("in range"));
     expect(getCurrentValue()).toBe("Today");
-    expect.verifySteps([formatExpr(`date >= ${pyDate("today")} and date < ${pyDate("days = 1")}`)]);
+    expect.verifySteps([formatExpr(`date >= ${pyDate()} and date < ${pyDate("days = 1")}`)]);
 });
 
 test(`datetime: "in range" operator`, async () => {
+    serverState.debug = "1";
     mockDate("2023-04-20 17:00:00", 0);
     await makeExpressionEditor({
         expression: `id`,
@@ -576,6 +595,7 @@ test(`datetime: "in range" operator`, async () => {
         "Year to date",
         "Last 365 days",
         "Date range",
+        "Relative range",
     ]);
 
     const datetimeRangeTests = [
@@ -620,6 +640,26 @@ test(`datetime: "in range" operator`, async () => {
         expect(getCurrentValue()).toBe(label);
         expect.verifySteps([formatExpr(expr)]);
     }
+
+    await selectValue("relativeRange");
+    expect(`${SELECTORS.valueEditor} select:first`).toHaveValue('"relativeRange"');
+    expect.verifySteps([
+        formatExpr(`datetime >= ${pyDatetime("days = -1")} and datetime < ${pyDatetime()}`),
+    ]);
+
+    await contains(`${SELECTORS.valueEditor} input[type="number"]`).edit(-5, { instantly: true });
+    await contains(`${SELECTORS.valueEditor} select:last`).select('"month"');
+    expect.verifySteps([
+        formatExpr(`datetime >= ${pyDatetime("days = -5")} and datetime < ${pyDatetime()}`),
+        formatExpr(`datetime >= ${pyDatetime("months = -5")} and datetime < ${pyDatetime()}`),
+    ]);
+
+    // Important that it stays a relative range with 0 to make key nav work on number input
+    await contains(`${SELECTORS.valueEditor} input[type="number"]`).edit("0");
+    await animationFrame();
+    expect.verifySteps([
+        formatExpr(`datetime >= ${pyDatetime()} and datetime < ${pyDatetime("days = 1")}`),
+    ]);
 
     await selectValue("dateRange");
     expect(queryOne(`${SELECTORS.valueEditor} select`).value).toBe('"dateRange"');

--- a/addons/web/static/tests/core/expression_editor/expression_editor.test.js
+++ b/addons/web/static/tests/core/expression_editor/expression_editor.test.js
@@ -491,37 +491,37 @@ test(`date: "in range" operator`, async () => {
         "Last month",
         "Year to date",
         "Last 365 days",
-        "Custom range",
+        "Date range",
     ]);
 
     const dateRangeTests = [
         {
-            val: "last 7 days",
+            val: "last7Days",
             label: "Last 7 days",
             expr: `date >= ${pyDate("days = -7")} and date < ${pyDate()}`,
         },
         {
-            val: "last 30 days",
+            val: "last30Days",
             label: "Last 30 days",
             expr: `date >= ${pyDate("days = -30")} and date < ${pyDate()}`,
         },
         {
-            val: "month to date",
+            val: "monthToDate",
             label: "Month to date",
             expr: `date >= ${pyDate("day = 1")} and date < ${pyDate("days = 1")}`,
         },
         {
-            val: "last month",
+            val: "lastMonth",
             label: "Last month",
             expr: `date >= ${pyDate("day = 1, months = -1")} and date < ${pyDate("day = 1")}`,
         },
         {
-            val: "year to date",
+            val: "yearToDate",
             label: "Year to date",
             expr: `date >= ${pyDate("day = 1, month = 1")} and date < ${pyDate("days = 1")}`,
         },
         {
-            val: "last 365 days",
+            val: "last365Days",
             label: "Last 365 days",
             expr: `date >= ${pyDate("days = -365")} and date < ${pyDate()}`,
         },
@@ -533,8 +533,8 @@ test(`date: "in range" operator`, async () => {
         expect.verifySteps([formatExpr(expr)]);
     }
 
-    await selectValue("custom range");
-    expect(queryOne(`${SELECTORS.valueEditor} select`).value).toBe('"custom range"');
+    await selectValue("dateRange");
+    expect(queryOne(`${SELECTORS.valueEditor} select`).value).toBe('"dateRange"');
     expect.verifySteps([formatExpr(`date >= "2023-04-20" and date <= "2023-04-20"`)]);
 
     await contains(".o_datetime_input:last").click();
@@ -575,41 +575,41 @@ test(`datetime: "in range" operator`, async () => {
         "Last month",
         "Year to date",
         "Last 365 days",
-        "Custom range",
+        "Date range",
     ]);
 
     const datetimeRangeTests = [
         {
-            val: "last 7 days",
+            val: "last7Days",
             label: "Last 7 days",
             expr: `datetime >= ${pyDatetime("days = -7")} and datetime < ${pyDatetime()}`,
         },
         {
-            val: "last 30 days",
+            val: "last30Days",
             label: "Last 30 days",
             expr: `datetime >= ${pyDatetime("days = -30")} and datetime < ${pyDatetime()}`,
         },
         {
-            val: "month to date",
+            val: "monthToDate",
             label: "Month to date",
             expr: `datetime >= ${pyDatetime("day = 1")} and datetime < ${pyDatetime("days = 1")}`,
         },
         {
-            val: "last month",
+            val: "lastMonth",
             label: "Last month",
             expr: `datetime >= ${pyDatetime("day = 1, months = -1")} and datetime < ${pyDatetime(
                 "day = 1"
             )}`,
         },
         {
-            val: "year to date",
+            val: "yearToDate",
             label: "Year to date",
             expr: `datetime >= ${pyDatetime("day = 1, month = 1")} and datetime < ${pyDatetime(
                 "days = 1"
             )}`,
         },
         {
-            val: "last 365 days",
+            val: "last365Days",
             label: "Last 365 days",
             expr: `datetime >= ${pyDatetime("days = -365")} and datetime < ${pyDatetime()}`,
         },
@@ -621,8 +621,8 @@ test(`datetime: "in range" operator`, async () => {
         expect.verifySteps([formatExpr(expr)]);
     }
 
-    await selectValue("custom range");
-    expect(queryOne(`${SELECTORS.valueEditor} select`).value).toBe('"custom range"');
+    await selectValue("dateRange");
+    expect(queryOne(`${SELECTORS.valueEditor} select`).value).toBe('"dateRange"');
     expect.verifySteps([
         formatExpr(`datetime >= "2023-04-20 00:00:00" and datetime <= "2023-04-20 23:59:59"`),
     ]);

--- a/addons/web/static/tests/core/tree_editor/in_range_operator.test.js
+++ b/addons/web/static/tests/core/tree_editor/in_range_operator.test.js
@@ -80,6 +80,12 @@ test(`"in range" operator: no introduction for complex paths (generateSmartDates
         },
         {
             tree_py: and([
+                condition("m2o.dt_2", ">=", "today -5d"),
+                condition("m2o.dt_2", "<", "today"),
+            ]),
+        },
+        {
+            tree_py: and([
                 condition("m2o.date_2", ">=", DATE_START),
                 condition("m2o.date_2", "<=", DATE_END),
             ]),
@@ -169,6 +175,18 @@ test(`"in range" operator: introduction/elimination for datetime fields (generat
         },
         {
             tree_py: and([
+                condition("dt_1", ">=", pyDatetime("today")),
+                condition("dt_1", "<", pyDatetime("days = 1")),
+            ]),
+            tree: inRange("dt_1", ["datetime", "today", false, false]),
+            domain: [
+                "&",
+                ["dt_1", ">=", "2025-07-02 23:00:00"],
+                ["dt_1", "<", "2025-07-03 23:00:00"],
+            ],
+        },
+        {
+            tree_py: and([
                 condition("dt_1", ">=", pyDatetime("days = -7")),
                 condition("dt_1", "<", pyDatetime("today")),
             ]),
@@ -230,13 +248,37 @@ test(`"in range" operator: introduction/elimination for datetime fields (generat
         {
             tree_py: and([
                 condition("dt_1", ">=", pyDatetime("days = -365")),
-                condition("dt_1", "<", pyDatetime()),
+                condition("dt_1", "<", pyDatetime("today")),
             ]),
             tree: inRange("dt_1", ["datetime", "last365Days", false, false]),
             domain: [
                 "&",
                 ["dt_1", ">=", "2024-07-02 23:00:00"],
                 ["dt_1", "<", "2025-07-02 23:00:00"],
+            ],
+        },
+        {
+            tree_py: and([
+                condition("dt_1", ">=", pyDatetime("days = -8")),
+                condition("dt_1", "<", pyDatetime("today")),
+            ]),
+            tree: inRange("dt_1", ["datetime", "relativeRange", -8, "day"]),
+            domain: [
+                "&",
+                ["dt_1", ">=", "2025-06-24 23:00:00"],
+                ["dt_1", "<", "2025-07-02 23:00:00"],
+            ],
+        },
+        {
+            tree_py: and([
+                condition("dt_1", ">", pyDatetime("days = 1")),
+                condition("dt_1", "<=", pyDatetime("weeks = 8, days = 1")),
+            ]),
+            tree: inRange("dt_1", ["datetime", "relativeRange", 8, "week"]),
+            domain: [
+                "&",
+                ["dt_1", ">", "2025-07-03 23:00:00"],
+                ["dt_1", "<=", "2025-08-28 23:00:00"],
             ],
         },
         {
@@ -342,6 +384,22 @@ test(`"in range" operator: introduction/elimination for date fields (generateSma
             ]),
             tree: inRange("date_1", ["date", "last365Days", false, false]),
             domain: ["&", ["date_1", ">=", "2024-07-03"], ["date_1", "<", "2025-07-03"]],
+        },
+        {
+            tree_py: and([
+                condition("date_1", ">=", pyDate("days = -8")),
+                condition("date_1", "<", pyDate("today")),
+            ]),
+            tree: inRange("date_1", ["date", "relativeRange", -8, "day"]),
+            domain: ["&", ["date_1", ">=", "2025-06-25"], ["date_1", "<", "2025-07-03"]],
+        },
+        {
+            tree_py: and([
+                condition("date_1", ">", pyDate("today")),
+                condition("date_1", "<=", pyDate("weeks = 8")),
+            ]),
+            tree: inRange("date_1", ["date", "relativeRange", 8, "week"]),
+            domain: ["&", ["date_1", ">", "2025-07-03"], ["date_1", "<=", "2025-08-28"]],
         },
         {
             tree_py: and(
@@ -542,6 +600,19 @@ test(`"in range" operator: introduction/elimination for datetime fields`, async 
             tree_py: and([condition("dt_1", ">=", "today -365d"), condition("dt_1", "<", "today")]),
             tree: inRange("dt_1", ["datetime", "last365Days", false, false]),
             domain: ["&", ["dt_1", ">=", "today -365d"], ["dt_1", "<", "today"]],
+        },
+        {
+            tree_py: and([condition("dt_1", ">=", "today -8d"), condition("dt_1", "<", "today")]),
+            tree: inRange("dt_1", ["datetime", "relativeRange", -8, "day"]),
+            domain: ["&", ["dt_1", ">=", "today -8d"], ["dt_1", "<", "today"]],
+        },
+        {
+            tree_py: and([
+                condition("dt_1", ">", "today +1d"),
+                condition("dt_1", "<=", "today +8w +1d"),
+            ]),
+            tree: inRange("dt_1", ["datetime", "relativeRange", 8, "week"]),
+            domain: ["&", ["dt_1", ">", "today +1d"], ["dt_1", "<=", "today +8w +1d"]],
         },
         {
             tree_py: and(

--- a/addons/web/static/tests/core/tree_editor/in_range_operator.test.js
+++ b/addons/web/static/tests/core/tree_editor/in_range_operator.test.js
@@ -164,7 +164,7 @@ test(`"in range" operator: introduction/elimination for datetime fields (generat
     const toTest = [
         {
             tree_py: and([condition("dt_1", ">=", DATE_START), condition("dt_1", "<=", DATE_END)]),
-            tree: inRange("dt_1", ["datetime", "custom range", DATE_START, DATE_END]),
+            tree: inRange("dt_1", ["datetime", "dateRange", DATE_START, DATE_END]),
             domain: ["&", ["dt_1", ">=", DATE_START], ["dt_1", "<=", DATE_END]],
         },
         {
@@ -172,7 +172,7 @@ test(`"in range" operator: introduction/elimination for datetime fields (generat
                 condition("dt_1", ">=", pyDatetime("days = -7")),
                 condition("dt_1", "<", pyDatetime("today")),
             ]),
-            tree: inRange("dt_1", ["datetime", "last 7 days", false, false]),
+            tree: inRange("dt_1", ["datetime", "last7Days", false, false]),
             domain: [
                 "&",
                 ["dt_1", ">=", "2025-06-25 23:00:00"],
@@ -184,7 +184,7 @@ test(`"in range" operator: introduction/elimination for datetime fields (generat
                 condition("dt_1", ">=", pyDatetime("days = -30")),
                 condition("dt_1", "<", pyDatetime("today")),
             ]),
-            tree: inRange("dt_1", ["datetime", "last 30 days", false, false]),
+            tree: inRange("dt_1", ["datetime", "last30Days", false, false]),
             domain: [
                 "&",
                 ["dt_1", ">=", "2025-06-02 23:00:00"],
@@ -196,7 +196,7 @@ test(`"in range" operator: introduction/elimination for datetime fields (generat
                 condition("dt_1", ">=", pyDatetime("day = 1")),
                 condition("dt_1", "<", pyDatetime("days = 1")),
             ]),
-            tree: inRange("dt_1", ["datetime", "month to date", false, false]),
+            tree: inRange("dt_1", ["datetime", "monthToDate", false, false]),
             domain: [
                 "&",
                 ["dt_1", ">=", "2025-06-30 23:00:00"],
@@ -208,7 +208,7 @@ test(`"in range" operator: introduction/elimination for datetime fields (generat
                 condition("dt_1", ">=", pyDatetime("day = 1, months = -1")),
                 condition("dt_1", "<", pyDatetime("day = 1")),
             ]),
-            tree: inRange("dt_1", ["datetime", "last month", false, false]),
+            tree: inRange("dt_1", ["datetime", "lastMonth", false, false]),
             domain: [
                 "&",
                 ["dt_1", ">=", "2025-05-31 23:00:00"],
@@ -220,7 +220,7 @@ test(`"in range" operator: introduction/elimination for datetime fields (generat
                 condition("dt_1", ">=", pyDatetime("day = 1, month = 1")),
                 condition("dt_1", "<", pyDatetime("days = 1")),
             ]),
-            tree: inRange("dt_1", ["datetime", "year to date", false, false]),
+            tree: inRange("dt_1", ["datetime", "yearToDate", false, false]),
             domain: [
                 "&",
                 ["dt_1", ">=", "2024-12-31 23:00:00"],
@@ -232,7 +232,7 @@ test(`"in range" operator: introduction/elimination for datetime fields (generat
                 condition("dt_1", ">=", pyDatetime("days = -365")),
                 condition("dt_1", "<", pyDatetime()),
             ]),
-            tree: inRange("dt_1", ["datetime", "last 365 days", false, false]),
+            tree: inRange("dt_1", ["datetime", "last365Days", false, false]),
             domain: [
                 "&",
                 ["dt_1", ">=", "2024-07-02 23:00:00"],
@@ -244,14 +244,14 @@ test(`"in range" operator: introduction/elimination for datetime fields (generat
                 [condition("dt_1", ">=", DATE_START), condition("dt_1", "<=", DATE_END)],
                 true
             ),
-            tree: inRange("dt_1", ["datetime", "custom range", DATE_START, DATE_END], true),
+            tree: inRange("dt_1", ["datetime", "dateRange", DATE_START, DATE_END], true),
             domain: ["!", "&", ["dt_1", ">=", DATE_START], ["dt_1", "<=", DATE_END]],
         },
         {
             tree_py: m2oAny(
                 and([condition("dt_2", ">=", DATE_START), condition("dt_2", "<=", DATE_END)])
             ),
-            tree: inRange("m2o.dt_2", ["datetime", "custom range", DATE_START, DATE_END]),
+            tree: inRange("m2o.dt_2", ["datetime", "dateRange", DATE_START, DATE_END]),
             domain: [["m2o", "any", ["&", ["dt_2", ">=", DATE_START], ["dt_2", "<=", DATE_END]]]],
         },
         {
@@ -259,7 +259,7 @@ test(`"in range" operator: introduction/elimination for datetime fields (generat
                 and([condition("dt_2", ">=", DATE_START), condition("dt_2", "<=", DATE_END)]),
                 true
             ),
-            tree: m2oAny(inRange("dt_2", ["datetime", "custom range", DATE_START, DATE_END]), true),
+            tree: m2oAny(inRange("dt_2", ["datetime", "dateRange", DATE_START, DATE_END]), true),
             domain: [
                 "!",
                 ["m2o", "any", ["&", ["dt_2", ">=", DATE_START], ["dt_2", "<=", DATE_END]]],
@@ -284,7 +284,7 @@ test(`"in range" operator: introduction/elimination for date fields (generateSma
                 condition("date_1", ">=", DATE_START),
                 condition("date_1", "<=", DATE_END),
             ]),
-            tree: inRange("date_1", ["date", "custom range", DATE_START, DATE_END]),
+            tree: inRange("date_1", ["date", "dateRange", DATE_START, DATE_END]),
             domain: ["&", ["date_1", ">=", DATE_START], ["date_1", "<=", DATE_END]],
         },
         {
@@ -300,7 +300,7 @@ test(`"in range" operator: introduction/elimination for date fields (generateSma
                 condition("date_1", ">=", pyDate("days = -7")),
                 condition("date_1", "<", pyDate("today")),
             ]),
-            tree: inRange("date_1", ["date", "last 7 days", false, false]),
+            tree: inRange("date_1", ["date", "last7Days", false, false]),
             domain: ["&", ["date_1", ">=", "2025-06-26"], ["date_1", "<", "2025-07-03"]],
         },
         {
@@ -308,7 +308,7 @@ test(`"in range" operator: introduction/elimination for date fields (generateSma
                 condition("date_1", ">=", pyDate("days = -30")),
                 condition("date_1", "<", pyDate("today")),
             ]),
-            tree: inRange("date_1", ["date", "last 30 days", false, false]),
+            tree: inRange("date_1", ["date", "last30Days", false, false]),
             domain: ["&", ["date_1", ">=", "2025-06-03"], ["date_1", "<", "2025-07-03"]],
         },
         {
@@ -316,7 +316,7 @@ test(`"in range" operator: introduction/elimination for date fields (generateSma
                 condition("date_1", ">=", pyDate("day = 1")),
                 condition("date_1", "<", pyDate("days = 1")),
             ]),
-            tree: inRange("date_1", ["date", "month to date", false, false]),
+            tree: inRange("date_1", ["date", "monthToDate", false, false]),
             domain: ["&", ["date_1", ">=", "2025-07-01"], ["date_1", "<", "2025-07-04"]],
         },
         {
@@ -324,7 +324,7 @@ test(`"in range" operator: introduction/elimination for date fields (generateSma
                 condition("date_1", ">=", pyDate("day = 1, months = -1")),
                 condition("date_1", "<", pyDate("day = 1")),
             ]),
-            tree: inRange("date_1", ["date", "last month", false, false]),
+            tree: inRange("date_1", ["date", "lastMonth", false, false]),
             domain: ["&", ["date_1", ">=", "2025-06-01"], ["date_1", "<", "2025-07-01"]],
         },
         {
@@ -332,15 +332,15 @@ test(`"in range" operator: introduction/elimination for date fields (generateSma
                 condition("date_1", ">=", pyDate("day = 1, month = 1")),
                 condition("date_1", "<", pyDate("days = 1")),
             ]),
-            tree: inRange("date_1", ["date", "year to date", false, false]),
+            tree: inRange("date_1", ["date", "yearToDate", false, false]),
             domain: ["&", ["date_1", ">=", "2025-01-01"], ["date_1", "<", "2025-07-04"]],
         },
         {
             tree_py: and([
-                condition("date_1", ">=", pyDate("days = - 365")),
-                condition("date_1", "<", pyDate()),
+                condition("date_1", ">=", pyDate("days = -365")),
+                condition("date_1", "<", pyDate("today")),
             ]),
-            tree: inRange("date_1", ["date", "last 365 days", false, false]),
+            tree: inRange("date_1", ["date", "last365Days", false, false]),
             domain: ["&", ["date_1", ">=", "2024-07-03"], ["date_1", "<", "2025-07-03"]],
         },
         {
@@ -348,14 +348,14 @@ test(`"in range" operator: introduction/elimination for date fields (generateSma
                 [condition("date_1", ">=", DATE_START), condition("date_1", "<=", DATE_END)],
                 true
             ),
-            tree: inRange("date_1", ["date", "custom range", DATE_START, DATE_END], true),
+            tree: inRange("date_1", ["date", "dateRange", DATE_START, DATE_END], true),
             domain: ["!", "&", ["date_1", ">=", DATE_START], ["date_1", "<=", DATE_END]],
         },
         {
             tree_py: m2oAny(
                 and([condition("date_2", ">=", DATE_START), condition("date_2", "<=", DATE_END)])
             ),
-            tree: inRange("m2o.date_2", ["date", "custom range", DATE_START, DATE_END]),
+            tree: inRange("m2o.date_2", ["date", "dateRange", DATE_START, DATE_END]),
             domain: [
                 ["m2o", "any", ["&", ["date_2", ">=", DATE_START], ["date_2", "<=", DATE_END]]],
             ],
@@ -365,7 +365,7 @@ test(`"in range" operator: introduction/elimination for date fields (generateSma
                 and([condition("date_2", ">=", DATE_START), condition("date_2", "<=", DATE_END)]),
                 true
             ),
-            tree: m2oAny(inRange("date_2", ["date", "custom range", DATE_START, DATE_END]), true),
+            tree: m2oAny(inRange("date_2", ["date", "dateRange", DATE_START, DATE_END]), true),
             domain: [
                 "!",
                 ["m2o", "any", ["&", ["date_2", ">=", DATE_START], ["date_2", "<=", DATE_END]]],
@@ -496,7 +496,7 @@ test(`"in range" operator: introduction/elimination for datetime fields`, async 
     const toTest = [
         {
             tree_py: and([condition("dt_1", ">=", DATE_START), condition("dt_1", "<=", DATE_END)]),
-            tree: inRange("dt_1", ["datetime", "custom range", DATE_START, DATE_END]),
+            tree: inRange("dt_1", ["datetime", "dateRange", DATE_START, DATE_END]),
             domain: ["&", ["dt_1", ">=", DATE_START], ["dt_1", "<=", DATE_END]],
         },
         {
@@ -506,12 +506,12 @@ test(`"in range" operator: introduction/elimination for datetime fields`, async 
         },
         {
             tree_py: and([condition("dt_1", ">=", "today -7d"), condition("dt_1", "<", "today")]),
-            tree: inRange("dt_1", ["datetime", "last 7 days", false, false]),
+            tree: inRange("dt_1", ["datetime", "last7Days", false, false]),
             domain: ["&", ["dt_1", ">=", "today -7d"], ["dt_1", "<", "today"]],
         },
         {
             tree_py: and([condition("dt_1", ">=", "today -30d"), condition("dt_1", "<", "today")]),
-            tree: inRange("dt_1", ["datetime", "last 30 days", false, false]),
+            tree: inRange("dt_1", ["datetime", "last30Days", false, false]),
             domain: ["&", ["dt_1", ">=", "today -30d"], ["dt_1", "<", "today"]],
         },
         {
@@ -519,7 +519,7 @@ test(`"in range" operator: introduction/elimination for datetime fields`, async 
                 condition("dt_1", ">=", "today =1d"),
                 condition("dt_1", "<", "today +1d"),
             ]),
-            tree: inRange("dt_1", ["datetime", "month to date", false, false]),
+            tree: inRange("dt_1", ["datetime", "monthToDate", false, false]),
             domain: ["&", ["dt_1", ">=", "today =1d"], ["dt_1", "<", "today +1d"]],
         },
         {
@@ -527,7 +527,7 @@ test(`"in range" operator: introduction/elimination for datetime fields`, async 
                 condition("dt_1", ">=", "today =1d -1m"),
                 condition("dt_1", "<", "today =1d"),
             ]),
-            tree: inRange("dt_1", ["datetime", "last month", false, false]),
+            tree: inRange("dt_1", ["datetime", "lastMonth", false, false]),
             domain: ["&", ["dt_1", ">=", "today =1d -1m"], ["dt_1", "<", "today =1d"]],
         },
         {
@@ -535,12 +535,12 @@ test(`"in range" operator: introduction/elimination for datetime fields`, async 
                 condition("dt_1", ">=", "today =1m =1d"),
                 condition("dt_1", "<", "today +1d"),
             ]),
-            tree: inRange("dt_1", ["datetime", "year to date", false, false]),
+            tree: inRange("dt_1", ["datetime", "yearToDate", false, false]),
             domain: ["&", ["dt_1", ">=", "today =1m =1d"], ["dt_1", "<", "today +1d"]],
         },
         {
             tree_py: and([condition("dt_1", ">=", "today -365d"), condition("dt_1", "<", "today")]),
-            tree: inRange("dt_1", ["datetime", "last 365 days", false, false]),
+            tree: inRange("dt_1", ["datetime", "last365Days", false, false]),
             domain: ["&", ["dt_1", ">=", "today -365d"], ["dt_1", "<", "today"]],
         },
         {
@@ -548,14 +548,14 @@ test(`"in range" operator: introduction/elimination for datetime fields`, async 
                 [condition("dt_1", ">=", DATE_START), condition("dt_1", "<=", DATE_END)],
                 true
             ),
-            tree: inRange("dt_1", ["datetime", "custom range", DATE_START, DATE_END], true),
+            tree: inRange("dt_1", ["datetime", "dateRange", DATE_START, DATE_END], true),
             domain: ["!", "&", ["dt_1", ">=", DATE_START], ["dt_1", "<=", DATE_END]],
         },
         {
             tree_py: m2oAny(
                 and([condition("dt_2", ">=", DATE_START), condition("dt_2", "<=", DATE_END)])
             ),
-            tree: inRange("m2o.dt_2", ["datetime", "custom range", DATE_START, DATE_END]),
+            tree: inRange("m2o.dt_2", ["datetime", "dateRange", DATE_START, DATE_END]),
             domain: [["m2o", "any", ["&", ["dt_2", ">=", DATE_START], ["dt_2", "<=", DATE_END]]]],
         },
         {
@@ -563,7 +563,7 @@ test(`"in range" operator: introduction/elimination for datetime fields`, async 
                 and([condition("dt_2", ">=", DATE_START), condition("dt_2", "<=", DATE_END)]),
                 true
             ),
-            tree: m2oAny(inRange("dt_2", ["datetime", "custom range", DATE_START, DATE_END]), true),
+            tree: m2oAny(inRange("dt_2", ["datetime", "dateRange", DATE_START, DATE_END]), true),
             domain: [
                 "!",
                 ["m2o", "any", ["&", ["dt_2", ">=", DATE_START], ["dt_2", "<=", DATE_END]]],
@@ -595,7 +595,7 @@ test(`"in range" operator: introduction/elimination for date fields`, async () =
                 condition("date_1", ">=", "today -7d"),
                 condition("date_1", "<", "today"),
             ]),
-            tree: inRange("date_1", ["date", "last 7 days", false, false]),
+            tree: inRange("date_1", ["date", "last7Days", false, false]),
             domain: ["&", ["date_1", ">=", "today -7d"], ["date_1", "<", "today"]],
         },
         {
@@ -603,7 +603,7 @@ test(`"in range" operator: introduction/elimination for date fields`, async () =
                 condition("date_1", ">=", "today -30d"),
                 condition("date_1", "<", "today"),
             ]),
-            tree: inRange("date_1", ["date", "last 30 days", false, false]),
+            tree: inRange("date_1", ["date", "last30Days", false, false]),
             domain: ["&", ["date_1", ">=", "today -30d"], ["date_1", "<", "today"]],
         },
         {
@@ -611,7 +611,7 @@ test(`"in range" operator: introduction/elimination for date fields`, async () =
                 condition("date_1", ">=", "today =1d"),
                 condition("date_1", "<", "today +1d"),
             ]),
-            tree: inRange("date_1", ["date", "month to date", false, false]),
+            tree: inRange("date_1", ["date", "monthToDate", false, false]),
             domain: ["&", ["date_1", ">=", "today =1d"], ["date_1", "<", "today +1d"]],
         },
         {
@@ -619,7 +619,7 @@ test(`"in range" operator: introduction/elimination for date fields`, async () =
                 condition("date_1", ">=", "today =1d -1m"),
                 condition("date_1", "<", "today =1d"),
             ]),
-            tree: inRange("date_1", ["date", "last month", false, false]),
+            tree: inRange("date_1", ["date", "lastMonth", false, false]),
             domain: ["&", ["date_1", ">=", "today =1d -1m"], ["date_1", "<", "today =1d"]],
         },
         {
@@ -627,7 +627,7 @@ test(`"in range" operator: introduction/elimination for date fields`, async () =
                 condition("date_1", ">=", "today =1m =1d"),
                 condition("date_1", "<", "today +1d"),
             ]),
-            tree: inRange("date_1", ["date", "year to date", false, false]),
+            tree: inRange("date_1", ["date", "yearToDate", false, false]),
             domain: ["&", ["date_1", ">=", "today =1m =1d"], ["date_1", "<", "today +1d"]],
         },
         {
@@ -635,7 +635,7 @@ test(`"in range" operator: introduction/elimination for date fields`, async () =
                 condition("date_1", ">=", "today -365d"),
                 condition("date_1", "<", "today"),
             ]),
-            tree: inRange("date_1", ["date", "last 365 days", false, false]),
+            tree: inRange("date_1", ["date", "last365Days", false, false]),
             domain: ["&", ["date_1", ">=", "today -365d"], ["date_1", "<", "today"]],
         },
         {
@@ -643,7 +643,7 @@ test(`"in range" operator: introduction/elimination for date fields`, async () =
                 condition("date_1", ">=", DATE_START),
                 condition("date_1", "<=", DATE_END),
             ]),
-            tree: inRange("date_1", ["date", "custom range", DATE_START, DATE_END]),
+            tree: inRange("date_1", ["date", "dateRange", DATE_START, DATE_END]),
             domain: ["&", ["date_1", ">=", DATE_START], ["date_1", "<=", DATE_END]],
         },
         {
@@ -651,14 +651,14 @@ test(`"in range" operator: introduction/elimination for date fields`, async () =
                 [condition("date_1", ">=", DATE_START), condition("date_1", "<=", DATE_END)],
                 true
             ),
-            tree: inRange("date_1", ["date", "custom range", DATE_START, DATE_END], true),
+            tree: inRange("date_1", ["date", "dateRange", DATE_START, DATE_END], true),
             domain: ["!", "&", ["date_1", ">=", DATE_START], ["date_1", "<=", DATE_END]],
         },
         {
             tree_py: m2oAny(
                 and([condition("date_2", ">=", DATE_START), condition("date_2", "<=", DATE_END)])
             ),
-            tree: inRange("m2o.date_2", ["date", "custom range", DATE_START, DATE_END]),
+            tree: inRange("m2o.date_2", ["date", "dateRange", DATE_START, DATE_END]),
             domain: [
                 ["m2o", "any", ["&", ["date_2", ">=", DATE_START], ["date_2", "<=", DATE_END]]],
             ],
@@ -668,7 +668,7 @@ test(`"in range" operator: introduction/elimination for date fields`, async () =
                 and([condition("date_2", ">=", DATE_START), condition("date_2", "<=", DATE_END)]),
                 true
             ),
-            tree: m2oAny(inRange("date_2", ["date", "custom range", DATE_START, DATE_END]), true),
+            tree: m2oAny(inRange("date_2", ["date", "dateRange", DATE_START, DATE_END]), true),
             domain: [
                 "!",
                 ["m2o", "any", ["&", ["date_2", ">=", DATE_START], ["date_2", "<=", DATE_END]]],

--- a/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
+++ b/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
@@ -1116,7 +1116,7 @@ test(`"in range" facets`, async () => {
         ".o_model_field_selector_popover .o_model_field_selector_popover_item_name:contains(Birthday)"
     ).click();
     await addNewRule();
-    await selectValue("custom range");
+    await selectValue("dateRange");
     await contains(".modal footer button").click();
     expect(getFacetTexts()).toEqual([
         "Birthday between 03/11/2019 and 03/11/2019 or Birthday is in Today",

--- a/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
+++ b/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
@@ -885,6 +885,49 @@ test("display of (not) set in facets", async () => {
     expect(searchBar.env.searchModel.domain).toEqual([["boolean", "=", false]]);
 });
 
+test("relative date and datetime fields facets display", async () => {
+    serverState.debug = "1";
+    onRpc("/web/domain/validate", () => true);
+    const searchBar = await mountWithSearch(SearchBar, {
+        resModel: "foo",
+        searchMenuTypes: ["filter"],
+        searchViewId: false,
+        searchViewArch: `<search/>`,
+    });
+    expect(getFacetTexts()).toEqual([]);
+    expect(searchBar.env.searchModel.domain).toEqual([]);
+
+    // Pick a datetime field and select relative range option
+    await toggleSearchBarMenu();
+    await openAddCustomFilterDialog();
+    await openModelFieldSelectorPopover();
+    await contains(".o_model_field_selector_popover_item_name:contains(create_date)").click();
+    await selectValue("relativeRange");
+
+    // First test -5 months labels
+    await contains(`${SELECTORS.valueEditor} input[type="number"]`).edit(-5, { instantly: true });
+    await contains(`${SELECTORS.valueEditor} select:last`).select('"month"');
+    await contains(".modal footer button").click();
+    expect(getFacetTexts()).toEqual(["Created on is in last 5 months"]);
+    expect(searchBar.env.searchModel.domain).toEqual([
+        "&",
+        ["create_date", ">=", "today -5m"],
+        ["create_date", "<", "today"],
+    ]);
+
+    // Then test +6 weeks weeks labels
+    await contains(".o_searchview_facet_label").click();
+    await contains(`${SELECTORS.valueEditor} input[type="number"]`).edit(6, { instantly: true });
+    await contains(`${SELECTORS.valueEditor} select:last`).select('"week"');
+    await contains(".modal footer button").click();
+    expect(getFacetTexts()).toEqual(["Created on is in next 6 weeks"]);
+    expect(searchBar.env.searchModel.domain).toEqual([
+        "&",
+        ["create_date", ">", "today +1d"],
+        ["create_date", "<=", "today +6w +1d"],
+    ]);
+});
+
 test("Add a custom filter: notification on invalid domain", async () => {
     serverState.debug = "1";
     mockService("notification", {


### PR DESCRIPTION
Changes the option of the date domain selector from a options containing spaces to camelCase to follow convention. Also removes duplicated tests.

enterprise PR: odoo/enterprise#112739

task#5959944
