### PR TITLE
[PERF] stock: avoid useless iterations when getting putaway location

### DIFF
--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -382,7 +382,9 @@ class Location(models.Model):
         specified."""
         self.ensure_one()
         if self.storage_category_id:
-            forecast_weight = self._get_weight(self.env.context.get('exclude_sml_ids', set()))[self]['forecast_weight']
+            forecast_weight = self.env.context.get("forecasted_weights", {}).get(self.id)
+            if forecast_weight is None:
+                forecast_weight = self._get_weight(self.env.context.get('exclude_sml_ids', set()))[self]['forecast_weight']
             # check if enough space
             if package and package.package_type_id:
                 # check weight

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -382,7 +382,10 @@ class Location(models.Model):
         specified."""
         self.ensure_one()
         if self.storage_category_id:
-            forecast_weight = self._get_weight(self.env.context.get('exclude_sml_ids', set()))[self]['forecast_weight']
+            forecast_weight = self.env.context.get("forecasted_weights", {}).get(self.id, None)
+            weights_to_recompute = self.env.context.get("weights_to_recompute", set())
+            if forecast_weight is None or self.id in weights_to_recompute:
+                forecast_weight = self._get_weight(self.env.context.get('exclude_sml_ids', set()))[self]['forecast_weight']
             # check if enough space
             if package and package.package_type_id:
                 # check weight

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1809,7 +1809,16 @@ Please change the quantity done or the rounding precision of your unit of measur
         StockMove.browse(assigned_moves_ids).write({'state': 'assigned'})
         if not self.env.context.get('bypass_entire_pack'):
             self.picking_id._check_entire_pack()
-        StockMove.browse(moves_to_redirect).move_line_ids._apply_putaway_strategy()
+
+        moves = StockMove.browse(moves_to_redirect)
+        locations = moves.location_dest_id.putaway_rule_ids.location_out_id.child_internal_location_ids._check_access_putaway()
+        weights_data = locations._get_weight(moves.move_line_ids.ids)
+        forecasted_weights = {
+            loc.id: weights_data[loc]['forecast_weight'] if weights_data.get(loc) else 0
+            for loc in locations
+        }
+        move_lines = moves.move_line_ids.with_context(forecasted_weights=forecasted_weights)
+        move_lines._apply_putaway_strategy()
 
     def _action_cancel(self):
         if any(move.state == 'done' and not move.scrapped for move in self):

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -248,14 +248,24 @@ class StockMoveLine(models.Model):
     def _apply_putaway_strategy(self):
         if self._context.get('avoid_putaway_rules'):
             return
-        self = self.with_context(do_not_unreserve=True)
-        for (package), smls in groupby(self, lambda sml: (sml.result_package_id)):
-            smls = self.env['stock.move.line'].concat(*smls)
+        moves = self.move_id
+        locations = moves.location_dest_id._check_access_putaway().putaway_rule_ids.location_out_id.child_internal_location_ids
+        forecasted_weights = {}
+        if locations.storage_category_id:
+            weights_data = locations._get_weight(moves.move_line_ids.ids)
+            forecasted_weights = {
+                loc.id: weights_data[loc]['forecast_weight']
+                for loc in locations
+            }
+        move_lines = self.with_context(do_not_unreserve=True, forecasted_weights=forecasted_weights)
+        for (package), smls in groupby(move_lines, lambda sml: (sml.result_package_id)):
+            smls = move_lines.env['stock.move.line'].concat(*smls)
             locations = smls.move_id.location_dest_id.child_internal_location_ids
             excluded_smls = set(smls.ids)
             if package.package_type_id:
                 best_loc = smls.move_id.location_dest_id.with_context(exclude_sml_ids=excluded_smls, products=smls.product_id, locations=locations)._get_putaway_strategy(self.env['product.product'], package=package)
                 smls.location_dest_id = smls.package_level_id.location_dest_id = best_loc
+                forecasted_weights.pop(best_loc.id, None)
             elif package:
                 used_locations = set()
                 for sml in smls:
@@ -264,6 +274,7 @@ class StockMoveLine(models.Model):
                     sml.location_dest_id = sml.move_id.location_dest_id.with_context(exclude_sml_ids=excluded_smls, locations=locations)._get_putaway_strategy(sml.product_id, quantity=sml.quantity)
                     excluded_smls.discard(sml.id)
                     used_locations.add(sml.location_dest_id)
+                    forecasted_weights.pop(sml.location_dest_id.id, None)
                 if len(used_locations) > 1:
                     for move, grouped_smls in smls.grouped('move_id').items():
                         grouped_smls.location_dest_id = move.location_dest_id
