### PR TITLE
[FIX] mail: do not trigger OOO reply when logging a note

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4450,7 +4450,8 @@ class MailThread(models.AbstractModel):
         """
         pids = [r['id'] for r in recipients_data if r['id']]
         additional_users_su = self.env['res.users'].sudo()
-        if self and 'user_id' in self:
+        subtype_internal = message.subtype_id.internal if message and message.subtype_id else False
+        if self and 'user_id' in self and not subtype_internal:
             additional_users_su += self.user_id.sudo().filtered(lambda u: u.partner_id != ooo_author)
 
         parent_msg = self.env['mail.message'].sudo()
@@ -4459,7 +4460,7 @@ class MailThread(models.AbstractModel):
         elif 'parent_id' not in (msg_vals or {}):
             parent_msg = message.parent_id
         parent_author = parent_msg.author_id if parent_msg.author_id.active else self.env['res.partner']
-        if parent_author and parent_author.id not in pids and parent_author != ooo_author and not parent_msg.author_id.partner_share:
+        if parent_author and parent_author.id not in pids and parent_author != ooo_author and not parent_msg.author_id.partner_share and not subtype_internal:
             additional_users_su |= parent_msg.author_id.main_user_id
         return additional_users_su
 

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -1648,6 +1648,30 @@ class TestMessagePost(TestMessagePostCommon, CronMixinCase):
                 )
 
     @users('employee')
+    def test_post_with_out_of_office_note(self):
+        """ Logging a note must not trigger OOO for the parent message author. """
+        self.test_record.with_user(self.user_employee_c2).message_post(
+            body='Can you have a look at this?',
+            message_type='comment',
+            partner_ids=self.partner_employee.ids,
+            subtype_id=self.env.ref('mail.mt_comment').id,
+        )
+        self._setup_out_of_office(self.user_employee_c2)
+
+        with self.mock_mail_gateway(), self.mock_mail_app():
+            self.test_record.message_post(
+                body='Working on it.',
+                message_type='comment',
+                subtype_id=self.env.ref('mail.mt_note').id,
+            )
+
+        self.assertEqual(len(self._new_msgs), 1, 'Only the note itself should be created')
+        self.assertFalse(
+            self._new_msgs.filtered(lambda m: m.message_type == 'out_of_office'),
+            'OOO must not fire when logging a note without addressing the OOO user',
+        )
+
+    @users('employee')
     def test_post_with_out_of_office(self):
         """ Test out of office support. Test setup :
          * record followers: user_employee_c2

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -714,7 +714,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     def test_message_log_with_post(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(admin=5, employee=5):
+        with self.assertQueryCount(admin=6, employee=6):
             record.message_post(
                 body=Markup('<p>Test message_post as log</p>'),
                 subtype_xmlid='mail.mt_note',
@@ -725,7 +725,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     def test_message_post_no_notification(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(admin=7, employee=7):
+        with self.assertQueryCount(admin=8, employee=8):
             record.message_post(
                 body=Markup('<p>Test Post Performances basic</p>'),
                 partner_ids=[],


### PR DESCRIPTION
When a user logs a note on a record, the out-of-office auto-reply of the parent message author fires incorrectly.

### Steps to reproduce

1. User A sets an out-of-office reply.
2. User A posts a message on a record, mentioning User B.
3. User B logs a note with no mention of User A.
4. User A's OOO reply is sent to User B.

### Cause

When deciding who should receive an OOO notification, the system checks not only the direct recipients of the message but also two implicit candidates: the record's assigned user and the author of the parent message. By default, every new message is automatically linked to the most recent message on the record as its parent. When User B logs a note, its parent is set to User A's last message, making User A an implicit candidate. Since User A has OOO enabled, their reply fires even though User B never addressed them.

### Fix

Notes carry an internal subtype, which means they are never directed at external or implicit recipients. The two implicit-candidate checks are skipped when the posted message has an internal subtype.

opw-5446119