### PR TITLE
[FIX] web: display meaningful title in quick search dialog

### DIFF
--- a/addons/web/static/src/core/record_selectors/record_autocomplete.js
+++ b/addons/web/static/src/core/record_selectors/record_autocomplete.js
@@ -79,8 +79,16 @@ export class RecordAutocomplete extends Component {
 
     async onSearchMore(name) {
         const { fieldString, multiSelect, resModel } = this.props;
+        let dialogTitle = fieldString;
         let operator;
         const ids = [];
+        if (!dialogTitle) {
+            const [modelInfo] = await this.orm
+                .cache()
+                .call("ir.model", "display_name_for", [[resModel]]);
+            dialogTitle = modelInfo?.display_name || resModel;
+        }
+
         if (name) {
             const nameGets = await this.search(name, SEARCH_MORE_LIMIT);
             this.addNames(nameGets);
@@ -101,7 +109,7 @@ export class RecordAutocomplete extends Component {
         // fine for now but we don't like this kind of dependence of core to views
         const SelectCreateDialog = registry.category("dialogs").get("select_create");
         this.addDialog(SelectCreateDialog, {
-            title: _t("Search: %s", fieldString),
+            title: _t("Search: %s", dialogTitle),
             dynamicFilters,
             domain: this.getDomain(),
             resModel,

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -558,7 +558,13 @@ export class Many2XAutocomplete extends Component {
 
     async onSearchMore(request) {
         const { resModel, getDomain, context, fieldString } = this.props;
-
+        let dialogTitle = fieldString;
+        if (!dialogTitle) {
+            const [modelInfo] = await this.orm
+                .cache()
+                .call("ir.model", "display_name_for", [[resModel]]);
+            dialogTitle = modelInfo?.display_name || resModel;
+        }
         const domain = getDomain();
         let dynamicFilters = [];
         if (request.length) {
@@ -578,7 +584,7 @@ export class Many2XAutocomplete extends Component {
             ];
         }
 
-        const title = _t("Search: %s", fieldString);
+        const title = _t("Search: %s", dialogTitle);
         this.selectCreate({
             domain,
             context,

--- a/addons/web/static/tests/core/record_selectors/multi_record_selector.test.js
+++ b/addons/web/static/tests/core/record_selectors/multi_record_selector.test.js
@@ -287,6 +287,13 @@ test("Can pass domain to search more", async () => {
         { id: 9, name: "Ivy" }
     );
     Partner._views["list"] = /* xml */ `<list><field name="name"/></list>`;
+
+    onRpc("ir.model", "display_name_for", ({ args }) => {
+        expect.step("display_name_for");
+        expect(args[0]).toEqual(["partner"]);
+        return [{ display_name: Partner.name, model: Partner._name }];
+    });
+
     await mountMultiRecordSelector({
         resModel: "partner",
         resIds: [],
@@ -299,4 +306,42 @@ test("Can pass domain to search more", async () => {
     await animationFrame();
 
     expect(".o_data_row").toHaveCount(8, { message: "should contain 8 records" });
+    expect.verifySteps(["display_name_for"]);
+});
+
+test.tags("desktop");
+test("search more dialog opens with a meaningful title", async () => {
+    Partner._records.push(
+        { id: 4, name: "David" },
+        { id: 5, name: "Eve" },
+        { id: 6, name: "Frank" },
+        { id: 7, name: "Grace" },
+        { id: 8, name: "Helen" },
+        { id: 9, name: "Ivy" }
+    );
+    Partner._views["list"] = /* xml */ `<list><field name="name"/></list>`;
+
+    onRpc("ir.model", "display_name_for", ({ args }) => {
+        expect.step("display_name_for");
+        expect(args[0]).toEqual(["partner"]);
+        return [{ display_name: Partner.name, model: Partner._name }];
+    });
+
+    // The fieldString parameter is intentionally omitted during MultiRecordSelector mounting.
+    await mountMultiRecordSelector({
+        resModel: "partner",
+        resIds: [],
+    });
+    await click(".o-autocomplete input");
+    await animationFrame();
+
+    await click(".o_multi_record_selector .o_m2o_dropdown_option");
+    await animationFrame();
+
+    expect(".modal-title").toHaveText("Search: Partner", {
+        message:
+            "dialog title should display the model name to guide users on what they're searching for",
+    });
+    expect(".o_data_row").toHaveCount(9, { message: "should contain 9 records" });
+    expect.verifySteps(["display_name_for"]);
 });

--- a/addons/web/static/tests/views/fields/many2one_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_field.test.js
@@ -3478,6 +3478,38 @@ test("search more in many2one: dropdown click", async () => {
     expect(getDropdownMenu(searchDropdown)).toBeVisible();
 });
 
+test.tags("desktop");
+test("search more dialog title falls back to model name when no fieldString is given", async () => {
+    Partner._views = {
+        list: `<list><field name="name"/></list>`,
+    };
+
+    onRpc("ir.model", "display_name_for", ({ args }) => {
+        expect.step("display_name_for");
+        expect(args[0]).toEqual(["partner"]);
+        return [{ display_name: Partner.name, model: Partner._name }];
+    });
+
+    await mountWithCleanup(Many2XAutocomplete, {
+        props: {
+            resModel: Partner._name,
+            fieldString: "",
+            getDomain: () => [],
+            update: () => {},
+            activeActions: {},
+        },
+    });
+
+    await click(".o-autocomplete input");
+    await animationFrame();
+
+    await click(".o_m2o_dropdown_option_search_more");
+    await animationFrame();
+
+    expect(".modal-title").toHaveText("Search: Partner");
+    expect.verifySteps(["display_name_for"]);
+});
+
 test("updating a many2one from a many2many", async () => {
     expect.assertions(5);
 


### PR DESCRIPTION
When clicking **"Search more..."** from **RecordAutocomplete** or **Many2XAutocomplete**, the quick search dialog could open with titles like **"Search: Undefined"** or **"Search: "** when no explicit title was provided.

This change falls back to the model display name to ensure the dialog always shows a meaningful title.

task-5932652

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
