### PR TITLE
[IMP] stock: adjust column sizes on Replenishment dashboard

### DIFF
--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -36,18 +36,18 @@
                 <field name="product_id" readonly="product_id" force_save="1" context="{'default_is_storable': True}"/>
                 <field name="location_id" options="{'no_create': True}" groups="stock.group_stock_multi_locations"/>
                 <field name="warehouse_id" options="{'no_create': True}" groups="stock.group_stock_multi_warehouses" optional="hide"/>
-                <field name="qty_on_hand" force_save="1"/>
-                <field name="qty_forecast" force_save="1"/>
+                <field name="qty_on_hand" force_save="1" width="60"/>
+                <field name="qty_forecast" force_save="1" width="60"/>
                 <button name="action_product_forecast_report" type="object" icon="fa-area-chart" title="Forecast Report" invisible="not id or unwanted_replenish"/>
                 <button name="action_product_forecast_report" type="object" icon="fa-warning text-warning" title="Due to receipts scheduled in the future, you might end up with excessive stock . Check the Forecasted Report  before reordering" invisible="not id or not unwanted_replenish"/>
                 <field name="route_id" widget="stock.forced_placeholder" options="{'no_create': True, 'no_open': True, 'placeholder_field': 'route_id_placeholder'}" optional="hidden" decoration-muted="not route_id"/>
                 <button name="action_stock_replenishment_info" type="object" icon="fa-info-circle" title="Replenishment Information" invisible="not id or show_supply_warning"/>
                 <button name="action_stock_replenishment_info" type="object" icon="fa-warning text-warning" title="Your product is missing a way to be replenished (Route, Vendor, Bill of Materials)." invisible="not id or not show_supply_warning"/>
-                <field name="trigger" optional="hide"/>
-                <field name="product_min_qty" string="Min" optional="show"/>
-                <field name="product_max_qty" string="Max" optional="show"/>
+                <field name="trigger" optional="hide" width="70"/>
+                <field name="product_min_qty" string="Min" optional="show" width="50"/>
+                <field name="product_max_qty" string="Max" optional="show" width="50"/>
                 <field name="replenishment_uom_id" widget="stock.forced_placeholder" options="{'no_create': True, 'placeholder_field': 'replenishment_uom_id_placeholder'}" optional="hide" decoration-muted="not replenishment_uom_id"/>
-                <field name="qty_to_order" readonly="trigger == 'auto'"/>
+                <field name="qty_to_order" readonly="trigger == 'auto'" width="60"/>
                 <field name="qty_to_order_manual" column_invisible="True"/>
                 <button name="action_remove_manual_qty_to_order" type="object" icon="fa-undo" title="Remove manually entered value and replace by the quantity to order based on the forecasted quantities" invisible="not qty_to_order_manual"/>
                 <button name="action_remove_manual_qty_to_order" type="object" icon="fa-undo" title="-" class="disabled opacity-0" invisible="qty_to_order_manual"/>


### PR DESCRIPTION
Purpose: the name of the product in the replenishment dashboard often gets truncated which is bad for UX.

Adjust column widths to make better use of space.

task-5097352