### PR TITLE
[IMP] mail,*: use code block

### DIFF
--- a/addons/html_editor/static/src/main/code_block_plugin.js
+++ b/addons/html_editor/static/src/main/code_block_plugin.js
@@ -1,0 +1,167 @@
+import { Plugin } from "@html_editor/plugin";
+import { isBlock, closestBlock } from "@html_editor/utils/blocks";
+import { unwrapContents } from "@html_editor/utils/dom";
+import { isEmptyBlock, isZWS } from "@html_editor/utils/dom_info";
+import {
+    childNodes,
+    closestElement,
+    createDOMPathGenerator,
+} from "@html_editor/utils/dom_traversal";
+import { DIRECTIONS } from "@html_editor/utils/position";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
+import { withSequence } from "@html_editor/utils/resource";
+import { _t } from "@web/core/l10n/translation";
+
+/** @typedef {((insertedNode: Node) => insertedNode)[]} before_insert_within_pre_processors */
+
+const rightLeafOnlyNotBlockPath = createDOMPathGenerator(DIRECTIONS.RIGHT, {
+    leafOnly: true,
+    stopTraverseFunction: isBlock,
+    stopFunction: isBlock,
+});
+
+export class CodeBlockPlugin extends Plugin {
+    static id = "codeBlock";
+    static dependencies = ["baseContainer", "dom", "selection", "split", "lineBreak", "delete"];
+    /** @type {import("plugins").EditorResources} */
+    resources = {
+        font_type_items: [
+            withSequence(50, { name: _t("Code"), tagName: "pre" }),
+        ],
+        user_commands: [
+            {
+                id: "setTagPre",
+                title: _t("Code"),
+                description: _t("Add a code section"),
+                icon: "fa-code",
+                run: () => this.dependencies.dom.setBlock({ tagName: "pre" }),
+                isAvailable: this.blockFormatIsAvailable.bind(this),
+            },
+        ],
+        powerbox_items: [
+            withSequence(30, {
+                categoryId: "format",
+                commandId: "setTagPre",
+            }),
+        ],
+        shorthands: [
+            {
+                literals: ["```"],
+                commandId: "setTagPre",
+            },
+        ],
+        hints: [{ selector: "PRE", text: _t("Code") }],
+        split_element_block_overrides: this.handleSplitBlockPRE.bind(this),
+        delete_backward_overrides: withSequence(20, this.handleDeleteBackward.bind(this)),
+        delete_backward_word_overrides: this.handleDeleteBackward.bind(this),
+        before_insert_processors: this.handleInsertWithinPre.bind(this),
+    };
+
+    blockFormatIsAvailable(selection) {
+        return isHtmlContentSupported(selection) && this.dependencies.dom.canSetBlock();
+    }
+
+    /**
+     * Specific behavior for pre: insert newline (\n) in text or insert p at
+     * end.
+     */
+    handleSplitBlockPRE({ targetNode, targetOffset }) {
+        const closestPre = closestElement(targetNode, "pre");
+        const closestBlockNode = closestBlock(targetNode);
+        if (
+            !closestPre ||
+            (closestBlockNode.nodeName !== "PRE" &&
+                ((closestBlockNode.textContent && !isZWS(closestBlockNode)) ||
+                    closestBlockNode.nextSibling))
+        ) {
+            return;
+        }
+
+        // Nodes to the right of the split position.
+        const nodesAfterTarget = [...rightLeafOnlyNotBlockPath(targetNode, targetOffset)];
+        if (
+            !nodesAfterTarget.length ||
+            (nodesAfterTarget.length === 1 && nodesAfterTarget[0].nodeName === "BR") ||
+            isEmptyBlock(closestBlockNode)
+        ) {
+            // Remove the last empty block node within pre tag
+            const [beforeElement, afterElement] = this.dependencies.split.splitElementBlock({
+                targetNode,
+                targetOffset,
+                blockToSplit: closestBlockNode,
+            });
+            const isPreBlock = beforeElement.nodeName === "PRE";
+            const baseContainer = isPreBlock
+                ? this.dependencies.baseContainer.createBaseContainer({
+                      children: [...afterElement.childNodes],
+                  })
+                : afterElement;
+            if (isPreBlock) {
+                afterElement.replaceWith(baseContainer);
+            } else {
+                beforeElement.remove();
+                closestPre.after(afterElement);
+            }
+            const dir = closestBlockNode.getAttribute("dir") || closestPre.getAttribute("dir");
+            if (dir) {
+                baseContainer.setAttribute("dir", dir);
+            }
+            this.dependencies.selection.setCursorStart(baseContainer);
+        } else {
+            const lineBreak = this.document.createElement("br");
+            targetNode.insertBefore(lineBreak, targetNode.childNodes[targetOffset]);
+            this.dependencies.selection.setCursorEnd(lineBreak);
+        }
+        return true;
+    }
+
+    handleDeleteBackward({ startContainer, startOffset, endContainer, endOffset }) {
+        const rangeIsCollapsed = startContainer === endContainer && startOffset === endOffset;
+        if (!rangeIsCollapsed) {
+            return;
+        }
+        const closestPre = closestElement(endContainer, "PRE");
+        if (!closestPre || closestPre.textContent.length) {
+            return;
+        }
+        if (this.dependencies.delete.isUnremovable(closestPre)) {
+            return;
+        }
+        const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+        baseContainer.append(...closestPre.childNodes);
+        closestPre.after(baseContainer);
+        closestPre.remove();
+        this.dependencies.selection.setCursorStart(baseContainer);
+        return true;
+    }
+
+    handleInsertWithinPre(insertContainer, block) {
+        if (block.nodeName !== "PRE") {
+            return insertContainer;
+        }
+        insertContainer = this.processThrough(
+            "before_insert_within_pre_processors",
+            insertContainer
+        );
+        const isDeepestBlock = (node) =>
+            isBlock(node) && ![...node.querySelectorAll("*")].some(isBlock);
+        let linebreak;
+        const processNode = (node) => {
+            const children = childNodes(node);
+            if (isDeepestBlock(node) && node.nextSibling) {
+                linebreak = this.document.createTextNode("\n");
+                node.append(linebreak);
+            }
+            if (node.nodeType === Node.ELEMENT_NODE) {
+                unwrapContents(node);
+            }
+            for (const child of children) {
+                processNode(child);
+            }
+        };
+        for (const node of childNodes(insertContainer)) {
+            processNode(node);
+        }
+        return insertContainer;
+    }
+}

