### PR TITLE
[FIX] web, *: no prefix icon in `o_form_header_group` on small screens

### DIFF
--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -127,29 +127,36 @@
                                 <field name="image_1920" widget='image' options='{"size": [128,158], "zoom": true, "preview_image":"avatar_128"}'/>
                                 <field name="show_hr_icon_display" invisible="1" />
                             </div>
-                            <div class="o_form_header_details">
-                                <h1 class="o_employee_form_header_info">
-                                    <field name="name" placeholder="Employee's Name (e.g. John Doe, ...)" required="True"/>
-                                </h1>
-                                <div class="o_input_box">
-                                    <i class="fa fa-envelope o_input_box_overlay_start" title="Work Email"/>
-                                    <field name="work_email" widget="email" placeholder="e.g. johndoe@example.com" string="Work Email"/>
+                            <group class="o_form_header_details">
+                                <div colspan="2">
+                                    <h1 class="o_employee_form_header_info">
+                                        <label for="name" class="d-md-none"/>
+                                        <field name="name" placeholder="Employee's Name (e.g. John Doe, ...)" required="True"/>
+                                    </h1>
+                                    <label for="work_email" class="d-md-none"/>
+                                    <div class="o_input_box">
+                                        <i class="d-none d-md-inline-flex fa fa-envelope o_input_box_overlay_start" title="Work Email"/>
+                                        <field name="work_email" widget="email" placeholder="e.g. johndoe@example.com" string="Work Email"/>
+                                    </div>
+                                    <label for="work_phone" class="d-md-none"/>
+                                    <div class="o_input_box">
+                                        <i class="d-none d-md-inline-flex fa fa-phone o_input_box_overlay_start" title="Work Phone"/>
+                                        <field name="work_phone" widget="phone" placeholder="Work Phone" string="Work Phone"/>
+                                    </div>
+                                    <label for="mobile_phone" class="d-md-none"/>
+                                    <div class="o_input_box">
+                                        <i class="d-none d-md-inline-flex fa fa-mobile o_input_box_overlay_start" title="Work Mobile"/>
+                                        <field name="mobile_phone" widget="phone" placeholder="Work Mobile" string="Work Mobile"/>
+                                    </div>
+                                    <label for="category_ids" class="d-md-none"/>
+                                    <div class="o_input_box">
+                                        <i class="d-none d-md-inline-flex fa fa-tags o_input_box_overlay_start" title="Tags"/>
+                                        <field name="category_ids" widget="many2many_tags"
+                                            options="{'color_field': 'color', 'no_create_edit': True}"
+                                            placeholder="e.g. Founder, Motorized, Building B, ..." groups="hr.group_hr_user"/>
+                                    </div>
                                 </div>
-                                <div class="o_input_box">
-                                    <i class="fa fa-phone o_input_box_overlay_start" title="Work Phone"/>
-                                    <field name="work_phone" widget="phone" placeholder="Work Phone" string="Work Phone"/>
-                                </div>
-                                <div class="o_input_box">
-                                    <i class="fa fa-mobile o_input_box_overlay_start" title="Work Mobile"/>
-                                    <field name="mobile_phone" widget="phone" placeholder="Work Mobile" string="Work Mobile"/>
-                                </div>
-                                <div class="o_input_box">
-                                    <i class="fa fa-tags o_input_box_overlay_start" title="Tags"/>
-                                    <field name="category_ids" widget="many2many_tags"
-                                        options="{'color_field': 'color', 'no_create_edit': True}"
-                                        placeholder="e.g. Founder, Motorized, Building B, ..." groups="hr.group_hr_user"/>
-                                </div>
-                            </div>
+                            </group>
                         </div>
                         <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
                         <field name="employee_properties" columns="2"/>

--- a/addons/hr/views/res_users.xml
+++ b/addons/hr/views/res_users.xml
@@ -57,18 +57,21 @@
                 <xpath expr="//div[hasclass('o_input_box')][@name='phone']" position="attributes">
                     <attribute name="invisible">1</attribute>
                 </xpath>
-                <xpath expr="//div[hasclass('o_form_header_details')]" position="inside">
+                <xpath expr="//*[hasclass('o_form_header_details')]//div" position="inside">
+                    <label for="work_email" class="d-md-none"/>
                     <div class="o_input_box">
                         <i class="o_input_box_overlay_start fa fa-envelope" title="Work Email"/>
-                        <field name="work_email" widget="email" placeholder="Work Email" string="Work Email"/>
+                        <field name="work_email" widget="email" placeholder="Work Email"/>
                     </div>
