### PR TITLE
[ADD] website_sale: add external identifier field on product attributes

### DIFF
--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -22,6 +22,7 @@
         'data/digest_data.xml',  # Needs mail_template_data
         'data/ir_cron_data.xml',
         'data/product_ribbon_data.xml',
+        'data/product_attribute_data.xml',
         'data/tour.xml',
         'data/website_checkout_step_data.xml',
         'data/website_snippet_filter_data.xml',

--- a/addons/website_sale/const.py
+++ b/addons/website_sale/const.py
@@ -436,3 +436,5 @@ GMC_SUPPORTED_UOM = {
 GMC_BASE_MEASURE = re.compile(r'(?P<base_count>\d+)?\s*(?P<base_unit>[a-z]+)')
 
 SHOP_PATH = '/shop'
+
+DIRECT_MAPPED_ATTRIBUTE_IDENTIFIERS = {'color', 'size', 'material', 'brand'}

--- a/addons/website_sale/data/product_attribute_data.xml
+++ b/addons/website_sale/data/product_attribute_data.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="product_attribute_brand" model="product.attribute">
+        <field name="name">Brand</field>
+        <field name="external_identifier">brand</field>
+    </record>
+
+    <record id="product_attribute_color" model="product.attribute">
+        <field name="name">Color</field>
+        <field name="external_identifier">color</field>
+    </record>
+
+    <record id="product_attribute_material" model="product.attribute">
+        <field name="name">Material</field>
+        <field name="external_identifier">material</field>
+    </record>
+
+    <record id="product_attribute_size" model="product.attribute">
+        <field name="name">Size</field>
+        <field name="external_identifier">size</field>
+    </record>
+
+</odoo>

--- a/addons/website_sale/models/product_attribute.py
+++ b/addons/website_sale/models/product_attribute.py
@@ -27,6 +27,11 @@ class ProductAttribute(models.Model):
         string="Show Thumbnails",
         help="Use product variant images instead of the attribute values displays.",
     )
+    external_identifier = fields.Char(
+        string="External Identifier",
+        help="External Identifier will ensure a precise matching between your attributes "
+        "and attributes in SEO and other external platforms.",
+    )
 
     @api.onchange('create_variant', 'display_type')
     def _onchange_disable_preview_variants(self):

--- a/addons/website_sale/models/product_feed.py
+++ b/addons/website_sale/models/product_feed.py
@@ -361,11 +361,11 @@ class ProductFeed(models.Model):
         return {'availability': 'in_stock'}
 
     def _prepare_gmc_additional_info(self, product):
+        direct, others = product._get_mapped_attribute_values()
+
         additional_info = {
-            'product_detail': [
-                (attr.attribute_id.name, attr.name)
-                for attr in product.product_template_attribute_value_ids
-            ],
+            'gmc_direct_attributes': list(direct.items()),
+            'product_detail': others,
             'is_bundle': 'yes' if product.type == 'combo' else 'no',
             'product_type': [
                 category.replace('/', '>')  # Google uses a different format

--- a/addons/website_sale/models/product_product.py
+++ b/addons/website_sale/models/product_product.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 from odoo.http import request
-
+from odoo.addons.website_sale import const
 
 class ProductProduct(models.Model):
     _inherit = 'product.product'
@@ -202,6 +202,15 @@ class ProductProduct(models.Model):
             markup_data['description'] = self.website_meta_description or self.description_sale
         if self.barcode:
             markup_data['gtin'] = self.barcode
+
+        direct, others = self._get_mapped_attribute_values()
+        markup_data.update(direct)
+        if others:
+            markup_data['additionalProperty'] = [
+                {'@type': 'PropertyValue', 'name': name, 'value': value}
+                for name, value in others
+            ]
+
         return markup_data
 
     def _get_image_1920_url(self):
@@ -282,3 +291,27 @@ class ProductProduct(models.Model):
         """
         self.ensure_one()
         return self.env['website'].image_url(self, 'image_1024')
+
+    def _get_mapped_attribute_values(self):
+        """Split product attributes into directly mapped fields and the rest.
+
+        Direct fields are attributes whose external_identifier matches a known
+        identifier used across Microdata, GMC Feeds, and Tracking.
+
+        :return: A tuple of:
+            - dict of {external_identifier: value} for known direct fields
+            - list of (attribute_name, value) for all other attributes
+        :rtype: tuple(dict, list)
+        """
+        self.ensure_one()
+        direct = {}
+        others = []
+        for ptav in self.product_template_attribute_value_ids:
+            external_id = ptav.attribute_id.external_identifier
+            ext_id = external_id and external_id.lower()
+            value = ptav.product_attribute_value_id.name
+            if ext_id and ext_id in const.DIRECT_MAPPED_ATTRIBUTE_IDENTIFIERS:
+                direct[ext_id] = value
+            else:
+                others.append((ptav.attribute_id.name, value))
+        return direct, others

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -969,13 +969,20 @@ class ProductTemplate(models.Model):
 
     def _get_google_analytics_data(self, product, combination_info):
         self.ensure_one()
-        return {
+        tracking_data = {
             'item_id': product.barcode or product.id,
             'item_name': combination_info['display_name'],
             'item_category': self.categ_id.name,
             'currency': combination_info['currency'].name,
             'price': combination_info['list_price'],
         }
+
+        direct, _ = product._get_mapped_attribute_values()
+        for ext_id, value in direct.items():
+            # 'brand' maps to predefined GA4 item_brand, others are custom item-scoped parameters
+            key = f'item_{ext_id}' if ext_id == 'brand' else ext_id
+            tracking_data[key] = value
+        return tracking_data
 
     def _get_contextual_pricelist(self):
         """ Override to fallback on website current pricelist """

--- a/addons/website_sale/templates/gmc_templates.xml
+++ b/addons/website_sale/templates/gmc_templates.xml
@@ -33,6 +33,13 @@
                             t-if="'unit_pricing_base_measure' in item"
                             t-out="item['unit_pricing_base_measure']"
                         />
+                        <t t-foreach="item['gmc_direct_attributes']" t-as="direct_attr">
+                            <t t-translation="off">
+                                &lt;g:<t t-out="direct_attr[0]"/>&gt;
+                                    <t t-out="direct_attr[1]"/>
+                                &lt;/g:<t t-out="direct_attr[0]"/>&gt;
+                            </t>
+                        </t>
                         <t t-foreach="item['custom_label']" t-as="tag_label">
                             <t t-translation="off">
                                 &lt;g:<t t-out="tag_label[0]"/>&gt;

--- a/addons/website_sale/views/product_attribute_views.xml
+++ b/addons/website_sale/views/product_attribute_views.xml
@@ -31,6 +31,10 @@
                                 invisible="preview_variants == 'hidden'"
                                 force_save="1"
                             />
+                            <field
+                                name="external_identifier"
+                                groups="base.group_no_one"
+                            />
                         </group>
                     </group>
                 </page>


### PR DESCRIPTION
Added an `external_identifier` field on `product.attribute` to allow precise matching with schema.org fields in Microdata, GMC Feeds, and GA4 Tracking. Known identifiers (color, size, material, brand) are mapped to their direct fields, while others fall back to additionalProperty/product_detail.

Affected Version: master
Task: 5154190