### PR TITLE
[REF] payment: run rendering context script 

### DIFF
--- a/addons/payment/static/src/xml/payment_form_templates.xml
+++ b/addons/payment/static/src/xml/payment_form_templates.xml
@@ -5,10 +5,10 @@
     <t t-name="payment.deleteTokenDialog">
         <div>
             <p>Are you sure you want to delete this payment method?</p>
-            <t t-if="linkedRecordsInfo.length > 0">
+            <t t-if="this.linkedRecordsInfo.length > 0">
                 <p>It is currently linked to the following documents:</p>
                 <ul>
-                    <li t-foreach="linkedRecordsInfo" t-as="documentInfo" t-key="documentInfoIndex">
+                    <li t-foreach="this.linkedRecordsInfo" t-as="documentInfo" t-key="this.documentInfoIndex">
                         <a t-att-title="documentInfo.description"
                            t-att-href="documentInfo.url"
                            t-out="documentInfo.name"


### PR DESCRIPTION
In preparation for OWL3, where template variables will need to use
`.this` to target component variables, we add `.this` to template
variables that are targetting the component.

Script PR: https://github.com/odoo/odoo/pull/247965

task: OWL3 prep - add this. to template variables


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
