### PR TITLE
[FIX] core: classmethod/staticmethod cannot be called remotely

### DIFF
--- a/addons/api_doc/tests/dummy_methods.py
+++ b/addons/api_doc/tests/dummy_methods.py
@@ -78,20 +78,6 @@ class DummyMethods:
         "return": {"annotation": "int"},
     }
 
-    # the cls param should be stripped away
-    @classmethod
-    def class_method(cls, a):
-        """
-        :param a: an A
-        """
-        pass
-
-    class_method.__func__.expected = {
-        'signature': '(a)',
-        'parameters': {'a': {'doc': '<p>an A</p>'}},
-        'doc': '<div class="document"></div>'
-    }
-
     # the self param should be stripped away
     def self_method(self, a):
         """
@@ -191,3 +177,19 @@ class DummyMethods:
         <p>a bit more text</p>
         </div>""",
     }
+
+    # Those methods cannot be called over RPC and should not appear in /doc
+    @classmethod
+    def class_method(cls):
+        pass
+
+    @staticmethod
+    def static_method():
+        pass
+
+    @api.private
+    def private_method(self):
+        pass
+
+    def _underscope_method(self):
+        pass

--- a/addons/api_doc/tests/test_doc.py
+++ b/addons/api_doc/tests/test_doc.py
@@ -5,10 +5,15 @@ from http import HTTPStatus
 from unittest.mock import patch
 
 from odoo.fields import Command
+from odoo.models import Model
 from odoo.tests import new_test_user, tagged
 
 from .dummy_methods import DummyMethods
-from odoo.addons.api_doc.controllers.api_doc import DocController, parse_signature
+from odoo.addons.api_doc.controllers.api_doc import (
+    DocController,
+    is_public_method,
+    parse_signature,
+)
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 
 
@@ -238,7 +243,7 @@ class TestDoc(HttpCaseWithUserDemo):
 
         methods = inspect.getmembers(DummyMethods, predicate=inspect.isroutine)
         for name, method in methods:
-            if name.startswith('__'):
+            if name.startswith('__') or not hasattr(method, 'expected'):
                 continue
             with self.subTest(method=name):
                 self.assertEqual(
@@ -262,3 +267,22 @@ class TestDoc(HttpCaseWithUserDemo):
         self.authenticate('demo', 'demo')
         res = self.url_open('/doc/index.json')
         res.raise_for_status()
+
+    def test_private_methods(self):
+        FakeCls = type('ModelDummyMethods', (DummyMethods, Model), {
+            '_name': 'model.dummy.methods',
+            '_register': False,
+            '__module__': 'odoo.addons.api_doc',
+        })
+        FakeModel = FakeCls(self.env, (), ())
+        assert is_public_method(FakeModel, 'one_arg')
+
+        for method_name in (
+            'class_method',
+            'static_method',
+            'private_method',
+            '_underscope_method',
+        ):
+            with self.subTest(method_name=method_name):
+                assert hasattr(FakeModel, method_name)
+                self.assertFalse(is_public_method(FakeModel, method_name))

--- a/odoo/service/model.py
+++ b/odoo/service/model.py
@@ -58,6 +58,9 @@ def get_public_method(model: BaseModel, name: str):
     method = getattr(cls, name, None)
     if not callable(method):
         raise AttributeError(f"The method '{model._name}.{name}' does not exist")  # noqa: TRY004
+    if method == getattr(model, name, None):  # classmethod, staticmethod
+        e = f"The method '{model._name}.{name}' cannot be called remotely."
+        raise AccessError(e)
 
     for mro_cls in cls.mro():
         if not (cla_method := getattr(mro_cls, name, None)):


### PR DESCRIPTION
Access /doc, see that `is_transient` is listed, call it via JSON-2. Error 422 "Unprocessable Entity": too many positional arguments.

The `is_transient` method is defined as follow:

```py
@classmethod
def is_transient(cls) -> bool:
    """ Return whether the model is transient.

    See :class:`TransientModel`.

    """
    return cls._transient
```

It is a `@classmethod` and take no argument. Only regular methods can be called remotely. The `@classmethod` and `@staticmethod` (actually, all methods that are defined on the class, and not on the instance) are now considered private.

Reported-by: Florent Xicluna <florent.xicluna@camptocamp.com>

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
