### PR TITLE
[FIX] mail, *: allow navigating back from message search panel

### DIFF
--- a/addons/crm_livechat/static/src/core/thread_actions.js
+++ b/addons/crm_livechat/static/src/core/thread_actions.js
@@ -9,15 +9,14 @@ import { usePopover } from "@web/core/popover/popover_hook";
 registerThreadAction("create-lead", {
     actionPanelClose: ({ action }) => action.popover?.close(),
     actionPanelComponent: LivechatCommandDialog,
-    actionPanelComponentProps: ({ action, thread }) => ({
-        close: () => action.actionPanelClose(),
+    actionPanelComponentProps: ({ thread }) => ({
         commandName: "lead",
         placeholderText: _t("e.g. Product pricing"),
         thread,
         title: _t("Create Lead"),
         icon: "fa fa-handshake-o",
     }),
-    actionPanelOpen({ owner, thread }) {
+    actionPanelOpen({ owner }) {
         this.popover?.open(
             owner.root.el.querySelector(`[name="${this.id}"]`),
             this.actionPanelComponentProps

--- a/addons/im_livechat/static/src/core/common/livechat_command_dialog.xml
+++ b/addons/im_livechat/static/src/core/common/livechat_command_dialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="im_livechat.LivechatCommandDialog">
-        <ActionPanel title="props.title" icon="props.icon" resizable="false">
+        <ActionPanel close="props.close" title="props.title" icon="props.icon" resizable="false">
             <div class="input-group my-2 shadow-sm">
                 <div class="o-livechat-LivechatCommandDialog-form form-control bg-view p-0" aria-autocomplete="list">
                     <input type="text" class="border-0 h-100 rounded px-2 form-control" accesskey="Q" t-att-placeholder="props.placeholderText" t-on-keydown="onKeydown" t-ref="autofocus" t-model="state.inputText"/>

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.js
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.js
@@ -14,7 +14,7 @@ import { url } from "@web/core/utils/urls";
 export class LivechatChannelInfoList extends Component {
     static components = { ActionPanel, ExpertiseTagsAutocomplete, TranscriptSender };
     static template = "im_livechat.LivechatChannelInfoList";
-    static props = ["thread"];
+    static props = ["close?", "thread"];
 
     setup() {
         super.setup();

--- a/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_info_list.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="im_livechat.LivechatChannelInfoList">
-        <ActionPanel title.translate="Information" minWidth="200" initialWidth="env.inMeetingView ? 400 : 300" icon="'fa fa-info'">
+        <ActionPanel close="props.close" title.translate="Information" minWidth="200" initialWidth="env.inMeetingView ? 400 : 300" icon="'fa fa-info'">
             <a t-if="visitorProfileURL" class="btn btn-primary mt-1 d-flex align-items-center justify-content-between" t-on-click.prevent="openVisitorProfile" t-att-href="visitorProfileURL" title="View Contact">
                 <span class="flex-grow-1 text-center">
                     <i class="fa fa-address-book-o opacity-50 me-1"/>

--- a/addons/mail/static/src/core/common/action.js
+++ b/addons/mail/static/src/core/common/action.js
@@ -143,7 +143,10 @@ export class Action {
 
     /** Props to pass to the action panel component of this action. */
     get actionPanelComponentProps() {
-        return this.definition.actionPanelComponentProps?.call(this, this.params);
+        return {
+            close: (opts) => this.actionPanelClose(opts),
+            ...(this.definition.actionPanelComponentProps?.call(this, this.params) ?? {}),
+        };
     }
 
     /**

--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -57,6 +57,7 @@ export class ChatWindow extends Component {
         this.isMobileOS = isMobileOS();
 
         useChildSubEnv({
+            /** @deprecated */
             closeActionPanel: () => this.threadActions.activeAction?.actionPanelClose(),
             messageHighlight: this.messageHighlight,
         });

--- a/addons/mail/static/src/core/common/search_messages_panel.js
+++ b/addons/mail/static/src/core/common/search_messages_panel.js
@@ -13,7 +13,7 @@ import { useMessageSearch } from "./message_search_hook";
 export class SearchMessagesPanel extends Component {
     static template = "mail.SearchMessagesPanel";
     static components = { ActionPanel, SearchMessageInput, SearchMessageResult };
-    static props = ["thread"];
+    static props = ["close?", "thread"];
 
     setup() {
         super.setup();

--- a/addons/mail/static/src/core/common/search_messages_panel.xml
+++ b/addons/mail/static/src/core/common/search_messages_panel.xml
@@ -2,6 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="mail.SearchMessagesPanel">
         <ActionPanel
+            close="props.close"
             title="title"
             minWidth="200"
             initialWidth="400"

--- a/addons/mail/static/src/discuss/call/common/call_settings.js
+++ b/addons/mail/static/src/discuss/call/common/call_settings.js
@@ -11,7 +11,7 @@ import { Dialog } from "@web/core/dialog/dialog";
 
 export class CallSettings extends Component {
     static template = "discuss.CallSettings";
-    static props = ["withActionPanel?", "isCompact?"];
+    static props = ["close?", "withActionPanel?", "isCompact?"];
     static defaultProps = {
         withActionPanel: true,
     };

--- a/addons/mail/static/src/discuss/call/common/call_settings.xml
+++ b/addons/mail/static/src/discuss/call/common/call_settings.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.CallSettings">
-        <ActionPanel t-if="props.withActionPanel" title.translate="Voice &amp; Video Settings" icon="'fa fa-gear'">
+        <ActionPanel t-if="props.withActionPanel" close="props.close" title.translate="Voice &amp; Video Settings" icon="'fa fa-gear'">
             <t t-call="discuss.CallSettings.content" />
         </ActionPanel>
         <t t-else="" t-call="discuss.CallSettings.content" />

--- a/addons/mail/static/src/discuss/call/common/meeting.js
+++ b/addons/mail/static/src/discuss/call/common/meeting.js
@@ -61,6 +61,7 @@ export class Meeting extends Component {
         this.messageHighlight = useMessageScrolling();
         this.messageSearch = useMessageSearch(this.channel.thread);
         useChildSubEnv({
+            /** @deprecated */
             closeActionPanel: (opts) => this.threadActions.activeAction?.actionPanelClose(opts),
             hasPreviousActionPanel: () => this.threadActions.actionStack.length > 0,
             messageHighlight: this.messageHighlight,

--- a/addons/mail/static/src/discuss/call/common/meeting_chat.js
+++ b/addons/mail/static/src/discuss/call/common/meeting_chat.js
@@ -20,7 +20,7 @@ export class MeetingChat extends Component {
         Thread,
         Typing,
     };
-    static props = [];
+    static props = ["close?"];
 
     setup() {
         this.store = useService("mail.store");

--- a/addons/mail/static/src/discuss/call/common/meeting_chat.xml
+++ b/addons/mail/static/src/discuss/call/common/meeting_chat.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.MeetingChat">
-        <ActionPanel t-if="channel" title.translate="In call messages" resizable="true" minWidth="300" initialWidth="400" icon="'fa fa-comments'" contentRef="panelContentRef">
+        <ActionPanel t-if="channel" close="props.close" title.translate="In call messages" resizable="true" minWidth="300" initialWidth="400" icon="'fa fa-comments'" contentRef="panelContentRef">
             <t t-set-slot="header-extra">
                 <button t-if="env.pinMenu and channel?.pinnedMessages?.length > 0" title="Pinned Messages" class="btn opacity-75 opacity-100-hover p-1 me-3 position-relative" t-on-click="() => env.pinMenu.open()">
                     <i class="fa fa-thumb-tack"/>

--- a/addons/mail/static/src/discuss/core/common/action_panel.js
+++ b/addons/mail/static/src/discuss/core/common/action_panel.js
@@ -14,6 +14,7 @@ export class ActionPanel extends Component {
     static template = "mail.ActionPanel";
     static components = { ResizablePanel };
     static props = [
+        "close?",
         "contentRef?",
         "icon?",
         "title?",
@@ -30,7 +31,10 @@ export class ActionPanel extends Component {
         this.ui = useService("ui");
         useForwardRefToParent("contentRef");
         useSubEnv({ inDiscussActionPanel: true });
-        useBackButton(() => this.env.closeActionPanel());
+        useBackButton(
+            () => this.props.close(),
+            () => this.props.close
+        );
     }
 
     get backButtonTitle() {

--- a/addons/mail/static/src/discuss/core/common/action_panel.xml
+++ b/addons/mail/static/src/discuss/core/common/action_panel.xml
@@ -13,13 +13,13 @@
     <t t-name="mail.ActionPanel.content">
         <div class="o-mail-ActionPanel-header position-sticky top-0 pt-2 pb-1 d-flex flex-column bg-inherit smaller" t-att-class="{ 'px-1 pb-1': env.inChatWindow, 'ps-1 pe-2 pb-2': !env.inChatWindow and !env.inMeetingView, 'o-ps-2_5 pe-2': env.inMeetingChat, 'ps-1': env.inMeetingView and !env.inMeetingChat }">
             <div class="d-flex align-items-center gap-1">
-                <button t-if="(env.closeActionPanel and env.inChatWindow) or env.hasPreviousActionPanel?.()" class="btn p-1 opacity-75 opacity-100-hover" t-att-title="backButtonTitle" t-on-click.stop="env.closeActionPanel">
+                <button t-if="props.close and (env.inChatWindow or env.hasPreviousActionPanel?.())" class="btn p-1 opacity-75 opacity-100-hover" t-att-title="backButtonTitle" t-on-click.stop="props.close">
                     <i class="oi oi-arrow-left fa-fw"/>
                 </button>
                 <i t-if="props.icon" class="text-muted fa-fw" t-att-class="props.icon"/>
                 <p t-if="props.title" class="fw-bold text-uppercase m-0 flex-grow-1" t-esc="props.title"/>
                 <t t-slot="header-extra"/>
-                <button t-if="env.closeActionPanel and !env.inChatWindow" class="btn p-1 opacity-75 opacity-100-hover ms-auto" title="Close panel" t-on-click.stop="() => env.closeActionPanel({ closeAll: true })">
+                <button t-if="props.close and !env.inChatWindow" class="btn p-1 opacity-75 opacity-100-hover ms-auto" title="Close panel" t-on-click.stop="() => props.close({ closeAll: true })">
                     <i class="oi oi-close fa-fw"/>
                 </button>
             </div>

--- a/addons/mail/static/src/discuss/core/common/attachment_panel.js
+++ b/addons/mail/static/src/discuss/core/common/attachment_panel.js
@@ -13,7 +13,7 @@ import { useSequential, useVisible } from "@mail/utils/common/hooks";
  */
 export class AttachmentPanel extends Component {
     static components = { ActionPanel, AttachmentList, DateSection };
-    static props = ["channel"];
+    static props = ["channel", "close?"];
     static template = "mail.AttachmentPanel";
 
     setup() {

--- a/addons/mail/static/src/discuss/core/common/attachment_panel.xml
+++ b/addons/mail/static/src/discuss/core/common/attachment_panel.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.AttachmentPanel">
-        <ActionPanel title.translate="Attachments" minWidth="200" initialWidth="400" icon="'fa fa-paperclip'">
+        <ActionPanel close="props.close" title.translate="Attachments" minWidth="200" initialWidth="400" icon="'fa fa-paperclip'">
             <div class="d-flex flex-column py-2 flex-grow-1">
                 <div class="flex-grow-1" t-att-class="{
                     'd-flex justify-content-center align-items-center': props.channel.attachments.length === 0,

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.ChannelInvitation">
-        <ActionPanel t-if="props.channel" title.translate="Invite people" resizable="!!env.inMeetingView" minWidth="env.inMeetingView ? 300 : undefined" initialWidth="env.inMeetingView ? 400 : undefined" icon="'oi oi-user-plus'">
+        <ActionPanel t-if="props.channel" close="props.close" title.translate="Invite people" resizable="!!env.inMeetingView" minWidth="env.inMeetingView ? 300 : undefined" initialWidth="env.inMeetingView ? 400 : undefined" icon="'oi oi-user-plus'">
             <t t-call="discuss.ChannelInvitation.main"/>
         </ActionPanel>
         <t t-else="" t-call="discuss.ChannelInvitation.main"/>

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.js
@@ -10,7 +10,7 @@ import { useService } from "@web/core/utils/hooks";
 
 export class ChannelMemberList extends Component {
     static components = { ActionPanel, ChannelActionDialog, ChannelMember };
-    static props = ["channel", "openChannelInvitePanel", "className?"];
+    static props = ["channel", "close?", "openChannelInvitePanel", "className?"];
     static template = "discuss.ChannelMemberList";
 
     setup() {

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.ChannelMemberList">
-        <ActionPanel title.translate="Members" minWidth="200" initialWidth="env.inMeetingView ? 400 : 250" icon="'oi oi-users'">
+        <ActionPanel close="props.close" title.translate="Members" minWidth="200" initialWidth="env.inMeetingView ? 400 : 250" icon="'oi oi-users'">
             <button name="inviteButton" t-on-click="() => this.openInviteDialog()" class="btn btn-sm btn-secondary mt-2 d-flex align-items-center justify-content-center gap-1 rounded-3" title="Invite People"><i class="oi oi-user-plus"/><span>Invite People</span></button>
             <t t-if="props.channel.onlineMembers.length > 0">
                 <t t-call="discuss.ChannelMemberList.section">

--- a/addons/mail/static/src/discuss/core/common/delete_thread_dialog.xml
+++ b/addons/mail/static/src/discuss/core/common/delete_thread_dialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="discuss.DeleteThreadDialog">
-        <ActionPanel title.translate="Delete Thread" icon="'fa fa-trash'" resizable="false">
+        <ActionPanel close="props.close" title.translate="Delete Thread" icon="'fa fa-trash'" resizable="false">
             <div class="d-flex justify-content-between align-items-center">
                 <p class="fs-5 mb-0">Permanently delete this thread?</p>
                 <button class="btn btn-danger" t-on-click="onConfirmation">

--- a/addons/mail/static/src/discuss/core/common/notification_settings.xml
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="discuss.NotificationSettings">
-        <ActionPanel t-if="!env[DROPDOWN_NESTING] and env.inChatWindow" title.translate="Notification Settings" resizable="!!env.inMeetingView" initialWidth="400" icon="'fa fa-bell'">
+        <ActionPanel t-if="!env[DROPDOWN_NESTING] and env.inChatWindow" close="props.close" title.translate="Notification Settings" resizable="!!env.inMeetingView" initialWidth="400" icon="'fa fa-bell'">
             <t t-call="discuss.NotificationSettings.content"/>
         </ActionPanel>
         <t t-else="" t-call="discuss.NotificationSettings.content"/>

--- a/addons/mail/static/src/discuss/core/common/pinned_messages_panel.js
+++ b/addons/mail/static/src/discuss/core/common/pinned_messages_panel.js
@@ -15,7 +15,7 @@ export class PinnedMessagesPanel extends Component {
         MessageCardList,
         ActionPanel,
     };
-    static props = ["channel", "className?"];
+    static props = ["close?", "channel", "className?"];
     static template = "discuss.PinnedMessagesPanel";
 
     setup() {

--- a/addons/mail/static/src/discuss/core/common/pinned_messages_panel.xml
+++ b/addons/mail/static/src/discuss/core/common/pinned_messages_panel.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="discuss.PinnedMessagesPanel">
-        <ActionPanel title.translate="Pinned Messages" minWidth="200" initialWidth="400" icon="'fa fa-thumb-tack'">
+        <ActionPanel close="props.close" title.translate="Pinned Messages" minWidth="200" initialWidth="400" icon="'fa fa-thumb-tack'">
             <MessageCardList emptyText="emptyText" messages="props.channel.pinnedMessages" thread="props.channel.thread" mode="'pin'"/>
         </ActionPanel>
     </t>

--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -156,10 +156,7 @@ registerThreadAction("attachments", {
 registerThreadAction("invite-people", {
     actionPanelClose: ({ action }) => action.popover?.close(),
     actionPanelComponent: ChannelInvitation,
-    actionPanelComponentProps: ({ action, channel }) => ({
-        close: () => action.actionPanelClose(),
-        channel,
-    }),
+    actionPanelComponentProps: ({ channel }) => ({ channel }),
     actionPanelOpen({ owner, store, channel }) {
         if (owner.isDiscussSidebarChannelActions) {
             store.env.services.dialog?.add(ChannelActionDialog, {
@@ -310,9 +307,7 @@ registerThreadAction("leave", {
 registerThreadAction("delete-thread", {
     actionPanelClose: ({ action }) => action.popover?.close(),
     actionPanelComponent: DeleteThreadDialog,
-    actionPanelComponentProps({ action, channel }) {
-        return { channel, close: () => action.actionPanelClose() };
-    },
+    actionPanelComponentProps: ({ channel }) => ({ channel }),
     actionPanelOuterClass: "bg-100",
     condition({ channel, owner, store }) {
         return (

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.SubChannelList">
-        <ActionPanel title.translate="Threads" resizable="!!env.inMeetingView" initialWidth="400" icon="'fa fa-comments-o'">
+        <ActionPanel close="props.close" title.translate="Threads" resizable="!!env.inMeetingView" initialWidth="400" icon="'fa fa-comments-o'">
             <t t-set-slot="header">
                 <div class="d-flex align-items-center my-0">
                     <div class="input-group ms-1 my-2">

--- a/addons/mail/static/src/discuss/core/public_web/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/public_web/thread_actions.js
@@ -7,10 +7,7 @@ import { usePopover } from "@web/core/popover/popover_hook";
 registerThreadAction("show-threads", {
     actionPanelClose: ({ action }) => action.popover?.close(),
     actionPanelComponent: SubChannelList,
-    actionPanelComponentProps: ({ action, channel }) => ({
-        close: () => action.actionPanelClose(),
-        channel,
-    }),
+    actionPanelComponentProps: ({ channel }) => ({ channel }),
     actionPanelOpen({ channel, owner }) {
         this.popover?.open(owner.root.el.querySelector(`[name="${this.id}"]`), {
             channel: channel.parent_channel_id || channel,

--- a/addons/mail/static/tests/discuss/search_messages_panel.test.js
+++ b/addons/mail/static/tests/discuss/search_messages_panel.test.js
@@ -364,3 +364,16 @@ test("Search a message containing single quotes", async () => {
     triggerHotkey("Enter");
     await contains(".o-mail-SearchMessagesPanel .o-mail-Message");
 });
+
+test.tags("mobile");
+test("Close message search panel when navigating back on mobile", async () => {
+    mockUserAgent("android");
+    patchUiSize({ size: SIZES.SM });
+    await startServer();
+    await start();
+    await openDiscuss("mail.box_bookmark");
+    await click("[title='Search Messages']");
+    await contains(".o-mail-SearchMessagesPanel");
+    history.back();
+    await contains(".o-mail-SearchMessagesPanel", { count: 0 });
+});


### PR DESCRIPTION
...in mailboxes on mobile

* = crm_livechat, im_livechat

Enterprise PR: https://github.com/odoo/enterprise/pull/110150

Before this commit, navigating back from a mailbox message search panel on mobile would result in a traceback.

Steps to reproduce:
1. Open Discuss on mobile
2. Navigate to bookmarks in bottom bar
3. Open message search
4. Navigate back -> traceback

This happens because the `useBackButton` in ActionPanel registers a callback function taken from the env.

Said function is missing when the ActionPanel is mounted outside of a chat window or meeting view.

This commit fixes the issue by adding a `close` props to ActionPanel, and using that as a callback for back navigation.

This is an established pattern for similar closable components like Popover, Dialog and EmojiPicker.

task-6013922