### PR TITLE
[FIX] l10n_es_edi_facturae: XML structure and rounding fixes

### DIFF
--- a/addons/l10n_es_edi_facturae/models/account_move.py
+++ b/addons/l10n_es_edi_facturae/models/account_move.py
@@ -76,6 +76,7 @@ SPANISH_CREDIT_REASON_TYPE = {
     '85': 'Base imponible modificada cuotas repercutidas no satisfechas. Auto de declaración de concurso',
 }
 
+
 class AccountMove(models.Model):
     _inherit = 'account.move'
 
@@ -456,20 +457,23 @@ class AccountMove(models.Model):
             invoice_values['Items'].append(invoice_line_values)
 
         def grouping_function_per_base_line_tax(base_line, tax_data):
+            if not tax_data:
+                return
             return {
-                'record': base_line['record'],
-                'tax': tax_data['tax'] if tax_data else None,
+                'tax_es_type': tax_data['tax'].l10n_es_edi_facturae_tax_type,
+                'tax_rate': tax_data['tax'].amount,
+                'tax_amount_type': tax_data['tax'].amount_type,
             }
 
         base_lines_aggregated_values = AccountTax._aggregate_base_lines_tax_details(base_lines, grouping_function_per_base_line_tax)
         values_per_grouping_key = AccountTax._aggregate_base_lines_aggregated_values(base_lines_aggregated_values)
         for grouping_key, values in values_per_grouping_key.items():
-            tax = grouping_key['tax']
-            if not tax:
+            tax_record = values['base_line_x_taxes_data'][0][1][0]['tax']
+            if not tax_record:
                 continue
 
-            is_withholding = tax.amount < 0.0
-            tax_data = self._l10n_es_edi_facturae_get_tax_node_from_tax_data({**values, 'grouping_key': tax})
+            is_withholding = values['grouping_key']['tax_rate'] < 0.0
+            tax_data = self._l10n_es_edi_facturae_get_tax_node_from_tax_data({**values, 'grouping_key': tax_record}, round=True)
             if is_withholding:
                 invoice_values['TaxesWithheld'].append(tax_data)
                 invoice_values['TotalTaxesWithheld'] -= values['tax_amount_currency']

--- a/addons/l10n_es_edi_facturae/tests/data/expected_in_invoice_document.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_in_invoice_document.xml
@@ -74,50 +74,10 @@
           <TaxTypeCode>01</TaxTypeCode>
           <TaxRate>21.000</TaxRate>
           <TaxableBase>
-            <TotalAmount>100.00</TotalAmount>
+            <TotalAmount>2400.00</TotalAmount>
           </TaxableBase>
           <TaxAmount>
-            <TotalAmount>21.00</TotalAmount>
-          </TaxAmount>
-        </Tax>
-        <Tax>
-          <TaxTypeCode>01</TaxTypeCode>
-          <TaxRate>21.000</TaxRate>
-          <TaxableBase>
-            <TotalAmount>100.00</TotalAmount>
-          </TaxableBase>
-          <TaxAmount>
-            <TotalAmount>21.00</TotalAmount>
-          </TaxAmount>
-        </Tax>
-        <Tax>
-          <TaxTypeCode>01</TaxTypeCode>
-          <TaxRate>21.000</TaxRate>
-          <TaxableBase>
-            <TotalAmount>200.00</TotalAmount>
-          </TaxableBase>
-          <TaxAmount>
-            <TotalAmount>42.00</TotalAmount>
-          </TaxAmount>
-        </Tax>
-        <Tax>
-          <TaxTypeCode>01</TaxTypeCode>
-          <TaxRate>21.000</TaxRate>
-          <TaxableBase>
-            <TotalAmount>900.00</TotalAmount>
-          </TaxableBase>
-          <TaxAmount>
-            <TotalAmount>189.00</TotalAmount>
-          </TaxAmount>
-        </Tax>
-        <Tax>
-          <TaxTypeCode>01</TaxTypeCode>
-          <TaxRate>21.000</TaxRate>
-          <TaxableBase>
-            <TotalAmount>1100.00</TotalAmount>
-          </TaxableBase>
-          <TaxAmount>
-            <TotalAmount>231.00</TotalAmount>
+            <TotalAmount>504.00</TotalAmount>
           </TaxAmount>
         </Tax>
       </TaxesOutputs>

--- a/addons/l10n_es_edi_facturae/tests/data/expected_out_invoice_negative.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_out_invoice_negative.xml
@@ -74,20 +74,10 @@
           <TaxTypeCode>01</TaxTypeCode>
           <TaxRate>21.000</TaxRate>
           <TaxableBase>
-            <TotalAmount>1000.00</TotalAmount>
+            <TotalAmount>900.00</TotalAmount>
           </TaxableBase>
           <TaxAmount>
