### PR TITLE
[FIX] html_editor: fix undo behavior when replacing image with caption

### DIFF
--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -123,7 +123,6 @@ export class MediaPlugin extends Plugin {
         const node = targetedNodes.find((node) => node.tagName === "IMG");
         if (node) {
             this.openMediaDialog({ node });
-            this.dependencies.history.addStep();
         }
     }
 

--- a/addons/html_editor/static/src/others/embedded_components/backend/caption/caption.js
+++ b/addons/html_editor/static/src/others/embedded_components/backend/caption/caption.js
@@ -19,7 +19,7 @@ export class EmbeddedCaptionComponent extends Component {
     setup() {
         super.setup();
         this.state = useState({
-            caption: "",
+            caption: this.props.image.getAttribute("data-caption") || "",
             host: this.props.host,
         });
         this.captionInput = useRef("captionInput");
@@ -28,12 +28,16 @@ export class EmbeddedCaptionComponent extends Component {
                 this.captionInput.el.focus();
             });
         }
+        this._appliedNativeHistory = true;
         // Ensure the state, the attribute and the placeholder are in sync.
         this.updateCaption();
         const observer = new MutationObserver((mutations) => {
             for (const mutation of mutations) {
                 if (mutation.type === "attributes" && mutation.attributeName === "data-caption") {
-                    this.updateCaption();
+                    const incomingValue = mutation.target.getAttribute("data-caption");
+                    if (incomingValue !== this.state.caption) {
+                        this.updateCaption();
+                    }
                 }
             }
         });
@@ -44,10 +48,8 @@ export class EmbeddedCaptionComponent extends Component {
     }
 
     updateCaption(caption = this.props.image.getAttribute("data-caption")) {
-        if (caption !== this.state.caption) {
-            this.state.caption = caption;
-            this.props.onUpdateCaption(caption);
-        }
+        this.state.caption = caption;
+        this.props.onUpdateCaption(caption);
     }
 
     onInputBlur() {

--- a/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
@@ -69,6 +69,7 @@ export class CaptionPlugin extends Plugin {
             const caption = figure.querySelector("figcaption")?.textContent;
             figure.remove();
             this.addImageCaption(image, caption, false);
+            this.dependencies.history.addStep();
         }
     }
 
@@ -105,6 +106,7 @@ export class CaptionPlugin extends Plugin {
             this.removeImageCaption(image);
         } else {
             this.addImageCaption(image, image.getAttribute("data-caption") || "");
+            this.dependencies.history.addStep();
         }
     }
 
@@ -113,7 +115,6 @@ export class CaptionPlugin extends Plugin {
     }
 
     addImageCaption(image, captionText = "", focusInput = true) {
-        this.captionsBeingAdded ||= new Set();
         // Move the image within a figure element.
         const figure = this.document.createElement("figure");
         const link = image.parentElement.nodeName === "A" && image.parentElement;
@@ -139,7 +140,6 @@ export class CaptionPlugin extends Plugin {
         }
         // Set the caption and its ID.
         const captionId = this.getCaptionId();
-        this.captionsBeingAdded.add(captionId);
         image.setAttribute("data-caption-id", captionId);
         image.setAttribute("data-caption", captionText || "");
         // Ensure it's not possible to write inside the figure.
@@ -171,8 +171,6 @@ export class CaptionPlugin extends Plugin {
             }),
         });
         figure.append(caption);
-        this.dependencies.history.addStep();
-        this.captionsBeingAdded.delete(captionId);
     }
 
     removeImageCaption(image) {
@@ -210,19 +208,23 @@ export class CaptionPlugin extends Plugin {
             const id = props.id;
             delete props.id;
             const image = this.editable.querySelector(`img[data-caption-id="${id}"]`);
+            const previousCaption = image.getAttribute("data-caption");
             Object.assign(props, {
                 image,
                 onUpdateCaption: (caption = "") => {
                     const figcaption = image.parentElement.querySelector("figcaption");
-                    if (figcaption && figcaption.getAttribute("placeholder") !== caption) {
+                    const didCaptionChanged = previousCaption !== caption;
+                    if (
+                        caption &&
+                        figcaption &&
+                        figcaption.getAttribute("placeholder") !== caption
+                    ) {
                         // Adapt the figcaption element's placeholder to the new
                         // caption for screen reader users.
                         figcaption.setAttribute("placeholder", caption);
                     }
-                    if (caption !== image.getAttribute("data-caption")) {
+                    if (didCaptionChanged) {
                         image.setAttribute("data-caption", caption);
-                    }
-                    if (!this.captionsBeingAdded?.has(id)) {
                         // If the caption is being added, we update without
                         // adding a history step because it will be added at the
                         // end of adding the caption, by `addImageCaption`.

--- a/addons/html_editor/static/tests/caption.test.js
+++ b/addons/html_editor/static/tests/caption.test.js
@@ -1365,3 +1365,57 @@ test("removing an image caption inside list item should wrap image in a base con
         ),
     });
 });
+
+test("Should be able to revert image replace", async () => {
+    onRpc("/web/dataset/call_kw/ir.attachment/search_read", () => [
+        {
+            id: 1,
+            name: "logo",
+            mimetype: "image/png",
+            image_src: "/web/static/img/logo2.png",
+            access_token: false,
+            public: true,
+        },
+    ]);
+
+    await makeMockEnv();
+    const captionText = "caption";
+
+    const { el } = await setupEditorWithEmbeddedCaption(
+        unformat(`
+            <p><br></p>
+            <figure>
+                <img src="/web/static/img/logo.png" class="img-fluid test-image">
+                <figcaption>${captionText}</figcaption>
+            </figure>
+            <h1>[]Heading</h1>
+        `)
+    );
+
+    await animationFrame();
+
+    await click("img");
+    await waitFor(".o-we-toolbar button[name='replace_image']");
+    await click("button[name='replace_image']");
+
+    // Select the image
+    await waitFor(".o_select_media_dialog");
+    await click("img.o_we_attachment_highlight");
+    await animationFrame();
+
+    // Check the image was successfully replaced
+    expect("img[src='/web/static/img/logo.png']").toHaveCount(0);
+    expect("img[src='/web/static/img/logo2.png']").toHaveCount(1);
+
+    // UNDO
+    await press(["ctrl", "z"]);
+    await animationFrame();
+
+    // Check the original image is back
+    expect("img[src='/web/static/img/logo.png']").toHaveCount(1);
+    expect("img[src='/web/static/img/logo2.png']").toHaveCount(0);
+
+    // Check the caption text is still same
+    const input = el.querySelector("input");
+    expect(input.value).toBe(captionText);
+});


### PR DESCRIPTION
Problem:
Undo does not work as expected when an image has a caption.

Cause:
When replacing an image that has a caption, two history steps are added. As a result, the first undo does not revert the image replacement.

Solution:
Remove the unnecessary history step so the image replacement is correctly reverted on the first undo.

Steps to reproduce:
- Go to To-do → Create New.
- Upload an image and add a caption.
- Replace the image with another one.
- Press Undo (Ctrl + Z).
- Observe that nothing happens on the first undo.

task-6014046

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
