### PR TITLE
[FIX] purchase_stock, stock_{account,dropshipping}: generate price diff amls drophsip bill

### DIFF
--- a/addons/purchase_stock/models/account_move_line.py
+++ b/addons/purchase_stock/models/account_move_line.py
@@ -43,7 +43,7 @@ class AccountMoveLine(models.Model):
             if float_is_zero(quantity, precision_rounding=uom.rounding):
                 continue
 
-            layers = line._get_valued_in_moves().stock_valuation_layer_ids.filtered(lambda svl: svl.product_id == line.product_id and not svl.stock_valuation_layer_id)
+            layers = line._get_valued_in_moves()._get_layers_price_diff().filtered(lambda svl: svl.product_id == line.product_id and not svl.stock_valuation_layer_id)
             if not layers:
                 continue
 
@@ -217,7 +217,7 @@ class AccountMoveLine(models.Model):
                     sign = 1
                     layers_to_consume = []
                     for layer in qty_to_invoice_per_layer:
-                        if layer.stock_move_id._is_in():
+                        if layer.stock_move_id._is_in() or layer.stock_move_id._is_dropshipped():
                             layers_to_consume.append((layer, qty_to_invoice_per_layer[layer][1]))
                 while float_compare(aml_qty, 0, precision_rounding=self.product_id.uom_id.rounding) > 0 and layers_to_consume:
                     layer, total_layer_qty_to_invoice = layers_to_consume[0]

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -789,3 +789,15 @@ class StockMove(models.Model):
     def _get_layer_candidates(self):
         self.ensure_one()
         return self.stock_valuation_layer_ids
+
+    def _get_layers_price_diff(self):
+        total_layers_ids = OrderedSet()
+        for move in self:
+            if move._is_dropshipped():
+                layers = move.stock_valuation_layer_ids.filtered(lambda svl: svl.quantity > 0)
+            elif move._is_dropshipped_returned():
+                layers = move.stock_valuation_layer_ids.filtered(lambda svl: svl.quantity < 0)
+            else:
+                layers = move.stock_valuation_layer_ids
+            total_layers_ids.update(layers.ids)
+        return self.env['stock.valuation.layer'].browse(total_layers_ids)

--- a/addons/stock_dropshipping/tests/test_stockvaluation.py
+++ b/addons/stock_dropshipping/tests/test_stockvaluation.py
@@ -21,7 +21,7 @@ class TestStockValuation(ValuationReconciliationTestCommon):
             'taxes_id': [(6, 0, [])],
         })
 
-    def _dropship_product1(self):
+    def _dropship_product1(self, bill_price=None):
         # enable the dropship route on the product
         dropshipping_route = self.env.ref('stock_dropshipping.route_drop_shipping')
         self.product1.write({'route_ids': [(6, 0, [dropshipping_route.id])]})
@@ -69,6 +69,8 @@ class TestStockValuation(ValuationReconciliationTestCommon):
         for i in range(len(self.purchase_order1.order_line)):
             with move_form.invoice_line_ids.edit(i) as line_form:
                 line_form.tax_ids.clear()
+                if bill_price:
+                    line_form.price_unit = bill_price
         self.vendor_bill1 = move_form.save()
         self.vendor_bill1.action_post()
 
@@ -429,3 +431,22 @@ class TestStockValuation(ValuationReconciliationTestCommon):
         self.assertEqual(dropship3_layers[0].value, 24)
         dropship3_cogs_line = customer_invoice3.line_ids.filtered(lambda aml: aml.account_id.id == account_output.id)
         self.assertEqual(dropship3_cogs_line.balance, -24)
+
+    def test_dropship_avco_anglo_saxon_price_diff_bill(self):
+        """ Check that the correction amls from expense to stock interim receipt
+        is created for a dropshipped avco product with automated valuation
+        """
+        self.env.company.anglo_saxon_accounting = True
+        self.product1.product_tmpl_id.categ_id.property_cost_method = 'average'
+        self.product1.product_tmpl_id.categ_id.property_valuation = 'real_time'
+
+        all_amls = self._dropship_product1(bill_price=6)
+
+        expected_aml = {
+            self.company_data['default_account_payable'].id:        (0.0, 6.0),
+            self.company_data['default_account_expense'].id:        (8.0, 2.0),
+            self.company_data['default_account_stock_in'].id:       (8.0, 8.0),
+            self.company_data['default_account_stock_out'].id:      (8.0, 8.0),
+        }
+
+        self._check_results(expected_aml, 12, all_amls)


### PR DESCRIPTION
**Problem:**
compensation amls are not created for dropshipped 
products when there is a difference between the 
price of the PO and the price on the bill

**Context:**
For non dropship avco real time products: 
When you create a PO for a product @ 10
- stock interim received is credited of 10
- stock valuation is debitted of 10

And you then validate a bill for a price of 8
- stock interim received is debitted of 8
- account payable is creditted of 8

