### PR TITLE
[FIX] website: invalidate website_published before web_save readback

### DIFF
--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -541,6 +541,9 @@ class WebsitePublishedMixin(models.AbstractModel):
             'published_date': fields.Datetime.now(),
             'publish_on': False,
         })
+        # Invalidate the ORM cache for website_published so hooks that read it
+        # during this method see the fresh "True" value instead of an old cache.
+        records.invalidate_recordset(['website_published'])
 
     @api.depends_context('uid')
     def _compute_can_publish(self):


### PR DESCRIPTION
Steps to reproduce:
1. Install `website_hr_recruitment`
2. Create a job position from form view
3. Click on Published toggle button

Issue:
- Publishing a job position from the `hr.job` form is showing an incorrect first-click result: the website page is actually published, but the form autosave response still return `website_published = false`, so the toggle flips back to unpublished until the next refresh.

Cause:
- In v19.0, `website.published.mixin.write()` was effectively a thin wrapper around `super().write()`. The backend autosave path used by boolean toggles (`web_save`) performs a `write()` and then an immediate `web_read()` in the same request, and that simple flow returned the fresh publish state.

- In saas-19.1, the publish flow became more complex:
  - `website.published.mixin.write()` now  triggers `_finalize_publication()`
  - `_finalize_publication()` performs an additional internal `write()`

- The record is published correctly, but the immediate `web_save()` readback can still use cached values for  `website_published` from the same ORM environment. This makes the first form response inconsistent with the actual state.

Solution:
- Invalidating `website_published` field after the`write()` in `_finalize_publication()` so the immediate `web_read()` performed by `web_save()` returns the real post-write state on the first click.

opw-6012359