### PR TITLE
[IMP] point_of_sale: load customer pricelist dynamically

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -658,10 +658,9 @@ export class PosOrder extends PosOrderAccounting {
                       (position) => position.id === newPartner.fiscal_position_id?.id
                   )
                 : defaultFiscalPosition;
+            const pricelistId = newPartner.property_product_pricelist_id;
             newPartnerPricelist =
-                this.config.available_pricelist_ids.find(
-                    (pricelist) => pricelist.id === newPartner.property_product_pricelist?.id
-                ) || this.config.pricelist_id;
+                this.models["product.pricelist"].get(pricelistId) || this.config.pricelist_id;
         } else {
             newPartnerFiscalPosition = defaultFiscalPosition;
             newPartnerPricelist = this.config.pricelist_id;

--- a/addons/point_of_sale/static/src/app/models/res_partner.js
+++ b/addons/point_of_sale/static/src/app/models/res_partner.js
@@ -10,6 +10,10 @@ export class ResPartner extends Base {
         this._searchString = null;
     }
 
+    get property_product_pricelist_id() {
+        return this.property_product_pricelist?.id || this.raw.property_product_pricelist;
+    }
+
     get searchString() {
         if (this._searchString) {
             return this._searchString;

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2389,7 +2389,15 @@ export class PosStore extends WithLazyGetterTrap {
         }
     }
     // There for override to do something before adding partner to current order from partner list
-    setPartnerToCurrentOrder(partner) {
+    async setPartnerToCurrentOrder(partner) {
+        const pricelistId = partner?.property_product_pricelist_id;
+        if (
+            pricelistId &&
+            typeof pricelistId === "number" &&
+            !this.models["product.pricelist"].get(pricelistId)
+        ) {
+            await this.data.read("product.pricelist", [pricelistId]);
+        }
         this.getOrder().setPartner(partner);
     }
     async selectPartner(currentOrder = this.getOrder()) {
@@ -2412,7 +2420,7 @@ export class PosStore extends WithLazyGetterTrap {
             partner: currentPartner,
         });
 
-        this.setPartnerToCurrentOrder(payload || false);
+        await this.setPartnerToCurrentOrder(payload || false);
 
         return payload;
     }


### PR DESCRIPTION
When selecting a customer in the POS, if their specific pricelist is not available in the pre-loaded configuration, it is now automatically fetched from the server.
This ensures that the correct prices and discounts are applied even for customers using pricelists not initially listed in the POS configuration.

task-id: 6023811

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
