### PR TITLE
[FIX] website_sale_collect: Override address check for pick up in store

### DIFF
--- a/addons/website_sale_collect/models/delivery_carrier.py
+++ b/addons/website_sale_collect/models/delivery_carrier.py
@@ -41,8 +41,7 @@ class DeliveryCarrier(models.Model):
     def create(self, vals_list):
         for vals in vals_list:
             if vals.get('delivery_type') == 'in_store':
-                vals['integration_level'] = 'rate'
-                vals['allow_cash_on_delivery'] = False
+                vals.update(self._get_in_store_default_vals())
 
                 # Set the default warehouses and publish if one is found.
                 if 'company_id' in vals:
@@ -63,9 +62,18 @@ class DeliveryCarrier(models.Model):
 
     def write(self, vals):
         if vals.get('delivery_type') == 'in_store':
-            vals['integration_level'] = 'rate'
-            vals['allow_cash_on_delivery'] = False
+            vals.update(self._get_in_store_default_vals())
         return super().write(vals)
+
+    @staticmethod
+    def _get_in_store_default_vals():
+        return {
+            "integration_level": "rate",
+            "allow_cash_on_delivery": False,
+            "country_ids": False,
+            "state_ids": False,
+            "zip_prefix_ids": False,
+        }
 
     # === BUSINESS METHODS ===#
 


### PR DESCRIPTION
The Availability fields are no longer available for pick up in store as they were removed from the view.
However, old databases that were upgraded might still have those fields filled, quietly preventing the option from showing up but also not allowing those fields being changed from the UI.

To prevent that and allow some extra robustness, the availability is also checked explicitly.

To reproduce:
- In 18, create a pick up carrier and add some countries and states.
- Upgrade to 19.
- Try to use pick up with an address not belonging to those states, it won't be possible but it also won't be possible to modify the carrier.