### PR TITLE
[REF] api_doc: run owl3 rendering context migration script

### DIFF
--- a/addons/api_doc/static/src/components/doc_method.xml
+++ b/addons/api_doc/static/src/components/doc_method.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="web.DocMethod">
-    <article class="o-doc-method mb-2 rounded" t-att-class="props.class" t-att-id="this.method.name">
+    <article class="o-doc-method mb-2 rounded" t-att-class="this.props.class" t-att-id="this.method.name">
         <div
             class="o-doc-method-header position-sticky d-flex flex-nowrap w-100 cursor-pointer rounded bg-1"
             t-on-click="() => this.state.open = !this.state.open"
@@ -15,42 +15,42 @@
             <h4 class="flex-grow ms-1" t-out="this.method.name"></h4>
             <a
                 class="ms-2 fs-5"
-                t-att-href="'#' + method.name"
+                t-att-href="'#' + this.method.name"
                 t-on-click.stop=""
             >#</a>
             <div class="text-muted align-self-center ms-auto" t-out="this.method.module"></div>
         </div>
 
         <div
-            t-if="state.open"
+            t-if="this.state.open"
             class="o-doc-method-content p-3 bg-1 d-flex flex-nowrap"
-            t-att-class="{ 'flex-column': isVertical }"
+            t-att-class="{ 'flex-column': this.isVertical }"
         >
-            <div t-att-class="{ 'w-100': isVertical, 'w-50 pe-2': !isVertical }">
+            <div t-att-class="{ 'w-100': this.isVertical, 'w-50 pe-2': !this.isVertical }">
                 <h4>Route</h4>
                 <pre t-out="this.method.url" class="mb-2"/>
 
-                <t t-if="doc">
+                <t t-if="this.doc">
                     <h4 class="mt-2">Description</h4>
-                    <p class="doc_method_description mb-2" t-out="doc"></p>
+                    <p class="doc_method_description mb-2" t-out="this.doc"></p>
                 </t>
                 <h4 class="mt-2">Parameters</h4>
                 <DocTable
-                    t-if="parametersData.items.length > 0"
-                    data="parametersData"
+                    t-if="this.parametersData.items.length > 0"
+                    data="this.parametersData"
                 />
                 <div class="text-muted" t-else="">There's no parameters for this method</div>
-                <t t-if="(method.returnAnnotation || method.returnDoc)">
+                <t t-if="(this.method.returnAnnotation || this.method.returnDoc)">
                     <h4 class="mt-2">Return</h4>
-                    <pre t-if="method.returnAnnotation" t-out="method.returnAnnotation"/>
-                    <p class="doc_method_description mb-2" t-if="method.returnDoc" t-out="method.returnDoc"/>
+                    <pre t-if="this.method.returnAnnotation" t-out="this.method.returnAnnotation"/>
+                    <p class="doc_method_description mb-2" t-if="this.method.returnDoc" t-out="this.method.returnDoc"/>
                 </t>
             </div>
-            <div t-att-class="{ 'w-100 pt-2 mt-2 border-top': isVertical, 'w-50 ps-3 border-start': !isVertical }">
+            <div t-att-class="{ 'w-100 pt-2 mt-2 border-top': this.isVertical, 'w-50 ps-3 border-start': !this.isVertical }">
                 <DocRequest
-                    url="method.url"
-                    request="request"
-                    method="method"
+                    url="this.method.url"
+                    request="this.request"
+                    method="this.method"
                 />
             </div>
         </div>

--- a/addons/api_doc/static/src/components/doc_modal_api_key.xml
+++ b/addons/api_doc/static/src/components/doc_modal_api_key.xml
@@ -7,7 +7,7 @@
             <h2 class="mb-2">API key</h2>
 
             <p class="mb-1">To try the API, please insert your API key here</p>
