### PR TITLE
[FIX] sale_project: overlapping in milestone view

### DIFF
--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -327,16 +327,16 @@
                     <field name="project_partner_id" invisible="1"/>
                     <field name="sale_line_id" groups="!sales_team.group_sale_salesman" placeholder="Non-billable" options="{'no_open': True}" readonly="1"/>
                     <field name="sale_line_id" groups="sales_team.group_sale_salesman" options="{'no_create': True}" placeholder="Non-billable" readonly="0"/>
-                    <label for="quantity_percentage" invisible="not sale_line_id"/>
-                    <div class="col-6" invisible="not sale_line_id">
-                        <field name="quantity_percentage" groups="!sales_team.group_sale_salesman" widget="percentage" readonly="1" class="mw-25"/>
-                        <field name="quantity_percentage" class="mw-25" groups="sales_team.group_sale_salesman"
+                    <label for="quantity_percentage" string="Quantity" invisible="not sale_line_id"/>
+                    <div class="d-flex align-items-baseline gap-2" invisible="not sale_line_id">
+                        <field name="quantity_percentage" groups="!sales_team.group_sale_salesman" widget="percentage" readonly="1" />
+                        <field name="quantity_percentage" groups="sales_team.group_sale_salesman"
                             widget="percentage" decoration-danger="quantity_percentage &lt; 0 or 1 &lt; quantity_percentage" readonly="0"/>
-                        <span>
-                            (<field name="product_uom_qty" class="mw-25"  decoration-danger="quantity_percentage &lt; 0 or 1 &lt; quantity_percentage"/>
-                            <field name="product_uom_id" class="w-auto text-end" groups="uom.group_uom" options="{'no_open': True}"/>
-                            <span>)</span>
-                        </span>
+                        =
+                        <div class="o_input_box">
+                            <field name="product_uom_qty" decoration-danger="quantity_percentage &lt; 0 or 1 &lt; quantity_percentage"/>
+                            <field name="product_uom_id" class="o_input_box_overlay_end" groups="uom.group_uom" options="{'no_open': True}"/>
+                        </div>
                     </div>
                 </group>
             </xpath>


### PR DESCRIPTION
Steps to reproduce:

- On small screen, go to project
- Click on milestone (the red flag) in the Home Construction kanban card
- Select "Piping Installation" -> The quantity and quantity (%) linked fields overlaps

task-6013884



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
