### PR TITLE
[REV] {purchase_,}stock: group SM in same picking

### DIFF
--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -791,7 +791,7 @@ class TestReorderingRule(TransactionCase):
         orderpoint.with_user(french_user).action_replenish()
         self.assertRecordValues(po_line, [{"name": "[A] produit en français", "product_qty": 9.0}])
         self.assertEqual(len(po_line.order_id.order_line), 1)
-        self.assertRecordValues(po_line.move_dest_ids, [{"product_uom_qty": 5.0}, {"product_uom_qty": 4.0}])
+        self.assertRecordValues(po_line.move_dest_ids, [{"product_uom_qty": 9.0}])
         orderpoint.product_min_qty = 10.0
         orderpoint.product_max_qty = 20.0
         # run the scheduler to test the use case where the user is always the SUPERUSER
@@ -802,8 +802,7 @@ class TestReorderingRule(TransactionCase):
         self.assertEqual(len(po_line.order_id.order_line), 1)
         # the moves_dest_ids are not expected to be merged since the scheduler is excuted by robodoo in en_US rather fr_FR
         self.assertRecordValues(po_line.move_dest_ids.sorted('product_uom_qty'), [
-            {"description_picking": "produit en français", "product_uom_qty": 4.0},
-            {"description_picking": "produit en français", "product_uom_qty": 5.0},
+            {"description_picking": "produit en français", "product_uom_qty": 9.0},
             {"description_picking": "product TEST", "product_uom_qty": 11.0},
         ])
 

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1346,8 +1346,8 @@ Please change the quantity done or the rounding precision of your unit of measur
     def _key_assign_picking(self):
         self.ensure_one()
         keys = (self.group_id, self.location_id, self.location_dest_id, self.picking_type_id)
-        if self.move_orig_ids.picking_id and not self.group_id:
-            keys += (self.move_orig_ids.picking_id, )
+        if self.partner_id and not self.group_id:
+            keys += (self.partner_id, )
         return keys
 
     def _search_picking_for_assignation_domain(self):
@@ -1358,12 +1358,12 @@ Please change the quantity done or the rounding precision of your unit of measur
             ('picking_type_id', '=', self.picking_type_id.id),
             ('printed', '=', False),
             ('state', 'in', ['draft', 'confirmed', 'waiting', 'partially_available', 'assigned'])]
+        if self.partner_id and not self.group_id:
+            domain += [('partner_id', '=', self.partner_id.id)]
         return domain
 
     def _search_picking_for_assignation(self):
         self.ensure_one()
-        if not self.group_id:
-            return self.env['stock.picking']
         domain = self._search_picking_for_assignation_domain()
         picking = self.env['stock.picking'].search(domain, limit=1)
         return picking

