### PR TITLE
[FIX] l10n_it_edi: fix signed data update

### DIFF
--- a/addons/l10n_it_edi/models/account_move_send.py
+++ b/addons/l10n_it_edi/models/account_move_send.py
@@ -119,7 +119,7 @@ class AccountMoveSend(models.AbstractModel):
                 attachment_name = attachment['name']
             attachment_data = results.get(attachment_name, {})
             if attachment_data.get('signed') and (signed_data := attachment_data.get('signed_data')):
-                attachment['raw'] = signed_data.encode()
+                move.l10n_it_edi_attachment_file = signed_data.encode()
                 # Show that those moves couldn't be sent
             if 'error_message' in attachment_data:
                 moves_data[move]['error'] = {'error_title': attachment_data['error_message']}

--- a/addons/l10n_it_edi/tests/test_account_move_send.py
+++ b/addons/l10n_it_edi/tests/test_account_move_send.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import base64
 from unittest.mock import patch
 
 from odoo.tests import tagged
@@ -182,6 +183,15 @@ class TestItAccountMoveSend(TestItEdi, TestAccountMoveSendCommon):
             self.assertEqual(results, {invoice.l10n_it_edi_attachment_name: success})
             self.assertEqual(invoice.l10n_it_edi_state, "processing")
             self.assertEqual(invoice.l10n_it_edi_transaction, success['id_transaction'])
+
+    def test_l10n_it_edi_send_success_with_signed_data_update_attachment(self):
+        invoice = self.init_invoice(self.italian_partner_a)
+        self.generate_l10n_it_edi_send_attachments(invoice)
+        signed_data_result = base64.b64encode(b'some signed data').decode()
+        success = {'id_transaction': "SDI ID 1", 'signed': True, 'signed_data': signed_data_result}
+        with patch('odoo.addons.l10n_it_edi.models.account_move.AccountMove._l10n_it_edi_upload_single', return_value=success, autospec=True):
+            self.env['account.move.send']._generate_and_send_invoices(invoice, sending_methods=['email'])
+            self.assertEqual(invoice.l10n_it_edi_attachment_file, signed_data_result.encode())
 
     def test_l10n_it_edi_send_proxy_error(self):
         invoice = self.init_invoice(self.italian_partner_a)


### PR DESCRIPTION
Currently, if we try to update the existing `l10n_it_edi_attachment_file` with the signed data received during the submission of an invoice (Invoices for Italian Public Administration businesses must be signed, handled on the IAP side), it fails.

The problem is that in this specific flow, the 'attachment' variable contains a binary rather than attachment_data.

Unfortunately, I could not find a complete flow to reproduce the issue, as there is no flow that sends an invoice to SdI while the l10n_it_edi_attachment_file variable is already set in the move, except maybe via manual import of an attachment into the invoice.

Expected flow:
- User creates a move with `l10n_it_edi_attachment_file` (unspecified how)
- User sends the move to SdI for a Public Administration partner
- IAP signs the attachment and sends it back to Odoo
- Odoo raises an error because it tries to use dictionary features on a binary field
- Odoo does not save the transaction ID, and if the user tries to resend the move, a Duplicate Error occurs from the SdI side.

Ticket [link](https://www.odoo.com/odoo/project.task/5954645)
opw-5954645