### PR TITLE
[IMP] sale: consider bank reconciled payments when posting invoice

### DIFF
--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -119,7 +119,7 @@ class AccountMove(models.Model):
         posted = super()._post(soft)
 
         for invoice in posted.filtered(lambda move: move.is_invoice()):
-            payments = invoice.mapped('transaction_ids.payment_id').filtered(lambda x: x.state == 'in_process')
+            payments = invoice.transaction_ids.payment_id.filtered(lambda x: x.state in ('in_process', 'paid'))
             move_lines = payments.move_id.line_ids.filtered(lambda line: line.account_type in ('asset_receivable', 'liability_payable') and not line.reconciled)
             for line in move_lines:
                 invoice.js_assign_outstanding_line(line.id)

--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -119,7 +119,7 @@ class AccountMove(models.Model):
         posted = super()._post(soft)
 
         for invoice in posted.filtered(lambda move: move.is_invoice()):
-            payments = invoice.mapped('transaction_ids.payment_id').filtered(lambda x: x.state == 'in_process')
+            payments = invoice.mapped('transaction_ids.payment_id').filtered(lambda x: x.state in ('in_process', 'paid'))
             move_lines = payments.move_id.line_ids.filtered(lambda line: line.account_type in ('asset_receivable', 'liability_payable') and not line.reconciled)
             for line in move_lines:
                 invoice.js_assign_outstanding_line(line.id)


### PR DESCRIPTION
If you have already reconciled a payment with a bank transaction, it should still be considered as a candidate for auto-reconciliation with the posted invoice, because the receivable/payable line will still be unreconciled.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
