### PR TITLE
[IMP] tools: prevent exception escaping (`safe_eval`)

### DIFF
--- a/odoo/addons/base/tests/test_ir_actions.py
+++ b/odoo/addons/base/tests/test_ir_actions.py
@@ -78,7 +78,7 @@ _logger.warning("This is a %s warning %s", "test", "log")
 _logger.error("This is a %s error %s", "test", "log")
 try:
     0/0
-except:
+except Exception:
     _logger.exception("This is a %s exception %s", "test", "log")
 """,
         })

--- a/odoo/addons/test_tools/tests/test_safe_eval.py
+++ b/odoo/addons/test_tools/tests/test_safe_eval.py
@@ -336,3 +336,14 @@ class TestSafeEvalRuntime(TransactionCase):
         # Note that without the assert protection, we get a `RecursionError`,
         # because after transformer, the code becomes:
         # `_save_eval_call = lambda callee, *args, **kwargs: _save_eval_call(callee, *args, **kwargs)`
+
+    @mute_logger('odoo.tools.safe_eval.runtime')
+    def test_prevent_bare_except(self):
+        expr = """
+            try:
+                UnsafeClass()
+            except:
+                pass
+        """
+        with self.assertRaises(SyntaxError):
+            safe_eval(dedent(expr), self.unsafe_context, mode='exec')

--- a/odoo/addons/test_tools/tests/test_safe_eval.py
+++ b/odoo/addons/test_tools/tests/test_safe_eval.py
@@ -331,7 +331,7 @@ class TestSafeEvalRuntime(TransactionCase):
             _save_eval_call = lambda callee, *args, **kwargs: callee(*args, **kwargs)
             UnsafeClass()
         """
-        with self.assertRaisesRegex(ValueError, '^AssertionError'):
+        with self.assertRaisesRegex(ValueError, '^UnsafeContextError'):
             safe_eval(dedent(expr), self.unsafe_context, mode='exec')
         # Note that without the assert protection, we get a `RecursionError`,
         # because after transformer, the code becomes:

--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -71,7 +71,23 @@ def unsafe_policy():
     return policy
 
 
-class UnsafeObjectError(BaseException):
+class UnsafeError(BaseException):
+    """
+    Base class for exceptions triggered by unsafe operations.
+
+    Ideally used as a high-level handler to catch exceptions related
+    to unsafe errors.
+    Since this inherits from `BaseException`, it will bypass standard
+    `except Exception:` blocks.
+    """
+
+
+class UnsafeContextError(UnsafeError):
+    """ Exception raised when the evaluation context is unsafe. """
+
+
+class UnsafeObjectError(UnsafeError):
+    """ Exception raised when an object is unsafe. """
 
     def __init__(self, obj):
         obj_path = safe_whitelist.get_full_path(obj)
@@ -462,7 +478,7 @@ def safe_eval(expr, /, context=None, *, mode="eval", filename=None):
     except _BUBBLEUP_EXCEPTIONS:
         raise
 
-    except (Exception, UnsafeObjectError) as e:  # noqa: BLE001
+    except (Exception, UnsafeError) as e:  # noqa: BLE001
         raise ValueError('%r while evaluating\n%r' % (e, expr))
 
     finally:
@@ -916,7 +932,7 @@ def safe_call(callee, /, *args, **kwargs):
     """ Ensure objects used for the call are safe """
     try:
         safe_checker.check((callee, args, kwargs))
-    except UnsafeObjectError as e:
+    except UnsafeError as e:
         _logger_runtime.warning(e)
         if unsafe_policy() is UnsafePolicy.RAISE:
             raise
@@ -929,11 +945,16 @@ def monitoring_call(code, instruction_offset, callee, arg0):
     """ Ensure `_save_eval_call` is not overridden """
     if callee is safe_call:
         return
+
     frame = sys._getframe(1)
     call_id = safe_transformer.CALL_ID
-    assert call_id not in frame.f_locals or frame.f_locals[call_id] is safe_call
-    assert call_id not in frame.f_globals or frame.f_globals[call_id] is safe_call
-    assert frame.f_builtins[call_id] is safe_call
+
+    if (
+        (call_id in frame.f_locals and frame.f_locals[call_id] is not safe_call) or
+        (call_id in frame.f_globals and frame.f_globals[call_id] is not safe_call) or
+        frame.f_builtins[call_id] is not safe_call
+    ):
+        raise UnsafeContextError(f'{call_id} is overridden')
 
 
 _BUILTINS[safe_transformer.CALL_ID] = safe_call

--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -644,6 +644,20 @@ class _SafeTransformer(ast.NodeTransformer):
 
         return [node, assign]
 
+    def visit_Try(self, node):
+        """ Ensure no bare except is used """
+        self.generic_visit(node)
+
+        for handler in node.handlers:
+            if not handler.type:
+                _logger_runtime.warning(
+                    'Use blind except (`except Exception:`) instead of bare except'
+                )
+                if unsafe_policy() >= UnsafePolicy.RAISE:
+                    raise SyntaxError('You cannot use bare except, use `except Exception:`')
+
+        return node
+
 
 encoder_ctx = contextvars.ContextVar('encoder_ctx')
 


### PR DESCRIPTION
The commit: 598d2b77f6d3267aadb2ceee271cde2969197962 introduces a dynamic analysis during the execution of arbitrary code.

When an unsafe object is detected, the `UnsafeObjectError` exception is triggered. This exception inherits from the `BaseException` class.

The following syntax can be used to perform a bare except:
```py
try:
    ...
except:
    ...
```
This prevents `BaseException` from being bubble up.

`_SafeTransformer` performs a syntax check to prevent the use of bare except and recommends using a blind except instead (`except Exception`).

A `SyntaxError` exception will be raised if the unsafe policy is set to `raise`.

This improvement means that `BaseException` are no longer ignored.

Note:
The introduction of the `UnsafeContextError` exception type enables that `AssertionError` is no longer used when checking the evaluation context.

Task-6030362