### PR TITLE
[REF] l10n_*: run owl3 rendering context migration script

### DIFF
--- a/addons/l10n_dk/static/src/components/verification_code_widget/verification_code_widget.xml
+++ b/addons/l10n_dk/static/src/components/verification_code_widget/verification_code_widget.xml
@@ -2,15 +2,15 @@
 <templates>
 
     <t t-name="l10n_dk.VerificationCodeWidget">
-        <div class="row w-50 mt-0 pt-0" t-on-focusout="_save">
+        <div class="row w-50 mt-0 pt-0" t-on-focusout="this._save">
             <t t-foreach="Array(6)" t-as="i" t-key="i_index">
                 <input class="verification_code col border border-2 rounded m-1 p-0 text-center"
                        type="text"
                        maxlength="1"
                        t-att-id="i_index"
                        t-custom-ref="input_{{i_index}}"
-                       t-on-keyup="onKeyUp"
-                       t-on-paste="onPaste"/>
+                       t-on-keyup="this.onKeyUp"
+                       t-on-paste="this.onPaste"/>
             </t>
         </div>
     </t>

--- a/addons/l10n_es_edi_tbai_pos/static/src/app/components/popups/add_tbai_refund_reason_popup/add_tbai_refund_reason_popup.xml
+++ b/addons/l10n_es_edi_tbai_pos/static/src/app/components/popups/add_tbai_refund_reason_popup/add_tbai_refund_reason_popup.xml
@@ -6,16 +6,16 @@
             <div class="mb-3">
                 <label for="tbai_refund_reason" class="form-label">TicketBAI Refund Reason: </label>
                 <select class="detail form-select" id="tbai_refund_reason" name="l10n_es_tbai_refund_reason" t-custom-model="state.l10n_es_tbai_refund_reason">
-                    <t t-foreach="pos.config._tbai_refund_reasons" t-as="l10n_es_tbai_refund_reason" t-key="l10n_es_tbai_refund_reason.value">
+                    <t t-foreach="this.pos.config._tbai_refund_reasons" t-as="l10n_es_tbai_refund_reason" t-key="l10n_es_tbai_refund_reason.value">
                         <option t-att-value="l10n_es_tbai_refund_reason.value"
-                                t-att-selected="l10n_es_tbai_refund_reason.value === state.l10n_es_tbai_refund_reason ? 'selected' : undefined">
+                                t-att-selected="l10n_es_tbai_refund_reason.value === this.state.l10n_es_tbai_refund_reason ? 'selected' : undefined">
                             <t t-out="l10n_es_tbai_refund_reason.name"/>
                         </option>
                     </t>
                 </select>
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-primary o-default-button" t-on-click="confirm">Ok</button>
+                <button class="btn btn-primary o-default-button" t-on-click="this.confirm">Ok</button>
             </t>
         </Dialog>
     </t>

--- a/addons/l10n_es_edi_verifactu_pos/static/src/app/components/popups/add_verifactu_refund_reason_popup/add_verifactu_refund_reason_popup.xml
+++ b/addons/l10n_es_edi_verifactu_pos/static/src/app/components/popups/add_verifactu_refund_reason_popup/add_verifactu_refund_reason_popup.xml
@@ -7,16 +7,16 @@
                 <label for="verifactu_refund_reason" class="form-label">Veri*Factu Refund Reason: </label>
                 <select class="detail form-select" id="verifactu_refund_reason" name="l10n_es_edi_verifactu_refund_reason"
                         t-custom-model="state.l10n_es_edi_verifactu_refund_reason">
-                    <t t-foreach="pos.config._verifactu_refund_reasons" t-as="l10n_es_edi_verifactu_refund_reason" t-key="l10n_es_edi_verifactu_refund_reason.value">
+                    <t t-foreach="this.pos.config._verifactu_refund_reasons" t-as="l10n_es_edi_verifactu_refund_reason" t-key="l10n_es_edi_verifactu_refund_reason.value">
                         <option t-att-value="l10n_es_edi_verifactu_refund_reason.value"
-                                t-att-selected="l10n_es_edi_verifactu_refund_reason.value === state.l10n_es_edi_verifactu_refund_reason ? 'selected' : undefined">
+                                t-att-selected="l10n_es_edi_verifactu_refund_reason.value === this.state.l10n_es_edi_verifactu_refund_reason ? 'selected' : undefined">
                             <t t-out="l10n_es_edi_verifactu_refund_reason.name"/>
                         </option>
                     </t>
                 </select>
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-primary o-default-button" t-on-click="confirm">Ok</button>
+                <button class="btn btn-primary o-default-button" t-on-click="this.confirm">Ok</button>
             </t>
         </Dialog>
     </t>


### PR DESCRIPTION
In preparation for OWL3, where template variables will need to use
`.this` to target component variables, we add `.this` to template
variables that are targetting the component.

Script PR: https://github.com/odoo/odoo/pull/247965

task: OWL3 prep - add this. to template variables