### PR TITLE
[REF] project*: run rendering context script

### DIFF
--- a/addons/project/static/src/components/project_many2one_field/project_many2one_field.xml
+++ b/addons/project/static/src/components/project_many2one_field/project_many2one_field.xml
@@ -2,8 +2,8 @@
 
     <t t-name="project.ProjectMany2OneField">
         <div class="d-flex align-items-center gap-1">
-            <t t-set="isPrivateTask" t-value="props.readonly and !props.record.data.parent_id and !props.record.data.project_id"/>
-            <Many2One t-if="!isPrivateTask" t-props="m2oProps"/>
+            <t t-set="isPrivateTask" t-value="this.props.readonly and !this.props.record.data.parent_id and !this.props.record.data.project_id"/>
+            <Many2One t-if="!isPrivateTask" t-props="this.m2oProps"/>
             <span class="text-danger fst-italic text-muted"
                 t-out="this.props.record.fields[this.props.name].falsy_value_label"
                 t-if="isPrivateTask"/>

--- a/addons/project/static/src/components/project_task_state_selection/project_task_stage_state_selection/project_task_stage_with_state_selection.xml
+++ b/addons/project/static/src/components/project_task_state_selection/project_task_stage_state_selection/project_task_stage_with_state_selection.xml
@@ -2,8 +2,8 @@
 
     <t t-name="project.TaskStageWithStateSelection">
         <div class="d-flex gap-1">
-            <Many2One t-props="stageProps"/>
-            <ProjectTaskStateSelection t-props="stateProps"/>
+            <Many2One t-props="this.stageProps"/>
+            <ProjectTaskStateSelection t-props="this.stateProps"/>
         </div>
     </t>
 

--- a/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_create/subtask_kanban_create.xml
+++ b/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_create/subtask_kanban_create.xml
@@ -3,15 +3,15 @@
     <div t-name="project.SubtaskCreate" class="subtask_create_input d-flex" owl="1">
         <input type="text" title="Rename" 
             class='o_input border-0 border-bottom py-1'
-            t-att-class="{'o_field_invalid border-danger': state.isFieldInvalid}"
+            t-att-class="{'o_field_invalid border-danger': this.state.isFieldInvalid}"
             t-custom-ref='subtaskCreateInput'
-            t-att-value="state.name"
-            t-att-placeholder="placeholder"
-            t-on-input="_onInput"
-            t-on-click="_onClick"
-            t-on-change="_onNameChanged"
-            t-att-disabled="props.isReadonly"/>
-        <button t-on-click="_onSaveClick" class="ms-auto fw-bold btn btn-link py-0 px-2">
+            t-att-value="this.state.name"
+            t-att-placeholder="this.placeholder"
+            t-on-input="this._onInput"
+            t-on-click="this._onClick"
+            t-on-change="this._onNameChanged"
+            t-att-disabled="this.props.isReadonly"/>
+        <button t-on-click="this._onSaveClick" class="ms-auto fw-bold btn btn-link py-0 px-2">
             SAVE
         </button>
     </div>

--- a/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_list.xml
+++ b/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_list.xml
@@ -3,9 +3,9 @@
 <templates>
 
     <t t-name="project.SubtaskKanbanList">
-        <t t-if="props.record.displaySubtasks">
+        <t t-if="this.props.record.displaySubtasks">
             <div class="subtask_list">
-                <div t-foreach="closedList" t-as="record" t-key="record.id"  class="subtask_list_row">
+                <div t-foreach="this.closedList" t-as="record" t-key="record.id"  class="subtask_list_row">
                     <a t-attf-class="subtask_name_col {{ ['1_done', '1_canceled'].includes(record.data.state) ? 'text-muted opacity-50' : '' }}"
                         t-att-title="record.data.display_name"
                         t-out="record.data.display_name"
@@ -21,16 +21,16 @@
                         class="`subtask_state_widget_col d-flex justify-content-center align-items-center`"
                         record="record"
                         type="'project_task_state_selection'"
