### PR TITLE
[FIX] website: fix link color lost when html_editor is unloaded 

### DIFF
--- a/addons/website/static/src/scss/website_common.scss
+++ b/addons/website/static/src/scss/website_common.scss
@@ -16,3 +16,9 @@
         width: 1px;
     }
 }
+
+// Ensure colored font wrapper is inherited by child links
+font[class^="text-o-"] a,
+font[style*="color"] a {
+    color: inherit !important;
+}


### PR DESCRIPTION
Problem:
Colored links revert to the default link color after saving and closing
the website editor.

Cause:
The rule forcing links to inherit color from their parent `<font>`
element is defined in the `html_editor` module, whose stylesheet is
unloaded when the editor is closed, so the rule no longer applies on
the frontend.

Solution:
Add the rule to `website_common.scss` so it applies on the frontend
regardless of whether the editor is loaded.

Steps to reproduce:
1. Open the website editor.
2. Apply Color to selection.
3. Apply link to the subset of the selection.
4. Save and close the editor.
5. Observe the link reverts to its default color.

task-5980854

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
