### PR TITLE
[REF] stock,*: run rendering context migration script

### DIFF
--- a/addons/mrp/static/src/mrp_forecasted/forecasted_buttons.xml
+++ b/addons/mrp/static/src/mrp_forecasted/forecasted_buttons.xml
@@ -2,10 +2,10 @@
 <templates xml:space="preserve">
     <t t-name="mrp.ForecastedButtons" t-inherit="stock.ForecastedButtons" t-inherit-mode="extension">
         <xpath expr="//button[@title='Replenish']" position="after">
-            <button t-if="bomId" t-name="mrp_replenish_report_buttons"
+            <button t-if="this.bomId" t-name="mrp_replenish_report_buttons"
                 class="btn btn-secondary o_bom_overview_report"
                 type="button" title="Manufacturing Forecast"
-                t-on-click="_onClickBom">
+                t-on-click="this._onClickBom">
                 Manufacturing Forecast
             </button>
         </xpath>

--- a/addons/mrp/static/src/mrp_forecasted/forecasted_details.xml
+++ b/addons/mrp/static/src/mrp_forecasted/forecasted_details.xml
@@ -2,21 +2,21 @@
 <templates id="template">
     <t t-name="mrp.ForecastedDetails" t-inherit="stock.ForecastedDetails" t-inherit-mode="extension">
         <xpath expr="//tr[@name='draft_picking_in']" position="after">
-            <tr t-if="currentProduct.draft_production_qty.in" name="draft_mo_in" t-attf-class="#{multipleProducts and 'collapse show' or ''} collapseGroup_#{line.product.id}">
+            <tr t-if="currentProduct.draft_production_qty.in" name="draft_mo_in" t-attf-class="#{this.multipleProducts and 'collapse show' or ''} collapseGroup_#{line.product.id}">
                 <td/>
                 <td>Production of Draft MO</td>
                 <td class="text-end text-success">
-                    <t t-out="_formatFloat(currentProduct.draft_production_qty.in)"/> <t t-out="line.uom_id.display_name"/>
+                    <t t-out="this._formatFloat(currentProduct.draft_production_qty.in)"/> <t t-out="line.uom_id.display_name"/>
                 </td>
             </tr>
         </xpath>
         <xpath expr="//tr[@name='draft_picking_out']" position="after">
-            <tr t-if="currentProduct.draft_production_qty.out" name="draft_mo_out" t-attf-class="#{multipleProducts and 'collapse show' or ''} collapseGroup_#{line.product.id}">
+            <tr t-if="currentProduct.draft_production_qty.out" name="draft_mo_out" t-attf-class="#{this.multipleProducts and 'collapse show' or ''} collapseGroup_#{line.product.id}">
                 <td/>
                 <td>Component of Draft MO</td>
                 <td class="text-end">
                     <span class="text-danger">
-                        <t t-out="_formatFloat(-currentProduct.draft_production_qty.out)"/> <t t-out="line.uom_id.display_name"/>
+                        <t t-out="this._formatFloat(-currentProduct.draft_production_qty.out)"/> <t t-out="line.uom_id.display_name"/>
                     </span>
                 </td>
             </tr>

--- a/addons/mrp_account/static/src/stock_valuation/stock_valuation_report.xml
+++ b/addons/mrp_account/static/src/stock_valuation/stock_valuation_report.xml
@@ -2,7 +2,7 @@
 <templates>
     <t t-inherit="stock_account.StockValuationReport" t-inherit-mode="extension">
         <xpath expr="//t[@t-call='stock_account.StockValuationReport.InventoryLoss']" position="after">
-            <t t-if="data.cost_of_production" t-call="mrp_account.StockValuationReport.CostOfProduction"/>
+            <t t-if="this.data.cost_of_production" t-call="mrp_account.StockValuationReport.CostOfProduction"/>
         </xpath>
     </t>
 

--- a/addons/product_expiry/static/src/forecasted_header.xml
+++ b/addons/product_expiry/static/src/forecasted_header.xml
@@ -3,11 +3,11 @@
 
     <t t-name="product_expiry.ForecastedHeader" t-inherit="stock.ForecastedHeader" t-inherit-mode="extension">
         <xpath expr="//div[@name='on_hand']" position="after">
-            <t t-if="props.docs.use_expiration_date">
+            <t t-if="this.props.docs.use_expiration_date">
                 <div class="h3 col-md-auto text-center">-</div>
-                <div t-attf-class="col-md-auto text-center #{to_remove_qty}">
+                <div t-attf-class="col-md-auto text-center #{this.to_remove_qty}">
                     <div class="h3">
-                        <t t-out="_formatFloat(to_remove_qty)"/>
+                        <t t-out="this._formatFloat(this.to_remove_qty)"/>
                     </div>
                     <div>To Remove</div>
                 </div>

--- a/addons/purchase_stock/static/src/purchase_stock_forecasted/forecasted_details.xml
+++ b/addons/purchase_stock/static/src/purchase_stock_forecasted/forecasted_details.xml
@@ -3,7 +3,7 @@
      <t t-name="purchase_stock.ForecastedDetails" t-inherit="stock.ForecastedDetails" t-inherit-mode="extension">
          <xpath expr="//tr[@name='draft_picking_in']" position="after">
             <tr t-if="currentProduct.draft_purchase_qty.in" name="draft_po_in"
-            t-attf-class="#{currentProduct.draft_purchase_orders_matched and 'table-info'} #{multipleProducts and 'collapse show' or ''} collapseGroup_#{line.product.id}">
+            t-attf-class="#{currentProduct.draft_purchase_orders_matched and 'table-info'} #{this.multipleProducts and 'collapse show' or ''} collapseGroup_#{line.product.id}">
                 <td/>
                 <td>Requests for quotation :
                     <t t-foreach="currentProduct.draft_purchase_orders" t-as="purchase_order" t-key="purchase_order_index">
@@ -14,7 +14,7 @@
                     </t>
                 </td>
                 <td class="text-end text-success">
-                    <t t-out="_formatFloat(currentProduct.draft_purchase_qty.in)"/> <t t-out="line.uom_id.display_name"/>
+                    <t t-out="this._formatFloat(currentProduct.draft_purchase_qty.in)"/> <t t-out="line.uom_id.display_name"/>
                 </td>
             </tr>
         </xpath>

--- a/addons/sale_stock/static/src/sale_stock_forecasted/forecasted_details.xml
+++ b/addons/sale_stock/static/src/sale_stock_forecasted/forecasted_details.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="sale_stock.ForecastedDetails" t-inherit="stock.ForecastedDetails" t-inherit-mode="extension">
         <xpath expr="//tr[@name='draft_picking_out']" position="after">
-            <tr t-if="currentProduct.draft_sale_qty.out" name="draft_so_out" t-attf-class="#{currentProduct.draft_sale_orders_matched and 'table-info'} #{multipleProducts and 'collapse show' or ''} collapseGroup_#{line.product.id}">
+            <tr t-if="currentProduct.draft_sale_qty.out" name="draft_so_out" t-attf-class="#{currentProduct.draft_sale_orders_matched and 'table-info'} #{this.multipleProducts and 'collapse show' or ''} collapseGroup_#{line.product.id}">
                 <td/>
                 <td>
                 <t t-set="draft_so_out_count" t-value="currentProduct.draft_sale_orders.length"/>
@@ -15,7 +15,7 @@
                 </td>
                 <td class="text-end">
                     <span class="text-danger">
-                        <t t-out="_formatFloat(-currentProduct.draft_sale_qty.out)"/> <t t-out="line.uom_id.display_name"/>
+                        <t t-out="this._formatFloat(-currentProduct.draft_sale_qty.out)"/> <t t-out="line.uom_id.display_name"/>
                     </span>
                 </td>
                 <td colspan="3"/>

