### PR TITLE
[FIX] pos: runbot 238454

### DIFF
--- a/addons/point_of_sale/report/pos_order_report.py
+++ b/addons/point_of_sale/report/pos_order_report.py
@@ -8,7 +8,7 @@ class ReportPosOrder(models.Model):
     _name = 'report.pos.order'
     _description = "Point of Sale Orders Report"
     _auto = False
-    _order = 'date desc'
+    _order = 'date desc, id desc'
     _rec_name = 'order_id'
 
     date = fields.Datetime(string='Order Date', readonly=True)


### PR DESCRIPTION
The test test_refund_multiple_products_amounts_compliance was doing a search on 'report.pos.order' and was wrongly assuming that the first order in the recordset returned was the refund one and the other one was the original order. This was because the search is ordered by date descending and the refund order is created after the original order. However, in some cases, the date of the refund order can be the same as the date of the original order cause the dates are precise to the second which can lead to a the records returned by id ascending which would give the original order first.
This commit adds an explicit order by id descending as second choice to ensure that the refund order is always returned first.

runbot-error: 238454

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
