### PR TITLE
[18.0][FIX] product_expiry: fix use of _origin in stock.lot._compute_dates

### DIFF
--- a/addons/product_expiry/models/production_lot.py
+++ b/addons/product_expiry/models/production_lot.py
@@ -12,11 +12,11 @@ class StockLot(models.Model):
     expiration_date = fields.Datetime(
         string='Expiration Date', compute='_compute_expiration_date', store=True, readonly=False,
         help='This is the date on which the goods with this Serial Number may become dangerous and must not be consumed.')
-    use_date = fields.Datetime(string='Best before Date', compute='_compute_dates', store=True, readonly=False,
+    use_date = fields.Datetime(string='Best before Date', compute='_compute_use_date', store=True, readonly=False,
         help='This is the date on which the goods with this Serial Number start deteriorating, without being dangerous yet.')
-    removal_date = fields.Datetime(string='Removal Date', compute='_compute_dates', store=True, readonly=False,
+    removal_date = fields.Datetime(string='Removal Date', compute='_compute_removal_date', store=True, readonly=False,
         help='This is the date on which the goods with this Serial Number should be removed from the stock. This date will be used in FEFO removal strategy.')
-    alert_date = fields.Datetime(string='Alert Date', compute='_compute_dates', store=True, readonly=False,
+    alert_date = fields.Datetime(string='Alert Date', compute='_compute_alert_date', store=True, readonly=False,
         help='Date to determine the expired lots and serial numbers using the filter "Expiration Alerts".')
     product_expiry_alert = fields.Boolean(compute='_compute_product_expiry_alert', help="The Expiration Date has been reached.")
     product_expiry_reminded = fields.Boolean(string="Expiry has been reminded")
@@ -38,28 +38,53 @@ class StockLot(models.Model):
                 duration = lot.product_id.product_tmpl_id.expiration_time
                 lot.expiration_date = datetime.datetime.now() + datetime.timedelta(days=duration)
 
-    @api.depends('product_id', 'expiration_date')
-    def _compute_dates(self):
-        for lot in self:
-            if not lot.product_id.use_expiration_date:
-                lot.use_date = False
-                lot.removal_date = False
-                lot.alert_date = False
-            elif lot.expiration_date:
-                # when create
-                if lot.product_id != lot._origin.product_id or \
-                   (not lot.use_date and not lot.removal_date and not lot.alert_date) or \
-                   (lot.expiration_date and not lot._origin.expiration_date):
-                    product_tmpl = lot.product_id.product_tmpl_id
-                    lot.use_date = lot.expiration_date - datetime.timedelta(days=product_tmpl.use_time)
-                    lot.removal_date = lot.expiration_date - datetime.timedelta(days=product_tmpl.removal_time)
-                    lot.alert_date = lot.expiration_date - datetime.timedelta(days=product_tmpl.alert_time)
-                # when change
-                elif lot._origin.expiration_date:
-                    time_delta = lot.expiration_date - lot._origin.expiration_date
-                    lot.use_date = lot._origin.use_date and lot._origin.use_date + time_delta
-                    lot.removal_date = lot._origin.removal_date and lot._origin.removal_date + time_delta
-                    lot.alert_date = lot._origin.alert_date and lot._origin.alert_date + time_delta
+    @api.depends(
+        "expiration_date",
+        "product_id.use_expiration_date",
+        "product_id.product_tmpl_id.use_time",
+    )
+    def _compute_use_date(self):
+        self.use_date = False
+        need_date_records = self.filtered(
+            lambda lot: lot.product_id.use_expiration_date and lot.expiration_date
+        )
+        for lot in need_date_records:
+            expiration_date = lot.expiration_date
+            product_tmpl = lot.product_id.product_tmpl_id
+            delta = datetime.timedelta(days=product_tmpl.use_time)
+            lot.use_date = expiration_date - delta
+
+    @api.depends(
+        "expiration_date",
+        "product_id.use_expiration_date",
+        "product_id.product_tmpl_id.removal_time",
+    )
+    def _compute_removal_date(self):
+        self.removal_date = False
+        need_date_records = self.filtered(
+            lambda lot: lot.product_id.use_expiration_date and lot.expiration_date
+        )
+        for lot in need_date_records:
+            expiration_date = lot.expiration_date
+            product_tmpl = lot.product_id.product_tmpl_id
+            delta = datetime.timedelta(days=product_tmpl.removal_time)
+            lot.removal_date = expiration_date - delta
+
+    @api.depends(
+        "expiration_date",
+        "product_id.use_expiration_date",
+        "product_id.product_tmpl_id.alert_time",
+    )
+    def _compute_alert_date(self):
+        self.alert_date = False
+        need_date_records = self.filtered(
+            lambda lot: lot.product_id.use_expiration_date and lot.expiration_date
+        )
+        for lot in need_date_records:
+            expiration_date = lot.expiration_date
+            product_tmpl = lot.product_id.product_tmpl_id
+            delta = datetime.timedelta(days=product_tmpl.alert_time)
+            lot.alert_date = expiration_date - delta
 
     @api.model
     def _alert_date_exceeded(self):

--- a/addons/product_expiry/tests/test_stock_lot.py
+++ b/addons/product_expiry/tests/test_stock_lot.py
@@ -27,6 +27,24 @@ class TestStockLot(TestStockCommon):
             'alert_time': 6,
         })
 
+    def test_stock_lot_date_compute(self):
+        lot = self.env["stock.lot"].create(
+            {
+                "product_id": self.apple_product.id,
+                "name": "apple lot",
+                "expiration_date": "2026-06-01 00:00:00",
+            }
+        )
+        self.assertEqual(str(lot.expiration_date), "2026-06-01 00:00:00")
+        self.assertEqual(str(lot.use_date), "2026-05-27 00:00:00")
+        self.assertEqual(str(lot.removal_date), "2026-05-30 00:00:00")
+        self.assertEqual(str(lot.alert_date), "2026-05-26 00:00:00")
+        lot.expiration_date = "2026-11-01 00:00:00"
+        self.assertEqual(str(lot.expiration_date), "2026-11-01 00:00:00")
+        self.assertEqual(str(lot.use_date), "2026-10-27 00:00:00")
+        self.assertEqual(str(lot.removal_date), "2026-10-30 00:00:00")
+        self.assertEqual(str(lot.alert_date), "2026-10-26 00:00:00")
+
     def test_00_stock_production_lot(self):
         """ Test Scheduled Task on lot with an alert_date in the past creates an activity """
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Changing lot expiration date from the orm doesn't update other dates (see the unittest I added).

Current behavior before PR:

use_date, removal_date and alert_date aren't updated correctly when modifying `lot.expiration_date`.
Reason is that `lot._origin.expiration_date` is always equal to `lot.expiration_date`.
Therefore the deducted timedelta is always `days=0`, and never modifies the other date fields.

Desired behavior after PR is merged:

use_date, removal_date and alert_date are correctly modified when expiration_date is updated.

ping @yhu-odoo 

related ticket number : #6036396


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
