### PR TITLE
[REF] product_*: run owl3 rendering context migration script

### DIFF
--- a/addons/product/static/src/js/pricelist_report/product_pricelist_report.xml
+++ b/addons/product/static/src/js/pricelist_report/product_pricelist_report.xml
@@ -11,7 +11,7 @@
             </style>
             <Layout display="{ controlPanel: {} }">
                 <t t-set-slot="control-panel-buttons">
-                    <button t-on-click="onClickPrint" type="button" class="btn btn-primary" title="Print">Print</button>
+                    <button t-on-click="this.onClickPrint" type="button" class="btn btn-primary" title="Print">Print</button>
                     <select name="formats" id="formats" class="form-select border-1 w-auto">
                         <option value="pdf">pdf</option>
                         <option value="csv">csv</option>
@@ -22,28 +22,28 @@
                     <form class="o_pricelist_report_form d-flex flex-row gap-1">
                         <div class="d-flex align-items-center gap-3 w-75">
                             <label class="visually-hidden" for="pricelists">Username</label>
-                            <div t-if="pricelists.length > 0" class="input-group w-auto">
+                            <div t-if="this.pricelists.length > 0" class="input-group w-auto">
                                 <div class="input-group-text fw-bold">Pricelist</div>
                                 <select
                                     name="pricelists"
                                     id="pricelists"
                                     class="o_select form-select"
-                                    t-on-change="onSelectPricelist"
+                                    t-on-change="this.onSelectPricelist"
                                 >
-                                    <option t-out="selectedPricelist.name" t-att-value="selectedPricelist.id"/>
-                                    <t t-foreach="pricelists" t-as="pricelist" t-key="pricelist.id">
-                                        <t t-if="pricelist.id != selectedPricelist.id">
+                                    <option t-out="this.selectedPricelist.name" t-att-value="this.selectedPricelist.id"/>
+                                    <t t-foreach="this.pricelists" t-as="pricelist" t-key="pricelist.id">
+                                        <t t-if="pricelist.id != this.selectedPricelist.id">
                                             <option t-out="pricelist.name" t-att-value="pricelist.id"/>
                                         </t>
                                     </t>
                                 </select>
                             </div>
-                            <div t-if="pricelists.length > 0" class="form-check w-auto">
+                            <div t-if="this.pricelists.length > 0" class="form-check w-auto">
                                 <input class="o_display_pricelist_title form-check-input ms-0 me-2"
                                     id="display_pricelist_title"
                                     type="checkbox"
-                                    t-att-checked="displayPricelistTitle"
-                                    t-on-click="onToggleDisplayPricelist"/>
+                                    t-att-checked="this.displayPricelistTitle"
+                                    t-on-click="this.onToggleDisplayPricelist"/>
                                 <label for="display_pricelist_title" class="form-check-label">Show Name</label>
                             </div>
                         </div>
@@ -52,8 +52,8 @@
                                 <span class="input-group-text fw-bold">Date</span>
                                 <DateTimeInput
                                     type="'date'"
-                                    value="state.date"
-                                    onChange.bind="onDateChange"
+                                    value="this.state.date"
+                                    onChange.bind="this.onDateChange"
                                     class="'form-control px-2 border-1'"
                                 />
                             </div>
@@ -69,17 +69,17 @@
                                     min="1"/>
                                 <button class="o_add_qty btn btn-primary fa fa-plus"
                                         type="submit"
-                                        t-on-click="onClickAddQty"
+                                        t-on-click="this.onClickAddQty"
                                         title="Add a quantity"/>
                             </div>
                             <div class="d-flex align-items-center w-50">
                                 <span class="o_badges_list d-flex">
-                                    <t t-foreach="quantities" t-as="qty" t-key="qty">
+                                    <t t-foreach="this.quantities" t-as="qty" t-key="qty">
                                         <span class="text-bg-300 o_remove_qty badge rounded-pill me-2 py-1 border " t-att-value="qty">
                                             <t class="me-2" t-out="qty"/>
                                             <i class="oi oi-close ms-1 opacity-50 opacity-100-hover text-900 cursor-pointer"
                                             title="Remove quantity"
-                                            t-on-click="onClickRemoveQty"/>
+                                            t-on-click="this.onClickRemoveQty"/>
                                         </span>
                                     </t>
                                 </span>
@@ -87,16 +87,16 @@
                         </div>
                     </form>
                     <div style="margin-left:100px;">
-                        <button t-on-click="onClickAddProducts" string="All Products" class="btn btn-link">
+                        <button t-on-click="this.onClickAddProducts" string="All Products" class="btn btn-link">
                             <i class="fa fa-pencil"/>
                             Add Products
                         </button>
                     </div>
                 </t>
-                <div t-on-click="onClickLink">
-                    <t t-out="html"/>
+                <div t-on-click="this.onClickLink">
+                    <t t-out="this.html"/>
                 </div>
