### PR TITLE
[FIX] crm: disable prefetch fields when filtering

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -462,7 +462,7 @@ class Lead(models.Model):
     @api.depends('email_normalized')
     def _compute_email_domain_criterion(self):
         self.email_domain_criterion = False
-        for lead in self.filtered('email_normalized'):
+        for lead in self.with_context(prefetch_fields=False).filtered('email_normalized'):
             lead.email_domain_criterion = iap_tools.mail_prepare_for_domain_search(
                 lead.email_normalized
             )


### PR DESCRIPTION
Use `with_context(prefetch_fields=False)` when evaluating `filtered('email_normalized')` to prevent the ORM from prefetching a large group of fields. This avoids fetching heavy fields such as `description` for the whole batch, as by default all the stored fields share the same prefetch group.
which could lead to excessive memory usage and `MemoryError` during recomputation.

```sql
apan_3928644=> select pg_size_pretty(sum(pg_column_size(description))) from crm_lead where description is not null;
 pg_size_pretty
----------------
 18 GB
(1 row)
```

MemoryError faced with target db:
```py
File "/home/odoo/src/odoo/17.0/addons/crm/models/crm_lead.py", line 465, in _compute_email_domain_criterion
    for lead in self.filtered('email_normalized'):
  File "/home/odoo/src/odoo/17.0/odoo/models.py", line 6166, in filtered
    return self.browse([rec.id for rec in self if func(rec)])
  File "/home/odoo/src/odoo/17.0/odoo/models.py", line 6166, in <listcomp>
    return self.browse([rec.id for rec in self if func(rec)])
  File "/home/odoo/src/odoo/17.0/odoo/models.py", line 6165, in <lambda>
    func = lambda rec: any(rec.mapped(name))
  File "/home/odoo/src/odoo/17.0/odoo/models.py", line 6142, in mapped
    recs = recs._fields[name].mapped(recs)
  File "/home/odoo/src/odoo/17.0/odoo/fields.py", line 1293, in mapped
    self.__get__(first(remaining), type(remaining))
  File "/home/odoo/src/odoo/17.0/odoo/fields.py", line 1182, in __get__
    recs._fetch_field(self)
  File "/home/odoo/src/odoo/17.0/odoo/models.py", line 3824, in _fetch_field
    self.fetch(fnames)
  File "/home/odoo/src/odoo/17.0/odoo/models.py", line 3874, in fetch
    fetched = self._fetch_query(query, fields_to_fetch)
  File "/home/odoo/src/odoo/17.0/odoo/models.py", line 3967, in _fetch_query
    rows = self.env.cr.fetchall()
MemoryError
```




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
