### PR TITLE
[IMP] web: change o_input_box overlay color

### DIFF
--- a/addons/web/static/src/core/input_box/input_box.scss
+++ b/addons/web/static/src/core/input_box/input_box.scss
@@ -62,9 +62,6 @@
         align-items: center;
         justify-content: center;
 
-        &:not(.btn-link, .btn-secondary) {
-            color: #{$o-gray-400};
-        }
         &.btn, .btn, button {
             border-radius: calc(1.5 * var(--inputbox-spacing-unit));
             line-height: 0;


### PR DESCRIPTION
This commit bring back the standard color for the overlays instead of a greyed out text. This will avoid having the muted look that could confuse the user.

task-6013898