### PR TITLE
[IMP] website_sale: open Product Feeds list view instead of dialog

### DIFF
--- a/addons/website_sale/models/res_config_settings.py
+++ b/addons/website_sale/models/res_config_settings.py
@@ -145,7 +145,6 @@ class ResConfigSettings(models.TransientModel):
             "type": "ir.actions.act_window",
             "res_model": "product.feed",
             "views": [(False, "list")],
-            "target": "new",
             "context": {"default_website_id": self.website_id.id, "hide_website_column": True},
             "domain": [("website_id", "=", self.website_id.id)],
         }


### PR DESCRIPTION
Before the commit:
- Clicking 'Manage feeds' opened the Product Feeds in a dialog window.
- The dialog was missing the 'New' button, making it harder to create new feeds.

After the commit:
- Updated the 'Manage feeds' link to open the Product Feeds list view directly instead of a dialog.

task-6014563