### PR TITLE
[FIX] website_project : hide unset task data

### DIFF
--- a/addons/website_project/controllers/main.py
+++ b/addons/website_project/controllers/main.py
@@ -53,9 +53,9 @@ class WebsiteForm(form.WebsiteForm):
             if partner:
                 data['record']['partner_id'] = partner.id
                 custom = [
-                    ('partner_name', data['record'].pop('partner_name', False)),
-                    ('partner_phone', data['record'].pop('partner_phone', False)),
-                    ('partner_company_name', data['record'].pop('partner_company_name', False)),
+                   (field, data['record'].pop(field))
+                   for field in ['partner_name', 'partner_phone', 'partner_company_name']
+                   if data['record'].get(field)
                 ]
                 data['custom'] += "\n" + "\n".join(["%s : %s" % c for c in custom])
             else:

--- a/addons/website_project/tests/test_project_portal_access.py
+++ b/addons/website_project/tests/test_project_portal_access.py
@@ -45,7 +45,6 @@ class TestProjectPortalAccess(TestProjectSharingCommon, HttpCase):
             'name': 'FIX',
             'partner_name': 'Not Jean Michel',
             'email_from': 'jean@michel.com',
-            'partner_phone': '+1234567',
             'partner_company_name': 'foo',
             'description': 'Fix this',
             'project_id': self.project_portal.id,
@@ -55,3 +54,6 @@ class TestProjectPortalAccess(TestProjectSharingCommon, HttpCase):
         task = self.env['project.task'].browse(response.json().get('id'))
         self.assertTrue(task.exists())
         self.assertEqual(partner.name, 'Jean Michel')
+        # The description should not contain the partner_phone since it was not provided
+        self.assertEqual(str(task.description), ('<p>Fix this</p><h4>Other Information</h4>Email : jean@michel.com<br>\n'
+            'partner_name : Not Jean Michel<br>\npartner_company_name : foo'))


### PR DESCRIPTION
# How to reproduce
- Add a contact form to your website
- Make it so the contact form creates a task on submit
- Remove some field from the contact form, but no the email (ex: Phone)
- Fill in the contact form; the email must be from one of the existing partners
- Submit the form and go look at the task in the project application

# The problem
The fields removed from the form are still present in the task's description (ex: partner_phone: False)

# Why
This commit (https://github.com/odoo/odoo/commit/7d0660e034f3be1b92869c266dc2cfb0bc6b6941) changed the way the partner's data was added to the description. When adding that data, it does not check if it exists before hand and instead adds a default value if not found.

opw-5920816

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
