### PR TITLE
[FIX] web: HTMLField has text overlapping on mobile

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -1239,10 +1239,11 @@
             }
 
             &:not(.o_field_widget *):not(.o_input_box_overlay_start, .o_input_box_overlay_end) {
-                line-height: calc(2.5 * var(--inputbox-spacing-unit));
-                // input boxes should always have at least the height of: line-height + vertical padding + border width
-                min-height: calc((2.5 + 2) * var(--inputbox-spacing-unit) + 2 * var(--fieldWidget-outline-width));
-
+                &:not(.o_field_html) {
+                    line-height: calc(2.5 * var(--inputbox-spacing-unit));
+                    // input boxes should always have at least the height of: line-height + vertical padding + border width
+                    min-height: calc((2.5 + 2) * var(--inputbox-spacing-unit) + 2 * var(--fieldWidget-outline-width));
+                }
                 .o_input, textarea, select, [contenteditable] {
                     border: none;
                 }


### PR DESCRIPTION
Inside Helpdesk, we see a text overlapping in email composition when
generating a coupon.

Steps to reproduce:
- On small screen / tablet
- Go to helpdesk > Select my tickets
- Select the first on the list
- Click on Coupon button
- Click on Send by email
-> The text inside the content editable is overlaps

task-6022030



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
