### PR TITLE
[REF] html_builder, *: introduce resource for submit button selectors

### DIFF
--- a/addons/html_builder/static/src/@types/plugins.d.ts
+++ b/addons/html_builder/static/src/@types/plugins.d.ts
@@ -14,6 +14,7 @@ declare module "plugins" {
     import { get_overlay_buttons, OverlayButtonsShared } from "@html_builder/core/overlay_buttons/overlay_buttons_plugin";
     import { empty_node_predicates, is_unremovable_selector, on_removed_handlers, on_will_remove_handlers, RemoveShared } from "@html_builder/core/remove_plugin";
     import { after_save_handlers, before_save_handlers, get_dirty_els, savable_selectors, save_element_handlers, save_elements_overrides, save_handlers, SaveShared } from "@html_builder/core/save_plugin";
+    import { submit_button_selectors } from "@html_builder/core/save_snippet_plugin";
     import { after_setup_editor_handlers, before_setup_editor_handlers, o_editable_selectors, SetupEditorShared } from "@html_builder/core/setup_editor_plugin";
     import { target_hide, target_show, VisibilityShared } from "@html_builder/core/visibility_plugin";
     import { default_shape_handlers, post_compute_shape_listeners } from "@html_builder/plugins/image/image_shape_option_plugin";
@@ -150,5 +151,6 @@ declare module "plugins" {
         savable_selectors: savable_selectors;
         so_content_addition_selector: so_content_addition_selector;
         so_snippet_addition_selector: so_snippet_addition_selector;
+        submit_button_selectors: submit_button_selectors;
     }
 }

--- a/addons/html_builder/static/src/core/save_snippet_plugin.js
+++ b/addons/html_builder/static/src/core/save_snippet_plugin.js
@@ -5,14 +5,9 @@ import { markup } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { escape } from "@web/core/utils/strings";
 
-const savableSelector = "[data-snippet], a.btn";
-// TODO `so_submit_button_selector` ?
-const savableExclude = ".o_no_save, .s_donation_donate_btn, .s_website_form_send";
-
-// Checks if the element can be saved as a custom snippet.
-function isSavable(el) {
-    return el.matches(savableSelector) && !el.matches(savableExclude);
-}
+/**
+ * @typedef {CSSSelector[]} submit_button_selectors
+ */
 
 export class SaveSnippetPlugin extends Plugin {
     static id = "saveSnippet";
@@ -24,8 +19,23 @@ export class SaveSnippetPlugin extends Plugin {
         ),
     };
 
+    /**
+     * Determine whether the given element can be saved as a custom snippet.
+     *
+     * @param {HTMLElement} el
+     * @returns {boolean}
+     */
+    isSavable(el) {
+        const savableSelector = "[data-snippet], a.btn";
+        const unsavableSelector = [
+            ".o_no_save",
+            ...this.getResource("submit_button_selectors"),
+        ].join(",");
+        return el.matches(savableSelector) && !el.matches(unsavableSelector);
+    }
+
     getOptionsContainerTopButtons(el) {
-        if (!isSavable(el)) {
+        if (!this.isSavable(el)) {
             return [];
         }
 

--- a/addons/website/static/src/builder/plugins/form/form_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/form/form_option_plugin.js
@@ -180,6 +180,7 @@ export class FormOptionPlugin extends Plugin {
             },
         ],
         so_content_addition_selector: [".s_website_form"],
+        submit_button_selectors: [".s_website_form_send"],
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
         on_cloned_handlers: this.onCloned.bind(this),
     };

--- a/addons/website_payment/static/src/website_builder/donation_option_plugin.js
+++ b/addons/website_payment/static/src/website_builder/donation_option_plugin.js
@@ -33,6 +33,7 @@ export class DonationOptionPlugin extends Plugin {
             SetMaximumAmountAction,
             SetSliderStepAction,
         },
+        submit_button_selectors: [".s_donation_donate_btn"],
     };
 }
 


### PR DESCRIPTION
\* = website, website_payment

Previously submit button selectors were defined in a single hardcoded
string in the save snippet logic. This made the list harder to maintain
and required modifying the base code whenever a new plugin needed to
exclude its submit button from being saved as a snippet.

Introduce a resource allowing plugins to register their own submit
button selectors. Plugins can now extend this list directly from their
code without modifying the base implementation.

This makes the logic easier to maintain and provides a reusable
extension point for other submit-button related behaviors in plugins.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
