### PR TITLE
[FIX] l10n_account_edi_ubl_cii{,_tests}: handles recupel on negative lines

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -312,13 +312,14 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         fixed_tax_charge_vals_list = []
         for grouping_key, tax_details in tax_values_list['tax_details'].items():
             if grouping_key['tax_amount_type'] == 'fixed':
+                is_charge = tax_details['tax_amount_currency'] >= 0
                 fixed_tax_charge_vals_list.append({
                     'currency_name': line.currency_id.name,
                     'currency_dp': line.currency_id.decimal_places,
-                    'charge_indicator': 'true',
-                    'allowance_charge_reason_code': 'AEO',
+                    'charge_indicator': 'true' if is_charge else 'false',
+                    'allowance_charge_reason_code': 'AEO' if is_charge else '100',
                     'allowance_charge_reason': tax_details['tax_name'],
-                    'amount': tax_details['tax_amount_currency'],
+                    'amount': abs(tax_details['tax_amount_currency']),
                 })
 
         if not line.discount:
@@ -394,9 +395,9 @@ class AccountEdiXmlUBL20(models.AbstractModel):
 
         uom = super()._get_uom_unece_code(line)
         total_fixed_tax_amount = sum(
-            vals['amount']
-            for vals in allowance_charge_vals_list
-            if vals.get('charge_indicator') == 'true'
+            tax_details['tax_amount_currency']
+            for grouping_key, tax_details in taxes_vals['tax_details'].items()
+            if grouping_key['tax_amount_type'] == 'fixed'
         )
         return {
             'currency': line.currency_id,

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case5.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/bis3_ecotaxes_case5.xml
@@ -1,0 +1,153 @@
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+  <cbc:ID>___ignore___</cbc:ID>
+  <cbc:IssueDate>2017-01-01</cbc:IssueDate>
+  <cbc:DueDate>2017-02-28</cbc:DueDate>
+  <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+  <cbc:Note>test narration</cbc:Note>
+  <cbc:DocumentCurrencyCode>USD</cbc:DocumentCurrencyCode>
+  <cbc:BuyerReference>ref_partner_2</cbc:BuyerReference>
+  <cac:OrderReference>
+    <cbc:ID>___ignore___</cbc:ID>
+  </cac:OrderReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="9925">BE0202239951</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>partner_1</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Chauss&#233;e de Namur 40</cbc:StreetName>
+        <cbc:CityName>Ramillies</cbc:CityName>
+        <cbc:PostalZone>1367</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>BE0202239951</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_1</cbc:RegistrationName>
+        <cbc:CompanyID>BE0202239951</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>partner_1</cbc:Name>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="9925">BE0477472701</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Rue des Bourlottes 9</cbc:StreetName>
+        <cbc:CityName>Ramillies</cbc:CityName>
+        <cbc:PostalZone>1367</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>BE0477472701</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_2</cbc:RegistrationName>
+        <cbc:CompanyID>BE0477472701</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+    <cbc:PaymentID>___ignore___</cbc:PaymentID>
+    <cac:PayeeFinancialAccount>
+      <cbc:ID>BE15001559627230</cbc:ID>
+    </cac:PayeeFinancialAccount>
+  </cac:PaymentMeans>
+  <cac:PaymentTerms>
+    <cbc:Note>Payment terms: 30% Advance End of Following Month</cbc:Note>
+  </cac:PaymentTerms>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="USD">4.62</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="USD">22.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="USD">4.62</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="USD">22.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="USD">22.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="USD">26.62</cbc:TaxInclusiveAmount>
+    <cbc:PrepaidAmount currencyID="USD">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="USD">26.62</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>___ignore___</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">5.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="USD">55.00</cbc:LineExtensionAmount>
+    <cac:AllowanceCharge>
+      <cbc:ChargeIndicator>true</cbc:ChargeIndicator>
+      <cbc:AllowanceChargeReasonCode>AEO</cbc:AllowanceChargeReasonCode>
+      <cbc:AllowanceChargeReason>RECUPEL</cbc:AllowanceChargeReason>
+      <cbc:Amount currencyID="USD">5.00</cbc:Amount>
+    </cac:AllowanceCharge>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="USD">10.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+  <cac:InvoiceLine>
+    <cbc:ID>___ignore___</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">-3.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="USD">-33.00</cbc:LineExtensionAmount>
+    <cac:AllowanceCharge>
+      <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+      <cbc:AllowanceChargeReasonCode>100</cbc:AllowanceChargeReasonCode>
+      <cbc:AllowanceChargeReason>RECUPEL</cbc:AllowanceChargeReason>
+      <cbc:Amount currencyID="USD">3.00</cbc:Amount>
+    </cac:AllowanceCharge>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="USD">10.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
@@ -511,6 +511,36 @@ class TestUBLBE(TestUBLCommon):
         self.assertEqual(invoice.amount_total, 218.042)
         self._assert_invoice_attachment(invoice, None, 'from_odoo/bis3_ecotaxes_case4.xml')
 
+    def test_export_with_fixed_taxes_case5(self):
+        """ CASE 5: simple invoice with a recupel tax, with one negative line.
+        1) Subtotal (price without taxes): (10+1) * 5 + (10+1) * -3 = 22.00
+        2) Taxes:
+            - recupel = 5 - 3 = 2
+            - VAT = (20 + 2) * 0.21 = 4.62
+        3) Total = 20 + 2 + 4.62 = 26.62
+        """
+        invoice = self._generate_move(
+            self.partner_1,
+            self.partner_2,
+            move_type='out_invoice',
+            invoice_line_ids=[
+                {
+                    'product_id': self.product_a.id,
+                    'quantity': 5,
+                    'price_unit': 10,
+                    'tax_ids': [Command.set([self.recupel.id, self.tax_21.id])],
+                },
+                {
+                    'product_id': self.product_a.id,
+                    'quantity': -3,
+                    'price_unit': 10,
+                    'tax_ids': [Command.set([self.recupel.id, self.tax_21.id])],
+                }
+            ],
+        )
+        self.assertEqual(invoice.amount_total, 26.62)
+        self._assert_invoice_attachment(invoice, None, 'from_odoo/bis3_ecotaxes_case5.xml')
+
     def test_export_payment_terms(self):
         """
         Tests the early payment discount using the example case from the VBO/FEB.


### PR DESCRIPTION
**PROBLEM**
If you set a recupel tax (fixed tax affecting base) and use it on a negative line, the generate xml will not pass validation.

**STEP TO REPRODUCE**
1. Setup Peppol.
2. Create a recupel tax (fixed tax of 1€, affecting the base).
3. Create an invoice with a negative line, with a VAT and the recupel tax.
4. Send the invoice using peppol, and validate the xml.
5. Notice the xml doesn't pass validation.

**CAUSES**
1. The negative fixed tax should be an allowance, but is marked as a charge in the xml.
2. Only fixed taxes that are charges influences the line_extension_amount, but it should also be the case with negative fixed taxes.
3. Negative fixed taxes should have a ChargeAllowanceReasonCode that is in the AllowanceReasonCode list.

opw-5955289