### PR TITLE
[FIX] website_event_exhibitor, hr_skills, iap_mail: adapt binary image rendering

### DIFF
--- a/addons/hr_skills/views/hr_employee_cv_templates.xml
+++ b/addons/hr_skills/views/hr_employee_cv_templates.xml
@@ -35,7 +35,7 @@
             background: #{color_primary};
             background-color: #{color_primary};">
             <div class="o_profile">
-                <img class="img img-fluid rounded-circle o_profile_image" t-attf-src="data:image/png;base64,#{o.image_128}" alt="" t-if="o.image_128"/>
+                <img class="img img-fluid rounded-circle o_profile_image" t-attf-src="data:image/png;base64,#{o.image_128.to_base64()}" alt="" t-if="o.image_128"/>
                 <h1 class="o_profile_name mt-2" t-field="o.name">Marc Demo</h1>
                 <h3 class="o_profile_job mb-2" t-field="o.job_id">Software Developer</h3>
             </div>

--- a/addons/iap_mail/data/mail_templates.xml
+++ b/addons/iap_mail/data/mail_templates.xml
@@ -118,7 +118,7 @@
                 <h4 class="me-3 align-middle" t-att-style="logo and 'margin-top:25px' or ''" t-out="name"/>
             </div>
             <div t-if="logo" class="col-sm-2 p-0 text-center text-md-end order-first order-md-last">
-                <img t-attf-src="data:image/png;base64, {{logo}}" alt="" style="max-width: 80px;"/>
+                <img t-attf-src="data:image/png;base64, {{logo.to_base64()}}" alt="" style="max-width: 80px;"/>
             </div>
             </div>
             <hr/>

--- a/addons/website_event_exhibitor/report/website_event_exhibitor_templates.xml
+++ b/addons/website_event_exhibitor/report/website_event_exhibitor_templates.xml
@@ -9,7 +9,7 @@
                         <div class="h-100 p-2 pb-0">
                             <!-- Has to be base64-ified otherwise the reporting engine will sometimes load images
                             and sometimes not before printing, resulting in random results. -->
-                            <img class="img img-fluid" t-attf-src="data:images/png;base64,#{sponsor.image_128}"/>
+                            <img class="img img-fluid" t-attf-src="data:images/png;base64,#{sponsor.image_128.to_base64()}"/>
                         </div>
                     </div>
                 </t>


### PR DESCRIPTION
Templates embedding binary images using data URIs expected base64
strings and crash when receiving raw binary values (UnicodeDecodeError)
during QWeb rendering.

Encode the binary values explicitly using `to_base64()` before
embedding them in the image source.

See also:
- https://github.com/odoo/enterprise/pull/109961