-            <a href="#" t-on-click="openAPIKeyForm">Generate a new API key here</a>
+            <a href="#" t-on-click="this.openAPIKeyForm">Generate a new API key here</a>
             <input
                 class="mt-2 w-100"
                 type="password"
@@ -17,8 +17,8 @@
             />
 
             <div class="d-flex flex-nowrap flex-content-between mt-2">
-                <button class="btn me-1" t-on-click="save">Save</button>
-                <button class="btn" t-on-click="cancel">Discard</button>
+                <button class="btn me-1" t-on-click="this.save">Save</button>
+                <button class="btn" t-on-click="this.cancel">Discard</button>
             </div>
         </div>
     </div>

--- a/addons/api_doc/static/src/components/doc_modal_search.xml
+++ b/addons/api_doc/static/src/components/doc_modal_search.xml
@@ -9,19 +9,19 @@
                 type="text"
                 autocorrect="off"
                 placeholder="Find anything..."
-                t-on-input="onInput"
+                t-on-input="this.onInput"
                 t-custom-ref="seachRef"
             />
 
             <div class="d-flex flex-nowrap mb-2 align-items-center">
                 <div
-                    t-foreach="state.activeFilters"
+                    t-foreach="this.state.activeFilters"
                     t-as="filter"
                     t-key="filter"
                     class="d-flex flex-nowrap ms-2 align-items-center cursor-pointer btn o-doc-modal-checkbox"
                     t-on-click="() => this.onFilterClick(filter)"
                 >
-                    <input class="me-2" type="checkbox" t-att-id="filter" t-att-checked="state.activeFilters[filter]"/>
+                    <input class="me-2" type="checkbox" t-att-id="filter" t-att-checked="this.state.activeFilters[filter]"/>
                     <label class="text-truncate" t-att-for="filter" t-out="filter" t-on-click.prevent=""></label>
                 </div>
                 <div class="text-muted ms-2 me-2">
@@ -34,12 +34,12 @@
                 <div class="overflow-hidden" t-att-style="`min-height: ${this.state.scrollHeight}px`">
                     <div t-att-style="`transform: translateY(${this.state.scrollOffsetY}px)`">
                         <button
-                            t-foreach="state.results"
+                            t-foreach="this.state.results"
                             t-as="result"
                             t-key="result_index + result.type + '/' + result.label + '/' + result.path"
                             class="btn mb-2 text-start w-100 d-flex flex-nowrap flex-row o-doc-modal-checkbox justify-content-between"
                             t-on-click="() => this.onSelect(result)"
-                            t-att-style="`min-height: ${itemHeight}px; max-height: ${itemHeight}px; margin-bottom: ${itemMargin}px`"
+                            t-att-style="`min-height: ${this.itemHeight}px; max-height: ${this.itemHeight}px; margin-bottom: ${this.itemMargin}px`"
                         >
                             <div class="h-100 flex-grow-1 me-2">
                                 <h5 t-out="result.label" class="text-truncate mb-0"></h5>

--- a/addons/api_doc/static/src/components/doc_model.xml
+++ b/addons/api_doc/static/src/components/doc_model.xml
@@ -2,9 +2,9 @@
 <templates xml:space="preserve">
 
 <t t-name="web.DocModel">
-    <div t-if="!state.error" class="o-doc-model position-relative d-flex flex-nowrap flex-fill flex-column p-3">
+    <div t-if="!this.state.error" class="o-doc-model position-relative d-flex flex-nowrap flex-fill flex-column p-3">
         <h2 class="w-100 mb-2 mt-2" t-out="this.state.model?.name ?? ''"></h2>
-        <DocTable data="state.modelData"/>
+        <DocTable data="this.state.modelData"/>
 
         <h3 class="mt-3 mb-2" id="fields">Fields</h3>
         <DocLoadingIndicator
@@ -20,24 +20,24 @@
             class="'o-fade-in position-relative'"
         >
             <DocMethod
