### PR TITLE
[FIX] im_livechat: show looking for help timer for member agents

### DIFF
--- a/addons/im_livechat/static/src/core/public_web/discuss_sidebar_channel_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/discuss_sidebar_channel_patch.js
@@ -12,8 +12,8 @@ const discussSidebarChannelPatch = {
         super.setup(...arguments);
         this.helpState = useState({ text: "" });
         useDynamicInterval(
-            (dt, selfMember) => {
-                if (!dt || selfMember) {
+            (dt) => {
+                if (!dt) {
                     return;
                 }
                 const diff = luxon.DateTime.now().diff(dt, ["days", "hours", "minutes", "seconds"]);
@@ -30,7 +30,7 @@ const discussSidebarChannelPatch = {
                     : _t("< 1m");
                 return (diff.minutes + 1 - diff.as("minutes")) * 60 * 1000;
             },
-            () => [this.channel.livechat_looking_for_help_since_dt, this.channel.self_member_id]
+            () => [this.channel.livechat_looking_for_help_since_dt]
         );
     },
 };

--- a/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel.js
@@ -2,7 +2,7 @@ import { mailModels } from "@mail/../tests/mail_test_helpers";
 import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
 
 import { fields, getKwArgs, makeKwArgs, serverState } from "@web/../tests/web_test_helpers";
-import { serializeDate } from "@web/core/l10n/dates";
+import { serializeDate, serializeDateTime } from "@web/core/l10n/dates";
 import { ensureArray } from "@web/core/utils/arrays";
 
 export class DiscussChannel extends mailModels.DiscussChannel {
@@ -217,7 +217,13 @@ export class DiscussChannel extends mailModels.DiscussChannel {
         for (const channel of this._filter([["livechat_status", "=", "need_help"]])) {
             needHelpBefore.push(channel.id);
         }
-        const result = super.write(...arguments);
+        if ("livechat_status" in values) {
+            values.livechat_looking_for_help_since_dt =
+                values.livechat_status === "need_help"
+                    ? serializeDateTime(luxon.DateTime.now())
+                    : false;
+        }
+        const result = super.write(idOrIds, values);
         const needHelpAfter = [];
         for (const channel of this._filter([["livechat_status", "=", "need_help"]])) {
             needHelpAfter.push(channel.id);

--- a/addons/im_livechat/static/tests/sidebar_patch.test.js
+++ b/addons/im_livechat/static/tests/sidebar_patch.test.js
@@ -484,7 +484,7 @@ test("show looking for help duration in the sidebar", async () => {
         { guest_id: guestId, channel_id: channelId, livechat_member_type: "visitor" },
     ]);
     await start();
-    await openDiscuss();
+    await openDiscuss(channelId);
     await waitFor(
         ".o-mail-DiscussSidebarChannel-container:has(:text(Visitor #1)) .o-livechat-LookingForHelp-timer:text(< 1m)"
     );
@@ -507,5 +507,14 @@ test("show looking for help duration in the sidebar", async () => {
     await advanceTime(60_000 * 60 * 24);
     await waitFor(
         ".o-mail-DiscussSidebarChannel-container:has(:text(Visitor #1)) .o-livechat-LookingForHelp-timer:text(2d)"
+    );
+    await click("button[name='join-channel']");
+    await contains(".o-livechat-LivechatStatusSelection .active:text('In Progress')");
+    await waitForNone(
+        ".o-mail-DiscussSidebarChannel-container:has(:text(Visitor #1)) .o-livechat-LookingForHelp-timer"
+    );
+    await click(".o-livechat-LivechatStatusSelection button:text('Looking for help')");
+    await waitFor(
+        ".o-mail-DiscussSidebarChannel-container:has(:text(Visitor #1)) .o-livechat-LookingForHelp-timer:text(< 1m)"
     );
 });


### PR DESCRIPTION
**Description of the issue this PR addresses:**
Ensure the `Looking for Help` timer is shown even when the current 
user is already a member of the livechat channel.

**Steps to Reproduce:**
1. Log in as a visitor and as Mitchell Admin (Live Chat operator).
2. From the visitor side, select I have a pricing question.
3. From the admin side, mark the conversation as Looking for Help.
4. The channel appears in the Looking for Help category.
5. Observe that the timer should be visible there (e.g., 1m).

**Current behavior before PR:**
- The timer was hidden when an agent was already a member of the 
conversation, assuming that once an agent joined, the `waiting for help` 
phase was over.

- However, in escalation workflows an analyst may escalate a chat and 
remain a member while the channel returns to the `Looking for Help` 
state for another expert. In this case, the escalating analyst could not 
see the timer needed to track SLA requirements (e.g., creating a 
ticket after 10 minutes).

- Also, the mock server did not recompute
`livechat_looking_for_help_since_dt` when `livechat_status`
changes, leading to incorrect timer values (e.g., showing 2d
instead of < 1m after switching back to Looking for Help).

**Desired behavior after PR is merged:**

- The timer is displayed whenever the channel is in `need_help` 
and `livechat_looking_for_help_since_dt` is set, regardless of 
whether the current user is a member of the channel.
- The mock server now mirrors server-side behavior by updating
`livechat_looking_for_help_since_dt` when livechat_status changes,
prevents missing recomputations and ensuring consistent test
behavior.

task-[6009851](https://www.odoo.com/odoo/project/1519/tasks/6009851)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
