### PR TITLE
[FIX] pos_self_order: multiple orders for the same table

### DIFF
--- a/addons/pos_self_order/tests/test_self_order_mobile.py
+++ b/addons/pos_self_order/tests/test_self_order_mobile.py
@@ -296,9 +296,24 @@ class TestSelfOrderMobile(SelfOrderCommonTest):
             'use_presets': False,
         })
 
+        floor = self.env["restaurant.floor"].create({
+            "name": 'Main Floor',
+            "background_color": 'rgb(249,250,251)',
+            "table_ids": [(0, 0, {
+                "table_number": 1,
+            }), (0, 0, {
+                "table_number": 2,
+            }), (0, 0, {
+                "table_number": 3,
+            })],
+        })
+        self.pos_config.write({
+            "floor_ids": [(6, 0, [floor.id])],
+        })
+
         self.pos_config.with_user(self.pos_user).open_ui()
         self.pos_config.current_session_id.set_opening_control(0, "")
-        table = self.pos_config.floor_ids.table_ids[0]
+        table = floor.table_ids[0]
         table_identifier = table.identifier
         self_route = self.pos_config._get_self_order_route(table_id=table.id)
 


### PR DESCRIPTION
In the test test_self_order_table_sharing, the test could fail due to multiple orders being created for the same table on different config since the same table was used on multiple config. This commit fixes this test by creating a new table for the config.

runbot-error: 240898, 240896

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
