### PR TITLE
[IMP] {im,crm}_livechat, *: improve Live Chat-related form views

### DIFF
--- a/addons/crm_livechat/models/discuss_channel.py
+++ b/addons/crm_livechat/models/discuss_channel.py
@@ -51,21 +51,10 @@ class DiscussChannel(models.Model):
         :param partner: internal user partner (operator) that created the lead;
         :param key: operator input in chat ('/lead Lead about Product')
         """
-        # if public user is part of the chat: consider lead to be linked to an
-        # anonymous user whatever the participants. Otherwise keep only share
-        # partners (no user or portal user) to link to the lead.
-        customers = self.env['res.partner']
-        for customer in self.with_context(active_test=False).channel_partner_ids.filtered(lambda p: p != partner and p.partner_share):
-            if customer.is_public:
-                customers = self.env['res.partner']
-                break
-            else:
-                customers |= customer
-
         return self.env['crm.lead'].create({
             "origin_channel_id": self.id,
             'name': html2plaintext(key[5:]),
-            'partner_id': customers[0].id if customers else False,
+            'partner_id': self.livechat_customer_partner_ids[0].id if self.livechat_customer_partner_ids else False,
             'user_id': False,
             'team_id': False,
             'description': self._get_channel_history(),

--- a/addons/crm_livechat/views/crm_lead_views.xml
+++ b/addons/crm_livechat/views/crm_lead_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//button[@name='action_schedule_meeting']" position="after">
                 <button name="action_open_livechat" type="object" class="oe_stat_button" icon="fa-comments" invisible="not origin_channel_id" groups="sales_team.group_sale_salesman">
-                    <div class="o_stat_info"><span class="o_stat_text">View chat</span></div>
+                    <div class="o_stat_info"><span class="o_stat_text">View Live Chat</span></div>
                 </button>
             </xpath>
         </field>

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -635,8 +635,10 @@ class DiscussChannel(models.Model):
             # sudo - res.partner: accessing livechat username or name is allowed to visitor
             message_author = message.author_id.sudo() or message.author_guest_id
             if previous_message_author != message_author:
+                if parts:
+                    parts.append(Markup("<br/>"))
                 parts.append(
-                    Markup("<br/><strong>%s:</strong><br/>")
+                    Markup("<strong>%s:</strong><br/>")
                     % (
                         (message_author.user_livechat_username if message_author._name == "res.partner" else None)
                         or message_author.name

--- a/addons/im_livechat/models/res_partner.py
+++ b/addons/im_livechat/models/res_partner.py
@@ -114,4 +114,8 @@ class ResPartner(models.Model):
             ast.literal_eval(action["domain"]),
             [('id', 'in', livechat_channel_ids)]
         ])
+        action["context"] = {
+            **ast.literal_eval(action["context"].strip()),
+            "search_default_filter_session_date": None,
+        }
         return action

--- a/addons/im_livechat/tests/test_discuss_channel.py
+++ b/addons/im_livechat/tests/test_discuss_channel.py
@@ -249,7 +249,7 @@ class TestDiscussChannel(TestImLivechatCommon, TestGetOperatorCommon, MailCase):
         channel_history = channel.with_user(self.visitor_user)._get_channel_history()
         self.assertEqual(
             channel_history,
-            "<br/><strong>Michel Operator:</strong><br/>Operator Here<br/>%(attachment_1)s<br/>"
+            "<strong>Michel Operator:</strong><br/>Operator Here<br/>%(attachment_1)s<br/>"
             "<br/><strong>Rajesh:</strong><br/>Visitor Here<br/>%(attachment_2)s<br/>"
             % {
                 "attachment_1": _convert_attachment_to_html(attachment1),

--- a/addons/im_livechat/views/res_partner_views.xml
+++ b/addons/im_livechat/views/res_partner_views.xml
@@ -15,9 +15,8 @@
                         name="action_view_livechat_sessions"
                         invisible="not livechat_channel_count"
                         icon="fa-comments"
-                        title="Live Chat History"
                     >
-                        <field string="Live Chat" name="livechat_channel_count" widget="statinfo"/>
+                        <field string="Live Chats" name="livechat_channel_count" widget="statinfo"/>
                     </button>
                 </div>
             </field>

--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -82,6 +82,7 @@ export class ChatWindow extends Component {
         return {
             "w-100 h-100 o-mobile": this.ui.isSmall,
             "o-rounded-bubble border border-dark o-border-opacity-15 mb-2": !this.ui.isSmall,
+            "o-highlighted": this.props.chatWindow.highlighted,
         };
     }
 

--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -9,6 +9,11 @@
         height: Min(95vh, $o-mail-ChatWindow-width * 15 / 9)
     }
     outline: none;
+
+    transition: box-shadow 2.0s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+    &.o-highlighted {
+        box-shadow: 0 0 1.5rem #{$o-component-active-border} !important;
+    }
 }
 
 .o-mail-ChatWindow-moreActions {

--- a/addons/mail/static/src/core/common/chat_window_model.js
+++ b/addons/mail/static/src/core/common/chat_window_model.js
@@ -1,4 +1,5 @@
 import { fields, Record } from "@mail/model/export";
+import { browser } from "@web/core/browser/browser";
 
 /** @typedef {{ thread?: import("models").Thread }} ChatWindowData */
 
@@ -13,6 +14,7 @@ export class ChatWindow extends Record {
     hidden = false;
     /** Whether the chat window was created from the messaging menu */
     fromMessagingMenu = false;
+    highlighted = false;
     hubAsOpened = fields.One("ChatHub", { inverse: "opened" });
     hubAsFolded = fields.One("ChatHub", { inverse: "folded" });
     hubAsCanShowOpened = fields.One("ChatHub", {
@@ -137,11 +139,20 @@ export class ChatWindow extends Record {
         this.bypassCompact = false;
     }
 
+    async highlight() {
+        this.highlighted = true;
+        await new Promise((resolve) => browser.setTimeout(resolve, 2000));
+        if (this.exists()) {
+            this.highlighted = false;
+        }
+    }
+
     async open({
         focus = false,
         notifyState = true,
         jumpToNewMessage = false,
         swapOpened = true,
+        highlight = false,
     } = {}) {
         await this.store.chatHub.initPromise;
         this.store.env.bus.trigger("ChatWindow:will-open");
@@ -155,6 +166,9 @@ export class ChatWindow extends Record {
         }
         if (focus) {
             this.focus({ jumpToNewMessage });
+        }
+        if (highlight) {
+            this.highlight();
         }
     }
 

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -735,14 +735,20 @@ export class Thread extends Record {
         return false;
     }
 
-    async openChatWindow({ focus = false, fromMessagingMenu, bypassCompact, swapOpened } = {}) {
+    async openChatWindow({
+        focus = false,
+        fromMessagingMenu,
+        bypassCompact,
+        swapOpened,
+        highlight,
+    } = {}) {
         const thread = await this.store["mail.thread"].getOrFetch(this);
         if (!thread) {
             return;
         }
         await this.store.chatHub.initPromise;
         this.channel.chatWindow = { fromMessagingMenu, bypassCompact };
-        this.channel.chatWindow.open({ focus, swapOpened });
+        this.channel.chatWindow.open({ focus, swapOpened, highlight });
         return this.channel.chatWindow;
     }
 

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -461,7 +461,7 @@ export class DiscussChannel extends Record {
         onUpdate() {
             if (this.open_chat_window) {
                 this.open_chat_window = undefined;
-                this.openChatWindow({ focus: true });
+                this.openChatWindow({ focus: true, highlight: this.chatWindow?.isOpen });
             }
         },
     });


### PR DESCRIPTION
* = mail

enterprise PR: https://github.com/odoo/enterprise/pull/110113

This commit improves the form views related to Live Chat by:
1. Setting the correct partner_id when creating a lead from a live chat.
2. Removing the extra starting line break in the channel history.
3. Highlighting the chat window if already open when clicking "View Live Chat".
4. Removing the 30 day filter when checking the live chats related to a partner.
5. Harmonizing the Live Chat copywriting.

task-6018898