### PR TITLE
[FIX] api_doc: Fix unescaped html in request errors

### DIFF
--- a/addons/api_doc/static/src/components/doc_request.js
+++ b/addons/api_doc/static/src/components/doc_request.js
@@ -1,6 +1,7 @@
 import { Component, useState } from "@odoo/owl";
 import { LANGUAGES, createRequestCode } from "@api_doc/utils/doc_code_gen";
 import { CodeEditor } from "@web/core/code_editor/code_editor";
+import { browser } from "@web/core/browser/browser";
 
 class CopyableCodeEditor extends CodeEditor {
     static template = "web.DocRequest.CodeEditor";
@@ -38,6 +39,7 @@ export class DocRequest extends Component {
             requestCode: this.createRequestCode(LANGUAGES.json),
             response: {},
             requestTab: 0,
+            showTraceback: false
         });
         this.selectLanguage(localStorage.getItem("doc/code-lang") || LANGUAGES.json);
     }
@@ -75,5 +77,15 @@ export class DocRequest extends Component {
         if (result) {
             this.state.response = result;
         }
+    }
+
+    toggleTraceback() {
+        this.state.showTraceback = !this.state.showTraceback;
+    }
+
+    onClickClipboard() {
+        browser.navigator.clipboard.writeText(
+            `Error ${this.state.response.status}:\n\n${this.responseText.title}\n\n${this.responseText.traceback}`
+        );
     }
 }

--- a/addons/api_doc/static/src/components/doc_request.xml
+++ b/addons/api_doc/static/src/components/doc_request.xml
@@ -39,8 +39,8 @@
 
         <div class="mt-2 d-flex flex-nowrap align-items-center mb-1">
             <h4>Response</h4>
-            <span t-if="hasResponse and !state.response.error" class="badge success ms-1">Success</span>
-            <span t-if="hasResponse and state.response.error" class="badge error ms-1">Failed</span>
+            <span t-if="hasResponse and !state.response.error" class="badge success ms-1 mb-1">Success</span>
+            <span t-if="hasResponse and state.response.error" class="badge error ms-1 mb-1">Failed</span>
         </div>
 
         <t t-if="hasResponse">
@@ -58,9 +58,22 @@
                     <i class="pe-1 fa fa-exclamation-triangle" aria-hidden="true"></i>
                     <span>Error <t t-out="state.response.status"/> while executing request</span>
                 </h5>
-                <div>
-                    <div t-out="responseText"></div>
+                <div t-if="state.showTraceback">
+                    <button
+                        class="btn bg-100 position-absolute top-0 end-0 p-1"
+                        t-ref="copyButton"
+                        t-on-click="onClickClipboard"
+                    >
+                        <span class="fa fa-clipboard"/>
+                    </button>
+                    <span t-out="responseText.title"/>
+                    <pre class="p-2 mt-2" style="max-height: 500px" t-out="responseText.traceback"/>
                 </div>
+                <button
+                    class="btn btn-sm mt-2 align-self-center"
+                    t-on-click="toggleTraceback"
+                    t-out="state.showTraceback ? 'Hide Details' : 'Show Technical Details'"
+                />
             </div>
         </t>
         <p t-else="" class="text-muted">Run to get a response</p>

--- a/addons/api_doc/static/src/doc_model_store.js
+++ b/addons/api_doc/static/src/doc_model_store.js
@@ -193,10 +193,10 @@ export class ModelStore extends Reactive {
             } else {
                 result.error = !json
                     ? body
-                    : [
-                        `<h3 class="mb-1">${json.message}</h3>`,
-                        `<pre class="p-2">${json.debug}</pre>`,
-                    ].join("\n");
+                    : {
+                        title: json.message,
+                        traceback: json.debug,
+                    };
             }
         } catch (error) {
             result.error = error;

--- a/addons/rpc/controllers/json2.py
+++ b/addons/rpc/controllers/json2.py
@@ -81,7 +81,7 @@ class WebJson2Controller(http.Controller):
         try:
             signature.bind(records, **kwargs)
         except TypeError as exc:
-            raise UnprocessableEntity(exc.args[0])
+            raise UnprocessableEntity(exc.args[0]) from exc
 
         result = func(records, **kwargs)
         if isinstance(result, BaseModel):


### PR DESCRIPTION
Before this commit:
Request errors were unescaped.

After this commit:
Request errors are properly escaped.

A clipboard and a collapse button were added for ease of use.
