### PR TITLE
[PERF] project_timesheet_holidays: avoid unnecessary public holiday t…

### DIFF
--- a/addons/project_timesheet_holidays/models/hr_employee.py
+++ b/addons/project_timesheet_holidays/models/hr_employee.py
@@ -21,8 +21,17 @@ class Employee(models.Model):
         return employees
 
     def write(self, vals):
+        old_calendars = {}
+
         if vals.get('active'):
             inactive_emp = self.filtered(lambda e: not e.active)
+
+        if 'resource_calendar_id' in vals:
+            old_calendars = {
+                employee.id: employee.resource_calendar_id.id
+                for employee in self
+            }
+
         result = super(Employee, self).write(vals)
         self_company = self.with_context(allowed_company_ids=self.company_id.ids)
         if 'active' in vals:
@@ -35,8 +44,12 @@ class Employee(models.Model):
                 self_company._delete_future_public_holidays_timesheets()
         elif 'resource_calendar_id' in vals:
             # Update future holiday timesheets
-            self_company._delete_future_public_holidays_timesheets()
-            self_company._create_future_public_holidays_timesheets(self_company)
+            changed = self_company.filtered(
+                lambda employee: old_calendars.get(employee.id) != employee.resource_calendar_id.id
+            )
+            if changed:
+                changed._delete_future_public_holidays_timesheets()
+                changed._create_future_public_holidays_timesheets(changed)
         return result
 
     def _delete_future_public_holidays_timesheets(self):


### PR DESCRIPTION
Reference:
opw-5938425

…imesheet regen

When hr.employee.write receives resource_calendar_id, we now compare old and new calendar IDs per employee and only refresh public-holiday timesheets for employees whose calendar actually changed. This avoids needless delete/recreate churn on no-op writes while preserving the same behavior for real calendar changes.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