-                        fieldInfo="fieldInfo.state"/>
+                        fieldInfo="this.fieldInfo.state"/>
                 </div>
                 <div class="subtask_create" t-on-click.stop="(ev) => this.onSubTaskCreated(ev)"
                     t-on-keydown="(ev) => ev.code === 'Escape' ? this._onBlur(ev) : ()=>{}">
-                    <t t-if="subtaskCreate.open">
+                    <t t-if="this.subtaskCreate.open">
                         <SubtaskCreate
-                            name="subtaskCreate.name"
-                            isReadonly="props.isReadonly" 
-                            onSubtaskCreateNameChanged.bind="_onSubtaskCreateNameChanged"
-                            onBlur.bind="_onBlur" />
+                            name="this.subtaskCreate.name"
+                            isReadonly="this.props.isReadonly" 
+                            onSubtaskCreateNameChanged.bind="this._onSubtaskCreateNameChanged"
+                            onBlur.bind="this._onBlur" />
                     </t>
                     <t t-else="">
                         <i class="fa fa-plus my-2"/> Add Sub-task

--- a/addons/project/static/src/views/components/project_task_template_dropdown.xml
+++ b/addons/project/static/src/views/components/project_task_template_dropdown.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates>
     <t t-name="project.TemplateDropdown">
-        <button t-if="!state.taskTemplates.length or offlineService.offline" type="button" t-att-data-available-offline="isNewButtonAvailableOffline" t-att-class="props.newButtonClasses" t-att-data-hotkey="props.hotkey" t-on-click.stop="props.onCreate" data-bounce-button="">New</button>
+        <button t-if="!this.state.taskTemplates.length or this.offlineService.offline" type="button" t-att-data-available-offline="this.isNewButtonAvailableOffline" t-att-class="this.props.newButtonClasses" t-att-data-hotkey="this.props.hotkey" t-on-click.stop="this.props.onCreate" data-bounce-button="">New</button>
         <Dropdown t-else="">
-            <button t-attf-class="{{ props.newButtonClasses }} o-dropdown-caret" t-att-data-hotkey="props.hotkey" data-bounce-button="">
+            <button t-attf-class="{{ this.props.newButtonClasses }} o-dropdown-caret" t-att-data-hotkey="this.props.hotkey" data-bounce-button="">
                 New
             </button>
             <t t-set-slot="content">
-                <DropdownItem tag="'button'" class="'btn btn-link'" onSelected="props.onCreate">
+                <DropdownItem tag="'button'" class="'btn btn-link'" onSelected="this.props.onCreate">
                     New Task
                 </DropdownItem>
                 <div role="separator" class="dropdown-divider"/>
                 <div class="dropdown-header">Task Templates</div>
-                <t t-foreach="state.taskTemplates" t-as="template" t-key="template.id">
+                <t t-foreach="this.state.taskTemplates" t-as="template" t-key="template.id">
                     <DropdownItem tag="'button'" class="'btn btn-link o-dropdopwn-item-indent o-task-template d-flex align-items-center pe-0'"
                         onSelected="() => this.createTaskFromTemplate(template.id)">
                         <span class="text-truncate" t-out="template.name"/>

--- a/addons/project/static/src/views/components/project_template_buttons.xml
+++ b/addons/project/static/src/views/components/project_template_buttons.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates>
     <t t-name="project.ProjectTemplateButtons">
-        <div class="btn-group o_template_icon_group ms-auto d-flex ps-1" t-if="isProjectManager">
-            <i role="button" t-on-click.stop="onEditClick" class="btn btn-link fa fa-pencil fs-3"></i>
-            <i role="button" t-on-click.stop="onDeleteClick" class="btn text-danger fa fa-trash fs-3"></i>
+        <div class="btn-group o_template_icon_group ms-auto d-flex ps-1" t-if="this.isProjectManager">
+            <i role="button" t-on-click.stop="this.onEditClick" class="btn btn-link fa fa-pencil fs-3"></i>
+            <i role="button" t-on-click.stop="this.onDeleteClick" class="btn text-danger fa fa-trash fs-3"></i>
         </div>
     </t>
 </templates>

