### PR TITLE
[FIX] base: ensure information for `res.session` records

### DIFF
--- a/odoo/addons/base/models/res_device.py
+++ b/odoo/addons/base/models/res_device.py
@@ -272,17 +272,21 @@ class ResSession(models.Model):
         for session in self:
             device_ids = session_map[session.session_identifier]
             session.device_ids = device_ids
-            if session.is_current:
+
+            # If a `res.session` record exists, there is at least one `res.device` record
+            last_device_id = device_ids[0]  # because order is `last_activity desc`
+
+            if session.is_current and \
+                (current_device_id := device_ids.filtered('is_current')):
                 # The user will see the information for the device he is
                 # currently using, even if there are more recent logs for
                 # another device.
-                current_device_id = device_ids.filtered('is_current')
-            else:
-                current_device_id = device_ids[0]  # because order is `last_activity desc`
-            session.ip_address = current_device_id.ip_address
-            session.user_agent = current_device_id.user_agent
-            session.country = current_device_id.country
-            session.city = current_device_id.city
+                last_device_id = current_device_id
+
+            session.ip_address = last_device_id.ip_address
+            session.user_agent = last_device_id.user_agent
+            session.country = last_device_id.country
+            session.city = last_device_id.city
             session.first_activity = min(device_ids.mapped('first_activity'))
 
     def _compute_display_name(self):

--- a/odoo/addons/test_http/tests/test_device.py
+++ b/odoo/addons/test_http/tests/test_device.py
@@ -13,7 +13,7 @@ from odoo.addons.test_http.utils import (
     USER_AGENT_linux_chrome,
     USER_AGENT_linux_firefox
 )
-from odoo.http import SESSION_LIFETIME
+from odoo.http import DEVICE_ACTIVITY_UPDATE_FREQUENCY, SESSION_LIFETIME
 from odoo.tests import tagged
 
 from .test_common import TestHttpBase
@@ -515,3 +515,71 @@ class TestDevice(TestHttpBase):
         self.user_internal.unlink()
 
         self.assertEqual(logs.user_id, self.user_internal.id)
+
+    def test_ensure_session_information(self):
+        # Scenario:
+        # ---------
+        # - device A detected at time T0: info A in session + new log A
+        # - device B detected at time T1: info B in session + new log B
+        # - log B is unlink (or marked as revoked)
+        # - device B detected at time T2: nothing ==> `web_read` on `res_users` (see explanation)
+        # T2 < T1 + `DEVICE_ACTIVITY_UPDATE_FREQUENCY`
+        # - device B detected at time T3: info B updated in session + new log B
+        # T3 > T1 + `DEVICE_ACTIVITY_UPDATE_FREQUENCY`
+
+        # Explanation:
+        # ------------
+        # At this moment, T2, because log A exists, a `res.session` record exists.
+        # When we compute information for the `res.session` record, as this record
+        # is the current session, we must get the current device.
+        # To retrieve the current device, we use the `res.device` model.
+        # Unfortunately, no current device is present (because log B has been deleted)
+        # and `DEVICE_ACTIVITY_UPDATE_FREQUENCY` has not been exceeded.
+        # In this case, we have a current session without current device.
+
+        # Note:
+        # -----
+        # However, we are certain that there is at least one device for this session record
+        # because session records are built with device records.
+
+        self.authenticate(self.user_internal.login, self.user_internal.login)
+        self.hit(datetime.now(), '/test_http/greeting-public', headers={'User-Agent': USER_AGENT_linux_chrome})
+        self.hit(datetime.now(), '/test_http/greeting-public', headers={'User-Agent': USER_AGENT_linux_firefox})
+
+        sessions, devices, logs = self.get_devices(self.user_internal)
+        self.assertEqual(len(sessions), 1)
+        self.assertEqual(len(devices), 2)
+        self.assertEqual(len(logs), 2)
+
+        logs.filtered(lambda log: log.user_agent == USER_AGENT_linux_firefox).unlink()
+
+        sessions, devices, logs = self.get_devices(self.user_internal)
+        self.assertEqual(len(sessions), 1)
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(len(logs), 1)
+
+        spec = {
+            'session_ids': {
+                'fields': {
+                    # A field which must compute information from user_agent
+                    'device_type': {},
+                },
+            }
+        }
+
+        with freeze_time(
+            datetime.now() + timedelta(seconds=DEVICE_ACTIVITY_UPDATE_FREQUENCY - 1)
+        ):
+            res = self.url_open(url='/web/dataset/call_kw',
+                json={
+                    'params': {
+                        'model': 'res.users',
+                        'method': 'web_read',
+                        'args': [self.user_internal.ids],
+                        'kwargs': {'specification': spec},
+                    },
+                },
+                cookies={'session_id': self.opener.cookies['session_id']},
+                headers={'User-Agent': USER_AGENT_linux_firefox},
+            )
+            self.assertNotIn('error', res.json())


### PR DESCRIPTION
This commit ensures that there is always information linked to a
`res.session` record.
This causes an error, for example, if `user_agent` is `False`:
```py
... = self.__user_agent_parser(device.user_agent)
```

We ensure that if we have a `is_current` `res.session` record which does
not have a `is_current` `res.device`, we have information (`ip_address`,
`user_agent`, `country`, `city`).

Scenario:
- device A detected at time T0: info A in session + new log A
- device B detected at time T1: info B in session + new log B
- log B is unlink (or marked as revoked)
- device B detected at time T2: nothing ==> `web_read` on `res_users` ==> error
T2 < T1 + `DEVICE_ACTIVITY_UPDATE_FREQUENCY`
- device B detected at time T3: info B updated in session + new log B
T3 > T1 + `DEVICE_ACTIVITY_UPDATE_FREQUENCY`

Explanation:
At this moment, T2, because log A exists, a `res.session` record exists.
When we compute information for the `res.session` record, as this record
is the current session, we must get the current device.
To retrieve the current device, we use the `res.device` model.
Unfortunately, no current device is present (because log B has been deleted)
and `DEVICE_ACTIVITY_UPDATE_FREQUENCY` has not been exceeded.
In this case, we have a current session without current device.

Note:
However, we are certain that there is at least one device for this session
record because session records are built with device records.

Task-6023651