### PR TITLE
[FIX] mail: click on a `message in reply` in mailboxes

### DIFF
--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -534,6 +534,22 @@ export class Thread extends Component {
         this.env.services.action.doAction(actionDescription);
     }
 
+    async onParentMessageClick(parentMessage) {
+        if (!parentMessage) {
+            return;
+        }
+        const targetThread = parentMessage.thread;
+        if (!targetThread) {
+            return;
+        }
+        if (targetThread.eq(this.props.thread)) {
+            this.env.messageHighlight?.highlightMessage(parentMessage, targetThread);
+        } else {
+            targetThread.highlightMessage = parentMessage;
+            await targetThread.open({ focus: true });
+        }
+    }
+
     getMessageClassName(message) {
         return !message.isNotification && this.messageHighlight?.highlightedMessageId === message.id
             ? "o-highlighted bg-view shadow-lg pb-1"

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -32,7 +32,7 @@
                         registerMessageRef="registerMessageRef"
                         messageToReplyTo="props.messageToReplyTo"
                         squashed="isSquashed(msg, prevMsg)"
-                        onParentMessageClick.bind="() => msg.parentMessage and env.messageHighlight?.highlightMessage(msg.parentMessage, props.thread)"
+                        onParentMessageClick.bind="() => this.onParentMessageClick(msg.parentMessage)"
                         thread="props.thread"
                         messageEdition="props.messageEdition"
                         isFirstMessage="msg_first"

--- a/addons/mail/static/tests/message/message_reply.test.js
+++ b/addons/mail/static/tests/message/message_reply.test.js
@@ -124,3 +124,31 @@ test("reply with only attachment shows parent message context", async () => {
         text: "Original message content",
     });
 });
+
+test("click on message in reply in inbox navigates to the parent message", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    const messageId = pyEnv["mail.message"].create({
+        body: "Parent message",
+        message_type: "comment",
+        model: "discuss.channel",
+        res_id: channelId,
+    });
+    pyEnv["mail.message"].create({
+        body: "Reply to parent message",
+        message_type: "comment",
+        model: "discuss.channel",
+        needaction: true,
+        parent_id: messageId,
+        res_id: channelId,
+    });
+    await start();
+    await openDiscuss("mail.box_inbox");
+    await click(".o-mail-MessageInReply-message", {
+        parent: [".o-mail-Message", { text: "Reply to parent message" }],
+    });
+    await contains(
+        ".o-mail-Discuss-content:has(.o-mail-Discuss-threadName[title='General']) .o-mail-Message.o-highlighted .o-mail-Message-content",
+        { text: "Parent message" }
+    );
+});


### PR DESCRIPTION
Before this change, clicking on a `message in reply` in mailboxes had no effect.
 The expected behavior is for it to jump to the message in its origin thread. To
  fix it, this commit ensures that `useMessageHighlight` hook receives the
  correct thread which in this case is the origin thread of the message in reply.

task-5343804

