### PR TITLE
[IMP] auth_totp: autocomplete="one-time-code"

### DIFF
--- a/addons/auth_totp/static/src/services/check_identity/check_identity.xml
+++ b/addons/auth_totp/static/src/services/check_identity/check_identity.xml
@@ -6,7 +6,10 @@
             <i class="fa fa-3x fa-mobile" aria-hidden="true"/>
             <h3>Authentication code</h3>
         </div>
-        <input name="token" inputmode="numeric" pattern="[0-9]+" class="form-control" placeholder="XXXXXX"/>
+        <input
+            name="token" inputmode="numeric" pattern="[0-9]+" class="form-control" placeholder="XXXXXX"
+            autocomplete="one-time-code"
+        />
         <div class="text-center gap-1 d-grid mb-1 pt-3">
             <button type="submit" class="btn btn-primary">Verify</button>
         </div>

--- a/addons/auth_totp/views/templates.xml
+++ b/addons/auth_totp/views/templates.xml
@@ -15,8 +15,10 @@
                     <input type="hidden" name="redirect" t-att-value="redirect"/>
                     <div class="mb-3">
                         <label class="fw-bold" for="totp_token">Authentication Code</label>
-                        <input id="totp_token" name="totp_token" class="form-control mb-2"
-                                autocomplete="off" inputmode="numeric" autofocus="autofocus" required="required" placeholder="e.g. 123456"/>
+                        <input
+                            id="totp_token" name="totp_token" class="form-control mb-2" autocomplete="one-time-code"
+                            inputmode="numeric" autofocus="autofocus" required="required" placeholder="e.g. 123456"
+                        />
                     </div>
                     <div class="text-center py-2 border-top">
                         <p class="alert alert-danger" t-if="error" role="alert">

--- a/addons/auth_totp_mail/static/src/services/check_identity/check_identity.xml
+++ b/addons/auth_totp_mail/static/src/services/check_identity/check_identity.xml
@@ -9,7 +9,10 @@
         <div>
             Enter below the six-digit authentication code just sent to your email
         </div>
-        <input name="token" inputmode="numeric" pattern="[0-9]+" class="form-control" placeholder="XXXXXX"/>
+        <input
+            name="token" inputmode="numeric" pattern="[0-9]+" class="form-control" placeholder="XXXXXX"
+            autocomplete="one-time-code"
+        />
         <div class="text-center gap-1 d-grid mb-1 pt-3">
             <button type="submit" class="btn btn-primary">Verify</button>
         </div>


### PR DESCRIPTION
Set the `autocomplete` attribute of the TOTP code inputs to `one-time-code` to help password managers such as bitwarden, keespassxc, apple passwords, to auto-fill the TOTP code input.

Setting it on the the TOTP by mail form also allows Apple / Android to automatically fill the input based on the notification / email that was just received.

<img width="300" alt="totp-from-gmail" src="https://github.com/user-attachments/assets/db7bc8a6-badc-40c7-ba03-471089a358e2" />


task-6001386
