### PR TITLE
[REV] api_doc: remove band-aid for renamed fields

### DIFF
--- a/addons/api_doc/controllers/api_doc.py
+++ b/addons/api_doc/controllers/api_doc.py
@@ -144,6 +144,7 @@ class DocController(http.Controller):
                     field.name: {'string': field.field_description}
                     for field in ir_model.field_id
                     # sorted(ir_model.field_id, key=partial(sort_key_field, modules, Model))
+                    if field.name in Model._fields  # band-aid, see task 5172546
                     if Model._has_field_access(Model._fields[field.name], 'read')
                 },
                 'methods': [


### PR DESCRIPTION
This reverts commit d29c2ea2c32204302e5043f1b67e0905e7025bfc.

There are databases that were upgraded from <19 and that still have badly renamed fields. So keep the bandaid, at least until we can have an upgrade script.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
