### PR TITLE
[FIX] point_of_sale: reprint all previous changes from ticket screen

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -205,7 +205,10 @@ export class TicketScreen extends Component {
     async onClickReprintAll(order) {
         const printingChanges = order.uiState?.lastPrints;
         if (printingChanges) {
-            await this.pos.ticketPrinter.printOrderChanges({ order, opts: printingChanges });
+            await this.pos.ticketPrinter.printOrderChanges({
+                order,
+                opts: { orderChange: printingChanges, reprintAll: true },
+            });
         }
     }
     async onNextPage() {

--- a/addons/point_of_sale/static/src/app/utils/printer/generate_printer_data.js
+++ b/addons/point_of_sale/static/src/app/utils/printer/generate_printer_data.js
@@ -335,19 +335,21 @@ export class GeneratePrinterData {
         let orderChange = override || changesToOrder(this.order, categoryIdsSet, opts.cancelled);
         let reprint = false;
 
-        if (
-            !orderChange.new.length &&
-            !orderChange.cancelled.length &&
-            !orderChange.noteUpdate.length &&
-            !orderChange.internal_note &&
-            !orderChange.general_customer_note &&
-            order.uiState.lastPrints
-        ) {
-            orderChange = [order.uiState.lastPrints.at(-1)];
-            reprint = true;
-        } else {
-            order.uiState.lastPrints.push(orderChange);
-            orderChange = [orderChange];
+        if (!opts.reprintAll) {
+            if (
+                !orderChange.new.length &&
+                !orderChange.cancelled.length &&
+                !orderChange.noteUpdate.length &&
+                !orderChange.internal_note &&
+                !orderChange.general_customer_note &&
+                order.uiState.lastPrints
+            ) {
+                orderChange = [order.uiState.lastPrints.at(-1)];
+                reprint = true;
+            } else {
+                order.uiState.lastPrints.push(orderChange);
+                orderChange = [orderChange];
+            }
         }
 
         if (reprint && opts.orderDone) {

--- a/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
+++ b/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
@@ -537,4 +537,65 @@ describe("pos_store.js", () => {
         expect(store.getPaymentMethodFmtAmount(cash2, order)).toBe("$ 17.85");
         expect(store.getPaymentMethodFmtAmount(card2, order)).toBeEmpty();
     });
+
+    test("generatePreparationData - reprint all scenario", async () => {
+        const store = await setupPosEnv();
+        const order = await getFilledOrder(store);
+
+        const posCategories = new Set(store.models["pos.category"].getAll().map((c) => c.id));
+
+        const generator = store.ticketPrinter.getGenerator({
+            models: store.models,
+            order,
+        });
+
+        const commitChanges = async () => {
+            order.updateLastOrderChange();
+            await store.syncAllOrders();
+        };
+
+        // Initial preparation (2 lines added)
+        const initialChanges = generator.generatePreparationData(posCategories, {});
+        await commitChanges();
+
+        expect(initialChanges).toHaveLength(1);
+        expect(initialChanges[0].changes.data).toHaveLength(2);
+        expect(initialChanges[0].changes.title).toBe("NEW");
+
+        // Add new product line
+        const product = store.models["product.template"].get(14);
+        await store.addLineToOrder({ product_tmpl_id: product, qty: 2 }, order);
+
+        const addedLineChanges = generator.generatePreparationData(posCategories, {});
+        await commitChanges();
+
+        expect(addedLineChanges).toHaveLength(1);
+        expect(addedLineChanges[0].changes.data).toHaveLength(1);
+        expect(addedLineChanges[0].changes.title).toBe("NEW");
+
+        // Reprint last change
+        const reprintLast = generator.generatePreparationData(posCategories, {
+            explicitReprint: true,
+        });
+        await commitChanges();
+
+        expect(reprintLast).toHaveLength(1);
+        expect(reprintLast[0].changes.data).toHaveLength(1);
+        expect(reprintLast[0].changes.title).toBe("NEW");
+
+        // Reprint ALL changes
+        const reprintAll = generator.generatePreparationData(posCategories, {
+            orderChange: order.uiState?.lastPrints,
+            reprintAll: true,
+        });
+        await commitChanges();
+
+        expect(reprintAll).toHaveLength(2);
+
+        expect(reprintAll[0].changes.data).toHaveLength(2);
+        expect(reprintAll[0].changes.title).toBe("NEW");
+
+        expect(reprintAll[1].changes.data).toHaveLength(1);
+        expect(reprintAll[1].changes.title).toBe("NEW");
+    });
 });


### PR DESCRIPTION
Steps:
----------
- Install point_of_sale.
- Open a POS session with a preparation printer configured.
- Process an order with two different changes.
- Open the ticket screen and try to reprint all previous changes.

Issue:
----------
- No changes are printed.

Cause:
----------
- Incorrect logic used when reprinting all changes.

Fix:
----------
- Correct the logic to properly reprint all previous changes.

Task-6008291
