### PR TITLE
[FIX] hr: prevent error when creating users for employees with same email

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -358,29 +358,36 @@ class HrEmployee(models.Model):
                 '|', ('email_normalized', 'in', employee_emails),
                 ('login', 'in', employee_emails),
             ])
+        emp_by_email = self.grouped(lambda employee: email_normalize(employee.work_email))
+        duplicate_emails = [email for email, employees in emp_by_email.items() if email and len(employees) > 1]
         old_users = []
         new_users = []
         users_without_emails = []
         users_with_invalid_emails = []
         users_with_existing_email = []
+        employees_with_duplicate_email = []
         for employee in self:
+            normalized_email = email_normalize(employee.work_email)
             if employee.user_id:
                 old_users.append(employee.name)
                 continue
             if not employee.work_email:
                 users_without_emails.append(employee.name)
                 continue
-            if not tools.email_normalize(employee.work_email):
+            if not normalized_email:
                 users_with_invalid_emails.append(employee.name)
                 continue
-            if email_normalize(employee.work_email) in conflicting_users.mapped('email_normalized'):
+            if normalized_email in conflicting_users.mapped('email_normalized'):
                 users_with_existing_email.append(employee.name)
+                continue
+            if normalized_email in duplicate_emails:
+                employees_with_duplicate_email.append(employee.name)
                 continue
             new_users.append({
                 'create_employee_id': employee.id,
                 'name': employee.name,
                 'phone': employee.work_phone,
-                'login': tools.email_normalize(employee.work_email),
+                'login': normalized_email,
                 'partner_id': employee.work_contact_id.id,
             })
 
@@ -408,6 +415,10 @@ class HrEmployee(models.Model):
 
         if users_with_existing_email:
             message = _('User already exists with the same email for Employees %s', ', '.join(users_with_existing_email))
+            next_action = _get_user_creation_notification_action(message, 'warning', next_action)
+
+        if employees_with_duplicate_email:
+            message = _('The following employees have the same work email address: %s', ', '.join(employees_with_duplicate_email))
             next_action = _get_user_creation_notification_action(message, 'warning', next_action)
 
         return next_action

--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -548,6 +548,12 @@ class TestHrEmployee(TestHrCommon):
             }, {
                 'name': 'Multi Email Employee',
                 'work_email': '"Name1" <name@test.example.com>, "Name 2" <name2@test.example.com>',
+            }, {
+                'name': 'Duplicate Email Employee 1',
+                'work_email': 'duplicate@example.com',
+            }, {
+                'name': 'Duplicate Email Employee 2',
+                'work_email': 'duplicate@example.com',
             },
         ])
         # Add an existing employee who already has a user to the employee list
@@ -557,13 +563,15 @@ class TestHrEmployee(TestHrCommon):
         action = confirmed_employees.action_create_users()
 
         params = action.get('params')
+        self.assertEqual(params.get('message'), f"The following employees have the same work email address: {employees[6].name}, {employees[7].name}")
+        params = params.get('next').get('params')
         self.assertEqual(params.get('message'), f"User already exists with the same email for Employees {employees[0].name}, {employees[4].name}")
         params = params.get('next').get('params')
         self.assertEqual(params.get('message'), f"You need to set a valid work email address for {employees[2].name}, {employees[5].name}")
         params = params.get('next').get('params')
         self.assertEqual(params.get('message'), f"You need to set the work email address for {employees[3].name}")
         params = params.get('next').get('params')
-        self.assertEqual(params.get('message'), f"User already exists for Those Employees {employees[6].name}")
+        self.assertEqual(params.get('message'), f"User already exists for Those Employees {employees[8].name}")
         params = params.get('next').get('params')
         self.assertEqual(params.get('message'), f"Users {employees[1].name} creation successful")
         self.assertTrue(employees[1].user_id)


### PR DESCRIPTION
Creating users for multiple employees sharing the same email address raises a traceback.

Stpes to reproduce the error:
- Install the ``hr`` module
- Create two employees with the same email
- Go to List view of employees > Select both employees > Actions > Create user

Traceback:
```py
ValueError: UniqueViolation('duplicate key value violates unique constraint "res_users_login_key"
```

https://github.com/odoo/odoo/blob/0bfd2a253781e43b0e0d16b3fd9d1df485f4fa6b/addons/hr/models/hr_employee.py#L389
The error occurs because the same email is used as the login for multiple users.

This commit ensures that when multiple employees share the same email address,
a warning notification is displayed instead of raising an error.

sentry-7324335174

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
