### PR TITLE
[REF] *: run rendering context migration script

### DIFF
--- a/addons/website_sale_slides/static/src/xml/website_slides_unsubscribe.xml
+++ b/addons/website_sale_slides/static/src/xml/website_slides_unsubscribe.xml
@@ -3,7 +3,7 @@
 
     <t t-inherit="website_slides.SlideUnsubscribeDialog" t-inherit-mode="extension">
         <xpath expr="//t[@t-if=&quot;state.mode === 'leave'&quot;] //p[last()]" position="after">
-            <t t-if="props.enroll === 'payment'">
+            <t t-if="this.props.enroll === 'payment'">
                 <p class="d-flex align-items-center gap-3 alert alert-warning mb-0">
                     <i class="fa fa-exclamation-triangle fa-3x"></i>
                     <div>

--- a/addons/website_slides/static/src/js/public/components/course_join_popup/course_join_popup.xml
+++ b/addons/website_slides/static/src/js/public/components/course_join_popup/course_join_popup.xml
@@ -2,19 +2,19 @@
 <templates xml:space="preserve">
     <t t-name="slide.course.join.popupContent">
         <div class="p-3">
-            <t t-if="props.text">
-                <t t-out="props.text" />
+            <t t-if="this.props.text">
+                <t t-out="this.props.text" />
             </t>
-            <div t-elif="props.invitePreview">
-                Please <a t-attf-href="/slides/#{props.channelId}/identify?invite_partner_id=#{props.invitePartnerId}&amp;invite_hash=#{props.inviteHash}">
-                <t t-if="props.isPartnerWithoutUser">create an account</t><t t-else="">login</t>
+            <div t-elif="this.props.invitePreview">
+                Please <a t-attf-href="/slides/#{this.props.channelId}/identify?invite_partner_id=#{this.props.invitePartnerId}&amp;invite_hash=#{this.props.inviteHash}">
+                <t t-if="this.props.isPartnerWithoutUser">create an account</t><t t-else="">login</t>
                 </a> to join this course
             </div>
-            <t t-elif="props.errorSignupAllowed">
-                Please <a t-attf-href="/web/login?redirect=#{props.courseUrl}">login</a> or <a t-attf-href="/web/signup?redirect=#{props.courseUrl}">create an account</a> to join this course
+            <t t-elif="this.props.errorSignupAllowed">
+                Please <a t-attf-href="/web/login?redirect=#{this.props.courseUrl}">login</a> or <a t-attf-href="/web/signup?redirect=#{this.props.courseUrl}">create an account</a> to join this course
             </t>
             <t t-else="">
-                Please <a t-attf-href="/web/login?redirect=#{props.courseUrl}">login</a> to join this course
+                Please <a t-attf-href="/web/login?redirect=#{this.props.courseUrl}">login</a> to join this course
             </t>
         </div>
     </t>

--- a/addons/website_slides/static/src/js/public/components/course_tag_add_dialog/course_tag_add_dialog.xml
+++ b/addons/website_slides/static/src/js/public/components/course_tag_add_dialog/course_tag_add_dialog.xml
@@ -4,28 +4,28 @@
   <t t-name="website_slides.CourseTagAddDialog">
     <Dialog size="'md'" title.translate="Add Tag">
         <t t-set-slot="footer">
-            <a role="button" class="btn btn-primary me-1" t-on-click.prevent="onClickFormSubmit">
+            <a role="button" class="btn btn-primary me-1" t-on-click.prevent="this.onClickFormSubmit">
                 <span>Add</span>
             </a>
-            <button type="button" class="btn btn-secondary" t-on-click="props.close">
+            <button type="button" class="btn btn-secondary" t-on-click="this.props.close">
                 <span>Back</span>
             </button>
         </t>
         <div class="mb-3">
-            <div t-if="state.alertMsg" t-out="state.alertMsg" class="alert alert-warning"/>
-            <div class="mb-3" t-att-class="{'form-control is-valid': validation.tagIsValid, 'form-control is-invalid': validation.tagIsValid === false}">
+            <div t-if="this.state.alertMsg" t-out="this.state.alertMsg" class="alert alert-warning"/>
+            <div class="mb-3" t-att-class="{'form-control is-valid': this.validation.tagIsValid, 'form-control is-invalid': this.validation.tagIsValid === false}">
                 <label class="col-form-label">Tag</label>
                 <SelectMenu
                     togglerClass="'form-control'"
-                    choices="choices.tagIds"
-                    onSelect.bind="onTagSelect"
+                    choices="this.choices.tagIds"
+                    onSelect.bind="this.onTagSelect"
                     required="true"
-                    value="choices.tagId"
+                    value="this.choices.tagId"
                 >
-                    <t t-out="displayTagValue"/>
+                    <t t-out="this.displayTagValue"/>
                     <t t-set-slot="bottomArea" t-slot-scope="select">
                         <DropdownItem
-                            t-if="select.data.searchValue and state.canCreateTag"
+                            t-if="select.data.searchValue and this.state.canCreateTag"
                             class="'btn text-primary'"
                             onSelected="() => this.createChoice(select.data.searchValue)"
                         >
@@ -34,19 +34,19 @@
                     </t>
                 </SelectMenu>
             </div>
