### PR TITLE
[REF] *: run rendering context migration script

### DIFF
--- a/addons/website_blog/static/src/website_builder/blog_page_option.xml
+++ b/addons/website_blog/static/src/website_builder/blog_page_option.xml
@@ -53,7 +53,7 @@
         </BuilderRow>
     </BuilderContext>
 
-    <BuilderRow label.translate="Recommended Post" tooltip.translate="Promote a post" level="1" t-if="isActiveItem('next_article_opt')">
+    <BuilderRow label.translate="Recommended Post" tooltip.translate="Promote a post" level="1" t-if="this.isActiveItem('next_article_opt')">
         <BuilderMany2One
             action="'setRecommendedNextPost'"
             applyTo="'#o_wblog_post_footer'"
@@ -63,7 +63,7 @@
                 ['id', '!=', this.services.website.currentWebsite.metadata.mainObject.id],
                 ['website_id', 'in', [false, this.services.website.currentWebsite.id]],
             ]"
-            allowUnselect="state.isNextPostRecommended"
+            allowUnselect="this.state.isNextPostRecommended"
             unselectBtnTitle.translate="Reset to default post"
         />
     </BuilderRow>

--- a/addons/website_blog/static/src/website_builder/blog_post_page_option.xml
+++ b/addons/website_blog/static/src/website_builder/blog_post_page_option.xml
@@ -6,7 +6,7 @@
         <BuilderRow label.translate="Top Banner">
             <BuilderCheckbox id="'blog_cover_opt'" actionParam="{views: ['website_blog.opt_blog_cover_post']}"/>
         </BuilderRow>
-        <BuilderRow label.translate="Full-Width" t-if="isActiveItem('blog_cover_opt')" level="1">
+        <BuilderRow label.translate="Full-Width" t-if="this.isActiveItem('blog_cover_opt')" level="1">
             <BuilderCheckbox actionParam="{views: ['website_blog.opt_blog_cover_post_fullwidth_design']}"/>
         </BuilderRow>
         <BuilderRow label.translate="Layout">
@@ -24,7 +24,7 @@
         <BuilderRow label.translate="Sidebar">
             <BuilderCheckbox id="'blog_posts_sidebar_opt'" actionParam="{views: ['website_blog.opt_blog_sidebar_show']}"/>
         </BuilderRow>
-        <t t-if="isActiveItem('blog_posts_sidebar_opt')">
+        <t t-if="this.isActiveItem('blog_posts_sidebar_opt')">
             <BuilderRow label.translate="Archives" level="1">
                 <BuilderCheckbox actionParam="{views: ['website_blog.opt_sidebar_blog_index_archives']}"/>
             </BuilderRow>

--- a/addons/website_blog/static/src/website_builder/blog_post_tags_option.xml
+++ b/addons/website_blog/static/src/website_builder/blog_post_tags_option.xml
@@ -7,7 +7,7 @@
             applyTo="'.o_wblog_post_name'"
             createAction="'createTag'"
             m2oField="'tag_ids'"
-            recordId="domState.blogId"
+            recordId="this.domState.blogId"
         />
     </BuilderRow>
 </t>

--- a/addons/website_crm_partner_assign/static/src/website_builder/website_crm_partner_assign_option.xml
+++ b/addons/website_crm_partner_assign/static/src/website_builder/website_crm_partner_assign_option.xml
@@ -9,7 +9,7 @@
         </xpath>
     </t>
     <t t-name="website_crm_partner_assign.PartnersPageOption">
-        <BuilderRow t-if="state.has_google_maps_api_key" label.translate="World Map">
+        <BuilderRow t-if="this.state.has_google_maps_api_key" label.translate="World Map">
             <BuilderCheckbox action="'websiteConfig'" actionParam="{views: ['website_crm_partner_assign.ref_country']}" />
         </BuilderRow>
     </t>

--- a/addons/website_customer/static/src/website_builder/customer_filter_option.xml
+++ b/addons/website_customer/static/src/website_builder/customer_filter_option.xml
@@ -17,7 +17,7 @@
                     views: ['website_customer.opt_tag_list'],
                 }"/>
         </BuilderRow>
-        <BuilderRow label.translate="Show Map" t-if="hasGoogleMapsApiKey">
+        <BuilderRow label.translate="Show Map" t-if="this.hasGoogleMapsApiKey">
             <BuilderCheckbox action="'websiteConfig'" actionParam="{
                     views: ['website_customer.opt_country'],
                 }"/>

