### PR TITLE
[IMP] website_sale: include barcode in product micro-data (GTIN)

### DIFF
--- a/addons/website_sale/models/product_product.py
+++ b/addons/website_sale/models/product_product.py
@@ -195,6 +195,8 @@ class ProductProduct(models.Model):
                 'ratingValue': self.sudo().rating_avg,
                 'reviewCount': self.rating_count,
             }
+        if self.barcode:
+            markup_data['gtin'] = self.barcode
         return markup_data
 
     def _get_image_1920_url(self):


### PR DESCRIPTION
Include the barcode (GTIN) in product micro-data to improve SEO indexing and comply with Google Merchant Center requirements.

Added gtin property to the JSON-LD metadata in product.product. 

Affected Version: 19.0
Task: 5953441