### PR TITLE
[FIX] l10n_fr_hr_holidays: correct half-day leave duration

### DIFF
--- a/addons/l10n_fr_hr_holidays/models/hr_leave.py
+++ b/addons/l10n_fr_hr_holidays/models/hr_leave.py
@@ -62,20 +62,16 @@ class HrLeave(models.Model):
             attendance_ids = self.company_id.resource_calendar_id.attendance_ids | self.resource_calendar_id.attendance_ids
             date_from, date_to = adjust_date_range(date_from, date_to, from_period, to_period, attendance_ids, self.employee_id)
 
-        similar = date_from.date() == date_to.date() and self.request_date_from_period == self.request_date_to_period
-        if self.request_unit_half and similar and self.request_date_from_period == 'am':
-            # In normal workflows request_unit_half implies that date_from and date_to are the same
-            # request_unit_half allows us to choose between `am` and `pm`
+        if self.request_unit_half and self.request_date_to_period == 'am':
             # In a case where we work from mon-wed and request a half day in the morning
             # we do not want to push date_to since the next work attendance is actually in the afternoon
-            date_from_weektype = str(self.env['resource.calendar.attendance'].get_week_type(date_from))
-            date_from_dayofweek = str(date_from.weekday())
+            date_to_weektype = str(self.env['resource.calendar.attendance'].get_week_type(date_to))
+            date_to_dayofweek = str(date_to.weekday())
             # Fetch the attendances we care about
-            attendance_ids = self.resource_calendar_id.attendance_ids.filtered(lambda a:
-                a.dayofweek == date_from_dayofweek
-                and a.day_period != "lunch"
-                and (not self.resource_calendar_id.two_weeks_calendar or a.week_type == date_from_weektype))
-            if len(attendance_ids) == 2:
+            if self.resource_calendar_id.attendance_ids.filtered(lambda a:
+                a.dayofweek == date_to_dayofweek
+                and a.day_period in ('afternoon', 'full_day')
+                and (not self.resource_calendar_id.two_weeks_calendar or a.week_type == date_to_weektype)):
                 # The employee took the morning off on a day where he works the afternoon aswell
                 return (date_from, date_to)
 
@@ -145,9 +141,6 @@ class HrLeave(models.Model):
                         holidays_days_list.append(current)
                         current += relativedelta(days=1)
                 for leave in leaves:
-                    if leave.request_unit_half:
-                        duration_by_leave_id.update(leave._get_durations(resource_calendar=company_cal))
-                        continue
                     # Extend the end date to next working day
                     date_start = leave.date_from
                     date_end = leave.date_to
@@ -160,12 +153,24 @@ class HrLeave(models.Model):
                     current = date_start.date()
                     end_date = extended_date_end.date()
                     legal_days = 0.0
+                    is_half_day_start = leave.request_unit_half and (
+                            (leave.request_date_from == leave.request_date_to and leave.request_date_from_period == leave.request_date_to_period)
+                            or (leave.request_date_from != leave.request_date_to and leave.request_date_from_period == 'pm')
+                    )
+                    is_half_day_end = (
+                            leave.request_unit_half and leave.request_date_to_period == 'am'
+                            and not leave.l10n_fr_date_to_changed  # date_to was not extended -> employee works PM
+                            and leave.request_date_from != leave.request_date_to  # same-day handled by is_half_day_start
+                    )
                     while current <= end_date:
                         if current in holidays_days_list:
                             current += relativedelta(days=1)
                             continue
                         if company_cal._works_on_date(current):
-                            legal_days += 1.0
+                            if is_half_day_start and current == date_start.date() or is_half_day_end and current == end_date:
+                                legal_days += 0.5
+                            else:
+                                legal_days += 1.0
                         current += relativedelta(days=1)
                     standard_duration = super()._get_durations(resource_calendar=resource_calendar)
                     _, hours = standard_duration.get(leave.id, (0.0, 0.0))

--- a/addons/l10n_fr_hr_holidays/models/hr_leave.py
+++ b/addons/l10n_fr_hr_holidays/models/hr_leave.py
@@ -62,10 +62,7 @@ class HrLeave(models.Model):
             attendance_ids = self.company_id.resource_calendar_id.attendance_ids | self.resource_calendar_id.attendance_ids
             date_from, date_to = adjust_date_range(date_from, date_to, from_period, to_period, attendance_ids, self.employee_id)
 
