### PR TITLE
[IMP] web: rounded avatar on small screen

### DIFF
--- a/addons/point_of_sale/views/res_partner_view.xml
+++ b/addons/point_of_sale/views/res_partner_view.xml
@@ -32,7 +32,7 @@
                         <div class="oe_button_box" name="button_box"/>
                         <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                         <div class="o_form_header_group">
-                            <field name="image_1920" widget="contact_image" options="{'preview_image': 'avatar_128', 'size': [130,130], 'img_class': 'rounded border'}"/>
+                            <field name="image_1920" widget="contact_image" options="{'preview_image': 'avatar_128', 'size': [130,130], 'img_class': 'border'}"/>
                             <field name="avatar_128" invisible="1"/> <!-- Needed in contact_image widget -->
                             <div class="o_form_header_details">
                                 <h1>

--- a/addons/web/static/src/views/fields/contact_image/contact_image_field.xml
+++ b/addons/web/static/src/views/fields/contact_image/contact_image_field.xml
@@ -8,6 +8,12 @@
                 add="{{containsValidImage ? 'bottom-0' : 'top-50 start-50 translate-middle z-1'}}"
                 separator=" "/>
         </xpath>
+        <xpath expr="//img" position="attributes">
+            <attribute
+                name="t-attf-class"
+                add="{{ env.isSmall ? 'rounded-circle' : 'rounded' }}"
+                separator=" "/>
+        </xpath>
         <xpath expr="//button[hasclass('o_select_file_button')]" position="attributes">
             <attribute name="t-if">containsValidImage</attribute>
         </xpath>

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -127,7 +127,7 @@
                     <div class="oe_button_box" name="button_box"/>
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                     <div class="o_form_header_group">
-                        <field name="image_1920" widget="contact_image" options="{'preview_image': 'avatar_128', 'size': [130,130], 'img_class': 'rounded border'}"/>
+                        <field name="image_1920" widget="contact_image" options="{'preview_image': 'avatar_128', 'size': [130,130], 'img_class': 'border'}"/>
                         <field name="avatar_128" invisible="1"/> <!-- Needed in contact_image widget -->
                         <div class="o_form_header_details">
                             <h1>


### PR DESCRIPTION
Previously, the avatar appeared square (or only slightly rounded) when displayed in the center of the screen, which did not look great on small screens.

It is now fully rounded, following the design commonly used in mobile contact applications.

On desktop, the avatar rounding is not always consistent, but we keep it as is for now.

task-6010516

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
