### PR TITLE
[FIX] website: prevent crash on carousel dispose

### DIFF
--- a/addons/website/static/src/libs/bootstrap/bootstrap.js
+++ b/addons/website/static/src/libs/bootstrap/bootstrap.js
@@ -13,3 +13,20 @@ Dropdown.prototype._getOffset = function () {
     }
     return offset;
 };
+
+/**
+ * A "transitionend" event is set on the active carousel item when the carousel
+ * is sliding. If the carousel is disposed while a transition is still
+ * happening, the "transitionend" event will be triggered on the now-null
+ * `this._element`, which can cause a crash. To prevent this, we preemptively
+ * dispatch the "transitionend" event on the active slide item as it can
+ * only be called once per transition.
+ */
+const bsCarouselDispose = window.Carousel.prototype.dispose;
+window.Carousel.prototype.dispose = function () {
+    if (this._isSliding) {
+        this._getActive().dispatchEvent(new Event("transitionend"));
+    }
+    this._clearInterval();
+    bsCarouselDispose.call(this);
+};

--- a/addons/website/static/tests/tours/carousel.js
+++ b/addons/website/static/tests/tours/carousel.js
@@ -149,6 +149,19 @@ registerWebsitePreviewTour(
         ...clickOnSave(),
         // Check that saving always sets the first slide as active.
         checkSlides(4, 1),
+        {
+            content: "Slide the carousel",
+            trigger: ":iframe .carousel .carousel-control-next",
+            run: "click",
+        },
+        // Ensure opening edit mode while sliding doesn't cause any issue.
+        ...clickOnEditAndWaitEditMode(),
+        {
+            content: "Slide the carousel in edit mode",
+            trigger: ":iframe .carousel .carousel-control-next",
+            run: "click",
+        },
+        checkSlides(4, 3),
     ]
 );
 


### PR DESCRIPTION
[FIX] website: prevent crash on carousel dispose

__Problem__
When calling `.dispose()` on a Bootstrap carousel, its `_element`
attribute is set to `null` [1]. If the carousel is sliding, a
`transitionend` event listener is active on the slide [2]. If the
carousel is destroyed during this transition, the listener crashes in
[`_slide`][3] because it attempts to find a slide item inside the
now-null `_element`.

This was previously addressed by a temporary hack [4], which was
removed in odoo/odoo@ac8a1af.

__Steps to reproduce__
1. Click on the "Next" button of a carousel.
2. Open the website builder while the carousel is sliding.
=> Crash

It's also possible to reproduce the crash by following these steps:
1. Open the website builder.
2. Open the snippet dialog.
3. Hover over a carousel snippet.
4. Click on it during a sliding transition.
=> Crash

This latter flow is only reproducible in Firefox. Unlike Chrome,
Firefox executes listeners attached to elements inside an iframe even
after the iframe is removed. This occurs here because the element is
hosted within the snippet dialog iframe.

__Fix__
Override the Bootstrap Carousel `dispose` method and preemptively
dispatch the `transitionend` event on the active slide item as it can
only be called once per transition.

[1]: https://github.com/odoo/odoo/blob/8c5fb1fb/addons/web/static/lib/bootstrap/js/dist/base-component.js#L47
[2]: https://github.com/odoo/odoo/blob/8c5fb1fb/addons/web/static/lib/bootstrap/js/dist/util/index.js#L225
[3]: https://github.com/odoo/odoo/blob/8c5fb1fb/addons/web/static/lib/bootstrap/js/dist/carousel.js#L265
[4]: https://github.com/odoo/odoo/blob/d8fa7af2/addons/website/static/src/js/content/snippets.animation.js#L61

task-6026710