### PR TITLE
[FIX] sale_project: fix for KeyError if not in project user group

### DIFF
--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -449,7 +449,7 @@ class ProjectProject(models.Model):
     def get_panel_data(self):
         panel_data = super().get_panel_data()
         foldable_sections = self._get_foldable_section()
-        if self._show_profitability() and 'revenues' in panel_data['profitability_items']:
+        if panel_data and self._show_profitability() and 'revenues' in panel_data['profitability_items']:
             for section in panel_data['profitability_items']['revenues']['data']:
                 if section['id'] in foldable_sections:
                     section['isSectionFoldable'] = True


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:
If you create a custom group and not using project user group, if you click on "Dashboard" in the project, KeyError profitability_items appears. It appears because it accesses to panel_data without checking if panel_data is not empty.

### Current behavior before PR:
Appear KeyError profitability_items

### Desired behavior after PR is merged:
No error




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
