### PR TITLE
[IMP] l10n_fr_hr_payroll: Drop module

### DIFF
--- a/odoo/addons/base/tests/test_ir_ui_view.py
+++ b/odoo/addons/base/tests/test_ir_ui_view.py
@@ -5003,7 +5003,6 @@ class TestInvisibleField(TransactionCaseWithUserDemo):
             'l10n_es_reports',
             'l10n_eu_oss_reports',
             'l10n_fr_hr_holidays',
-            'l10n_fr_hr_payroll',
             'l10n_fr_intrastat',
             'l10n_fr_pos_cert',
             'l10n_fr_reports',


### PR DESCRIPTION
The French Payroll localization has been removed as it was unmaintained, outdated, and not suitable for real-world usage. Maintaining it in its current state could lead to confusion or incorrect implementations.

TaskID: 6023819

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