--- a/addons/stock/static/src/client_actions/stock_traceability_report_backend.xml
+++ b/addons/stock/static/src/client_actions/stock_traceability_report_backend.xml
@@ -3,7 +3,7 @@
 
     <t t-name="stock.TraceabilityReport">
         <div class="o_action">
-            <Layout display="display">
+            <Layout display="this.display">
                 <t t-set-slot="control-panel-buttons">
                     <div class="o_cp_buttons" role="toolbar" aria-label="Control panel buttons" t-custom-ref="buttons">
                         <button type="button" class="btn btn-primary" t-on-click="() => this.onClickPrint()">Print</button>
@@ -11,7 +11,7 @@
                 </t>
 
                 <div class="container-fluid o_stock_reports_page o_stock_reports_no_print">
-                    <t t-if="state.lines.length">
+                    <t t-if="this.state.lines.length">
                         <h1 class="o_report_heading text-start">Traceability Report</h1>
                         <div class="o_stock_reports_table table-responsive">
                             <table class="table">
@@ -28,7 +28,7 @@
                                 </thead>
                                 <tbody>
                                     <t t-call="stock.ReportMRPLines">
-                                        <t t-set="lines" t-value="state.lines"/>
+                                        <t t-set="lines" t-value="this.state.lines"/>
                                         <t t-set="hasUpDown" t-value="true"/>
                                     </t>
                                 </tbody>

--- a/addons/stock/static/src/components/reception_report_line/stock_reception_report_line.xml
+++ b/addons/stock/static/src/components/reception_report_line/stock_reception_report_line.xml
@@ -2,31 +2,31 @@
 <templates xml:space="preserve">
 
     <tr t-name="stock.ReceptionReportLine" class="align-middle">
-        <td t-out="data.product.display_name"/>
+        <td t-out="this.data.product.display_name"/>
         <td>
-            <t t-out="formatFloat(data.quantity)"/> <t t-if="props.showUom" t-out="data.uom"/>
-            <button class="btn btn-link fa fa-area-chart" t-on-click="onClickForecast" name="forecasted_report_link"/>
+            <t t-out="this.formatFloat(this.data.quantity)"/> <t t-if="this.props.showUom" t-out="this.data.uom"/>
+            <button class="btn btn-link fa fa-area-chart" t-on-click="this.onClickForecast" name="forecasted_report_link"/>
         </td>
-        <td t-if="data.is_qty_assignable">
-            <button t-if="!data.is_assigned"
-                t-on-click="onClickAssign"
+        <td t-if="this.data.is_qty_assignable">
+            <button t-if="!this.data.is_assigned"
+                t-on-click="this.onClickAssign"
                 class="btn btn-sm btn-primary"
                 name="assign_link">
                 Assign
             </button>
             <button t-else=""
-                t-on-click="onClickUnassign"
+                t-on-click="this.onClickUnassign"
                 class="btn btn-sm btn-primary"
                 name="unassign_link">
                 Unassign
             </button>
         </td>
         <td>
-            <button t-if="data.is_qty_assignable &amp;&amp; data.source"
+            <button t-if="this.data.is_qty_assignable &amp;&amp; this.data.source"
                 class="btn btn-sm btn-primary"
-                t-attf-disabled="{{ !data.is_assigned }}"
+                t-attf-disabled="{{ !this.data.is_assigned }}"
                 name="print_label"
-                t-on-click="onClickPrint">
+                t-on-click="this.onClickPrint">
                 <span class="d-sm-block">Print Label</span>
             </button>
         </td>

--- a/addons/stock/static/src/components/reception_report_main/stock_reception_report_main.xml
+++ b/addons/stock/static/src/components/reception_report_main/stock_reception_report_main.xml
@@ -2,38 +2,38 @@
 <templates xml:space="preserve">
 
     <div t-name="stock.ReceptionReportMain" class="o_action">
-        <ControlPanel display="controlPanelDisplay">
+        <ControlPanel display="this.controlPanelDisplay">
             <t t-set-slot="control-panel-buttons">
-                <button t-on-click="onClickPrint" type="button" class="btn btn-primary" title="Print">Print</button>
-                <button t-on-click="onClickAssignAll" class="btn btn-secondary" t-att-disabled="isAssignAllDisabled">Assign All</button>
-                <button t-on-click="onClickPrintLabels" class="btn btn-secondary" t-att-disabled="isPrintLabelDisabled">Print Labels</button>
+                <button t-on-click="this.onClickPrint" type="button" class="btn btn-primary" title="Print">Print</button>
+                <button t-on-click="this.onClickAssignAll" class="btn btn-secondary" t-att-disabled="this.isAssignAllDisabled">Assign All</button>
+                <button t-on-click="this.onClickPrintLabels" class="btn btn-secondary" t-att-disabled="this.isPrintLabelDisabled">Print Labels</button>
             </t>
         </ControlPanel>
         <div class="o_report_reception o_report_reception_no_print container-fluid justify-content-between">
             <div class="o_report_reception_header my-4">
                 <h1>
-                    <t t-if="data.docs">
-                        <div t-foreach="data.docs" t-as="doc" t-key="doc.id">
+                    <t t-if="this.data.docs">
+                        <div t-foreach="this.data.docs" t-as="doc" t-key="doc.id">
                             <a href="#" t-on-click.prevent="() => this.onClickTitle(doc.id)" view-type="form" t-out="doc.name"/>
                             <span t-out="doc.display_state" t-attf-class="ms-1 align-text-top badge rounded-pill bg-opacity-50 {{ doc.state == 'done' ? 'bg-success' : 'bg-info' }}"/>
                         </div>
                     </t>
                     <t t-else="">
-                        <span t-out="data.reason"/>
+                        <span t-out="this.data.reason"/>
                     </t>
                 </h1>
             </div>
-            <t t-if="hasContent">
+            <t t-if="this.hasContent">
                 <table class="table table-sm">
                     <ReceptionReportTable
-                        t-foreach="state.sourcesToLines" t-as="source" t-key="source"
+                        t-foreach="this.state.sourcesToLines" t-as="source" t-key="source"
                         index="source"
-                        scheduledDate="data.sources_to_formatted_scheduled_date[source]"
-                        lines="state.sourcesToLines[source]"
-                        source="data.sources_info[source]"
-                        labelReport="receptionReportLabelAction"
-                        showUom="data.show_uom"
-                        precision="data.precision"/>
+                        scheduledDate="this.data.sources_to_formatted_scheduled_date[source]"
+                        lines="this.state.sourcesToLines[source]"
+                        source="this.data.sources_info[source]"
+                        labelReport="this.receptionReportLabelAction"
+                        showUom="this.data.show_uom"
+                        precision="this.data.precision"/>
                 </table>
             </t>
             <p t-else="">

--- a/addons/stock/static/src/components/reception_report_table/stock_reception_report_table.xml
+++ b/addons/stock/static/src/components/reception_report_table/stock_reception_report_table.xml
@@ -5,23 +5,23 @@
         <thead>
             <tr class="bg-light">
                 <th>
-                    <i t-if="props.source[0].priority == '1'" class="o_priority o_priority_star fa fa-star"/>
-                    <a href="#" t-on-click.prevent="() => this.onClickLink(props.source[0].model, props.source[0].id, 'form')" t-out="props.source[0].name"/>
-                    <span t-if="props.source.length > 1">
-                        (<a href="#" t-on-click.prevent="() => this.onClickLink(props.source[1].model, props.source[1].id, 'form')" t-out="props.source[1].name"/>)
+                    <i t-if="this.props.source[0].priority == '1'" class="o_priority o_priority_star fa fa-star"/>
+                    <a href="#" t-on-click.prevent="() => this.onClickLink(this.props.source[0].model, this.props.source[0].id, 'form')" t-out="this.props.source[0].name"/>
+                    <span t-if="this.props.source.length > 1">
+                        (<a href="#" t-on-click.prevent="() => this.onClickLink(this.props.source[1].model, this.props.source[1].id, 'form')" t-out="this.props.source[1].name"/>)
                     </span>
