### PR TITLE
[FIX] website_sale: fix box purchase style display

### DIFF
--- a/addons/website_sale/static/src/js/sale_variant_mixin.js
+++ b/addons/website_sale/static/src/js/sale_variant_mixin.js
@@ -388,6 +388,24 @@ var VariantMixin = {
             $product.trigger('view_item_event', combination['product_tracking_info']);
         }
         const addToCart = $parent.find('#add_to_cart_wrap');
+        const ctaWrapper = $parent.find('#o_wsale_cta_wrapper');
+        const isBoxedCtaWrapper = !!ctaWrapper?.find('.product_price')?.length
+        if (isBoxedCtaWrapper) {
+            const showBox =
+                !combination.prevent_zero_price_sale
+                || !!$parent.find('#product_option_block').children().length;
+
+            ctaWrapper.toggleClass('o_wsale_cta_wrapper_boxed border rounded p-3', showBox);
+            ctaWrapper.toggleClass('pt-3', !showBox);
+
+            const boxedPriceContainer = ctaWrapper.find('.product_price').closest('.order-first');
+            if (boxedPriceContainer.length) {
+                const showPrice = !combination.prevent_zero_price_sale;
+                boxedPriceContainer
+                    .toggleClass('d-none', !showPrice)
+                    .toggleClass('d-flex', showPrice);
+            }
+        }
         const contactUsButton = $parent.parents('#product_details').find('#contact_us_wrapper');
         const productPrice = $parent.find('.product_price');
         const quantity = $parent.find('.css_quantity');

--- a/addons/website_sale/static/src/js/sale_variant_mixin.js
+++ b/addons/website_sale/static/src/js/sale_variant_mixin.js
@@ -388,6 +388,11 @@ var VariantMixin = {
             $product.trigger('view_item_event', combination['product_tracking_info']);
         }
         const addToCart = $parent.find('#add_to_cart_wrap');
+        const ctaWrapper = $parent.find('#o_wsale_cta_wrapper');
+        if (ctaWrapper.length) {
+            const showBox = !combination.prevent_zero_price_sale || !!$parent.find('#product_option_block').children().length;
+            ctaWrapper.toggleClass('o_wsale_cta_wrapper_boxed border rounded p-3', showBox);
+        }
         const contactUsButton = $parent.parents('#product_details').find('#contact_us_wrapper');
         const productPrice = $parent.find('.product_price');
         const quantity = $parent.find('.css_quantity');

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2226,11 +2226,24 @@
         active="False"
         name="Bordered CTA Wrapper"
     >
+        <xpath expr="//div[@id='o_wsale_cta_wrapper']" position="before">
+            <t t-set="ptals" t-value="product.valid_product_template_attribute_line_ids"/>
+            <t t-set="product_variant_id" t-value="product._get_first_possible_variant_id()"/>
+            <t t-set="show_boxed_cta" t-value="
+                not combination_info['prevent_zero_price_sale']
+                or is_view_active('website_sale_wishlist.product_add_to_wishlist')
+                or (
+                    is_view_active('website_sale_comparison.product_add_to_compare')
+                    and product_variant_id and ptals
+                )
+            "/>
+        </xpath>
+
         <xpath expr="//div[@id='o_wsale_cta_wrapper']" position="attributes">
             <attribute
                 name="t-att-class"
-                remove="pt-3"
-                add="' o_wsale_cta_wrapper_boxed border rounded p-3'"
+                remove="('pt-3' if show_boxed_cta else '')"
+                add="(' o_wsale_cta_wrapper_boxed border rounded p-3' if show_boxed_cta else '')"
                 separator=" + "
             />
         </xpath>
@@ -2241,7 +2254,7 @@
             <attribute name="t-att-class" remove="flex-lg-grow-0" separator=" "/>
         </xpath>
         <xpath expr="//div[@id='o_wsale_cta_wrapper']" position="inside">
