### PR TITLE
[FIX] html_builder, *: prevent indefinite UI block on media dialog

### DIFF
--- a/addons/html_builder/static/src/core/builder_action.js
+++ b/addons/html_builder/static/src/core/builder_action.js
@@ -29,6 +29,7 @@
 export class BuilderAction {
     /** @type { string[] } */
     static dependencies = [];
+    static cancelReload = Symbol("cancel reload");
     /**
      * @param { EditorContext } context
      */
@@ -163,7 +164,10 @@ export class BuilderAction {
      * value is passed as `loadResult` in the `apply` context.
      * /!\ By itself, `load` SHOULD NOT have any effect.
      *
-     * Should be used when there is a preview: when triggering an action after
+     * Should be used in 2 cases:
+     * 1. when the action's reload is set and you want to open a dialog: open
+     * the dialog in `load`, otherwise the interface will be blocked.
+     * 2. when there is a preview: when triggering an action after
      * another one, the previous call to `apply` is cancelled. But if `apply` is
      * async, the builder has to wait for the end of the call (and clean) before
      * applying the next action. In order to avoid stalling the builder, you can

--- a/addons/html_builder/static/src/core/utils.js
+++ b/addons/html_builder/static/src/core/utils.js
@@ -18,6 +18,7 @@ import {
 import { useBus } from "@web/core/utils/hooks";
 import { effect } from "@web/core/utils/reactive";
 import { useDebounced } from "@web/core/utils/timing";
+import { BuilderAction } from "./builder_action";
 
 /**
  * @typedef { import("../../../../html_editor/static/src/editor").EditorContext } EditorContext
@@ -597,7 +598,7 @@ export function useClickableBuilderComponent() {
                 );
             }
         }
-        await Promise.all(cleanOrApplyProms);
+        return await Promise.all(cleanOrApplyProms);
     }
     function getPriority() {
         return (
@@ -627,12 +628,14 @@ function useOperationWithReload(callApply, reload) {
     return async (...args) => {
         const { editingElement } = args[0][0];
         env.services.ui.block();
-        await callApply(...args);
-        env.editor.shared.history.addStep();
-        await env.editor.shared.savePlugin.save();
-        const target = env.editor.shared.builderOptions.getReloadSelector(editingElement);
-        const url = reload.getReloadUrl?.();
-        await env.editor.config.reloadEditor({ target, url });
+        const applyResults = await callApply(...args);
+        if (!applyResults.includes(BuilderAction.cancelReload)) {
+            env.editor.shared.history.addStep();
+            await env.editor.shared.savePlugin.save();
+            const target = env.editor.shared.builderOptions.getReloadSelector(editingElement);
+            const url = reload.getReloadUrl?.();
+            await env.editor.config.reloadEditor({ target, url });
+        }
         env.services.ui.unblock();
     };
 }
@@ -682,7 +685,7 @@ export function useInputBuilderComponent({
                 })
             );
         }
-        await Promise.all(proms);
+        return await Promise.all(proms);
     }
 
     const applyOperation = comp.env.editor.shared.history.makePreviewableAsyncOperation(callApply);

--- a/addons/html_builder/static/tests/utils.test.js
+++ b/addons/html_builder/static/tests/utils.test.js
@@ -218,3 +218,53 @@ test("System should not crash if an asynchronous useDomState is working with rem
     queryOne(":iframe .test").remove();
     editingElRemoved.resolve();
 });
+
+test("Shouldn't reload(save, etc) when a reload is canceled", async () => {
+    const { promise, resolve } = Promise.withResolvers();
+
+    onRpc("ir.ui.view", "save", async () => {
+        await promise;
+        expect.step("save");
+        return true;
+    });
+    addBuilderAction({
+        TestCancelReloadAction: class extends BuilderAction {
+            static id = "testCancelReload";
+            setup() {
+                this.reload = {};
+            }
+            load({ editingElement }) {
+                return { shouldReload: editingElement.classList.contains("should_reload") };
+            }
+            async apply({ editingElement, loadResult }) {
+                editingElement.dataset.applied = "true";
+                if (!loadResult.shouldReload) {
+                    return BuilderAction.cancelReload;
+                }
+            }
+        },
+    });
+
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static selector = ".test-options-target";
+            static template = xml`<BuilderButton action="'testCancelReload'">Click</BuilderButton>`;
+        }
+    );
+
+    await setupHTMLBuilder(`<div class="test-options-target">Target</div>`);
+    await contains(":iframe .test-options-target").click();
+    await contains(".options-container [data-action-id='testCancelReload']").click();
+    expect(".o_blockUI").toHaveCount(0);
+    expect.verifySteps([]);
+
+    const editingEl = queryOne(":iframe .test-options-target");
+    editingEl.classList.add("should_reload");
+    await contains(":iframe .test-options-target").click();
+    await contains(".options-container [data-action-id='testCancelReload']").click();
+    expect(".o_blockUI").toHaveCount(1);
+    resolve();
+    await animationFrame();
+    expect(".o_blockUI").toHaveCount(0);
+    expect.verifySteps(["save"]);
+});

--- a/addons/website_sale/static/src/website_builder/product_page_option_plugin.js
+++ b/addons/website_sale/static/src/website_builder/product_page_option_plugin.js
@@ -357,15 +357,15 @@ export class ProductReplaceMainImageAction extends BaseProductPageAction {
 export class ProductAddExtraImageAction extends BaseProductPageAction {
     static id = "productAddExtraImage";
     static dependencies = [...super.dependencies, "media"];
-    async apply({ editingElement: el }) {
-        // Prompts the user for images, then saves the new images.
+
+    async load({ editingElement: el }) {
         if (this.model === "product.template") {
             this.services.notification.add(
                 'Pictures will be added to the main image. Use "Instant" attributes to set pictures on each variants',
                 { type: "info" }
             );
         }
-        await new Promise((resolve) => {
+        return new Promise((resolve) => {
             const onClose = this.dependencies.media.openMediaDialog({
                 addFieldImage: true,
                 multiImages: true,
@@ -375,14 +375,20 @@ export class ProductAddExtraImageAction extends BaseProductPageAction {
                 // Kinda hack-ish but the regular save does not get the information we need
                 save: async (imgEls, selectedMedia, activeTab) => {
                     if (selectedMedia.length) {
-                        const type =
-                            activeTab === TABS["IMAGES"].id ? "image" : "video";
-                        await this.extraMediaSave(el, type, selectedMedia, imgEls);
+                        const type = activeTab === TABS["IMAGES"].id ? "image" : "video";
+                        resolve({ imgEls, selectedMedia, type });
                     }
                 },
             });
             onClose.then(resolve);
         });
+    }
+    async apply({ editingElement: el, loadResult }) {
+        if (!loadResult) {
+            return BuilderAction.cancelReload;
+        }
+        const { imgEls, selectedMedia, type } = loadResult;
+        await this.extraMediaSave(el, type, selectedMedia, imgEls);
     }
 }
 export class ProductRemoveAllExtraImagesAction extends BaseProductPageAction {


### PR DESCRIPTION
*: website_sale
Commit [1] added a UI block when doing a reloadable operation, and
unblocked it once the action finished. However, if the action didn't
complete, `ui.unblock` would never be called, leaving the UI blocked
indefinitely.

To reproduce the issue in website_sale:
- Install Website & eCommerce
- Go to /shop page
- Open a product page
- Open the editor
- Click on the main product image
- In the "Images" section > Click on "Add more" in the Extra media field
- Popup shows up but it loads indefinitely

Fix this by always calling `ui.unblock` regardless of the reload
outcome. Also move the media dialog opening to `load`, which runs before
the UI is blocked, passing the selected media as `loadResult` to `apply`.

[1]: https://github.com/odoo/odoo/commit/453b7eb8e038ee8e8a54de16fc1a45fb2fab573a
Co-authored by: Robin Lejeune (role) <role@odoo.com>

opw-6003505, opw-6006393, opw-6016898, opw-6013484, opw-6014383