### PR TITLE
[REF] bus, mail, *: improve assertion on bus notifications

### DIFF
--- a/addons/bus/tests/common.py
+++ b/addons/bus/tests/common.py
@@ -2,6 +2,7 @@
 
 import json
 import struct
+from itertools import chain, zip_longest
 from threading import Event
 import unittest
 from unittest.mock import patch
@@ -17,8 +18,9 @@ except ImportError:
 from odoo.http import request
 from odoo.tests.common import HOST, release_test_lock, TEST_CURSOR_COOKIE_NAME, Like, _registry_test_lock
 from odoo.tests import HttpCase
+from odoo.tests.common import BaseCase
 from ..websocket import CloseCode, Websocket, WebsocketConnectionHandler
-from ..models.bus import dispatch, hashable, channel_with_db
+from ..models.bus import channel_with_db, dispatch, hashable, json_dump
 
 
 class WebsocketCase(HttpCase):
@@ -173,7 +175,142 @@ class WebsocketCase(HttpCase):
             self.assertEqual(payload[2:].decode(), expected_reason)
 
 
-class BusCase:
+class BusResult:
+    """Descriptor for an expected bus notification.
+    :param channel: the bus channel
+    :param str type: the notification type
+    :param payload: the notification payload
+    When a payload dict is provided, only the specified keys and values are
+    checked against the actual notification; extra keys in the actual payload
+    are ignored.
+    """
+
+    def __init__(self, channel, type=None, payload=None):
+        self.channel = channel
+        self.type = type
+        self.payload = payload
+        self.matched = False
+
+    def match(self, received, *, show_store_versioning):
+        if (
+            self._normalized_channel() == received._normalized_channel()
+            and (self.type is None or self.type == received.type)
+            and (
+                self.payload is None
+                or self._normalized_message(show_store_versioning=show_store_versioning)
+                == received._normalized_message(show_store_versioning=show_store_versioning)
+            )
+        ):
+            self.matched = True
+            received.matched = True
+            return True
+        return False
+
+    def format_log(self, idx, *, show_store_versioning):
+        payload = json.loads(json_dump(self.payload)) if self.payload is not None else None
+        if not show_store_versioning:
+            BusResult._pop_store_version(payload)
+        return (
+            f"# {'✅ matched' if self.matched else '❌ missing'} #{idx}\n"
+            "(\n"
+            f"    {json_dump(self._normalized_channel())},\n"
+            f"    {json_dump(self.type)},\n"
+            f"    {json_dump(payload)},\n"
+            "),"
+        )
+
+    @staticmethod
+    def _pop_store_version(data):
+        if not isinstance(data, dict):
+            return
+        data.pop("__store_version__", False)
+        for value in data.values():
+            BusResult._pop_store_version(value)
+
+    def _normalized_channel(self):
+        if isinstance(self.channel, str):
+            return tuple(json.loads(self.channel))
+        return tuple(self.channel)
+
+    def _normalized_message(self, *, show_store_versioning):
+        message = {}
+        if self.type is not None:
+            message["type"] = self.type
+        if self.payload is not None:
+            message["payload"] = self.payload
+            if not show_store_versioning:
+                BusResult._pop_store_version(message["payload"])
+        return json.loads(json_dump(message)) if message else None
+
+
+class BusCase(BaseCase):
     def _reset_bus(self):
         self.env.cr.precommit.run()  # trigger the creation of bus.bus records
         self.env["bus.bus"].sudo().search([]).unlink()
+
+    @contextlib.contextmanager
+    def assertBus(self, notifications, *, show_store_versioning=False):
+        """Check content of bus notifications.
+        `notifications` is a :class:`BusResult` instance or a list of them, e.g.:
+            BusResult(self.user_employee, "mail.record/insert", {...})
+            BusResult(self.user_employee)
+            BusResult(self.user_employee, "mail.message/inbox")
+            BusResult(self.user_employee, payload={"key": val})
+            BusResult(self.user_employee, "mail.record/insert", {"key": val})
+        A single :class:`BusResult` may be passed directly instead of a one-element list.
+        Notifications are matched in emitted order.
+        `notifications` may be either a :class:`BusResult`, a list of them,
+        or a callable evaluated after the tested code that returns one of
+        those forms.
+        """
+        self._reset_bus()
+        yield
+        self._assertBusNotifications(notifications, show_store_versioning=show_store_versioning)
+
+    def _assertBusNotifications(self, notifications, *, show_store_versioning=False):
+        """Assert bus notifications with coupled channel and message.
+
+        :param notifications: expected notifications as :class:`BusResult`, list,
+            or callable returning one of those forms.
+        Expected notifications must appear in order.
+        """
+        notifications = notifications() if callable(notifications) else notifications
+        if isinstance(notifications, BusResult):
+            notifications = [notifications]
+        notifications = notifications or []
+        self.env.cr.precommit.run()  # trigger the creation of bus.bus records
+        expected_list = []
+        for notif in notifications:
+            if not isinstance(notif, BusResult):
+                msg = "Bus: expected notification items must be a BusResult instance."
+                raise TypeError(msg)
+            expected_list.append(
+                BusResult(
+                    json_dump(channel_with_db(self.cr.dbname, notif.channel)),
+                    notif.type,
+                    notif.payload,
+                ),
+            )
+        received_list = [
+            BusResult(notif.channel, **json.loads(notif.message))
+            for notif in self.env["bus.bus"].sudo().search([])
+        ]
+        for expected_notif, actual_notif in zip_longest(expected_list, received_list):
+            if expected_notif is not None and actual_notif is not None:
+                expected_notif.match(actual_notif, show_store_versioning=show_store_versioning)
+        if any(not notif.matched for notif in chain(expected_list, received_list)):
+
+            def format_notifications(title, notifications):
+                error_parts.append(title)
+                if notifications:
+                    for idx, notif in enumerate(notifications, 1):
+                        error_parts.append(
+                            notif.format_log(idx, show_store_versioning=show_store_versioning),
+                        )
+                else:
+                    error_parts.append("<no notifications>")
+
+            error_parts = ["Bus notifications."]
+            format_notifications("\nExpected notifications:", expected_list)
+            format_notifications("\nReceived notifications:", received_list)
+            raise AssertionError("\n".join(error_parts))

--- a/addons/calendar/tests/test_event_notifications.py
+++ b/addons/calendar/tests/test_event_notifications.py
@@ -9,6 +9,7 @@ from odoo import fields
 from odoo.tests import Form, tagged
 from odoo.tests.common import new_test_user
 from odoo.addons.base.tests.test_ir_cron import CronMixinCase
+from odoo.addons.bus.tests.common import BusResult
 from odoo.addons.mail.tests.common import MailCase
 
 
@@ -279,28 +280,26 @@ class TestEventNotifications(CalendarMailCommon):
         })
         now = fields.Datetime.now()
 
-        def get_bus_params():
-            return (
-                [self.user],
-                [
-                    {
-                        "type": "calendar.alarm",
-                        "payload": [
-                            {
-                                "alarm_id": alarm.id,
-                                "event_id": self.event.id,
-                                "title": "Doom's day",
-                                "message": self.event.display_time,
-                                "timer": 20 * 60,
-                                "notify_at": fields.Datetime.to_string(now + relativedelta(minutes=20)),
-                            },
-                        ],
-                    },
-                ],
-            )
+        def notifications():
+            return [
+                BusResult(
+                    self.user,
+                    "calendar.alarm",
+                    [
+                        {
+                            "alarm_id": alarm.id,
+                            "event_id": self.event.id,
+                            "title": "Doom's day",
+                            "message": self.event.display_time,
+                            "timer": 20 * 60,
+                            "notify_at": fields.Datetime.to_string(now + relativedelta(minutes=20)),
+                        },
+                    ],
+                ),
+            ]
 
         with patch.object(fields.Datetime, 'now', lambda: now):
-            with self.assertBus(get_params=get_bus_params):
+            with self.assertBus(notifications):
                 self.event.with_context(no_mail_to_attendees=True).write({
                     'start': now + relativedelta(minutes=50),
                     'stop': now + relativedelta(minutes=55),
@@ -589,28 +588,26 @@ class TestEventNotifications(CalendarMailCommon):
 
         now = fields.Datetime.now()
 
-        def get_bus_params():
-            return (
-                [self.user],
-                [
-                    {
-                        "type": "calendar.alarm",
-                        "payload": [
-                            {
-                                "alarm_id": alarm.id,
-                                "event_id": self.event.id,
-                                "title": "Doom's day",
-                                "message": self.event.display_time,
-                                "timer": 20 * 60,
-                                "notify_at": fields.Datetime.to_string(now + relativedelta(minutes=20)),
-                            },
-                        ],
-                    },
-                ],
-            )
+        def notifications():
+            return [
+                BusResult(
+                    self.user,
+                    "calendar.alarm",
+                    [
+                        {
+                            "alarm_id": alarm.id,
+                            "event_id": self.event.id,
+                            "title": "Doom's day",
+                            "message": self.event.display_time,
+                            "timer": 20 * 60,
+                            "notify_at": fields.Datetime.to_string(now + relativedelta(minutes=20)),
+                        },
+                    ],
+                ),
+            ]
 
         with patch.object(fields.Datetime, 'now', lambda: now):
-            with self.assertBus(get_params=get_bus_params):
+            with self.assertBus(notifications):
                 self.event.with_context(no_mail_to_attendees=True).write({
                     'start': now + relativedelta(minutes=50),
                     'stop': now + relativedelta(minutes=55),

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -4,6 +4,7 @@ from freezegun import freeze_time
 
 from odoo import Command, fields
 from odoo.addons.im_livechat.tests import chatbot_common
+from odoo.addons.bus.tests.common import BusResult
 from odoo.tests.common import JsonRpcException, new_test_user
 from odoo.tools.misc import mute_logger
 from odoo.addons.mail.tests.common import freeze_all_time, MailCommon
@@ -183,7 +184,7 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
             "channel_id": discuss_channel.id,
         }
 
-        def get_forward_op_bus_params():
+        def notifications():
             messages = self.env["mail.message"].search([], order="id desc", limit=3)
             # only data relevant to the test are asserted for simplicity
             store = Store(bus_channel=discuss_channel).add(messages[1], "_store_message_fields")
@@ -273,133 +274,133 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
             agent_history_id = discuss_channel.livechat_channel_member_history_ids.filtered(
                 lambda h: h.livechat_member_type == "agent"
             ).id
-            channels, message_items = (
-                [
-                    discuss_channel,  # discuss.channel/new_message (transfer)
-                    discuss_channel,  # mail.record/insert
-                    self.user_employee,  # discuss.channel/joined
-                    discuss_channel,  # discuss.channel/new_message (joined)
-                    discuss_channel,  # mail.record/insert
-                    discuss_channel,  # mail.record/insert"
-                    discuss_channel,  # mail.record/insert"
-                    discuss_channel,  # mail.record/insert"
-                    self.user_employee,  # mail.record/insert"
-                ],
-                [
+            return [
+                BusResult(
+                    discuss_channel,
+                    "discuss.channel/new_message",
+                    {"data": transfer_message_data, "id": discuss_channel.id},
+                ),
+                BusResult(
+                    discuss_channel,
+                    "mail.record/insert",
                     {
-                        "type": "discuss.channel/new_message",
-                        "payload": {"data": transfer_message_data, "id": discuss_channel.id},
+                        "discuss.channel": [
+                            {
+                                "id": discuss_channel.id,
+                                "livechat_channel_member_history_ids": [
+                                    ["ADD", [agent_history_id]]
+                                ],
+                            },
+                        ],
+                        "im_livechat.channel.member.history": [
+                            {
+                                "channel_id": discuss_channel.id,
+                                "id": agent_history_id,
+                                "livechat_member_type": "agent",
+                                "partner_id": self.partner_employee.id,
+                                "member_id": member_emp.id,
+                            }
+                        ],
+                        "res.partner": [
+                            {
+                                "avatar_128_access_token": self.partner_employee._get_avatar_128_access_token(),
+                                "id": self.partner_employee.id,
+                                "name": "Ernest Employee",
+                                "user_livechat_username": False,
+                                "write_date": fields.Datetime.to_string(
+                                    self.partner_employee.write_date
+                                ),
+                            }
+                        ],
                     },
+                ),
+                BusResult(
+                    self.user_employee,
+                    "discuss.channel/joined",
                     {
-                        "type": "discuss.channel/joined",
-                        "payload": {
-                            "channel_id": discuss_channel.id,
-                            "invite_to_rtc_call": False,
-                            "data": channel_data_join,
-                            "invited_by_user_id": self.env.user.id,
-                        },
+                        "channel_id": discuss_channel.id,
+                        "invite_to_rtc_call": False,
+                        "data": channel_data_join,
+                        "invited_by_user_id": self.env.user.id,
                     },
+                ),
+                BusResult(
+                    discuss_channel,
+                    "discuss.channel/new_message",
+                    {"data": joined_message_data, "id": discuss_channel.id},
+                ),
+                BusResult(
+                    discuss_channel,
+                    "mail.record/insert",
                     {
-                        "type": "discuss.channel/new_message",
-                        "payload": {"data": joined_message_data, "id": discuss_channel.id},
-                    },
-                    {
-                        "type": "mail.record/insert",
-                        "payload": {
-                            "discuss.channel": [{"id": discuss_channel.id, "member_count": 3}],
-                            "discuss.channel.member": [
-                                {
-                                    "channel_role": False,
-                                    "create_date": fields.Datetime.to_string(
-                                        member_emp.create_date
-                                    ),
-                                    "id": member_emp.id,
-                                    "livechat_member_type": "agent",
-                                    "last_seen_dt": fields.Datetime.to_string(
-                                        member_emp.last_seen_dt
-                                    ),
-                                    "partner_id": self.partner_employee.id,
-                                    "seen_message_id": False,
-                                    "channel_id": discuss_channel.id,
-                                }
-                            ],
-                            "res.country": [
-                                {"code": "BE", "id": self.env.ref("base.be").id, "name": "Belgium"}
-                            ],
-                            "res.partner": self._filter_partners_fields(
-                                {
-                                    "active": True,
-                                    "avatar_128_access_token": self.partner_employee._get_avatar_128_access_token(),
-                                    "country_id": self.env.ref("base.be").id,
-                                    "id": self.partner_employee.id,
-                                    "is_public": False,
-                                    "mention_token": self.partner_employee._get_mention_token(),
-                                    "name": "Ernest Employee",
-                                    "user_livechat_username": False,
-                                    "write_date": fields.Datetime.to_string(
-                                        self.partner_employee.write_date
-                                    ),
-                                }
+                        "discuss.channel": [{"id": discuss_channel.id, "member_count": 3}],
+                        "discuss.channel.member": [
+                            {
+                                "channel_role": False,
+                                "create_date": fields.Datetime.to_string(member_emp.create_date),
+                                "id": member_emp.id,
+                                "livechat_member_type": "agent",
+                                "last_seen_dt": fields.Datetime.to_string(member_emp.last_seen_dt),
+                                "partner_id": self.partner_employee.id,
+                                "seen_message_id": False,
+                                "channel_id": discuss_channel.id,
+                            }
+                        ],
+                        "res.country": [
+                            {"code": "BE", "id": self.env.ref("base.be").id, "name": "Belgium"}
+                        ],
+                        "res.partner": self._filter_partners_fields({
+                            "active": True,
+                            "avatar_128_access_token": self.partner_employee._get_avatar_128_access_token(),
+                            "country_id": self.env.ref("base.be").id,
+                            "id": self.partner_employee.id,
+                            "is_public": False,
+                            "mention_token": self.partner_employee._get_mention_token(),
+                            "name": "Ernest Employee",
+                            "user_livechat_username": False,
+                            "write_date": fields.Datetime.to_string(
+                                self.partner_employee.write_date
                             ),
-                        },
+                        }),
                     },
+                ),
+                BusResult(
+                    discuss_channel,
+                    "mail.record/insert",
                     {
-                        "type": "mail.record/insert",
-                        "payload": {
-                            "discuss.channel": [
-                                {
-                                    "id": discuss_channel.id,
-                                    "livechat_channel_member_history_ids": [
-                                        ["ADD", [agent_history_id]]
-                                    ],
-                                },
-                            ],
-                            "im_livechat.channel.member.history": [
-                                {
-                                    "channel_id": discuss_channel.id,
-                                    "id": agent_history_id,
-                                    "livechat_member_type": "agent",
-                                    "partner_id": self.partner_employee.id,
-                                    "member_id": member_emp.id,
-                                }
-                            ],
-                            "res.partner": [
-                                {
-                                    "avatar_128_access_token": self.partner_employee._get_avatar_128_access_token(),
-                                    "id": self.partner_employee.id,
-                                    "name": "Ernest Employee",
-                                    "user_livechat_username": False,
-                                    "write_date": fields.Datetime.to_string(
-                                        self.partner_employee.write_date
-                                    ),
-                                }
-                            ],
-                        },
+                        "discuss.channel": [{"id": discuss_channel.id, "member_count": 2}],
+                        "discuss.channel.member": [{"_DELETE": True, "id": member_bot.id}],
                     },
+                ),
+                BusResult(
+                    discuss_channel,
+                    "mail.record/insert",
                     {
-                        "type": "mail.record/insert",
-                        "payload": {
-                            "discuss.channel": [{"id": discuss_channel.id, "member_count": 2}],
-                            "discuss.channel.member": [{"_DELETE": True, "id": member_bot.id}],
-                        },
+                        "discuss.channel": [
+                            {
+                                "id": discuss_channel.id,
+                                "name": "OdooBot Ernest Employee",
+                            },
+                        ],
                     },
+                ),
+                BusResult(
+                    discuss_channel,
+                    "mail.record/insert",
                     {
-                        "type": "mail.record/insert",
-                        "payload": {
-                            "discuss.channel": [
-                                {
-                                    "id": discuss_channel.id,
-                                    "name": "OdooBot Ernest Employee",
-                                },
-                            ],
-                        },
+                        "ChatbotStep": [
+                            {
+                                "id": [self.step_forward_operator.id, False],
+                                "message": False,
+                                "operatorFound": True,
+                                "scriptStep": self.step_forward_operator.id,
+                            }
+                        ]
                     },
-                    {"type": "mail.record/insert", "payload": channel_data_emp},
-                ],
-            )
-
-            return (channels, message_items)
-        with self.assertBus(get_params=get_forward_op_bus_params):
+                ),
+                BusResult(self.user_employee, "mail.record/insert", channel_data_emp),
+            ]
+        with self.assertBus(notifications):
             discuss_channel._forward_human_operator(self.step_forward_operator, users=self.user_employee)
         self.assertEqual(discuss_channel.name, "OdooBot Ernest Employee")
         self.assertEqual(discuss_channel.livechat_agent_partner_ids, self.partner_employee)

--- a/addons/im_livechat/tests/test_discuss_channel.py
+++ b/addons/im_livechat/tests/test_discuss_channel.py
@@ -6,7 +6,9 @@ from markupsafe import Markup
 from odoo import Command, fields
 from odoo.tests import new_test_user, users
 from odoo.addons.im_livechat.tests.common import TestImLivechatCommon, TestGetOperatorCommon
+from odoo.addons.bus.tests.common import BusResult
 from odoo.addons.mail.tests.common import MailCase
+from odoo.addons.mail.tools.discuss import Store
 
 
 class TestDiscussChannel(TestImLivechatCommon, TestGetOperatorCommon, MailCase):
@@ -81,11 +83,11 @@ class TestDiscussChannel(TestImLivechatCommon, TestGetOperatorCommon, MailCase):
         )
         channel = self.env["discuss.channel"].browse(data["channel_id"])
         with self.assertBus(
-            [(channel, "internal_users")],
             [
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                BusResult(
+                    (channel, "internal_users"),
+                    "mail.record/insert",
+                    {
                         "discuss.channel": [
                             {
                                 "id": channel.id,
@@ -93,7 +95,7 @@ class TestDiscussChannel(TestImLivechatCommon, TestGetOperatorCommon, MailCase):
                             }
                         ]
                     },
-                }
+                ),
             ],
         ):
             channel.description = "Description of the conversation"
@@ -123,11 +125,11 @@ class TestDiscussChannel(TestImLivechatCommon, TestGetOperatorCommon, MailCase):
         )
         channel = self.env["discuss.channel"].browse(data["channel_id"])
         with self.assertBus(
-            [(channel, "internal_users")],
             [
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                BusResult(
+                    (channel, "internal_users"),
+                    "mail.record/insert",
+                    {
                         "discuss.channel": [
                             {
                                 "id": channel.id,
@@ -138,7 +140,7 @@ class TestDiscussChannel(TestImLivechatCommon, TestGetOperatorCommon, MailCase):
                             }
                         ]
                     },
-                }
+                ),
             ],
         ):
             channel.livechat_note = "This is a note for the internal user."