-                t-foreach="state.methods"
+                t-foreach="this.state.methods"
                 t-as="method"
                 t-key="method.model + '/' + method.name"
-                t-if="isModuleActive(method.module)"
+                t-if="this.isModuleActive(method.module)"
                 method="method"
-                class="modelStore.activeMethod === method.name ? 'o-doc-active' : ''"
+                class="this.modelStore.activeMethod === method.name ? 'o-doc-active' : ''"
             />
         </DocLoadingIndicator>
         <div style="min-height: 30vh"/>
     </div>
 
-    <aside t-if="!ui.isSmall and !state.error" class="o-doc-model-aside overflow-auto position-sticky d-block flex-fill bg-default pt-2 pb-2 ps-3 pe-3 border-start">
+    <aside t-if="!this.ui.isSmall and !this.state.error" class="o-doc-model-aside overflow-auto position-sticky d-block flex-fill bg-default pt-2 pb-2 ps-3 pe-3 border-start">
         <div
             class="d-flex flex-nowrap w-100 cursor-pointer text-capitalize align-items-center"
             t-on-click="() => this.state.showModulesFilter = !this.state.showModulesFilter"
             role="button"
         >
-            <div class="icon-btn ps-1" role="button" t-att-class="{ o_collapsed: !state.showModulesFilter}">
+            <div class="icon-btn ps-1" role="button" t-att-class="{ o_collapsed: !this.state.showModulesFilter}">
                 <i class="fa fa-angle-right" aria-hidden="true"></i>
             </div>
             <h3 class="ms-2">Modules</h3>
@@ -52,24 +52,24 @@
                 </a>
             </span>
             <div
-                t-foreach="state.modules"
+                t-foreach="this.state.modules"
                 t-as="module"
                 t-key="module"
                 class="d-flex flex-nowrap align-items-center mb-2 cursor-pointer btn o-doc-module-checks"
                 t-on-click="() => this.setActiveModules([module], !this.state.activeModules[module])"
             >
-                <input class="me-1" type="checkbox" t-att-id="module" t-att-checked="state.activeModules[module]"/>
+                <input class="me-1" type="checkbox" t-att-id="module" t-att-checked="this.state.activeModules[module]"/>
                 <label class="text-truncate" t-att-for="module" t-out="module" t-on-click.prevent=""></label>
             </div>
         </t>
 
         <h3 class="mt-2">On This Page</h3>
         <a
-            t-foreach="state.methods"
+            t-foreach="this.state.methods"
             t-as="method"
             t-key="method.model + '/' + method.name"
             t-out="method.name"
-            t-if="isModuleActive(method.module)"
+            t-if="this.isModuleActive(method.module)"
             t-att-href="'#' + method.name"
             class="d-block w-100 text-truncate"
         >
@@ -77,13 +77,13 @@
     </aside>
 
     <div
-        t-if="state.error and !modelStore.activeModel"
+        t-if="this.state.error and !this.modelStore.activeModel"
         class="d-flex flex-nowrap align-items-center justify-content-center w-100 h-100"
     >
         <DocErrorDialog
-            name="modelStore.error.name"
-            status="modelStore.error.status"
-            traceback="modelStore.error.traceback"
+            name="this.modelStore.error.name"
+            status="this.modelStore.error.status"
+            traceback="this.modelStore.error.traceback"
         />
     </div>
 </t>

--- a/addons/api_doc/static/src/components/doc_request.xml
+++ b/addons/api_doc/static/src/components/doc_request.xml
@@ -8,18 +8,18 @@
             <div class="d-flex flex-nowrap">
                 <select class="me-1" t-on-change="event => this.selectLanguage(event.target.value)">
                     <option
-                        t-foreach="LANGUAGES"
+                        t-foreach="this.LANGUAGES"
                         t-as="lang"
                         t-key="lang"
