### PR TITLE
[FIX] pos_self_order: missing available in pos

### DIFF
--- a/addons/pos_self_order/tests/test_self_order_prices.py
+++ b/addons/pos_self_order/tests/test_self_order_prices.py
@@ -40,6 +40,7 @@ class TestSelfOrderCombo(SelfOrderCommonTest):
             'uom_id': self.env.ref('uom.product_uom_unit').id,
             'combo_ids': [(6, 0, [self.combo1.id, self.combo2.id, self.combo3.id])],
             'pos_categ_ids': [(6, 0, [self.combo_category.id])],
+            'available_in_pos': True,
         })
 
         self.env['product.product'].create({
@@ -48,6 +49,7 @@ class TestSelfOrderCombo(SelfOrderCommonTest):
             'lst_price': 15.0,
             'taxes_id': [(6, 0, [self.tax_21.id])],
             'pos_categ_ids': [(6, 0, [self.combo_category.id])],
+            'available_in_pos': True,
         })
         self.env['product.product'].create({
             'name': 'Random Product 2',
@@ -55,6 +57,7 @@ class TestSelfOrderCombo(SelfOrderCommonTest):
             'lst_price': 25.0,
             'taxes_id': [(6, 0, [self.tax_12.id])],
             'pos_categ_ids': [(6, 0, [self.combo_category.id])],
+            'available_in_pos': True,
         })
         self.env['product.product'].create({
             'name': 'Random Product 3',
@@ -62,6 +65,7 @@ class TestSelfOrderCombo(SelfOrderCommonTest):
             'lst_price': 35.0,
             'taxes_id': [(6, 0, [self.tax_6.id])],
             'pos_categ_ids': [(6, 0, [self.combo_category.id])],
+            'available_in_pos': True,
         })
 
         self.price_extra_product = self.env['product.product'].create({


### PR DESCRIPTION
In some self order tests, available in pos was not set to true which could cause some errors in the tests as some products were not loaded in the self frontend.

runbot-error: 241086

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
