### PR TITLE
[FIX] website_sale_wishlist: fix wishlist Contact Us button

### DIFF
--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -353,9 +353,17 @@
                                                 <a
                                                     t-if="combination_info['prevent_zero_price_sale']"
                                                     t-att-href="website.contact_us_button_url + '?subject=' + combination_info['display_name']"
-                                                    class="btn btn-primary btn_cta"
+                                                    class="o_wsale_product_btn_primary btn btn-primary btn_cta"
                                                 >
-                                                    Contact Us
+                                                   <span class="d-inline-flex align-items-baseline">
+                                                        <i
+                                                            class="fa fa-fw fa-envelope o_not-animable"
+                                                            role="presentation"
+                                                        />
+                                                        <span class="o_label small ms-1">
+                                                            Contact Us
+                                                        </span>
+                                                    </span>
                                                 </a>
                                                 <button
                                                     t-else=""
@@ -368,11 +376,15 @@
                                                     t-att-data-product-type="product.type"
                                                     t-att-data-ptav-ids="json.dumps(product_variant.product_template_attribute_value_ids.ids)"
                                                 >
-                                                    <i
-                                                        class="fa fa-fw fa-shopping-cart o_not-animable"
-                                                        role="presentation"
-                                                    />
-                                                    <span class="o_label small ms-1">Add to Cart</span>
+                                                    <span class="d-inline-flex align-items-baseline">
+                                                        <i
+                                                            class="fa fa-fw fa-shopping-cart o_not-animable"
+                                                            role="presentation"
+                                                        />
+                                                        <span class="o_label small ms-1">
+                                                            Add to Cart
+                                                        </span>
+                                                    </span>
                                                 </button>
                                             </div>
                                         </t>


### PR DESCRIPTION
Steps to produce:
---
- Install `website_sale` module.
- From the settings, enable `Prevent Sale of Zero-priced Products`.
- Create a product with a sale price of `0` and publish it.
- From the website, open the product page and add the product to the wishlist.
- Open the wishlist page.
- Enable the editor and change the product design to Chips, Cards, or Grid.

Issue:
---
- The Contact Us button is displayed incorrectly in some product designs.

Root cause:
---
- At [1], in the wishlist template, only the Contact Us text is displayed without the icon and label structure used by the Add to Cart button.
- Because of this, when different product designs are applied, the layout becomes inconsistent and the button appears misaligned.

Solution:
---
- Apply the same structure used for the Add to Cart button by adding the icon and label wrapper to the Contact Us button to ensure consistent styling across all product designs.

Backport of [commit]

[1]https://github.com/odoo/odoo/blob/e49536031f61b90212eb6f0d1a8a3e15927e723d/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml#L353-L359

[commit]: https://github.com/odoo/odoo/commit/c697217ed0e009bd368617f25b5773c5d6ce3c92

Before:
---
<img width="261" height="358" alt="image" src="https://github.com/user-attachments/assets/cf3fe6de-5a7c-4a22-a908-09b8c121cdf4" />

After:
---
<img width="263" height="334" alt="image" src="https://github.com/user-attachments/assets/d44c41b9-0b48-41d0-992b-a506ba4428b6" />


opw-5798833
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
