### PR TITLE
[FIX] mail: self-member LFH conversations have poor visual

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.xml
@@ -34,7 +34,7 @@
                 <div class="position-relative d-flex flex-shrink-0 o-my-0_5 rounded-2" name="threadAvatar" t-att-class="{ 'ms-2': !store.discuss.isSidebarCompact }">
                     <DiscussAvatar channel="channel" size="26"/>
                 </div>
-                <div t-if="!store.discuss.isSidebarCompact" class="o-mail-DiscussSidebarChannel-itemName overflow-hidden ms-2 text-start flex-grow-1" t-att-class="itemNameAttClass">
+                <div t-if="!store.discuss.isSidebarCompact" class="o-mail-DiscussSidebarChannel-itemName overflow-hidden ms-2 text-start flex-grow-1 z-1" t-att-class="itemNameAttClass">
                     <div class="d-flex align-items-baseline o-min-width-0 gap-2">
                         <span class="text-truncate" t-esc="channel.displayName" t-ref="displayName"/>
                         <div class="d-flex gap-2 ms-auto" t-ref="displayNameAdditionalContent"/>


### PR DESCRIPTION
Before this commit, looking for help conversations with self user as member had poor readability on country flag, conversation name and description, and the language code.

This happens because when a looking for help conversation has self member, there's a hatched purple background. This background is done with an overlay over the whole item, and some items were below it like country flag and conversation name, reducing clarity of these items.

This commit fixes the issue with increased `z-index` just to be on top of this overlay.

Before / After (see text and country flag with hatched pattern / purple tint that comes from overlay)
<img width="878" height="503" alt="Screenshot 2026-03-10 at 15 36 20" src="https://github.com/user-attachments/assets/fa5764e9-436b-48bc-b920-20064b176e68" />
<img width="888" height="493" alt="Screenshot 2026-03-10 at 15 36 39" src="https://github.com/user-attachments/assets/1aadd167-9449-433c-bc5f-1505abe02a77" />
