### PR TITLE
[FIX] point_of_sale, pos_restaurant: don't await send in preparation call

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1469,7 +1469,7 @@ export class PosStore extends WithLazyGetterTrap {
         for (const order of orders) {
             const context = this.getSyncAllOrdersContext([order], options);
             await this.preSyncAllOrders([order]);
-            this.syncingOrders.add(order.id);
+            this.syncingOrders.add(order.uuid);
 
             try {
                 const serialized = order.serializeForORM();
@@ -1822,28 +1822,37 @@ export class PosStore extends WithLazyGetterTrap {
             return this.sendOrderInPreparation(order, opts);
         }
 
-        const data = await this.data.call("pos.order", "get_preparation_change", [order.id]);
-        const rawchange = data.last_order_preparation_change || "{}";
-        const lastChanges = JSON.parse(rawchange);
-        const lastServerDate = DateTime.fromSQL(lastChanges.metadata?.serverDate).toUTC();
-        const lastLocalDate = DateTime.fromSQL(
-            order.last_order_preparation_change?.metadata?.serverDate
-        ).toUTC();
+        try {
+            this.syncingOrders.add(order.uuid);
+            const data = await this.data.call("pos.order", "get_preparation_change", [order.id]);
+            const rawchange = data.last_order_preparation_change || "{}";
+            const lastChanges = JSON.parse(rawchange);
+            const lastServerDate = DateTime.fromSQL(lastChanges.metadata?.serverDate).toUTC();
+            const lastLocalDate = DateTime.fromSQL(
+                order.last_order_preparation_change?.metadata?.serverDate
+            ).toUTC();
 
-        if (lastServerDate.isValid && lastServerDate.ts != lastLocalDate.ts) {
-            this.dialog.add(AlertDialog, {
-                title: _t("Order Outdated"),
-                body: _t(
-                    "The order has been modified on another device. If you have modified existing " +
-                        "order lines, check that your changes have not been overwritten.\n\n" +
-                        "The order will be sent to the server with the last changes made on this device."
-                ),
-            });
+            if (lastServerDate.isValid && lastServerDate.ts != lastLocalDate.ts) {
+                this.dialog.add(AlertDialog, {
+                    title: _t("Order Outdated"),
+                    body: _t(
+                        "The order has been modified on another device. If you have modified existing " +
+                            "order lines, check that your changes have not been overwritten.\n\n" +
+                            "The order will be sent to the server with the last changes made on this device."
+                    ),
+                });
 
-            // Update before syncing otherwise it will overwrite the last change
-            order.last_order_preparation_change = lastChanges;
-            await this.syncAllOrders({ orders: [order] });
-            return;
+                // Update before syncing otherwise it will overwrite the last change
+                order.last_order_preparation_change = lastChanges;
+
+                // Delete from syncingOrders to allow syncAllOrders to
+                // sync the order with the new changes
+                this.syncingOrders.delete(order.uuid);
+                await this.syncAllOrders({ orders: [order] });
+                return;
+            }
+        } finally {
+            this.syncingOrders.delete(order.uuid);
         }
 
         return this.sendOrderInPreparation(order, opts);

--- a/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.js
@@ -688,6 +688,13 @@ export class FloorScreen extends Component {
             return;
         }
         if (!this.pos.isOrderTransferMode) {
+            const isSyncing = this.getTableIsSyncing(table);
+            if (isSyncing) {
+                this.pos.notification.add(
+                    _t("This table is currently syncing, please wait a moment before selecting it.")
+                );
+                return;
+            }
             await this.pos.setTableFromUi(table);
         }
     }
@@ -923,6 +930,14 @@ export class FloorScreen extends Component {
     }
     getLighterShade(color) {
         return this.formatColor([...this._getColors()[color], 0.75]);
+    }
+    getTableIsSyncing(table) {
+        const order = table.getOrder();
+        if (!order) {
+            return false;
+        }
+
+        return this.pos.syncingOrders.has(order?.uuid);
     }
     async deleteFloor() {
         const confirmed = await ask(this.dialog, {

--- a/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.xml
+++ b/addons/pos_restaurant/static/src/app/screens/floor_screen/floor_screen.xml
@@ -132,6 +132,7 @@
                                 <t t-set="isOccupied" t-value="pos.tableHasOrders(table)"/>
                                 <t t-set="isIntersecting" t-value="state.potentialLink?.child?.id === table.id"/>
                                 <t t-set="isIntersected" t-value="state.potentialLink?.parent?.id === table.id"/>
+                                <t t-set="isSyncing" t-value="this.getTableIsSyncing(table)"/>
                                 <div
                                     t-on-click="(ev) => this.onClickTable(table, ev)"
                                     class="floor-table table o_draggable d-flex flex-column align-items-center justify-content-between cursor-pointer"
@@ -140,6 +141,7 @@
                                         'position-absolute': pos.floorPlanStyle !== 'kanban',
                                         'selected': state.selectedTableIds.includes(table.id),
                                         'occupied': isOccupied,
+                                        'syncing': isSyncing,
                                     }"
                                     t-attf-class="tableId-{{table.id}}"
                                     t-attf-style="

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -552,10 +552,15 @@ patch(PosStore.prototype, {
     },
     async submitOrder() {
         const order = this.getOrder();
+        this.showDefault();
+
+        // We need to launch the sync here before mounting floor_screen
+        // to ensure the syncingStatus is only managed from this method
+        // and not the floor screen mounting which can cause some race condition
+        await this.syncAllOrders();
         await this.ensureGuestCustomerCount(order);
         await this.sendOrderInPreparationUpdateLastChange(order);
         this.addPendingOrder([order.id]);
-        this.showDefault();
     },
     async reprintOrder() {
         const order = this.getOrder();

--- a/addons/pos_restaurant/static/tests/tours/utils/floor_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/floor_screen_util.js
@@ -2,7 +2,7 @@ import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
 import { negate } from "@point_of_sale/../tests/generic_helpers/utils";
 
 export function table({ name, withClass = "", withoutClass, run = () => {}, numOfSeats }) {
-    let trigger = `.floor-map .table${withClass}`;
+    let trigger = `.floor-map .table${withClass}:not(.syncing)`;
     if (withoutClass) {
         trigger += `:not(${withoutClass})`;
     }


### PR DESCRIPTION
When clicking on "order" button from the product screen we were waiting for the "send in preparation" call to be done before going back to the floor screen. This was causing a bad user experience as if the connection was slow, the user had to wait for a long time.

Now, we don't await this call anymore and we show a notification if the user tries to click on a table that is currently syncing.

