### PR TITLE
[FIX] im_livechat: stabilize non-member operator description test

### DIFF
--- a/addons/im_livechat/tests/test_discuss_channel.py
+++ b/addons/im_livechat/tests/test_discuss_channel.py
@@ -102,13 +102,13 @@ class TestDiscussChannel(TestImLivechatCommon, TestGetOperatorCommon, MailCase):
             "operator_non_member",
             groups="base.group_user,im_livechat.im_livechat_group_user",
         )
-        self.livechat_channel.user_ids |= operator
         data = self.make_jsonrpc_request(
             "/im_livechat/get_session",
             {"channel_id": self.livechat_channel.id},
         )
+        self.livechat_channel.user_ids |= operator
         channel = self.env["discuss.channel"].browse(data["channel_id"])
-        self.assertNotIn(operator.partner_id, channel.channel_member_ids.partner_id)
+        self.assertNotEqual(operator.partner_id, channel.livechat_operator_id)
         self.assertTrue(operator.has_access_livechat)
         channel.with_user(operator).channel_change_description("Updated by non-member operator")
         self.assertEqual(channel.description, "Updated by non-member operator")


### PR DESCRIPTION
this PR is resolving [runbot error](https://runbot.odoo.com/odoo/runbot.build.error/241727)


due to **/get_session** now creates the assigned operator as a channel member, so the previous non-member assertion became invalid and could fail depending on operator assignment. The test now uses a distinct livechat operator added after session creation to keep validating description edit access without relying on outdated membership assumptions.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
