### PR TITLE
[FIX] web, *: rename class as expected

### DIFF
--- a/addons/account/views/product_view.xml
+++ b/addons/account/views/product_view.xml
@@ -94,7 +94,7 @@
                                 'append_fields': ['company_id'],
                             }"
                         />
-                        <field name="tax_string" class="o_input_box_overlay_end o_input_box_inline"/>
+                        <field name="tax_string" class="o_input_box_overlay_end o_input_box_overlay_inline"/>
                     </div>
                 </field>
                 <div name="standard_price_uom" position="after">

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -140,7 +140,7 @@
                             <label for="duration" class="fw-bold text-900 opacity-100"/>
                             <div class="o_input_box" invisible="allday">
                                 <field name="duration" widget="float_time" string="Duration" readonly="(id and recurrency) or not user_can_edit"/>
-                                <span class="o_input_box_overlay_end o_input_box_inline">hours</span>
+                                <span class="o_input_box_overlay_end o_input_box_overlay_inline">hours</span>
                             </div>
                             <field name="location" placeholder="Online Meeting" readonly="not user_can_edit"/>
                             <label for="videocall_location" class="opacity-100"/>

--- a/addons/crm/views/crm_stage_views.xml
+++ b/addons/crm/views/crm_stage_views.xml
@@ -51,7 +51,7 @@
                             <label for="rotting_threshold_days" string="Rotting in" invisible="is_won"/>
                             <div class="o_input_box" invisible="is_won">
                                 <field name="rotting_threshold_days"/>
-                                <span class="o_input_box_overlay_end o_input_box_inline">days</span>
+                                <span class="o_input_box_overlay_end o_input_box_overlay_inline">days</span>
                             </div>
                         </group>
                         <group>

--- a/addons/delivery/views/delivery_carrier_views.xml
+++ b/addons/delivery/views/delivery_carrier_views.xml
@@ -171,12 +171,12 @@
                                         <label for="max_weight"/>
                                         <div name="max_weight_row" class="o_input_box">
                                             <field name="max_weight"/>
-                                            <field class="o_input_box_overlay_end o_input_box_inline" name="weight_uom_name"/>
+                                            <field class="o_input_box_overlay_end o_input_box_overlay_inline" name="weight_uom_name"/>
                                         </div>
                                         <label for="max_volume"/>
                                         <div name="max_volume_row" class="o_input_box">
                                             <field name="max_volume"/>
-                                            <field class="o_input_box_overlay_end o_input_box_inline" name="volume_uom_name"/>
+                                            <field class="o_input_box_overlay_end o_input_box_overlay_inline" name="volume_uom_name"/>
                                         </div>
                                         <field name="must_have_tag_ids"
                                                 widget="many2many_tags"

--- a/addons/hr_recruitment/views/hr_recruitment_stage_views.xml
+++ b/addons/hr_recruitment/views/hr_recruitment_stage_views.xml
@@ -76,7 +76,7 @@
                             <label for="rotting_threshold_days" string="Rotting in" invisible="hired_stage"/>
                             <div class="o_input_box" invisible="hired_stage">
                                 <field name="rotting_threshold_days"/>
-                                <span class="o_input_box_overlay_end o_input_box_inline">days</span>
+                                <span class="o_input_box_overlay_end o_input_box_overlay_inline">days</span>
                             </div>
                         </group>
                         <group name="details">

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -174,12 +174,12 @@
                                     <label for="produce_delay" string="Manuf. Lead Time"/>
                                     <div class="o_input_box">
                                         <field name="produce_delay"/>
-                                        <span class="o_input_box_overlay_end o_input_box_inline">days</span>
+                                        <span class="o_input_box_overlay_end o_input_box_overlay_inline">days</span>
                                     </div>
                                     <label for="days_to_prepare_mo"/>
                                     <div class="o_input_box">
                                         <field name="days_to_prepare_mo"/>
-                                        <span class="o_input_box_overlay_end o_input_box_inline">days</span>
+                                        <span class="o_input_box_overlay_end o_input_box_overlay_inline">days</span>
                                         <button name="action_compute_bom_days" type="object"
                                                 help="Compute the days required to resupply all components from BoM, by either buying or manufacturing the components and/or subassemblies."
                                                 class="btn btn-link o_input_box_overlay_end fa fa-calculator"/>
@@ -187,7 +187,7 @@
                                     <field name="enable_batch_size" widget="boolean_toggle"/>
                                     <div class="o_input_box" invisible="type != 'normal'">
                                         <field name="batch_size" invisible="not enable_batch_size" decoration-danger="batch_size &lt;= 0.0"/>
-                                        <field name="uom_id" groups="uom.group_uom" readonly="1" invisible="not enable_batch_size" class="o_input_box_overlay_end o_input_box_inline"/>
+                                        <field name="uom_id" groups="uom.group_uom" readonly="1" invisible="not enable_batch_size" class="o_input_box_overlay_end o_input_box_overlay_inline"/>
                                     </div>
                                 </group>
                                 <group>

--- a/addons/mrp/views/mrp_routing_views.xml
+++ b/addons/mrp/views/mrp_routing_views.xml
@@ -112,7 +112,7 @@
                                 <label for="time_total" string="Total Duration" invisible="not show_time_total"/>
                                 <div class="o_input_box" invisible="not show_time_total">
                                     <field name="time_total" widget="float_time" options="{'unit': 'minutes'}"/>
-                                    <span class="o_input_box_overlay_end o_input_box_inline">minutes</span>
+                                    <span class="o_input_box_overlay_end o_input_box_overlay_inline">minutes</span>
                                 </div>
                                 <field name="company_id" groups="base.group_multi_company" />
                             </group>