@@ -151,8 +153,24 @@ class TestDiscussChannel(TestImLivechatCommon, TestGetOperatorCommon, MailCase):
         )
         channel = self.env["discuss.channel"].browse(data["channel_id"])
         group = self.env.ref("im_livechat.im_livechat_group_user")
+
         with self.assertBus(
-            [(channel, "internal_users"), (group, "LOOKING_FOR_HELP")],
+            lambda: [
+                BusResult(
+                    (channel, "internal_users"),
+                    "mail.record/insert",
+                    Store(bus_channel=channel, bus_subchannel="internal_users")
+                    .add(channel, ["livechat_status", "livechat_looking_for_help_since_dt"])
+                    .get_result(),
+                ),
+                BusResult(
+                    (group, "LOOKING_FOR_HELP"),
+                    "mail.record/insert",
+                    Store(bus_channel=group, bus_subchannel="LOOKING_FOR_HELP")
+                    .add(channel, "_store_channel_fields")
+                    .get_result(),
+                ),
+            ]
         ):
             channel.livechat_status = "need_help"
 

--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -6,6 +6,7 @@ from markupsafe import Markup
 from odoo import Command, fields
 from odoo.exceptions import AccessError
 from odoo.tests.common import users
+from odoo.addons.bus.tests.common import BusResult
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.addons.mail.tools.discuss import Store
 from odoo.addons.im_livechat.tests.chatbot_common import ChatbotCase
@@ -228,90 +229,85 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
             )["channel_id"]
         )
 
-        def _get_feedback_bus():
+        def notifications():
             message = self.env["mail.message"].sudo().search([], order="id desc", limit=1)