--- a/addons/website_event_exhibitor/static/src/components/exhibitor_connect_closed_dialog/exhibitor_connect_closed_dialog.xml
+++ b/addons/website_event_exhibitor/static/src/components/exhibitor_connect_closed_dialog/exhibitor_connect_closed_dialog.xml
@@ -8,74 +8,74 @@
         </div>
         <div class="o_wesponsor_js_connect_modal_main container">
             <div class="row mt-2">
-                <t t-if="! sponsorData.event_is_ongoing">
+                <t t-if="! this.sponsorData.event_is_ongoing">
                     <div class="col-12 alert alert-warning text-center" role="alert"
-                        t-if="sponsorData.event_is_done">
-                        Event <span t-out="sponsorData.event_name" class="fw-bold"/> is over.
+                        t-if="this.sponsorData.event_is_done">
+                        Event <span t-out="this.sponsorData.event_name" class="fw-bold"/> is over.
 
                         <br/>
-                        <span>Join us next time to meet <b t-out="sponsorData.name"/>!</span>
+                        <span>Join us next time to meet <b t-out="this.sponsorData.name"/>!</span>
                     </div>
                     <div class="col-12 alert alert-warning text-center" role="alert"
                         t-else="">
-                        <span t-out="sponsorData.name" class="fw-bold"/> is not available right now.<br />
-                        Event <span t-out="sponsorData.event_name" class="fw-bold"/>
-                        <span t-if="sponsorData.event_start_today">
+                        <span t-out="this.sponsorData.name" class="fw-bold"/> is not available right now.<br />
+                        Event <span t-out="this.sponsorData.event_name" class="fw-bold"/>
+                        <span t-if="this.sponsorData.event_start_today">
                             starts in
-                            <span t-if="sponsorData.event_start_remaining &gt;= 1" t-out="formatEventStartRemaining"/>
+                            <span t-if="this.sponsorData.event_start_remaining &gt;= 1" t-out="this.formatEventStartRemaining"/>
                             <t t-else="">
                                 a few seconds
                             </t>.
                         </span>
                         <span class="my-0" t-else="">
                             starts on
-                            <span t-out="formatEventDateBegin"/>
+                            <span t-out="this.formatEventDateBegin"/>
                         </span>
                     </div>
                 </t>
                 <div class="col-12 alert alert-warning text-center" role="alert"
                     t-else="">
-                    <span t-out="sponsorData.name" class="fw-bold"/> is not available right now.<br />
+                    <span t-out="this.sponsorData.name" class="fw-bold"/> is not available right now.<br />
                     Come back between
                     <strong>
-                        <t t-out="sponsorData.hour_from_str"/>
+                        <t t-out="this.sponsorData.hour_from_str"/>
                         -
-                        <t t-out="sponsorData.hour_to_str"/>
-                    </strong> (<span t-out="sponsorData.event_date_tz"/>)
+                        <t t-out="this.sponsorData.hour_to_str"/>
+                    </strong> (<span t-out="this.sponsorData.event_date_tz"/>)
                     to meet them!
                 </div>
-                <div class="col-2" t-if="sponsorData.website_image_url">
+                <div class="col-2" t-if="this.sponsorData.website_image_url">
                     <img class="img" style="max-width: 100%;"
-                        t-att-src="sponsorData.website_image_url"
-                        t-att-alt="sponsorData.name"/>
+                        t-att-src="this.sponsorData.website_image_url"
+                        t-att-alt="this.sponsorData.name"/>
                 </div>
                 <div class="col-10">
                     <div class="d-flex align-items-top mb-3">
                         <div class="d-flex flex-column me-2">
                             <div class="mb4">
-                                <h4 class="d-inline" t-out="sponsorData.name"/>
+                                <h4 class="d-inline" t-out="this.sponsorData.name"/>
                                 <span class="badge text-bg-primary ms-2"
-                                    t-out="sponsorData.sponsor_type_name"/>
+                                    t-out="this.sponsorData.sponsor_type_name"/>
                             </div>
