### PR TITLE
[REF] l10n_*: run owl3 rendering context migration script

### DIFF
--- a/addons/l10n_dk/static/src/components/verification_code_widget/verification_code_widget.xml
+++ b/addons/l10n_dk/static/src/components/verification_code_widget/verification_code_widget.xml
@@ -2,15 +2,15 @@
 <templates>
 
     <t t-name="l10n_dk.VerificationCodeWidget">
-        <div class="row w-50 mt-0 pt-0" t-on-focusout="_save">
+        <div class="row w-50 mt-0 pt-0" t-on-focusout="this._save">
             <t t-foreach="Array(6)" t-as="i" t-key="i_index">
                 <input class="verification_code col border border-2 rounded m-1 p-0 text-center"
                        type="text"
                        maxlength="1"
                        t-att-id="i_index"
                        t-custom-ref="input_{{i_index}}"
-                       t-on-keyup="onKeyUp"
-                       t-on-paste="onPaste"/>
+                       t-on-keyup="this.onKeyUp"
+                       t-on-paste="this.onPaste"/>
             </t>
         </div>
     </t>

--- a/addons/l10n_es_edi_tbai_pos/static/src/app/components/popups/add_tbai_refund_reason_popup/add_tbai_refund_reason_popup.xml
+++ b/addons/l10n_es_edi_tbai_pos/static/src/app/components/popups/add_tbai_refund_reason_popup/add_tbai_refund_reason_popup.xml
@@ -6,16 +6,16 @@
             <div class="mb-3">
                 <label for="tbai_refund_reason" class="form-label">TicketBAI Refund Reason: </label>
                 <select class="detail form-select" id="tbai_refund_reason" name="l10n_es_tbai_refund_reason" t-custom-model="state.l10n_es_tbai_refund_reason">
-                    <t t-foreach="pos.config._tbai_refund_reasons" t-as="l10n_es_tbai_refund_reason" t-key="l10n_es_tbai_refund_reason.value">
+                    <t t-foreach="this.pos.config._tbai_refund_reasons" t-as="l10n_es_tbai_refund_reason" t-key="l10n_es_tbai_refund_reason.value">
                         <option t-att-value="l10n_es_tbai_refund_reason.value"
-                                t-att-selected="l10n_es_tbai_refund_reason.value === state.l10n_es_tbai_refund_reason ? 'selected' : undefined">
+                                t-att-selected="l10n_es_tbai_refund_reason.value === this.state.l10n_es_tbai_refund_reason ? 'selected' : undefined">
                             <t t-out="l10n_es_tbai_refund_reason.name"/>
                         </option>
                     </t>
                 </select>
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-primary o-default-button" t-on-click="confirm">Ok</button>
+                <button class="btn btn-primary o-default-button" t-on-click="this.confirm">Ok</button>
             </t>
         </Dialog>
     </t>

--- a/addons/l10n_es_edi_verifactu_pos/static/src/app/components/popups/add_verifactu_refund_reason_popup/add_verifactu_refund_reason_popup.xml
+++ b/addons/l10n_es_edi_verifactu_pos/static/src/app/components/popups/add_verifactu_refund_reason_popup/add_verifactu_refund_reason_popup.xml
@@ -7,16 +7,16 @@
                 <label for="verifactu_refund_reason" class="form-label">Veri*Factu Refund Reason: </label>
                 <select class="detail form-select" id="verifactu_refund_reason" name="l10n_es_edi_verifactu_refund_reason"
                         t-custom-model="state.l10n_es_edi_verifactu_refund_reason">
-                    <t t-foreach="pos.config._verifactu_refund_reasons" t-as="l10n_es_edi_verifactu_refund_reason" t-key="l10n_es_edi_verifactu_refund_reason.value">
+                    <t t-foreach="this.pos.config._verifactu_refund_reasons" t-as="l10n_es_edi_verifactu_refund_reason" t-key="l10n_es_edi_verifactu_refund_reason.value">
                         <option t-att-value="l10n_es_edi_verifactu_refund_reason.value"
