### PR TITLE
[FIX] payment: show payment methods in portal

### DIFF
--- a/addons/payment/data/portal_entry_data.xml
+++ b/addons/payment/data/portal_entry_data.xml
@@ -6,6 +6,7 @@
         <field name="url">/my/payment_method</field>
         <field name="image" type="base64" file="payment/static/img/payment-methods.svg"/>
         <field name="category">client_category</field>
+        <field name="is_config_card" eval="True"/>
         <field name="sequence" eval="20"/>
     </record>
 </odoo>

--- a/addons/payment/models/portal_entry.py
+++ b/addons/payment/models/portal_entry.py
@@ -10,7 +10,7 @@ class PortalEntryPayment(models.Model):
     def should_show_portal_card(self):
         res = super().should_show_portal_card()
         external_id = self.get_external_id().get(self.id, '')
-        if external_id == "payment.portal_payment_orders":
+        if external_id == "payment.payment_methods_portal_entry":
             partner_sudo = request.env.user.partner_id.sudo()
             providers_sudo = request.env['payment.provider'].sudo()._get_compatible_providers(
                 request.env.company.id,
@@ -28,5 +28,6 @@ class PortalEntryPayment(models.Model):
                 partner_sudo.payment_token_ids
                 + partner_sudo.commercial_partner_id.payment_token_ids
             )
-            res &= bool(methods_allowing_tokenization or existing_tokens)
+            # To do in master: & with the res from superclass implementation
+            res = bool(methods_allowing_tokenization or existing_tokens)
         return res


### PR DESCRIPTION
Versions:
---
saas-19.1+

Issue
--
Payment methods are not shown in portal page.

Cause:
---
In #212880 two issues were overlooked:

1. The payment portal entry ID is `payment_methods_portal_entry`, but the `should_show_portal_card` override was using the wrong external ID: `portal_payment_orders`.

2. The payment card should have `is_config_card=True`, which was missed. Because of this, the superclass implementation (which checks `is_config_card`) returns False and hides the card.

Setting `is_config_card=True` would normally fix the issue, but it would require updating views for already existing databases. To avoid this, the override is adjusted to not `&` with the parent implementation.

In master we can restore the `&` superclass.

This change should have no negative impact since the issue only affects versions saas-19.1, saas-19.2 and there should be no custom overrides in saas versions.

opw-6013786
