### PR TITLE
[FIX] mail_group: 405 Method not allowed in mail_footer

### DIFF
--- a/addons/mail_group/models/mail_group.py
+++ b/addons/mail_group/models/mail_group.py
@@ -451,7 +451,7 @@ class MailGroup(models.Model):
                     'mailto': f'{self.alias_email}',
                     'group_url': f'{base_url}/groups/{self.env["ir.http"]._slug(self)}',
                     'unsub_label': f'{base_url}/groups?unsubscribe',
-                    'unsub_url':  unsubscribe_url,
+                    'unsub_url':  f'{base_url}/groups?unsubscribe',
                 }
                 footer = self.env['ir.qweb']._render('mail_group.mail_group_footer', template_values, minimal_qcontext=True)
                 member_body = append_content_to_html(body, footer, plaintext=False)

--- a/doc/cla/corporate/therp.md
+++ b/doc/cla/corporate/therp.md
@@ -27,4 +27,5 @@ List of contributors:
 *  Nikos Tsirintanis ntsirintanis@therp.nl https://github.com/ntsirintanis
 *  Jan Verbeek jverbeek@therp.nl https://github.com/janverb
 *  Danny de Jong ddejong@therp.nl https://github.com/ddejong-therp
+*  Dan Kiplangat dkiplangat@therp.nl https://github.com/Kiplangatdan
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The email footer includes the [Unsubscribe URL](https://github.com/odoo/odoo/blob/ea6c34f9844962b1e9fc63b3e1e86520a008f5f8/addons/mail_group/models/mail_group.py#L454) intended for the mail_header `List-Unsubscribe=One-Click`. 


Current behavior before PR:

Clicking this results in a `405 Method Not Allowed`

Desired behavior after PR is merged:

It should open the `/groups?unsubscribe`, for instance, https://www.odoo.com/groups?unsubscribe




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
