### PR TITLE
[FIX] l10n_jo_edi_pos: fix unset ref account move

### DIFF
--- a/addons/l10n_jo_edi_pos/models/pos_order.py
+++ b/addons/l10n_jo_edi_pos/models/pos_order.py
@@ -173,7 +173,7 @@ class PosOrder(models.Model):
         vals = super()._prepare_invoice_vals()
         return {
             **vals,
-            'ref': self.l10n_jo_edi_pos_return_reason,
+            'ref': self.l10n_jo_edi_pos_return_reason or vals.get('ref', False),
             'l10n_jo_edi_uuid': self.l10n_jo_edi_pos_uuid,
             'l10n_jo_edi_state': self.l10n_jo_edi_pos_state,
             'l10n_jo_edi_error': self.l10n_jo_edi_pos_error,


### PR DESCRIPTION
Before this commit, an override of _prepare_invoice_vals in l10n_jo_edi_pos was setting the ref field of the created account move to l10n_jo_edi_pos_return_reason, which was False when the country was not Jordan. This was causing the ref to be unset for every move created from a pos order when the module was installed but the field l10n_jo_edi_pos_return_reason was not set. This is now fixed by taking the value of the field if set, else take the original value.

runbot-error: 241014

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
