### PR TITLE
[IMP] mail_bot, test_mail_full: improve OdooBot onboarding UX

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -198,7 +198,7 @@
 </t>
 
 <t t-name="mail.Message.bodyAsNotification">
-    <div class="o-mail-Message-body text-break mb-0 w-100" t-att-class="{'o-note': this.message.message_type == 'notification', 'o_track': this.message.message_type == 'tracking'}">
+    <div class="o-mail-Message-body text-break mb-0 w-100" t-att-class="{'o-note': this.message.isNote || this.message.message_type == 'notification', 'o_track': this.message.message_type == 'tracking'}">
         <t t-out="this.props.messageSearch?.highlight(this.message.richBody) ?? this.message.richBody"/>
     </div>
 </t>

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -637,6 +637,9 @@ export class Thread extends Component {
         if (!msg.thread?.eq(prevMsg.thread)) {
             return false;
         }
+        if (msg.message_type !== prevMsg.message_type) {
+            return false;
+        }
         if (msg.isNote) {
             return false;
         }

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1103,10 +1103,17 @@ test("message comment of same author within 5min. should be squashed", async () 
             model: "discuss.channel",
             res_id: channelId,
         },
+        {
+            author_id: partnerId,
+            body: "<p>body3</p>",
+            date: "2019-04-20 10:04:00",
+            model: "discuss.channel",
+            res_id: channelId,
+        },
     ]);
     await start();
     await openDiscuss(channelId);
-    await contains(".o-mail-Message", { count: 2 });
+    await contains(".o-mail-Message", { count: 3 });
     await contains(".o-mail-Message", {
         contains: [
             [".o-mail-Message-content:text('body1')"],
@@ -1128,6 +1135,8 @@ test("message comment of same author within 5min. should be squashed", async () 
             [".o-mail-Message-sidebar .o-mail-Message-date:text('10:02 AM')"],
         ],
     });
+    // body3 has a different message_type than body2, so it is not squashed.
+    await contains(".o-mail-Message:has(:text('body3')) .o-mail-Message-header");
 });
 
 test("open author avatar card", async () => {

--- a/addons/mail_bot/models/mail_bot.py
+++ b/addons/mail_bot/models/mail_bot.py
@@ -49,6 +49,8 @@ class MailBot(models.AbstractModel):
             "slides_link_start": Markup("<a href='https://www.odoo.com/slides' target='_blank'>"),
             "slides_link_end": Markup("</a>"),
             "paperclip_icon": Markup("<i class='fa fa-paperclip' aria-hidden='true'/>"),
+            "smile_icon": Markup("<i class='fa fa-smile-o' aria-hidden='true'/>"),
+            "plus_icon": Markup("<i class='fa fa-plus-circle' aria-hidden='true'/>"),
         }
 
     def _get_answer(self, channel, body, values, command=False):
@@ -59,31 +61,30 @@ class MailBot(models.AbstractModel):
         if channel.channel_type == "chat" and odoobot in channel.channel_member_ids.partner_id:
             # main flow
             source = _("Thanks")
-            description = _("This is a temporary canned response to see how canned responses work.")
             if odoobot_state == 'onboarding_emoji' and self._body_contains_emoji(body):
-                self.env.user.odoobot_state = "onboarding_command"
-                self.env.user.odoobot_failed = False
-                return self.env._(
-                    "Great! 👍%(new_line)sTo access special commands, %(bold_start)sstart your "
-                    "sentence with%(bold_end)s %(command_start)s/%(command_end)s. Try getting "
-                    "help.",
-                    **self._get_style_dict()
-                )
-            elif odoobot_state == 'onboarding_command' and command == 'help':
                 self.env.user.odoobot_state = "onboarding_ping"
                 self.env.user.odoobot_failed = False
                 return self.env._(
-                    "Wow you are a natural!%(new_line)sPing someone with @username to grab their "
-                    "attention. %(bold_start)sTry to ping me using%(bold_end)s "
-                    "%(command_start)s@OdooBot%(command_end)s in a sentence.",
+                    "Wow, you're a natural!%(new_line)s Use @username to mention someone and grab their "
+                    "attention.%(new_line)s %(bold_start)sTry mentioning me by typing%(bold_end)s "
+                    "%(command_start)s@OdooBot%(command_end)s in your message.",
                     **self._get_style_dict()
                 )
             elif odoobot_state == "onboarding_ping" and odoobot.id in values.get("partner_ids", []):
+                self.env.user.odoobot_state = "onboarding_channel"
+                self.env.user.odoobot_failed = False
+                return self.env._(
+                    "Yep, I'm here! 🎉 %(new_line)sNow, use %(bold_start)s#channel%(bold_end)s to reference another "
+                    "channel in your message.%(new_line)s %(bold_start)sTry typing%(bold_end)s "
+                    "%(command_start)s#%(command_end)s and selecting a channel from the suggestions.",
+                    **self._get_style_dict()
+                )
+            elif odoobot_state == "onboarding_channel" and "o_channel_redirect" in body:
                 self.env.user.odoobot_state = "onboarding_attachement"
                 self.env.user.odoobot_failed = False
                 return self.env._(
-                    "Yep, I am here! 🎉 %(new_line)sNow, try %(bold_start)ssending an "
-                    "attachment%(bold_end)s, like a picture of your cute dog...",
+                    "Awesome!%(new_line)sNow, try %(bold_start)ssending an "
+                    "attachment%(bold_end)s 📎 - maybe a picture of your cute dog... 🐕",
                     **self._get_style_dict()
                 )
             elif odoobot_state == "onboarding_attachement" and values.get("attachment_ids"):
@@ -95,7 +96,7 @@ class MailBot(models.AbstractModel):
                 self.env.user.odoobot_state = "onboarding_canned"
                 return self.env._(
                     "Wonderful! 😇%(new_line)sTry typing %(command_start)s::%(command_end)s to use "
-                    "canned responses. I've created a temporary one for you.",
+                    "canned responses. I've created a temporary one just for you.",
                     **self._get_style_dict()
                 )
             elif odoobot_state == "onboarding_canned" and self.env.context.get("canned_response_ids"):
@@ -104,29 +105,38 @@ class MailBot(models.AbstractModel):
                     ("source", "=", source),
                 ]).unlink()
                 self.env.user.odoobot_failed = False
