### PR TITLE
[FIX] l10n_jo_edi_pos: Fix payment methods issues

### DIFF
--- a/addons/l10n_jo_edi/tests/jo_edi_common.py
+++ b/addons/l10n_jo_edi/tests/jo_edi_common.py
@@ -53,6 +53,7 @@ class JoEdiCommon(AccountTestInvoicingCommon):
         })
 
         # The rate of 1 USD = 2 JOD is meant to simplify tests
+        cls.jod = cls.env.ref('base.JOD')
         cls.usd = cls.env.ref('base.USD')
         cls.setup_currency_rate(cls.usd, 0.5)
 

--- a/addons/l10n_jo_edi_pos/models/pos_order.py
+++ b/addons/l10n_jo_edi_pos/models/pos_order.py
@@ -50,8 +50,16 @@ class PosOrder(models.Model):
     def _get_order_scope_code(self):
         return '0'
 
+    def _l10n_jo_edi_pos_get_payment_type(self):
+        """
+        :returns: 'cash', 'receivable', or None if payments are of different types or missing.
+        """
+        is_cash_set = set(self.payment_ids.payment_method_id.mapped('l10n_jo_edi_pos_is_cash'))
+        if len(is_cash_set) == 1:
+            return 'cash' if is_cash_set.pop() else 'receivable'
+
     def _get_order_payment_method_code(self):
