### PR TITLE
[FIX] html_editor: toolbar not opening on macOS with Cmd+Shift+Arrow

### DIFF
--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -3,7 +3,7 @@ import { isZWS } from "@html_editor/utils/dom_info";
 import { reactive } from "@odoo/owl";
 import { isTextNode } from "@web/views/view_compiler";
 import { Toolbar } from "./toolbar";
-import { hasTouch } from "@web/core/browser/feature_detection";
+import { hasTouch, isMacOS } from "@web/core/browser/feature_detection";
 import { registry } from "@web/core/registry";
 import { ToolbarMobile } from "./mobile_toolbar";
 import { debounce } from "@web/core/utils/timing";
@@ -182,18 +182,35 @@ export class ToolbarPlugin extends Plugin {
             // Close toolbar on keydown Arrows and prevent it from opening until
             // keyup. Opening is debounced to avoid open/close between
             // sequential keystrokes.
+            // On macOS, keyup is not triggered when Cmd is held down (e.g. Cmd+Shift+Arrow),
+            // so we use selectionchange as a fallback to re-enable the toolbar.
             this.addDomListener(this.editable, "keydown", (ev) => {
                 if (ev.key?.startsWith("Arrow")) {
                     this.overlay.close();
                     this.onSelectionChangeActive = false;
+                    if (isMacOS() && ev.metaKey) {
+                        this.pendingArrowKey = true;
+                    }
                 }
             });
             this.addDomListener(this.editable, "keyup", (ev) => {
                 if (ev.key?.startsWith("Arrow")) {
+                    this.pendingArrowKey = false;
                     this.onSelectionChangeActive = true;
                     this.debouncedUpdateToolbar();
                 }
             });
+            if (isMacOS()) {
+                this.addDomListener(this.document, "selectionchange", () => {
+                    if (this.pendingArrowKey && !this.isMouseDown) {
+                        this.pendingArrowKey = false;
+                        this.onSelectionChangeActive = true;
+                        this.debouncedUpdateToolbar();
+                    }
+                });
+                this.addDomListener(this.editable, "mousedown", () => (this.isMouseDown = true));
+                this.addDomListener(this.document, "mouseup", () => (this.isMouseDown = false));
+            }
         }
     }
 

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -1,5 +1,5 @@
 import { withSequence } from "@html_editor/utils/resource";
-import { describe, expect, test } from "@odoo/hoot";
+import { describe, expect, mockUserAgent, test } from "@odoo/hoot";
 import {
     click,
     getActiveElement,
@@ -1158,6 +1158,29 @@ describe("toolbar open and close on user interaction", () => {
 
             // Toolbar opens some time after the last keyup
             await advanceTime(500);
+            await expectElementCount(".o-we-toolbar", 1);
+        });
+
+        test("toolbar should open on Cmd+Shift+Arrow on macOS", async () => {
+            mockUserAgent("mac");
+            const { el } = await setupEditor("<p>[]test</p>");
+            await expectElementCount(".o-we-toolbar", 0);
+
+            // Simulate Cmd+Shift+ArrowRight: keydown fires but keyup is suppressed by macOS
+            await keyDown(["Meta", "Shift", "ArrowRight"]);
+            setContent(el, "<p>[test]</p>");
+            await tick(); // selectionChange
+
+            await animationFrame();
+            // Toolbar should still be closed
+            await expectElementCount(".o-we-toolbar", 0);
+
+            // keyup is NOT fired (macOS suppresses it when Cmd is held)
+            // selectionchange fires and acts as the fallback trigger
+            manuallyDispatchProgrammaticEvent(document, "selectionchange");
+            await tick();
+
+            await waitFor(".o-we-toolbar");
             await expectElementCount(".o-we-toolbar", 1);
         });
     });


### PR DESCRIPTION
Problem:
The toolbar does not open when using Cmd+Shift+Arrow to select text on macOS.

Cause:
On macOS, when the Cmd key is held down, the `keyup` event is never fired for other keys. The toolbar relies on `keyup` for Arrow keys to re-enable `onSelectionChangeActive` and trigger the toolbar update, so it never opens.

See section ("Issue 3 - keyup event put on hold for other keys"): https://web.archive.org/web/20160304022453/http://bitspushedaround.com/on-a-few-things-you-may-not-know-about-the-hellish-command-key-and-javascript-events/

Solution:
Track when an Arrow key is pressed while Cmd is held (`pendingArrowKey`) and use a `selectionchange` listener as a fallback to re-enable the toolbar. The `selectionchange` event fires reliably on macOS even when `keyup` is suppressed. A `isMouseDown` guard ensures the listener does not interfere with the existing mousedown/mouseup flow.

Steps to reproduce:
1- Type some text
2- Use Cmd+Shift+Arrow (left or right) to select text 3- Observe the toolbar does not appear

task-6013408

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
