### PR TITLE
[REF] html_editor, website: direct reference to table selection and qweb node

### DIFF
--- a/addons/html_editor/static/src/@types/plugins.d.ts
+++ b/addons/html_editor/static/src/@types/plugins.d.ts
@@ -9,7 +9,7 @@ declare module "plugins" {
     import { on_will_delete_handlers, delete_backward_line_overrides, delete_backward_overrides, delete_backward_word_overrides, delete_forward_line_overrides, delete_forward_overrides, delete_forward_word_overrides, on_deleted_handlers, delete_range_overrides, DeleteShared, is_functional_empty_node_predicates, removable_descendants_providers, system_node_selectors, is_node_removable_predicates } from "@html_editor/core/delete_plugin";
     import { DialogShared } from "@html_editor/core/dialog_plugin";
     import { on_inserted_handlers, before_insert_processors, on_will_set_tag_handlers, DomShared, node_to_insert_processors, system_attributes, system_classes, system_style_properties, are_inlines_allowed_at_root_predicates } from "@html_editor/core/dom_plugin";
-    import { is_format_class_predicates, on_will_format_selection_handlers, FormatShared, has_format_predicates, on_all_formats_removed_handlers } from "@html_editor/core/format_plugin";
+    import { is_format_class_predicates, format_selection_overrides, FormatShared, has_format_predicates, on_all_formats_removed_handlers } from "@html_editor/core/format_plugin";
     import { on_attribute_changed_handlers, attribute_change_processors, on_will_add_step_handlers, on_will_filter_mutation_record_handlers, on_content_updated_handlers, on_external_step_added_handlers, on_new_records_handled_handlers, on_history_cleaned_handlers, on_history_reset_from_steps_handlers, on_history_reset_handlers, history_step_processors, HistoryShared, on_redone_handlers, on_undone_handlers, on_savepoint_restored_handlers, is_mutation_record_savable_predicates, serializable_descendants_processors, set_attribute_overrides, on_step_added_handlers, is_step_reversible_predicates } from "@html_editor/core/history_plugin";
     import { on_beforeinput_handlers, on_input_handlers } from "@html_editor/core/input_plugin";
     import { on_will_break_line_handlers, insert_line_break_element_overrides, LineBreakShared } from "@html_editor/core/line_break_plugin";
@@ -25,7 +25,7 @@ declare module "plugins" {
     import { BannerShared } from "@html_editor/main/banner_plugin";
     import { EmojiShared } from "@html_editor/main/emoji_plugin";
     import { feff_providers, FeffShared, would_feff_be_legit_predicates, selectors_for_feff_providers } from "@html_editor/main/feff_plugin";
-    import { apply_background_color_processors, apply_color_style_overrides, color_apply_overrides, color_combination_providers, ColorShared, background_color_processors } from "@html_editor/main/font/color_plugin";
+    import { apply_background_color_processors, apply_color_style_overrides, apply_color_overrides, color_combination_providers, ColorShared, background_color_processors } from "@html_editor/main/font/color_plugin";
     import { ColorUIShared } from "@html_editor/main/font/color_ui_plugin";
     import { before_insert_within_pre_processors, font_items } from "@html_editor/main/font/font_plugin";
     import { hint_targets_providers, hints } from "@html_editor/main/hint_plugin";
@@ -161,7 +161,6 @@ declare module "plugins" {
         on_will_break_line_handlers: on_will_break_line_handlers;
         on_will_delete_handlers: on_will_delete_handlers;
         on_will_filter_mutation_record_handlers: on_will_filter_mutation_record_handlers;
-        on_will_format_selection_handlers: on_will_format_selection_handlers;
         on_will_mount_component_handlers: on_will_mount_component_handlers;
         on_will_paste_handlers: on_will_paste_handlers;
         on_will_process_image_handlers: on_will_process_image_handlers;
@@ -172,7 +171,7 @@ declare module "plugins" {
 
         // Overrides
         apply_color_style_overrides: apply_color_style_overrides;
-        color_apply_overrides: color_apply_overrides;
+        apply_color_overrides: apply_color_overrides;
         delete_backward_line_overrides: delete_backward_line_overrides;
         delete_backward_overrides: delete_backward_overrides;
         delete_backward_word_overrides: delete_backward_word_overrides;
@@ -183,6 +182,7 @@ declare module "plugins" {
         delete_range_overrides: delete_range_overrides;
         double_click_overrides: double_click_overrides;
         fix_selection_on_editable_root_overrides: fix_selection_on_editable_root_overrides;
+        format_selection_overrides: format_selection_overrides;
         insert_line_break_element_overrides: insert_line_break_element_overrides;
         paste_text_overrides: paste_text_overrides;
         paste_url_overrides: paste_url_overrides;

--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -52,7 +52,7 @@ function isFormatted(formatPlugin, format) {
  * @typedef {((formatName: string, options: {
  *      formatProps: object,
  *      applyStyle: boolean,
- * }) => void | boolean)[]} on_will_format_selection_handlers
+ * }) => void | boolean)[]} format_selection_overrides
  * @typedef {(() => void)[]} on_all_formats_removed_handlers
  *
  * @typedef {((className: string) => boolean | undefined)[]} is_format_class_predicates
@@ -305,7 +305,6 @@ export class FormatPlugin extends Plugin {
     }
 
     formatSelection(formatName, options) {
-        this.trigger("on_will_format_selection_handlers", formatName, options);
         if (this._formatSelection(formatName, options) && !options?.removeFormat) {
             this.dependencies.history.addStep();
         }
@@ -318,6 +317,16 @@ export class FormatPlugin extends Plugin {
         const selection = this.dependencies.split.splitSelection();
         if (typeof applyStyle === "undefined") {
             applyStyle = !this.isSelectionFormat(formatName);
+        }
+
+        const formattedNodes = new Set();
+        if (
+            this.delegateTo("format_selection_overrides", formatName, formattedNodes, {
+                applyStyle,
+                formatProps,
+            })
+        ) {
+            return;
         }
 
         let zws;
@@ -350,24 +359,7 @@ export class FormatPlugin extends Plugin {
                         isContentEditable(n)
                 )
         );
-        const unformattedTextNodes = selectedTextNodes.filter((n) => {
-            const listItem = closestElement(n, "li");
-            if (listItem && this.dependencies.selection.areNodeContentsFullySelected(listItem)) {
-                const hasFontSizeStyle =
-                    formatName === "setFontSizeClassName"
-                        ? listItem.classList.contains(formatProps?.className)
-                        : listItem.style.fontSize;
-                return !hasFontSizeStyle;
-            }
-            return true;
-        });
-
-        const tagetedFieldNodes = new Set(
-            this.dependencies.selection
-                .getTargetedNodes()
-                .map((n) => closestElement(n, "*[t-field],*[t-out],*[t-esc]"))
-                .filter(Boolean)
-        );
+        const unformattedTextNodes = selectedTextNodes.filter((n) => !formattedNodes.has(n));
         const formatSpec = formatsSpecs[formatName];
         for (const node of unformattedTextNodes) {
             const inlineAncestors = [];
@@ -461,14 +453,6 @@ export class FormatPlugin extends Plugin {
             }
         }
 
-        for (const targetedFieldNode of tagetedFieldNodes) {
-            if (applyStyle) {
-                formatSpec.addStyle(targetedFieldNode, formatProps);
-            } else {
-                formatSpec.removeStyle(targetedFieldNode);
-            }
-        }
-
         if (zws) {
             const siblings = [...zws.parentElement.childNodes];
             if (
@@ -513,9 +497,9 @@ export class FormatPlugin extends Plugin {
             this.dependencies.selection.setSelection(newSelection, { normalize: false });
             return true;
         }
-        if (tagetedFieldNodes.size > 0) {
-            return true;
-        }
+        // To ensure history step is added when overrides apply formatting.
+        // @see formatSelection
+        return !!formattedNodes.size;
     }
 
     normalize(root) {

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -35,7 +35,7 @@ const COLOR_COMBINATION_SELECTOR = COLOR_COMBINATION_CLASSES.map((c) => `.${c}`)
 
 /**
  * @typedef {((element: HTMLElement, cssProp: string, color: string, params: Object) => boolean)[]} apply_color_style_overrides
- * @typedef {((color: string, mode: "color" | "backgroundColor") => void)[]} color_apply_overrides
+ * @typedef {((color: string, mode: "color" | "backgroundColor") => void)[]} apply_color_overrides
  * @typedef {((color: string, mode: "color" | "backgroundColor") => string)[]} apply_background_color_processors
  * @typedef {((color: string) => string)[]} background_color_processors
  *
@@ -114,21 +114,26 @@ export class ColorPlugin extends Plugin {
 
     removeAllColor() {
         const colorModes = ["color", "backgroundColor"];
+        const colorNodeProviders = this.getResource("color_target_providers");
         let someColorWasRemoved = true;
         while (someColorWasRemoved) {
             someColorWasRemoved = false;
             for (const mode of colorModes) {
                 let max = 40;
                 const hasAnySelectedNodeColor = (mode) => {
-                    const nodes = this.dependencies.selection
-                        .getTargetedNodes()
-                        .filter(
-                            (n) =>
-                                isTextNode(n) ||
-                                (mode === "backgroundColor" &&
-                                    n.classList.contains("o_selected_td"))
-                        );
-                    return hasAnyNodesColor(nodes, mode);
+                    const nodes = new Set();
+                    for (const node of this.dependencies.selection.getTargetedNodes()) {
+                        for (const getColorNode of colorNodeProviders) {
+                            const colorNode = getColorNode(node);
+                            if (colorNode) {
+                                nodes.add(colorNode);
+                            }
+                        }
+                        if (isTextNode(node)) {
+                            nodes.add(node);
+                        }
+                    }
+                    return hasAnyNodesColor([...nodes], mode);
                 };
                 while (hasAnySelectedNodeColor(mode) && max > 0) {
                     this.applyColor("", mode);
@@ -155,7 +160,8 @@ export class ColorPlugin extends Plugin {
         if (mode === "backgroundColor") {
             color = this.processThrough("apply_background_color_processors", color, mode);
         }
-        if (this.delegateTo("color_apply_overrides", color, mode, previewMode)) {
+        const coloredNodes = new Set();
+        if (this.delegateTo("apply_color_overrides", color, mode, coloredNodes, previewMode)) {
             return;
         }
         const selection = this.dependencies.selection.getEditableSelection();
@@ -200,33 +206,18 @@ export class ColorPlugin extends Plugin {
                 : current;
         };
 
-        const hexColor = rgbaToHex(color).toLowerCase();
         const systemNodesSelector = this.getResource("system_node_selectors").join(", ");
         const selectedNodes = targetedNodes
             .filter((node) => {
-                if (systemNodesSelector && closestElement(node, systemNodesSelector)) {
+                if (
+                    coloredNodes.has(node) ||
+                    (systemNodesSelector && closestElement(node, systemNodesSelector))
+                ) {
                     return false;
-                }
-                if (mode === "backgroundColor" && color) {
-                    return !closestElement(node, "table.o_selected_table");
-                }
-                if (closestElement(node).classList.contains("o_default_color")) {
-                    return false;
-                }
-                const li = closestElement(node, "li");
-                if (li && color && this.dependencies.selection.areNodeContentsFullySelected(li)) {
-                    return rgbaToHex(li.style.color).toLowerCase() !== hexColor;
                 }
                 return true;
             })
             .map((node) => findTopMostDecoration(node));
-
-        const targetedFieldNodes = new Set(
-            this.dependencies.selection
-                .getTargetedNodes()
-                .map((n) => closestElement(n, "*[t-field],*[t-out],*[t-esc]"))
-                .filter(Boolean)
-        );
 
         const alreadyWithinFont = new Set();
         const getFonts = (selectedNodes) =>
@@ -332,10 +323,6 @@ export class ColorPlugin extends Plugin {
                 }
                 return font;
             });
-
-        for (const fieldNode of targetedFieldNodes) {
-            this.colorElement(fieldNode, color, mode);
-        }
 
         let fonts = getFonts(selectedNodes);
         // Dirty fix as the previous call could have unconnected elements

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -183,7 +183,6 @@ export class ListPlugin extends Plugin {
         on_step_added_handlers: this.updateToolbarButtons.bind(this),
         on_deleted_handlers: this.adjustListPaddingOnDelete.bind(this),
         on_will_insert_separator_handlers: this.exitList.bind(this),
-        on_will_format_selection_handlers: this.applyFormatToListItem.bind(this),
 
         /** Processors */
         normalize_processors: this.normalize.bind(this),
@@ -197,7 +196,8 @@ export class ListPlugin extends Plugin {
         tab_overrides: this.handleTab.bind(this),
         shift_tab_overrides: this.handleShiftTab.bind(this),
         split_element_block_overrides: this.handleSplitBlock.bind(this),
-        color_apply_overrides: this.applyColorToListItem.bind(this),
+        apply_color_overrides: this.applyColorToListItem.bind(this),
+        format_selection_overrides: this.applyFormatToListItem.bind(this),
         triple_click_overrides: this.handleTripleClick.bind(this),
 
         is_node_fully_selected_predicates: (node, selection, range) => {
@@ -215,6 +215,14 @@ export class ListPlugin extends Plugin {
                         return true;
                     }
                 }
+            }
+        },
+
+        /** Providers */
+        color_target_providers: (node) => {
+            const li = closestElement(node, isListItem);
+            if (li && this.dependencies.selection.areNodeContentsFullySelected(li)) {
+                return li;
             }
         },
     };
@@ -1113,7 +1121,7 @@ export class ListPlugin extends Plugin {
         );
     }
 
-    applyColorToListItem(color, mode) {
+    applyColorToListItem(color, mode, coloredNodes) {
         this.dependencies.split.splitSelection();
         const targetedNodes = this.dependencies.selection.getTargetedNodes();
         const listItems = new Set(
@@ -1125,9 +1133,10 @@ export class ListPlugin extends Plugin {
         const cursors = this.dependencies.selection.preserveSelection();
         for (const listItem of listItems) {
             if (this.dependencies.selection.areNodeContentsFullySelected(listItem)) {
+                const listItemDescendants = descendants(listItem);
                 for (const node of [
                     listItem,
-                    ...descendants(listItem).filter(
+                    ...listItemDescendants.filter(
                         (n) => isElement(n) && closestElement(n, "LI") === listItem
                     ),
                 ]) {
@@ -1142,9 +1151,13 @@ export class ListPlugin extends Plugin {
                     }
                 }
 
+                const sublists = childNodes(listItem).filter(isListElement);
+                coloredNodes.add(listItem);
+                listItemDescendants
+                    .filter((n) => !sublists.some((list) => list.contains(n)))
+                    .forEach((n) => coloredNodes.add(n));
                 if (color) {
                     this.dependencies.color.colorElement(listItem, color, mode);
-                    const sublists = childNodes(listItem).filter(isListElement);
                     for (const list of sublists) {
                         list.classList.add("o_default_color");
                     }
@@ -1172,7 +1185,7 @@ export class ListPlugin extends Plugin {
         cursors.restore();
     }
 
-    applyFormatToListItem(formatName, { formatProps, applyStyle } = {}) {
+    applyFormatToListItem(formatName, formattedNodes, { formatProps, applyStyle } = {}) {
         if (!["setFontSizeClassName", "fontSize"].includes(formatName)) {
             return;
         }
@@ -1201,9 +1214,10 @@ export class ListPlugin extends Plugin {
             }
 
             if (this.dependencies.selection.areNodeContentsFullySelected(listItem)) {
+                const listItemDescendants = descendants(listItem);
                 for (const node of [
                     listItem,
-                    ...descendants(listItem).filter(
+                    ...listItemDescendants.filter(
                         (n) => isElement(n) && closestElement(n, "LI") === listItem
                     ),
                 ]) {
@@ -1213,13 +1227,17 @@ export class ListPlugin extends Plugin {
                     }
                 }
 
+                const sublists = childNodes(listItem).filter(isListElement);
+                formattedNodes.add(listItem);
+                listItemDescendants
+                    .filter((n) => !sublists.some((list) => list.contains(n)))
+                    .forEach((n) => formattedNodes.add(n));
                 if (applyStyle) {
                     if (formatName === "setFontSizeClassName") {
                         listItem.classList.add(formatProps.className);
                     } else if (formatName === "fontSize") {
                         listItem.style.fontSize = formatProps.size;
                     }
-                    const sublists = childNodes(listItem).filter(isListElement);
                     for (const list of sublists) {
                         list.classList.add("o_default_font_size");
                     }
@@ -1245,7 +1263,6 @@ export class ListPlugin extends Plugin {
         for (const list of listsSet) {
             this.adjustListPadding(list);
         }
-        return true;
     }
 
     /**

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -123,6 +123,7 @@ export class TablePlugin extends Plugin {
                     closestElement(editableSelection.anchorNode, ".o_selected_td") && "compact"
             ),
         ],
+        color_target_providers: (node) => closestElement(node, ".o_selected_td"),
         overlay_selection_target_rect_providers: this.getTableSelectionRangeRect.bind(this),
 
         /** Handlers */
@@ -149,7 +150,7 @@ export class TablePlugin extends Plugin {
         tab_overrides: withSequence(20, this.handleTab.bind(this)),
         shift_tab_overrides: withSequence(20, this.handleShiftTab.bind(this)),
         delete_range_overrides: this.handleDeleteRange.bind(this),
-        color_apply_overrides: this.applyTableColor.bind(this),
+        apply_color_overrides: this.applyTableColor.bind(this),
         paste_html_overrides: this.handlePasteTableIntoExistingTable.bind(this),
         paste_odoo_editor_html_overrides: this.handlePasteTableIntoExistingTable.bind(this),
 
@@ -1724,7 +1725,7 @@ export class TablePlugin extends Plugin {
         return didDeselectTable;
     }
 
-    applyTableColor(color, mode, previewMode) {
+    applyTableColor(color, mode, coloredNodes, previewMode) {
         const selectedTds = [...this.editable.querySelectorAll(".o_selected_td")].filter(
             (node) => node.isContentEditable
         );
@@ -1735,10 +1736,9 @@ export class TablePlugin extends Plugin {
             );
             for (const td of selectedTds) {
                 this.dependencies.color.colorElement(td, color, mode);
-                if (color) {
-                    td.style["color"] = getComputedStyle(td).color;
-                } else {
-                    td.style["color"] = "";
+                td.style["color"] = color ? getComputedStyle(td).color : "";
+                if (mode === "backgroundColor" && color) {
+                    [td, ...descendants(td)].forEach((n) => coloredNodes.add(n));
                 }
             }
         }

--- a/addons/html_editor/static/src/others/qweb_plugin.js
+++ b/addons/html_editor/static/src/others/qweb_plugin.js
@@ -1,9 +1,10 @@
 import { Plugin } from "@html_editor/plugin";
-import { closestElement, selectElements } from "@html_editor/utils/dom_traversal";
+import { closestElement, descendants, selectElements } from "@html_editor/utils/dom_traversal";
 import { leftPos, rightPos } from "@html_editor/utils/position";
 import { QWebPicker } from "./qweb_picker";
 import { isElement } from "@html_editor/utils/dom_info";
 import { withSequence } from "@html_editor/utils/resource";
+import { formatsSpecs } from "@html_editor/utils/formatting";
 
 const isUnsplittableQWebElement = (node) =>
     isElement(node) &&
@@ -34,11 +35,15 @@ export const isUnremovableQWebElement = (node) =>
 
 export class QWebPlugin extends Plugin {
     static id = "qweb";
-    static dependencies = ["overlay", "protectedNode", "selection"];
+    static dependencies = ["color", "overlay", "protectedNode", "selection"];
     /** @type {import("plugins").EditorResources} */
     resources = {
         /** Handlers */
         on_selectionchange_handlers: withSequence(8, this.onSelectionChange.bind(this)),
+
+        /** Overrides */
+        apply_color_overrides: this.applyColorToFieldNodes.bind(this),
+        format_selection_overrides: this.applyFormatToFieldNodes.bind(this),
 
         /** Processors */
         clean_for_save_processors: (root) => {
@@ -68,6 +73,9 @@ export class QWebPlugin extends Plugin {
             }
         },
 
+        /** Providers */
+        color_target_providers: (node) => closestElement(node, "*[t-field],*[t-out],*[t-esc]"),
+
         system_attributes: QWEB_DATA_ATTRIBUTES,
     };
 
@@ -78,6 +86,37 @@ export class QWebPlugin extends Plugin {
         });
         this.addDomListener(this.editable, "click", this.onClick);
         this.groupIndex = 0;
+    }
+
+    applyColorToFieldNodes(color, mode, coloredNodes) {
+        const fieldNodes = new Set(
+            this.dependencies.selection
+                .getTargetedNodes()
+                .map((n) => closestElement(n, "*[t-field],*[t-out],*[t-esc]"))
+                .filter(Boolean)
+        );
+        for (const fieldNode of fieldNodes) {
+            this.dependencies.color.colorElement(fieldNode, color, mode);
+            [fieldNode, ...descendants(fieldNode)].forEach((n) => coloredNodes.add(n));
+        }
+    }
+
+    applyFormatToFieldNodes(formatName, formattedNodes, { formatProps, applyStyle } = {}) {
+        const fieldNodes = new Set(
+            this.dependencies.selection
+                .getTargetedNodes()
+                .map((n) => closestElement(n, "*[t-field],*[t-out],*[t-esc]"))
+                .filter(Boolean)
+        );
+        const formatSpec = formatsSpecs[formatName];
+        for (const fieldNode of fieldNodes) {
+            if (applyStyle) {
+                formatSpec.addStyle(fieldNode, formatProps);
+            } else {
+                formatSpec.removeStyle(fieldNode);
+            }
+            [fieldNode, ...descendants(fieldNode)].forEach((n) => formattedNodes.add(n));
+        }
     }
 
     isValidTargetForDomListener(ev) {

--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -4,6 +4,8 @@ import { unformat } from "./_helpers/format";
 import { setColor } from "./_helpers/user_actions";
 import { getContent } from "./_helpers/selection";
 import { animationFrame, press } from "@odoo/hoot-dom";
+import { QWebPlugin } from "@html_editor/others/qweb_plugin";
+import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 
 const redToBlueGradient = "linear-gradient(rgb(255, 0, 0), rgb(0, 0, 255))";
 const greenToBlueGradient = "linear-gradient(rgb(0, 255, 0), rgb(0, 0, 255))";
@@ -21,7 +23,8 @@ test("should apply a color to the qweb tag (1)", async () => {
     await testEditor({
         contentBefore: `<div><p t-out="'Test'" contenteditable="false">[Test]</p></div>`,
         stepFunction: setColor("rgb(255, 0, 0)", "color"),
-        contentAfter: `<div>[<p t-out="'Test'" contenteditable="false" style="color: rgb(255, 0, 0);">Test</p>]</div>`,
+        contentAfter: `<div>[<p t-out="'Test'" style="color: rgb(255, 0, 0);">Test</p>]</div>`,
+        config: { Plugins: [...MAIN_PLUGINS, QWebPlugin] },
     });
 });
 
@@ -29,7 +32,8 @@ test("should apply a color to the qweb tag (2)", async () => {
     await testEditor({
         contentBefore: `<div><p t-field="record.display_name" contenteditable="false">[Test]</p></div>`,
         stepFunction: setColor("rgb(255, 0, 0)", "color"),
-        contentAfter: `<div>[<p t-field="record.display_name" contenteditable="false" style="color: rgb(255, 0, 0);">Test</p>]</div>`,
+        contentAfter: `<div>[<p t-field="record.display_name" style="color: rgb(255, 0, 0);">Test</p>]</div>`,
+        config: { Plugins: [...MAIN_PLUGINS, QWebPlugin] },
     });
 });
 
@@ -206,6 +210,7 @@ test("should not apply font tag to t nodes (protects if else nodes separation)",
                 </t>
             </p>
         ]`),
+        config: { Plugins: [...MAIN_PLUGINS, QWebPlugin] },
     });
 });
 

--- a/addons/html_editor/static/tests/format/bold.test.js
+++ b/addons/html_editor/static/tests/format/bold.test.js
@@ -14,6 +14,8 @@ import {
     tripleClick,
     undo,
 } from "../_helpers/user_actions";
+import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
+import { QWebPlugin } from "@html_editor/others/qweb_plugin";
 
 const styleH1Bold = `h1 { font-weight: bold; }`;
 
@@ -53,7 +55,8 @@ test("should make qweb tag bold (1)", async () => {
     await testEditor({
         contentBefore: `<div><p t-out="'Test'" contenteditable="false">[Test]</p></div>`,
         stepFunction: bold,
-        contentAfter: `<div>[<p t-out="'Test'" contenteditable="false" style="font-weight: bolder;">Test</p>]</div>`,
+        contentAfter: `<div>[<p t-out="'Test'" style="font-weight: bolder;">Test</p>]</div>`,
+        config: { Plugins: [...MAIN_PLUGINS, QWebPlugin] },
     });
 });
 
@@ -61,18 +64,20 @@ test("should make qweb tag bold (2)", async () => {
     await testEditor({
         contentBefore: `<div><p t-field="record.name" contenteditable="false">[Test]</p></div>`,
         stepFunction: bold,
-        contentAfter: `<div>[<p t-field="record.name" contenteditable="false" style="font-weight: bolder;">Test</p>]</div>`,
+        contentAfter: `<div>[<p t-field="record.name" style="font-weight: bolder;">Test</p>]</div>`,
+        config: { Plugins: [...MAIN_PLUGINS, QWebPlugin] },
     });
 });
 
 test("should make qweb tag bold and create a step even with partial selection inside contenteditable false", async () => {
     const { editor, el } = await setupEditor(
-        `<div><p t-out="'Test'" contenteditable="false">T[e]st</p></div>`
+        `<div><p t-out="'Test'" contenteditable="false">T[e]st</p></div>`,
+        { config: { Plugins: [...MAIN_PLUGINS, QWebPlugin] } }
     );
     bold(editor);
     expect(getContent(el)).toBe(
         '<p data-selection-placeholder=""><br></p>' +
-            `<div>[<p t-out="'Test'" contenteditable="false" style="font-weight: bolder;">Test</p>]</div>` +
+            `<div>[<p t-out="'Test'" contenteditable="false" data-oe-protected="true" style="font-weight: bolder;">Test</p>]</div>` +
             '<p data-selection-placeholder=""><br></p>'
     );
     expect(queryOne(`p[contenteditable="false"]`).childNodes.length).toBe(1);

--- a/addons/html_editor/static/tests/format/font_size.test.js
+++ b/addons/html_editor/static/tests/format/font_size.test.js
@@ -8,6 +8,7 @@ import { animationFrame } from "@odoo/hoot-mock";
 import { execCommand } from "../_helpers/userCommands";
 import { press } from "@odoo/hoot-dom";
 import { getContent } from "../_helpers/selection";
+import { QWebPlugin } from "@html_editor/others/qweb_plugin";
 
 test("should change the font size of a few characters", async () => {
     await testEditor({
@@ -21,7 +22,8 @@ test("should change the font size the qweb tag", async () => {
     await testEditor({
         contentBefore: `<div><p t-out="'Test'" contenteditable="false">[Test]</p></div>`,
         stepFunction: setFontSize("36px"),
-        contentAfter: `<div>[<p t-out="'Test'" contenteditable="false" style="font-size: 36px;">Test</p>]</div>`,
+        contentAfter: `<div>[<p t-out="'Test'" style="font-size: 36px;">Test</p>]</div>`,
+        config: { Plugins: [...MAIN_PLUGINS, QWebPlugin] },
     });
 });
 

--- a/addons/html_editor/static/tests/format/italic.test.js
+++ b/addons/html_editor/static/tests/format/italic.test.js
@@ -12,6 +12,8 @@ import {
 } from "../_helpers/user_actions";
 import { unformat } from "../_helpers/format";
 import { tick } from "@odoo/hoot-mock";
+import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
+import { QWebPlugin } from "@html_editor/others/qweb_plugin";
 
 test("should make a few characters italic", async () => {
     await testEditor({
@@ -49,7 +51,8 @@ test("should make qweb tag italic", async () => {
     await testEditor({
         contentBefore: `<div><p t-out="'Test'" contenteditable="false">[Test]</p></div>`,
         stepFunction: italic,
-        contentAfter: `<div>[<p t-out="'Test'" contenteditable="false" style="font-style: italic;">Test</p>]</div>`,
+        contentAfter: `<div>[<p t-out="'Test'" style="font-style: italic;">Test</p>]</div>`,
+        config: { Plugins: [...MAIN_PLUGINS, QWebPlugin] },
     });
 });
 

--- a/addons/html_editor/static/tests/format/strike_through.test.js
+++ b/addons/html_editor/static/tests/format/strike_through.test.js
@@ -12,6 +12,8 @@ import {
     undo,
 } from "../_helpers/user_actions";
 import { unformat } from "../_helpers/format";
+import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
+import { QWebPlugin } from "@html_editor/others/qweb_plugin";
 
 test("should make a few characters strikeThrough", async () => {
     await testEditor({
@@ -107,7 +109,8 @@ test("should make qweb tag strikeThrough", async () => {
     await testEditor({
         contentBefore: `<div><p t-out="'Test'" contenteditable="false">[Test]</p></div>`,
         stepFunction: strikeThrough,
-        contentAfter: `<div>[<p t-out="'Test'" contenteditable="false" style="text-decoration-line: line-through;">Test</p>]</div>`,
+        contentAfter: `<div>[<p t-out="'Test'" style="text-decoration-line: line-through;">Test</p>]</div>`,
+        config: { Plugins: [...MAIN_PLUGINS, QWebPlugin] },
     });
 });
 

--- a/addons/html_editor/static/tests/format/underline.test.js
+++ b/addons/html_editor/static/tests/format/underline.test.js
@@ -13,6 +13,8 @@ import {
     undo,
 } from "../_helpers/user_actions";
 import { unformat } from "../_helpers/format";
+import { QWebPlugin } from "@html_editor/others/qweb_plugin";
+import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 
 test("should make a few characters underline", async () => {
     await testEditor({
@@ -50,7 +52,8 @@ test("should make qweb tag underline", async () => {
     await testEditor({
         contentBefore: `<div><p t-out="'Test'" contenteditable="false">[Test]</p></div>`,
         stepFunction: underline,
-        contentAfter: `<div>[<p t-out="'Test'" contenteditable="false" style="text-decoration-line: underline;">Test</p>]</div>`,
+        contentAfter: `<div>[<p t-out="'Test'" style="text-decoration-line: underline;">Test</p>]</div>`,
+        config: { Plugins: [...MAIN_PLUGINS, QWebPlugin] },
     });
 });
 

--- a/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
@@ -70,7 +70,7 @@ export class HighlightPlugin extends Plugin {
             // we rely on the normalize handler to start it again
             this.dependencies.edit_interaction.stopInteraction("website.text_highlight");
         },
-        on_will_format_selection_handlers: () => {
+        format_selection_overrides: () => {
             this.dependencies.edit_interaction.stopInteraction("website.text_highlight");
         },
         on_will_save_handlers: () => {


### PR DESCRIPTION
Purpose of this PR:

- Several plugins were directly referencing the `o_selected_td` class and QWeb directives (e.g. `t-field`, `t-esc`, `t-out`, etc.). These elements belong to specific features (custom table selection and QWeb integration) and should not be coupled with unrelated plugins.
- This PR removes the remaining direct checks and replaces them with appropriate resources so that plugins no longer depend on feature-specific implementation details.

task-4381414

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
