### PR TITLE
[IMP] base, {test_}mail, {test_}tool: make attachment links impossibl…

### DIFF
--- a/addons/mail/data/mail_templates_mailgateway.xml
+++ b/addons/mail/data/mail_templates_mailgateway.xml
@@ -41,13 +41,16 @@
         </template>
 
         <template id="mail_attachment_links" name="Attachment links">
-<div style="max-width: 900px; width: 100%;">
-    <hr style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 16px 0px 10px 0px;"/>
-    <div t-foreach="attachments" t-as="attachment">
-        <a t-attf-href="{{attachment.get_base_url()}}/web/content/{{attachment.id}}?download=1&amp;access_token={{attachment.access_token}}"
-           style="font-size: 12px; color: #875A7B; text-decoration:none !important; text-decoration:none; font-weight: 400;">
-            &amp;#128229; <t t-out="attachment.name"/>
-        </a>
+<div t-if="attachments" style="margin-top: 10px; margin-bottom: 10px; display: flex; flex-wrap:wrap; max-width: 900px; width: 100%;">
+    <div t-foreach="attachments" t-as="attachment" style="padding:0; margin:3px; vertical-align:middle; min-width:425px; width:fit-content; display:inline-block"
+        width="fit-content">
+        <div style="margin:0; padding: 10px; border-style:solid; border-width:0 0 0 3px; border-radius:5px; border-color:#a2dae3; background-color:#d1ecf1; color:#09414a;">
+            <a t-attf-href="{{attachment.get_base_url()}}/web/content/{{attachment.id}}?download=1&amp;access_token={{attachment.access_token}}"
+                style="margin:0; padding:0; text-decoration:none; border-radius:0; border-style:none; border-color:#008f8c; border-width:0; font-weight:500; width:100%; color:#008f8c"
+                width="100%" target="_blank">
+                <span style="filter: grayscale(1);">&amp;#128229;</span> <t t-out="attachment.name"/>
+            </a>
+        </div>
     </div>
 </div>
         </template>

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -480,7 +480,8 @@ class MailMail(models.Model):
         if url_attachments:
             url_attachments.sudo().generate_access_token()
             attachments_links = self.env['ir.qweb']._render('mail.mail_attachment_links', {'attachments': url_attachments})
-            body = tools.mail.append_content_to_html(body, attachments_links, plaintext=False)
+            body = tools.mail.append_content_to_html(body, attachments_links, plaintext=False,
+                                                     before_classes=["o-signature-container", "o_signature"])
             attachments -= url_attachments
 
         # Turn remaining attachments into links if they are too heavy and
@@ -490,14 +491,14 @@ class MailMail(models.Model):
                 lambda a: a.res_model and a.res_id and a.res_model != 'mail.message'):
             estimated_email_size_bytes = self._estimate_email_size(
                 headers, body, [a.file_size for a in attachments.sudo()])
-            max_email_size_bytes = (mail_server or self.env['ir.mail_server']
-                                    ).sudo()._get_max_email_size() * 1024 * 1024
+            max_email_size_bytes = self.env['ir.mail_server'].sudo()._get_max_email_size() * 1024 * 1024
             if estimated_email_size_bytes > max_email_size_bytes:
                 # Remove attachments and prepare downloadable links to be added in the body
                 record_owned_attachments.sudo().generate_access_token()
                 attachments_links = self.env['ir.qweb']._render('mail.mail_attachment_links',
                                                                 {'attachments': record_owned_attachments})
-                body = tools.mail.append_content_to_html(body, attachments_links, plaintext=False)
+                body = tools.mail.append_content_to_html(
+                    body, attachments_links, plaintext=False, before_classes=["o-signature-container", "o_signature"])
                 attachments -= record_owned_attachments
         # attachments sorted by increasing ID to match front-end and upload ordering
         attachments.sudo().fetch(['name', 'raw', 'mimetype'])

--- a/addons/mail/static/src/core/web/mail_composer_attachment_selector.js
+++ b/addons/mail/static/src/core/web/mail_composer_attachment_selector.js
@@ -4,18 +4,27 @@ import { standardFieldProps } from "@web/views/fields/standard_field_props";
 import { useService } from "@web/core/utils/hooks";
 import { useX2ManyCrud } from "@web/views/fields/relational_utils";
 
