### PR TITLE
[FIX] account_edi_ubl_cii: correct tax amount when grouping lines

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_move.py
+++ b/addons/account_edi_ubl_cii/models/account_move.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import re
 
+from collections import defaultdict
+
 from odoo import _, api, fields, models, Command
 from odoo.exceptions import UserError
 
@@ -45,11 +47,12 @@ class AccountMove(models.Model):
             raise UserError(error_message)
 
         file_data = self.ubl_cii_xml_id._unwrap_edi_attachments()[0]
-        ubl_cii_xml_builder = self._get_ubl_cii_builder_from_xml_tree(file_data['xml_tree'])
-        if ubl_cii_xml_builder is None:
-            raise UserError(_("Cannot decode the origin file, try by importing it again"))
+        decoder = self._get_edi_decoder(file_data)
+        if decoder is None:
+            raise UserError(_("Cannot decode origin file, try by importing it again"))
+
         self.invoice_line_ids = [Command.clear()]
-        if ubl_cii_xml_builder.with_context(ungroup_lines=True)._import_invoice_ubl_cii(self, file_data):
+        if decoder(self, file_data):
             self._message_log(body=_("Ungrouped lines from %s", file_data['attachment'].name))
         else:
             raise UserError(error_message)
@@ -62,10 +65,44 @@ class AccountMove(models.Model):
         if not self.is_invoice(include_receipts=True):
             raise UserError(_("You can only group lines of an invoice"))
 
+        tax_lines = self.line_ids.filtered('tax_line_id')
+        tax_amounts = defaultdict(lambda: {
+            'tax_amount_currency': 0.0,
+            'tax_amount': 0.0,
+        })
+        for tax_line in tax_lines:
+            tax_amounts[tax_line.tax_key]['tax_amount_currency'] += tax_line.amount_currency
+            tax_amounts[tax_line.tax_key]['tax_amount'] += tax_line.balance
+
+        currency = self.currency_id
+        old_tax_amount = currency.round(sum(tax_line.amount_currency for tax_line in self.line_ids.filtered('tax_line_id')))
+
         line_vals = self._get_line_vals_group_by_tax(self.partner_id, fields.Date.to_string(self.date))
         self.invoice_line_ids = [Command.clear()]
         self.invoice_line_ids = line_vals
+
         self._message_log(body=_("Grouped lines by tax"))