--- a/addons/html_editor/static/src/main/font/font_type_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_type_plugin.js
@@ -7,7 +7,6 @@ import {
     isRedundantElement,
     isEmptyBlock,
     isVisibleTextNode,
-    isZWS,
     isStylable,
     isContentEditableAncestor,
 } from "@html_editor/utils/dom_info";
@@ -15,11 +14,9 @@ import {
     ancestors,
     childNodes,
     closestElement,
-    createDOMPathGenerator,
     descendants,
     selectElements,
 } from "@html_editor/utils/dom_traversal";
-import { DIRECTIONS } from "@html_editor/utils/position";
 import { _t } from "@web/core/l10n/translation";
 import { FontTypeSelector } from "./font_type_selector";
 import {
@@ -37,14 +34,8 @@ import { weakMemoize } from "@html_editor/utils/functions";
  * @typedef {{ name: LazyTranslatedString; tagName: string; extraClass?: string; }[]} font_type_items
  */
 
-const rightLeafOnlyNotBlockPath = createDOMPathGenerator(DIRECTIONS.RIGHT, {
-    leafOnly: true,
-    stopTraverseFunction: isBlock,
-    stopFunction: isBlock,
-});
-
 const headingTags = ["H1", "H2", "H3", "H4", "H5", "H6"];
-const handledElemSelector = [...headingTags, "PRE", "BLOCKQUOTE"].join(", ");
+const handledElemSelector = [...headingTags, "BLOCKQUOTE"].join(", ");
 
 export class FontTypePlugin extends Plugin {
     static id = "fontType";
@@ -81,7 +72,6 @@ export class FontTypePlugin extends Plugin {
                 selector: getBaseContainerSelector("DIV"),
             }),
             withSequence(40, { name: _t("Paragraph"), tagName: "p" }),
-            withSequence(50, { name: _t("Code"), tagName: "pre" }),
             withSequence(60, { name: _t("Quote"), tagName: "blockquote" }),
         ],
         user_commands: [
@@ -110,14 +100,6 @@ export class FontTypePlugin extends Plugin {
                 description: _t("Add a blockquote section"),
                 icon: "fa-quote-right",
                 run: () => this.dependencies.dom.setBlock({ tagName: "blockquote" }),
-                isAvailable: this.blockFormatIsAvailable.bind(this),
-            },
-            {
-                id: "setTagPre",
-                title: _t("Code"),
-                description: _t("Add a code section"),
-                icon: "fa-code",
-                run: () => this.dependencies.dom.setBlock({ tagName: "pre" }),
                 isAvailable: this.blockFormatIsAvailable.bind(this),
             },
         ],
