### PR TITLE
[IMP] base, mail, tools: make attachment links impossible to miss

### DIFF
--- a/addons/cloud_storage_azure/tests/test_cloud_storage_azure.py
+++ b/addons/cloud_storage_azure/tests/test_cloud_storage_azure.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
+import re
 import requests
 
 from datetime import datetime, timezone, timedelta
@@ -215,6 +216,9 @@ class TestCloudStorageAzure(TestCloudStorageAzureCommon, MockEmail):
 
     def test_cloud_storage_attachments(self):
         """Cloud attachments should be converted to links in outgoing emails."""
+        def normalize_html(html):
+            return re.sub(r'(?=<)', '\n',
+                          " ".join(line.strip() for line in html.strip().splitlines() if line.strip()))
 
         thread_model = self.env["res.partner"].create({"name": "Cloud Test Partner", "email": "cloud@test.com"})
         cloud_attachment = self.env["ir.attachment"].create({
@@ -246,7 +250,8 @@ class TestCloudStorageAzure(TestCloudStorageAzureCommon, MockEmail):
         self.assertEqual(len(self._mails), 2, "Two emails should be sent.")
 
         for body, attachment in zip([m["body"] for m in self._mails], self._new_mails.attachment_ids):
-            large_attachment_link = str(self.env["ir.qweb"]._render("mail.mail_attachment_links", {"attachments": attachment}))
+            body = normalize_html(body)
+            large_attachment_link = normalize_html(str(self.env["mail.mail"]._render_attachments_links(attachment)))
             self.assertEqual(body.count(large_attachment_link), 1,
                     "Sending mail with cloud_storage attachment should rendered it as a link in the outgoing email.",
             )
@@ -283,7 +288,8 @@ class TestCloudStorageAzure(TestCloudStorageAzureCommon, MockEmail):
                 "Only text attachment should be sent in the message")
 
         for body, attachment in zip([m["body"] for m in self._mails], self._new_mails.attachment_ids):
-            large_attachment_link = str(self.env["ir.qweb"]._render("mail.mail_attachment_links", {"attachments": cloud_attachment}))
+            body = normalize_html(body)
+            large_attachment_link = normalize_html(str(self.env["mail.mail"]._render_attachments_links(cloud_attachment)))
             self.assertEqual(body.count(large_attachment_link), 1,
                     "Sending mail with cloud_storage attachment should rendered it as a link in the outgoing email.",
             )
@@ -321,13 +327,11 @@ class TestCloudStorageAzure(TestCloudStorageAzureCommon, MockEmail):
         with self.mock_mail_gateway(mail_unlink_sent=False):
             composer._action_send_mail()
 
-        for body, attachment in zip([m["body"] for m in self._mails], self._new_mails.attachment_ids):
-            cloud_attachment_present = body.count(cloud_attachment.access_token) == body.count(cloud_attachment.name) == 1
-            cloud_attachment2_present = body.count(cloud_attachment2.access_token) == body.count(cloud_attachment2.name) == 1
-            large_attachment_link = str(self.env["ir.qweb"]._render("mail.mail_attachment_links", {"attachments": large_attachment}))
-            self.assertTrue(body.count(large_attachment_link) == 1 and cloud_attachment_present and cloud_attachment2_present,
-                "Two cloud and one large attachments should be converted and sent as links in the outgoing email.",
-            )
+        self.assertEqual(len(self._new_mails.attachment_ids), 3)
+        for body in [m["body"] for m in self._mails]:
+            self.assertIn(cloud_attachment.access_token, body, "cloud attachment should be converted as link")
+            self.assertIn(cloud_attachment2.access_token, body, "cloud attachment should be converted as link")
+            self.assertIn(large_attachment.access_token, body, "large attachment should be converted as link")
 
     def test_uninstall_fail(self):
         with self.assertRaises(UserError, msg="Don't uninstall the module if there are Azure attachments in use"):

--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -149,6 +149,7 @@ For more specific needs, you may also assign custom-defined actions
             'mail/static/src/**/public_web/**/*',
             'mail/static/src/**/web_portal/**/*',
             'mail/static/src/**/web/**/*',
+            'mail/static/src/xml/**/*',
             ('remove', 'mail/static/src/**/*.dark.scss'),
             # discuss (loaded last to fix dependencies)
             ('remove', 'mail/static/src/discuss/**/*'),

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -5,6 +5,8 @@ import ast
 import datetime
 import json
 import logging
+import lxml
+import markupsafe
 import psycopg2
 import pytz
 import re
@@ -393,6 +395,70 @@ class MailMail(models.Model):
             body = re.sub(_UNFOLLOW_REGEX, '', body)
         return body
 
+    @api.model
+    def _render_attachments_links(self, attachments):
+        """ Temporary replacement for the mail.mail_attachment_links template in stable. """
+        rendered_attachments = [markupsafe.Markup("""
+        <div style="display: inline" data-attachment-id="%(attachment_id)s">
+            <div style="padding:0; margin:3px; vertical-align:middle; min-width:425px; width:fit-content; display:inline-block" width="fit-content">
+                <div style="margin:0; padding: 10px; border-style:solid; border-width:0 0 0 3px; border-radius:5px; border-color:#a2dae3; background-color:#d1ecf1; color:#09414a;">
+                    <a href="%(attachment_base_url)s/web/content/%(attachment_id)s?download=1&amp;access_token=%(attachment_access_token)s"
+                        style="margin:0; padding:0; text-decoration:none; border-radius:0; border-style:none; border-color:#008f8c; border-width:0; font-weight:500; width:100%%; color:#008f8c; vertical-align: middle; font-size: 15px;"
+                        width="100%%" target="_blank">
+                         &#11015; %(attachment_name)s
+                    </a>
+                </div>
+            </div>
+        </div>
+        """) % {
+            'attachment_id': a.id,
+            'attachment_access_token': a.access_token,
+            'attachment_name': a.name,
+            'attachment_base_url': a.get_base_url(),
+        }
+                                for a in attachments]
+        return markupsafe.Markup(
+            """<div class="o-attachments-container" style="margin-top: 10px; margin-bottom: 10px; max-width: 900px; width: 100%%;">
+                %(attachments)s
+            </div>""") % {'attachments': markupsafe.Markup('').join(rendered_attachments)}
+
+    @api.model
+    def _render_attachment_links_in_body(self, body, attachments):
+        """ Render the attachment container in the email body with download links when required.
+
+        :param str body: the original email body (HTML).
+        :param recordset attachments: attachments to render as links.
+        :return: the modified body with the inserted download links
+        :rtype: str
+        """
+        try:
+            root = lxml.html.fromstring(body or '').getroottree()
+            container = root.xpath('//div[hasclass("o-attachments-container")][not(ancestor::*[@data-oe-version])]')
+        except lxml.etree.ParserError:
+            root = None
+            container = []
+
+        attachments.generate_access_token()
+        attachments_node = lxml.etree.fromstring(self._render_attachments_links(attachments))
+        if len(container) == 0:
+            if root is None:
+                # We just add it at the end as the parsing of the body has failed
+                return tools.mail.append_content_to_html(
+                    body or '', lxml.html.tostring(attachments_node).decode(), plaintext=False)
+            elif len(signature_container := root.xpath('//div[hasclass("o-signature-container")][not(ancestor::*[@data-oe-version])]')):
+                signature_container[0].addprevious(attachments_node)
+            # elif len(body_node := root.findall('body')):
+            elif len(body_node := root.xpath('//body')):
+                body_node[0].insert(0, attachments_node)
+            elif len(html_node := root.xpath('//html')):
+                html_node[0].insert(0, attachments_node)
+            else:
+                root.append(attachments_node)
+        else:
+            # Add a second container just after the existing one
+            container[0].addnext(attachments_node)
+        return lxml.html.tostring(root).decode()
+
     def _prepare_outgoing_list(self, mail_server=False, recipients_follower_status=None):
         """ Return a list of emails to send based on current mail.mail. Each
         is a dictionary for specific email values, depending on a partner, or
@@ -483,13 +549,9 @@ class MailMail(models.Model):
                 attachments = attachments - self.env['ir.attachment'].browse(list(link_ids))
 
         # Convert URL-only attachments (e.g. cloud or plain external links) into email links
-        url_attachments = attachments.sudo().filtered(
+        attachments_to_links = attachments.sudo().filtered(
             lambda a: a.url and not a.file_size and a.url.startswith(('http://', 'https://', 'ftp://')))
-        if url_attachments:
-            url_attachments.sudo().generate_access_token()
-            attachments_links = self.env['ir.qweb']._render('mail.mail_attachment_links', {'attachments': url_attachments})
-            body = tools.mail.append_content_to_html(body, attachments_links, plaintext=False)
-            attachments -= url_attachments
+        attachments -= attachments_to_links
 
         # Turn remaining attachments into links if they are too heavy and
         # their ownership are business models (i.e. something != mail.message,
@@ -501,12 +563,15 @@ class MailMail(models.Model):
             max_email_size_bytes = (mail_server or self.env['ir.mail_server']
                                     ).sudo()._get_max_email_size() * 1024 * 1024
             if estimated_email_size_bytes > max_email_size_bytes:
-                # Remove attachments and prepare downloadable links to be added in the body
-                record_owned_attachments.sudo().generate_access_token()
-                attachments_links = self.env['ir.qweb']._render('mail.mail_attachment_links',
-                                                                {'attachments': record_owned_attachments})
-                body = tools.mail.append_content_to_html(body, attachments_links, plaintext=False)
+                attachments_to_links |= record_owned_attachments
                 attachments -= record_owned_attachments
+
+        if attachments_to_links:
+            # force = True as we already have determined that the attachments must be turned into links
+            # append = True as an attachment link container could already have been added by the client in the body,
+            # and all attachment corresponding to a link in the body are removed above.
+            body = self._render_attachment_links_in_body(body, attachments_to_links)
+
         # Prepare the remaining attachment (those not embedded as link)
         # load attachment binary data with a separate read(), as prefetching all
         # `datas` (binary field) could bloat the browse cache, triggering

--- a/addons/mail/static/src/core/web/mail_composer_attachment_selector.js
+++ b/addons/mail/static/src/core/web/mail_composer_attachment_selector.js
@@ -4,7 +4,7 @@ import { standardFieldProps } from "@web/views/fields/standard_field_props";
 import { useService } from "@web/core/utils/hooks";
 import { useX2ManyCrud } from "@web/views/fields/relational_utils";
 
-import { Component } from "@odoo/owl";
+import { Component, onMounted } from "@odoo/owl";
 import { FileUploader } from "@web/views/fields/file_handler";
 
 export class MailComposerAttachmentSelector extends Component {
@@ -18,6 +18,11 @@ export class MailComposerAttachmentSelector extends Component {
         this.operations = useX2ManyCrud(() => {
             return this.props.record.data["attachment_ids"];
         }, true);
+        // Turn attachments into links if needed when opening the composer.
+        onMounted(() => {
+            // The delay is required for the html-editor to be ready to receive the event that does the work.
+            setTimeout(this.onAttachmentAdded.bind(this), 1000);
+        });
     }
 
     /** @param {Object} data */
@@ -41,10 +46,22 @@ export class MailComposerAttachmentSelector extends Component {
             await this.operations.saveRecord([attachment.id]);
         }
     }
+
+    onAttachmentAdded() {
+        this.env.fullComposerBus?.trigger("ATTACHMENT_ADDED", {
+            attachments: this.props.record.data.attachment_ids.records,
+        });
+    }
 }
 
 export const mailComposerAttachmentSelector = {
     component: MailComposerAttachmentSelector,
+    relatedFields: () => {
+        return [
+            { name: "file_size", type: "integer", readOnly: true },
+            { name: "id", type: "integer", readonly: true },
+        ];
+    },
 };
 
 registry

--- a/addons/mail/static/src/core/web/mail_composer_attachment_selector.xml
+++ b/addons/mail/static/src/core/web/mail_composer_attachment_selector.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates>
     <t t-name="mail.MailComposerAttachmentSelector">
-        <FileUploader multiUpload="true" onUploaded.bind="onFileUploaded">
+        <!-- This template is used by mail_attachments_selector without the method onAttachmentAdded -->
+        <FileUploader multiUpload="true" onUploaded.bind="onFileUploaded"
+            onUploadComplete="() => this.onAttachmentAdded?.()">
             <t t-set-slot="toggler">
                 <button class="btn btn-light w-auto" data-hotkey="a">
                     <i class="fa fa-fw fa-paperclip"/>

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.js
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.js
@@ -1,7 +1,9 @@
 import { DYNAMIC_PLACEHOLDER_PLUGINS } from "@html_editor/plugin_sets";
 import { isEmpty } from "@html_editor/utils/dom_info";
+import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
-import { useBus } from "@web/core/utils/hooks";
+import { useBus, useService } from "@web/core/utils/hooks";
+import { renderToElement } from "@web/core/utils/render";
 import { HtmlMailField, htmlMailField } from "../html_mail_field/html_mail_field";
 import { MentionPlugin } from "./mention_plugin";
 import { SIGNATURE_CLASS } from "@html_editor/main/signature_plugin";
@@ -10,6 +12,8 @@ import { fillEmpty } from "@html_editor/utils/dom";
 export class HtmlComposerMessageField extends HtmlMailField {
     setup() {
         super.setup();
+        const notification = useService("notification");
+        const uploadService = useService("uploadLocalFiles");
         if (this.env.fullComposerBus) {
             useBus(this.env.fullComposerBus, "ACCIDENTAL_DISCARD", (ev) => {
                 const elContent = this.getNoSignatureElContent();
@@ -27,6 +31,68 @@ export class HtmlComposerMessageField extends HtmlMailField {
                 const textValue = elContent.innerText.replace(/(\t|\n)+/g, "\n");
                 elContent.remove();
                 ev.detail.onSaveContent(textValue, emailAddSignature);
+            });
+            useBus(this.env.fullComposerBus, "ATTACHMENT_ADDED", async (ev) => {
+                // Attachments added with the html editor directly should not be taken into account
+                const allAttachmentIdsNode = Array.from(
+                    this.editor.editable.querySelectorAll("[data-attachment-id]")
+                );
+                const outSideAttachmentIds = allAttachmentIdsNode
+                    .filter((el) => el.closest(".o-attachments-container") === null)
+                    .map((el) => Number(el.getAttribute("data-attachment-id")));
+                const attachments = ev.detail.attachments
+                    .map((a) => a.data)
+                    .filter((a) => !outSideAttachmentIds.includes(a.id));
+                // Filter out already added attachments
+                const allAttachmentIds = allAttachmentIdsNode.map((el) =>
+                    Number(el.getAttribute("data-attachment-id"))
+                );
+                const filteredAttachments = attachments.filter(
+                    (a) => !allAttachmentIds.includes(a.id)
+                );
+                if (!filteredAttachments.length) {
+                    return;
+                }
+                const maxEmailSize = 10;
+                const totalSize = attachments
+                    .map((a) => a.file_size)
+                    .reduce((acc, current) => acc + current, 0);
+                // Approximate the server-side mail size estimation (mail_mail._estimate_email_size)
+                const emailOverhead = 100 * 1024;
+                if (totalSize + emailOverhead <= maxEmailSize * 1024 * 1024) {
+                    return;
+                }
+                const newAttachmentContainer = renderToElement("mail.mail_attachment_links", {
+                    attachments: attachments.map((attachment) => ({
+                        ...attachment,
+                        url: uploadService.getURL(attachment, {
+                            download: true,
+                            unique: true,
+                            accessToken: true,
+                        }),
+                    })),
+                });
+                const attachmentContainer = this.editor.editable.querySelector(
+                    ".o-attachments-container"
+                );
+                if (!attachmentContainer) {
+                    const signature = this.editor.editable.querySelector(".o-signature-container");
+                    if (signature) {
+                        signature.before(newAttachmentContainer);
+                    } else {
+                        this.editor.editable.firstChild.before(newAttachmentContainer);
+                    }
+                } else {
+                    attachmentContainer.replaceWith(newAttachmentContainer);
+                }
+                this.editor.shared.history.addStep();
+                notification.add(
+                    _t(
+                        "Your attachments exceed %(maxSizeInMB)sMB and will be sent as secure links to ensure they reach your recipients",
+                        { maxSizeInMB: Math.round(maxEmailSize) }
+                    ),
+                    { type: "info" }
+                );
             });
             useBus(this.env.fullComposerBus, "ATTACHMENT_REMOVED", (ev) => {
                 const attachmentElements = this.editor.editable.querySelectorAll(

--- a/addons/mail/static/src/xml/mail_attachments.xml
+++ b/addons/mail/static/src/xml/mail_attachments.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="mail.mail_attachment_links">
+        <div class="o-attachments-container o-contenteditable-false" style="margin-top: 10px; margin-bottom: 10px; max-width: 900px; width: 100%;">
+            <div style="display: inline" t-foreach="attachments" t-key="attachment.id" t-as="attachment" t-att-data-attachment-id="attachment.id">
+                <div style="padding:0; margin:3px; vertical-align:middle; min-width:425px; width:fit-content; display:inline-block" width="fit-content">
+                    <div style="margin:0; padding: 10px; border-style:solid; border-width:0 0 0 3px; border-radius:5px; border-color:#a2dae3; background-color:#d1ecf1; color:#09414a;">
+                        <a t-att-href="attachment.url"
+                            style="margin:0; padding:0; text-decoration:none; border-radius:0; border-style:none; border-color:#008f8c; border-width:0; font-weight:500; width:100%; color:#008f8c; vertical-align: middle; font-size: 15px;"
+                            width="100%" target="_blank">
+                             &#11015; <t t-out="attachment.name"/>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </t>
+
+</templates>

--- a/addons/mail/tests/test_mail_mail.py
+++ b/addons/mail/tests/test_mail_mail.py
@@ -1,3 +1,7 @@
+import base64
+from itertools import product
+import re
+
 from odoo.tests import TransactionCase
 from unittest import mock
 import smtplib
@@ -33,3 +37,52 @@ class MailCase(TransactionCase):
             "Error without exception. Probably due to sending "
             "an email without computed recipients."
         )
+
+    def test_render_attachment_links_in_body(self):
+        """Test attachment link rendering over various body formats and attachment counts."""
+        # size of header ({}), overhead from _estimate_email_size, overhead from _render_attachment_links_in_body
+        MailMail = self.env['mail.mail']
+        default_overhead_size = 2 + 10 * 1024 + 5000
+        no_attachments = self.env['ir.attachment']
+        content = b'TEST'
+        content_len = len(base64.b64encode(content))
+        all_attachments = self.env['ir.attachment'].create(
+            [{'name': name, 'raw': content}
+             for name in ['test1.txt', 'test2.txt', 'outside.txt']])
+        outside_attachment = all_attachments[2]
+        outside_attachment.generate_access_token()
+        for attachments, (body, expected_match) in product(
+                (
+                        no_attachments,
+                        all_attachments[0],
+                        all_attachments[:2],
+                ),
+                (
+                        (False, r'.*<div class="o-attachments-container"'),
+                        ('', r'.*<div class="o-attachments-container"'),
+                        ('OUTSIDE only text', r'.*<div class="o-attachments-container".*only text'),
+                        ('<html>OUTSIDE <p>broken html</p></htm>',
+                         r'.*<html>.*<div class="o-attachments-container".*broken html'),
+                        ('<root>OUTSIDE broken html</root>', r'.*<div class="o-attachments-container".*broken html'),
+                        ('<html>OUTSIDE <p>fine html</p></html>',
+                         r'.*<div class="o-attachments-container".*fine html</p>'),
+                        ('<html><body><p>OUTSIDE correct html</p></body></html>', r'.*<div class="o-attachments-container".*correct html'),
+                        ('<html><body>OUTSIDE Hello, <div class="o-signature-container">Signature</div></body></html>',
+                         r'.*Hello,.*<div class="o-attachments-container".*o-signature-container'),
+                        (('<html><body>OUTSIDE Hello <div class="o-attachments-container">can be replaced</div>..., '
+                          '<div class="o-signature-container">Signature</div></body></html>'),
+                         r'.*Hello.*<div class="o-attachments-container".*o-signature-container'),
+                ),
+        ):
+            # Setup limit to be reach with the second attachment only
+            self.env['ir.config_parameter'].sudo().set_param(
+                'base.default_max_email_size',
+                (default_overhead_size + (len(body) if body else 0) + content_len + 1) / 1024.0 / 1024.0)
+            with self.subTest(test='without outside attachment', body=body, attachments=attachments):
+                rendered = MailMail._render_attachment_links_in_body(body, attachments)
+                self.assertEqual(rendered.count('o-attachments-container'),
+                                 (body or '').count('o-attachments-container') + 1)
+                self.assertTrue(re.match(expected_match, rendered, re.DOTALL))
+                for idx, attachment in enumerate(attachments):
+                    self.assertTrue(attachment.access_token, f'attachment {idx} must have a token')
+                    self.assertIn(attachment.access_token, rendered, f'attachment {idx} must be present')

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -422,7 +422,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         test_record, _test_template = self._create_test_records()
         customer = self.env['res.partner'].browse(self.customer.ids)
         attachments = self.env['ir.attachment'].with_user(self.env.user).create(self.test_attachments_vals)
-        with self.assertQueryCount(admin=10, employee=10):  # tm 8/8
+        with self.assertQueryCount(admin=19, employee=19):  # tm 18/18
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',


### PR DESCRIPTION
When an email is too big the server turns attachments into links but often recipients don't see the links as they are appended at the end of the email. To avoid that, we turn the attachments into links directly in the composer when the attachments are added so the sender is aware that the attachments are converted into links and can layout them to avoid the problem.

We keep the server mechanism that turns attachments into links as a fallback as we only support the convertion into link in the composer for now.

Task-5912830