-            <TotalAmount>210.00</TotalAmount>
-          </TaxAmount>
-        </Tax>
-        <Tax>
-          <TaxTypeCode>01</TaxTypeCode>
-          <TaxRate>21.000</TaxRate>
-          <TaxableBase>
-            <TotalAmount>-100.00</TotalAmount>
-          </TaxableBase>
-          <TaxAmount>
-            <TotalAmount>-21.00</TotalAmount>
+            <TotalAmount>189.00</TotalAmount>
           </TaxAmount>
         </Tax>
       </TaxesOutputs>
@@ -96,20 +86,10 @@
           <TaxTypeCode>04</TaxTypeCode>
           <TaxRate>15.000</TaxRate>
           <TaxableBase>
-            <TotalAmount>1000.00</TotalAmount>
+            <TotalAmount>900.00</TotalAmount>
           </TaxableBase>
           <TaxAmount>
-            <TotalAmount>150.00</TotalAmount>
-          </TaxAmount>
-        </Tax>
-        <Tax>
-          <TaxTypeCode>04</TaxTypeCode>
-          <TaxRate>15.000</TaxRate>
-          <TaxableBase>
-            <TotalAmount>-100.00</TotalAmount>
-          </TaxableBase>
-          <TaxAmount>
-            <TotalAmount>-15.00</TotalAmount>
+            <TotalAmount>135.00</TotalAmount>
           </TaxAmount>
         </Tax>
       </TaxesWithheld>

--- a/addons/l10n_es_edi_facturae/tests/data/expected_out_invoice_round_2.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_out_invoice_round_2.xml
@@ -8,13 +8,13 @@
             <BatchIdentifier>INV/2023/00001</BatchIdentifier>
             <InvoicesCount>1</InvoicesCount>
             <TotalInvoicesAmount>
-                <TotalAmount>410.41</TotalAmount>
+                <TotalAmount>6084.80</TotalAmount>
             </TotalInvoicesAmount>
             <TotalOutstandingAmount>
-                <TotalAmount>410.41</TotalAmount>
+                <TotalAmount>6084.80</TotalAmount>
             </TotalOutstandingAmount>
             <TotalExecutableAmount>
-                <TotalAmount>410.41</TotalAmount>
+                <TotalAmount>6084.80</TotalAmount>
             </TotalExecutableAmount>
             <InvoiceCurrencyCode>EUR</InvoiceCurrencyCode>
         </Batch>
@@ -74,40 +74,40 @@
                     <TaxTypeCode>01</TaxTypeCode>
                     <TaxRate>21.000</TaxRate>
                     <TaxableBase>
-                        <TotalAmount>339.18</TotalAmount>
+                        <TotalAmount>5028.76</TotalAmount>
                     </TaxableBase>
                     <TaxAmount>
-                        <TotalAmount>71.23</TotalAmount>
+                        <TotalAmount>1056.04</TotalAmount>
                     </TaxAmount>
                 </Tax>
             </TaxesOutputs>
             <InvoiceTotals>
-                <TotalGrossAmount>339.18</TotalGrossAmount>
-                <TotalGrossAmountBeforeTaxes>339.18</TotalGrossAmountBeforeTaxes>
-                <TotalTaxOutputs>71.23</TotalTaxOutputs>
+                <TotalGrossAmount>5028.76</TotalGrossAmount>
+                <TotalGrossAmountBeforeTaxes>5028.76</TotalGrossAmountBeforeTaxes>
+                <TotalTaxOutputs>1056.04</TotalTaxOutputs>
                 <TotalTaxesWithheld>0.00</TotalTaxesWithheld>
-                <InvoiceTotal>410.41</InvoiceTotal>
-                <TotalOutstandingAmount>410.41</TotalOutstandingAmount>
-                <TotalExecutableAmount>410.41</TotalExecutableAmount>
+                <InvoiceTotal>6084.80</InvoiceTotal>
+                <TotalOutstandingAmount>6084.80</TotalOutstandingAmount>
+                <TotalExecutableAmount>6084.80</TotalExecutableAmount>
             </InvoiceTotals>
             <Items>
                 <InvoiceLine>
                     <FileDate>2023-01-01</FileDate>
                     <ItemDescription>product_a</ItemDescription>
-                    <Quantity>25.0</Quantity>
+                    <Quantity>1.0</Quantity>
                     <UnitOfMeasure>01</UnitOfMeasure>
-                    <UnitPriceWithoutTax>2.02000000</UnitPriceWithoutTax>
-                    <TotalCost>50.50</TotalCost>
-                    <GrossAmount>50.50</GrossAmount>
+                    <UnitPriceWithoutTax>2478.13550000</UnitPriceWithoutTax>
+                    <TotalCost>2478.14</TotalCost>
+                    <GrossAmount>2478.14</GrossAmount>
                     <TaxesOutputs>
                         <Tax>
                             <TaxTypeCode>01</TaxTypeCode>
                             <TaxRate>21.000</TaxRate>
                             <TaxableBase>