-                <t t-if="noProducts">
+                <t t-if="this.noProducts">
                     <div class="o_view_nocontent" role="alert">
                         <div class="o_nocontent_help">
                             <p class="o_view_nocontent_smiling_face">

--- a/addons/product/static/src/js/product_document_kanban/upload_button/upload_button.xml
+++ b/addons/product/static/src/js/product_document_kanban/upload_button/upload_button.xml
@@ -5,14 +5,14 @@
             type="file"
             multiple="true"
             t-custom-ref="uploadFileInput"
-            t-att-accept="props.allowedMIMETypes"
+            t-att-accept="this.props.allowedMIMETypes"
             class="o_input_file o_hidden"
-            t-on-change.stop="onFileInputChange"
+            t-on-change.stop="this.onFileInputChange"
         />
         <button
             type="button"
             name="product_upload_document"
-            t-if="!props.formData.hideUploadButton"
+            t-if="!this.props.formData.hideUploadButton"
             t-attf-class="btn btn-primary"
             t-on-click.stop.prevent="() => this.uploadFileInputRef.el.click()"
         >

--- a/addons/product/static/src/product_catalog/kanban_record.xml
+++ b/addons/product/static/src/product_catalog/kanban_record.xml
@@ -3,16 +3,16 @@
     <t t-name="ProductCatalogKanbanRecord">
         <article
             class="o_product_catalog_kanban_record"
-            t-att-class="getRecordClasses() + (productCatalogData.quantity ? ' o_product_added' : '')"
-            t-att-data-id="props.record.id"
-            t-att-tabindex="props.record.model.useSampleModel ? -1 : 0"
-            t-on-click="onGlobalClick"
+            t-att-class="this.getRecordClasses() + (this.productCatalogData.quantity ? ' o_product_added' : '')"
+            t-att-data-id="this.props.record.id"
+            t-att-tabindex="this.props.record.model.useSampleModel ? -1 : 0"
+            t-on-click="this.onGlobalClick"
             t-custom-ref="root"
         >
             <div class="d-flex flex-column h-100">
-                <t t-call="{{ templates[this.constructor.KANBAN_CARD_ATTRIBUTE] }}"
+                <t t-call="{{ this.templates[this.constructor.KANBAN_CARD_ATTRIBUTE] }}"
                    t-call-context="this.renderingContext"/>
-                <t t-component="orderLineComponent" productId="props.record.resId" t-props="productCatalogData"/>
+                <t t-component="this.orderLineComponent" productId="this.props.record.resId" t-props="this.productCatalogData"/>
             </div>
             <t t-call="{{ this.constructor.menuTemplate }}"/>
         </article>

--- a/addons/product/static/src/product_catalog/order_line/order_line.xml
+++ b/addons/product/static/src/product_catalog/order_line/order_line.xml
@@ -3,32 +3,32 @@
     <t t-name="product.ProductCatalogOrderLine">
         <!-- Replace the element found using the css selector by the content of the portalled
              template.  -->
-        <t t-custom-portal="`#product-${props.productId}-price`">
+        <t t-custom-portal="`#product-${this.props.productId}-price`">
             <div class="d-inline-flex align-items-baseline">
-                <span t-if="showPrice" t-out="price" class="o_product_catalog_price fw-bold me-4"/>
-                <span t-if="props.code" t-out="props.code" class="text-muted"/>
+                <span t-if="this.showPrice" t-out="this.price" class="o_product_catalog_price fw-bold me-4"/>
+                <span t-if="this.props.code" t-out="this.props.code" class="text-muted"/>
             </div>
         </t>
         <div 
-            t-if="props.readOnly and props.warning"
+            t-if="this.props.readOnly and this.props.warning"
             class="text-danger text-truncate my-2 pt-3 border-top">
-            <i class="fa fa-warning" t-att-title="props.warning"/>
+            <i class="fa fa-warning" t-att-title="this.props.warning"/>
             <span 
                 class="px-1" 
-                t-att-title="props.warning"
-                t-out="props.warning"/>
+                t-att-title="this.props.warning"
+                t-out="this.props.warning"/>
         </div>
-        <span t-elif="props.readOnly" class="m-2 pt-3 border-top" t-out="props.warning">
+        <span t-elif="this.props.readOnly" class="m-2 pt-3 border-top" t-out="this.props.warning">
             You can't edit this product in the catalog.
         </span>
         <div t-else="" class="d-flex justify-content-end align-items-center m-2">
-            <div t-if="isInOrder()"
+            <div t-if="this.isInOrder()"
                 class="o_product_catalog_quantity o_product_catalog_cancel_global_click input-group flex-nowrap mw-75">
                 <button
                     class="btn btn-primary border"
                     t-on-click.stop="this.env.decreaseQuantity"
-                    t-att-disabled="disableRemove"
-                    t-att-data-tooltip="disabledButtonTooltip"
+                    t-att-disabled="this.disableRemove"
+                    t-att-data-tooltip="this.disabledButtonTooltip"
                     aria-label="Decrease quantity"
                 >
                     <i class="oi oi-minus" aria-hidden="true"/>