-                    <span t-if="props.source[0].model == 'stock.picking' and props.source[0].partner_id">:
-                        <a href="#" t-on-click.prevent="() => this.onClickLink('res.partner', props.source[0].partner_id, 'form')" t-out="props.source[0].partner_name"/>
+                    <span t-if="this.props.source[0].model == 'stock.picking' and this.props.source[0].partner_id">:
+                        <a href="#" t-on-click.prevent="() => this.onClickLink('res.partner', this.props.source[0].partner_id, 'form')" t-out="this.props.source[0].partner_name"/>
                     </span>
                 </th>
-                <th>Expected Delivery: <t t-out="props.scheduledDate"/></th>
-                <th t-if="hasMovesIn">
-                    <button t-if="hasAssignAllButton" t-on-click="onClickAssignAll" class="btn btn-sm btn-primary" t-att-disabled="isAssignAllDisabled" name="assign_source_link">
+                <th>Expected Delivery: <t t-out="this.props.scheduledDate"/></th>
+                <th t-if="this.hasMovesIn">
+                    <button t-if="this.hasAssignAllButton" t-on-click="this.onClickAssignAll" class="btn btn-sm btn-primary" t-att-disabled="this.isAssignAllDisabled" name="assign_source_link">
                         Assign All
                     </button>
                 </th>
                 <th>
-                    <button t-if="hasMovesIn" t-on-click="onClickPrintLabels" class="btn btn-sm btn-primary" t-att-disabled="isPrintLabelDisabled" name="print_labels">
+                    <button t-if="this.hasMovesIn" t-on-click="this.onClickPrintLabels" class="btn btn-sm btn-primary" t-att-disabled="this.isPrintLabelDisabled" name="print_labels">
                         <span class="d-none d-sm-block">Print Labels</span>
                         <span class="d-block d-sm-none fa fa-print"/>
                     </button>
@@ -29,13 +29,13 @@
             </tr>
         </thead>
         <tbody>
-            <t t-foreach="props.lines" t-as="line" t-key="line.index">
+            <t t-foreach="this.props.lines" t-as="line" t-key="line.index">
                 <ReceptionReportLine
                     data="line"
-                    labelReport="props.labelReport"
-                    parentIndex="props.index"
-                    showUom="props.showUom"
-                    precision="props.precision"/>
+                    labelReport="this.props.labelReport"
+                    parentIndex="this.props.index"
+                    showUom="this.props.showUom"
+                    precision="this.props.precision"/>
             </t>
         </tbody>
     </t>

--- a/addons/stock/static/src/fields/stock_action_field.xml
+++ b/addons/stock/static/src/fields/stock_action_field.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates>
     <t t-name="stock.actionField" owl="1">
-        <a t-if="! disabled" href="#" t-on-click="_onClick" class="btn-link">
+        <a t-if="! this.disabled" href="#" t-on-click="this._onClick" class="btn-link">
             <t t-call="stock.actionFieldContent"/>
         </a>
         <t t-else="">
@@ -10,11 +10,11 @@
     </t>
 
     <t t-name="stock.actionFieldContent" owl="1">
-        <t t-if="fieldType === 'monetary'">
-            <MonetaryField t-props="extractProps()"/>
+        <t t-if="this.fieldType === 'monetary'">
+            <MonetaryField t-props="this.extractProps()"/>
         </t>
         <t t-else="">
-            <FloatField t-props="extractProps()"/>
+            <FloatField t-props="this.extractProps()"/>
         </t>
     </t>
 </templates>

--- a/addons/stock/static/src/fields/stock_picking_locked_statusbar_field.xml
+++ b/addons/stock/static/src/fields/stock_picking_locked_statusbar_field.xml
@@ -4,7 +4,7 @@
     <t t-name="stock.PickingLockedStatusBarField.ItemLabel">
         <span t-out="item.label"/>
         <t t-if="['done', 'cancel'].includes(item.value) and item.isSelected">
-            <i t-attf-class="fa fa-fw ms-1 #{isLocked ? 'fa-lock text-success' : 'fa-unlock text-warning'}"/>
+            <i t-attf-class="fa fa-fw ms-1 #{this.isLocked ? 'fa-lock text-success' : 'fa-unlock text-warning'}"/>
         </t>
     </t>
 

--- a/addons/stock/static/src/stock_forecasted/forecasted_buttons.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_buttons.xml
@@ -2,11 +2,11 @@
 <templates xml:space="preserve">
 
     <t t-name="stock.ForecastedButtons">
-        <button title="Replenish" t-on-click="_onClickReplenish"
+        <button title="Replenish" t-on-click="this._onClickReplenish"
             class="o_forecasted_replenish_btn btn btn-primary">
             Replenish
         </button>
-        <button title="Update Quantity" t-on-click="_onClickUpdateQuantity"
+        <button title="Update Quantity" t-on-click="this._onClickUpdateQuantity"
             class="o_forecasted_update_qty_btn btn btn-secondary">
             Update Quantity
         </button>

--- a/addons/stock/static/src/stock_forecasted/forecasted_details.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_details.xml
@@ -13,10 +13,10 @@
                 </tr>
             </thead>
             <tbody>
-                <t t-set="last_line_index" t-value="lines.length - 1"/>
-                <t t-foreach="lines" t-as="line" t-key="line_index">
-                    <t t-set="currentProduct" t-value="props.docs.product[line.product.id]"/>
-                    <t t-if="multipleProducts and (line_index === 0 or line.product.id !== lines[line_index - 1].product.id)">
+                <t t-set="last_line_index" t-value="this.lines.length - 1"/>
+                <t t-foreach="this.lines" t-as="line" t-key="line_index">
+                    <t t-set="currentProduct" t-value="this.props.docs.product[line.product.id]"/>
+                    <t t-if="this.multipleProducts and (line_index === 0 or line.product.id !== this.lines[line_index - 1].product.id)">
                         <tr class="o_forecasted_product_header">
                             <td class="border-0 p-0">
                                 <button class="btn btn-sm border-0"
@@ -31,10 +31,10 @@
                             </td>
                         </tr>
                     </t>
-                    <tr t-attf-class="#{line.is_late and 'table-warning' or ''} #{multipleProducts and 'collapse show' or ''} collapseGroup_#{line.product.id}" >
+                    <tr t-attf-class="#{line.is_late and 'table-warning' or ''} #{this.multipleProducts and 'collapse show' or ''} collapseGroup_#{line.product.id}" >
                         <t t-if="skip_row > 0" t-set="skip_row" t-value="skip_row - 1"/>
                         <t t-if="!skip_row or skip_row == 0">
-                            <t t-if="mergesLinesData[line_index]" t-set="skip_row" t-value="mergesLinesData[line_index]['rowcount']"/>
+                            <t t-if="this.mergesLinesData[line_index]" t-set="skip_row" t-value="this.mergesLinesData[line_index]['rowcount']"/>
                             <td t-attf-rowspan="#{skip_row > 0 and skip_row}"/>
                             <td t-attf-rowspan="#{skip_row > 0 and skip_row}">
                                 <t t-if="line.document_in">
@@ -44,7 +44,7 @@
                                         t-out="line.document_in.name"
                                         class="fw-bold"/>
                                     <span t-if="line.receipt_date">:
-                                        <t t-out="_formatFloat(skip_row > 0 ? mergesLinesData[line_index].tot_qty : line.quantity)"/> <t t-out="line.uom_id.display_name"/> expected on <t t-out="line.receipt_date"/>
+                                        <t t-out="this._formatFloat(skip_row > 0 ? this.mergesLinesData[line_index].tot_qty : line.quantity)"/> <t t-out="line.uom_id.display_name"/> expected on <t t-out="line.receipt_date"/>
                                     </span>
                                 </t>
                                 <t t-elif="line.in_transit">
@@ -57,14 +57,14 @@
                                 </t>
                                 <t t-elif="line.replenishment_filled">
                                     <t name="onHand_cell" t-if="line.document_out">
