### PR TITLE
19.0 successive sync issues frbin

### DIFF
--- a/addons/calendar/models/res_users.py
+++ b/addons/calendar/models/res_users.py
@@ -181,6 +181,10 @@ class ResUsers(models.Model):
     def check_calendar_credentials(self):
         return {}
 
+    def get_calendar_email(self):
+        """Meant to be overridden by a specific calendar provider"""
+        return False
+
     def check_synchronization_status(self):
         return {}
 

--- a/addons/calendar/static/src/scss/calendar.scss
+++ b/addons/calendar/static/src/scss/calendar.scss
@@ -92,6 +92,10 @@
     display: none;
 }
 
+.o_calendar_stop_small {
+    font-size: 0.65rem !important;
+}
+
 .btn-group .btn.active {
     z-index: 2;
 }

--- a/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.xml
+++ b/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.xml
@@ -6,24 +6,32 @@
                 <button class="btn btn-primary o-calendar-button-new" t-on-click="onClickAddButton">New</button>
             </t>
         </xpath>
+        <!-- Remove the ms-auto from the today button so that the synchronization buttons can be right-aligned -->
+        <xpath expr="//button[contains(@class, 'o_calendar_button_today')]" position="attributes">
+            <attribute name="class" remove="ms-auto" separator=" "/>
+        </xpath>
         <!-- Add header div to be filled with synchronization buttons in synchronization modules. -->
         <xpath expr="//Layout//div[hasclass('o_calendar_container')]//h5[hasclass('d-inline-flex')]" position="after">
-            <div id="header_synchronization_settings" class="mx-2 ms-lg-auto">
-                <t t-if="(model.credentialStatus.google_calendar or model.credentialStatus.microsoft_calendar)
+            <div id="header_synchronization_settings" class="mx-2 ms-auto d-flex flex-wrap align-items-end">
+                <div t-if="model.state?.googlePendingSync || model.state?.microsoftPendingSync" class="text-center me-2">
+                    <i class="fa fa-spinner fa-spin"/>
+                    <span class="ms-1">Sync in progress...</span>
+                    <div t-if="model.state?.googleSyncResetting" class="small">This may take several minutes</div>
+                </div>
+                <t t-elif="(model.credentialStatus.google_calendar or model.credentialStatus.microsoft_calendar)
                 and (!model.syncStatus.google_calendar or ['sync_stopped', 'missing_credentials'].includes(model.syncStatus.google_calendar))
                 and (!model.syncStatus.microsoft_calendar or ['sync_stopped', 'missing_credentials'].includes(model.syncStatus.microsoft_calendar))">
-                    <h5 id="synchronize_with" class="d-inline-flex" >Synchronize with</h5>
+                    <h5 id="synchronize_with" class="d-inline-flex my-auto">Synchronize with</h5>
                 </t>
-                <t t-elif="(model.googleCredentialsSet and model.syncStatus.google_calendar == 'sync_active')
-                or (model.microsoftCredentialsSet and model.syncStatus.microsoft_calendar == 'sync_active')">
+                <t t-elif="(model.googleCredentialsSet and model.syncStatus.google_calendar === 'sync_active')
+                or (model.microsoftCredentialsSet and model.syncStatus.microsoft_calendar === 'sync_active')">
                     <div id="google_calendar_sync" class="o_calendar_sync mx-1 d-inline-flex">
-                        <button class="btn text-nowrap"
-                        t-on-click="model.syncStatus.google_calendar == 'sync_active' ? onStopGoogleSynchronization : onStopMicrosoftSynchronization">
+                        <button class="btn text-nowrap py-0"
+                        t-on-click="model.syncStatus.google_calendar === 'sync_active' ? onStopGoogleSynchronization : onStopMicrosoftSynchronization">
                             <div>
                                 <i id="check_symbol" class='fa fa-check px-1 o_text_green o_calendar_check'/>
-                                <i id="stop_symbol" class='fa fa-square px-1 o_text_red o_calendar_stop'/>
                                 <span id="check_text" class='o_calendar_check'>
-                                    <t t-if="model.syncStatus.google_calendar == 'sync_active'">Google</t>
+                                    <t t-if="model.syncStatus.google_calendar === 'sync_active'">Google</t>
                                     <t t-else="">Outlook</t>
                                 </span>
                                 <div class="o_calendar_stop flex-col o_calendar_stop_small text-end">
@@ -35,8 +43,8 @@
                         </button>
                     </div>
                 </t>
-                <t t-elif="model.syncStatus.google_calendar == 'sync_paused' or model.syncStatus.microsoft_calendar =='sync_paused'">
-                    <button class="btn text-nowrap" t-on-click="model.syncStatus.google_calendar == 'sync_paused' ? onUnpauseGoogleSynchronization : onUnpauseMicrosoftSynchronization">
+                <t t-elif="model.syncStatus.google_calendar === 'sync_paused' or model.syncStatus.microsoft_calendar === 'sync_paused'">
+                    <button class="btn text-nowrap" t-on-click="model.syncStatus.google_calendar === 'sync_paused' ? onUnpauseGoogleSynchronization : onUnpauseMicrosoftSynchronization">
                         <div>
                             <i id="pause_symbol" class='fa fa-pause px-1 o_text_orange o_calendar_pause'/>
                             <i id="stop_symbol" class='fa fa-square px-1 o_text_red o_calendar_stop'/>

--- a/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.xml
+++ b/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_controller.xml
@@ -26,7 +26,11 @@
                                     <t t-if="model.syncStatus.google_calendar == 'sync_active'">Google</t>
                                     <t t-else="">Outlook</t>
                                 </span>
-                                <span id="stop_text" class="o_text_red o_calendar_stop">Stop synchro</span>
+                                <div class="o_calendar_stop flex-col o_calendar_stop_small text-end">
+                                    <i id="stop_symbol" class='fa fa-square px-1 o_text_red'/>
+                                    <span id="stop_text" class="o_text_red">Stop Sync</span>
+                                    <div t-if="model.syncEmail"><t t-out="model.syncEmail"/></div>
+                                </div>
                             </div>
                         </button>
                     </div>
@@ -36,8 +40,8 @@
                         <div>
                             <i id="pause_symbol" class='fa fa-pause px-1 o_text_orange o_calendar_pause'/>
                             <i id="stop_symbol" class='fa fa-square px-1 o_text_red o_calendar_stop'/>
