### PR TITLE
[FIX] purchase_stock,mrp: prevent buy_to_resupply from auto re-enabling

### DIFF
--- a/addons/mrp/models/stock_warehouse.py
+++ b/addons/mrp/models/stock_warehouse.py
@@ -45,7 +45,7 @@ class StockWarehouse(models.Model):
     def _compute_manufacture_to_resupply(self):
         for warehouse in self:
             manufacture_route = warehouse.manufacture_pull_id.route_id
-            warehouse.manufacture_to_resupply = warehouse.id in manufacture_route.warehouse_ids.ids
+            warehouse.manufacture_to_resupply = bool(manufacture_route.product_selectable or manufacture_route.warehouse_ids.filtered(lambda w: w.id == warehouse.id))
 
     def _inverse_manufacture_to_resupply(self):
         for warehouse in self:
@@ -59,6 +59,7 @@ class StockWarehouse(models.Model):
                 manufacture_route.warehouse_ids = [Command.link(warehouse.id)]
             else:
                 manufacture_route.warehouse_ids = [Command.unlink(warehouse.id)]
+                manufacture_route.product_selectable = False
 
     def _create_or_update_route(self):
         manufacture_route = self._find_or_create_global_route('mrp.route_warehouse0_manufacture', _('Manufacture'))

--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -889,6 +889,9 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
     def test_manufacture_to_resupply_unchecks_and_unlinks_warehouse(self):
         """Unchecking Manufacture to Resupply should keep manufacture_to_resupply disabled."""
         manufacture_route = self.warehouse.manufacture_pull_id.route_id
-        self.warehouse.manufacture_to_resupply = False
-        self.assertFalse(self.warehouse.manufacture_to_resupply)
-        self.assertNotIn(self.warehouse, manufacture_route.warehouse_ids)
+        manufacture_route.product_selectable = True
+        warehouse_form = Form(self.warehouse)
+        warehouse_form.manufacture_to_resupply = False
+        warehouse = warehouse_form.save()
+        self.assertFalse(warehouse.manufacture_to_resupply)
+        self.assertNotIn(warehouse, manufacture_route.warehouse_ids)

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -66,6 +66,7 @@ class StockWarehouse(models.Model):
                 buy_route.warehouse_ids = [Command.link(warehouse.id)]
             else:
                 buy_route.warehouse_ids = [Command.unlink(warehouse.id)]
+                buy_route.product_selectable = False
 
     def _create_or_update_route(self):
         purchase_route = self._find_or_create_global_route('purchase_stock.route_warehouse0_buy', _('Buy'))


### PR DESCRIPTION

Issue before this commit:
=========================
- Following a previous [PR](https://github.com/odoo/odoo/pull/239217), we fixed a similar issue for the Buy route.
- However, that change introduced another issue related to the upgrade behaviour. 
- See the actual issue in the [ticket](https://www.odoo.com/odoo/my-tasks/6012594) for more details.

Steps to Reproduce:
=========================
- Install purchase_stock with demo data.
- Go to Inventory > Configuration > Settings and enable Multi-Step Routes.
- Go to Configuration > Warehouse Management > Warehouses.
- Open the YourCompany warehouse.
- Click Routes and open the Buy route.
- Enable Products (product_selectable).
- Return to the YourCompany warehouse and disable Buy to Resupply. 
  After disabling Buy to Resupply, the option is automatically re-enabled.

Cause of the issue:
=========================
buy_to_resupply is computed as True if either:
- buy_route.product_selectable is True, or
- The current warehouse is included in buy_route.warehouse_ids.

In the _inverse_buy_to_resupply method, unchecking the flag only removes the 
warehouse from buy_route.warehouse_ids.

However, if product_selectable remains enabled, the compute logic sets buy_to_resupply 
back to True, causing the field to be automatically re-enabled.

With This Commit:
=========================
When a user manually disables buy_to_resupply, the _inverse_buy_to_resupply method 
now also disables product_selectable on the Buy route.

This prevents the compute method from automatically setting buy_to_resupply back to True.

Also, improved the test case, as it was passing even without the fix.