+
+        # Correct Tax Amount if a difference of 0.01 or less is detected
+        new_tax_amount = currency.round(sum(tax_line.amount_currency for tax_line in self.line_ids.filtered('tax_line_id')))
+        difference = currency.round(new_tax_amount - old_tax_amount)
+        if currency.is_zero(difference) or currency.compare_amounts(difference, 0.01) > 0:
+            return
+
+        line_commands = []
+        for tax_line in self.line_ids.filtered('tax_line_id'):
+            tax_key = tax_line.tax_key
+            if tax_key not in tax_amounts:
+                continue
+
+            expected_amounts = tax_amounts[tax_key]
+            line_commands.append(Command.update(tax_line.id, {
+                'amount_currency': expected_amounts['tax_amount_currency'],
+                'balance': expected_amounts['tax_amount'],
+            }))
+
+        if line_commands:
+            self.line_ids = line_commands
 
     def _get_line_vals_group_by_tax(self, partner, date):
         """
@@ -145,8 +182,7 @@ class AccountMove(models.Model):
             return
 
         if (
-            self.env.context.get('ungroup_lines')
-            or not invoice.partner_id
+            not invoice.partner_id
             or not invoice.ubl_cii_xml_id
         ):
             return

--- a/addons/account_edi_ubl_cii/tests/test_files/bis3_bill_group_by_tax.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/bis3_bill_group_by_tax.xml
@@ -1,62 +1,55 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+         xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+         xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
   <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
   <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
-  <cbc:ID>FAC/2023/00052</cbc:ID>
-  <cbc:IssueDate>2023-08-04</cbc:IssueDate>
-  <cbc:DueDate>2023-09-04</cbc:DueDate>
+  <cbc:ID>INV/2017/00001</cbc:ID>
+  <cbc:IssueDate>2017-01-01</cbc:IssueDate>
+  <cbc:DueDate>2017-01-01</cbc:DueDate>
   <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
   <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
-  <cac:OrderReference>
-    <cbc:ID>FAC/2023/00052</cbc:ID>
-    <cbc:SalesOrderID>S00012</cbc:SalesOrderID>
-  </cac:OrderReference>
-  <cac:AdditionalDocumentReference>
-    <cbc:ID>FAC_2023_00052.pdf</cbc:ID>
-    <cac:Attachment>
-    </cac:Attachment>
-  </cac:AdditionalDocumentReference>
   <cac:AccountingSupplierParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="9938">LU25587702</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9938">0202239951</cbc:EndpointID>
       <cac:PartyName>
-        <cbc:Name>ALD Automotive LU</cbc:Name>
+        <cbc:Name>company_1_data</cbc:Name>
       </cac:PartyName>
       <cac:PostalAddress>
-        <cbc:StreetName>270 rte d'Arlon</cbc:StreetName>
-        <cbc:CityName>Strassen</cbc:CityName>
-        <cbc:PostalZone>8010</cbc:PostalZone>
+        <cbc:StreetName>Chaussée de Namur 40</cbc:StreetName>
+        <cbc:CityName>Ramillies</cbc:CityName>
+        <cbc:PostalZone>1367</cbc:PostalZone>
         <cac:Country>
-          <cbc:IdentificationCode>LU</cbc:IdentificationCode>
+          <cbc:IdentificationCode>BE</cbc:IdentificationCode>
         </cac:Country>
       </cac:PostalAddress>
       <cac:PartyTaxScheme>
-        <cbc:CompanyID>LU12977109</cbc:CompanyID>
+        <cbc:CompanyID>BE0202239951</cbc:CompanyID>
         <cac:TaxScheme>
           <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
-        <cbc:RegistrationName>ALD Automotive LU</cbc:RegistrationName>
-        <cbc:CompanyID>LU12977109</cbc:CompanyID>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+        <cbc:CompanyID>BE0202239951</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
-        <cbc:Name>ALD Automotive LU</cbc:Name>
-        <cbc:ElectronicMail>adl@test.com</cbc:ElectronicMail>
+        <cbc:Name>company_1_data</cbc:Name>
       </cac:Contact>
     </cac:Party>
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="9938">LU25587702</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9938">0477472701</cbc:EndpointID>
       <cac:PartyName>
-        <cbc:Name>Odoo Lu</cbc:Name>
+        <cbc:Name>partner_a</cbc:Name>
       </cac:PartyName>
       <cac:PostalAddress>
-        <cbc:StreetName>Rue de l'industrie 13</cbc:StreetName>
-        <cbc:CityName>Windhof</cbc:CityName>
+        <cbc:StreetName>Rue des Bourlottes 9</cbc:StreetName>
+        <cbc:CityName>Ramillies</cbc:CityName>
+        <cbc:PostalZone>1367</cbc:PostalZone>
         <cac:Country>
-          <cbc:IdentificationCode>LU</cbc:IdentificationCode>
+          <cbc:IdentificationCode>BE</cbc:IdentificationCode>
         </cac:Country>
       </cac:PostalAddress>
       <cac:PartyTaxScheme>
@@ -66,41 +59,22 @@
         </cac:TaxScheme>
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
-        <cbc:RegistrationName>Odoo Lu</cbc:RegistrationName>
-        <cbc:CompanyID>LU25587702</cbc:CompanyID>
+        <cbc:RegistrationName>partner_a</cbc:RegistrationName>
+        <cbc:CompanyID>BE0477472701</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
-        <cbc:Name>Odoo Lu</cbc:Name>
-        <cbc:ElectronicMail>odoo@test.com</cbc:ElectronicMail>
+        <cbc:Name>partner_a</cbc:Name>
       </cac:Contact>
     </cac:Party>
   </cac:AccountingCustomerParty>
-  <cac:Delivery>
-    <cac:DeliveryLocation>
-      <cac:Address>
-        <cbc:StreetName>Rue de l'industrie 13</cbc:StreetName>
-        <cbc:CityName>Windhof</cbc:CityName>
-        <cac:Country>
-          <cbc:IdentificationCode>LU</cbc:IdentificationCode>
-        </cac:Country>
-      </cac:Address>
-    </cac:DeliveryLocation>
-  </cac:Delivery>
-  <cac:PaymentMeans>
-    <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
-    <cbc:PaymentID>FAC/2023/00052</cbc:PaymentID>
-    <cac:PayeeFinancialAccount>
-      <cbc:ID>LU071241358706500000</cbc:ID>
-    </cac:PayeeFinancialAccount>
-  </cac:PaymentMeans>
   <cac:TaxTotal>
     <cbc:TaxAmount currencyID="EUR">369.00</cbc:TaxAmount>
     <cac:TaxSubtotal>
       <cbc:TaxableAmount currencyID="EUR">600.00</cbc:TaxableAmount>
-      <cbc:TaxAmount currencyID="EUR">96.00</cbc:TaxAmount>
+      <cbc:TaxAmount currencyID="EUR">36.00</cbc:TaxAmount>
       <cac:TaxCategory>
         <cbc:ID>S</cbc:ID>
-        <cbc:Percent>16.0</cbc:Percent>
+        <cbc:Percent>6.0</cbc:Percent>
         <cac:TaxScheme>
           <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>
@@ -121,19 +95,18 @@
   <cac:LegalMonetaryTotal>
     <cbc:LineExtensionAmount currencyID="EUR">1900.00</cbc:LineExtensionAmount>
     <cbc:TaxExclusiveAmount currencyID="EUR">1900.00</cbc:TaxExclusiveAmount>
-    <cbc:TaxInclusiveAmount currencyID="EUR">2269.00</cbc:TaxInclusiveAmount>
-    <cbc:PayableAmount currencyID="EUR">2269.00</cbc:PayableAmount>
+    <cbc:TaxInclusiveAmount currencyID="EUR">2209.00</cbc:TaxInclusiveAmount>
+    <cbc:PayableAmount currencyID="EUR">2209.00</cbc:PayableAmount>
   </cac:LegalMonetaryTotal>
   <cac:InvoiceLine>
     <cbc:ID>1</cbc:ID>
     <cbc:InvoicedQuantity unitCode="EA">1.0</cbc:InvoicedQuantity>
     <cbc:LineExtensionAmount currencyID="EUR">600.00</cbc:LineExtensionAmount>
     <cac:Item>
-      <cbc:Description>Locations et leasing opérationnel - Véhicule HG6542</cbc:Description>
-      <cbc:Name>Locations et leasing opérationnel</cbc:Name>
+      <cbc:Name>Product 6%</cbc:Name>
       <cac:ClassifiedTaxCategory>
         <cbc:ID>S</cbc:ID>
-        <cbc:Percent>16.0</cbc:Percent>
+        <cbc:Percent>6.0</cbc:Percent>
         <cac:TaxScheme>
           <cbc:ID>VAT</cbc:ID>
         </cac:TaxScheme>
@@ -148,7 +121,6 @@
     <cbc:InvoicedQuantity unitCode="EA">1.0</cbc:InvoicedQuantity>
     <cbc:LineExtensionAmount currencyID="EUR">300.0</cbc:LineExtensionAmount>
     <cac:Item>
-      <cbc:Description>A product 21% tax</cbc:Description>
       <cbc:Name>Product 21%</cbc:Name>
       <cac:ClassifiedTaxCategory>
         <cbc:ID>S</cbc:ID>
@@ -167,7 +139,6 @@
     <cbc:InvoicedQuantity unitCode="EA">2.0</cbc:InvoicedQuantity>
     <cbc:LineExtensionAmount currencyID="EUR">1000.0</cbc:LineExtensionAmount>
     <cac:Item>
-      <cbc:Description>An other product 21% tax</cbc:Description>
       <cbc:Name>Other product 21%</cbc:Name>
       <cac:ClassifiedTaxCategory>
         <cbc:ID>S</cbc:ID>

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -798,82 +798,89 @@ comment-->1000.0</TaxExclusiveAmount></xpath>"""
 
         # Datas
         self.env.ref('base.EUR').active = True
