### PR TITLE
[IMP] im_livechat: live chat channel views

### DIFF
--- a/addons/im_livechat/data/im_livechat_channel_data.xml
+++ b/addons/im_livechat/data/im_livechat_channel_data.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
         <record id="im_livechat_channel_data" model="im_livechat.channel">
-            <field name="name">YourWebsite.com</field>
+            <field name="name">Support</field>
             <field name="default_message">Hello, how may I help you?</field>
         </record>
     </data>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot.xml
@@ -12,7 +12,7 @@
             <field name="operator_partner_id" ref="support_bot_operator_partner_demo"/>
         </record>
         <record id="support_bot_channel_demo" model="im_livechat.channel">
-            <field name="name">Support</field>
+            <field name="name">Support Bot</field>
         </record>
         <record id="im_livechat_channel_rule_demo" model="im_livechat.channel.rule">
             <field name="regex_url">/im_livechat/</field>

--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -25,7 +25,7 @@ class Im_LivechatChannel(models.Model):
     _name = 'im_livechat.channel'
     _inherit = ['rating.parent.mixin']
     _description = 'Livechat Channel'
-    _rating_satisfaction_days = 14  # include only last 14 days to compute satisfaction
+    _rating_satisfaction_days = 30  # include only last 30 days to compute satisfaction
 
     def _default_user_ids(self):
         return [(6, 0, [self.env.uid])]
@@ -69,7 +69,7 @@ class Im_LivechatChannel(models.Model):
         "Agents Connected", compute="_compute_available_operator_ids"
     )
     script_external = fields.Html('Script (external)', compute='_compute_script_external', store=False, readonly=True, sanitize=False)
-    nbr_channel = fields.Integer('Number of conversation', compute='_compute_nbr_channel', store=False, readonly=True)
+    nbr_channel = fields.Integer('Number of conversations in the past 30 days', compute='_compute_nbr_channel', store=False, readonly=True)
 
     # relationnal fields
     user_ids = fields.Many2many('res.users', 'im_livechat_channel_im_user', 'channel_id', 'user_id', string='Agents', default=_default_user_ids)
@@ -238,14 +238,17 @@ class Im_LivechatChannel(models.Model):
         for record in self:
             record.web_page = "%s/im_livechat/support/%i" % (record.get_base_url(), record.id) if record.id else False
 
-    @api.depends('channel_ids')
+    @api.depends("channel_ids.create_date")
     def _compute_nbr_channel(self):
-        data = self.env['discuss.channel']._read_group([
-            ('livechat_channel_id', 'in', self.ids),
-        ], ['livechat_channel_id'], ['__count'])
-        channel_count = {livechat_channel.id: count for livechat_channel, count in data}
+        count_by_channel = dict(
+            self.env["discuss.channel"]._read_group(
+                [("livechat_channel_id", "in", self.ids), ("create_date", ">", "today -29d")],
+                ["livechat_channel_id"],
+                ["__count"],
+            ),
+        )
         for record in self:
-            record.nbr_channel = channel_count.get(record.id, 0)
+            record.nbr_channel = count_by_channel.get(record, 0)
 
     # --------------------------
     # Action Methods
@@ -275,7 +278,10 @@ class Im_LivechatChannel(models.Model):
         )
         action["context"] = {
             "search_default_parent_res_name": self.name,
-            "search_default_fiter_session_rated": "1"
+            "search_default_filter_session_rating_happy": "1",
+            "search_default_filter_session_rating_neutral": "1",
+            "search_default_fiter_session_rating_unhappy": "1",
+            "search_default_filter_session_date": "custom_rated_on_last_30_days",
         }
         return action
 

--- a/addons/im_livechat/views/discuss_channel_views.xml
+++ b/addons/im_livechat/views/discuss_channel_views.xml
@@ -204,6 +204,7 @@
             <field name="view_mode">kanban,list,pivot,graph,form</field>
             <field name="domain">[('livechat_channel_id', 'in', [active_id])]</field>
             <field name="context">{
+                'search_default_filter_session_date': 'custom_rated_on_last_30_days',
                 'search_default_livechat_channel_id': [active_id],
                 'default_livechat_channel_id': active_id,
             }</field>

--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -49,18 +49,18 @@
                             <main class="pe-4 py-2 ps-4 col" t-att-class="{'o-livechat-ChannelKanban-highlighted': record.available_operator_ids.raw_value.length > 0}">
                                 <div class="d-flex justify-content-between">
                                     <div>
-                                        <field name="name" class="fs-4" style="word-wrap: break-word;"/>
-                                        <p class="fst-italic fs-5"><field name="nbr_channel"/> Sessions</p>
+                                        <field name="name" class="fw-bold fs-4" style="word-wrap: break-word;"/>
+                                        <p class="text-muted"><field name="ongoing_session_count"/> Ongoing Conversations</p>
                                     </div>
                                     <div class="pe-1">
-                                        <button t-if="record.are_you_inside.raw_value" name="action_quit" type="object" class="btn btn-primary">Leave</button>
-                                        <button t-else="" name="action_join" type="object" class="btn btn-secondary" groups="im_livechat.im_livechat_group_user">Join</button>
+                                        <button t-if="record.are_you_inside.raw_value" name="action_quit" type="object" class="btn btn-secondary shadow-sm"><i class="fa fa-sign-out o-me-1_5" role="img"/>Leave</button>
+                                        <button t-else="" name="action_join" type="object" class="btn btn-primary" groups="im_livechat.im_livechat_group_user"><i class="fa fa-sign-in o-me-1_5" role="img"/>Join</button>
                                     </div>
                                 </div>
                                 <footer class="pt-0">
                                     <field name="available_operator_ids" widget="many2many_avatar_user" readonly="True"/>
-                                    <a t-if="record.rating_count.raw_value > 0" name="action_view_rating" class="ms-auto fs-6" type="object" tabindex="10">
-                                        <i class="fa fa-smile-o text-success" title="Percentage of happy ratings" role="img" aria-label="Happy face"/> <field name="rating_percentage_satisfaction"/>%
+                                    <a t-if="record.rating_count.raw_value > 0" name="action_view_rating" class="ms-auto fs-6" type="object" tabindex="10" title="Percentage of positive ratings in the last 30 days">
+                                        <i class="fa fa-smile-o text-success" role="img" aria-label="Happy face"/> <field name="rating_percentage_satisfaction"/>%
                                     </a>
                                 </footer>
                             </main>
@@ -87,7 +87,7 @@
                                 invisible="chatbot_script_count == 0" groups="im_livechat.im_livechat_group_manager">
                                 <field string="Chatbots" name="chatbot_script_count" widget="statinfo"/>
                             </button>
-                            <button class="oe_stat_button" type="action" invisible="nbr_channel == 0" name="%(discuss_channel_action_from_livechat_channel)d" icon="fa-comments">
+                            <button class="oe_stat_button" type="action" invisible="nbr_channel == 0" title="Number of conversations and percentage of positive ratings in the last 30 days" name="%(discuss_channel_action_from_livechat_channel)d" icon="fa-comments">
                                 <div>
                                     <div class="o_stat_info flex-row-reverse align-items-baseline gap-1 me-1">
                                         <span class="o_stat_value"><field name="nbr_channel"/></span>


### PR DESCRIPTION
This commit improves the live chat channel kanban and form views:
- Rename default channel from "Yourwebsite.com" to "Support".
- Tweak some styles in the kanban cards.
- Show ratings for the last 30 days in the kanban card and in the form view stat button, update related actions to display conversations for the last 30 days.

part of task-5867464 (37)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
