### PR TITLE
[FIX] mail: match discuss dropdown bg dark theme with odoo

### DIFF
--- a/addons/mail/static/src/core/common/core.dark.scss
+++ b/addons/mail/static/src/core/common/core.dark.scss
@@ -6,10 +6,6 @@ a.o_mail_redirect, a.o_channel_redirect, a.o_message_redirect_transformed {
     @include o-mention-variant(rgba(lighten($o-action, 5%), .075), rgba(lighten($o-action, 10%), .25), lighten($o-action, 10%), rgba(lighten($o-action, 5%), .2), rgba(lighten($o-action, 5%), .3), lighten($o-action, 10%));
 }
 
-.o-discuss-dropdownMenu {
-    --discuss-dropdownMenuBg: #{$gray-100};
-}
-
 a.o-discuss-mention {
     @include o-mention-variant(rgba(lighten($o-action, 5%), .075), rgba(lighten($o-action, 10%), .25), lighten($o-action, 10%), rgba(lighten($o-action, 5%), .075), rgba(lighten($o-action, 10%), .25), lighten($o-action, 10%));
 }

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -91,7 +91,7 @@ $o-discuss-talkingColor: lighten($success, 10%);
     }
 
     &:not(.o-simulateDarkTheme) {
-        background-color: var(--discuss-dropdownMenuBg, $o-view-background-color);
+        background-color: $o-view-background-color;
     }
 
     .o_bottom_sheet_sheet:has(&) {

--- a/addons/mail/static/src/discuss/core/common/notification_settings.dark.scss
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.dark.scss
@@ -1,3 +1,3 @@
 .o-discuss-NotificationSettings {
-    --mail-NotificationSettings-btnHoverBg: #{$gray-200};
+    --mail-NotificationSettings-btnHoverBg: #{$gray-300};
 }


### PR DESCRIPTION
Before this commit, background of dropdown discuss actions in dark theme were darker than other dropdown in web client.

This comes from https://github.com/odoo/odoo/pull/247352 that harmonized NotificationSettings bg with discuss dropdown bg, by changing discuss dropdown BG to match NotificationSettings. However, the inverse should have been done, which is what this commit does.

Before / After
<img width="1241" height="810" alt="Screenshot 2026-03-09 at 16 30 10" src="https://github.com/user-attachments/assets/d1b1d201-a175-4f34-b95b-999126616a98" />