-                            <span class="text-muted" t-if="sponsorData.subtitle" t-out="sponsorData.subtitle"/>
-                            <span t-if="sponsorData.url">
-                                <i class="fa fa-globe me-2"/><a t-att-href="sponsorData.url"><span t-out="sponsorData.url"/></a>
+                            <span class="text-muted" t-if="this.sponsorData.subtitle" t-out="this.sponsorData.subtitle"/>
+                            <span t-if="this.sponsorData.url">
+                                <i class="fa fa-globe me-2"/><a t-att-href="this.sponsorData.url"><span t-out="this.sponsorData.url"/></a>
                             </span>
-                            <span t-if="sponsorData.email">
-                                <i class="fa fa-envelope me-2"/><a t-att-mailto="sponsorData.email"><span t-out="sponsorData.email"/></a>
+                            <span t-if="this.sponsorData.email">
+                                <i class="fa fa-envelope me-2"/><a t-att-mailto="this.sponsorData.email"><span t-out="this.sponsorData.email"/></a>
                             </span>
-                            <span t-if="sponsorData.phone">
-                                <i class="fa fa-phone me-2"/><span t-out="sponsorData.phone"/>
+                            <span t-if="this.sponsorData.phone">
+                                <i class="fa fa-phone me-2"/><span t-out="this.sponsorData.phone"/>
                             </span>
                         </div>
-                        <img t-if="sponsorData.country_flag_url"
+                        <img t-if="this.sponsorData.country_flag_url"
                             class="img ms-auto"
                             style="max-height: 36px;"
-                            t-att-src="sponsorData.country_flag_url"
-                            t-att-alt="sponsorData.country_name"/>
+                            t-att-src="this.sponsorData.country_flag_url"
+                            t-att-alt="this.sponsorData.country_name"/>
                     </div>
                 </div>
-                <div class="col-12" t-if="sponsorData.website_description" t-out="sponsorData.website_description"/>
+                <div class="col-12" t-if="this.sponsorData.website_description" t-out="this.sponsorData.website_description"/>
             </div>
         </div>
     </Dialog>

--- a/addons/website_event_track/static/src/xml/website_event_track_form_tags_wrapper.xml
+++ b/addons/website_event_track/static/src/xml/website_event_track_form_tags_wrapper.xml
@@ -2,14 +2,14 @@
 <templates id="template" xml:space="preserve">
 
 <t t-name="website_event_track.WebsiteEventTrackProposalFormTagsWrapper">
-    <input name="tags" type="hidden" class="form-control o_wetrack_select_tags d-none" t-att-value="state.value"/>
+    <input name="tags" type="hidden" class="form-control o_wetrack_select_tags d-none" t-att-value="this.state.value"/>
     <SelectMenu
         togglerClass="'form-control'"
-        choices="state.defaultChoices"
+        choices="this.state.defaultChoices"
         multiSelect="true"
-        onSelect.bind="onSelect"
-        value="state.value"
-        placeholder="state.placeholder"/>
+        onSelect.bind="this.onSelect"
+        value="this.state.value"
+        placeholder="this.state.placeholder"/>
 </t>
 
 </templates>

--- a/addons/website_event_track_quiz/static/src/xml/quiz_templates.xml
+++ b/addons/website_event_track_quiz/static/src/xml/quiz_templates.xml
@@ -3,8 +3,8 @@
     <t t-name="quiz.main">
         <div class="h-100 w-100 overflow-auto px-2 py-2">
             <div class="container">
-                <div t-foreach="widget.quiz.questions" t-as="question" t-key="question_index"
-                     t-attf-class="o_quiz_js_quiz_question mt-3 mb-4 #{widget.track.completed ? 'completed-disabled' : ''}"
+                <div t-foreach="this.widget.quiz.questions" t-as="question" t-key="question_index"
+                     t-attf-class="o_quiz_js_quiz_question mt-3 mb-4 #{this.widget.track.completed ? 'completed-disabled' : ''}"
                      t-att-data-question-id="question.id" t-att-data-title="question.question">
                     <div class="h4">
                         <small class="text-muted"><span t-out="question_index+1"/>. </small> <span t-out="question.question"/>
@@ -13,16 +13,16 @@
                         <t t-foreach="question.answer_ids" t-as="answer" t-key="answer_index">
                             <a t-att-data-answer-id="answer.id" href="#"
                                 t-att-data-text="answer.text_value"
