### PR TITLE
[IMP] web: allow dropdown to be active elements

### DIFF
--- a/addons/web/static/src/core/bottom_sheet/bottom_sheet.js
+++ b/addons/web/static/src/core/bottom_sheet/bottom_sheet.js
@@ -5,6 +5,7 @@
  */
 import { Component, useState, useRef, onMounted } from "@odoo/owl";
 import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
+import { useActiveElement } from "@web/core/ui/ui_service";
 import { useBackButton, useForwardRefToParent } from "@web/core/utils/hooks";
 import { useThrottleForAnimation } from "@web/core/utils/timing";
 import { compensateScrollbar } from "@web/core/utils/scrolling";
@@ -17,6 +18,7 @@ export class BottomSheet extends Component {
 
     static defaultProps = {
         class: "",
+        setActiveElement: false,
     };
 
     static props = {
@@ -27,6 +29,7 @@ export class BottomSheet extends Component {
 
         class: { optional: true },
         role: { optional: true, type: String },
+        setActiveElement: { optional: true, type: Boolean },
 
         // Technical props
         ref: { optional: true, type: Function },
@@ -50,6 +53,10 @@ export class BottomSheet extends Component {
             maxHeight: 0,
             dismissThreshold: 0,
         };
+
+        if (this.props.setActiveElement) {
+            useActiveElement("ref");
+        }
 
         // Popover Ref Requirement
         useForwardRefToParent("ref");

--- a/addons/web/static/src/core/bottom_sheet/bottom_sheet_service.js
+++ b/addons/web/static/src/core/bottom_sheet/bottom_sheet_service.js
@@ -10,6 +10,7 @@ import { registry } from "@web/core/registry";
  *   role?: string;
  *   ref?: Function;
  *   useBottomSheet?: Boolean;
+ *   setActiveElement?: Boolean;
  * }} PopoverServiceAddOptions
  *
  * @typedef {ReturnType<popoverService["start"]>["add"]} PopoverServiceAddFunction
@@ -47,6 +48,7 @@ export const popoverService = {
                     ref: options.ref,
                     class: options.class,
                     role: options.role,
+                    setActiveElement: options.setActiveElement,
                 },
                 {
                     env: options.env,

--- a/addons/web/static/src/core/dropdown/dropdown.js
+++ b/addons/web/static/src/core/dropdown/dropdown.js
@@ -82,6 +82,7 @@ export class Dropdown extends Component {
         disabled: { type: Boolean, optional: true },
         holdOnHover: { type: Boolean, optional: true },
         focusToggleOnClosed: { type: Boolean, optional: true },
+        setActiveElement: { type: Boolean, optional: true },
 
         beforeOpen: { type: Function, optional: true },
         onOpened: { type: Function, optional: true },
@@ -119,6 +120,7 @@ export class Dropdown extends Component {
         noClasses: false,
         navigationOptions: {},
         bottomSheet: true,
+        setActiveElement: false,
     };
 
     setup() {
@@ -167,7 +169,7 @@ export class Dropdown extends Component {
             },
             ref: this.menuRef,
             shrink: true,
-            setActiveElement: false,
+            setActiveElement: this.props.setActiveElement,
         };
         if (this.isBottomSheet) {
             Object.assign(options, {
@@ -359,6 +361,9 @@ export class Dropdown extends Component {
     }
 
     closePopover() {
+        if (this.props.setActiveElement && this.menuRef.el) {
+            this.uiService.deactivateElement(this.menuRef.el);
+        }
         this.popover.close();
         if (this.props.focusToggleOnClosed && !this.group.isInGroup) {
             this._focusedElBeforeOpen?.focus();

--- a/addons/web/static/tests/core/dropdown/dropdown.test.js
+++ b/addons/web/static/tests/core/dropdown/dropdown.test.js
@@ -19,6 +19,7 @@ import {
     contains,
     defineParams,
     getMockEnv,
+    getService,
     makeMockEnv,
     mockService,
     mountWithCleanup,
@@ -147,6 +148,40 @@ test("can be toggled", async () => {
     await animationFrame();
     expect(DROPDOWN_MENU).toHaveCount(0);
     expect(DROPDOWN_TOGGLE).toHaveAttribute("aria-expanded", "false");
+});
+
+test("can become the active UI element when opening with setActiveElement", async () => {
+    class Parent extends Component {
+        static components = { Dropdown };
+        static props = [];
+        static template = xml`
+            <div class="outside">outside</div>
+            <Dropdown setActiveElement="true">
+                <button>Dropdown</button>
+                <t t-set-slot="content">
+                    <input class="dropdown-input" />
+                </t>
+            </Dropdown>
+        `;
+    }
+
+    await mountWithCleanup(Parent);
+
+    const uiService = getService("ui");
+
+    expect(uiService.activeElement).toBe(document);
+    await click(DROPDOWN_TOGGLE);
+    await animationFrame();
+
+    expect(uiService.activeElement).toBe(
+        queryOne(getMockEnv().isSmall ? ".o_bottom_sheet_body.dropdown-menu" : ".o_popover")
+    );
+    expect(".dropdown-input").toBeFocused();
+
+    await click(getMockEnv().isSmall ? ".o_bottom_sheet_backdrop" : "div.outside");
+    await animationFrame();
+    expect(DROPDOWN_MENU).toHaveCount(0);
+    expect(uiService.activeElement).toBe(document);
 });
 
 test("initial open state can be true", async () => {


### PR DESCRIPTION
`Popover` instances have an option for them to be active element once
opened: `setActiveElement`. `Dropdown` is a specialized `Popover` class
but was forced to use `setActiveElement: false`. This commit allows the
option for `Dropdown`, allowing to fix a bug in the voip (enterprise)
counter-part of this commit.

It also allows the same the mobile specific "dropdown": "bottom sheet".

task-5999452