@@ -182,10 +164,6 @@ export class FontTypePlugin extends Plugin {
                 categoryId: "format",
                 commandId: "setTagQuote",
             },
-            {
-                categoryId: "format",
-                commandId: "setTagPre",
-            },
         ],
         shorthands: [
             {
@@ -222,10 +200,6 @@ export class FontTypePlugin extends Plugin {
                 literals: [">"],
                 commandId: "setTagQuote",
             },
-            {
-                literals: ["```"],
-                commandId: "setTagPre",
-            },
         ],
         hints: [
             { selector: "H1", text: _t("Heading 1") },
@@ -234,7 +208,6 @@ export class FontTypePlugin extends Plugin {
             { selector: "H4", text: _t("Heading 4") },
             { selector: "H5", text: _t("Heading 5") },
             { selector: "H6", text: _t("Heading 6") },
-            { selector: "PRE", text: _t("Code") },
             { selector: "BLOCKQUOTE", text: _t("Quote") },
         ],
 
@@ -250,7 +223,6 @@ export class FontTypePlugin extends Plugin {
         /** Overrides */
         split_element_block_overrides: [
             this.handleSplitBlockHeading.bind(this),
-            this.handleSplitBlockPRE.bind(this),
             this.handleSplitBlockquote.bind(this),
         ],
         delete_backward_overrides: withSequence(20, this.handleDeleteBackward.bind(this)),
@@ -258,7 +230,6 @@ export class FontTypePlugin extends Plugin {
 
         /** Processors */
         clipboard_content_processors: this.processContentForClipboard.bind(this),
-        before_insert_processors: this.handleInsertWithinPre.bind(this),
     };
 
     setup() {
@@ -311,61 +282,6 @@ export class FontTypePlugin extends Plugin {
 
     blockFormatIsAvailable(selection) {
         return this.blockFormatIsAvailableMemoized(selection);
-    }
-
-    // @todo @phoenix: Move this to a specific Pre/CodeBlock plugin?
-    /**
-     * Specific behavior for pre: insert newline (\n) in text or insert p at
-     * end.
-     */
-    handleSplitBlockPRE({ targetNode, targetOffset }) {
-        const closestPre = closestElement(targetNode, "pre");
-        const closestBlockNode = closestBlock(targetNode);
-        if (
-            !closestPre ||
-            (closestBlockNode.nodeName !== "PRE" &&
-                ((closestBlockNode.textContent && !isZWS(closestBlockNode)) ||
-                    closestBlockNode.nextSibling))
-        ) {
-            return;
-        }
-
-        // Nodes to the right of the split position.
-        const nodesAfterTarget = [...rightLeafOnlyNotBlockPath(targetNode, targetOffset)];
-        if (
-            !nodesAfterTarget.length ||
-            (nodesAfterTarget.length === 1 && nodesAfterTarget[0].nodeName === "BR") ||
-            isEmptyBlock(closestBlockNode)
-        ) {
-            // Remove the last empty block node within pre tag
-            const [beforeElement, afterElement] = this.dependencies.split.splitElementBlock({
-                targetNode,
-                targetOffset,
-                blockToSplit: closestBlockNode,
-            });
-            const isPreBlock = beforeElement.nodeName === "PRE";
-            const baseContainer = isPreBlock
-                ? this.dependencies.baseContainer.createBaseContainer({
-                      children: [...afterElement.childNodes],
-                  })
-                : afterElement;
-            if (isPreBlock) {
-                afterElement.replaceWith(baseContainer);
-            } else {
-                beforeElement.remove();
-                closestPre.after(afterElement);
-            }
-            const dir = closestBlockNode.getAttribute("dir") || closestPre.getAttribute("dir");
-            if (dir) {
-                baseContainer.setAttribute("dir", dir);
-            }
-            this.dependencies.selection.setCursorStart(baseContainer);
-        } else {
-            const lineBreak = this.document.createElement("br");
-            targetNode.insertBefore(lineBreak, targetNode.childNodes[targetOffset]);
-            this.dependencies.selection.setCursorEnd(lineBreak);
-        }
-        return true;
     }
 
     /**
@@ -513,35 +429,5 @@ export class FontTypePlugin extends Plugin {
             }
         }
         return clonedContents;
-    }
-
-    handleInsertWithinPre(insertContainer, block) {
-        if (block.nodeName !== "PRE") {
-            return insertContainer;
-        }
-        insertContainer = this.processThrough(
-            "before_insert_within_pre_processors",
-            insertContainer
-        );
-        const isDeepestBlock = (node) =>
-            isBlock(node) && ![...node.querySelectorAll("*")].some(isBlock);
-        let linebreak;
-        const processNode = (node) => {
-            const children = childNodes(node);
-            if (isDeepestBlock(node) && node.nextSibling) {
-                linebreak = this.document.createTextNode("\n");
-                node.append(linebreak);
-            }
-            if (node.nodeType === Node.ELEMENT_NODE) {
-                unwrapContents(node);
-            }
-            for (const child of children) {
-                processNode(child);
-            }
-        };
-        for (const node of childNodes(insertContainer)) {
-            processNode(node);
-        }
-        return insertContainer;
     }
 }

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.js
@@ -100,6 +100,9 @@ export class SyntaxHighlightingPlugin extends Plugin {
             // Save only the `<pre>` element, with information to rebuild the
             // embedded component, so the saved DOM is independent of this plugin.
             const pre = codeBlock.querySelector("pre");
+            if (!pre) {
+                continue;
+            }
             pre.dataset.embedded = "readonlySyntaxHighlighting"; // Make it work in readonly.
             const embeddedProps = getEmbeddedProps(codeBlock);
             const value = embeddedProps.value;

--- a/addons/html_editor/static/src/plugin_sets.js
+++ b/addons/html_editor/static/src/plugin_sets.js
@@ -19,6 +19,7 @@ import { SplitPlugin } from "./core/split_plugin";
 import { UserCommandPlugin } from "./core/user_command_plugin";
 import { AlignPlugin } from "./main/align/align_plugin";
 import { BannerPlugin } from "./main/banner_plugin";
+import { CodeBlockPlugin } from "./main/code_block_plugin";
 import { ColumnPlugin } from "./main/column_plugin";
 import { EmojiPlugin } from "./main/emoji_plugin";
 import { ColorPlugin } from "./main/font/color_plugin";
@@ -104,6 +105,7 @@ export const CORE_PLUGINS = [
 export const MAIN_PLUGINS = [
     ...CORE_PLUGINS,
     BannerPlugin,
+    CodeBlockPlugin,
     ColorPlugin,
     ColorUIPlugin,
     SeparatorPlugin,

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -48,6 +48,7 @@ import { useComposerActions } from "@mail/core/common/composer_actions";
 import { ActionList } from "@mail/core/common/action_list";
 import { closestElement, lastLeaf } from "@html_editor/utils/dom_traversal";
 import { rightPos } from "@html_editor/utils/position";
+import { syntaxHighlightingEmbedding } from "@html_editor/others/embedded_components/backend/syntax_highlighting/syntax_highlighting";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { usePopover } from "@web/core/popover/popover_hook";
 
@@ -381,6 +382,7 @@ export class Composer extends Component {
         return {
             content: this.props.composer.composerHtml,
             placeholder: this.placeholder,
+            baseContainers: ["DIV", "P"],
             Plugins: this.ui.isSmall ? MAIL_SMALL_UI_PLUGINS : MAIL_PLUGINS,
             composerPluginDependencies: {
                 onBeforePaste: (selection, ev) => this.onPaste(ev),
@@ -389,7 +391,11 @@ export class Composer extends Component {
                 onInput: this.onInput.bind(this),
                 onKeydown: this.onKeydown.bind(this),
             },
-            classList: ["o-mail-Composer-html"],
+            embeddedComponentInfo: { app: this.__owl__.app, env: this.env },
+            resources: {
+                embedded_components: [syntaxHighlightingEmbedding],
+            },
+            classList: ["o-mail-Composer-html", "min-w-0"],
             onChange: () => this.onChangeWysiwygContent(),
             onEditorReady: () => {
                 this.setEditorCursorEnd();

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -30,7 +30,7 @@
             <div t-if="this.showComposerAvatar" class="o-mail-Composer-sidebarMain flex-shrink-0 d-flex">
                 <img class="o-mail-Composer-avatar mx-auto o_avatar rounded-3" t-att-src="(this.thread?.effectiveSelf or this.message.effectiveSelf).avatarUrl" alt="Avatar of user"/>
             </div>
-            <div class="o-mail-Composer-coreHeader">
+            <div class="o-mail-Composer-coreHeader min-w-0">
                 <div t-if="this.props.composer.replyToMessage" class="text-truncate small p-2">
                     <span class="cursor-pointer" t-on-click="() => this.env.messageHighlight?.highlightMessage(this.props.composer.replyToMessage)">
                         Replying to <b t-out="this.props.composer.replyToMessage.authorName"/>
@@ -47,8 +47,8 @@
                     </button>
                 </span>
             </div>
-            <div class="o-mail-Composer-coreMain d-flex flex-nowrap align-items-start flex-grow-1" t-att-class="{ 'flex-column' : this.extended or this.props.composer.message }">
-                <div class="o-mail-Composer-inputContainer o-mail-Composer-bg d-flex flex-grow-1 border o-rounded-bubble"
+            <div class="o-mail-Composer-coreMain min-w-0 d-flex flex-nowrap align-items-start flex-grow-1" t-att-class="{ 'flex-column' : this.extended or this.props.composer.message }">
+                <div class="o-mail-Composer-inputContainer o-mail-Composer-bg d-flex flex-grow-1 min-w-0 overflow-x-hidden border o-rounded-bubble"
                     t-att-class="{
                         'o-iosPwa': this.isIosPwa,
                         'align-self-stretch' : this.extended,
@@ -59,14 +59,14 @@
                     <div t-if="!this.extended" t-attf-class="{{ actionsContainerClass }}">
                         <t t-if="this.moreActions" t-call="mail.Composer.moreActions"/>
                     </div>
-                    <div class="position-relative flex-grow-1">
+                    <div class="position-relative flex-grow-1 min-w-0">
                         <t t-set="inputClasses" t-value="{
                             'o-mail-Composer-inputStyle form-control border-0 o-rounded-bubble': true,
                             'o-mobile': this.isMobileOS,
                             'ps-2': partitionedActions.other.length === 0,
                             'text-muted': this.props.composer.restoredFromFullComposer,
                         }"/>
-                        <Wysiwyg t-if="this.composerService.htmlEnabled" class="'w-100 text-break overflow-auto'" config="this.wysiwygConfig" onLoad.bind="this.onLoadWysiwyg"/>
+                        <Wysiwyg t-if="this.composerService.htmlEnabled" class="'w-100 min-w-0 text-break overflow-auto'" config="this.wysiwygConfig" onLoad.bind="this.onLoadWysiwyg"/>
                         <t t-else="">
                                 <textarea class="o-mail-Composer-input o-mail-Composer-bg shadow-none overflow-auto o-scrollbar-thin o-discuss-text-body user-select-auto"
                                 t-att-class="inputClasses"
@@ -100,7 +100,7 @@
                     <t t-call="mail.Composer.quickActions"/>
                 </div>
             </div>
-            <div class="o-mail-Composer-footer overflow-auto o-scrollbar-thin">
+            <div class="o-mail-Composer-footer min-w-0 overflow-auto o-scrollbar-thin">
                 <AttachmentList
                     t-if="this.props.composer.attachments.length > 0"
                     attachments="this.props.composer.attachments"

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -1,4 +1,5 @@
 import { useChildSubEnv, useLayoutEffect, useRef, useState, useSubEnv } from "@web/owl2/utils";
+import { readonlySyntaxHighlightingEmbedding } from "@html_editor/others/embedded_components/core/syntax_highlighting/readonly_syntax_highlighting";
 import { AttachmentList } from "@mail/core/common/attachment_list";
 import { Composer } from "@mail/core/common/composer";
 import { ImStatus } from "@mail/core/common/im_status";
@@ -202,9 +203,12 @@ export class Message extends Component {
                             : this.props.messageSearch?.highlight(this.message.richBody) ??
                                   this.message.richBody
                     );
-                    this.prepareMessageBody(bodyEl);
+                    const roots = this.prepareMessageBody(bodyEl) ?? [];
                     this.shadowRoot.appendChild(bodyEl);
                     return () => {
+                        for (const root of roots) {
+                            root.destroy();
+                        }
                         this.shadowRoot.removeChild(bodyEl);
                     };
                 }
@@ -219,11 +223,16 @@ export class Message extends Component {
         );
         useLayoutEffect(
             () => {
-                if (!this.isEditing) {
-                    this.prepareMessageBody(this.messageBody.el);
-                }
+                const roots = this.isEditing
+                    ? []
+                    : this.prepareMessageBody(this.messageBody.el) ?? [];
+                return () => {
+                    for (const root of roots) {
+                        root.destroy();
+                    }
+                };
             },
-            () => [this.isEditing, this.message.richBody]
+            () => [this.isEditing, this.message.richBody, this.props.messageSearch?.searchTerm]
         );
     }
 
@@ -521,6 +530,33 @@ export class Message extends Component {
                 }
             }
         }
+        return this.renderEmbeddedCodeBlocks(bodyEl);
+    }
+
+     /** @param {HTMLElement} bodyEl */
+    renderEmbeddedCodeBlocks(bodyEl) {
+        const { name, Component, getProps } = readonlySyntaxHighlightingEmbedding;
+        const selector = `[data-embedded='${name}']`;
+        const embeddedElements = [...bodyEl.querySelectorAll(selector)];
+        if (bodyEl.matches(selector)) {
+            embeddedElements.unshift(bodyEl);
+        }
+        const roots = [];
+        for (const el of embeddedElements) {
+            if (el.dataset.embeddedMounted === "1") {
+                continue;
+            }
+            const props = getProps(el);
+            el.replaceChildren();
+            const root = this.__owl__.app.createRoot(Component, {
+                props,
+                env: this.env,
+            });
+            root.mount(el).catch();
+            el.dataset.embeddedMounted = "1";
+            roots.push(root);
+        }
+        return roots;
     }
 
     getAuthorAttClass() {

--- a/addons/mail/static/src/core/common/plugin/mail_code_block_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mail_code_block_plugin.js
@@ -1,0 +1,19 @@
+import { CodeBlockPlugin } from "@html_editor/main/code_block_plugin";
+import { withSequence } from "@html_editor/utils/resource";
+import { _t } from "@web/core/l10n/translation";
+
+export class MailCodeBlockPlugin extends CodeBlockPlugin {
+    static id = "mailCodeBlock";
+
+    resources = Object.assign(this.resources, {
+        toolbar_items: [
+            withSequence(25, {
+                id: "code_block",
+                groupId: "layout",
+                namespaces: ["compact", "expanded"],
+                commandId: "setTagPre",
+                description: _t("Insert code block"),
+            }),
+        ],
+    });
+}

--- a/addons/mail/static/src/core/common/plugin/plugin_sets.js
+++ b/addons/mail/static/src/core/common/plugin/plugin_sets.js
@@ -1,19 +1,23 @@
 import { ColorPlugin } from "@html_editor/main/font/color_plugin";
 import { CORE_PLUGINS } from "@html_editor/plugin_sets";
+import { EmbeddedComponentPlugin } from "@html_editor/others/embedded_component_plugin";
 import { EmojiPlugin } from "@html_editor/main/emoji_plugin";
 import { FeffPlugin } from "@html_editor/main/feff_plugin";
 import { HintPlugin } from "@html_editor/main/hint_plugin";
 import { InlineCodePlugin } from "@html_editor/main/inline_code";
 import { LinkPastePlugin } from "@html_editor/main/link/link_paste_plugin";
 import { LinkPlugin } from "@html_editor/main/link/link_plugin";
+import { ProtectedNodePlugin } from "@html_editor/core/protected_node_plugin";
+import { SelectionPlaceholderPlugin } from "@html_editor/main/selection_placeholder_plugin";
 import { ShortCutPlugin } from "@html_editor/core/shortcut_plugin";
+import { SyntaxHighlightingPlugin } from "@html_editor/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin";
 import { TabulationPlugin } from "@html_editor/main/tabulation_plugin";
 import { ToolbarPlugin } from "@html_editor/main/toolbar/toolbar_plugin";
 import { TranslatePlugin } from "@html_editor/main/translate/translate_plugin";
 
+import { MailCodeBlockPlugin } from "@mail/core/common/plugin/mail_code_block_plugin";
 import { MailComposerPlugin } from "@mail/core/common/plugin/mail_composer_plugin";
 import { MentionPlugin } from "@mail/core/common/plugin/mention_plugin";
-import { ProtectedNodePlugin } from "@html_editor/core/protected_node_plugin";
 
 export const MAIL_CORE_PLUGINS = [
     ...CORE_PLUGINS,
@@ -27,10 +31,17 @@ export const MAIL_CORE_PLUGINS = [
     MailComposerPlugin,
     MentionPlugin,
     ProtectedNodePlugin,
+    SelectionPlaceholderPlugin,
     ShortCutPlugin,
     TabulationPlugin,
     TranslatePlugin,
 ];
 
-export const MAIL_PLUGINS = [...MAIL_CORE_PLUGINS, ToolbarPlugin];
+export const MAIL_PLUGINS = [
+    ...MAIL_CORE_PLUGINS,
+    EmbeddedComponentPlugin,
+    MailCodeBlockPlugin,
+    SyntaxHighlightingPlugin,
+    ToolbarPlugin,
+];
 export const MAIL_SMALL_UI_PLUGINS = MAIL_CORE_PLUGINS;

--- a/addons/mail/static/tests/core/search_highlight.test.js
+++ b/addons/mail/static/tests/core/search_highlight.test.js
@@ -199,6 +199,31 @@ test("Display multiple highlighted search in Discuss", async () => {
     });
 });
 
+test("Search update keeps embedded code block rendering in Discuss", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    pyEnv["mail.message"].create({
+        author_id: serverState.partnerId,
+        body: `<p>prefix text</p><pre data-embedded="readonlySyntaxHighlighting" data-language-id="python">print('hello')</pre><p>suffix text</p>`,
+        attachment_ids: [],
+        message_type: "comment",
+        model: "discuss.channel",
+        res_id: channelId,
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Message");
+    await click("button[title='Search Messages']");
+    await insertText(".o_searchview_input", "prefix");
+    triggerHotkey("Enter");
+    await contains(`.o-mail-SearchMessagesPanel .o-mail-Message span.${HIGHLIGHT_CLASS}:text('prefix')`);
+    await contains(".o-mail-SearchMessagesPanel pre[data-embedded='readonlySyntaxHighlighting']");
+    await insertText(".o_searchview_input", " suffix");
+    triggerHotkey("Enter");
+    await contains(`.o-mail-SearchMessagesPanel .o-mail-Message span.${HIGHLIGHT_CLASS}:text('suffix')`);
+    await contains(".o-mail-SearchMessagesPanel pre[data-embedded='readonlySyntaxHighlighting']");
+});
+
 test("Display highlighted with escaped character must ignore them", async () => {
     patchUiSize({ size: SIZES.XXL });
     const pyEnv = await startServer();


### PR DESCRIPTION
Splitting the code block plugin from the font plugin, and make it available in mail composer.

Use the syntax highlighting embedded component to render code blocks in readonly mode in the message bodies.

task-5262721

after:
<img width="1257" height="635" alt="image" src="https://github.com/user-attachments/assets/93c78e75-b4af-4faa-b3ee-44a2954bb92a" />


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
