### PR TITLE
[FIX] discuss: wait initial channel fetches...

### DIFF
--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -346,6 +346,7 @@ test("Inset card is hidden when sidebar is open", async () => {
 test("join/leave sounds are only played on main tab", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    listenStoreFetch("channels_as_member");
     const env1 = await start({ asTab: true });
     const env2 = await start({ asTab: true });
     patchWithCleanup(env1.services["mail.sound_effects"], {
@@ -359,7 +360,9 @@ test("join/leave sounds are only played on main tab", async () => {
         },
     });
     await openDiscuss(channelId, { target: env1 });
+    await waitStoreFetch("channels_as_member");
     await openDiscuss(channelId, { target: env2 });
+    await waitStoreFetch("channels_as_member");
     await click(`${env1.selector} [title='Start Call']`);
     await contains(`${env1.selector} .o-discuss-Call`);
     await contains(`${env2.selector} .o-discuss-Call`);


### PR DESCRIPTION
...in crosstab call test

The "join/leave sounds are only played on main tab" test could race with the
initial `channels_as_member` fetches triggered when opening Discuss in both
tab

Those fetches return full channel data, including `rtc_session_ids`.
one of their responses could arive after the call had already progressed
or ended and overwrite the state with stale RTC data

Wait for `channels_as_member` to be fully processed after opening Discuss in
each tab before starting the call.

fix for: https://runbot.odoo.com/odoo/runbot.build.error/241061