### PR TITLE
[FIX] stock: print inventory count sheet with minimal accesses

### DIFF
--- a/addons/stock/report/report_stockinventory.xml
+++ b/addons/stock/report/report_stockinventory.xml
@@ -35,7 +35,7 @@
                                         <td groups="stock.group_tracking_lot"><span t-field="line.package_id"/></td>
                                         <td class="o_td_quantity text-end">
                                             <!-- If 0, then leave blank so users have space to write a number -->
-                                            <t t-if="not line.env['ir.config_parameter'].get_param('stock.show_expected_quantity_count', default='False') == 'True'"><span></span></t>
+                                            <t t-if="not line.env['ir.config_parameter'].sudo().get_param('stock.show_expected_quantity_count', default='False') == 'True'"><span></span></t>
                                             <t t-else=""><span t-field="line.quantity" class="text-nowrap">7</span></t>
                                             <span t-field="line.product_uom_id" groups="uom.group_uom">Units</span>
                                         </td>


### PR DESCRIPTION
### Steps to reproduce:

- Impersonate a user with only Inventory user access rights
- Inventory > Operations > Adjustments> Physical Inventory
- Select any quant in the list > Print > Count Sheet
#### > Access Error: You are not allowed to access 'System Parameter' (ir.config_parameter) records.

### Cause of the issue:

The template of the count sheet relies on the `get_param` methods of the `ir.config_parameter` model which requires read access rights on the model:
https://github.com/odoo/odoo/blob/69ec92cd6fd1b5f19c3db8763c12f003c9acf0dd/addons/stock/report/report_stockinventory.xml#L36-L39 https://github.com/odoo/odoo/blob/69ec92cd6fd1b5f19c3db8763c12f003c9acf0dd/odoo/addons/base/models/ir_config_parameter.py#L59-L69 This access right is limited to the the `base.group_system` (admin) user group:
https://github.com/odoo/odoo/blob/69ec92cd6fd1b5f19c3db8763c12f003c9acf0dd/odoo/addons/base/security/ir.model.access.csv#L118

opw-5959200

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
