### PR TITLE
[IMP] website, *: add a number input field next to the sliders

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_range.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_range.js
@@ -28,6 +28,7 @@ export class BuilderRange extends Component {
         saveUnit: { type: String, optional: true },
         applyWithUnit: { type: Boolean, optional: true },
         withNumberInput: { type: Boolean, optional: true },
+        displayNormalizedValue: { type: Boolean, optional: true },
     };
     static defaultProps = {
         ...BuilderComponent.defaultProps,
@@ -38,12 +39,19 @@ export class BuilderRange extends Component {
         displayRangeValue: false,
         applyWithUnit: true,
         withNumberInput: false,
+        displayNormalizedValue: false,
     };
     static components = { BuilderComponent, BuilderNumberInputBase };
 
     setup() {
         if (this.props.saveUnit && !this.props.unit) {
             throw new Error("'unit' must be defined to use the 'saveUnit' props");
+        }
+
+        if (this.props.displayNormalizedValue && !this.props.withNumberInput) {
+            throw new Error(
+                "'withNumberInput' must be enabled to use the 'displayNormalizedValue' prop"
+            );
         }
 
         if (this.props.withNumberInput) {
@@ -71,13 +79,29 @@ export class BuilderRange extends Component {
         this.preview = (value) => {
             if (this.props.withNumberInput) {
                 // Syncronize the values of range and text inputs during preview
-                this.inputRefNumber.el.value = value;
-                this.inputRefRange.el.value = value;
+                this.inputRefNumber.el.value = this.convertToRatio(value);
+                this.inputRefRange.el.value = value || this.min;
                 this.state.value = this.parseDisplayValue(value);
             }
             return preview(value);
         };
         this.state = state;
+    }
+
+    convertToRatio(value) {
+        if (!this.props.displayNormalizedValue || !value) {
+            return value;
+        }
+        const ratioValue = ((parseFloat(value) - this.min) / (this.max - this.min)) * 99 + 1;
+        return Math.round(ratioValue);
+    }
+
+    convertToValue(ratio) {
+        if (!this.props.displayNormalizedValue || !ratio) {
+            return String(ratio);
+        }
+        const originalValue = ((parseFloat(ratio) - 1) / 99) * (this.max - this.min) + this.min;
+        return String(originalValue.toFixed(2));
     }
 
     onChangeRange(e) {
@@ -112,8 +136,28 @@ export class BuilderRange extends Component {
         this.debouncedCommitNumberValue();
     }
 
+    clampValueForInput(value) {
+        // When displayNormalizedValue is true, the input displays ratioed
+        // values. So we simply clamp to that range. When false, use the
+        // original clampValue.
+        if (this.props.displayNormalizedValue) {
+            return Math.min(100, Math.max(1, value));
+        }
+        return this.clampValue(value);
+    }
+
+    previewInput(ratio) {
+        this.preview(this.convertToValue(ratio));
+    }
+
+    commitInput(value) {
+        const originalValue = value ? this.convertToValue(value) : this.min.toString();
+        const committedValue = this.commit(originalValue);
+        return this.convertToRatio(committedValue);
+    }
+
     get inputValueRange() {
-        return this.state.value ? this.formatRawValue(this.state.value) : "0";
+        return this.formatRawValue(this.state.value || this.min);
     }
 
     get displayValueRange() {
@@ -127,7 +171,7 @@ export class BuilderRange extends Component {
     }
 
     get displayValueNumber() {
-        return this.formatRawValue(this.state.value).toString();
+        return this.formatRawValue(this.convertToRatio(this.state.value || this.min));
     }
 
     get className() {
@@ -145,5 +189,11 @@ export class BuilderRange extends Component {
 
     get textInputBaseProps() {
         return pick(this.props, ...Object.keys(textInputBasePassthroughProps));
+    }
+
+    get step() {
+        return this.props.displayNormalizedValue
+            ? Math.round((this.props.step / (this.max - this.min)) * 99)
+            : this.props.step;
     }
 }

--- a/addons/html_builder/static/src/core/building_blocks/builder_range.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_range.js
@@ -22,8 +22,6 @@ export class BuilderRange extends Component {
         max: { type: Number, optional: true },
         step: { type: Number, optional: true },
         default: { type: Number, optional: true },
-        displayRangeValue: { type: Boolean, optional: true },
-        computedOutput: { type: Function, optional: true },
         unit: { type: String, optional: true },
         saveUnit: { type: String, optional: true },
         applyWithUnit: { type: Boolean, optional: true },
@@ -36,7 +34,6 @@ export class BuilderRange extends Component {
         max: 100,
         step: 1,
         default: 0,
-        displayRangeValue: false,
         applyWithUnit: true,
         withNumberInput: false,
         displayNormalizedValue: false,
@@ -111,9 +108,6 @@ export class BuilderRange extends Component {
 
     onInputRange(e) {
         this.preview(e.target.value);
-        if (this.props.displayRangeValue) {
-            this.state.value = this.parseDisplayValue(e.target.value);
-        }
     }
 
     onKeydownRange(e) {
@@ -158,16 +152,6 @@ export class BuilderRange extends Component {
 
     get inputValueRange() {
         return this.formatRawValue(this.state.value || this.min);
-    }
-
-    get displayValueRange() {
-        let value = this.inputValueRange;
-        if (this.props.computedOutput) {
-            value = this.props.computedOutput(value);
-        } else if (this.props.unit) {
-            value = `${value}${this.props.unit}`;
-        }
-        return value;
     }
 
     get displayValueNumber() {

--- a/addons/html_builder/static/src/core/building_blocks/builder_range.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_range.xml
@@ -25,7 +25,6 @@
                 t-on-change="this.onChangeRange"
                 t-on-input="this.onInputRange"
                 t-on-keydown="this.onKeydownRange"/>
-            <output t-if="this.props.displayRangeValue" t-out="this.displayValueRange" class="ms-1" />
         </div>
         <BuilderNumberInputBase
             t-if="this.props.withNumberInput"

--- a/addons/html_builder/static/src/core/building_blocks/builder_range.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_range.xml
@@ -34,14 +34,14 @@
             value="this.displayValueNumber"
             classes="'o-hb-input-field-number justify-content-end'"
             inputClasses="'o-hb-input-number text-end'"
-            commit="this.commit"
-            preview="this.preview"
-            clampValue.bind="this.clampValue"
+            commit.bind="this.commitInput"
+            preview.bind="this.previewInput"
+            clampValue.bind="this.clampValueForInput"
             onKeydown.bind="this.onKeydownNumber"
             selectTextOnFocus="true"
             min="this.min"
             max="this.max"
-            step="this.props.step"
+            step="this.step"
         >
             <span class="o-hb-input-field-unit" t-out="this.props.unit"/>
         </BuilderNumberInputBase>

--- a/addons/html_builder/static/src/core/building_blocks/builder_sliding_panel.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_sliding_panel.scss
@@ -1,4 +1,7 @@
 .hb-sliding-panel {
+
+    @include o-input-number-no-arrows();
+
     background-color: $o-we-bg-darker;
     z-index: 10;
 

--- a/addons/html_builder/static/src/plugins/background_option/background_shape_option.js
+++ b/addons/html_builder/static/src/plugins/background_option/background_shape_option.js
@@ -1,6 +1,5 @@
 import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 import { useDomState } from "@html_builder/core/utils";
-import { toRatio } from "@html_builder/utils/utils";
 import { getBgImageURLFromEl } from "@html_builder/utils/utils_css";
 import { _t } from "@web/core/l10n/translation";
 import { BackgroundShapeSelector } from "./background_shape_selector";
@@ -12,7 +11,6 @@ export class BackgroundShapeOption extends BaseOptionComponent {
     setup() {
         super.setup();
         this.backgroundShapePlugin = this.dependencies.backgroundShapeOption;
-        this.toRatio = toRatio;
         this.state = useDomState((editingElement) => {
             const shapeData = this.backgroundShapePlugin.getShapeData(editingElement);
             const shapeInfo = this.backgroundShapePlugin.getBackgroundShapes()[shapeData.shape];

--- a/addons/html_builder/static/src/plugins/background_option/background_shape_option.xml
+++ b/addons/html_builder/static/src/plugins/background_option/background_shape_option.xml
@@ -73,8 +73,10 @@
                 min="-2"
                 max="2"
                 step="0.1"
-                displayRangeValue="true"
-                computedOutput="this.toRatio"/>
+                unit="'%'"
+                applyWithUnit="false"
+                withNumberInput="true"
+                displayNormalizedValue="true" />
         </BuilderRow>
     </t>
 </t>

--- a/addons/html_builder/static/src/plugins/image/image_filter_option.xml
+++ b/addons/html_builder/static/src/plugins/image/image_filter_option.xml
@@ -39,7 +39,11 @@
                 actionParam="'saturation'"
                 min="-100"
                 max="100"
-                step="10" />
+                step="10"
+                unit="'%'"
+                applyWithUnit="false"
+                withNumberInput="true"
+                displayNormalizedValue="true" />
         </BuilderRow>
         <BuilderRow level="this.props.level + 1" label.translate="Contrast">
             <BuilderRange
@@ -47,7 +51,11 @@
                 actionParam="'contrast'"
                 min="-100"
                 max="100"
-                step="10" />
+                step="10"
+                unit="'%'"
+                applyWithUnit="false"
+                withNumberInput="true"
+                displayNormalizedValue="true" />
         </BuilderRow>
         <BuilderRow level="this.props.level + 1" label.translate="Brightness">
             <BuilderRange
@@ -55,7 +63,11 @@
                 actionParam="'brightness'"
                 min="-100"
                 max="100"
-                step="10" />
+                step="10"
+                unit="'%'"
+                applyWithUnit="false"
+                withNumberInput="true"
+                displayNormalizedValue="true" />
         </BuilderRow>
         <BuilderRow level="this.props.level + 1" label.translate="Sepia">
             <BuilderRange
@@ -63,7 +75,10 @@
                 actionParam="'sepia'"
                 min="0"
                 max="100"
-                step="5" />
+                step="5"
+                unit="'%'"
+                applyWithUnit="false"
+                withNumberInput="true" />
         </BuilderRow>
         <BuilderRow level="this.props.level + 1" label.translate="Blur">
             <BuilderRange
@@ -71,7 +86,11 @@
                 actionParam="'blur'"
                 min="0"
                 max="2000"
-                step="100" />
+                step="100"
+                unit="'%'"
+                applyWithUnit="false"
+                withNumberInput="true"
+                displayNormalizedValue="true" />
         </BuilderRow>
     </t>
 </t>

--- a/addons/html_builder/static/src/plugins/image/image_format_option.xml
+++ b/addons/html_builder/static/src/plugins/image/image_format_option.xml
@@ -19,7 +19,10 @@
             action="'setImageQuality'"
             min="0"
             max="100"
-            t-if="!this.state.compressionUnsupported" />
+            t-if="!this.state.compressionUnsupported"
+            unit="'%'"
+            applyWithUnit="false"
+            withNumberInput="true" />
         <span t-if="this.state.compressionUnsupported" class="fst-italic">
             WebP compression not supported on this browser
         </span>

--- a/addons/html_builder/static/src/plugins/image/image_shape_option.js
+++ b/addons/html_builder/static/src/plugins/image/image_shape_option.js
@@ -1,6 +1,5 @@
 import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 import { useDomState } from "@html_builder/core/utils";
-import { toRatio } from "@html_builder/utils/utils";
 import { ShapeSelector } from "@html_builder/plugins/shape/shape_selector";
 import { deepCopy } from "@web/core/utils/objects";
 import { loadImageInfo } from "@html_editor/utils/image_processing";
@@ -21,7 +20,6 @@ export class ImageShapeOption extends BaseOptionComponent {
         super.setup();
         this.customizeTabPlugin = this.dependencies.customizeTab;
         this.imageShapeOption = this.dependencies.imageShapeOption;
-        this.toRatio = toRatio;
         this.state = useDomState(async (editingElement) => {
             const { originalSrc } = editingElement.dataset.originalSrc
                 ? editingElement.dataset

--- a/addons/html_builder/static/src/plugins/image/image_shape_option.xml
+++ b/addons/html_builder/static/src/plugins/image/image_shape_option.xml
@@ -78,8 +78,10 @@
                 min="-2"
                 max="2"
                 step="0.1"
-                displayRangeValue="true"
-                computedOutput="this.toRatio" />
+                unit="'%'"
+                applyWithUnit="false"
+                withNumberInput="true"
+                displayNormalizedValue="true" />
         </BuilderRow>
 
         <BuilderRow label.translate="Stretch" level="1" t-if="this.state.togglableRatio" preview="false" tooltip.translate="Will remove the crop factor">

--- a/addons/html_builder/static/src/utils/utils.js
+++ b/addons/html_builder/static/src/utils/utils.js
@@ -105,17 +105,6 @@ export function getValueFromVar(value) {
 }
 
 /**
- * Converts a value to a ratio.
- *
- * @param {string} value
- */
-export function toRatio(value) {
-    const inputValueAsNumber = Number(value);
-    const ratio = inputValueAsNumber >= 0 ? 1 + inputValueAsNumber : 1 / (1 - inputValueAsNumber);
-    return `${ratio.toFixed(2)}x`;
-}
-
-/**
  * Filters an array of classes to only include those that extend a given class.
  */
 export function filterExtends(arr, PotentialSuperClass) {

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_range.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_range.test.js
@@ -419,3 +419,44 @@ describe("unit & saveUnit", () => {
         expect(":iframe .test-options-target").toHaveInnerHTML("7000ms");
     });
 });
+
+test("should map range from 0 to 100 scale when 'displayNormalizedValue' is true", async () => {
+    addBuilderAction({
+        customAction: class extends BuilderAction {
+            static id = "customAction";
+            getValue({ editingElement }) {
+                return editingElement.textContent;
+            }
+            apply({ editingElement, value }) {
+                expect.step(`applied ${value}`);
+                editingElement.textContent = value;
+            }
+        },
+    });
+    addBuilderOption({
+        selector: ".test-ratio-target",
+        template: xml`<BuilderRange action="'customAction'" min="-2" max="2" withNumberInput="true" displayNormalizedValue="true" step="0.1"/>`,
+    });
+    await setupHTMLBuilder(`<div class="test-ratio-target">-2</div>`);
+    await contains(":iframe .test-ratio-target").click();
+    expect(".options-container input[type='number']").toHaveProperty("value", 1);
+    // Arrow down at min (-2) stays at -2 (boundary check)
+    await contains(".options-container input[type='range']").focus();
+    await press("ArrowDown");
+    await advanceTime(750);
+    expect.verifySteps(["applied -2", "applied -2"]);
+    // Arrow up on slider: moves from 0 -> 2.5 (ratio), applies -1.9
+    // Ratioed step: (0.1 / 4) * 100 = 2.5 per arrow press
+    await press("ArrowUp");
+    await advanceTime(750);
+    expect.verifySteps(["applied -1.9", "applied -1.9"]);
+    expect(".options-container input[type='number']").toHaveProperty("value", 3);
+    // Arrow up on input: moves from 2.5 -> 5 (ratio), applies -1.8
+    await contains(".options-container input[type='number']").focus();
+    await press("ArrowUp");
+    await advanceTime(750);
+    // Since the values are not committed when pressing the up/down arrow keys,
+    // we expect the change to be applied only once which is preview operation.
+    expect.verifySteps(["applied -1.84"]);
+    expect(".options-container input[type='number']").toHaveProperty("value", 5);
+});

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_range.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_range.test.js
@@ -28,7 +28,7 @@ test("should commit changes", async () => {
     });
     addBuilderOption({
         selector: ".test-options-target",
-        template: xml`<BuilderRange action="'customAction'" displayRangeValue="true"/>`,
+        template: xml`<BuilderRange action="'customAction'"/>`,
     });
     await setupHTMLBuilder(`
         <div class="test-options-target">10</div>
@@ -61,11 +61,11 @@ test("range input should step up or down with arrow keys", async () => {
     });
     addBuilderOption({
         selector: ".test-integer-step",
-        template: xml`<BuilderRange action="'customAction'" step="2" displayRangeValue="true"/>`,
+        template: xml`<BuilderRange action="'customAction'" step="2"/>`,
     });
     addBuilderOption({
         selector: ".test-fractional-step",
-        template: xml`<BuilderRange action="'customAction'" step="0.15" displayRangeValue="true"/>`,
+        template: xml`<BuilderRange action="'customAction'" step="0.15"/>`,
     });
     await setupHTMLBuilder(`
         <div class="test-integer-step">10</div>
@@ -153,7 +153,7 @@ test("keeping an arrow key pressed should commit only once", async () => {
     });
     addBuilderOption({
         selector: ".test-options-target",
-        template: xml`<BuilderRange action="'customAction'" step="2" displayRangeValue="true"/>`,
+        template: xml`<BuilderRange action="'customAction'" step="2"/>`,
     });
     freezeTime();
     await setupHTMLBuilder(`

--- a/addons/website/static/src/builder/plugins/carousel_cards_option.xml
+++ b/addons/website/static/src/builder/plugins/carousel_cards_option.xml
@@ -20,8 +20,8 @@
                 min="10"
                 max="75"
                 step="5"
-                displayRangeValue="true"
-                unit="'%'"/>
+                unit="'%'"
+                withNumberInput="true" />
         </BuilderRow>
 
         <BuilderRow label.translate="Extra height" tooltip.translate="Add extra height to cards">
@@ -30,8 +30,8 @@
                 min="0"
                 max="500"
                 step="10"
-                displayRangeValue="true"
-                unit="'px'"/>
+                unit="'px'"
+                withNumberInput="true" />
         </BuilderRow>
     </xpath>
 </t>

--- a/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_option.xml
+++ b/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_option.xml
@@ -25,8 +25,7 @@
         <BuilderRange
             applyTo="'.s_floating_blocks_wrapper'"
             action="'floatingBlocksRoundness'"
-            max="5"
-            displayRangeValue="false"/>
+            max="5" />
     </BuilderRow>
     <BuilderRow label.translate="Shadows" level="1"
         tooltip.translate="Applies to all cards">

--- a/addons/website/static/src/builder/plugins/options/animate_option.xml
+++ b/addons/website/static/src/builder/plugins/options/animate_option.xml
@@ -70,7 +70,9 @@
                 min="1"
                 max="100"
                 step="1"
-                displayRangeValue="true"/>
+                unit="'%'"
+                applyWithUnit="false"
+                withNumberInput="true" />
         </BuilderRow>
         <!-- Scroll Zone -->
         <BuilderRow label.translate="Scroll Zone" level="1" t-if="this.isActiveItem('animation_on_scroll_opt')" preview="false">
@@ -100,9 +102,16 @@
                 </BuilderSelect>
             </BuilderRow>
             <BuilderRow label.translate="Intensity" tooltip.translate="Adjust how strong the hover effect is" level="2">
-                <BuilderRange action="'setHoverEffectIntensity'"
+                <BuilderRange
+                    action="'setHoverEffectIntensity'"
                     t-if="this.isActiveItems(['hover_effect_zoom_in_opt', 'hover_effect_zoom_out_opt', 'hover_effect_mirror_blur_opt', 'hover_effect_dolly_zoom_opt'])"
-                    preview="false" min="1" max="100" step="1" displayRangeValue="true"/>
+                    preview="false"
+                    min="1"
+                    max="100"
+                    step="1"
+                    unit="'%'"
+                    applyWithUnit="false"
+                    withNumberInput="true" />
             </BuilderRow>
             <t t-if="this.isActiveItems(['hover_effect_zoom_in_opt', 'hover_effect_zoom_out_opt', 'hover_effect_dolly_zoom_opt'])" t-set="color_label">Overlay</t>
             <t t-else="" t-set="color_label">Color</t>

--- a/addons/website/static/src/builder/plugins/options/announcement_scroll_option.xml
+++ b/addons/website/static/src/builder/plugins/options/announcement_scroll_option.xml
@@ -46,7 +46,10 @@
             min="40"
             max="320"
             step="8"
-            displayRangeValue="true"/>
+            unit="'%'"
+            applyWithUnit="false"
+            withNumberInput="true"
+            displayNormalizedValue="true" />
     </BuilderRow>
     <BuilderRow label.translate="Font Family"
             applyTo="'.s_announcement_scroll_marquee_container'"

--- a/addons/website/static/src/builder/plugins/options/avatars_option.xml
+++ b/addons/website/static/src/builder/plugins/options/avatars_option.xml
@@ -3,7 +3,13 @@
 
 <t t-name="website.AvatarsOption">
     <BuilderRow label.translate="Size">
-        <BuilderRange styleAction="'--avatars-size'" min="2" max="6" step="0.1" unit="'rem'"/>
+        <BuilderRange
+            styleAction="'--avatars-size'"
+            min="2"
+            max="6"
+            step="0.1"
+            unit="'rem'"
+            withNumberInput="true" />
     </BuilderRow>
 
     <BuilderRow label.translate="Order">

--- a/addons/website/static/src/builder/plugins/options/card_image_option.xml
+++ b/addons/website/static/src/builder/plugins/options/card_image_option.xml
@@ -75,8 +75,9 @@
                 min="8"
                 max="132"
                 step="4"
-                displayRangeValue="true"
-                unit="'%'"/>
+                unit="'%'"
+                withNumberInput="true"
+                displayNormalizedValue="true" />
         </BuilderRow>
 
         <!-- Width -->
@@ -88,7 +89,8 @@
                 min="colSize"
                 max="colSize * 11"
                 step="colSize"
-                unit="'%'"/>
+                unit="'%'"
+                withNumberInput="true" />
         </BuilderRow>
 
         <!-- Alignment -->

--- a/addons/website/static/src/builder/plugins/options/card_width_option.xml
+++ b/addons/website/static/src/builder/plugins/options/card_width_option.xml
@@ -9,8 +9,8 @@
             actionParam="'max-width'"
             min="8"
             max="100"
-            displayRangeValue="true"
-            unit="'%'"/>
+            unit="'%'"
+            withNumberInput="true" />
     </BuilderRow>
     <BuilderRow t-if="this.getItemValue('card_width') !== '100%'" label.translate="Alignment" level="1">
         <BuilderButtonGroup action="'setCardAlignment'">

--- a/addons/website/static/src/builder/plugins/options/countdown_option.xml
+++ b/addons/website/static/src/builder/plugins/options/countdown_option.xml
@@ -173,7 +173,13 @@
         </BuilderRow>
         <hr class="mx-3"/>
         <BuilderRow label.translate="Edge Spacing" applyTo="'.s_countdown_inline_wrapper'">
-            <BuilderRange styleAction="'padding'" min="0" max="200" step="1" displayRangeValue="true" unit="'px'"/>
+            <BuilderRange
+                styleAction="'padding'"
+                min="0"
+                max="200"
+                step="1"
+                unit="'px'"
+                withNumberInput="true" />
         </BuilderRow>
         <BuilderContext applyTo="'.s_countdown_inline_wrapper'">
             <BorderConfigurator label.translate="Border"/>

--- a/addons/website/static/src/builder/plugins/options/parallax_option.xml
+++ b/addons/website/static/src/builder/plugins/options/parallax_option.xml
@@ -19,25 +19,37 @@
                 min="0.15"
                 max="3"
                 step="0.15"
-            />
-            <BuilderRange t-if="this.isActiveItem('parallax_bottom_opt')" 
+                unit="'%'"
+                applyWithUnit="false"
+                withNumberInput="true"
+                displayNormalizedValue="true" />
+            <BuilderRange t-if="this.isActiveItem('parallax_bottom_opt')"
                 dataAttributeAction="'scrollBackgroundRatio'"
                 min="-0.15"
                 max="-3"
                 step="0.15"
-            />
+                unit="'%'"
+                applyWithUnit="false"
+                withNumberInput="true"
+                displayNormalizedValue="true" />
             <BuilderRange t-if="this.isActiveItem('parallax_zoom_in_opt')"
                 dataAttributeAction="'scrollBackgroundRatio'"
                 min="0.05"
                 max="0.95"
                 step="0.05"
-            />
+                unit="'%'"
+                applyWithUnit="false"
+                withNumberInput="true"
+                displayNormalizedValue="true" />
             <BuilderRange t-if="this.isActiveItem('parallax_zoom_out_opt')"
                 dataAttributeAction="'scrollBackgroundRatio'"
                 min="0.15"
                 max="3"
                 step="0.15"
-            />
+                unit="'%'"
+                applyWithUnit="false"
+                withNumberInput="true"
+                displayNormalizedValue="true" />
         </BuilderRow>
     </BuilderContext>
 </t>

--- a/addons/website/static/src/builder/plugins/theme/theme_colors_option.xml
+++ b/addons/website/static/src/builder/plugins/theme/theme_colors_option.xml
@@ -215,9 +215,13 @@
                                             </div>
                                         </BuilderRow>
                                         <BuilderRow label.translate="Saturation" level="1">
-                                            <BuilderRange action="'customizeGray'" actionParam="'gray-extra-saturation'"
+                                            <BuilderRange
+                                                action="'customizeGray'"
+                                                actionParam="'gray-extra-saturation'"
                                                 step="0.1"
-                                            />
+                                                unit="'%'"
+                                                applyWithUnit="false"
+                                                withNumberInput="true" />
                                         </BuilderRow>
                                     </t>
                                 </BuilderRow>

--- a/addons/website/static/tests/builder/options/card_option.test.js
+++ b/addons/website/static/tests/builder/options/card_option.test.js
@@ -22,7 +22,7 @@ test("set card width", async () => {
     await setupWebsiteBuilderWithSnippet("s_card");
     await contains(":iframe .s_card").click();
     await waitFor("[data-action-id='setCardWidth']");
-    expect("[data-action-id='setCardWidth']").toHaveCount(1);
+    expect("[data-action-id='setCardWidth']").toHaveCount(2);
     expect(queryOne(":iframe .s_card").style.maxWidth).toBeEmpty();
     // Default value for range input is 100%
     expect("[data-action-id='setCardWidth'] input").toHaveValue(100);

--- a/addons/website_payment/static/src/website_builder/supported_payment_methods_option.xml
+++ b/addons/website_payment/static/src/website_builder/supported_payment_methods_option.xml
@@ -18,9 +18,8 @@
                 max="64"
                 step="1"
                 unit="'px'"
-                displayRangeValue="true"
                 action="'supportedPaymentMethodsHeight'"
-            />
+                withNumberInput="true" />
         </BuilderRow>
     </t>
 

--- a/addons/website_sale/static/src/website_builder/products_design_panel.xml
+++ b/addons/website_sale/static/src/website_builder/products_design_panel.xml
@@ -299,16 +299,14 @@
                         min="0"
                         max="28"
                         unit="'px'"
-                        displayRangeValue="true"
-                    />
+                        withNumberInput="true" />
                     <BuilderRange
                         t-else=""
                         action="'setGap'"
                         min="0"
                         max="28"
                         unit="'px'"
-                        displayRangeValue="true"
-                    />
+                        withNumberInput="true" />
                 </BuilderRow>
 
                 <BuilderRow


### PR DESCRIPTION
[*]=html_builder, website_sale, website_payment

1. **Add a number input field next to the sliders**
  Before this PR, sliders in the website builder only allowed users to set values by dragging, which could be imprecise.
   This PR introduces a numeric input field next to slider, enabling users to enter exact values for improved precision. Additionally, for sliders with non-standard ranges (e.g., [-2, 2] or [0, 1000]), displaying raw values in the adjacent input can be confusing. To address this, the optional support for normalizing values to a [0, 100] scale is also added.

2.  **Remove unnecessary code from `BuilderRange` and related files**
  This PR removes code related to the "displayRangeValue" prop of the "BuilderRange" component, which was used to display the current value of the range input. This is no longer needed, as the value is now shown in the number input when "withNumberInput" is true.
It also removes the "toRatio" function, which converted a value to a ratio. Moreover, the "computedOutput" prop and its related logic in the "BuilderRange" component have been removed, as they were only used to pass the "toRatio" function and are now handled within the component itself.

task-5245374