### PR TITLE
[FIX] account_peppol_selfbilling: Use delivery contact on selfbilling

### DIFF
--- a/addons/account_peppol_selfbilling/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_peppol_selfbilling/models/account_edi_xml_ubl_bis3.py
@@ -30,4 +30,4 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
         supplier = vals['supplier']
         vals['supplier'] = customer
         vals['customer'] = supplier
-        vals['delivery'] = supplier
+        vals['delivery'] = supplier.child_ids.filtered(lambda p: p.type == 'delivery')[:1] or supplier

--- a/addons/account_peppol_selfbilling/tests/test_files/export/bis3/self_invoice/be/test_selfbilling.xml
+++ b/addons/account_peppol_selfbilling/tests/test_files/export/bis3/self_invoice/be/test_selfbilling.xml
@@ -82,6 +82,7 @@
   </cac:AccountingCustomerParty>
   <cac:Delivery>
     <cac:DeliveryLocation>
+      <cbc:ID schemeID="0088">0123456789</cbc:ID>
       <cac:Address>
         <cbc:StreetName>Chaussée de Namur 40</cbc:StreetName>
         <cbc:CityName>Ramillies</cbc:CityName>
@@ -93,7 +94,7 @@
     </cac:DeliveryLocation>
     <cac:DeliveryParty>
       <cac:PartyName>
-        <cbc:Name>company_1_data</cbc:Name>
+        <cbc:Name>custom delivery address</cbc:Name>
       </cac:PartyName>
     </cac:DeliveryParty>
   </cac:Delivery>

--- a/addons/account_peppol_selfbilling/tests/test_ubl_import_bis3_self_billing_be.py
+++ b/addons/account_peppol_selfbilling/tests/test_ubl_import_bis3_self_billing_be.py
@@ -22,6 +22,17 @@ class TestUblBis3SelfBilling(TestUblBis3Common, TestUblCiiBECommon):
         return subfolder_format, 'self_invoice', subfolder_country
 
     def test_export_selfbilling(self):
+        self.env['res.partner'].create({
+            'name': 'custom delivery address',
+            'parent_id': self.company.partner_id.id,
+            'type': 'delivery',
+            'street': 'Chaussée de Namur 40',
+            'city': 'Ramillies',
+            'zip': '1367',
+            'global_location_number': '0123456789',
+            'country_id': self.ref('base.be'),
+        })
+
         tax_21 = self.percent_tax(21.0)
         product = self._create_product(lst_price=100.0, taxes_id=tax_21)
         invoice = self._create_invoice_one_line(


### PR DESCRIPTION
**PROBLEM**
When selfbilling with peppol, we have no way of providing a GLN number, or modifying the delivery address. Even if we create a delivery address partner on the current company partner, it's not taken into account.

**STEP TO REPRODUCE**
1. Create a delivery address on the current company, set up a GLN number.
2. Configure the purchase journal to do selfbilling.
3. Create a vendor bill with this journal and send it using peppol.
4. Download the xml, and look for the Delivery tag, and notice it doesn't have the GLN number.

**FIX**
We search for a delivery address on the current company. If there is one, we use it for the Delivery tag.

opw-6014374