### PR TITLE
[FIX] l10n_din5008: crash on document layout preview

### DIFF
--- a/addons/l10n_din5008/report/din5008_report.xml
+++ b/addons/l10n_din5008/report/din5008_report.xml
@@ -97,7 +97,7 @@
                             <t t-if="din5008_document_title">
                                 <t t-out="din5008_document_title"/>
                             </t>
-                            <span t-elif="'name' in o" t-field="o.name"/>
+                            <span t-elif="o and o.exists() and 'name' in o" t-field="o.name"/>
                         </span>
                     </h2>
                     <t t-out="0"/>


### PR DESCRIPTION
**Steps to reproduce**
- Settings -> Configure Document Layout
- Set layout to DIN 5008, save
- Click Preview Document

**Error**
`MissingError: Record does not exist or has been deleted.(Record: res.company(X,), User: 2)`

Raised in l10n_din5008.external_layout_din5008 because of this line:
`<span t-elif="'name' in o" t-field="o.name"/>`

**Cause**
The "Preview Document" button renders web.preview_externalreport, which passes a res.company record as the QWeb variable o. When the template then tried to render t-field="o.name" (the title line), where o is a missing res.company(2) (not in the database), QWeb raised the MissingError.

**Fix**
Guard the title block with `if o and o.exists()` to check if the record exists, so it's safe to access `o.name`.

opw-5951003

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
