### PR TITLE
[FIX] repair: fix access error

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -60,7 +60,7 @@ class Repair(models.Model):
 
     # Specific Fields
     internal_notes = fields.Html('Internal Notes')
-    tag_ids = fields.Many2many('repair.tags', string="Tags")
+    tag_ids = fields.Many2many('repair.tags', string="Tags", groups="stock.group_stock_user")
     under_warranty = fields.Boolean(
         'Under Warranty',
         help='If ticked, the sales price will be set to 0 for all products transferred from the repair order.')
@@ -187,7 +187,7 @@ class Repair(models.Model):
         help="True if this repair is linked to a Return Order and the order is 'Done'. False otherwise.")
     picking_product_ids = fields.One2many('product.product', compute='_compute_picking_product_ids')
     picking_product_id = fields.Many2one(related="picking_id.product_id")
-    allowed_lot_ids = fields.One2many('stock.lot', compute='_compute_allowed_lot_ids')
+    allowed_lot_ids = fields.One2many('stock.lot', compute='_compute_allowed_lot_ids', groups="stock.group_stock_user")
     # UI Fields
     has_uncomplete_moves = fields.Boolean(compute='_compute_has_uncomplete_moves')
     unreserve_visible = fields.Boolean(

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -102,11 +102,13 @@
                     </div>
                     <group>
                         <group>
-                            <field name="allowed_lot_ids" invisible="1"/>
+                            <field name="allowed_lot_ids" invisible="1" groups="stock.group_stock_user"/>
                             <field name="repair_request" invisible="not sale_order_line_id"/>
                             <field name="partner_id" widget="res_partner_many2one" context="{'res_partner_search_mode': 'customer', 'show_vat': True}" readonly="sale_order_id"/>
                             <field name="product_id" readonly="state in ['cancel', 'done']"/>
-                            <field name="lot_id" context="{'default_product_id': product_id}" groups="stock.group_production_lot" options="{'no_create': True, 'no_create_edit': True}" invisible="tracking not in ['serial', 'lot']" readonly="state == 'done'" required="tracking in ['serial', 'lot']"/>
+                            <field name="lot_id" context="{'default_product_id': product_id}"
+                                groups="stock.group_production_lot,stock.group_stock_user" options="{'no_create': True, 'no_create_edit': True}"
+                                invisible="tracking not in ['serial', 'lot']" readonly="state == 'done'" required="tracking in ['serial', 'lot']"/>
                             <field name="product_uom_category_id" invisible="1"/>
                             <label for="product_qty" invisible="not product_id"/>
                             <div class="o_row" invisible="not product_id">
@@ -120,7 +122,8 @@
                             <field name="schedule_date" readonly="state in ['done', 'cancel']"/>
                             <field name="user_id" domain="[('share', '=', False)]"/>
                             <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
-                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"
+                                groups="stock.group_stock_user"/>
                             <field name="parts_availability_state" invisible="True"/>
                             <field name="parts_availability"
                                 invisible="state not in ['confirmed', 'under_repair']"

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -106,7 +106,9 @@
                             <field name="repair_request" invisible="not sale_order_line_id"/>
                             <field name="partner_id" widget="res_partner_many2one" context="{'res_partner_search_mode': 'customer', 'show_vat': True}" readonly="sale_order_id"/>
                             <field name="product_id" readonly="state in ['cancel', 'done']"/>
-                            <field name="lot_id" context="{'default_product_id': product_id}" groups="stock.group_production_lot" options="{'no_create': True, 'no_create_edit': True}" invisible="tracking not in ['serial', 'lot']" readonly="state == 'done'" required="tracking in ['serial', 'lot']"/>
+                            <field name="lot_id" context="{'default_product_id': product_id}"
+                                groups="stock.group_production_lot,stock.group_stock_user" options="{'no_create': True, 'no_create_edit': True}"
+                                invisible="tracking not in ['serial', 'lot']" readonly="state == 'done'" required="tracking in ['serial', 'lot']"/>
                             <field name="product_uom_category_id" invisible="1"/>
                             <label for="product_qty" invisible="not product_id"/>
                             <div class="o_row" invisible="not product_id">


### PR DESCRIPTION
steps to reproduce:
-----------
  - install the industry_fsm_repair module
  - create a product with type goods and enable `create repair`
  - enable `create repair orders` from returns in delivery orders in operation types
  - create a sale order with an fsm product and a goods product
  - confirm the sale order and validate the delivery
  - return the delivery and validate it (wh/in/0000x)
  - open the return receipt (wh/in/0000x) and create a repair
  - create an fsm user without stock access
  - log in with the fsm user
  - open a task, go to `pick up`, and open the stock move
  - open the repair order

issue:
--------
   the fsm user does not have access to stock lots and repair tags, which causes an access error.

fix:
----
  added the stock user group to the repair tags and stock lot fields so  that users without the stock user group cannot access them.

technical:
------
  in the stable version, i did not extend the repair view in the industry_fsm_repair module. instead, i added the group directly in the repair module.
  In master, the group is added through the industry_fsm_repair module.
  
  task-6032336