-            return (
-                [
-                    self.env.user,  # unread counter/new message separator (not asserted below)
-                    channel,  # new_message
-                ],
-                [
+            return [
+                BusResult(self.env.user, "mail.record/insert"),
+                BusResult(
+                    channel,
+                    "discuss.channel/new_message",
                     {
-                        "type": "discuss.channel/new_message",
-                        "payload": {
-                            "data": {
-                                "mail.message": self._filter_messages_fields(
-                                    {
-                                        "attachment_ids": [],
-                                        "author_guest_id": False,
-                                        "author_id": self.env.user.partner_id.id,
-                                        "body": [
-                                            "markup",
-                                            '<div class="o_mail_notification o_hide_author">Rating: <img class="o_livechat_emoji_rating" src="/rating/static/src/img/rating_5.png" alt="rating"><br>\nGood service</div>',
-                                        ],
-                                        "create_date": fields.Datetime.to_string(
-                                            message.create_date
-                                        ),
-                                        "date": fields.Datetime.to_string(message.date),
-                                        "default_subject": "Chell Gladys Ernest Employee",
-                                        "id": message.id,
-                                        "incoming_email_cc": False,
-                                        "incoming_email_to": False,
-                                        "message_link_preview_ids": [],
-                                        "message_type": "notification",
-                                        "model": "discuss.channel",
-                                        "parent_id": False,
-                                        "partner_ids": [],
-                                        "pinned_at": False,
-                                        "rating_id": False,
-                                        "reactions": [],
-                                        "record_name": "Chell Gladys Ernest Employee",
-                                        "res_id": channel.id,
-                                        "scheduledDatetime": False,
-                                        "subject": False,
-                                        "subtype_id": self.env.ref("mail.mt_comment").id,
-                                        "thread": {"id": channel.id, "model": "discuss.channel"},
-                                        "write_date": fields.Datetime.to_string(message.write_date),
-                                    },
-                                ),
-                                "mail.message.subtype": [
-                                    {"description": False, "id": self.env.ref("mail.mt_comment").id}
-                                ],
-                                "mail.thread": self._filter_threads_fields(
-                                    {
-                                        "display_name": "Chell Gladys Ernest Employee",
-                                        "id": channel.id,
-                                        "model": "discuss.channel",
-                                    },
-                                ),
-                                "res.partner": self._filter_partners_fields(
-                                    {
-                                        "avatar_128_access_token": self.env.user.partner_id._get_avatar_128_access_token(),
-                                        "id": self.env.user.partner_id.id,
-                                        "is_company": False,
-                                        "main_user_id": self.env.user.id,
-                                        "name": "Chell Gladys",
-                                        "user_livechat_username": False,
-                                        "write_date": fields.Datetime.to_string(
-                                            self.env.user.write_date
-                                        ),
-                                    },
-                                ),
-                                "res.users": self._filter_users_fields(
-                                    {
-                                        "id": self.env.user.id,
-                                        "partner_id": self.env.user.partner_id.id,
-                                        "share": True,
-                                    },
-                                ),
-                            },
-                            "id": channel.id,
+                        "data": {
+                            "mail.message": self._filter_messages_fields(
+                                {
+                                    "attachment_ids": [],
+                                    "author_guest_id": False,
+                                    "author_id": self.env.user.partner_id.id,
+                                    "body": [
+                                        "markup",
+                                        '<div class="o_mail_notification o_hide_author">Rating: <img class="o_livechat_emoji_rating" src="/rating/static/src/img/rating_5.png" alt="rating"><br>\nGood service</div>',
+                                    ],
+                                    "create_date": fields.Datetime.to_string(message.create_date),
+                                    "date": fields.Datetime.to_string(message.date),
+                                    "default_subject": "Chell Gladys Ernest Employee",
+                                    "id": message.id,
+                                    "incoming_email_cc": False,
+                                    "incoming_email_to": False,
+                                    "message_link_preview_ids": [],
+                                    "message_type": "notification",
+                                    "model": "discuss.channel",
+                                    "parent_id": False,
+                                    "partner_ids": [],
+                                    "pinned_at": False,
+                                    "rating_id": False,
+                                    "reactions": [],
+                                    "record_name": "Chell Gladys Ernest Employee",
+                                    "res_id": channel.id,
+                                    "scheduledDatetime": False,
+                                    "subject": False,
+                                    "subtype_id": self.env.ref("mail.mt_comment").id,
+                                    "thread": {"id": channel.id, "model": "discuss.channel"},
+                                    "write_date": fields.Datetime.to_string(message.write_date),
+                                },
+                            ),
+                            "mail.message.subtype": [
+                                {"description": False, "id": self.env.ref("mail.mt_comment").id},
+                            ],
+                            "mail.thread": self._filter_threads_fields(
+                                {
+                                    "display_name": "Chell Gladys Ernest Employee",
+                                    "id": channel.id,
+                                    "model": "discuss.channel",
+                                    "rating_id": False,
+                                },
+                            ),
+                            "res.partner": self._filter_partners_fields(
+                                {
+                                    "avatar_128_access_token": self.env.user.partner_id._get_avatar_128_access_token(),
+                                    "id": self.env.user.partner_id.id,
+                                    "is_company": False,
+                                    "main_user_id": self.env.user.id,
+                                    "name": "Chell Gladys",
+                                    "user_livechat_username": False,
+                                    "write_date": fields.Datetime.to_string(
+                                        self.env.user.write_date,
+                                    ),
+                                },
+                            ),
+                            "res.users": self._filter_users_fields(
+                                {
+                                    "id": self.env.user.id,
+                                    "partner_id": self.env.user.partner_id.id,
+                                    "share": True,
+                                },
+                            ),
                         },
+                        "id": channel.id,
                     },
-                ],
-            )
+                ),
+            ]
 
-        with self.assertBus(get_params=_get_feedback_bus):
+        with self.assertBus(notifications):
             self.make_jsonrpc_request(
                 "/im_livechat/feedback",
                 {

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -357,7 +357,9 @@ class MailActivity(models.Model):
         # update activity counter
         if original_user_todo_activity_count is not None:
             new_user_todo_activity_count = get_user_todo_activity_count(self)
-            for user in new_user_todo_activity_count.keys() | original_user_todo_activity_count.keys():
+            users = new_user_todo_activity_count.keys() | original_user_todo_activity_count.keys()
+            # sorting users by id to ensure deterministic order because keys views are set-like
+            for user in sorted(users, key=lambda user: user.id):
                 count_diff = new_user_todo_activity_count.get(user, 0) - original_user_todo_activity_count.get(user, 0)
                 if count_diff > 0:
                     user._bus_send("mail.activity/updated", {"activity_created": True, "count_diff": count_diff})

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -22,8 +22,8 @@ from urllib.parse import urlparse, urlencode, parse_qsl
 from odoo import tools, fields
 from odoo.addons.base.models.ir_mail_server import IrMail_Server
 from odoo.addons.base.tests.common import MockSmtplibCase
-from odoo.addons.bus.models.bus import BusBus, channel_with_db, json_dump
-from odoo.addons.bus.tests.common import BusCase
+from odoo.addons.bus.models.bus import BusBus
+from odoo.addons.bus.tests.common import BusCase, BusResult
 from odoo.addons.mail.models import mail_thread
 from odoo.addons.mail.models.mail_mail import MailMail
 from odoo.addons.mail.models.mail_message import MailMessage
@@ -1419,51 +1419,6 @@ class MailCase(common.TransactionCase, MockEmail, BusCase):
             self.assertEqual(self._new_msgs, done_msgs, 'Mail: invalid message creation (%s) / expected (%s)' % (len(self._new_msgs), len(done_msgs)))
             self.assertEqual(self._new_notifs, done_notifs, 'Mail: invalid notification creation (%s) / expected (%s)' % (len(self._new_notifs), len(done_notifs)))
 
-    def _pop_store_version(self, data):
-        if not isinstance(data, dict):
-            return
-        data.pop("__store_version__", False)
-        for value in data.values():
-            self._pop_store_version(value)
-
-    @contextmanager
-    def assertBus(self, channels=None, message_items=None, get_params=None, show_store_versioning=False):
-        """Check content of bus notifications.
-        Params might not be determined in advance (newly created id, create_date, ...), in this case
-        the `get_params` function can be given to return the expected values, called after the
-        execution of the tested code.
-        """
-        def format_notif(notif):
-            if not notif.message:
-                return ""
-            return f"{tuple(json.loads(notif.channel))},  # {json.loads(notif.message).get('type')}"
-
-        def notif_to_string(notif):
-            notification_message = json.loads(notif.message)
-            if not show_store_versioning:
-                self._pop_store_version(notification_message)
-            return f"{format_notif(notif)}\n{json.dumps(notification_message)}"
-
-        self._reset_bus()
-        try:
-            with self.mock_bus():
-                yield
-        finally:
-            if get_params:
-                channels, message_items = get_params()
-            found_bus_notifs = self.assertBusNotifications(
-                channels,
-                message_items=message_items,
-                show_store_versioning=show_store_versioning,
-            )
-            new_lines = "\n\n"
-            self.assertEqual(
-                self._new_bus_notifs,
-                found_bus_notifs,
-                f"\n\nExpected:\n{new_lines[0].join(found_bus_notifs.mapped(format_notif))}"
-                f"\n\nResult:\n{new_lines.join(self._new_bus_notifs.mapped(notif_to_string))}",
-            )
-
     @contextmanager
     def assertMsgWithoutNotifications(self, mail_unlink_sent=False):
         try:
@@ -1679,7 +1634,14 @@ class MailCase(common.TransactionCase, MockEmail, BusCase):
             # check bus notifications that should be sent (hint: message author, multiple notifications)
             bus_notifications = message.notification_ids._filtered_for_web_client().filtered(lambda n: n.notification_status == 'exception')
             if bus_notifications:
-                self.assertMessageBusNotifications(message, bus_notif_count)
+                expected = [
+                    BusResult(
+                        message.author_id.user_ids,
+                        "mail.record/insert",
+                        Store().add(message, "_store_notification_fields").get_result(),
+                    )
+                ] * bus_notif_count
+                self._assertBusNotifications(expected)
 
             # check emails that should be sent (hint: mail.mail per group, email par recipient)
             email_values = {
@@ -1734,96 +1696,6 @@ class MailCase(common.TransactionCase, MockEmail, BusCase):
                 self.assertNoMail(partners, email_to=email_addrs, mail_message=message, author=message.author_id)
 
         return done_msgs, done_notifs
-
-    def assertMessageBusNotifications(self, message, count=1):
-        """Asserts that the expected notification updates have been sent on the
-        bus for the given message."""
-        self.assertBusNotifications([message.author_id.user_ids] * count, [{
-            "type": "mail.record/insert",
-            "payload": Store().add(message, "_store_notification_fields").get_result(),
-        }], check_unique=False)
-
-    def assertBusNotifications(self, channels, message_items=None, check_unique=True, show_store_versioning=False):
-        """ Check bus notifications content. Mandatory and basic check is about
-        channels being notified. Content check is optional.
-
-        EXPECTED
-        :param channels: list of expected bus channels, like [self.user_employee]
-        :param message_items: if given, list of expected message making a valid
-          pair (channel, message) to be found in bus.bus, like [
-            {'type': 'mail.message/notification_update',
-             'elements': {self.msg.id: {
-                'message_id': self.msg.id,
-                'message_type': 'sms',
-                'notifications': {...},
-                ...
-              }}
-            }, {...}]
-        """
-        self.env.cr.precommit.run()  # trigger the creation of bus.bus records
-        channels_with_db = [json_dump(channel_with_db(self.cr.dbname, c)) for c in channels]
-        bus_notifs = self.env["bus.bus"].sudo().search([("channel", "in", channels_with_db)])
-        new_lines = "\n\n"
-
-        def notif_to_string(notif):
-            notification_message = json.loads(notif.message)
-            if not show_store_versioning:
-                self._pop_store_version(notification_message)
-            return f"{notif.channel}\n{json.dumps(notification_message)}"
-
-        self.assertEqual(
-            bus_notifs.mapped("channel"),
-            channels_with_db,
-            f"\n\nExpected:\n{new_lines[0].join(channels_with_db)}"
-            f"\n\nReturned:\n{new_lines.join([notif_to_string(notif) for notif in bus_notifs])}",
-        )
-        for expected in message_items or []:
-            for notification in bus_notifs:
-                notification_message = json.loads(notification.message)
-                if not show_store_versioning:
-                    self._pop_store_version(notification_message)
-                if json.loads(json_dump(expected)) == notification_message:
-                    break
-            else:
-                matching_notifs = [n for n in bus_notifs if json.loads(n.message).get("type") == expected.get("type")]
-                if len(matching_notifs) == 1:
-                    notification_message = json.loads(matching_notifs[0].message)
-                    if not show_store_versioning:
-                        self._pop_store_version(notification_message)
-                    self.assertEqual(expected, json.loads(matching_notifs[0].message))
-                if not matching_notifs:
-                    matching_notifs = bus_notifs
-                raise AssertionError(
-                    "No notification was found with the expected value.\n\n"
-                    f"Expected:\n{json_dump(expected)}\n\n"
-                    f"Returned:\n{new_lines.join([notif_to_string(notif) for notif in matching_notifs])}"
-                )
-        if check_unique:
-            self.assertEqual(len(bus_notifs), len(channels))
-        return bus_notifs
-
-    @contextmanager
-    def assertBusNotificationType(self, expected_pairs):
-        """Check bus notifications type.
-        :param expected_pairs: list of tuples containing the expected bus channel and bus
-        notification type"""
-        try:
-            with self.mock_bus():
-                yield
-        finally:
-            channels_with_db = [
-                json_dump(channel_with_db(self.cr.dbname, channel))
-                for channel, _ in expected_pairs
-            ]
-            bus_notifs = self.env["bus.bus"].sudo().search([("channel", "in", channels_with_db)])
-            notif_types = [
-                (json.loads(notif.message).get("type"), notif.channel) for notif in bus_notifs
-            ]
-            expected_notif_types = [
-                (notif_type, json_dump(channel_with_db(self.cr.dbname, channel)))
-                for channel, notif_type in expected_pairs
-            ]
-            self.assertEqual(notif_types, expected_notif_types)
 
     def assertNotified(self, message, recipients_info, is_complete=False):
         """ Lightweight check for notifications (mail.notification).
@@ -2127,6 +1999,7 @@ class MailCommon(MailCase):
                     self.env.registry[data["model"]], self.env.registry["rating.mixin"]
                 )
             ):
+                data.pop("rating_id", None)
                 data.pop("rating_avg", None)
                 data.pop("rating_count", None)
         return list(threads_data)

--- a/addons/mail/tests/discuss/test_discuss_category.py
+++ b/addons/mail/tests/discuss/test_discuss_category.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.addons.bus.tests.common import BusResult
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.tests import HttpCase
 
@@ -13,31 +14,29 @@ class TestDiscussCategory(MailCommon, HttpCase):
         self.authenticate("admin", "admin")
         category_id = self.env["discuss.category"].create({"name": "Services"})
 
-        def get_assign_channel_category_bus():
-            return (
-                [self.channel],
-                [
+        def notifications():
+            return [
+                BusResult(
+                    self.channel,
+                    "mail.record/insert",
                     {
-                        "type": "mail.record/insert",
-                        "payload": {
-                            "discuss.category": [
-                                {
-                                    "id": category_id.id,
-                                    "name": category_id.name,
-                                    "sequence": category_id.sequence,
-                                    "bus_channel_access_token": category_id._get_bus_channel_access_token(),
-                                },
-                            ],
-                            "discuss.channel": [
-                                {
-                                    "id": self.channel.id,
-                                    "discuss_category_id": category_id.id,
-                                },
-                            ],
-                        },
+                        "discuss.category": [
+                            {
+                                "id": category_id.id,
+                                "name": category_id.name,
+                                "sequence": category_id.sequence,
+                                "bus_channel_access_token": category_id._get_bus_channel_access_token(),
+                            },
+                        ],
+                        "discuss.channel": [
+                            {
+                                "id": self.channel.id,
+                                "discuss_category_id": category_id.id,
+                            },
+                        ],
                     },
-                ],
-            )
+                ),
+            ]
 
-        with self.assertBus(get_params=get_assign_channel_category_bus):
+        with self.assertBus(notifications):
             category_id.channel_ids = [(4, self.channel.id)]

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -9,9 +9,9 @@ from markupsafe import Markup
 from odoo import Command, fields
 from odoo.addons.base.models.avatar_mixin import get_random_ui_color_from_seed
 from odoo.addons.bus.models.bus import channel_with_db, json_dump
+from odoo.addons.bus.tests.common import BusResult
 from odoo.addons.mail.models.discuss.discuss_channel import channel_avatar, group_avatar
-from odoo.addons.mail.tests.common import mail_new_test_user
-from odoo.addons.mail.tests.common import MailCommon
+from odoo.addons.mail.tests.common import MailCommon, mail_new_test_user
 from odoo.addons.mail.tools.discuss import Store
 from odoo.exceptions import ValidationError
 from odoo.tests import HttpCase, users
@@ -75,189 +75,183 @@ class TestChannelInternals(MailCommon, HttpCase):
         self.assertEqual(test_group.channel_partner_ids, self.partner_employee)
 
         emp_partner_write_date = fields.Datetime.to_string(self.env.user.partner_id.write_date)
-        test_partner_write_date = fields.Datetime.to_string(self.env.user.partner_id.write_date)
+        test_partner_write_date = fields.Datetime.to_string(self.test_partner.write_date)
 
-        def get_add_member_bus():
+        def notifications():
             message = self.env["mail.message"].search([], order="id desc", limit=1)
             member = self.env["discuss.channel.member"].search([], order="id desc", limit=1)
-            return (
-                [
+            return [
+                BusResult(test_group),
+                BusResult(self.test_user),
+                BusResult(self.user_employee),
+                BusResult(
                     test_group,
-                    self.test_user,
-                    self.user_employee,
-                    test_group,
-                    test_group,
-                ],
-                [
+                    "discuss.channel/new_message",
                     {
-                        "type": "discuss.channel/new_message",
-                        "payload": {
-                            "data": {
-                                "mail.message": self._filter_messages_fields(
-                                    {
-                                        "attachment_ids": [],
-                                        "author_id": self.env.user.partner_id.id,
-                                        "author_guest_id": False,
-                                        "body": [
-                                            "markup",
-                                            f'<div class="o_mail_notification" data-oe-type="channel-joined">invited <a href="#" data-oe-model="res.partner" data-oe-id="{self.test_partner.id}" class="o_mail_redirect">@Test Partner</a> to the channel</div>',
-                                        ],
-                                        "create_date": fields.Datetime.to_string(
-                                            message.create_date,
-                                        ),
-                                        "date": "2020-03-22 10:42:06",
-                                        "default_subject": "Group",
-                                        "id": message.id,
-                                        "incoming_email_cc": False,
-                                        "incoming_email_to": False,
-                                        "message_link_preview_ids": [],
-                                        "message_type": "notification",
-                                        "model": "discuss.channel",
-                                        "parent_id": False,
-                                        "partner_ids": [],
-                                        "pinned_at": False,
-                                        "rating_id": False,
-                                        "reactions": [],
-                                        "record_name": "Group",
-                                        "res_id": test_group.id,
-                                        "scheduledDatetime": False,
-                                        "subject": False,
-                                        "subtype_id": self.env.ref("mail.mt_comment").id,
-                                        "thread": {"id": test_group.id, "model": "discuss.channel"},
-                                        "write_date": fields.Datetime.to_string(message.write_date),
-                                    },
-                                ),
-                                "mail.message.subtype": [
-                                    {
-                                        "description": False,
-                                        "id": self.env.ref("mail.mt_comment").id,
-                                    },
-                                ],
-                                "mail.thread": self._filter_threads_fields(
-                                    {
-                                        "display_name": "Group",
-                                        "id": test_group.id,
-                                        "model": "discuss.channel",
-                                        "rating_avg": 0.0,
-                                        "rating_count": 0,
-                                    },
-                                ),
-                                "res.partner": self._filter_partners_fields(
-                                    {
-                                        "avatar_128_access_token": self.env.user.partner_id._get_avatar_128_access_token(),
-                                        "id": self.env.user.partner_id.id,
-                                        "is_company": False,
-                                        "main_user_id": self.env.user.id,
-                                        "name": "Ernest Employee",
-                                        "write_date": emp_partner_write_date,
-                                    },
-                                ),
-                                "res.users": self._filter_users_fields(
-                                    {
-                                        "id": self.env.user.id,
-                                        "partner_id": self.env.user.partner_id.id,
-                                        "share": False,
-                                    },
-                                ),
-                            },
-                            "id": test_group.id,
-                        },
-                    },
-                    {
-                        "type": "mail.record/insert",
-                        "payload": {
-                            "discuss.channel": [{"id": test_group.id, "member_count": 2}],
-                            "discuss.channel.member": [
+                        "data": {
+                            "mail.message": self._filter_messages_fields(
                                 {
-                                    "channel_id": test_group.id,
-                                    "channel_role": False,
-                                    "create_date": fields.Datetime.to_string(member.create_date),
-                                    "id": member.id,
-                                    "last_seen_dt": False,
-                                    "partner_id": self.test_partner.id,
-                                    "seen_message_id": False,
+                                    "attachment_ids": [],
+                                    "author_id": self.env.user.partner_id.id,
+                                    "author_guest_id": False,
+                                    "body": [
+                                        "markup",
+                                        f'<div class="o_mail_notification" data-oe-type="channel-joined">invited <a href="#" data-oe-model="res.partner" data-oe-id="{self.test_partner.id}" class="o_mail_redirect">@Test Partner</a> to the channel</div>',
+                                    ],
+                                    "create_date": fields.Datetime.to_string(
+                                        message.create_date,
+                                    ),
+                                    "date": "2020-03-22 10:42:06",
+                                    "default_subject": "Group",
+                                    "id": message.id,
+                                    "incoming_email_cc": False,
+                                    "incoming_email_to": False,
+                                    "message_link_preview_ids": [],
+                                    "message_type": "notification",
+                                    "model": "discuss.channel",
+                                    "parent_id": False,
+                                    "partner_ids": [],
+                                    "pinned_at": False,
+                                    "rating_id": False,
+                                    "reactions": [],
+                                    "record_name": "Group",
+                                    "res_id": test_group.id,
+                                    "scheduledDatetime": False,
+                                    "subject": False,
+                                    "subtype_id": self.env.ref("mail.mt_comment").id,
+                                    "thread": {"id": test_group.id, "model": "discuss.channel"},
+                                    "write_date": fields.Datetime.to_string(message.write_date),
+                                },
+                            ),
+                            "mail.message.subtype": [
+                                {
+                                    "description": False,
+                                    "id": self.env.ref("mail.mt_comment").id,
                                 },
                             ],
+                            "mail.thread": self._filter_threads_fields(
+                                {
+                                    "display_name": "Group",
+                                    "id": test_group.id,
+                                    "model": "discuss.channel",
+                                    "rating_avg": 0.0,
+                                    "rating_count": 0,
+                                },
+                            ),
                             "res.partner": self._filter_partners_fields(
                                 {
-                                    "active": True,
-                                    "avatar_128_access_token": self.test_partner._get_avatar_128_access_token(),
-                                    "id": self.test_partner.id,
-                                    "im_status": "offline",
-                                    "im_status_access_token": self.test_partner._get_im_status_access_token(),
+                                    "avatar_128_access_token": self.env.user.partner_id._get_avatar_128_access_token(),
+                                    "id": self.env.user.partner_id.id,
                                     "is_company": False,
-                                    "main_user_id": self.test_user.id,
-                                    "mention_token": self.test_partner._get_mention_token(),
-                                    "name": "Test Partner",
-                                    "write_date": test_partner_write_date,
+                                    "main_user_id": self.env.user.id,
+                                    "name": "Ernest Employee",
+                                    "write_date": emp_partner_write_date,
                                 },
                             ),
                             "res.users": self._filter_users_fields(
                                 {
-                                    "active": True,
-                                    "id": self.test_user.id,
-                                    "partner_id": self.test_partner.id,
+                                    "id": self.env.user.id,
+                                    "partner_id": self.env.user.partner_id.id,
                                     "share": False,
                                 },
                             ),
                         },
+                        "id": test_group.id,
                     },
-                ],
-            )
+                ),
+                BusResult(
+                    test_group,
+                    "mail.record/insert",
+                    {
+                        "discuss.channel": [{"id": test_group.id, "member_count": 2}],
+                        "discuss.channel.member": [
+                            {
+                                "channel_id": test_group.id,
+                                "channel_role": False,
+                                "create_date": fields.Datetime.to_string(member.create_date),
+                                "id": member.id,
+                                "last_seen_dt": False,
+                                "partner_id": self.test_partner.id,
+                                "seen_message_id": False,
+                            },
+                        ],
+                        "res.partner": self._filter_partners_fields(
+                            {
+                                "active": True,
+                                "avatar_128_access_token": self.test_partner._get_avatar_128_access_token(),
+                                "id": self.test_partner.id,
+                                "im_status": "offline",
+                                "im_status_access_token": self.test_partner._get_im_status_access_token(),
+                                "is_company": False,
+                                "main_user_id": self.test_user.id,
+                                "mention_token": self.test_partner._get_mention_token(),
+                                "name": "Test Partner",
+                                "write_date": test_partner_write_date,
+                            },
+                        ),
+                        "res.users": self._filter_users_fields(
+                            {
+                                "active": True,
+                                "id": self.test_user.id,
+                                "partner_id": self.test_partner.id,
+                                "share": False,
+                            },
+                        ),
+                    },
+                ),
+            ]
 
-        with self.assertBus(get_params=get_add_member_bus):
+        with self.assertBus(notifications):
             test_group._add_members(partners=self.test_partner)
 
-        def get_add_member_again_bus():
+        def notifications_again():
             member = self.env["discuss.channel.member"].search([], order="id desc", limit=1)
-            return (
-                [self.env.user],
-                [
+            return [
+                BusResult(
+                    self.env.user,
+                    "mail.record/insert",
                     {
-                        "type": "mail.record/insert",
-                        "payload": {
-                            "discuss.channel": [{"id": test_group.id, "member_count": 2}],
-                            "discuss.channel.member": [
-                                {
-                                    "channel_role": False,
-                                    "create_date": fields.Datetime.to_string(member.create_date),
-                                    "id": member.id,
-                                    "last_seen_dt": False,
-                                    "partner_id": self.test_partner.id,
-                                    "seen_message_id": False,
-                                    "channel_id": test_group.id,
-                                },
-                            ],
-                            "res.partner": self._filter_partners_fields(
-                                {
-                                    "active": True,
-                                    "avatar_128_access_token": self.test_partner._get_avatar_128_access_token(),
-                                    "email": "test_customer@example.com",
-                                    "id": self.test_partner.id,
-                                    "im_status": "offline",
-                                    "im_status_access_token": self.test_partner._get_im_status_access_token(),
-                                    "is_company": False,
-                                    "main_user_id": self.test_user.id,
-                                    "mention_token": self.test_partner._get_mention_token(),
-                                    "name": "Test Partner",
-                                    "tz": False,
-                                    "write_date": test_partner_write_date,
-                                },
-                            ),
-                            "res.users": self._filter_users_fields(
-                                {
-                                    "active": True,
-                                    "id": self.test_user.id,
-                                    "employee_ids": [],
-                                    "partner_id": self.test_partner.id,
-                                    "share": False,
-                                },
-                            ),
-                        },
+                        "discuss.channel": [{"id": test_group.id, "member_count": 2}],
+                        "discuss.channel.member": [
+                            {
+                                "channel_role": False,
+                                "create_date": fields.Datetime.to_string(member.create_date),
+                                "id": member.id,
+                                "last_seen_dt": False,
+                                "partner_id": self.test_partner.id,
+                                "seen_message_id": False,
+                                "channel_id": test_group.id,
+                            },
+                        ],
+                        "res.partner": self._filter_partners_fields(
+                            {
+                                "active": True,
+                                "avatar_128_access_token": self.test_partner._get_avatar_128_access_token(),
+                                "email": "test_customer@example.com",
+                                "id": self.test_partner.id,
+                                "im_status": "offline",
+                                "im_status_access_token": self.test_partner._get_im_status_access_token(),
+                                "is_company": False,
+                                "main_user_id": self.test_user.id,
+                                "mention_token": self.test_partner._get_mention_token(),
+                                "name": "Test Partner",
+                                "tz": False,
+                                "write_date": test_partner_write_date,
+                            },
+                        ),
+                        "res.users": self._filter_users_fields(
+                            {
+                                "active": True,
+                                "id": self.test_user.id,
+                                "employee_ids": [],
+                                "partner_id": self.test_partner.id,
+                                "share": False,
+                            },
+                        ),
                     },
-                ],
-            )
-        with self.assertBus(get_params=get_add_member_again_bus):
+                ),
+            ]
+        with self.assertBus(notifications_again):
             test_group._add_members(partners=self.test_partner)
         self.assertEqual(test_group.message_partner_ids, self.env["res.partner"])
         self.assertEqual(test_group.channel_partner_ids, self.test_partner + self.partner_employee)
@@ -454,31 +448,16 @@ class TestChannelInternals(MailCommon, HttpCase):
         msg_1 = self._add_messages(chat, 'Body1', author=self.user_employee.partner_id)
         member = chat.channel_member_ids.filtered(lambda m: m.partner_id == self.test_user.partner_id)
         member.seen_message_id = read_message
-        self._reset_bus()
 
         def get_mark_as_read_notifs(for_internal_user):
             user_data = {"id": self.test_user.id, "partner_id": self.test_partner.id}
             if for_internal_user:
                 user_data["employee_ids"] = []
             return [
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
-                        "discuss.channel.member": [
-                            {
-                                "channel_id": chat.id,
-                                "id": member.id,
-                                "message_unread_counter": 0,
-                                "message_unread_counter_bus_id": 0,
-                                "new_message_separator": msg_1.id + 1,
-                                "partner_id": self.test_partner.id,
-                            },
-                        ],
-                    },
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                BusResult(
+                    self.test_user if for_internal_user else chat,
+                    "mail.record/insert",
+                    {
                         "discuss.channel.member": [
                             {
                                 "id": member.id,
@@ -501,19 +480,28 @@ class TestChannelInternals(MailCommon, HttpCase):
                         ),
                         "res.users": self._filter_users_fields(user_data),
                     },
-                },
+                ),
+                BusResult(
+                    self.test_user,
+                    "mail.record/insert",
+                    {
+                        "discuss.channel.member": [
+                            {
+                                "channel_id": chat.id,
+                                "id": member.id,
+                                "message_unread_counter": 0,
+                                "message_unread_counter_bus_id": 0,
+                                "new_message_separator": msg_1.id + 1,
+                                "partner_id": self.test_partner.id,
+                            },
+                        ],
+                    },
+                ),
             ]
 
-        with self.assertBus(
-            [chat, self.test_user],
-            get_mark_as_read_notifs(for_internal_user=False),
-        ):
+        with self.assertBus(get_mark_as_read_notifs(for_internal_user=False)):
             member._mark_as_read(msg_1.id)
-        self._reset_bus()
-        with self.assertBus(
-            [self.test_user, self.test_user],
-            get_mark_as_read_notifs(for_internal_user=True),
-        ):
+        with self.assertBus(get_mark_as_read_notifs(for_internal_user=True)):
             member._mark_as_read(msg_1.id)
 
     def test_channel_message_post_should_not_allow_adding_wrong_parent(self):
@@ -662,12 +650,12 @@ class TestChannelInternals(MailCommon, HttpCase):
     def test_channel_write_should_send_notification(self):
         channel = self.env['discuss.channel'].create({"name": "test", "description": "test"})
         with self.assertBus(
-            [channel],
             [
-                {
-                    "type": "mail.record/insert",
-                    "payload": {"discuss.channel": [{"id": channel.id, "name": "test test"}]},
-                },
+                BusResult(
+                    channel,
+                    "mail.record/insert",
+                    {"discuss.channel": [{"id": channel.id, "name": "test test"}]},
+                ),
             ],
         ):
             channel.name = "test test"
@@ -679,18 +667,17 @@ class TestChannelInternals(MailCommon, HttpCase):
         avatar_cache_key = channel.avatar_cache_key
         channel.image_128 = False
         with self.assertBus(
-            [channel],
-            [
+            BusResult(
+                channel,
+                "mail.record/insert",
                 {
-                    "type": "mail.record/insert",
-                    "payload": {
-                        "discuss.channel": [{"avatar_cache_key": avatar_cache_key, "id": channel.id}],
-                    },
+                    "discuss.channel": [{"avatar_cache_key": avatar_cache_key, "id": channel.id}],
                 },
-            ],
+            ),
         ):
             channel.image_128 = BinaryBytes(b"<svg/>")
 
+    @freeze_time("2025-04-08 10:00:00")
     def test_channel_notification(self):
         all_test_user = mail_new_test_user(
             self.env,
@@ -742,8 +729,9 @@ class TestChannelInternals(MailCommon, HttpCase):
         self.assertEqual(len(nothing_notif), 0, "nothing + normal message = no needaction")
 
         all_users = all_test_user + mentions_test_user + nothing_test_user
-        self._reset_bus()
-        with self.assertBusNotificationType([(user, "mail.message/inbox") for user in all_users]):
+        notifications = [BusResult(user, "mail.message/inbox") for user in all_users]
+        notifications.append(BusResult(channel, "discuss.channel/new_message"))
+        with self.assertBus(notifications):
             # sending mention message
             with self.with_user("employee"):
                 channel_msg = channel.message_post(
@@ -865,11 +853,11 @@ class TestChannelInternals(MailCommon, HttpCase):
         channel = self.env["discuss.channel"].browse(self.test_channel.ids)
         channel.name = "<strong>R&D</strong>"
         with self.assertBus(
-            [self.env.user],
             [
-                {
-                    "type": "discuss.channel/transient_message",
-                    "payload": {
+                BusResult(
+                    self.env.user,
+                    "discuss.channel/transient_message",
+                    {
                         "body":
                             "<span class='o_mail_notification'>"
                             "You are in <b>#&lt;strong&gt;R&amp;D&lt;/strong&gt;</b>."
@@ -882,7 +870,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                             "</span>",
                         "channel_id": channel.id,
                     },
-                },
+                ),
             ],
         ):
             channel.execute_command_help()
@@ -902,11 +890,11 @@ class TestChannelInternals(MailCommon, HttpCase):
         })
         test_group._add_members(users=self.user_employee_nomail)
         with self.assertBus(
-            [self.env.user],
             [
-                {
-                    "type": "discuss.channel/transient_message",
-                    "payload": {
+                BusResult(
+                    self.env.user,
+                    "discuss.channel/transient_message",
+                    {
                         "body":
                             "<span class='o_mail_notification'>"
                             "You are in a private conversation with "
@@ -921,7 +909,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                             "</span>",
                         "channel_id": test_group.id,
                     },
-                },
+                ),
             ],
         ):
             test_group.execute_command_help()
@@ -936,11 +924,11 @@ class TestChannelInternals(MailCommon, HttpCase):
             "res_id": channel.id,
         })
         with self.assertBus(
-            [channel],
             [
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                BusResult(
+                    channel,
+                    "mail.record/insert",
+                    {
                         "mail.message": [
                             {
                                 "attachment_ids": [],
@@ -954,7 +942,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                             },
                         ],
                     },
-                },
+                ),
             ],
         ):
             with freeze_time('2025-04-08 10:00:00'):

--- a/addons/mail/tests/discuss/test_discuss_mail_presence.py
+++ b/addons/mail/tests/discuss/test_discuss_mail_presence.py
@@ -11,6 +11,7 @@ from itertools import product
 
 from odoo.tests import new_test_user
 from odoo.addons.bus.tests.common import WebsocketCase
+from odoo.addons.bus.tests.common import BusResult
 from odoo.addons.mail.tests.common import MailCommon, freeze_all_time
 from odoo.addons.bus.models.bus import channel_with_db, json_dump
 
@@ -80,15 +81,13 @@ class TestMailPresence(WebsocketCase, MailCommon):
         bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
         session = self.authenticate(bob.login, bob.login)
         with self.assertBus(
-            [(bob, "presence")],
-            [
+            BusResult(
+                (bob, "presence"),
+                "mail.record/insert",
                 {
-                    "type": "mail.record/insert",
-                    "payload": {
-                        "res.partner": [{"id": bob.partner_id.id, "im_status": "offline"}],
-                    },
+                    "res.partner": [{"id": bob.partner_id.id, "im_status": "offline"}],
                 },
-            ],
+            ),
         ):
             self.make_jsonrpc_request(
                 "/mail/set_manual_im_status",

--- a/addons/mail/tests/discuss/test_guest.py
+++ b/addons/mail/tests/discuss/test_guest.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields
+from odoo.addons.bus.tests.common import BusResult
 from odoo.addons.mail.tests.common import MailCase
 
 
@@ -16,28 +17,53 @@ class TestGuest(MailCase):
         channel_1._add_members(guests=guest)
         channel_2._add_members(guests=guest)
 
-        def get_guest_bus_params():
+        def notifications():
             guest_write_date = fields.Datetime.to_string(guest.write_date)
-            message = {
-                "type": "mail.record/insert",
-                "payload": {
-                    "mail.guest": [
-                        {
-                            "avatar_128_access_token": guest._get_avatar_128_access_token(),
-                            "id": guest.id,
-                            "name": "Guest Name Updated",
-                            "write_date": guest_write_date,
-                        },
-                    ],
-                },
-            }
+            return [
+                BusResult(
+                    channel_1,
+                    "mail.record/insert",
+                    {
+                        "mail.guest": [
+                            {
+                                "avatar_128_access_token": guest._get_avatar_128_access_token(),
+                                "id": guest.id,
+                                "name": "Guest Name Updated",
+                                "write_date": guest_write_date,
+                            },
+                        ],
+                    },
+                ),
+                BusResult(
+                    channel_2,
+                    "mail.record/insert",
+                    {
+                        "mail.guest": [
+                            {
+                                "avatar_128_access_token": guest._get_avatar_128_access_token(),
+                                "id": guest.id,
+                                "name": "Guest Name Updated",
+                                "write_date": guest_write_date,
+                            },
+                        ],
+                    },
+                ),
+                BusResult(
+                    guest,
+                    "mail.record/insert",
+                    {
+                        "mail.guest": [
+                            {
+                                "avatar_128_access_token": guest._get_avatar_128_access_token(),
+                                "id": guest.id,
+                                "name": "Guest Name Updated",
+                                "write_date": guest_write_date,
+                            },
+                        ],
+                    },
+                ),
+            ]
 
-            return (
-                [channel_1, channel_2, guest],
-                [message, message, message],
-            )
-
-        self._reset_bus()
-        with self.assertBus(get_params=get_guest_bus_params):
+        with self.assertBus(notifications):
             guest._update_name("Guest Name Updated")
         self.assertEqual(guest.name, "Guest Name Updated")

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -5,6 +5,7 @@ from freezegun import freeze_time
 from unittest.mock import patch
 
 from odoo import fields
+from odoo.addons.bus.tests.common import BusResult
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.addons.mail.tools.discuss import Store
 from odoo.tests.common import HttpCase, new_test_user, tagged, users
@@ -39,32 +40,32 @@ class TestChannelRTC(MailCommon, HttpCase):
             "id": channel_member.id,
             "partner_id": channel_member.partner_id.id,
         }
-        with self.assertBus(
-            [
-                # end of old sessions
-                self.user_employee,
-                # delete of old sessions, update history with duration of previous session
-                channel,
-                # new_message_separator (message post)
-                self.user_employee,
-                # start call notification (message post) (not asserted below)
-                channel,
-                # insert new session, new call history
-                channel,
-            ],
-            [
-                {
-                    "type": "discuss.channel.rtc.session/ended",
-                    "payload": {"sessionId": last_rtc_session_id},
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+
+        def notifications():
+            message = self.env["mail.message"].search(
+                [
+                    ("model", "=", "discuss.channel"),
+                    ("res_id", "=", channel.id),
+                    ("message_type", "=", "notification"),
+                ],
+                order="id desc",
+                limit=1,
+            )
+            return [
+                BusResult(
+                    self.user_employee,
+                    "discuss.channel.rtc.session/ended",
+                    {"sessionId": last_rtc_session_id},
+                ),
+                BusResult(
+                    channel,
+                    "mail.record/insert",
+                    {
                         "discuss.call.history": [
                             {
                                 "duration_hour": 0.0,
                                 "end_dt": "2023-03-15 12:34:56",
-                                "id": channel.call_history_ids.id,
+                                "id": channel.call_history_ids.filtered("end_dt").sorted("id")[-1].id,
                             },
                         ],
                         "discuss.channel": [
@@ -74,10 +75,24 @@ class TestChannelRTC(MailCommon, HttpCase):
                             },
                         ],
                     },
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                ),
+                BusResult(
+                    self.user_employee,
+                    "mail.record/insert",
+                    {
+                        "discuss.channel.member": [
+                            {
+                                **member_data,
+                                "new_message_separator": channel_member.new_message_separator,
+                            },
+                        ],
+                    },
+                ),
+                BusResult(channel, "discuss.channel/new_message"),
+                BusResult(
+                    channel,
+                    "mail.record/insert",
+                    {
                         "discuss.channel": [
                             {
                                 "id": channel.id,
@@ -90,8 +105,8 @@ class TestChannelRTC(MailCommon, HttpCase):
                         ],
                         "mail.message": [
                             {
-                                "call_history_ids": [channel.call_history_ids.id + 1],
-                                "id": channel_member.new_message_separator,
+                                "call_history_ids": [message.call_history_ids.id],
+                                "id": message.id,
                             },
                         ],
                         "res.partner": self._filter_partners_fields(partner_data),
@@ -103,20 +118,10 @@ class TestChannelRTC(MailCommon, HttpCase):
                             },
                         ),
                     },
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
-                        "discuss.channel.member": [
-                            {
-                                **member_data,
-                                "new_message_separator": channel_member.new_message_separator + 1,
-                            },
-                        ],
-                    },
-                },
-            ],
-        ):
+                ),
+            ]
+
+        with self.assertBus(notifications):
             store = Store()
             channel_member._rtc_join_call(store)
             res = store.get_result()
@@ -162,23 +167,38 @@ class TestChannelRTC(MailCommon, HttpCase):
         channel_member._rtc_join_call()
         last_rtc_session_id = channel_member.rtc_session_ids.id
         channel_member._rtc_leave_call()
-        with self.assertBus(
-            [
-                # update new message separator (message_post) (not asserted below)
-                self.user_employee,
-                # message_post "started a live conference" (not asserted below)
-                channel,
-                # update new session, update call history
-                channel,
-                # incoming invitation
-                test_user,
-                # update list of invitations (not asserted below)
-                channel,
-            ],
-            [
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+
+        def notifications():
+            message = self.env["mail.message"].search(
+                [
+                    ("model", "=", "discuss.channel"),
+                    ("res_id", "=", channel.id),
+                    ("message_type", "=", "notification"),
+                ],
+                order="id desc",
+                limit=1,
+            )
+            return [
+                BusResult(
+                    # update new message separator (message_post)
+                    self.user_employee,
+                    "mail.record/insert",
+                    {
+                        "discuss.channel.member": [
+                            {
+                                "channel_id": channel.id,
+                                "id": channel_member.id,
+                                "new_message_separator": channel_member.new_message_separator,
+                                "partner_id": channel_member.partner_id.id,
+                            },
+                        ],
+                    },
+                ),
+                BusResult(channel, "discuss.channel/new_message"),
+                BusResult(
+                    channel,
+                    "mail.record/insert",
+                    {
                         "discuss.channel": [
                             {
                                 "id": channel.id,
@@ -200,8 +220,8 @@ class TestChannelRTC(MailCommon, HttpCase):
                         ],
                         "mail.message": [
                             {
-                                "call_history_ids": [channel.call_history_ids.id + 1],
-                                "id": channel_member.new_message_separator,
+                                "call_history_ids": [message.call_history_ids.id],
+                                "id": message.id,
                             },
                         ],
                         "res.partner": self._filter_partners_fields(
@@ -225,10 +245,62 @@ class TestChannelRTC(MailCommon, HttpCase):
                             },
                         ),
                     },
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                ),
+                BusResult(
+                    # incoming invitation
+                    test_user,
+                    "mail.record/insert",
+                    {
+                        "discuss.channel.member": [
+                            {
+                                "channel_id": channel.id,
+                                "id": channel_member_test_user.id,
+                                "partner_id": channel_member_test_user.partner_id.id,
+                                "rtc_inviting_session_id": last_rtc_session_id + 1,
+                            },
+                            {
+                                "channel_id": channel.id,
+                                "id": channel_member.id,
+                                "partner_id": channel_member.partner_id.id,
+                            },
+                        ],
+                        "discuss.channel.rtc.session": [
+                            {
+                                "channel_member_id": channel_member.id,
+                                "id": last_rtc_session_id + 1,
+                                "is_camera_on": False,
+                                "is_deaf": False,
+                                "is_muted": False,
+                                "is_screen_sharing_on": False,
+                            },
+                        ],
+                        "res.partner": self._filter_partners_fields(
+                            {
+                                "avatar_128_access_token": channel_member.partner_id._get_avatar_128_access_token(),
+                                "id": channel_member.partner_id.id,
+                                "im_status": channel_member.partner_id.im_status,
+                                "im_status_access_token": channel_member.partner_id._get_im_status_access_token(),
+                                "main_user_id": self.user_employee.id,
+                                "mention_token": channel_member.partner_id._get_mention_token(),
+                                "name": channel_member.partner_id.name,
+                                "write_date": fields.Datetime.to_string(
+                                    channel_member.partner_id.write_date
+                                ),
+                            },
+                        ),
+                        "res.users": self._filter_users_fields(
+                            {
+                                "employee_ids": [],
+                                "id": self.user_employee.id,
+                                "partner_id": self.user_employee.partner_id.id,
+                            },
+                        ),
+                    },
+                ),
+                BusResult(
+                    channel,
+                    "mail.record/insert",
+                    {
                         "discuss.channel": [
                             {
                                 "id": channel.id,
@@ -263,9 +335,10 @@ class TestChannelRTC(MailCommon, HttpCase):
                             },
                         ),
                     },
-                },
-            ],
-        ):
+                ),
+            ]
+
+        with self.assertBus(notifications):
             now = fields.Datetime.now()
             with patch.object(fields.Datetime, 'now', lambda: now + relativedelta(seconds=5)):
                 channel_member._rtc_join_call()
@@ -285,25 +358,37 @@ class TestChannelRTC(MailCommon, HttpCase):
         last_rtc_session_id = channel_member.rtc_session_ids.id
         channel_member._rtc_leave_call()
 
-        with self.assertBus(
-            [
-                # update new message separator (not asserted below)
-                self.user_employee,
-                # message_post "started a live conference" (not asserted below)
-                channel,
-                # update new session, update call history
-                channel,
-                # incoming invitation
-                test_user,
-                # incoming invitation
-                test_guest,
-                # update list of invitations
-                channel,
-            ],
-            [
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+        def notifications():
+            message = self.env["mail.message"].search(
+                [
+                    ("model", "=", "discuss.channel"),
+                    ("res_id", "=", channel.id),
+                    ("message_type", "=", "notification"),
+                ],
+                order="id desc",
+                limit=1,
+            )
+            return [
+                BusResult(
+                    self.user_employee,
+                    # Update of the author's member record after posting the call message.
+                    "mail.record/insert",
+                    {
+                        "discuss.channel.member": [
+                            {
+                                "channel_id": channel.id,
+                                "id": channel_member.id,
+                                "new_message_separator": channel_member.new_message_separator,
+                                "partner_id": channel_member.partner_id.id,
+                            },
+                        ],
+                    },
+                ),
+                BusResult(channel, "discuss.channel/new_message"),
+                BusResult(
+                    channel,
+                    "mail.record/insert",
+                    {
                         "discuss.channel": [
                             {
                                 "id": channel.id,
@@ -325,8 +410,8 @@ class TestChannelRTC(MailCommon, HttpCase):
                         ],
                         "mail.message": [
                             {
-                                "call_history_ids": [channel.call_history_ids.id + 1],
-                                "id": channel_member.new_message_separator,
+                                "call_history_ids": [message.call_history_ids.id],
+                                "id": message.id,
                             },
                         ],
                         "res.partner": self._filter_partners_fields(
@@ -350,17 +435,19 @@ class TestChannelRTC(MailCommon, HttpCase):
                             },
                         ),
                     },
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
-                        "discuss.channel": [
-                            {
-                                "id": channel.id,
-                                "rtc_session_ids": [("ADD", [last_rtc_session_id + 1])],
-                            },
-                        ],
+                ),
+                BusResult(
+                    # incoming invitation
+                    test_user,
+                    "mail.record/insert",
+                    {
                         "discuss.channel.member": [
+                            {
+                                "channel_id": channel.id,
+                                "id": channel_member_test_user.id,
+                                "partner_id": channel_member_test_user.partner_id.id,
+                                "rtc_inviting_session_id": last_rtc_session_id + 1,
+                            },
                             {
                                 "channel_id": channel.id,
                                 "id": channel_member.id,
@@ -371,12 +458,61 @@ class TestChannelRTC(MailCommon, HttpCase):
                             {
                                 "channel_member_id": channel_member.id,
                                 "id": last_rtc_session_id + 1,
+                                "is_camera_on": False,
+                                "is_deaf": False,
+                                "is_muted": False,
+                                "is_screen_sharing_on": False,
                             },
                         ],
-                        "mail.message": [
+                        "res.partner": self._filter_partners_fields(
                             {
-                                "call_history_ids": [channel.call_history_ids.id + 1],
-                                "id": channel_member.new_message_separator,
+                                "avatar_128_access_token": channel_member.partner_id._get_avatar_128_access_token(),
+                                "id": channel_member.partner_id.id,
+                                "im_status": channel_member.partner_id.im_status,
+                                "im_status_access_token": channel_member.partner_id._get_im_status_access_token(),
+                                "main_user_id": self.user_employee.id,
+                                "mention_token": channel_member.partner_id._get_mention_token(),
+                                "name": channel_member.partner_id.name,
+                                "write_date": fields.Datetime.to_string(
+                                    channel_member.partner_id.write_date
+                                ),
+                            },
+                        ),
+                        "res.users": self._filter_users_fields(
+                            {
+                                "employee_ids": [],
+                                "id": self.user_employee.id,
+                                "partner_id": self.user_employee.partner_id.id,
+                            },
+                        ),
+                    },
+                ),
+                BusResult(
+                    # incoming invitation
+                    test_guest,
+                    "mail.record/insert",
+                    {
+                        "discuss.channel.member": [
+                            {
+                                "channel_id": channel.id,
+                                "guest_id": channel_member_test_guest.guest_id.id,
+                                "id": channel_member_test_guest.id,
+                                "rtc_inviting_session_id": last_rtc_session_id + 1,
+                            },
+                            {
+                                "channel_id": channel.id,
+                                "id": channel_member.id,
+                                "partner_id": channel_member.partner_id.id,
+                            },
+                        ],
+                        "discuss.channel.rtc.session": [
+                            {
+                                "channel_member_id": channel_member.id,
+                                "id": last_rtc_session_id + 1,
+                                "is_camera_on": False,
+                                "is_deaf": False,
+                                "is_muted": False,
+                                "is_screen_sharing_on": False,
                             },
                         ],
                         "res.partner": self._filter_partners_fields(
@@ -396,14 +532,15 @@ class TestChannelRTC(MailCommon, HttpCase):
                         "res.users": self._filter_users_fields(
                             {
                                 "id": self.user_employee.id,
-                                "partner_id": self.partner_employee.id,
+                                "partner_id": self.user_employee.partner_id.id,
                             },
                         ),
                     },
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                ),
+                BusResult(
+                    channel,
+                    "mail.record/insert",
+                    {
                         "discuss.channel": [
                             {
                                 "id": channel.id,
@@ -460,9 +597,10 @@ class TestChannelRTC(MailCommon, HttpCase):
                             },
                         ),
                     },
-                },
-            ],
-        ):
+                ),
+            ]
+
+        with self.assertBus(notifications):
             now = fields.Datetime.now()
             with patch.object(fields.Datetime, 'now', lambda: now + relativedelta(seconds=5)):
                 channel_member._rtc_join_call()
@@ -481,14 +619,10 @@ class TestChannelRTC(MailCommon, HttpCase):
         last_rtc_session_id = channel_member.rtc_session_ids.id
         with self.assertBus(
             [
-                test_user,  # update invitation
-                channel,  # update list of invitations
-                channel,  # update sessions
-            ],
-            [
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                BusResult(
+                    test_user,
+                    "mail.record/insert",
+                    {
                         "discuss.channel.member": [
                             {
                                 "channel_id": channel.id,
@@ -498,10 +632,11 @@ class TestChannelRTC(MailCommon, HttpCase):
                             },
                         ],
                     },
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                ),
+                BusResult(
+                    channel,
+                    "mail.record/insert",
+                    {
                         "discuss.channel": [
                             {
                                 "id": channel.id,
@@ -536,10 +671,11 @@ class TestChannelRTC(MailCommon, HttpCase):
                             },
                         ),
                     },
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                ),
+                BusResult(
+                    channel,
+                    "mail.record/insert",
+                    {
                         "discuss.channel": [
                             {
                                 "id": channel.id,
@@ -580,7 +716,7 @@ class TestChannelRTC(MailCommon, HttpCase):
                             },
                         ),
                     },
-                },
+                ),
             ],
         ):
             channel_member_test_user._rtc_join_call()
@@ -588,14 +724,10 @@ class TestChannelRTC(MailCommon, HttpCase):
         channel_member_test_guest = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.guest_id == test_guest)
         with self.assertBus(
             [
-                test_guest,  # update invitation
-                channel,  # update list of invitations
-                channel,  # update sessions
-            ],
-            [
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                BusResult(
+                    test_guest,
+                    "mail.record/insert",
+                    {
                         "discuss.channel.member": [
                             {
                                 "channel_id": channel.id,
@@ -605,10 +737,11 @@ class TestChannelRTC(MailCommon, HttpCase):
                             },
                         ],
                     },
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                ),
+                BusResult(
+                    channel,
+                    "mail.record/insert",
+                    {
                         "discuss.channel": [
                             {
                                 "id": channel.id,
@@ -635,10 +768,11 @@ class TestChannelRTC(MailCommon, HttpCase):
                             },
                         ],
                     },
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                ),
+                BusResult(
+                    channel,
+                    "mail.record/insert",
+                    {
                         "discuss.channel": [
                             {
                                 "id": channel.id,
@@ -671,7 +805,7 @@ class TestChannelRTC(MailCommon, HttpCase):
                             },
                         ],
                     },
-                },
+                ),
             ],
         ):
             channel_member_test_guest._rtc_join_call()
@@ -690,13 +824,10 @@ class TestChannelRTC(MailCommon, HttpCase):
         channel_member_test_user = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == test_user.partner_id)
         with self.assertBus(
             [
-                test_user,  # update invitation
-                channel,  # update list of invitations
-            ],
-            [
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                BusResult(
+                    test_user,
+                    "mail.record/insert",
+                    {
                         "discuss.channel.member": [
                             {
                                 "channel_id": channel.id,
@@ -706,10 +837,11 @@ class TestChannelRTC(MailCommon, HttpCase):
                             },
                         ],
                     },
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                ),
+                BusResult(
+                    channel,
+                    "mail.record/insert",
+                    {
                         "discuss.channel": [
                             {
                                 "id": channel.id,
@@ -744,7 +876,7 @@ class TestChannelRTC(MailCommon, HttpCase):
                             },
                         ),
                     },
-                },
+                ),
             ],
         ):
             channel_member_test_user._rtc_leave_call()
@@ -752,13 +884,10 @@ class TestChannelRTC(MailCommon, HttpCase):
         channel_member_test_guest = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.guest_id == test_guest)
         with self.assertBus(
             [
-                test_guest,  # update invitation
-                channel,  # update list of invitations
-            ],
-            [
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                BusResult(
+                    test_guest,
+                    "mail.record/insert",
+                    {
                         "discuss.channel.member": [
                             {
                                 "channel_id": channel.id,
@@ -768,10 +897,11 @@ class TestChannelRTC(MailCommon, HttpCase):
                             },
                         ],
                     },
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                ),
+                BusResult(
+                    channel,
+                    "mail.record/insert",
+                    {
                         "discuss.channel": [
                             {
                                 "id": channel.id,
@@ -798,7 +928,7 @@ class TestChannelRTC(MailCommon, HttpCase):
                             },
                         ],
                     },
-                },
+                ),
             ],
         ):
             channel_member_test_guest._rtc_leave_call()
@@ -819,20 +949,10 @@ class TestChannelRTC(MailCommon, HttpCase):
         last_rtc_session_id = channel_member.rtc_session_ids.id
         with self.assertBus(
             [
-                test_user,  # update invitation
-                test_guest,  # update invitation
-                channel,  # update list of invitations
-                self.user_employee,  # end session
-                channel,  # update sessions, update call history
-            ],
-            [
-                {
-                    "type": "discuss.channel.rtc.session/ended",
-                    "payload": {"sessionId": last_rtc_session_id},
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                BusResult(
+                    test_user,
+                    "mail.record/insert",
+                    {
                         "discuss.channel.member": [
                             {
                                 "channel_id": channel.id,
@@ -842,10 +962,11 @@ class TestChannelRTC(MailCommon, HttpCase):
                             },
                         ],
                     },
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                ),
+                BusResult(
+                    test_guest,
+                    "mail.record/insert",
+                    {
                         "discuss.channel.member": [
                             {
                                 "channel_id": channel.id,
@@ -855,10 +976,11 @@ class TestChannelRTC(MailCommon, HttpCase):
                             },
                         ],
                     },
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                ),
+                BusResult(
+                    channel,
+                    "mail.record/insert",
+                    {
                         "discuss.channel": [
                             {
                                 "id": channel.id,
@@ -915,10 +1037,16 @@ class TestChannelRTC(MailCommon, HttpCase):
                             },
                         ),
                     },
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                ),
+                BusResult(
+                    self.user_employee,
+                    "discuss.channel.rtc.session/ended",
+                    {"sessionId": last_rtc_session_id},
+                ),
+                BusResult(
+                    channel,
+                    "mail.record/insert",
+                    {
                         "discuss.call.history": [
                             {
                                 "duration_hour": 0.0,
@@ -933,7 +1061,7 @@ class TestChannelRTC(MailCommon, HttpCase):
                             },
                         ],
                     },
-                },
+                ),
             ],
         ):
             channel_member._rtc_leave_call()
@@ -949,44 +1077,24 @@ class TestChannelRTC(MailCommon, HttpCase):
         now = fields.Datetime.now()
         with patch.object(fields.Datetime, 'now', lambda: now + relativedelta(seconds=5)):
             channel_member._rtc_join_call()
-        self._reset_bus()
 
-        with self.mock_bus():
-            with patch.object(fields.Datetime, 'now', lambda: now + relativedelta(seconds=10)):
-                channel._add_members(users=test_user, guests=test_guest, invite_to_rtc_call=True)
-
-        channel_member_test_user = channel.sudo().channel_member_ids.filtered(lambda member: member.partner_id == test_user.partner_id)
-        channel_member_test_guest = channel.sudo().channel_member_ids.filtered(lambda member: member.guest_id == test_guest)
-        last_rtc_session_id = channel_member.rtc_session_ids.id
-        found_bus_notifs = self.assertBusNotifications(
-            [
-                # mail.record/insert - discuss.channel (channel_name_member_ids)
-                channel,
-                # discuss.channel/joined
-                test_user,
-                # mail.record/insert - discuss.channel.member (message_unread_counter, new_message_separator, …)
-                self.user_employee,
-                # discuss.channel/new_message
-                channel,
-                # discuss.channel/joined
-                test_guest,
-                # mail.record/insert - discuss.channel.member (message_unread_counter, new_message_separator, …)
-                self.user_employee,
-                # discuss.channel/new_message
-                channel,
-                # mail.record/insert - discuss.channel (member_count), discuss.channel.member
-                channel,
-                # mail.record/insert - discuss.channel.member (rtc_inviting_session_id)
-                test_user,
-                # mail.record/insert - discuss.channel.member (rtc_inviting_session_id)
-                test_guest,
-                # mail.record/insert - discuss.channel (invited_member_ids), discuss.channel.member
-                channel,
-            ],
-            message_items=[
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+        def notifications():
+            channel_member_test_user = channel.sudo().channel_member_ids.filtered(lambda member: member.partner_id == test_user.partner_id)
+            channel_member_test_guest = channel.sudo().channel_member_ids.filtered(lambda member: member.guest_id == test_guest)
+            last_rtc_session_id = channel_member.rtc_session_ids.id
+            return [
+                BusResult(channel, "mail.record/insert"),  # discuss.channel (channel_name_member_ids)
+                BusResult(test_user, "discuss.channel/joined"),
+                BusResult(self.user_employee, "mail.record/insert"),  # discuss.channel.member (message_unread_counter, new_message_separator, …)
+                BusResult(channel, "discuss.channel/new_message"),
+                BusResult(test_guest, "discuss.channel/joined"),
+                BusResult(self.user_employee, "mail.record/insert"),  # discuss.channel.member (message_unread_counter, new_message_separator, …)
+                BusResult(channel, "discuss.channel/new_message"),
+                BusResult(channel, "mail.record/insert"),  # discuss.channel (member_count), discuss.channel.member
+                BusResult(
+                    test_user,
+                    "mail.record/insert",
+                    {
                         "discuss.channel.member": [
                             {
                                 "channel_id": channel.id,
@@ -1032,10 +1140,11 @@ class TestChannelRTC(MailCommon, HttpCase):
                             },
                         ),
                     },
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                ),
+                BusResult(
+                    test_guest,
+                    "mail.record/insert",
+                    {
                         "discuss.channel.member": [
                             {
                                 "channel_id": channel.id,
@@ -1080,10 +1189,11 @@ class TestChannelRTC(MailCommon, HttpCase):
                             },
                         ),
                     },
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                ),
+                BusResult(
+                    channel,
+                    "mail.record/insert",
+                    {
                         "discuss.channel": [
                             {
                                 "id": channel.id,
@@ -1140,10 +1250,12 @@ class TestChannelRTC(MailCommon, HttpCase):
                             },
                         ),
                     },
-                },
-            ],
-        )
-        self.assertEqual(self._new_bus_notifs, found_bus_notifs)
+                ),
+            ]
+
+        with self.assertBus(notifications):
+            with patch.object(fields.Datetime, 'now', lambda: now + relativedelta(seconds=10)):
+                channel._add_members(users=test_user, guests=test_guest, invite_to_rtc_call=True)
 
     @users('employee')
     @mute_logger('odoo.models.unlink')
@@ -1156,17 +1268,15 @@ class TestChannelRTC(MailCommon, HttpCase):
         last_rtc_session_id = channel_member.rtc_session_ids.id
         with self.assertBus(
             [
-                self.user_employee,  # end session
-                channel,  # update list of sessions, update call history
-            ],
-            [
-                {
-                    "type": "discuss.channel.rtc.session/ended",
-                    "payload": {"sessionId": last_rtc_session_id},
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                BusResult(
+                    self.user_employee,
+                    "discuss.channel.rtc.session/ended",
+                    {"sessionId": last_rtc_session_id},
+                ),
+                BusResult(
+                    channel,
+                    "mail.record/insert",
+                    {
                         "discuss.call.history": [
                             {
                                 "duration_hour": 1.0,
@@ -1181,7 +1291,7 @@ class TestChannelRTC(MailCommon, HttpCase):
                             },
                         ],
                     },
-                },
+                ),
             ],
         ):
             now = fields.Datetime.now()
@@ -1201,17 +1311,15 @@ class TestChannelRTC(MailCommon, HttpCase):
         last_rtc_session_id = channel_member.rtc_session_ids.id
         with self.assertBus(
             [
-                self.user_employee,  # session ended
-                channel,  # update list of sessions, update call history duration
-            ],
-            [
-                {
-                    "type": "discuss.channel.rtc.session/ended",
-                    "payload": {"sessionId": last_rtc_session_id},
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                BusResult(
+                    self.user_employee,
+                    "discuss.channel.rtc.session/ended",
+                    {"sessionId": last_rtc_session_id},
+                ),
+                BusResult(
+                    channel,
+                    "mail.record/insert",
+                    {
                         "discuss.call.history": [
                             {
                                 "duration_hour": 0.0,
@@ -1226,7 +1334,7 @@ class TestChannelRTC(MailCommon, HttpCase):
                             },
                         ],
                     },
-                },
+                ),
             ],
         ):
             self.env['discuss.channel.rtc.session'].sudo()._gc_inactive_sessions()
@@ -1242,17 +1350,15 @@ class TestChannelRTC(MailCommon, HttpCase):
         last_rtc_session_id = channel_member.rtc_session_ids.id
         with self.assertBus(
             [
-                self.user_employee,  # session ended
-                channel,  # update list of sessions, update call history duration
-            ],
-            [
-                {
-                    "type": "discuss.channel.rtc.session/ended",
-                    "payload": {"sessionId": last_rtc_session_id},
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                BusResult(
+                    self.user_employee,
+                    "discuss.channel.rtc.session/ended",
+                    {"sessionId": last_rtc_session_id},
+                ),
+                BusResult(
+                    channel,
+                    "mail.record/insert",
+                    {
                         "discuss.call.history": [
                             {
                                 "duration_hour": 0.0,
@@ -1267,7 +1373,7 @@ class TestChannelRTC(MailCommon, HttpCase):
                             },
                         ],
                     },
-                },
+                ),
             ],
         ):
             channel_member.rtc_session_ids.action_disconnect()
@@ -1292,22 +1398,20 @@ class TestChannelRTC(MailCommon, HttpCase):
         unused_ids = [9998, 9999]
         with self.assertBus(
             [
-                test_guest,  # session ended
-                channel,  # update list of sessions
-            ],
-            [
-                {
-                    "type": "discuss.channel.rtc.session/ended",
-                    "payload": {"sessionId": test_session.id},
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                BusResult(
+                    test_guest,
+                    "discuss.channel.rtc.session/ended",
+                    {"sessionId": test_session.id},
+                ),
+                BusResult(
+                    channel,
+                    "mail.record/insert",
+                    {
                         "discuss.channel": [
                             {"id": channel.id, "rtc_session_ids": [("DELETE", [test_session.id])]},
                         ],
                     },
-                },
+                ),
             ],
         ):
             current_rtc_sessions, outdated_rtc_sessions = channel_member._rtc_sync_sessions(

--- a/addons/mail/tests/discuss/test_store_versioning.py
+++ b/addons/mail/tests/discuss/test_store_versioning.py
@@ -7,6 +7,7 @@ from odoo.http import Controller
 from odoo.tests import new_test_user
 
 from odoo.addons.base.tests.common import HttpCase, TransactionCase
+from odoo.addons.bus.tests.common import BusResult
 from odoo.addons.mail.models.discuss.discuss_channel import DiscussChannel
 from odoo.addons.mail.tests.common import MailCase
 from odoo.addons.mail.tools.discuss import Store, mail_route, store_version
@@ -144,28 +145,29 @@ class TestStoreVersioning(HttpCase, MailCase):
             "current_xact_id": current_xact_id,
         }
         with self.assertBus(
-            [bob, general],
             [
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                BusResult(
+                    bob,
+                    "mail.record/insert",
+                    {
                         "res.users": [{"id": bob.id, "name": "bob (base.group_user)"}],
                         "__store_version__": {
                             "snapshot": expected_snapshot,
                             "written_fields_by_record": {},
                         },
                     },
-                },
-                {
-                    "type": "mail.record/insert",
-                    "payload": {
+                ),
+                BusResult(
+                    general,
+                    "mail.record/insert",
+                    {
                         "discuss.channel": [{"id": general.id, "name": "general"}],
                         "__store_version__": {
                             "snapshot": expected_snapshot,
                             "written_fields_by_record": {},
                         },
                     },
-                },
+                ),
             ],
             show_store_versioning=True,
         ):

--- a/addons/mail/tests/test_link_preview.py
+++ b/addons/mail/tests/test_link_preview.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import io
 import requests
 
+from odoo.addons.bus.tests.common import BusResult
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.addons.mail.tools import link_preview
 from odoo.tests.common import tagged
@@ -142,45 +143,43 @@ class TestLinkPreview(MailCommon):
                 body=Markup(f'<a href={self.source_url}>Nothing link</a>'),
             )
 
-            def get_bus_params():
-                return (
-                    [self.env.user],
-                    [
+            def notifications():
+                return [
+                    BusResult(
+                        self.env.user,
+                        "mail.record/insert",
                         {
-                            "type": "mail.record/insert",
-                            "payload": {
-                                "mail.link.preview": [
-                                    {
-                                        "id": message.message_link_preview_ids.link_preview_id.id,
-                                        "image_mimetype": False,
-                                        "og_description": self.og_description,
-                                        "og_image": self.og_image,
-                                        "og_mimetype": False,
-                                        "og_site_name": False,
-                                        "og_title": self.og_title,
-                                        "og_type": False,
-                                        "source_url": self.source_url,
-                                    },
-                                ],
-                                "mail.message": self._filter_messages_fields(
-                                    {
-                                        "id": message.id,
-                                        "message_link_preview_ids": message.message_link_preview_ids.ids,
-                                    },
-                                ),
-                                "mail.message.link.preview": [
-                                    {
-                                        "id": message.message_link_preview_ids.id,
-                                        "link_preview_id": message.message_link_preview_ids.link_preview_id.id,
-                                        "message_id": message.id,
-                                    }
-                                ],
-                            },
-                        }
-                    ],
-                )
+                            "mail.link.preview": [
+                                {
+                                    "id": message.message_link_preview_ids.link_preview_id.id,
+                                    "image_mimetype": False,
+                                    "og_description": self.og_description,
+                                    "og_image": self.og_image,
+                                    "og_mimetype": False,
+                                    "og_site_name": False,
+                                    "og_title": self.og_title,
+                                    "og_type": False,
+                                    "source_url": self.source_url,
+                                },
+                            ],
+                            "mail.message": self._filter_messages_fields(
+                                {
+                                    "id": message.id,
+                                    "message_link_preview_ids": message.message_link_preview_ids.ids,
+                                },
+                            ),
+                            "mail.message.link.preview": [
+                                {
+                                    "id": message.message_link_preview_ids.id,
+                                    "link_preview_id": message.message_link_preview_ids.link_preview_id.id,
+                                    "message_id": message.id,
+                                }
+                            ],
+                        },
+                    )
+                ]
 
-            with self.assertBus(get_params=get_bus_params):
+            with self.assertBus(notifications):
                 self.env["mail.link.preview"]._create_from_message_and_notify(message)
 
     def test_link_preview_no_content_type(self):

--- a/addons/mail/tests/test_mail_message.py
+++ b/addons/mail/tests/test_mail_message.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.addons.bus.tests.common import BusResult
 from odoo.addons.mail.tests import common
 from odoo.tests import HttpCase, new_test_user, tagged, users
 
@@ -57,10 +58,9 @@ class TestMailMessage(common.MailCommon, HttpCase):
         self.assertEqual(message.notification_ids.res_partner_id, recipient.partner_id)
         self.assertEqual(message.notification_ids.author_id, self.env.user.partner_id)
         with self.assertBus(
-            [recipient, self.env.user],
             [
-                {"type": "mail.message/delete", "payload": {"message_ids": [message.id]}},
-                {"type": "mail.message/delete", "payload": {"message_ids": [message.id]}},
+                BusResult(recipient, "mail.message/delete", {"message_ids": [message.id]}),
+                BusResult(self.env.user, "mail.message/delete", {"message_ids": [message.id]}),
             ],
         ):
             message.unlink()

--- a/addons/mail/tests/test_res_users.py
+++ b/addons/mail/tests/test_res_users.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 from odoo.addons.base.models.res_users import ResUsersPatchedInTest
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
+from odoo.addons.bus.tests.common import BusResult
 from odoo.addons.mail.tests.common import MailCommon, mail_new_test_user
 from odoo.tests import RecordCapturer, tagged, users
 from odoo.tools import mute_logger
@@ -249,15 +250,16 @@ class TestUserSettings(MailCommon):
         settings.channel_notifications = False
 
         with self.assertBus(
-                [self.user_employee],
-                [{
-                    'type': 'res.users.settings',
-                    'payload': {
-                        'id': settings.id,
-                        'channel_notifications': "no_notif",
-                    },
-                }]):
-            settings.set_res_users_settings({'channel_notifications': "no_notif"})
+            BusResult(
+                self.user_employee,
+                "res.users.settings",
+                {
+                    "id": settings.id,
+                    "channel_notifications": "no_notif",
+                },
+            ),
+        ):
+            settings.set_res_users_settings({"channel_notifications": "no_notif"})
 
     @users('employee')
     def test_set_res_users_settings_should_set_settings_properly(self):

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -10,6 +10,7 @@ from dateutil.relativedelta import relativedelta
 from psycopg2 import IntegrityError
 
 from odoo import fields, exceptions, tests
+from odoo.addons.bus.tests.common import BusResult
 from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.mail.tests.common_activity import ActivityScheduleCase
 from odoo.addons.test_mail.models.test_mail_models import MailTestActivity
@@ -690,100 +691,43 @@ class TestActivitySystrayBusNotify(TestActivityCommon):
     @users('employee')
     def test_notify_create_unlink_activities(self):
         """Check creating and unlinking activities notifies of the change in 'to be done' activity count per user."""
-        users = self.env.user + self.user_employee_2
-
-        expected_create_notifs = [
-            ([user], [{
-                "type": "mail.activity/updated",
-                "payload": {
-                    "activity_created": True,
-                    "count_diff": 2,
-                },
-            }])
-            for user in users
-        ]
-        expected_unlink_notifs = [
-            ([user], [{
-                "type": "mail.activity/updated",
-                "payload": {
-                    "activity_deleted": True,
-                    "count_diff": -2,
-                },
-            }])
-            for user in users
-        ]
-        for (
-            user,
-            (expected_create_notif_channels, expected_create_notif_message_items),
-            (expected_unlink_notif_channels, expected_unlink_notif_message_items),
-        ) in zip(users, expected_create_notifs, expected_unlink_notifs):
+        for user in self.env.user + self.user_employee_2:
             user_activity_vals = [vals | {'user_id': user.id} for vals in self.activity_vals]
-            with self.assertBus(expected_create_notif_channels, expected_create_notif_message_items):
+            with self.assertBus(BusResult(user, "mail.activity/updated", {"activity_created": True, "count_diff": 2})):
                 activities = self.env['mail.activity'].create(user_activity_vals)
-            with self.assertBus(expected_unlink_notif_channels, expected_unlink_notif_message_items):
+            with self.assertBus(BusResult(user, "mail.activity/updated", {"activity_deleted": True, "count_diff": -2})):
                 activities.unlink()
 
     @users('employee')
     def test_notify_update_activities(self):
-        write_vals_all = [
-            # added to counter for employee 2, removed from counter for current employee
-            {'user_id': self.user_employee_2.id},
-            {'user_id': self.user_employee_2.id, 'date_deadline': datetime(2023, 12, 31, 15, 0, 0), 'active': True},
-            # just notify
-            {'date_deadline': datetime(2024, 1, 2, 15, 0, 0)},  # everything is in the future -> all removed from counter
-            {'date_deadline': datetime(2023, 12, 31, 15, 0, 0)},  # everything is in the past -> the one from the future is added
-            {'active': False},  # everything is archived -> all removed from counter
-            {'active': True},  # the archived one is unarchived -> added to counter
-            {},  # no "to be done" count change -> no notif
-            [{'date_deadline': datetime(2024, 1, 2, 15, 0, 0), 'active': True}, {}, {}, {}],
-        ]
+        def format_notif(user, count_diff):
+            return BusResult(
+                user,
+                "mail.activity/updated",
+                {"count_diff": count_diff} | ({"activity_created": True} if count_diff > 0 else {"activity_deleted": True}),
+            )
 
-        expected_notifs = [
-            # transfer 4 activities to the second employee, 2 todos taken and 2 given
-            [
-                ([user], [{
-                    "type": "mail.activity/updated",
-                    "payload": {
-                        "count_diff": count_diff,
-                    } | ({"activity_created": True} if count_diff > 0 else {"activity_deleted": True}),
-                }])
-                for user, count_diff
-                in zip(self.user_employee + self.user_employee_2, [-2, 2])
-            ],
-            # transfer 4 activities to the second employee, 2 todos are taken and 4 are given
-            [
-                ([user], [{
-                    "type": "mail.activity/updated",
-                    "payload": {
-                        "count_diff": count_diff,
-                    } | ({"activity_created": True} if count_diff > 0 else {"activity_deleted": True}),
-                }])
-                for user, count_diff
-                in zip(self.user_employee + self.user_employee_2, [-2, 4])
-            ],
-        ] + [[
-                ([self.user_employee], [{
-                    "type": "mail.activity/updated",
-                    "payload": {
-                        "count_diff": count_diff,
-                    } | ({"activity_created": True} if count_diff > 0 else {"activity_deleted": True}),
-                }])
-            ] for count_diff in (-2, 1, -2, 1)
-        ] + [
-            [([], [])],  # no change -> no notif
-            [([], [])],  # no change in "todo" count -> no notif
+        cases = [
+            # added to counter for employee 2, removed from counter for current employee
+            ({'user_id': self.user_employee_2.id}, [format_notif(self.user_employee, -2), format_notif(self.user_employee_2, 2)]),
+            ({'user_id': self.user_employee_2.id, 'date_deadline': datetime(2023, 12, 31, 15, 0, 0), 'active': True}, [format_notif(self.user_employee, -2), format_notif(self.user_employee_2, 4)]),
+            # just notify
+            ({'date_deadline': datetime(2024, 1, 2, 15, 0, 0)}, [format_notif(self.user_employee, -2)]),  # everything is in the future -> all removed from counter
+            ({'date_deadline': datetime(2023, 12, 31, 15, 0, 0)}, [format_notif(self.user_employee, 1)]),  # everything is in the past -> the one from the future is added
+            ({'active': False}, [format_notif(self.user_employee, -2)]),  # everything is archived -> all removed from counter
+            ({'active': True}, [format_notif(self.user_employee, 1)]),  # the archived one is unarchived -> added to counter
+            ({}, []),  # no "to be done" count change -> no notif
+            ([{'date_deadline': datetime(2024, 1, 2, 15, 0, 0), 'active': True}, {}, {}, {}], []),  # no change in "todo" count -> no notif
         ]
-        for write_vals, expected_notif_vals in zip(write_vals_all, expected_notifs):
+        for write_vals, expected_notifications in cases:
             with self.subTest(vals=write_vals):
                 _past_archived, _past_active, _today, _tomorrow = activities = self.env['mail.activity'].create(self.activity_vals)
-                self._reset_bus()
-                if isinstance(write_vals, list):
-                    for activity, vals in zip(activities, write_vals):
-                        activity.write(vals)
-                else:
-                    activities.write(write_vals)
-                for (notif_channels, notif_messages) in expected_notif_vals:
-                    self.assertBusNotifications(notif_channels, notif_messages)
+                with self.assertBus(expected_notifications):
+                    if isinstance(write_vals, list):
+                        for activity, vals in zip(activities, write_vals):
+                            activity.write(vals)
+                    else:
+                        activities.write(write_vals)
                 activities.unlink()
 
 

--- a/addons/test_mail/tests/test_mail_management.py
+++ b/addons/test_mail/tests/test_mail_management.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.addons.bus.tests.common import BusResult
 from odoo.addons.mail.tests.common import MailCommon
+from odoo.addons.mail.tools.discuss import Store
 from odoo.addons.test_mail.tests.common import TestRecipients
 from odoo.tests import tagged
 
@@ -45,10 +47,13 @@ class TestMailManagement(MailCommon, TestRecipients):
         })
 
     def test_mail_notify_cancel(self):
-        self._reset_bus()
-
-        self.test_record.with_user(self.user_employee).notify_cancel_by_type('email')
+        with self.assertBus(lambda: [
+            BusResult(
+                self.msg.author_id.user_ids,
+                "mail.record/insert",
+                Store().add(self.msg, "_store_notification_fields").get_result(),
+            ),
+        ]):
+            self.test_record.with_user(self.user_employee).notify_cancel_by_type('email')
         self.assertEqual((self.notif_p1 | self.notif_p2 | self.notif_p3).mapped('notification_status'),
                          ['canceled', 'canceled', 'sent'])
-
-        self.assertMessageBusNotifications(self.msg)

--- a/addons/test_mail/tests/test_mail_multicompany.py
+++ b/addons/test_mail/tests/test_mail_multicompany.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 from werkzeug.urls import url_parse
 
 from odoo.addons.mail.models.mail_message import MailMessage
+from odoo.addons.bus.tests.common import BusResult
 from odoo.addons.mail.tests.common import MailCommon, mail_new_test_user
 from odoo.addons.test_mail.tests.common import TestRecipients
 from odoo.exceptions import AccessError
@@ -255,7 +256,7 @@ class TestMultiCompanySetup(TestMailMCCommon, HttpCase):
     def test_recipients_multi_company(self):
         """Test mentioning a partner with no common company."""
         test_records_mc_c2 = self.test_records_mc[1]
-        with self.assertBus([self.user_employee_c3]):
+        with self.assertBus(BusResult(self.user_employee_c3, "mail.message/inbox")):
             test_records_mc_c2.with_user(self.user_employee_c2).with_context(
                 allowed_company_ids=self.company_2.ids
             ).message_post(

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from unittest.mock import DEFAULT
 
 from odoo import exceptions, tools
+from odoo.addons.bus.tests.common import BusResult
 from odoo.addons.mail.tests.common import mail_new_test_user, MailCommon
 from odoo.addons.test_mail.models.test_mail_models import MailTestSimple
 from odoo.addons.test_mail.tests.common import TestRecipients
@@ -1173,14 +1174,15 @@ class TestDiscuss(MailCommon, TestRecipients):
             # mark all as read clear needactions
             msg1 = self.test_record.message_post(body='Test', message_type='comment', subtype_xmlid='mail.mt_comment', partner_ids=[employee_partner.id])
             with self.assertBus(
-                    [self.user_employee],
-                    message_items=[{
-                        'type': 'mail.message/mark_as_read',
-                        'payload': {
-                            'message_ids': [msg1.id],
-                            'needaction_inbox_counter': 0,
-                        },
-                    }]):
+                BusResult(
+                    self.user_employee,
+                    "mail.message/mark_as_read",
+                    {
+                        "message_ids": [msg1.id],
+                        "needaction_inbox_counter": 0,
+                    },
+                ),
+            ):
                 employee_partner.env['mail.message'].mark_all_as_read(domain=[])
             na_count = employee_partner._get_needaction_count()
             self.assertEqual(na_count, 0, "mark all as read should conclude all needactions")
@@ -1199,14 +1201,15 @@ class TestDiscuss(MailCommon, TestRecipients):
             self.assertEqual(na_count, 1, "message not accessible is currently still counted")
 
             with self.assertBus(
-                    [self.user_employee],
-                    message_items=[{
-                        'type': 'mail.message/mark_as_read',
-                        'payload': {
-                            'message_ids': [msg2.id],
-                            'needaction_inbox_counter': 0,
-                        },
-                    }]):
+                BusResult(
+                    self.user_employee,
+                    "mail.message/mark_as_read",
+                    {
+                        "message_ids": [msg2.id],
+                        "needaction_inbox_counter": 0,
+                    },
+                )
+            ):
                 employee_partner.env['mail.message'].mark_all_as_read(domain=[])
             na_count = employee_partner._get_needaction_count()
             self.assertEqual(na_count, 0, "mark all read should conclude all needactions even inacessible ones")

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from odoo import Command, fields
 from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
+from odoo.addons.bus.tests.common import BusResult
 from odoo.addons.mail.tests.common import MailCommon, mail_new_test_user
 from odoo.addons.mail.tools.discuss import Store
 from odoo.tests import Form, users, warmup, tagged
@@ -1624,7 +1625,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
             lambda f: f.partner_id == self.user_follower_emp_inbox.partner_id
         )
 
-        def get_bus_params():
+        def notifications():
             message = self.env["mail.message"].search([], order="id desc", limit=1)
             notif_1 = message.notification_ids.filtered(
                 lambda n: n.res_partner_id == self.user_emp_inbox.partner_id
@@ -1632,250 +1633,245 @@ class TestMessageToStorePerformance(BaseMailPerformance):
             notif_2 = message.notification_ids.filtered(
                 lambda n: n.res_partner_id == self.user_follower_emp_inbox.partner_id
             )
-            return (
-                [self.user_emp_inbox, self.user_follower_emp_inbox],
-                [
+            return [
+                BusResult(
+                    self.user_emp_inbox,
+                    "mail.message/inbox",
                     {
-                        "type": "mail.message/inbox",
-                        "payload": {
-                            "message_id": message.id,
-                            "store_data": {
-                                "mail.followers": [
-                                    {
-                                        "id": follower_1.id,
-                                        "is_active": True,
-                                        "partner_id": self.user_emp_inbox.partner_id.id,
-                                    },
-                                ],
-                                "mail.message": self._filter_messages_fields(
-                                    {
-                                        "attachment_ids": [],
-                                        "author_guest_id": False,
-                                        "author_id": self.env.user.partner_id.id,
-                                        "body": [
-                                            "markup",
-                                            "<p>Test Post Performances with multiple inbox ping!</p>",
-                                        ],
-                                        "create_date": fields.Datetime.to_string(
-                                            message.create_date
-                                        ),
-                                        "date": fields.Datetime.to_string(message.date),
-                                        "default_subject": "Test",
-                                        "email_from": '"OdooBot" <odoobot@example.com>',
-                                        "id": message.id,
-                                        "incoming_email_cc": False,
-                                        "incoming_email_to": False,
-                                        "message_link_preview_ids": [],
-                                        "message_type": "comment",
-                                        "model": "mail.test.simple",
-                                        "needaction": True,
-                                        "notification_ids": [notif_1.id, notif_2.id],
-                                        "partner_ids": [],
-                                        "pinned_at": False,
-                                        "rating_id": False,
-                                        "reactions": [],
-                                        "record_name": "Test",
-                                        "reply_to": '"OdooBot" <catchall.test@test.mycompany.com>',
-                                        "res_id": record.id,
-                                        "scheduledDatetime": False,
-                                        "is_bookmarked": False,
-                                        "subject": False,
-                                        "subtype_id": self.env.ref("mail.mt_comment").id,
-                                        "thread": {"id": record.id, "model": "mail.test.simple"},
-                                        "trackingValues": [],
-                                        "write_date": fields.Datetime.to_string(message.write_date),
-                                    },
-                                ),
-                                "mail.message.subtype": [
-                                    {
-                                        "description": False,
-                                        "id": self.env.ref("mail.mt_comment").id,
-                                    },
-                                ],
-                                "mail.notification": [
-                                    {
-                                        "mail_email_address": False,
-                                        "failure_type": False,
-                                        "id": notif_1.id,
-                                        "mail_message_id": message.id,
-                                        "notification_status": "sent",
-                                        "notification_type": "inbox",
-                                        "res_partner_id": self.user_emp_inbox.partner_id.id,
-                                    },
-                                    {
-                                        "mail_email_address": False,
-                                        "failure_type": False,
-                                        "id": notif_2.id,
-                                        "mail_message_id": message.id,
-                                        "notification_status": "sent",
-                                        "notification_type": "inbox",
-                                        "res_partner_id": self.user_follower_emp_inbox.partner_id.id,
-                                    },
-                                ],
-                                "mail.thread": self._filter_threads_fields(
-                                    {
-                                        "display_name": "Test",
-                                        "id": record.id,
-                                        "model": "mail.test.simple",
-                                        "module_icon": "/base/static/description/icon.png",
-                                        "selfFollower": follower_1.id,
-                                    },
-                                ),
-                                "res.partner": self._filter_partners_fields(
-                                    {
-                                        "avatar_128_access_token": self.env.user.partner_id._get_avatar_128_access_token(),
-                                        "id": self.env.user.partner_id.id,
-                                        "is_company": False,
-                                        "main_user_id": self.env.user.id,
-                                        "name": "OdooBot",
-                                        "write_date": fields.Datetime.to_string(
-                                            self.env.user.partner_id.write_date
-                                        ),
-                                    },
-                                    {
-                                        "email": self.user_emp_inbox.partner_id.email,
-                                        "id": self.user_emp_inbox.partner_id.id,
-                                        "name": "Ignasse Inbox",
-                                    },
-                                    {
-                                        "email": self.user_follower_emp_inbox.partner_id.email,
-                                        "id": self.user_follower_emp_inbox.partner_id.id,
-                                        "name": "Isabelle Follower Inbox",
-                                    },
-                                ),
-                                "res.users": self._filter_users_fields(
-                                    {
-                                        "id": self.env.user.id,
-                                        "partner_id": self.env.user.partner_id.id,
-                                        "share": False,
-                                    },
-                                ),
-                            },
+                        "message_id": message.id,
+                        "store_data": {
+                            "mail.followers": [
+                                {
+                                    "id": follower_1.id,
+                                    "is_active": True,
+                                    "partner_id": self.user_emp_inbox.partner_id.id,
+                                },
+                            ],
+                            "mail.message": self._filter_messages_fields(
+                                {
+                                    "attachment_ids": [],
+                                    "author_guest_id": False,
+                                    "author_id": self.env.user.partner_id.id,
+                                    "body": [
+                                        "markup",
+                                        "<p>Test Post Performances with multiple inbox ping!</p>",
+                                    ],
+                                    "create_date": fields.Datetime.to_string(message.create_date),
+                                    "date": fields.Datetime.to_string(message.date),
+                                    "default_subject": "Test",
+                                    "email_from": '"OdooBot" <odoobot@example.com>',
+                                    "id": message.id,
+                                    "incoming_email_cc": False,
+                                    "incoming_email_to": False,
+                                    "message_link_preview_ids": [],
+                                    "message_type": "comment",
+                                    "model": "mail.test.simple",
+                                    "needaction": True,
+                                    "notification_ids": [notif_1.id, notif_2.id],
+                                    "partner_ids": [],
+                                    "pinned_at": False,
+                                    "rating_id": False,
+                                    "reactions": [],
+                                    "record_name": "Test",
+                                    "reply_to": '"OdooBot" <catchall.test@test.mycompany.com>',
+                                    "res_id": record.id,
+                                    "scheduledDatetime": False,
+                                    "is_bookmarked": False,
+                                    "subject": False,
+                                    "subtype_id": self.env.ref("mail.mt_comment").id,
+                                    "thread": {"id": record.id, "model": "mail.test.simple"},
+                                    "trackingValues": [],
+                                    "write_date": fields.Datetime.to_string(message.write_date),
+                                },
+                            ),
+                            "mail.message.subtype": [
+                                {
+                                    "description": False,
+                                    "id": self.env.ref("mail.mt_comment").id,
+                                },
+                            ],
+                            "mail.notification": [
+                                {
+                                    "mail_email_address": False,
+                                    "failure_type": False,
+                                    "id": notif_1.id,
+                                    "mail_message_id": message.id,
+                                    "notification_status": "sent",
+                                    "notification_type": "inbox",
+                                    "res_partner_id": self.user_emp_inbox.partner_id.id,
+                                },
+                                {
+                                    "mail_email_address": False,
+                                    "failure_type": False,
+                                    "id": notif_2.id,
+                                    "mail_message_id": message.id,
+                                    "notification_status": "sent",
+                                    "notification_type": "inbox",
+                                    "res_partner_id": self.user_follower_emp_inbox.partner_id.id,
+                                },
+                            ],
+                            "mail.thread": self._filter_threads_fields(
+                                {
+                                    "display_name": "Test",
+                                    "id": record.id,
+                                    "model": "mail.test.simple",
+                                    "module_icon": "/base/static/description/icon.png",
+                                    "selfFollower": follower_1.id,
+                                },
+                            ),
+                            "res.partner": self._filter_partners_fields(
+                                {
+                                    "avatar_128_access_token": self.env.user.partner_id._get_avatar_128_access_token(),
+                                    "id": self.env.user.partner_id.id,
+                                    "is_company": False,
+                                    "main_user_id": self.env.user.id,
+                                    "name": "OdooBot",
+                                    "write_date": fields.Datetime.to_string(
+                                        self.env.user.partner_id.write_date
+                                    ),
+                                },
+                                {
+                                    "email": self.user_emp_inbox.partner_id.email,
+                                    "id": self.user_emp_inbox.partner_id.id,
+                                    "name": "Ignasse Inbox",
+                                },
+                                {
+                                    "email": self.user_follower_emp_inbox.partner_id.email,
+                                    "id": self.user_follower_emp_inbox.partner_id.id,
+                                    "name": "Isabelle Follower Inbox",
+                                },
+                            ),
+                            "res.users": self._filter_users_fields(
+                                {
+                                    "id": self.env.user.id,
+                                    "partner_id": self.env.user.partner_id.id,
+                                    "share": False,
+                                },
+                            ),
                         },
                     },
+                ),
+                BusResult(
+                    self.user_follower_emp_inbox,
+                    "mail.message/inbox",
                     {
-                        "type": "mail.message/inbox",
-                        "payload": {
-                            "message_id": message.id,
-                            "store_data": {
-                                "mail.followers": [
-                                    {
-                                        "id": follower_2.id,
-                                        "is_active": True,
-                                        "partner_id": self.user_follower_emp_inbox.partner_id.id,
-                                    },
-                                ],
-                                "mail.message": self._filter_messages_fields(
-                                    {
-                                        "attachment_ids": [],
-                                        "author_guest_id": False,
-                                        "author_id": self.env.user.partner_id.id,
-                                        "body": [
-                                            "markup",
-                                            "<p>Test Post Performances with multiple inbox ping!</p>",
-                                        ],
-                                        "create_date": fields.Datetime.to_string(
-                                            message.create_date
-                                        ),
-                                        "date": fields.Datetime.to_string(message.date),
-                                        "default_subject": "Test",
-                                        "email_from": '"OdooBot" <odoobot@example.com>',
-                                        "id": message.id,
-                                        "incoming_email_cc": False,
-                                        "incoming_email_to": False,
-                                        "message_link_preview_ids": [],
-                                        "message_type": "comment",
-                                        "model": "mail.test.simple",
-                                        "needaction": True,
-                                        "notification_ids": [notif_1.id, notif_2.id],
-                                        "partner_ids": [],
-                                        "pinned_at": False,
-                                        "rating_id": False,
-                                        "reactions": [],
-                                        "record_name": "Test",
-                                        "res_id": record.id,
-                                        "reply_to": '"OdooBot" <catchall.test@test.mycompany.com>',
-                                        "scheduledDatetime": False,
-                                        "is_bookmarked": False,
-                                        "subject": False,
-                                        "subtype_id": self.env.ref("mail.mt_comment").id,
-                                        "thread": {"id": record.id, "model": "mail.test.simple"},
-                                        "trackingValues": [],
-                                        "write_date": fields.Datetime.to_string(message.write_date),
-                                    },
-                                ),
-                                "mail.message.subtype": [
-                                    {
-                                        "description": False,
-                                        "id": self.env.ref("mail.mt_comment").id,
-                                    },
-                                ],
-                                "mail.notification": [
-                                    {
-                                        "mail_email_address": False,
-                                        "failure_type": False,
-                                        "id": notif_1.id,
-                                        "mail_message_id": message.id,
-                                        "notification_status": "sent",
-                                        "notification_type": "inbox",
-                                        "res_partner_id": self.user_emp_inbox.partner_id.id,
-                                    },
-                                    {
-                                        "mail_email_address": False,
-                                        "failure_type": False,
-                                        "id": notif_2.id,
-                                        "mail_message_id": message.id,
-                                        "notification_status": "sent",
-                                        "notification_type": "inbox",
-                                        "res_partner_id": self.user_follower_emp_inbox.partner_id.id,
-                                    },
-                                ],
-                                "mail.thread": self._filter_threads_fields(
-                                    {
-                                        "display_name": "Test",
-                                        "id": record.id,
-                                        "model": "mail.test.simple",
-                                        "module_icon": "/base/static/description/icon.png",
-                                        "selfFollower": follower_2.id,
-                                    },
-                                ),
-                                "res.partner": self._filter_partners_fields(
-                                    {
-                                        "avatar_128_access_token": self.env.user.partner_id._get_avatar_128_access_token(),
-                                        "id": self.env.user.partner_id.id,
-                                        "is_company": False,
-                                        "main_user_id": self.env.user.id,
-                                        "name": "OdooBot",
-                                        "write_date": fields.Datetime.to_string(
-                                            self.env.user.partner_id.write_date
-                                        ),
-                                    },
-                                    {
-                                        "email": self.user_emp_inbox.partner_id.email,
-                                        "id": self.user_emp_inbox.partner_id.id,
-                                        "name": "Ignasse Inbox",
-                                    },
-                                    {
-                                        "email": self.user_follower_emp_inbox.partner_id.email,
-                                        "id": self.user_follower_emp_inbox.partner_id.id,
-                                        "name": "Isabelle Follower Inbox",
-                                    },
-                                ),
-                                "res.users": self._filter_users_fields(
-                                    {
-                                        "id": self.env.user.id,
-                                        "partner_id": self.env.user.partner_id.id,
-                                        "share": False,
-                                    },
-                                ),
-                            },
+                        "message_id": message.id,
+                        "store_data": {
+                            "mail.followers": [
+                                {
+                                    "id": follower_2.id,
+                                    "is_active": True,
+                                    "partner_id": self.user_follower_emp_inbox.partner_id.id,
+                                },
+                            ],
+                            "mail.message": self._filter_messages_fields(
+                                {
+                                    "attachment_ids": [],
+                                    "author_guest_id": False,
+                                    "author_id": self.env.user.partner_id.id,
+                                    "body": [
+                                        "markup",
+                                        "<p>Test Post Performances with multiple inbox ping!</p>",
+                                    ],
+                                    "create_date": fields.Datetime.to_string(message.create_date),
+                                    "date": fields.Datetime.to_string(message.date),
+                                    "default_subject": "Test",
+                                    "email_from": '"OdooBot" <odoobot@example.com>',
+                                    "id": message.id,
+                                    "incoming_email_cc": False,
+                                    "incoming_email_to": False,
+                                    "message_link_preview_ids": [],
+                                    "message_type": "comment",
+                                    "model": "mail.test.simple",
+                                    "needaction": True,
+                                    "notification_ids": [notif_1.id, notif_2.id],
+                                    "partner_ids": [],
+                                    "pinned_at": False,
+                                    "rating_id": False,
+                                    "reactions": [],
+                                    "record_name": "Test",
+                                    "res_id": record.id,
+                                    "reply_to": '"OdooBot" <catchall.test@test.mycompany.com>',
+                                    "scheduledDatetime": False,
+                                    "is_bookmarked": False,
+                                    "subject": False,
+                                    "subtype_id": self.env.ref("mail.mt_comment").id,
+                                    "thread": {"id": record.id, "model": "mail.test.simple"},
+                                    "trackingValues": [],
+                                    "write_date": fields.Datetime.to_string(message.write_date),
+                                },
+                            ),
+                            "mail.message.subtype": [
+                                {
+                                    "description": False,
+                                    "id": self.env.ref("mail.mt_comment").id,
+                                },
+                            ],
+                            "mail.notification": [
+                                {
+                                    "mail_email_address": False,
+                                    "failure_type": False,
+                                    "id": notif_1.id,
+                                    "mail_message_id": message.id,
+                                    "notification_status": "sent",
+                                    "notification_type": "inbox",
+                                    "res_partner_id": self.user_emp_inbox.partner_id.id,
+                                },
+                                {
+                                    "mail_email_address": False,
+                                    "failure_type": False,
+                                    "id": notif_2.id,
+                                    "mail_message_id": message.id,
+                                    "notification_status": "sent",
+                                    "notification_type": "inbox",
+                                    "res_partner_id": self.user_follower_emp_inbox.partner_id.id,
+                                },
+                            ],
+                            "mail.thread": self._filter_threads_fields(
+                                {
+                                    "display_name": "Test",
+                                    "id": record.id,
+                                    "model": "mail.test.simple",
+                                    "module_icon": "/base/static/description/icon.png",
+                                    "selfFollower": follower_2.id,
+                                },
+                            ),
+                            "res.partner": self._filter_partners_fields(
+                                {
+                                    "avatar_128_access_token": self.env.user.partner_id._get_avatar_128_access_token(),
+                                    "id": self.env.user.partner_id.id,
+                                    "is_company": False,
+                                    "main_user_id": self.env.user.id,
+                                    "name": "OdooBot",
+                                    "write_date": fields.Datetime.to_string(
+                                        self.env.user.partner_id.write_date
+                                    ),
+                                },
+                                {
+                                    "email": self.user_emp_inbox.partner_id.email,
+                                    "id": self.user_emp_inbox.partner_id.id,
+                                    "name": "Ignasse Inbox",
+                                },
+                                {
+                                    "email": self.user_follower_emp_inbox.partner_id.email,
+                                    "id": self.user_follower_emp_inbox.partner_id.id,
+                                    "name": "Isabelle Follower Inbox",
+                                },
+                            ),
+                            "res.users": self._filter_users_fields(
+                                {
+                                    "id": self.env.user.id,
+                                    "partner_id": self.env.user.partner_id.id,
+                                    "share": False,
+                                },
+                            ),
                         },
                     },
-                ],
-            )
+                ),
+            ]
 
         self.env.invalidate_all()
-        with self.assertBus(get_params=get_bus_params):
+        with self.assertBus(notifications):
             with self.assertQueryCount(21):
                 record.message_post(
                     body=Markup("<p>Test Post Performances with multiple inbox ping!</p>"),

--- a/addons/test_mail_sms/tests/test_sms_management.py
+++ b/addons/test_mail_sms/tests/test_sms_management.py
@@ -2,6 +2,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import Command
+from odoo.addons.bus.tests.common import BusResult
+from odoo.addons.mail.tools.discuss import Store
 from odoo.addons.sms.tests.common import SMSCommon
 from odoo.addons.test_mail_sms.tests.common import TestSMSRecipients
 from odoo.tests import tagged, users
@@ -60,26 +62,38 @@ class TestSMSActionsCommon(SMSCommon, TestSMSRecipients):
             'failure_type': 'sms_credit',
         })
 
+    def _get_msg_notification_bus_params(self, msg, users=None):
+        """Helper to get bus parameters for message notification updates."""
+        if users is None:
+            users = self.env.user | msg.author_id.user_ids
+        return [
+            BusResult(
+                user,
+                "mail.record/insert",
+                Store().add(msg, "_store_notification_fields").get_result(),
+            )
+            for user in users
+        ]
+
 
 @tagged('sms_management')
 @tagged('at_install', '-post_install')  # LEGACY at_install
 class TestSMSActions(TestSMSActionsCommon):
 
     def test_sms_notify_cancel(self):
-        self._reset_bus()
-
-        with self.with_user('employee'):
-            self.test_record.with_user(self.env.user).notify_cancel_by_type('sms')
-            self.assertEqual((self.notif_p1 | self.notif_p2).mapped('notification_status'), ['canceled', 'canceled'])
-
-        self.assertMessageBusNotifications(self.msg)
+        with self.assertBus(
+            notifications=lambda: self._get_msg_notification_bus_params(self.msg, self.msg.author_id.user_ids)
+        ):
+            with self.with_user('employee'):
+                self.test_record.with_user(self.env.user).notify_cancel_by_type('sms')
+                self.assertEqual((self.notif_p1 | self.notif_p2).mapped('notification_status'), ['canceled', 'canceled'])
 
     def test_sms_set_cancel(self):
-        self._reset_bus()
-        self.sms_p1.action_set_canceled()
+        with self.assertBus(
+            notifications=lambda: self._get_msg_notification_bus_params(self.msg)
+        ):
+            self.sms_p1.action_set_canceled()
         self.assertEqual(self.sms_p1.state, 'canceled')
-
-        self.assertMessageBusNotifications(self.msg)
         self.assertSMSNotification([
             {'partner': self.partner_1, 'number': self.notif_p1.sms_number, 'state': 'canceled', 'failure_type': 'sms_number_format'},
             {'partner': self.partner_2, 'number': self.notif_p2.sms_number, 'state': 'exception', 'failure_type': 'sms_credit'}
@@ -102,11 +116,12 @@ class TestSMSActions(TestSMSActionsCommon):
         self.assertEqual(self.sms_p2.state, 'canceled')
         self.assertEqual(self.env['bus.bus'].search([]), self.env['bus.bus'], 'SMS: no bus notifications unless asked')
 
-        (self.sms_p1 + self.sms_p2).action_set_error('sms_server')
+        with self.assertBus(
+            notifications=lambda: self._get_msg_notification_bus_params(self.msg)
+        ):
+            (self.sms_p1 + self.sms_p2).action_set_error('sms_server')
         self.assertEqual(self.sms_p1.state, 'error')
         self.assertEqual(self.sms_p2.state, 'error')
-
-        self.assertMessageBusNotifications(self.msg)
         self.assertSMSNotification([
             {'partner': self.partner_1, 'number': self.notif_p1.sms_number, 'state': 'exception', 'failure_type': 'sms_server'},
             {'partner': self.partner_2, 'number': self.notif_p2.sms_number, 'state': 'exception', 'failure_type': 'sms_server'}
@@ -114,12 +129,12 @@ class TestSMSActions(TestSMSActionsCommon):
 
     @users('admin')
     def test_sms_set_outgoing(self):
-        self._reset_bus()
-        (self.sms_p1 + self.sms_p2).with_user(self.env.user).action_set_outgoing()
+        with self.assertBus(
+            notifications=lambda: self._get_msg_notification_bus_params(self.msg)
+        ):
+            (self.sms_p1 + self.sms_p2).with_user(self.env.user).action_set_outgoing()
         self.assertEqual(self.sms_p1.state, 'outgoing')
         self.assertEqual(self.sms_p2.state, 'outgoing')
-
-        self.assertMessageBusNotifications(self.msg)
         self.assertSMSNotification([
             {'partner': self.partner_1, 'number': self.notif_p1.sms_number, 'state': 'ready'},
             {'partner': self.partner_2, 'number': self.notif_p2.sms_number, 'state': 'ready'}


### PR DESCRIPTION
Replaces the separate `channels` and `messages` validation logic with a single list of `BusResult`. This ensures assertions verify that the specific message reached the specific intended channel.

1. Accepts a list of `BusResult` instead of two disjointed lists.
2. Bus is cleared upon entering the context manager to prevent stale data from affecting assertions.
3. Comparison ignores dictionary key order to prevent brittle test failures.
4. Error messages now provide clear comparisons between expected and actual notifications.

task-4715511

https://github.com/odoo/enterprise/pull/110168
