### PR TITLE
[IMP] stock, stock_dropshipping: show return_picking_type field on dropship operation types

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -138,6 +138,7 @@ class StockPickingType(models.Model):
              " * Always: a backorder is automatically created for the remaining products\n"
              " * Never: remaining products are cancelled")
     show_picking_type = fields.Boolean(compute='_compute_show_picking_type')
+    show_return_picking_type = fields.Boolean(compute='_compute_show_return_picking_type')
 
     picking_properties_definition = fields.PropertiesDefinition("Picking Properties")
     favorite_user_ids = fields.Many2many(
@@ -356,6 +357,11 @@ class StockPickingType(models.Model):
     def _compute_show_picking_type(self):
         for record in self:
             record.show_picking_type = record.code in ['incoming', 'outgoing', 'internal']
+
+    @api.depends('code')
+    def _compute_show_return_picking_type(self):
+        for picking_type in self:
+            picking_type.show_return_picking_type = picking_type.code in ['incoming', 'outgoing', 'internal']
 
     def _compute_kanban_dashboard_graph(self):
         grouped_records = self._get_aggregated_records_by_date()

--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -102,7 +102,7 @@
                                 </group>
                                 <group>
                                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
-                                    <field invisible="code not in ['incoming', 'outgoing', 'internal']" name="return_picking_type_id" string="Returns Type"/>
+                                    <field invisible="not show_return_picking_type" name="return_picking_type_id" string="Returns Type"/>
                                     <field name="create_backorder"/>
                                     <field name="move_type" help="Unless previously specified by the source document, this will be the default shipping policy for this operation type." invisible="code != 'internal'"/>
                                 </group>

--- a/addons/stock_dropshipping/models/stock.py
+++ b/addons/stock_dropshipping/models/stock.py
@@ -77,6 +77,10 @@ class StockPickingType(models.Model):
             if record.code == "dropship":
                 record.show_picking_type = True
 
+    def _compute_show_return_picking_type(self):
+        super()._compute_show_return_picking_type()
+        self.filtered(lambda pt: pt.code == 'dropship').show_return_picking_type = True
+
 
 class StockLot(models.Model):
     _inherit = 'stock.lot'


### PR DESCRIPTION
Previously the 'Returns Type' field was not visible for 'dropship' operation types.

This made it so all dropship operations had to be automatically returned with another dropship as it was not possible to set a different return type. As original deliveries and returns share the same type and sequence, it's not straightforward to differentiate both.

Now the 'Returns Type' field will also be visible for 'Dropship' operations (on the Operation Type form).

task-5911001