### PR TITLE
[REF] tests: flush use

### DIFF
--- a/addons/sale_timesheet/tests/test_performance.py
+++ b/addons/sale_timesheet/tests/test_performance.py
@@ -19,7 +19,7 @@ class TestPerformanceTimesheet(TestSaleTimesheet):
         })
         self.assertFalse(project.task_ids.sale_line_id)
         self.env.invalidate_all()
-        with self.assertQueryCount(85):
+        with self.assertQueryCount(165):
             project.write({
                 'allow_billable': True,
                 'partner_id': self.partner_b.id,
@@ -34,7 +34,7 @@ class TestPerformanceTimesheet(TestSaleTimesheet):
             'project_id': project.id,
         } for i in range(50, 100)])
         self.env.invalidate_all()
-        with self.assertQueryCount(130):
+        with self.assertQueryCount(236):
             project.write({
                 'allow_billable': True,
                 'partner_id': self.partner_b.id,

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -598,7 +598,6 @@ class BaseCase(case.TestCase):
             return Cursor_execute(self, query, params, log_exceptions)
 
         if flush:
-            self.env.flush_all()
             self.env.cr.flush()
 
         with (
@@ -607,7 +606,6 @@ class BaseCase(case.TestCase):
         ):
             yield actual_queries
             if flush:
-                self.env.flush_all()
                 self.env.cr.flush()
 
     @contextmanager
@@ -652,19 +650,16 @@ class BaseCase(case.TestCase):
 
             The second form is convenient when used with :func:`users`.
         """
+        flush_func = self.env.cr.flush if flush else lambda: None
         if self.warm:
             # mock random in order to avoid random bus gc
             with patch('random.random', lambda: 1):
                 login = self.env.user.login
                 expected = counters.get(login, default)
-                if flush:
-                    self.env.flush_all()
-                    self.env.cr.flush()
+                flush_func()
                 count0 = self.cr.sql_log_count
                 yield
-                if flush:
-                    self.env.flush_all()
-                    self.env.cr.flush()
+                flush_func()
                 count = self.cr.sql_log_count - count0
                 if count != expected:
                     # add some info on caller to allow semi-automatic update of query count
@@ -684,13 +679,9 @@ class BaseCase(case.TestCase):
         else:
             # flush before and after during warmup, in order to reproduce the
             # same operations, otherwise the caches might not be ready!
-            if flush:
-                self.env.flush_all()
-                self.env.cr.flush()
+            flush_func()
             yield
-            if flush:
-                self.env.flush_all()
-                self.env.cr.flush()
+            flush_func()
 
     def assertRecordValues(
             self,
@@ -1269,8 +1260,8 @@ class SingleTransactionCase(BaseCase):
         cls.env = api.Environment(cls.cr, api.SUPERUSER_ID, {})
 
     def setUp(self):
-        super(SingleTransactionCase, self).setUp()
-        self.env.flush_all()
+        super().setUp()
+        self.cr.flush()
 
 
 class ChromeBrowserException(Exception):


### PR DESCRIPTION
`cr.flush()` already calls `env.flush_all()` not need to do it twice. The former function also flushes registered pre-commits. This can affect some query counts.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
