### PR TITLE
[FIX] hr_holidays: fix load demo data for faketime build

### DIFF
--- a/addons/hr_holidays/data/hr_holidays_demo.xml
+++ b/addons/hr_holidays/data/hr_holidays_demo.xml
@@ -273,8 +273,8 @@
     <record id="hr_holidays_cl_mit_1" model="hr.leave">
         <field name="name">Trip</field>
         <field name="holiday_status_id" ref="leave_type_paid_time_off"/>
-        <field name="request_date_from" eval="(datetime.today().date() - relativedelta(months=1, day=5, weekday=0))"/>
-        <field name="request_date_to" eval="(datetime.today().date() - relativedelta(months=1, day=5, weekday=0))"/>
+        <field name="request_date_from" eval="time.strftime('%Y-01-15')"/>
+        <field name="request_date_to" eval="time.strftime('%Y-01-15')"/>
         <field name="employee_id" ref="hr.employee_mit"/>
         <field name="state">confirm</field>
     </record>


### PR DESCRIPTION
Issue:
The Anita Oliver contract starts on %Y-01-01, so her leave allocation begins from that date.
When running with faketime set to 2027-01-01, the system attempts to create leave for the previous month, which results in an error stating that there is no allocation for that time off.

Fix:
Update the demo data to create the leave and payslip for the first month of the year. This prevents failures when using faketime and ensures it works correctly for real usage of `time off to defer`.

task-6026690