### PR TITLE
[IMP] project: restrict assignee and manager dropdowns to allowed users

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -122,7 +122,8 @@ class ProjectProject(models.Model):
                                domain="[('is_closed', '=', False)]")
     color = fields.Integer(string='Color Index', export_string_translation=False)
     user_id = fields.Many2one('res.users', string='Project Manager', default=lambda self: self.env.user, tracking=True, falsy_value_label=_lt("👤 Unassigned"),
-        domain="[('share', '=', False), '|', ('company_id', '=?', company_id), ('company_ids', 'in', company_id)]")
+        domain=lambda self: [('share', '=', False), ('all_group_ids', 'in', self.env.ref('project.group_project_user').id),
+                            '|', ('company_id', '=?', self.env.company.id), ('company_ids', 'in', self.env.company.id)])
     alias_id = fields.Many2one(help="Internal email associated with this project. Incoming emails are automatically synchronized "
                                     "with Tasks (or optionally Issues if the Issue Tracker module is installed).")
     privacy_visibility = fields.Selection([

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -117,7 +117,8 @@ class ProjectProject(models.Model):
     task_ids = fields.One2many('project.task', 'project_id', string='Tasks', export_string_translation=False,
                                domain="[('is_closed', '=', False)]")
     color = fields.Integer(string='Color Index', export_string_translation=False)
-    user_id = fields.Many2one('res.users', string='Project Manager', default=lambda self: self.env.user, tracking=True, falsy_value_label=_lt("👤 Unassigned"))
+    user_id = fields.Many2one('res.users', string='Project Manager', default=lambda self: self.env.user, tracking=True,
+                              domain=lambda self: [('share', '=', False), ('all_group_ids', 'in', self.env.ref('project.group_project_manager').id)], falsy_value_label=_lt("👤 Unassigned"))
     alias_id = fields.Many2one(help="Internal email associated with this project. Incoming emails are automatically synchronized "
                                     "with Tasks (or optionally Issues if the Issue Tracker module is installed).")
     privacy_visibility = fields.Selection([

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -204,7 +204,7 @@ class ProjectTask(models.Model):
     # Tracking of this field is done in the write function
     user_ids = fields.Many2many('res.users', relation='project_task_user_rel', column1='task_id', column2='user_id',
         string='Assignees', context={'active_test': False}, tracking=True, default=_default_user_ids,
-        domain="['|', ('share', '=', False), '&', ('share', '=', True), ('followed_project_ids', '=', project_id), ('active', '=', True)]", falsy_value_label=_lt("👤 Unassigned"))
+        domain=lambda self: f"['|', '&', ('share', '=', False), ('all_group_ids', 'in', {self.env.ref('project.group_project_user').id}), '&', ('share', '=', True), ('followed_project_ids', '=', project_id), ('active', '=', True)]", falsy_value_label=_lt("👤 Unassigned"))
     # User names displayed in project sharing views
     portal_user_names = fields.Char(compute='_compute_portal_user_names', compute_sudo=True, search='_search_portal_user_names', export_string_translation=False)
     # Second Many2many containing the actual personal stage for the current user

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -204,7 +204,7 @@ class ProjectTask(models.Model):
     # Tracking of this field is done in the write function
     user_ids = fields.Many2many('res.users', relation='project_task_user_rel', column1='task_id', column2='user_id',
         string='Assignees', context={'active_test': False}, tracking=3, default=_default_user_ids,
-        domain="['|', ('share', '=', False), '&', ('share', '=', True), ('followed_project_ids', '=', project_id), ('active', '=', True), '|', ('company_id', '=?', company_id), ('company_ids', 'in', company_id)]", falsy_value_label=_lt("👤 Unassigned"))
+        domain=lambda self: f"['|', '&', ('share', '=', False), ('all_group_ids', 'in', {self.env.ref('project.group_project_user').id}), '&', ('share', '=', True), ('followed_project_ids', '=', project_id), ('active', '=', True), '|', ('company_id', '=?', company_id), ('company_ids', 'in', company_id)]", falsy_value_label=_lt("👤 Unassigned"))
     # User names displayed in project sharing views
     portal_user_names = fields.Char(compute='_compute_portal_user_names', compute_sudo=True, search='_search_portal_user_names', export_string_translation=False)
     # Second Many2many containing the actual personal stage for the current user

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -558,7 +558,7 @@
                                     <field name="activity_ids" widget="kanban_activity" class="ms-2"/>
                                 </div>
                                 <div class="d-flex ms-auto align-items-center">
-                                    <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]" class="me-1"/>
+                                    <field name="user_id" widget="many2one_avatar_user" class="me-1"/>
                                     <field t-if="record.last_update_status.value &amp;&amp; widget.editable &amp;&amp; !record.is_template.raw_value" name="last_update_status" widget="project_state_selection"/>
                                     <span t-if="record.last_update_status.value &amp;&amp; !widget.editable" t-att-class="'o_status_bubble mx-0 o_color_bubble_' + record.last_update_color.value" t-att-title="record.last_update_status.value"></span>
                                 </div>

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -107,7 +107,7 @@
                         </div>
                         <group>
                             <field name="active" invisible="1"/>
-                            <field name="user_id" string="Project Manager" widget="many2one_avatar_user" readonly="not active" domain="[('share', '=', False)]"/>
+                            <field name="user_id" string="Project Manager" widget="many2one_avatar_user" readonly="not active"/>
                             <field name="date_start" string="Planned Date" widget="daterange" options='{"end_date_field": "date", "always_range": True}' required="date_start or date" />
                             <field name="date" invisible="1" required="date_start"/>
                         </group>
@@ -539,7 +539,7 @@
                                     <field name="activity_ids" widget="kanban_activity" class="ms-2"/>
                                 </div>
                                 <div class="d-flex ms-auto align-items-center">
-                                    <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]" class="me-1"/>
+                                    <field name="user_id" widget="many2one_avatar_user" class="me-1"/>
                                     <field t-if="record.last_update_status.value &amp;&amp; widget.editable &amp;&amp; !record.is_template.raw_value" name="last_update_status" widget="project_state_selection"/>
                                     <span t-if="record.last_update_status.value &amp;&amp; !widget.editable" t-att-class="'o_status_bubble mx-0 o_color_bubble_' + record.last_update_color.value" t-att-title="record.last_update_status.value"></span>
                                 </div>

