### PR TITLE
[FIX] core: set faketime on raw connection

### DIFF
--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -265,8 +265,8 @@ class Cursor(_CursorProtocol):
         self._closed = False   # real initialization value
 
         if os.getenv('ODOO_FAKETIME_TEST_MODE') and self.dbname in tools.config['db_name']:
-            self.execute("SET search_path = public, pg_catalog;")
-            self.commit()  # ensure that the search_path remains after a rollback
+            self._obj.execute("SET SESSION search_path = public, pg_catalog;")
+            self._cnx.commit()  # ensure that the search_path remains after a rollback
 
     def flush(self) -> None:
         """ Flush the current transaction, and run precommit hooks. """


### PR DESCRIPTION
This avoids calling overrides in TestCursor which is not entirely setup during initialization.

runbot-241265

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
