### PR TITLE
[REF] web_unsplash: add this. in rendering context

### DIFF
--- a/addons/web_unsplash/static/src/unsplash_credentials/unsplash_credentials.xml
+++ b/addons/web_unsplash/static/src/unsplash_credentials/unsplash_credentials.xml
@@ -8,9 +8,9 @@
                    class="o_input o_required_modifier form-control w-auto mx-2"
                    id="accessKeyInput"
                    placeholder="Paste your access key here"
-                   t-custom-model="state.key"
+                   t-custom-model="this.state.key"
                    t-on-input="() => this.state.hasKeyError = false"
-                   t-att-class="{ 'is-invalid': state.hasKeyError }"/>
+                   t-att-class="{ 'is-invalid': this.state.hasKeyError }"/>
             and paste
             <a href="https://www.odoo.com/documentation/latest/applications/websites/website/optimize/unsplash.html#generate-an-unsplash-application-id"
                class="mx-1" target="_blank">Application ID</a>
@@ -18,9 +18,9 @@
             <input type="text"
                    class="o_input o_required_modifier form-control w-auto ms-2"
                    placeholder="Paste your application ID here"
-                   t-custom-model="state.appId"
+                   t-custom-model="this.state.appId"
                    t-on-input="() => this.state.hasAppIdError = false"
-                   t-att-class="{ 'is-invalid': state.hasAppIdError }"/>
+                   t-att-class="{ 'is-invalid': this.state.hasAppIdError }"/>
             <button type="button" class="btn btn-primary w-auto ms-3 p-auto save_unsplash" t-on-click="() => this.submitCredentials()">Apply</button>
         </div>
     </t>

--- a/addons/web_unsplash/static/src/unsplash_error/unsplash_error.xml
+++ b/addons/web_unsplash/static/src/unsplash_error/unsplash_error.xml
@@ -1,9 +1,9 @@
 <templates id="template" xml:space="preserve">
     <t t-name="web_unsplash.UnsplashError">
         <div class="alert alert-info w-100">
-            <h4><t t-out="props.title"/></h4>
-            <p><t t-out="props.subtitle"/></p>
-            <UnsplashCredentials t-if="props.showCredentials" submitCredentials="props.submitCredentials" hasCredentialsError="props.hasCredentialsError"/>
+            <h4><t t-out="this.props.title"/></h4>
+            <p><t t-out="this.props.subtitle"/></p>
+            <UnsplashCredentials t-if="this.props.showCredentials" submitCredentials="this.props.submitCredentials" hasCredentialsError="this.props.hasCredentialsError"/>
         </div>
     </t>
 </templates>


### PR DESCRIPTION
The goal of this commit is to prepare the migration to owl 3, which requires a clean separation between the template rendering context, and the component.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