-                            <span id="pause_text" class='o_text_orange o_calendar_pause'>Synchro is paused</span>
-                            <span id="stop_text" class="o_text_red o_calendar_stop">Stop synchro</span>
+                            <span id="pause_text" class='o_text_orange o_calendar_pause'>Sync is paused</span>
+                            <span id="stop_text" class="o_text_red o_calendar_stop">Stop Sync</span>
                         </div>
                     </button>
                 </t>

--- a/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_model.js
+++ b/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_model.js
@@ -23,14 +23,16 @@ export class AttendeeCalendarModel extends CalendarModel {
     async load() {
         const res = await super.load(...arguments);
         if (!this._loaded) {
-            const [credentialStatus, syncStatus, defaultDuration] = await Promise.all([
+            const [credentialStatus, syncStatus, syncEmail, defaultDuration] = await Promise.all([
                 rpc("/calendar/check_credentials"),
                 this.orm.call("res.users", "check_synchronization_status", [[user.userId]]),
+                this.orm.call("res.users", "get_calendar_email", [[user.userId]]),
                 this.orm.call("calendar.event", "get_default_duration"),
             ]);
             this.syncStatus = syncStatus;
             this.credentialStatus = credentialStatus;
             this.defaultDuration = defaultDuration;
+            this.syncEmail = syncEmail;
             this._loaded = true;
         }
         return res;

--- a/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_model.js
+++ b/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_model.js
@@ -91,6 +91,24 @@ export class AttendeeCalendarModel extends CalendarModel {
     }
 
     /**
+     * Make sure that events filters also check the partner_id (organizer) field instead of just attendees
+     * @ override
+     */
+    computeFiltersDomain(data) {
+        const domain = super.computeFiltersDomain(data);
+        const partnerIndex = domain.findIndex((d) => d[0] === "partner_ids" && d[1] === "in");
+        if (partnerIndex !== -1) {
+            const partnerValues = domain[partnerIndex][2];
+            domain.splice(partnerIndex, 1, "|",
+                ["partner_ids", "in", partnerValues],
+                ["partner_id", "in", partnerValues]
+            );
+        }
+
+        return domain;
+    }
+
+    /**
      * @override
      */
     async updateData(data) {
@@ -131,10 +149,10 @@ export class AttendeeCalendarModel extends CalendarModel {
             let duplicatedRecordIdx = -1;
             for (const event of Object.values(data.records)) {
                 const eventData = event.rawRecord;
-                const attendees =
-                    eventData.partner_ids && eventData.partner_ids.length
-                        ? eventData.partner_ids
-                        : [eventData.partner_id[0]];
+                const attendees = eventData.partner_id
+                    ? [...new Set([...eventData.partner_ids, eventData.partner_id[0]])]
+                    : eventData.partner_ids;
+
                 let duplicatedRecords = 0;
                 for (const attendee of attendees) {
                     if (!activeAttendeeIds.has(attendee)) {

--- a/addons/calendar/static/tests/attendee_calendar_views.test.js
+++ b/addons/calendar/static/tests/attendee_calendar_views.test.js
@@ -102,6 +102,7 @@ test("Linked record rendering", async () => {
     onRpc("res.users", "has_group", () => true);
     onRpc("res.users", "check_synchronization_status", () => ({}));
     onRpc("res.partner", "get_attendee_detail", () => []);
+    onRpc("res.users", "get_calendar_email", () => false);
     onRpc("/calendar/check_credentials", () => ({}));
     const { id: modelId, display_name } = pyEnv["ir.model"].search_read(
         [["model", "=", "res.partner"]],
@@ -128,6 +129,7 @@ test("Linked record rendering", async () => {
 test("Default duration rendering", async () => {
     onRpc("res.users", "has_group", () => true);
     onRpc("res.users", "check_synchronization_status", () => ({}));
+    onRpc("res.users", "get_calendar_email", () => false);
     onRpc("res.partner", "get_attendee_detail", () => []);
     onRpc("/calendar/check_credentials", () => ({}));
     await mountView({ type: "calendar", resModel: "calendar.event", arch });

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -435,6 +435,7 @@
                 <field name="partner_ids" options="{'block': True, 'icon': 'fa fa-users'}"
                        filters="1" widget="many2manyattendeeexpandable" write_model="calendar.filters"
                        write_field="partner_id" filter_field="partner_checked" avatar_field="avatar_128"
+                       filter_label="Calendars"
                 />
                 <field name="videocall_location" widget="CopyClipboardURL" text="Join Video Call"
                        options="{'icon': 'fa fa-lg fa-video-camera'}" invisible="not videocall_location"/>

--- a/addons/google_account/controllers/main.py
+++ b/addons/google_account/controllers/main.py
@@ -34,6 +34,7 @@ class GoogleAuth(http.Controller):
             service_field = 'res_users_settings_id'
             if service_field in request.env.user:
                 request.env.user[service_field]._set_google_auth_tokens(access_token, refresh_token, ttl)
+                request.env.user.prepare_for_google_calendar_sync()
             else:
                 raise Warning('No callback field for service <%s>' % service)
 

--- a/addons/google_account/controllers/main.py
+++ b/addons/google_account/controllers/main.py
@@ -2,10 +2,15 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
+import logging
+import requests
 from werkzeug.exceptions import BadRequest
 
 from odoo import http
 from odoo.http import request
+from odoo.addons.google_account.models.google_service import TIMEOUT
+
+_logger = logging.getLogger(__name__)
 
 
 class GoogleAuth(http.Controller):
@@ -31,8 +36,21 @@ class GoogleAuth(http.Controller):
                 request.env.user[service_field]._set_google_auth_tokens(access_token, refresh_token, ttl)
             else:
                 raise Warning('No callback field for service <%s>' % service)
+
+            self._set_google_email(token=access_token)
             return request.redirect(url_return)
         elif kw.get('error'):
             return request.redirect("%s%s%s" % (url_return, "?error=", kw['error']))
         else:
             return request.redirect("%s%s" % (url_return, "?error=Unknown_error"))
+
+    def _set_google_email(self, token=None, timeout=TIMEOUT):
+        headers = {'Content-type': 'application/json'}
+        params = {'access_token': token}
+        url = '/oauth2/v2/userinfo'
+        try:
+            status, mail_info, _ = self.env['google.service']._do_request(url, params, headers, method='GET', timeout=timeout)
+            if status == 200:
+                self.env.user.sudo().res_users_settings_id._set_google_calendar_email(mail_info['email'])
+        except requests.exceptions.RequestException as e:
+            _logger.error('Error setting google email: %s', e)

--- a/addons/google_calendar/controllers/main.py
+++ b/addons/google_calendar/controllers/main.py
@@ -4,13 +4,12 @@ from odoo import http
 from odoo.http import request
 from odoo.addons.google_calendar.utils.google_calendar import GoogleCalendarService
 from odoo.addons.calendar.controllers.main import CalendarController
-from odoo.addons.google_account.models.google_service import _get_client_secret
 
 
 class GoogleCalendarController(CalendarController):
 
     @http.route('/google_calendar/sync_data', type='jsonrpc', auth='user')
-    def google_calendar_sync_data(self, model, **kw):
+    def google_calendar_sync_data(self, model, force_auth=False, **kw):
         """ This route/function is called when we want to synchronize Odoo
             calendar with Google Calendar.
             Function return a dictionary with the status :  need_config_from_admin, need_auth,
@@ -36,7 +35,8 @@ class GoogleCalendarController(CalendarController):
                 }
 
             # Checking that user have already accepted Odoo to access his calendar !
-            if not GoogleCal.is_authorized(request.env.user):
+            # Force auth can be used if we need to switch accounts
+            if not GoogleCal.is_authorized(request.env.user) or force_auth:
                 url = GoogleCal._google_authentication_url(from_url=kw.get('fromurl'))
                 return {
                     "status": "need_auth",

--- a/addons/google_calendar/models/res_users.py
+++ b/addons/google_calendar/models/res_users.py
@@ -163,6 +163,14 @@ class ResUsers(models.Model):
     def restart_google_synchronization(self):
         self.ensure_one()
         self.sudo().google_synchronization_stopped = False
+        self.sudo().google_synchronization_needs_reset = False
+        self.env['calendar.recurrence']._restart_google_sync()
+        self.env['calendar.event']._restart_google_sync()
+
+    def prepare_for_google_calendar_sync(self):
+        self.sudo().google_synchronization_needs_reset = True
+
+    def reset_google_sync_records(self):
         self.env['calendar.recurrence']._restart_google_sync()
         self.env['calendar.event']._restart_google_sync()
 

--- a/addons/google_calendar/models/res_users.py
+++ b/addons/google_calendar/models/res_users.py
@@ -17,12 +17,14 @@ _logger = logging.getLogger(__name__)
 class ResUsers(models.Model):
     _inherit = 'res.users'
 
+    google_calendar_email = fields.Char(related='res_users_settings_id.google_calendar_email', groups="base.group_system")
     google_calendar_rtoken = fields.Char(related='res_users_settings_id.google_calendar_rtoken', groups="base.group_system")
     google_calendar_token = fields.Char(related='res_users_settings_id.google_calendar_token', groups="base.group_system")
     google_calendar_token_validity = fields.Datetime(related='res_users_settings_id.google_calendar_token_validity', groups="base.group_system")
     google_calendar_sync_token = fields.Char(related='res_users_settings_id.google_calendar_sync_token', groups="base.group_system")
     google_calendar_cal_id = fields.Char(related='res_users_settings_id.google_calendar_cal_id', groups="base.group_system")
     google_synchronization_stopped = fields.Boolean(related='res_users_settings_id.google_synchronization_stopped', readonly=False, groups="base.group_system")
+    google_synchronization_needs_reset = fields.Boolean(related='res_users_settings_id.google_synchronization_needs_reset', readonly=False)
 
     def _get_google_calendar_token(self):
         self.ensure_one()
@@ -156,6 +158,7 @@ class ResUsers(models.Model):
     def stop_google_synchronization(self):
         self.ensure_one()
         self.sudo().google_synchronization_stopped = True
+        self.sudo().res_users_settings_id._set_google_calendar_email(False)
 
     def restart_google_synchronization(self):
         self.ensure_one()
@@ -182,6 +185,12 @@ class ResUsers(models.Model):
         res = super().check_calendar_credentials()
         res['google_calendar'] = self._has_setup_credentials()
         return res
+
+    def get_calendar_email(self):
+        if self.res_users_settings_id.sudo().google_calendar_email:
+            return self.res_users_settings_id.sudo().google_calendar_email
+        else:
+            return super().get_calendar_email()
 
     def check_synchronization_status(self):
         res = super().check_synchronization_status()

--- a/addons/google_calendar/models/res_users_settings.py
+++ b/addons/google_calendar/models/res_users_settings.py
@@ -21,6 +21,7 @@ class ResUsersSettings(models.Model):
     google_calendar_cal_id = fields.Char('Calendar ID', copy=False, groups='base.group_system',
         help='Last Calendar ID who has been synchronized. If it is changed, we remove all links between GoogleID and Odoo Google Internal ID')
     google_synchronization_stopped = fields.Boolean('Google Synchronization stopped', copy=False, groups='base.group_system')
+    google_synchronization_needs_reset = fields.Boolean('Google synchronization needs reset', copy=False)
 
     @api.model
     def _get_fields_blacklist(self):
@@ -32,7 +33,8 @@ class ResUsersSettings(models.Model):
             'google_calendar_token_validity',
             'google_calendar_sync_token',
             'google_calendar_cal_id',
-            'google_synchronization_stopped'
+            'google_synchronization_stopped',
+            'google_synchronization_needs_reset',
         ]
         return super()._get_fields_blacklist() + google_fields_blacklist
 

--- a/addons/google_calendar/models/res_users_settings.py
+++ b/addons/google_calendar/models/res_users_settings.py
@@ -13,6 +13,7 @@ class ResUsersSettings(models.Model):
     _inherit = "res.users.settings"
 
     # Google Calendar tokens and synchronization information.
+    google_calendar_email = fields.Char('Google Calendar Email', copy=False, groups="base.group_system")
     google_calendar_rtoken = fields.Char('Refresh Token', copy=False, groups='base.group_system')
     google_calendar_token = fields.Char('User token', copy=False, groups='base.group_system')
     google_calendar_token_validity = fields.Datetime('Token Validity', copy=False, groups='base.group_system')
@@ -25,6 +26,7 @@ class ResUsersSettings(models.Model):
     def _get_fields_blacklist(self):
         """ Get list of google fields that won't be formatted in session_info. """
         google_fields_blacklist = [
+            'google_calendar_email',
             'google_calendar_rtoken',
             'google_calendar_token',
             'google_calendar_token_validity',
@@ -39,6 +41,11 @@ class ResUsersSettings(models.Model):
             'google_calendar_rtoken': refresh_token,
             'google_calendar_token': access_token,
             'google_calendar_token_validity': fields.Datetime.now() + timedelta(seconds=ttl) if ttl else False,
+        })
+
+    def _set_google_calendar_email(self, email):
+        self.sudo().write({
+            'google_calendar_email': email,
         })
 
     def _google_calendar_authenticated(self):

--- a/addons/google_calendar/static/src/views/google_calendar/google_calendar_controller.js
+++ b/addons/google_calendar/static/src/views/google_calendar/google_calendar_controller.js
@@ -45,6 +45,7 @@ patch(AttendeeCalendarController.prototype, {
             "stop_google_synchronization",
             [[user.userId]],
         );
+        this.model._loaded = false;
         await this.model.load();
         this.render(true);
     },
@@ -55,7 +56,8 @@ patch(AttendeeCalendarController.prototype, {
             "unpause_google_synchronization",
             [[user.userId]],
         );
-        await this.onStopGoogleSynchronization();
+        this.model._loaded = false;
+        await this.model.load();
         this.render(true);
     }
 });

--- a/addons/google_calendar/static/src/views/google_calendar/google_calendar_controller.js
+++ b/addons/google_calendar/static/src/views/google_calendar/google_calendar_controller.js
@@ -14,12 +14,10 @@ patch(AttendeeCalendarController.prototype, {
     },
 
     async onGoogleSyncCalendar() {
-        await this.orm.call(
-            "res.users",
-            "restart_google_synchronization",
-            [[user.userId]],
-        );
-        const syncResult = await this.model.syncGoogleCalendar();
+        /* Force auth, to offer the user the choice of an account to synchronize.
+        If the authorization is successful, it will set the necessary configuration
+        in `oauth2callback` */
+        const syncResult = await this.model.syncGoogleCalendar(false, true);
         if (syncResult.status === "need_auth") {
             window.location.assign(syncResult.url);
         } else if (syncResult.status === "need_config_from_admin") {
@@ -38,9 +36,6 @@ patch(AttendeeCalendarController.prototype, {
                     body: _t("An administrator needs to configure Google Synchronization before you can use it!"),
                 });
             }
-        } else {
-            await this.model.load();
-            this.render(true);
         }
     },
 

--- a/addons/google_calendar/static/src/views/google_calendar/google_calendar_controller.xml
+++ b/addons/google_calendar/static/src/views/google_calendar/google_calendar_controller.xml
@@ -3,7 +3,7 @@
     <t t-name="google_calendar.GoogleCalendarController" t-inherit="calendar.AttendeeCalendarController" t-inherit-mode="extension">
         <!-- Credentials configured: show 'Google' button concatenated with the 'Synchronize with' label. -->
         <xpath expr="//div[@id='header_synchronization_settings']//h5[@id='synchronize_with']" position="after">
-            <div t-if="model.googleCredentialsSet and !model.googleIsSync and !model.googleIsPaused" id="google_calendar_sync" class="mx-1 d-inline-flex">
+            <div t-if="model.googleCredentialsSet and !model.state.googleIsSync and !model.state.googleIsPaused and !model.state.googlePendingSync" id="google_calendar_sync" class="mx-1 d-inline-flex">
                 <button type="button" id="google_sync_pending" class="btn btn-primary text-nowrap" t-on-click="onGoogleSyncCalendar">
                     <b>Google</b>
                 </button>

--- a/addons/google_calendar/static/src/views/google_calendar/google_calendar_model.js
+++ b/addons/google_calendar/static/src/views/google_calendar/google_calendar_model.js
@@ -2,13 +2,16 @@ import { AttendeeCalendarModel } from "@calendar/views/attendee_calendar/attende
 import { rpc } from "@web/core/network/rpc";
 import { patch } from "@web/core/utils/patch";
 import { useState } from "@odoo/owl";
+import { user } from "@web/core/user";
 
 patch(AttendeeCalendarModel.prototype, {
     setup(params) {
         super.setup(...arguments);
         this.isAlive = params.isAlive;
-        this.googlePendingSync = false;
+        this.googleSyncTimedOut = false;
         this.state = useState({
+            googleSyncResetting: false,
+            googlePendingSync: false,
             googleIsSync: true,
             googleIsPaused: false,
         });
@@ -18,20 +21,21 @@ patch(AttendeeCalendarModel.prototype, {
      * @override
      */
     async updateData() {
-        if (this.googlePendingSync) {
+        this.googleSyncTimedOut = false;
+        if (this.state.googlePendingSync) {
             return super.updateData(...arguments);
         }
         try {
-            await Promise.race([
-                new Promise(resolve => setTimeout(resolve, 1000)),
-                this.syncGoogleCalendar(true)
+            this.googleSyncTimedOut = await Promise.race([
+                new Promise(resolve => setTimeout(resolve, 1000)).then(() => true),
+                this.syncGoogleCalendar(true).then(() => false),
             ]);
         } catch (error) {
             if (error.event) {
                 error.event.preventDefault();
             }
             console.error("Could not synchronize Google events now.", error);
-            this.googlePendingSync = false;
+            this.state.googlePendingSync = false;
         }
         if (this.isAlive()) {
             return super.updateData(...arguments);
@@ -40,7 +44,22 @@ patch(AttendeeCalendarModel.prototype, {
     },
 
     async syncGoogleCalendar(silent = false, force_auth = false) {
-        this.googlePendingSync = true;
+        this.state.googlePendingSync = true;
+        const [{google_synchronization_needs_reset}] = await this.orm.read(
+            "res.users",
+            [user.userId],
+            ["google_synchronization_needs_reset"],
+        );
+        if (google_synchronization_needs_reset) {
+            this.state.googleSyncResetting = true;
+            await this.orm.call(
+                "res.users",
+                "restart_google_synchronization",
+                [[user.userId]],
+            );
+            this.state.googleSyncResetting = false;
+        }
+
         const result = await rpc(
             "/google_calendar/sync_data",
             {
@@ -57,8 +76,14 @@ patch(AttendeeCalendarModel.prototype, {
         } else if (result.status === "no_new_event_from_google" || result.status === "need_refresh") {
             this.state.googleIsSync = true;
         }
-        this.state.googleIsPaused = result.status == "sync_paused";
-        this.googlePendingSync = false;
+        this.state.googleIsPaused = result.status === "sync_paused";
+        this.state.googlePendingSync = false;
+        if (this.googleSyncTimedOut && result.status === "need_refresh") {
+            const data = { ...this.data };
+            await this.keepLast.add(super.updateData(data));
+            this.data = data;
+            this.notify();
+        }
         return result;
     },
 

--- a/addons/google_calendar/static/src/views/google_calendar/google_calendar_model.js
+++ b/addons/google_calendar/static/src/views/google_calendar/google_calendar_model.js
@@ -39,12 +39,13 @@ patch(AttendeeCalendarModel.prototype, {
         return new Promise(() => {});
     },
 
-    async syncGoogleCalendar(silent = false) {
+    async syncGoogleCalendar(silent = false, force_auth = false) {
         this.googlePendingSync = true;
         const result = await rpc(
             "/google_calendar/sync_data",
             {
                 model: this.resModel,
+                force_auth: force_auth,
                 fromurl: window.location.href
             },
             {

--- a/addons/google_calendar/static/tests/google_calendar.test.js
+++ b/addons/google_calendar/static/tests/google_calendar.test.js
@@ -85,6 +85,7 @@ onRpc("/google_calendar/sync_data", () => ({ status: "no_new_event_from_google" 
 onRpc("check_synchronization_status", async () => ({ google_calendar: "sync_active" }));
 onRpc("get_attendee_detail", () => []);
 onRpc("get_default_duration", () => 3.25);
+onRpc("get_calendar_email", () => false);
 
 beforeEach(() => {
     mockDate("2016-12-12 08:00:00");

--- a/addons/google_calendar/utils/google_calendar.py
+++ b/addons/google_calendar/utils/google_calendar.py
@@ -117,7 +117,7 @@ class GoogleCalendarService():
 
     def _get_calendar_scope(self, RO=False):
         readonly = '.readonly' if RO else ''
-        return 'https://www.googleapis.com/auth/calendar%s' % (readonly)
+        return 'https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/calendar%s' % (readonly)
 
     def _google_authentication_url(self, from_url='http://www.odoo.com'):
         state = {

--- a/addons/hr_homeworking_calendar/static/tests/calendar_homeworking.test.js
+++ b/addons/hr_homeworking_calendar/static/tests/calendar_homeworking.test.js
@@ -117,6 +117,7 @@ onRpc("get_state_selections", () => [
     ["needsAction", "Needs Action"],
 ]);
 onRpc("res.users", "read", () => [{ user: serverState.userId }]);
+onRpc("res.users", "get_calendar_email", () => false);
 
 beforeEach(() => {
     mockDate("2020-12-10 15:00:00");

--- a/addons/microsoft_account/controllers/main.py
+++ b/addons/microsoft_account/controllers/main.py
@@ -32,6 +32,7 @@ class MicrosoftAuth(http.Controller):
                 redirect_uri=f'{base_url}/microsoft_account/authentication'
             )
             request.env.user._set_microsoft_auth_tokens(access_token, refresh_token, ttl)
+            request.env.user.restart_microsoft_synchronization()
             self._set_outlook_email(token=access_token)
             return request.redirect(url_return)
         elif kw.get('error'):

--- a/addons/microsoft_account/controllers/main.py
+++ b/addons/microsoft_account/controllers/main.py
@@ -2,10 +2,15 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
+import logging
+import requests
 from werkzeug.exceptions import BadRequest
 
 from odoo import http
 from odoo.http import request
+from odoo.addons.microsoft_account.models.microsoft_service import TIMEOUT
+
+_logger = logging.getLogger(__name__)
 
 
 class MicrosoftAuth(http.Controller):
@@ -27,8 +32,22 @@ class MicrosoftAuth(http.Controller):
                 redirect_uri=f'{base_url}/microsoft_account/authentication'
             )
             request.env.user._set_microsoft_auth_tokens(access_token, refresh_token, ttl)
+            self._set_outlook_email(token=access_token)
             return request.redirect(url_return)
         elif kw.get('error'):
             return request.redirect("%s%s%s" % (url_return, "?error=", kw['error']))
         else:
             return request.redirect("%s%s" % (url_return, "?error=Unknown_error"))
+
+    def _set_outlook_email(self, token=None, timeout=TIMEOUT):
+        url = '/v1.0/me'
+        headers = {'Content-type': 'application/json', 'Authorization': 'Bearer %s' % token}
+        try:
+            status, user_info, _ = self.env["microsoft.service"]._do_request(url, {}, headers, method='GET', timeout=timeout)
+            if status == 200:
+                # 'mail' can be None for some accounts, fall back to userPrincipalName
+                email = user_info.get('mail') or user_info.get('userPrincipalName')
+                if email:
+                    self.env.user.sudo()._set_microsoft_email(email)
+        except requests.exceptions.RequestException as e:
+            _logger.error('Error setting outlook email: %s', e)

--- a/addons/microsoft_account/models/microsoft_service.py
+++ b/addons/microsoft_account/models/microsoft_service.py
@@ -83,7 +83,7 @@ class MicrosoftService(models.AbstractModel):
         return response.get('access_token'), response.get('expires_in')
 
     @api.model
-    def _get_authorize_uri(self, from_url, service, scope, redirect_uri):
+    def _get_authorize_uri(self, from_url, service, scope, redirect_uri, prompt):
         """ This method return the url needed to allow this instance of Odoo to access to the scope
             of gmail specified as parameters
         """
@@ -102,7 +102,8 @@ class MicrosoftService(models.AbstractModel):
             'state': json.dumps(state),
             'scope': scope,
             'redirect_uri': redirect_uri,
-            'access_type': 'offline'
+            'access_type': 'offline',
+            'prompt': prompt,
         })
         return "%s?%s" % (self._get_auth_endpoint(), encoded_params)
 

--- a/addons/microsoft_account/models/microsoft_service.py
+++ b/addons/microsoft_account/models/microsoft_service.py
@@ -46,7 +46,7 @@ class MicrosoftService(models.AbstractModel):
         return ICP.get_param('microsoft_%s_client_id' % service)
 
     def _get_calendar_scope(self):
-        return 'offline_access openid Calendars.ReadWrite'
+        return 'offline_access openid profile email User.Read Calendars.ReadWrite'
 
     @api.model
     def _get_auth_endpoint(self):

--- a/addons/microsoft_account/models/res_users.py
+++ b/addons/microsoft_account/models/res_users.py
@@ -4,12 +4,13 @@
 from datetime import timedelta
 
 
-from odoo import api, fields, models, _
+from odoo import fields, models
 
 
 class ResUsers(models.Model):
     _inherit = 'res.users'
 
+    microsoft_calendar_email = fields.Char("Microsoft Calendar Email", copy=False, groups='base.group_system')
     microsoft_calendar_rtoken = fields.Char('Microsoft Refresh Token', copy=False, groups="base.group_system")
     microsoft_calendar_token = fields.Char('Microsoft User token', copy=False, groups="base.group_system")
     microsoft_calendar_token_validity = fields.Datetime('Microsoft Token Validity', copy=False)
@@ -19,4 +20,9 @@ class ResUsers(models.Model):
             'microsoft_calendar_rtoken': refresh_token,
             'microsoft_calendar_token': access_token,
             'microsoft_calendar_token_validity': fields.Datetime.now() + timedelta(seconds=ttl) if ttl else False,
+        })
+
+    def _set_microsoft_email(self, email):
+        self.write({
+            'microsoft_calendar_email': email,
         })

--- a/addons/microsoft_calendar/controllers/main.py
+++ b/addons/microsoft_calendar/controllers/main.py
@@ -8,7 +8,7 @@ from odoo.addons.calendar.controllers.main import CalendarController
 class MicrosoftCalendarController(CalendarController):
 
     @http.route('/microsoft_calendar/sync_data', type='jsonrpc', auth='user')
-    def microsoft_calendar_sync_data(self, model, **kw):
+    def microsoft_calendar_sync_data(self, model, force_auth=False, **kw):
         """ This route/function is called when we want to synchronize Odoo
             calendar with Microsoft Calendar.
             Function return a dictionary with the status :  need_config_from_admin, need_auth,
@@ -33,7 +33,8 @@ class MicrosoftCalendarController(CalendarController):
                 }
 
             # Checking that user have already accepted Odoo to access his calendar !
-            if not MicrosoftCal.is_authorized(request.env.user):
+            # Force auth can be used if we need to switch accounts
+            if not MicrosoftCal.is_authorized(request.env.user) or force_auth:
                 url = MicrosoftCal._microsoft_authentication_url(from_url=kw.get('fromurl'))
                 return {
                     "status": "need_auth",

--- a/addons/microsoft_calendar/models/res_users.py
+++ b/addons/microsoft_calendar/models/res_users.py
@@ -21,6 +21,7 @@ class ResUsers(models.Model):
     microsoft_calendar_sync_token = fields.Char(related='res_users_settings_id.microsoft_calendar_sync_token', groups='base.group_system')
     microsoft_synchronization_stopped = fields.Boolean(related='res_users_settings_id.microsoft_synchronization_stopped', readonly=False, groups='base.group_system')
     microsoft_last_sync_date = fields.Datetime(related='res_users_settings_id.microsoft_last_sync_date', readonly=False, groups='base.group_system')
+    microsoft_synchronization_needs_reset = fields.Boolean(related='res_users_settings_id.microsoft_synchronization_needs_reset', readonly=False)
 
     def _microsoft_calendar_authenticated(self):
         return bool(self.sudo().microsoft_calendar_rtoken)
@@ -128,6 +129,7 @@ class ResUsers(models.Model):
         self.ensure_one()
         self.sudo().microsoft_synchronization_stopped = True
         self.sudo().microsoft_last_sync_date = None
+        self.sudo()._set_microsoft_email(False)
 
     def restart_microsoft_synchronization(self):
         self.ensure_one()
@@ -149,6 +151,13 @@ class ResUsers(models.Model):
         client_id = self.env['microsoft.service']._get_microsoft_client_id('calendar')
         client_secret = microsoft_service._get_microsoft_client_secret(ICP_sudo, 'calendar')
         return bool(client_id and client_secret)
+
+    def get_calendar_email(self):
+        # Only one calendar provider should be active at a time
+        if self.sudo().microsoft_calendar_email:
+            return self.sudo().microsoft_calendar_email
+        else:
+            return super().get_calendar_email()
 
     @api.model
     def check_calendar_credentials(self):

--- a/addons/microsoft_calendar/models/res_users_settings.py
+++ b/addons/microsoft_calendar/models/res_users_settings.py
@@ -10,6 +10,7 @@ class ResUsersSettings(models.Model):
     microsoft_calendar_sync_token = fields.Char('Microsoft Next Sync Token', copy=False, groups='base.group_system')
     microsoft_synchronization_stopped = fields.Boolean('Outlook Synchronization stopped', copy=False, groups='base.group_system')
     microsoft_last_sync_date = fields.Datetime('Last Sync Date', copy=False, help='Last synchronization date with Outlook Calendar', groups='base.group_system')
+    microsoft_synchronization_needs_reset = fields.Boolean('Microsoft synchronization needs reset', copy=False)
 
     @api.model
     def _get_fields_blacklist(self):
@@ -18,5 +19,6 @@ class ResUsersSettings(models.Model):
             'microsoft_calendar_sync_token',
             'microsoft_synchronization_stopped',
             'microsoft_last_sync_date',
+            'microsoft_synchronization_needs_reset',
         ]
         return super()._get_fields_blacklist() + microsoft_fields_blacklist

--- a/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_controller.js
+++ b/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_controller.js
@@ -44,6 +44,7 @@ patch(AttendeeCalendarController.prototype, {
             "stop_microsoft_synchronization",
             [[user.userId]],
         );
+        this.model._loaded = false;
         await this.model.load();
         this.render(true);
     },
@@ -54,7 +55,8 @@ patch(AttendeeCalendarController.prototype, {
             "unpause_microsoft_synchronization",
             [[user.userId]],
         );
-        await this.onStopMicrosoftSynchronization();
+        this.model._loaded = false;
+        await this.model.load();
         this.render(true);
     }
 });

--- a/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_controller.js
+++ b/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_controller.js
@@ -13,12 +13,10 @@ patch(AttendeeCalendarController.prototype, {
     },
 
     async onMicrosoftSyncCalendar() {
-        await this.orm.call(
-            "res.users",
-            "restart_microsoft_synchronization",
-            [[user.userId]],
-        );
-        const syncResult = await this.model.syncMicrosoftCalendar();
+        /* Force auth, to offer the user the choice of an account to synchronize.
+        If the authorization is successful, it will set the necessary configuration
+        in `oauth2callback` */
+        const syncResult = await this.model.syncMicrosoftCalendar(false, true);
         if (syncResult.status === "need_auth") {
             window.location.assign(syncResult.url);
         } else if (syncResult.status === "need_config_from_admin") {
@@ -37,9 +35,6 @@ patch(AttendeeCalendarController.prototype, {
                     body: _t("An administrator needs to configure Outlook Synchronization before you can use it!"),
                 });
             }
-        } else {
-            await this.model.load();
-            this.render(true);
         }
     },
 

--- a/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_controller.xml
+++ b/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_controller.xml
@@ -2,7 +2,7 @@
 <templates>
     <t t-name="microsoft_calendar.MicrosoftCalendarController" t-inherit="calendar.AttendeeCalendarController" t-inherit-mode="extension">
         <xpath expr="//div[@id='header_synchronization_settings']//h5[@id='synchronize_with']" position="after">
-            <div id="microsoft_calendar_sync" class="mx-1 d-inline-flex" t-if="model.microsoftCredentialsSet and !model.microsoftIsSync and !model.microsoftIsPaused">
+            <div id="microsoft_calendar_sync" class="mx-1 d-inline-flex" t-if="model.microsoftCredentialsSet and !model.state.microsoftIsSync and !model.state.microsoftIsPaused and !model.state.microsoftPendingSync">
                 <button type="button" id="microsoft_sync_pending" class="btn btn-primary text-nowrap" t-on-click="onMicrosoftSyncCalendar">
                     <b>Outlook</b>
                 </button>

--- a/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_model.js
+++ b/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_model.js
@@ -2,6 +2,7 @@ import { AttendeeCalendarModel } from "@calendar/views/attendee_calendar/attende
 import { rpc } from "@web/core/network/rpc";
 import { patch } from "@web/core/utils/patch";
 import { useState } from "@odoo/owl";
+import { user } from "@web/core/user";
 
 patch(AttendeeCalendarModel, {
     services: [...AttendeeCalendarModel.services],
@@ -11,8 +12,10 @@ patch(AttendeeCalendarModel.prototype, {
     setup(params) {
         super.setup(...arguments);
         this.isAlive = params.isAlive;
-        this.microsoftPendingSync = false;
+        this.microsoftSyncTimedOut = false;
         this.state = useState({
+            microsoftSyncResetting: false,
+            microsoftPendingSync: false,
             microsoftIsSync: true,
             microsoftIsPaused: false,
         })
@@ -22,20 +25,21 @@ patch(AttendeeCalendarModel.prototype, {
      * @override
      */
     async updateData() {
-        if (this.microsoftPendingSync) {
+        this.microsoftSyncTimedOut = false;
+        if (this.state.microsoftPendingSync) {
             return super.updateData(...arguments);
         }
         try {
-            await Promise.race([
-                new Promise(resolve => setTimeout(resolve, 1000)),
-                this.syncMicrosoftCalendar(true)
+            this.microsoftSyncTimedOut = await Promise.race([
+                new Promise(resolve => setTimeout(resolve, 1000)).then(() => true),
+                this.syncMicrosoftCalendar(true).then(() => false),
             ]);
         } catch (error) {
             if (error.event) {
                 error.event.preventDefault();
             }
             console.error("Could not synchronize microsoft events now.", error);
-            this.microsoftPendingSync = false;
+            this.state.microsoftPendingSync = false;
         }
         if (this.isAlive()) {
             return super.updateData(...arguments);
@@ -44,7 +48,23 @@ patch(AttendeeCalendarModel.prototype, {
     },
 
     async syncMicrosoftCalendar(silent = false, force_auth = false) {
-        this.microsoftPendingSync = true;
+        this.state.microsoftPendingSync = true;
+
+        const [{microsoft_synchronization_needs_reset}] = await this.orm.read(
+            "res.users",
+            [user.userId],
+            ["microsoft_synchronization_needs_reset"],
+        );
+        if (microsoft_synchronization_needs_reset) {
+            this.state.microsoftSyncResetting = true;
+            await this.orm.call(
+                "res.users",
+                "restart_microsoft_synchronization",
+                [[user.userId]],
+            );
+            this.state.microsoftSyncResetting = false;
+        }
+
         const result = await rpc(
             "/microsoft_calendar/sync_data",
             {
@@ -61,8 +81,14 @@ patch(AttendeeCalendarModel.prototype, {
         } else if (result.status === "no_new_event_from_microsoft" || result.status === "need_refresh") {
             this.state.microsoftIsSync = true;
         }
-        this.state.microsoftIsPaused = result.status == "sync_paused";
-        this.microsoftPendingSync = false;
+        this.state.microsoftIsPaused = result.status === "sync_paused";
+        this.state.microsoftPendingSync = false;
+        if (this.microsoftSyncTimedOut && result.status === "need_refresh") {
+            const data = { ...this.data };
+            await this.keepLast.add(super.updateData(data));
+            this.data = data;
+            this.notify();
+        }
         return result;
     },
 

--- a/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_model.js
+++ b/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_model.js
@@ -43,12 +43,13 @@ patch(AttendeeCalendarModel.prototype, {
         return new Promise(() => {});
     },
 
-    async syncMicrosoftCalendar(silent = false) {
+    async syncMicrosoftCalendar(silent = false, force_auth = false) {
         this.microsoftPendingSync = true;
         const result = await rpc(
             "/microsoft_calendar/sync_data",
             {
                 model: this.resModel,
+                force_auth: force_auth,
                 fromurl: window.location.href
             },
             {

--- a/addons/microsoft_calendar/static/tests/microsoft_calendar.test.js
+++ b/addons/microsoft_calendar/static/tests/microsoft_calendar.test.js
@@ -84,6 +84,7 @@ onRpc("/microsoft_calendar/sync_data", () => ({ status: "no_new_event_from_micro
 onRpc("check_synchronization_status", async () => ({ microsoft_calendar: "sync_active" }));
 onRpc("get_attendee_detail", () => []);
 onRpc("get_default_duration", () => 3.25);
+onRpc("get_calendar_email", () => false);
 
 beforeEach(() => {
     mockDate("2016-12-12 08:00:00");

--- a/addons/microsoft_calendar/utils/microsoft_calendar.py
+++ b/addons/microsoft_calendar/utils/microsoft_calendar.py
@@ -203,7 +203,7 @@ class MicrosoftCalendarService():
         return bool(user.sudo().microsoft_calendar_rtoken)
 
     def _get_calendar_scope(self):
-        return 'offline_access openid Calendars.ReadWrite'
+        return 'offline_access openid profile email User.Read Calendars.ReadWrite'
 
     def _microsoft_authentication_url(self, from_url='http://www.odoo.com'):
         redirect_uri = self.microsoft_service.get_base_url() + '/microsoft_account/authentication'

--- a/addons/microsoft_calendar/utils/microsoft_calendar.py
+++ b/addons/microsoft_calendar/utils/microsoft_calendar.py
@@ -211,7 +211,8 @@ class MicrosoftCalendarService():
             from_url,
             service='calendar',
             scope=self._get_calendar_scope(),
-            redirect_uri=redirect_uri
+            redirect_uri=redirect_uri,
+            prompt='select_account'
         )
 
     def _can_authorize_microsoft(self, user):

--- a/addons/microsoft_calendar/views/res_config_settings_views.xml
+++ b/addons/microsoft_calendar/views/res_config_settings_views.xml
@@ -12,7 +12,7 @@
                             <field name="cal_microsoft_client_id" nolabel="1"/>
                         </div>
                         <div class="mt16 row">
-                            <label for="cal_microsoft_client_secret" string="Client Secret" class="col-3 col-lg-3 o_light_label"/>
+                            <label for="cal_microsoft_client_secret" string="Value" class="col-3 col-lg-3 o_light_label"/>
                             <field name="cal_microsoft_client_secret" password="True" nolabel="1"/>
                         </div>
                         <div class="mt16 d-flex">

--- a/addons/web/static/src/views/calendar/calendar_arch_parser.js
+++ b/addons/web/static/src/views/calendar/calendar_arch_parser.js
@@ -94,7 +94,7 @@ export class CalendarArchParser {
                                 context: fieldInfo.context || "{}",
                                 fieldName,
                                 filterFieldName: null,
-                                label: field.string,
+                                label: node.getAttribute("filter_label") || field.string,
                                 resModel: field.relation,
                                 writeFieldName: null,
                                 writeResModel: null,

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -2641,6 +2641,32 @@ test(`dynamic filters with selection fields`, async () => {
     ).toEqual(["Desert", "Forest", "Undefined"]);
 });
 
+test(`filter_label is used as label when provided`, async () => {
+    await mountView({
+        resModel: "event",
+        type: "calendar",
+        arch: `
+            <calendar date_start="start" date_stop="stop" all_day="is_all_day" mode="week">
+                <field name="attendee_ids" write_model="filter.partner" write_field="partner_id" filter_field="is_checked" filter_label="Custom Label"/>
+            </calendar>
+        `,
+    });
+    expect(`.o_calendar_filter[data-name="attendee_ids"] .o_cw_filter_label`).toHaveText("Custom Label");
+});
+
+test(`filter label falls back to field string when filter_label is absent`, async () => {
+    await mountView({
+        resModel: "event",
+        type: "calendar",
+        arch: `
+            <calendar date_start="start" date_stop="stop" all_day="is_all_day" mode="week">
+                <field name="attendee_ids" write_model="filter.partner" write_field="partner_id" filter_field="is_checked"/>
+            </calendar>
+        `,
+    });
+    expect(`.o_calendar_filter[data-name="attendee_ids"] .o_cw_filter_label`).toHaveText("Attendees");
+});
+
 test(`Colors: cycling through available colors`, async () => {
     FilterPartner._records = Array.from({ length: 56 }, (_, i) => ({
         id: i + 1,

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -639,6 +639,12 @@ class IrModuleModule(models.Model):
         self.env.cr.reset()
         assert self.env.registry is registry
 
+        if self.env.context.get('force_refresh_only', False):
+            return {
+                'type': 'ir.actions.client',
+                'tag': 'reload',
+            }
+
         # pylint: disable=next-method-called
         config = self.env['ir.module.module'].next() or {}
         if config.get('type') not in ('ir.actions.act_window_close',):

--- a/odoo/addons/base/models/res_config.py
+++ b/odoo/addons/base/models/res_config.py
@@ -387,6 +387,7 @@ class ResConfigSettings(models.TransientModel):
                 'view_mode': 'form',
                 'res_model': 'base.module.uninstall',
                 'context': {
+                    'force_refresh_only': True,
                     'default_module_ids': to_uninstall.ids,
                 },
             }

--- a/odoo/addons/base/rng/common.rng
+++ b/odoo/addons/base/rng/common.rng
@@ -250,6 +250,7 @@
             <rng:optional><rng:attribute name="write_model" /></rng:optional>
             <rng:optional><rng:attribute name="write_field" /></rng:optional>
             <rng:optional><rng:attribute name="filter_field" /></rng:optional>
+            <rng:optional><rng:attribute name="filter_label" /></rng:optional>
             <rng:optional><rng:attribute name="text" /></rng:optional>
             <rng:optional><rng:attribute name="optional" /></rng:optional>
             <rng:optional><rng:attribute name="add-label"/></rng:optional>


### PR DESCRIPTION
## Behavior before the commit:

Sync is started from calendar / settings
-> account selection & login, confirm -> done!

Oops! wrong account! (or I simply wish to change the synced calendar)
-> Stop sync -> nothing seems to happen until page refreshed.
-> Click "Synchronize with Google" (or outlook) to sync with another account

Nothing seems to happen. Page loads for a bit, then remains as-is
Upon page refresh, it's synchronized to with the first account again.

## Behavior after commit:

### Allow account selection

To ensure that the user can select a different account when they click the sync
button, and that they aren't just logged back in with the saved tokens, a
`force_auth` argument was added to the sync methods. When called from the UI,
always ask for a sign in, but keep original behaviour for automatic syncs.

### Fix UI freeze on sync restart

The long loading period when nothing happens in the UI after clicking the sync
button in the UI was caused by the RPC call to `restart_google_synchronization`
This method flagged events with `'need_sync': true`. This however also triggered
methods annotated with `@after_commit` to synchronize the entire calendar
before returning the result to the frontend layer, causing a lot of lag. In
testing with recurring events and worklocations, this sometimes took up to 40
seconds.

Restarting the synchronization was moved to the oauth2callback methods, after
the user is successfully re-authenticated instead of before, and is called
without `_restart_google_sync()` TODO: investigate the necessity/purpose of
this call

### Update wizard to disconnect the calendar sync

The user settings contained a wizard for disconnecting a synced account. This
task simplifies it, removing some of the less used options. A part of the wizard
relating to re-sync policies was removed - the use cases where it would be
useful are minimal, and letting the user decide which events to sync and
which not to would just lead to inconsistencies in the events

### Update the UI if synchronization takes longer

Added a loading indicator to display the satus of the calendar synchronization.
Previous behaviour:
- If the sync takes less then a second (Promise.race with a setTimeout of 1000),
let it finish and reload the ui with the synced data
- If it takes longer, update with what we have so that we don't freeze the UI

This way, the user needed to refresh to see the result of the sync (without any
prompts to do so)

Updated behavior:
If the sync takes longer than a second and results in "needs_refresh", update
the UI again (without triggering another sync)

UI addition:
When hovering over the sync button while synchronized, show the currently linked
account/email. To fetch the email, additional claims had to be added to the
oauth requests for both Microsoft and Google, as the calendar ones did not
provide access to the user's email

Task-5346620
