### PR TITLE
[FIX] base_import: better import info logs

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -1391,7 +1391,7 @@ class Import(models.TransientModel):
             import_skip_records=options.get('import_skip_records', []),
             _import_limit=import_limit)
         import_result = model.load(import_fields, merged_data)
-        _logger.info('done')
+        _logger.info('done importing data into model: %s', model._name)
 
         # If transaction aborted, RELEASE SAVEPOINT is going to raise
         # an InternalError (ROLLBACK should work, maybe). Ignore that.
@@ -1406,6 +1406,7 @@ class Import(models.TransientModel):
                 # cancel all changes done to the registry/ormcache
                 self.pool.clear_caches()
                 self.pool.reset_changes()
+                _logger.info('Previous import was a dry/test run, changes were reset')
             else:
                 self._cr.execute('RELEASE SAVEPOINT import')
         except psycopg2.InternalError:


### PR DESCRIPTION
When investigating support tickets (and the server logs), it is not always clear if:
1) The `info`` log from base_import refers to a dry run or a "real" import 
2) The "done" log does not explicitly specify which model the data was imported to

While an experienced user can still extrapolate what happened by the immediate context of the preceding/following log lines, it makes it unnecessary difficult to see at first glance where the data was imported to.

This PR aims at rectifying it to improve the quality of life of people investigating the server logs.

OPW-5999195

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
