### PR TITLE
[FIX] pos: fix typo and increase timeout for indexedDB transactions

### DIFF
--- a/addons/point_of_sale/static/tests/generic_helpers/utils.js
+++ b/addons/point_of_sale/static/tests/generic_helpers/utils.js
@@ -48,13 +48,13 @@ export function refresh() {
                 setTimeout(() => {
                     const activeTx = posmodel.data.indexedDB.activeTransactions;
                     const storeNames = Array.from(activeTx).flatMap((tx) =>
-                        Array.from(tx.objectStoreName)
+                        Array.from(tx.objectStoreNames)
                     );
                     const uniqueStores = [...new Set(storeNames)].join(", ");
                     throw new Error(
                         `Timeout waiting indexedDB for transactions to finish. Stores open: [${uniqueStores}]`
                     );
-                }, 2000);
+                }, 5000);
             });
         },
         "refresh page",


### PR DESCRIPTION
In some tests, we use refresh which will refresh the page after letting the indexedDB finish its transactions. In some cases, the transactions take more time than expected. In this commit, we increase this timeout to avoid failures that could be caused by not letting the time to the db to finish its transactions.

runbot-errors: 240911, 240912

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
