### PR TITLE
[FIX] hr: read im_status from _store_im_status_fields

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -2104,7 +2104,16 @@ class HrEmployee(models.Model):
 
     def _store_avatar_card_fields(self, res: Store.FieldList):
         res.one("department_id", ["name"])
-        res.one("user_id", lambda res: (res.attr("share"), res.one("partner_id", ["im_status", "tz"])))
+        res.one(
+            "user_id",
+            lambda res: (
+                res.attr("share"),
+                res.one(
+                    "partner_id",
+                    lambda res: (res.from_method("_store_im_status_fields"), res.attr("tz")),
+                ),
+            ),
+        )
         res.one("work_location_id", ["location_type", "name"])
         res.extend(["company_id", "hr_icon_display", "job_title", "name", "show_hr_icon_display"])
         res.extend(["work_email", "work_phone"])

--- a/addons/hr/models/hr_employee_public.py
+++ b/addons/hr/models/hr_employee_public.py
@@ -236,7 +236,16 @@ class HrEmployeePublic(models.Model):
 
     def _store_avatar_card_fields(self, res: Store.FieldList):
         res.one("department_id", ["name"])
-        res.one("user_id", lambda res: (res.attr("share"), res.one("partner_id", ["im_status", "tz"])))
+        res.one(
+            "user_id",
+            lambda res: (
+                res.attr("share"),
+                res.one(
+                    "partner_id",
+                    lambda res: (res.from_method("_store_im_status_fields"), res.attr("tz")),
+                ),
+            ),
+        )
         res.one("work_location_id", ["location_type", "name"])
         res.extend(["company_id", "hr_icon_display", "job_title", "name", "show_hr_icon_display"])
         res.extend(["work_email", "work_phone"])


### PR DESCRIPTION
Just reading `im_status` instead of the dedicated method makes the maintenance harder and it is potentially problematic as it doesn't return the `im_status_access_token` nor the necessary extra information from employee records to compute out of office.

In the 2 flows that are fixed here, the token is not mandatory as employee data is typically returned to internal users which have the right to read partners regardless.

Leave status is also sent as part of `_store_avatar_card_fields` so that is also fine, but homeworking status appears to not be sent.

`_store_avatar_card_fields` does return `work_location_id` and its type but `_store_im_status_fields` returns `work_location_type` and that is what is used in `hr-homeworking-office` of `imStatusDataRegistry`.