### PR TITLE
[FIX] website : allow masonry row to grow

### DIFF
--- a/addons/html_editor/static/src/scss/html_editor.frontend.scss
+++ b/addons/html_editor/static/src/scss/html_editor.frontend.scss
@@ -73,7 +73,7 @@
 @include media-breakpoint-up(lg) {
     .o_grid_mode {
         display: grid !important;
-        grid-auto-rows: 50px;
+        grid-auto-rows: minmax(50px, auto);
         grid-template-columns: repeat(12, 1fr);
         row-gap: 0px;
         column-gap: 0px;


### PR DESCRIPTION
# How to reproduce
- Edit a website
- Add a masonry content block
- Add any inner content block with a height than can be changed (by the user or by editing the block)
- Increase the height of that inner content block

# The problem
The inner content block overflows into the other blocks. This can be particularly annoying for the user when using an accordion inside a masonry.

# Why
The masonry sets the size of the rows to a fixed 50px (a block can be assigned to multiple rows). So when the content of the inner content block is bigger than the size of the rows, it overflows

This fix keeps the min-size of the rows to 50px but allow them to adapt to bigger inner content size.

opw-5947313

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
