### PR TITLE
[FIX] point_of_sale: sort taxes before groupby in session load

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1677,7 +1677,7 @@ class PosSession(models.Model):
             # - values: list of tax ids
             key_company_id = itemgetter('company_id')
             key_id = itemgetter('id')
-            for key, group in groupby(loaded_data['account.tax'], key=key_company_id):
+            for key, group in groupby(sorted(loaded_data['account.tax'], key=key_company_id), key=key_company_id):
                 taxes_by_company[key[0]] = list(map(key_id, group))
         if len(taxes_by_company) > 1:
             for product in loaded_data['product.product']:


### PR DESCRIPTION
itertools.groupby only groups consecutive elements. When taxes from different companies are interleaved in loaded_data, taxes from the same company get split into multiple groups, causing incorrect tax assignment per company.

Sort the tax list by company_id before calling groupby to ensure all taxes per company are contiguous.

opw-5931261

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
