### PR TITLE
[FIX] hr: First contract date on Kanban

### DIFF
--- a/addons/hr/static/tests/tours/hr_employee_flow.js
+++ b/addons/hr/static/tests/tours/hr_employee_flow.js
@@ -55,3 +55,14 @@ registry.category("web_tour.tours").add("hr_officer_create_employee_tour", {
         },
     ],
 });
+
+registry.category("web_tour.tours").add("hr_user_kanban_view_tour", {
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        {
+            content: "Open Employees app",
+            trigger: ".o_app[data-menu-xmlid='hr.menu_hr_root']",
+            run: "click",
+        }
+    ]
+})

--- a/addons/hr/tests/test_ui.py
+++ b/addons/hr/tests/test_ui.py
@@ -53,3 +53,7 @@ class TestEmployeeUi(HttpCase):
 
         emp = self.env['hr.employee'].search([('name', 'ilike', 'My Employee')])
         self.assertTrue(emp)
+
+    def test_first_contract_date_with_hr_user_rights(self):
+        new_test_user(self.env, login='hr_user', groups='hr.group_hr_user')
+        self.start_tour('/odoo', 'hr_user_kanban_view_tour', login='hr_user', timeout=350)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
. Fix traceback when user with group_hr_user rights open employees kanban-view

Current behavior before PR:

Desired behavior after PR is merged:
. Update first_contract_date access group
. Verify that first_contract_date is visible for hr_payroll_user group 
. Add corresponding tests


task-6030294
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
