### PR TITLE
[FIX] web: fix daterange padding for each input

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -324,30 +324,29 @@
                     <field name="unavailable_partner_ids" widget="many2many_tags"/>
                 </div>
                 <field name="invalid_email_partner_ids" invisible="1"/> <!--used in many2many_attendees widget-->
-                <div class="d-flex align-items-center pt-1 pb-2" colspan="2">
-                    <i class="fa fa-fw flex-shrink-0 fa-tag text-600 me-2" title="Booking Name"/>
+                <div class="o_input_box">
+                    <i class="o_input_box_overlay_start fa fa-tag" title="Booking Name"/>
                     <field name="name" nolabel="1"
                         placeholder="Add Title"
-                        class="w-100 mb-0"
                     />
                 </div>
                 <div class="d-flex align-items-center pt-1 pb-2" colspan="2">
-                    <i class="fa fa-fw flex-shrink-0 fa-clock-o text-600 me-2" title="Dates"/>
                     <!--when "stop" is set manually, "duration" is computed. When "start" is changed
                     "stop" is computed based on the previously-computed "duration". Hence we need to
                     keep the last computed duration in the front-end model and send it with "start"
                     when it changes-->
                     <!--field is also used for custom behavior in default_get, check before removing-->
-                    <div class="d-flex align-items-center flex-wrap gap-2 w-100">
+                    <div class="o_input_box">
+                        <i class="o_input_box_overlay_start fa fa-clock-o d-touch-none" title="Dates"/>
                         <field name="duration" invisible="1" force_save="1"/>
                         <field name="start" nolabel="1"
                             widget="daterange" options="{'end_date_field': 'stop'}"
-                            placeholder="Dates" class="text-nowrap flex-grow-1 mb-0"
+                            placeholder="Dates"
                             invisible="allday"
                         />
                         <field name="start_date" nolabel="1"
                             widget="daterange" options="{'end_date_field': 'stop_date'}"
-                            placeholder="Dates" class="text-nowrap flex-grow-1 mb-0"
+                            placeholder="Dates"
                             invisible="not allday"
                         />
                         <span class="text-nowrap w-auto">
@@ -359,50 +358,45 @@
                         <field name="stop" invisible="1"/>
                     </div>
                 </div>
-                <div class="d-flex align-items-center pt-1 pb-2" colspan="2">
-                    <i class="fa fa-fw flex-shrink-0 fa-user text-600 me-2" title="Participants"/>
+                <div class="o_input_box">
+                    <i class="o_input_box_overlay_start fa fa-user" title="Participants"/>
                     <field name="partner_ids" nolabel="1"
                         widget="many2many_tags"
                         placeholder="Participants"
-                        class="w-100 mb-0"
                     />
                 </div>
-                <div class="d-flex align-items-center pt-1 pb-2" colspan="2">
-                    <i class="fa fa-fw flex-shrink-0 fa-map text-600 me-2" title="Location"/>
+                <div class="o_input_box">
+                    <i class="o_input_box_overlay_start fa fa-map" title="Location"/>
                     <field name="location" nolabel="1"
                         placeholder="Room or Location"
-                        class="w-100 mb-0"
                     />
                     <!--fields set via the fake front-end only actions must be force saved (see calendar_form)-->
                     <field name="recurrence_update" invisible="1"/>
                     <field name="access_token" force_save="1" invisible="1"/>
                     <field name="videocall_location" force_save="1" invisible="1"/>
                     <field name="videocall_source" force_save="1" invisible="1"/>
-                    <button name="set_discuss_videocall_location" type="object" class="ms-1 pe-0 btn-link text-nowrap"
+                    <button name="set_discuss_videocall_location" type="object" class="o_input_box_overlay_end btn btn-link"
                         invisible="videocall_location" context="{'recurrence_update': recurrence_update}">
                         <span class="fa fa-plus me-1"/>Video conference
                     </button>
                 </div>
-                <div class="d-flex align-items-center pt-1 pb-2" colspan="2" invisible="not videocall_location">
-                    <i class="fa fa-fw flex-shrink-0 fa-video-camera text-600 me-2" title="Videocall URL"/>
-                    <field name="videocall_location" nolabel="1"
-                        widget="CopyClipboardChar"
-                        class="w-100 mb-0 o_field_CopyClipboardChar"
-                    />
-                    <button name="clear_videocall_location" class="btn btn-sm px-0"><i class="fa fa-remove" title="Remove"/></button>
+                <div class="o_input_box" invisible="not videocall_location">
+                    <i class="o_input_box_overlay_start fa fa-video-camera" title="Videocall URL"/>
+                    <field name="videocall_location" nolabel="1" widget="CopyClipboardChar"/>
+                    <button name="clear_videocall_location" class="o_input_box_overlay_end btn btn-link"><i class="fa fa-remove" title="Remove"/></button>
                 </div>
