### PR TITLE
[FIX] mail: remove wrong 'deprecate' of 'openChannelInvitePanel'

### DIFF
--- a/addons/mail/static/src/discuss/core/common/channel_member_list.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.js
@@ -41,7 +41,7 @@ export class ChannelMemberList extends Component {
         });
     }
 
-    openInviteDialog() {
+    onClickInviteButton() {
         if (this.env.inMeetingView) {
             this.props.openChannelInvitePanel?.({ keepPrevious: true });
         } else {

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -3,7 +3,7 @@
 
     <t t-name="discuss.ChannelMemberList">
         <ActionPanel title.translate="Members" minWidth="200" initialWidth="this.env.inMeetingView ? 400 : 250" icon="'oi oi-users'">
-            <button name="inviteButton" t-on-click="() => this.openInviteDialog()" class="btn btn-sm btn-secondary mt-2 d-flex align-items-center justify-content-center gap-1 rounded-3" title="Invite People"><i class="oi oi-user-plus"/><span>Invite People</span></button>
+            <button name="inviteButton" t-on-click="() => this.onClickInviteButton()" class="btn btn-sm btn-secondary mt-2 d-flex align-items-center justify-content-center gap-1 rounded-3" title="Invite People"><i class="oi oi-user-plus"/><span>Invite People</span></button>
             <t t-if="this.props.channel.onlineMembers.length > 0">
                 <t t-call="discuss.ChannelMemberList.section">
                     <t t-set="sectionName" t-value="this.onlineSectionText"/>

--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -222,7 +222,6 @@ registerThreadAction("member-list", {
     },
     actionPanelComponent: ChannelMemberList,
     actionPanelComponentProps: ({ actions, channel }) => ({
-        /** @deprecated */
         openChannelInvitePanel({ keepPrevious } = {}) {
             actions.actions
                 .find(({ id }) => id === "invite-people")


### PR DESCRIPTION
This prop was flagged as deprecated as this was unused [1]. However quite recently this has been reused for genuine reasons [2].

Therefore the `@deprecate` should simply be removed.

This also rename the handler method of click on "invite button" of members panel, as this was mistakenly suggesting this opens in a dialog when in practice this could be in panel instead.

[1]: https://github.com/odoo/odoo/pull/233389
[2]: https://github.com/odoo/odoo/pull/252620