--- a/addons/project/static/src/views/components/project_template_dropdown.xml
+++ b/addons/project/static/src/views/components/project_template_dropdown.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates>
     <t t-name="project.ProjectTemplateDropdown">
-        <button t-if="!state.projectTemplates.length" type="button" t-att-class="props.newButtonClasses" t-att-disabled="props.isDisabled" t-att-data-hotkey="props.hotkey" t-on-click.stop="props.onCreate" data-bounce-button="">New</button>
+        <button t-if="!this.state.projectTemplates.length" type="button" t-att-class="this.props.newButtonClasses" t-att-disabled="this.props.isDisabled" t-att-data-hotkey="this.props.hotkey" t-on-click.stop="this.props.onCreate" data-bounce-button="">New</button>
         <Dropdown t-else="">
-            <button t-attf-class="{{ props.newButtonClasses }} o-dropdown-caret" t-att-disabled="props.isDisabled" t-att-data-hotkey="props.hotkey" data-bounce-button="">
+            <button t-attf-class="{{ this.props.newButtonClasses }} o-dropdown-caret" t-att-disabled="this.props.isDisabled" t-att-data-hotkey="this.props.hotkey" data-bounce-button="">
                 New
             </button>
             <t t-set-slot="content">
-                <DropdownItem tag="'button'" class="'btn btn-link'" onSelected="props.onCreate">
+                <DropdownItem tag="'button'" class="'btn btn-link'" onSelected="this.props.onCreate">
                     New Project
                 </DropdownItem>
                 <div role="separator" class="dropdown-divider"/>
                 <div class="dropdown-header">Project Templates</div>
-                <t t-foreach="state.projectTemplates" t-as="template" t-key="template.id">
+                <t t-foreach="this.state.projectTemplates" t-as="template" t-key="template.id">
                     <DropdownItem tag="'button'" class="'btn btn-link o-dropdopwn-item-indent o-project-template d-flex align-items-center pe-0'"
                         onSelected="() => this.createProjectFromTemplate(template)">
                         <span class="text-truncate" t-out="template.name"/>

--- a/addons/project/static/src/views/project_task_control_panel/project_task_control_panel.xml
+++ b/addons/project/static/src/views/project_task_control_panel/project_task_control_panel.xml
@@ -28,7 +28,7 @@
     </t>
 
    <t t-name="project.MobileCombinedActionsDropdown">
-        <t t-if="env.isSmall and state.embeddedInfos.embeddedActions?.length">
+        <t t-if="this.env.isSmall and this.state.embeddedInfos.embeddedActions?.length">
             <Dropdown menuClass="'o_combined_mobile_dropdown'">
                 <button class="btn btn-secondary">
                     <i class="fa fa-sliders" />
@@ -36,13 +36,13 @@
                 <t t-set-slot="content">
                     <DropdownItem
                         onSelected="() => this.onClickShowSubtasks()"
-                        class="state.showSubtasks ? 'selected' : ''"
+                        class="this.state.showSubtasks ? 'selected' : ''"
                     >
                         Show Sub-Tasks
                     </DropdownItem>
                     <div role="separator" class="dropdown-divider"/>
-                    <t t-if="state.embeddedInfos.embeddedActions?.length">
-                        <t t-foreach="state.embeddedInfos.embeddedActions" t-as="action" t-key="action.id">
+                    <t t-if="this.state.embeddedInfos.embeddedActions?.length">
+                        <t t-foreach="this.state.embeddedInfos.embeddedActions" t-as="action" t-key="action.id">
                             <DropdownItem
                                 class="this.getDropdownClass(action)"
                                 onSelected="() => this.onEmbeddedActionClick(action)"

--- a/addons/project/static/src/views/widget/subtask_counter.xml
+++ b/addons/project/static/src/views/widget/subtask_counter.xml
@@ -3,11 +3,11 @@
 <templates>
 
     <t t-name="project.SubtaskCounter" owl="1">
