### PR TITLE
[FIX] point_of_sale: invoice button not taken into account

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/utils/payment_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/payment_screen_util.js
@@ -116,6 +116,12 @@ export function clickInvoiceButton() {
         },
     ];
 }
+export function checkInvoiceIsChecked() {
+    return {
+        content: "check invoice button is checked",
+        trigger: ".payment-buttons .js_invoice i.fa-check-square",
+    };
+}
 export function clickValidate() {
     return [
         {


### PR DESCRIPTION
This commit adds a method used in some tests.
runbot-error: 238505
Enterprise PR: https://github.com/odoo/enterprise/pull/110171

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
