### PR TITLE
[FIX] web: set min-height to fields on touch devices

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -1240,6 +1240,8 @@
 
             &:not(.o_field_widget *):not(.o_input_box_overlay_start, .o_input_box_overlay_end) {
                 line-height: calc(2.5 * var(--inputbox-spacing-unit));
+                // input boxes should always have at least the height of: line-height + vertical padding + border width
+                min-height: calc((2.5 + 2) * var(--inputbox-spacing-unit) + 2 * var(--fieldWidget-outline-width));
 
                 .o_input, textarea, select, [contenteditable] {
                     border: none;

--- a/addons/web/static/tests/views/fields/char_field.test.js
+++ b/addons/web/static/tests/views/fields/char_field.test.js
@@ -935,3 +935,23 @@ test("edit a char field should display the status indicator buttons without flic
     });
     expect.verifySteps(["onchange"]);
 });
+
+test("editable and readonly/empty fields have the same minimum size", async () => {
+    Partner._records[0].name = false;
+    // The o_input_box border is only visible on touch devices, using css rules
+    document.body.classList.add("o_touch_device");
+    await mountView({
+        type: "form",
+        resModel: "res.partner",
+        resId: 1,
+        arch: `
+        <form>
+            <field name="name"/>
+            <field name="name" readonly="1"/>
+            <field name="int_field"/>
+        </form>`,
+    });
+    const targetSize = Math.floor(queryFirst(".o_field_widget").getBoundingClientRect().height);
+    expect(Math.floor(queryFirst(".o_field_widget.o_readonly_modifier").getBoundingClientRect().height)).toBe(targetSize);
+    expect(Math.floor(queryFirst(".o_field_widget[name='int_field']").getBoundingClientRect().height)).toBe(targetSize);
+});


### PR DESCRIPTION
This commit adds an minimum height to any field using an input box to ensure a consistent display. Even when the field is empty, or displays a different type of content (favorites, progressbar, etc.)

A test has been added as well, to make sure the field has the right size.

task-6019135