### PR TITLE
[FIX] hr_presence: fix presence control items

### DIFF
--- a/addons/hr_presence/static/src/search/hr_presence_cog_menu/hr_presence_cog_menu.js
+++ b/addons/hr_presence/static/src/search/hr_presence_cog_menu/hr_presence_cog_menu.js
@@ -29,7 +29,7 @@ export class HrPresenceCogMenu extends FormCogMenu {
         return result[0];
     }
 
-    get PresenceActionItems() {
+    get presenceControlActions() {
         return this.presenceActionItems;
     }
 }

--- a/addons/hr_presence/static/src/search/hr_presence_cog_menu/hr_presence_cog_menu.xml
+++ b/addons/hr_presence/static/src/search/hr_presence_cog_menu/hr_presence_cog_menu.xml
@@ -3,7 +3,7 @@
 
     <t t-name="hr_presence.cogmenu" t-inherit="web.FormCogMenu" t-inherit-mode="primary">
         <xpath expr="//t[@t-if='state.printItems.length']" position="after">
-            <t t-if="PresenceActionItems.length">
+            <t t-if="presenceControlActions.length">
                 <t t-call="hr_presence.menu">
                     <t t-set="is_actionmenu" t-value="''"/>
                 </t>
@@ -18,7 +18,7 @@
                 <span class="o_dropdown_title">Presence Control</span>
             </button>
             <t t-set-slot="content">
-                <t t-foreach="this.PresenceActionItems" t-as="item" t-key="item.key">
+                <t t-foreach="presenceControlActions" t-as="item" t-key="item.key">
                     <t t-if="currentGroup !== null and currentGroup !== item.groupNumber">
                         <div role="separator" class="dropdown-divider"/>
                     </t>


### PR DESCRIPTION
Version:
-  saas-19.3

Issue:
- Presence control dropdown does not display options such as "Set Present" and "Set Absent".

Cause:
- After this PR:https://github.com/odoo/odoo/pull/251512 the getter method was called incorrectly, preventing the values from being returned.

Solution:
- Rename/update the method so the getter correctly returns the presence control action items.

Reason:
- Because the PresenceControl variable name and the method name were the same, after this PR ([https://github.com/odoo/odoo/pull/251512](https://github.com/odoo/odoo/pull/251512)) the script started running and added `this` when calling the `get` method.
So, I changed the method name to avoid the conflict.


Task-6018268


