### PR TITLE
[IMP] l10n_pl_edi: Set Attachment in the same transaction as The moves

### DIFF
--- a/addons/l10n_pl_edi/models/account_move_send.py
+++ b/addons/l10n_pl_edi/models/account_move_send.py
@@ -72,14 +72,38 @@ class AccountMoveSend(models.AbstractModel):
                     response_data = service.send_invoice(xml_content)
                     l10n_pl_edi_ref = response_data.get('referenceNumber')
 
-                    move.write({
-                        'l10n_pl_edi_status': 'sent',
-                        'l10n_pl_edi_ref': l10n_pl_edi_ref,
-                        'l10n_pl_edi_session_id': move.company_id.l10n_pl_edi_session_id,
-                        'l10n_pl_edi_header': False,
-                    })
-                    # Will be linked in _link_invoice_documents
-                    invoices_data[move]['l10n_pl_edi_attachment_file'] = xml_content
+                    move.write(
+                        {
+                            'l10n_pl_edi_status': 'sent',
+                            'l10n_pl_edi_ref': l10n_pl_edi_ref,
+                            'l10n_pl_edi_session_id': move.company_id.l10n_pl_edi_session_id,
+                            'l10n_pl_edi_header': False,
+                            'l10n_pl_edi_attachment_id': self.env['ir.attachment'].sudo().create(
+                                {
+                                    'description': self.env._('KSeF Sent Invoice XML'),
+                                    'name': f"FA3-{move.name.replace('/', '_')}.xml",
+                                    'type': 'binary',
+                                    'mimetype': 'application/xml',
+                                    'raw': xml_content,
+                                    'res_id': move.id,
+                                    'res_model': move._name,
+                                    'res_field': 'l10n_pl_edi_attachment_file',
+                                },
+                            ),
+                        },
+                    )
+
+                    move.sudo().with_context(no_new_invoice=True).message_post(
+                        body=self.env._("The KSeF XML has been attached."),
+                        attachment_ids=move.l10n_pl_edi_attachment_id.ids,
+                    )
+
+                    move.invalidate_recordset(
+                        fnames=[
+                            'l10n_pl_edi_attachment_id',
+                            'l10n_pl_edi_attachment_file',
+                        ]
+                    )
 
                 except Exception as errors:  # noqa: BLE001
                     set_error(move, str(errors))
@@ -90,29 +114,3 @@ class AccountMoveSend(models.AbstractModel):
         # Check the status already
         if moves_by_company:
             self.env.ref('l10n_pl_edi.cron_auto_checks_the_polish_invoice_status')._trigger()
-
-    def _link_invoice_documents(self, invoices_data):
-        # EXTENDS 'account'
-        super()._link_invoice_documents(invoices_data)
-
-        for move, invoice_data in invoices_data.items():
-            if 'l10n_pl_edi_attachment_file' in invoice_data:
-                move.l10n_pl_edi_attachment_id = self.env['ir.attachment'].sudo().create({
-                    'description': self.env._('KSeF Sent Invoice XML'),
-                    'name': f"FA3-{move.name.replace('/', '_')}.xml",
-                    'type': 'binary',
-                    'mimetype': 'application/xml',
-                    'raw': invoice_data['l10n_pl_edi_attachment_file'],
-                    'res_id': move.id,
-                    'res_model': move._name,
-                    'res_field': 'l10n_pl_edi_attachment_file',
-                })
-                move.sudo().with_context(no_new_invoice=True).message_post(
-                    body=self.env._("The KSeF XML has been attached."),
-                    attachment_ids=move.l10n_pl_edi_attachment_id.ids,
-                )
-
-        self.env['account.move'].union(*invoices_data).invalidate_recordset(fnames=[
-            'l10n_pl_edi_attachment_id',
-            'l10n_pl_edi_attachment_file',
-        ])


### PR DESCRIPTION
Was committing the move fields update, then updating the attachment. This might create an issue were the move update commits successfully, but setting the attachment fails and we end up with an inconsistency.

Set attachment in the same transaction as the move update.

no-task

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
