### PR TITLE
[FIX] mail: add text start class

### DIFF
--- a/addons/mail/static/src/views/web/fields/avatar/avatar.xml
+++ b/addons/mail/static/src/views/web/fields/avatar/avatar.xml
@@ -7,7 +7,7 @@
                 t-att-src="this.src"
                 t-on-click.stop.prevent="this.onClickAvatar"
             />
-            <span t-if="this.props.displayName" class="text-truncate w-0 flex-grow-1" t-out="this.props.displayName"/>
+            <span t-if="this.props.displayName" class="text-truncate w-0 flex-grow-1 text-start fw-normal" t-out="this.props.displayName"/>
         </div>
     </t>
 


### PR DESCRIPTION
Steps to reproduce:
- Go to any record where the user avatar/name is shown
- The name appears styled like a button/link

Before this PR, the avatar name (e.g., Mitchell Admin) was displayed as a clickable button because `btn btn-link-inline` classes were added to the div in this PR : https://github.com/odoo/odoo/pull/250051/changes#diff-f7871cd65a80efb8402c739e292e355de520ffeb9c25e6e6da945614b1e0171eR5.

After this PR, add `start-text` classes from the avatar name span so the name displays normally without button styling.

Task -6007958