-                self.env.user.odoobot_state = "idle"
+                self.env.user.odoobot_state = "onboarding_command"
                 return [
                     self.env._(
-                        "Great! You can customize %(bold_start)scanned responses%(bold_end)s in the Discuss app.",
+                        "Great! You can customize %(bold_start)scanned responses%(bold_end)s in the Discuss app settings.",
                         **self._get_style_dict(),
                     ),
                     self.env._(
-                        "That’s the end of this overview. You can %(bold_start)sclose this conversation%(bold_end)s or type "
-                        "%(command_start)sstart the tour%(command_end)s to see it again. Enjoy exploring Odoo!",
+                        "To use special commands, %(bold_start)sstart your message with a %(bold_end)s %(command_start)s/%(command_end)s. "
+                        "For example, try typing %(command_start)s/help%(command_end)s.",
                         **self._get_style_dict(),
                     ),
                 ]
+            elif odoobot_state == 'onboarding_command' and command == 'help':
+                self.env.user.odoobot_state = "idle"
+                self.env.user.odoobot_failed = False
+                return self.env._(
+                    "That's the end of this overview. You can %(bold_start)sclose this conversation%(bold_end)s or type "
+                    "%(command_start)sstart the tour%(command_end)s to see it again. Enjoy exploring Odoo!",
+                    **self._get_style_dict(),
+                )
             # repeat question if needed
-            elif odoobot_state == 'onboarding_canned' and not self._is_help_requested(body):
+            elif odoobot_state == 'onboarding_command' and not self._is_help_requested(body):
                 self.env.user.odoobot_failed = True
                 return self.env._(
-                    "Not sure what you are doing. Please, type %(command_start)s:%(command_end)s "
-                    "and wait for the propositions. Select one of them and press enter.",
+                    "It looks like you're not sure what to do next. Please type "
+                    "%(command_start)s/%(command_end)s to see the suggestions, then "
+                    "select %(command_start)shelp%(command_end)s and press Enter.",
                     **self._get_style_dict()
                 )
             elif odoobot_state in (False, "idle", "not_initialized") and (_('start the tour') in body.lower()):
                 self.env.user.odoobot_state = "onboarding_emoji"
-                return _("To start, try to send me an emoji :)")
+                return self.env._("To get started, try sending me an emoji 😊")
             # easter eggs
             elif odoobot_state == "idle" and body in ['❤️', _('i love you'), _('love')]:
                 return _("Aaaaaw that's really cute but, you know, bots don't work that way. You're too human for me! Let's keep it professional ❤️")
