### PR TITLE
[REF] *: run owl3 rendering context migration script

### DIFF
--- a/addons/hr/static/src/views/hr_employee_hierarchy/hr_employee_hierarchy_card.xml
+++ b/addons/hr/static/src/views/hr_employee_hierarchy/hr_employee_hierarchy_card.xml
@@ -7,10 +7,10 @@
             <attribute name="class" separator=" " remove="rounded-0"/>
         </xpath>
         <xpath expr="//button[@name='hierarchy_search_subsidiaries']" position="inside">
-            <t t-out="props.node.childResIds.length"/> people
+            <t t-out="this.props.node.childResIds.length"/> people
         </xpath>
         <xpath expr="//button[@name='hierarchy_search_subsidiaries']/t[@t-if]" position="replace">
-            <t t-if="!props.node.nodes.length">
+            <t t-if="!this.props.node.nodes.length">
                 <i class="fa fa-fw fa-caret-right"/>
             </t>
         </xpath>

--- a/addons/hr/static/src/views/hr_employee_hierarchy/hr_employee_hierarchy_renderer.xml
+++ b/addons/hr/static/src/views/hr_employee_hierarchy/hr_employee_hierarchy_renderer.xml
@@ -6,9 +6,9 @@
             <attribute name="class" add="flex-column align-items-center" separator=" "/>
         </xpath>
         <xpath expr="//div[hasclass('o_hierarchy_container')]" position="before">
-            <div t-if="employeesInCycleIds.length" class="my-custom-header alert alert-warning mb-2 w-100 text-center">
+            <div t-if="this.employeesInCycleIds.length" class="my-custom-header alert alert-warning mb-2 w-100 text-center">
                 Some employees are present in a loop.
-                Click <a class="cursor-pointer p-0" t-on-click.prevent="_displayEmployeesInCycle">here</a> to see those employees.
+                Click <a class="cursor-pointer p-0" t-on-click.prevent="this._displayEmployeesInCycle">here</a> to see those employees.
             </div>
         </xpath>
         <xpath expr="//div[hasclass('o_hierarchy_parent_node_container')]/span" position="replace">

--- a/addons/web_hierarchy/static/src/hierarchy_card.xml
+++ b/addons/web_hierarchy/static/src/hierarchy_card.xml
@@ -2,50 +2,50 @@
 <templates>
 
     <t t-name="web_hierarchy.HierarchyCard">
-        <div class="o_hierarchy_node_container d-flex flex-column" t-att-class="classNames" t-att-data-node-id="props.node.id">
+        <div class="o_hierarchy_node_container d-flex flex-column" t-att-class="this.classNames" t-att-data-node-id="this.props.node.id">
             <div class="o_hierarchy_node_button_container w-100 d-flex justify-content-end">
-                <button t-if="props.node.canShowParentNode"
+                <button t-if="this.props.node.canShowParentNode"
                         name="hierarchy_search_parent_node"
                         class="btn p-0"
-                        t-on-click.synthetic="onClickArrowUp"
+                        t-on-click.synthetic="this.onClickArrowUp"
                 >
                     <i class="fa fa-chevron-up"/>
                 </button>
             </div>
             <div class="o_hierarchy_node w-100 h-100 d-flex flex-column justify-content-between border"
                 t-att-class="{
-                    'border-bottom-0': props.node.nodes.length or props.node.canShowChildNodes,
+                    'border-bottom-0': this.props.node.nodes.length or this.props.node.canShowChildNodes,
                 }"
-                t-att-data-node-id="props.node.id"
+                t-att-data-node-id="this.props.node.id"
                 t-custom-click.synthetic="onGlobalClick"
             >
                 <div class="o_hierarchy_node_content">
-                    <Record resModel="props.node.model.resModel"
-                            resId="props.node.resId"
-                            fields="props.node.model.fields"
-                            activeFields="props.node.model.activeFields"
-                            values="props.node.data"
+                    <Record resModel="this.props.node.model.resModel"
+                            resId="this.props.node.resId"
+                            fields="this.props.node.model.fields"
+                            activeFields="this.props.node.model.activeFields"
+                            values="this.props.node.data"
                             t-slot-scope="data"
                     >
-                        <t t-call="{{ templates['hierarchy-box'] }}" t-call-context="getRenderingContext(data)"/>
+                        <t t-call="{{ this.templates['hierarchy-box'] }}" t-call-context="this.getRenderingContext(data)"/>
                     </Record>
                 </div>
-                <button t-if="props.node.nodes.length or props.node.canShowChildNodes"
+                <button t-if="this.props.node.nodes.length or this.props.node.canShowChildNodes"
                         name="hierarchy_search_subsidiaries"
                         class="o_hierarchy_node_button btn rounded-0 d-grid"
                         t-att-class="{
-                            'btn-primary': !props.node.nodes.length,
-                            'btn-secondary': props.node.nodes.length > 0,
+                            'btn-primary': !this.props.node.nodes.length,
+                            'btn-secondary': this.props.node.nodes.length > 0,
                         }"
-                        t-on-click.synthetic="onClickArrowDown"
+                        t-on-click.synthetic="this.onClickArrowDown"
                 >
