### PR TITLE
[REF] partner_autocomplete: run rendering context script

### DIFF
--- a/addons/partner_autocomplete/static/src/xml/partner_autocomplete.xml
+++ b/addons/partner_autocomplete/static/src/xml/partner_autocomplete.xml
@@ -69,13 +69,13 @@
 
     <t t-name="partner_autocomplete.InsufficientCreditNotification">
         <div class="o-hidden-ios">
-            <a class="btn btn-link" t-att-href="credits_url"><i class="oi oi-arrow-right"/> Buy more credits</a>
+            <a class="btn btn-link" t-att-href="this.credits_url"><i class="oi oi-arrow-right"/> Buy more credits</a>
         </div>
     </t>
 
     <t t-name="partner_autocomplete.AccountTokenMissingNotification">
         <div class="">
-            <a class="btn btn-link" t-att-href="account_url" ><i class="oi oi-arrow-right"/> Set Your Account Token</a>
+            <a class="btn btn-link" t-att-href="this.account_url" ><i class="oi oi-arrow-right"/> Set Your Account Token</a>
         </div>
     </t>
 


### PR DESCRIPTION
In preparation for OWL3, where template variables will need to use .this to target component variables, we add .this to template variables that are targetting the component.

Script PR: #247965

task: OWL3 prep - add this. to template variables


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
