### PR TITLE
[FIX] website_sale: prevent coupon_form being hidden

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2201,7 +2201,7 @@
             method="post" name="coupon_code">
             <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()" t-nocache="The csrf token must always be up to date."/>
             <div class="input-group w-100 my-2">
-                <input name="promo" class="form-control" type="text" placeholder="Discount code..." t-att-value="website_sale_order.pricelist_id.code or None"/>
+                <input name="promo" class="form-control" type="text" placeholder="Discount code..."/>
                 <a href="#" role="button" class="btn btn-secondary a-submit ps-2">Apply</a>
             </div>
         </form>
@@ -3062,8 +3062,9 @@
             <tr t-if="not hide_promotions">
                 <td colspan="3" class="text-end text-xl-end border-0 p-0">
                 <span>
+                    <!-- force_coupon to be removed in master -->
                     <t t-set="force_coupon" t-value="website_sale_order.pricelist_id.code"/>
-                    <div t-if="not force_coupon" class="coupon_form">
+                    <div class="coupon_form">
                         <t t-call="website_sale.coupon_form"/>
                     </div>
                 </span>


### PR DESCRIPTION
Issue:
---
If the current pricelist has `E-commerce Promotional Code` set, the coupon form is hidden.

Steps to reproduce:
---
1- Create a pricelist and set `E-commerce Promotional Code`.
2- Navigate to the cart in website.
3- Enter pricelist code in the coupon form.

Result: Once the code is entered, pricelist is changed and the coupon form is hidden.

Cause:
---
This is done intentionally on #23713. However, it seems it's not relevant anymore.

Fix:
---
We can remove `force_coupon` condition from `reduction_code` template. However `force_coupon `is also used inside xpath expression in `reduction_coupon_code` template.
In order not to break stable we can keep `t-set="force_coupon"` inside the `reduction_code` template, and remove it on master.

opw-5977474

