### PR TITLE
[FIX] point_of_sale: remove stale orders from localStorage on load

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -691,6 +691,17 @@ export class PosStore extends Reactive {
             return;
         }
         this.loadOpenOrders(this.open_orders_json);
+
+        const openIds = new Set(this.open_orders_json.map((o) => o.id));
+        for (const order of [...this.get_order_list()]) {
+            if (order.server_id && !openIds.has(order.server_id)) {
+                this.removeOrder(order, false);
+            }
+        }
+        if (!this.get_order_list().includes(this.selectedOrder)) {
+            this.selectedOrder = null;
+            this.set_start_order();
+        }
     }
     async _loadMissingProducts(orders) {
         const missingProductIds = new Set([]);

--- a/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
@@ -8,6 +8,7 @@ import { registry } from "@web/core/registry";
 import * as Order from "@point_of_sale/../tests/tours/helpers/generic_components/OrderWidgetMethods";
 import { inLeftSide, scan_barcode } from "@point_of_sale/../tests/tours/helpers/utils";
 import * as ProductConfiguratorPopup from "@point_of_sale/../tests/tours/helpers/ProductConfiguratorTourMethods";
+import * as TicketScreen from "@point_of_sale/../tests/tours/helpers/TicketScreenTourMethods";
 
 registry.category("web_tour.tours").add("ProductScreenTour", {
     test: true,
@@ -288,5 +289,47 @@ registry.category("web_tour.tours").add("test_products_variants_attribute_value_
             ProductScreen.clickProductInfoAttributeValue("Size", "Medium"),
             ProductScreen.checkProductsNumber(1),
             ProductScreen.productIsDisplayed("Small Shelf (Medium)"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_only_unpaid_orders_are_loaded", {
+    test: true,
+    steps: () =>
+        [
+            // open pos "shop"
+            {
+                content: "start new session",
+                trigger: ".o_kanban_primary_left button:contains('New Session')",
+            },
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.addOrderline("Desk Pad", "1"),
+            ProductScreen.saveOrder(),
+            Chrome.clickMenuButton(),
+            {
+                content: "click backend button",
+                trigger: "li.backend-button",
+            },
+            // open pos "shop2"
+            {
+                content: "start another new session",
+                trigger: ".o_kanban_primary_left button:contains('New Session')",
+            },
+            Chrome.clickMenuButton(),
+            Chrome.clickTicketButton(),
+            TicketScreen.selectOrder("-0001"),
+            TicketScreen.loadSelectedOrder(),
+            ProductScreen.isShown(),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            Chrome.closeSession(),
+            // reopen pos "shop"
+            {
+                content: "open session",
+                trigger: ".o_kanban_primary_left button:contains('Continue Selling')",
+            },
+            // there should not be any order
+            ProductScreen.orderIsEmpty(),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
@@ -571,3 +571,19 @@ export function doubleClickOrder(name) {
         },
     ];
 }
+
+export function saveOrder() {
+    return inLeftSide(
+        [
+            {
+                content: "click more button",
+                trigger: ".mobile-more-button",
+                mobile: true,
+            },
+            {
+                content: "click save button",
+                trigger: '.control-buttons .control-button:contains("Save")',
+            },
+        ].flat()
+    );
+}

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1433,6 +1433,12 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_products_variants_attribute_value_filtering', login="pos_user")
 
+    def test_only_unpaid_orders_are_loaded(self):
+        other_pos = self.main_pos_config.copy({"name": "shop2"})
+        self.main_pos_config.trusted_config_ids += other_pos
+        other_pos.trusted_config_ids += self.main_pos_config
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_only_unpaid_orders_are_loaded', login="pos_admin")
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Create 2 mutually trusted PoS configs (S1 and S2).
2. From S1, create an order, save it, and close the PoS.
3. Open S2, go to ticket screen, and pay S1's order.
4. Reopen S1.

-> The paid order still appears as unpaid in S1.

The fix:
--------
In `load_server_orders`, after loading open orders, remove the local
orders from LS that are still considered "draft', but are now paid by
other shops. If during that process, the selected order was removed, we reset it
and call `set_start_order` which adds a new one.

Note: this fix is similar to what's done when going to the ticket screen
where the function `_syncAllOrdersFromServer` is being called: all the
local orders that are not anymore draft are removed from local storage's
open orders.

opw-5946365