-        similar = date_from.date() == date_to.date() and self.request_date_from_period == self.request_date_to_period
-        if self.request_unit_half and similar and self.request_date_from_period == 'am':
-            # In normal workflows request_unit_half implies that date_from and date_to are the same
-            # request_unit_half allows us to choose between `am` and `pm`
+        if self.request_unit_half and self.request_date_to_period == 'am':
             # In a case where we work from mon-wed and request a half day in the morning
             # we do not want to push date_to since the next work attendance is actually in the afternoon
             date_from_weektype = str(self.env['resource.calendar.attendance'].get_week_type(date_from))
@@ -75,7 +72,7 @@ class HrLeave(models.Model):
                 a.dayofweek == date_from_dayofweek
                 and a.day_period != "lunch"
                 and (not self.resource_calendar_id.two_weeks_calendar or a.week_type == date_from_weektype))
-            if len(attendance_ids) == 2:
+            if len(attendance_ids) == 2 or len(attendance_ids) == 1 and attendance_ids.day_period == 'full_day':
                 # The employee took the morning off on a day where he works the afternoon aswell
                 return (date_from, date_to)
 
@@ -145,9 +142,6 @@ class HrLeave(models.Model):
                         holidays_days_list.append(current)
                         current += relativedelta(days=1)
                 for leave in leaves:
-                    if leave.request_unit_half:
-                        duration_by_leave_id.update(leave._get_durations(resource_calendar=company_cal))
-                        continue
                     # Extend the end date to next working day
                     date_start = leave.date_from
                     date_end = leave.date_to
@@ -160,12 +154,24 @@ class HrLeave(models.Model):
                     current = date_start.date()
                     end_date = extended_date_end.date()
                     legal_days = 0.0
+                    is_half_day_start = leave.request_unit_half and (
+                            (leave.request_date_from == leave.request_date_to and leave.request_date_from_period == leave.request_date_to_period)
+                            or (leave.request_date_from != leave.request_date_to and leave.request_date_from_period == 'pm')
+                    )
+                    is_half_day_end = (
+                            leave.request_unit_half and leave.request_date_to_period == 'am'
+                            and not leave.l10n_fr_date_to_changed  # date_to was not extended -> employee works PM
+                            and leave.request_date_from != leave.request_date_to  # same-day handled by is_half_day_start
+                    )
                     while current <= end_date:
                         if current in holidays_days_list:
                             current += relativedelta(days=1)
                             continue
                         if company_cal._works_on_date(current):
-                            legal_days += 1.0
+                            if is_half_day_start and current == date_start.date() or is_half_day_end and current == end_date:
+                                legal_days += 0.5
+                            else:
+                                legal_days += 1.0
                         current += relativedelta(days=1)
                     standard_duration = super()._get_durations(resource_calendar=resource_calendar)
                     _, hours = standard_duration.get(leave.id, (0.0, 0.0))

--- a/addons/l10n_fr_hr_holidays/tests/test_french_leaves.py
+++ b/addons/l10n_fr_hr_holidays/tests/test_french_leaves.py
@@ -141,8 +141,8 @@ class TestFrenchLeaves(TransactionCase):
         })
         # Since the employee works on the afternoon, the date_to is not post-poned
         self.assertEqual(leave.number_of_days, 0.5, 'The number of days should be equal to 0.5.')
-        leave.request_date_from_period = 'pm'
         leave.request_date_to_period = 'pm'
+        leave.request_date_from_period = 'pm'
         # This however should push the date_to
         self.assertEqual(leave.number_of_days, 2.5, 'The number of days should be equal to 2.5.')
 
@@ -299,9 +299,12 @@ class TestFrenchLeaves(TransactionCase):
         Test Case:
         ==========
         - Employee works from 8 to 12 and 14 to 17 Monday to Wednesday -> 7h/d
