### PR TITLE
[FIX] l10n_sa_pos: error in receipt

### DIFF
--- a/addons/l10n_sa_pos/receipt/pos_order_receipt.xml
+++ b/addons/l10n_sa_pos/receipt/pos_order_receipt.xml
@@ -8,7 +8,7 @@
                 </div>
             </div>
             <t t-set="show_title" position="after">
-                <t t-set="show_title" t-if="True"/>
+                <t t-set="show_title" t-if="conditions.get('code_sa')" t-value="order['state'] != 'draft'"/>
             </t>
             <t t-set="show_simplified_title" position="after">
                 <t t-set="show_simplified_title"


### PR DESCRIPTION
With the commit moving receipt template to the backend, an override on the l10n_sa receipt was wrongly modified. This commit fixes the issue by changing the override condition to the correct one.

runbot-error: 239134

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
