### PR TITLE
[FIX] project: prevent traceback in mobile view

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -758,7 +758,7 @@
                 <xpath expr="//field[@name='parent_id']" position="after">
                     <field invisible="project_id == context.get('active_id', False)" class="mt-1" name="project_id" options="{'no_open': True}"/>
                 </xpath>
-                <xpath expr="//field[@name='parent_id']" position="replace"/>
+                <xpath expr="//a[hasclass('o_kanban_parent')]" position="replace"/>
             </field>
         </record>
 


### PR DESCRIPTION
Steps to reproduce:
- Install Project
- Create a project and a task and enable task dependencies
- In mobile view, go to the "Blocked by" tab and click "Add"

Issue:
A traceback occurs in the mobile view.

Cause:
In this pr https://github.com/odoo/odoo/pull/230738 parent_id was moved inside anchor element.

Fix:
Update the XPath to correctly replace the element containing parent_id.

task-6009997