-            <div t-if="state.showTagGroup" class="mb-3" t-att-class="{'form-control is-valid': validation.tagGroupIsValid, 'form-control is-invalid': validation.tagGroupIsValid === false}">
+            <div t-if="this.state.showTagGroup" class="mb-3" t-att-class="{'form-control is-valid': this.validation.tagGroupIsValid, 'form-control is-invalid': this.validation.tagGroupIsValid === false}">
                 <label class="col-form-label">Tag Group</label>
                 <SelectMenu
                     togglerClass="'form-control'"
-                    choices="choices.tagGroupIds"
-                    onSelect.bind="onTagGroupSelect"
+                    choices="this.choices.tagGroupIds"
+                    onSelect.bind="this.onTagGroupSelect"
                     required="true"
-                    value="choices.tagGroupId"
+                    value="this.choices.tagGroupId"
                 >
-                    <t t-out="displayTagGroupValue"/>
+                    <t t-out="this.displayTagGroupValue"/>
                     <t t-set-slot="bottomArea" t-slot-scope="select">
                         <DropdownItem
-                            t-if="select.data.searchValue and state.canCreateTagGroup"
+                            t-if="select.data.searchValue and this.state.canCreateTagGroup"
                             class="'btn text-primary'"
                             onSelected="() => this.createChoice(select.data.searchValue, 'tagGroup')"
                         >

--- a/addons/website_slides/static/src/js/public/components/slide_quiz_finish_dialog/slide_quiz_finish_dialog.xml
+++ b/addons/website_slides/static/src/js/public/components/slide_quiz_finish_dialog/slide_quiz_finish_dialog.xml
@@ -16,32 +16,32 @@
             </div>
             <div class="d-flex flex-column flex-grow-1 justify-content-between ps-md-5 p-3 overflow-visible">
                 <div>
-                    <h1 class="mt-3 display-4 fw-bold" t-out="title"/>
+                    <h1 class="mt-3 display-4 fw-bold" t-out="this.title"/>
                     <div class="pb-3">
-                        <h4 class="pb-2 d-flex fade" t-att-class="state.animateKarmaGain ? 'show in': ''">
-                            <t t-if="props.quiz.quizKarmaWon > 0">
-                                You gained <span class="badge text-bg-success text-white fw-bold ms-2 me-1"><t t-out="props.quiz.quizKarmaWon"/> XP</span>!
+                        <h4 class="pb-2 d-flex fade" t-att-class="this.state.animateKarmaGain ? 'show in': ''">
+                            <t t-if="this.props.quiz.quizKarmaWon > 0">
+                                You gained <span class="badge text-bg-success text-white fw-bold ms-2 me-1"><t t-out="this.props.quiz.quizKarmaWon"/> XP</span>!
                             </t>
                             <t t-else="">You did it!</t>
                         </h4>
                         <div class="mt-5 mb-4">
                             <SlideXPProgressBar
-                                previousRank="props.quiz.rankProgress.previous_rank"
-                                newRank="props.quiz.rankProgress.new_rank"
-                                levelUp="props.quiz.rankProgress.level_up"
+                                previousRank="this.props.quiz.rankProgress.previous_rank"
+                                newRank="this.props.quiz.rankProgress.new_rank"
+                                levelUp="this.props.quiz.rankProgress.level_up"
                             />
                         </div>
                     </div>
-                    <div class="pb-3 o_wslides_quiz_modal_rank_motivational" t-att-class="{'fade': state.fadeRankMotivational, 'show in': state.showRankMotivational}">
-                        <t t-if="props.quiz.rankProgress.last_rank" t-out="props.quiz.rankProgress.description"/>
-                        <t t-else="" t-out="props.quiz.rankProgress.new_rank.motivational"/>
+                    <div class="pb-3 o_wslides_quiz_modal_rank_motivational" t-att-class="{'fade': this.state.fadeRankMotivational, 'show in': this.state.showRankMotivational}">
+                        <t t-if="this.props.quiz.rankProgress.last_rank" t-out="this.props.quiz.rankProgress.description"/>
+                        <t t-else="" t-out="this.props.quiz.rankProgress.new_rank.motivational"/>
                     </div>
                 </div>
                 <div t-attf-class="o_wslides_quiz_modal_dismiss align-self-end ${this.state.hideDismissBtns ? 'd-none': ''}">
-                    <a t-if="props.quiz.rankProgress.level_up" type="button" target="_blank" t-attf-href="/profile/user/#{props.userId}" class="btn btn-light border me-1">
+                    <a t-if="this.props.quiz.rankProgress.level_up" type="button" target="_blank" t-attf-href="/profile/user/#{this.props.userId}" class="btn btn-light border me-1">
                         Check Profile
                     </a>
-                    <button t-if="props.hasNext" type="button" class="btn btn-light border" t-on-click="onClickNext">
+                    <button t-if="this.props.hasNext" type="button" class="btn btn-light border" t-on-click="this.onClickNext">
                         Next <i class="oi oi-chevron-right"/>
                     </button>
                     <a t-else="" type="button" href="/slides" class="btn btn-light border">End course</a>

--- a/addons/website_slides/static/src/js/public/components/slide_quiz_finish_dialog/slide_xp_progress_bar.xml
+++ b/addons/website_slides/static/src/js/public/components/slide_quiz_finish_dialog/slide_xp_progress_bar.xml
@@ -3,18 +3,18 @@
 
     <t t-name="website_slides.SlideXPProgressBar" owl="1">
         <div class="progress">
