### PR TITLE
[FIX] pos_self: fix snooze loading

### DIFF
--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -111,7 +111,7 @@ class PosConfig(models.Model):
             'rounding_method', 'cash_rounding', 'only_round_cash_method', 'has_active_session',
             'available_preset_ids', 'default_preset_id', 'epson_printer_ip', 'use_presets', 'iface_tax_included',
             'status', 'self_ordering_image_background_ids', 'preparation_printer_ids', 'default_receipt_printer_id',
-            'receipt_printer_ids', 'use_order_printer', 'other_devices',
+            'receipt_printer_ids', 'use_order_printer', 'other_devices', 'pos_snooze_ids',
         ]
 
     def _update_access_token(self):


### PR DESCRIPTION
The `pos_snooze_ids` was not included in the `load_pos_self_data_fields` so the field was not accessible in the config in self and it would not display the temporary disabled products.

I added it now so that products will be disabled in real time based on updates from the cashier screen

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
