### PR TITLE
[FIX] base: override activity_type_id

### DIFF
--- a/addons/mail/models/ir_actions_server.py
+++ b/addons/mail/models/ir_actions_server.py
@@ -85,7 +85,8 @@ class IrActionsServer(models.Model):
     activity_type_id = fields.Many2one(
         'mail.activity.type', string='Activity Type',
         domain="['|', ('res_model', '=', False), ('res_model', '=', model_name)]",
-        compute='_compute_activity_type_id', readonly=False, store=True,
+        related=False, compute='_compute_activity_type_id', search=False,
+        readonly=False, store=True,
         ondelete='restrict')
     activity_summary = fields.Char('Summary', readonly=False, store=True)
     activity_note = fields.Html('Note', readonly=False, store=True)

--- a/addons/test_mail/tests/test_ir_actions.py
+++ b/addons/test_mail/tests/test_ir_actions.py
@@ -192,10 +192,9 @@ class TestServerActionsEmail(MailCommon, TestServerActionsBase):
             action_form.model_id = self.res_partner_model
             action_form.state = 'next_activity'
             self.assertTrue(action_form._get_modifier('activity_plan_id', 'invisible'))
-            self.assertEqual(action_form.name, 'Create Activity')
             self.assertTrue(action_form._get_modifier('activity_type_id', 'required'))
 
-            action_form.activity_type_id = self.env.ref('mail.mail_activity_data_todo')
+            self.assertEqual(action_form.activity_type_id, self.env.ref('mail.mail_activity_data_todo'))
             self.assertEqual(action_form.name, 'Create To-Do')
             self.assertEqual(action_form.activity_summary, 'To-Do')
             self.assertEqual(action_form.activity_date_deadline_range, 1)


### PR DESCRIPTION
The field ``ir.actions.server.activity_type_id`` is still a related field with ``_compute_related`` and ``_inverse_related`` even if we specify its compute methods as ``_compute_activity_type_id``

The base field of the field ``ir.actions.server.activity_type_id`` is in the model ``mail.activity.mixin``. It is a non-stored related field. When overriding the field with a customized compute method, we have to explicitly override the ``field.related`` attribute to prevent the orm populates attributes for related fields. Also since the field ``ir.actions.server.activity_type_id`` is stored, it doesn't need a search method.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
