### PR TITLE
[FIX] sale_mrp: filter only done moves when getting kit cogs value

### DIFF
--- a/addons/sale_mrp/models/account_move.py
+++ b/addons/sale_mrp/models/account_move.py
@@ -28,7 +28,7 @@ class AccountMoveLine(models.Model):
                 reversal_cogs = posted_invoice_lines.move_id.reversal_move_ids.line_ids.filtered(lambda l: l.display_type == 'cogs' and l.product_id == self.product_id and l.balance > 0)
                 qty_invoiced -= sum([line.product_uom_id._compute_quantity(line.quantity, line.product_id.uom_id) for line in reversal_cogs])
 
-                moves = so_line.move_ids
+                moves = so_line.move_ids.filtered(lambda m: m.state == 'done')
                 average_price_unit = 0
                 # Components quantities for 1 'unit' in the product's base uom
                 components_qty = so_line._get_bom_component_qty(bom)


### PR DESCRIPTION
Currently cancelled moves are also being used when getting the value. This is already done in the main method: https://github.com/odoo/odoo/blob/049321aa5e0d4271050b406477bac5fb788b410b/addons/stock_account/models/account_move_line.py#L67



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