-                                        Stock To Reserve: <t t-out="_formatFloat(OnHandTotalQty[line.product.id])"/> <t t-out="line.uom_id.display_name"/>
+                                        Stock To Reserve: <t t-out="this._formatFloat(this.OnHandTotalQty[line.product.id])"/> <t t-out="line.uom_id.display_name"/>
                                     </t>
-                                    <t name="freeStock_cell" t-else="" t-out="freeStockLabel"/>
+                                    <t name="freeStock_cell" t-else="" t-out="this.freeStockLabel"/>
                                 </t>
                                 <span t-else="" class="text-muted">Not Available</span>
                             </td>
                         </t>
-                        <td name="quantity_cell" class="text-end"><t t-attf-class="#{(!line.replenishment_filled and 'text-danger')" t-out="_formatFloat(line.quantity)"/> <t t-out="line.uom_id.display_name"/></td>
+                        <td name="quantity_cell" class="text-end"><t t-attf-class="#{(!line.replenishment_filled and 'text-danger')" t-out="this._formatFloat(line.quantity)"/> <t t-out="line.uom_id.display_name"/></td>
                         <td class="border-end-0 o_forecasted_details_line_button" t-attf-class="#{(!line.replenishment_filled and 'table-danger') or (line.is_matched and 'table-info')}" name="usedby_cell">
                             <button t-if="line.move_out and line.move_out.picking_id"
                                 t-attf-class="o_priority o_priority_star me-1 fa fa-star#{line.move_out.picking_id.priority=='1' ? '' : '-o'}"
@@ -78,20 +78,20 @@
                                 class="fw-bold"/>
                         </td>
                         <td class="p-0 text-center border-start-0">
-                            <t t-if="displayReserve(line)">
+                            <t t-if="this.displayReserve(line)">
                                 <a t-if="line.reservation"
                                     href="#"
                                     name="unreserve_link"
                                     t-on-click="() => this._unreserve(line.move_out.id)">
                                     Unreserve
                                 </a>
-                                <button t-elif="line.replenishment_filled or AvailableOnHandTotalQty[line.product.id] &gt; 0"
+                                <button t-elif="line.replenishment_filled or this.AvailableOnHandTotalQty[line.product.id] &gt; 0"
                                     class="btn btn-sm btn-secondary"
                                     name="reserve_link"
                                     t-on-click="() => this._reserve(line.move_out.id)">
                                     Reserve
-                                    <t t-if="AvailableOnHandTotalQty[line.product.id] &gt; 0 and !isOnHand(line)">
-                                        (<t t-out="_formatFloat(Math.min(AvailableOnHandTotalQty[line.product.id], line.quantity))"/> <t t-out="line.uom_id.display_name"/>)
+                                    <t t-if="this.AvailableOnHandTotalQty[line.product.id] &gt; 0 and !this.isOnHand(line)">
+                                        (<t t-out="this._formatFloat(Math.min(this.AvailableOnHandTotalQty[line.product.id], line.quantity))"/> <t t-out="line.uom_id.display_name"/>)
                                     </t>
                                 </button>
                             </t>
@@ -99,7 +99,7 @@
                         <td t-out="line.delivery_date or ''"
                             t-attf-class="#{line.delivery_late and 'text-danger'}"/>
                     </tr>
-                    <t t-if="line_index === last_line_index or line.product.id !== lines[line_index + 1].product.id">
+                    <t t-if="line_index === last_line_index or line.product.id !== this.lines[line_index + 1].product.id">
                         <!-- Check in progress with DALA
                         <tr t-if="! multipleProducts and this.props.docs.qty_to_order" t-attf-class="#{multipleProducts and 'collapse show' or ''} collapseGroup_#{line.product.id}">
                             <td/>
@@ -109,33 +109,35 @@
                                 <span ><t t-out="_formatFloat(this.props.docs.qty_to_order)"/> <t t-out="line.uom_id.display_name"/></span>
                             </td>
                         </tr> -->
-                        <tr class="o_forecasted_row fw-bold table-secondary" t-attf-class="#{multipleProducts and 'collapse show' or ''} collapseGroup_#{line.product.id}">
+                        <tr
+                            class="o_forecasted_row fw-bold table-secondary" t-attf-class="#{this.multipleProducts and 'collapse show' or ''} collapseGroup_#{line.product.id}">
                             <td/>
                             <td class="border-end-0">Forecasted Inventory</td>
-                            <td class="text-end border-start-0 border-end-0" t-attf-class="#{currentProduct.virtual_available &lt;= 0 and 'text-danger' or 'text-success'}">
-                                <t t-out="_formatFloat(currentProduct.virtual_available)"/> <t t-out="line.uom_id.display_name"/>
+                            <td class="text-end border-start-0 border-end-0"
+                                t-attf-class="#{currentProduct.virtual_available &lt;= 0 and 'text-danger' or 'text-success'}">
+                                <t t-out="this._formatFloat(currentProduct.virtual_available)"/> <t t-out="line.uom_id.display_name"/>
                             </td>
                             <td class="border-start-0" colspan="3"/>
                         </tr>
-                        <tr t-if="currentProduct.draft_picking_qty.in" name="draft_picking_in" t-attf-class="#{multipleProducts and 'collapse show' or ''} collapseGroup_#{line.product.id}">
+                        <tr t-if="currentProduct.draft_picking_qty.in" name="draft_picking_in" t-attf-class="#{this.multipleProducts and 'collapse show' or ''} collapseGroup_#{line.product.id}">
                             <td/>
                             <td>Incoming Draft Transfer</td>
                             <td class="text-end">
-                                <t t-out="_formatFloat(currentProduct.draft_picking_qty.in)"/> <t t-out="line.uom_id.display_name"/>
+                                <t t-out="this._formatFloat(currentProduct.draft_picking_qty.in)"/> <t t-out="line.uom_id.display_name"/>
                             </td>
                         </tr>
-                        <tr t-if="currentProduct.draft_picking_qty.out" name="draft_picking_out" t-attf-class="#{multipleProducts and 'collapse show' or ''} collapseGroup_#{line.product.id}">
+                        <tr t-if="currentProduct.draft_picking_qty.out" name="draft_picking_out" t-attf-class="#{this.multipleProducts and 'collapse show' or ''} collapseGroup_#{line.product.id}">
                             <td/>
                             <td>Outgoing Draft Transfer</td>
                             <td class="text-end">
-                                <t t-out="_formatFloat(-currentProduct.draft_picking_qty.out)"/> <t t-out="line.uom_id.display_name"/>
+                                <t t-out="this._formatFloat(-currentProduct.draft_picking_qty.out)"/> <t t-out="line.uom_id.display_name"/>
                             </td>
                         </tr>
-                        <tr class="o_forecasted_row fw-bold table-secondary" t-attf-class="#{multipleProducts and 'collapse show' or ''} collapseGroup_#{line.product.id}">
+                        <tr class="o_forecasted_row fw-bold table-secondary" t-attf-class="#{this.multipleProducts and 'collapse show' or ''} collapseGroup_#{line.product.id}">
                             <td/>
                             <td class="border-end-0">Forecasted with Pending</td>
-                            <td class="text-end border-start-0 border-end-0" t-attf-class="#{futureVirtualAvailable(line) &lt;= 0 and 'text-danger' or 'text-success'}">
-                                <t t-out="_formatFloat(futureVirtualAvailable(line))"/> <t t-out="line.uom_id.display_name"/>
+                            <td class="text-end border-start-0 border-end-0" t-attf-class="#{this.futureVirtualAvailable(line) &lt;= 0 and 'text-danger' or 'text-success'}">
+                                <t t-out="this._formatFloat(this.futureVirtualAvailable(line))"/> <t t-out="line.uom_id.display_name"/>
                             </td>
                             <td class="border-start-0" colspan="3"/>
                         </tr>