-            <div class="progress-bar" t-att-class="{'level-up': props.levelUp}" role="progressbar"
-                 t-att-aria-valuenow="props.previousRank.progress" aria-valuemin="0" aria-valuemax="100" aria-label="Progress bar"
-                 t-attf-style="width: #{state.rankProgressPercentage}%"/>
+            <div class="progress-bar" t-att-class="{'level-up': this.props.levelUp}" role="progressbar"
+                 t-att-aria-valuenow="this.props.previousRank.progress" aria-valuemin="0" aria-valuemax="100" aria-label="Progress bar"
+                 t-attf-style="width: #{this.state.rankProgressPercentage}%"/>
         </div>
-        <small class="float-start text-primary fw-bold" t-att-class="{'d-none': state.hideRankBounds}"
-               t-out="state.rankLowerBound"/>
-        <small t-if="state.rankUpperBound" class="float-end fw-bold"
-               t-att-class="{'d-none': state.hideRankBounds}" t-out="state.rankUpperBound"/>
-        <div class="o_wlides_xp_progressbar_tooltip tooltip fade show bs-tooltip-top position-relative" t-att-class="{'level-up': props.levelUp}" role="tooltip"
-             t-attf-style="left: #{state.rankProgressPercentage}%">
+        <small class="float-start text-primary fw-bold" t-att-class="{'d-none': this.state.hideRankBounds}"
+               t-out="this.state.rankLowerBound"/>
+        <small t-if="this.state.rankUpperBound" class="float-end fw-bold"
+               t-att-class="{'d-none': this.state.hideRankBounds}" t-out="this.state.rankUpperBound"/>
+        <div class="o_wlides_xp_progressbar_tooltip tooltip fade show bs-tooltip-top position-relative" t-att-class="{'level-up': this.props.levelUp}" role="tooltip"
+             t-attf-style="left: #{this.state.rankProgressPercentage}%">
             <div class="tooltip-arrow"/>
-            <div class="tooltip-inner d-flex justify-content-center w-100" t-out="state.userKarma"/>
+            <div class="tooltip-inner d-flex justify-content-center w-100" t-out="this.state.userKarma"/>
         </div>
     </t>
 

--- a/addons/website_slides/static/src/js/public/components/slide_share_dialog/email_sharing_input.xml
+++ b/addons/website_slides/static/src/js/public/components/slide_share_dialog/email_sharing_input.xml
@@ -6,8 +6,8 @@
             <div t-if="!this.state.isDone and !this.isWebsiteUser" class="input-group">
                 <input t-custom-ref="input" type="text" placeholder="friend1@email.com, friend2@email.com"
                        class="form-control" t-att-class="{'is-invalid': this.state.isInvalid}"
-                       t-on-keypress="onKeyPress"/>
-                <button type="button" class="btn btn-primary" t-on-click.stop="onShareByEmailClick">
+                       t-on-keypress="this.onKeyPress"/>
+                <button type="button" class="btn btn-primary" t-on-click.stop="this.onShareByEmailClick">
                     <i class="fa fa-envelope-o mx-1"/>Send Email
                 </button>
             </div>

--- a/addons/website_slides/static/src/js/public/components/slide_share_dialog/slide_share_dialog.xml
+++ b/addons/website_slides/static/src/js/public/components/slide_share_dialog/slide_share_dialog.xml
@@ -11,7 +11,7 @@
                     <div class="input-group">
                         <input type="text" class="form-control text-center" t-att-value="this.props.url"
                                readonly="readonly" onClick="this.select();"/>
-                        <CopyButton content="this.props.url" copyText="copyUrlText" className="'btn-primary'" successText="successText"/>
+                        <CopyButton content="this.props.url" copyText="this.copyUrlText" className="'btn-primary'" successText="this.successText"/>
                     </div>
                 </div>
                 <div class="col-12 mt-4">
@@ -19,23 +19,23 @@
                     <div class="btn-group" role="group">
                         <div class="s_share">
                             <a class="btn border bg-white" aria-label="Share on Facebook" title="Share on Facebook"
-                               t-on-click.prevent="() => onSocialShareClick(`https://www.facebook.com/sharer/sharer.php?u=${props.url}`)">
+                               t-on-click.prevent="() => this.onSocialShareClick(`https://www.facebook.com/sharer/sharer.php?u=${this.props.url}`)">
                                 <i class="fa fa-facebook-square fa-fw"/>
                             </a>
                             <a class="btn border bg-white" aria-label="Share on X" title="Share on X"
-                               t-on-click.prevent="() => onSocialShareClick(`https://twitter.com/intent/tweet?text=${props.name}&amp;url=${props.url}`)">
+                               t-on-click.prevent="() => this.onSocialShareClick(`https://twitter.com/intent/tweet?text=${this.props.name}&amp;url=${this.props.url}`)">
                                 <i class="fa fa-twitter fa-fw"/>
                             </a>
                             <a class="btn border bg-white" aria-label="Share on LinkedIn" title="Share on LinkedIn"
-                               t-on-click.prevent="() => onSocialShareClick(`http://www.linkedin.com/sharing/share-offsite/?url=${props.url}`)">
+                               t-on-click.prevent="() => this.onSocialShareClick(`http://www.linkedin.com/sharing/share-offsite/?url=${this.props.url}`)">
                                 <i class="fa fa-linkedin fa-fw"/>
                             </a>
                             <a class="btn border bg-white" aria-label="Share on Whatsapp" title="Share on Whatsapp"