--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -321,29 +321,29 @@
                                         <label for="time_efficiency"/>
                                         <div class="o_input_box">
                                             <field name="time_efficiency"/>
-                                            <span class="o_input_box_overlay_end o_input_box_inline">%</span>
+                                            <span class="o_input_box_overlay_end o_input_box_overlay_inline">%</span>
                                         </div>
                                         <label for="oee_target"/>
                                         <div class="o_input_box">
                                             <field name="oee_target"/>
-                                            <span class="o_input_box_overlay_end o_input_box_inline">%</span>
+                                            <span class="o_input_box_overlay_end o_input_box_overlay_inline">%</span>
                                         </div>
                                         <label for="time_start"/>
                                         <div class="o_input_box">
                                             <field name="time_start" widget="float_time" options="{'unit': 'minutes'}"/>
-                                            <span class="o_input_box_overlay_end o_input_box_inline">minutes</span>
+                                            <span class="o_input_box_overlay_end o_input_box_overlay_inline">minutes</span>
                                         </div>
                                         <label for="time_stop"/>
                                         <div class="o_input_box">
                                             <field name="time_stop" widget="float_time" options="{'unit': 'minutes'}"/>
-                                            <span class="o_input_box_overlay_end o_input_box_inline">minutes</span>
+                                            <span class="o_input_box_overlay_end o_input_box_overlay_inline">minutes</span>
                                         </div>
                                     </group>
                                     <group string="Costing Information" name="costing">
                                         <label for="costs_hour"/>
                                         <div class="o_input_box" id="costs_hour">
                                             <field name="costs_hour" widget="monetary"/>
-                                            <span class="o_input_box_overlay_end o_input_box_inline">per workcenter</span>
+                                            <span class="o_input_box_overlay_end o_input_box_overlay_inline">per workcenter</span>
                                         </div>
                                     </group>
                                 </group>

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -204,7 +204,7 @@
                         <label for="duration_expected"/>
                         <div class="o_input_box">
                             <field name="duration_expected" widget="float_time" options="{'unit': 'minutes'}" readonly="state in ['cancel', 'done']"/>
-                            <span class="o_input_box_overlay_end o_input_box_inline">minutes</span>
+                            <span class="o_input_box_overlay_end o_input_box_overlay_inline">minutes</span>
                         </div>
                     </group>
                     <group>

--- a/addons/project/views/project_project_stage_views.xml
+++ b/addons/project/views/project_project_stage_views.xml
@@ -48,7 +48,7 @@
                             <label for="rotting_threshold_days" string="Rotting in"/>
                             <div class="o_input_box">
                                 <field name="rotting_threshold_days"/>
-                                <span class="o_input_box_overlay_end o_input_box_inline">days</span>
+                                <span class="o_input_box_overlay_end o_input_box_overlay_inline">days</span>
                             </div>
                         </group>
                         <group>

--- a/addons/project/views/project_task_type_views.xml
+++ b/addons/project/views/project_task_type_views.xml
@@ -37,7 +37,7 @@
                                 <label for="rotting_threshold_days" string="Rotting in"/>
                                 <div class="o_input_box">
                                     <field name="rotting_threshold_days"/>
-                                    <span class="o_input_box_overlay_end o_input_box_inline">days</span>
+                                    <span class="o_input_box_overlay_end o_input_box_overlay_inline">days</span>
                                 </div>
                                 <field name="rating_active" widget="boolean_toggle"/>
                                 <field name="rating_status" invisible="not rating_active"/>

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -203,7 +203,7 @@
                     <label for="sale_delay" invisible="not sale_ok"/>
                     <div class="o_input_box" invisible="not sale_ok">
                         <field name="sale_delay"/>
-                        <span class="o_input_box_overlay_end o_input_box_inline">days</span>
+                        <span class="o_input_box_overlay_end o_input_box_overlay_inline">days</span>
                     </div>
                 </xpath>
                 <xpath expr="//group[@name='group_lots_and_weight']" position="before">
@@ -223,7 +223,7 @@
                         <label for="serial_prefix_format" string="Custom Lot/Serial"/>
                         <div class="o_input_box">
                             <field name="serial_prefix_format"/>
-                            <field class="o_input_box_overlay_end o_input_box_inline" name="next_serial"/>
+                            <field class="o_input_box_overlay_end o_input_box_overlay_inline" name="next_serial"/>
                         </div>
                     </group>
                      <group string="Counterpart Locations" name="stock_property" groups="base.group_no_one">

--- a/addons/web/static/src/views/fields/properties/properties_field.xml
+++ b/addons/web/static/src/views/fields/properties/properties_field.xml
@@ -74,7 +74,7 @@
                                 onTagsChange.bind="(newTags, newValue) => this.onTagsChange(propertyConfiguration.name, newTags, newValue)"
                                 record="props.record"
                             />
-                            <span class="o_input_box_overlay_end o_input_box_inline" t-if="propertyConfiguration.suffix" t-out="propertyConfiguration.suffix"/>
+                            <span class="o_input_box_overlay_end o_input_box_overlay_inline" t-if="propertyConfiguration.suffix" t-out="propertyConfiguration.suffix"/>
                         </div>
                     </div>
                     <div


### PR DESCRIPTION
In commit [1], the class 'o_input_box_overlay_inline' was introduced, but many elements were using an invalid 'o_input_box_inline' class instead of that one.

This commit replaces all the wrong implementation of inline suffixes by the right one.

[1]: dc8f38b1054664a0e382530bb4fc73983e2085cb