### PR TITLE
[FIX] website_sale: parse purchase tracking info from JSON string

### DIFF
--- a/addons/website_sale/static/src/interactions/tracking.js
+++ b/addons/website_sale/static/src/interactions/tracking.js
@@ -21,7 +21,7 @@ export class Tracking extends Interaction {
         const confirmation = this.el.querySelector('div[name="order_confirmation"]');
         if (confirmation) {
             this._vpv('/stats/ecom/order_confirmed/' + confirmation.dataset.orderId);
-            this._trackGa('event', 'purchase', confirmation.dataset.orderTrackingInfo);
+            this._trackGa('event', 'purchase', JSON.parse(confirmation.dataset.orderTrackingInfo));
         }
     }
 

--- a/doc/cla/corporate/comma.md
+++ b/doc/cla/corporate/comma.md
@@ -1,0 +1,15 @@
+Belgium, 2026-03-10
+
+Comma agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Neal Focke 121771073+nealwebdev@users.noreply.github.com https://github.com/nealwebdev
+
+List of contributors:
+
+Neal Focke 121771073+nealwebdev@users.noreply.github.com https://github.com/nealwebdev


### PR DESCRIPTION
## Description

The `Tracking` interaction's `setup()` method reads order tracking info from the HTML `data-order-tracking-info` attribute and passes it directly to `_trackGa()` → `gtag()`. Since the DOM `dataset` API always returns strings, `gtag()` receives a JSON string instead of an object, causing GA4 to silently drop all purchase event parameters (`transaction_id`, `value`, `items`, etc.).

Compare with `onAddToCart()` in the same file, which receives its data via `CustomEvent.detail` (already a JS object) and works correctly.

**Impacted versions:**

- 19.0

**Steps to reproduce:**

1. Configure a Google Analytics key in Website > Settings
2. Add a product to cart and complete checkout
3. On `/shop/confirmation`, inspect the dataLayer or GA4 debug view

**Current behavior:**

- `add_to_cart` event fires with correct ecommerce parameters (object)
- `purchase` event fires with a JSON **string** instead of an object — GA4 silently drops the parameters

**Expected behavior:**

- `purchase` event fires with a parsed object containing `transaction_id`, `value`, `currency`, `tax`, `items`

**Fix:**

Add `JSON.parse()` to convert the data attribute string back to an object before passing it to `gtag()`.

---

I hereby confirm I have signed the Odoo CLA (included in this PR as `doc/cla/corporate/comma.md`).