### PR TITLE
[FIX] hr: disallow archived versions on payslips

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -423,8 +423,9 @@ class HrEmployee(models.Model):
         If no valid version is found, we return the very first version of the employee.
         """
         self.ensure_one()
-        versions = self.version_ids.filtered_domain([('date_version', '<=', date)])
-        return max(versions, key=lambda v: v.date_version) if versions else self.version_ids[0]
+        active_versions = self.version_ids.filtered(lambda v: v.active)
+        versions = active_versions.filtered_domain([('date_version', '<=', date)])
+        return max(versions, key=lambda v: v.date_version) if versions else active_versions[0]
 
     def create_version(self, values):
         self.ensure_one()


### PR DESCRIPTION
In this commit, the versions on payslips are restricted to only unarchived ones. This ensures that when changing dates/employee, the version selected is never archived.

Task-6022151

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
