### PR TITLE
[IMP] mail: make message bubble size with content (shrink-wrap)

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -1,4 +1,11 @@
-import { reactive, useChildSubEnv, useExternalListener, useLayoutEffect, useRef, useState } from "@web/owl2/utils";
+import {
+    reactive,
+    useChildSubEnv,
+    useExternalListener,
+    useLayoutEffect,
+    useRef,
+    useState,
+} from "@web/owl2/utils";
 import { AttachmentList } from "@mail/core/common/attachment_list";
 import { useAttachmentUploader } from "@mail/core/common/attachment_uploader_hook";
 import { useCustomDropzone } from "@web/core/dropzone/dropzone_hook";
@@ -15,14 +22,7 @@ import { isEventHandled, markEventHandled } from "@web/core/utils/misc";
 import { browser } from "@web/core/browser/browser";
 import { useDebounced } from "@web/core/utils/timing";
 
-import {
-    Component,
-    markup,
-    onMounted,
-    onWillUnmount,
-    toRaw,
-    EventBus,
-} from "@odoo/owl";
+import { Component, markup, onMounted, onWillUnmount, toRaw, EventBus } from "@odoo/owl";
 
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
@@ -187,6 +187,9 @@ export class Composer extends Component {
                     (!this.store.rtc.isFullscreen || this.env.inMeetingView)
             );
         }
