### PR TITLE
[FIX] resource: avoid ZeroDivisionError when duration_hours is zero

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -633,7 +633,8 @@ class ResourceCalendar(models.Model):
             if len(self) == 1 and self.flexible_hours:
                 day_days[start.date()] += interval_hours / self.hours_per_day if self.hours_per_day else 0
             else:
-                day_days[start.date()] += sum(meta.mapped('duration_days')) * interval_hours / sum(meta.mapped('duration_hours'))
+                duration_hours = sum(meta.mapped('duration_hours'))
+                day_days[start.date()] += sum(meta.mapped('duration_days')) * interval_hours / duration_hours if duration_hours else 0
 
         return {
             # Round the number of days to the closest 16th of a day.


### PR DESCRIPTION
---
  Description of the issue/feature this PR addresses:
  Fixes ZeroDivisionError: float division by zero in resource/models/resource_calendar.py when computing work duration data. When an employee has an attendance record with a duration of zero (check-in time equals check-out time, or a 0-minute attendance entry exists), the Attendance Gantt view crashes with a ZeroDivisionError, completely blocking access to the Attendance module for all users on that database.

  Closes #245804

  Current behavior before PR:
  When attendance intervals have a total duration_hours of zero, the calculation:
  sum(meta.mapped('duration_days')) * interval_hours / sum(meta.mapped('duration_hours'))
  raises a ZeroDivisionError, making the Attendance app inaccessible.

  Desired behavior after PR is merged:
  When duration_hours sums to zero, the division is skipped and 0 is used instead — consistent with the same guard already applied
  for the flexible_hours case on the line above. The Attendance app loads without error.

  ---I confirm I have signed the CLA and read the PR guidelines at http://www.odoo.com/submit-pr