### PR TITLE
[IMP] l10n_in_pos: to invoice toggle based on GST treatment

### DIFF
--- a/addons/l10n_in_pos/models/__init__.py
+++ b/addons/l10n_in_pos/models/__init__.py
@@ -11,4 +11,5 @@ from . import pos_bill
 from . import pos_session
 from . import pos_order
 from . import pos_config
+from . import res_partner
 from . import res_company

--- a/addons/l10n_in_pos/models/res_partner.py
+++ b/addons/l10n_in_pos/models/res_partner.py
@@ -1,0 +1,12 @@
+from odoo import api, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.partner"
+
+    @api.model
+    def _load_pos_data_fields(self, config):
+        fields = super()._load_pos_data_fields(config)
+        if self.env.company.country_id.code == 'IN':
+            fields += ['l10n_in_gst_treatment']
+        return fields

--- a/addons/l10n_in_pos/static/src/app/models/pos_order.js
+++ b/addons/l10n_in_pos/static/src/app/models/pos_order.js
@@ -7,6 +7,23 @@ patch(PosOrder.prototype, {
     get isInCompany() {
         return this.company.country_id?.code === "IN";
     },
+    setPartner(partner) {
+        super.setPartner(partner);
+
+        if (!this.isInCompany) {
+            return;
+        }
+
+        const l10n_in_gst_treatment = partner?.l10n_in_gst_treatment;
+        if (
+            !l10n_in_gst_treatment ||
+            ["unregistered", "consumer"].includes(l10n_in_gst_treatment)
+        ) {
+            this.setToInvoice(false);
+        } else {
+            this.setToInvoice(true);
+        }
+    },
     _prepareL10nInHsnSummary() {
         const company = this.company;
         const orderLines = this.lines;

--- a/addons/l10n_in_pos/static/src/app/models/pos_order.js
+++ b/addons/l10n_in_pos/static/src/app/models/pos_order.js
@@ -7,6 +7,24 @@ patch(PosOrder.prototype, {
     get isInCompany() {
         return this.company.country_id?.code === "IN";
     },
+    setPartner(partner) {
+        super.setPartner(partner);
+
+        if (!this.isInCompany) {
+            return;
+        }
+
+        const l10n_in_gst_treatment = partner?.l10n_in_gst_treatment;
+        if (
+            !partner?.vat ||
+            !l10n_in_gst_treatment ||
+            ["unregistered", "consumer", "overseas"].includes(l10n_in_gst_treatment)
+        ) {
+            this.setToInvoice(false);
+        } else {
+            this.setToInvoice(true);
+        }
+    },
     _prepareL10nInHsnSummary() {
         const company = this.company;
         const orderLines = this.lines;


### PR DESCRIPTION
### **PURPOSE**
 - Currently, we enable Invoice checked based on 'is_company' (i.e Contact Type)
 - However, in India, for businesses registered under GST, It is mandatory to issue a Tax Invoice.

### **SPECIFICATION**
 - Invoice generation in POS must be determined based on GST Treatment Type
 - If the contact’s GST Treatment Type is not equal to “Consumer,” not equal to “Unregistered,” and not empty. Treat it as B2B and make the invoice boolean True.
 - For all other cases than this, treat it as B2C and make invoice boolean False

task-4894111