-                                t-attf-class="o_quiz_quiz_answer list-group-item d-flex align-items-center list-group-item-action #{widget.track.completed  &amp;&amp; answer.is_correct ? 'list-group-item-success' : '' }">
+                                t-attf-class="o_quiz_quiz_answer list-group-item d-flex align-items-center list-group-item-action #{this.widget.track.completed  &amp;&amp; answer.is_correct ? 'list-group-item-success' : '' }">
 
                                 <label class="my-0 d-flex align-items-center justify-content-center me-2">
                                     <input type="radio"
                                         t-att-name="question.id"
                                         t-att-value="answer.id"
                                         class="d-none"/>
-                                    <i t-att-class="'fa fa-circle text-400' + (!(widget.track.completed &amp;&amp; answer.is_correct) ? '' : ' d-none')"></i>
+                                    <i t-att-class="'fa fa-circle text-400' + (!(this.widget.track.completed &amp;&amp; answer.is_correct) ? '' : ' d-none')"></i>
                                     <i class="fa fa-times-circle text-danger d-none"></i>
-                                    <i t-att-class="'fa fa-check-circle text-success' + (widget.track.completed &amp;&amp; answer.is_correct ? '' :  ' d-none')"></i>
+                                    <i t-att-class="'fa fa-check-circle text-success' + (this.widget.track.completed &amp;&amp; answer.is_correct ? '' :  ' d-none')"></i>
                                 </label>
                                 <span t-out="answer.text_value"/>
                             </a>

--- a/addons/website_forum/static/src/components/flag_mark_as_offensive/flag_mark_as_offensive.xml
+++ b/addons/website_forum/static/src/components/flag_mark_as_offensive/flag_mark_as_offensive.xml
@@ -2,8 +2,8 @@
 <templates xml:space="preserve">
 
   <t t-name="website_forum.FlagMarkAsOffensiveDialog">
-    <Dialog size="'md'" title="props.title" footer="false" modalRef="modalRef" >
-      <t t-out="props.body"/>
+    <Dialog size="'md'" title="this.props.title" footer="false" modalRef="this.modalRef" >
+      <t t-out="this.props.body"/>
     </Dialog>
   </t>
 

--- a/addons/website_forum/static/src/xml/public_templates.xml
+++ b/addons/website_forum/static/src/xml/public_templates.xml
@@ -49,7 +49,7 @@
         <p>On average, <b>45% of questions shared</b> on social networks get an answer within
         5 hours. Questions shared on two social networks have <b>65% more chance to get an
         answer</b>!</p>
-        <p t-if="state == 'pending'">You can share your question once it has been validated</p>
+        <p t-if="this.state == 'pending'">You can share your question once it has been validated</p>
     </t>
     <t t-name="website_forum.social_message_answer">
         <p>By sharing you answer, you will get additional <b>karma points</b> if your

--- a/addons/website_forum/static/src/xml/website_forum_tags_wrapper.xml
+++ b/addons/website_forum/static/src/xml/website_forum_tags_wrapper.xml
@@ -2,16 +2,16 @@
 <templates id="template" xml:space="preserve">
 
 <t t-name="website_forum.WebsiteForumTagsWrapper">
-    <input name="post_tags" type="hidden" class="form-control" t-att-value="state.value"/>
+    <input name="post_tags" type="hidden" class="form-control" t-att-value="this.state.value"/>
     <SelectMenu
         togglerClass="'form-control'"
-        choices="state.choices"
-        value="state.value"
-        onInput.bind="loadChoices"
-        onSelect.bind="onSelect"
+        choices="this.state.choices"
+        value="this.state.value"
+        onInput.bind="this.loadChoices"
+        onSelect.bind="this.onSelect"
         multiSelect="true"
         placeholder.translate="Tags"
-        disabled="props.isReadOnly"
+        disabled="this.props.isReadOnly"
         searchPlaceholder.translate="Please enter 2 or more characters">
         <t t-set-slot="bottomArea" t-slot-scope="select">
             <DropdownItem


### PR DESCRIPTION
In preparation for OWL3, where template variables will need to use `.this` to target component variables, we add `.this` to template variables that are targetting the component.

Script PR: https://github.com/odoo/odoo/pull/247965

THIS_TARGETS = [website_blog, website_cf_turnstile, website_crm, website_customer, website_delivery_sendcloud, website_documents, website_enterprise, website_event,  website_forum]

task: OWL3 prep - add this. to template variables



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