-                               t-on-click.prevent="() => onSocialShareClick(`https://wa.me/?text=${window.location.href}`)">
+                               t-on-click.prevent="() => this.onSocialShareClick(`https://wa.me/?text=${window.location.href}`)">
                                 <i class="fa fa-whatsapp fa-fw"/>
                             </a>
                             <a class=" btn border bg-white" aria-label="Share on Pinterest" title="Share on Pinterest"
-                               t-on-click.prevent="() => onSocialShareClick(`http://pinterest.com/pin/create/button/?url=${window.location.href}`)">
+                               t-on-click.prevent="() => this.onSocialShareClick(`http://pinterest.com/pin/create/button/?url=${window.location.href}`)">
                                 <i class="fa fa-pinterest fa-fw"/>
                             </a>
                         </div>
@@ -51,12 +51,12 @@
                     <div class="input-group">
                         <textarea t-custom-ref="codeInput" class="form-control" t-att-value="this.props.embedCode"
                                   readonly="readonly" onClick="this.select();"/>
-                        <CopyButton content="this.props.embedCode" copyText="copyEmbedCodeText"
-                                    successText="successText"/>
+                        <CopyButton content="this.props.embedCode" copyText="this.copyEmbedCodeText"
+                                    successText="this.successText"/>
                     </div>
                     <div t-if="this.props.category == 'document' and this.props.documentMaxPage > 1" class="input-group mt-4">
                         <span class="input-group-text">Start at Page</span>
-                        <input type="number" class="form-control" t-on-change="onPageChange"
+                        <input type="number" class="form-control" t-on-change="this.onPageChange"
                                value="1" min="1" t-att-max="this.props.documentMaxPage"/>
                     </div>
                 </div>

--- a/addons/website_slides/static/src/js/public/components/slide_unsubscribe_dialog/slide_unsubscribe_dialog.xml
+++ b/addons/website_slides/static/src/js/public/components/slide_unsubscribe_dialog/slide_unsubscribe_dialog.xml
@@ -2,32 +2,32 @@
 <templates xml:space="preserve">
 
   <t t-name="website_slides.SlideUnsubscribeDialog">
-    <Dialog size="'md'" title="state.title">
+    <Dialog size="'md'" title="this.state.title">
       <div>
-        <t t-if="state.mode === 'subscription'">
+        <t t-if="this.state.mode === 'subscription'">
             <form class="clearfix">
                 <div class="controls mt8">
-                    <CheckBox value="isChecked" name="subscribed" onChange="(isChecked) => this.onChangeCheckbox(isChecked)">
+                    <CheckBox value="this.isChecked" name="this.subscribed" onChange="(isChecked) => this.onChangeCheckbox(isChecked)">
                         Be notified when a new content is added.
                     </CheckBox>
                 </div>
             </form>
         </t>
-        <t t-if="state.mode === 'leave'">
+        <t t-if="this.state.mode === 'leave'">
             <p>Do you really want to leave the course?</p>
             <p>All progress will be lost until you rejoin this course.</p>
         </t>
       </div>
 
       <t t-set-slot="footer">
-        <t t-if="state.mode === 'subscription'">
-            <button class="btn btn-primary" t-att-disabled="state.buttonDisabled" t-on-click="() => this.onClickSubscriptionSubmit()">Save</button>
-            <button class="btn" t-att-disabled="state.buttonDisabled" t-on-click="() => this.props.close()">Discard</button>
-            <button class="btn btn-danger ms-auto" t-att-disabled="state.buttonDisabled" t-on-click="() => this.onClickLeaveCourse()">or Leave the course</button>
+        <t t-if="this.state.mode === 'subscription'">
+            <button class="btn btn-primary" t-att-disabled="this.state.buttonDisabled" t-on-click="() => this.onClickSubscriptionSubmit()">Save</button>
+            <button class="btn" t-att-disabled="this.state.buttonDisabled" t-on-click="() => this.props.close()">Discard</button>
+            <button class="btn btn-danger ms-auto" t-att-disabled="this.state.buttonDisabled" t-on-click="() => this.onClickLeaveCourse()">or Leave the course</button>
         </t>
-        <t t-if="state.mode === 'leave'">
-            <button class="btn btn-danger" t-att-disabled="state.buttonDisabled" t-on-click="() => this.onClickLeaveCourseSubmit()">Leave the course</button>
-            <button class="btn" t-att-disabled="state.buttonDisabled" t-on-click="() => this.onClickLeaveCourseCancel()">Discard</button>
+        <t t-if="this.state.mode === 'leave'">
+            <button class="btn btn-danger" t-att-disabled="this.state.buttonDisabled" t-on-click="() => this.onClickLeaveCourseSubmit()">Leave the course</button>
+            <button class="btn" t-att-disabled="this.state.buttonDisabled" t-on-click="() => this.onClickLeaveCourseCancel()">Discard</button>
         </t>
       </t>
     </Dialog>

--- a/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_install_module.xml
+++ b/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_install_module.xml
@@ -2,17 +2,17 @@
 <templates xml:space="preserve">
     <t t-name="website_slides.SlideInstallModule">
         <span
-            t-if="state.status === 'installing'"
+            t-if="this.state.status === 'installing'"
             class="spinner-border spinner-border-sm me-1"
         />