+                    <label for="work_phone" class="d-md-none"/>
                     <div class="o_input_box">
                         <i class="o_input_box_overlay_start fa fa-phone" title="Work Phone"/>
-                        <field name="work_phone" widget="phone" placeholder="Work Phone" string="Work Phone"/>
+                        <field name="work_phone" widget="phone" placeholder="Work Phone"/>
                     </div>
+                    <label for="mobile_phone" class="d-md-none"/>
                     <div class="o_input_box">
                         <i class="o_input_box_overlay_start fa fa-mobile" title="Work Mobile"/>
-                        <field name="mobile_phone" widget="phone" placeholder="Work Mobile" string="Work Mobile"/>
+                        <field name="mobile_phone" widget="phone" placeholder="Work Mobile"/>
                     </div>
                 </xpath>
                 <xpath expr="//group[@name='other_preferences']" position="inside">
@@ -234,19 +237,22 @@
                 <xpath expr="//div[hasclass('o_input_box')][@name='login']/i[hasclass('fa-key')]" position="attributes">
                     <attribute name="invisible">(not employee_id and login == email) or (employee_id and login == work_email)</attribute>
                 </xpath>
-                <xpath expr="//div[hasclass('o_form_header_details')]" position="inside">
+                <xpath expr="//*[hasclass('o_form_header_details')]//div" position="inside">
+                    <label for="work_email" class="d-md-none" invisible="not employee_id or login == work_email"/>
                     <div class="o_input_box" invisible="not employee_id or login == work_email">
-                        <i class="fa fa-envelope fa-fw o_input_box_overlay_start" title="Work Email"/>
+                        <i class="d-none d-md-inline-flex fa fa-envelope fa-fw o_input_box_overlay_start" title="Work Email"/>
                         <field name="email_domain_placeholder" invisible="1" />
-                        <field name="work_email" widget="email" string="Work Email" options="{'placeholder_field': 'email_domain_placeholder'}"/>
+                        <field name="work_email" widget="email" options="{'placeholder_field': 'email_domain_placeholder'}"/>
                     </div>
+                    <label for="work_phone" class="d-md-none" invisible="not employee_id"/>
                     <div class="o_input_box" invisible="not employee_id">
-                        <i class="fa fa-phone fa-fw o_input_box_overlay_start" title="Work Phone"/>
-                        <field name="work_phone" widget="phone" placeholder="Work Phone" string="Work Phone"/>
+                        <i class="d-none d-md-inline-flex fa fa-phone fa-fw o_input_box_overlay_start" title="Work Phone"/>
+                        <field name="work_phone" widget="phone" placeholder="Work Phone"/>
                     </div>
+                    <label for="mobile_phone" class="d-md-none" invisible="not employee_id"/>
                     <div class="o_input_box" invisible="not employee_id">
-                        <i class="fa fa-mobile fa-fw o_input_box_overlay_start" title="Work Mobile"/>
-                        <field name="mobile_phone" widget="phone" placeholder="Work Mobile" string="Work Mobile"/>
+                        <i class="d-none d-md-inline-flex fa fa-mobile fa-fw o_input_box_overlay_start" title="Work Mobile"/>
+                        <field name="mobile_phone" widget="phone" placeholder="Work Mobile"/>
                     </div>
                 </xpath>
                 <xpath expr="//group[@name='other_preferences']" position="inside">

--- a/addons/point_of_sale/views/res_partner_view.xml
+++ b/addons/point_of_sale/views/res_partner_view.xml
@@ -34,27 +34,33 @@
                         <div class="o_form_header_group">
                             <field name="image_1920" widget="contact_image" options="{'preview_image': 'avatar_128', 'size': [130,130], 'img_class': 'border'}"/>
                             <field name="avatar_128" invisible="1"/> <!-- Needed in contact_image widget -->
