### PR TITLE
[FIX] web: datetime field weird displayed

### DIFF
--- a/addons/web/static/src/views/fields/datetime/datetime_field.xml
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.xml
@@ -2,11 +2,11 @@
 <templates xml:space="preserve">
     <t t-name="web.DateTimeField">
         <t t-set="showSeparator" t-value="shouldShowSeparator()" />
-        <div class="o_input_box" t-att-class="{'d-flex gap-2 align-items-center position-relative' : showSeparator}" t-custom-ref="root">
-            <i class="o_input_box_overlay_start fa fa-calendar d-none d-touch-inline-flex" />
+        <div class="o_input_box d-flex flex-nowrap align-items-center" t-att-class="{'d-flex gap-2 align-items-center position-relative' : showSeparator}" t-custom-ref="root">
+            <i class="fa fa-calendar d-none d-touch-inline-block ps-3" />
             <!-- Start date -->
             <t t-if="props.readonly">
-                <span t-if="!isEmpty(startDateField)" class="text-truncate" t-out="window.String(getFormattedValue(0))" t-att-data-tooltip="getFormattedValue(0, true)"/>
+                <span t-if="!isEmpty(startDateField)" class="text-truncate d-inline-block" t-out="window.String(getFormattedValue(0))" t-att-data-tooltip="getFormattedValue(0, true)"/>
             </t>
             <t t-elif="isRange(values) or isRequired(startDateField) or !isEmpty(startDateField) or startDateField === props.name">
                 <t t-if="picker.activeInput !== startDateField and values[0]">
@@ -17,7 +17,7 @@
                         t-on-focus="() => picker.activeInput = startDateField"
                         t-att-data-field="startDateField"
                         data-available-offline=""
-                        t-att-class="'o_input o_daterange_start w-100 text-start ' + (props.warnFuture and isDateInTheFuture(0) ? 'text-danger' : '')">
+                        t-att-class="'o_input o_daterange_start w-100 text-start d-inline-block ' + (props.warnFuture and isDateInTheFuture(0) ? 'text-danger' : '')">
                         <t t-out="window.String(getFormattedValue(0))" />
                     </button>
                 </t>
@@ -26,7 +26,7 @@
                         t-custom-ref="start-date"
                         type="text"
                         t-att-id="showSeparator ? props.endDateField and props.id : props.id"
-                        t-att-class="'o_input cursor-pointer user-select-none' + (props.warnFuture and isDateInTheFuture(0) ? 'text-danger' : '')"
+                        t-att-class="'o_input cursor-pointer user-select-none d-inline-block ' + (props.warnFuture and isDateInTheFuture(0) ? 'text-danger' : '')"
                         autocomplete="off"
                         inputmode="none"
                         t-att-placeholder="props.placeholder"
@@ -40,13 +40,13 @@
 
             <!-- Separator -->
             <t t-if="showSeparator">
-                <i class="fa fa-long-arrow-right" aria-label="Arrow icon" title="Arrow" />
+                <i class="fa fa-long-arrow-right d-inline-block" aria-label="Arrow icon" title="Arrow" />
             </t>
 
             <!-- End date -->
             <t t-if="endDateField">
                 <t t-if="props.readonly">
-                    <span class="text-truncate" t-out="getFormattedValue(1)" t-att-data-tooltip="getFormattedValue(1, true)"/>
+                    <span class="text-truncate d-inline-block" t-out="getFormattedValue(1)" t-att-data-tooltip="getFormattedValue(1, true)"/>
                 </t>
                 <t t-elif="isRange(values) or isRequired(endDateField) or !isEmpty(endDateField) or (isEmpty(startDateField) and endDateField === props.name)">
                     <t t-if="picker.activeInput !== endDateField and values[1]">
@@ -57,7 +57,7 @@
                             t-att-id="props.startDateField and props.id"
                             t-att-data-field="endDateField"
                             data-available-offline=""
-                            t-att-class="'o_input o_daterange_end w-100 text-start ' + (props.warnFuture and isDateInTheFuture(1) ? 'text-danger' : '')">
+                            t-att-class="'o_input o_daterange_end w-100 text-start d-inline-block ' + (props.warnFuture and isDateInTheFuture(1) ? 'text-danger' : '')">
                             <t t-out="getFormattedValue(1)" />
                         </button>
                     </t>
@@ -66,7 +66,7 @@
                             t-custom-ref="end-date"
                             type="text"
                             t-att-id="props.startDateField and props.id"
-                            t-att-class="'o_input cursor-pointer user-select-none' + (props.warnFuture and isDateInTheFuture(1) ? 'text-danger' : '')"
+                            t-att-class="'o_input cursor-pointer user-select-none d-inline-block ' + (props.warnFuture and isDateInTheFuture(1) ? 'text-danger' : '')"
                             autocomplete="off"
                             inputmode="none"
                             t-att-placeholder="props.placeholder"


### PR DESCRIPTION
Steps to reproduce:

- Open Odoo on mobile
- Accounting / Reporting / Management / Budget Report
- Go toList view and select a report
- Edit the period field

You see the wrong space between arrow and end date and the wrong display of the double icon

task-6012443


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