@@ -135,8 +145,8 @@ class MailBot(models.AbstractModel):
             # help message
             elif self._is_help_requested(body) or odoobot_state == 'idle':
                 return self.env._(
-                    "Unfortunately, I'm just a bot 😞 I don't understand! If you need help "
-                    "discovering our product, please check %(document_link_start)sour "
+                    "Unfortunately, I'm just a bot 😞 I don't understand that.%(new_line)s"
+                    "If you need help exploring our apps, please check out %(document_link_start)sour "
                     "documentation%(document_link_end)s or %(slides_link_start)sour "
                     "videos%(slides_link_end)s.",
                     **self._get_style_dict()
@@ -146,32 +156,38 @@ class MailBot(models.AbstractModel):
                 if odoobot_state == 'onboarding_emoji':
                     self.env.user.odoobot_failed = True
                     return self.env._(
-                        "Not exactly. To continue the tour, send an emoji:"
-                        " %(bold_start)stype%(bold_end)s%(command_start)s :)%(command_end)s and "
-                        "press enter.",
-                        **self._get_style_dict()
-                    )
-                elif odoobot_state == 'onboarding_attachement':
-                    self.env.user.odoobot_failed = True
-                    return self.env._(
-                        "To %(bold_start)ssend an attachment%(bold_end)s, click on the "
-                        "%(paperclip_icon)s icon and select a file.",
-                        **self._get_style_dict()
-                    )
-                elif odoobot_state == 'onboarding_command':
-                    self.env.user.odoobot_failed = True
-                    return self.env._(
-                        "Not sure what you are doing. Please, type "
-                        "%(command_start)s/%(command_end)s and wait for the propositions."
-                        " Select %(command_start)shelp%(command_end)s and press enter.",
+                        "Not quite. To continue the tour, please send an emoji by typing"
+                        " %(command_start)s:)%(command_end)s and "
+                        "pressing Enter, or by clicking the %(smile_icon)s icon to pick one.",
                         **self._get_style_dict()
                     )
                 elif odoobot_state == 'onboarding_ping':
                     self.env.user.odoobot_failed = True
                     return self.env._(
-                        "Sorry, I am not listening. To get someone's attention, %(bold_start)sping "
-                        "him%(bold_end)s. Write %(command_start)s@OdooBot%(command_end)s and select"
+                        "Sorry, I'm not listening right now. To get my attention, %(bold_start)smention "
+                        "me%(bold_end)s by typing %(command_start)s@OdooBot%(command_end)s and selecting"
                         " me.",
+                        **self._get_style_dict()
+                    )
+                elif odoobot_state == 'onboarding_channel':
+                    self.env.user.odoobot_failed = True
+                    return self.env._(
+                        "To %(bold_start)smention a channel%(bold_end)s, type %(command_start)s#%(command_end)s "
+                        "and select one from the suggestions.",
+                        **self._get_style_dict()
+                    )
+                elif odoobot_state == 'onboarding_attachement':
+                    self.env.user.odoobot_failed = True
+                    return self.env._(
+                        "To %(bold_start)ssend an attachment%(bold_end)s, first click the "
+                        "%(plus_icon)s icon, then select %(paperclip_icon)s Attach files.",
+                        **self._get_style_dict()
+                    )
+                elif odoobot_state == 'onboarding_canned':
+                    self.env.user.odoobot_failed = True
+                    return self.env._(
+                        "Not sure what you're doing? Please type %(command_start)s::%(command_end)s "
+                        "to see canned responses. Select one and press Enter.",
                         **self._get_style_dict()
                     )
                 return random.choice(

--- a/addons/mail_bot/models/res_users.py
+++ b/addons/mail_bot/models/res_users.py
@@ -2,7 +2,7 @@
 
 from markupsafe import Markup
 
-from odoo import models, fields, _
+from odoo import models, fields
 
 
 class ResUsers(models.Model):
@@ -13,6 +13,7 @@ class ResUsers(models.Model):
             ('not_initialized', 'Not initialized'),
             ('onboarding_emoji', 'Onboarding emoji'),
             ('onboarding_attachement', 'Onboarding attachment'),
+            ('onboarding_channel', 'Onboarding channel'),
             ('onboarding_command', 'Onboarding command'),
             ('onboarding_ping', 'Onboarding ping'),
             ('onboarding_canned', 'Onboarding canned'),
@@ -30,10 +31,10 @@ class ResUsers(models.Model):
         self.ensure_one()
         odoobot_id = self.env['ir.model.data']._xmlid_to_res_id("base.partner_root")
         channel = self.env['discuss.channel']._get_or_create_chat([odoobot_id, self.partner_id.id])
-        message = Markup("%s<br/>%s<br/><b>%s</b> <span class=\"o_odoobot_command\">:)</span>") % (
-            _("Hello,"),
-            _("Odoo's chat helps employees collaborate efficiently. I'm here to help you discover its features."),
-            _("Try to send me an emoji")
+        message = Markup("%s<br/>%s<br/><b>%s</b>") % (
+            self.env._("Hello 👋"),
+            self.env._("Odoo's Discuss application helps employees collaborate efficiently. I'm here to help you explore its features."),
+            self.env._("Go ahead - Try sending me an emoji 😊")
         )
         channel.sudo().message_post(
             author_id=odoobot_id,

--- a/addons/test_mail_full/tests/test_mail_bot.py
+++ b/addons/test_mail_full/tests/test_mail_bot.py
@@ -14,6 +14,10 @@ class TestOdoobot(MailCommon, TestRecipients):
     def setUpClass(cls):
         super().setUpClass()
         cls.test_record = cls.env['mail.test.simple'].with_context(cls._test_context).create({'name': 'Test', 'email_from': 'ignasse@example.com'})
+        cls.canned_response = cls.env['mail.canned.response'].create({
+            'source': 'hello',
+            'substitution': 'Hello, how may I help you?',
+        })
 
         cls.odoobot = cls.env.ref("base.partner_root")
         cls.message_post_default_kwargs = {
@@ -56,19 +60,19 @@ class TestOdoobot(MailCommon, TestRecipients):
         channel = self.user_employee.with_user(self.user_employee)._init_odoobot()
 
         kwargs['body'] = 'tagada 😊'
-        last_message = self.assertNextMessage(
-            channel.message_post(**kwargs),
-            sender=self.odoobot,
-            answer=("help",)
-        )
-        channel.execute_command_help()
         self.assertNextMessage(
-            last_message,  # no message will be post with command help, use last odoobot message instead
+            channel.message_post(**kwargs),
             sender=self.odoobot,
             answer=("@OdooBot",)
         )
         kwargs['body'] = ''
         kwargs['partner_ids'] = [self.env['ir.model.data']._xmlid_to_res_id("base.partner_root")]
+        self.assertNextMessage(
+            channel.message_post(**kwargs),
+            sender=self.odoobot,
+            answer=("#", "selecting a channel")
+        )
+        kwargs['body'] = '<a href="#" class="o_channel_redirect">#general</a>'
         self.assertNextMessage(
             channel.message_post(**kwargs),
             sender=self.odoobot,
@@ -81,11 +85,27 @@ class TestOdoobot(MailCommon, TestRecipients):
             'res_model': 'mail.compose.message',
         })
         kwargs['attachment_ids'] = [attachment.id]
-        # For the end of the flow, we only test that the state changed, but not to which
-        # one since it depends on the intalled apps, which can add more steps (like livechat)
         channel.message_post(**kwargs)
         self.assertNotEqual(self.user_employee.odoobot_state, 'onboarding_attachement')
-
+        kwargs['attachment_ids'] = []
+        kwargs['body'] = 'Thanks'
+        last_message = self.assertNextMessage(
+            self.assertNextMessage(
+                channel.with_context(canned_response_ids=[self.canned_response.id]).message_post(**kwargs),
+                sender=self.odoobot,
+                answer=("canned responses",)
+            ),
+            sender=self.odoobot,
+            answer=("/help",)
+        )
+        # The 'help' command is the last step of the onboarding flow
+        # (which can be extended by other apps like livechat).
+        channel.execute_command_help()
+        self.assertNextMessage(
+            last_message,  # No message is posted with 'help' command, so use the last odoobot message instead.
+            sender=self.odoobot,
+            answer=("close this conversation",)
+        )
         # Test miscellaneous messages
         self.user_employee.odoobot_state = "idle"
         kwargs['partner_ids'] = []


### PR DESCRIPTION
**Purpose of this PR:**

Before this PR, the onboarding steps were not ordered progressively, which could introduce more advanced features before basic interactions.

This PR reorders the onboarding flow and adds a channel mention step to follow a more logical sequence:

1. Emoji
2. @mention
3. Channel mention
4. Attachment
5. Canned responses
6. Commands

It also updates the on-boarding messages and failure hints to make the instructions clearer and more consistent with the Discuss UI.

task-5881683

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
