### PR TITLE
[FIX] account: set default account on journal creation

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -773,6 +773,7 @@ class AccountJournal(models.Model):
         )
         digits = len(random_account.code) if random_account else 6
 
+        Property = self.env['ir.property'].with_company(company)
         if journal_type in ('bank', 'cash'):
             has_liquidity_accounts = vals.get('default_account_id')
             has_profit_account = vals.get('profit_account_id')
@@ -803,6 +804,12 @@ class AccountJournal(models.Model):
                 vals['profit_account_id'] = company.default_cash_difference_income_account_id.id
             if journal_type in ('cash', 'bank') and not has_loss_account:
                 vals['loss_account_id'] = company.default_cash_difference_expense_account_id.id
+        elif journal_type == 'purchase':
+            if account := Property._get('property_account_expense_categ_id', 'product.category'):
+                vals.setdefault('default_account_id', account.id)
+        elif journal_type == 'sale':
+            if account := Property._get('property_account_income_categ_id', 'product.category'):
+                vals.setdefault('default_account_id', account.id)
 
         if is_import and not vals.get('code'):
             code = vals['name'][:5]

--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -810,6 +810,15 @@ class AccountJournal(models.Model):
             if not vals['code']:
                 raise UserError(_("Cannot generate an unused journal code. Please change the name for journal %s.", vals['name']))
 
+        # === Fill missing default account for sale/purchase journals ===
+        if journal_type in ('sale', 'purchase') and not vals.get('default_account_id'):
+            if journal_type == 'purchase':
+                default_account = self.env['ir.property'].with_company(company)._get('property_account_expense_categ_id', 'product.category')
+            else:
+                default_account = self.env['ir.property'].with_company(company)._get('property_account_income_categ_id', 'product.category')
+            if default_account:
+                vals['default_account_id'] = default_account.id
+
         # === Fill missing refund_sequence ===
         if 'refund_sequence' not in vals:
             vals['refund_sequence'] = vals['type'] in ('sale', 'purchase')

--- a/addons/account/tests/test_account_journal.py
+++ b/addons/account/tests/test_account_journal.py
@@ -390,3 +390,14 @@ class TestAccountJournalAlias(AccountTestInvoicingCommon, MailCommon):
             journal_form.default_account_id = default_account
             journal_2 = journal_form.save()
         self.assertNotEqual(journal_1.alias_id.alias_name, journal_2.alias_id.alias_name)
+
+    def test_new_purchase_journal_gets_default_account(self):
+        journal = self.env['account.journal'].create({
+            'name': 'Test Purchase',
+            'type': 'purchase',
+            'code': 'TPUR',
+        })
+        self.assertEqual(
+            journal.default_account_id,
+            self.env['ir.property'].with_company(journal.company_id)._get('property_account_expense_categ_id', 'product.category'),
+        )


### PR DESCRIPTION
When a user installs only the Invoicing app and creates a new purchase journal, no default_account_id is set on the journal. The Invoicing app does not expose account configuration, so the user cannot fix this manually. As a result, importing a Peppol XML invoice through that journal fails with a database constraint error because the generated account.move.line has a null account_id.

https://github.com/odoo/odoo/blob/16245530f0e3e9be21c8b96baaecd3a679420cac/addons/account/models/account_journal.py#L776-L805 This already auto-creates accounts for bank/cash journals, but does nothing for sale/purchase journals.

Steps to reproduce:
- Install the Invoicing app (no full Accounting)
- Create a new purchase journal with type 'purchase'
- Go to Vendors -> Bills and Upload a Peppol XML file
- Error importing attachment as invoice (decoder=_import_invoice_ubl_cii)

Ticket [link](https://www.odoo.com/odoo/action-4043/6014363)
opw-6014363