### PR TITLE
[FIX] website_sale: adjust field sizes in rating emails

### DIFF
--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -241,7 +241,7 @@
                 >
                     <field name="send_order_rating_emails"/>
                     <div invisible="not send_order_rating_emails" class="mt-1">
-                        <field name="rating_email_delay" class="oe_inline" /> days after order confirmation
+                        <field name="rating_email_delay" style="width: 1rem;"/> days after order confirmation
                     </div>
                     <div invisible="not send_order_rating_emails" class="mt-2">
                         <label
@@ -249,7 +249,11 @@
                             for="rating_email_template_id"
                             class="o_light_label me-2"
                         />
-                        <field name="rating_email_template_id" class="oe_inline"/>
+                        <field 
+                            name="rating_email_template_id"
+                            class="oe_inline"
+                            style="min-width: 16rem;"
+                        />
                     </div>
                 </setting>
                 <setting string="Orders Assignment" help="Assignment of online orders">


### PR DESCRIPTION
Resize the "Days after order confirmation" field
Correct the size of the email template field for better readability