### PR TITLE
[FIX] mail: 'Threads' popover should have limited width

### DIFF
--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -417,11 +417,6 @@ a.o-discuss-mention {
     }
 }
 
-.o-mail-Discuss-threadActionPopover {
-    width: Min(95vw, 400px);
-    max-height: Min(50vh, 530px);
-}
-
 .o-mail-starred {
     color: $o-main-favorite-color;
     filter: drop-shadow(1px 1px 0px #000000b0);

--- a/addons/mail/static/src/discuss/core/common/action_panel.scss
+++ b/addons/mail/static/src/discuss/core/common/action_panel.scss
@@ -27,3 +27,11 @@
 .o-mail-ActionPanel-header {
     z-index: $o-mail-NavigableList-zIndex - 1;
 }
+
+.popover:has(.o-mail-ActionPanel-content) {
+    width: Min(95vw, 400px);
+}
+
+.popover .o-mail-ActionPanel-content {
+    max-height: Min(50vh, 530px);
+}

--- a/addons/mail/static/src/discuss/core/common/action_panel.xml
+++ b/addons/mail/static/src/discuss/core/common/action_panel.xml
@@ -24,7 +24,7 @@
             </div>
             <t t-slot="header"/>
         </div>
-        <div class="px-1 d-flex flex-column flex-grow-1 bg-inherit o-min-height-0" t-ref="contentRef">
+        <div class="o-mail-ActionPanel-content px-1 d-flex flex-column flex-grow-1 bg-inherit o-min-height-0" t-ref="contentRef">
             <t t-slot="default"/>
         </div>
     </t>

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -9,7 +9,7 @@
     </t>
 
     <t t-name="discuss.ChannelInvitation.main">
-        <div class="d-flex flex-column flex-grow-1 bg-inherit o-min-height-0" t-att-class="{ 'o-mail-Discuss-threadActionPopover w-100': props.hasSizeConstraints, 'px-1': !props.thread }">
+        <div class="d-flex flex-column flex-grow-1 bg-inherit o-min-height-0" t-att-class="{ 'w-100': props.hasSizeConstraints, 'px-1': !props.thread }">
             <t t-if="store.self_partner">
                 <input class="o-discuss-ChannelInvitation-search form-control lh-1 px-2 bg-view" t-att-value="searchStr" t-ref="input" t-att-placeholder="searchPlaceholder" t-on-input="onInput"/>
                 <ul class="d-flex flex-column mx-0 pt-1 pb-0 overflow-auto o-scrollbar-thin list-group border-0 flex-grow-1" t-att-class="{ 'align-items-center justify-content-center': selectablePartners.length === 0 and state.selectableEmails.length === 0 }">

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
@@ -18,7 +18,7 @@
                     </div>
                 </div>
             </t>
-            <div class="o-mail-SubChannelList o-mail-Discuss-threadActionPopover mw-100 w-100 h-100" t-att-class="{ 'align-items-center justify-content-center': state.subChannels.length === 0 }">
+            <div class="o-mail-SubChannelList mw-100 w-100 h-100" t-att-class="{ 'align-items-center justify-content-center': state.subChannels.length === 0 }">
                 <div t-if="state.subChannels.length === 0" class="flex-grow-1 d-flex flex-column justify-content-center align-items-center">
                     <p class="my-1 text-center fst-italic text-500">
                         <t t-if="state.searching" t-esc="NO_THREAD_FOUND"/>


### PR DESCRIPTION
Before this commit, the "Threads" action in Discuss app had its popover width that would take the browser width.

This happens because, althought there's a classname to limit its size (`o-mail-Discuss-threadActionPopover`), this was applied on a part of popover and was ignored due to `mw-100 w-100`.

This commit fixes the issue by replacing the classname `.o-mail-Discuss-threadActionPopover` with 2 CSS rules for all action panels in popover:

```
.popover:has(ActionPanel) => max-width
.popover .ActionPanel-content => max-height
```

These 2 rules handle popover sizing as desired: fixed width for all these popovers, and max-height on the content part of the action panel. This fixes the problem of limited width for both 'Threads' and 'Invite People' popovers, in addition to handle scrollable content thanks to max-height.

Before / After
<img width="911" height="384" alt="Screenshot 2026-03-10 at 16 12 23" src="https://github.com/user-attachments/assets/f4b77fdb-f946-4d71-904a-d0b273fbe955" />
<img width="915" height="398" alt="Screenshot 2026-03-10 at 16 12 10" src="https://github.com/user-attachments/assets/b2e461e7-a39a-4698-bae0-421d9d87eccb" />