@@ -276,6 +287,7 @@ class StockMoveLine(models.Model):
                     )
                     if putaway_loc_id != sml.location_dest_id:
                         sml.location_dest_id = putaway_loc_id
+                        forecasted_weights.pop(putaway_loc_id.id, None)
                     excluded_smls.discard(sml.id)
 
     def _get_default_dest_location(self):

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -249,21 +249,28 @@ class StockMoveLine(models.Model):
         if self._context.get('avoid_putaway_rules'):
             return
         self = self.with_context(do_not_unreserve=True)
+        weights_to_recompute = set()
         for (package), smls in groupby(self, lambda sml: (sml.result_package_id)):
             smls = self.env['stock.move.line'].concat(*smls)
             locations = smls.move_id.location_dest_id.child_internal_location_ids
             excluded_smls = set(smls.ids)
             if package.package_type_id:
-                best_loc = smls.move_id.location_dest_id.with_context(exclude_sml_ids=excluded_smls, products=smls.product_id, locations=locations)._get_putaway_strategy(self.env['product.product'], package=package)
+                best_loc = smls.move_id.location_dest_id.with_context(
+                    exclude_sml_ids=excluded_smls, products=smls.product_id, locations=locations, weights_to_recompute=weights_to_recompute
+                )._get_putaway_strategy(self.env['product.product'], package=package)
                 smls.location_dest_id = smls.package_level_id.location_dest_id = best_loc
+                weights_to_recompute.add(best_loc.id)
             elif package:
                 used_locations = set()
                 for sml in smls:
                     if len(used_locations) > 1:
                         break
-                    sml.location_dest_id = sml.move_id.location_dest_id.with_context(exclude_sml_ids=excluded_smls, locations=locations)._get_putaway_strategy(sml.product_id, quantity=sml.quantity)
+                    sml.location_dest_id = sml.move_id.location_dest_id.with_context(
+                        exclude_sml_ids=excluded_smls, locations=locations, weights_to_recompute=weights_to_recompute
+                    )._get_putaway_strategy(sml.product_id, quantity=sml.quantity)
                     excluded_smls.discard(sml.id)
                     used_locations.add(sml.location_dest_id)
+                    weights_to_recompute.add(sml.location_dest_id.id)
                 if len(used_locations) > 1:
                     for move, grouped_smls in smls.grouped('move_id').items():
                         grouped_smls.location_dest_id = move.location_dest_id
@@ -271,11 +278,14 @@ class StockMoveLine(models.Model):
                     smls.package_level_id.location_dest_id = smls.location_dest_id
             else:
                 for sml in smls:
-                    putaway_loc_id = sml.move_id.location_dest_id.with_context(exclude_sml_ids=excluded_smls, locations=locations)._get_putaway_strategy(
+                    putaway_loc_id = sml.move_id.location_dest_id.with_context(
+                        exclude_sml_ids=excluded_smls, locations=locations, weights_to_recompute=weights_to_recompute
+                    )._get_putaway_strategy(
                         sml.product_id, quantity=sml.quantity, packaging=sml.move_id.product_packaging_id,
                     )
                     if putaway_loc_id != sml.location_dest_id:
                         sml.location_dest_id = putaway_loc_id
+                        weights_to_recompute.add(putaway_loc_id.id)
                     excluded_smls.discard(sml.id)
 
     def _get_default_dest_location(self):


### PR DESCRIPTION
The _get_putaway_location() method tries to determine a location in which a product can be stored:

https://github.com/odoo/odoo/blob/441a6d1b928a44b9a760f926180a925159edff3e/addons/stock/models/product_strategy.py#L175-L181

When no location can be used, the loop iterates over the whole list
to call _get_weight() method on each one.

We propose to batch the call to _get_weight() method for all locations
that will be used and store the result in a dictionnary passed in the context
to avoid computing them several times during the same delivery preparation.

Benchmarks
--------------

For one product with no possible location:

| No locations | Before PR | After PR |
|------------|--------|-------|
|       780  |    9 s  |   < 1 s |

For 98 products that can be placed in various locations:

| No locations | Before PR | After PR |
|------------|--------|-------|
|       6000  |    20 s |    8 s |

For one product that could be placed in any of the indicated locations, we will compute the weights for every location while only the first one would have been computed without the fix:

| No locations | Before PR | After PR |
|--------------|-----------|----------|
|          500 |     41 ms |   524 ms |
|         2000 |     97 ms |   2.02 s |
|        10000 |    513 ms |  10.83 s |

opw-5949370

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
