### PR TITLE
[FIX] pos_self_order: fix tracker info for self order

### DIFF
--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -180,11 +180,8 @@ class PosOrder(models.Model):
 
             if device_type == 'kiosk':
                 floating_order_name = f"Table tracker {order['table_stand_number']}" if order.get('table_stand_number') else tracking_number
-
-            if not order.get('floating_order_name') and table:
-                floating_order_name = f"Self-Order T {table.table_number}"
-            elif not order.get('floating_order_name'):
-                floating_order_name = f"Self-Order {tracking_number}"
+            elif not floating_order_name:
+                floating_order_name = f"Self-Order T {table.table_number}" if table else f"Self-Order {tracking_number}"
 
             tracking_number = f"{prefix}{tracking_number}"
         else:

--- a/addons/pos_self_order/tests/test_self_order_kiosk.py
+++ b/addons/pos_self_order/tests/test_self_order_kiosk.py
@@ -62,6 +62,7 @@ class TestSelfOrderKiosk(SelfOrderCommonTest):
 
         # Without location choices, since we need preset to do so.
         self.start_tour(self_route, "self_kiosk_each_table_takeaway_in")
+        self.assertEqual("Table tracker 3", self.pos_config.session_ids.order_ids[0].floating_order_name)
         self.pos_config.write({
             'self_ordering_service_mode': 'counter',
         })


### PR DESCRIPTION
Step to reproduce:
- install "pos_self_order"
- have a kiosk type pos, with "service at" = "table"
- start kiosk and fulfill a order
- on confirmation page, add a tracker number for that order.
- go to backend and open that order

Observation:
- check "order name" in "Extra info" page, we do not get tracker number

Cause:
- After this commit [1], the tracker data is overridden by next if blocks
- hence the data is lost.

Fix:
- fix the condition.

[1] https://github.com/odoo/odoo/commit/c3ea329f1dce44c668e4907fa98cb5104ed11741

opw-5975717


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
