### PR TITLE
[IMP] mail: redesign invitation screen

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_preview.scss
+++ b/addons/mail/static/src/discuss/call/common/call_preview.scss
@@ -1,0 +1,7 @@
+.o-mail-CallPreview-deviceSelect {
+    width: auto;
+
+    @include media-breakpoint-up(lg) {
+        width: 30%;
+    }
+}

--- a/addons/mail/static/src/discuss/call/common/call_preview.xml
+++ b/addons/mail/static/src/discuss/call/common/call_preview.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="mail.CallPreview">
         <div class="o-mail-CallPreview ratio ratio-16x9">
-            <div t-att-class="{'bg-dark': this.env.inWelcomePage}">
+            <div t-att-class="{'bg-dark rounded': this.env.inWelcomePage}">
                 <video t-if="this.state.videoStream" class="object-fit-cover h-100 w-100 position-relative z-0" autoplay="" t-custom-ref="video"/>
                 <div t-else="" class="position-absolute top-0 start-0 end-0 bottom-0 d-flex flex-column align-items-center justify-content-center text-center px-3 z-1" t-att-class="{'text-white': this.env.inWelcomePage}">
                     <t t-if="this.env.inWelcomePage and this.rtc.cameraPermission !== 'granted'">
@@ -26,21 +26,19 @@
             </div>
             <audio autoplay="" t-custom-ref="audio"/>
         </div>
-        <div t-if="this.props.hasSettingsAtBottom" class="d-flex flex-row justify-content-between mt-2 w-100 mw-100 flex-nowrap px-3">
-            <div class="px-2" style="width: 30%">
+        <div t-if="this.props.hasSettingsAtBottom" class="d-flex justify-content-center gap-2 flex-wrap flex-lg-nowrap w-100 mw-100 mt-2">
+            <div class="o-mail-CallPreview-deviceSelect">
                 <DeviceSelect icon="'fa fa-fw fa-microphone'" kind="'audioinput'"/>
             </div>
-            <div class="px-2" style="width: 30%">
+            <div class="o-mail-CallPreview-deviceSelect">
                 <DeviceSelect icon="'fa fa-fw fa-volume-up'" kind="'audiooutput'"/>
             </div>
-            <div class="px-2" style="width: 30%">
+            <div class="o-mail-CallPreview-deviceSelect">
                 <DeviceSelect icon="'fa fa-fw fa-video-camera'" kind="'videoinput'"/>
             </div>
-            <div class="d-flex align-items-center flex-grow-0 flex-shrink-0 px-2 text-muted">
-                <a role="button" t-on-click="this.onClickSettings" title="Advanced Settings">
-                    <i class="fa fa-fw fa-gear"/>
-                </a>
-            </div>
+            <a role="button" class="btn btn-secondary" t-on-click="this.onClickSettings" title="Advanced Settings">
+                <i class="fa fa-fw fa-gear"/>
+            </a>
         </div>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/call/common/device_select.js
+++ b/addons/mail/static/src/discuss/call/common/device_select.js
@@ -31,7 +31,7 @@ export class DeviceSelect extends Component {
     };
     static components = { Dropdown, DropdownItem };
     static template = "discuss.CallDeviceSelect";
