### PR TITLE
[REF] web_tour: remove url from tour API key

### DIFF
--- a/addons/web_tour/static/src/js/tour_service.js
+++ b/addons/web_tour/static/src/js/tour_service.js
@@ -54,7 +54,6 @@ const stepSchemaDebug = {
 
 const tourSchema = {
     steps: Function,
-    url: { type: String, optional: true },
     undeterministicTour_doNotCopy: { type: Boolean, optional: true },
 };
 


### PR DESCRIPTION
In this commit, we remove `url` key from tour API what is no longer used.
The URL key in a tour's JavaScript file implies a redirect to that URL once the browser opens. If this URL is the same as the one used in start_tour() (Python), then it serves no purpose. It's even detrimental because it implies a redirect (and therefore a waste of time). The URL key in the JS file is (for now) only used for onboarding tours.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
