### PR TITLE
[FIX] account_edi_ubl_cii: swap customer/supplier for non self-billing invoices

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -63,7 +63,7 @@ class AccountEdiXmlUbl_Bis3(models.AbstractModel):
         self._ubl_add_values_currency(vals, invoice.currency_id)
         self._ubl_add_values_customer(vals, invoice.partner_id)
         self._ubl_add_values_delivery(vals, invoice.partner_shipping_id or invoice.partner_id)
-        if vals['process_type'] == 'selfbilling':
+        if invoice.is_purchase_document():
             customer = vals['customer']
             supplier = vals['supplier']
             vals['supplier'] = customer

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -1245,3 +1245,24 @@ comment-->1000.0</TaxExclusiveAmount></xpath>"""
         self.assertEqual(due_date.text, '20251231')
         self.assertEqual(days.text, '15')
         self.assertEqual(percent.text, '3.0')
+
+    def test_export_supplier_and_customer_fields(self):
+        file_path = "bis3_bill_example.xml"
+        file_path = f"{self.test_module}/tests/test_files/{file_path}"
+        with file_open(file_path, 'rb') as file:
+            xml_attachment = self.env['ir.attachment'].create({
+                'mimetype': 'application/xml',
+                'name': 'test_invoice.xml',
+                'raw': file.read(),
+            })
+        bill = self._import_as_attachment_on(attachment=xml_attachment)
+        raw = self.env['account.edi.xml.ubl_bis3']._export_invoice(bill)[0]
+        xml_tree = etree.fromstring(raw)
+        self.assertEqual(
+            xml_tree.find(".//cac:AccountingSupplierParty/cac:Party/cac:PartyName/cbc:Name", namespaces=self.ubl_namespaces).text,
+            "ALD Automotive LU",
+        )
+        self.assertEqual(
+            xml_tree.find(".//cac:AccountingCustomerParty/cac:Party/cac:PartyName/cbc:Name", namespaces=self.ubl_namespaces).text,
+            self.env.company.partner_id.name
+        )


### PR DESCRIPTION
## Issue
When exporting the `.xml` of an invoice whose `journal_id.is_self_billing` is `False`, the `AccountingSupplierParty` and `AccountingCustomerParty` are swapped.

## Steps to reproduce
1. Install *Belgium - Accounting* (`l10n_be`)
2. With a Belgian company, create a Vendors Bills
    - Vendor: Any company with a Belgian VAT
    - Any Date
    - Any Product
3. Confirm the bill
4. Click (Cogwheel > Print >) Export XML
5. **In the resulting XML, the `AccountingSupplierParty` is set to the current company, while the `AccountingCustomerParty` is set to the Vendor of the bill**

## Cause
In `AccountEdiXmlUBL20._add_invoice_config_vals`, the `supplier` is set to the current company, the `customer` is set to the vendor, but then the two variables are correctly swapped, leading to both the `supplier` and `customer` to hold the correct partners:

https://github.com/odoo/odoo/blob/049321aa5e0d4271050b406477bac5fb788b410b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py#L151-L159

These values are then ovewritten in `AccountEdiXmlUbl_Bis3._add_invoice_config_vals`, where `_ubl_add_values_company` sets the `supplier` to the current company ([here](https://github.com/odoo/odoo/blob/049321aa5e0d4271050b406477bac5fb788b410b/addons/account_edi_ubl_cii/models/account_edi_ubl.py#L307)) and `_ubl_add_values_customer` sets the `customer` to `invoice.partner_id` ([here](https://github.com/odoo/odoo/blob/049321aa5e0d4271050b406477bac5fb788b410b/addons/account_edi_ubl_cii/models/account_edi_ubl.py#L315)).

https://github.com/odoo/odoo/blob/049321aa5e0d4271050b406477bac5fb788b410b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py#L58-L71

The values are **not** swapped, because `vals['process_type']` is set to `'billing'`, as the `invoice.journal_id.is_self_billing` is not necessarily True in such cases.

opw-5969173