-                        t-att-selected="state.exampleLanguage === lang"
+                        t-att-selected="this.state.exampleLanguage === lang"
                         t-att-value="lang"
                         t-out="lang"
                     />
                 </select>
                 <button
                     class="btn primary d-flex flex-nowrap align-items-center"
-                    t-on-click="execute"
-                    t-att-disabled="state.exampleLanguage !== 'json'"
+                    t-on-click="this.execute"
+                    t-att-disabled="this.state.exampleLanguage !== 'json'"
                 >
                     <span>Run</span>
                     <i class="fa fa-play ms-2" aria-hidden="true"></i>
@@ -28,38 +28,38 @@
         </div>
 
         <CodeEditor
-            mode="LANGUAGES[state.exampleLanguage]"
-            value="state.exampleLanguage === 'json' ? state.requestCode : state.exampleCode"
-            readonly="state.exampleLanguage !== 'json'"
+            mode="this.LANGUAGES[this.state.exampleLanguage]"
+            value="this.state.exampleLanguage === 'json' ? this.state.requestCode : this.state.exampleCode"
+            readonly="this.state.exampleLanguage !== 'json'"
             onChange="value => this.state.requestCode = value"
-            maxLines="maxLines"
+            maxLines="this.maxLines"
             theme="'monokai'"
             showLineNumbers="false"
         />
 
         <div class="mt-2 d-flex flex-nowrap align-items-center mb-1">
             <h4>Response</h4>
-            <span t-if="hasResponse and !state.response.error" class="badge success ms-1">Success</span>
-            <span t-if="hasResponse and state.response.error" class="badge error ms-1">Failed</span>
+            <span t-if="this.hasResponse and !this.state.response.error" class="badge success ms-1">Success</span>
+            <span t-if="this.hasResponse and this.state.response.error" class="badge error ms-1">Failed</span>
         </div>
 
-        <t t-if="hasResponse">
+        <t t-if="this.hasResponse">
             <CodeEditor
-                t-if="!state.response.error"
+                t-if="!this.state.response.error"
                 mode="'json'"
-                value="state.response.body"
+                value="this.state.response.body"
                 readonly="true"
-                maxLines="maxLines"
+                maxLines="this.maxLines"
                 theme="'monokai'"
                 showLineNumbers="false"
             />
             <div t-else="" class="alert error mt-1 d-flex flex-nowrap flex-column">
                 <h5 class="mb-2 d-flex flex-nowrap align-items-center">
                     <i class="pe-1 fa fa-exclamation-triangle" aria-hidden="true"></i>
-                    <span>Error <t t-out="state.response.status"/> while executing request</span>
+                    <span>Error <t t-out="this.state.response.status"/> while executing request</span>
                 </h5>
                 <div>
-                    <div t-out="responseText"></div>
+                    <div t-out="this.responseText"></div>
                 </div>
             </div>
         </t>
@@ -72,10 +72,10 @@
         <t t-call="web.CodeEditor"></t>
         <button
             class="position-absolute p-1 top-0 end-0 d-flex align-items-center cursor-pointer"
-            t-on-click="copyToClipboard"
+            t-on-click="this.copyToClipboard"
             type="button"
         >
-            <i t-if="!state.copied" class="fa fa-clipboard fs-6 text-light"/>
+            <i t-if="!this.state.copied" class="fa fa-clipboard fs-6 text-light"/>
             <span t-else="" class="fs-6 text-light">Copied!</span>
         </button>
     </div>

--- a/addons/api_doc/static/src/components/doc_sidebar.xml
+++ b/addons/api_doc/static/src/components/doc_sidebar.xml
@@ -4,28 +4,28 @@
 <t t-name="web.DocSidebar">
     <div class="o-doc-sidebar pt-3 ps-3 position-sticky bg-1 border-end d-flex flex-nowrap flex-column">
         <div class="pe-4 pb-4">
