### PR TITLE
[FIX] mrp_account: normalize kit cost by bom.product_qty

### DIFF
--- a/addons/mrp_account/models/product.py
+++ b/addons/mrp_account/models/product.py
@@ -75,7 +75,7 @@ class ProductProduct(models.Model):
             line_qty = bom_line.product_uom_id._compute_quantity(bom_lines[bom_line]['qty'], bom_line.product_id.uom_id)
             moves = self.env['stock.move'].concat(*moves_list)
             value += line_qty * bom_line.product_id._compute_average_price(qty_invoiced * line_qty, qty_to_invoice * line_qty, moves, is_returned=is_returned)
-        return value
+        return bom.product_uom_id._compute_price(value / bom.product_qty, self.uom_id)
 
     def _compute_bom_price(self, bom, boms_to_recompute=False, byproduct_bom=False):
         self.ensure_one()

--- a/addons/sale_mrp_margin/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp_margin/tests/test_sale_mrp_flow.py
@@ -50,3 +50,40 @@ class TestSaleMrpFlow(test_sale_mrp_flow.TestSaleMrpFlowCommon):
         self.assertEqual(so.order_line.purchase_price, 60)
         so.action_confirm()
         self.assertEqual(so.order_line.purchase_price, 60)
+
+    def test_kit_cost_calculation_multi_qty_bom(self):
+        """ Check that the average cost price is correctly normalized by bom.product_qty.
+
+            BOM: 12 units of "Kit X" = 12 x Comp A + 12 x Comp B
+            Comp A cost = $10, Comp B cost = $20
+            Per-unit cost of Kit X = (12*10 + 12*20) / 12 = $30
+
+            Without normalization the cost would incorrectly be 12*10 + 12*20 = $360.
+        """
+        kit_x = self._cls_create_product('Kit X', self.uom_unit)
+        (kit_x + self.component_a + self.component_b).categ_id.property_cost_method = 'average'
+        self.env['mrp.bom'].create({
+            'product_tmpl_id': kit_x.product_tmpl_id.id,
+            'product_qty': 12.0,
+            'type': 'phantom',
+            'bom_line_ids': [
+                (0, 0, {'product_id': self.component_a.id, 'product_qty': 12.0}),
+                (0, 0, {'product_id': self.component_b.id, 'product_qty': 12.0}),
+            ],
+        })
+        self.component_a.standard_price = 10
+        self.component_b.standard_price = 20
+
+        stock_location = self.env['stock.warehouse'].search(
+            [('company_id', '=', self.env.company.id)], limit=1,
+        ).lot_stock_id
+        self.env['stock.quant']._update_available_quantity(self.component_a, stock_location, 100)
+        self.env['stock.quant']._update_available_quantity(self.component_b, stock_location, 100)
+
+        so_form = Form(self.env['sale.order'])
+        so_form.partner_id = self.partner_a
+        with so_form.order_line.new() as line:
+            line.product_id = kit_x
+        so = so_form.save()
+        so.action_confirm()
+        self.assertEqual(so.order_line.purchase_price, 30)


### PR DESCRIPTION
### Issue:
When a kit BoM has `product_qty` > 1 (e.g. 12 Kit X = 12 Comp A + 12 Comp B), the SO line cost after confirmation is multiplied by the batch size. Selling 1 Kit X shows a cost of 360 instead of 30.

### Cause:
The method `_compute_average_price` uses `bom.explode(self, 1)`, which returns raw BoM line quantities for one full batch. It accumulates the total batch cost but returns it without dividing by `bom.product_qty`.

### Steps to Reproduce:
- Costing Method = AVCO, Inventory Valuation = Automated
- Comp A (cost 10), Comp B (cost 20), Kit X (cost 0)
- Kit BoM: 12 Kit X = 12 x Comp A + 12 x Comp B
- Create and confirm a SO for 1 x Kit X
- Expected SO line cost: 30
- Actual SO line cost: 360

Solution:
This fix mirrors the normalization already done in `_compute_bom_price`, which correctly divides by `bom.product_qty` and converts UoMs.

opw-5969310
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
