### PR TITLE
[FIX] point_of_sale: input not set when searching

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/utils/partner_list_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/partner_list_util.js
@@ -133,6 +133,14 @@ export function searchCustomerValue(val, pressEnter = false) {
 
     if (pressEnter) {
         steps.push({
+            trigger: "body",
+            run: () =>
+                // wait 200ms so state.query can be updated with the new value before triggering keydown
+                new Promise((resolve) => {
+                    setTimeout(resolve, 200);
+                }),
+        });
+        steps.push({
             content: `Manually trigger keyup event`,
             trigger: ".modal-header:has(.modal-title:contains(choose customer)) .input-group input",
             run: function () {


### PR DESCRIPTION
In some test, we try to search the database for a partner through the partner_list. To do this, we edit the partner_list input and trigger an "Enter" event. In some case, the value is not set to the state of the partner_list before we dispatch the event and result in no search in the database being done. This is partly due to the debounce of the input before setting the state of the partner list and due to some method running asynchronously every method triggered by the insertion of text.

To fix this, we add a little sleep in the tour (200ms) to ensure that the state of the component is well updated before triggering the event.

runbot-error: 238511

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