-        <t t-out="state.message"/>
+        <t t-out="this.state.message"/>
         <t t-custom-portal="'#o_w_slide_upload_btns'">
             <button
                 class="btn btn-primary"
-                t-att-disabled="state.status === 'installing'"
-                t-on-click="installModule"
+                t-att-disabled="this.state.status === 'installing'"
+                t-on-click="this.installModule"
             >
-                <span t-if="state.status === 'failure'">Retry</span>
+                <span t-if="this.state.status === 'failure'">Retry</span>
                 <span t-else="">Install</span>
             </button>
         </t>

--- a/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_category.xml
+++ b/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_category.xml
@@ -3,23 +3,23 @@
 
     <t t-name="website_slides.SlideUploadCategory" owl="1">
         <div>
-            <div t-if="state.alert.show" t-attf-class="alert {{state.alert.class}}"
-                role="alert" t-out="state.alert.message" />
+            <div t-if="this.state.alert.show" t-attf-class="alert {{this.state.alert.class}}"
+                role="alert" t-out="this.state.alert.message" />
             <form
                 id="o_w_slide_upload_category_form"
-                t-att-class="{'clearfix': true, 'was-validated': state.form.wasValidated}"
+                t-att-class="{'clearfix': true, 'was-validated': this.state.form.wasValidated}"
                 t-on-submit.prevent="(ev) => ev.preventDefault()"
             >
                 <div class="row">
                     <!-- Left column: slide upload form -->
                     <div class="col-md-6">
                         <SlideUploadSourceTypes
-                            t-if="props.slideCategory in sourceSettings"
-                            attributes="sourceSettings[props.slideCategory]"
-                            isLocalSource="state.form.isLocalSource"
-                            onClickSourceType.bind="onClickSourceType"
-                            onChangeFileInput.bind="onChangeFileInput"
-                            onChangeUrl.bind="onChangeUrl"
+                            t-if="this.props.slideCategory in this.sourceSettings"
+                            attributes="this.sourceSettings[this.props.slideCategory]"
+                            isLocalSource="this.state.form.isLocalSource"
+                            onClickSourceType.bind="this.onClickSourceType"
+                            onChangeFileInput.bind="this.onChangeFileInput"
+                            onChangeUrl.bind="this.onChangeUrl"
                         />
                         <canvas id="data_canvas" class="d-none"/>
                         <t t-call="website_slides.UploadFormCommonInputs"/>
@@ -28,20 +28,20 @@
                     <div class="col-md-6">
                         <div class="img-thumbnail h-100">
                             <div
-                                t-if="state.preview.show"
+                                t-if="this.state.preview.show"
                                 class="o_slide_preview h-100 flex-column justify-content-center"
                             >
                                 <img
                                     referrerPolicy="no-referrer"
-                                    t-att-src="state.form.slideImage"
+                                    t-att-src="this.state.form.slideImage"
                                     id="slide-image"
                                     title="Content Preview"
                                     alt="Content Preview"
                                     class="img-fluid"
                                 />
                                 <div
-                                    t-att-class="{'d-none': state.preview.hideSlideVideoTitle, 'mt-1': true}"
-                                    t-out="state.preview.videoTitle"
+                                    t-att-class="{'d-none': this.state.preview.hideSlideVideoTitle, 'mt-1': true}"
+                                    t-out="this.state.preview.videoTitle"
                                 />
                             </div>
                             <div t-else="" class="p-3">
@@ -52,7 +52,7 @@
                 </div>
             </form>
         </div>
-        <t t-if="state.form.isLoading" t-call="website_slides.UploadDialogLoading"/>
+        <t t-if="this.state.form.isLoading" t-call="website_slides.UploadDialogLoading"/>
         <t t-call="website_slides.UploadBtns"/>
     </t>
 
@@ -62,15 +62,15 @@
         <t t-custom-portal="'#o_w_slide_upload_btns'">
             <div>
                 <button
-                    t-if="props.canPublish"
+                    t-if="this.props.canPublish"
                     class="btn btn-primary o_w_slide_upload_published"
                     t-on-click="() => this.onClickFormSubmit(true)"
                 >
                     <span>Save and Publish</span>
                 </button>
                 <button
-                    t-if="props.canUpload"
-                    t-att-class="{ 'btn': true, 'btn-primary': !props.canPublish }"
+                    t-if="this.props.canUpload"
+                    t-att-class="{ 'btn': true, 'btn-primary': !this.props.canPublish }"
                     t-on-click="() => this.onClickFormSubmit(false)"
                 >
                     <span>Save</span>
@@ -83,7 +83,7 @@
         <div class="mb-3">
             <label for="name" class="col-form-label">Title</label>
             <input
-                t-custom-model="state.form.slideName"
+                t-custom-model="this.state.form.slideName"
                 id="name"
                 name="name"
                 placeholder="Title"
@@ -92,13 +92,13 @@
                 autocomplete="off"
             />
         </div>
-        <div t-if="!state.defaultCategoryID" class="mb-3">
+        <div t-if="!this.state.defaultCategoryID" class="mb-3">
             <label for="category_id" class="col-form-label">Section</label>
             <SelectMenu
                 togglerClass="'form-control form-select'"
-                choices="state.choices.categories"
-                value="state.choices.categoryId"
-                onSelect.bind="onCategorySelect"
+                choices="this.state.choices.categories"
+                value="this.state.choices.categoryId"
+                onSelect.bind="this.onCategorySelect"
                 placeholder.translate="Select or create a category"
             >
                 <t t-set-slot="bottomArea" t-slot-scope="select">
