### PR TITLE
[FIX] web: show company's TIN in documents

### DIFF
--- a/addons/web/tests/test_reports.py
+++ b/addons/web/tests/test_reports.py
@@ -6,7 +6,7 @@ import odoo.tests
 from odoo.addons.http_routing.tests.common import MockRequest
 from odoo.exceptions import UserError
 from odoo.http import root
-from odoo.tests import tagged
+from odoo.tests import tagged, TransactionCase
 
 from odoo.tools import mute_logger
 
@@ -141,3 +141,21 @@ class TestReports(odoo.tests.HttpCase):
             self.assertIn('report.footer.tmp', deleted_files)
             self.assertIn('report.body.tmp', deleted_files)
             self.assertIn('report.tmp', deleted_files)
+
+
+@tagged('post_install', '-at_install')
+class TestBaseDocumentLayout(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+    def test_company_vat_appears_in_documents(self):
+        self.env.company.vat = 'BE987654321'
+        rendered = self.env['ir.ui.view']._render_template(
+            'web.company_address_list',
+            {
+                'company': self.env.company,
+                'forced_vat': False,
+            },
+        )
+        self.assertIn('BE987654321', rendered)

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -378,15 +378,10 @@
                     </div>
                 </span>
             </li>
-            <li t-if="not forced_vat">
-                <t t-if="company.vat">
-                    <t t-out="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
-                    <span t-out="company.vat">US12345671</span>
-                </t>
-            </li>
-            <li t-else="">
-                <t t-out="company.country_id.vat_label or 'Tax ID'">Tax ID</t>:
-                <span t-out="forced_vat">US12345671</span>
+            <t t-set="vat_number" t-value="forced_vat or company.vat"/>
+            <li t-if="vat_number">
+                <t t-out="company.country_id.vat_label or 'Tax ID'"/>:
+                <span t-out="vat_number">US12345671</span>
             </li>
         </ul>
     </template>


### PR DESCRIPTION
### Steps to reproduce:
- Download Accounting app
- Open 'Settings' > 'Companies' > 'Document Layout' > 'Configure Document Layout'
- Enter a 'Tax ID' and click continue

> 'Tax ID' doesn't show in the document

### Cause of issue:
The problem was introduced by https://github.com/odoo-dev/odoo/commit/fa55c2d1ca5db203ffaa13e10e4e4209717b7a6d, as the commited changes don't use the `company.vat` set by the user to be displayed in the documents.

### Fix:
Since the `forced_vat` is only used in a few localizations, it is logical to check if the `company.vat` available for usage if there's no `forced_vat`.

opw-5981630