### PR TITLE
[FIX] account: Domain for bank accounts on credit notes

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1322,6 +1322,12 @@
                                         <field name="partner_bank_id"
                                                context="{'default_partner_id': bank_partner_id, 'display_account_trust': True}"
                                                domain="[('partner_id.ref_company_ids', 'parent_of', company_id)]"
+                                               invisible="move_type != 'out_invoice'"
+                                               readonly="state != 'draft'"/>
+                                        <field name="partner_bank_id"
+                                               context="{'default_partner_id': bank_partner_id, 'display_account_trust': True}"
+                                               domain="[('partner_id', '=', bank_partner_id)]"
+                                               invisible="move_type != 'out_refund'"
                                                readonly="state != 'draft'"/>
                                         <field name="qr_code_method"
                                                invisible="not display_qr_code"/>


### PR DESCRIPTION
Description of the issue this commit addresses:

The Recipient Bank field in the Other Info tab of the Account Move form view refilters accounts to only show you company's ones. This is expected for invoices but is blocking when doing a credit note. You can't find a partner's bank account to fill that field.

---

Steps to reproduce:

1. Install account.
2. Create an Invoice to a partner which has a bank account setup.
3. Create a Credit Note for that Invoice.
4. In the "Other Info" tab, remove the partner's bank account.
5. Try to search for his bank account to add it back. It won't show up.

---

Desired behavior after this commit is merged:

The Recipient Bank field prefilters bank accounts based on who is expected to be the recipient of the move.

---

task-5976951

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr