### PR TITLE
[REF] l10n_*: add this. in rendering context

### DIFF
--- a/addons/l10n_es_edi_tbai_pos/static/src/app/components/popups/add_tbai_refund_reason_popup/add_tbai_refund_reason_popup.xml
+++ b/addons/l10n_es_edi_tbai_pos/static/src/app/components/popups/add_tbai_refund_reason_popup/add_tbai_refund_reason_popup.xml
@@ -5,7 +5,7 @@
         <Dialog title.translate="Additional Refund Information">
             <div class="mb-3">
                 <label for="tbai_refund_reason" class="form-label">TicketBAI Refund Reason: </label>
-                <select class="detail form-select" id="tbai_refund_reason" name="l10n_es_tbai_refund_reason" t-custom-model="state.l10n_es_tbai_refund_reason">
+                <select class="detail form-select" id="tbai_refund_reason" name="l10n_es_tbai_refund_reason" t-custom-model="this.state.l10n_es_tbai_refund_reason">
                     <t t-foreach="this.pos.config._tbai_refund_reasons" t-as="l10n_es_tbai_refund_reason" t-key="l10n_es_tbai_refund_reason.value">
                         <option t-att-value="l10n_es_tbai_refund_reason.value"
                                 t-att-selected="l10n_es_tbai_refund_reason.value === this.state.l10n_es_tbai_refund_reason ? 'selected' : undefined">

--- a/addons/l10n_es_edi_verifactu_pos/static/src/app/components/popups/add_verifactu_refund_reason_popup/add_verifactu_refund_reason_popup.xml
+++ b/addons/l10n_es_edi_verifactu_pos/static/src/app/components/popups/add_verifactu_refund_reason_popup/add_verifactu_refund_reason_popup.xml
@@ -6,7 +6,7 @@
             <div class="mb-3">
                 <label for="verifactu_refund_reason" class="form-label">Veri*Factu Refund Reason: </label>
                 <select class="detail form-select" id="verifactu_refund_reason" name="l10n_es_edi_verifactu_refund_reason"
-                        t-custom-model="state.l10n_es_edi_verifactu_refund_reason">
+                        t-custom-model="this.state.l10n_es_edi_verifactu_refund_reason">
                     <t t-foreach="this.pos.config._verifactu_refund_reasons" t-as="l10n_es_edi_verifactu_refund_reason" t-key="l10n_es_edi_verifactu_refund_reason.value">
                         <option t-att-value="l10n_es_edi_verifactu_refund_reason.value"
                                 t-att-selected="l10n_es_edi_verifactu_refund_reason.value === this.state.l10n_es_edi_verifactu_refund_reason ? 'selected' : undefined">

--- a/addons/l10n_sa_pos/static/src/app/add_zatca_refund_reason_popup/add_zatca_refund_reason_popup.xml
+++ b/addons/l10n_sa_pos/static/src/app/add_zatca_refund_reason_popup/add_zatca_refund_reason_popup.xml
@@ -5,7 +5,7 @@
         <Dialog title.translate="Additional Refund Information"> 
             <div class="mb-3">
                 <label for="zatca_refund_reason" class="form-label">ZATCA Refund Reason: </label>
-                <select class="detail form-select" id="zatca_refund_reason" name="l10n_sa_reason" t-custom-model="state.l10n_sa_reason">
+                <select class="detail form-select" id="zatca_refund_reason" name="l10n_sa_reason" t-custom-model="this.state.l10n_sa_reason">
                     <t t-foreach="this.pos.config._zatca_refund_reasons" t-as="l10n_sa_reason" t-key="l10n_sa_reason.value">
                         <option t-att-value="l10n_sa_reason.value"
                                 t-att-selected="l10n_sa_reason.value === this.state.l10n_sa_reason ? 'selected' : undefined">


### PR DESCRIPTION
In preparation for OWL3, where template variables will need to use `.this` to target component variables, we add `.this` to template variables that are targetting the component.

Script PR: #247965

task: OWL3 prep - add this. to template variables

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
