### PR TITLE
[FIX] l10n_pl_edi: fix access to non-admin users

### DIFF
--- a/addons/l10n_pl_edi/models/account_move_send.py
+++ b/addons/l10n_pl_edi/models/account_move_send.py
@@ -75,7 +75,7 @@ class AccountMoveSend(models.AbstractModel):
                     move.write({
                         'l10n_pl_edi_status': 'sent',
                         'l10n_pl_edi_ref': l10n_pl_edi_ref,
-                        'l10n_pl_edi_session_id': move.company_id.l10n_pl_edi_session_id,
+                        'l10n_pl_edi_session_id': move.company_id.sudo().l10n_pl_edi_session_id,
                         'l10n_pl_edi_header': False,
                     })
                     # Will be linked in _link_invoice_documents

--- a/addons/l10n_pl_edi/models/res_company.py
+++ b/addons/l10n_pl_edi/models/res_company.py
@@ -4,7 +4,7 @@ from odoo import api, fields, models
 class ResCompany(models.Model):
     _inherit = 'res.company'
 
-    l10n_pl_edi_register = fields.Boolean("KSeF Integration Enabled", compute="_compute_l10n_pl_edi_register")
+    l10n_pl_edi_register = fields.Boolean("KSeF Integration Enabled", compute="_compute_l10n_pl_edi_register", compute_sudo=True)
     l10n_pl_edi_certificate = fields.Many2one('certificate.certificate', "KSeF Certificate", store=True, groups='base.group_system')
     l10n_pl_edi_access_token = fields.Char("KSeF Token", readonly=True, copy=False, groups='base.group_system')
     l10n_pl_edi_refresh_token = fields.Char("KSeF Token Expiration", readonly=True, copy=False, groups='base.group_system')

--- a/addons/l10n_pl_edi/tools/ksef_api_service.py
+++ b/addons/l10n_pl_edi/tools/ksef_api_service.py
@@ -25,10 +25,10 @@ class KsefApiService:
         self.company = company
         self.env = company.env
         self.mode = self.env['ir.config_parameter'].sudo().get_param('l10n_pl_edi_ksef.mode') or 'prod'
-        self.refresh_token = company.l10n_pl_edi_refresh_token
         self.api_url = self._get_api_url()
-        self.raw_symmetric_key = base64.b64decode(company.l10n_pl_edi_session_key) if company.l10n_pl_edi_session_key else None
-        self.raw_iv = base64.b64decode(company.l10n_pl_edi_session_iv) if company.l10n_pl_edi_session_iv else None
+        company_sudo = company.sudo()
+        self.raw_symmetric_key = base64.b64decode(company_sudo.l10n_pl_edi_session_key) if company_sudo.l10n_pl_edi_session_key else None
+        self.raw_iv = base64.b64decode(company_sudo.l10n_pl_edi_session_iv) if company_sudo.l10n_pl_edi_session_iv else None
 
     def _get_api_url(self):
         """Gets the correct KSeF API URL from the company's settings."""
