### PR TITLE
[IMP] hr: Add _get_hours_per_day util function:

### DIFF
--- a/addons/hr/models/hr_version.py
+++ b/addons/hr/models/hr_version.py
@@ -639,6 +639,14 @@ class HrVersion(models.Model):
             return self.hours_per_week
         return self.company_id.resource_calendar_id._get_hours_per_week()
 
+    def _get_hours_per_day(self):
+        self.ensure_one()
+        if self.resource_calendar_id:
+            return self.resource_calendar_id._get_hours_per_day()
+        if self.is_flexible:
+            return self.hours_per_day
+        return self.company_id.resource_calendar_id._get_hours_per_day()
+
     def action_open_version(self):
         self.ensure_one()
 


### PR DESCRIPTION
Similar to _get_hours_per_week(), a new util function is introduced to get the hours per day, to account for fully flexible employees

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
