### PR TITLE
[FIX] l10n_mx: remove duplicate CLABE field in bank form

### DIFF
--- a/addons/l10n_mx/views/partner_view.xml
+++ b/addons/l10n_mx/views/partner_view.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_partner_bank_form_inherit_account"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='acc_number']" position="after">
-                <field name="l10n_mx_edi_clabe" optional="hide"/>
+                <field name="l10n_mx_edi_clabe" invisible="1"/>  <!-- TODO: remove this inherited view in master -->
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Currently, the CLABE field appears twice in the bank account form 
for mexican companies.

**Steps to reproduce:**
- Install the `l10n_mx` module and switch to the `ESCUELA KEMPER URGATE` company.
- Go to Invoicing > Customers > Customers and open any company partner.
- Open the `Invoicing` tab.
- For `Banks`, enter any number and click `Create and edit...`.

**Observation:**
The `CLABE` field is displayed twice in the bank account form.

**Root Cause:**
In previous versions, Banks were displayed as `lines` in the contact form. 
However, starting from `saas-18.2`, Banks are displayed as a 
`regular field with an internal link` that opens the bank form view.

After commit [1], the view at [2] indirectly inherits from 
`base.view_partner_bank_form`, while the view at [3] directly inherits 
from the same base view. Both views add the field `l10n_mx_edi_clabe`, 
resulting in the `CLABE` field being displayed twice for Mexican companies.

**Fix:**
Since removing an XML view is not considered a stable solution, in 
the stable versions, so we make this field invisible. 
In the master, removes the redundant inherited view [2].

[1]:
https://github.com/odoo/odoo/pull/187357/commits/05575b10d90cedb1ca9910aaa9f1293c3fafdd26

[2]:
https://github.com/odoo/odoo/blob/6c0baa2a976eace1f414731d66674243e90664f2/addons/l10n_mx/views/partner_view.xml#L1-L13

[3]:
https://github.com/odoo/odoo/blob/6c0baa2a976eace1f414731d66674243e90664f2/addons/l10n_mx/views/res_bank_view.xml#L15-L25

opw-6014799