### PR TITLE
[IMP] tests: ChromeBrowser cleanup sequence

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1278,6 +1278,7 @@ class ChromeBrowser:
     remote_debugging_port = 0  # 9222, change it in a non-git-tracked file
 
     def __init__(self, test_case: HttpCase, success_signal: str = DEFAULT_SUCCESS_SIGNAL, headless: bool = True, debug: bool = False):
+        self.cleanup = ExitStack()
         self.throttling_factor = 1
         self._logger = test_case._logger
         self.test_case = test_case
@@ -1285,28 +1286,37 @@ class ChromeBrowser:
         if websocket is None:
             self._logger.warning("websocket-client module is not installed")
             raise unittest.SkipTest("websocket-client module is not installed")
-        self.user_data_dir = tempfile.mkdtemp(suffix='_chrome_odoo')
-
-        if scs := odoo.tools.config['screencasts']:
-            self.screencaster = Screencaster(self, scs)
-        else:
-            self.screencaster = NoScreencast()
+        self.user_data_dir = self.cleanup.enter_context(
+            tempfile.TemporaryDirectory(
+                suffix='_chrome_odoo',
+                ignore_cleanup_errors=True,
+            )
+        )
+        self.cleanup.callback(
+            self._logger.info,
+            'Removing chrome user profile "%s"',
+            self.user_data_dir,
+        )
 
         if os.name == 'posix':
-            self.sigxcpu_handler = signal.getsignal(signal.SIGXCPU)
-            signal.signal(signal.SIGXCPU, self.signal_handler)
-        else:
-            self.sigxcpu_handler = None
+            sigxcpu_handler = signal.signal(signal.SIGXCPU, self.signal_handler)
+            self.cleanup.callback(
+                signal.signal, signal.SIGXCPU, sigxcpu_handler)
 
         test_case.browser_size = test_case.browser_size.replace('x', ',')
 
-        self.chrome, self.devtools_port = self._chrome_start(
+        self.chrome, self.devtools_port = self.cleanup.enter_context(self._chrome_start(
             user_data_dir=self.user_data_dir,
             touch_enabled=test_case.touch_enabled,
             headless=headless,
             debug=debug,
-        )
-        self.ws = self._open_websocket()
+        ))
+        self.ws = self.cleanup.enter_context(self._open_websocket())
+        if scs := odoo.tools.config['screencasts']:
+            self.screencaster = self.cleanup.enter_context(Screencaster(self, scs))
+        else:
+            self.screencaster = self.cleanup.enter_context(NoScreencast())
+
         self._request_id = itertools.count()
         self._result = Future()
         self.error_checker = None
@@ -1346,6 +1356,27 @@ class ChromeBrowser:
         }
         emulated_device['width'], emulated_device['height'] = [int(size) for size in test_case.browser_size.split(",")]
         self._websocket_request('Emulation.setDeviceMetricsOverride', params=emulated_device)
+        self.cleanup.callback(self._ws_winddown)
+
+    def _ws_winddown(self):
+        try:
+            self._websocket_request('Page.stopLoading')
+            self._websocket_request('Runtime.evaluate', params={'expression': """
+            ('serviceWorker' in navigator) &&
+                navigator.serviceWorker.getRegistrations().then(
+                    registrations => Promise.all(registrations.map(r => r.unregister()))
+                )
+            """, 'awaitPromise': True})
+            # wait for the screenshot or whatever
+            wait(self._responses.values(), 10)
+            self._result.cancel()
+
+            self._logger.info("Closing chrome headless with pid %s", self.chrome.pid)
+            self._websocket_request('Browser.close')
+        except ChromeBrowserException as e:
+            _logger.runbot("WS error during browser shutdown: %s", e)
+        except Exception:  # noqa: BLE001
+            _logger.warning("Error during browser shutdown", exc_info=True)
 
     def signal_handler(self, sig, frame):
         if sig == signal.SIGXCPU:
@@ -1362,45 +1393,7 @@ class ChromeBrowser:
         self._websocket_request('Emulation.setCPUThrottlingRate', params={'rate': factor})
 
     def stop(self):
-        # method may be called during `_open_websocket`
-        if hasattr(self, 'ws'):
-            try:
-                self.screencaster.stop()
-
-                self._websocket_request('Page.stopLoading')
-                self._websocket_request('Runtime.evaluate', params={'expression': """
-                ('serviceWorker' in navigator) &&
-                    navigator.serviceWorker.getRegistrations().then(
-                        registrations => Promise.all(registrations.map(r => r.unregister()))
-                    )
-                """, 'awaitPromise': True})
-                # wait for the screenshot or whatever
-                wait(self._responses.values(), 10)
-                self._result.cancel()
-
-                self._logger.info("Closing chrome headless with pid %s", self.chrome.pid)
-                self._websocket_request('Browser.close')
-            except ChromeBrowserException as e:
-                _logger.runbot("WS error during browser shutdown: %s", e)
-            except Exception:  # noqa: BLE001
-                _logger.warning("Error during browser shutdown", exc_info=True)
-            self._logger.info("Closing websocket connection")
-            self.ws.close()
-
-        self._logger.info("Terminating chrome headless with pid %s", self.chrome.pid)
-        self.chrome.terminate()
-        try:
-            self.chrome.wait(5)
-        except subprocess.TimeoutExpired:
-            self._logger.warning("Killing chrome headless with pid %s: still alive", self.chrome.pid)
-            self.chrome.kill()
-
-        self._logger.info('Removing chrome user profile "%s"', self.user_data_dir)
-        shutil.rmtree(self.user_data_dir, ignore_errors=True)
-
-        # Restore previous signal handler
-        if self.sigxcpu_handler:
-            signal.signal(signal.SIGXCPU, self.sigxcpu_handler)
+        self.cleanup.close()
 
     @property
     def executable(self):
