### PR TITLE
[FIX] point_of_sale: Prevent assigning multiple POS shop to one cash payment. 

### DIFF
--- a/addons/point_of_sale/models/pos_payment_method.py
+++ b/addons/point_of_sale/models/pos_payment_method.py
@@ -217,6 +217,16 @@ class PosPaymentMethod(models.Model):
             if self.env['pos.config'].search_count([('id', 'in', payment.config_ids.ids), ('company_id', '!=', payment.company_id.id)]):
                 raise ValidationError(_("The points of sale for the payment method %s must belong to its company.", payment.name))
 
+    @api.constrains('config_ids', 'is_cash_count', 'journal_id')
+    def _check_cash_method_single_shop(self):
+        for method in self:
+            is_cash = method.is_cash_count or (method.journal_id and method.journal_id.type == 'cash')
+            if is_cash and len(method.config_ids) > 1:
+                raise ValidationError(_(
+                    "Validation Error: You cannot assign the same Cash payment method to multiple POS Shops. "
+                    "Please create a separate Cash payment method for each shop."
+                ))
+
     @api.depends('payment_method_type', 'journal_id')
     def _compute_qr(self):
         for pm in self:


### PR DESCRIPTION
**Before this commit**
The user will be able to assign two different POS shop to a cash payment
method by going to
POS -> Configuration -> Payment Methods -> Cash -> Point of sale,
this will not raise a validation error when they try to save it but it
will prevent the user from opening the POS session.

**After this commit**
It will raise a validation error if a user tries to assign more than one POS shop to one cash 
payment method and save it.

opw-6015025