### PR TITLE
[FIX] website_crm_partner_assign: use child_of for chatter access check

### DIFF
--- a/addons/website_crm_partner_assign/models/crm_lead.py
+++ b/addons/website_crm_partner_assign/models/crm_lead.py
@@ -352,9 +352,9 @@ class CrmLead(models.Model):
         # Allow readonly posting for assigned users, to avoid ACLs issue in frontend
         # as they do not have write access anymore on the lead itself, just specific
         # controllers and UI
-        assigned = self.filtered(
-            lambda lead: lead.partner_assigned_id == self.env.user.partner_id
-        ) if message_operation == "create" else self.browse()
+        assigned = self.filtered_domain([
+            ('partner_assigned_id', 'child_of', self.env.user.commercial_partner_id.id),
+        ]) if message_operation == "create" else self.browse()
         result = super()._mail_get_operation_for_mail_message_operation(message_operation)
         result.update(dict.fromkeys(assigned, 'read'))
         return result

--- a/addons/website_crm_partner_assign/tests/test_partner_assign.py
+++ b/addons/website_crm_partner_assign/tests/test_partner_assign.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 from odoo.exceptions import AccessError
 from odoo.fields import Command
-from odoo.tests.common import tagged, new_test_user, TransactionCase
+from odoo.tests.common import tagged, new_test_user, JsonRpcException, TransactionCase
 from odoo.tools import mute_logger
 
 from odoo.addons.base.tests.common import HttpCase
@@ -268,6 +268,60 @@ class TestPartnerLeadPortal(TestCrmCommon, HttpCase):
                 'message_type': 'comment',
             }
         )
+
+    def test_portal_post_child_contact_assigned(self):
+        """ Test that a child contact of the assigned partner can post a
+        message on the lead, and that an unrelated portal user cannot. """
+        child_partner = self.env['res.partner'].create({
+            'name': 'Child Portal Contact',
+            'parent_id': self.user_portal.partner_id.id,
+            'email': 'child.portal@test.example.com',
+        })
+        user_child_portal = mail_new_test_user(
+            self.env, login='user_child_portal',
+            partner_id=child_partner.id,
+            groups='base.group_portal',
+        )
+        self.authenticate(user_child_portal.login, user_child_portal.login)
+        result = self.make_jsonrpc_request(
+            route="/mail/message/post",
+            params={
+                'thread_model': self.lead_portal._name,
+                'thread_id': self.lead_portal.id,
+                'post_data': {
+                    'body': 'Test',
+                    'message_type': 'comment',
+                    'subtype_xmlid': 'mail.mt_comment',
+                },
+            },
+        )
+        message = self.env['mail.message'].browse(result['message_id'])
+        self.assertMessageFields(
+            message, {
+                'author_id': child_partner,
+                'body': '<p>Test</p>',
+                'message_type': 'comment',
+            },
+        )
+        # An unrelated portal user (not a child of the assigned partner) must not be able to post
+        unrelated_portal_user = mail_new_test_user(
+            self.env, login='user_unrelated_portal',
+            groups='base.group_portal',
+        )
+        self.authenticate(unrelated_portal_user.login, unrelated_portal_user.login)
+        with self.assertRaises(JsonRpcException), mute_logger('odoo.http'):
+            self.make_jsonrpc_request(
+                route="/mail/message/post",
+                params={
+                    'thread_model': self.lead_portal._name,
+                    'thread_id': self.lead_portal.id,
+                    'post_data': {
+                        'body': 'Should not post',
+                        'message_type': 'comment',
+                        'subtype_xmlid': 'mail.mt_comment',
+                    },
+                },
+            )
 
     def test_route_portal_my_opportunities_as_portal(self):
         """Test that the portal user can access its own opportunities even if


### PR DESCRIPTION
Steps to reproduce:
1) Create a partner contact form
2) Create a child contact for this partner, and grant it portal access
3) Create a customer contact form
4) Create an opportunity for the customer, with the previously created partner as "assigned partner"
5) Connect on the portal account of the partner
6) Send a message from an opportunity

When a company partner is assigned to an opportunity (instead of a specific contact person), posting a message in the chatter raised a 404 NotFound error.

_mail_get_operation_for_mail_message_operation was using a strict equality check (partner_assigned_id == user.partner_id), which fails when the assigned partner is the company and the user is a child contact under it.

Replace the equality check with a child_of domain filter on commercial_partner_id, consistent with the logic already used in _assert_portal_write_access.
