### PR TITLE
[FIX] web: prevent error when uploading an svg

### DIFF
--- a/addons/web/models/base_document_layout.py
+++ b/addons/web/models/base_document_layout.py
@@ -210,6 +210,8 @@ class BaseDocumentLayout(models.TransientModel):
         except Exception:
             return False, False
 
+        if not image:
+            return False, False
         base_w, base_h = image.size
         w = ceil(50 * base_w / base_h)
         h = 50

--- a/addons/web/tests/test_base_document_layout.py
+++ b/addons/web/tests/test_base_document_layout.py
@@ -239,3 +239,10 @@ class TestBaseDocumentLayout(TestBaseDocumentLayoutHelpers):
         self.company.write({'street2': 'street_2_detail'})
         doc_layout_2 = self.env['base.document.layout'].create({'company_id': self.company.id})
         self.assertTrue('street_2_detail' in doc_layout_2.company_details)
+
+    def test_extract_primary_secondary_on_svg(self):
+        svg_b64 = base64.b64encode(b'<svg xmlns="http://www.w3.org/2000/svg"/>')
+        primary, secondary = self.env['base.document.layout'].extract_image_primary_secondary_colors(svg_b64)
+
+        self.assertFalse(primary)
+        self.assertFalse(secondary)


### PR DESCRIPTION
Currently an error occurs when user tries to upload a svg image as a logo in document layout.

Steps to replicate:
- Initialize a db and open settings.
- Under the Document Layout section, click on `Configure Document Layout`.
- In the logo field add any SVG image.

Error:
```
  File '/home/odoo/odoo19/community/addons/web/models/base_document_layout.py', line 106, in _compute_logo_colors
    wizard.logo_primary_color, wizard.logo_secondary_color = wizard.extract_image_primary_secondary_colors(wizard_for_image.logo)
                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File '/home/odoo/odoo19/community/addons/web/models/base_document_layout.py', line 215, in extract_image_primary_secondary_colors
    base_w, base_h = image.size
                     ^^^^^^^^^^
AttributeError: 'bool' object has no attribute 'size'
```

Cause:
- As user added an svg to the logo field, `tools.ImageProcess(logo)` tried to load the SVG which returned `self.image` as False because we dont process SVG or WEBP images [1].

- Later when we try to access `image.size` where image is false, we get error.

Solution:
- In earlier versions the method `base64_to_image()` was used [2], which raised an UserError on attempting `Image.open()` on a SVG.

- This error was caught by the try except block and returned `False, False` [3].

- To match to this behavior we return from the function when there is no image.

[1]: https://github.com/odoo/odoo/blob/4b2aaf2b711c9cfd8fd9f4a5915d6310064af6a9/odoo/tools/image.py#L83-L85

[2]: https://github.com/odoo/odoo/blob/39974cea6c37d21e21e3ed46a914d58f5ac16aad/addons/web/models/base_document_layout.py#L207

[3]: https://github.com/odoo/odoo/blob/4b2aaf2b711c9cfd8fd9f4a5915d6310064af6a9/addons/web/models/base_document_layout.py#L207-L211

sentry-7323084659
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
