### PR TITLE
[18.0][FIX] product: allow adding attributes to archived product templates

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -394,7 +394,7 @@ class ProductProduct(models.Model):
 
         # Check if products still exists, in case they've been unlinked by unlinking their template
         existing_products = self.exists()
-        product_ids_by_template_id = {template.id: set(ids) for template, ids in self._read_group(
+        product_ids_by_template_id = {template.id: set(ids) for template, ids in self.with_context(active_test=False)._read_group(
             domain=[('product_tmpl_id', 'in', existing_products.product_tmpl_id.ids)],
             groupby=['product_tmpl_id'],
             aggregates=['id:array_agg'],

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -795,7 +795,8 @@ class ProductTemplate(models.Model):
             variants_to_unlink += all_variants - current_variants_to_activate
 
         if variants_to_activate:
-            variants_to_activate.write({'active': True})
+            # Only activate variants whose template is active
+            variants_to_activate.filtered(lambda v: v.product_tmpl_id.active).write({'active': True})
         if variants_to_create:
             Product.create(variants_to_create)
         if variants_to_unlink:

--- a/addons/product/tests/test_variants.py
+++ b/addons/product/tests/test_variants.py
@@ -1450,6 +1450,37 @@ class TestVariantsArchive(ProductVariantsCommon):
         (multiple_archived + multiple_active).unlink()
         self.assertFalse(products.exists())
 
+    @mute_logger('odoo.models.unlink')
+    def test_add_attribute_to_archived_template(self):
+        template = self.env['product.template'].create({
+            'name': 'Test Product',
+            'attribute_line_ids': [Command.create({
+                'attribute_id': self.size_attribute.id,
+                'value_ids': [Command.link(self.size_attribute_s.id)],
+            })]
+        })
+        self.assertEqual(len(template.product_variant_ids), 1)
+        template_id = template.id
+        template.action_archive()
+        self.assertFalse(template.active)
+        template.write({
+            'attribute_line_ids': [Command.create({
+                'attribute_id': self.color_attribute.id,
+                'value_ids': [
+                    Command.link(self.color_attribute_red.id),
+                    Command.link(self.color_attribute_blue.id),
+                ],
+            })]
+        })
+        template = self.env['product.template'].browse(template_id).with_context(active_test=False)
+        self.assertTrue(template.exists(), "Template should not be deleted when adding attributes to archived template")
+        self.assertFalse(template.active, "Template should remain archived")
+        # Verify new variants are created but remain archived
+        all_variants = template.product_variant_ids
+        self.assertEqual(len(all_variants), 2, "Should create 2 variants: S+Red and S+Blue")
+        for variant in all_variants:
+            self.assertFalse(variant.active, "Variants should remain archived when template is archived")
+
 @tagged('post_install', '-at_install')
 class TestVariantWrite(TransactionCase):
 


### PR DESCRIPTION
When adding attributes to an archived product template, an error was raised because the template was incorrectly deleted. This happened because variant counting only considered active variants.

Now counts all variants (active and archived) to prevent template deletion, and filters variants before activation to keep them archived when their template is archived.

@qrtl QT6449