@@ -116,10 +116,10 @@
             <label for="tag_ids" class="col-form-label">Tags</label>
             <SelectMenu
                 togglerClass="'form-control form-select'"
-                choices="state.choices.tags"
+                choices="this.state.choices.tags"
                 multiSelect="true"
-                value="state.choices.tagIds"
-                onSelect.bind="onTagsSelect"
+                value="this.state.choices.tagIds"
+                onSelect.bind="this.onTagsSelect"
                 placeholder.translate="Select or create tags"
             >
                 <t t-set-slot="bottomArea" t-slot-scope="select">
@@ -137,7 +137,7 @@
             <label for="duration" class="col-form-label">Estimated Completion Time</label>
             <div class="input-group">
                 <input
-                    t-custom-model="state.form.duration"
+                    t-custom-model="this.state.form.duration"
                     type="number"
                     id="duration"
                     min="0"

--- a/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_dialog.xml
+++ b/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_dialog.xml
@@ -2,35 +2,35 @@
 <templates xml:space="preserve">
 
     <t t-name="website_slides.SlideUploadDialog" owl="1">
-        <Dialog size="state.size" title="state.title" contentClass="'o_w_slide_upload_dialog_content'">
+        <Dialog size="this.state.size" title="this.state.title" contentClass="'o_w_slide_upload_dialog_content'">
             <t t-set-slot="footer">
-                <button t-if="state.page ==='select'" type="button" class="btn" t-on-click="() => this.props.close()">
+                <button t-if="this.state.page ==='select'" type="button" class="btn" t-on-click="() => this.props.close()">
                     <span>Discard</span>
                 </button>
-                <t t-elif="!['select', 'upload'].includes(state.page)">
+                <t t-elif="!['select', 'upload'].includes(this.state.page)">
                     <div id="o_w_slide_upload_btns"/>
-                    <button class="btn" t-on-click="onClickGoBack">
+                    <button class="btn" t-on-click="this.onClickGoBack">
                         <span>Back</span>
                     </button>
                 </t>
             </t>
             <div class="o_w_slide_upload_modal_container">
                 <SlideUploadCategory
-                    t-if="Object.keys(slideCategoryData).includes(state.page)"
-                    alertMsg="state.alertMsg"
-                    categoryId="props.categoryId"
-                    channelId="props.channelId"
-                    slideCategory="state.page"
-                    canPublish="props.canPublish"
-                    canUpload="props.canUpload"
-                    upload.bind="uploadSlide"
+                    t-if="Object.keys(this.slideCategoryData).includes(this.state.page)"
+                    alertMsg="this.state.alertMsg"
+                    categoryId="this.props.categoryId"
+                    channelId="this.props.channelId"
+                    slideCategory="this.state.page"
+                    canPublish="this.props.canPublish"
+                    canUpload="this.props.canUpload"
+                    upload.bind="this.uploadSlide"
                 >
                     <t t-set-slot="tutorial">
-                        <t t-call="{{pagesTemplates[state.page]}}"/>
+                        <t t-call="{{this.pagesTemplates[this.state.page]}}"/>
                     </t>
                 </SlideUploadCategory>
                 <t t-else="">
-                    <t t-call="{{pagesTemplates[state.page]}}"/>
+                    <t t-call="{{this.pagesTemplates[this.state.page]}}"/>
                 </t>
             </div>
         </Dialog>

--- a/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_dialog_select.xml
+++ b/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_dialog_select.xml
@@ -5,48 +5,48 @@
     <t t-name="website_slides.SlideUploadDialogSelect">
         <div class="row p-1 mt-4 mb-2">
             <div
-                t-foreach="slideCategoryData"
+                t-foreach="this.slideCategoryData"
                 t-as="slide_category"
                 t-key="slide_category_index"
                 class="col-6 col-md-4"
             >
                 <SlideCategoryIcon
                     slideCategory="slide_category"
-                    categoryData="slideCategoryData[slide_category]"
-                    onClickSlideCategoryIcon.bind="onClickSlideCategoryIcon"
+                    categoryData="this.slideCategoryData[slide_category]"
+                    onClickSlideCategoryIcon.bind="this.onClickSlideCategoryIcon"
                 />
             </div>
         </div>
         <ModuleToInstallIcon
-            t-if="props.modulesToInstall.length"
-            t-foreach="props.modulesToInstall"
+            t-if="this.props.modulesToInstall.length"
+            t-foreach="this.props.modulesToInstall"
             t-as="module_info"
             t-key="module_info_index"
             title="module_info['name']"
             moduleId="module_info['id']"
             motivational="module_info['motivational']"
-            onClickInstallModuleIcon.bind="onClickInstallModuleIcon"
+            onClickInstallModuleIcon.bind="this.onClickInstallModuleIcon"
         />
     </t>
 
     <t t-name="website_slides.SlideCategoryIcon" owl="1">
         <a
             href="#"
-            t-on-click="() => props.onClickSlideCategoryIcon(props.slideCategory)"
-            t-att-data-slide-category="props.slideCategory"
+            t-on-click="() => this.props.onClickSlideCategoryIcon(this.props.slideCategory)"
+            t-att-data-slide-category="this.props.slideCategory"
             class="content-type d-flex flex-column align-items-center mb-4 btn rounded border text-600 p-3"
         >