-import { Component } from "@odoo/owl";
+import { Component, onMounted } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
 import { FileUploader } from "@web/views/fields/file_handler";
 
 export class MailComposerAttachmentSelector extends Component {
     static template = "mail.MailComposerAttachmentSelector";
     static components = { FileUploader };
-    static props = { ...standardFieldProps };
+    static props = {
+        ...standardFieldProps,
+        maxEmailSizeField: { type: String, optional: true },
+    };
 
     setup() {
         this.mailStore = useService("mail.store");
         this.attachmentUploadService = useService("mail.attachment_upload");
         this.operations = useX2ManyCrud(() => this.props.record.data["attachment_ids"], true);
+        // Turn attachments into links if needed when opening the composer.
+        onMounted(() => {
+            // The delay is required for the html-editor to be ready to receive the event that does the work.
+            setTimeout(this.inlineAttachmentIfNeeded.bind(this), 1000);
+        });
     }
 
     /** @param {Object} data */
@@ -39,10 +48,48 @@ export class MailComposerAttachmentSelector extends Component {
             await this.operations.saveRecord([attachment.id]);
         }
     }
+
+    /**
+     * Turn attachments into link if the mail exceeds the configured maximum size (if provided).
+     *
+     * Note that this method emits the ADD_INLINE_ATTACHMENTS events to turn the attachments into links.
+     */
+    inlineAttachmentIfNeeded() {
+        const maxEmailSize =
+            this.props.maxEmailSizeField && this.props.record.data[this.props.maxEmailSizeField];
+        if (!maxEmailSize) {
+            return;
+        }
+        const totalSize = this.props.record.data.attachment_ids.records
+            .map((a) => a.data.file_size)
+            .reduce((acc, current) => acc + current, 0);
+        // The server estimate not only the attachment size but also the content, see mail_mail._estimate_email_size
+        const emailOverhead = 100 * 1024;
+        if (totalSize + emailOverhead > maxEmailSize * 1024 * 1024) {
+            this.env.fullComposerBus.trigger("ADD_INLINE_ATTACHMENTS", {
+                attachments: this.props.record.data.attachment_ids.records,
+                message: _t(
+                    "Your attachments exceed %(maxSizeInMB)sMB and will be sent as secure links to ensure they reach your recipients",
+                    {
+                        maxSizeInMB: Math.round(maxEmailSize),
+                    }
+                ),
+            });
+        }
+    }
 }
 
 export const mailComposerAttachmentSelector = {
     component: MailComposerAttachmentSelector,
+    extractProps: (fieldInfo, _) => ({
+        maxEmailSizeField: fieldInfo.options.max_email_size_field,
+    }),
+    relatedFields: () => {
+        return [
+            { name: "file_size", type: "integer", readOnly: true },
+            { name: "id", type: "integer", readonly: true },
+        ];
+    },
 };
 
 registry

--- a/addons/mail/static/src/core/web/mail_composer_attachment_selector.xml
+++ b/addons/mail/static/src/core/web/mail_composer_attachment_selector.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates>
     <t t-name="mail.MailComposerAttachmentSelector">
-        <FileUploader multiUpload="true" onUploaded.bind="this.onFileUploaded">
+        <!-- This template is used by mail_attachments_selector without the method inlineAttachmentIfNeeded -->
+        <FileUploader multiUpload="true" onUploaded.bind="this.onFileUploaded"
+            onUploadComplete="() => this.inlineAttachmentIfNeeded?.()">
             <t t-set-slot="toggler">
                 <button class="btn btn-light w-auto" data-hotkey="a" title="Add Attachment">
                     <i class="fa fa-fw fa-paperclip"/>

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.js
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.js
@@ -1,7 +1,8 @@
 import { DYNAMIC_FIELD_PLUGINS } from "@html_editor/backend/dynamic_field/dynamic_field_plugin";
+import { FilePlugin } from "@html_editor/main/media/file_plugin";
 import { isEmpty } from "@html_editor/utils/dom_info";
 import { registry } from "@web/core/registry";
-import { useBus } from "@web/core/utils/hooks";
+import { useBus, useService } from "@web/core/utils/hooks";
 import { HtmlMailField, htmlMailField } from "../html_mail_field/html_mail_field";
 import { MailFullComposerSuggestionPlugin } from "./mail_full_composer_suggestion_plugin";
 import { ContentExpandablePlugin } from "./content_expandable_plugin";
