### PR TITLE
[FIX] web: form: call `await record.isDirty()` before leaving

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -235,9 +235,6 @@ export class HtmlField extends Component {
         // Keep track of every change individually to avoid resetting dirtiness
         // after committing a change if another change occurred in the meantime.
         this.lastChangeId++;
-        // Ensure that FormController.beforeLeave is able to save record
-        // changes.
-        this.props.record.setDirty();
         this.props.record.model.bus.trigger("FIELD_IS_DIRTY", true);
     }
 

--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_fieldchar.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_fieldchar.js
@@ -86,9 +86,6 @@ export class PartnerAutoCompleteCharField extends CharField {
                 this.props.record.load();
             }
         }
-        if (this.props.setDirty) {
-            this.props.setDirty(false);
-        }
     }
 }
 

--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -272,15 +272,6 @@ export class Record extends DataPoint {
     }
 
     /**
-     * Sometimes necessary when fields have an expensive computation to do
-     * before an update (e.g. HtmlField). Could be removed when external usages
-     * of dirty are replaced by isDirty() (e.g. FormController.beforeLeave)
-     */
-    setDirty() {
-        this.dirty = true;
-    }
-
-    /**
      * @param {string} fieldName
      */
     async setInvalidField(fieldName) {

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -532,7 +532,11 @@ export class FormController extends Component {
     }
 
     async beforeLeave({ forceLeave } = {}) {
-        if (this.model.root.dirty && !forceLeave) {
+        if (forceLeave) {
+            return true;
+        }
+        const isDirty = await this.model.root.isDirty();
+        if (isDirty) {
             return this.save({
                 reload: false,
                 onError: (error, options) => this.onSaveError(error, options, true),

--- a/addons/web/static/tests/views/fields/many2many_checkboxes_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_checkboxes_field.test.js
@@ -4,13 +4,19 @@ import { runAllTimers } from "@odoo/hoot-mock";
 import {
     clickSave,
     contains,
+    defineActions,
     defineModels,
     fields,
+    getService,
     models,
     mountView,
+    mountWithCleanup,
     onRpc,
+    webModels,
 } from "@web/../tests/web_test_helpers";
+import { WebClient } from "@web/webclient/webclient";
 
+const { ResCompany, ResPartner, ResUsers } = webModels;
 class Partner extends models.Model {
     int_field = fields.Integer({ sortable: true });
     timmy = fields.Many2many({ string: "pokemon", relation: "partner.type" });
@@ -31,7 +37,7 @@ class PartnerType extends models.Model {
     ];
 }
 
-defineModels([Partner, PartnerType]);
+defineModels([Partner, PartnerType, ResCompany, ResPartner, ResUsers]);
 
 test("Many2ManyCheckBoxesField", async () => {
     Partner._records[0].timmy = [12];
@@ -515,4 +521,34 @@ test("Many2ManyCheckBoxesField in a notebook tab", async () => {
     // save
     await clickSave();
     expect.verifySteps(["get_views", "web_read", "name_search", "web_save"]);
+});
+
+test(`Many2ManyCheckBoxesField: edit and leave within 500ms`, async () => {
+    Partner._views = {
+        form: `<form><field name="timmy" widget="many2many_checkboxes" /></form>`,
+        list: `<list><field name="timmy"/></list>`,
+        search: `<search/>`,
+    };
+    defineActions([
+        {
+            id: 1,
+            name: "Partner",
+            res_model: "partner",
+            views: [
+                [false, "list"],
+                [false, "form"],
+            ],
+        },
+    ]);
+
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction(1);
+    expect(queryAllTexts(".o_data_cell")).toEqual(["No records"]);
+
+    await contains(".o_data_cell").click();
+
+    // edit and leave directly => the value must be saved anyway
+    await contains(".o_field_many2many_checkboxes input[type=checkbox]").click();
+    await contains(".o_breadcrumb .o_back_button").click();
+    expect(queryAllTexts(".o_data_cell")).toEqual(["1 record"]);
 });

--- a/addons/web/static/tests/views/fields/one2many_field.test.js
+++ b/addons/web/static/tests/views/fields/one2many_field.test.js
@@ -11931,7 +11931,7 @@ test("open a one2many record with optional open record displayed", async () => {
     });
 
     await contains(`td.o_list_record_open_form_view`).click();
-    expect.verifySteps(["partner.get_views"]);
+    expect.verifySteps([["getItem", localStorageKey, "true"], "partner.get_views"]);
 });
 
 test("if there are less than 4 lines in a one2many, empty lines must be displayed to cover the difference.", async () => {

--- a/addons/web/static/tests/views/form/auto_save.test.js
+++ b/addons/web/static/tests/views/form/auto_save.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { unload, waitFor } from "@odoo/hoot-dom";
+import { press, unload, waitFor } from "@odoo/hoot-dom";
 import { animationFrame, Deferred, mockSendBeacon } from "@odoo/hoot-mock";
 import {
     contains,
@@ -366,6 +366,51 @@ test(`save when breadcrumb clicked`, async () => {
     expect(`.o_form_editable`).toHaveCount(1);
     expect(`.o_breadcrumb`).toHaveText("Partner\naaa");
     expect('.o_field_widget[name="name"] input').toHaveValue("aaa");
+});
+
+test.tags("desktop");
+test(`save unblured char field when alt+B (breadcrumb back) pressed`, async () => {
+    defineActions([
+        {
+            id: 1,
+            name: "Partner",
+            res_model: "partner",
+            views: [
+                [false, "list"],
+                [false, "form"],
+            ],
+        },
+    ]);
+
+    Partner._views = {
+        list: `<list><field name="name"/></list>`,
+        form: `
+            <form>
+                <group>
+                    <field name="name"/>
+                </group>
+            </form>
+        `,
+    };
+
+    onRpc("web_save", ({ args }) => {
+        expect.step("web_save");
+        expect(args).toEqual([[1], { name: "aaa" }]);
+    });
+
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction(1);
+    expect(`.o_field_cell:eq(0)`).toHaveText("Xavier Lancer");
+
+    await contains(`.o_data_row td.o_data_cell`).click();
+    expect(`.o_breadcrumb`).toHaveText("Partner\nXavier Lancer");
+
+    await contains(`.o_field_widget[name='name'] input`).edit("aaa", { confirm: false });
+    await press(["alt", "b"]);
+    await waitFor(".o_list_view");
+    expect(`.o_breadcrumb`).toHaveText("Partner");
+    expect(`.o_field_cell:eq(0)`).toHaveText("aaa");
+    expect.verifySteps(["web_save"]);
 });
 
 test.tags("desktop");


### PR DESCRIPTION
When the form view is about to be left (e.g. breadcrumbs, menu,
stat button clicks), we first check if it is "dirty" (i.e. if there
are pending changes) and if so, we try to save it. We allow to
leave the form only if the save operation succeeded.

For historical reasons, we checked the "dirty" status by reading
the `record.dirty` property. However, this property isn't fully
reliable [1], because some fields could have local changes, not
yet sent to the model, who might think that the record isn't
dirty whether it actually is. The "safe" way to check the status
is to call `await record.isDirty()` which first ask all fields to
send their potential local changes. Until recently, we couldn't
use `isDirty` because of the HtmlField, which always considered
itself as "dirty", so the form view could never be left if we'd
check `isDirty`.

Here're a few faulty scenarios that were occurring:
 - from a list view, open a record, edit a char field, do browser
  back => change lost
 - widget many2many_checkboxes (eg social post template form view):
  toggle checkboxes and leave the view within 500ms (e.g. alt+B)
  => crash "Component is destroyed" 
 - in a view with the mass_mailing_html field (i.e. the mailing
  form view), add an image to the field and click on a menu item
  => either crash or image lost

This commit uses `await record.isDirty()` instead of `record.dirty`
and thus fixes the faulty scenario above. This highlighted an
issue in the action service though: we didn't always correctly
provide the `forceLeave` flag, in particular when calling
`historyBack` after discarding the changes in form view.

[1] https://github.com/odoo/odoo/blob/master/addons/web/static/src/model/relational_model/record.js#L56

Task~6019276