### PR TITLE
[FIX] sale: avoid unnecessary analytic line search when no reinvoicable SO lines

### DIFF
--- a/addons/sale/models/account_move.py
+++ b/addons/sale/models/account_move.py
@@ -245,6 +245,8 @@ class AccountMove(models.Model):
         # from invoice lines at once, certain implementations need to search analytic lines
         # per invoice line individually. See the override in `sale_subscription_timesheet`.
         so_lines = self.invoice_line_ids.sale_line_ids.filtered(lambda line: line._is_line_reinvoicable())
+        if not so_lines:
+            return self.env['account.analytic.line']
 
         return self.env['account.analytic.line'].sudo().search(
             self._analytic_line_domain_get_invoiced_lines(so_lines)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When retrieving analytic lines to link for reinvoicing, the method performs a search even when there are no reinvoicable sale order lines associated with the invoice lines.

Current behavior before PR:

The method always executes an account.analytic.line search using the domain returned by _analytic_line_domain_get_invoiced_lines, even when no reinvoicable sale order lines are found.
This results in an unnecessary query that will always return an empty recordset.

Desired behavior after PR is merged:

If no reinvoicable sale order lines are found, the method directly returns an empty account.analytic.line recordset, avoiding the extra query and slightly improving performance.

part of: https://github.com/odoo/enterprise/pull/108685


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
