### PR TITLE
[FIX] rpc: xmlrpc removal postponed to 21.1/22

### DIFF
--- a/addons/rpc/controllers/__init__.py
+++ b/addons/rpc/controllers/__init__.py
@@ -5,7 +5,7 @@ from . import json2
 
 RPC_DEPRECATION_NOTICE = """\
 The /xmlrpc, /xmlrpc/2 and /jsonrpc endpoints are deprecated in Odoo 19 \
-and scheduled for removal in Odoo 20. Please report the problem to the \
+and scheduled for removal in Odoo 22. Please report the problem to the \
 client making the request.
 Mute this logger: --log-handler %s:ERROR
 https://www.odoo.com/documentation/latest/developer/reference/external_api.html#migrating-from-xml-rpc-json-rpc"""


### PR DESCRIPTION
The "rpc service" API (xmlrpc/jsonrpc) have been deprecated in 19.0, JSON-2 acting as replacement. It was at first planned to be removed in 19.1/20 but we succeeded in convicing the management It Was A Bad Idea.

The removal is postponed to Odoo 21.1/22. This makes so that if the [Standard and extended support] policy remains the same until the release of Odoo 22, all versions supported with no additional fees (20, 21, 22) at that time will have JSON-2:

| version | supported at 22 release | rpc services          | JSON-2 |
| ------- | ----------------------- | --------------------- | ------ |
| 18.0    | no[^1]                  | active                | absent |
| 19.0    | no[^1]                  | active but deprecated | active |
| 20.0    | yes                     | active but deprecated | active |
| 21.0    | yes                     | active but deprecated | active |
| 22.0    | yes                     | absent                | active |

[Standard and extended support]: https://www.odoo.com/documentation/19.0/administration/standard_extended_support.html

[^1]: with no additionnal fees.