@@ -1431,12 +1424,11 @@ class ChromeBrowser:
                 proc.kill()
                 proc.wait()
         self._logger.warning('Chrome headless failed to start:\n%s', log_path.read_text(encoding="utf-8"))
-        # since the chrome never started, it's not going to be `stop`-ed so we
-        # need to cleanup the directory here
-        shutil.rmtree(self.user_data_dir, ignore_errors=True)
+        self.stop()
 
         raise unittest.SkipTest(f'Failed to detect chrome devtools port after {BROWSER_WAIT :.1f}s.')
 
+    @contextlib.contextmanager
     def _chrome_start(
             self,
             user_data_dir: str,
@@ -1501,8 +1493,16 @@ class ChromeBrowser:
             raise unittest.SkipTest("%s not found" % cmd[0])
         self._logger.info('Chrome pid: %s', proc.pid)
         self._logger.info('Chrome headless temporary user profile dir: %s', self.user_data_dir)
-
-        return proc, devtools_port
+        try:
+            yield proc, devtools_port
+        finally:
+            self._logger.info("Terminating chrome headless with pid %s", proc.pid)
+            proc.terminate()
+            try:
+                proc.wait(5)
+            except subprocess.TimeoutExpired:
+                self._logger.warning("Killing chrome headless with pid %s: still alive", proc.pid)
+                proc.kill()
 
     def _json_command(self, command, timeout=3):
         """Queries browser state using JSON
@@ -1556,6 +1556,7 @@ class ChromeBrowser:
         self.stop()
         raise unittest.SkipTest("Error during Chrome headless connection")
 
+    @contextlib.contextmanager
     def _open_websocket(self):
         version = self._json_command('version')
         self._logger.info('Browser version: %s', version['Browser'])
@@ -1581,7 +1582,11 @@ class ChromeBrowser:
         if ws.getstatus() != 101:
             raise unittest.SkipTest("Cannot connect to chrome dev tools")
         ws.settimeout(0.01)
-        return ws
+        try:
+            yield ws
+        finally:
+            self._logger.info("Closing websocket connection")
+            ws.close()
 
     def _receive(self, dbname):
         threading.current_thread().dbname = dbname
@@ -1985,7 +1990,10 @@ class NoScreencast:
     def start(self):
         pass
 
-    def stop(self):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
         pass
 
     def save(self):
@@ -2025,7 +2033,10 @@ class Screencaster:
             'timestamp': metadata.get('timestamp')
         })
 
-    def stop(self):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
         self.browser._websocket_send('Page.stopScreencast')
         self.stopped = True
         if self.frames_dir.is_dir():
@@ -2446,6 +2457,7 @@ class HttpCase(TransactionCase):
         browser = ChromeBrowser(self, headless=not watch, success_signal=success_signal, debug=debug)
         with self.allow_requests(browser=browser), contextlib.ExitStack() as atexit:
             atexit.callback(self._wait_remaining_requests)
+            atexit.enter_context(browser.cleanup)
             if "bus.bus" in self.env.registry:
                 from odoo.addons.bus.websocket import CloseCode, _kick_all, WebsocketConnectionHandler  # noqa: PLC0415
                 from odoo.addons.bus.models.bus import BusBus  # noqa: PLC0415
@@ -2495,7 +2507,6 @@ class HttpCase(TransactionCase):
                 browser.throttle(cpu_throttling)
 
             browser.navigate_to(url, wait_stop=not bool(ready))
-            atexit.callback(browser.stop)
 
             # Needed because tests like test01.js (qunit tests) are passing a ready
             # code = ""


### PR DESCRIPTION
Trying to find out why I kept having a bunch of leftover `tmpsomethingsomethign_chrome_odoo` leftovers I realised #203412 had a bit of an error in the location of the
`atexit.callback(browser.stop)`: the temporary directory for the user data dir is created as soon as the browser is instantiated, but the cleanup is only recorded after a successful `navigate_to`, so if that (or a previous step e.g. authentication) fails then the tempdir is never cleaned up.

Rather than just move the call up the body and re-introduce conditionals to `stop` to handle more partial initializations though, use the magic of ~~buying two of them~~ `ExitStack` to record cleanup requirements dynamically as the `ChromeBrowser` initialises.

This initially used a bunch of `ExitStack.callback` calls with ad-hoc cleanup, but turns out most of these cases are better as CMs:

- replace `mkdtemp` / `rmtree` by `TemporaryDirectory`, which Just Works as a CM
- add context-manager methods to the screencaster classes (also remove `stop` which is redundant with `__exit__`) so they Just Work as CMs
- convert `_chrome_start` and `_open_websocket` to `@contextmanager`... for obvious reasons

This makes the relation between setup and cleanup clearer, as well as more self-contained in case we want to move stuff to a submodule eventually. It also ensures cleanups run in the correct order, and avoids having to deal with partial initializations.

Keep `ChromeBrowser.stop` because it seems unnecessary to edit those out for now, but have it just `close` the exitstack (which runs all the registered cleanups).

NOTE: it might make sense for `browser_js` to just use `ChromeBrowser.cleanup` instead of having its own exitstack, not entirely sure... Alternatively it might make sense for ChromeBrowser to *take* a CM as parameter... and / or for ChromeBrowser to *be* a CM?