### PR TITLE
[FIX] core: avoid leaking custom fields in registry

### DIFF
--- a/odoo/addons/base/tests/test_ir_model.py
+++ b/odoo/addons/base/tests/test_ir_model.py
@@ -294,6 +294,17 @@ class TestIrModelEdition(TransactionCase):
             default_ttype="char"
         ).name_create("field_name")
 
+    def test_setup_models(self):
+        self.env['ir.model'].create({
+            'name': 'Bananas',
+            'model': 'x_bananas',
+            'field_id': [Command.create({'name': 'x_name', 'ttype': 'char'})],
+        })
+        # check that registry setup doesn't introduce duplicates in registry.field_depends
+        self.registry._setup_models__(self.env.cr, [])
+        fnames = [str(field) for field in self.registry.field_depends]
+        self.assertEqual(len(fnames), len(set(fnames)), "registry.field_depends contains duplicates")
+
 
 @tagged('test_eval_context')
 class TestEvalContext(TransactionCase):

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -451,6 +451,9 @@ class Registry(Mapping[str, type["BaseModel"]]):
             # recursively mark fields to re-setup
             todo = []
             for model_cls in self.models.values():
+                if model_cls._custom:
+                    # custom models are going to be reloaded and set up below
+                    model_cls._setup_done__ = False
                 if model_cls._setup_done__:
                     models_field_depends_done.add(model_cls)
                 else:


### PR DESCRIPTION
During upgrades we observed an uncontrolled growth of the mappings `field_depends` and `field_depends_context` in the registry.  The Field instances that serve as keys are duplicated for custom models.  This comes from the fact that custom models are completely reloaded during registry setup, even incremental setup.  To avoid duplication we consider custom models to be re-setup, which they actually are.
    
Co-authored-by: Raphael Collet <rco@odoo.com>
Co-authored-by: Xavier Dollé (xdo) <xdo@odoo.com>