-            <input t-on-input="onSearchInput" class="w-100" placeholder="Search for models..."/>
+            <input t-on-input="this.onSearchInput" class="w-100" placeholder="Search for models..."/>
         </div>
         <div class="o-doc-sidebar-content h-100 flex-fill d-flex flex-nowrap flex-column gap-1" t-custom-ref="containerRef">
-            <t t-foreach="filteredAddons" t-as="addon" t-key="addon.name">
+            <t t-foreach="this.filteredAddons" t-as="addon" t-key="addon.name">
                 <div
                     class="position-sticky o-doc-sidebar-header top-0 d-flex flex-nowrap w-100 cursor-pointer text-capitalize user-select-none"
                     t-on-click="(ev) => this.toggleAddon(ev, addon.name)"
                     role="button"
                 >
-                    <div class="icon-btn ps-2 pt-2" role="button" t-att-class="{ o_collapsed: isCollapsed(addon.name)}">
+                    <div class="icon-btn ps-2 pt-2" role="button" t-att-class="{ o_collapsed: this.isCollapsed(addon.name)}">
                         <i class="fa fa-angle-right" aria-hidden="true"></i>
                     </div>
                     <h4 class="ms-2" t-out="addon.name"></h4>
                 </div>
 
-                <div t-if="!isCollapsed(addon.name)" class="ms-2 ps-2 border-start">
+                <div t-if="!this.isCollapsed(addon.name)" class="ms-2 ps-2 border-start">
                     <t t-foreach="addon.models" t-as="model" t-key="model.model">
                         <a
                             class="btn d-block bg-none text-start"
                             href="#"
                             t-on-click="() => this.modelStore.setActiveModel({ model })"
-                            t-att-class="{ o_active: isActiveItem(model) }"
+                            t-att-class="{ o_active: this.isActiveItem(model) }"
                             role="button"
                         >
                             <div t-out="model.name"></div>

--- a/addons/api_doc/static/src/components/doc_table.xml
+++ b/addons/api_doc/static/src/components/doc_table.xml
@@ -4,30 +4,30 @@
 <t t-name="web.DocTable">
     <div class="overflow-auto w-100 p-1">
         <table class="o-doc-table rounded bg-1 w-100">
-            <tr t-if="props.data.headers" class="bg-1">
+            <tr t-if="this.props.data.headers" class="bg-1">
                 <th
-                    t-foreach="props.data.headers"
+                    t-foreach="this.props.data.headers"
                     t-as="header"
                     t-key="header_index"
                     t-on-click="() => this.onRowHeaderClick(header_index)"
                     class="position-relative text-nowrap text-start cursor-pointer user-select-none pt-1 pb-1 ps-2"
-                    t-attf-style="width: {{ 100 / props.data.headers.length }}%"
+                    t-attf-style="width: {{ 100 / this.props.data.headers.length }}%"
                 >
                     <span class="me-2" t-out="header"></span>
                     <i
-                        t-att-class="getSortIcon(header_index)"
+                        t-att-class="this.getSortIcon(header_index)"
                         aria-hidden="true"
                     ></i>
                 </th>
             </tr>
 
             <tr
-                t-foreach="items"
+                t-foreach="this.items"
                 t-as="rows"
                 t-key="rows_index"
                 class="bg-1"
-                t-att-class="{ 'o-doc-active': rows_index === props.activeIndex }"
-                t-att-id="getId(rows)"
+                t-att-class="{ 'o-doc-active': rows_index === this.props.activeIndex }"
+                t-att-id="this.getId(rows)"
             >
                 <td
                     t-foreach="rows"
@@ -51,7 +51,7 @@
                             t-on-mouseleave="(ev) => this.scheduleHide(ev)"
                         ></i>
                     </t>
-                    <t t-else="" t-tag="getTag(row)" t-att-class="getClass(row)" t-out="getValue(row)"/>
+                    <t t-else="" t-tag="this.getTag(row)" t-att-class="this.getClass(row)" t-out="this.getValue(row)"/>
 
                     <a
                         t-if="row.relation"