-                <div class="d-flex align-items-center pt-1 pb-2" colspan="2">
-                    <i class="fa fa-fw flex-shrink-0 fa-lock text-600 me-2" title="Visibility"/>
+                <div class="o_input_box">
+                    <i class="o_input_box_overlay_start fa fa-lock" title="Visibility"/>
                     <field name="privacy_placeholder" invisible="1"/> <!-- Used to generate the privacy field's placeholder. -->
-                    <field name="privacy" nolabel="1" class="w-100 mb-0" options="{'placeholder_field': 'privacy_placeholder'}"/>
+                    <field name="privacy" nolabel="1" options="{'placeholder_field': 'privacy_placeholder'}"/>
                 </div>
-                <div class="d-flex align-items-center pt-1 pb-2" colspan="2">
-                    <i class="fa fa-fw flex-shrink-0 fa-circle text-600 me-2" title="Show as"/>
-                    <field name="show_as" nolabel="1" class="w-100 mb-0"/>
+                <div class="o_input_box">
+                    <i class="o_input_box_overlay_start fa fa-circle" title="Show as"/>
+                    <field name="show_as" nolabel="1"/>
                 </div>
-                <div class="d-flex pt-1 pb-2" colspan="2">
-                    <i class="fa fa-fw flex-shrink-0 fa-sticky-note mt-2 text-600 me-2" title="Notes"/>
-                    <field name="notes" nolabel="1" class="w-100" placeholder="Notes" widget="calendar_event_notes_html"/>
+                <div class="o_input_box">
+                    <i class="o_input_box_overlay_start fa fa-sticky-note" title="Notes"/>
+                    <field name="notes" nolabel="1" placeholder="Notes" widget="calendar_event_notes_html"/>
                 </div>
             </form>
         </field>

--- a/addons/web/static/src/views/fields/datetime/datetime_field.scss
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.scss
@@ -1,3 +1,7 @@
-.o_field_daterange .o_input_box button:nth-of-type(2) {
+
+.o_field_daterange:has(.o_daterange_end) .o_daterange_start  {
+    --inputbox-inner-padding-end: 0;
+}
+.o_field_daterange:has(.o_daterange_start) .o_daterange_end {
     --inputbox-inner-padding-start: 0;
 }

--- a/addons/web/static/src/views/fields/datetime/datetime_field.xml
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.xml
@@ -3,7 +3,7 @@
     <t t-name="web.DateTimeField">
         <t t-set="showSeparator" t-value="shouldShowSeparator()" />
         <div class="o_input_box" t-att-class="{'d-flex gap-2 align-items-center position-relative' : showSeparator}" t-custom-ref="root">
-            <i class="o_input_box_overlay_start fa fa-calendar d-none d-touch-inline-flex" />
+            <i t-if="!this.props.readonly" class="o_input_box_overlay_start fa fa-calendar d-none d-touch-inline-flex" />
             <!-- Start date -->
             <t t-if="props.readonly">
                 <span t-if="!isEmpty(startDateField)" class="text-truncate" t-out="window.String(getFormattedValue(0))" t-att-data-tooltip="getFormattedValue(0, true)"/>

--- a/addons/web/static/tests/core/input_box.test.js
+++ b/addons/web/static/tests/core/input_box.test.js
@@ -112,4 +112,27 @@ describe("Elements with o_input_box classname", () => {
         expect(".o_input_box .o_input_box").not.toHaveAttribute("style");
         expect(".o_input_box .fa-phone").toBeVisible();
     });
+
+    test("InputBox overlays that are invisible don't affect the padding", async () => {
+        class Root extends Component {
+            static components = {};
+            static props = {};
+            static template = xml`
+                <div class="o_input_box">
+                    <i class="o_input_box_overlay_start fa fa-phone d-none d-touch-block"/>
+                    <div class="o_input_box">
+                        <span>0123456</span>
+                        <i class="o_input_box_overlay_end fa fa-arrow"/>
+                    </div>
+                </div>
+            `;
+        }
+        await mountWithCleanup(Root);
+        // Component with o_input_box class having o_input_box_overlay elements must call the positioning function after the render
+        positionInputBoxOverlay(getFixture());
+        await animationFrame();
+        const overlayPaddingEnd = queryFirst(".o_input_box_overlay_end").clientWidth + INPUTBOX_SPACING_UNIT;
+        expect(".o_input_box:not(.o_input_box .o_input_box").toHaveAttribute("style",`--inputbox-overlay-padding-prefix: 0px; --inputbox-overlay-padding-suffix: ${overlayPaddingEnd}px;`);
+        expect(".o_input_box .fa-phone").not.toBeVisible();
+    });
 });

