### PR TITLE
[FIX] website: fix attribute change processor for display of popup

### DIFF
--- a/addons/website/static/src/builder/plugins/popup_visibility_plugin.js
+++ b/addons/website/static/src/builder/plugins/popup_visibility_plugin.js
@@ -20,7 +20,7 @@ export class PopupVisibilityPlugin extends Plugin {
         clean_for_save_handlers: this.cleanForSave.bind(this),
         on_restore_containers_handlers: this.hidePopupsWithoutTarget.bind(this),
         on_reveal_target_handlers: this.hidePopupsWithoutTarget.bind(this),
-        attribute_change_processors: ({ target, attributeName, value, oldValue }) => {
+        attribute_change_processors: ({ target, attributeName, value }) => {
             // On hide/show of the popup, the `style` attribute of the modal in
             // the popup is changed. This also happens with the option
             // "Backdrop" on the popup. When reverting/re-applying steps that
@@ -30,8 +30,8 @@ export class PopupVisibilityPlugin extends Plugin {
             // revert/re-apply a step that modified it.
             if (attributeName === "style" && target.matches(".s_popup > .modal")) {
                 const re = /display: .*?;/;
-                const oldDisplay = oldValue.match(re)?.[0] ?? "";
-                value = re.test(value) ? value.replace(re, oldDisplay) : value + oldDisplay;
+                const currentDisplay = target.attributes.style?.value.match(re)?.[0] ?? "";
+                value = re.test(value) ? value.replace(re, currentDisplay) : value + currentDisplay;
             }
             return value;
         },


### PR DESCRIPTION
The attribute change processor supposed to avoid changing the `display` property of the `style` attribute of the popup element when an history step is replayed (added in cce4527c85e3240ff50fa573b141bc5973a46c2e) was mistakenly using the old display value from the history instead of the current value of the target. This was usually not an issue because in the cases where those value differed, the popup was about to be revealed (or hidden) anyway to show the target at that history step.

This commit keeps the value of the property `display` of the `style` attribute as it is currently on the target, instead of the value of what it should have been as registered by the history.

task-5149984