### PR TITLE
[PERF] mail: speed up operation grouping

### DIFF
--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -86,12 +86,9 @@ class Base(models.AbstractModel):
         """ Globally reverse result of '_mail_get_operation_for_mail_message_operation'
         aka return documents for a given access to check on them. """
         document_operations = self._mail_get_operation_for_mail_message_operation(message_operation)
-        operation_documents = defaultdict(lambda: self.env[self._name])
-        for record, record_operation in document_operations.items():
-            operation_documents[record_operation] += record
-        # force prefetch in a post-loop as recordset concatenation may lose it
-        for operation, records in operation_documents.items():
-            records = records.with_prefetch(self.ids)
+        documents = self.browse(record.id for record in document_operations).with_prefetch(self._prefetch_ids)
+        operation_documents = documents.grouped(document_operations.__getitem__)
+        operation_documents.pop(None, None)  # discard documents without a permission
         return operation_documents
 
     # ------------------------------------------------------------


### PR DESCRIPTION
opw-5969596
Replace per-record recordset concatenation in _mail_group_by_operation_for_mail_message_operation with an id-first aggregation strategy.

Collect ids per access operation, then browse once per operation and restore prefetch. This avoids repeated recordset additions in a loop, which are expensive on large batches.

| No. records | Before | After |
|------------|--------|-------|
| 57,725 | 9,351.744 ms | 143.174 ms |
| 1,122 | 4.563 ms | 2.732 ms |
| 2,093 | 11.194 ms | 2.747 ms |

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