-                            <div class="o_form_header_details">
-                                <h1>
-                                    <field options="{'line_breaks': False}" widget="text" class="text-break d-block" name="name" default_focus="1" placeholder="Name (company or person)" required="type == 'contact'"/>
-                                </h1>
-                                <div class="o_input_box">
-                                    <i class="o_input_box_overlay_start fa fa-building" title="Company"/>
-                                    <field name="parent_id"
-                                        widget="res_partner_many2one"
-                                        placeholder="Company Employer"
-                                        domain="[('parent_id', '=', False)]"
-                                        context="{'default_user_id': user_id}"/>
+                            <group class="o_form_header_details">
+                                <div colspan="2">
+                                    <h1>
+                                        <label for="name" class="d-md-none"/>
+                                        <field options="{'line_breaks': False}" widget="text" class="text-break d-block" name="name" default_focus="1" placeholder="Name (company or person)" required="type == 'contact'"/>
+                                    </h1>
+                                    <label for="parent_id" class="d-md-none"/>
+                                    <div class="o_input_box">
+                                        <i class="o_input_box_overlay_start d-none d-md-inline-flex fa fa-building" title="Company"/>
+                                        <field name="parent_id"
+                                            widget="res_partner_many2one"
+                                            placeholder="Company Employer"
+                                            domain="[('parent_id', '=', False)]"
+                                            context="{'default_user_id': user_id}"/>
+                                    </div>
+                                    <label for="email" class="d-md-none"/>
+                                    <div class="o_input_box">
+                                        <i class="o_input_box_overlay_start d-none d-md-inline-flex fa fa-envelope" title="Email"/>
+                                        <field name="email" widget="email" required="user_ids" placeholder="Email"/>
+                                    </div>
+                                    <label for="phone" class="d-md-none"/>
+                                    <div class="o_input_box">
+                                        <i class="o_input_box_overlay_start d-none d-md-inline-flex fa fa-phone" title="Phone"/>
+                                        <field name="phone" widget="phone" placeholder="Phone"/>
+                                    </div>
                                 </div>
-                                <div class="o_input_box">
-                                    <i class="o_input_box_overlay_start fa fa-envelope" title="Email"/>
-                                    <field name="email" widget="email" required="user_ids" placeholder="Email"/>
-                                </div>
-                                <div class="o_input_box">
-                                    <i class="o_input_box_overlay_start fa fa-phone" title="Phone"/>
-                                    <field name="phone" widget="phone" placeholder="Phone"/>
-                                </div>
-                            </div>
+                            </group>
                         </div>
                         <group>
                             <group>

--- a/addons/web/static/src/core/input_box/input_box.js
+++ b/addons/web/static/src/core/input_box/input_box.js
@@ -4,6 +4,7 @@ import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { hasTouch } from "@web/core/browser/feature_detection";
 import { browser } from "@web/core/browser/browser";
 import { Component } from "@odoo/owl";