-        - Company works from 9 to 12 and 13 to 18 Monday to Friday -> 8h/d
+        - Company works from 9 to 12 and 13 to 18 Monday to Friday (except Tuesday) -> 8h/d
+        - Company works from 9 to 18 without a lunch break on Tuesday
         - Employee requests 1 day off on Monday -> duration should be 1.0
         - Employee requests 0.5 day off on Monday morning or afternoon -> duration should be 0.5
+        - Employee requests a full day off on Tuesday using a time off type in half-days -> duration should be 1.0
+        - Employee requests a half-day off on Tuesday in the morning -> duration should be 0.5
         """
         employee_calendar = self.env['resource.calendar'].create({
             'name': 'Employee Calendar',
@@ -324,9 +327,7 @@ class TestFrenchLeaves(TransactionCase):
                 (0, 0, {'name': 'Monday Morning', 'dayofweek': '0', 'hour_from': 9, 'hour_to': 12, 'day_period': 'morning'}),
                 (0, 0, {'name': 'Monday Lunch', 'dayofweek': '0', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'}),
                 (0, 0, {'name': 'Monday Afternoon', 'dayofweek': '0', 'hour_from': 13, 'hour_to': 18, 'day_period': 'afternoon'}),
-                (0, 0, {'name': 'Tuesday Morning', 'dayofweek': '1', 'hour_from': 9, 'hour_to': 12, 'day_period': 'morning'}),
-                (0, 0, {'name': 'Tuesday Lunch', 'dayofweek': '1', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'}),
-                (0, 0, {'name': 'Tuesday Afternoon', 'dayofweek': '1', 'hour_from': 13, 'hour_to': 18, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Tuesday', 'dayofweek': '1', 'hour_from': 9, 'hour_to': 18, 'day_period': 'full_day'}),
                 (0, 0, {'name': 'Wednesday Morning', 'dayofweek': '2', 'hour_from': 9, 'hour_to': 12, 'day_period': 'morning'}),
                 (0, 0, {'name': 'Wednesday Lunch', 'dayofweek': '2', 'hour_from': 12, 'hour_to': 13, 'day_period': 'lunch'}),
                 (0, 0, {'name': 'Wednesday Afternoon', 'dayofweek': '2', 'hour_from': 13, 'hour_to': 18, 'day_period': 'afternoon'}),
@@ -342,26 +343,74 @@ class TestFrenchLeaves(TransactionCase):
         self.company.resource_calendar_id = company_calendar
         self.employee.resource_calendar_id = employee_calendar
 
-        leave = self.env['hr.leave'].create({
-            'name': 'Test',
-            'holiday_status_id': self.time_off_type.id,
-            'employee_id': self.employee.id,
-            'request_date_from': '2024-07-29',
-            'request_date_to': '2024-07-29',
-            'request_date_from_period': 'am',
-            'request_date_to_period': 'am',
-        })
-        self.assertEqual(leave.number_of_days, 0.5, 'The duration should be 0.5 day.')
-        self.assertEqual(leave.date_from.date(), date(2024, 7, 29))
-        self.assertEqual(leave.date_to.date(), date(2024, 7, 29))
-        self.assertNotEqual(leave.number_of_hours, 8.0, 'Company and employee hours per day should not match in this case')
+        leave_1, leave_2, leave_3, leave_4, leave_5 = self.env['hr.leave'].create([
+            {
+                'name': 'Test',
+                'holiday_status_id': self.time_off_type.id,
+                'employee_id': self.employee.id,
+                'request_date_from': '2024-07-29',
+                'request_date_to': '2024-07-29',
+                'request_date_from_period': 'am',
+                'request_date_to_period': 'am',
+            },
+            {
+                'name': 'Test full day leave on tuesday',
+                'holiday_status_id': self.time_off_type.id,
+                'employee_id': self.employee.id,
+                'request_date_from': '2024-07-30',
+                'request_date_to': '2024-07-30',
+                'request_date_from_period': 'am',
+                'request_date_to_period': 'pm',
+            },
+            {
+                'name': 'Test Monday PM to Tuesday AM',
+                'holiday_status_id': self.time_off_type.id,
+                'employee_id': self.employee.id,
+                'request_date_from': '2024-08-05',
+                'request_date_to': '2024-08-06',
+                'request_date_from_period': 'pm',
+                'request_date_to_period': 'am',
+            },
+            {
+                'name': 'Test Monday AM to Tuesday AM',
+                'holiday_status_id': self.time_off_type.id,
+                'employee_id': self.employee.id,
+                'request_date_from': '2024-08-12',
+                'request_date_to': '2024-08-13',
+                'request_date_from_period': 'am',
+                'request_date_to_period': 'am',
+            },
+            {
+                'name': 'Test Tuesday PM to Wednesday PM',
+                'holiday_status_id': self.time_off_type.id,
+                'employee_id': self.employee.id,
+                'request_date_from': '2024-08-20',
+                'request_date_to': '2024-08-21',
+                'request_date_from_period': 'pm',
+                'request_date_to_period': 'am',
+            }
+        ])
+        self.assertEqual(leave_1.number_of_days, 0.5, 'The duration should be 0.5 day.')
+        self.assertEqual(leave_1.date_from.date(), date(2024, 7, 29))
+        self.assertEqual(leave_1.date_to.date(), date(2024, 7, 29))
+        self.assertNotEqual(leave_1.number_of_hours, 8.0, 'Company and employee hours per day should not match in this case')
 
-        leave.request_date_to_period = 'pm'
-        leave.request_date_from_period = 'pm'
-        self.assertEqual(leave.number_of_days, 0.5, 'The duration should be 0.5 day.')
-        self.assertEqual(leave.date_from.date(), date(2024, 7, 29))
-        self.assertEqual(leave.date_to.date(), date(2024, 7, 29))
-        self.assertNotEqual(leave.number_of_hours, 8.0, 'Company and employee hours per day should not match in this case')
+        self.assertEqual(leave_2.number_of_days, 1)
+        self.assertEqual(leave_2.number_of_hours, 7, "Leave duration should be based on employee's calendar")
+        leave_2.request_date_to_period = 'am'
+        self.assertEqual(leave_2.number_of_days, 0.5)
+
+        self.assertEqual(leave_3.number_of_days, 1)
+        self.assertEqual(leave_4.number_of_days, 1.5, "Employee works PM, time off duration should not count the afternoon")
+        self.assertEqual(leave_5.number_of_days, 1)
+        self.assertEqual(leave_5.date_to.date(), date(2024, 8, 21), "Time off end should not be pushed as employee works in the afternoon")
+
+        leave_1.request_date_to_period = 'pm'
+        leave_1.request_date_from_period = 'pm'
+        self.assertEqual(leave_1.number_of_days, 0.5, 'The duration should be 0.5 day.')
+        self.assertEqual(leave_1.date_from.date(), date(2024, 7, 29))
+        self.assertEqual(leave_1.date_to.date(), date(2024, 7, 29))
+        self.assertNotEqual(leave_1.number_of_hours, 8.0, 'Company and employee hours per day should not match in this case')
 
         self.time_off_type.request_unit = "day"
         leave = self.env['hr.leave'].create({


### PR DESCRIPTION
**Steps to reproduce**
- Use a french company with `l10n_fr_hr_holidays` installed
- Change the duration type of the time off type set as the "Company Paid Time Off Type" in the French Time Off Localization settings to "Half-Day"
- Company Working Schedule:
	- Attendance on a day from 10 to 19, Day Period: Full Day
- Part-time employee Working Schedule:
	- Attendance on the same day from 11 to 12, Day Period: Morning
	- Attendance on the same day from 13 to 19, Day Period: Afternoon
- Create a full day time off for the part time employee on that day, using the time off type set as the "Company Paid Time Off Type" (start am, end pm)

-> Excepted: time off duration is 1 day
-> Actual: time off duration is 0.89 day

**Change**
Now that `request_unit_half` of a leave is a simple related to the `request_unit` of the leave type, it becomes important to not rely on a call to `_get_durations` using the company's calendar to compute the leave's duration, as it may not be fully accurate when the company's working hours and employee's working hours are not aligned.
Continuation of 05e71eb206eb02a8d15708e6fb532a732a767d6d

`_get_fr_date_from_to` is also adapted to take into account multi-day leaves ending in the morning while the employee works in the afternoon (in which case it should not be extended in case the employee doesn't work the next day).

opw-6000011