-        tax_16 = self.env["account.tax"].create({
-            'name': '16 %',
-            'amount_type': 'percent',
-            'type_tax_use': 'purchase',
-            'amount': 16.0,
-        })
-        tax_21 = self.env["account.tax"].create({
-            'name': '21 %',
-            'amount_type': 'percent',
-            'type_tax_use': 'purchase',
-            'amount': 21.0,
-        })
-
-        lines_grouped = [
-            {
-                'quantity': 1.0,
-                'price_unit': 600.0,
-                'price_subtotal': 600.0,
-                'price_total': 696.00,
-                'tax_ids': tax_16.ids,
-            },
-            {
-                'quantity': 1.0,
-                'price_unit': 1300.0,
-                'price_subtotal': 1300.0,
-                'price_total': 1573.00,
-                'tax_ids': tax_21.ids,
-            },
-        ]
-        total_values = [{
-            'amount_untaxed': 1900.0,
-            'amount_tax': 369,
-            'amount_total': 2269.00,
-        }]
+        tax_6 = self.percent_tax(6.0, type_tax_use='purchase')
+        tax_21 = self.percent_tax(21.0, type_tax_use='purchase')
 
         # Import bill
         file_path = "bis3_bill_group_by_tax.xml"
-        bill = create_bill(file_path)
+        invoice = create_bill(file_path)
 
