### PR TITLE
[FIX] l10n_ar: restrict Argentinean partner detection to country 'AR'

### DIFF
--- a/addons/l10n_ar/models/res_partner.py
+++ b/addons/l10n_ar/models/res_partner.py
@@ -55,10 +55,10 @@ class ResPartner(models.Model):
     @api.depends('l10n_latam_identification_type_id', 'l10n_ar_vat')
     def _compute_is_company(self):
         "True if partner is considered a company in Argentina, based on Identification Type and CUIT prefix."
-        l10n_ar_partners = self.filtered(lambda p: p.vat and (
+        l10n_ar_partners = self.filtered(lambda p: p.vat and
             p.l10n_latam_identification_type_id.l10n_ar_afip_code
-            or p.country_code == 'AR'
-        ))
+            and p.country_code == 'AR'
+        )
         for partner in l10n_ar_partners:
             afip_code = partner.l10n_latam_identification_type_id.l10n_ar_afip_code
             prefix = (partner.l10n_ar_vat or '')[:2]

--- a/addons/l10n_ar/tests/test_manual.py
+++ b/addons/l10n_ar/tests/test_manual.py
@@ -309,6 +309,17 @@ class TestArManual(common.TestArCommon):
             'subtotals': [],
         })
 
+    def test_l10n_ar_is_company(self):
+        """Check that `is_company` is computed correctly for AR and non-AR partners."""
+        foreign_partner = self.env['res.partner'].create({
+            'name': "Foreign Partner",
+            'country_id': self.env.ref('base.us').id,
+            'l10n_latam_identification_type_id': self.env.ref('l10n_latam_base.it_fid').id,
+            'vat': '1234567890',
+        })
+        self.assertTrue(self.res_partner_adhoc.is_company, "AR partners with company CUIT should be companies.")
+        self.assertTrue(foreign_partner.is_company, "Foreign partners should not be computed based on AR CUIT rules.")
+
     def test_l10n_ar_prices_and_taxes(self):
         invoice = self.env['account.move'].create({
             "move_type": 'out_invoice',


### PR DESCRIPTION
In `_compute_is_company`, partners were identified as Argentinean (`l10n_ar_partners`) if their identification type had an AFIP code.

However, some foreign identification types also carry an AFIP code (e.g., US 'it_fid' uses AFIP code '91'). This caused foreign partners to be incorrectly identified as Argentinean, which led to incorrect `is_company` computation for those records.

This change ensures that only partners actually located in Argentina are processed using the local identification heuristic.

runbot-241126