--- a/addons/web/static/tests/views/fields/date_field.test.js
+++ b/addons/web/static/tests/views/fields/date_field.test.js
@@ -630,3 +630,11 @@ test("DateField with onchange forcing a specific date", async () => {
     await contains(getPickerCell("22")).click(); // 22 May 2009
     expect(".o_field_date").toHaveText("May 4"); // value forced by the onchange
 });
+
+test("DateField contains a calendar icon on touch devices", async () => {
+    // The icon is only visible on touch devices, using css rules
+    document.body.classList.add("o_touch_device");
+    await mountView({ type: "form", resModel: "res.partner", resId: 1 });
+    expect(".fa-calendar").toHaveCount(1);
+    expect(".fa-calendar").toBeVisible();
+});

--- a/addons/web/static/tests/views/fields/daterange_field.test.js
+++ b/addons/web/static/tests/views/fields/daterange_field.test.js
@@ -1472,3 +1472,46 @@ test("daterange in list view with missing first date", async () => {
 
     expect(".o_field_daterange[name=datetime_end]").toHaveText("Feb 8, 2017, 3:30 PM");
 });
+
+test("DateRangeField contains a calendar icon on touch devices", async () => {
+    Partner._records[0].datetime_end = "2017-02-01 00:00:00";
+    // The icon is only visible on touch devices, using css rules
+    document.body.classList.add("o_touch_device");
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: `
+            <form>
+                <field name="datetime" widget="daterange" options="{'end_date_field': 'datetime_end'}"/>
+            </form>`,
+        resId: 1,
+    });
+    expect(".o_field_daterange .o_input").toHaveCount(2);
+    expect(".fa-calendar").toHaveCount(1);
+    expect(".fa-calendar").toBeVisible();
+});
+
+test("DateRangeField has the right padding on touch devices with overlay suffix", async () => {
+    Partner._records[0].datetime_end = "2017-02-01 00:00:00";
+    // The icon is only visible on touch devices, using css rules
+    document.body.classList.add("o_touch_device");
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: `
+            <form>
+                <div class="o_input_box">
+                    <field name="datetime" widget="daterange" options="{'end_date_field': 'datetime_end'}"/>
+                    <i class="fa fa-close btn btn-link o_input_box_overlay_end"/>
+                </div>
+            </form>`,
+        resId: 1,
+    });
+    const gap = parseInt(
+        getComputedStyle(queryFirst(".o_input_box")).getPropertyValue("--inputbox-spacing-unit")
+    );
+    const targetPaddingStart = 1.5 * gap + (queryFirst(".o_input_box_overlay_start").clientWidth + gap)
+    const targetPaddingEnd = queryFirst(".o_input_box_overlay_end").clientWidth + 2 * gap;
+    expect(getComputedStyle(queryFirst(".o_daterange_start")).paddingInline).toBe(`${targetPaddingStart}px 0px`);
+    expect(getComputedStyle(queryFirst(".o_daterange_end")).paddingInline).toBe(`0px ${targetPaddingEnd}px`);
+});

--- a/addons/web/static/tests/views/fields/datetime_field.test.js
+++ b/addons/web/static/tests/views/fields/datetime_field.test.js
@@ -706,3 +706,17 @@ test("list datetime: column widths (numeric format)", async () => {
     ]);
     expect(queryAllProperties(".o_list_table thead th", "offsetWidth")).toEqual([40, 144, 616]);
 });
+test("DateTimeField contains a calendar icon on touch devices", async () => {
+    // The icon is only visible on touch devices, using css rules
+    document.body.classList.add("o_touch_device");
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `<form>
+            <field name="datetime"/>
+        </form>`,
+    });
+    expect(".fa-calendar").toHaveCount(1);
+    expect(".fa-calendar").toBeVisible();
+});


### PR DESCRIPTION
This commit fixes the display of dateranges, when two different inputs
are present. Before the fix, the padding-inline-end property was set
on the first input, resulting in squeezed content and an new line
could happen even if enough space was present below.

Tests have been added for any implementation of the Date(*)Field
component.