### PR TITLE
[FIX] sale_timesheet: disable extension of Services & Materials search view

### DIFF
--- a/addons/sale_timesheet/views/account_analytic_line_views.xml
+++ b/addons/sale_timesheet/views/account_analytic_line_views.xml
@@ -4,6 +4,10 @@
         <field name="name">account.analytic.line.services.search.inherit.sale.project</field>
         <field name="model">account.analytic.line</field>
         <field name="inherit_id" ref="sale.view_analytic_lines_service_search"/>
+        <!-- !Disabled because this view adds filters and group-by options on project_id, task_id
+            !and employee_id, which are never set on Services & Materials analytic lines.
+            TODO: Remove this view entirely in master. -->
+        <field name="active">False</field>
         <field name="arch" type="xml">
             <filter name="my_orders" position="after">
                 <filter name="my_team" string="My Team" domain="[('employee_id.parent_id.user_id', '=', uid)]"/>


### PR DESCRIPTION
This commit disables an unnecessary search view extension in `sale_timesheet` for the *Services & Materials* view. The extension was adding *group by* and *filter* options based on the fields `project_id`, `employee_id`, and `task_id` which are never set on Services analytic lines.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
