### PR TITLE
[FIX] stock_account: handle returns of moves without valued quantity

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -453,8 +453,9 @@ class StockMove(models.Model):
     def _get_value_from_returns(self, quantity, at_date=None):
         if self.origin_returned_move_id and self.origin_returned_move_id.is_out:
             origin_move = self.origin_returned_move_id
+            origin_valued_qty = origin_move._get_valued_qty()
             return {
-                'value': origin_move.value * quantity / origin_move._get_valued_qty(),
+                'value': 0 if self.product_uom.is_zero(origin_valued_qty) else origin_move.value * quantity / origin_valued_qty,
                 'quantity': quantity,
                 'description': _('Value based on original move %(reference)s', reference=origin_move.reference),
             }

--- a/addons/stock_account/tests/test_stockvaluationlayer.py
+++ b/addons/stock_account/tests/test_stockvaluationlayer.py
@@ -1,6 +1,9 @@
 """ Implementation of "INVENTORY VALUATION TESTS" spreadsheet. """
 
-from odoo import Command
+from datetime import timedelta
+from freezegun import freeze_time
+
+from odoo import fields
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.stock_account.tests.common import TestStockValuationCommon
 from odoo.exceptions import ValidationError
@@ -320,15 +323,26 @@ class TestStockValuationAVCO(TestStockValuationCommon):
         self.assertEqual(self.product.total_value, 0)
         self.assertEqual(self.product.qty_available, 0)
 
+    @freeze_time("2026-03-10 10:00:00")
     def test_return_receipt_1(self):
+        """
+        Receive a product twice, return one unit and deliver the other one.
+        The total value should be 0 and the price should be (10+20)/2 = 15.
+        Return the delivery and set the original quantity to 0.
+        The total value should be 15.
+        """
         move1 = self._make_in_move(self.product, 1, unit_cost=10, create_picking=True)
         self._make_in_move(self.product, 1, unit_cost=20)
-        self._make_out_move(self.product, 1)
+        move2 = self._make_out_move(self.product, 1)
         self._make_return(move1, 1)
 
         self.assertEqual(self.product.total_value, 0)
         self.assertEqual(self.product.qty_available, 0)
         self.assertEqual(self.product.standard_price, 15)
+
+        self._make_return(move2, 1)
+        move2.quantity = 0
+        self.assertEqual(self.product.with_context(to_date=fields.Datetime.now() + timedelta(days=1)).total_value, 15.0)
 
     def test_return_delivery_1(self):
         self._make_in_move(self.product, 1, unit_cost=10)


### PR DESCRIPTION
An error is raised when we try to acces the inventory valuation if a move has been returned and the quantity set on the original move is changed to 0

Steps to reproduce:
1. Install Accounting and Inventory
2. Create a product called "Product" and set the Category to "Goods"
3. Go to Inventory > Configuration > Categories, open category "Goods" and change the costing method to "Average Cost (AVCO)"
4. Go to Inventory > Operations > Deliveries and create a new delivery for any customer with one of product "Product"
5. Validate the delivery, click on "Return" then on "Return All"
6. Validate the return
7. Go back to the original delivery and in Actions, click on "Lock/Unlock"
8. Set the quantity to 0 and save
9. Go to Accounting > Review > Inventory valuation
10. Change the day to any day after today
11. An error is raised

Issue:
Trying to get the inventory valuation at another day then today will replay the history
https://github.com/odoo/odoo/blob/88df50bc96448dfaff28bd37e970ffd18bf8d554/addons/stock_account/models/product.py#L444-L450
Which will call `_get_value()` on the moves related to the product
https://github.com/odoo/odoo/blob/88df50bc96448dfaff28bd37e970ffd18bf8d554/addons/stock_account/models/stock_move.py#L388-L391
A ZeroDivisionError will then be raised when trying to get the value of a return move and the original move's quantity is 0
https://github.com/odoo/odoo/blob/873d4d262ed3e85362aa677b5a782d6e7fa00f09/addons/stock_account/models/stock_move.py#L457

Solution:
If the original move's quantity is 0, set the value to 0
This ensures the move is valued at 0 if the move has no quantity. In other words, a move that has no quantity shouldn't be considered to have any value as there really is nothing to value.

opw-5980600