+        if (this.env.messageComposerAutoresize) {
+            this.env.messageComposerAutoresize.invoke = this.autoresize.bind(this);
+        }
         useChildSubEnv({ inComposer: true });
         useLayoutEffect(
             (focus) => {
@@ -210,18 +213,7 @@ export class Composer extends Component {
         );
         useLayoutEffect(
             () => {
-                if (this.fakeTextarea.el?.scrollHeight) {
-                    let wasEmpty = false;
-                    if (!this.fakeTextarea.el.value) {
-                        wasEmpty = true;
-                        this.fakeTextarea.el.value = "0";
-                    }
-                    this.ref.el.style.height = this.fakeTextarea.el.scrollHeight + "px";
-                    if (wasEmpty) {
-                        this.fakeTextarea.el.value = "";
-                    }
-                }
-                this.saveContentDebounced();
+                this.autoresize();
             },
             () => [this.props.composer.composerText, this.ref.el]
         );
@@ -264,6 +256,21 @@ export class Composer extends Component {
 
     get areAllActionsDisabled() {
         return this.props.disabled;
+    }
+
+    autoresize() {
+        if (this.fakeTextarea.el?.scrollHeight) {
+            let wasEmpty = false;
+            if (!this.fakeTextarea.el.value) {
+                wasEmpty = true;
+                this.fakeTextarea.el.value = "0";
+            }
+            this.ref.el.style.height = this.fakeTextarea.el.scrollHeight + "px";
+            if (wasEmpty) {
+                this.fakeTextarea.el.value = "";
+            }
+        }
+        this.saveContentDebounced();
     }
 
     get isMultiUpload() {

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -368,12 +368,12 @@ $o-mail-utilities: map-merge(
 a.o_mail_redirect, a.o_channel_redirect, a.o-discuss-mention, a.o_message_redirect_transformed {
     user-select: none;
     border-radius: $btn-border-radius-sm;
-    padding: 0rem 0.15rem;
+    padding: 0.15rem;
     margin: 0rem 0.025rem;
     outline: 1px solid;
     outline-offset: -1px;
     font-weight: $font-weight-bold;
-    display: inline-block;
+    display: inline;
 }
 
 a.o_mail_redirect, a.o_channel_redirect, a.o_message_redirect_transformed {

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -29,7 +29,7 @@ import { getOrigin, url } from "@web/core/utils/urls";
 import { useMessageActions } from "./message_actions";
 import { discussComponentRegistry } from "./discuss_component_registry";
 import { NotificationMessage } from "./notification_message";
-import { useForwardRefsToParent, useLongPress } from "@mail/utils/common/hooks";
+import { useForwardRefsToParent, useLongPress, useShrinkWrap } from "@mail/utils/common/hooks";
 import { ActionList } from "@mail/core/common/action_list";
 import { loadCssFromBundle } from "@mail/utils/common/misc";
 import { MessageContextMenu } from "@mail/core/common/message_context_menu";
@@ -128,6 +128,17 @@ export class Message extends Component {
         this.ui = useService("ui");
         this.openReactionMenu = this.openReactionMenu.bind(this);
         this.optionsDropdown = useDropdownState();
+        useSubEnv({ messageComposerAutoresize: {} }); // sub-composer expected to register its auto-resize function as `invoke`
+        useShrinkWrap(this.root, this.messageBody, {
+            onAfterShrinkWrap: (element) => {
+                if (this.state.isEditing) {
+                    element.style.width = "auto";
+                    element.style.boxSizing = "auto";
+                    // Composer autoresize happens before message shrink-wrap, so need to ask to auto-resize composer again
+                    this.env.messageComposerAutoresize?.invoke();
+                }
+            },
+        });
         useSubEnv({ inMessage: true });
         useChildSubEnv({
             message: this.props.message,

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -3,6 +3,11 @@
 }
 
 .o-mail-Message {
+
+    &:not([data-o-shrink-wrap-ready]) {
+        visibility: hidden;
+    }
+
     transition: background-color .2s ease-out, opacity .25s ease-out, box-shadow .5s ease-out, transform .2s ease-out;
 
     &.o-card {

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -6,7 +6,17 @@ import {
     useState,
     useSubEnv,
 } from "@web/owl2/utils";
-import { Component, onMounted, onPatched, onWillUnmount, toRaw, xml } from "@odoo/owl";
+import {
+    Component,
+    markRaw,
+    onMounted,
+    onPatched,
+    onWillUnmount,
+    status,
+    toRaw,
+    useEffect,
+    xml,
+} from "@odoo/owl";
 
 import { monitorAudio } from "@mail/utils/common/media_monitoring";
 import { browser } from "@web/core/browser/browser";
@@ -795,4 +805,106 @@ export class UseForwardRefsToParent {
  */
 export function useForwardRefsToParent(propName, getRefIdFn, ref) {
     new UseForwardRefsToParent(propName, getRefIdFn, ref);
+}
+
+/**
+ * @param {import("@web/core/utils/hooks").Ref} rootRef The root element of component. Useful to observe resize in order to re-trigger shrink-wrap.
+ * @param {import("@web/core/utils/hooks").Ref} elementRef The element to apply shrink-wrap.
+ * @param {Object} [param2={}]
+ * @param {(HTMLElement) => void} [param2.onAfterShrinkWrap] Optional post-process after shrink-wrap has been applied.
+ */
+export function useShrinkWrap(rootRef, elementRef, { onAfterShrinkWrap } = {}) {
+    const component = useComponent();
+    const store = useService("mail.store");
+    const rawStore = toRaw(store);
+    const elementResizeObserver = new ResizeObserver(() => requestShrinkWrap());
+    useEffect(
+        (el) => {
+            elementResizeObserver.observe(el);
+            return () => {
+                elementResizeObserver.unobserve(el);
+            };
+        },
+        () => [rootRef.el]
+    );
+
+    async function requestShrinkWrap() {
+        rootRef.el.dataset.oShrinkWrapReady ??= false;
+        const element = elementRef.el;
+        if (!element || ["destroyed", "cancelled"].includes(status(component))) {
+            return;
+        }
+        if (!rawStore.toShrinkWrapElements) {
+            rawStore.toShrinkWrapElements = markRaw([]);
+            rawStore.shrinkWrapSequential = useSequential();
+        }
+        rawStore.toShrinkWrapElements.push([
+            element,
+            () => {
+                if (
+                    ["destroyed", "cancelled"].includes(status(component)) ||
+                    elementRef.el !== element
+                ) {
+                    return;
+                }
+                onAfterShrinkWrap?.(element);
+            },
+        ]);
+        await new Promise((resolve) => setTimeout(() => requestAnimationFrame(resolve))); // batch shrink wrap so sequential getBoundingRect() trigger a single painting
+        rawStore.shrinkWrapSequential(() => {
+            const toHandle = rawStore.toShrinkWrapElements;
+            rawStore.toShrinkWrapElements = markRaw([]);
+            const toChange = [];
+            for (const [element] of toHandle) {
+                shrinkWrap(element, toChange);
+            }
+            for (const [element, width] of toChange) {
+                element.style.width = width + "px";
+                element.style.boxSizing = "content-box";
+            }
+            for (const [element, toShrinkWrapElements] of toHandle) {
+                toShrinkWrapElements?.(element);
+            }
+            if (rootRef.el) {
+                rootRef.el.dataset.oShrinkWrapReady = true;
+            }
+        });
+    }
+
+    /**
+     * Courtesy of https://stackoverflow.com/a/78307608
+     *
+     * @param {HTMLElement} element
+     * @param {Array<[HTMLElement, Number]>} toChange
+     */
+    function shrinkWrap(element, toChange) {
+        const { firstChild, lastChild } = element;
+        if (!element || !firstChild || !lastChild) {
+            return;
+        }
+        element
+            .querySelectorAll("p, .o-mail-Message-richBody")
+            .forEach((p) => shrinkWrap(p, toChange));
+        element.style.width = "auto";
+        element.style.boxSizing = "auto";
+        const range = document.createRange();
+        const firstChildStyle =
+            firstChild.nodeType !== 3 ? getComputedStyle(firstChild) : undefined;
+        const lastChildStyle = lastChild.nodeType !== 3 ? getComputedStyle(lastChild) : undefined;
+        const marginLeft = Math.max(
+            parseFloat(firstChildStyle?.marginLeft ?? 0),
+            parseFloat(lastChildStyle?.marginLeft ?? 0)
+        );
+        const marginRight = Math.max(
+            parseFloat(firstChildStyle?.marginRight ?? 0),
+            parseFloat(lastChildStyle?.marginRight ?? 0)
+        );
+        range.setStartBefore(firstChild);
+        range.setEndAfter(lastChild);
+        const { width } = range.getBoundingClientRect();
+        const resultingWidth = width + marginLeft + marginRight;
+        if (element.tagName === "P" || element.classList.contains("o-mail-Message-richBody")) {
+            toChange.push([element, resultingWidth]);
+        }
+    }
 }

--- a/addons/mail/static/tests/composer/composer.test.js
+++ b/addons/mail/static/tests/composer/composer.test.js
@@ -791,11 +791,18 @@ test("[text composer] quick edit last self-message from UP arrow", async () => {
     ]);
     await start();
     await openDiscuss(channelId);
-    await contains(".o-mail-Message-content:text('Test-1')");
-    await contains(".o-mail-Message-content:text('Test-2')");
+    await contains(
+        ".o-mail-Message:eq(0)[data-o-shrink-wrap-ready] .o-mail-Message-content:text('Test-1')"
+    );
+    await contains(
+        ".o-mail-Message:eq(1)[data-o-shrink-wrap-ready] .o-mail-Message-content:text('Test-2')"
+    );
     await contains(".o-mail-Message .o-mail-Composer", { count: 0 });
+    await contains(".o-mail-Composer.o-focused");
     triggerHotkey("ArrowUp");
-    await contains(".o-mail-Message .o-mail-Composer-input", { value: "Test-2" });
+    await contains(".o-mail-Message .o-mail-Composer.o-focused .o-mail-Composer-input", {
+        value: "Test-2",
+    });
     triggerHotkey("Escape");
     await contains(".o-mail-Message .o-mail-Composer", { count: 0 });
     await contains(".o-mail-Composer.o-focused");


### PR DESCRIPTION
Before this commit, some messages could have bubble layout with over-estimated width compared to text content of message.

Steps to reproduce:

- Have a 1080p monitor on Discuss app, window taking half screen
- post the following message in a discuss conversation:

```
[REF] mail: refactor attachment list https://github.com/odoo/odoo/pull/250619
```

=> The bubble takes whole width when message content takes about 60% of the width.

This happens because message body is a div that contains a span. The span has work-break so it is wrapped, but the div does not adapt its width. This div represents the size of bubble, and because it doesn't resize with content wrap this over-estimates the size.

Strangely, there's no CSS feature to solve this issue. The visual of self-messages do not look good in such scenario. This scenario happens quite a lot in chat window or in Discuss app when the message list is somewhat narrow (e.g .with a panel open at the same time, or when browser takes half screen).

This commit fixes the issue with a shrink-wrap algorithm on the message body, that is detecting the actual width and setting it on the message body, so that the parent correctly computes its width to auto-fit the content, and thus bubble takes exact size to fit content.

Before / After
<img width="620" height="269" alt="Screenshot 2026-03-06 at 16 44 10" src="https://github.com/user-attachments/assets/12715a16-ac37-4f23-bfe8-9507829dfdef" />
<img width="613" height="267" alt="Screenshot 2026-03-06 at 16 43 53" src="https://github.com/user-attachments/assets/236a0c6a-c9d8-49df-aa74-de06b31927e8" />
