### PR TITLE
[IMP] mail: make message inline actions rounded-circle

### DIFF
--- a/addons/mail/static/src/core/common/action.js
+++ b/addons/mail/static/src/core/common/action.js
@@ -26,6 +26,10 @@ export const ACTION_TAGS = Object.freeze({
  */
 
 /**
+ * @typedef {{quick: Action[], group: Array<Action[]>, other: Action[]}} PartitionedActions
+ */
+
+/**
  * @typedef {Object} ActionDefinition
  * @property {(params: Action & ActionPanelCloseSpecificParams) => void} [actionPanelClose]
  * @property {Component} [actionPanelComponent]
@@ -280,7 +284,9 @@ export class Action {
     get disabledCondition() {
         return Boolean(
             this._disabledCondition(this.params) ??
-                this.definition.disabledCondition?.call(this, this.params)
+                (typeof this.definition.disabledCondition === "function"
+                    ? this.definition.disabledCondition.call(this, this.params)
+                    : this.definition.disabledCondition)
         );
     }
 
@@ -578,13 +584,14 @@ export class UseActions extends Reactive {
      */
     /** @typedef {ActionDefinition & MoreActionSpecificDefinition} MoreActionDefinition */
     /** @param {MoreActionDefinition} [data] */
-    more(data = {}, id) {
+    more(actionsParams = {}, data = {}, id) {
         let moreAction = toRaw(this).moreActions.get(id);
         if (moreAction) {
             moreAction = this.moreActions.get(id);
             moreAction.definition.actions = data.actions;
         } else {
             moreAction = new this.ActionClass({
+                ...actionsParams,
                 owner: this.component,
                 id: `more-action:${id}`,
                 definition: {
@@ -610,6 +617,7 @@ export class UseActions extends Reactive {
         return actions;
     }
 
+    /** @return {PartitionedActions} */
     get partition() {
         const actions = this.transformedActions.filter((action) => action.condition);
         const quick = actions

--- a/addons/mail/static/src/core/common/action_list.xml
+++ b/addons/mail/static/src/core/common/action_list.xml
@@ -43,7 +43,7 @@
 </t>
 
 <t t-name="mail.Action.main">
-    <t t-set="isInlineCircleButton" t-value="this.env.inComposer or (this.action.tags.includes('JOIN_LEAVE_CALL') and this.action.icon and !this.action.inlineName)"/>
+    <t t-set="isInlineCircleButton" t-value="this.env.inComposer or this.env.inMessage or (this.action.tags.includes('JOIN_LEAVE_CALL') and this.action.icon and !this.action.inlineName)"/>
     <!-- core-->
     <t t-set="btnClass" t-value="this.attClassObjectToString({
         'o-mail-ActionList-button btn btn-group-item position-relative': true,
@@ -53,6 +53,7 @@
         'o-odooControlPanelSwitchStyle': this.props.odooControlPanelSwitchStyle,
         'o-hasBtnBg': this.hasBtnBg,
         'o-inline': this.props.inline,
+        'bg-secondary': this.action.isActive and !this.action.tags.includes('PRIMARY') and !this.action.tags.includes('DANGER') and !this.action.tags.includes('SUCCESS'),
         'btn-secondary': !this.action.tags.includes('PRIMARY') and !this.action.tags.includes('DANGER') and !this.action.tags.includes('SUCCESS'),
         'btn-primary': this.action.tags.includes('PRIMARY'),
         'btn-danger': this.action.tags.includes('DANGER'),
@@ -91,7 +92,8 @@
         'o-p-1_5':       this.props.inline   and  !this.env.inMeetingView and this.hasBtnBg and isInlineCircleButton and !this.env.inChatWindow,
         'o-px-0_5':      this.props.inline   and  !this.env.inMeetingView and !this.hasBtnBg and !this.action.icon,
         'p-1':           this.props.inline   and  this.hasBtnBg and isInlineCircleButton and this.env.inChatWindow,
-        'o-p-0_5':       this.props.inline   and  ((!this.env.inMeetingView and !this.hasBtnBg and !this.env.inComposer) or this.env.inMessage),
+        'o-p-0_5':       this.props.inline   and  !this.env.inMeetingView and !this.hasBtnBg and !this.env.inComposer,
+        'o-px-0_5 py-0': this.props.inline   and  this.env.inMessage,
         'px-3 py-2':     this.props.dropdown and   this.ui.isSmall,
         'px-2 py-1':     this.props.dropdown and  !this.ui.isSmall,
     })"/>

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -127,7 +127,7 @@ export class Composer extends Component {
         this.isMobileOS = isMobileOS();
         this.isIosPwa = isIOS() && isDisplayStandalone();
         this.store = useService("mail.store");
-        this.composerActions = useComposerActions({ composer: () => this.props.composer });
+        this.composerActions = useComposerActions(this.composerActionsParams);
         this.EDIT_CLICK_TYPE = EDIT_CLICK_TYPE;
         this.OR_PRESS_SEND_KEYBIND = _t("or press %(send_keybind)s", {
             send_keybind: htmlJoin(
@@ -330,6 +330,25 @@ export class Composer extends Component {
 
     get areAllActionsDisabled() {
         return this.props.disabled;
+    }
+
+    get composerActionsParams() {
+        return { composer: () => this.props.composer };
+    }
+
+    /** @param {import("@mail/core/common/action").PartitionedActions} partitionedActions */
+    computeMoreActions(partitionedActions) {
+        if (this.props.mode === "extended" || partitionedActions.other.length === 0) {
+            this.moreActions = undefined;
+            return;
+        }
+        this.moreActions = this.composerActions.more(this.composerActionsParams, {
+            actions: partitionedActions.other,
+            disabledCondition: this.areAllActionsDisabled,
+            dropdownPosition: "top-start",
+            icon: "fa fa-plus-circle",
+            name: _t("More Actions"),
+        });
     }
 
     get isMultiUpload() {

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -4,6 +4,7 @@
 <t t-name="mail.Composer">
     <t t-set="isChatterComposer" t-value="this.extended and !this.props.composer.message"/>
     <t t-set="partitionedActions" t-value="this.composerActions.partition"/>
+    <t t-set="dummy" t-value="this.computeMoreActions(partitionedActions)"/>
     <t t-set="actionsContainerClass" t-value="'o-mail-Composer-actions d-flex o-rounded-bubble'"/>
     <div t-custom-ref="root">
         <div class="o-mail-Composer d-grid flex-shrink-0 pt-0 position-relative"
@@ -56,12 +57,7 @@
                     t-custom-ref="input-container"
                 >
                     <div t-if="!this.extended" t-attf-class="{{ actionsContainerClass }}">
-                        <Dropdown t-if="partitionedActions.other.length > 0" position="'top-start'" menuClass="this.store.discussDropdownMenuClass(this)">
-                            <t t-call="mail.Composer.moreActions"/>
-                            <t t-set-slot="content">
-                                <ActionList actions="partitionedActions.other" dropdown="true"/>
-                            </t>
-                        </Dropdown>
+                        <t t-if="this.moreActions" t-call="mail.Composer.moreActions"/>
                     </div>
                     <div class="position-relative flex-grow-1">
                         <t t-set="inputClasses" t-value="{
@@ -161,18 +157,11 @@
 </t>
 
 <t t-name="mail.Composer.moreActions">
-    <button class="btn btn-link p-0 d-flex border-0" t-att-disabled="this.areAllActionsDisabled" t-custom-ref="more-actions">
+    <div class="o-mail-Composer-moreActions o-mail-Composer-bg" t-attf-class="{{ actionsContainerClass }}" t-custom-ref="more-actions">
         <div class="o-mail-Composer-mainActions d-flex flex-grow-1 align-items-baseline">
-            <t t-set="moreName">More Actions</t>
-            <ActionList inline="true" actions="[{
-                'disabledCondition': this.areAllActionsDisabled,
-                'icon': 'fa fa-plus-circle',
-                'id': 'more-actions',
-                'name': moreName,
-                'tags': [],
-            }]"/>
+            <ActionList actions="[this.moreActions]" inline="true"/>
         </div>
-    </button>
+    </div>
 </t>
 
 <t t-name="mail.Composer.extraActions">

--- a/addons/mail/static/src/core/common/composer_actions.js
+++ b/addons/mail/static/src/core/common/composer_actions.js
@@ -89,10 +89,12 @@ registerComposerAction("send-message", {
         );
     },
     sequenceQuick: 30,
+    tags: ({ action }) => (action.isActive ? ACTION_TAGS.PRIMARY : undefined),
 });
 registerComposerAction("add-emoji", {
     disabledCondition: ({ owner }) => owner.areAllActionsDisabled,
     icon: "fa fa-smile-o",
+    isActive: ({ action, owner }) => toRaw(owner.getActivePicker()) === toRaw(action.picker),
     isPicker: true,
     pickerName: _t("Emoji"),
     name: _t("Add Emojis"),

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -119,10 +119,7 @@ export class Message extends Component {
         }
         useForwardRefsToParent("messageRefs", (props) => props.message.id, this.root);
         this.messageBody = useRef("body");
-        this.messageActions = useMessageActions({
-            message: () => this.message,
-            thread: () => this.props.thread,
-        });
+        this.messageActions = useMessageActions(this.messageActionsParams);
         this.shadowBody = useRef("shadowBody");
         this.dialog = useService("dialog");
         this.ui = useService("ui");
@@ -218,6 +215,13 @@ export class Message extends Component {
         );
     }
 
+    get messageActionsParams() {
+        return {
+            message: () => this.message,
+            thread: () => this.props.thread,
+        };
+    }
+
     computeActions() {
         const allActions = this.messageActions.actions;
         const quickActions = allActions.slice(
@@ -231,7 +235,7 @@ export class Message extends Component {
                 ? allActions.slice(this.quickActionCount - 1)
                 : false;
         const moreAction = moreActions?.length
-            ? this.messageActions.more({
+            ? this.messageActions.more(this.messageActionsParams, {
                   actions: moreActions,
                   dropdownMenuClass: "o-mail-Message-moreMenu",
                   dropdownPosition: this.isAlignedRight

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -162,7 +162,7 @@
     <div t-if="this.props.hasActions and this.message.hasActions and !this.isEditing and !this.env.inChatter?.disabled" class="o-mail-Message-actions d-print-none d-flex align-items-start"
         t-att-class="{
             'start-0': this.isAlignedRight,
-            'mt-1': this.message.bubbleColor and !this.props.asCard and !this.isMobileOS,
+            'o-mt-0_5': this.message.bubbleColor and !this.props.asCard and !this.isMobileOS,
             'my-n2': !this.message.bubbleColor and !this.props.asCard and !this.isMobileOS,
             'gap-1': this.isMobileOS,
             'mx-1': !this.isMobileOS,

--- a/addons/mail/static/src/core/common/quick_reaction_menu.xml
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.xml
@@ -18,7 +18,7 @@
     </t>
 
     <t t-name="mail.QuickReactionMenu.toggler">
-        <button class="btn border-0 o-p-0_5 o-inline o-mail-QuickReactionMenu-toggler" t-att-class="this.attClass" t-att-title="this.props.action.name" t-att-aria-label="this.props.action.name" t-on-click="this.onClick">
+        <button class="btn border-0 o-px-0_5 py-0 o-inline o-mail-QuickReactionMenu-toggler" t-att-class="this.attClass" t-att-title="this.props.action.name" t-att-aria-label="this.props.action.name" t-on-click="this.onClick">
             <i t-att-class="this.props.action.icon"/>
         </button>
     </t>

--- a/addons/mail/static/src/discuss/call/common/call_action_list.js
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.js
@@ -20,7 +20,7 @@ export class CallActionList extends Component {
         this.store = useService("mail.store");
         this.rtc = useService("discuss.rtc");
         this.pipService = useService("discuss.pip_service");
-        this.callActions = useCallActions({ channel: () => this.props.channel });
+        this.callActions = useCallActions(this.callActionsParams);
         this.more = useRef("more");
         this.root = useRef("root");
         this.popover = usePopover(Tooltip, {
@@ -44,6 +44,7 @@ export class CallActionList extends Component {
                     ? [
                           ...quickActions,
                           this.callActions.more(
+                              this.callActionsParams,
                               {
                                   actions: moreActions,
                                   dropdownMenuClass: "m-0 mb-1 overflow-x-hidden",
@@ -58,6 +59,10 @@ export class CallActionList extends Component {
             }
             this.actions = [...group2, other];
         });
+    }
+
+    get callActionsParams() {
+        return { channel: () => this.props.channel };
     }
 
     get MORE() {

--- a/addons/mail/static/src/discuss/call/common/meeting_side_actions.js
+++ b/addons/mail/static/src/discuss/call/common/meeting_side_actions.js
@@ -21,8 +21,12 @@ export class MeetingSideActions extends Component {
 
     setup() {
         this.store = useService("mail.store");
-        this.callActions = useCallActions({ channel: () => this.store.rtc.channel });
+        this.callActions = useCallActions(this.callActionsParams);
         useSubEnv({ inMeetingSideActions: true });
+    }
+
+    get callActionsParams() {
+        return { channel: () => this.store.rtc.channel };
     }
 
     computeActions() {
@@ -46,7 +50,7 @@ export class MeetingSideActions extends Component {
             quickThreadActionIds.includes(action.id)
         );
         actions.push(
-            threadActions.more({
+            threadActions.more(this.callActionsParams, {
                 actions: [
                     partitionedActions.quick,
                     partitionedActions.other,

--- a/addons/mail/static/src/discuss/gif_picker/common/composer_actions_patch.js
+++ b/addons/mail/static/src/discuss/gif_picker/common/composer_actions_patch.js
@@ -3,7 +3,7 @@ import {
     pickerOnClick,
     pickerSetup,
 } from "@mail/core/common/composer_actions";
-import { markup } from "@odoo/owl";
+import { markup, toRaw } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { markEventHandled } from "@web/core/utils/misc";
 import { useGifPicker } from "./gif_picker";
@@ -13,6 +13,7 @@ registerComposerAction("add-gif", {
         (store.hasGifPickerFeature || store.self_user?.is_admin) &&
         !owner.env.inChatter &&
         !composer.message,
+    isActive: ({ action, owner }) => toRaw(owner.getActivePicker()) === toRaw(action.picker),
     isPicker: true,
     pickerName: _t("GIF"),
     icon: "oi oi-gif-picker",


### PR DESCRIPTION
BG color and shape of message actions, like the "expand" button, looks weird. This commit makes the following improvements around it:

- Clickable area of message action is now rounded-circle.
- Color is now bg-secondary when active instead of green tint.
- Composer actions also inherit same improvements.
- Composer "more actions" is now made with `actions.more()`, to have the same improvements as the other inline buttons when active.

Part of Task-5867464 (part 67)

Before / After

<img width="247" height="221" alt="Screenshot 2026-03-13 at 18 36 20" src="https://github.com/user-attachments/assets/9ba029fc-4bc7-4064-b2c7-0cd982691745" /> <img width="249" height="228" alt="Screenshot 2026-03-13 at 18 36 03" src="https://github.com/user-attachments/assets/98d3afd4-6aca-429b-8eea-86b2802da0a3" />
