### PR TITLE
[FIX] account_edi_ubl_cii: zugferd xml name

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
@@ -184,13 +184,8 @@ class AccountEdiXmlCII(models.AbstractModel):
             'purchase_order_reference': invoice.purchase_order_reference if 'purchase_order_reference' in invoice._fields
                 and invoice.purchase_order_reference else invoice.ref or invoice.name,
             'contract_reference': invoice.contract_reference if 'contract_reference' in invoice._fields and invoice.contract_reference else '',
+            'document_context_id': "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended",
         }
-
-        # Change the document context based on the country of the partner, the default value is France (factur-X)
-        if invoice.commercial_partner_id.country_code == 'DE':
-            template_values['document_context_id'] = "urn:cen.eu:en16931:2017#conformant#urn:zugferd.de:2p2:extended"
-        else:
-            template_values['document_context_id'] = "urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended"
 
         # data used for IncludedSupplyChainTradeLineItem / SpecifiedLineTradeSettlement
         for line_vals in template_values['invoice_line_vals_list']:

--- a/addons/account_edi_ubl_cii/wizard/account_move_send.py
+++ b/addons/account_edi_ubl_cii/wizard/account_move_send.py
@@ -242,7 +242,7 @@ class AccountMoveSend(models.TransientModel):
 
         attachment_name = 'factur-x.xml'
         if invoice.commercial_partner_id.country_code == 'DE' and invoice.commercial_partner_id.peppol_eas != '0204':
-            attachment_name = 'zugferd.xml'
+            attachment_name = 'zugferd-invoice.xml'
 
         writer.addAttachment(attachment_name, xml_facturx, subtype='text/xml')
 

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/zugferd_out_invoice.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/zugferd_out_invoice.xml
@@ -2,7 +2,7 @@
 <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
   <rsm:ExchangedDocumentContext>
     <ram:GuidelineSpecifiedDocumentContextParameter>
-      <ram:ID>urn:cen.eu:en16931:2017#conformant#urn:zugferd.de:2p2:extended</ram:ID>
+      <ram:ID>urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended</ram:ID>
     </ram:GuidelineSpecifiedDocumentContextParameter>
   </rsm:ExchangedDocumentContext>
   <rsm:ExchangedDocument>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/zugferd_out_invoice_without_vat.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/zugferd_out_invoice_without_vat.xml
@@ -2,7 +2,7 @@
 <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
   <rsm:ExchangedDocumentContext>
     <ram:GuidelineSpecifiedDocumentContextParameter>
-      <ram:ID>urn:cen.eu:en16931:2017#conformant#urn:zugferd.de:2p2:extended</ram:ID>
+      <ram:ID>urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended</ram:ID>
     </ram:GuidelineSpecifiedDocumentContextParameter>
   </rsm:ExchangedDocumentContext>
   <rsm:ExchangedDocument>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/zugferd_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/zugferd_out_refund.xml
@@ -2,7 +2,7 @@
 <rsm:CrossIndustryInvoice xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
   <rsm:ExchangedDocumentContext>
     <ram:GuidelineSpecifiedDocumentContextParameter>
-      <ram:ID>urn:cen.eu:en16931:2017#conformant#urn:zugferd.de:2p2:extended</ram:ID>
+      <ram:ID>urn:cen.eu:en16931:2017#conformant#urn:factur-x.eu:1p0:extended</ram:ID>
     </ram:GuidelineSpecifiedDocumentContextParameter>
   </rsm:ExchangedDocumentContext>
   <rsm:ExchangedDocument>


### PR DESCRIPTION
Fix the name of the embedded xml for zugferd eInvoice format.

Before this PR:

For the validator https://www.portinvoice.com/en/, the error
> No, the file is called zugferd.xml. The following naming conventions are
> permitted: “factur-x.xml”, “xrechnung.xml”, “zugferd-invoice.xml”,
> “ZUGFeRD-invoice.xml”, “order-x.xml”, “cida.xml”

And also:
> The XML has a valid profile? No

This corresponds to the document_context, as the french factur-x and the
german ZUGFeRD are a common standard, we can put the same context.

After this PR:

The ZUGFeRD file passes on different validators.
Validators:
 * https://erechnungs-validator.de/
 * https://easyfirma.net/e-rechnung/validieren
 * https://www.portinvoice.com/en/
 * https://demo.verapdf.org/

task-6010416

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