@@ -68,8 +68,8 @@
                 </td>
             </tr>
 
-            <tr t-if="items.length === 0 and props.data.headers" class="bg-1">
-                <td t-foreach="props.data.headers" t-as="row" t-key="row_index" t-attf-style="width: {{ 100 / props.data.headers.length }}%" class="text-start text-muted">
+            <tr t-if="this.items.length === 0 and this.props.data.headers" class="bg-1">
+                <td t-foreach="this.props.data.headers" t-as="row" t-key="row_index" t-attf-style="width: {{ 100 / this.props.data.headers.length }}%" class="text-start text-muted">
                     <t t-if="row_index === 0">
                         No Data
                     </t>
@@ -79,21 +79,21 @@
     </div>
 
     <div
-        t-if="state.subTable"
+        t-if="this.state.subTable"
         class="o-doc-sub-table overflow-auto position-fixed bg-1 p-1 shadow border z-index-1 rounded"
-        t-att-style="state.subTableStyle"
+        t-att-style="this.state.subTableStyle"
         t-custom-ref="subTableRef"
     >
-        <DocTable data="state.subTable"/>
+        <DocTable data="this.state.subTable"/>
     </div>
     <div
         class="o-doc-dynamic-tooltip p-3 border overflow-auto"
-        t-att-style="state.tooltipStyle"
+        t-att-style="this.state.tooltipStyle"
         t-ref="tooltipRef"
         t-on-mouseenter="() => this.keepAlive()"
         t-on-mouseleave="(ev) => this.scheduleHide(ev)"
     >
-        <t t-out="state.tooltipContent"/>
+        <t t-out="this.state.tooltipContent"/>
     </div>
 </t>
 

--- a/addons/api_doc/static/src/doc_client.xml
+++ b/addons/api_doc/static/src/doc_client.xml
@@ -21,26 +21,26 @@
         </div>
     </header>
     <main class="position-relative d-flex flex-nowrap">
-        <DocSidebar t-if="!ui.isSmall"/>
-        <t t-if="modelStore.models.length > 0">
-            <DocModel t-if="modelStore.activeModel"/>
+        <DocSidebar t-if="!this.ui.isSmall"/>
+        <t t-if="this.modelStore.models.length > 0">
+            <DocModel t-if="this.modelStore.activeModel"/>
         </t>
-        <div t-elif="!modelStore.error" class="h-100 w-100 d-flex flex-nowrap align-items-center justify-content-center gap-1">
+        <div t-elif="!this.modelStore.error" class="h-100 w-100 d-flex flex-nowrap align-items-center justify-content-center gap-1">
             <i class="fa fa-spinner o-doc-spinner" aria-hidden="true"></i>
             <div>Loading Models</div>
         </div>
 
-        <div t-if="modelStore.error" class="d-flex flex-column align-items-center justify-content-center w-100 h-100">
+        <div t-if="this.modelStore.error" class="d-flex flex-column align-items-center justify-content-center w-100 h-100">
             <DocErrorDialog
-                name="modelStore.error.name"
-                status="modelStore.error.status"
-                traceback="modelStore.error.traceback"
+                name="this.modelStore.error.name"
+                status="this.modelStore.error.status"
+                traceback="this.modelStore.error.traceback"
             />
         </div>
     </main>
-    <ApiKeyModal t-if="modelStore.showApiKeyModal"/>
+    <ApiKeyModal t-if="this.modelStore.showApiKeyModal"/>
     <SearchModal
-        t-if="state.showSearchModal"
+        t-if="this.state.showSearchModal"
         close="() => this.state.showSearchModal = false"
     />
 </t>


### PR DESCRIPTION
In preparation for OWL3, where template variables will need to use `this` to target component variables, we add `this.` to template variables that are targetting the component.

Script PR: odoo/odoo#247965

task: OWL3 prep - add this. to template variables

