### PR TITLE
[FIX] l10n_sa: error when unlinking move

### DIFF
--- a/addons/l10n_sa/models/ir_attachment.py
+++ b/addons/l10n_sa/models/ir_attachment.py
@@ -18,4 +18,10 @@ class IrAttachment(models.Model):
         '''
         Returns the moves to check whether they can be unlinked.
         '''
-        return self.env['account.move'].browse(self.filtered(lambda rec: rec.res_model == 'account.move' and rec.res_field == 'invoice_pdf_report_file').mapped('res_id'))
+        res_ids = [
+            att.res_id
+            for att in self
+            if att.res_model == 'account.move' and att.res_field == 'invoice_pdf_report_file'
+        ]
+        # the corresponding moves may have been deleted already
+        return self.env['account.move'].browse(res_ids).exists()


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/242777 the deletion of an account.move may crash.

Indeed, the deletion of the move delete its corresponding attachments, and ir.attachment has an ondelete method that checks the attached move, namely _unlink_except_posted_pdf_invoices().  The method checks some condition on the corresponding moves, which have just been deleted, hence raising a MissingError.

runbot_build_error-237850
