### PR TITLE
[FIX] hr_holidays: bug time off balance mobile view

### DIFF
--- a/addons/hr_holidays/static/src/views/calendar/calendar_side_panel/calendar_side_panel.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_side_panel/calendar_side_panel.js
@@ -72,7 +72,7 @@ export class TimeOffCalendarSidePanel extends CalendarSidePanel {
                 continue;
             }
             promises.push(
-                this.orm.call("hr.leave.type", "get_allocation_data_request", [])
+                this.orm.call("hr.leave.type", "get_allocation_data_request", [], { context: { from_dashboard: true } })
             );
         }
         const filterData = {};

--- a/addons/hr_holidays/static/src/views/calendar/calendar_side_panel/calendar_side_panel.xml
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_side_panel/calendar_side_panel.xml
@@ -16,7 +16,12 @@
                         <li t-foreach="leaveState.holidays" t-as="holiday" t-key="holiday[3]" class="mt-2 list-unstyled">
                             <strong t-esc="holiday[0]"/>
                             : <span class="o_timeoff_green text-success" t-esc="holiday[2] ? holiday[1].virtual_remaining_leaves : holiday[1].virtual_leaves_taken"/>
-                                <t t-if="holiday[2]"> / <span t-esc="holiday[1].max_leaves"/> <t t-if="holiday[1].request_unit == 'hour'">Hours</t><t t-else="">Days</t> <span class="o_timeoff_green text-success">Available</span></t>
+                                <t t-if="holiday[2]"> /
+                                    <span t-esc="holiday[1].max_leaves"/>
+                                    <t t-if="holiday[1].request_unit == 'hour'"> Hours</t>
+                                    <t t-else=""> Days</t>
+                                </t>
+                                <span class="o_timeoff_green text-success"> Available</span>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
This change fixes 2 problems in the mobile UX side panel: 
- Time off types with zero allocations were shown.
- Leave types without a max leave amount didn't show the "Available” label.

task-6030539

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
