### PR TITLE
[FIX] l10n_my_edi_pos: fix year-range sequence error in MyInvois

### DIFF
--- a/addons/l10n_my_edi_pos/models/myinvois_document.py
+++ b/addons/l10n_my_edi_pos/models/myinvois_document.py
@@ -232,7 +232,12 @@ class MyInvoisDocument(models.Model):
         """ Make sure that the sequence date range follows the company's fiscal year """
         if reset == 'year_range':
             company = self.company_id
-            return date_utils.get_fiscal_year(self.myinvois_issuance_date, day=company.fiscalyear_last_day, month=int(company.fiscalyear_last_month))
+            date_start, date_end = date_utils.get_fiscal_year(
+                self.myinvois_issuance_date,
+                day=company.fiscalyear_last_day,
+                month=int(company.fiscalyear_last_month),
+            )
+            return (date_start, date_end) + (None, None)
         return super()._get_sequence_date_range(reset)
 
     @api.ondelete(at_uninstall=False)

--- a/addons/l10n_my_edi_pos/models/myinvois_document.py
+++ b/addons/l10n_my_edi_pos/models/myinvois_document.py
@@ -230,9 +230,14 @@ class MyInvoisDocument(models.Model):
 
     def _get_sequence_date_range(self, reset):
         """ Make sure that the sequence date range follows the company's fiscal year """
-        if reset == 'year_range':
+        if reset in ('year_range', 'year_range_month'):
             company = self.company_id
-            return date_utils.get_fiscal_year(self.myinvois_issuance_date, day=company.fiscalyear_last_day, month=int(company.fiscalyear_last_month))
+            date_start, date_end = date_utils.get_fiscal_year(
+                self.myinvois_issuance_date,
+                day=company.fiscalyear_last_day,
+                month=int(company.fiscalyear_last_month),
+            )
+            return (date_start, date_end) + (None, None)
         return super()._get_sequence_date_range(reset)
 
     @api.ondelete(at_uninstall=False)

--- a/addons/l10n_my_edi_pos/tests/test_myinvois_pos.py
+++ b/addons/l10n_my_edi_pos/tests/test_myinvois_pos.py
@@ -783,6 +783,23 @@ class TestMyInvoisPoS(TestPoSCommon):
                 expected_xml = etree.fromstring(f.read())
             self.assertXmlTreeEqual(root, expected_xml)
 
+    def test_consolidate_invoices_with_year_range_sequence(self):
+        with freeze_time("2026-01-01"):
+            # Create the orders
+            with self.with_pos_session():
+                first_order = self._create_order({'pos_order_lines_ui_args': [(self.product_one, 1.0)]})
+            # Consolidate them
+            wizard = self.env['myinvois.consolidate.invoice.wizard'].create({
+                'date_from': '2026-01-01',
+                'date_to': '2026-01-31',
+            })
+            wizard.button_consolidate_orders()
+            consolidated_invoice = first_order.consolidated_invoice_ids
+            consolidated_invoice.name = "POS/2025-2026/000001"
+            with patch(CONTACT_PROXY_METHOD, new=self._mock_successful_submission):
+                consolidated_invoice.action_submit_to_myinvois()
+            self.assertTrue(consolidated_invoice.myinvois_file_id)
+
     #################
     # Patched methods
     #################

--- a/addons/l10n_my_edi_pos/tests/test_myinvois_pos.py
+++ b/addons/l10n_my_edi_pos/tests/test_myinvois_pos.py
@@ -767,6 +767,23 @@ class TestMyInvoisPoS(TestPoSCommon):
                 expected_xml = etree.fromstring(f.read())
             self.assertXmlTreeEqual(root, expected_xml)
 
+    def test_consolidate_invoices_with_year_range_sequence(self):
+        with freeze_time("2026-01-01"):
+            # Create the orders
+            with self.with_pos_session():
+                first_order = self._create_order({'pos_order_lines_ui_args': [(self.product_one, 1.0)]})
+            # Consolidate them
+            wizard = self.env['myinvois.consolidate.invoice.wizard'].create({
+                'date_from': '2026-01-01',
+                'date_to': '2026-01-31',
+            })
+            wizard.button_consolidate_orders()
+            consolidated_invoice = first_order.consolidated_invoice_ids
+            consolidated_invoice.name = "POS/2025-2026/000001"
+            with patch(CONTACT_PROXY_METHOD, new=self._mock_successful_submission):
+                consolidated_invoice.action_submit_to_myinvois()
+            self.assertTrue(consolidated_invoice.myinvois_file_id)
+
     #################
     # Patched methods
     #################


### PR DESCRIPTION
Currently, an error is produced when sending invoices to MyInvois if the invoice number uses a year-range sequence.

**Steps to Reproduce:(v-19.0)**
1. Install the `accountant` and `l10n_my_edi` modules (with demo data).
2. Switch to "MY Company"(Malaysian company).
3. Enable "_Quick Encoding_" for Customer Invoices in Settings.
4. Create a customer invoice with customer "_MY Company_", set a Malaysian classification code and taxes on the invoice line, and confirm the invoice.
5. Set the invoice back to Draft and modify the invoice number with a year-range sequence (e.g., INV/2025-2026/00001), then confirm it again.
6. Open the invoice list view and click **"Send to MyInvois"**.

**Error:**
`ValueError: not enough values to unpack (expected 4, got 2)`

The `_get_sequence_date_range()` method on `myinvois.document` overrides the method from `sequence.mixin` and returns only two values from `date_utils.get_fiscal_year()`. However, it expects the method to return four values at [1].

[1] - https://github.com/odoo/odoo/blob/57b6b8d63b038ede32dfcc833c30e93d0cf4166c/addons/account/models/sequence_mixin.py#L146
Ref: https://github.com/odoo/odoo/blob/1ce06257f877711bd5de5487364909d72b476318/addons/account/models/account_move.py#L4263

sentry-7320998540