### PR TITLE
[IMP] data_recycle: make time field required with constrains

### DIFF
--- a/addons/data_recycle/models/data_recycle_model.py
+++ b/addons/data_recycle/models/data_recycle_model.py
@@ -44,13 +44,17 @@ class Data_RecycleModel(models.Model):
     time_field_id = fields.Many2one(
         'ir.model.fields', string='Time Field',
         domain="[('model_id', '=', res_model_id), ('ttype', 'in', ('date', 'datetime')), ('store', '=', True)]",
-        ondelete='cascade')
-    time_field_delta = fields.Integer(string='Delta', default=1)
+        ondelete='cascade', store=True,
+        compute='_compute_time_field_id', readonly=False,
+        help='Date or datetime field on the target model used to determine how old a record is.')
+    time_field_delta = fields.Integer(string='Delta', default=1, required=True,
+        help='Number of time units a record must exceed to be considered for recycling.')
     time_field_delta_unit = fields.Selection([
         ('days', 'Days'),
         ('weeks', 'Weeks'),
         ('months', 'Months'),
-        ('years', 'Years')], string='Delta Unit', default='months')
+        ('years', 'Years')], string='Delta Unit', default='months', required=True,
+        help='Unit of time applied to the delta to compute the age threshold.')
     include_archived = fields.Boolean()
 
     records_to_recycle_count = fields.Integer(
@@ -83,6 +87,28 @@ class Data_RecycleModel(models.Model):
     @api.depends('res_model_id')
     def _compute_domain(self):
         self.domain = '[]'
+
+    def _get_default_time_field_id(self, model_id):
+        """ Return write_date if available, otherwise the first stored date/datetime field on the model. """
+        IrModelFields = self.env['ir.model.fields']
+        base_domain = [('model_id', '=', model_id)]
+        write_date_field = IrModelFields.search(base_domain + [('name', '=', 'write_date')], limit=1)
+        first_date_field = IrModelFields.search(base_domain + [('ttype', 'in', ('date', 'datetime')), ('store', '=', True)], limit=1)
+        return write_date_field or first_date_field
+
+    @api.depends('res_model_id')
+    def _compute_time_field_id(self):
+        """ Default to write_date, or the first stored date/datetime field on the model.
+        Only sets the field when it is currently empty, preserving values defined by the user. """
+        for recycle_model in self:
+            if not recycle_model.time_field_id:
+                recycle_model.time_field_id = self._get_default_time_field_id(recycle_model.res_model_id.id)
+
+    @api.constrains('time_field_id')
+    def _check_time_field_id(self):
+        for model in self:
+            if not model.time_field_id:
+                raise UserError(_("A Time Field is required to determine which records are old enough to recycle."))
 
     @api.depends('res_model_id')
     def _compute_name(self):

--- a/addons/data_recycle/tests/test_data_recycle.py
+++ b/addons/data_recycle/tests/test_data_recycle.py
@@ -84,3 +84,53 @@ class TestDataRecycle(TransactionCase):
         self.recycle_model.include_archived = True
         self.recycle_model._recycle_records()
         self.assertEqual(len(self.recycle_model.recycle_record_ids), 5)
+
+    def test_time_field_defaults(self):
+        """ Ensure that when no time field is specified, write_date with a 1-month delta is used by default. """
+        recycle_model = self.env['data_recycle.model'].create({
+            'name': 'Recycle Default Time Field',
+            'res_model_id': self.server_model.id,
+            'recycle_action': 'archive',
+        })
+        self.assertEqual(recycle_model.time_field_id.name, 'write_date', 'time_field_id should default to write_date.')
+        self.assertEqual(recycle_model.time_field_delta, 1, 'time_field_delta should default to 1.')
+        self.assertEqual(recycle_model.time_field_delta_unit, 'months', 'time_field_delta_unit should default to months.')
+
+        # Only servers with write_date older than 1 month should be picked up.
+        recycle_model._recycle_records()
+        self.assertTrue(
+            all(r.res_id in self.old_servers.ids for r in recycle_model.recycle_record_ids),
+            'Only old servers should be queued for recycling.'
+        )
+        self.assertTrue(
+            all(s.id not in recycle_model.recycle_record_ids.mapped('res_id') for s in self.new_servers),
+            'New servers should not be queued for recycling.'
+        )
+
+    def test_time_field_user_override(self):
+        """ Ensure that user-specified time_field_id and delta are preserved and applied correctly. """
+        date_field = self.env['ir.model.fields'].search(
+            [('name', '=', 'date'), ('model_id', '=', self.server_model.id)], limit=1)
+        recycle_model = self.env['data_recycle.model'].create({
+            'name': 'Recycle User Override Time Field',
+            'res_model_id': self.server_model.id,
+            'time_field_id': date_field.id,
+            'time_field_delta': 6,
+            'time_field_delta_unit': 'months',
+            'recycle_action': 'archive',
+        })
+        self.assertEqual(
+            recycle_model.time_field_id, date_field,
+            'The time_field_id inputted by the user should not be overridden by the compute.'
+        )
+
+        # Servers with date older than 6 months are picked up, but not the ones created today.
+        recycle_model._recycle_records()
+        self.assertEqual(
+            set(recycle_model.recycle_record_ids.mapped('res_id')), set(self.old_servers.ids),
+            'Only the 2-year-old servers should be queued using the user-defined date field and 6-month delta.'
+        )
+        self.assertFalse(
+            any(s.id in recycle_model.recycle_record_ids.mapped('res_id') for s in self.new_servers),
+            'Servers created today should not be queued for recycling.'
+        )

--- a/addons/data_recycle/views/data_recycle_model_views.xml
+++ b/addons/data_recycle/views/data_recycle_model_views.xml
@@ -67,7 +67,7 @@
                         </group>
                         <group invisible="not res_model_id">
                             <field name="domain" widget="domain" options="{'model': 'res_model_name'}"/>
-                            <field name="time_field_id"/>
+                            <field name="time_field_id" options="{'no_create': True}"/>
                             <field name="time_field_delta"/>
                             <field name="time_field_delta_unit"/>
                         </group>


### PR DESCRIPTION
Before this commit, the time field on a recycling rule was optional, so a rule could grab every matching record regardless of age. There was also no guidance on what the time settings actually do.

After this commit, the time field auto-fills with the write date when you pick a model (both from the UI and in code). You can still change it, but you can't leave it blank once you save. Older existing rules keep working just fine. Each setting also has a short tooltip explaining what it does.

task-5952551