### PR TITLE
[FIX] project: traceback on task resequence in kanban view

### DIFF
--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_renderer.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_renderer.js
@@ -4,7 +4,7 @@ import { KanbanRenderer } from '@web/views/kanban/kanban_renderer';
 import { ProjectTaskKanbanRecord } from './project_task_kanban_record';
 import { ProjectTaskKanbanHeader } from './project_task_kanban_header';
 import { useService } from '@web/core/utils/hooks';
-import { onWillStart } from "@odoo/owl";
+import { onWillStart, status } from "@odoo/owl";
 import { user } from "@web/core/user";
 
 export class ProjectTaskKanbanRenderer extends KanbanRenderer {
@@ -21,6 +21,16 @@ export class ProjectTaskKanbanRenderer extends KanbanRenderer {
         onWillStart(async () => {
             this.isProjectManager = await user.hasGroup('project.group_project_manager');
         });
+    }
+
+    async sortRecordDrop(dataRecordId, dataGroupId, params) {
+        try {
+            await super.sortRecordDrop(dataRecordId, dataGroupId, params);
+        } catch (e) {
+            if (status(this) !== 'destroyed') {
+                throw e;
+            }
+        }
     }
 
     canCreateGroup() {


### PR DESCRIPTION
Steps to reproduce:
----------------------------------------
1. Install the Project module with the demo data
2. Go to Task > All Tasks> Kanban View
3. Move all the tasks to any one stage except one task
4. Now move that one task and quickly press (Alt + 1) to exit

Observation:
----------------------------------------
Traceback occurs:
```
Uncaught Promise > Component is destroyed
Occured on localhost:8069 on 2026-03-10 09:47:35 GMT
Error: Component is destroyed
```

Issue:
---------------------------------------
When dragging a record between groups, `moveRecord` calls `_resequence()`, which checks `canResequence()`
https://github.com/odoo/odoo/blob/f86baa6ba1c915145dbfe43b67de0eff13959e91/addons/web/static/src/model/relational_model/dynamic_list.js#L311-L314

For Project Tasks, `canResequence()` returns `true`, so the full async chain runs:

1. `rpc('/web/dataset/resequence')` — raw, unprotected call (succeeds)
2. `orm.read()` — protected by `useService` wrapper

If the user navigates away (ALT+1) between step 1 and step 2, the component is destroyed, and `orm.read()` throws Error('Component is destroyed') via `_protectMethod`

https://github.com/odoo/odoo/blob/f86baa6ba1c915145dbfe43b67de0eff13959e91/addons/web/static/src/core/utils/hooks.js#L106-L110

This error propagates up unhandled.

Solution:
---------------------------------------
Override `sortRecordDrop` in `ProjectTaskKanbanRenderer` to catch the 'Component is destroyed' error. Since the resequence RPC has already succeeded server-side, the follow-up `orm.read()` failure is harmless, the component is being destroyed anyway.

opw-5932085