### PR TITLE
[FIX] mail: fix runbot error 'Show start message of conversation'

### DIFF
--- a/addons/mail/static/tests/thread/thread.test.js
+++ b/addons/mail/static/tests/thread/thread.test.js
@@ -947,8 +947,7 @@ test("Show start message of conversation", async () => {
         },
     ]);
     await start();
-    await openDiscuss();
-    await click(".o-mail-DiscussSidebarChannel-itemName:text('General')");
+    await openDiscuss(channelId);
     await contains(".o-mail-Thread:has(:text('Welcome to #General!'))");
     await contains(".o-mail-Thread:has(:text('This is the start of the #General channel'))");
     await click(".o-mail-DiscussSidebarChannel-subChannel:text('ThreadOne')");


### PR DESCRIPTION
Before this commit, test `'Show start message of conversation'` could fail non-deterministically at the following step:

```
[HOOT] Test "@mail/thread/thread/Show start message of conversation" failed:

Failed assertions:

2. [toBe] expected values to be strictly equal (Failed to find 1 of ".o-mail-Thread:has(:text('Welcome to #General!'))" (Timeout of 3 seconds). Found 0 instead.)
> Expected: true
> Received: false
```

This happens because the test opens discuss with no active conversation and then clicks on Discuss sidebar item "General". This is a problem because on rendering of the Discuss client action, it triggers a `restoreThread` and since there's no `active_id` it sets to no active conversation. This side-effect could happen just after the click on "General" in sidebar, and thus cancel it.

This commit fixes the issue by using `openDiscuss()` with passing the "General" channel as param, so that it opens the channel immediately using the active_id of the channel "General".

Fixes runbot-error-241261