### PR TITLE
[FIX] account_edi_ubl_cii*: reverse charges and code mappings

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -4,7 +4,7 @@ from lxml import etree
 from collections import defaultdict
 
 from odoo import models, _
-from odoo.tools import html2plaintext, cleanup_xml_node
+from odoo.tools import frozendict, html2plaintext, cleanup_xml_node
 
 UBL_NAMESPACES = {
     'cbc': "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2",
@@ -210,7 +210,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
                 }
                 if epd_tax_to_discount:
                     # early payment discounts: need to recompute the tax/taxable amounts
-                    taxable_amount_after_epd = subtotal['taxable_amount'] - epd_tax_to_discount.get(subtotal['percent'], 0)
+                    epd_key = self._get_epd_grouping_key(subtotal['percent'], subtotal['tax_category_vals']['id'])
+                    taxable_amount_after_epd = subtotal['taxable_amount'] - epd_tax_to_discount.get(epd_key, 0)
                     tax_amount_after_epd = taxable_amount_after_epd * subtotal['tax_category_vals']['percent'] / 100
                     subtotal.update({
                         'taxable_amount': taxable_amount_after_epd,
@@ -268,7 +269,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         epd_tax_to_discount = self._get_early_payment_discount_grouped_by_tax_rate(invoice)
         if epd_tax_to_discount:
             # One Allowance per tax rate (VAT included)
-            for tax_amount, discount_amount in epd_tax_to_discount.items():
+            for grouping_key, discount_amount in epd_tax_to_discount.items():
+                tax_amount, tax_category_code = grouping_key.values()
                 vals_list.append({
                     'charge_indicator': 'false',
                     'allowance_charge_reason_code': '66',
@@ -277,7 +279,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
                     'currency_dp': 2,
                     'currency_name': invoice.currency_id.name,
                     'tax_category_vals': [{
-                        'id': 'S',
+                        'id': tax_category_code,
                         'percent': tax_amount,
                         'tax_scheme_id': 'VAT',
                     }],
@@ -424,10 +426,17 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         """
         return True
 
+    @staticmethod
+    def _get_epd_grouping_key(tax_amount=None, tax_code=False):
+        return frozendict({
+            'tax_amount': tax_amount,
+            'tax_code': tax_code,
+        })
+
     def _get_early_payment_discount_grouped_by_tax_rate(self, invoice):
         """
         Get the early payment discounts grouped by the tax rate of the product it is linked to
-        :returns {float: float}: mapping tax amounts to early payment discount amounts
+        :returns {(float, string): float}: mapping tax amounts to early payment discount amounts
         """
         if invoice.company_id.early_pay_discount_computation != 'mixed':
             return {}
@@ -442,7 +451,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         # - https://docs.peppol.eu/poacc/billing/3.0/2024-Q2/rules/ubl-tc434/BR-CO-12/
         for line in invoice.line_ids.filtered(lambda l: l.display_type == 'epd' and not currency.is_zero(l.amount_currency)):
             for tax in line.tax_ids:
-                tax_to_discount[tax.amount] += line.amount_currency
+                grouping_key = self._get_epd_grouping_key(tax.amount, self._get_tax_unece_codes(invoice, tax).get('tax_category_code', 'S'))
+                tax_to_discount[grouping_key] += line.amount_currency
         return tax_to_discount
 
     def _export_invoice_vals(self, invoice):

--- a/addons/account_edi_ubl_cii_tax_extension/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii_tax_extension/models/account_edi_common.py
@@ -62,16 +62,32 @@ TAX_EXEMPTION_MAPPING = {
     'VATEX-FR-CNWVAT': 'France domestic Credit Notes without VAT, due to supplier forfeit of VAT for discount',
 }
 
+# Some codes were added with _ instead of -, this is a fix for stable version to add them correctly in XML files.
+FIX_WRONG_CODES_MAPPING = {
+    'VATEX_EU_AE': 'VATEX-EU-AE',
+    'VATEX_EU_D': 'VATEX-EU-D',
+    'VATEX_EU_F': 'VATEX-EU-F',
+    'VATEX_EU_G': 'VATEX-EU-G',
+    'VATEX_EU_I': 'VATEX-EU-I',
+    'VATEX_EU_IC': 'VATEX-EU-IC',
+    'VATEX_EU_O': 'VATEX-EU-O',
+    'VATEX_EU_J': 'VATEX-EU-J',
+    'VATEX_FR-FRANCHISE': 'VATEX-FR-FRANCHISE',
+    'VATEX_FR-CNWVAT': 'VATEX-FR-CNWVAT',
+}
+
 
 class AccountEdiCommon(models.AbstractModel):
     _inherit = "account.edi.common"
 
     def _get_tax_unece_codes(self, invoice, tax):
         if tax.ubl_cii_tax_category_code:
-            tax_exemption_reason = TAX_EXEMPTION_MAPPING.get(tax.ubl_cii_tax_exemption_reason_code)
+            reason_code = tax.ubl_cii_tax_exemption_reason_code
+            reason_code = FIX_WRONG_CODES_MAPPING.get(reason_code, reason_code)
+            tax_exemption_reason = TAX_EXEMPTION_MAPPING.get(reason_code)
             return {
                 'tax_category_code': tax.ubl_cii_tax_category_code,
-                'tax_exemption_reason_code': tax.ubl_cii_tax_exemption_reason_code,
+                'tax_exemption_reason_code': reason_code,
                 'tax_exemption_reason': tax_exemption_reason,
             }
         return super()._get_tax_unece_codes(invoice, tax)

--- a/addons/account_edi_ubl_cii_tax_extension/tests/test_ubl_cii_tax_extension.py
+++ b/addons/account_edi_ubl_cii_tax_extension/tests/test_ubl_cii_tax_extension.py
@@ -3,6 +3,7 @@
 from lxml import etree
 from odoo import Command
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.account_edi_ubl_cii_tax_extension.models.account_edi_common import FIX_WRONG_CODES_MAPPING
 from odoo.tests import tagged
 
 
@@ -32,5 +33,7 @@ class TestAccountEdiUblCiiTaxExtension(AccountTestInvoicingCommon):
             xml = self.env['account.edi.xml.ubl_bis3']._export_invoice(invoice)[0]
             root = etree.fromstring(xml)
             for tax, node in zip(taxes, root.findall('.//{*}TaxTotal/{*}TaxSubtotal/{*}TaxCategory')):
+                reason_code = tax.ubl_cii_tax_exemption_reason_code
+                reason_code = FIX_WRONG_CODES_MAPPING.get(reason_code, reason_code)
                 self.assertEqual(node.findtext('.//{*}ID') or False, tax.ubl_cii_tax_category_code)
-                self.assertEqual(node.findtext('.//{*}TaxExemptionReasonCode') or False, tax.ubl_cii_tax_exemption_reason_code)
+                self.assertEqual(node.findtext('.//{*}TaxExemptionReasonCode') or False, reason_code)

--- a/addons/account_edi_ubl_cii_tax_extension/tests/test_ubl_cii_tax_extension.py
+++ b/addons/account_edi_ubl_cii_tax_extension/tests/test_ubl_cii_tax_extension.py
@@ -11,7 +11,7 @@ from odoo.tests import tagged
 class TestAccountEdiUblCiiTaxExtension(AccountTestInvoicingCommon):
 
     @classmethod
-    def setUpClass(cls, chart_template_ref=None):
+    def setUpClass(cls, chart_template_ref='l10n_be.l10nbe_chart_template'):
         super().setUpClass(chart_template_ref=chart_template_ref)
 
         cls.reverse_charge_tax = cls.company_data['default_tax_sale'].copy({'ubl_cii_tax_category_code': 'AE', 'ubl_cii_tax_exemption_reason_code': 'VATEX_EU_AE'})
@@ -37,3 +37,39 @@ class TestAccountEdiUblCiiTaxExtension(AccountTestInvoicingCommon):
                 reason_code = FIX_WRONG_CODES_MAPPING.get(reason_code, reason_code)
                 self.assertEqual(node.findtext('.//{*}ID') or False, tax.ubl_cii_tax_category_code)
                 self.assertEqual(node.findtext('.//{*}TaxExemptionReasonCode') or False, reason_code)
+
+    def test_reverse_charge_tax_with_discount_ubl_20(self):
+        self.reverse_charge_tax.amount = 0
+        self.company_data['company'].early_pay_discount_computation = 'mixed'
+        epd_payment_term = self.env['account.payment.term'].create({
+            'name': '2% discount if paid within 7 days',
+            'company_id': self.company_data['company'].id,
+            'line_ids': [Command.create({
+                'value': 'balance',
+                'days': 0,
+                'discount_percentage': 2,
+                'discount_days': 7
+            })]
+        })
+        invoice = self.env["account.move"].create({
+            "partner_id": self.partner_a.id,
+            "move_type": "out_invoice",
+            "invoice_payment_term_id": epd_payment_term.id,
+            "invoice_line_ids": [
+                Command.create({"name": "Test product", "price_unit": 100, "tax_ids": [Command.set(self.reverse_charge_tax.ids)]})],
+        })
+        invoice.action_post()
+        xml = self.env['account.edi.xml.ubl_20']._export_invoice(invoice)[0]
+        root = etree.fromstring(xml)
+
+        subtotals = root.findall('.//{*}TaxTotal/{*}TaxSubtotal/{*}TaxCategory')
+        self.assertEqual(len(subtotals), 2, "Expected for the Tax and the EPD")
+        reverse_charge, discount = subtotals
+
+        self.assertEqual(reverse_charge.findtext('.//{*}ID'), 'AE')
+        self.assertEqual(reverse_charge.findtext('.//{*}TaxExemptionReasonCode'), 'VATEX-EU-AE')
+        self.assertEqual(reverse_charge.findtext('.//{*}TaxableAmount'), '98.00')
+
+        self.assertEqual(discount.findtext('.//{*}ID'), 'AE')
+        self.assertEqual(discount.findtext('.//{*}TaxableAmount'), '2.00')
+        self.assertEqual(discount.findtext('.//{*}TaxAmount'), '0.00')


### PR DESCRIPTION
Backport of Claire's commit about tax exemption reason codes d123df0a0aacd88d89cefb51a795e7865374a46d

And fix about vat category for epd lines with reverse charge tax:

____

Steps to reproduce [l10n_be]:
- Set on the tax O% Cocont the Tax Exemption Reason Code VATEX-EU-AE
(reverse charge)
- Set a payment term with a percentage early-payment discount
- Create and confirm a customer invoice using both

Issue:
The generated xml fails Peppol validation (https://peppol-ap.test.odoo.com/filevalidator/validate).
The early-payment discount AllowanceCharge has VAT category "S" (standard) but
the invoice lines use "AE" (reverse charge).
The AE TaxSubtotal also shows the full taxable amount instead of the reduced one.

Cause:
`_get_early_payment_discount_grouped_by_tax_rate` groups by `tax.amount` only, losing the tax category (both percentage at 0%). Because of this, `_get_document_allowance_charge_vals_list`
always hardcodes `'id': 'S'` and `_get_invoice_tax_totals_vals_list` fails to find the matching key and skips the subtraction.

Solution:
Group by `(tax.amount, tax_category_code)` using the existing `_get_tax_unece_codes`
which is already overridden by `account_edi_ubl_cii_tax_extension` for exempt codes.
The real category is then used in the AllowanceCharge and the taxable base is
correctly reduced in the TaxSubtotal.

opw-4817958

