### PR TITLE
[FIX] l10n_latam_invoice_document: make custom headers work again

### DIFF
--- a/addons/l10n_latam_invoice_document/views/report_templates.xml
+++ b/addons/l10n_latam_invoice_document/views/report_templates.xml
@@ -17,10 +17,10 @@
 
     <template id="external_layout_standard" inherit_id="web.external_layout_standard" >
         <!-- support for custom header -->
-        <xpath expr="//img/../.." position="attributes">
+        <xpath expr="//div[contains(@t-attf-class, 'header')]" position="attributes">
             <attribute name="t-if">not custom_header</attribute>
         </xpath>
-        <xpath expr="//img/../.." position="after">
+        <xpath expr="//div[contains(@t-attf-class, 'header')]" position="after">
             <div t-attf-class="header o_company_#{company.id}_layout"
                  t-if="custom_header and company._localization_use_documents()">
                 <t t-call="#{custom_header}"/>
@@ -30,11 +30,12 @@
 
     <template id="external_layout_bubble" inherit_id="web.external_layout_bubble">
         <!-- support for custom header -->
-        <xpath expr="//img/../.." position="attributes">
+        <xpath expr="//div[contains(@t-attf-class, 'header')]" position="attributes">
             <attribute name="t-if">not custom_header</attribute>
         </xpath>
-        <xpath expr="//img/../.." position="after">
-            <div t-if="custom_header and company._localization_use_documents()">
+        <xpath expr="//div[contains(@t-attf-class, 'header')]" position="after">
+            <div t-attf-class="header o_company_#{company.id}_layout"
+                 t-if="custom_header and company._localization_use_documents()">
                 <t t-call="#{custom_header}"/>
             </div>
         </xpath>
@@ -42,11 +43,12 @@
 
     <template id="external_layout_wave" inherit_id="web.external_layout_wave">
         <!-- support for custom header -->
-        <xpath expr="//img/../.." position="attributes">
+        <xpath expr="//div[contains(@t-attf-class, 'header')]" position="attributes">
             <attribute name="t-if">not custom_header</attribute>
         </xpath>
-        <xpath expr="//img/../.." position="after">
-            <div t-if="custom_header and company._localization_use_documents()">
+        <xpath expr="//div[contains(@t-attf-class, 'header')]" position="after">
+            <div t-attf-class="header o_company_#{company.id}_layout"
+                 t-if="custom_header and company._localization_use_documents()">
                 <t t-call="#{custom_header}"/>
             </div>
         </xpath>
@@ -54,11 +56,12 @@
 
     <template id="external_layout_folder" inherit_id="web.external_layout_folder">
         <!-- support for custom header -->
-        <xpath expr="//img/../.." position="attributes">
+        <xpath expr="//div[contains(@t-attf-class, 'header')]" position="attributes">
             <attribute name="t-if">not custom_header</attribute>
         </xpath>
-        <xpath expr="//img/../.." position="after">
-            <div t-if="custom_header and company._localization_use_documents()">
+        <xpath expr="//div[contains(@t-attf-class, 'header')]" position="after">
+            <div t-attf-class="header o_company_#{company.id}_layout"
+                 t-if="custom_header and company._localization_use_documents()">
                 <t t-call="#{custom_header}"/>
             </div>
         </xpath>


### PR DESCRIPTION
The document layout was made more flexible [1], but in the process the custom_header feature broke. The xpath was targeting a `<tr>` instead of the `<div>` it was meant to replace. Change it to target the right `<div>` in a slightly more robust way. Also consistently add the same header classes to the replacement `<div>`s in all the themes.

[1] https://github.com/odoo/odoo/pull/237109

task-5949275

Backport of https://github.com/odoo/odoo/pull/251341.