-                                <TotalAmount>50.50</TotalAmount>
+                                <TotalAmount>2478.14</TotalAmount>
                             </TaxableBase>
                             <TaxAmount>
-                                <TotalAmount>10.61</TotalAmount>
+                                <TotalAmount>520.41</TotalAmount>
                             </TaxAmount>
                         </Tax>
                     </TaxesOutputs>
@@ -115,20 +115,20 @@
                 <InvoiceLine>
                     <FileDate>2023-01-01</FileDate>
                     <ItemDescription>product_a</ItemDescription>
-                    <Quantity>2.0</Quantity>
+                    <Quantity>1.0</Quantity>
                     <UnitOfMeasure>01</UnitOfMeasure>
-                    <UnitPriceWithoutTax>7.29000000</UnitPriceWithoutTax>
-                    <TotalCost>14.58</TotalCost>
-                    <GrossAmount>14.58</GrossAmount>
+                    <UnitPriceWithoutTax>1062.50000000</UnitPriceWithoutTax>
+                    <TotalCost>1062.50</TotalCost>
+                    <GrossAmount>1062.50</GrossAmount>
                     <TaxesOutputs>
                         <Tax>
                             <TaxTypeCode>01</TaxTypeCode>
                             <TaxRate>21.000</TaxRate>
                             <TaxableBase>
-                                <TotalAmount>14.58</TotalAmount>
+                                <TotalAmount>1062.50</TotalAmount>
                             </TaxableBase>
                             <TaxAmount>
-                                <TotalAmount>3.06</TotalAmount>
+                                <TotalAmount>223.13</TotalAmount>
                             </TaxAmount>
                         </Tax>
                     </TaxesOutputs>
@@ -136,41 +136,20 @@
                 <InvoiceLine>
                     <FileDate>2023-01-01</FileDate>
                     <ItemDescription>product_a</ItemDescription>
-                    <Quantity>5.0</Quantity>
+                    <Quantity>1.0</Quantity>
                     <UnitOfMeasure>01</UnitOfMeasure>
-                    <UnitPriceWithoutTax>7.32000000</UnitPriceWithoutTax>
-                    <TotalCost>36.60</TotalCost>
-                    <GrossAmount>36.60</GrossAmount>
+                    <UnitPriceWithoutTax>1488.12500000</UnitPriceWithoutTax>
+                    <TotalCost>1488.12</TotalCost>
+                    <GrossAmount>1488.12</GrossAmount>
                     <TaxesOutputs>
                         <Tax>
                             <TaxTypeCode>01</TaxTypeCode>
                             <TaxRate>21.000</TaxRate>
                             <TaxableBase>
-                                <TotalAmount>36.60</TotalAmount>
+                                <TotalAmount>1488.13</TotalAmount>
                             </TaxableBase>
                             <TaxAmount>
-                                <TotalAmount>7.69</TotalAmount>
-                            </TaxAmount>
-                        </Tax>
-                    </TaxesOutputs>
-                </InvoiceLine>
-                <InvoiceLine>
-                    <FileDate>2023-01-01</FileDate>
-                    <ItemDescription>product_a</ItemDescription>
-                    <Quantity>25.0</Quantity>
-                    <UnitOfMeasure>01</UnitOfMeasure>
-                    <UnitPriceWithoutTax>9.50000000</UnitPriceWithoutTax>
-                    <TotalCost>237.50</TotalCost>
-                    <GrossAmount>237.50</GrossAmount>
-                    <TaxesOutputs>
-                        <Tax>
-                            <TaxTypeCode>01</TaxTypeCode>
-                            <TaxRate>21.000</TaxRate>
-                            <TaxableBase>
-                                <TotalAmount>237.50</TotalAmount>
-                            </TaxableBase>
-                            <TaxAmount>
-                                <TotalAmount>49.88</TotalAmount>
+                                <TotalAmount>312.51</TotalAmount>
                             </TaxAmount>
                         </Tax>
                     </TaxesOutputs>
@@ -179,7 +158,7 @@
             <PaymentDetails>
                 <Installment>
                     <InstallmentDueDate>2023-01-01</InstallmentDueDate>
-                    <InstallmentAmount>410.41</InstallmentAmount>
+                    <InstallmentAmount>6084.80</InstallmentAmount>
                     <PaymentMeans>04</PaymentMeans>
                     <AccountToBeCredited>
                         <IBAN>ES9121000418450200051332</IBAN>

--- a/addons/l10n_es_edi_facturae/tests/data/expected_refund_document.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_refund_document.xml
@@ -88,20 +88,10 @@
           <TaxTypeCode>01</TaxTypeCode>
           <TaxRate>21.000</TaxRate>
           <TaxableBase>