-                    <t t-if="!props.node.nodes.length">
+                    <t t-if="!this.props.node.nodes.length">
                         <span style="grid-column: 2;">
                             Unfold
                         </span>
                         <span class="text-end" style="grid-column: 3;">
-                            <t t-out="props.node.childResIds.length"/>
-                            <i class="fa ps-1" t-att-class="props.archInfo.icon"/>
+                            <t t-out="this.props.node.childResIds.length"/>
+                            <i class="fa ps-1" t-att-class="this.props.archInfo.icon"/>
                         </span>
                     </t>
                     <t t-else="">

--- a/addons/web_hierarchy/static/src/hierarchy_controller.xml
+++ b/addons/web_hierarchy/static/src/hierarchy_controller.xml
@@ -2,38 +2,38 @@
 <templates>
     <t t-name="web_hierarchy.HierarchyButtons">
         <div class="d-flex o_grid_buttons">
-            <div class="me-2" t-if="props.archInfo.activeActions.create and (!props.archInfo.createInline or displayNoContent)">
+            <div class="me-2" t-if="this.props.archInfo.activeActions.create and (!this.props.archInfo.createInline or this.displayNoContent)">
                 <button class="btn btn-primary o_hierarchy_button_add"
                         type="button"
-                        t-on-click="props.createRecord">
+                        t-on-click="this.props.createRecord">
                     New
                 </button>
             </div>
         </div>
     </t>
     <t t-name="web_hierarchy.HierarchyView">
-        <div t-attf-class="o_hierarchy_view {{ isMobile ? 'o_action_delegate_scroll' : '' }} {{ props.className }}" t-custom-ref="root">
-            <Layout className="(model.useSampleModel ? 'o_view_sample_data' : '') + ' d-flex'" display="props.display">
+        <div t-attf-class="o_hierarchy_view {{ this.isMobile ? 'o_action_delegate_scroll' : '' }} {{ this.props.className }}" t-custom-ref="root">
+            <Layout className="(this.model.useSampleModel ? 'o_view_sample_data' : '') + ' d-flex'" display="this.props.display">
                 <t t-set-slot="control-panel-additional-actions">
                     <CogMenu/>
                 </t>
                 <t t-set-slot="control-panel-buttons">
-                    <t t-call="{{ props.buttonTemplate }}"/>
+                    <t t-call="{{ this.props.buttonTemplate }}"/>
                 </t>
                 <t t-set-slot="control-panel-actions">
-                    <SearchBar toggler="searchBarToggler"/>
+                    <SearchBar toggler="this.searchBarToggler"/>
                 </t>
                 <t t-set-slot="control-panel-navigation-additional">
-                    <t t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>
+                    <t t-component="this.searchBarToggler.component" t-props="this.searchBarToggler.props"/>
                 </t>
                 <t t-set-slot="default" t-slot-scope="layout">
-                <t t-if="displayNoContent">
-					<ActionHelper noContentHelp="props.info.noContentHelp"/>
+                <t t-if="this.displayNoContent">
+					<ActionHelper noContentHelp="this.props.info.noContentHelp"/>
                 </t>
-                    <t t-component="props.Renderer"
-                        model="model"
-                        openRecord.bind="openRecord"
-                        archInfo="props.archInfo"
+                    <t t-component="this.props.Renderer"
+                        model="this.model"
+                        openRecord.bind="this.openRecord"
+                        archInfo="this.props.archInfo"
                     />
                 </t>
             </Layout>

--- a/addons/web_hierarchy/static/src/hierarchy_renderer.xml
+++ b/addons/web_hierarchy/static/src/hierarchy_renderer.xml
@@ -4,8 +4,8 @@
     <t t-name="web_hierarchy.HierarchyRenderer">
         <div class="o_hierarchy_renderer o_renderer w-100 d-flex justify-content-center" t-custom-ref="renderer">
             <div class="o_hierarchy_container d-flex flex-column w-100 w-lg-75 h-100 p-2">
-                <t t-foreach="rows" t-as="row" t-key="row_index">
-                    <t t-set="previousRow" t-value="!row_first ? rows[row_index - 1] : null"/>
+                <t t-foreach="this.rows" t-as="row" t-key="row_index">
+                    <t t-set="previousRow" t-value="!row_first ? this.rows[row_index - 1] : null"/>
                     <t t-if="!row_first">
                         <div t-if="row.parentNode and previousRow.nodes.length > 1"
                             class="o_hierarchy_parent_node_container d-flex justify-content-center"
@@ -24,8 +24,8 @@
                         <t t-foreach="row.nodes" t-as="node" t-key="node.id">
                             <HierarchyCard
                                 node="node"
-                                openRecord="props.openRecord"
-                                archInfo="props.archInfo"
+                                openRecord="this.props.openRecord"
+                                archInfo="this.props.archInfo"
                             />
                         </t>
                     </div>


### PR DESCRIPTION
In preparation for OWL3, where template variables will need to use `.this` to target component variables, we add `.this` to template variables that are targeting the component.

Script PR: odoo/odoo#247965
*targets: ["web_gantt", "web_grid", "web_hierarchy"]

task: OWL3 prep - add this. to template variables