### PR TITLE
[FIX] stock_account: missing inherited method in purchase_stock, sale_stock, point_of_sale

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -165,7 +165,10 @@ class AccountMove(models.Model):
         """
         return self.env.context
 
-    def _get_related_stock_moves(self):
+    def _stock_account_get_last_step_stock_moves(self):
+        """ To be overridden for customer invoices and vendor bills in order to
+        return the stock moves related to the invoices in self.
+        """
         return self.env['stock.move']
 
     def _get_invoiced_lot_values(self):


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

A new method name was introduced but not fixed in the inherited modules which leads to a missing method in their related super call.


**Current behavior before PR:**

Missing super method in related super calls in these modules

**Desired behavior after PR is merged:**

Proper inheritance based on a method removed by accident


Info: @wt-io-it



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
