### PR TITLE
[FIX] point_of_sale: add util for checking that the refresh worked

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
@@ -389,3 +389,10 @@ export function waitForOrdersSync() {
         },
     ];
 }
+
+export function isLoader() {
+    return {
+        content: "Check that the loader is visible",
+        trigger: "body .loader-feedback",
+    };
+}


### PR DESCRIPTION
This commit adds a util to check that pos page is opened and ready

runbot-error: 241213
Enterprise PR: https://github.com/odoo/enterprise/pull/110320

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
