### PR TITLE
[FIX] test: chrome littering

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1067,7 +1067,12 @@ class ChromeBrowser:
         log_path = pathlib.Path(self.user_data_dir, 'err.log')
         with log_path.open('wb') as log_file:
             # pylint: disable=subprocess-popen-preexec-fn
-            proc = subprocess.Popen(cmd, stderr=log_file, preexec_fn=_preexec)  # noqa: PLW1509
+            proc = subprocess.Popen(
+                cmd,
+                stderr=log_file,
+                preexec_fn=_preexec,
+                env={**os.environ, 'TMPDIR': self.user_data_dir},
+            )  # noqa: PLW1509
 
         port_file = pathlib.Path(self.user_data_dir, 'DevToolsActivePort')
         for _ in range(CHECK_BROWSER_ITERATIONS):


### PR DESCRIPTION
It's unclear since when or under what configuration exactly, but Chrome(ium?) seems prone to creating directories called `org.chromium.Chromium.*` (or some variant thereof) in the temp dir (some people report them to be prefixed by a `.`) and never clean them.

By telling chromium that its tempdir is its data dir, it creates its litter in there, and we remove the entire thing during cleanup, solving the littering.
