### PR TITLE
[FIX] purchase: "Days before confirmation" overlap the label

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -223,15 +223,14 @@
                                 <field name="date_planned" readonly="state not in ('draft', 'sent', 'to approve', 'purchase')"/>
                             </div>
                             <field name="receipt_reminder_email" string="Ask confirmation" widget="boolean_toggle" groups="purchase.group_send_reminder" />
-                            <label for="reminder_date_before_receipt" string="Days before confirmation" invisible="not receipt_reminder_email" groups="purchase.group_send_reminder"/>
-                            <div name="reminder" groups="purchase.group_send_reminder"
+                            <label for="reminder_date_before_receipt" string="Days before confirmation" invisible="not receipt_reminder_email" groups="purchase.group_send_reminder" />
+                            <div name="reminder" class="o_input_box d-flex"
+                                 invisible="not receipt_reminder_email" groups="purchase.group_send_reminder"
                                  title="Automatically send a confirmation email to the vendor X days before the expected receipt date, asking him to confirm the exact date.">
-                                <div class="o_input_box" invisible="not receipt_reminder_email">
-                                    <field name="reminder_date_before_receipt" />
-                                    <widget name="toaster_button" button_name="send_reminder_preview"
-                                            additionalClasses="o_external_button o_input_box_overlay_end"
-                                            title="Preview the reminder email by sending it to yourself." invisible="not id"/>
-                                </div>
+                                <field name="reminder_date_before_receipt" />
+                                <widget name="toaster_button" button_name="send_reminder_preview"
+                                        additionalClasses="o_external_button"
+                                        title="Preview the reminder email by sending it to yourself."  invisible="not id" />
                             </div>
                             <label for="receipt_status" invisible="state !='purchase'"/>
                                 <div class="d-flex align-items-center" invisible="state !='purchase'">

--- a/addons/purchase_stock/views/purchase_views.xml
+++ b/addons/purchase_stock/views/purchase_views.xml
@@ -40,7 +40,7 @@
                 <field name="date_promised" optional="hide" column_invisible="parent.state not in ('purchase', 'cancel')"/>
             </xpath>
             <xpath expr="//div[@name='reminder']" position="attributes">
-                <attribute name="invisible">effective_date</attribute>
+                <attribute name="invisible" add="effective_date" separator=" or "/>
             </xpath>
             <xpath expr="//field[@name='order_line']/form//field[@name='invoice_lines']" position="after">
                 <field name="move_ids"/>


### PR DESCRIPTION
Move the label node closed to the field to avoid an orphan overlap label

Steps to reproduce

- On small screen, go to purchase
- Select the P00019 item
- You can see the overlap label "Days before confirmation"

task-6026186


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