--- a/addons/project_todo/models/project_task.py
+++ b/addons/project_todo/models/project_task.py
@@ -21,6 +21,19 @@ class ProjectTask(models.Model):
                     vals['name'] = self.env._('Untitled to-do')
         return super().create(vals_list)
 
+    def read(self, fields=None, load='_classic_read'):
+        """
+        Intercept the data being sent to the form view.
+        If the 'Convert to Task' dialog is opening, clear the assignees in the UI.
+        """
+        result = super().read(fields, load)
+        if self.env.context.get('is_todo_conversion') and result:
+            for record_data in result:
+                if 'user_ids' in record_data:
+                    record_data['user_ids'] = []
+
+        return result
+
     def action_convert_to_task(self):
         self.ensure_one()
         self.company_id = self.project_id.company_id

--- a/addons/project_todo/static/src/views/todo_form/todo_form_controller.js
+++ b/addons/project_todo/static/src/views/todo_form/todo_form_controller.js
@@ -58,6 +58,9 @@ export class TodoFormController extends FormControllerWithHTMLExpander {
                             props: {
                                 resId: this.model.root.resId,
                             },
+                            additionalContext: {
+                                is_todo_conversion: true,
+                            }
                         }
                     );
                 },

--- a/addons/project_todo/views/project_task_views.xml
+++ b/addons/project_todo/views/project_task_views.xml
@@ -65,7 +65,7 @@
                   js_class="todo_list">
                 <field name="state" widget="todo_done_checkmark" nolabel="1" width="20px"/>
                 <field name="name"/>
-                <field name="user_ids" optional="show" required="1" widget="many2many_avatar_user"/>
+                <field name="user_ids" optional="show" required="1" widget="many2many_avatar_user" domain="[('share', '=', False), ('active', '=', True)]"/>
                 <field name="priority" widget="priority" optional="hidden" width="70px"/>
                 <field name="date_deadline" optional="show" widget="relative_date"/>
                 <field name="activity_ids" optional="show" widget="list_activity"/>
@@ -113,7 +113,8 @@
                             <field name="user_ids"
                                 widget="many2many_avatar_user"
                                 required="1"
-                                placeholder="Assignees"/>
+                                placeholder="Assignees"
+                                domain="[('share', '=', False), ('active', '=', True)]"/>
                         </group>
                         <group>
                             <field name="tag_ids"


### PR DESCRIPTION
Before this commit:
- On the project task page, the assignee dropdown included users who did not have access rights to the Project app.
- On the project settings page, the Project Manager dropdown included all internal users, even those without project access rights.

After this commit:
- Tasks can only be assigned to users who have Project access rights.
- The Project Manager field is restricted to users who have the Project User access right or higher.

Task-5220094