--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -2048,8 +2048,7 @@ class TestSinglePicking(TestStockCommon):
 
     def test_merge_chained_moves(self):
         """ Imagine multiple step reception. Two different receipt picking for the same product should only generate
-        1 picking from input to QC and another from QC to stock, only when both receipt moves share the same procurement group.
-        The link at the end should follow this scheme.
+        1 picking from input to QC and another from QC to stock. The link at the end should follow this scheme.
         Move receipt 1 \
                         Move Input-> QC - Move QC -> Stock
         Move receipt 2 /
@@ -2059,13 +2058,20 @@ class TestSinglePicking(TestStockCommon):
             'code': 'TEST1',
             'reception_steps': 'three_steps',
         })
-        # procurement group simulating a common source document (e.g. PO/SO)
-        pg = self.env['procurement.group'].create({})
         receipt1 = self.env['stock.picking'].create({
             'location_id': self.supplier_location,
             'location_dest_id': warehouse.wh_input_stock_loc_id.id,
             'picking_type_id': warehouse.in_type_id.id,
             'state': 'draft',
+        })
+        move_receipt_1 = self.MoveObj.create({
+            'name': self.productA.name,
+            'product_id': self.productA.id,
+            'product_uom_qty': 5,
+            'product_uom': self.productA.uom_id.id,
+            'picking_id': receipt1.id,
+            'location_id': self.supplier_location,
+            'location_dest_id': warehouse.wh_input_stock_loc_id.id,
         })
         receipt2 = self.env['stock.picking'].create({
             'location_id': self.supplier_location,
@@ -2073,18 +2079,15 @@ class TestSinglePicking(TestStockCommon):
             'picking_type_id': warehouse.in_type_id.id,
             'state': 'draft',
         })
-        move_values = {
+        move_receipt_2 = self.MoveObj.create({
             'name': self.productA.name,
             'product_id': self.productA.id,
+            'product_uom_qty': 3,
             'product_uom': self.productA.uom_id.id,
+            'picking_id': receipt2.id,
             'location_id': self.supplier_location,
             'location_dest_id': warehouse.wh_input_stock_loc_id.id,
-            'group_id': pg.id,
-        }
-        move_receipt_1, move_receipt_2 = self.MoveObj.create([
-            {**move_values, 'product_uom_qty': 5, 'picking_id': receipt1.id},
-            {**move_values, 'product_uom_qty': 3, 'picking_id': receipt2.id},
-        ])
+        })
         receipt1.action_confirm()
         receipt2.action_confirm()
         (receipt1 | receipt2).button_validate()
@@ -2109,10 +2112,11 @@ class TestSinglePicking(TestStockCommon):
         self.assertEqual(len(qc_move), 1)
         self.assertTrue(qc_move.move_orig_ids == input_move, 'Move between QC and stock should only have the input move as origin')
 
-    def test_prevent_merge_moves_without_procurement_group(self):
-        """Imagine multiple step reception. When two receipts are created manually that
-        do not have a procurement group, they should not merge in the next steps even if
-        they share the same partner. Each receipt must generate its own Input→QC and QC→Stock moves.
+    def test_merge_chained_moves_multi_confirm(self):
+        """ Imagine multiple step reception. A receipt picking for the same product should by add to
+        a existing picking from input to QC and another from QC to stock.
+        This existing picking is confirm in the same time (not possible in stock, but can be with batch picking)
+        and have some move to merge.
         """
         warehouse = self.env['stock.warehouse'].create({
             'name': 'TEST WAREHOUSE',
@@ -2125,27 +2129,57 @@ class TestSinglePicking(TestStockCommon):
             'picking_type_id': warehouse.in_type_id.id,
             'state': 'draft',
         })
-        receipt2 = self.env['stock.picking'].create({
-            'location_id': self.supplier_location,
-            'location_dest_id': warehouse.wh_input_stock_loc_id.id,
-            'picking_type_id': warehouse.in_type_id.id,
-            'state': 'draft',
-        })
-        move_values = {
+        move_receipt_1 = self.MoveObj.create({
             'name': self.productA.name,
             'product_id': self.productA.id,
-            'product_uom': self.productA.uom_id.id,
             'product_uom_qty': 5,
+            'product_uom': self.productA.uom_id.id,
+            'picking_id': receipt1.id,
             'location_id': self.supplier_location,
             'location_dest_id': warehouse.wh_input_stock_loc_id.id,
-        }
-        self.MoveObj.create([
-            {**move_values, 'picking_id': receipt1.id},
-            {**move_values, 'picking_id': receipt2.id},
-        ])
-        self.assertFalse((receipt1 | receipt2).group_id)
-        (receipt1 | receipt2).button_validate()
-        self.assertNotEqual(receipt1._get_next_transfers(), receipt2._get_next_transfers(), "Input→QC pickings should not merged without a procurement group.")
+        })
+        receipt2 = self.env['stock.picking'].create({
+            'location_id': warehouse.wh_input_stock_loc_id.id,
+            'location_dest_id': warehouse.wh_qc_stock_loc_id.id,
+            'picking_type_id': warehouse.qc_type_id.id,
+            'state': 'draft',
+        })
+        move1_receipt_2 = self.MoveObj.create({
+            'name': self.productB.name,
+            'product_id': self.productB.id,
+            'product_uom_qty': 1,
+            'product_uom': self.productB.uom_id.id,
+            'picking_id': receipt2.id,
+            'location_id': warehouse.wh_input_stock_loc_id.id,
+            'location_dest_id':  warehouse.wh_qc_stock_loc_id.id,
+        })
+        move2_receipt_2 = self.MoveObj.create({
+            'name': self.productB.name,
+            'product_id': self.productB.id,
+            'product_uom_qty': 2,
+            'product_uom': self.productB.uom_id.id,
+            'picking_id': receipt2.id,
+            'location_id': warehouse.wh_input_stock_loc_id.id,
+            'location_dest_id': warehouse.wh_qc_stock_loc_id.id,
+        })
+        (receipt1 | receipt2).action_confirm()
+        # Validate first picking to trigger its push rules
+        move_receipt_1.quantity = 5
+        receipt1.button_validate()
+
+        # Check following move has been created
+        self.assertTrue(move_receipt_1.move_dest_ids, 'No move created from push rules')
+        self.assertFalse((move1_receipt_2 | move2_receipt_2).exists().move_dest_ids, 'Push rule shoudn\'t be triggered yet')
+        self.assertEqual(len((move1_receipt_2 | move2_receipt_2).exists()), 1, 'Move has been merged with the other one')
+        self.assertEqual(move_receipt_1.move_dest_ids.picking_id, receipt2, 'Dest Move of receipt1 should be in the receipt2')
+
+        # Check no move is still in draft
+        self.assertTrue("draft" not in (receipt1 | receipt2).move_ids.mapped("state"))
+
+        # Check the content of the pickings
+        self.assertEqual(receipt1.move_ids.mapped("product_uom_qty"), [5])
+        self.assertEqual(receipt2.move_ids.filtered(lambda m: m.product_id == self.productB).mapped("product_uom_qty"), [3])
+        self.assertEqual(receipt2.move_ids.filtered(lambda m: m.product_id == self.productA).mapped("product_uom_qty"), [5])
 
     def test_empty_moves_validation_1(self):
         """ Use button validate on a picking that contains only moves

--- a/addons/stock/tests/test_packing.py
+++ b/addons/stock/tests/test_packing.py
@@ -42,23 +42,31 @@ class TestPacking(TestPackingCommon):
         """
         self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 20.0)
         self.env['stock.quant']._update_available_quantity(self.productB, self.stock_location, 20.0)