-            <TotalAmount>-100.00</TotalAmount>
+            <TotalAmount>-200.00</TotalAmount>
           </TaxableBase>
           <TaxAmount>
-            <TotalAmount>-21.00</TotalAmount>
-          </TaxAmount>
-        </Tax>
-        <Tax>
-          <TaxTypeCode>01</TaxTypeCode>
-          <TaxRate>21.000</TaxRate>
-          <TaxableBase>
-            <TotalAmount>-100.00</TotalAmount>
-          </TaxableBase>
-          <TaxAmount>
-            <TotalAmount>-21.00</TotalAmount>
+            <TotalAmount>-42.00</TotalAmount>
           </TaxAmount>
         </Tax>
       </TaxesOutputs>

--- a/addons/l10n_es_edi_facturae/tests/data/expected_signed_document.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_signed_document.xml
@@ -74,50 +74,10 @@
           <TaxTypeCode>01</TaxTypeCode>
           <TaxRate>21.000</TaxRate>
           <TaxableBase>
-            <TotalAmount>100.00</TotalAmount>
+            <TotalAmount>2400.00</TotalAmount>
           </TaxableBase>
           <TaxAmount>
-            <TotalAmount>21.00</TotalAmount>
-          </TaxAmount>
-        </Tax>
-        <Tax>
-          <TaxTypeCode>01</TaxTypeCode>
-          <TaxRate>21.000</TaxRate>
-          <TaxableBase>
-            <TotalAmount>100.00</TotalAmount>
-          </TaxableBase>
-          <TaxAmount>
-            <TotalAmount>21.00</TotalAmount>
-          </TaxAmount>
-        </Tax>
-        <Tax>
-          <TaxTypeCode>01</TaxTypeCode>
-          <TaxRate>21.000</TaxRate>
-          <TaxableBase>
-            <TotalAmount>200.00</TotalAmount>
-          </TaxableBase>
-          <TaxAmount>
-            <TotalAmount>42.00</TotalAmount>
-          </TaxAmount>
-        </Tax>
-        <Tax>
-          <TaxTypeCode>01</TaxTypeCode>
-          <TaxRate>21.000</TaxRate>
-          <TaxableBase>
-            <TotalAmount>900.00</TotalAmount>
-          </TaxableBase>
-          <TaxAmount>
-            <TotalAmount>189.00</TotalAmount>
-          </TaxAmount>
-        </Tax>
-        <Tax>
-          <TaxTypeCode>01</TaxTypeCode>
-          <TaxRate>21.000</TaxRate>
-          <TaxableBase>
-            <TotalAmount>1100.00</TotalAmount>
-          </TaxableBase>
-          <TaxAmount>
-            <TotalAmount>231.00</TotalAmount>
+            <TotalAmount>504.00</TotalAmount>
           </TaxAmount>
         </Tax>
       </TaxesOutputs>

--- a/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
@@ -551,3 +551,25 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
             with file_open("l10n_es_edi_facturae/tests/data/expected_out_invoice_round_glob.xml", "rt") as f:
                 expected_xml = lxml.etree.fromstring(f.read().encode())
             self.assertXmlTreeEqual(lxml.etree.fromstring(generated_file), expected_xml)
+
+    def test_out_invoice_rounding_2(self):
+        company = self.company_data['company']
+        company.tax_calculation_rounding_method = 'round_globally'
+        with freeze_time(self.frozen_today):
+            invoice = self._create_invoice(
+                partner_id=self.partner_a.id,
+                move_type='out_invoice',
+                invoice_line_ids=[
+                    self._prepare_invoice_line(product_id=self.product_a.id, price_unit=2478.1355, quantity=1.0, tax_ids=self.tax),
+                    self._prepare_invoice_line(product_id=self.product_a.id, price_unit=1062.50, quantity=1.0, tax_ids=self.tax),
+                    self._prepare_invoice_line(product_id=self.product_a.id, price_unit=1488.125, quantity=1.0, tax_ids=self.tax),
+                ],
+                post=True,
+            )
+            generated_file, errors = invoice._l10n_es_edi_facturae_render_facturae()
+            self.assertFalse(errors)
+            self.assertTrue(generated_file)
+
+            with file_open("l10n_es_edi_facturae/tests/data/expected_out_invoice_round_2.xml", "rt") as f:
+                expected_xml = lxml.etree.fromstring(f.read().encode())
+            self.assertXmlTreeEqual(lxml.etree.fromstring(generated_file), expected_xml)


### PR DESCRIPTION
- Adjusting invoice-level `<TaxesOutputs>` nodes to be generated per tax rather than per line
- Enabling rounding for invoice-level tax data aggregation
- Adding a second rounding test derived from bug ticket
task-6009108

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
