### PR TITLE
[FIX] sale_timesheet: fix breaking test

### DIFF
--- a/addons/sale_timesheet/tests/test_sale_timesheet.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet.py
@@ -1218,6 +1218,9 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
     def test_invoice_with_already_invoiced_timesheets(self):
         """Checks that when an invoice is created, the hours that have already been invoiced aren't taken into
         account."""
+        if not self.env['ir.module.module'].search([('name', '=', 'account_accountant'), ('state', '=', 'installed')]):
+            self.skipTest("This test requires the installation of the account_account module")
+
         product = self.env['product.product'].create({
             'name': "Service delivered, create task in global project",
             'standard_price': 30,


### PR DESCRIPTION
__

## Error description
When the test runs following a specific configuration, the field `invoicing_switch_threshold` isn't found. However, we have to keep this field in the test because we can't replicate the issue the test checks without it.

## Origin of the issue
This field belongs to the `account_accountant` (Invoicing) module. However, `sale_timesheet` doesn't have a dependency on this module: there's only an auto install for `account_accountant` when installing the module from the front-end.
Therefore, if we launch the test without the `account_accountant` auto install, it will fail.

__
original commit: https://github.com/odoo/odoo/pull/250946/changes/52a9841c754466c2df65c75d13c9ed2ae86a51ce
