### PR TITLE
[FIX] hr_work_entry: Configuration menu went missing.

### DIFF
--- a/addons/hr_work_entry/views/menuitems.xml
+++ b/addons/hr_work_entry/views/menuitems.xml
@@ -34,7 +34,7 @@
 
     <!-- Work Entries Configuration in HR/Employees app -->
     <menuitem
-        id="menu_hr_work_entry_type_view"
+        id="menu_hr_work_entry_type_view_employee"
         action="hr_work_entry.hr_work_entry_type_action"
         parent="hr.menu_config_working_times"
         sequence="20"/>


### PR DESCRIPTION
The work entry configuration menu was missing in the payroll app due to a duplicate ID. The the work entry configuration menu in the employees app used the same ID causing the menu in payroll to go missing. This PR resolves the issue by assigning a unique ID to the employees app menu.

Task-6018889

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
