### PR TITLE
[FIX] website: wrap editable buttons to allow space key insertion

### DIFF
--- a/addons/website_sale/static/src/website_builder/editable_button_plugin.js
+++ b/addons/website_sale/static/src/website_builder/editable_button_plugin.js
@@ -1,0 +1,37 @@
+import { Plugin } from "@html_editor/plugin";
+import { registry } from "@web/core/registry";
+
+class EditableButtonPlugin extends Plugin {
+    static id = "editableButton";
+    resources = {
+        normalize_handlers: this.wrapEditableButtons.bind(this),
+    };
+
+    /**
+     * Buttons with `contenteditable="true"` cannot receive spaces because the
+     * browser natively triggers a click on them when the space key is pressed.
+     * To work around this, we move the `contenteditable` attribute up to a
+     * wrapping <span>, allowing text editing (including spaces) to work
+     * correctly without triggering the button's click handler.
+     */
+    wrapEditableButtons(root) {
+        const editableButtons = root.querySelectorAll("button.o_savable[contenteditable='true']");
+        for (const button of editableButtons) {
+            const parent = button.parentElement;
+            const isOnlyChildOfEditableParent =
+                parent.childNodes.length === 1 && parent.getAttribute("contenteditable") === "true";
+
+            if (isOnlyChildOfEditableParent) {
+                continue;
+            }
+
+            const span = this.document.createElement("span");
+            span.setAttribute("contenteditable", "true");
+            button.removeAttribute("contenteditable");
+            button.after(span);
+            span.append(button);
+        }
+    }
+}
+
+registry.category("website-plugins").add(EditableButtonPlugin.id, EditableButtonPlugin);


### PR DESCRIPTION
Problem:
After https://github.com/odoo/odoo/commit/e809b492c1b138c1af7bb1d4aa61b39d87686df9 typing spaces inside an
"Add to cart" button label in the website editor triggers the button
click instead of inserting a space character.

Cause:
Browsers natively intercept the space key on `button[contenteditable="true"]`
elements and fire a click event instead of inserting the character, making it
impossible to type spaces in the button label.

Solution:
Introduce an `EditableButtonPlugin` that moves the `contenteditable`
attribute from the button up to a wrapping `<span>`. This preserves full text
editing capability (including spaces) without triggering the button's click handler.

Steps to reproduce:
* Go to a product page on the website.
* Open the editor.
* Try to add a space in the "Add to cart" button label.
* Observe that the button is triggered instead of inserting a space.

opw-5994828

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
