### PR TITLE
[FIX] hr_holidays : fill leave employee_ids on create

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1046,6 +1046,10 @@ Attempting to double-book your time off won't magically make your vacation 2x be
         return super(HolidaysRequest, self.with_context(leave_skip_date_check=True)).unlink()
 
     def copy_data(self, default=None):
+        if len(self.employee_ids) == 1:
+            if default is None:
+                default = {}
+            default['employee_ids'] = self.employee_ids
         if default and 'request_date_from' in default and 'request_date_to' in default:
             return super().copy_data(default)
         elif self.state in {"cancel", "refuse"}:  # No overlap constraint in these cases

--- a/addons/hr_holidays/tests/test_hr_leave_type.py
+++ b/addons/hr_holidays/tests/test_hr_leave_type.py
@@ -72,3 +72,18 @@ class TestHrLeaveType(TestHrHolidaysCommon):
             ).search([('has_valid_allocation', '=', True)], limit=1)
 
         self.assertFalse(leave_types, "Got valid leaves outside vaild period")
+
+    def test_duplicate_leave(self):
+        employee = self.env['hr.employee'].create({'name': 'Test Employee'})
+        leave_type = self.env['hr.leave.type'].create({'name': 'Sick', 'requires_allocation': 'no'})
+        leave_1 = self.env['hr.leave'].create({
+            'employee_id': employee.id,
+            'holiday_status_id': leave_type.id,
+            'request_date_from': date(2021, 11, 24),
+            'request_date_to': date(2021, 11, 24),
+        })
+        leave_1.action_refuse()
+        leave_2 = leave_1.copy()
+        self.assertEqual(leave_2.employee_id.id, employee.id)
+        self.assertEqual(len(leave_2.employee_ids), 1)
+        self.assertEqual(leave_2.employee_ids[0].id, employee.id)


### PR DESCRIPTION
# How to reproduce
- Create a time off request for a single employee
- Refuse it
- Duplicate it
- Refuse the duplicate
- Try to go back to draft

# The problem
The user is deadlocked and cannot go back to draft because of a client validation on the field employee_ids. The user cannot change that field because it is readonly, so he is stuck.

# Why
When duplicating a hr.leave, employee_id is copied but not employee_ids. Going back to the issue steps, if you look at the Employees field of the duplicate, it is empty. This later cause the issue with the client side validation.

Copying employee_ids when there are multiple employees did not seem like the best idea because a lot of flows relies on employee_id. employee_id is computed as follows :
```py
    def _compute_from_employee_ids(self):
        for holiday in self:
            if len(holiday.employee_ids) == 1:
                holiday.employee_id = holiday.employee_ids[0]._origin
            else:
                holiday.employee_id = False
```
So if we copy multiple employees in employee_ids, employee_id will be null, which might break these flows.

opw-5995398

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
