### PR TITLE
[FIX] mail: send presence on user instead of partner

### DIFF
--- a/addons/mail/models/ir_websocket.py
+++ b/addons/mail/models/ir_websocket.py
@@ -84,7 +84,10 @@ class IrWebsocket(models.AbstractModel):
             )
             | guest
         )
-        data["channels"].update((partner, "presence") for partner in allowed_partners)
+        # sudo - res.users: can access users of allowed partners
+        data["channels"].update(
+            (user, "presence") for user in allowed_partners.sudo().user_ids.sudo(False)
+        )
         data["channels"].update((guest, "presence") for guest in allowed_guests)
         # There is a gap between a subscription client side (which is debounced)
         # and the actual subcription thus presences can be missed. Send a

--- a/addons/mail/models/mail_presence.py
+++ b/addons/mail/models/mail_presence.py
@@ -97,7 +97,7 @@ class MailPresence(models.Model):
         :param im_status: 'online', 'away' or 'offline'
         """
         for presence in self:
-            persona = presence.guest_id or presence.user_id.partner_id
+            persona = presence.guest_id or presence.user_id
             target = bus_target or (persona, "presence")
             self.env["bus.bus"]._sendone(
                 target,

--- a/addons/mail/tests/discuss/test_discuss_mail_presence.py
+++ b/addons/mail/tests/discuss/test_discuss_mail_presence.py
@@ -32,13 +32,13 @@ class TestMailPresence(WebsocketCase, MailCommon):
             channel_parts.append(target_channel._get_im_status_access_token())
         self.subscribe(websocket, ["-".join(channel_parts)], self.env["bus.bus"]._bus_last_id())
         self.env["mail.presence"]._update_presence(target)
-        self.trigger_notification_dispatching([(target_channel, "presence")])
+        self.trigger_notification_dispatching([(target, "presence")])
         notifications = json.loads(websocket.recv())
         self._close_websockets()
         bus_record = self.env["bus.bus"].search([("id", "=", int(notifications[0]["id"]))])
         self.assertEqual(
             bus_record.channel,
-            json_dump(channel_with_db(self.env.cr.dbname, (target_channel, "presence"))),
+            json_dump(channel_with_db(self.env.cr.dbname, (target, "presence"))),
         )
         self.assertEqual(notifications[0]["message"]["type"], "bus.bus/im_status_updated")
         self.assertEqual(notifications[0]["message"]["payload"]["im_status"], "online")
@@ -73,3 +73,24 @@ class TestMailPresence(WebsocketCase, MailCommon):
                 else:
                     with self.assertRaises(ws._exceptions.WebSocketTimeoutException):
                         self._receive_presence(requested_by, target, has_token=has_token)
+
+    def test_manual_im_status(self):
+        bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
+        session = self.authenticate(bob.login, bob.login)
+        with self.assertBus(
+            [(bob, "presence")],
+            [
+                {
+                    "type": "bus.bus/im_status_updated",
+                    "payload": {
+                        "im_status": "offline",
+                        "partner_id": bob.partner_id.id,
+                    },
+                },
+            ],
+        ):
+            self.make_jsonrpc_request(
+                "/mail/set_manual_im_status",
+                {"status": "offline"},
+                cookies={"session_id": session.sid},
+            )

--- a/addons/mail/tests/test_ir_websocket.py
+++ b/addons/mail/tests/test_ir_websocket.py
@@ -26,7 +26,7 @@ class TestIrWebsocket(WebsocketCase):
         )
         # offline => online
         self.env["mail.presence"]._update_presence(bob)
-        self.trigger_notification_dispatching([(bob.partner_id, "presence")])
+        self.trigger_notification_dispatching([(bob, "presence")])
         message = json.loads(websocket.recv())[0]["message"]
         self.assertEqual(message["type"], "bus.bus/im_status_updated")
         self.assertEqual(message["payload"]["im_status"], "online")
@@ -36,7 +36,7 @@ class TestIrWebsocket(WebsocketCase):
         away_timer_later = datetime.now() + timedelta(seconds=AWAY_TIMER + 1)
         with freeze_time(away_timer_later):
             self.env["mail.presence"]._update_presence(bob, (AWAY_TIMER + 1) * 1000)
-            self.trigger_notification_dispatching([(bob.partner_id, "presence")])
+            self.trigger_notification_dispatching([(bob, "presence")])
             message = json.loads(websocket.recv())[0]["message"]
             self.assertEqual(message["type"], "bus.bus/im_status_updated")
             self.assertEqual(message["payload"]["im_status"], "away")
@@ -46,7 +46,7 @@ class TestIrWebsocket(WebsocketCase):
         ten_minutes_later = datetime.now() + timedelta(minutes=10)
         with freeze_time(ten_minutes_later):
             self.env["mail.presence"]._update_presence(bob)
-            self.trigger_notification_dispatching([(bob.partner_id, "presence")])
+            self.trigger_notification_dispatching([(bob, "presence")])
             message = json.loads(websocket.recv())[0]["message"]
             self.assertEqual(message["type"], "bus.bus/im_status_updated")
             self.assertEqual(message["payload"]["im_status"], "online")
@@ -56,7 +56,7 @@ class TestIrWebsocket(WebsocketCase):
         ten_minutes_later = datetime.now() + timedelta(minutes=10)
         with freeze_time(ten_minutes_later):
             self.env["mail.presence"]._update_presence(bob)
-            self.trigger_notification_dispatching([(bob.partner_id, "presence")])
+            self.trigger_notification_dispatching([(bob, "presence")])
             timeout_occurred = False
             # Save point rollback of `assertRaises` can compete with `on_websocket_close`
             # leading to `InvalidSavepoint` errors. We need to avoid it.
@@ -77,7 +77,7 @@ class TestIrWebsocket(WebsocketCase):
             [f"odoo-presence-res.partner_{bob.partner_id.id}"],
             self.env["bus.bus"]._bus_last_id(),
         )
-        self.trigger_notification_dispatching([(bob.partner_id, "presence")])
+        self.trigger_notification_dispatching([(bob, "presence")])
         notification = json.loads(websocket.recv())[0]
         self._close_websockets()
         bus_record = self.env["bus.bus"].search([("id", "=", int(notification["id"]))])


### PR DESCRIPTION
Since [1], the partner bus channel is actually the user themselves.
However, the presences are still sending on partner. As a result,
updates are not received correctly.

This commit ensures presences are sent on user.

[1]: https://github.com/odoo/odoo/pull/249095

task-6022919