### PR TITLE
[IMP] Filter time off types by country

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -144,6 +144,7 @@ class HrLeave(models.Model):
         ]""",
         tracking=True)
     work_entry_type_requires_allocation = fields.Boolean(related="work_entry_type_id.requires_allocation")
+    work_entry_type_filter_domain = fields.Json(compute="_compute_work_entry_type_filter_domain")
     color = fields.Integer("Color", related='work_entry_type_id.color')
     validation_type = fields.Selection(string='Validation Type', related='work_entry_type_id.leave_validation_type', readonly=False)
     # HR data
@@ -492,6 +493,26 @@ class HrLeave(models.Model):
                     holiday.work_entry_type_id = no_allocation_required_work_entry_types[0] if no_allocation_required_work_entry_types else None
                 else:
                     holiday.work_entry_type_id = valid_types[0]
+
+    @api.depends('company_id', 'company_id.country_id')
+    def _compute_work_entry_type_filter_domain(self):
+        for record in self:
+            country_id = record.company_id.country_id.id
+            has_system_types = False
+            if country_id:
+                has_system_types = self.env['hr.work.entry.type'].sudo().search_count([
+                    ('country_id', '=', country_id),
+                    ('create_uid', '=', 1)
+                ]) > 0
+            if not country_id:
+                domain = [('country_id', '=', False)]
+            elif has_system_types:
+                domain = [('country_id', '=', country_id)]
+            else:
+                domain = ['|', ('country_id', '=', False), ('country_id', '=', country_id)]
+
+        matching_types = self.env['hr.work.entry.type'].sudo().search(domain)
+        record.work_entry_type_filter_domain = matching_types.ids
 
     @api.depends('employee_id')
     def _compute_department_id(self):

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -342,6 +342,7 @@
         <field name="arch" type="xml">
             <form string="Time Off Request" class="o_hr_leave_form" duplicate="false">
             <field name="employee_id" invisible="1"/> <!-- for the employee's default value-->
+            <field name="work_entry_type_filter_domain" invisible="1"/>
             <field name="user_id" invisible="1"/> <!-- for conditional rendering of buttons on card -->
             <header>
                 <button string="Approve" name="action_approve" type="object" class="oe_highlight" invisible="not can_approve or not id"/>
@@ -400,15 +401,17 @@
                             </div>
                             <field name="work_entry_type_id" force_save="1"
                                 domain="[
-                                    '|',
-                                        ('requires_allocation', '=', False),
-                                        '&amp;',
-                                            ('has_valid_allocation', '=', True),
-                                            '|',
-                                                ('allows_negative', '=', True),
-                                                '&amp;',
-                                                    ('virtual_remaining_leaves', '&gt;', 0),
-                                                    ('allows_negative', '=', False),
+                                    '&amp;',
+                                        ('id', 'in', work_entry_type_filter_domain or []),
+                                        '|',
+                                            ('requires_allocation', '=', False),
+                                            '&amp;',
+                                                ('has_valid_allocation', '=', True),
+                                                '|',
+                                                    ('allows_negative', '=', True),
+                                                    '&amp;',
+                                                        ('virtual_remaining_leaves', '>', 0),
+                                                        ('allows_negative', '=', False),
                                 ]"
                                 context="{'employee_id': employee_id, 'default_date_from': date_from, 'default_date_to': date_to}"
                                 options="{'no_create': True, 'request_type': 'leave'}"


### PR DESCRIPTION
In order to improve the user experience while assigning time off to the employees of a company, it is required to omit any time off types that are not applicable or relevant to the company and display only the time off types that are available in the country where the company is founded.

Task: 5979706

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
