### PR TITLE
[REF] uom: run owl3 rendering context migration script

### DIFF
--- a/addons/uom/static/src/components/many2one_uom/many2one_uom_field.xml
+++ b/addons/uom/static/src/components/many2one_uom/many2one_uom_field.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="uom.Many2OneUomField">
-        <UomMany2One t-props="m2oProps">
+        <UomMany2One t-props="this.m2oProps">
             <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                 <t t-if="autoCompleteItemScope.record?.relative_info">
                     <div class="uom_autocomplete_grid">


### PR DESCRIPTION
In preparation for OWL3, where template variables will need to use `.this` to target component variables, we add `.this` to template variables that are targeting the component.

Script PR: odoo/odoo#247965

task: OWL3 prep - add this. to template variables
