### PR TITLE
[FIX] point_of_sale: archive product in test

### DIFF
--- a/addons/point_of_sale/tests/test_pos_cash_rounding.py
+++ b/addons/point_of_sale/tests/test_pos_cash_rounding.py
@@ -164,6 +164,7 @@ class TestPosCashRounding(TestPointOfSaleHttpCommon):
         Tests that once product is archived after order is created
         product is not shown but the order can still be refunded.
         """
+        self.env['pos.session'].sudo().search([('state', '!=', 'closed')]).write({'state': 'closed'})
         self.pos_admin.write({
             'group_ids': [
                 (4, self.env.ref('product.group_product_manager').id),


### PR DESCRIPTION
After this commit https://github.com/odoo/odoo/pull/252211/changes/3344bd72b9c5591b466aeca7f9da218da53dee3b the test test_archived_product_removed_and_order_is_refunded was sometimes broken because some session were still opened and the product could not be archived. This commit ensures that all sessions are closed before lauching the test.

runbot-error: 241842

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