@@ -37,14 +37,14 @@
                     class="form-control text-bg-view flex-grow-0 flex-shrink-0 text-center"
                     name="product_catalog_quantity_input"
                     type="number"
-                    t-att-value="quantity"
+                    t-att-value="this.quantity"
                     t-on-change="this.env.setQuantity"
-                    t-on-focus="_onFocus"
+                    t-on-focus="this._onFocus"
                 />
                 <span
                     t-if="this.env.displayUoM"
                     class="input-group-text d-block rounded-0 text-truncate cursor-default"
-                    t-out="props.uomDisplayName" t-att-title="props.uomDisplayName"
+                    t-out="this.props.uomDisplayName" t-att-title="this.props.uomDisplayName"
                 />
                 <button
                     class="btn btn-primary border"
@@ -54,17 +54,17 @@
                     <i class="oi oi-plus" aria-hidden="true"/>
                 </button>
             </div>
-            <t t-elif="props.warning">
-                <i class="fa fa-warning text-warning" t-att-title="props.warning"/>
+            <t t-elif="this.props.warning">
+                <i class="fa fa-warning text-warning" t-att-title="this.props.warning"/>
                 <span 
                     class="text-truncate text-warning px-1" 
-                    t-att-title="props.warning"
-                    t-out="props.warning"/>
+                    t-att-title="this.props.warning"
+                    t-out="this.props.warning"/>
             </t>
             <div 
                 class="ms-auto o_product_catalog_buttons o_product_catalog_cancel_global_click"
                 style="min-width: max-content;">
-                <button t-if="!isInOrder()"
+                <button t-if="!this.isInOrder()"
                         t-on-click.stop="() => this.env.addProduct()"
                         class="btn btn-secondary">
                     <i class="fa fa-shopping-cart"/>
@@ -72,7 +72,7 @@
                 </button>
                 <div t-else="" class="o_tooltip_div_remove" t-att-data-tooltip="this.disabledButtonTooltip">
                     <button t-on-click.stop="this.env.removeProduct"
-                            t-att-disabled="disableRemove"
+                            t-att-disabled="this.disableRemove"
                             class="btn btn-light border">
                         <i class="fa fa-trash"/>
                         Remove

--- a/addons/product_matrix/static/src/xml/product_matrix.xml
+++ b/addons/product_matrix/static/src/xml/product_matrix.xml
@@ -61,7 +61,7 @@
             accurate to display it.
             -->
         <span class="variant_price_extra" style="white-space: nowrap;">
-            <t t-out="format(cell)"/>
+            <t t-out="this.format(cell)"/>
         </span>
     </span>
 </template>

--- a/addons/product_matrix/static/src/xml/product_matrix.xml
+++ b/addons/product_matrix/static/src/xml/product_matrix.xml
@@ -28,7 +28,7 @@
                                 <t t-call="product_matrix.extra_price"/>
                             </div>
                         </th>
-                        <td t-else="" 
+                        <td t-else=""
                             class="o_matrix_input_td text-end"
                             t-attf-class="{{cell_last?'o_matrix_pe':''}}">
                             <div t-if="cell.is_possible_combination" class="input-group">
@@ -61,7 +61,7 @@
             accurate to display it.
             -->
         <span class="variant_price_extra" style="white-space: nowrap;">
-            <t t-out="this.format(cell)"/>
+            <t t-out="format(cell)"/>
         </span>
     </span>
 </template>

--- a/addons/product_matrix/static/src/xml/product_matrix_dialog.xml
+++ b/addons/product_matrix/static/src/xml/product_matrix_dialog.xml
@@ -1,13 +1,13 @@
 <templates>
     <t t-name="product_matrix.dialog">
-        <Dialog size="size" title.translate="Choose Product Variants" withBodyPadding="false">
+        <Dialog size="this.size" title.translate="Choose Product Variants" withBodyPadding="false">
             <t t-call="product_matrix.matrix">
-                <t t-set="header" t-value="props.header"/>
-                <t t-set="rows" t-value="props.rows"/>
-                <t t-set="format" t-value="_format"/>
+                <t t-set="header" t-value="this.props.header"/>
+                <t t-set="rows" t-value="this.props.rows"/>
+                <t t-set="format" t-value="this._format"/>
             </t>
             <t t-set-slot="footer">
-                <button class="btn btn-primary" t-on-click="_onConfirm">Confirm</button>
+                <button class="btn btn-primary" t-on-click="this._onConfirm">Confirm</button>
                 <button class="btn btn-secondary" t-on-click="() => this.props.close()">
                     Discard
                 </button>


### PR DESCRIPTION
In preparation for OWL3, where template variables will need to use `.this` to target component variables, we add `.this` to template variables that are targeting the component.

Script PR: odoo/odoo#247965
changes in: ["product", "product_matrix"]

task: OWL3 prep - add this. to template variables