-        # Group lines by tax and post
-        bill.action_group_ungroup_lines_by_tax()
-        self.assertRecordValues(bill.invoice_line_ids, lines_grouped)
-        self.assertRecordValues(bill, total_values)
-        bill.action_post()
-
-        # Import the bill a second time, should be grouped as last posted bill from this supplier is grouped
-        bill_2 = create_bill(file_path)
-        self.assertRecordValues(bill_2.invoice_line_ids, lines_grouped)
-        self.assertRecordValues(bill_2, total_values)
-
-        # Should ungroup lines from xml
-        bill_2.action_group_ungroup_lines_by_tax()
-        self.assertRecordValues(bill_2.invoice_line_ids, [
+        expected_not_grouped_lines = [
             {
                 'quantity': 1.0,
                 'price_unit': 600.0,
-                'price_subtotal': 600.0,
-                'price_total': 696.00,
-                'tax_ids': tax_16.ids,
+                'tax_ids': tax_6.ids,
             },
             {
                 'quantity': 1.0,
                 'price_unit': 300.0,
-                'price_subtotal': 300.0,
-                'price_total': 363.00,
                 'tax_ids': tax_21.ids,
             },
             {
                 'quantity': 2.0,
                 'price_unit': 500.0,
-                'price_subtotal': 1000.0,
-                'price_total': 1210.00,
                 'tax_ids': tax_21.ids,
             },
-        ])
-        self.assertRecordValues(bill_2, total_values)
+        ]
+        self.assertRecordValues(invoice.invoice_line_ids, expected_not_grouped_lines)
+
+        # Group lines by tax and post
+        invoice.action_group_ungroup_lines_by_tax()
+
+        expected_grouped_lines = [
+            {
+                'quantity': 1.0,
+                'price_unit': 600.0,
+                'tax_ids': tax_6.ids,
+            },
+            {
+                'quantity': 1.0,
+                'price_unit': 1300.0,
+                'tax_ids': tax_21.ids,
+            },
+        ]
+        self.assertRecordValues(invoice.invoice_line_ids, expected_grouped_lines)
+        invoice.action_post()
+
+        # Import the bill a second time, should be grouped as last posted bill from this supplier is grouped
+        invoice_2 = create_bill(file_path)
+        self.assertRecordValues(invoice_2.invoice_line_ids, expected_grouped_lines)
+
+        # Should ungroup lines from xml
+        invoice_2.action_group_ungroup_lines_by_tax()
+        self.assertRecordValues(invoice_2.invoice_line_ids, expected_not_grouped_lines)
+
+    def test_group_lines_correct_amount(self):
+        tax_21 = self.percent_tax(21.0, type_tax_use='purchase')
+        # The following invoice is a known case where amount_tax = 9.06 before grouping, and 9.07 after
+        move = self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'journal_id': self.company_data['default_journal_purchase'].id,
+            'partner_id': self.partner_a.id,
+            'invoice_date': '2019-11-12',
+            'date': '2019-11-12',
+            'invoice_line_ids': [
+                Command.create({
+                    'price_unit': 28.10,
+                    'quantity': 1,
+                    'tax_ids': [Command.set(tax_21.ids)],
+                }),
+                Command.create({
+                    'price_unit': 14.88,
+                    'quantity': 1,
+                    'tax_ids': [Command.set(tax_21.ids)],
+                }),
+                Command.create({
+                    'price_unit': 0.19,
+                    'quantity': 1,
+                    'tax_ids': [Command.set(tax_21.ids)],
+                }),
+            ],
+        })
+
+        old_tax_amount = move.amount_tax
+        move.action_group_ungroup_lines_by_tax()
+        self.assertEqual(move.amount_tax, old_tax_amount)
 
     def test_ubl_split_fixed_taxes_into_allowance_charges_or_extra_invoice_lines(self):
         """Test that fixed taxes are split correctly:


### PR DESCRIPTION
[FIX] account_edi_ubl_cii: correct tax amount when grouping lines

When the user group lines of a move, the tax amount is now corrected if there's a difference in the tax amount before and after grouping

This commit also removes the `ungroup_lines` context key, as the flow was changed in odoo/odoo#252458

Reword the `test_import_and_group_lines_by_tax` test: use belgian company and belgian taxes

task-5993555