-                                t-att-selected="l10n_es_edi_verifactu_refund_reason.value === state.l10n_es_edi_verifactu_refund_reason ? 'selected' : undefined">
+                                t-att-selected="l10n_es_edi_verifactu_refund_reason.value === this.state.l10n_es_edi_verifactu_refund_reason ? 'selected' : undefined">
                             <t t-out="l10n_es_edi_verifactu_refund_reason.name"/>
                         </option>
                     </t>
                 </select>
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-primary o-default-button" t-on-click="confirm">Ok</button>
+                <button class="btn btn-primary o-default-button" t-on-click="this.confirm">Ok</button>
             </t>
         </Dialog>
     </t>

--- a/addons/l10n_in/static/src/components/hsn_autocomplete/hsn_autocomplete.xml
+++ b/addons/l10n_in/static/src/components/hsn_autocomplete/hsn_autocomplete.xml
@@ -2,10 +2,10 @@
 <templates>
     <t t-name="l10n_in.hsnAutoComplete">
         <AutoComplete
-            value="props.record.data[props.name] || ''"
-            sources="sources"
-            input="inputRef"
-            placeholder="props.placeholder || ''"
+            value="this.props.record.data[this.props.name] || ''"
+            sources="this.sources"
+            input="this.inputRef"
+            placeholder="this.props.placeholder || ''"
         >
             <t t-set-slot="option" t-slot-scope="optionScope">
                 <div class="text-wrap">

--- a/addons/l10n_in_pos/static/src/app/components/popups/company_state_dialog/company_state_dialog.xml
+++ b/addons/l10n_in_pos/static/src/app/components/popups/company_state_dialog/company_state_dialog.xml
@@ -9,10 +9,10 @@
             </div>
             <t t-set-slot="footer">
                 <div class="modal-footer-right d-flex gap-2">
-                    <button class="button icon btn btn-lg btn-primary" t-on-click="redirect">
+                    <button class="button icon btn btn-lg btn-primary" t-on-click="this.redirect">
                             Go to company configuration
                     </button>
-                    <button class="button btn btn-secondary" t-on-click="onClose">
+                    <button class="button btn btn-secondary" t-on-click="this.onClose">
                             Ok
                     </button>
                 </div>

--- a/addons/l10n_in_pos/static/src/app/components/popups/hsn_code_dialog/hsn_code_dialog.xml
+++ b/addons/l10n_in_pos/static/src/app/components/popups/hsn_code_dialog/hsn_code_dialog.xml
@@ -14,7 +14,7 @@
             </div>
             <t t-set-slot="footer">
                 <div class="modal-footer-right d-flex gap-2">
-                    <button class="button icon btn btn-lg btn-primary" t-on-click="redirect">
+                    <button class="button icon btn btn-lg btn-primary" t-on-click="this.redirect">
                         Go to Products
                     </button>
                 </div>

--- a/addons/l10n_ke_edi_tremol/static/src/components/ke_proxy_dialog.xml
+++ b/addons/l10n_ke_edi_tremol/static/src/components/ke_proxy_dialog.xml
@@ -8,27 +8,27 @@
                 </h4>
             </t>
             <t t-set-slot="default">
-                <div t-att-class="{'alert alert-danger': state.error}">
-                    <p t-out="state.message"/>
-                    <t t-if="!state.error">
+                <div t-att-class="{'alert alert-danger': this.state.error}">
+                    <p t-out="this.state.message"/>
+                    <t t-if="!this.state.error">
                         <div t-attf-class="o_progressbar align-items-center w-100 d-flex">
                             <div class="progress w-100 flex-fill"
                                  aria-valuemin="0"
-                                 t-att-aria-valuemax="props.invoices.length"
-                                 t-att-aria-valuenow="state.successfullySent">
+                                 t-att-aria-valuemax="this.props.invoices.length"
+                                 t-att-aria-valuenow="this.state.successfullySent">
                                 <div class="bg-primary h-100"
-                                     t-att-style="'width: min(' + 100 * state.successfullySent / props.invoices.length + '%, 100%)'"/>
+                                     t-att-style="'width: min(' + 100 * this.state.successfullySent / this.props.invoices.length + '%, 100%)'"/>
                             </div>
                             <div class="o_progressbar_value flex-shrink-0 ms-2"
