### PR TITLE
[FIX] website: Provide access to basic configuration for website Designer.

### DIFF
--- a/addons/website/views/res_config_settings_views.xml
+++ b/addons/website/views/res_config_settings_views.xml
@@ -223,7 +223,7 @@
     </record>
 
     <menuitem id="menu_website_global_configuration" parent="menu_website_configuration"
-        sequence="100" name="Configuration" groups="base.group_system"/>
+        sequence="100" name="Configuration" groups="website.group_website_designer"/>
 
     <menuitem name="Settings"
         id="menu_website_website_settings"


### PR DESCRIPTION
**rational:**

for the time being, website designer (`website.group_website_designer`) (the higher group in 'Website' Category) doesn't have access to any 'website configuration' menu entries. As a result, he can not manage blog, tags, tags categories, etc... 

Note : This change doesn't give any access. the user for the time being, has access by API. the menu entry is just 'hidden'. user so has to be in 'system' group, that is a too high group

