### PR TITLE
[FIX] hr{_attendance, _contract} : Exclude employee with no contracts from absence

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -687,6 +687,11 @@ We can redirect you to the public employee list."""
             return
         convert.convert_file(self.env, 'hr', 'data/scenarios/hr_scenario.xml', None, mode='init', kind='data')
 
+    def filter_valid(self, checked_date):
+        # A method that can be overridden
+        # to get the valid employees with running contracts.
+        return self
+
     # ---------------------------------------------------------
     # Business Methods
     # ---------------------------------------------------------

--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -800,7 +800,9 @@ class HrAttendance(models.Model):
                                                            ('company_id', 'in', companies.ids),
                                                            ('resource_calendar_id.flexible_hours', '=', False)])
 
-        for emp in absent_employees:
+        filtered_employees = absent_employees.filter_valid(fields.Date.today() - relativedelta(days=1))
+
+        for emp in filtered_employees:
             local_day_start = pytz.utc.localize(yesterday).astimezone(pytz.timezone(emp._get_tz()))
             technical_attendances_vals.append({
                 'check_in': local_day_start.strftime('%Y-%m-%d %H:%M:%S'),

--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -63,6 +63,7 @@ class TestHrAttendanceOvertime(TransactionCase):
             'tz': 'UTC',
             'resource_calendar_id': cls.calendar_flex_40h.id,
         })
+        cls.is_module_hr_contract_installed = hasattr(cls.env['hr.employee'], 'contract_id')
 
     def test_overtime_company_settings(self):
         self.company.write({
@@ -614,10 +615,12 @@ class TestHrAttendanceOvertime(TransactionCase):
 
         self.env['hr.attendance']._cron_absence_detection()
 
+        overtime_assertion = -8 if not self.is_module_hr_contract_installed else 0
+
         # Check that absences were correctly attributed
-        self.assertAlmostEqual(self.other_employee.total_overtime, -8, 2)
-        self.assertAlmostEqual(self.jpn_employee.total_overtime, -8, 2)
-        self.assertAlmostEqual(self.honolulu_employee.total_overtime, -8, 2)
+        self.assertAlmostEqual(self.other_employee.total_overtime, overtime_assertion, 2)
+        self.assertAlmostEqual(self.jpn_employee.total_overtime, overtime_assertion, 2)
+        self.assertAlmostEqual(self.honolulu_employee.total_overtime, overtime_assertion, 2)
 
         # Employee Checked in yesterday, no absence found
         self.assertAlmostEqual(self.employee.total_overtime, 0, 2)

--- a/addons/hr_contract/models/hr_employee.py
+++ b/addons/hr_contract/models/hr_employee.py
@@ -285,6 +285,10 @@ class Employee(models.Model):
             duration_data['hours'] += contract_duration_data['hours']
         return duration_data
 
+    def filter_valid(self, checked_date):
+        valid_contracts = self._get_contracts(checked_date, checked_date, states=['open', 'close'])
+        return valid_contracts.mapped('employee_id')
+
     def write(self, vals):
         res = super().write(vals)
         if vals.get('contract_id'):


### PR DESCRIPTION
### Steps to reproduce:
	- Create an employee with contract starts in the future
	- Activate the Absence Management from attendance settings
	- Run the cron of Absence Detection
	- Notice an absence attendance got created for the emp with the future contract

### Cause:
We don't check for contracts start dates when fetching absent employees and we get expected attendance for them from their working schedule so we create -ve overtime for them.

### Fix:
We filter the absent employees on their running contracts.

It has been fixed in since 18.4 in this commit https://github.com/odoo/odoo/commit/5db242416522524849a20eb83df3937c193c98d3

opw-5942239