### PR TITLE
[FIX] orm: reset transaction after uninstall

### DIFF
--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -239,6 +239,7 @@ class Registry(Mapping[str, type["BaseModel"]]):
                     registry = object.__new__(cls)
                     registry.init(db_name, models_to_check=models_to_check)
                     cls.registries[db_name] = registry  # pylint: disable=unsupported-assignment-operation
+                    cr.transaction.reset()  # rebind the transaction to the new registry
                     upgrade_modules = install_modules = reinit_modules = ()
                 else:
                     raise Exception(f'Failed to load registry after {retries} attempts')  # noqa: TRY301


### PR DESCRIPTION
After uninstalling modules, we create a new registry. In a recent change #245919, we use the same cursor for the whole loading process. This broke uninstallation because the cursor is linked to the previous registry. Reset it to break the link.

runbot-241880


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
