### PR TITLE
[FIX] l10n_es_edi_tbai: change RegEx that checks freelance VAT

### DIFF
--- a/addons/l10n_es_edi_tbai/models/res_company.py
+++ b/addons/l10n_es_edi_tbai/models/res_company.py
@@ -164,4 +164,11 @@ class ResCompany(models.Model):
 
     def _l10n_es_freelancer(self):
         self.ensure_one()
-        return self.vat and re.fullmatch(r"(ES)?(\d{8}[A-Z]|[X-Z].*)", self.vat) or False
+        if not self.vat:
+            return False
+
+        vat = self.vat
+        if vat.startswith('ES'):
+            vat = vat[2:]
+
+        return re.fullmatch(r"(\d{8}[TRWAGMYFPDXBNJZSQVHLCKE]|[XYZ]\d{7}[TRWAGMYFPDXBNJZSQVHLCKE]|E\d{7}[A-J0-9])", vat) or False


### PR DESCRIPTION
In Spain, "Comunidades de Bienes" (VAT starting with 'E') are entities without legal personality that tax via income attribution to their members. For accounting and tax reporting purposes, they must be treated as individuals/freelancers rather than corporations.

The current _l10n_es_freelancer logic was too restrictive, only matching standard DNI (8 digits + letter) or NIE (starting with X, Y, Z). This caused CBs to be excluded from freelancer-specific logic, leading to incorrect fiscal categorization in reports and tax modules.

The regex has been updated to optionally allow the 'E' prefix while ensuring the rest of the string maintains a valid format, effectively broadening the scope of what the system considers a Spanish freelancer. task-6014192

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
