### PR TITLE
[PERF] stock_account_report: Optimize memory usage in inventory valuation report

### DIFF
--- a/addons/stock_account/models/res_company.py
+++ b/addons/stock_account/models/res_company.py
@@ -86,7 +86,7 @@ class ResCompany(models.Model):
         self.ensure_one()
         value_by_account: dict = defaultdict(float)
         if not accounts_by_product:
-            accounts_by_product = self._get_accounts_by_product()
+            accounts_by_product = self.with_context(prefetch_fields=False)._get_accounts_by_product()
         for product, accounts in accounts_by_product.items():
             account = accounts['valuation']
             product_value = product.with_context(to_date=at_date).total_value


### PR DESCRIPTION
Behavior before:
Opening the inventory valuation report on databases with 300k+ products
(storable) caused an out-of-memory (OOM) error, making the report completely
unusable at this scale.

Behavior after:
The inventory valuation report loads successfully and efficiently for 300k+
products without any memory errors or RAM spikes.

Root Cause:
In `_get_accounts_by_product()`, querying all storable products creates a massive
recordset. When iterating through this recordset, the call to `_get_product_accounts()`
accesses various relational and property fields (like categories and accounts).
Because standard ORM prefetching was active, accessing these relational fields on the
first loop iteration triggered a massive batch-fetch for all 300k+ products in the
recordset simultaneously. This cascading prefetch overloaded the environment cache
and caused an immediate OOM crash.

Fix:
Wrapped the `_get_accounts_by_product()` call in `with_context(prefetch_fields=False)`.
This disables the greedy batch-loading behavior across the entire recordset. The ORM
now fetches the required relational accounting fields surgically, record-by-record
inside the loop, maintaining a minimal memory footprint and preventing the crash.

Benchmark:

| Products Count | Memory Before  | Memory After | Time Before | Time After |
|------------------------|-------------------------|----------------------|------------------- |----------------|
| 300k+                  | Memory Error     | 1.1. GB             | 46.63 s           | 1.9 m         |
| 200k                    | Memory Error     | 566.4 MB         | 1.2 m              | 1 m            |
| 100k                    | 873.1 MB             | 286.8 MB         | 36.74 s            | 32.15 s      |
| 50k                      | 442.1 MB             | 145.6 MB         | 18.96 s            | 17.65 s      |

opw-5462037



Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
