### PR TITLE
[IMP] stock_picking_batch: search batches by description

### DIFF
--- a/addons/stock_picking_batch/views/stock_picking_batch_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_batch_views.xml
@@ -243,6 +243,7 @@
         <field name="arch" type="xml">
             <search string="Search Batch Transfer">
                 <field name="name" string="Batch Transfer"/>
+                <field name="description"/>
                 <field name="picking_type_id" invisible="1"/>
                 <field name="user_id"/>
                 <filter name="to_do_transfers" string="To Do" domain="['&amp;',('user_id', 'in', [uid, False]),('state','not in',['done','cancel'])]"/>


### PR DESCRIPTION
Purpose: When batches are automatically created, the description is filled with the grouping criteria but it was not possible to search on it.

Add the description field to the default search of batches.

task-5917797
