### PR TITLE
[IMP] purchase_stock: prevent missing MO link to Purchase Order

### DIFF
--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -123,6 +123,8 @@ class PurchaseOrder(models.Model):
             # The purpose is to link the po that the user will manually generate to the existing moves's chain.
             if order.state in ('draft', 'sent', 'to approve', 'purchase'):
                 for order_line in order.order_line:
+                    # do not remove move_dest
+                    move_dest = order_line.move_ids.move_dest_ids
                     order_line.move_ids._action_cancel()
                     if order_line.move_dest_ids:
                         move_dest_ids = order_line.move_dest_ids.filtered(lambda move: move.state != 'done' and not move.scrapped)
@@ -135,6 +137,7 @@ class PurchaseOrder(models.Model):
                         else:
                             move_dest_ids.write({'procure_method': 'make_to_stock'})
                             move_dest_ids._recompute_state()
+                    order_line.move_ids.move_dest_ids = move_dest
 
             for pick in order.picking_ids.filtered(lambda r: r.state != 'cancel'):
                 pick.action_cancel()


### PR DESCRIPTION
* A MO contain component that have MTO + buy route , that component has subcontract BOm

* Confirm MO will create Subcontract PO, but try to cancel that PO the MO link missing becasue we remove move_dest_ids out of order_line.move_ids in _action_cancel

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
