### PR TITLE
[FIX] pos*: disable confirm button in `TextInputPopup` if input empty

### DIFF
--- a/addons/point_of_sale/static/src/app/utils/input_popups/text_input_popup.js
+++ b/addons/point_of_sale/static/src/app/utils/input_popups/text_input_popup.js
@@ -25,7 +25,9 @@ export class TextInputPopup extends AbstractAwaitablePopup {
     }
     _onWindowKeyup(event) {
         if (event.key === this.props.confirmKey) {
-            this.confirm();
+            if (this.state.inputValue.trim()) {
+                this.confirm();
+            }
         } else {
             super._onWindowKeyup(...arguments);
         }

--- a/addons/point_of_sale/static/src/app/utils/input_popups/text_input_popup.xml
+++ b/addons/point_of_sale/static/src/app/utils/input_popups/text_input_popup.xml
@@ -10,7 +10,8 @@
                     <input class="form-control form-control-lg w-75 mx-auto" type="text" t-model="state.inputValue" t-ref="input" t-att-placeholder="props.placeholder"/>
                 </div>
                 <div class="footer footer-flex modal-footer">
-                    <div class="button confirm highlight btn btn-lg btn-primary" t-on-click="confirm">
+                    <div class="button confirm highlight btn btn-lg btn-primary"
+                        t-att-class="{'disabled': !state.inputValue.trim()}" t-on-click="confirm">
                         <t t-esc="props.confirmText" />
                     </div>
                     <div class="button cancel btn btn-lg btn-secondary" t-on-click="cancel">

--- a/addons/point_of_sale/static/tests/tours/helpers/TextInputPopupTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/TextInputPopupTourMethods.js
@@ -27,3 +27,22 @@ export function isShown() {
         },
     ];
 }
+
+export function clickCancel() {
+    return [
+        {
+            content: "discard text input popup",
+            trigger: ".modal-dialog .cancel",
+        },
+    ];
+}
+
+export function checkConfirmDisabled() {
+    return [
+        {
+            content: "confirm button disabled",
+            trigger: ".modal-dialog .confirm.disabled",
+            isCheck: true,
+        },
+    ];
+}

--- a/addons/pos_loyalty/static/tests/tours/PosLoyaltyTour.js
+++ b/addons/pos_loyalty/static/tests/tours/PosLoyaltyTour.js
@@ -4,6 +4,7 @@ import * as Chrome from "@point_of_sale/../tests/tours/helpers/ChromeTourMethods
 import * as PosLoyalty from "@pos_loyalty/../tests/tours/PosLoyaltyTourMethods";
 import * as ProductScreen from "@point_of_sale/../tests/tours/helpers/ProductScreenTourMethods";
 import * as SelectionPopup from "@point_of_sale/../tests/tours/helpers/SelectionPopupTourMethods";
+import * as TextInputPopup from "@point_of_sale/../tests/tours/helpers/TextInputPopupTourMethods";
 import { registry } from "@web/core/registry";
 import { scan_barcode } from "@point_of_sale/../tests/tours/helpers/utils";
 
@@ -613,7 +614,7 @@ registry.category("web_tour.tours").add("test_number_buffer_popup", {
                     window.dispatchEvent(ev);
                 },
             },
-            Chrome.confirmPopup(),
+            TextInputPopup.clickCancel(),
             ProductScreen.selectedOrderlineHas("Whiteboard Pen", "2.0"),
             ProductScreen.totalAmountIs("3.52"),
             Chrome.endTour(),

--- a/addons/pos_restaurant/static/tests/tours/FloorScreen.tour.js
+++ b/addons/pos_restaurant/static/tests/tours/FloorScreen.tour.js
@@ -72,6 +72,13 @@ registry.category("web_tour.tours").add("FloorScreenTour", {
             FloorScreen.clickTrash(),
             Chrome.confirmPopup(),
 
+            //add new floor
+            FloorScreen.clickAddFloor(),
+            TextInputPopup.isShown(),
+            TextInputPopup.checkConfirmDisabled(),
+            TextInputPopup.inputText("New Floor"),
+            TextInputPopup.clickConfirm(),
+
             FloorScreen.clickFloor("Main Floor"),
             FloorScreen.hasTable("2"),
             FloorScreen.hasTable("4"),

--- a/addons/pos_restaurant/static/tests/tours/helpers/FloorScreenTourMethods.js
+++ b/addons/pos_restaurant/static/tests/tours/helpers/FloorScreenTourMethods.js
@@ -174,3 +174,12 @@ export function tableIsNotSelected(name) {
         },
     ];
 }
+
+export function clickAddFloor() {
+    return [
+        {
+            content: `click add floor`,
+            trigger: `.floor-selector .button-add`,
+        },
+    ];
+}


### PR DESCRIPTION
*= point_of_sale, pos_loyalty, pos_restaurant

Before this commit:
===================
- User was able to confirm `TextInputPopup` with an empty input value.

Affected functionalities:
- Add New Floor
- Rename Floor / Table
- Enter Code (Gift card or Discount code)
- Generate a Gift Card

After this commit:
==================
- The confirm button will be disabled if the input value is empty or has only
spaces so that an empty string will not be accepted.

Task-6019160



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
