### PR TITLE
[FIX] stock: Don't put the destination package for reusable packages

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1312,7 +1312,6 @@ class Picking(models.Model):
                     move_lines_without_package_level = move_lines_to_pack - move_lines_in_package_level
                     if package.package_use == 'disposable':
                         (move_lines_in_package_level | move_lines_without_package_level).result_package_id = package
-                    move_lines_in_package_level.result_package_id = package
                     for ml in move_lines_in_package_level:
                         ml.package_level_id = ml.move_id.package_level_id.id
                     move_lines_without_package_level.package_level_id = package_level_ids[0].id

--- a/addons/stock/tests/test_packing.py
+++ b/addons/stock/tests/test_packing.py
@@ -2062,3 +2062,65 @@ class TestPackagePropagation(TestPackingCommon):
         # action_assign => On move lines, result_package_id is not set.
         self.assertEqual(partial_deliveries.move_line_ids.package_id, package, "The package should be used as source.")
         self.assertFalse(partial_deliveries.move_line_ids.result_package_id, "If the contents of a single pack are reserved by multiple picks, the entire pack can't reproduce on each pick.")
+
+    def test_reusable_package_propagation_backorder(self):
+        """ Test a reusable package should not be propagated to the next picking
+        when a backorder occured and using the same reusable package"""
+        reusable_package = self.env['stock.quant.package'].create({
+            'name': 'Reusable Package',
+            'package_use': 'reusable',
+        })
+        self.productA = self.env['product.product'].create({
+            'name': 'productA',
+            'is_storable': True,
+            'tracking': 'none',
+        })
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 2)
+        pg = self.env['procurement.group'].create({'name': 'propagation_test'})
+        self.env['procurement.group'].run([
+            pg.Procurement(
+                self.productA,
+                2.0,
+                self.productA.uom_id,
+                self.customer_location,
+                'propagation_test',
+                'propagation_test',
+                self.warehouse.company_id,
+                {
+                    'warehouse_id': self.warehouse,
+                    'group_id': pg
+                }
+            )
+        ])
+        picking = self.env['stock.picking'].search([
+            ('group_id', '=', pg.id),
+            ('location_id', '=', self.stock_location.id),
+        ])
+        picking.action_assign()
+        picking.move_ids.move_line_ids.result_package_id = reusable_package
+        picking.move_ids.move_line_ids.quantity = 1
+        picking.move_ids.picked = True
+        picking._action_done()
+        self.assertEqual(picking.state, 'done')
+        pack_lines = self.env['stock.picking'].search([
+            ('group_id', '=', pg.id),
+            ('location_id', '=', self.pack_location.id),
+        ]).move_line_ids
+
+        self.assertEqual(len(pack_lines), 1, 'Should have only 1 stock move line')
+        self.assertFalse(pack_lines[0].result_package_id, 'Should not have the reusable package')
+
+        # Do the backorder
+        backorder = picking.backorder_ids
+        backorder.action_assign()
+
+        # Put in the same package
+        backorder.move_ids.move_line_ids.result_package_id = reusable_package
+        backorder.move_ids.move_line_ids.quantity = 1
+        backorder.move_ids.picked = True
+        backorder._action_done()
+        pack = self.env['stock.picking'].search([
+            ('group_id', '=', pg.id),
+            ('location_id', '=', self.pack_location.id),
+        ])
+        self.assertFalse(pack.move_line_ids.result_package_id, 'Should not have the reusable package')


### PR DESCRIPTION
Commit https://github.com/odoo/odoo/commit/0358963e2088a309141f092fbe8f7a98786cc1d8 forces the `result_package_id` on the package level stock move lines (meaning move lines being part of entire package move) to be the source package. This makes sense when moving entire packs but not in case of delivery with disposable packages.
We remove the line that set the destination package for any package type and keep the one doing this for disposable package only. 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
