### PR TITLE
[FIX] web: fix `priority_switch` widget color

### DIFF
--- a/addons/web/static/src/views/fields/priority/priority_field.scss
+++ b/addons/web/static/src/views/fields/priority/priority_field.scss
@@ -1,4 +1,4 @@
-.o_field_priority .o_priority {
+.o_field_widget .o_priority {
     gap: 0.5em;
     > .o_priority_star {
         font-size: 1.25em !important;


### PR DESCRIPTION
| Master | This PR |
|--------|--------|
| <img width="83" height="52" alt="image" src="https://github.com/user-attachments/assets/c18b97c1-111e-4d4d-8ec2-de9db2e97f0d" /> | <img width="119" height="56" alt="image" src="https://github.com/user-attachments/assets/081ebaf0-5264-4147-8a59-d0fc8db6df9f" /> | 

In Commit[^1], the `priority` field was fine-tuned to improve the visual result on both small and large screen. Part of the change was also to scope all that new style within the `.o_priority` when it's inside a `.o_field_priority` element.

While this affect most of the priority fields, the `priority_switch` one in `project` is registered as `priority_switch` meaning it will receive the `.o_priority_switch` class, preventing the element to receive all the styling from `priority_field.scss`

Prior to Commit[^1], the styling was scoped within `.o_field_widget .o_priority` which is common to both fields. The most obvious solution is the to reuse that selector to ensure consistent styling.

[^1]: https://github.com/odoo/odoo/commit/dc8f38b1054664a0e382530bb4fc73983e2085cb#diff-6fd554fc6cc9c710c06244c7ec3ade376282bb3bf3251f78a9cee0d289a4c2dfL1

task-6024493

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
