### PR TITLE
[PERF] account: precompute parent (sub)section mapping before rendering

### DIFF
--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
@@ -1,4 +1,4 @@
-import { Component, useEffect } from "@odoo/owl";
+import { Component, useEffect, onWillRender } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { x2ManyCommands } from "@web/core/orm_service";
 import { registry } from "@web/core/registry";
@@ -95,10 +95,14 @@ export class SectionAndNoteListRenderer extends ListRenderer {
         this.priceColumns = [...this.props.aggregatedFields, "price_unit"];
         // invisible fields to force copy when duplicating a section
         this.copyFields = ["display_type", "collapse_composition", "collapse_prices"];
+        this.parentSectionMap = new Map();
         useEffect(
             (editedRecord) => this.focusToName(editedRecord),
             () => [this.editedRecord]
         );
+        onWillRender(() => {
+            this.buildParentSectionMap();
+        });
     }
 
     get disabledMoveDownItemTooltip() {
@@ -123,6 +127,25 @@ export class SectionAndNoteListRenderer extends ListRenderer {
 
     get disableCompositionButton() {
         return this.shouldCollapse(this.record, 'collapse_composition');
+    }
+
+    buildParentSectionMap() {
+        this.parentSectionMap.clear();
+        let lastSection = null;
+        let lastSubSection = null;
+
+        for (const record of this.props.list.records) {
+            if (record.data.display_type === DISPLAY_TYPES.SECTION) {
+                lastSection = record;
+                lastSubSection = null;
+                this.parentSectionMap.set(record, null);
+            } else if (record.data.display_type === DISPLAY_TYPES.SUBSECTION) {
+                lastSubSection = record;
+                this.parentSectionMap.set(record, lastSection);
+            } else {
+                this.parentSectionMap.set(record, lastSubSection ?? lastSection);
+            }
+        }
     }
 
     async toggleCollapse(record, fieldName) {
@@ -329,7 +352,7 @@ export class SectionAndNoteListRenderer extends ListRenderer {
      * @returns {boolean}
      */
     shouldCollapse(record, fieldName, checkSection = false) {
-        const parentSection = getParentSectionRecord(this.props.list, record);
+        const parentSection = this.parentSectionMap.get(record);
 
         // --- For sections ---
         if (this.isSection(record) && checkSection) {
@@ -353,7 +376,7 @@ export class SectionAndNoteListRenderer extends ListRenderer {
 
         // --- For regular lines ---
         if (this.isSubSection(parentSection)) {
-            const grandParent = getParentSectionRecord(this.props.list, parentSection);
+            const grandParent = this.parentSectionMap.get(parentSection);
             return parentSection.data[fieldName] || grandParent?.data[fieldName];
         }
 
@@ -481,7 +504,7 @@ export class SectionAndNoteListRenderer extends ListRenderer {
         await super.sortDrop(dataRowId, dataGroupId, options);
 
         const record = this.props.list.records.find(r => r.id === dataRowId);
-        const parentSection = getParentSectionRecord(this.props.list, record);
+        const parentSection = this.parentSectionMap.get(record);
         const commands = [];
 
         if (this.resetOnResequence(record, parentSection)) {


### PR DESCRIPTION
This commit resolves a performance bottleneck that occurred when handling very
large sale orders (e.g., ~200 order lines). Previously, the util function
`getParentSectionRecord` determined the parent (sub)section of an order line by
iterating over all preceding order lines. Since this logic was executed for each
order line, the overall complexity became O(n²).

Moreover, this function was invoked inside the `shouldCollapse` method, which is
used in multiple UI flows during rendering. As a result, large sale orders could
cause noticeable UI slowdowns and block the main JavaScript thread.

To address this, we now build a parent–child section mapping once per render
in O(n) time. Subsequent lookups simply read from this mapping instead of
recomputing the parent by scanning previous lines.

This significantly reduces the computational cost and prevents UI blocking when
working with large orders, leading to a much smoother rendering experience.

opw-5865167

Benchmark:

| No. records | Before      | After        |
|----------------|---------------|--------------|
|       150      |   1300ms  |   ~850ms |


| Before      | After        |
|---------------|--------------|
|   <img width="287" height="284" alt="image" src="https://github.com/user-attachments/assets/dd73ab18-3c53-4958-99b7-083dd5cd9e64" />  |   <img width="311" height="277" alt="image" src="https://github.com/user-attachments/assets/b6e90fa3-85eb-4d72-b616-28aff9a938e8" />|
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
