### PR TITLE
[FIX] point_of_sale,pos_sale_margin: fix margin sign for refund orders

### DIFF
--- a/addons/point_of_sale/report/pos_order_report.py
+++ b/addons/point_of_sale/report/pos_order_report.py
@@ -66,10 +66,10 @@ class ReportPosOrder(models.Model):
                 l.id AS id,
                 1 AS nbr_lines, -- number of lines in order line is always 1
                 s.date_order AS date,
-                ROUND((l.price_subtotal * CASE WHEN s.is_refund THEN -1 ELSE 1 END) / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END, cu.decimal_places) AS price_subtotal_excl,
+                ROUND((SIGN(l.qty) * SIGN(l.price_unit) * ABS(l.price_subtotal)) / CASE COALESCE(s.currency_rate, 0) WHEN 0 THEN 1.0 ELSE s.currency_rate END, cu.decimal_places) AS price_subtotal_excl,
                 l.qty AS product_qty,
                 l.qty * l.price_unit / COALESCE(NULLIF(s.currency_rate, 0), 1.0) AS price_sub_total,
-                ROUND((l.price_subtotal_incl * CASE WHEN s.is_refund THEN -1 ELSE 1 END) / COALESCE(NULLIF(s.currency_rate, 0), 1.0), cu.decimal_places) AS price_total,
+                ROUND((SIGN(l.qty) * SIGN(l.price_unit) * ABS(l.price_subtotal_incl)) / COALESCE(NULLIF(s.currency_rate, 0), 1.0), cu.decimal_places) AS price_total,
                 (l.qty * l.price_unit) * (l.discount / 100) / COALESCE(NULLIF(s.currency_rate, 0), 1.0) AS total_discount,
                 CASE
                     WHEN l.qty * u.factor = 0 THEN NULL
@@ -89,7 +89,7 @@ class ReportPosOrder(models.Model):
                 s.pricelist_id,
                 s.session_id,
                 s.account_move IS NOT NULL AS invoiced,
-                (l.price_subtotal * CASE WHEN s.is_refund THEN -1 ELSE 1 END) - COALESCE(l.total_cost,0) / COALESCE(NULLIF(s.currency_rate, 0), 1.0) AS margin,
+                (SIGN(l.qty) * SIGN(l.price_unit) * ABS(l.price_subtotal)) - COALESCE(l.total_cost,0) / COALESCE(NULLIF(s.currency_rate, 0), 1.0) AS margin,
                 pm.payment_method_id AS payment_method_id,
                 fpc.id AS pos_categ_id
 

--- a/addons/pos_sale_margin/report/sale_report.py
+++ b/addons/pos_sale_margin/report/sale_report.py
@@ -9,5 +9,5 @@ class SaleReport(models.Model):
 
     def _fill_pos_fields(self, additional_fields):
         values = super()._fill_pos_fields(additional_fields)
-        values['margin'] = 'SUM((l.price_subtotal - COALESCE(l.total_cost,0)) / CASE COALESCE(pos.currency_rate, 0) WHEN 0 THEN 1.0 ELSE pos.currency_rate END)'
+        values['margin'] = 'SUM((SIGN(l.qty) * SIGN(l.price_unit) * ABS(l.price_subtotal) - COALESCE(l.total_cost, 0)) / CASE COALESCE(pos.currency_rate, 0) WHEN 0 THEN 1.0 ELSE pos.currency_rate END)'
         return values

--- a/addons/pos_sale_margin/tests/test_pos_sale_margin_report.py
+++ b/addons/pos_sale_margin/tests/test_pos_sale_margin_report.py
@@ -41,3 +41,28 @@ class TestPoSSaleMarginReport(TestPoSCommon):
         reports = self.env['sale.report'].sudo().search([('product_id', '=', product1.id)], order='id')
 
         self.assertEqual(reports[0].margin, 100)
+
+    def test_pos_sale_margin_report_refund_sign(self):
+        product = self.create_product('Refund Product', self.categ_basic, 150, standard_price=0)
+
+        self.open_new_session()
+        self.env['pos.order'].create({
+            'session_id': self.pos_session.id,
+            'is_refund': True,
+            'lines': [(0, 0, {
+                'name': "OL/0001",
+                'product_id': product.id,
+                'price_unit': 150,
+                'qty': -1.0,
+                'price_subtotal': 150,
+                'price_subtotal_incl': 150,
+                'total_cost': 0,
+            })],
+            'amount_total': -150.0,
+            'amount_tax': 0.0,
+            'amount_paid': 0.0,
+            'amount_return': 0.0,
+        })
+
+        reports = self.env['sale.report'].sudo().search([('product_id', '=', product.id)], order='id')
+        self.assertEqual(reports[0].margin, -150)


### PR DESCRIPTION
Refund orders were reporting incorrect values because the sign was
derived from `is_refund`, which is not reliable. Replace with
`SIGN(qty) * SIGN(price_unit) * ABS(...)` so the sign is computed
directly from the line data in both `pos_order_report` and `sale.report`.

opw-6017438

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
