### PR TITLE
[FIX] mass_mailing: properly keep track of dirtiness

### DIFF
--- a/addons/mass_mailing/static/src/builder/plugins/empty_not_editable_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/empty_not_editable_plugin.js
@@ -23,7 +23,7 @@ export class EmptyNotEditableElementsPlugin extends Plugin {
                 emptyNonEditableBlock.remove();
             }
         });
-        const selection = this.document.getSelection();
+        const selection = this.document.getSelection() ?? undefined;
         if (!this.dependencies.selection.isSelectionInEditable(selection)) {
             this.dependencies.selection.resetSelection();
         }

--- a/addons/mass_mailing/static/src/builder/plugins/snippet_visibility_option_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/snippet_visibility_option_plugin.js
@@ -11,6 +11,13 @@ class DataAttributeChangeAction extends DataAttributeAction {
         super.apply(context);
         this.config.onChange?.(context);
     }
+    isApplied({ editingElement, params: { mainParam: attributeName } = {}, value }) {
+        if (value) {
+            return Boolean(editingElement.dataset[attributeName]) === Boolean(value);
+        } else {
+            return super.isApplied(...arguments);
+        }
+    }
 }
 
 class SnippetVisibilityPlugin extends Plugin {

--- a/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
@@ -124,10 +124,16 @@ export class MassMailingHtmlField extends HtmlField {
         return this.state.activeTheme !== "basic" && !this.props.readonly;
     }
 
+    /**
+     * @deprecated
+     */
     resetIframe() {
         this.iframeLoaded = new Deferred();
     }
 
+    /**
+     * @deprecated
+     */
     async ensureIframeLoaded() {
         const iframeLoaded = this.iframeLoaded;
         // iframeInfo is deprecated
@@ -135,6 +141,9 @@ export class MassMailingHtmlField extends HtmlField {
         return iframeLoaded === this.iframeLoaded ? iframeInfo : undefined;
     }
 
+    /**
+     * @deprecated
+     */
     onIframeLoad(iframeLoaded) {
         this.iframeLoaded.resolve(iframeLoaded);
     }
@@ -190,7 +199,7 @@ export class MassMailingHtmlField extends HtmlField {
             onFocus: this.onFocus.bind(this),
             onBlur: this.onBlur.bind(this), // deprecated
             onEditorLoad: this.onEditorLoad.bind(this),
-            onIframeLoad: this.onIframeLoad.bind(this),
+            onIframeLoad: this.onIframeLoad.bind(this), // deprecated
             readonly: this.props.readonly,
             showThemeSelector: this.state.showThemeSelector,
             showCodeView: this.state.showCodeView,
@@ -297,6 +306,10 @@ export class MassMailingHtmlField extends HtmlField {
         };
     }
 
+    isEditorReady() {
+        return this.editor && this.editor.isReady && !this.editor.isDestroyed;
+    }
+
     onChange() {
         // Ensure that a change in the edited field will reset the validity
         // of the inlineField (since it is most likely invisible and not
@@ -346,7 +359,7 @@ export class MassMailingHtmlField extends HtmlField {
     async commitChanges({ urgent } = {}) {
         if (!urgent) {
             await this.mutex.exec(() => {
-                if (this.withBuilder && this.editor && !this.editor.isDestroyed) {
+                if (this.withBuilder && this.isEditorReady()) {
                     return this.editor.shared.operation.getUnlockedDef();
                 }
             });
@@ -361,20 +374,15 @@ export class MassMailingHtmlField extends HtmlField {
      * @override
      */
     async _commitChanges({ urgent }) {
+        if (!this.state.showCodeView && !this.isEditorReady()) {
+            return;
+        }
         if (
-            this.editor &&
-            !this.editor.isDestroyed &&
+            this.props.record.data[this.props.name].toString() !== "" &&
             this.props.record.data[this.props.inlineField].toString() === ""
         ) {
-            if ((await this.ensureIframeLoaded()) && this.editor && !this.editor.isDestroyed) {
-                this.isDirty = true;
-                this.lastValue = undefined;
-            } else {
-                return;
-            }
-        }
-        if (!this.state.showCodeView && this.editor?.isDestroyed) {
-            return;
+            this.isDirty = true;
+            this.lastValue = undefined;
         }
         return super._commitChanges({ urgent });
     }

--- a/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/fields/html_field/mass_mailing_html_field.js
@@ -22,6 +22,7 @@ import { useChildRef, useService } from "@web/core/utils/hooks";
 import { batched } from "@web/core/utils/timing";
 import { PowerButtonsPlugin } from "@html_editor/main/power_buttons_plugin";
 import { useEmailHtmlConverter } from "@mail/convert_inline/hooks";
+import { fixInvalidHTML } from "@html_editor/utils/sanitize";
 
 export class MassMailingHtmlField extends HtmlField {
     static template = "mass_mailing.HtmlField";
@@ -287,19 +288,39 @@ export class MassMailingHtmlField extends HtmlField {
 
     getThemeSelectorConfig() {
         return {
-            setThemeHTML: (html) =>
-                this.mutex.exec(() =>
+            setThemeHTML: (html) => {
+                this.onChange();
+                const changeId = this.lastChangeId;
+                const record = this.props.record;
+                return this.mutex.exec(() => {
+                    if (this.props.record !== record) {
+                        return;
+                    }
                     // The inlineField can not be updated to its final value at
                     // this point since the editor is needed to process the
                     // theme template. (i.e. applying the default style).
                     // It will be updated onEditorReady since it has become empty.
-                    this.props.record
+                    return record
                         .update({
                             [this.props.name]: html,
                             [this.props.inlineField]: "",
                         })
-                        .catch(() => {})
-                ),
+                        .then(
+                            () => {
+                                this.state.key++;
+                                this.lastValue = normalizeHTML(
+                                    fixInvalidHTML(record.data[this.props.name]),
+                                    this.clearElementToCompare.bind(this)
+                                );
+                                record.model.bus.trigger(
+                                    "FIELD_IS_DIRTY",
+                                    this.lastChangeId !== changeId
+                                );
+                            },
+                            () => {}
+                        );
+                });
+            },
             filterTemplates: this.props.filterTemplates,
             mailingModelId: this.props.record.data.mailing_model_id.id,
             mailingModelName: this.props.record.data.mailing_model_id.display_name || "",
@@ -381,7 +402,12 @@ export class MassMailingHtmlField extends HtmlField {
             this.props.record.data[this.props.name].toString() !== "" &&
             this.props.record.data[this.props.inlineField].toString() === ""
         ) {
-            this.isDirty = true;
+            if (!this.isDirty) {
+                // Fields values are desynchronized and the inlineField
+                // has to be computed, even if the user made no change. In
+                // this specific case, onChange is forced.
+                this.onChange();
+            }
             this.lastValue = undefined;
         }
         return super._commitChanges({ urgent });
@@ -393,7 +419,7 @@ export class MassMailingHtmlField extends HtmlField {
      * the style of the inlineField.
      * @override
      */
-    async updateValue(value) {
+    async updateValue(value, { changeId } = { changeId: this.lastChangeId }) {
         const record = this.props.record;
         // Ensure the edited value is updated immediately to avoid data loss,
         // and reset the inline field (need async computation) to avoid
@@ -405,9 +431,12 @@ export class MassMailingHtmlField extends HtmlField {
                 [this.props.name]: value,
                 [this.props.inlineField]: "",
             })
-            .then(() => {
-                record.model.bus.trigger("FIELD_IS_DIRTY", false);
-            });
+            .then(
+                () => {
+                    record.model.bus.trigger("FIELD_IS_DIRTY", this.lastChangeId !== changeId);
+                },
+                () => {}
+            );
         this.lastValue = normalizeHTML(value, this.clearElementToCompare.bind(this));
         const valueFragment = parseHTML(document, value);
         let inlineValue;
@@ -425,10 +454,14 @@ export class MassMailingHtmlField extends HtmlField {
         if (record.resId !== this.props.record?.resId || inlineValue === null) {
             return;
         }
-        this.isDirty = false;
-        await record
-            .update({ [this.props.inlineField]: inlineValue })
-            .catch(() => (this.isDirty = true));
+        await record.update({ [this.props.inlineField]: inlineValue }).then(
+            () => {
+                if (this.lastChangeId === changeId) {
+                    this.isDirty = false;
+                }
+            },
+            () => {}
+        );
         record.model.bus.trigger("FIELD_IS_DIRTY", this.isDirty);
     }
     /**

--- a/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.js
+++ b/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.js
@@ -58,7 +58,7 @@ export class MassMailingIframe extends Component {
         iframeRef: { type: Function },
         iframeWrapperRef: { type: Function },
         showThemeSelector: { type: Boolean, optional: true },
-        onIframeLoad: { type: Function, optional: true },
+        onIframeLoad: { type: Function, optional: true }, // deprecated
         showCodeView: { type: Boolean, optional: true },
         toggleCodeView: { type: Function, optional: true },
         readonly: { type: Boolean, optional: true },
@@ -207,6 +207,9 @@ export class MassMailingIframe extends Component {
             },
             () => [this.state.isMobile]
         );
+        onWillDestroy(() => {
+            this.iframeLoaded.resolve(false);
+        });
     }
 
     get isBrowserSafari() {
@@ -366,7 +369,9 @@ export class MassMailingIframe extends Component {
         return {
             overlayRef: this.overlayRef,
             // TODO EGGMAIL: iframeInfo is deprecated (should resolve to iframe directly)
-            iframeLoaded: this.iframeLoaded.then((iframeInfo) => iframeInfo.iframe),
+            iframeLoaded: this.iframeLoaded.then((iframeInfo) =>
+                iframeInfo ? iframeInfo.iframe : false
+            ),
             snippetsName: "mass_mailing.email_designer_snippets",
             config: this.props.config,
             isMobile: this.state.isMobile,

--- a/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
+++ b/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
@@ -11,8 +11,8 @@ import {
     getPagerValue,
     getPagerLimit,
 } from "@web/../tests/web_test_helpers";
-import { click, queryAny, queryOne, waitFor } from "@odoo/hoot-dom";
-import { animationFrame, runAllTimers } from "@odoo/hoot-mock";
+import { click, queryOne, waitFor } from "@odoo/hoot-dom";
+import { animationFrame } from "@odoo/hoot-mock";
 import { defineMailModels } from "@mail/../tests/mail_test_helpers";
 import { unmockedOrm } from "@web/../tests/_framework/module_set.hoot";
 import { MassMailingIframe } from "../src/iframe/mass_mailing_iframe";
@@ -418,16 +418,25 @@ describe("field HTML", () => {
         });
         await click(waitFor(".o_mailing_template_preview_wrapper [data-name='default']"));
         await waitFor(".o_mass_mailing_iframe_wrapper iframe:not(.d-none)");
-        expect(await waitFor(":iframe .o_layout", { timeout: 3000 })).toHaveClass(
-            "o_default_theme"
+        expect(
+            await waitFor(".o_mass_mailing_iframe_wrapper :iframe .o_layout", { timeout: 3000 })
+        ).toHaveClass("o_default_theme");
+        const section = await waitFor(".o_mass_mailing_iframe_wrapper :iframe section", {
+            timeout: 3000,
+        });
+        await click(section);
+        await waitFor(
+            ".o-snippets-menu:has([data-action-id='dataAttributeChangeAction'].active:contains(Visible))",
+            { timeout: 3000 }
         );
-        await runAllTimers();
-        const section = queryAny(":iframe section");
         section.dataset.filterDomain = JSON.stringify([["id", "=", 1]]);
         htmlField.editor.config.onChange({ isPreviewing: false });
-        await click(section);
-        await waitFor(".hb-row .hb-row-label span:contains(Domain)");
-        expect(queryOne(".hb-row span.fa-filter + span").textContent.toLowerCase()).toBe("id = 1");
+        await waitFor(".o-snippets-menu [data-label='Domain']", { timeout: 3000 });
+        expect(
+            queryOne(
+                ".o-snippets-menu [data-label='Domain'] span.fa-filter + span"
+            ).textContent.toLowerCase()
+        ).toBe("id = 1");
         await clickSave();
         await waitFor("table[t-if]");
         expect(queryOne("table[t-if]")).toHaveAttribute(

--- a/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
+++ b/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
@@ -495,36 +495,3 @@ describe("field HTML", () => {
         expect(fixture.querySelectorAll(".o_mass_mailing-builder_sidebar")).toHaveCount(0);
     });
 });
-describe("field HTML: with loaded assets", () => {
-    test("Ensure style bundles loaded in the `MassMailingIframe` can be toggled On or Off", async () => {
-        await mountView({
-            type: "form",
-            resModel: "mailing.mailing",
-            resId: 1,
-            arch: mailViewArch,
-        });
-        await click(waitFor(".o_mailing_template_preview_wrapper [data-name='default']"));
-        await waitFor(".o_mass_mailing_iframe_wrapper iframe:not(.d-none)");
-        const { bundleControls } = await htmlField.ensureIframeLoaded();
-
-        expect(
-            htmlField.iframeRef.el.contentDocument.head.querySelectorAll(
-                '[href*="mass_mailing.assets_inside_builder_iframe"]'
-            )
-        ).toHaveLength(1);
-
-        bundleControls["mass_mailing.assets_inside_builder_iframe"].toggle(false);
-        expect(
-            htmlField.iframeRef.el.contentDocument.head.querySelectorAll(
-                '[href*="mass_mailing.assets_inside_builder_iframe"]'
-            )
-        ).toHaveLength(0);
-
-        bundleControls["mass_mailing.assets_inside_builder_iframe"].toggle(true);
-        expect(
-            htmlField.iframeRef.el.contentDocument.head.querySelectorAll(
-                '[href*="mass_mailing.assets_inside_builder_iframe"]'
-            )
-        ).toHaveLength(1);
-    });
-});

--- a/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
+++ b/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
@@ -396,12 +396,13 @@ describe("field HTML", () => {
             resId: 1,
         });
         await contains(".o_data_cell").click();
-        await waitFor(".o_dialog");
-        await contains(".o_dialog [data-name='event']").click();
-        await waitFor(".o_dialog .o_mass_mailing-builder_sidebar", { timeout: 1000 });
-        await contains(".o_dialog :iframe p", { timeout: 1000 }).click();
+        await waitFor(".o_dialog", { timeout: 3000 });
+        await contains(".o_dialog [data-name='event']", { timeout: 3000 }).click();
+        await waitFor(".o_dialog .o_mass_mailing-builder_sidebar", { timeout: 3000 });
+        await contains(".o_dialog :iframe p", { timeout: 3000 }).click();
         await waitFor(
-            ".o_dialog .o_mass_mailing-builder_sidebar .options-container-header:contains(Text)"
+            ".o_dialog .o_mass_mailing-builder_sidebar .options-container-header:contains(Text)",
+            { timeout: 3000 }
         );
         const overlayOptionsSelect =
             ".o-main-components-container .o-overlay-container .o_overlay_options";

--- a/addons/mass_mailing/static/tests/tours/mailing_editor_theme.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_editor_theme.js
@@ -47,6 +47,9 @@ registry.category("web_tour.tours").add('mailing_editor_theme', {
             content: "Make sure the snippets menu is hidden",
             trigger: "html:not(:has(.o-snippets-menu))",
         },
+        {
+            trigger: ".o_mass_mailing_iframe_wrapper :iframe .o_layout.o_basic_theme",
+        },
         ...stepUtils.saveForm(),
         {
             content: "Click on the New button to create another mailing",


### PR DESCRIPTION
### Ensure correct visibility option state
Prior to this commit, the `dataAttributeChangeAction` selected item depended on
the domain value computed during the last template rendering, compared to the
current edited element value. The issue is that when an edited element receives
a new `data-filter-domain`, the selected options are evaluated before the
component can register the new domain in its state, so the wrong values are
compared. In this particular case, since we only need 2 values (on/off), an
acceptable trade-off is to choose the selected item ("always visible" vs
"conditionally") based on the Boolean value of the attribute.

### Remove deprecated assets toggle test
The toggle assets feature was deprecated in a prior [commit1].

The test is removed as its outcome is non-deterministic, because it depends on
the `target` property of `event` returned as a promise resolution value by
`loadBundle`, however the browser can set that target to `null` after the event
was dispatched, so relying on the target value to keep track of the inserted
link is not reliable.

Since that `toggle` feature is not used anymore, it is not needed to run a test
for it. The feature will be removed in the latest `dev` branch.

[commit1]: https://github.com/odoo/odoo/commit/a0aa581636e257894c6c7e87c3793edebecad303

### prevent crash on commitChanges if editor is not ready
Prior to this commit, various checks in `commitChanges` did not take into
account that the editor could be instanced but not ready yet (meaning that
plugins are not available, and it is not possible to extract the editable
content).

This commit ensures that `commitChanges` can not crash if called when the editor
is not ready.

### Properly keep track of dirtiness
mass_mailing changes related to [commit2], which added a way to keep track of a
specific change handled during one `commitChanges` call. The field should stay
dirty if it received changes during a `commitChanges` execution.

In mass_mailing specifically, there were 2 other situations with invalid
tracking of dirtiness:

1) A new record with no change could not be discarded as it was incorrectly
marked as dirty since the `inlineField` value is "".

After this commit, the field is marked as dirty only if the edited field value
is not "" while the `inlineField` value is "", which is the problematic
situation where both values are desynchronized. A new record with both values at
"" is not marked as dirty anymore.

2) Setting a new theme in mass_mailing did not communicate properly with the
relational model about dirtiness.

After this commit, using `setThemeHTML` triggers `onChange`, and the record
update properly tracks that change to communicate with the
`FormStatusIndicator`. The field `isDirty` property stays at `true` though,
because it still needs to execute `convertToEmailHtml` to compute the
`inlineField` value, and it needs the `editor` for that. A `commitChanges`
occurs `onEditorReady` to execute this computation, at the end of which the
field is finally set as not dirty.

### Prevent crash with null selection
`document.getSelection()` returns `null` when the selection is not in the
document. However the selection plugin `isSelectionInEditable` function only
support a selection object or `undefined` as an argument, and will crash with
`null`.

This commit ensures that a valid value is provided to the plugin function to
prevent crashes where the selection is moved outside of the `mass_mailing`
iframe before `normalize_handlers` execution.

[commit2]: https://github.com/odoo/odoo/commit/378580735c785bdcf8b184342834d2b3ddaaaedd

task-5976348
