### PR TITLE
[REF] survey: run owl3 rendering context migration script

### DIFF
--- a/addons/survey/static/src/views/components/survey_survey_action_helper/survey_survey_action_helper.xml
+++ b/addons/survey/static/src/views/components/survey_survey_action_helper/survey_survey_action_helper.xml
@@ -13,9 +13,9 @@
                 </div>
 
                 <div class="row g-2 g-md-3 mx-auto mt-2 justify-content-center">
-                    <t t-set="templateNames" t-value="Object.keys(surveyTemplateData)"/>
+                    <t t-set="templateNames" t-value="Object.keys(this.surveyTemplateData)"/>
                     <div class="col-12 col-md-4 col-xl-3" t-foreach="templateNames" t-as="templateName" t-key="templateName">
-                        <t t-set="templateInfo" t-value="surveyTemplateData[templateName]"/>
+                        <t t-set="templateInfo" t-value="this.surveyTemplateData[templateName]"/>
                         <button
                             type="button"
                             t-attf-class="o_survey_load_sample o_survey_sample_card card flex-row flex-md-column align-items-center w-100 h-100 gap-4 gap-md-3 p-3 border rounded"

--- a/addons/survey/static/src/xml/survey_paginated_results_rows_template.xml
+++ b/addons/survey/static/src/xml/survey_paginated_results_rows_template.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="survey.paginated_results_rows">
-        <t t-foreach="records" t-as="input_line" t-key="input_line.id">
+        <t t-foreach="this.records" t-as="input_line" t-key="input_line.id">
             <tr>
                 <td>
                     <a t-att-href="input_line.url">
@@ -11,7 +11,7 @@
                 </td>
                 <td>
                     <!-- If answer already covered by filter or if there is only one line to display, do not allow filtering on it again -->
-                    <t t-if="hide_filter">
+                    <t t-if="this.hide_filter">
                         <t t-out="input_line.value"/>
                     </t>
                     <t t-else="">


### PR DESCRIPTION
In preparation for OWL3, where template variables will need to use `.this` to target component variables, we add `.this` to template variables that are targetting the component.

Script PR: odoo/odoo#247965

task: OWL3 prep - add this. to template variables