-            <i t-attf-class="fa #{props.categoryData.icon} mb-2 fa-3x"/>
-            <t t-out="props.categoryData.label"/>
+            <i t-attf-class="fa #{this.props.categoryData.icon} mb-2 fa-3x"/>
+            <t t-out="this.props.categoryData.label"/>
         </a>
     </t>
 
     <t t-name="website_slides.ModuleToInstallIcon" owl="1">
         <a class="w-100 text-center mb-4 btn rounded border text-600 p-3"
-            href="#" t-on-click="() => props.onClickInstallModuleIcon(props.moduleId)"
-            t-att-title="props.title"
-            t-att-data-module-id="props.moduleId">
-            <i class="fa fa-trophy"/> <t t-out="props.motivational"/><span class="text-primary"> Install the <t t-out="props.title"/> app.</span>
+            href="#" t-on-click="() => this.props.onClickInstallModuleIcon(this.props.moduleId)"
+            t-att-title="this.props.title"
+            t-att-data-module-id="this.props.moduleId">
+            <i class="fa fa-trophy"/> <t t-out="this.props.motivational"/><span class="text-primary"> Install the <t t-out="this.props.title"/> app.</span>
         </a>
     </t>
 </templates>

--- a/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_source_types.xml
+++ b/addons/website_slides/static/src/js/public/components/slide_upload_dialog/slide_upload_source_types.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="website_slides.SlideUploadSourceTypes" owl="1">
-        <div t-if="props.attributes.urlInputName === 'video_url'" class="mb-3">
+        <div t-if="this.props.attributes.urlInputName === 'video_url'" class="mb-3">
             <label
-                t-att-for="props.attributes.urlInputName"
+                t-att-for="this.props.attributes.urlInputName"
                 class="col-form-label"
-                t-out="props.attributes.urlInputLabel"
+                t-out="this.props.attributes.urlInputLabel"
             />
             <input
-                t-custom-model="state.url"
-                t-att-id="props.attributes.urlInputName"
-                t-att-name="props.attributes.urlInputName"
+                t-custom-model="this.state.url"
+                t-att-id="this.props.attributes.urlInputName"
+                t-att-name="this.props.attributes.urlInputName"
                 class="form-control"
                 autocomplete="off"
                 placeholder='e.g "https://www.youtube.com/watch?v=ebBez6bcSEc"'
                 required="required"
-                t-on-change="() => props.onChangeUrl(state.url)"
+                t-on-change="() => this.props.onChangeUrl(this.state.url)"
             />
         </div>
         <t t-else="">
@@ -23,7 +23,7 @@
                 <label
                     for="source_type"
                     class="col-form-label"
-                    t-out="props.attributes.sourceTypeLabel"
+                    t-out="this.props.attributes.sourceTypeLabel"
                 /><br/>
                 <div class="d-flex flex-wrap">
                     <div class="form-check ms-2">
@@ -34,7 +34,7 @@
                             id="source_type_local_file"
                             data-value="local_file"
                             checked="checked"
-                            t-on-click="() => props.onClickSourceType(true)"
+                            t-on-click="() => this.props.onClickSourceType(true)"
                         />
                         <label
                             class="form-check-label fw-normal"
@@ -50,7 +50,7 @@
                             name="source_type"
                             id="source_type_external"
                             data-value="external"
-                            t-on-click="() => props.onClickSourceType(false)"
+                            t-on-click="() => this.props.onClickSourceType(false)"
                         />
                         <label
                             class="form-check-label fw-normal"
@@ -61,37 +61,37 @@
                     </div>
                 </div>
             </div>
-            <div t-if="props.isLocalSource" class="mb-3">
+            <div t-if="this.props.isLocalSource" class="mb-3">
                 <label
                     for="upload"
                     class="col-form-label"
-                    t-out="props.attributes.selectFileLabel"
+                    t-out="this.props.attributes.selectFileLabel"
                 />
                 <input
                     id="upload"
                     name="file"
                     class="form-control h-100"
-                    t-att-accept="props.attributes.acceptedFiles"
+                    t-att-accept="this.props.attributes.acceptedFiles"
                     type="file"
                     required="required"
-                    t-on-change.prevent="(ev) => props.onChangeFileInput(ev)"
+                    t-on-change.prevent="(ev) => this.props.onChangeFileInput(ev)"
                 />
             </div>
             <div t-else="" class="mb-3">
                 <label
-                    t-att-for="props.attributes.urlInputName"
+                    t-att-for="this.props.attributes.urlInputName"
                     class="col-form-label"
-                    t-out="props.attributes.urlInputLabel"
+                    t-out="this.props.attributes.urlInputLabel"
                 />
                 <input
-                    t-custom-model="state.url"
-                    t-att-id="props.attributes.urlInputName"
-                    t-att-name="props.attributes.urlInputName"
+                    t-custom-model="this.state.url"
+                    t-att-id="this.props.attributes.urlInputName"
+                    t-att-name="this.props.attributes.urlInputName"
                     class="form-control h-100"
                     autocomplete="off"
                     placeholder='e.g "https://drive.google.com/file/..."'
                     required="required"
-                    t-on-change="() => props.onChangeUrl(state.url)"
+                    t-on-change="() => this.props.onChangeUrl(this.state.url)"
                 />
             </div>
         </t>

