### PR TITLE
[FIX] core: avoid sending invalid json-rpc responses

### DIFF
--- a/addons/web/static/src/views/view_hook.js
+++ b/addons/web/static/src/views/view_hook.js
@@ -48,7 +48,7 @@ export function useActionLinks({ resModel, reload }) {
                 options.onClose = reload || (() => render(component));
             }
             const action = await keepLast.add(orm.call(data.model, data.method));
-            if (action !== undefined) {
+            if (action !== null) {
                 keepLast.add(Promise.resolve(doAction(action, options)));
             }
         } else if (target.getAttribute("name")) {

--- a/odoo/addons/test_http/controllers.py
+++ b/odoo/addons/test_http/controllers.py
@@ -115,6 +115,10 @@ class TestHttp(http.Controller):
             raise werkzeug.exceptions.BadRequest("Invalid JSON data") from exc
         return request.make_json_response(data)
 
+    @http.route('/test_http/echo-json-null', type='jsonrpc', auth='none', readonly=True)
+    def echo_json_null(self):
+        return
+
     # =====================================================
     # Models
     # =====================================================

--- a/odoo/addons/test_http/tests/test_echo_reply.py
+++ b/odoo/addons/test_http/tests/test_echo_reply.py
@@ -93,6 +93,18 @@ class TestHttpEchoReplyJsonNoDB(TestHttpBase):
         self.assertEqual(res.status_code, 400, res.text)
         self.assertEqual(res.text, "Invalid JSON-RPC data")
 
+    def test_echojson5_null(self):
+        payload = json.dumps({
+            'jsonrpc': '2.0',
+            'id': 1234,
+            'params': {},
+        })
+        res = self.nodb_url_open("/test_http/echo-json-null", data=payload, headers=CT_JSON)
+        res.raise_for_status()
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.headers['Content-Type'], 'application/json; charset=utf-8')
+        self.assertEqual(res.text, r'{"jsonrpc": "2.0", "id": 1234, "result": null}', "result must not be absent")
+
 
 @tagged('post_install', '-at_install')
 class TestHttpEchoReplyHttpWithDB(TestHttpBase):

--- a/odoo/http/dispatcher.py
+++ b/odoo/http/dispatcher.py
@@ -338,7 +338,7 @@ class JsonRPCDispatcher(Dispatcher):
         response = {'jsonrpc': '2.0', 'id': self.request_id}
         if error is not None:
             response['error'] = error
-        if result is not None:
+        else:
             response['result'] = result
 
         return self.request.make_json_response(response)

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2687,10 +2687,9 @@ class HttpCase(TransactionCase):
         if 'error' in decoded_response:
             raise JsonRpcException(
                 code=decoded_response['error']['code'],
-                message=decoded_response['error']['data']['name']
+                message=decoded_response['error']['data']['name'],
             )
-        # workaround: JsonRPCDispatcher is broken and may send neither result nor error
-        return decoded_response.get('result')
+        return decoded_response['result']
 
 
 def no_retry(arg):


### PR DESCRIPTION
Before this change, if a jsonrpc handler was successful but returned the value `None` the dispatcher would return a response object containing just the `jsonrpc` and `id` keys.

This is an invalid response according to [JSON-RPC 2.0 Specification section 5 "Response Object"][jsonrpc-response]:

> Either the result member or error member MUST be included [...]

Prior-work: #203270 (16.0), reverted by #206444.

[jsonrpc-response]: https://www.jsonrpc.org/specification#response_object

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
