### PR TITLE
[FIX] point_of_sale: fix QR code display and closing behavior

### DIFF
--- a/addons/point_of_sale/static/src/customer_display/customer_display.js
+++ b/addons/point_of_sale/static/src/customer_display/customer_display.js
@@ -35,7 +35,7 @@ export class CustomerDisplay extends Component {
                 if (!qrPaymentData || qrPaymentData.qrCode !== this.state.prevQrCode) {
                     singleDialog.close();
                 }
-                if (qrPaymentData) {
+                if (qrPaymentData?.qrCode) {
                     singleDialog.open(QRPopup, qrPaymentData);
                 }
 

--- a/addons/point_of_sale/static/tests/customer_display/customer_display_tour.js
+++ b/addons/point_of_sale/static/tests/customer_display/customer_display_tour.js
@@ -1,7 +1,9 @@
 import * as Order from "@point_of_sale/../tests/generic_helpers/order_widget_util";
 import * as CustomerDisplay from "@point_of_sale/../tests/customer_display/customer_display_utils";
+import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import { registry } from "@web/core/registry";
 import { isVisible } from "@web/core/utils/ui";
+import { negateStep } from "@point_of_sale/../tests/generic_helpers/utils";
 
 registry.category("web_tour.tours").add("CustomerDisplayTour", {
     steps: () =>
@@ -107,6 +109,7 @@ registry.category("web_tour.tours").add("CustomerDisplayTourWithQr", {
             { trigger: "img[alt='QR Code']" },
             CustomerDisplay.postMessage(CustomerDisplay.PAY_WITH_CARD, "confirm payment"),
             CustomerDisplay.postMessage(CustomerDisplay.ORDER_IS_FINALIZED, "order is finalized"),
+            negateStep(Dialog.is()),
             {
                 content: "Check that we are now on the 'Thank you' screen",
                 trigger: "div:contains('Thank you.')",


### PR DESCRIPTION
Steps:
---
- Configure a UPI payment method.
- Open a POS session and add a product to the order.
- Click Validate and select the UPI payment method.

Issues:
---
1. The UPI QR code was not displayed.
2. After confirming the payment, the QR code popup on the customer display remained open.

Cause:
---
1. The QR barcode data was encoded twice when generating the image.
2. The popup visibility was based only on the presence of `qrPaymentData`, not on the QR code value itself.

Fix:
---
- Remove the extra encoding when generating the QR barcode.
- Display the popup only when a QR code is present.

task-6023605

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
