### PR TITLE
[FIX] hr_attendance: Working schedule visibility

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -1,3 +1,4 @@
+
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import re
@@ -1391,22 +1392,24 @@ We can redirect you to the public employee list."""
         """
         calendar_periods_by_employee = defaultdict(list)
         for employee in self.sudo():
-            for version in employee._get_versions_with_contract_overlap_with_period(start.date(), stop.date()):
-                # if employee is under fully flexible contract, use timezone of the employee
-                calendar_tz = timezone(version.resource_calendar_id.tz) if version.resource_calendar_id else timezone(employee.resource_id.tz)
-                date_start = datetime.combine(
-                    version.contract_date_start,
-                    time(0, 0, 0)
-                ).replace(tzinfo=calendar_tz).astimezone(utc)
-                if version.date_end:
-                    date_end = datetime.combine(
-                        version.date_end + relativedelta(days=1),
-                        time(0, 0, 0)
-                    ).replace(tzinfo=calendar_tz).astimezone(utc)
-                else:
-                    date_end = stop
-                calendar_periods_by_employee[employee].append(
-                    (max(date_start, start), min(date_end, stop), version.resource_calendar_id))
+            versions_with_contract = employee._get_versions_with_contract_overlap_with_period(start.date(), stop.date())
+            if versions_with_contract:
+                versions = versions_with_contract.filtered_domain([
+                        ('date_start', '<=', stop),
+                        '|',
+                        ('date_end', '=', False),
+                        ('date_end', '>=', start),
+                ])
+                for version in versions:
+                    calendar_tz = timezone(version.resource_calendar_id.tz) if version.resource_calendar_id else timezone(employee.resource_id.tz)
+                    v_start = datetime.combine(version.date_start, time.min).replace(tzinfo=calendar_tz).astimezone(utc)
+                    if version.date_end:
+                        v_end = datetime.combine(version.date_end + relativedelta(days=1), time.min).replace(tzinfo=calendar_tz).astimezone(utc)
+                    else:
+                        v_end = stop
+                    calendar_periods_by_employee[employee].append(
+                        (max(v_start, start), min(v_end, stop), version.resource_calendar_id)
+                    )
         return calendar_periods_by_employee
 
     @api.model

--- a/addons/hr/tests/__init__.py
+++ b/addons/hr/tests/__init__.py
@@ -14,3 +14,4 @@ from . import test_scenario
 from . import test_hr_department
 from . import test_hr_version
 from . import test_hr_contract_versions
+from . import test_hr_version_calendars

