### PR TITLE
[FIX] website_crm_partner_assign: fix reset mail template error

### DIFF
--- a/addons/website_crm_partner_assign/data/mail_template_data.xml
+++ b/addons/website_crm_partner_assign/data/mail_template_data.xml
@@ -5,9 +5,9 @@
         <record id="email_template_lead_forward_mail" model="mail.template">
             <field name="name">Lead Forward: Send to partner</field>
             <field name="model_id" ref="website_crm_partner_assign.model_crm_lead_forward_to_partner" />
-            <field name="subject">Fwd: Lead: {{ ctx['partner_id'].name }}</field>
+            <field name="subject">Fwd: Lead: {{ ctx['partner_id'].name if ctx.get('partner_id') else ''}}</field>
             <field name="email_from">{{ user.email_formatted }}</field>
-            <field name="email_to">{{ ctx['partner_id'].email_formatted }}</field>
+            <field name="email_to">{{ ctx['partner_id'].email_formatted if ctx.get('partner_id') else ''}}</field>
             <field name="use_default_to" eval="False"/>
             <field name="description">Sent to partner when a lead has been assigned to him</field>
             <field name="body_html" type="html">
@@ -37,22 +37,22 @@
                     <td valign="top" style="font-size: 13px;">
                         <div>
                             Hello,<br/>
-                            We have been contacted by those prospects that are in your region. Thus, the following leads have been assigned to <t t-out="ctx['partner_id'].name or ''"></t>:<br/>
+                            We have been contacted by those prospects that are in your region. Thus, the following leads have been assigned to <t t-out="ctx['partner_id'].name if ctx.get('partner_id') else ''"></t>:<br/>
                             <ol>
-                                <li t-foreach="ctx['partner_leads']" t-as="lead"><a t-att-href="lead['lead_link']" t-out="lead['lead_id'].name or 'Subject Undefined'">Subject Undefined</a>, <t t-out="lead['lead_id'].partner_name or lead['lead_id'].contact_name or 'Contact Name Undefined'">Contact Name Undefined</t>, <t t-out="lead['lead_id'].country_id and lead['lead_id'].country_id.name or 'Country Undefined'">Country Undefined</t>, <t t-out="lead['lead_id'].email_from or 'Email Undefined' or ''">Email Undefined</t>, <t t-out="lead['lead_id'].phone or ''">+1 650-123-4567</t> </li><br/>
+                                <li t-foreach="ctx.get('partner_leads', [])" t-as="lead"><a t-att-href="lead['lead_link']" t-out="lead['lead_id'].name or 'Subject Undefined'">Subject Undefined</a>, <t t-out="lead['lead_id'].partner_name or lead['lead_id'].contact_name or 'Contact Name Undefined'">Contact Name Undefined</t>, <t t-out="lead['lead_id'].country_id and lead['lead_id'].country_id.name or 'Country Undefined'">Country Undefined</t>, <t t-out="lead['lead_id'].email_from or 'Email Undefined' or ''">Email Undefined</t>, <t t-out="lead['lead_id'].phone or ''">+1 650-123-4567</t> </li><br/>
                             </ol>
                             <t t-if="ctx.get('partner_in_portal')">
                                 Please connect to your <a t-att-href="'%s?db=%s' % (object.get_base_url(), object.env.cr.dbname)">Partner Portal</a> to get details. On each lead are two buttons on the top left corner that you should press after having contacted the lead: "I'm interested" &amp; "I'm not interested".<br/>
                             </t>
                             <t t-else="">
                                 You do not have yet a portal access to our database. Please contact
-                                <t t-out="ctx['partner_id'].user_id and ctx['partner_id'].user_id.email and 'your account manager %s (%s)' % (ctx['partner_id'].user_id.name,ctx['partner_id'].user_id.email) or 'us'">us</t>.<br/>
+                                <t t-out="ctx.get('partner_id') and ctx['partner_id'].user_id and ctx['partner_id'].user_id.email and 'your account manager %s (%s)' % (ctx['partner_id'].user_id.name,ctx['partner_id'].user_id.email) or 'us'">us</t>.<br/>
                             </t>
                             The lead will be sent to another partner if you do not contact the lead before 20 days.<br/><br/>
                             Thank you,<br/>
-                            <t t-out="ctx['partner_id'].user_id and ctx['partner_id'].user_id.signature or ''"></t>
+                            <t t-out="ctx.get('partner_id') and ctx['partner_id'].user_id and ctx['partner_id'].user_id.signature or ''"></t>
                             <br/>
-                            <t t-if="not ctx['partner_id'].user_id">
+                            <t t-if="not ctx.get('partner_id') or not ctx['partner_id'].user_id">
                                 PS: It looks like you do not have an account manager assigned to you, please contact us.
                             </t>
                         </div>
@@ -96,7 +96,7 @@
 </td></tr>
 </table>
             </field>
-            <field name="lang">{{ ctx['partner_id'].lang }}</field>
+            <field name="lang">{{ ctx['partner_id'].lang if ctx.get('partner_id') else ''}}</field>
             <field name="auto_delete" eval="True"/>
         </record>
     </data>


### PR DESCRIPTION
Steps to reproduce:
- Create a lead > click on gear icon > Forward to partner
- Send the forward and ensure there is at least one record of crm.forward.to.partner
- Navigate to email templates technical settings menu and search for Lead Forward: Send to partner
- Click on Reset Template in the template form

Current behavior:
- Validation Error thrown

Expected behavior:
- No validation error thrown and template is reset

Note:
MailTemplate._check_can_be_rendered was added in version 18.3 which checks for invalid object references when trying to alter  + save templates. This template was out of date and fails the check

Referenced PR: https://github.com/odoo/odoo/pull/176623

opw-6001560