-            <div class="d-flex gap-5 flex-grow-1 justify-content-between align-items-center order-first w-100 mb-3 pb-3 border-bottom">
+            <div t-attf-class="{{'d-none' if combination_info['prevent_zero_price_sale'] else 'd-flex'}} gap-5 flex-grow-1 justify-content-between align-items-center order-first w-100 mb-3 pb-3 border-bottom">
                 <span class="text-muted">Price</span>
                 <t t-call="website_sale.product_price"/>
             </div>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2222,11 +2222,24 @@
         active="False"
         name="Bordered CTA Wrapper"
     >
+        <xpath expr="//div[@id='o_wsale_cta_wrapper']" position="before">
+            <t t-set="ptals" t-value="product.valid_product_template_attribute_line_ids"/>
+            <t t-set="product_variant_id" t-value="product._get_first_possible_variant_id()"/>
+            <t t-set="show_boxed_cta" t-value="
+                not combination_info['prevent_zero_price_sale']
+                or is_view_active('website_sale_wishlist.product_add_to_wishlist')
+                or (
+                    is_view_active('website_sale_comparison.product_add_to_compare')
+                    and product_variant_id and ptals
+                )
+            "/>
+        </xpath>
+
         <xpath expr="//div[@id='o_wsale_cta_wrapper']" position="attributes">
             <attribute
                 name="t-att-class"
-                remove="pt-3"
-                add="' o_wsale_cta_wrapper_boxed border rounded p-3'"
+                remove="('pt-3' if show_boxed_cta else '')"
+                add="(' o_wsale_cta_wrapper_boxed border rounded p-3' if show_boxed_cta else '')"
                 separator=" + "
             />
         </xpath>
@@ -2237,7 +2250,7 @@
             <attribute name="t-att-class" remove="flex-lg-grow-0" separator=" "/>
         </xpath>
         <xpath expr="//div[@id='o_wsale_cta_wrapper']" position="inside">
-            <div class="d-flex gap-5 flex-grow-1 justify-content-between align-items-center order-first w-100 mb-3 pb-3 border-bottom">
+            <div t-attf-class="{{'d-none' if combination_info['prevent_zero_price_sale'] else 'd-flex'}} gap-5 flex-grow-1 justify-content-between align-items-center order-first w-100 mb-3 pb-3 border-bottom">
                 <span class="text-muted">Price</span>
                 <t t-call="website_sale.product_price"/>
             </div>


### PR DESCRIPTION
When `Prevent Sale of Zero Priced Products` is enabled and a product with a sales price of `0` is opened on the website, switching the purchase style to `Box` causes the price text to render incorrectly.

Steps to produce:
---
- Install the `website_sale` module.
- Go to Settings and enable `Prevent Sale of Zero Priced Products`.
- Create a product with a sales price of `0` and publish it.
- Open the product on the website.
- Open the editor and change the purchase style to `Box`.

Issue:
---
- The price text renders incorrectly inside the box.

Root Cause:
---
- At [1], the `<span>` element responsible for rendering the price text does not check whether zero-price sale prevention is enabled, causing the price string to appear regardless.
- At [2], after hiding the price span, the `o_wsale_cta_wrapper` element still renders an empty box because no corresponding guard exists there either.

Solution:
---
- Add a conditional check on the price `<span>`: apply `d-none` when zero-price sale prevention is active, so the price string is not displayed.
- Also, add the same zero-price sale prevention check on `o_wsale_cta_wrapper` to avoid rendering an empty box when no price is shown.

[1]https://github.com/odoo/odoo/blob/71d176d462b9db743788e4889974931ae9afc94d/addons/website_sale/views/templates.xml#L2233
[2]https://github.com/odoo/odoo/blob/71d176d462b9db743788e4889974931ae9afc94d/addons/website_sale/views/templates.xml#L2221

Before:
---
<img width="1488" height="689" alt="image" src="https://github.com/user-attachments/assets/5b3a565f-5ced-4d75-b538-63abc3690e09" />

After:
---
<img width="1457" height="612" alt="image" src="https://github.com/user-attachments/assets/1e04fe54-98b6-4e1c-bd26-4d56bb34b90e" />

opw-5994812
---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
