### PR TITLE
[FIX] pos_self_order: respect custom order name from kiosk

### DIFF
--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -182,10 +182,13 @@ class PosOrder(models.Model):
             pos_reference, tracking_number = pos_config._get_next_order_refs()
             prefix = f"K{pos_config.id}-" if device_type == "kiosk" else "S"
 
-            if device_type == 'kiosk':
-                floating_order_name = f"Table tracker {order['table_stand_number']}" if order.get('table_stand_number') else tracking_number
-            elif not floating_order_name:
-                floating_order_name = f"Self-Order T {table.table_number}" if table else f"Self-Order {tracking_number}"
+            if not floating_order_name:
+                if device_type == 'kiosk':
+                    floating_order_name = f"Table tracker {order['table_stand_number']}" if order.get('table_stand_number') else tracking_number
+                elif table:
+                    floating_order_name = f"Self-Order T {table.table_number}"
+                else:
+                    floating_order_name = f"Self-Order {tracking_number}"
 
             tracking_number = f"{prefix}{tracking_number}"
         else:


### PR DESCRIPTION
Before this commit, when a customer placed an order from a kiosk and provided a custom name, it was systematically overwritten by the backend with a generic "Table tracker X" or the tracking number.

task-id: 6014281

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