--- a/addons/website_slides/static/src/js/public/components/slides_course_quiz_question_form/slides_course_quiz_question_form.xml
+++ b/addons/website_slides/static/src/js/public/components/slides_course_quiz_question_form/slides_course_quiz_question_form.xml
@@ -3,29 +3,29 @@
 
     <t t-name="slide.quiz.question.input">
         <div
-            t-attf-class="o_wsildes_quiz_question_input mt-3 #{!props.update ? 'col' : ''}">
+            t-attf-class="o_wsildes_quiz_question_input mt-3 #{!this.props.update ? 'col' : ''}">
             <form class="mb-3" t-custom-ref="form">
                 <div class="o_wslides_quiz_question row align-items-center me-0 mb-2">
                     <div class="input-group">
-                        <span class="input-group-text o_wslides_quiz_question_sequence" t-custom-ref="sequence"><t t-out="props.question.sequence"/></span>
+                        <span class="input-group-text o_wslides_quiz_question_sequence" t-custom-ref="sequence"><t t-out="this.props.question.sequence"/></span>
                         <input type="text" name="question-name" class="form-control col-11" placeholder='e.g. "Which animal cannot fly?"'
-                            t-custom-model="props.question.text" t-custom-ref="input"/>
+                            t-custom-model="this.props.question.text" t-custom-ref="input"/>
                     </div>
                 </div>
                 <div class="text-muted mb-2">
                     <span>Select the correct answer below:</span>
                 </div>
                 <div class="list-group">
-                    <t t-foreach="state.answerLines" t-as="answer" t-key="answer.id">
+                    <t t-foreach="this.state.answerLines" t-as="answer" t-key="answer.id">
                         <t t-call="slide.quiz.answer.line"/>
                     </t>
                 </div>
             </form>
             <div>
                 <t t-call="slide.quiz.buttons"/>
-                <div class="ms-2 text-danger o_wslides_js_quiz_validation_error" t-att-class="{ 'd-none': !state.error }">
+                <div class="ms-2 text-danger o_wslides_js_quiz_validation_error" t-att-class="{ 'd-none': !this.state.error }">
                     <i class="fa fa-close me-1"/>
-                    <span class="o_wslides_js_quiz_validation_error_text"><t t-out="state.error || ''" /></span>
+                    <span class="o_wslides_js_quiz_validation_error_text"><t t-out="this.state.error || ''" /></span>
                 </div>
             </div>
         </div>
@@ -50,7 +50,7 @@
                     </div>
                     <i
                         t-attf-class="o_wslides_js_quiz_icon o_wslides_js_quiz_comment_answer fa fa-lg fa-info-circle col-auto p-md-2 py-2 ps-2 pe-1 #{answer.comment.trim() !== '' ? 'text-primary' : 'text-muted'}"
-                        t-on-click="onToggleAnswerLineCommentClick" title="Add comment on this answer" />
+                        t-on-click="this.onToggleAnswerLineCommentClick" title="Add comment on this answer" />
                     <i
                         class="o_wslides_js_quiz_icon o_wslides_js_quiz_add_answer fa fa-lg fa-plus-circle col-auto p-md-2 py-2 px-1 text-muted"
                         title="Add an answer below this one"
@@ -75,14 +75,14 @@
 
     <t t-name="slide.quiz.buttons">
         <a
-            t-on-click="onValidateQuestionClick"
+            t-on-click="this.onValidateQuestionClick"
             class="o_wslides_js_quiz_validate_question btn btn-primary text-white border me-1"
             role="button">
-            <span t-if="props.update">Update</span>
+            <span t-if="this.props.update">Update</span>
             <span t-else="">Save</span>
         </a>
         <a
-            t-on-click="onCancelValidationClick"
+            t-on-click="this.onCancelValidationClick"
             class="o_wslides_js_quiz_cancel_question btn btn-light border"
             role="button">
             <span>Cancel</span>

--- a/addons/website_slides_survey/static/src/js/public/components/slide_upload_dialog/slide_upload_category.xml
+++ b/addons/website_slides_survey/static/src/js/public/components/slide_upload_dialog/slide_upload_category.xml
@@ -6,16 +6,16 @@
         t-inherit-mode="extension"
     >
         <xpath expr="//canvas[@id='data_canvas']" position="before">
-            <t t-if="props.slideCategory === 'certification'">
+            <t t-if="this.props.slideCategory === 'certification'">
                 <SelectMenu
-                    choices="state.choices.certifications"
-                    value="state.choices.certificationId"
+                    choices="this.state.choices.certifications"
+                    value="this.state.choices.certificationId"
                     required="true"
-                    onSelect.bind="onCertificationSelect"
+                    onSelect.bind="this.onCertificationSelect"
                 >
-                    <t t-out="displayCertificationValue"/>
+                    <t t-out="this.displayCertificationValue"/>
                 </SelectMenu>
-                <span t-if="state.showCertificationRequiredError" class="text-danger">Please select a certification.</span>
+                <span t-if="this.state.showCertificationRequiredError" class="text-danger">Please select a certification.</span>
             </t>
         </xpath>
     </t>


### PR DESCRIPTION
In preparation for OWL3, where template variables will need to use `.this` to target component variables, we add `.this` to template variables that are targetting the component.

Script PR: https://github.com/odoo/odoo/pull/247965

THIS_TARGETS = [website_slides]

task: OWL3 prep - add this. to template variables




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
