### PR TITLE
[FIX] web: fix input end padding when used with o_input_box

### DIFF
--- a/addons/web/static/src/core/input_box/input_box.scss
+++ b/addons/web/static/src/core/input_box/input_box.scss
@@ -12,7 +12,7 @@
     --inputbox-overlay-padding-suffix: 0px;
     // STORE THE COMPUTED VALUE IN REUSABLE VARIABLES
     --inputbox-inner-padding-start: calc((1.5 * var(--inputbox-overlay-padding-x)) + var(--inputbox-overlay-padding-prefix));
-    --inputbox-inner-padding-end: calc(var(--inputbox-overlay-padding-x) + var(--inputbox-overlay-padding-suffix)) + var(--inputbox-overlay-padding-toggler);
+    --inputbox-inner-padding-end: calc(var(--inputbox-overlay-padding-x) + var(--inputbox-overlay-padding-suffix) + var(--inputbox-overlay-padding-toggler));
 
     &:is(.o_touch_device .o_input_box) {
         --inputbox-overlay-padding-x: var(--inputbox-spacing-unit);
@@ -23,7 +23,7 @@
         --inputbox-overlay-padding-toggler: calc(var(--inputbox-overlay-padding-x) + (2 * var(--inputbox-spacing-unit)));
 
         .o_dropdown_button {
-            inset-inline-end: var(--inputbox-overlay-padding-suffix);
+            inset-inline-end: var(--inputbox-overlay-padding-suffix) !important;
         }
     }
 

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -477,10 +477,6 @@
                 margin-bottom: calc(1.5 * var(--fieldWidget-margin-bottom));
             }
         }
-
-        div[role='radiogroup'] {
-            padding-inline-start: calc(1.5 * var(--inputbox-spacing-unit));
-        }
     }
 
     .o_checkbox_optional_field {
@@ -1248,6 +1244,10 @@
                 .o_input, textarea, select, [contenteditable] {
                     border: none;
                 }
+            }
+
+            div[role='radiogroup'] {
+                padding-inline-start: calc(1.5 * var(--inputbox-spacing-unit));
             }
         }
 

--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -463,7 +463,6 @@
                     }
                     > .o_dropdown_button,
                     .o_datepicker_button {
-                        margin-right: 5px;
                         @include o-position-absolute(0, 0);
                     }
                 }


### PR DESCRIPTION
Since commit (1), the padding value applied in css was simply wrong.
The result was not right, since the end result was an addition of
values, not correctly encapsulated in the calc() function.

Also, the dropdown button was not placed correctly when being used
next to a floating icon (such as External button). Now, the element
has the padding-inline-end value used as expected, even if other
styling rules were previously applied to the element.

1) https://github.com/odoo/odoo/commit/dc8f38b1054664a0e382530bb4fc73983e2085cb