-    PERMISSION_NEEDED = _t("Permission Needed");
+    CLICK_TO_ACTIVATE = _t("Click to Activate");
     BROWSER_DEFAULT = isBrowserChrome() ? _t("Default") : _t("Browser Default");
 
     setup() {

--- a/addons/mail/static/src/discuss/call/common/device_select.xml
+++ b/addons/mail/static/src/discuss/call/common/device_select.xml
@@ -29,7 +29,7 @@
                 <span
                     class="text-truncate flex-grow-1"
                     t-attf-class="{{ this.props.icon ? 'ps-2' : '' }}"
-                    t-out="this.PERMISSION_NEEDED"/>
+                    t-out="this.CLICK_TO_ACTIVATE"/>
             </button>
             <t t-set-slot="content">
                 <DropdownItem t-if="!this.isBrowserChrome or this.props.kind === 'videoinput'" class="{ 'active': this.isSelected() }" onSelected="this.onSelectAudioDevice.bind(this)" closingMode="'closest'">

--- a/addons/mail/static/src/discuss/core/public/welcome_page.js
+++ b/addons/mail/static/src/discuss/core/public/welcome_page.js
@@ -1,10 +1,11 @@
 import { useLayoutEffect, useState, useSubEnv } from "@web/owl2/utils";
 import { CallPreview } from "@mail/discuss/call/common/call_preview";
 
-import { Component } from "@odoo/owl";
+import { Component, markup } from "@odoo/owl";
 
 import { browser } from "@web/core/browser/browser";
 import { useService } from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
 
 export class WelcomePage extends Component {
     static props = ["proceed?"];
@@ -73,6 +74,19 @@ export class WelcomePage extends Component {
 
     get noActiveParticipants() {
         return !this.store.discuss.thread.channel.hasRtcSessionActive;
+    }
+
+    get subtitle() {
+        return _t(
+            "%(open_tag_1)swith%(close_tag_1)s %(open_tag_2)s%(company_name)s%(close_tag_2)s",
+            {
+                open_tag_1: markup`<span class="text-muted">`,
+                close_tag_1: markup`</span>`,
+                open_tag_2: markup`<span>`,
+                close_tag_2: markup`</span>`,
+                company_name: this.store.companyName,
+            }
+        );
     }
 
     get showCallPreview() {

--- a/addons/mail/static/src/discuss/core/public/welcome_page.xml
+++ b/addons/mail/static/src/discuss/core/public/welcome_page.xml
@@ -2,34 +2,40 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.WelcomePage">
-    <div class="o-mail-WelcomePage w-100 d-flex flex-column justify-content-md-center align-items-center bg-light p-3" style="min-height: 100dvh;">
-        <h1 class="fw-light text-center">
-            <span t-if="this.showCallPreview">You've been invited to a meeting!</span>
-            <span t-else="">You've been invited to a chat!</span>
-        </h1>
-        <h2 class="m-3 m-md-5" t-out="this.store.companyName"/>
-        <div class="w-100 d-flex justify-content-center gap-5" t-att-class="{'flex-column': this.ui.isSmall}">
-            <div t-if="this.showCallPreview" class="w-100 rounded-3 overflow-hidden" style="max-width: 640px;">
-                <CallPreview activateCamera="this.state.activateCamera" activateMicrophone="this.state.activateMicrophone" onSettingsChanged="(settings) => this.onCallSettingsChanged(settings)" hasSettingsAtBottom="true"/>
+    <div class="o-mail-WelcomePage container d-flex flex-column justify-content-md-center p-3" style="min-height: 100dvh;">
+        <div class="row row-gap-3 flex-lg-row-reverse justify-content-center">
+            <div class="col-12 col-lg-4">
+                <div class="d-flex flex-column justify-content-center h-100 rounded p-4 p-lg-5 bg-white">
+                    <div class="text-center mb-4">
+                        <i class="oi oi-users oi-2x mb-3 p-2 rounded text-bg-primary"/>
+                        <h1 class="h2">
+                            <span t-if="this.showCallPreview">You've been invited to a meeting!</span>
+                            <span t-else="">You've been invited to a chat!</span>
+                        </h1>
+                        <span t-out="this.subtitle"/>
+                    </div>
+                    <div class="mb-3" t-if="this.store.self_guest and !this.store.self_user">
+                        <label class="d-flex justify-content-between align-items-center mb-2">
+                            <span>Enter your name</span>
+                            <small class="text-muted" t-att-class="{'text-danger': this.state.userName.length > 60}"><t t-out="this.state.userName.length"/>/60</small>
+                        </label>
+                        <input class="form-control form-control-lg rounded bg-white" type="text" name="guest_name" placeholder="E.g: John Doe" t-custom-model="this.state.userName" t-on-keydown="this.onKeydownInput"/>
+                    </div>
+                    <div t-if="this.store.self_user" class="mt-2 mb-4 text-center">
+                        <img t-attf-src="/web/image/res.users/{{this.store.self_user.id}}/avatar_128/32x32" class="rounded me-2" alt="User avatar"/>
+                        <span><t t-out="this.store.self_user.name"/></span>
+                    </div>
+                    <button class="btn btn-primary btn-lg" title="Join Channel" t-att-disabled="!this.canJoin" t-on-click="this.joinChannel">
+                        <t t-if="this.showCallPreview" t-set="joinText">Join call</t>
+                        <t t-else="" t-set="joinText">Join</t>
+                        <span t-out="joinText"/>
+                        <i class="oi oi-arrow-right ms-2"/>
+                    </button>
+                    <small t-if="this.store.self_user and this.showCallPreview and this.noActiveParticipants" class="mt-2 text-center text-muted">No one else is here.</small>
+                </div>
             </div>
-            <div class="d-flex flex-column text-center justify-content-center">
-                <div class="d-flex flex-column" t-if="this.store.self_guest and !this.store.self_user">
-                    <label class="fs-4 mb-2">What's your name?</label>
-                    <input class="form-control bg-white rounded" type="text" name="guest_name" placeholder="Your name" t-custom-model="this.state.userName" t-on-keydown="this.onKeydownInput"/>
-                    <small class="form-text text-end" t-att-class="{'text-danger': this.state.userName.length > 60}"><t t-out="this.state.userName.length"/>/60</small>
-                </div>
-                <div t-if="this.store.self_user">
-                    <p class="fs-3">Ready to join?</p>
-                    <p t-if="this.showCallPreview and this.noActiveParticipants" class="fs-4 mt-n3 text-muted">No one else is here.</p>
-                </div>
-                <button class="d-flex btn btn-light rounded-pill align-items-center justify-content-center gap-3 px-4 fs-3" title="Join Channel" t-att-disabled="!this.canJoin" t-on-click="this.joinChannel">
-                    <t t-if="this.showCallPreview" t-set="joinText">Join call</t>
-                    <t t-else="" t-set="joinText">Join</t>
-                    <span class="mb-0 text-success" t-out="joinText"/>
-                    <span class="rounded-circle bg-success d-flex align-items-center justify-content-center p-2">
-                        <i class="oi oi-arrow-right text-white"/>
-                    </span>
-                </button>
+            <div t-if="this.showCallPreview" class="col-12 col-lg-8">
+                <CallPreview activateCamera="this.state.activateCamera" activateMicrophone="this.state.activateMicrophone" onSettingsChanged="(settings) => this.onCallSettingsChanged(settings)" hasSettingsAtBottom="true"/>
             </div>
         </div>
     </div>

--- a/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
+++ b/addons/mail/static/tests/discuss/call/call_settings_menu.test.js
@@ -60,7 +60,7 @@ test("Renders the call settings", async () => {
     await contains("label[aria-label='Camera']");
     await contains("label[aria-label='Microphone']");
     await contains("label[aria-label='Speakers']");
-    await contains(".o-mail-DeviceSelect-button:has(:text('Permission Needed'))", { count: 3 });
+    await contains(".o-mail-DeviceSelect-button:has(:text('Click to activate'))", { count: 3 });
     rtc.microphonePermission = "granted";
     const browserDefaultLabel = isBrowserChrome() ? "Default" : "Browser Default";
     await click(".o-mail-DeviceSelect-button[data-kind='audioinput']:has(:text('Default'))");


### PR DESCRIPTION
This commit improves the design of the meeting invitation screen.

task-5223747

|  | Before | After |
|--------|--------|--------|
| desktop | <img width="1840" height="1133" alt="Screenshot 2026-03-09 at 17 08 29" src="https://github.com/user-attachments/assets/0feb6150-31ca-426e-84fd-5ad1f351042b" /> | <img width="1840" height="1133" alt="Screenshot 2026-03-10 at 16 13 17" src="https://github.com/user-attachments/assets/7ee0db0c-da9e-4a94-9437-3b0537d42b7e" /> |
| mobile | <img width="402" height="835" alt="Screenshot 2026-03-10 at 16 11 29" src="https://github.com/user-attachments/assets/05e441da-9f58-4841-9409-17de96cfe79e" /> | <img width="402" height="837" alt="Screenshot 2026-03-10 at 16 14 10" src="https://github.com/user-attachments/assets/0d979335-10ed-47c9-bbc1-f5e687202223" /> | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