@@ -52,7 +52,7 @@ class KsefApiService:
         """
         kwargs.setdefault('headers', {})
         kwargs.setdefault('timeout', TIMEOUT)
-        kwargs['headers'].update(self._make_headers(self.company.l10n_pl_edi_access_token))
+        kwargs['headers'].update(self._make_headers(self.company.sudo().l10n_pl_edi_access_token))
         try:
             response = requests.request(method, endpoint, **kwargs)
 
@@ -119,7 +119,7 @@ class KsefApiService:
 
     def open_ksef_session(self):
         """Builds the encrypted request and opens an interactive session, with one retry on token expiry."""
-        if self.company.l10n_pl_edi_session_id and self.get_session_status().get('code') == 100:
+        if self.company.sudo().l10n_pl_edi_session_id and self.get_session_status().get('code') == 100:
             return
         self.raw_symmetric_key = os.urandom(32)
         self.raw_iv = os.urandom(16)
@@ -158,11 +158,12 @@ class KsefApiService:
 
     def refresh_access_token(self):
         """Uses a refresh token to obtain a new access token and updates the service and company."""
-        if not self.refresh_token:
+        refresh_token = self.company.sudo().l10n_pl_edi_refresh_token
+        if not refresh_token:
             raise UserError(self.env._("No refresh token found to renew the session."))
 
         endpoint = f"{self.api_url}/auth/token/refresh"
-        headers = self._make_headers(self.refresh_token)
+        headers = self._make_headers(refresh_token)
 
         try:
             response = requests.post(endpoint, headers=headers, timeout=TIMEOUT)
@@ -173,7 +174,7 @@ class KsefApiService:
             if not new_access_token:
                 raise UserError(self.env._("Failed to retrieve a new access token from KSeF response."))
 
-            self.company.l10n_pl_edi_access_token = new_access_token
+            self.company.sudo().write({'l10n_pl_edi_access_token': new_access_token})
             _logger.info("KSeF access token successfully refreshed.")
             return new_access_token
 
@@ -198,7 +199,7 @@ class KsefApiService:
             'encryptedInvoiceContent': base64.b64encode(encrypted_data).decode('utf-8'),
         }
 
-        endpoint = f"{self.api_url}/sessions/online/{self.company.l10n_pl_edi_session_id}/invoices"
+        endpoint = f"{self.api_url}/sessions/online/{self.company.sudo().l10n_pl_edi_session_id}/invoices"
         headers = {'Content-Type': 'application/json'}
 
         response = self._make_request(
@@ -211,11 +212,12 @@ class KsefApiService:
 
     def close_ksef_session(self):
         """Closes an interactive session."""
-        if not self.company.l10n_pl_edi_session_id:
+        session_id = self.company.sudo().l10n_pl_edi_session_id
+        if not session_id:
             _logger.warning("No KSeF session data found to close.")
             return
 
-        endpoint = f"{self.api_url}/sessions/online/{self.company.l10n_pl_edi_session_id}/close"
+        endpoint = f"{self.api_url}/sessions/online/{session_id}/close"
         try:
             self._make_request('POST', endpoint)
             _logger.info("KSeF session closed gracefully")
@@ -229,9 +231,10 @@ class KsefApiService:
             ], False))
 
     def get_session_status(self):
-        if not self.company.l10n_pl_edi_session_id:
+        session_id = self.company.sudo().l10n_pl_edi_session_id
+        if not session_id:
             raise UserError(self.env._("No active KSeF session found. Please open a session first."))
-        endpoint = f"{self.api_url}/sessions/{self.company.l10n_pl_edi_session_id}"
+        endpoint = f"{self.api_url}/sessions/{session_id}"
         try:
             response = self._make_request('GET', endpoint)
             return response.json().get('status')
@@ -243,10 +246,11 @@ class KsefApiService:
         Gets the status of all invoices sent within the current session (paginated).
         Corresponds to: GET /api/v2/sessions/online/{referenceNumber}/invoices
         """
-        if not self.company.l10n_pl_edi_session_id:
+        session_id = self.company.sudo().l10n_pl_edi_session_id
+        if not session_id:
             raise UserError(self.env._("No active KSeF session found. Please open a session first."))
 
-        endpoint = f"{self.api_url}/sessions/online/{self.company.l10n_pl_edi_session_id}/invoices"
+        endpoint = f"{self.api_url}/sessions/online/{session_id}/invoices"
         params = {'pageSize': page_size, 'pageOffset': page_offset}
         response = self._make_request('GET', endpoint, params=params)
         return response.json()
@@ -256,14 +260,14 @@ class KsefApiService:
         Gets the processing status of a specific invoice within the current session.
         :param invoice_reference_number: The 'invoiceReferenceNumber' returned by the send_invoice response.
         """
-        session_id = session_id or self.company.l10n_pl_edi_session_id
+        session_id = session_id or self.company.sudo().l10n_pl_edi_session_id
         endpoint = f"{self.api_url}/sessions/{session_id}/invoices/{invoice_reference_number}"
 
         response = self._make_request('GET', endpoint)
         return response.json()
 
     def get_invoice_upo(self, invoice_reference_number, session_id=None):
-        session_id = session_id or self.company.l10n_pl_edi_session_id
+        session_id = session_id or self.company.sudo().l10n_pl_edi_session_id
         endpoint = f"{self.api_url}/sessions/{session_id}/invoices/{invoice_reference_number}/upo"
         response = self._make_request('GET', endpoint)
         return response.content


### PR DESCRIPTION
Fields on `res_company` related to KSeF are marked only for group `base.group_system`, as are the `certificate.certificate` and `certificate.key` models. Adding `compute_sudo` and `sudo()` calls where it's needed in actions that can be performed by non-admin users.

task-6018713


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