+import { getVisibleElements } from "../utils/ui";
 
 function _positionInputBoxOverlay(target) {
     const _hasTouch = hasTouch();
@@ -13,8 +14,8 @@ function _positionInputBoxOverlay(target) {
     if (!closestInputBox) {
         return;
     }
-    const startOverlays = closestInputBox.querySelectorAll(`.o_input_box_overlay_start:is(:not(.d-none),${_hasTouch ? '[class*="d-touch-"]:not(.d-touch-none)' : ''})`);
-    const endOverlays = closestInputBox.querySelectorAll(`.o_input_box_overlay_end:is(:not(.d-none),${_hasTouch ? '[class*="d-touch-"]:not(.d-touch-none)' : ''})`);
+    const startOverlays = getVisibleElements(closestInputBox, `.o_input_box_overlay_start`);
+    const endOverlays = getVisibleElements(closestInputBox, `.o_input_box_overlay_end`);
     if (!startOverlays.length && !endOverlays.length) {
         return;
     }

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -129,27 +129,35 @@
                     <div class="o_form_header_group">
                         <field name="image_1920" widget="contact_image" options="{'preview_image': 'avatar_128', 'size': [130,130], 'img_class': 'border'}"/>
                         <field name="avatar_128" invisible="1"/> <!-- Needed in contact_image widget -->
-                        <div class="o_form_header_details">
-                            <h1>
-                                <field options="{'line_breaks': False}" widget="text" class="text-break d-block" name="name" default_focus="1" placeholder="Name (company or person)" required="type == 'contact'"/>
-                            </h1>
-                            <div class="o_input_box">
-                                <i class="o_input_box_overlay_start fa fa-building" title="Company"/>
-                                <field name="parent_id"
-                                    widget="res_partner_many2one"
-                                    placeholder="Company Employer"
-                                    domain="[('parent_id', '=', False)]"
-                                    context="{'default_user_id': user_id}"/>
+                        <group class="o_form_header_details">
+                            <div colspan="2">
+                                <h1>
+                                    <label for="name" class="d-md-none"/>
+                                    <field options="{'line_breaks': False}" widget="text" class="text-break d-block" name="name" default_focus="1" placeholder="Name (company or person)" required="type == 'contact'"/>
+                                </h1>
+                                <label for="parent_id" class="d-md-none"/>
+                                <div class="o_input_box">
+                                    <i class="o_input_box_overlay_start d-none d-md-inline-flex fa fa-building" title="Company"/>
+                                    <field name="parent_id"
+                                        widget="res_partner_many2one"
+                                        placeholder="Company Employer"
+                                        domain="[('parent_id', '=', False)]"
+                                        context="{'default_user_id': user_id}"/>
+                                </div>
+
+                                <label for="email" class="d-md-none"/>
+                                <div class="o_input_box">
+                                    <i class="o_input_box_overlay_start d-none d-md-inline-flex fa fa-envelope" title="Email"/>
+                                    <field name="email" widget="email" required="user_ids" placeholder="Email"/>
+                                </div>
+
+                                <label for="phone" class="d-md-none"/>
+                                <div class=" o_input_box">
+                                    <i class="o_input_box_overlay_start d-none d-md-inline-flex fa fa-phone" title="Phone"/>
+                                    <field name="phone" widget="phone" placeholder="Phone"/>
+                                </div>
                             </div>
-                            <div class="o_input_box">
-                                <i class="o_input_box_overlay_start fa fa-envelope" title="Email"/>
-                                <field name="email" widget="email" required="user_ids" placeholder="Email"/>
-                            </div>
-                            <div class=" o_input_box">
-                                <i class="o_input_box_overlay_start fa fa-phone" title="Phone"/>
-                                <field name="phone" widget="phone" placeholder="Phone"/>
-                            </div>
-                        </div>
+                        </group>
                     </div>
                     <group>
                         <group>

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -61,30 +61,34 @@
                     <sheet>
                         <div class="d-flex gap-3 flex-column flex-sm-row mb-3">
                             <div class="text-center">
-                                <field name="image_1920" widget="contact_image" options="{'preview_image': 'avatar_128', 'zoom': true, 'size': [130,130], 'img_class': 'rounded-4'}"/>
+                                <field name="image_1920" widget="contact_image" options="{'preview_image': 'avatar_128', 'zoom': true, 'size': [130,130]}"/>
                                 <field name="avatar_128" invisible="1"/> <!-- Needed in contact_image widget -->
                             </div>
-                            <div class="flex-fill d-flex">
-                                <div class="d-flex flex-column flex-grow-1 justify-content-center">
+                            <group class="o_form_header_details">
+                                <div colspan="2">
                                     <h1 class="d-flex align-items-baseline w-100">
+                                        <label for="name" class="d-md-none"/>
                                         <field name="name" class="w-100" placeholder="e.g. John Doe" required="1"/>
                                     </h1>
+                                    <label for="login" class="d-md-none"/>
                                     <div class="o_input_box">
                                         <field name="email" invisible="1"/> <!-- needed to update partner's email from on_change_login() -->
-                                        <i class="o_input_box_overlay_start fa fa-envelope" title="Email"/>
+                                        <i class="o_input_box_overlay_start d-none d-md-inline-flex fa fa-envelope" title="Email"/>
                                         <field name="email_domain_placeholder" invisible="1" /> <!-- needed to compute the placeholder whenever the dialog opens -->
                                         <field name="login" options="{'placeholder_field': 'email_domain_placeholder'}"/>
                                     </div>
+                                    <label for="phone" class="d-md-none"/>
                                     <div class="o_input_box">
-                                        <i class="o_input_box_overlay_start fa fa-phone" title="Phone"/>
+                                        <i class="o_input_box_overlay_start d-none d-md-inline-flex fa fa-phone" title="Phone"/>
                                         <field name="phone" widget="phone" placeholder="Phone"/>
                                     </div>
+                                    <label for="company_id" class="d-md-none" groups="base.group_multi_company"/>
                                     <div class="o_input_box" groups="base.group_multi_company">
-                                        <i class="o_input_box_overlay_start fa fa-building" title="Company"/>
+                                        <i class="o_input_box_overlay_start d-none d-md-inline-flex fa fa-building" title="Company"/>
                                         <field name="company_id" context="{'user_preference': 0}" placeholder="Company"/>
                                     </div>
                                 </div>
-                            </div>
+                            </group>
                         </div>
                         <group name="access_groups" invisible="id &gt; 0">
                             <label for="group_ids" string="Access Rights"  groups="base.group_no_one"/>
@@ -131,24 +135,30 @@
                         <div class="o_form_header_group">
                             <field name="image_1920" widget="contact_image" options="{'preview_image': 'avatar_128', 'img_class': 'rounded-4'}"/>
                             <field name="avatar_128" invisible="1"/> <!-- Needed in contact_image widget -->
-                            <div class="o_form_header_details">
-                                <h1>
-                                    <field name="name" placeholder="e.g. John Doe" required="1"/>
-                                </h1>
-                                <div name="login" class="o_input_box">
-                                    <i class="fa fa-envelope o_input_box_overlay_start" title="Login / Email" invisible="login != email"/>
-                                    <i class="fa fa-key o_input_box_overlay_start" title="Login" invisible="login == email"/>
-                                    <field name="login" placeholder="Login"/>
+                            <group class="o_form_header_details">
+                                <div colspan="2">
+                                    <h1>
+                                        <label for="name" class="d-md-none"/>
+                                        <field name="name" placeholder="e.g. John Doe" required="1"/>
+                                    </h1>
+                                    <label for="login" class="d-md-none"/>
+                                    <div name="login" class="o_input_box">
+                                        <i class="d-none d-md-inline-flex fa fa-envelope o_input_box_overlay_start" title="Login / Email" invisible="login != email"/>
+                                        <i class="d-none d-md-inline-flex fa fa-key o_input_box_overlay_start" title="Login" invisible="login == email"/>
+                                        <field name="login" placeholder="Login"/>
+                                    </div>
+                                    <label for="email" class="d-md-none" invisible="login == email"/>
+                                    <div name="email" class="o_input_box" invisible="login == email">
+                                        <i class="d-none d-md-inline-flex fa fa-envelope o_input_box_overlay_start" title="Email"/>
+                                        <field name="email" placeholder="Email"/>
+                                    </div>
+                                    <label for="phone" class="d-md-none"/>
+                                    <div name="phone" class="o_input_box">
+                                        <i class="d-none d-md-inline-flex fa fa-phone o_input_box_overlay_start" title="Phone"/>
+                                        <field name="phone" placeholder="Phone"/>
+                                    </div>
                                 </div>
-                                <div name="email" class="o_input_box" invisible="login == email">
-                                    <i class="fa fa-envelope o_input_box_overlay_start" title="Email"/>
-                                    <field name="email" placeholder="Email"/>
-                                </div>
-                                <div name="phone" class="o_input_box">
-                                    <i class="fa fa-phone o_input_box_overlay_start" title="Phone"/>
-                                    <field name="phone" placeholder="Phone"/>
-                                </div>
-                            </div>
+                            </group>
                         </div>
                         <group>
                             <field name="partner_id" groups="base.group_no_one"
@@ -415,19 +425,24 @@
                                 <field name="image_1920" widget="contact_image" options="{'preview_image': 'avatar_128'}"/>
                                 <field name="avatar_128" invisible="1"/> <!-- Needed in contact_image widget -->
                             </div>
-                            <div class="o_form_header_details">
-                                <h1>
-                                    <field name="name"/>
-                                </h1>
-                                <div name="email" class="o_input_box">
-                                    <i class="fa fa-fw fa-envelope o_input_box_overlay_start" title="Email"/>
-                                    <field name="email" placeholder="Email"/>
+                            <group class="o_form_header_details">
+                                <div colspan="2">
+                                    <h1>
+                                        <label for="name" class="d-md-none"/>
+                                        <field name="name"/>
+                                    </h1>
+                                    <label for="email" class="d-md-none"/>
+                                    <div name="email" class="o_input_box">
+                                        <i class="d-none d-md-inline-flex fa fa-fw fa-envelope o_input_box_overlay_start" title="Email"/>
+                                        <field name="email" placeholder="Email"/>
+                                    </div>
+                                    <label for="phone" class="d-md-none"/>
+                                    <div name="phone" class="o_input_box">
+                                        <i class="d-none d-md-inline-flex fa fa-fw fa-phone o_input_box_overlay_start" title="Phone"/>
+                                        <field name="phone" placeholder="Phone"/>
+                                    </div>
                                 </div>
-                                <div name="phone" class="o_input_box">
-                                    <i class="fa fa-fw fa-phone o_input_box_overlay_start" title="Phone"/>
-                                    <field name="phone" placeholder="Phone"/>
-                                </div>
-                            </div>
+                            </group>
                         </div>
                         <notebook>
                             <page string="Preferences" name="preferences_page">


### PR DESCRIPTION
We only want these icons on desktop, as the content is not aligned with the rest of the form view.

On small screens, each field is displayed one below the other, regardless of whether it is inside a header_group or not.

task-6010516

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
