### PR TITLE
[FIX] pos_restaurant: avoid cross-config order matching on shared tables

### DIFF
--- a/addons/pos_restaurant/models/pos_order.py
+++ b/addons/pos_restaurant/models/pos_order.py
@@ -16,7 +16,7 @@ class PosOrder(models.Model):
 
         domain = []
         if order.get('table_id', False) and order.get('state') == 'draft':
-            domain += ['|', ('uuid', '=', order.get('uuid')), '&', ('table_id', '=', order.get('table_id')), ('state', '=', 'draft')]
+            domain += ['|', ('uuid', '=', order.get('uuid')), '&', '&', ('table_id', '=', order.get('table_id')), ('state', '=', 'draft'), ('config_id', '=', config_id.id)]
         else:
             domain += [('uuid', '=', order.get('uuid'))]
         return self.env["pos.order"].search(domain, limit=1, order='id desc')


### PR DESCRIPTION
When multiple POS configurations share the same restaurant floor, an order placed on a table in one POS could be incorrectly retrieved or merged by another POS selecting the same table.

task-id: 6024012

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
