### PR TITLE
[FIX] base_geolocalize,mail,partner_autocomplete: avoid some actions when installing demo data

### DIFF
--- a/addons/base_geolocalize/models/res_partner.py
+++ b/addons/base_geolocalize/models/res_partner.py
@@ -36,6 +36,7 @@ class ResPartner(models.Model):
             self.env.context.get('import_file')
             or modules.module.current_test
             or not self.env.registry.ready
+            or self.env.context.get('install_demo')
         ):
             return False
         partners_not_geo_localized = self.env['res.partner']

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4726,6 +4726,8 @@ class MailThread(models.AbstractModel):
             return
         if not self.env.registry.ready:  # Don't send notification during install
             return
+        if self.env.context.get('install_demo'):
+            return
 
         for record in self:
             model_description = self.env['ir.model']._get(record._name).display_name

--- a/addons/partner_autocomplete/models/res_company.py
+++ b/addons/partner_autocomplete/models/res_company.py
@@ -40,7 +40,7 @@ class ResCompany(models.Model):
     def iap_enrich_auto(self):
         """ Enrich company. This method should be called by automatic processes
         and a protection is added to avoid doing enrich in a loop. """
-        if self.env.user._is_system() and self.env.registry.ready:
+        if self.env.user._is_system() and self.env.registry.ready and not self.env.context.get('install_demo'):
             for company in self.filtered(lambda company: not company.iap_enrich_auto_done):
                 company._enrich()
             self.iap_enrich_auto_done = True


### PR DESCRIPTION
Followup on https://github.com/odoo/odoo/pull/25086 to avoid makin api calls, sending emails when installing demo data on an existing database