--- a/addons/stock/static/src/stock_forecasted/forecasted_header.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_header.xml
@@ -4,15 +4,15 @@
         <div class="d-flex flex-wrap pb-1 justify-content-between">
             <div class="o_product_name">
                 <h3 name="product_name">
-                    <t t-if="props.docs.product_templates">
-                        <t t-foreach="props.docs.product_templates" t-as="product_template" t-key='product_template.id'>
+                    <t t-if="this.props.docs.product_templates">
+                        <t t-foreach="this.props.docs.product_templates" t-as="product_template" t-key='product_template.id'>
                             <a href="#"
                             t-on-click.prevent="() => this.props.openView('product.template', 'form', product_template.id)"
                             t-out="product_template.display_name"/>
                         </t>
                     </t>
-                    <t t-elif="props.docs.product_variants">
-                        <t t-foreach="props.docs.product_variants" t-as="product_variant" t-key="product_variant.id">
+                    <t t-elif="this.props.docs.product_variants">
+                        <t t-foreach="this.props.docs.product_variants" t-as="product_variant" t-key="product_variant.id">
                             <a href="#"
                             t-on-click.prevent="() => this.props.openView('product.product', 'form', product_variant.id)"
                             t-out="product_variant.display_name"/>
@@ -25,28 +25,28 @@
                     <div class="h3">
                         <a href="#"
                             t-on-click.prevent="() => this._onClickInventory()"
-                           t-out="_formatFloat(this.quantityOnHand)"/>
+                           t-out="this._formatFloat(this.quantityOnHand)"/>
                     </div>
                     <div>On Hand</div>
                 </div>
                 <div class="h3 col-md-auto text-center">+</div>
-                <div t-attf-class="col-md-auto text-center #{props.docs.incoming_qty}">
+                <div t-attf-class="col-md-auto text-center #{this.props.docs.incoming_qty}">
                     <div class="h3">
-                        <t t-out="_formatFloat(this.incomingQty)"/>
+                        <t t-out="this._formatFloat(this.incomingQty)"/>
                     </div>
                     <div>Incoming</div>
                 </div>
                 <div class="h3 col-md-auto text-center">-</div>
-                <div t-attf-class="col-md-auto text-center #{props.docs.outgoing_qty}">
+                <div t-attf-class="col-md-auto text-center #{this.props.docs.outgoing_qty}">
                     <div class="h3">
-                        <t t-out="_formatFloat(this.outgoingQty)"/>
+                        <t t-out="this._formatFloat(this.outgoingQty)"/>
                     </div>
                     <div>Outgoing</div>
                 </div>
                 <div class="h3 col-md-auto text-center">=</div>
-                <div t-attf-class="col-md-auto text-center #{props.docs.virtual_available &lt; 0 and 'text-danger'}" name="forecasted_value">
+                <div t-attf-class="col-md-auto text-center #{this.props.docs.virtual_available &lt; 0 and 'text-danger'}" name="forecasted_value">
                     <div class="h3">
-                        <span t-out="_formatFloat(this.virtualAvailable)"/>
+                        <span t-out="this._formatFloat(this.virtualAvailable)"/>
                         <span t-out="' ' + this.uom"/>
                     </div>
                     <div>Forecasted</div>
@@ -68,9 +68,9 @@
         <table>
             <tr>
                 <td>Today</td>
-                <td><span t-out="today"/></td>
+                <td><span t-out="this.today"/></td>
             </tr>
-            <t t-foreach="details" t-as="detail" t-key="detail[0]">
+            <t t-foreach="this.details" t-as="detail" t-key="detail[0]">
                 <tr>
                     <td><span t-out="detail[0]"/></td>
                     <td><span t-out="detail[1]"/></td>
@@ -78,7 +78,7 @@
             </t>
             <tr>
                 <td>Earliest Possible Arrival</td>
-                <td><span t-out="earliestPossibleArrival"/></td>
+                <td><span t-out="this.earliestPossibleArrival"/></td>
             </tr>
         </table>
     </t>

--- a/addons/stock/static/src/stock_forecasted/forecasted_warehouse_filter.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_warehouse_filter.xml
@@ -2,10 +2,10 @@
 <templates xml:space="preserve">
 
     <t t-name="stock.ForecastedWarehouseFilter">
-        <div t-if="displayWarehouseFilter" class="btn-group">
-            <Dropdown menuClass="o_filter_menu" items="warehousesItems">
+        <div t-if="this.displayWarehouseFilter" class="btn-group">
+            <Dropdown items="this.warehousesItems">
                 <button class="btn btn-secondary">
-                    <span class="fa fa-home"/> Warehouse: <t t-out="activeWarehouse.name"/>
+                    <span class="fa fa-home"/> Warehouse: <t t-out="this.activeWarehouse.name"/>
                 </button>
             </Dropdown>
         </div>

--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.xml
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.xml
@@ -3,28 +3,28 @@
     <div t-name="stock.Forecasted" class="o_action o_stock_forecast">
         <ControlPanel>
             <t t-set-slot="control-panel-buttons">
-                <ForecastedButtons action="props.action" reloadReport.bind="reloadReport" resModel="resModel"/>
+                <ForecastedButtons action="this.props.action" reloadReport.bind="this.reloadReport" resModel="this.resModel"/>
             </t>
             <t t-set-slot="control-panel-actions">
                 <div class="btn-group o_search_options position-static" role="search">
-                    <ForecastedWarehouseFilter action="props.action" warehouses="warehouses" setWarehouseInContext.bind="updateWarehouse"/>
+                    <ForecastedWarehouseFilter action="this.props.action" warehouses="this.warehouses" setWarehouseInContext.bind="this.updateWarehouse"/>
                 </div>
             </t>
         </ControlPanel>
         <div class="o-content pt-3 container-fluid overflow-auto o_stock_forecasted_page">
-            <ForecastedHeader docs="docs" openView.bind="openView"/>
-            <t t-if="context.warehouse_id">
+            <ForecastedHeader docs="this.docs" openView.bind="this.openView"/>
+            <t t-if="this.context.warehouse_id">
                 <View type="'graph'"
-                viewId="stock_report_view_graph"
+                viewId="this.stock_report_view_graph"
                 resModel="'report.stock.quantity'"
-                domain="graphDomain"
+                domain="this.graphDomain"
                 display="{controlPanel: false}"
                 context="{fill_temporal: false}"
-                info="graphInfo"
+                info="this.graphInfo"
                 useSampleModel="true"
                 />
             </t>
-            <ForecastedDetails docs="docs" openView.bind="openView" reloadReport.bind="reloadReport"/>
+            <ForecastedDetails docs="this.docs" openView.bind="this.openView" reloadReport.bind="this.reloadReport"/>
         </div>
     </div>
 </templates>

--- a/addons/stock/static/src/views/picking_form/stock_move_product_label.xml
+++ b/addons/stock/static/src/views/picking_form/stock_move_product_label.xml
@@ -2,8 +2,8 @@
 <templates xml:space="preserve">
     <t t-name="stock.MoveProductLabelField">
         <div class="o_input_box">
-            <Many2One t-props="this.m2oProps" t-on-keydown="onM2oInputKeydown"/>
-            <t t-if="showLabelVisibilityToggler">
+            <Many2One t-props="this.m2oProps" t-on-keydown="this.onM2oInputKeydown"/>
+            <t t-if="this.showLabelVisibilityToggler">
                 <button
                     class="o_input_box_overlay_end btn btn-link fa fa-bars"
                     id="labelVisibilityButtonId"
@@ -17,9 +17,9 @@
             placeholder="Enter a description"
             rows="1"
             type="text"
-            t-att-class="{ 'd-none': !(columnIsProductAndLabel.value and (label or labelVisibility.value)) }"
-            t-att-readonly="isDescriptionReadonly"
-            t-att-value="label"
+            t-att-class="{ 'd-none': !(this.columnIsProductAndLabel.value and (this.label or this.labelVisibility.value)) }"
+            t-att-readonly="this.isDescriptionReadonly"
+            t-att-value="this.label"
             t-custom-ref="labelNodeRef"
         />
     </t>

