### PR TITLE
[FIX] point_of_sale: sync selectedOrderUuid on navigate

### DIFF
--- a/addons/point_of_sale/static/src/app/hooks/pos_router_hook.js
+++ b/addons/point_of_sale/static/src/app/hooks/pos_router_hook.js
@@ -12,8 +12,8 @@ export const useRouterParamsChecker = () => {
     if (params.orderUuid) {
         const order = pos.models["pos.order"].getBy("uuid", router.state.params.orderUuid);
         if (!order || order.finalized !== params.orderFinalized) {
-            const params = pos.defaultPage;
-            router.navigate(params.page, params.params);
+            const defaultPage = pos.defaultPage;
+            pos.navigate(defaultPage.page, defaultPage.params);
         }
     }
 };

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -201,6 +201,10 @@ export class PosStore extends WithLazyGetterTrap {
         const pageParams = registry.category("pos_pages").get(routeName);
         const component = pageParams.component;
 
+        if (routeParams.orderUuid) {
+            this.selectedOrderUuid = routeParams.orderUuid;
+        }
+
         if (component.storeOnOrder ?? true) {
             this.getOrder()?.setScreenData({ name: routeName, props: routeParams });
         }
@@ -2884,12 +2888,12 @@ export class PosStore extends WithLazyGetterTrap {
 
     orderDone(order) {
         order.setScreenData({ name: "" });
-        if (!this.config.module_pos_restaurant) {
-            this.selectedOrderUuid = this.getEmptyOrder().uuid;
-        }
         this.searchProductWord = "";
-        const nextPage = this.defaultPage;
-        this.navigate(nextPage.page, nextPage.params);
+        const { page, params } = this.defaultPage;
+        this.navigate(
+            page,
+            page === "ProductScreen" ? { orderUuid: this.getEmptyOrder().uuid } : params
+        );
     }
 
     displayPrinterWarning(printResult, printerName) {

--- a/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
@@ -74,6 +74,55 @@ registry.category("web_tour.tours").add("OrderNumberConflictTour", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("test_show_default_with_register_screen", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            // Add a product to the first direct-sale order
+            ProductScreen.addOrderline("Coca-Cola", "1"),
+            // Assign the order to table 5: Set Table → enter 5 → Assign
+            {
+                content: "click Set Table button",
+                trigger: ".product-screen .actionpad .set-table",
+                run: "click",
+            },
+            ProductScreen.clickNumpad("5"),
+            {
+                content: "table number 5 is shown in the input",
+                trigger: ".product-screen .input .input-value:contains('5')",
+            },
+            {
+                content: "click Assign to assign order to table 5",
+                trigger: ".product-screen .actionpad .assign-button",
+                run: "click",
+            },
+            // Click "New" which calls showDefault() - this is the bug trigger
+            {
+                content: "click New button to navigate to a new empty order",
+                trigger: ".product-screen .actionpad button:contains('New')",
+                run: "click",
+            },
+            // Go to ticket screen and load the table order with Coca-Cola
+            Chrome.clickOrders(),
+            TicketScreen.selectOrder("001"),
+            TicketScreen.loadSelectedOrder(),
+            // Verify the loaded order has Coca-Cola (not an empty order due to wrong selectedOrderUuid)
+            {
+                content: "loaded order should contain Coca-Cola",
+                trigger: ".product-screen .orderline .product-name:contains('Coca-Cola')",
+            },
+            // Click "New" again from the loaded table order
+            {
+                content: "click New button again",
+                trigger: ".product-screen .actionpad button:contains('New')",
+                run: "click",
+            },
+            // Verify the resulting order is empty
+            ProductScreen.orderIsEmpty(),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("test_sync_lines_qty_update_ticket_screen", {
     steps: () =>
         [

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -719,6 +719,20 @@ class TestFrontend(TestFrontendCommon):
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_open_default_register_screen_config')
 
+    def test_show_default_with_register_screen(self):
+        """
+        Test that showDefault() correctly updates the selected order when
+        default_screen is 'register' (ProductScreen mode, not floor/tables).
+        Regression test: navigating via showDefault() must sync selectedOrderUuid
+        so that ProductScreen displays the correct order.
+        """
+        self.pos_config.write({
+            'default_screen': 'register',
+            'printer_ids': False,
+        })
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_show_default_with_register_screen')
+
     def test_fast_payment_validation_from_restaurant_product_screen_with_automatic_receipt_printing(self):
         self.env['pos.printer'].create({
                 'name': 'Printer',


### PR DESCRIPTION
When navigating via `showDefault` from the ReceiptScreen to the ProductScreen, the route and URL update correctly but `selectedOrderUuid` remains pointing to the previous (receipt) order. Since ProductScreen resolves `currentOrder` through `pos.getOrder()` (which relies on `selectedOrderUuid`), it ends up displaying the stale order instead of the one specified in the route params.

Update `selectedOrderUuid` from `routeParams.orderUuid` at the start of `navigate()` so that `getOrder()` and `setScreenData` both operate on the correct order.

opw-6014753

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
