### PR TITLE
[IMP] core: mask connection already closed

### DIFF
--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -481,6 +481,11 @@ class Cursor(_CursorProtocol):
 
             self.cache.clear()
 
+        except psycopg2.InterfaceError:
+            # mask 'connection already closed' error
+            if not self._cnx.closed:
+                raise
+
         finally:
             # The connection may have been closed, so give it back in finally block.
             self._closed = True
@@ -686,11 +691,10 @@ class ConnectionPool:
                 cnx.close()
                 last = self._free_connections.pop(i)
                 count += 1
-        for cnx in list(self._used_connections):
+        for cnx in self._used_connections:
             if dsn is None or self._dsn_equals(cnx.dsn, dsn):
                 cnx.close()
                 last = cnx
-                self._used_connections.discard(cnx)
                 count += 1
         if count:
             _logger.info('%r: Closed %d connections %s', self, count,


### PR DESCRIPTION
When closing Odoo, we `close_all` connections including used ones. In that case, we should let the Cursor deallocate the connection properly without tracebacks once it is freed.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