--- a/addons/stock/static/src/views/stock_empty_list_help.xml
+++ b/addons/stock/static/src/views/stock_empty_list_help.xml
@@ -11,8 +11,8 @@
 
     <t t-name="stock.StockActionHelper">
         <div class="o_view_nocontent">
-            <div t-on-click="handler" class="o_nocontent_help">
-                <t t-out="props.noContentHelp"/>
+            <div t-on-click="this.handler" class="o_nocontent_help">
+                <t t-out="this.props.noContentHelp"/>
             </div>
         </div>
     </t>

--- a/addons/stock/static/src/widgets/forced_placeholder.xml
+++ b/addons/stock/static/src/widgets/forced_placeholder.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--This field displays a placeholder even if the field is currently not selected.-->
-
 <templates xml:space="preserve">
 
      <t t-name="stock.ForcedPlaceholderField">
-        <ForcedPlaceholder t-props="m2oProps"/>
+        <ForcedPlaceholder t-props="this.m2oProps"/>
     </t>
 
     <t t-name="stock.ForcedPlaceholder" t-inherit="web.Many2One">

--- a/addons/stock/static/src/widgets/forecast_widget.xml
+++ b/addons/stock/static/src/widgets/forecast_widget.xml
@@ -2,15 +2,15 @@
 <templates id="template" xml:space="preserve">
     <t t-name="stock.ForecastWidget">
         <span title="Forecasted Report"
-              t-on-click="_openReport" t-att="resId ? {} : {'disabled': ''}"
+              t-on-click="this._openReport" t-att="resId ? {} : {'disabled': ''}"
               class="badge rounded-pill align-middle"
-              t-att-class="decoration"
+              t-att-class="this.decoration"
         >
-            <t t-if="!forecastExpectedDate and willBeFulfilled">
+            <t t-if="!this.forecastExpectedDate and this.willBeFulfilled">
                 Available
             </t>
-            <t t-elif="forecastExpectedDate and willBeFulfilled">
-                Exp <t t-out="forecastExpectedDate"/>
+            <t t-elif="this.forecastExpectedDate and this.willBeFulfilled">
+                Exp <t t-out="this.forecastExpectedDate"/>
             </t>
             <t t-else="">Not Available</t>
         </span>

--- a/addons/stock/static/src/widgets/json_widget.xml
+++ b/addons/stock/static/src/widgets/json_widget.xml
@@ -3,13 +3,13 @@
     <div t-name="stock.leadDays">
         <h2>Forecasted Date</h2>
         <hr/>
-        <table t-if="jsonValue.lead_days_description" class="table table-borderless table-sm">
+        <table t-if="this.jsonValue.lead_days_description" class="table table-borderless table-sm">
             <tbody>
                 <tr class="table-secondary">
                     <td>Today</td>
-                    <td class="text-end" t-out="jsonValue.today"/>
+                    <td class="text-end" t-out="this.jsonValue.today"/>
                 </tr>
-                <tr t-foreach="jsonValue.lead_days_description" t-key="descr_index" t-as="descr"
+                <tr t-foreach="this.jsonValue.lead_days_description" t-key="descr_index" t-as="descr"
                     t-attf-class="{{ descr[2] ? 'table-secondary' : '' }}">
                     <td t-out="descr[0]"/>
                     <td class="text-end" t-out="descr[1]"/>
@@ -17,7 +17,7 @@
                 <tr class="table-info">
                     <td>Forecasted Date</td>
                     <td class="text-end text-nowrap">
-                        = <t t-out="jsonValue.lead_horizon_date"/>
+                        = <t t-out="this.jsonValue.lead_horizon_date"/>
                     </td>
                 </tr>
             </tbody>
@@ -30,13 +30,13 @@
         </div>
         <div class="d-flex pt-3">
             <h6 class="row text-muted">
-                <span>Daily Demand: <span t-out="dailyDemand"/> <span t-out="productUomName"/>/day</span>
-                <span class="pt-2">Average Stock: <span t-out="averageStock"/> <span t-out="productUomName"/></span>
+                <span>Daily Demand: <span t-out="this.dailyDemand"/> <span t-out="this.productUomName"/>/day</span>
+                <span class="pt-2">Average Stock: <span t-out="this.averageStock"/> <span t-out="this.productUomName"/></span>
             </h6>
             <h6 class="row text-muted">
-                <span t-if="!qtiesAreTheSame">Ordering Frequency: <span t-out="orderingPeriod"/> day(s)</span>
-                <span t-if="qtiesAreTheSame">Ordering Frequency: On demand</span>
-                <span class="pt-2">Lead Time: <span t-out="leadTime"/> day(s)</span>
+                <span t-if="!this.qtiesAreTheSame">Ordering Frequency: <span t-out="this.orderingPeriod"/> day(s)</span>
+                <span t-if="this.qtiesAreTheSame">Ordering Frequency: On demand</span>
+                <span class="pt-2">Lead Time: <span t-out="this.leadTime"/> day(s)</span>
             </h6>
         </div>
     </div>

--- a/addons/stock/static/src/widgets/lots_dialog.xml
+++ b/addons/stock/static/src/widgets/lots_dialog.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="stock.GenerateSerials">
-        <button class="btn btn-link" t-on-click="openDialog">Generate Serials/Lots</button>
+        <button class="btn btn-link" t-on-click="this.openDialog">Generate Serials/Lots</button>
     </t>
     <t t-name="stock.ImportLots">
-        <button class="btn btn-link" t-on-click="openDialog">Import Serials/Lots</button>
+        <button class="btn btn-link" t-on-click="this.openDialog">Import Serials/Lots</button>
     </t>
     <t t-name="stock.generate_serial_dialog">
-        <Dialog size="size" title="title" withBodyPadding="false">
+        <Dialog size="this.size" title="this.title" withBodyPadding="false">
             <t t-set-slot="footer">
-                <button class="btn btn-primary" t-on-click="_onGenerate">
-                    <t t-if="props.mode === 'generate'">Validate</t>
-                    <t t-if="props.mode === 'import'">Import</t>
+                <button class="btn btn-primary" t-on-click="this._onGenerate">
+                    <t t-if="this.props.mode === 'generate'">Validate</t>
+                    <t t-if="this.props.mode === 'import'">Import</t>
                 </button>
                 <button class="btn btn-secondary" t-on-click="() => this.props.close()">
                     Discard
                 </button>
             </t>
             <div class="o_form_view o_form_nosheet">
-                <t t-if="props.mode === 'generate'">
+                <t t-if="this.props.mode === 'generate'">
                     <div class="container">
                         <div class="row mb-2">
                             <div class="col-3">
                                 <label class="o_form_label" for="next_serial_0">
-                                    <t t-if="isLotTracking">First Lot Number</t>
+                                    <t t-if="this.isLotTracking">First Lot Number</t>
                                     <t t-else="">First Serial Number</t>
                                 </label>
                             </div>
@@ -36,19 +36,19 @@
                         <div class="row mb-2">
                             <div class="col">
                                 <label class="o_form_label" for="next_serial_count_0">
-                                    <t t-if="isLotTracking">Quantity per Lot</t>
+                                    <t t-if="this.isLotTracking">Quantity per Lot</t>
                                     <t t-else="">Number of SN</t>
                                 </label>
                             </div>
                             <div class="col-9">
                                 <div name="next_serial_count" class="o_field_widget o_field_integer">
                                     <input inputmode="numeric" t-custom-ref="nextSerialCount" class="o_input" id="next_serial_count_0" type="number"
-                                        t-on-keydown="(ev) => !isLotTracking and ev.key === '.' and ev.preventDefault()"/>
+                                        t-on-keydown="(ev) => !this.isLotTracking and ev.key === '.' and ev.preventDefault()"/>
                                 </div>