-        picking = self.env['stock.picking'].create({
-            'picking_type_id': self.warehouse.out_type_id.id,
-            'location_id': self.stock_location.id,
-            'location_dest_id': self.pack_location.id,
-        })
-        move_values = {
+        pick_move_a = self.env['stock.move'].create({
             'name': 'The ship move',
+            'product_id': self.productA.id,
             'product_uom_qty': 5.0,
+            'product_uom': self.productA.uom_id.id,
             'location_id': self.stock_location.id,
             'location_dest_id': self.pack_location.id,
             'warehouse_id': self.warehouse.id,
-            'picking_id': picking.id,
-        }
-        pick_move_a = self.env['stock.move'].create([
-            {**move_values, 'product_id': self.productA.id, 'product_uom': self.productA.uom_id.id},
-            {**move_values, 'product_id': self.productB.id, 'product_uom': self.productB.uom_id.id},
-        ])[0]
+            'picking_type_id': self.warehouse.out_type_id.id,
+            'state': 'draft',
+        })
+        pick_move_b = self.env['stock.move'].create({
+            'name': 'The ship move',
+            'product_id': self.productB.id,
+            'product_uom_qty': 5.0,
+            'product_uom': self.productB.uom_id.id,
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.pack_location.id,
+            'warehouse_id': self.warehouse.id,
+            'picking_type_id': self.warehouse.out_type_id.id,
+            'state': 'draft',
+        })
+        pick_move_a._assign_picking()
+        pick_move_b._assign_picking()
+        picking = pick_move_a.picking_id
         picking.action_confirm()
         picking.action_assign()
         picking.button_validate()


### PR DESCRIPTION
This reverts [1]. Let's quote the commit:
> - `Observation`: the next transfers for both receipts are merged into a single
>  transfer, even though both receipts were created manually and not generated
>  from any common source document like PO/SO.

The above behavior was and is the expected one for years and should not
suddenly change on stable. Even the tests were protecting the cases but [1]
have changed the `assert`.

Commit [1] quickly leads to the creation of tickets. For instance, in the
mentioned OPW, where the user resupplies a warehouse from another one: he
now has several pickings for the same supply chain, which lead to extra work
(e.g., printing all the pickings)

[1] https://github.com/odoo/odoo/commit/840b42fd2365a652e53d607f38ac78ccb8dd63dc

OPW-6011532