This leaves stock interim received with credit of 
2 and stock valuation is over valued by 2. 
So we create 2 extra account move lines 
- One debit of 2 for stock interim received
- One credit of 2 for stock valuation (or Expenses 
if the product is not in stock anymore because then 
it's the expense account which was over valuated)
nb: if the product is still in stock those 2 lines are 
created via stock valuation layer

In the case of a dropshipped product, the product 
is not in stock anymore so it should be creditting 
expense, but no extra amls are created at all.

**Steps to reproduce:**
- enable the "dropshipping" and "anglo saxon accounting" 
settings
- create a storable product with avco automated category
- in the inventory tab, select the dropship route
- in the purchase tab, set a vendor
- create and a confirm a quotation for this product
- on the linked purchase order, set a unit price of 10$ and 
confirm
- validate the dropship move
- create a bill for the purchase order
- set the price to 8$ and confirm
- navigate to journal items and search for your product

**Current behavior:**
no compensation account move lines were created

**Expected behavior:**
2 account move lines should have been created: 
- One debitting 2 in stock interim received
- One creditting 2 in expense

**Cause of the issue:**
*the following logic was introduced by* https://github.com/odoo/odoo/pull/126536
to create those extra amls and layers, 
_apply_price_difference() is called inside _post()
https://github.com/odoo/odoo/blob/32408a8dea43f57bba1a56c775ae228131720749/addons/purchase_stock/models/account_invoice.py#L129

There we have 2 problems : 

Problem 1: When fetching the layers linked to the account move line, 
we fetch both the incoming and the outgoing valuation 
layers because they are both linked to the dropship move. 
https://github.com/odoo/odoo/blob/455b289abd691ccb274dfce43c1b4347add20a41/addons/purchase_stock/models/account_move_line.py#L46
But we only want the incoming layer because the outgoing 
layer should not interfere with the bill.
nb: In a standard case like the one of the steps to reproduce, 
it would work to leave both layers, but : 
- it works for the wrong reasons : the quantity of the aml would 
first be consumed on the incoming 
layer and nothing would happen with the second layer as the 
quantity of the incoming layer is the same as the one of the aml.
- it would probably break in more complex use cases.

So it feels unnecessarily risky to leave it like that.

Problem 2: Inside _generate_price_difference_vals we call _replay_history
which returns two values that are assigned to two variables. 
https://github.com/odoo/odoo/blob/455b289abd691ccb274dfce43c1b4347add20a41/addons/purchase_stock/models/account_move_line.py#L82
The second variable, layers_and_invoices_qties is a default dict
which keys are tuples (layer L, invoice I) mapped with [the initial 
quantity invoiced by I on L, the remanining qty invoiced by I on L]
(here 'remaining' is related to invoice and has nothing to do with stock qties)
https://github.com/odoo/odoo/blob/455b289abd691ccb274dfce43c1b4347add20a41/addons/purchase_stock/models/account_move_line.py#L168-L171

So in our very basic use case, with a single invoice and a single layer, 
we should have a key (our layer, our invoice) linked 
to the value [1,1].
But this key is not in the dictonary. 

*The reason is the following :* 
inside _replay_history the parameter "history"
contains the layers and the amls (in our case 
1 layer and one aml which is self). 
Each layer is added to qty_to_invoice_per_layer
https://github.com/odoo/odoo/blob/455b289abd691ccb274dfce43c1b4347add20a41/addons/purchase_stock/models/account_move_line.py#L177-L178
https://github.com/odoo/odoo/blob/455b289abd691ccb274dfce43c1b4347add20a41/addons/purchase_stock/models/account_move_line.py#L191-L192

Then, for each aml: the layers are added to 
layer_to_consume, alongside their remaining 
quantity.
https://github.com/odoo/odoo/blob/455b289abd691ccb274dfce43c1b4347add20a41/addons/purchase_stock/models/account_move_line.py#L215-L221
And for each layer which has a quantity billed
by the invoice, a key is added to layers_and_invoices_qties
https://github.com/odoo/odoo/blob/455b289abd691ccb274dfce43c1b4347add20a41/addons/purchase_stock/models/account_move_line.py#L222-L231

In our case, the move linked to the layer is the
dropship move so _is_in() will be false and 
the layer won't be added to layers_to_consume.
https://github.com/odoo/odoo/blob/455b289abd691ccb274dfce43c1b4347add20a41/addons/purchase_stock/models/account_move_line.py#L220-L221
So the key will not be created.

*The consequence is the following:*
Later in _generate_price_difference_vals() we acces the value 
of this key (the key that should be there (layer, invoice)) 
https://github.com/odoo/odoo/blob/455b289abd691ccb274dfce43c1b4347add20a41/addons/purchase_stock/models/account_move_line.py#L91
to get the invoiced qty which will later be used to determine which 
quantity is still in stock and which is out of stock (giving us 
the quantities for the compensation layers and amls) 
but as the key does not exist, invoicing_layer_qty will have a value of 0 
so we will exit the loop and no amls or svls will be created
https://github.com/odoo/odoo/blob/455b289abd691ccb274dfce43c1b4347add20a41/addons/purchase_stock/models/account_move_line.py#L92-L93

opw-5498878