### PR TITLE
[FIX] html_editor: Remove file box with backspace

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -661,7 +661,8 @@ export class DeletePlugin extends Plugin {
             }
             if (
                 this.isUnremovable(node, root) ||
-                !this.dependencies.selection.isNodeEditable(node)
+                (!this.dependencies.selection.isNodeEditable(node) &&
+                    !node.parentElement?.isContentEditable)
             ) {
                 return false;
             }

--- a/addons/html_editor/static/tests/file.test.js
+++ b/addons/html_editor/static/tests/file.test.js
@@ -4,9 +4,9 @@ import { isZwnbsp } from "@html_editor/utils/dom_info";
 import { describe, expect, test } from "@odoo/hoot";
 import { animationFrame, click, press, queryAll, queryOne, waitFor } from "@odoo/hoot-dom";
 import { onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
-import { setupEditor } from "./_helpers/editor";
+import { setupEditor, testEditor } from "./_helpers/editor";
 import { getContent } from "./_helpers/selection";
-import { insertText } from "./_helpers/user_actions";
+import { deleteBackward, insertText } from "./_helpers/user_actions";
 import { execCommand } from "./_helpers/userCommands";
 import { expandToolbar } from "./_helpers/toolbar";
 import { nodeSize } from "@html_editor/utils/position";
@@ -256,6 +256,14 @@ test("Should not apply color to file box", async () => {
     await animationFrame();
     const fileBox = queryOne(".o_file_box");
     expect(fileBox).not.toHaveClass("text-o-color-1");
+});
+
+test("should remove contenteditable=false on backspace", async () => {
+    await testEditor({
+        contentBefore: `<p>a<span contenteditable="false">test</span>[]</p>`,
+        stepFunction: deleteBackward,
+        contentAfter: `<p>a[]</p>`,
+    });
 });
 
 describe("document tab in media dialog", () => {


### PR DESCRIPTION
Steps to reproduce:
===================
1- Go to website & add a file using /file or /upload file 
2- Click on the file box and press backspace

-> Nothing happens.

Cause:
======
After this commit [1], `is_node_editable_predicates` was added to prevent color from being applied to the file box so when removing the file box, The delete plugin's removeNode checks `isNodeEditable(node)` which returns false for the file box and thus prevents it from being removed.

Solution:
=========
a non-editable node that sits inside an editable parent should still be removable so now : node is not removable if !isNodeEditable(node) & its parent is also not contentEditable

[1]: https://github.com/odoo/odoo/pull/226927/changes/7f4eedd76c833f3a162070563f3982a1fbdb77c7

opw-5995236

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