-        return '1' if any(self.payment_ids.payment_method_id.mapped('l10n_jo_edi_pos_is_cash')) else '2'
+        return '1' if self._l10n_jo_edi_pos_get_payment_type() == 'cash' else '2'
 
     def _get_order_tax_payer_type_code(self):
         return {
@@ -92,8 +100,14 @@ class PosOrder(models.Model):
                 error_msgs.append(self.env._("Refund order must have a return reason"))
         if any(line.price_unit < 0 for line in self.lines) or (not self.refunded_order_id and any(line.qty < 0 for line in self.lines)):
             error_msgs.append(self.env._("Downpayments, global discounts, and negative lines are not supported at the moment. To revert this order, please go to Orders > Select the Order > Refund or create a Return from the backend by going to Orders > Select the Order > Return"))
-        if len(self.payment_ids.payment_method_id.mapped('l10n_jo_edi_pos_is_cash')) > 1:
+        if not self._l10n_jo_edi_pos_get_payment_type():
             error_msgs.append(self.env._("Please select the payment methods that are consistent with the value set in 'JoFotara Cash'. If set, the payment method is Cash. If empty, then it is Receivable."))
+        else:
+            jod = self.env.ref('base.JOD')
+            amount_total_jod = self.amount_total if self.currency_id == jod else self.currency_id._convert(self.amount_total, jod, self.company_id, self.date_order)
+            amount_total_requires_customer = jod.compare_amounts(amount_total_jod, 10_000) == 1
+            if not self.partner_id and (self._l10n_jo_edi_pos_get_payment_type() == 'receivable' or amount_total_requires_customer):
+                error_msgs.append(self.env._("Customer is required on either Receivable or more than 10,000 JOD Cash Orders."))
 
         for line in self.lines:
             if self.company_id.l10n_jo_edi_taxpayer_type == 'income' and len(line.tax_ids) != 0:

--- a/addons/l10n_jo_edi_pos/static/tests/tours/l10n_jo_edi_pos_tour.js
+++ b/addons/l10n_jo_edi_pos/static/tests/tours/l10n_jo_edi_pos_tour.js
@@ -12,7 +12,7 @@ registry.category("web_tour.tours").add("L10nJoEdiPosTour", {
             Dialog.confirm("Open Register"),
             ProductScreen.addOrderline("Desk Pad", "1"),
             ProductScreen.clickPayButton(),
-            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickPaymentMethod("Cash"),
             PaymentScreen.clickValidate(),
             ReceiptScreen.receiptIsThere(),
             {

--- a/addons/l10n_jo_edi_pos/tests/jo_edi_pos_common.py
+++ b/addons/l10n_jo_edi_pos/tests/jo_edi_pos_common.py
@@ -15,14 +15,22 @@ class JoEdiPosCommon(JoEdiCommon, TestPoSCommon, TestPointOfSaleHttpCommon):
             'country_id': cls.env.ref('base.jo').id,
         })
 
-    def _l10n_jo_create_order(self, order_vals):
+    def _pay_order(self, order, payments=None, default_payment=True):
+        if default_payment:
+            bank_pm = self.main_pos_config.payment_method_ids.filtered(lambda pm: not pm.l10n_jo_edi_pos_is_cash)[0]
+            payments = [(bank_pm, order.amount_total)]  # the default is to pay all the order by bank payment method
+
+        for pm, amount in (payments or []):
+            self.make_payment(order, pm, amount)
+
+    def _l10n_jo_create_order(self, order_vals, payments=None, default_payment=True):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         order_vals.update({
             'company_id': self.company.id,
             'session_id': self.main_pos_config.current_session_id.id,
-            'partner_id': self.partner_jo.id,
             'date_order': order_vals.get('date_order', '2019-01-01'),
         })
+        order_vals.setdefault('partner_id', self.partner_jo.id)
         order_vals.setdefault('amount_tax', 0)
         order_vals.setdefault('amount_paid', 0)
         order_vals.setdefault('amount_total', 0)
@@ -34,14 +42,19 @@ class JoEdiPosCommon(JoEdiCommon, TestPoSCommon, TestPointOfSaleHttpCommon):
         if 'currency_id' in order_vals:
             order.currency_id = order_vals['currency_id']
 
+        self._pay_order(order, payments, default_payment)
+
         return order
 
-    def _l10n_jo_create_order_refund(self, order, refund_vals):
-        order = self._l10n_jo_create_order(order) if isinstance(order, dict) else order
+    def _l10n_jo_create_order_refund(self, order, refund_vals, payments=None, default_payment=True):
+        order = self._l10n_jo_create_order(order, payments, default_payment) if isinstance(order, dict) else order
         order_refund = order._refund()
         if 'lines' in refund_vals:
             for order_line, line_write_vals in zip(order_refund.lines, refund_vals['lines']):
                 order_line.write(line_write_vals)
             del refund_vals['lines']
         order_refund.write(refund_vals)
+
+        self._pay_order(order_refund, payments, default_payment)
+
         return order_refund

--- a/addons/l10n_jo_edi_pos/tests/test_jo_edi_pos_types.py
+++ b/addons/l10n_jo_edi_pos/tests/test_jo_edi_pos_types.py
@@ -310,14 +310,7 @@ class TestJoEdiPosTypes(JoEdiPosCommon):
         self.assertGreater(int(xml_tree.findall('./{*}InvoiceLine')[-1].findtext('{*}ID')), 4)
 
     def test_different_payment_methods(self):
-        def get_xml_order_type(order, amount_cash, amount_bank):
-            cash_pm = order.config_id.payment_method_ids.filtered(lambda pm: pm.l10n_jo_edi_pos_is_cash)[0]
-            bank_pm = order.config_id.payment_method_ids.filtered(lambda pm: not pm.l10n_jo_edi_pos_is_cash)[0]
-
-            if amount_cash:
-                self.make_payment(order, cash_pm, amount_cash)
-            if amount_bank:
-                self.make_payment(order, bank_pm, amount_bank)
+        def get_xml_order_type(order):
             if order._l10n_jo_validate_fields():  # conflicting payment methods
                 return False
 
@@ -328,10 +321,39 @@ class TestJoEdiPosTypes(JoEdiPosCommon):
         self.company.l10n_jo_edi_taxpayer_type = 'income'
         self.company.l10n_jo_edi_sequence_income_source = '4419618'
 
-        for (cash_amount, bank_amount, expected_type) in [
-            (100, 0, '011'),
-            (0, 100, '021'),
-            (50, 50, False),
+        cash_pm1, cash_pm2, bank_pm1, bank_pm2 = self.env['pos.payment.method'].create([
+            {
+                'name': 'Cash 1',
+                'l10n_jo_edi_pos_is_cash': True,
+            },
+            {
+                'name': 'Cash 2',
+                'l10n_jo_edi_pos_is_cash': True,
+            },
+            {
+                'name': 'Bank 1',
+                'l10n_jo_edi_pos_is_cash': False,
+            },
+            {
+                'name': 'Bank 2',
+                'l10n_jo_edi_pos_is_cash': False,
+            },
+        ])
+        self.main_pos_config.write({
+            'payment_method_ids': [
+                Command.link(cash_pm1.id),
+                Command.link(cash_pm2.id),
+                Command.link(bank_pm1.id),
+                Command.link(bank_pm2.id),
+            ],
+        })
+        for (payments, expected_type) in [
+            ([(cash_pm1, 100)], '011'),
+            ([(bank_pm1, 100)], '021'),
+            ([(cash_pm1, 50), (bank_pm1, 50)], False),
+            ([], False),
+            ([(cash_pm1, 50), (cash_pm2, 50)], '011'),
+            ([(bank_pm1, 50), (bank_pm2, 50)], '021'),
         ]:
             order_vals = {
                 'name': 'EIN/998833/0',
@@ -347,6 +369,63 @@ class TestJoEdiPosTypes(JoEdiPosCommon):
                     },
                 ],
             }
-            order = self._l10n_jo_create_order(order_vals)
-            order_type = get_xml_order_type(order, cash_amount, bank_amount)
+            order = self._l10n_jo_create_order(order_vals, payments=payments, default_payment=False)
+            order_type = get_xml_order_type(order)
             self.assertEqual(order_type, expected_type)
+
+    def test_mandatory_customer(self):
+        self.company.l10n_jo_edi_taxpayer_type = 'income'
+        self.company.l10n_jo_edi_sequence_income_source = '4419618'
+        cash_pm, bank_pm = self.env['pos.payment.method'].create([
+            {
+                'name': 'Cash',
+                'l10n_jo_edi_pos_is_cash': True,
+            },
+            {
+                'name': 'Bank',
+                'l10n_jo_edi_pos_is_cash': False,
+            },
+        ])
+        self.main_pos_config.write({
+            'payment_method_ids': [
+                Command.link(cash_pm.id),
+                Command.link(bank_pm.id),
+            ],
+        })
+        # The rate is 1 USD = 2 JOD
+        for currency_id, has_partner, amount_total, payment_method, is_valid in [
+            (self.jod,   True,        100,          cash_pm,        True),
+            (self.jod,   True,        10_000,       cash_pm,        True),
+            (self.jod,   True,        10_001,       cash_pm,        True),
+            (self.jod,   False,       100,          cash_pm,        True),
+            (self.jod,   False,       10_000,       cash_pm,        True),
+            (self.jod,   False,       10_001,       cash_pm,        False),
+            (self.jod,   False,       20_000,       cash_pm,        False),
+            (self.usd,   False,       5000.1,       cash_pm,        False),
+            (self.usd,   False,       5000,         cash_pm,        True),
+            (self.jod,   True,        100,          bank_pm,        True),
+            (self.jod,   True,        10_000,       bank_pm,        True),
+            (self.jod,   True,        10_001,       bank_pm,        True),
+            (self.jod,   False,       100,          bank_pm,        False),
+            (self.usd,   False,       100,          bank_pm,        False),
+            (self.jod,   False,       10_000,       bank_pm,        False),
+            (self.jod,   False,       10_001,       bank_pm,        False),
+        ]:
+            order_vals = {
+                'name': 'EIN/998833/0',
+                'partner_id': self.partner_jo.id if has_partner else False,
+                'currency_id': currency_id,
+                'date_order': '2022-09-27',
+                'general_note': 'ملاحظات 2',
+                'lines': [
+                    {
+                        'product_id': self.product_a.id,
+                        'price_unit': amount_total,
+                        'qty': 1,
+                        'discount': 0,
+                        'tax_ids': [Command.clear()],
+                    },
+                ],
+            }
+            order = self._l10n_jo_create_order(order_vals, payments=[(payment_method, amount_total)], default_payment=False)
+            self.assertEqual(bool(order._l10n_jo_validate_fields()), not is_valid)


### PR DESCRIPTION
This commit fixes the following issues
1) Having more than one payment method on a pos.order led to an error
2) Customer should be required if payment method is receivable, or cash with amount > 10,000 JOD

task-6005832

