### PR TITLE
[FIX] test_website: wait for complete page reset in test

### DIFF
--- a/addons/test_website/static/tests/tours/website_page_properties.js
+++ b/addons/test_website/static/tests/tours/website_page_properties.js
@@ -140,7 +140,6 @@ function testCommonProperties(url, canPublish, modifiedUrl = undefined) {
             {
                 content: "Verify is not in menu",
                 trigger: `:visible :iframe #top_menu:not(:has(a[href="${url}"]))`,
-                timeout: 30000,
             },
             stepUtils.goToUrl(getClientActionUrl("/")),
             ...assertPageCanonicalUrlIs("/"),
@@ -288,6 +287,15 @@ function testWebsitePageProperties() {
             content: "Remove from templates",
             trigger: "#is_new_page_template_0",
             run: "uncheck",
+        },
+        {
+            content: "Wait for complete template unlinking",
+            trigger: "body",
+            async run() {
+                const { promise, resolve } = Promise.withResolvers();
+                setTimeout(resolve, 500);
+                return promise;
+            },
         },
     );
     steps.checkTorndown.push(


### PR DESCRIPTION
## Versions
18.0 to saas-18.3
Fixed in saas-18.4

## Issue
The test assumes that a page has been correctly been unset as homepage end unpublished but depending on the test execution speed, this step might not be completed and can introduce issues during later checks (e.g. on menu content verification).

opw-223225