### PR TITLE
[FIX] hr_skills, website_event_exhibitor: base64 in qweb templates

### DIFF
--- a/addons/hr_skills/views/hr_employee_cv_templates.xml
+++ b/addons/hr_skills/views/hr_employee_cv_templates.xml
@@ -35,7 +35,7 @@
             background: #{color_primary};
             background-color: #{color_primary};">
             <div class="o_profile">
-                <img class="img img-fluid rounded-circle o_profile_image" t-attf-src="data:image/png;base64,#{o.image_128}" alt="" t-if="o.image_128"/>
+                <img class="img img-fluid rounded-circle o_profile_image" t-attf-src="data:image/png;base64,#{o.image_128.to_base64()}" alt="" t-if="o.image_128"/>
                 <h1 class="o_profile_name mt-2" t-field="o.name">Marc Demo</h1>
                 <h3 class="o_profile_job mb-2" t-field="o.job_id">Software Developer</h3>
             </div>

--- a/addons/website_event_exhibitor/report/website_event_exhibitor_templates.xml
+++ b/addons/website_event_exhibitor/report/website_event_exhibitor_templates.xml
@@ -9,7 +9,7 @@
                         <div class="h-100 p-2 pb-0">
                             <!-- Has to be base64-ified otherwise the reporting engine will sometimes load images
                             and sometimes not before printing, resulting in random results. -->
-                            <img class="img img-fluid" t-attf-src="data:images/png;base64,#{sponsor.image_128}"/>
+                            <img class="img img-fluid" t-attf-src="data:images/png;base64,#{sponsor.image_128.to_base64()}"/>
                         </div>
                     </div>
                 </t>


### PR DESCRIPTION
Images not encoded as base64.

runbot-241770


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
