### PR TITLE
[IMP] payment: add DuitNow payment method for Razorpay in Malaysia

### DIFF
--- a/addons/payment/data/payment_method_data.xml
+++ b/addons/payment/data/payment_method_data.xml
@@ -1076,6 +1076,29 @@
         />
     </record>
 
+    <!-- duitnow_pay logo to be updated  -->
+    <record id="payment_method_duitnow_pay" model="payment.method">
+        <field name="name">DuitNow Pay</field>
+        <field name="code">duitnow_pay</field>
+        <field name="sequence">1000</field>
+        <field name="active">False</field>
+        <field name="image" type="base64" file="payment/static/img/duitnow.png"/>
+        <field name="support_tokenization">False</field>
+        <field name="support_express_checkout">False</field>
+        <field name="support_manual_capture">none</field>
+        <field name="support_refund">partial</field>
+        <field name="supported_country_ids"
+               eval="[Command.set([
+                         ref('base.my'),
+                     ])]"
+        />
+        <field name="supported_currency_ids"
+               eval="[Command.set([
+                         ref('base.MYR'),
+                     ])]"
+        />
+    </record>
+
     <record id="payment_method_easypaisa" model="payment.method">
         <field name="name">EasyPaisa</field>
         <field name="code">easypaisa</field>

--- a/addons/payment/data/payment_provider_data.xml
+++ b/addons/payment/data/payment_provider_data.xml
@@ -380,6 +380,7 @@
                          ref('payment.payment_method_emi_india'),
                          ref('payment.payment_method_fpx'),
                          ref('payment.payment_method_netbanking'),
+                         ref('payment.payment_method_duitnow_pay'),
                          ref('payment.payment_method_paylater_india'),
                          ref('payment.payment_method_paynow'),
                          ref('payment.payment_method_upi'),

--- a/addons/payment_razorpay/const.py
+++ b/addons/payment_razorpay/const.py
@@ -119,6 +119,7 @@ FALLBACK_PAYMENT_METHOD_CODES = {
     'fpx',
     'paylater_india',
     'wallets_india',
+    'duitnow_pay',
 }
 
 # The codes of payment methods that require redirection back to the website
@@ -131,6 +132,7 @@ PAYMENT_METHODS_MAPPING = {
     'wallets_india': 'wallet',
     'paylater_india': 'paylater',
     'emi_india': 'emi',
+    'duitnow_pay': 'duitnow_pay',
 }
 
 # The maximum amount in INR that can be paid through an eMandate.


### PR DESCRIPTION
Add support for the DuitNow payment method when using Razorpay as the payment provider. The method is restricted to Malaysia.

task-5443419