-        <a t-att-title="counterTitle"
+        <a t-att-title="this.counterTitle"
            class="subtask_list_button btn-link text-dark"
            t-on-click.prevent="() => this.onClick()">
             <i class="fa fa-level-down me-1"></i>
-            <t t-out="counterDisplay"/>
+            <t t-out="this.counterDisplay"/>
         </a>
     </t>
 

--- a/addons/project_todo/static/src/components/todo_chatter_panel/todo_chatter_panel.xml
+++ b/addons/project_todo/static/src/components/todo_chatter_panel/todo_chatter_panel.xml
@@ -3,15 +3,15 @@
 <templates xml:space="preserve">
 
     <div t-name="project_todo.TodoChatterPanel" t-custom-ref="root">
-        <chatter t-if="state.displayChatter" class="o_FormRenderer_chatterContainer">
+        <chatter t-if="this.state.displayChatter" class="o_FormRenderer_chatterContainer">
             <Chatter
                 threadModel="'project.task'"
-                threadId="props.record.resId"
-                record="props.record"
+                threadId="this.props.record.resId"
+                record="this.props.record"
                 hasParentReloadOnAttachmentsChanged="true"
                 hasParentReloadOnFollowersUpdate="true"
                 hasParentReloadOnMessagePosted="true"
-                saveRecord="props.record.save.bind(props.record, { reload: false })"
+                saveRecord="this.props.record.save.bind(this.props.record, { reload: false })"
             />
         </chatter>
     </div>

--- a/addons/project_todo/static/src/components/todo_done_checkmark/todo_done_checkmark.xml
+++ b/addons/project_todo/static/src/components/todo_done_checkmark/todo_done_checkmark.xml
@@ -2,17 +2,17 @@
 <templates xml:space="preserve">
 
     <t t-name="project_todo.TodoDoneCheckmark">
-        <t t-if="!env.isSmall">
-            <a t-att-title="stateDone.isDone ? 'Mark as to-do' : 'Mark as done'"
-               t-on-click.stop="onDoneToggled"
-               t-on-mouseleave="actualizeDoneState"
-               t-on-mouseover="freezeDoneState"
-               t-attf-class="o_todo_done_button fa fa-lg fa-check-circle{{!stateDone.isDone ? '-o' : ' done_button_enabled'}}"/>
+        <t t-if="!this.env.isSmall">
+            <a t-att-title="this.stateDone.isDone ? 'Mark as to-do' : 'Mark as done'"
+               t-on-click.stop="this.onDoneToggled"
+               t-on-mouseleave="this.actualizeDoneState"
+               t-on-mouseover="this.freezeDoneState"
+               t-attf-class="o_todo_done_button fa fa-lg fa-check-circle{{!this.stateDone.isDone ? '-o' : ' done_button_enabled'}}"/>
         </t>
         <t t-else="">
-            <a t-att-title="stateDone.isDone ? 'Mark as to-do' : 'Mark as done'"
-               t-on-click.stop="onDoneToggled"
-               t-attf-class="o_todo_done_button_mobile fa fa-lg fa-check-circle{{!stateDone.isDone ? '-o' : ' done_button_enabled'}}"/>
+            <a t-att-title="this.stateDone.isDone ? 'Mark as to-do' : 'Mark as done'"
+               t-on-click.stop="this.onDoneToggled"
+               t-attf-class="o_todo_done_button_mobile fa fa-lg fa-check-circle{{!this.stateDone.isDone ? '-o' : ' done_button_enabled'}}"/>
         </t>
     </t>
 


### PR DESCRIPTION
This PR runs the rendering context migration script on `project` and its dependency chain.

It adds `this.` before template variables targeting the component instance (props, state, env, and methods) to comply with Owl 3 requirements.

**Script Source:** https://github.com/odoo/odoo/pull/247965

**Affected Modules:**
- project and modules that inherit project (project_todo, project_enterprise, etc.)

Task: OWL3