### PR TITLE
[FIX] hr_attendance: Fix overtime calculation for shifts crossing UTC midnight

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -270,8 +270,8 @@ class HrAttendance(models.Model):
             return Domain.FALSE
         domain_list = [Domain.AND([
             Domain('employee_id', '=', employee.id),
-            Domain('date', '<=', max(attendances.mapped('check_out')).date() + relativedelta(SU)),
-            Domain('date', '>=', min(attendances.mapped('check_in')).date() + relativedelta(MO(-1))),
+            Domain('date', '<=', max(attendances.mapped('check_out')).date() + relativedelta(weekday=SU(1))),
+            Domain('date', '>=', min(attendances.mapped('check_in')).date() + relativedelta(weekday=MO(-1))),
         ]) for employee, attendances in self.filtered(lambda att: att.check_out).grouped('employee_id').items()]
         if not domain_list:
             return Domain.FALSE
@@ -280,7 +280,11 @@ class HrAttendance(models.Model):
     def _update_overtime(self, attendance_domain=None):
         if not attendance_domain:
             attendance_domain = self._get_overtimes_to_update_domain()
-        self.env['hr.attendance.overtime.line'].search(attendance_domain).unlink()
+        all_overtime_lines = self.env['hr.attendance.overtime.line'].search(attendance_domain)
+        manual_overtimes = set(all_overtime_lines.filtered(
+            lambda l: l.manual_duration != l.duration or l.status == 'to_approve'
+        ).mapped(lambda l: (l.employee_id.id, l.date)))
+        all_overtime_lines.unlink()
         all_attendances = (self | self.env['hr.attendance'].search(attendance_domain)).filtered_domain([('check_out', '!=', False)])
         if not all_attendances:
             return
@@ -305,9 +309,13 @@ class HrAttendance(models.Model):
         overtime_vals_list = []
         for ruleset_sudo, ruleset_attendances in attendances_by_ruleset.items():
             attendances_dates = list(chain(*ruleset_attendances._get_dates().values()))
-            overtime_vals_list.extend(
-                ruleset_sudo.rule_ids._generate_overtime_vals_v2(min(attendances_dates), max(attendances_dates), ruleset_attendances, schedules_intervals_by_employee)
-            )
+            overtime_vals_list.extend([
+                {
+                    **val,
+                    'status': 'to_approve'
+                } if (val['employee_id'], val['date']) in manual_overtimes else val
+                for val in ruleset_sudo.rule_ids._generate_overtime_vals_v2(min(attendances_dates), max(attendances_dates), ruleset_attendances, schedules_intervals_by_employee)
+            ])
         self.env['hr.attendance.overtime.line'].create(overtime_vals_list)
         self.env.add_to_compute(self._fields['overtime_hours'], all_attendances)
         self.env.add_to_compute(self._fields['validated_overtime_hours'], all_attendances)

--- a/addons/hr_attendance/tests/test_hr_attendance_rulesets.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_rulesets.py
@@ -112,15 +112,16 @@ class TestHrAttendanceOvertime(TransactionCase):
     def test_weekly_overtime(self):
         """ Test weekly overtime for the 40-hour rule """
         with freeze_time("2021-01-04"):
