### PR TITLE
[FIX] website_sale: translate view more/view less

### DIFF
--- a/addons/website_sale/static/src/interactions/website_sale.js
+++ b/addons/website_sale/static/src/interactions/website_sale.js
@@ -3,6 +3,8 @@ import { registry } from '@web/core/registry';
 import { hasTouch, isBrowserFirefox } from '@web/core/browser/feature_detection';
 import { redirect, url } from '@web/core/utils/urls';
 import { uniqueId } from '@web/core/utils/functions';
+import { setElementContent } from "@web/core/utils/html";
+import { _t } from "@web/core/l10n/translation";
 import { markup } from '@odoo/owl';
 import wSaleUtils from '@website_sale/js/website_sale_utils';
 import { ProductImageViewer } from '@website_sale/js/components/website_sale_image_viewer';
@@ -340,7 +342,7 @@ export class WebsiteSale extends Interaction {
         const button = ev.target;
         const isExpanded = button.getAttribute('aria-expanded') === 'true';
 
-        button.innerHTML = isExpanded ? "View Less" : "View More";
+        setElementContent(button, isExpanded ? _t("View Less") : _t("View More"))
     }
 
     /**


### PR DESCRIPTION
When browsing an eCommerce in any language but English and trying to filter on an attribute with more than 8 values and at most 20, the "View more" and "View less" options are not translated

Steps to reproduce:
1. Install eCommerce
2. Create a product with one attribute that has 9 to 20 values and publish the product to the eCommerce (the attribute should have radio display type and should be visible in the eCommerce)
3. Add a language (e.g. French) and translate the eCommerce's website
4. Open the website and set the language to French
5. In the left column, open the filter for the attribute previously created
6. Click on "Voir plus"
7. "View less" is not translated, if you click on it, "View more" is not translated anymore

Issue:
The translation for "View more" is generated because it is present in the template `filter_radio_and_multi_attributes` but when we update the text in website_sale.js, the terms are not translated anymore

Solution:
Use `_t` to translate the "View more" and "View less" terms

opw-5985712