### PR TITLE
[FIX] stock: allow reservation from sub locations for returns

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1963,7 +1963,9 @@ Please change the quantity done or the rounding precision of your unit of measur
                     all_move_line_vals = []
                     for (location_id, lot_id, package_id, owner_id), quantity in available_move_lines.items():
                         need = move.product_qty - sum(move.move_line_ids.mapped('quantity_product_uom')) - sum(taken_quantities.values())
-                        move_line_vals, taken_quantity = move._update_reserved_quantity_vals(min(quantity, need), location_id, lot_id, package_id, owner_id, strict=True)
+                        # Allow return moves to search for quants in child locations as well
+                        strict = not move.picking_id.return_id
+                        move_line_vals, taken_quantity = move._update_reserved_quantity_vals(min(quantity, need), location_id, lot_id, package_id, owner_id, strict)
                         all_move_line_vals += move_line_vals
                         if move_line_vals:  # Only subtract for new lines (updates are already reflected in sum(move_line_ids))
                             taken_quantities[need, location_id, lot_id, package_id, owner_id] = taken_quantity

--- a/addons/stock/tests/test_stock_return_picking.py
+++ b/addons/stock/tests/test_stock_return_picking.py
@@ -346,3 +346,55 @@ class TestReturnPicking(TestStockCommon):
         # 2 exchanged products received: both on-hand and forecasted quantities should be 10
         self.assertEqual(self.productA.qty_available, 10)
         self.assertEqual(self.productA.virtual_available, 10)
+
+    def test_return_to_partner_from_sub_location(self):
+        '''
+        Ensure that products moved to a sub location can still be reserved when creating a return.
+        '''
+        self.env.user.groups_id += self.env.ref('stock.group_stock_multi_locations')
+        wh_stock = self.env['stock.location'].browse(self.stock_location)
+        sub_loc = wh_stock.child_ids and wh_stock.child_ids[0] or self.env['stock.location'].create({
+            'name': 'New sub location',
+            'usage': 'internal',
+            'location_id': wh_stock.id,
+        })
+
+        # Receive 13 of the product in stock
+        receipt_picking = self.PickingObj.create({
+            'picking_type_id': self.picking_type_in,
+            'location_id': self.customer_location,
+            'location_dest_id': self.stock_location,
+        })
+        in_move = self.MoveObj.create({
+            'name': "OUT move",
+            'product_id': self.productA.id,
+            'product_uom_qty': 13,
+            'picking_id': receipt_picking.id,
+            'location_id': self.customer_location,
+            'location_dest_id': self.stock_location,
+        })
+        in_move.quantity = 1
+        receipt_picking.button_validate()
+
+        # Transfer the product to the sub location
+        transfer_move = self.env['stock.move'].create({
+            'name': 'Move 1 product',
+            'product_id': self.productA.id,
+            'product_uom_qty': 13,
+            'product_uom': self.product.uom_id.id,
+            'location_id': self.stock_location,
+            'location_dest_id': sub_loc.id,
+        })
+        transfer_move._action_confirm()
+        transfer_move._action_assign()
+        transfer_move.quantity = 13
+        transfer_move.picked = True
+        transfer_move._action_done()
+
+        # Create a return on the reception transfer
+        return_wizard = self.env['stock.return.picking'].with_context(active_id=receipt_picking.id, active_model='stock.picking').create({})
+        return_wizard.product_return_moves.quantity = 13
+        res = return_wizard.action_create_returns()
+        return_picking = self.PickingObj.browse(res["res_id"])
+        self.assertEqual(return_picking.location_dest_id.id, self.customer_location)
+        self.assertEqual(return_picking.state, 'assigned')


### PR DESCRIPTION
Issue
-----
Returning products doesn't work if they were transferred to a sub location.

Steps to reproduce
-----
- Enable storage locations
- Create a new sub location to WH/Stock (eg WH/Stock/Shelf)
- Receive a product in WH/Stock & confirm
- Transfer the product to WH/Stock/Shelf
- Go to the reception transfer and return it

> The return cannot reserve the product from WH/Stock/Shelf

Cause
-----
The problem was introduced by 13567aa.

https://github.com/odoo/odoo/blob/f86baa6ba1c915145dbfe43b67de0eff13959e91/addons/stock/models/stock_move.py#L1966

The strategy used to find available quants is set as strict, so the domain contains an exact match for the location instead of `child_of` which would include sub locations.

https://github.com/odoo/odoo/blob/f86baa6ba1c915145dbfe43b67de0eff13959e91/addons/stock/models/stock_quant.py#L770-L787

-----
Ticket:
opw-5364331