### PR TITLE
[FIX] project: prevent crash on Blocked By page in mobile kanban view

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -701,7 +701,7 @@
                         </t>
                         <t t-name="card">
                             <main t-att-class="['1_done', '1_canceled'].includes(record.state.raw_value) ? 'opacity-50' : ''">
-                                <a t-if="record.parent_id.raw_value" class="o_kanban_parent mw-100 me-auto pe-3 btn-link o_small-fs text-dark text-truncate" title="See Parent Task" name="action_open_parent_task" type="object" role="button">
+                                <a t-if="record.parent_id and record.parent_id.raw_value" class="o_kanban_parent mw-100 me-auto pe-3 btn-link o_small-fs text-dark text-truncate" title="See Parent Task" name="action_open_parent_task" type="object" role="button">
                                     <i class="fa fa-level-down me-1"/>
                                     <field name="parent_id"/>
                                 </a>


### PR DESCRIPTION
Currently, opening a task in mobile view and clicking on the 'Add Blocked By' crashes.

### **Steps to reproduce:**
1) Install project app with demo data
2) Open any task from the project, switch to mobile view
3) Click on the **Blocked By** page and click **Add Blocked By**.

### **Error:**
TypeError: Cannot read properties of undefined (reading 'raw_value')

### **Root cause:**
The `project_sub_task_view_kanban_mobile` view inherits the base task kanban and removes the `parent_id` field via xpath `position='replace'` at [1]. However, the wrapping `<a>` element with `t-if='record.parent_id.raw_value'` at [2] remains in the template. Since the field is no longer declared, `record.parent_id` is undefined, and accessing `.raw_value` on it causes the crash.

[1]- https://github.com/odoo/odoo/blob/e602fc2279e85b66c9983741df5d84fab42a3c44/addons/project/views/project_task_views.xml#L759

[2]- https://github.com/odoo/odoo/blob/e602fc2279e85b66c9983741df5d84fab42a3c44/addons/project/views/project_task_views.xml#L704

### **Fix:**
This commit ensures that in the base kanban template, it checks that `record.parent_id` exists before accessing `.raw_value`.

**opw-5920660**