### PR TITLE
[FIX] project_todo: Done button should be right side

### DIFF
--- a/addons/project_todo/static/src/components/todo_done_checkmark/todo_done_checkmark.scss
+++ b/addons/project_todo/static/src/components/todo_done_checkmark/todo_done_checkmark.scss
@@ -1,3 +1,6 @@
 .o_todo_done_checkmark_cell {
     width: 40px;
 }
+.o_form_view .o_form_sheet .o_field_widget.o_field_todo_done_checkmark {
+    width: initial;
+}


### PR DESCRIPTION
Since this commit, the Done button in the To-Do app is centered on the screen for small devices.

task-6014528

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