-            # Week: Mon-Fri, 10 hours/day = 50 hours total (40 expected + 10 overtime at 200%)
-            [
-                self.env['hr.attendance'].create({
-                    'employee_id': self.employee.id,  # This employee have a calendar with no lunch
+            # Week: Mon-Fri, 10 hours/day = 50 hours total (10h daily OT + 8h weekly OT = 18h total)
+            attendance_vals = [
+                {
+                    'employee_id': self.employee.id,
                     'check_in': datetime(2021, 1, day, 8, 0),
                     'check_out': datetime(2021, 1, day, 18, 0)
-                }) for day in range(4, 9)  # Monday to Friday
+                } for day in range(4, 9)  # Monday to Friday
             ]
-            self.assertAlmostEqual(self.employee.total_overtime, 10, 2, msg="He should work from 8-16h so each day he did 2 hours of overtime")
+            self.env['hr.attendance'].create(attendance_vals)
+            self.assertAlmostEqual(self.employee.total_overtime, 18, 2, msg="He should work from 8-16h so each day he did 2 hours of overtime")
 
     def test_multiple_attendances_same_day(self):
         """ Test multiple attendances in one day """

--- a/addons/hr_attendance/tests/test_hr_attendance_undertime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_undertime.py
@@ -477,8 +477,8 @@ class TestHrAttendanceUndertime(HttpCase):
 
     def test_no_validation_extra_hours_change(self):
         """
-         In case of attendances requiring no validation, check that extra hours are not recomputed
-         if the value is different from `validated_hours` (meaning it has been modified by the user).
+         Check that manual edits are recomputed when updating another attendance,
+         but flags the record as 'to_approve'.
         """
         self.company.attendance_overtime_validation = "no_validation"
 
@@ -494,7 +494,7 @@ class TestHrAttendanceUndertime(HttpCase):
         self.assertAlmostEqual(attendance.overtime_hours, -2, 2)
         self.assertAlmostEqual(attendance.validated_overtime_hours, -2, 2)
 
-        attendance.linked_overtime_ids.manual_duration = previous = -1.5
+        attendance.linked_overtime_ids.manual_duration = -1.5
         self.assertNotEqual(attendance.validated_overtime_hours, attendance.overtime_hours)
 
         # Create another attendance for the same employee
@@ -503,7 +503,11 @@ class TestHrAttendanceUndertime(HttpCase):
             'check_in': datetime(2023, 1, 4, 8, 0),
             'check_out': datetime(2023, 1, 4, 18, 0),
         })
-        self.assertEqual(attendance.validated_overtime_hours, previous, "Extra hours shouldn't be recomputed")
+        # The hours will now be recomputed
+        # But they should have the 'to_approve' status
+        self.assertEqual(attendance.linked_overtime_ids.status, 'to_approve', "Record should be flagged for approval")
+        self.assertAlmostEqual(attendance.linked_overtime_ids.duration, -2.0, 2, "Math should be reset to -2.0")
+        self.assertEqual(attendance.validated_overtime_hours, 0.0, "Validated hours should be 0 until approved")
 
     def test_overtime_employee_tolerance(self):
         self.ruleset.rule_ids[0].employee_tolerance = 10 / 60


### PR DESCRIPTION
**Steps to reproduce:**
Configure Working Hours: Set up a night-shift schedule that splits at midnight (Local Time): Thursday: 20:00 to 24:00
Friday: 00:00 to 04:00

Assign the above calendar to an employee.

Set the Employee’s Timezone to Asia/Kolkata (UTC+5:30).

Assign an active Overtime Ruleset to the employee.

Create Attendance Record: Log an attendance that corresponds to the night shift

When the attendance calendar is in Europe/Brussels TZ Check-in: Jan 15, 15:30 CET
Check-out: Jan 15, 23:30 CET

Expected Behavior: Worked Hours = 8.0, Overtime (Extra Hours) = 0.0
Actual Behavior (Bug): Worked Hours = 8.0, Overtime = 4.0

**Bug Cause:**
1. The _update_overtime function normalized the Ruleset version periods using time.min for both the start and end of the day. This forced the validity period of the rules to end exactly at 00:00:00 UTC on the final day.
2. The overtime recalculation logic failed to delete existing overtime records because the search domain was incorrectly computed. Specifically, using relativedelta(SU) and relativedelta(MO(-1)) without the weekday= keyword argument did not shift the dates to the week boundaries. This resulted in an empty or incorrect deletion range, leading to duplicated overtime hours as new records were layered on top of un-removed old ones.

**Solution:**
1. Modified the version_periods_by_employee mapping to use time.max (23:59:59) for the end of the version period. This ensures that the ruleset remains active through the entire final calendar day in UTC, allowing shifts that cross the midnight boundary to be fully captured.

2. Corrected the date range logic by explicitly passing the weekday argument to relativedelta. This ensures the domain correctly targets the full week window—from the preceding Monday to the following Sunday, ensuring all relevant stale overtime lines are purged before recalculation.

3. Updated Manual Edit Handling: Refined the logic to detect days with manual overrides or "To Approve" statuses before unlinking. If an attendance change triggers a recalculation on such a day, the system now replaces the manual entry with the mathematically correct value but flags the new record with a to_approve status for manager review.

4. Adjusted the expected overtime in test_weekly_overtime to 18.0 to correctly reflect the cumulative calculation of daily overtime (2h/day) plus the weekly overtime threshold reached on Friday. 

Task: 5710273
Original PR: [https://github.com/odoo/odoo/pull/245247](https://github.com/odoo/odoo/pull/245247)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
