### PR TITLE
[FIX] html_builder: avoid blocking UI during media dialog

### DIFF
--- a/addons/html_builder/static/src/core/utils.js
+++ b/addons/html_builder/static/src/core/utils.js
@@ -617,8 +617,8 @@ function useOperationWithReload(callApply, reload) {
     const env = useEnv();
     return async (...args) => {
         const { editingElement } = args[0][0];
-        env.services.ui.block();
         await callApply(...args);
+        env.services.ui.block();
         env.editor.shared.history.addStep();
         await env.editor.shared.savePlugin.save();
         const target = env.editor.shared.builderOptions.getReloadSelector(editingElement);


### PR DESCRIPTION
Issue:
---
Adding extra image to product using editor, blocks the page.

#### Steps to reproduce:
1- On the website, navigate to a product page.
2- Click on edit.
3- Click on `Exta Media` -> `Add`.

Cause:
---
When performing actions in the builder that open a media dialog, the UI was blocked due to #249526.
Because the media dialog requires user interaction, blocking the UI at that point caused a deadlock: the dialog opened, but the user could not interact with it, so the promise never resolved, and the action appeared to be stuck forever.

Fix:
---
The `env.services.ui.block()` call was placed before callApply(), which includes interactive dialogs. While the original fix correctly blocks the UI for reloadable actions, it unintentionally blocked user interactions when dialogs were opened. We can fix this issue by changing the place of block().

opw-6005701