--- a/addons/hr/tests/test_hr_version_calendars.py
+++ b/addons/hr/tests/test_hr_version_calendars.py
@@ -1,0 +1,168 @@
+from datetime import date
+from pytz import utc
+from odoo.tests.common import TransactionCase
+from odoo.fields import Datetime
+
+
+class TestHrVersionCalendars(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env['res.company'].create({
+            'name': 'Test Company',
+            'country_id': cls.env.ref('base.us').id,
+        })
+        cls.env.user.company_id = cls.company
+        cls.employee = cls.env['hr.employee'].create({
+            'name': 'Youssef Ahmed',
+            'date_version': '2025-01-01',
+            'date_start': '2025-01-01',
+        })
+
+        cls.calendar_1 = cls.env['resource.calendar'].create([{
+            'name': "Standard 40 hours/week",
+            'company_id': cls.env.company.id,
+            'tz': "UTC",
+            'two_weeks_calendar': False,
+            'attendance_ids': [(5, 0, 0)] + [(0, 0, {
+                'name': "Attendance",
+                'dayofweek': dayofweek,
+                'hour_from': hour_from,
+                'hour_to': hour_to,
+                'day_period': day_period,
+            }) for dayofweek, hour_from, hour_to, day_period in [
+                ("0", 8.0, 12.0, "morning"),
+                ("0", 13.0, 17.0, "afternoon"),
+                ("1", 8.0, 12.0, "morning"),
+                ("1", 13.0, 17.0, "afternoon"),
+                ("2", 8.0, 12.0, "morning"),
+                ("2", 13.0, 17.0, "afternoon"),
+                ("3", 8.0, 12.0, "morning"),
+                ("3", 13.0, 17.0, "afternoon"),
+                ("4", 8.0, 12.0, "morning"),
+                ("4", 13.0, 17.0, "afternoon"),
+            ]],
+        }])
+
+        cls.calendar_2 = cls.env['resource.calendar'].create([{
+            'name': "Standard 20 hours/week",
+            'company_id': cls.env.company.id,
+            'tz': "UTC",
+            'two_weeks_calendar': False,
+            'attendance_ids': [(5, 0, 0)] + [(0, 0, {
+                'name': "Attendance",
+                'dayofweek': dayofweek,
+                'hour_from': hour_from,
+                'hour_to': hour_to,
+                'day_period': day_period,
+            }) for dayofweek, hour_from, hour_to, day_period in [
+                ("0", 8.0, 12.0, "morning"),
+                ("1", 8.0, 12.0, "morning"),
+                ("2", 8.0, 12.0, "morning"),
+                ("3", 8.0, 12.0, "morning"),
+                ("4", 8.0, 12.0, "morning"),
+
+            ]],
+        }])
+
+        cls.start = Datetime.from_string('2025-01-01 00:00:00').replace(tzinfo=utc)
+        cls.stop = Datetime.from_string('2025-01-31 23:59:59').replace(tzinfo=utc)
+
+    def test_01_two_versions_same_contract_same_calendar(self):
+        v1 = self.employee.version_id
+        v1.name = "Version 1"
+        v1.resource_calendar_id = self.calendar_1.id
+
+        v2 = self.employee.create_version({
+            'name': "Version 2",
+            'date_version': '2025-01-16',
+            'resource_calendar_id': self.calendar_1.id,
+        })
+
+        contract_versions = v1 | v2
+        contract_versions.contract_date_start = date(2025, 1, 1)
+
+        periods = self.employee._get_calendar_periods(self.start, self.stop)
+        employee_periods = periods[self.employee]
+        self.assertEqual(len(employee_periods), 2)
+
+        self.assertEqual(employee_periods[0][0].date(), date(2025, 1, 1))
+        self.assertEqual(employee_periods[0][1].date(), date(2025, 1, 16))
+        self.assertEqual(employee_periods[0][2].id, self.calendar_1.id)
+
+        self.assertEqual(employee_periods[1][0].date(), date(2025, 1, 16))
+        self.assertEqual(employee_periods[1][1].date(), date(2025, 1, 31))
+        self.assertEqual(employee_periods[1][2].id, self.calendar_1.id)
+
+    def test_02_two_versions_same_contract_different_calendars(self):
+        v1 = self.employee.version_id
+        v1.name = "Version 1"
+        v1.resource_calendar_id = self.calendar_1.id
+
+        v2 = self.employee.create_version({
+            'name': "Version 2",
+            'date_version': '2025-01-16',
+            'resource_calendar_id': self.calendar_2.id,
+        })
+
+        contract_versions = v1 | v2
+        contract_versions.contract_date_start = date(2025, 1, 1)
+
+        periods = self.employee._get_calendar_periods(self.start, self.stop)
+        employee_periods = periods[self.employee]
+        self.assertEqual(len(employee_periods), 2)
+
+        self.assertEqual(employee_periods[0][0].date(), date(2025, 1, 1))
+        self.assertEqual(employee_periods[0][1].date(), date(2025, 1, 16))
+        self.assertEqual(employee_periods[0][2].id, self.calendar_1.id)
+
+        self.assertEqual(employee_periods[1][0].date(), date(2025, 1, 16))
+        self.assertEqual(employee_periods[1][1].date(), date(2025, 1, 31))
+        self.assertEqual(employee_periods[1][2].id, self.calendar_2.id)
+
+    def test_03_two_versions_different_contracts_different_calendars(self):
+        v1 = self.employee.version_id
+        v1.name = "Version 1"
+        v1.resource_calendar_id = self.calendar_1.id
+
+        v1.contract_date_start = date(2025, 1, 1)
+        v1.contract_date_end = date(2025, 1, 15)
+
+        v2 = self.employee.create_version({
+            'name': "Version 2",
+            'date_version': '2025-01-16',
+            'resource_calendar_id': self.calendar_2.id,
+        })
+
+        v2.contract_date_start = date(2025, 1, 16)
+        v2.contract_date_end = date(2025, 1, 31)
+
+        periods = self.employee._get_calendar_periods(self.start, self.stop)
+        employee_periods = periods[self.employee]
+
+        self.assertEqual(len(employee_periods), 2)
+
+        self.assertEqual(employee_periods[0][0].date(), date(2025, 1, 1))
+        self.assertEqual(employee_periods[0][1].date(), date(2025, 1, 16))
+        self.assertEqual(employee_periods[0][2].id, self.calendar_1.id)
+
+        self.assertEqual(employee_periods[1][0].date(), date(2025, 1, 16))
+        self.assertEqual(employee_periods[1][1].date(), date(2025, 1, 31))
+        self.assertEqual(employee_periods[1][2].id, self.calendar_2.id)
+
+    def test_04_two_versions_without_contract_different_calendars(self):
+        v1 = self.employee.version_id
+        v1.name = "Version 1"
+        v1.resource_calendar_id = self.calendar_1.id
+
+        self.employee.create_version({
+            'name': "Version 2",
+            'date_version': '2025-01-16',
+            'resource_calendar_id': self.calendar_2.id,
+        })
+
+        self.employee.contract_date_start = ''
+        periods = self.employee._get_calendar_periods(self.start, self.stop)
+
+        self.assertEqual(len(periods[self.employee]), 0)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Based on this feedback : [https://www.odoo.com/odoo/project.task/5436300](https://www.odoo.com/odoo/project.task/5436300%C2%A0)
When I got two versions with different working schedules, normally, in Attendance, the gant view should show the unavaibilities by putting in gray days you're not working.

As the feedback shows:-
. If you have two different working schedules on two different versions and two different occupations period (contract dates), it's working fine. ✅
. If the two versions have the same occupation period (contract date), it's only considering the latest working schedule ❌
. If both versions are under the same contract, then it only shows the working schedule on the latest version ❌
. Mad Max, Work from 1 to 31 january. On the 15 a second version with full working schedule. Before the 15 only works on Monday. 
. If a new version is created with a start date earlier than the current version, only the most recently created version with the earlier start date is taken into account ❌
. If there are two working schedules, one flexible and one non-flexible each appears correctly within its own date range. However, when the date filter is expanded to include both, the display does not work correctly ❌

Desired behavior after PR is merged:
. Modify _get_calendar_periods() method to return the correct working schedule for each period
. Fix version_date to use the specified date instead of the creation date.
. Add the corresponding tests

task-5473047