### PR TITLE
[FIX] web,*: detect manual changes in autocomplete fields

### DIFF
--- a/addons/google_address_autocomplete/static/tests/google_address_autocomplete.test.js
+++ b/addons/google_address_autocomplete/static/tests/google_address_autocomplete.test.js
@@ -216,3 +216,30 @@ test("support field mapping in options", async () => {
         expect(`.o_field_widget[name='${field}'] input`).toHaveValue(value);
     }
 });
+
+test("select a value, then empty the input and save", async () => {
+    onRpc("web_save", ({ args }) => {
+        expect.step(args[1]);
+    });
+    await mountView({
+        type: "form",
+        resModel: "res.partner",
+        arch: `
+            <form>
+                <field name="street" widget="google_address_autocomplete"/>
+            </form>`,
+        resId: 1,
+    });
+
+    await contains(".o_field_widget[name=street] input").edit("odoo farm 2", {
+        confirm: false,
+    });
+    await runAllTimers();
+    await contains(
+        ".o_field_widget[name=street] .o-autocomplete--dropdown-item a:contains(Bourlottes)"
+    ).click();
+    expect(".o_field_widget[name=street] input").toHaveValue("rue des Bourlottes 9");
+    await contains(".o_field_widget[name=street] input").edit("");
+    await contains(".o_form_button_save").click();
+    expect.verifySteps([{ street: false }]);
+});

--- a/addons/partner_autocomplete/static/tests/partner_autocomplete.test.js
+++ b/addons/partner_autocomplete/static/tests/partner_autocomplete.test.js
@@ -386,3 +386,38 @@ test("Partner autocomplete : onChange should not disturb option selection", asyn
         });
     }
 });
+
+test("Partner autocomplete: select a value, then empty the input and save", async () => {
+    class OtherModel extends models.Model {
+        _name = "other.model";
+        name = fields.Char();
+        email = fields.Char();
+    }
+    defineModels([OtherModel]);
+
+    onRpc("web_save", ({ args }) => {
+        expect.step(args[1]);
+    });
+    await mountView({
+        resModel: "other.model",
+        type: "form",
+        arch: `
+            <form>
+                <field name="name" widget="field_partner_autocomplete"/>
+                <field name="email"/>
+            </form>`,
+        });
+
+    await editAutocomplete("[name=name] .dropdown input", "company");
+    expect("[name=name] .o-autocomplete .o-autocomplete--dropdown-item").toHaveCount(4);
+    await contains("[name=name] .o-autocomplete ul li").click();
+    expect("[name=name] input").toHaveValue("First Company");
+    expect("[name=email] input").toHaveValue("hello@odoo.com");
+
+    await contains("[name=name] input").edit("");
+    await contains(".o_form_button_save").click();
+    expect.verifySteps([{
+        email: "hello@odoo.com",
+        name: false,
+    }]);
+});

--- a/addons/web/static/src/views/fields/input_field_hook.js
+++ b/addons/web/static/src/views/fields/input_field_hook.js
@@ -132,11 +132,13 @@ export function useInputField(params) {
         // the corresponding value in the record. Otherwise, in some cases,
         // if the value in the record change the useEffect isn't triggered.
         const value = params.getValue();
-        if (
-            inputRef.el &&
-            !isDirty &&
-            !component.props.record.isFieldInvalid(fieldName)
-        ) {
+        if (!inputRef.el) {
+            return;
+        }
+        if (inputRef.el.value === value) {
+            isDirty = false;
+        }
+        if (!isDirty && !component.props.record.isFieldInvalid(fieldName)) {
             inputRef.el.value = value;
             lastSetValue = inputRef.el.value;
         }


### PR DESCRIPTION
*google_address_autocomplete,partner_autocomplete

This commit aims at fixing the behavior of 2 field widgets using the Autocomplete component.

Those widgets rely on the `useInputField` hook, because they basically render an input (spiced with the autocomplete feature), so they must handle "manual" updates (listen to `input`, `change`, `keydown` events), like regular input fields.

However, the input also acts as a "search bar" for the autocomplete. As a consequence, it might happend that the `useInputField` hook internals weren't correctly reflecting the actual state of the field.

Here's a faulty scenario to highlight the issue, involving any of the two widgets:
 - open a form view with the field set to value "XYZ"
 - type in the input "ABC" and select a suggestion from the autocomplete dropdown => say the value is now "Value ABC"
 - manually erase the content of the input and type "XYZ" as before
 - save => the value sent to the server was actually "Value ABC"

The reason is that the hook still believes that the field is dirty after the value has been picked from the dropdown, and set (in the model) to "Value ABC", so `lastSetValue` isn't correctly updated to "Value ABC" (it's still "XYZ"). Later on, after the manual update to go back to the value "XYZ", we compare this value with `lastSetValue`, and as they are the same, we do nothing, so the value in the model remains "Value ABC".

Those widgets need to use the hook, because the logic encapsulated inside it is really tricky and we don't want to duplicate it. But the hooks internals aren't exposed, and we don't want to expose them to keep it under control. So we did the fix inside the hook itself: in `useEffect`, so after a patch, if the value in the model is the same than the value in the input, it means that the field isn't dirty anymore, so we force-reset the flag to `false`. This scenario only makes sense for inputs that are handled both internally by the hook and externally (e.g. by the autocomplete).

Task~6018655

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