-                                 t-out="state.successfullySent + ' / ' + props.invoices.length"/>
+                                 t-out="this.state.successfullySent + ' / ' + this.props.invoices.length"/>
                         </div>
                     </t>
                 </div>
             </t>
             <t t-set-slot="footer">
-                <button t-if="state.error"
+                <button t-if="this.state.error"
                         class="btn btn-primary o-default-button"
-                        t-on-click="props.close">
+                        t-on-click="this.props.close">
                     OK
                 </button>
             </t>

--- a/addons/l10n_latam_base/static/src/components/select_menu_wrapper/select_menu_wrapper.xml
+++ b/addons/l10n_latam_base/static/src/components/select_menu_wrapper/select_menu_wrapper.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
 
 <t t-name="l10n_latam_base.SelectMenuWrapper">
-    <SelectMenu t-props="state" togglerClass="'form-control'" class="'o_extended_address'" onSelect.bind="onSelect"/>
+    <SelectMenu t-props="this.state" togglerClass="'form-control'" class="'o_extended_address'" onSelect.bind="this.onSelect"/>
 </t>
 
 </templates>

--- a/addons/l10n_ro_edi/static/src/components/fetch_invoices.xml
+++ b/addons/l10n_ro_edi/static/src/components/fetch_invoices.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="l10n_ro_edi.FetchInvoices" owl="1">
-        <DropdownItem class="'o_cog_menu'" onSelected.bind="fetchInvoices">
+        <DropdownItem class="'o_cog_menu'" onSelected.bind="this.fetchInvoices">
             Synchronize with ANAF
         </DropdownItem>
     </t>

--- a/addons/l10n_sa_pos/static/src/app/add_zatca_refund_reason_popup/add_zatca_refund_reason_popup.xml
+++ b/addons/l10n_sa_pos/static/src/app/add_zatca_refund_reason_popup/add_zatca_refund_reason_popup.xml
@@ -6,16 +6,16 @@
             <div class="mb-3">
                 <label for="zatca_refund_reason" class="form-label">ZATCA Refund Reason: </label>
                 <select class="detail form-select" id="zatca_refund_reason" name="l10n_sa_reason" t-custom-model="state.l10n_sa_reason">
-                    <t t-foreach="pos.config._zatca_refund_reasons" t-as="l10n_sa_reason" t-key="l10n_sa_reason.value">
+                    <t t-foreach="this.pos.config._zatca_refund_reasons" t-as="l10n_sa_reason" t-key="l10n_sa_reason.value">
                         <option t-att-value="l10n_sa_reason.value"
-                                t-att-selected="l10n_sa_reason.value === state.l10n_sa_reason ? 'selected' : undefined">
+                                t-att-selected="l10n_sa_reason.value === this.state.l10n_sa_reason ? 'selected' : undefined">
                             <t t-out="l10n_sa_reason.name"/>
                         </option>
                     </t>
                 </select>
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-primary o-default-button" t-on-click="confirm">Ok</button>
+                <button class="btn btn-primary o-default-button" t-on-click="this.confirm">Ok</button>
             </t>
         </Dialog>
     </t>

--- a/addons/l10n_tr_nilvera_edispatch/static/src/views/list_view/ereceipt_upload.xml
+++ b/addons/l10n_tr_nilvera_edispatch/static/src/views/list_view/ereceipt_upload.xml
@@ -5,8 +5,8 @@
         <FileUploader
             acceptedFileExtensions="'.xml'"
             multiUpload="true"
-            onUploaded.bind="onEreceiptFileUpload"
-            onUploadComplete.bind="onEreceiptUploadComplete"
+            onUploaded.bind="this.onEreceiptFileUpload"
+            onUploadComplete.bind="this.onEreceiptUploadComplete"
             >
             <t t-set-slot="toggler">
                 <t t-slot="toggler"/>


### PR DESCRIPTION
In preparation for OWL3, where template variables will need to use
`.this` to target component variables, we add `.this` to template
variables that are targetting the component.

Script PR: https://github.com/odoo/odoo/pull/247965

task: OWL3 prep - add this. to template variables