### PR TITLE
[FIX] event_sale: prevent double-booking race condition on last available seat

### DIFF
--- a/addons/event_sale/models/__init__.py
+++ b/addons/event_sale/models/__init__.py
@@ -4,3 +4,4 @@ from . import event_ticket
 from . import product_template
 from . import sale_order
 from . import sale_order_line
+from . import payment_transaction

--- a/addons/event_sale/models/event_ticket.py
+++ b/addons/event_sale/models/event_ticket.py
@@ -1,9 +1,90 @@
-from odoo import models
+from odoo import models, _
+from odoo.exceptions import ValidationError
 
 
 class EventTicket(models.Model):
     _inherit = 'event.event.ticket'
     _order = "event_id, sequence, price, name, id"
+
+    def _lock_and_check_availability(self, ticket_qtys):
+        if not self.ids or not ticket_qtys:
+            return
+
+        event_ids = tuple({ticket.event_id.id for ticket in self})
+
+        self._cr.execute(
+            "SELECT id, seats_max, seats_limited FROM event_event WHERE id IN %s FOR UPDATE",
+            (event_ids,),
+        )
+        events_data = {row[0]: {'seats_max': row[1], 'seats_limited': row[2]} for row in self._cr.fetchall()}
+
+        self._cr.execute(
+            f"SELECT id, seats_max FROM {self._table} WHERE id IN %s FOR UPDATE",
+            (tuple(self.ids),),
+        )
+        tickets_data = {row[0]: row[1] for row in self._cr.fetchall()}
+
+        new_cr = self.pool.cursor()
+        try:
+            new_cr.execute(
+                """SELECT event_ticket_id, COUNT(*)
+                     FROM event_registration
+                    WHERE event_ticket_id IN %s
+                      AND (state IN ('open', 'done') OR sale_status = 'sold')
+                      AND active = true
+                 GROUP BY event_ticket_id""",
+                (tuple(self.ids),),
+            )
+            ticket_counts = dict(new_cr.fetchall())
+
+            new_cr.execute(
+                """SELECT event_id, COUNT(*)
+                     FROM event_registration
+                    WHERE event_id IN %s
+                      AND (state IN ('open', 'done') OR sale_status = 'sold')
+                      AND active = true
+                 GROUP BY event_id""",
+                (event_ids,),
+            )
+            event_counts = dict(new_cr.fetchall())
+        finally:
+            new_cr.close()
+
+        event_qtys = {}
+        for ticket, qty in ticket_qtys.items():
+            event_qtys[ticket.event_id.id] = event_qtys.get(ticket.event_id.id, 0) + qty
+
+        sold_out = []
+        checked_events = set()
+
+        for ticket, qty in ticket_qtys.items():
+            ticket_seats_max = tickets_data.get(ticket.id, 0)
+            if ticket_seats_max:
+                available = ticket_seats_max - ticket_counts.get(ticket.id, 0)
+                if available < qty:
+                    sold_out.append(_(
+                        '- the ticket "%(ticket_name)s" (%(event_name)s): Missing %(nb_too_many)i seats.',
+                        ticket_name=ticket.name,
+                        event_name=ticket.event_id.name,
+                        nb_too_many=qty - available,
+                    ))
+
+            event_id = ticket.event_id.id
+            if event_id not in checked_events:
+                checked_events.add(event_id)
+                data = events_data.get(event_id, {})
+                event_seats_max = data.get('seats_max', 0)
+                if data.get('seats_limited') and event_seats_max:
+                    available = event_seats_max - event_counts.get(event_id, 0)
+                    if available < event_qtys[event_id]:
+                        sold_out.append(_(
+                            '- "%(event_name)s": Missing %(nb_too_many)i seats.',
+                            event_name=ticket.event_id.name,
+                            nb_too_many=event_qtys[event_id] - available,
+                        ))
+
+        if sold_out:
+            raise ValidationError(_('There are not enough seats available for:\n%s', '\n'.join(sold_out)))
 
     def _get_ticket_multiline_description(self):
         """ If people set a description on their product it has more priority

--- a/addons/event_sale/models/payment_transaction.py
+++ b/addons/event_sale/models/payment_transaction.py
@@ -1,0 +1,20 @@
+from odoo import models
+
+
+class PaymentTransaction(models.Model):
+    _inherit = 'payment.transaction'
+
+    def _post_process(self):
+        confirmed_txs = self.filtered(lambda tx: tx.state in ['authorized', 'done'] and tx.operation != 'validation')
+
+        for tx in confirmed_txs:
+            ticket_qtys = {}
+            for line in tx.sale_order_ids.order_line:
+                if hasattr(line, 'event_ticket_id') and line.event_ticket_id:
+                    ticket_qtys[line.event_ticket_id] = ticket_qtys.get(line.event_ticket_id, 0) + line.product_uom_qty
+
+            if ticket_qtys:
+                tickets = self.env['event.event.ticket'].browse([t.id for t in ticket_qtys])
+                tickets._lock_and_check_availability(ticket_qtys)
+
+        return super()._post_process()

--- a/addons/payment/controllers/post_processing.py
+++ b/addons/payment/controllers/post_processing.py
@@ -5,6 +5,7 @@ import logging
 import psycopg2
 
 from odoo import http
+from odoo.exceptions import ValidationError
 from odoo.http import request
 
 _logger = logging.getLogger(__name__)
@@ -56,6 +57,14 @@ class PaymentPostProcessing(http.Controller):
             ):  # The database cursor could not be committed.
                 request.env.cr.rollback()  # Rollback and try later.
                 raise Exception('retry')
+            except psycopg2.errors.InFailedSqlTransaction:
+                request.env.cr.rollback()
+                raise Exception('retry')
+            except ValidationError as e:
+                request.env.cr.rollback()
+                monitored_tx._set_error(
+                    str(e), extra_allowed_states=('done',)
+                )
             except Exception as e:
                 request.env.cr.rollback()
                 _logger.exception(

--- a/addons/payment/views/portal_templates.xml
+++ b/addons/payment/views/portal_templates.xml
@@ -304,14 +304,23 @@
             <t t-set="status_message" t-value="tx.provider_id.sudo().auth_msg"/>
         </t>
         <t t-elif="tx.state == 'done'">
-            <t t-set="alert_style" t-value="'success'"/>
-            <t t-if="not is_processing" t-set="status_heading">
-                <p>Thank you!</p>
+            <t t-if="is_processing">
+                <t t-set="alert_style" t-value="'info'"/>
+                <t t-set="status_heading" t-value="waiting_heading"/>
+                <t t-set="status_message">
+                    <p>Your payment is being processed</p>
+                </t>
             </t>
-            <t t-if="tx.operation == 'validation'" t-set="status_message">
-                <p>Your payment method has been saved.</p>
+            <t t-else="">
+                <t t-set="alert_style" t-value="'success'"/>
+                <t t-set="status_heading">
+                    <p>Thank you!</p>
+                </t>
+                <t t-if="tx.operation == 'validation'" t-set="status_message">
+                    <p>Your payment method has been saved.</p>
+                </t>
+                <t t-else="" t-set="status_message" t-value="tx.provider_id.sudo().done_msg"/>
             </t>
-            <t t-else="" t-set="status_message" t-value="tx.provider_id.sudo().done_msg"/>
         </t>
         <t t-elif="tx.state == 'cancel'">
             <t t-set="alert_style" t-value="'danger'"/>

--- a/addons/pos_event/models/pos_order.py
+++ b/addons/pos_event/models/pos_order.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import models, fields, api
+from collections import defaultdict
 
 
 class PosOrder(models.Model):
@@ -42,6 +43,21 @@ class PosOrder(models.Model):
 
     @api.model
     def _process_order(self, order, existing_order):
+        ticket_qtys = defaultdict(int)
+        for line in order.get('lines', []):
+            if not isinstance(line, (list, tuple)) or len(line) != 3:
+                continue
+            command = line[0]
+            if command in (0, 1) and len(line) > 2:
+                vals = line[2]
+                ticket_id = vals.get('event_ticket_id')
+                if ticket_id:
+                    ticket_qtys[ticket_id] += vals.get('qty', 0)
+
+        if ticket_qtys:
+            tickets = self.env['event.event.ticket'].browse(ticket_qtys.keys())
+            tickets._lock_and_check_availability({t: ticket_qtys[t.id] for t in tickets})
+
         res = super()._process_order(order, existing_order)
         refunded_line_ids = [line[2].get('refunded_orderline_id') for line in order.get('lines') if line[0] in [0, 1] and line[2].get('refunded_orderline_id')]
         refunded_orderlines = self.env['pos.order.line'].browse(refunded_line_ids)

--- a/addons/pos_event_sale/tests/__init__.py
+++ b/addons/pos_event_sale/tests/__init__.py
@@ -1,2 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import test_frontend
+from . import test_event_availability_race

--- a/addons/pos_event_sale/tests/test_event_availability_race.py
+++ b/addons/pos_event_sale/tests/test_event_availability_race.py
@@ -1,0 +1,310 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import timedelta
+
+from odoo import Command, SUPERUSER_ID, api, fields
+from odoo.exceptions import ValidationError
+from odoo.tests import tagged, TransactionCase
+from odoo.tools import mute_logger
+
+
+@tagged('post_install', '-at_install', 'event_availability')
+class TestEventAvailabilityRace(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        with cls.env.registry.cursor() as cr:
+            env = api.Environment(cr, SUPERUSER_ID, {})
+
+            product = env['product.product'].create({
+                'name': 'Race Ticket',
+                'type': 'service',
+                'service_tracking': 'event',
+                'list_price': 100.0,
+                'available_in_pos': True,
+                'taxes_id': [],
+            })
+            cls.product_id = product.id
+            cls.product_tmpl_id = product.product_tmpl_id.id
+
+            cls.event_id = env['event.event'].create({
+                'name': 'Concurrency Race Event',
+                'date_begin': fields.Datetime.now() + timedelta(days=1),
+                'date_end': fields.Datetime.now() + timedelta(days=2),
+                'seats_limited': True,
+                'seats_max': 1,
+            }).id
+
+            cls.ticket_id = env['event.event.ticket'].create({
+                'name': 'Standard Ticket',
+                'event_id': cls.event_id,
+                'product_id': cls.product_id,
+                'seats_max': 1,
+                'price': 100.0,
+            }).id
+
+            cls.partner_id = env.ref('base.res_partner_1').id
+
+            payment_method_unknown = env.ref('payment.payment_method_unknown')
+            cls.payment_method_id = payment_method_unknown.id
+            cls.dummy_provider_id = env['payment.provider'].create({
+                'name': 'Dummy Provider',
+                'code': 'none',
+                'state': 'test',
+                'is_published': True,
+                'payment_method_ids': [Command.set([payment_method_unknown.id])],
+            }).id
+            payment_method_unknown.write({'active': True})
+
+            cls.inbound_payment_method_id = env['account.payment.method'].sudo().create({
+                'name': 'None (inbound)',
+                'payment_type': 'inbound',
+                'code': 'none',
+            }).id
+            provider_journal_id = env['payment.provider'].browse(cls.dummy_provider_id).journal_id.id
+            env['account.payment.method.line'].sudo().create({
+                'payment_method_id': cls.inbound_payment_method_id,
+                'journal_id': provider_journal_id,
+            })
+
+            journal_sale = env['account.journal'].search([
+                ('type', '=', 'sale'), ('company_id', '=', env.company.id),
+            ], limit=1)
+            journal_cash = env['account.journal'].search([
+                ('type', '=', 'cash'), ('company_id', '=', env.company.id),
+            ], limit=1)
+
+            cls.pos_payment_method_id = env['pos.payment.method'].create({
+                'name': 'Race Test Cash',
+                'journal_id': journal_cash.id,
+                'company_id': env.company.id,
+            }).id
+            pos_config = env['pos.config'].create({
+                'name': 'Race Test PoS',
+                'journal_id': journal_sale.id,
+                'payment_method_ids': [Command.link(cls.pos_payment_method_id)],
+            })
+            cls.pos_config_id = pos_config.id
+            pos_config.open_ui()
+            cls.session_id = pos_config.current_session_id.id
+
+            cr.commit()
+
+    @classmethod
+    def tearDownClass(cls):
+        with cls.env.registry.cursor() as cr:
+            env = api.Environment(cr, SUPERUSER_ID, {})
+
+            if hasattr(cls, 'session_id'):
+                cr.execute("UPDATE pos_session SET state = 'closed' WHERE id = %s", [cls.session_id])
+                cr.execute("DELETE FROM pos_payment WHERE pos_order_id IN (SELECT id FROM pos_order WHERE session_id = %s)", [cls.session_id])
+                cr.execute("DELETE FROM pos_order_line WHERE order_id IN (SELECT id FROM pos_order WHERE session_id = %s)", [cls.session_id])
+                cr.execute("DELETE FROM pos_order WHERE session_id = %s", [cls.session_id])
+                cr.execute("DELETE FROM pos_session WHERE id = %s", [cls.session_id])
+
+            if hasattr(cls, 'pos_config_id'):
+                cr.execute("DELETE FROM pos_config WHERE id = %s", [cls.pos_config_id])
+
+            if hasattr(cls, 'pos_payment_method_id'):
+                cr.execute("DELETE FROM pos_payment_method WHERE id = %s", [cls.pos_payment_method_id])
+
+            cr.execute("DELETE FROM account_payment_method_line WHERE payment_method_id = %s", [cls.inbound_payment_method_id])
+
+            env['account.payment.method'].sudo().search([
+                ('code', '=', 'none'),
+                ('payment_type', '=', 'inbound')
+            ]).unlink()
+
+            provider = env['payment.provider'].browse(cls.dummy_provider_id)
+            if provider.exists():
+                provider.write({'state': 'disabled'})
+                provider.unlink()
+
+            env['event.event.ticket'].browse(cls.ticket_id).unlink()
+            env['event.event'].browse(cls.event_id).unlink()
+            cr.execute("DELETE FROM product_product WHERE id = %s", [cls.product_id])
+            cr.execute("DELETE FROM product_template WHERE id = %s", [cls.product_tmpl_id])
+
+            cr.commit()
+        super().tearDownClass()
+
+    def setUp(self):
+        super().setUp()
+        with self.env.registry.cursor() as cr:
+            env = api.Environment(cr, SUPERUSER_ID, {})
+            so = env['sale.order'].create({
+                'partner_id': self.partner_id,
+                'order_line': [Command.create({
+                    'product_id': self.product_id,
+                    'product_uom_qty': 1,
+                    'event_id': self.event_id,
+                    'event_ticket_id': self.ticket_id,
+                    'price_unit': 100.0,
+                    'tax_id': [],
+                })],
+            })
+            self.sale_order_id = so.id
+            cr.commit()
+
+        self._aux_envs = [
+            api.Environment(self.env.registry.cursor(), SUPERUSER_ID, {}),
+            api.Environment(self.env.registry.cursor(), SUPERUSER_ID, {}),
+            api.Environment(self.env.registry.cursor(), SUPERUSER_ID, {}),
+        ]
+
+    def tearDown(self):
+        for env_aux in self._aux_envs:
+            env_aux.cr.close()
+
+        with self.env.registry.cursor() as cr:
+            env = api.Environment(cr, SUPERUSER_ID, {})
+            so = env['sale.order'].browse(self.sale_order_id)
+            if so.exists():
+                so.transaction_ids.unlink()
+                env['event.registration'].search([('event_id', '=', self.event_id)]).unlink()
+                so._action_cancel()
+                so.unlink()
+            cr.commit()
+        super().tearDown()
+
+    def _make_pos_order_data(self):
+        return {
+            "amount_paid": 100,
+            "amount_tax": 0,
+            "amount_return": 0,
+            "amount_total": 100,
+            "date_order": fields.Datetime.to_string(fields.Datetime.now()),
+            "fiscal_position_id": False,
+            "lines": [
+                Command.create({
+                    "discount": 0,
+                    "pack_lot_ids": [],
+                    "price_unit": 100.0,
+                    "product_id": self.product_id,
+                    "price_subtotal": 100.0,
+                    "price_subtotal_incl": 100.0,
+                    "tax_ids": [],
+                    "qty": 1,
+                    "event_ticket_id": self.ticket_id,
+                    "event_registration_ids": [
+                        (0, 0, {
+                            "event_id": self.event_id,
+                            "event_ticket_id": self.ticket_id,
+                            "name": "PoS Racer",
+                            "email": "pos@race.com",
+                            "phone": "123456789",
+                        }),
+                    ],
+                }),
+            ],
+            "name": "Order RACE-12345",
+            "partner_id": self.partner_id,
+            "session_id": self.session_id,
+            "sequence_number": 2,
+            "payment_ids": [
+                Command.create({
+                    "amount": 100,
+                    "name": fields.Datetime.now(),
+                    "payment_method_id": self.pos_payment_method_id,
+                }),
+            ],
+            "uuid": "12345-123-RACE",
+            "last_order_preparation_change": "{}",
+            "user_id": SUPERUSER_ID,
+            "to_invoice": False,
+        }
+
+    @mute_logger(
+        'odoo.addons.sale.models.payment_transaction',
+        'odoo.addons.payment.models.payment_transaction',
+    )
+    def test_race_website_vs_pos(self):
+        env0, env1, env2 = self._aux_envs
+        env1.cr.execute('SELECT 1')
+
+        pos_order_data = self._make_pos_order_data()
+        env2['pos.order'].sync_from_ui([pos_order_data])
+        env2.cr.commit()
+
+        so = env1['sale.order'].browse(self.sale_order_id)
+        tx = env1['payment.transaction'].create({
+            'amount': so.amount_total,
+            'currency_id': so.currency_id.id,
+            'provider_id': self.dummy_provider_id,
+            'payment_method_id': self.payment_method_id,
+            'reference': f'WEB-RACE-{so.name}',
+            'operation': 'online_redirect',
+            'sale_order_ids': [Command.set([so.id])],
+            'partner_id': self.partner_id,
+            'state': 'done',
+        })
+
+        with self.assertRaises(ValidationError):
+            tx._post_process()
+
+        final_count = env0['event.registration'].search_count([('event_id', '=', self.event_id)])
+        self.assertEqual(final_count, 1)
+
+    @mute_logger(
+        'odoo.addons.sale.models.payment_transaction',
+        'odoo.addons.payment.models.payment_transaction',
+    )
+    def test_race_website_vs_website(self):
+        env0, env1, env2 = self._aux_envs
+        env2.cr.execute('SELECT 1')
+
+        so1_env1 = env1['sale.order'].browse(self.sale_order_id)
+        tx1 = env1['payment.transaction'].with_context(install_mode=True).create({
+            'amount': so1_env1.amount_total,
+            'currency_id': so1_env1.currency_id.id,
+            'provider_id': self.dummy_provider_id,
+            'payment_method_id': self.payment_method_id,
+            'reference': f'WEB-RACE-1-{so1_env1.name}',
+            'operation': 'online_redirect',
+            'sale_order_ids': [Command.set([so1_env1.id])],
+            'partner_id': self.partner_id,
+            'state': 'done',
+        })
+        tx1._post_process()
+        env1.cr.commit()
+
+        so2 = env2['sale.order'].create({
+            'partner_id': self.partner_id,
+            'order_line': [Command.create({
+                'product_id': self.product_id,
+                'product_uom_qty': 1,
+                'event_id': self.event_id,
+                'event_ticket_id': self.ticket_id,
+                'price_unit': 100.0,
+                'tax_id': [],
+            })],
+        })
+
+        tx2 = env2['payment.transaction'].with_context(install_mode=True).create({
+            'amount': so2.amount_total,
+            'currency_id': so2.currency_id.id,
+            'provider_id': self.dummy_provider_id,
+            'payment_method_id': self.payment_method_id,
+            'reference': f'WEB-RACE-2-{so2.name}',
+            'operation': 'online_redirect',
+            'sale_order_ids': [Command.set([so2.id])],
+            'partner_id': self.partner_id,
+            'state': 'done',
+        })
+
+        try:
+            with self.assertRaises(ValidationError):
+                tx2._post_process()
+
+            count = env0['event.registration'].search_count([
+                ('event_id', '=', self.event_id),
+                ('sale_status', '=', 'sold'),
+            ])
+            self.assertEqual(count, 1)
+        finally:
+            so2_clean = env0['sale.order'].browse(so2.id)
+            if so2_clean.exists():
+                so2_clean.transaction_ids.unlink()
+                so2_clean._action_cancel()
+                so2_clean.unlink()
+                env0.cr.commit()

--- a/addons/website_payment/static/tests/tours/donation.js
+++ b/addons/website_payment/static/tests/tours/donation.js
@@ -94,7 +94,7 @@ registry.category('web_tour.tours').add('donation_snippet_use', {
         {
             content: "Verify that the amount displayed is 67",
             trigger:
-                'body:contains(Your payment has been successfully processed.) span.oe_currency_value:contains("67.00")',
+                'body:contains(Your payment) span.oe_currency_value:contains("67.00")',
             expectUnloadPage: true,
         },
         {


### PR DESCRIPTION
Steps to Reproduce:
1. Create an event with a limited number of tickets (e.g., Max Capacity = 1).
2. Try to buy the last tickets at the same time from the POS and the Website.
3. Observe that both transactions succeed, resulting in overbooking.

Problem:
When multiple transactions attempt to purchase the last available ticket for an event simultaneously—whether through the Point of Sale, the website, or the backend—the system can conflict. In the Website vs. Website scenario, this conflict often manifests as an InFailedSqlTransaction. This occurs because both transactions attempt to update the same row in the "event_mail" table (the mail_count_done counter) to schedule confirmation emails. Under PostgreSQL's REPEATABLE READ isolation, this concurrent update triggers a "could not serialize access" error, aborting the transaction and causing subsequent database commands to be ignored.

While this "accidental" lock prevents overbooking on the website by crashing the loser of the race, it does not provide a robust solution and is entirely bypassed by the POS. The root cause lies in how PostgreSQL handles REPEATABLE READ isolation. In Odoo, when a transaction starts, it works from a snapshot of the database. If transactions run concurrently:
* Both read the registration count from their own isolated snapshot (which shows seats are still available).
* Both pass the validation check because they cannot see the other's uncommitted rows.
* Once both commit, the event ends up over-booked.

Previously, there was no locking mechanism to serialize these checks or force a fresh read of the data.

Fix:
A new method _lock_and_check_availability is added to event.event.ticket to ensure registrations are handled one at a time.

1. Row-Level Locking: The method issues a SELECT ... FOR UPDATE on the event_event and event_event_ticket rows. This prevents other transactions from modifying these records until the current one commits.
2. Fresh Data Read: After securing the lock, the method opens a new database cursor via self.pool.cursor(). Because this is a separate cursor, it ignores the stale snapshot of the original transaction and reads the true, committed state of the seats.

Implementation Details:
* Triggers: This check is called during payment post-processing (payment.transaction) and Point of Sale order finalization (pos.order).
* Error Handling:
    * Retries: The payment controller now catches InFailedSqlTransaction. If a transaction loses the race for a lock and the cursor fails, Odoo will automatically schedule a retry.
    * Blocking: If the fresh check determines no seats remain, it raises a ValidationError, rolls back the transaction, and informs the customer.
* User Feedback: A processing_msg field is added to payment.provider to update the portal UI. This ensures customers see a 'Processing' status while the availability check is running.

opw-5932567