-                                <span t-if="isLotTracking &amp;&amp; displayUOM" t-out="props.move.data.uom_id.display_name"/>
+                                <span t-if="this.isLotTracking &amp;&amp; this.displayUOM" t-out="this.props.move.data.uom_id.display_name"/>
                             </div>
                         </div>
-                        <div t-if="isLotTracking" class="row mb-2">
+                        <div t-if="this.isLotTracking" class="row mb-2">
                             <div class="col">
                                 <label class="o_form_label" for="total_received_0">Quantity Received</label>
                             </div>
@@ -56,7 +56,7 @@
                                 <div name="total_received" class="o_field_widget o_field_integer">
                                     <input inputmode="numeric" t-custom-ref="totalReceived" class="o_input" id="total_received_0" type="number"/>
                                 </div>
-                                <span t-if="displayUOM" t-out="props.move.data.uom_id.display_name"/>
+                                <span t-if="this.displayUOM" t-out="this.props.move.data.uom_id.display_name"/>
                             </div>
                         </div>
                         <div class="row">
@@ -71,12 +71,12 @@
                         </div>
                     </div>
                 </t>
-                <t t-if="props.mode === 'import'" class="d-flex">
+                <t t-if="this.props.mode === 'import'" class="d-flex">
                     <div class="grid o_inner_group">
                         <div class="d-flex">
                             <div class="o_cell flex-grow-0 flex-sm-grow-0 text-900 pe-3">
                                 <label class="o_form_label" for="next_serial_0">
-                                    <t t-if="isLotTracking">Lot numbers</t>
+                                    <t t-if="this.isLotTracking">Lot numbers</t>
                                     <t t-else="">Serial numbers</t>
                                 </label>
                             </div>

--- a/addons/stock/static/src/widgets/popover_widget.xml
+++ b/addons/stock/static/src/widgets/popover_widget.xml
@@ -2,12 +2,12 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="stock.popoverButton">
-        <a tabindex="0" t-on-click.stop="showPopup" t-attf-class="p-1 fa #{ icon || 'fa-info-circle'} #{ color || 'text-primary'}"/>
+        <a tabindex="0" t-on-click.stop="this.showPopup" t-attf-class="p-1 fa #{ this.icon || 'fa-info-circle'} #{ this.color || 'text-primary'}"/>
     </t>
 
     <div t-name="stock.popoverContent" class="m-3">
-        <h6 t-out="props.title"/>
-        <t t-if="props.popoverTemplate" t-call="{{props.popoverTemplate}}" />
-        <t t-else="" t-out="props.msg"/>
+        <h6 t-out="this.props.title"/>
+        <t t-if="this.props.popoverTemplate" t-call="{{this.props.popoverTemplate}}" />
+        <t t-else="" t-out="this.props.msg"/>
     </div>
 </templates>

--- a/addons/stock/static/src/widgets/stock_package_m2o.xml
+++ b/addons/stock/static/src/widgets/stock_package_m2o.xml
@@ -2,8 +2,8 @@
 <templates>
 
     <t t-name="stock.StockPackageMany2One">
-        <t t-if="!isEditing" t-out="displayValue.display_name"/>
-        <Many2One t-else="" t-props="m2oProps"/>
+        <t t-if="!this.isEditing" t-out="this.displayValue.display_name"/>
+        <Many2One t-else="" t-props="this.m2oProps"/>
     </t>
 
 </templates>

--- a/addons/stock/static/src/widgets/stock_pick_from.xml
+++ b/addons/stock/static/src/widgets/stock_pick_from.xml
@@ -2,7 +2,7 @@
 <templates>
 
     <t t-name="stock.StockPickFrom">
-        <Many2One t-props="m2oProps"/>
+        <Many2One t-props="this.m2oProps"/>
     </t>
 
 </templates>

--- a/addons/stock/static/src/widgets/stock_rescheduling_popover.xml
+++ b/addons/stock/static/src/widgets/stock_rescheduling_popover.xml
@@ -4,9 +4,9 @@
     <div t-name="stock.PopoverStockRescheduling">
         <h6>Planning Issue</h6>
         <p>Preceding operations
-        <t t-foreach="props.late_elements" t-as="late_element" t-key="late_element.id">
-            <a t-out="late_element.name" t-on-click="openElement" href="#" t-att-element-id="late_element.id" t-att-element-model="late_element.model"/>,
+        <t t-foreach="this.props.late_elements" t-as="late_element" t-key="late_element.id">
+            <a t-out="late_element.name" t-on-click="this.openElement" href="#" t-att-element-id="late_element.id" t-att-element-model="late_element.model"/>,
         </t>
-        planned on <t t-out="props.delay_alert_date"/>.</p>
+        planned on <t t-out="this.props.delay_alert_date"/>.</p>
     </div>
 </templates>

--- a/addons/stock_account/static/src/fields/boolean_confirm.xml
+++ b/addons/stock_account/static/src/fields/boolean_confirm.xml
@@ -3,9 +3,9 @@
     <t t-name="stock_account.BooleanToggleConfirm">
         <ConfirmCheckBox
             className="'o_field_boolean o_boolean_toggle'"
-            id="props.id"
-            value="props.record.data[props.name] or false"
-            disabled="isReadonly"
+            id="this.props.id"
+            value="this.props.record.data[this.props.name] or false"
+            disabled="this.isReadonly"
             onChange="(value) => this.onChange(value)"
         />
     </t>

--- a/addons/stock_account/static/src/stock_account_forecasted/forecasted_header.xml
+++ b/addons/stock_account/static/src/stock_account_forecasted/forecasted_header.xml
@@ -2,11 +2,11 @@
 <templates id="template">
     <t t-name="stock_account.ForecastedHeader" t-inherit="stock.ForecastedHeader" t-inherit-mode="extension">
         <xpath expr="//h3[@name='product_name']" position="after">
-            <h6 t-if="() => env.user.has_group('stock.group_stock_manager')">
+            <h6 t-if="() => this.env.user.has_group('stock.group_stock_manager')">
                 Value On Hand:
                 <a href="#"
-                   t-out="props.docs.value"
-                   t-on-click.prevent="_onClickValuation"/>
+                   t-out="this.props.docs.value"
+                   t-on-click.prevent="this._onClickValuation"/>
             </h6>
         </xpath>
     </t>

--- a/addons/stock_account/static/src/stock_valuation/buttons_bar/buttons_bar.xml
+++ b/addons/stock_account/static/src/stock_valuation/buttons_bar/buttons_bar.xml
@@ -12,7 +12,7 @@
             XLSX
         </button> -->
         <button class="o_report_button_generate_entry btn text-nowrap btn-secondary"
-                t-on-click="onClickGenerateEntry">
+                t-on-click="this.onClickGenerateEntry">
             Generate Entry
         </button>
     </t>

--- a/addons/stock_account/static/src/stock_valuation/filters/filter_date.xml
+++ b/addons/stock_account/static/src/stock_valuation/filters/filter_date.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates>
     <t t-name="stock_account.StockValuationReport.FilterDate">
-        <div id="filter_date" t-custom-ref="filterDate" class="d-print-none" t-on-click="onDateClick">
+        <div id="filter_date" t-custom-ref="filterDate" class="d-print-none" t-on-click="this.onDateClick">
             <button class="btn btn-secondary">
-                <i class="fa fa-calendar me-1"/>As of <t t-out="date"/>
+                <i class="fa fa-calendar me-1"/>As of <t t-out="this.date"/>
             </button>
         </div>
         <div class="d-none d-print-block">
-            At the date of <t t-out="date"/>
+            At the date of <t t-out="this.date"/>
         </div>
     </t>
 </templates>

--- a/addons/stock_account/static/src/stock_valuation/line/line.xml
+++ b/addons/stock_account/static/src/stock_valuation/line/line.xml
@@ -1,44 +1,44 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates>
     <t t-name="stock_account.StockValuationReport.InventoryValuationLine">
