### PR TITLE
[FIX] website_cf_turnstile: safari can connect in private tab


### DIFF
--- a/addons/website_cf_turnstile/static/src/interactions/turnstile.js
+++ b/addons/website_cf_turnstile/static/src/interactions/turnstile.js
@@ -31,7 +31,11 @@ export class TurnStile {
             for (const button of buttons) {
                 button.classList.remove("disabled", "cf_form_disabled");
             }
-            form.querySelector("input.turnstile_captcha_valid").value = "done";
+            const inputValidation = form.querySelector("input.turnstile_captcha_valid");
+            // ensure form is unlocked without using `.value = …` that may be
+            // blocked by Safari tracking and fingreprinting protection
+            inputValidation.setAttribute('value', 'done');
+            inputValidation.required = false;
         };
         // unhide if interaction is needed
         globalThis.turnstileBecomeVisible = function () {


### PR DESCRIPTION

Scenario:

- set up turnstile
- with recent safari mac os or ios (reproduced from 26.2) go to
  /web/login page in a private window
- enter login and password and pass the turnstile challenge
- click on Log in

Result: nothing happens and there is an error in the console "An invalid
form control with name='' is not focusable."

Cause:

By default Safari has the Settings > Advanced > "Use advanced tracking
and fingerprinting protection" set to "in Private Browsing".

If this options is enabled in private browser or in all browsing, you
can't login to Odoo with turnstile because safari is preventing the
update of the element that is preventing to send the form:

<input style="display: none;" class="turnstile_captcha_valid" required>

When turnstile challenge succeeds, a value should be set to this input
that will unlock the form, the .value property is updated but the
browser Shadow Content is not (and if we remove display:none, the input
is empty).

Fix:

I've not been able to reproduce the issue without turnstile using same
situation and iframe. We don't know Safari heuristic but the unlocking
is working if:

- we use setProperty instead of .value
- we unset required
- we remove the input
- we display the turnstile_captcha_valid input before challenge

This fix replaces setting .value by setProperty, and add a failsafe of
unsetting required.

opw-5917286
fixes #247536