@@ -12,6 +13,7 @@ import { markup } from "@odoo/owl";
 export class HtmlComposerMessageField extends HtmlMailField {
     setup() {
         super.setup();
+        const notification = useService("notification");
         if (this.env.fullComposerBus) {
             useBus(this.env.fullComposerBus, "ACCIDENTAL_DISCARD", (ev) => {
                 const elContent = this.getNoSignatureElContent();
@@ -23,6 +25,50 @@ export class HtmlComposerMessageField extends HtmlMailField {
                 );
                 const composerHtml = markup(this.getNoSignatureElContent().innerHTML);
                 ev.detail.onSaveContent({ composerHtml, emailAddSignature });
+            });
+            useBus(this.env.fullComposerBus, "ADD_INLINE_ATTACHMENTS", async (ev) => {
+                const filePlugin = this.editor.plugins.find(
+                    (p) => p.constructor.id === FilePlugin.id
+                );
+                if (!filePlugin) {
+                    return;
+                }
+                const attachments = ev.detail.attachments.map((a) => a.data);
+                // Filter out already added attachments
+                const filteredAttachments = attachments.filter(
+                    (a) =>
+                        !this.editor.editable.querySelectorAll(`[data-attachment-id="${a.id}"]`)
+                            .length
+                );
+                if (!filteredAttachments.length) {
+                    return;
+                }
+                const attachmentContainer = this.editor.editable.querySelector(
+                    ".o-attachments-container"
+                );
+                if (!attachmentContainer) {
+                    const newAttachmentContainer = document.createElement("div");
+                    newAttachmentContainer.classList.add(
+                        "o-attachments-container",
+                        "o-contenteditable-false"
+                    );
+                    newAttachmentContainer.contentEditable = false;
+                    attachments.forEach((a) =>
+                        newAttachmentContainer.appendChild(filePlugin.renderDownloadBox(a))
+                    );
+                    const signature = this.editor.editable.querySelector(".o-signature-container");
+                    if (signature) {
+                        signature.before(newAttachmentContainer);
+                    } else {
+                        this.editor.editable.firstChild.before(newAttachmentContainer);
+                    }
+                } else {
+                    filteredAttachments.forEach((a) =>
+                        attachmentContainer.appendChild(filePlugin.renderDownloadBox(a))
+                    );
+                }
+                this.editor.shared.history.addStep();
+                notification.add(ev.detail.message, { type: "info" });
             });
             useBus(this.env.fullComposerBus, "ATTACHMENT_REMOVED", (ev) => {
                 const attachmentElements = this.editor.editable.querySelectorAll(

--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -192,6 +192,7 @@ class MailComposeMessage(models.TransientModel):
     use_exclusion_list = fields.Boolean(
         'Use Exclusion List', default=True, copy=False,
         help='Prevent sending messages to blacklisted contacts. Disable only when absolutely necessary.')
+    max_email_size = fields.Float("Max Email Size in MB", compute="_compute_max_email_size")
     # template generation
     template_name = fields.Char('Template Name')
 
@@ -684,6 +685,10 @@ class MailComposeMessage(models.TransientModel):
         if field.compute_sudo:
             return super(MailComposeMessage, self.with_context(prefetch_fields=False))._compute_field_value(field)
         return super()._compute_field_value(field)
+
+    @api.depends('mail_server_id')
+    def _compute_max_email_size(self):
+        self.max_email_size = self.env['ir.mail_server'].sudo()._get_max_email_size()
 
     # ------------------------------------------------------------
     # CRUD / ORM

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -37,6 +37,7 @@
                         <field name="subtype_id" invisible="1"/>
                         <field name="subtype_is_log" invisible="1"/>
                         <field name="use_exclusion_list" invisible="1"/>
+                        <field name="max_email_size" invisible="1"/>
                         <!-- visible wizard -->
                         <field name="email_from"
                             invisible="composition_mode != 'mass_mail'"/>
@@ -98,7 +99,8 @@
                         <button string="Schedule" name="action_schedule_message" type="object" class="btn-primary" data-hotkey="q" disabled="1"
                                 invisible="(composition_mode != 'comment' or composition_batch or not scheduled_date) or partner_ids_all_have_email"/>
                         <button class="btn-secondary" special="cancel" data-hotkey="x"/>
-                        <field name="attachment_ids" widget="mail_composer_attachment_selector" invisible="not can_edit_body"/>
+                        <field name="attachment_ids" widget="mail_composer_attachment_selector" invisible="not can_edit_body"
+                            options="{'max_email_size_field': 'max_email_size'}"/>
                         <field name="scheduled_date" widget="text_scheduled_date" invisible="composition_batch or composition_mode != 'comment'"/>
                         <field name="template_id" widget="mail_composer_template_selector"/>
                     </footer>

--- a/addons/test_mail/tests/test_mail_mail.py
+++ b/addons/test_mail/tests/test_mail_mail.py
@@ -1024,7 +1024,7 @@ class TestMailMailServer(MailCommon):
         email content.
 
         The feature is tested in the following conditions:
-        - using a specified server or the default one (to test command ICP parameter)
+        - using a specified server or the default one
         - in batch mode
         - with mail that exceed (with one or more attachments) or not the limit
         - with attachment owned by a business record or not: attachments not owned by a
@@ -1053,7 +1053,7 @@ class TestMailMailServer(MailCommon):
                 (3, self.env['ir.mail_server'], True, True),
                 # 1 attachment: exceed max size
                 (1, self.env['ir.mail_server'], True, True),
-                # Same as above with a specific server. Note that the default and server max_email size are reversed.
+                # Same as above with a specific server as the max_email_size is global
                 (1, test_mail_server, True, False),
                 (3, test_mail_server, True, True),
                 (1, test_mail_server, True, True),
@@ -1064,15 +1064,9 @@ class TestMailMailServer(MailCommon):
             # Setup max email size to check that the right maximum is used (default or mail server one)
             if expected_is_links:
                 max_size_test_succeed = max_size_always_exceed * n_attachment
-                max_size_test_fail = max_size_never_exceed
             else:
                 max_size_test_succeed = max_size_never_exceed
-                max_size_test_fail = max_size_always_exceed * n_attachment
-            if mail_server:
-                self.env['ir.config_parameter'].sudo().set_float('base.default_max_email_size', max_size_test_fail)
-                mail_server.max_email_size = max_size_test_succeed
-            else:
-                self.env['ir.config_parameter'].sudo().set_float('base.default_max_email_size', max_size_test_succeed)
+            self.env['ir.config_parameter'].sudo().set_float('base.default_max_email_size', max_size_test_succeed)
 
             attachments = self.env['ir.attachment'].sudo().create([{
                 'name': f'attachment{idx_attachment}',

--- a/odoo/addons/base/data/ir_config_parameter_data.xml
+++ b/odoo/addons/base/data/ir_config_parameter_data.xml
@@ -3,7 +3,7 @@
     <data noupdate="1">
         <record id="default_max_email_size" model="ir.config_parameter">
             <field name="key">base.default_max_email_size</field>
-            <field name="value">10</field>
+            <field name="value">20</field>
         </record>
     </data>
 </odoo>

--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -272,10 +272,9 @@ class IrMail_Server(models.Model):
         """
         return dict()
 
+    @api.model
     def _get_max_email_size(self):
-        if self.max_email_size:
-            return self.max_email_size
-        return self.env['ir.config_parameter'].sudo().get_float('base.default_max_email_size') or 10
+        return self.env['ir.config_parameter'].sudo().get_float('base.default_max_email_size') or 20
 
     def _get_test_email_from(self):
         self.ensure_one()
@@ -297,16 +296,13 @@ class IrMail_Server(models.Model):
     def _get_test_email_to(self):
         return "noreply@odoo.com"
 
-    def test_smtp_connection(self, autodetect_max_email_size=False):
-        """Test the connection and if autodetect_max_email_size, set auto-detected max email size.
+    def test_smtp_connection(self):
+        """Test the connection.
 
-        :param bool autodetect_max_email_size: whether to autodetect the max email size
-        :return: client action to notify the user of the result of the operation (connection test or
-            auto-detection successful depending on the ``autodetect_max_email_size`` parameter)
+        :return: client action to notify the user of the result of the operation
         :rtype: dict
 
-        :raises UserError: if the connection fails and if ``autodetect_max_email_size`` and
-            the server doesn't support the auto-detection of email max size
+        :raises UserError: if the connection fails
         """
         for server in self:
             smtp = False
@@ -329,12 +325,6 @@ class IrMail_Server(models.Model):
                 (code, repl) = smtp.getreply()
                 if code != 354:
                     raise UserError(_('The server refused the test connection with error %(repl)s', repl=repl))  # noqa: TRY301
-                if autodetect_max_email_size:
-                    max_size = smtp.esmtp_features.get('size')
-                    if not max_size:
-                        raise UserError(_('The server "%(server_name)s" doesn\'t return the maximum email size.',
-                                          server_name=server.name))
-                    server.max_email_size = float(max_size) / (1024 ** 2)
             except (UnicodeError, idna.core.InvalidCodepoint) as e:
                 raise UserError(_("Invalid server name!\n %s", e)) from e
             except (gaierror, timeout) as e:
@@ -363,27 +353,16 @@ class IrMail_Server(models.Model):
                 except Exception:
                     # ignored, just a consequence of the previous exception
                     pass
-
-        if autodetect_max_email_size:
-            message = _(
-                'Email maximum size updated (%(details)s).',
-                details=', '.join(f'{server.name}: {human_size(server.max_email_size * 1024 ** 2)}' for server in self))
-        else:
-            message = _('Connection Test Successful!')
         return {
             'type': 'ir.actions.client',
             'tag': 'display_notification',
             'params': {
-                'message': message,
+                'message': _('Connection Test Successful!'),
                 'type': 'success',
                 'sticky': False,
                 'next': {'type': 'ir.actions.act_window_close'},  # force a form reload
             },
         }
-
-    def action_retrieve_max_email_size(self):
-        self.ensure_one()
-        return self.test_smtp_connection(autodetect_max_email_size=True)
 
     @classmethod
     def _disable_send(cls):

--- a/odoo/addons/base/views/ir_mail_server_views.xml
+++ b/odoo/addons/base/views/ir_mail_server_views.xml
@@ -19,17 +19,6 @@
                             </group>
                             <group>
                                 <field name="sequence"/>
-                                <div colspan="2" class="d-flex justify-content-between">
-                                    <div>
-                                        <label for="max_email_size"
-                                               string="Convert attachments to links for emails over"/>
-                                        <field name="max_email_size" class="oe_inline mx-1"/>
-                                        <span class="o_form_label">MB</span>
-                                    </div>
-                                    <button class="btn btn-link pt-0" type="object" name="action_retrieve_max_email_size">
-                                        <i class="fa fa-gear"/> Detect Max Limit
-                                    </button>
-                                </div>
                             </group>
                         </group>
                         <group>

--- a/odoo/addons/test_tools/tests/test_mail.py
+++ b/odoo/addons/test_tools/tests/test_mail.py
@@ -484,17 +484,29 @@ class TestHtmlTools(BaseCase):
 
     def test_append_to_html(self):
         test_samples = [
-            ('<!DOCTYPE...><HTML encoding="blah">some <b>content</b></HtMl>', '--\nYours truly', True, True, False,
+            ('<!DOCTYPE...><HTML encoding="blah">some <b>content</b></HtMl>', '--\nYours truly', True, True, False, False,
              '<!DOCTYPE...><html encoding="blah">some <b>content</b>\n<pre>--\nYours truly</pre>\n</html>'),
-            ('<!DOCTYPE...><HTML encoding="blah">some <b>content</b></HtMl>', '--\nYours truly', True, False, False,
+            ('<!DOCTYPE...><HTML encoding="blah">some <b>content</b></HtMl>', '--\nYours truly', True, False, False, False,
              '<!DOCTYPE...><html encoding="blah">some <b>content</b>\n<p>--<br/>Yours truly</p>\n</html>'),
-            ('<html><body>some <b>content</b></body></html>', '--\nYours & <truly>', True, True, False,
+            ('<html><body>some <b>content</b></body></html>', '--\nYours & <truly>', True, True, False, False,
              '<html><body>some <b>content</b>\n<pre>--\nYours &amp; &lt;truly&gt;</pre>\n</body></html>'),
-            ('<html><body>some <b>content</b></body></html>', '<!DOCTYPE...>\n<html><body>\n<p>--</p>\n<p>Yours truly</p>\n</body>\n</html>', False, False, False,
+            ('<html><body>some <b>content</b></body></html>', '<!DOCTYPE...>\n<html><body>\n<p>--</p>\n<p>Yours truly</p>\n</body>\n</html>', False, False, False, False,
              '<html><body>some <b>content</b>\n\n\n<p>--</p>\n<p>Yours truly</p>\n\n\n</body></html>'),
+            ('<html><body>Hello <div class="o-signature-container"><div class="o_signature">Marc Demo</div></div></body></html>',
+             Markup('<div>attachments</div>'), False, False, False, ['o-signature-container', 'o_signature'],
+             '<html><body>Hello \n<div>attachments</div>\n<div class="o-signature-container"><div class="o_signature">Marc Demo</div></div></body></html>'),
+            ('<html><body>Hello <DIV class="o_signature">Marc Demo</DIV></body></html>',
+             Markup('<div>attachments</div>'), False, False, False, ['o-signature-container', 'o_signature'],
+             '<html><body>Hello \n<div>attachments</div>\n<div class="o_signature">Marc Demo</div></body></html>'),
+            ('<html><body>Hello\n \n--- Marc Demo</body></html>',
+             Markup('<div>attachments</div>'), False, False, False, ['o-signature-container', 'o_signature'],
+             '<html><body>Hello\n \n--- Marc Demo\n<div>attachments</div>\n</body></html>'),
+            ('<html><body>Hello\n \n--- Marc Demo</body></html>',
+             'Text before < signature', True, True, False, ['o-signature-container', 'o_signature'],
+             '<html><body>Hello\n \n--- Marc Demo\n<pre>Text before &lt; signature</pre>\n</body></html>'),
         ]
-        for html, content, plaintext_flag, preserve_flag, container_tag, expected in test_samples:
-            self.assertEqual(append_content_to_html(html, content, plaintext_flag, preserve_flag, container_tag), expected, 'append_content_to_html is broken')
+        for html, content, plaintext_flag, preserve_flag, container_tag, before_classes, expected in test_samples:
+            self.assertEqual(append_content_to_html(html, content, plaintext_flag, preserve_flag, container_tag, before_classes), expected, 'append_content_to_html is broken')
 
     def test_is_html_empty(self):
         void_strings_samples = ['', False, ' ']

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -700,7 +700,8 @@ def plaintext2html(text: str, container_tag: str | None = None, with_paragraph: 
         final = '<%s>%s</%s>' % (container_tag, final, container_tag)
     return markupsafe.Markup(final)
 
-def append_content_to_html(html, content, plaintext=True, preserve=False, container_tag=None):
+
+def append_content_to_html(html, content, plaintext=True, preserve=False, container_tag=None, before_classes=None):
     """ Append extra content at the end of an HTML snippet, trying
         to locate the end of the HTML document (</body>, </html>, or
         EOF), and converting the provided content in html unless ``plaintext``
@@ -723,6 +724,8 @@ def append_content_to_html(html, content, plaintext=True, preserve=False, contai
         :param bool preserve: if content is plaintext, wrap it into a <pre>
             instead of converting it into html
         :param str container_tag: tag to wrap the content into, defaults to `div`.
+        :param List[str] before_classes: try to append before the first div
+            with one of the specified classes (otherwise fallback to standard behavior)
         :rtype: markupsafe.Markup
     """
     if plaintext and preserve:
@@ -735,7 +738,15 @@ def append_content_to_html(html, content, plaintext=True, preserve=False, contai
     # Force all tags to lowercase
     html = re.sub(r'(</?)(\w+)([ >])',
         lambda m: '%s%s%s' % (m[1], m[2].lower(), m[3]), html)
-    insert_location = html.find('</body>')
+    insert_location = -1
+    if before_classes:
+        classes_or = '|'.join(re.escape(cls) for cls in before_classes)
+        pattern = rf'<div\s[^>]*class\s*=\s*["\'][^"\']*({classes_or})[^"\']*["\'][^>]*>'
+        match = re.search(pattern, html, re.IGNORECASE | re.DOTALL)
+        if match:
+            insert_location = match.start()
+    if insert_location == -1:
+        insert_location = html.find('</body>')
     if insert_location == -1:
         insert_location = html.find('</html>')
     if insert_location == -1:


### PR DESCRIPTION
…e to miss

When an email is too big the server turns attachments into links but often recipients don't see the links as they are appended at the end of the email. To avoid that, we turn the attachments into links directly in the composer when the attachments are added so the sender is aware that the attachments are converted into links and can layout them to avoid the problem.

We also remove the possibility to configure a specific maximum email size per mail server and always use the base.default_max_email_size system parameter that we set to 20MB.

We keep the server mechanism that turns attachments into links as a fallback as we only support the convertion into link in the composer for now but we improve the rendering of the attachments with a layout similar (to the one in the composer) and append them just before the signature to make them more visible.

Task-5912830