### PR TITLE
Fix assets cache in tests

### DIFF
--- a/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.js
+++ b/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.js
@@ -10,7 +10,8 @@ import {
     useState,
     useSubEnv,
 } from "@odoo/owl";
-import { LazyComponent, loadBundle } from "@web/core/assets";
+import { loadBundle } from "@web/core/assets";
+import { LazyComponent } from "@web/core/lazy_component";
 import { Deferred } from "@web/core/utils/concurrency";
 import { uniqueId } from "@web/core/utils/functions";
 import { useChildRef, useForwardRefToParent } from "@web/core/utils/hooks";

--- a/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.js
+++ b/addons/mass_mailing/static/src/iframe/mass_mailing_iframe.js
@@ -117,7 +117,7 @@ export class MassMailingIframe extends Component {
                 const height = Math.trunc(
                     iframe.contentDocument.body
                         .querySelector(IFRAME_VALUE_SELECTOR)
-                        .getBoundingClientRect().height
+                        .getBoundingClientRect().height,
                 );
                 iframe.style.height = height + "px";
             }
@@ -163,7 +163,7 @@ export class MassMailingIframe extends Component {
                           // height to fill remaining viewport space on an unscrolled page
                           window.innerHeight - sidebar.parentElement.getBoundingClientRect().y - 5,
                           // height of the parent element
-                          sidebar.parentElement.clientHeight
+                          sidebar.parentElement.clientHeight,
                       );
                 const offsetHeight =
                     window.innerHeight -
@@ -196,7 +196,7 @@ export class MassMailingIframe extends Component {
                     this.editor?.shared.builderOverlay?.refreshOverlays();
                 });
             },
-            () => [this.state.showFullscreen]
+            () => [this.state.showFullscreen],
         );
         useEffect(
             () => {
@@ -211,7 +211,7 @@ export class MassMailingIframe extends Component {
                     this.editor?.shared.builderOverlay?.refreshOverlays();
                 });
             },
