### PR TITLE
[FIX] hr_timesheet: fix missing spaces in overlay

### DIFF
--- a/addons/hr_timesheet/views/project_task_sharing_views.xml
+++ b/addons/hr_timesheet/views/project_task_sharing_views.xml
@@ -35,8 +35,8 @@
                 <div id="allocated_hours_container" class="o_input_box" invisible="not allow_timesheets">
                     <field name="allocated_hours" widget="float_time" readonly="1"/>
                     <span invisible="subtask_count == 0" class="o_input_box_overlay_end">
-                        incl. <field name="subtask_allocated_hours" nolabel="1" widget="timesheet_uom_no_toggle" class="oe_inline"/> on
-                        <span class="fw-bold text-dark"> Sub-tasks</span>
+                        incl. <field name="subtask_allocated_hours" nolabel="1" widget="timesheet_uom_no_toggle" class="oe_inline mx-1"/> on
+                        <span class="fw-bold ms-1">Sub-tasks</span>
                     </span>
                     <field name="progress" invisible="not project_id" class="o_input_box_overlay_end" nolabel="1" decoration-danger="progress > 1.005" digits="[1, 0]" widget="percentage"/>
                 </div>

--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -22,8 +22,8 @@
                     <div id="allocated_hours_container" class="o_input_box" invisible="not allow_timesheets" groups="hr_timesheet.group_hr_timesheet_user">
                         <field name="allocated_hours" class="o_field_float_time o_task_planned_hours" widget="timesheet_uom_no_toggle"/>
                         <span invisible="subtask_count == 0" class="o_input_box_overlay_end">
-                            incl. <field name="subtask_allocated_hours" nolabel="1" widget="timesheet_uom_no_toggle" class="oe_inline"/> on
-                            <span class="fw-bold text-dark"> Sub-tasks</span>
+                            incl. <field name="subtask_allocated_hours" nolabel="1" widget="timesheet_uom_no_toggle" class="oe_inline mx-1"/> on
+                            <span class="fw-bold ms-1">Sub-tasks</span>
                         </span>
                          <span invisible="is_template or has_project_template">
                             <field name="progress" invisible="not project_id" class="o_input_box_overlay_end" nolabel="1" decoration-danger="progress > 1.005" digits="[1, 0]" widget="percentage"/>


### PR DESCRIPTION
This commit adds some space around textual elements of the "incl. 0h on Sub-tasks" overlay item.

The 'text-dark' classname has been removed, as the text is already
using this color. 'mx-1' has been used for the spacing, and 'fw-bold'
has been kept.

task-6019005