-        <tr t-att-class="cssClass">
-            <td class="line_name w-50" t-on-click="onClick">
+        <tr t-att-class="this.cssClass">
+            <td class="line_name w-50" t-on-click="this.onClick">
                 <div class="wrapper">
-                    <t t-if="label">
-                        <a t-if="props.onClickMethod" href="#" t-out="label"/>
-                        <span t-else="" t-out="label"/>
+                    <t t-if="this.label">
+                        <a t-if="this.props.onClickMethod" href="#" t-out="this.label"/>
+                        <span t-else="" t-out="this.label"/>
                     </t>
                 </div>
             </td>
             <td class="w-25">
-                <div t-if="formattedValue" t-out="formattedValue"/>
-                <div t-elif="debit" t-out="debit"/>
+                <div t-if="this.formattedValue" t-out="this.formattedValue"/>
+                <div t-elif="this.debit" t-out="this.debit"/>
             </td>
-            <td t-if="credit" class="w-25">
-                <div t-out="credit"/>
+            <td t-if="this.credit" class="w-25">
+                <div t-out="this.credit"/>
             </td>
-            <td t-else="" t-on-click="onClickToggle" class="w-25">
-                <button t-attf-class="btn btn_foldable#{props.sublines ? '' : '_empty'}"
-                        t-att-tabindex="props.lines ? 0 : -1">
-                    <i t-if="hasSublines"
-                        t-attf-class="fa fa-folder#{state.displaySublines ? '-open' : ''}-o"/>
+            <td t-else="" t-on-click="this.onClickToggle" class="w-25">
+                <button t-attf-class="btn btn_foldable#{this.props.sublines ? '' : '_empty'}"
+                        t-att-tabindex="this.props.lines ? 0 : -1">
+                    <i t-if="this.hasSublines"
+                        t-attf-class="fa fa-folder#{this.state.displaySublines ? '-open' : ''}-o"/>
                 </button>
             </td>
         </tr>
-        <t t-if="state.displaySublines &amp;&amp; hasSublines">
-            <t t-if="props.displayDebitCredit">
+        <t t-if="this.state.displaySublines &amp;&amp; this.hasSublines">
+            <t t-if="this.props.displayDebitCredit">
                 <tr>
                     <td/>
                     <td>Debit</td>
                     <td>Credit</td>
                 </tr>
             </t>
-            <t t-foreach="props.sublines" t-as="line" t-key="line.account_id">
+            <t t-foreach="this.props.sublines" t-as="line" t-key="line.account_id">
                 <StockValuationReportLine
                     label="line.display_name || line.label"
                     line="line"
                     sublines="line.lines"
-                    level="props.level + 2"
+                    level="this.props.level + 2"
                     onClickMethod="line.method"
                     value="line.value"/>
             </t>

--- a/addons/stock_account/static/src/stock_valuation/line/toggle_line.xml
+++ b/addons/stock_account/static/src/stock_valuation/line/toggle_line.xml
@@ -4,24 +4,24 @@
        t-inherit="stock_account.StockValuationReport.InventoryValuationLine"
        t-inherit-mode="primary">
         <xpath expr="//div[hasclass('wrapper')]//button//i" position="attributes">
-            <attribute name="t-attf-class">fa fa-#{state.displaySublines ? 'check-' : ''}square-o</attribute>
+            <attribute name="t-attf-class">fa fa-#{this.state.displaySublines ? 'check-' : ''}square-o</attribute>
         </xpath>
-        <xpath expr="//t[@t-foreach='props.sublines']//StockValuationReportLine" position="replace">
+        <xpath expr="//t[@t-foreach='this.props.sublines']//StockValuationReportLine" position="replace">
             <t t-if="line.lines">
                 <StockValuationReportToggleLine
                     label="line.display_name"
                     line="line"
                     sublines="line.lines"
-                    level="props.level + 2"
-                    onClickMethod="props.onClickMethod || line.method"
+                    level="this.props.level + 2"
+                    onClickMethod="this.props.onClickMethod || line.method"
                     value="line.value"/>
             </t>
             <t t-else="">
                 <StockValuationReportLine
                     label="line.display_name"
                     line="line"
-                    level="props.level + 2"
-                    onClickMethod="props.onClickMethod || line.method"
+                    level="this.props.level + 2"
+                    onClickMethod="this.props.onClickMethod || line.method"
                     value="line.value"/>
             </t>
         </xpath>

--- a/addons/stock_account/static/src/stock_valuation/stock_valuation_report.xml
+++ b/addons/stock_account/static/src/stock_valuation/stock_valuation_report.xml
@@ -24,7 +24,7 @@
                     <table class="table table-borderless table-hover w-print-100 mx-auto">
                         <tbody>
                             <t t-call="stock_account.StockValuationReport.InitialBalance"/>
-                            <t t-if="data.inventory_loss" t-call="stock_account.StockValuationReport.InventoryLoss"/>
+                            <t t-if="this.data.inventory_loss" t-call="stock_account.StockValuationReport.InventoryLoss"/>
                             <t t-call="stock_account.StockValuationReport.StockVariation"/>
                             <t t-call="stock_account.StockValuationReport.EndingStock"/>
                             <!-- <t t-call="stock_account.StockValuationReport.Accrual"/> -->
@@ -43,9 +43,9 @@
         <StockValuationReportLine
             label.translate="Initial Balance"
             level="0"
-            onClickMethod.bind="openAccountMoves"
-            sublines="data.initial_balance.lines"
-            value="data.initial_balance.value"/>
+            onClickMethod.bind="this.openAccountMoves"
+            sublines="this.data.initial_balance.lines"
+            value="this.data.initial_balance.value"/>
         <t t-call="stock_account.StockValuationReport.EmptyLine"/>
     </t>
 
@@ -53,9 +53,9 @@
         <StockValuationReportLine
             label.translate="Stock Variation"
             level="0"
-            sublines="data.stock_variation.lines"
+            sublines="this.data.stock_variation.lines"
             displayDebitCredit="true"
-            value="data.stock_variation.value"/>
+            value="this.data.stock_variation.value"/>
         <t t-call="stock_account.StockValuationReport.EmptyLine"/>
     </t>
 
@@ -63,9 +63,9 @@
         <StockValuationReportLine
             label.translate="Ending Stock"
             level="0"
-            onClickMethod.bind="openStockReport"
-            sublines="data.ending_stock.lines"
-            value="data.ending_stock.value"/>
+            onClickMethod.bind="this.openStockReport"
+            sublines="this.data.ending_stock.lines"
+            value="this.data.ending_stock.value"/>
         <t t-call="stock_account.StockValuationReport.EmptyLine"/>
     </t>
 
@@ -74,17 +74,17 @@
             label.translate="Inventory Loss"
             level="0"
             displayDebitCredit="true"
-            onClickMethod.bind="openInventoryLoss"
-            sublines="data.inventory_loss.lines"
-            value="data.inventory_loss.value"/>
+            onClickMethod.bind="this.openInventoryLoss"
+            sublines="this.data.inventory_loss.lines"
+            value="this.data.inventory_loss.value"/>
         <t t-call="stock_account.StockValuationReport.EmptyLine"/>
     </t>
 
     <t t-name="stock_account.StockValuationReport.Accrual">
-        <t t-if="accrual.lines.length">
+        <t t-if="this.accrual.lines.length">
             <StockValuationReportToggleLine
                 label.translate="Accrual"
-                sublines="accrual.lines"
+                sublines="this.accrual.lines"
                 level="0"/>
         </t>
     </t>


### PR DESCRIPTION
In preparation for OWL3, where template variables will need to use 
`.this` to target component variables, we add `.this` to template 
variables that are targetting the component.

Script PR: https://github.com/odoo/odoo/pull/247965

THIS_TARGETS = ['stock']
task: OWL3 prep - add `this.` to template variables

Enterprise PR : https://github.com/odoo/enterprise/pull/110128

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