-            () => [this.state.isMobile]
+            () => [this.state.isMobile],
         );
         onWillUnmount(() => {
             if (this.htmlResizeObserver) {
@@ -260,11 +260,11 @@ export class MassMailingIframe extends Component {
         }
         this.iframeRef.el.contentDocument.body.appendChild(this.renderBodyContent());
         this.htmlResizeObserver.observe(
-            this.iframeRef.el.contentDocument.body.querySelector(IFRAME_VALUE_SELECTOR)
+            this.iframeRef.el.contentDocument.body.querySelector(IFRAME_VALUE_SELECTOR),
         );
         if (this.props.readonly) {
             this.retargetLinks(
-                this.iframeRef.el.contentDocument.body.querySelector(IFRAME_VALUE_SELECTOR)
+                this.iframeRef.el.contentDocument.body.querySelector(IFRAME_VALUE_SELECTOR),
             );
             this.fixInlineDynamicPlaceholders(this.iframeRef.el);
         }
@@ -320,7 +320,7 @@ export class MassMailingIframe extends Component {
             ref: this.overlayRef,
         };
         this.editor.attachTo(
-            this.iframeRef.el.contentDocument.body.querySelector(IFRAME_VALUE_SELECTOR)
+            this.iframeRef.el.contentDocument.body.querySelector(IFRAME_VALUE_SELECTOR),
         );
     }
 
@@ -330,13 +330,11 @@ export class MassMailingIframe extends Component {
      */
     async loadIframeAssets() {
         const bundleEntryPromises = this.getIframeBundles().map(async (bundle) => {
-            const targets = (
-                await loadBundle(bundle, {
-                    targetDoc: this.iframeRef.el.contentDocument,
-                    css: true,
-                    js: false,
-                })
-            ).map((bundleEvent) => bundleEvent.target);
+            const targets = await loadBundle(bundle, {
+                targetDoc: this.iframeRef.el.contentDocument,
+                css: true,
+                js: false,
+            });
             const iframe = this.iframeRef.el;
             return [
                 bundle,
@@ -381,7 +379,7 @@ export class MassMailingIframe extends Component {
             overlayRef: this.overlayRef,
             // TODO EGGMAIL: iframeInfo is deprecated (should resolve to iframe directly)
             iframeLoaded: this.iframeLoaded.then((iframeInfo) =>
-                iframeInfo ? iframeInfo.iframe : false
+                iframeInfo ? iframeInfo.iframe : false,
             ),
             snippetsName: "mass_mailing.email_designer_snippets",
             config: this.props.config,

--- a/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
+++ b/addons/mass_mailing/static/tests/mass_mailing_html_field.test.js
@@ -1,26 +1,26 @@
-import { expect, test, describe, beforeEach, getFixture, before, waitUntil } from "@odoo/hoot";
+import { defineMailModels } from "@mail/../tests/mail_test_helpers";
+import { beforeEach, describe, expect, test, waitUntil } from "@odoo/hoot";
+import { click, waitFor } from "@odoo/hoot-dom";
+import { animationFrame } from "@odoo/hoot-mock";
+import { unmockedOrm } from "@web/../tests/_framework/module_set.hoot";
 import {
+    clickSave,
+    contains,
     defineModels,
     fields,
+    getPagerLimit,
+    getPagerValue,
     models,
     mountView,
     onRpc,
-    clickSave,
     patchWithCleanup,
-    contains,
-    getPagerValue,
-    getPagerLimit,
 } from "@web/../tests/web_test_helpers";
-import { click, queryOne, waitFor } from "@odoo/hoot-dom";
-import { animationFrame } from "@odoo/hoot-mock";
-import { defineMailModels } from "@mail/../tests/mail_test_helpers";
-import { unmockedOrm } from "@web/../tests/_framework/module_set.hoot";
-import { MassMailingIframe } from "../src/iframe/mass_mailing_iframe";
-import { MassMailingHtmlField } from "../src/fields/html_field/mass_mailing_html_field";
-import { ThemeSelector } from "../src/themes/theme_selector/theme_selector";
-import { ThemeSelectorIframe } from "../src/themes/theme_selector/theme_selector_iframe";
 import { user } from "@web/core/user";
 import { FormController } from "@web/views/form/form_controller";
+import { MassMailingHtmlField } from "../src/fields/html_field/mass_mailing_html_field";
+import { MassMailingIframe } from "../src/iframe/mass_mailing_iframe";
+import { ThemeSelector } from "../src/themes/theme_selector/theme_selector";
+import { ThemeSelectorIframe } from "../src/themes/theme_selector/theme_selector_iframe";
 
 class Mailing extends models.Model {
     _name = "mailing.mailing";
@@ -145,7 +145,7 @@ class IrUiView extends models.Model {
         const args = ["ir.ui.view", "render_public_asset", [template, values], {}];
         if (
             ["mass_mailing.email_designer_snippets", "mass_mailing.email_designer_themes"].includes(
-                template
+                template,
             )
         ) {
             if (!publicAssetsCache.has(template)) {
@@ -239,7 +239,7 @@ async function waitForThemeSelector() {
             themeSelector &&
             themeSelector.props.favoriteThemes.promise &&
             !themeSelector.state.loading,
-        { timeout: 3000 }
+        { timeout: 3000 },
     );
     await waitFor(":iframe .o_mailing_template_preview_wrapper [data-name]", {
         timeout: 3000,
@@ -283,7 +283,7 @@ describe("field HTML", () => {
             resId: 1,
             arch: mailViewArch,
         });
-        expect(queryOne(".o_mass_mailing_iframe_wrapper iframe")).toHaveClass("d-none");
+        expect(".o_mass_mailing_iframe_wrapper iframe").toHaveClass("d-none");
         await waitForThemeSelector();
         await contains(":iframe .o_mailing_template_preview_wrapper [data-name='empty']").click();
         await waitFor(".o_mass_mailing_iframe_wrapper iframe:not(.d-none)");
@@ -354,7 +354,7 @@ describe("field HTML", () => {
                 await waitFor(".o_field_widget[name='body_html']:contains(BuilderUpdated)", {
                     timeout: 3000,
                 })
-            ).innerText.trim()
+            ).innerText.trim(),
         ).toBe("BuilderUpdated");
     });
     test("beforeLeave a FormController with html field should save the record", async () => {
@@ -398,7 +398,7 @@ describe("field HTML", () => {
                 await waitFor(".o_field_widget[name='body_html']:contains(Builder)", {
                     timeout: 3000,
                 })
-            ).innerText.trim()
+            ).innerText.trim(),
         ).toBe("Builder");
         const p = htmlField.editor.editable.querySelector("p");
         p.append(htmlField.editor.document.createTextNode("Updated"));
@@ -409,7 +409,7 @@ describe("field HTML", () => {
                 await waitFor(".o_field_widget[name='body_html']:contains(BuilderUpdated)", {
                     timeout: 3000,
                 })
-            ).innerText.trim()
+            ).innerText.trim(),
         ).toBe("BuilderUpdated");
     });
     test("builder in modal -- owl reconciliation iframe unload", async () => {
@@ -418,12 +418,10 @@ describe("field HTML", () => {
         // When those popovers are killed, OWL tries to reconcile its element List
         // in OverlayContainer, displaces the node that contains the iframe
         // and the editor subsequently crashes
-        before(() => {
-            patchWithCleanup(user, {
-                checkAccessRight() {
-                    return true;
-                },
-            });
+        patchWithCleanup(user, {
+            checkAccessRight() {
+                return true;
+            },
         });
         const base64Img =
             "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII=";
@@ -456,7 +454,7 @@ describe("field HTML", () => {
         await waitForThemeSelector();
         await contains(
             ".o_dialog :iframe .o_mailing_template_preview_wrapper [data-name='event']",
-            { timeout: 3000 }
+            { timeout: 3000 },
         ).click();
         await waitFor(".o_dialog .o_mass_mailing-builder_sidebar .o_snippet_thumbnail", {
             timeout: 3000,
@@ -464,7 +462,7 @@ describe("field HTML", () => {
         await contains(".o_dialog :iframe .s_text_block", { timeout: 3000 }).click();
         await waitFor(
             ".o_dialog .o_mass_mailing-builder_sidebar .options-container-header:contains(Text)",
-            { timeout: 3000 }
+            { timeout: 3000 },
         );
         const overlayOptionsSelect =
             ".o-main-components-container .o-overlay-container .o_overlay_options";
@@ -483,7 +481,7 @@ describe("field HTML", () => {
         await contains(":iframe .o_mailing_template_preview_wrapper [data-name='default']").click();
         await waitFor(".o_mass_mailing_iframe_wrapper iframe:not(.d-none)");
         expect(
-            await waitFor(".o_mass_mailing_iframe_wrapper :iframe .o_layout", { timeout: 3000 })
+            await waitFor(".o_mass_mailing_iframe_wrapper :iframe .o_layout", { timeout: 3000 }),
         ).toHaveClass("o_default_theme");
         const section = await waitFor(".o_mass_mailing_iframe_wrapper :iframe section", {
             timeout: 3000,
@@ -491,22 +489,17 @@ describe("field HTML", () => {
         await click(section);
         await waitFor(
             ".o-snippets-menu:has([data-action-id='dataAttributeChangeAction'].active:contains(Visible))",
-            { timeout: 3000 }
+            { timeout: 3000 },
         );
         section.dataset.filterDomain = JSON.stringify([["id", "=", 1]]);
         htmlField.editor.config.onChange({ isPreviewing: false });
         await waitFor(".o-snippets-menu [data-label='Domain']", { timeout: 3000 });
-        expect(
-            queryOne(
-                ".o-snippets-menu [data-label='Domain'] span.fa-filter + span"
-            ).textContent.toLowerCase()
-        ).toBe("id = 1");
+        expect(".o-snippets-menu [data-label='Domain'] span.fa-filter + span").toHaveText("Id = 1");
         await clickSave();
         const table = await waitFor(".o_mail_body_inline table[t-if]", { timeout: 3000 });
         expect(table).toHaveAttribute("t-if", 'object.filtered_domain([("id", "=", 1)])');
     });
     test(`Switching mailing records in the Form view properly switches between basic Editor, HtmlBuilder and readonly`, async () => {
-        const fixture = getFixture();
         await mountView({
             resModel: "mailing.mailing",
             type: "form",
@@ -516,12 +509,12 @@ describe("field HTML", () => {
         });
         // readonly default
         expect(await waitFor(":iframe .o_layout", { timeout: 3000 })).toHaveClass(
-            "o_default_theme"
+            "o_default_theme",
         );
         expect(getPagerValue()).toEqual([1]);
         expect(getPagerLimit()).toBe(3);
         expect(htmlField.state.activeTheme).toBe("default");
-        expect(fixture.querySelectorAll(".o_mass_mailing-builder_sidebar")).toHaveCount(0);
+        expect(".o_mass_mailing-builder_sidebar").toHaveCount(0);
         // editable basic
         await contains(`.o_pager_next`).click();
         await waitFor(".o_mass_mailing_iframe_wrapper :iframe .o_layout.o_basic_theme:only-child", {
@@ -529,7 +522,7 @@ describe("field HTML", () => {
         });
         expect(getPagerValue()).toEqual([2]);
         expect(htmlField.state.activeTheme).toBe("basic");
-        expect(fixture.querySelectorAll(".o_mass_mailing-builder_sidebar")).toHaveCount(0);
+        expect(".o_mass_mailing-builder_sidebar").toHaveCount(0);
         // editable builder
         await contains(`.o_pager_next`).click();
         await waitFor(".o_mass_mailing_iframe_wrapper :iframe .o_layout.o_empty_theme:only-child", {
@@ -537,15 +530,15 @@ describe("field HTML", () => {
         });
         expect(getPagerValue()).toEqual([3]);
         expect(htmlField.state.activeTheme).toBe("empty");
-        expect(fixture.querySelectorAll(".o_mass_mailing-builder_sidebar")).toHaveCount(1);
+        expect(".o_mass_mailing-builder_sidebar").toHaveCount(1);
         // readonly default
         await contains(`.o_pager_next`).click();
         await waitFor(
             ".o_mass_mailing_iframe_wrapper :iframe .o_layout.o_default_theme:only-child",
-            { timeout: 3000 }
+            { timeout: 3000 },
         );
         expect(getPagerValue()).toEqual([1]);
         expect(htmlField.state.activeTheme).toBe("default");
-        expect(fixture.querySelectorAll(".o_mass_mailing-builder_sidebar")).toHaveCount(0);
+        expect(".o_mass_mailing-builder_sidebar").toHaveCount(0);
     });
 });

--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -478,6 +478,7 @@ This module provides the core of the Odoo Web Client.
             'web/static/src/session.js',
             'web/static/src/core/registry.js',
             'web/static/src/core/assets.js',
+            'web/static/src/core/lazy_component.js',
             'web/static/src/core/user.js',
             'web/static/src/core/transition.js',
             'web/static/src/core/currency.js',

--- a/addons/web/static/lib/hoot/mock/navigator.js
+++ b/addons/web/static/lib/hoot/mock/navigator.js
@@ -238,7 +238,7 @@ export class MockPermissions {
     async query({ name }) {
         if (!(name in currentPermissions)) {
             throw new TypeError(
-                `The provided value '${name}' is not a valid enum value of type PermissionName`
+                `The provided value '${name}' is not a valid enum value of type PermissionName`,
             );
         }
         return new MockPermissionStatus(name);
@@ -296,38 +296,26 @@ export class MockServiceWorker extends MockEventTarget {
 export class MockServiceWorkerContainer extends MockEventTarget {
     static publicListeners = ["controllerchange", "message", "messageerror"];
 
+    /** @type {MockServiceWorker | null} */
+    controller = null;
+
+    /**
+     * @private
+     * @type {PromiseWithResolvers<MockServiceWorkerRegistration>}
+     */
+    _readyDef = Promise.withResolvers();
     /**
      * @private
      */
     _readyResolved = false;
-
     /**
      * @private
      * @type {Map<string, MockServiceWorkerRegistration>}
      */
     _registrations = new Map();
 
-    /** @type {MockServiceWorker | null} */
-    controller = null;
-
     get ready() {
-        return this._readyPromise;
-    }
-
-    constructor() {
-        super(...arguments);
-
-        const { promise, resolve } = Promise.withResolvers();
-        /**
-         * @type {Promise<MockServiceWorkerRegistration>}
-         * @private
-         */
-        this._readyPromise = promise;
-        /**
-         * @type {(value: MockServiceWorkerRegistration) => void}
-         * @private
-         */
-        this._resolveReady = resolve;
+        return this._readyDef.promise;
     }
 
     async getRegistration(scope = "/") {
@@ -355,13 +343,23 @@ export class MockServiceWorkerContainer extends MockEventTarget {
 
         if (!this._readyResolved) {
             this._readyResolved = true;
-            this._resolveReady(registration);
+            this._readyDef.resolve(registration);
         }
 
         return registration;
     }
 
     startMessages() {}
+
+    /**
+     * @private
+     */
+    _clear() {
+        this.controller = null;
+        this._readyDef = Promise.withResolvers();
+        this._readyResolved = false;
+        this._registrations.clear();
+    }
 }
 
 export class MockServiceWorkerRegistration {
@@ -408,6 +406,7 @@ export const mockNavigator = createMock(navigator, {
 
 export function cleanupNavigator() {
     permissionStatuses.clear();
+    mockServiceWorker._clear();
     $assign(currentPermissions, getPermissions());
     $assign(mockValues, getMockValues());
 }
@@ -420,7 +419,7 @@ export function mockPermission(name, value) {
     ensureTest("mockPermission");
     if (!(name in currentPermissions)) {
         throw new TypeError(
-            `The provided value '${name}' is not a valid enum value of type PermissionName`
+            `The provided value '${name}' is not a valid enum value of type PermissionName`,
         );
     }
 

--- a/addons/web/static/lib/hoot/mock/window.js
+++ b/addons/web/static/lib/hoot/mock/window.js
@@ -352,9 +352,9 @@ function observeAddedNodes(mutations) {
     for (const mutation of mutations) {
         for (const node of mutation.addedNodes) {
             if (runner.dry) {
-                node.remove();
+                removeDiscardableHeadNode(node);
             } else {
-                runner.after(node.remove.bind(node));
+                runner.after(removeDiscardableHeadNode.bind(null, node));
             }
         }
     }
@@ -386,6 +386,23 @@ function onAnchorHrefClick(ev) {
 
 function onWindowResize() {
     callMediaQueryChanges();
+}
+
+/**
+ * @param {Node} node
+ */
+function removeDiscardableHeadNode(node) {
+    if (
+        node.nodeType !== Node.ELEMENT_NODE ||
+        !(
+            (node.nodeName === "SCRIPT" && node.getAttribute("src")) ||
+            (node.nodeName === "LINK" &&
+                node.getAttribute("rel") === "stylesheet" &&
+                node.getAttribute("href"))
+        )
+    ) {
+        node.remove();
+    }
 }
 
 /**
@@ -702,6 +719,14 @@ export function setupWindow() {
 }
 
 /**
+ * Attaches an observer to the document's head and returns a cleanup function that
+ * will remove anything that was added to it, except scripts and links with external
+ * reference;
+ *
+ * The rationale is that some caches built manually may rely on existing script/link
+ * elements and their 'src'/'href' attributes. Also, since scripts are executed
+ * immediatly, it is no use removing them afterwards.
+ *
  * @param {typeof globalThis} [view=getWindow()]
  */
 export function watchAddedNodes(view = getWindow()) {

--- a/addons/web/static/src/@types/odoo.d.ts
+++ b/addons/web/static/src/@types/odoo.d.ts
@@ -33,26 +33,19 @@ class OdooModuleLoader {
     modules: Map<string, OdooModule>;
 
     constructor(root?: HTMLElement);
-
     addJob: (name: string) => void;
-
     define: (
         name: string,
         deps: string[],
         factory: OdooModuleFactoryFn,
         lazy?: boolean
     ) => OdooModule;
-
     findErrors: (jobs?: Iterable<string>) => OdooModuleErrors;
-
     findJob: () => string | null;
-
     reportErrors: (errors: OdooModuleErrors) => Promise<void>;
-
+    require: (dependency: string) => OdooModule;
     sortFactories: () => void;
-
     startModule: (name: string) => OdooModule;
-
     startModules: () => void;
 }
 

--- a/addons/web/static/src/core/assets.js
+++ b/addons/web/static/src/core/assets.js
@@ -1,6 +1,5 @@
-import { Component, onWillStart, whenReady, xml } from "@odoo/owl";
+import { whenReady } from "@odoo/owl";
 import { session } from "@web/session";
-import { registry } from "./registry";
 
 /**
  * @typedef {{
@@ -85,28 +84,6 @@ export function loadCSS() {
 }
 
 export class AssetsLoadingError extends Error {}
-
-/**
- * Utility component that loads an asset bundle before instanciating a component
- */
-export class LazyComponent extends Component {
-    static template = xml`<t t-component="Component" t-props="componentProps"/>`;
-    static props = {
-        Component: String,
-        bundle: String,
-        props: { type: [Object, Function], optional: true },
-    };
-    setup() {
-        onWillStart(async () => {
-            await loadBundle(this.props.bundle);
-            this.Component = registry.category("lazy_components").get(this.props.Component);
-        });
-    }
-
-    get componentProps() {
-        return typeof this.props.props === "function" ? this.props.props() : this.props.props;
-    }
-}
 
 /**
  * This export is done only in order to modify the behavior of the exported

--- a/addons/web/static/src/core/assets.js
+++ b/addons/web/static/src/core/assets.js
@@ -2,66 +2,67 @@ import { whenReady } from "@odoo/owl";
 import { session } from "@web/session";
 
 /**
+ * @typedef {{ targetDoc?: Document }} LoadAssetOptions
+ *
+ * @typedef {HTMLLinkElement | HTMLScriptElement} LoadTarget
+ *
  * @typedef {{
  *  cssLibs: string[];
  *  jsLibs: string[];
  * }} BundleFileNames
  */
 
-export const globalBundleCache = new Map();
-export const assetCacheByDocument = new WeakMap();
-
-function getGlobalBundleCache() {
-    return globalBundleCache;
-}
-
-function getAssetCache(targetDoc) {
-    if (!assetCacheByDocument.has(targetDoc)) {
-        assetCacheByDocument.set(targetDoc, new Map());
+function computeAssetCaches() {
+    for (const script of document.head.querySelectorAll("script[src]")) {
+        assets.globalCache.set(script.getAttribute("src"), Promise.resolve(script));
     }
-    return assetCacheByDocument.get(targetDoc);
-}
-
-export function computeBundleCacheMap(targetDoc) {
-    const cacheMap = getGlobalBundleCache();
-    for (const script of targetDoc.head.querySelectorAll("script[src]")) {
-        cacheMap.set(script.getAttribute("src"), Promise.resolve());
-    }
-    for (const link of targetDoc.head.querySelectorAll("link[rel=stylesheet][href]")) {
-        cacheMap.set(link.getAttribute("href"), Promise.resolve());
+    for (const link of document.head.querySelectorAll("link[rel=stylesheet][href]")) {
+        assets.globalCache.set(link.getAttribute("href"), Promise.resolve(link));
     }
 }
-
-whenReady(() => computeBundleCacheMap(document));
 
 /**
- * @param {HTMLLinkElement | HTMLScriptElement} el
- * @param {(event: Event) => any} onLoad
+ * @param {Document} targetDoc
+ */
+function getDocumentAssetCache(targetDoc) {
+    if (!assets.documentCaches.has(targetDoc)) {
+        assets.documentCaches.set(targetDoc, new Map());
+    }
+    return assets.documentCaches.get(targetDoc);
+}
+
+/**
+ * @param {LoadTarget} el
+ * @param {(target: LoadTarget) => void} onLoad
  * @param {(error: Error) => any} onError
  */
-const onLoadAndError = (el, onLoad, onError) => {
-    const onLoadListener = (event) => {
+function onLoadAndError(el, onLoad, onError) {
+    function onLoadListener() {
         removeListeners();
-        onLoad(event);
-    };
+        onLoad(el);
+    }
 
-    const onErrorListener = (error) => {
+    /**
+     * @param {Error} error
+     */
+    function onErrorListener(error) {
         removeListeners();
         onError(error);
-    };
+    }
 
-    const removeListeners = () => {
+    function removeListeners() {
         el.removeEventListener("load", onLoadListener);
         el.removeEventListener("error", onErrorListener);
-    };
+    }
 
     el.addEventListener("load", onLoadListener);
     el.addEventListener("error", onErrorListener);
 
-    window.addEventListener("pagehide", () => {
-        removeListeners();
-    });
-};
+    const view = el.ownerDocument.defaultView || window;
+    view.addEventListener("pagehide", removeListeners);
+}
+
+whenReady(computeAssetCaches);
 
 /** @type {typeof assets["getBundle"]} */
 export function getBundle() {
@@ -91,6 +92,11 @@ export class AssetsLoadingError extends Error {}
  * Modules should only use the methods exported below.
  */
 export const assets = {
+    /** @type {WeakMap<Document, Map<string, Promise<LoadTarget>>>} */
+    documentCaches: new WeakMap(),
+    /** @type {Map<string, Promise<LoadTarget>>} */
+    globalCache: new Map(),
+
     retries: {
         count: 3,
         delay: 5000,
@@ -104,9 +110,8 @@ export const assets = {
      * @returns {Promise<BundleFileNames>}
      */
     getBundle(bundleName) {
-        const cacheMap = getGlobalBundleCache();
-        if (cacheMap.has(bundleName)) {
-            return cacheMap.get(bundleName);
+        if (assets.globalCache.has(bundleName)) {
+            return assets.globalCache.get(bundleName);
         }
         const url = new URL(`/web/bundle/${bundleName}`, location.origin);
         for (const [key, value] of Object.entries(session.bundle_params || {})) {
@@ -129,10 +134,10 @@ export const assets = {
                 return { cssLibs, jsLibs };
             })
             .catch((reason) => {
-                cacheMap.delete(bundleName);
+                assets.globalCache.delete(bundleName);
                 throw new AssetsLoadingError(`The loading of ${url} failed`, { cause: reason });
             });
-        cacheMap.set(bundleName, promise);
+        assets.globalCache.set(bundleName, promise);
         return promise;
     },
 
@@ -141,27 +146,31 @@ export const assets = {
      * asset will be loaded if it was already done before.
      *
      * @param {string} bundleName
-     * @param {Object} options
-     * @param {Document} [options.targetDoc=document] document to which the bundle will be applied (e.g. iframe document)
-     * @param {Boolean} [options.css=true] apply bundle css on targetDoc
-     * @param {Boolean} [options.js=true] apply bundle js on targetDoc
-     * @returns {Promise<void[]>}
+     * @param {LoadAssetOptions & {
+     *  css?: boolean;
+     *  js?: boolean;
+     * }} [options]
+     * @returns {Promise<LoadTarget>}
      */
-    loadBundle(bundleName, { targetDoc = document, css = true, js = true } = {}) {
+    loadBundle(bundleName, options) {
         if (typeof bundleName !== "string") {
             throw new Error(
                 `loadBundle(bundleName:string) accepts only bundleName argument as a string ! Not ${JSON.stringify(
-                    bundleName
-                )} as ${typeof bundleName}`
+                    bundleName,
+                )} as ${typeof bundleName}`,
             );
         }
         return getBundle(bundleName).then(({ cssLibs, jsLibs }) => {
             const promises = [];
-            if (css && cssLibs) {
-                promises.push(...cssLibs.map((url) => assets.loadCSS(url, { targetDoc })));
+            if (options?.css ?? true) {
+                for (const url of cssLibs) {
+                    promises.push(assets.loadCSS(url, options));
+                }
             }
-            if (js && jsLibs) {
-                promises.push(...jsLibs.map((url) => assets.loadJS(url, { targetDoc })));
+            if (options?.js ?? true) {
+                for (const url of jsLibs) {
+                    promises.push(assets.loadJS(url, options));
+                }
             }
             return Promise.all(promises);
         });
@@ -171,20 +180,25 @@ export const assets = {
      * Loads the given url as a stylesheet.
      *
      * @param {string} url the url of the stylesheet
-     * @param {number} [retryCount]
-     * @param {Object} options
-     * @param {number} [retryCount]
-     * @param {Document} [options.targetDoc=document] document to which the bundle will be applied (e.g. iframe document)
-     * @returns {Promise<void>} resolved when the stylesheet has been loaded
+     * @param {LoadAssetOptions & {
+     *  retryCount?: number;
+     *  type?: string;
+     * }} [options]
+     * @returns {Promise<LoadTarget>} resolved when the stylesheet has been loaded
      */
-    loadCSS(url, { retryCount = 0, targetDoc = document } = {}) {
-        const cacheMap = getAssetCache(targetDoc);
+    loadCSS(url, options) {
+        if (assets.globalCache.has(url)) {
+            return assets.globalCache.get(url);
+        }
+        const targetDoc = options?.targetDoc || document;
+        const cacheMap = getDocumentAssetCache(targetDoc);
         if (cacheMap.has(url)) {
             return cacheMap.get(url);
         }
+        const retryCount = options?.retryCount || 0;
         const linkEl = targetDoc.createElement("link");
         linkEl.setAttribute("href", url);
-        linkEl.type = "text/css";
+        linkEl.type = options?.type || "text/css";
         linkEl.rel = "stylesheet";
         const promise = new Promise((resolve, reject) =>
             onLoadAndError(linkEl, resolve, async (error) => {
@@ -193,7 +207,8 @@ export const assets = {
                     const delay = assets.retries.delay + assets.retries.extraDelay * retryCount;
                     await new Promise((res) => setTimeout(res, delay));
                     linkEl.remove();
-                    loadCSS(url, { retryCount: retryCount + 1, targetDoc })
+                    assets
+                        .loadCSS(url, { ...options, retryCount: retryCount + 1 })
                         .then(resolve)
                         .catch((reason) => {
                             cacheMap.delete(url);
@@ -201,10 +216,10 @@ export const assets = {
                         });
                 } else {
                     reject(
-                        new AssetsLoadingError(`The loading of ${url} failed`, { cause: error })
+                        new AssetsLoadingError(`The loading of ${url} failed`, { cause: error }),
                     );
                 }
-            })
+            }),
         );
         cacheMap.set(url, promise);
         targetDoc.head.appendChild(linkEl);
@@ -215,23 +230,28 @@ export const assets = {
      * Loads the given url inside a script tag.
      *
      * @param {string} url the url of the script
-     * @param {Document} targetDoc document to which the bundle will be applied (e.g. iframe document)
-     * @param {String} type type of JavaScript file (e.g. javascript or module)
-     * @returns {Promise<void>} resolved when the script has been loaded
+     * @param {LoadAssetOptions & {
+     *  type?: string;
+     * }} [options]
+     * @returns {Promise<LoadTarget>} resolved when the script has been loaded
      */
-    loadJS(url, { type = "text/javascript", targetDoc = document } = {}) {
-        const cacheMap = getAssetCache(targetDoc);
+    loadJS(url, options) {
+        if (assets.globalCache.has(url)) {
+            return assets.globalCache.get(url);
+        }
+        const targetDoc = options?.targetDoc || document;
+        const cacheMap = getDocumentAssetCache(targetDoc);
         if (cacheMap.has(url)) {
             return cacheMap.get(url);
         }
         const scriptEl = targetDoc.createElement("script");
         scriptEl.setAttribute("src", url);
-        scriptEl.type = type;
+        scriptEl.type = options?.type || "text/javascript";
         const promise = new Promise((resolve, reject) =>
             onLoadAndError(scriptEl, resolve, (error) => {
                 cacheMap.delete(url);
                 reject(new AssetsLoadingError(`The loading of ${url} failed`, { cause: error }));
-            })
+            }),
         );
         cacheMap.set(url, promise);
         targetDoc.head.appendChild(scriptEl);

--- a/addons/web/static/src/core/lazy_component.js
+++ b/addons/web/static/src/core/lazy_component.js
@@ -1,0 +1,25 @@
+import { Component, onWillStart, xml } from "@odoo/owl";
+import { loadBundle } from "@web/core/assets";
+import { registry } from "@web/core/registry";
+
+/**
+ * Utility component that loads an asset bundle before instanciating a component
+ */
+export class LazyComponent extends Component {
+    static template = xml`<t t-component="Component" t-props="componentProps"/>`;
+    static props = {
+        Component: String,
+        bundle: String,
+        props: { type: [Object, Function], optional: true },
+    };
+    setup() {
+        onWillStart(async () => {
+            await loadBundle(this.props.bundle);
+            this.Component = registry.category("lazy_components").get(this.props.Component);
+        });
+    }
+
+    get componentProps() {
+        return typeof this.props.props === "function" ? this.props.props() : this.props.props;
+    }
+}

--- a/addons/web/static/src/core/utils/search.js
+++ b/addons/web/static/src/core/utils/search.js
@@ -1,152 +1,59 @@
 import { normalize } from "@web/core/l10n/utils";
+import { isIterable } from "./arrays";
 
 /**
- * @param {string} pattern
- * @param {string|string[]} strs
- * @returns {number}
- */
-function match(pattern, strs) {
-    if (!Array.isArray(strs)) {
-        strs = [strs];
-    }
-    let globalScore = 0;
-    for (const str of strs) {
-        globalScore = Math.max(globalScore, _match(pattern, str));
-    }
-    return globalScore;
-}
-
-/**
- * This private function computes a score that represent the fact that the
- * string contains the pattern, or not
+ * This private function computes a score that represents how much the string contains
+ * the given pattern:
  *
- * - If the score is 0, the string does not contain the letters of the pattern in
- *   the correct order.
+ * - if the score is 0, the string does not contain the letters of the pattern in
+ *   the correct order;
  * - if the score is > 0, it actually contains the letters.
  *
- * Better matches will get a higher score: consecutive letters are better,
- * and a match closer to the beginning of the string is also scored higher.
+ * Better matches will get a higher score: consecutive letters are better, and a
+ * match closer to the beginning of the string is also scored higher.
  *
- * @param {string} pattern
- * @param {string} str
- * @returns {number}
+ * Note that both strings are considered normalized and will **not** be processed
+ * (trimmed, lower-cased, etc.).
+ *
+ * @param {string} nPattern (normalized)
+ * @param {string} nString (normalized)
  */
-function _match(pattern, str) {
+function getFuzzyScore(nPattern, nString) {
     let totalScore = 0;
     let currentScore = 0;
     let patternIndex = 0;
-
-    pattern = normalize(pattern);
-    str = normalize(str);
-
-    const len = str.length;
-
+    const len = nString.length;
     for (let i = 0; i < len; i++) {
-        if (str[i] === pattern[patternIndex]) {
+        if (nString[i] === nPattern[patternIndex]) {
             patternIndex++;
             currentScore += 100 + currentScore - i / 200;
         } else {
             currentScore = 0;
         }
-        totalScore = totalScore + currentScore;
+        totalScore += currentScore;
     }
-
-    return patternIndex === pattern.length ? totalScore : 0;
+    return patternIndex === nPattern.length ? totalScore : 0;
 }
 
 /**
- * Return a list of things that matches a pattern, ordered by their 'score' (
- * higher score first). An higher score means that the match is better. For
- * example, consecutive letters are considered a better match.
+ * Computes the Levenshtein distance between two given strings.
  *
- * @template T
- * @param {string} pattern
- * @param {T[]} list
- * @param {(element: T) => (string|string[])} fn
- * @returns {T[]}
- */
-export function fuzzyLookup(pattern, list, fn) {
-    const results = [];
-    list.forEach((data) => {
-        const score = match(pattern, fn(data));
-        if (score > 0) {
-            results.push({ score, elem: data });
-        }
-    });
-
-    // we want better matches first
-    results.sort((a, b) => b.score - a.score);
-
-    return results.map((r) => r.elem);
-}
-
-// Does `pattern` fuzzy match `string`?
-/**
- * @param {string} pattern
- * @param {string} string
- * @returns {boolean}
- */
-export function fuzzyTest(pattern, string) {
-    return _match(pattern, string) !== 0;
-}
-
-/**
- * Performs fuzzy matching using a Levenshtein distance algorithm
- * to find matches within an error margin between a pattern
- * and a list of words.
- *
- * If the pattern is found directly inside an item,
- * it's treated as a perfect match (score 0).
- * Otherwise, the `getScore` function calculates the distance
- * between the pattern and each candidate
- *
- * @param {string} pattern - The string to match.
- * @param {string[]} list - The list of strings to compare against the pattern.
- * @param {number} errorRatio - Controls how many errors can a word have depending of its length.
- * @returns {string[]} The list of the words that matches within a defined number of errors.
- */
-export function fuzzyLevenshteinLookup(pattern, list, errorRatio = 3) {
-    // We limit the maximum number of errors depending on the word length
-    // to not have "overcorrections" into words that doesn't have anything
-    // in common with what the user typed
-    const maxNbrCorrection = Math.round(pattern.length / errorRatio);
-    const results = [];
-    list.forEach((candidate) => {
-        let score = -1;
-        if (candidate.includes(pattern)) {
-            score = 0;
-            results.push({ score, elem: pattern });
-        } else {
-            score = getLevenshteinScore(pattern, candidate);
-            if (score >= 0 && score <= maxNbrCorrection) {
-                results.push({ score, elem: candidate });
-            }
-        }
-    });
-    results.sort((a, b) => a.score - b.score);
-    return results.map((r) => r.elem);
-}
-
-
-/**
- * Computes the Levenshtein distance between two strings.
+ * Note that both strings are considered normalized and will **not** be processed
+ * (trimmed, lower-cased, etc.).
  *
  * @param {string} a
  * @param {string} b
- * @returns {number} The Levenshtein distance between `a` and `b`.
  */
-function getLevenshteinScore(a, b) {
-    let aLength = a.length;
-    let bLength = b.length;
-
-    let distanceMatrix = [];
+function getLevenshteinDistance(a, b) {
+    const aLength = a.length;
+    const bLength = b.length;
+    const distanceMatrix = [];
     for (let i = 0; i <= aLength; i++) {
         distanceMatrix[i] = [];
         for (let j = 0; j <= bLength; j++) {
             distanceMatrix[i][j] = 0;
         }
     }
-
     for (let i = 0; i <= aLength; i++) {
         for (let j = 0; j <= bLength; j++) {
             if (Math.min(i, j) === 0) {
@@ -165,4 +72,92 @@ function getLevenshteinScore(a, b) {
         }
     }
     return distanceMatrix[aLength][bLength];
+}
+
+/**
+ * Returns a list of things that matches a pattern, ordered by their 'score' (higher
+ * score first). A higher score means that the match is better. For example, consecutive
+ * letters are considered a better match.
+ *
+ * @template T
+ * @param {string} pattern
+ * @param {Iterable<T>} items
+ * @param {(element: T) => (string | Iterable<string>)} mapFn
+ * @returns {T[]}
+ */
+export function fuzzyLookup(pattern, items, mapFn) {
+    const nPattern = normalize(pattern);
+    /** @type {{ item: T, score: number }[]} */
+    const results = [];
+    for (const item of items) {
+        let strings = mapFn(item);
+        if (strings instanceof String || !isIterable(strings)) {
+            strings = [strings];
+        }
+        let score = 0;
+        for (const string of strings) {
+            score = Math.max(score, getFuzzyScore(nPattern, normalize(string)));
+        }
+        if (score > 0) {
+            results.push({ score, item });
+        }
+    }
+
+    // Put best scores at the start of the list
+    results.sort((a, b) => b.score - a.score);
+
+    return results.map((result) => result.item);
+}
+
+/**
+ * Returns whether `pattern` fuzzy matches `string`.
+ *
+ * @param {string} pattern
+ * @param {string} string
+ * @returns {boolean}
+ */
+export function fuzzyTest(pattern, string) {
+    return getFuzzyScore(normalize(pattern), normalize(string)) > 0;
+}
+
+/**
+ * Performs fuzzy matching using a Levenshtein distance algorithm to find matches
+ * within an error margin between a pattern and a list of words.
+ *
+ * If the pattern is found directly inside an item, it is treated as a perfect match
+ * (distance = 0). Otherwise, the {@link getLevenshteinDistance} function calculates
+ * the distance between the pattern and each candidate.
+ *
+ * Note that `pattern` and each string in `items` are all normalized {@see {@link normalize}}.
+ *
+ * @param {string} pattern The string to match
+ * @param {Iterable<string>} items The list of strings to compare against the pattern
+ * @param {number} errorRatio Controls how many "errors" are allowed for each word,
+ *  depending on its length
+ * @returns {string[]} The list of matching words within the defined error margin
+ */
+export function fuzzyLevenshteinLookup(pattern, items, errorRatio = 3) {
+    const nPattern = normalize(pattern);
+    // We limit the maximum number of errors depending on the word length to not
+    // have "overcorrections" into words that doe not have anything in common with
+    // the user input.
+    const maxNbrCorrection = Math.round(nPattern.length / errorRatio);
+    /** @type {{ distance: number, item: string }[]} */
+    const results = [];
+    for (const item of items) {
+        const nCandidate = normalize(item);
+        if (nCandidate.includes(nPattern)) {
+            results.push({ distance: 0, item: nPattern });
+        } else {
+            const distance = getLevenshteinDistance(nPattern, nCandidate);
+            if (distance >= 0 && distance <= maxNbrCorrection) {
+                results.push({ distance, item });
+            }
+        }
+    }
+
+    // Put lowest distances at the start of the list
+    results.sort((a, b) => a.distance - b.distance);
+
+    return results.map((result) => result.item);
 }

--- a/addons/web/static/src/module_loader.js
+++ b/addons/web/static/src/module_loader.js
@@ -206,6 +206,13 @@
             }
         }
 
+        /**
+         * @param {string} dependency
+         */
+        require(dependency) {
+            return this.modules.get(dependency);
+        }
+
         /** @type {OdooModuleLoader["startModules"]} */
         startModules() {
             let job;
@@ -216,14 +223,12 @@
 
         /** @type {OdooModuleLoader["startModule"]} */
         startModule(name) {
-            /** @type {(dependency: string) => OdooModule} */
-            const require = (dependency) => this.modules.get(dependency);
             this.jobs.delete(name);
             const factory = this.factories.get(name);
             /** @type {OdooModule | null} */
             let module = null;
             try {
-                module = factory.fn(require);
+                module = factory.fn(this.require.bind(this));
             } catch (error) {
                 this.failed.add(name);
                 throw new Error(`Error while loading "${name}":\n${error}`);

--- a/addons/web/static/tests/_framework/mock_assets.hoot.js
+++ b/addons/web/static/tests/_framework/mock_assets.hoot.js
@@ -1,0 +1,51 @@
+// ! WARNING: this module cannot depend on modules not ending with ".hoot" (except libs) !
+
+const { loader } = odoo;
+
+/**
+ * @param {string} moduleName
+ * @param {Record<string, unknown>} mockModules
+ */
+function startWithMockModules(moduleName, mockModules) {
+    const addedModules = new Set();
+    const originalModules = new Map();
+    const mockModuleEntries = Object.entries(mockModules);
+    for (const [name, mockModule] of mockModuleEntries) {
+        if (loader.modules.has(name)) {
+            originalModules.set(name, loader.modules.get(name));
+        } else {
+            addedModules.add(name);
+        }
+        loader.modules.set(name, mockModule);
+    }
+
+    const result = loader.startModule(moduleName);
+
+    for (const [name, originalModule] of originalModules) {
+        loader.modules.set(name, originalModule);
+    }
+    for (const name of addedModules) {
+        loader.modules.delete(name);
+    }
+
+    return result;
+}
+
+//-----------------------------------------------------------------------------
+// Exports
+//-----------------------------------------------------------------------------
+
+/**
+ * Browser module needs to be mocked to patch the `location` global object since
+ * it can't be directly mocked on the window object.
+ *
+ * @param {string} name
+ */
+export function mockAssetsFactory(name) {
+    return function mockAssets() {
+        if (loader.modules.has(name)) {
+            return loader.modules.get(name);
+        }
+        return startWithMockModules(name, { "@web/session": { session: {} } });
+    };
+}

--- a/addons/web/static/tests/_framework/mock_browser.hoot.js
+++ b/addons/web/static/tests/_framework/mock_browser.hoot.js
@@ -33,7 +33,7 @@ const READONLY_PROPERTIES = [
  * @param {OdooModuleFactory} factory
  */
 export function mockBrowserFactory(name, { fn }) {
-    return (...args) => {
+    return function mockBrowser(...args) {
         const browserModule = fn(...args);
         const properties = {
             location: {

--- a/addons/web/static/tests/_framework/mock_currency.hoot.js
+++ b/addons/web/static/tests/_framework/mock_currency.hoot.js
@@ -23,7 +23,7 @@ const makeCurrencies = ({ currencies }) =>
  * @param {OdooModuleFactory} factory
  */
 export function mockCurrencyFactory(name, { fn }) {
-    return (requireModule, ...args) => {
+    return function mockCurrency(requireModule, ...args) {
         const currencyModule = fn(requireModule, ...args);
 
         onServerStateChange(currencyModule.currencies, makeCurrencies);

--- a/addons/web/static/tests/_framework/mock_functions.hoot.js
+++ b/addons/web/static/tests/_framework/mock_functions.hoot.js
@@ -11,7 +11,7 @@ import { after } from "@odoo/hoot";
  * @param {OdooModuleFactory} factory
  */
 export function mockFunctionsFactory(name, { fn }) {
-    return (...args) => {
+    return function mockFunctions(...args) {
         function clearMemoizeCaches() {
             for (const cache of memoizeCaches) {
                 cache.clear();

--- a/addons/web/static/tests/_framework/mock_indexed_db.hoot.js
+++ b/addons/web/static/tests/_framework/mock_indexed_db.hoot.js
@@ -1,7 +1,13 @@
+// ! WARNING: this module cannot depend on modules not ending with ".hoot" (except libs) !
+
 import { afterEach } from "@odoo/hoot";
 
-export function mockIndexedDB(_name, { fn }) {
-    return (requireModule, ...args) => {
+/**
+ * @param {string} name
+ * @param {OdooModuleFactory} factory
+ */
+export function mockIndexedDBFactory(name, { fn }) {
+    return function mockIndexedDB(requireModule, ...args) {
         const indexedDBModule = fn(requireModule, ...args);
 
         const { IndexedDB } = indexedDBModule;

--- a/addons/web/static/tests/_framework/mock_session.hoot.js
+++ b/addons/web/static/tests/_framework/mock_session.hoot.js
@@ -68,7 +68,7 @@ const makeSession = ({
 //-----------------------------------------------------------------------------
 
 export function mockSessionFactory() {
-    return () => {
+    return function mockSession() {
         const session = makeSession(serverState);
 
         onServerStateChange(session, makeSession);

--- a/addons/web/static/tests/_framework/mock_templates.hoot.js
+++ b/addons/web/static/tests/_framework/mock_templates.hoot.js
@@ -47,8 +47,8 @@ const { loader } = odoo;
  * @param {string} name
  * @param {OdooModuleFactory} factory
  */
-export function makeTemplateFactory(name, factory) {
-    return () => {
+export function mockTemplatesFactory(name, factory) {
+    return function mockTemplates() {
         if (loader.modules.has(name)) {
             return loader.modules.get(name);
         }

--- a/addons/web/static/tests/_framework/mock_user.hoot.js
+++ b/addons/web/static/tests/_framework/mock_user.hoot.js
@@ -11,7 +11,7 @@ import { onServerStateChange } from "./mock_server_state.hoot";
  * @param {OdooModuleFactory} factory
  */
 export function mockUserFactory(name, { fn }) {
-    return (requireModule, ...args) => {
+    return function mockUser(requireModule, ...args) {
         const { session } = requireModule("@web/session");
         const userModule = fn(requireModule, ...args);
 

--- a/addons/web/static/tests/_framework/module_set.hoot.js
+++ b/addons/web/static/tests/_framework/module_set.hoot.js
@@ -13,6 +13,7 @@ import {
     watchListeners,
 } from "@odoo/hoot";
 
+import { mockAssetsFactory } from "./mock_assets.hoot";
 import { mockBrowserFactory } from "./mock_browser.hoot";
 import { mockCurrencyFactory } from "./mock_currency.hoot";
 import { mockFunctionsFactory } from "./mock_functions.hoot";
@@ -520,6 +521,7 @@ const MODULE_MOCKS_BY_NAME = new Map([
     // Fixed modules
     ["@web/core/template_inheritance", mockFixedFactory],
     // Other mocks
+    ["@web/core/assets", mockAssetsFactory],
     ["@web/core/browser/browser", mockBrowserFactory],
     ["@web/core/currency", mockCurrencyFactory],
     ["@web/core/templates", mockTemplatesFactory],

--- a/addons/web/static/tests/_framework/module_set.hoot.js
+++ b/addons/web/static/tests/_framework/module_set.hoot.js
@@ -16,9 +16,9 @@ import {
 import { mockBrowserFactory } from "./mock_browser.hoot";
 import { mockCurrencyFactory } from "./mock_currency.hoot";
 import { mockFunctionsFactory } from "./mock_functions.hoot";
-import { mockIndexedDB } from "./mock_indexed_db.hoot";
+import { mockIndexedDBFactory } from "./mock_indexed_db.hoot";
 import { mockSessionFactory } from "./mock_session.hoot";
-import { makeTemplateFactory } from "./mock_templates.hoot";
+import { mockTemplatesFactory } from "./mock_templates.hoot";
 import { mockUserFactory } from "./mock_user.hoot";
 
 /**
@@ -274,16 +274,21 @@ function getSuitePath(name) {
 }
 
 /**
- * Keeps the original definition of a factory.
+ * Returns a mocked version of the module factory function to ensure that the same
+ * module instance is used for all test suites.
  *
- * @param {string} name
+ * These "fixed" modules CANNOT require any other module, except:
+ * - Owl/Hoot;
+ * - other "fixed" modules.
+ *
+ * @param {string} moduleName
  */
-function makeFixedFactory(name) {
-    return () => {
-        if (!loader.modules.has(name)) {
-            loader.startModule(name);
+function mockFixedFactory(moduleName) {
+    return function fixedFactory() {
+        if (loader.modules.has(moduleName)) {
+            return loader.modules.get(moduleName);
         }
-        return loader.modules.get(name);
+        return loader.startModule(moduleName);
     };
 }
 
@@ -513,19 +518,19 @@ const CSRF_TOKEN = odoo.csrf_token;
 const DEFAULT_ADDONS = ["base", "web"];
 const MODULE_MOCKS_BY_NAME = new Map([
     // Fixed modules
-    ["@web/core/template_inheritance", makeFixedFactory],
+    ["@web/core/template_inheritance", mockFixedFactory],
     // Other mocks
     ["@web/core/browser/browser", mockBrowserFactory],
-    ["@web/core/utils/indexed_db", mockIndexedDB],
     ["@web/core/currency", mockCurrencyFactory],
-    ["@web/core/templates", makeTemplateFactory],
+    ["@web/core/templates", mockTemplatesFactory],
     ["@web/core/user", mockUserFactory],
     ["@web/core/utils/functions", mockFunctionsFactory],
+    ["@web/core/utils/indexed_db", mockIndexedDBFactory],
     ["@web/session", mockSessionFactory],
 ]);
 const MODULE_MOCKS_BY_REGEX = new Map([
     // Fixed modules
-    [/\.bundle\.xml$/, makeFixedFactory],
+    [/\.bundle\.xml$/, mockFixedFactory],
 ]);
 const R_DEFAULT_MODULE = /^@odoo\/(owl|hoot)/;
 const R_PATH_ADDON = /^[@/]?(\w+)/;

--- a/addons/web/static/tests/core/utils/assets.test.js
+++ b/addons/web/static/tests/core/utils/assets.test.js
@@ -3,14 +3,7 @@ import { animationFrame, manuallyDispatchProgrammaticEvent } from "@odoo/hoot-do
 import { mockFetch } from "@odoo/hoot-mock";
 import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 
-import {
-    assets,
-    assetCacheByDocument,
-    globalBundleCache,
-    loadBundle,
-    loadCSS,
-    loadJS,
-} from "@web/core/assets";
+import { assets, loadBundle, loadCSS, loadJS } from "@web/core/assets";
 
 describe.current.tags("headless");
 
@@ -33,8 +26,14 @@ const bundles = {
 };
 
 beforeEach(() => {
-    globalBundleCache.clear();
-    assetCacheByDocument.delete(document);
+    mockFetch((route) => {
+        expect.step(`fetch bundle: ${route.pathname}`);
+        return bundles[route.pathname];
+    });
+    patchWithCleanup(assets, {
+        globalCache: new Map(),
+        documentCaches: new WeakMap(),
+    });
 });
 
 test("loadJS: load invalid JS lib", async () => {
@@ -51,7 +50,7 @@ test("loadJS: load invalid JS lib", async () => {
 
     await expect(loadJS("/some/invalid/file.js")).rejects.toThrow(
         /The loading of \/some\/invalid\/file.js failed/,
-        { message: "Trying to load an invalid file rejects the promise" }
+        { message: "Trying to load an invalid file rejects the promise" },
     );
 });
 
@@ -72,16 +71,11 @@ test("loadCSS: load invalid CSS lib", async () => {
 
     await expect(loadCSS("/some/invalid/file.css")).rejects.toThrow(
         /The loading of \/some\/invalid\/file.css failed/,
-        { message: "Trying to load an invalid file rejects the promise" }
+        { message: "Trying to load an invalid file rejects the promise" },
     );
 });
 
 test("loadBundle: load js and css files", async () => {
-    mockFetch((route) => {
-        expect.step(`fetch bundle: ${route.pathname}`);
-        return bundles[route.pathname];
-    });
-
     mockHeadAppendChild(async (node) => {
         const srcAttribute = node.tagName === "LINK" ? "href" : "src";
         expect.step(`add ${node.tagName} - ${node.type} - ${node.getAttribute(srcAttribute)}`);
@@ -99,11 +93,6 @@ test("loadBundle: load js and css files", async () => {
 });
 
 test("loadBundle: load only js files", async () => {
-    mockFetch((route) => {
-        expect.step(`fetch bundle: ${route.pathname}`);
-        return bundles[route.pathname];
-    });
-
     mockHeadAppendChild(async (node) => {
         const srcAttribute = node.tagName === "LINK" ? "href" : "src";
         expect.step(`add ${node.tagName} - ${node.type} - ${node.getAttribute(srcAttribute)}`);
@@ -119,11 +108,6 @@ test("loadBundle: load only js files", async () => {
 });
 
 test("loadBundle: load only css files", async () => {
-    mockFetch((route) => {
-        expect.step(`fetch bundle: ${route.pathname}`);
-        return bundles[route.pathname];
-    });
-
     mockHeadAppendChild(async (node) => {
         const srcAttribute = node.tagName === "LINK" ? "href" : "src";
         expect.step(`add ${node.tagName} - ${node.type} - ${node.getAttribute(srcAttribute)}`);
@@ -139,15 +123,10 @@ test("loadBundle: load only css files", async () => {
 });
 
 test("loadBundle: load same bundle in main document and an iframe", async () => {
-    mockFetch((route) => {
-        expect.step(`fetch bundle: ${route.pathname}`);
-        return bundles[route.pathname];
-    });
-
     mockHeadAppendChild(async (node) => {
         const srcAttribute = node.tagName === "LINK" ? "href" : "src";
         expect.step(
-            `add document ${node.tagName} - ${node.type} - ${node.getAttribute(srcAttribute)}`
+            `add document ${node.tagName} - ${node.type} - ${node.getAttribute(srcAttribute)}`,
         );
     });
 
@@ -159,8 +138,8 @@ test("loadBundle: load same bundle in main document and an iframe", async () => 
             const srcAttribute = node.tagName === "LINK" ? "href" : "src";
             expect.step(
                 `add iframe document ${node.tagName} - ${node.type} - ${node.getAttribute(
-                    srcAttribute
-                )}`
+                    srcAttribute,
+                )}`,
             );
         },
     });
@@ -189,15 +168,10 @@ test("loadBundle: load same bundle in main document and an iframe", async () => 
 });
 
 test("loadBundle: load same bundles in 2 iframes", async () => {
-    mockFetch((route) => {
-        expect.step(`fetch bundle: ${route.pathname}`);
-        return bundles[route.pathname];
-    });
-
     mockHeadAppendChild(async (node) => {
         const srcAttribute = node.tagName === "LINK" ? "href" : "src";
         expect.step(
-            `add document ${node.tagName} - ${node.type} - ${node.getAttribute(srcAttribute)}`
+            `add document ${node.tagName} - ${node.type} - ${node.getAttribute(srcAttribute)}`,
         );
     });
 
@@ -212,8 +186,8 @@ test("loadBundle: load same bundles in 2 iframes", async () => {
             const srcAttribute = node.tagName === "LINK" ? "href" : "src";
             expect.step(
                 `add iframe document ${node.tagName} - ${node.type} - ${node.getAttribute(
-                    srcAttribute
-                )}`
+                    srcAttribute,
+                )}`,
             );
         },
     });
@@ -222,8 +196,8 @@ test("loadBundle: load same bundles in 2 iframes", async () => {
             const srcAttribute = node.tagName === "LINK" ? "href" : "src";
             expect.step(
                 `add iframe document ${node.tagName} - ${node.type} - ${node.getAttribute(
-                    srcAttribute
-                )}`
+                    srcAttribute,
+                )}`,
             );
         },
     });

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -12,7 +12,8 @@ import {
     useState,
     useSubEnv,
 } from "@odoo/owl";
-import { LazyComponent, loadBundle } from "@web/core/assets";
+import { loadBundle } from "@web/core/assets";
+import { LazyComponent } from "@web/core/lazy_component";
 import { browser } from "@web/core/browser/browser";
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 import { _t } from "@web/core/l10n/translation";

--- a/odoo/addons/test_assetsbundle/static/tests/lazy_component.test.js
+++ b/odoo/addons/test_assetsbundle/static/tests/lazy_component.test.js
@@ -1,8 +1,7 @@
 import { expect, test } from "@odoo/hoot";
-import { queryOne } from "@odoo/hoot-dom";
-import { mountWithCleanup } from "@web/../tests/web_test_helpers";
-import { LazyComponent } from "@web/core/assets";
 import { Component, xml } from "@odoo/owl";
+import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { LazyComponent } from "@web/core/lazy_component";
 
 test("LazyComponent loads the required bundle", async () => {
     class Test extends Component {
@@ -21,8 +20,7 @@ test("LazyComponent loads the required bundle", async () => {
     await mountWithCleanup(Test);
     expect.verifySteps(["Lazy test component created"]);
     expect(".o_lazy_test_component").toHaveText("Lazy Component!");
-    expect(window.getComputedStyle(queryOne(".o_lazy_test_component")).backgroundColor).toBe(
-        "rgb(165, 94, 117)"
-    );
+    expect(".o_lazy_test_component:only").toHaveStyle({
+        backgroundColor: "rgb(165, 94, 117)",
+    });
 });
-


### PR DESCRIPTION
Preparation work for an upcoming [emoji loader](https://github.com/odoo/odoo/pull/253078) feature that will ease and centralize the loading and management of emoji data.

This PR focuses on making assets caches work accross test suites, and to speed up the processing of some utils to increase performance or to reduce memory consumption.

See commit messages for details.

- Enterprise: https://github.com/odoo/enterprise/pull/110330

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr