### PR TITLE
[FIX] im_livechat: stacked rating values in reports

### DIFF
--- a/addons/im_livechat/report/im_livechat_report_channel.py
+++ b/addons/im_livechat/report/im_livechat_report_channel.py
@@ -40,7 +40,8 @@ class Im_LivechatReportChannel(models.Model):
     nbr_message = fields.Integer("Messages per Session", readonly=True, aggregator="avg", help="Number of message in the conversation")
     country_id = fields.Many2one('res.country', 'Country of the visitor', readonly=True)
     lang_id = fields.Many2one("res.lang", related="channel_id.livechat_lang_id", string="Language", readonly=True)
-    rating = fields.Integer('Rating', aggregator="avg", readonly=True)
+    rating = fields.Integer('Rating', readonly=True)
+    rating_percentage = fields.Float("Rating (%)", aggregator="avg", digits=(16, 1), readonly=True)
     # TODO DBE : Use Selection field - Need : Pie chart must show labels, not keys.
     rating_text = fields.Char('Satisfaction Rate', readonly=True)
     partner_id = fields.Many2one("res.partner", "Agent", readonly=True)
@@ -126,6 +127,10 @@ class Im_LivechatReportChannel(models.Model):
                     WHEN C.rating_last_value = 3 THEN 'Neutral'
                     ELSE null
                 END as rating_text,
+                CASE
+                    WHEN C.rating_last_value >= 1 THEN ROUND((C.rating_last_value - 1) * 100.0 / 4.0)
+                    ELSE NULL
+                END AS rating_percentage,
                 COALESCE(livechat_agent.partner_id, livechat_bot.partner_id) as partner_id,
                 CASE WHEN livechat_agent.partner_id IS NOT NULL THEN 1 ELSE 0 END as handled_by_agent,
                 CASE WHEN livechat_bot.partner_id IS NOT NULL AND livechat_agent.partner_id IS NULL THEN 1 ELSE 0 END as handled_by_bot,

--- a/addons/im_livechat/report/im_livechat_report_channel_views.xml
+++ b/addons/im_livechat/report/im_livechat_report_channel_views.xml
@@ -13,7 +13,7 @@
                     <field name="percentage_of_calls" type="measure" widget="percentage"/>
                     <field name="time_to_answer" string="Response Time" type="measure" widget="float_time" options="{'show_seconds': true}"/>
                     <field name="duration" type="measure"/>
-                    <field name="rating" string="Rating (%)" type="measure" widget="im_livechat.rating_percentage"/>
+                    <field name="rating" invisible="1"/>
                     <field name="number_of_calls" string="# of calls" type="measure" widget="integer"/>
                 </pivot>
             </field>
@@ -54,7 +54,7 @@
                     <field name="percentage_of_calls" type="measure" widget="percentage"/>
                     <field name="start_date" interval="day"/>
                     <field name="rating_text"/>
-                    <field name="rating" string="Rating (%)" type="measure" widget="im_livechat.rating_percentage"/>
+                    <field name="rating" invisible="1"/>
                 </graph>
             </field>
         </record>
@@ -116,7 +116,7 @@
             <field name="context">
                 {
                     "search_default_filter_date_last_month": 1,
-                    "pivot_measures": ["__count", "time_to_answer", "duration", "rating", "number_of_calls"],
+                    "pivot_measures": ["__count", "time_to_answer", "duration", "rating_percentage", "number_of_calls"],
                     "graph_measure": "__count__",
                     "im_livechat_hide_partner_company": True,
                 }


### PR DESCRIPTION
The rating percentage in the session analysis reports was previously calculated via a JS widget. This led to incorrect values in aggregated views like stacked graphs, as the percentage math was performed on already aggregated raw rating values.

This change performs the percentage calculation on the python side through a new field to ensure correct stacking.

task-5956820

**Before:**

<img width="942" height="806" alt="image" src="https://github.com/user-attachments/assets/4403fdb3-84c0-4935-b0d3-5bd41d648e07" />


**After:**

<img width="943" height="802" alt="image" src="https://github.com/user-attachments/assets/d274e99d-4e81-4a32-98ee-97eea9ad84e2" />
