### PR TITLE
[IMP] mail: mentioning an archived user should not send them an email

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3554,6 +3554,12 @@ class MailThread(models.AbstractModel):
         if notif_create_values:
             SafeNotification.create(notif_create_values)
 
+        if message and message.message_type == 'comment' and message.subtype_id.name == 'Notes':
+            emails = emails.filtered(
+                lambda m: any(u.active for p in m.recipient_ids for u in p.user_ids)
+            )
+            emails = self.env['mail.mail'].sudo().browse(emails.ids)
+
         # NOTE:
         #   1. for more than 50 followers, use the queue system
         #   2. do not send emails immediately if the registry is not loaded,

--- a/addons/mail/static/src/core/common/message_notification_popover.xml
+++ b/addons/mail/static/src/core/common/message_notification_popover.xml
@@ -9,7 +9,9 @@
                 <t t-set="email_to" t-value="notification.mail_email_address or notification.res_partner_id?.email"/>
                 <i class="me-2 fa-fw" t-att-class="notification.statusIcon" t-att-title="notification.statusTitle" role="img"/>
                 <span t-if="notification.res_partner_id">
-                    <t t-out="this.props.message.getPersonaName(notification.res_partner_id)"/>
+                    <span t-att-class="notification.notification_status === 'ready' ? 'text-decoration-line-through text-danger' : ''">
+                        <t t-out="this.props.message.getPersonaName(notification.res_partner_id)"/>
+                    </span>
                     <t t-if="email_to and !notification.isFailure"> <span class="text-muted">(<t t-out="email_to" />)</span></t>
                 </span>
                 <span t-elif="email_to" t-out="email_to"/>
@@ -24,7 +26,9 @@
                 <t t-set="email_to" t-value="notification.mail_email_address or notification.res_partner_id?.email"/>
                 <i class="me-2 fa-fw" t-att-class="notification.statusIcon" t-att-title="notification.statusTitle" role="img"/>
                 <span t-if="notification.res_partner_id">
-                    <t t-out="this.props.message.getPersonaName(notification.res_partner_id)"/>
+                    <span t-att-class="notification.notification_status === 'ready' ? 'text-decoration-line-through text-danger' : ''">
+                        <t t-out="this.props.message.getPersonaName(notification.res_partner_id)"/>
+                    </span>
                     <t t-if="email_to and !notification.isFailure"> <span class="text-muted">(<t t-out="email_to" />)</span></t>
                 </span>
                 <span t-elif="email_to" t-out="email_to"/>

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -1278,7 +1278,7 @@ class TestMessagePost(TestMessagePostCommon, CronMixinCase):
                         message_type='comment',
                         partner_ids=[self.partner_1.id],
                         subject='Exotic email',
-                        subtype_xmlid='mt_comment',
+                        subtype_xmlid='mail.mt_comment',
                     )
 
                 self.assertSentEmail(
@@ -1313,7 +1313,7 @@ class TestMessagePost(TestMessagePostCommon, CronMixinCase):
                         partner_ids=partner_ids,
                         outgoing_email_to=','.join(email_to_lst),
                         subject='Email recipients',
-                        subtype_xmlid='mt_comment',
+                        subtype_xmlid='mail.mt_comment',
                     )
                 for partner in exp_partner_mail:
                     # one mail for the asked recipient
@@ -1327,6 +1327,75 @@ class TestMessagePost(TestMessagePostCommon, CronMixinCase):
                     author=self.partner_employee,
                     email_to_all=email_to_normalized_lst,
                 )
+
+    @users('employee')
+    @mute_logger('odoo.addons.mail.models.mail_mail')
+    def test_notification_states_based_on_user_and_email(self):
+        """ Validate notification behavior:
+        - Archived user → no email sent
+        - Invalid email → exception
+        - Valid email + active user → email should be sent
+        """
+
+        test_record = self.env['mail.test.simple'].browse(self.test_record.ids)
+
+        # Active user (valid email)
+        user_active = mail_new_test_user(
+            self.env(su=True),
+            login='user_active',
+            groups='base.group_user',
+            email='active@example.com',
+            name='Active User',
+            notification_type='email',
+        )
+        partner_active = user_active.partner_id
+
+        # Archived user (valid email)
+        user_archived = mail_new_test_user(
+            self.env(su=True),
+            login='user_archived',
+            groups='base.group_user',
+            email='archived@example.com',
+            name='Archived User',
+            active=False
+        )
+        partner_archived = user_archived.partner_id
+
+        # Invalid email user
+        user_invalid = mail_new_test_user(
+            self.env(su=True),
+            login='user_invalid',
+            groups='base.group_user',
+            email='invalid-email',
+            name='Invalid User',
+            notification_type='email',
+        )
+        partner_invalid = user_invalid.partner_id
+
+        with self.mock_mail_gateway():
+            message = test_record.message_post(
+                body='Test notification matrix',
+                message_type='comment',
+                subtype_xmlid='mail.mt_note',
+                partner_ids=[
+                    partner_active.id,
+                    partner_archived.id,
+                    partner_invalid.id,
+                ],
+            )
+
+        def _notif(partner):
+            return message.notification_ids.filtered(
+                lambda n: n.res_partner_id == partner
+            )
+
+        notif_active = _notif(partner_active)
+        notif_archived = _notif(partner_archived)
+        notif_invalid = _notif(partner_invalid)
+
+        self.assertEqual(notif_active.notification_status, 'sent')
+        self.assertEqual(notif_archived.notification_status, False)
+        self.assertEqual(notif_invalid.notification_status, 'exception')
 
     @users('employee')
     @mute_logger('odoo.addons.mail.models.mail_mail', 'odoo.addons.mail.models.mail_message_schedule', 'odoo.models.unlink')


### PR DESCRIPTION
**Before this PR:**
- The user receives an email notification even though the user is archived.
- The popover shows all partners who are mentioned in the message.

**After this PR:**
- Once a user is archived, they will not receive any email notifications
after being mentioned in a message.
- The popover will show all partners, but those who will not receive emails
will be displayed with a strike-through.

task-**4510403**




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
