### PR TITLE
[FIX] sale_stock, stock_account: fix the computation of cogs unit price

### DIFF
--- a/addons/sale_stock/tests/test_anglo_saxon_valuation.py
+++ b/addons/sale_stock/tests/test_anglo_saxon_valuation.py
@@ -978,19 +978,36 @@ class TestAngloSaxonValuation(TestStockValuationCommon, TestSaleStockCommon):
             'order_line': [Command.create({
                 'name': self.product_fifo_auto.name,
                 'product_id': self.product_fifo_auto.id,
-                'product_uom_qty': 1,
+                'product_uom_qty': 2,
                 'product_uom_id': unit_12.id,
                 'price_unit': 18,
                 'tax_ids': False,  # no love taxes amls
             })],
         })
         so_2.action_confirm()
-        so_2.picking_ids.move_ids.write({'quantity': 12, 'picked': True})
-        so_2.picking_ids.button_validate()
 
-        # Invoice the sale order.
-        invoice_2 = so_2._create_invoices()
-        invoice_2.action_post()
+        picking = so_2.picking_ids
+        picking.move_ids.write({'quantity': 12, 'picked': True})
+        res = picking.button_validate()
+
+        backorder_wizard = self.env['stock.backorder.confirmation'].with_context(
+            res['context']
+        ).create({})
+        backorder_wizard.process()
+        picking.button_validate()
+
+        # Invoice the first sale order.
+        invoice_2_1 = so_2._create_invoices()
+        invoice_2_1.line_ids[0].quantity = 1
+        invoice_2_1.action_post()
+
+        picking = so_2.picking_ids[1]
+        picking.move_ids.write({'quantity': 12, 'picked': True})
+        picking.button_validate()
+
+        # Invoice the second sale order.
+        invoice_2_2 = so_2._create_invoices()
+        invoice_2_2.action_post()
 
         # Invoice 2
 
@@ -1003,19 +1020,22 @@ class TestAngloSaxonValuation(TestStockValuationCommon, TestSaleStockCommon):
         # Default Account Stock Out        0.00$       12.0$
         # Expenses                        12.00$        0.0$
 
-        aml = invoice_2.line_ids
-        # Product Sales
-        self.assertEqual(aml[0].debit, 0.0)
-        self.assertEqual(aml[0].credit, 18.0)
-        # Account Receivable
-        self.assertEqual(aml[1].debit, 18.0)
-        self.assertEqual(aml[1].credit, 0.0)
-        # Default Account Stock Out
-        self.assertEqual(aml[2].debit, 0.0)
-        self.assertEqual(aml[2].credit, 12.0)
-        # Expenses
-        self.assertEqual(aml[3].debit, 12.0)
-        self.assertEqual(aml[3].credit, 0.0)
+        aml1 = invoice_2_1.line_ids.sorted(lambda line: (max(line.credit, line.debit), line.credit), reverse=True)
+        aml2 = invoice_2_2.line_ids.sorted(lambda line: (max(line.credit, line.debit), line.credit), reverse=True)
+
+        expected = [
+            # Product Sales
+            {'debit': 0.0, 'credit': 18.0},
+            # Account Receivable
+            {'debit': 18.0, 'credit': 0.0},
+            # Default Account Stock Out
+            {'debit': 0.0, 'credit': 12.0},
+            # Expenses
+            {'debit': 12.0, 'credit': 0.0},
+        ]
+
+        self.assertRecordValues(aml1, expected)
+        self.assertRecordValues(aml2, expected)
 
     def test_fifo_return_and_credit_note(self):
         """

--- a/addons/stock_account/models/account_move_line.py
+++ b/addons/stock_account/models/account_move_line.py
@@ -64,6 +64,7 @@ class AccountMoveLine(models.Model):
             return self.price_unit
 
         cogs_qty = self._get_cogs_qty()
+        factor = self.product_uom_id.factor
         if moves := self._get_stock_moves().filtered(lambda m: m.state == 'done'):
             price_unit = moves._get_cogs_price_unit(cogs_qty)
         else:
@@ -71,7 +72,7 @@ class AccountMoveLine(models.Model):
                 price_unit = self.product_id.standard_price
             else:
                 price_unit = self.product_id._run_fifo(cogs_qty) / cogs_qty if cogs_qty else 0
-        return (price_unit * cogs_qty - self._get_posted_cogs_value()) / self.quantity
+        return (price_unit * cogs_qty * factor - self._get_posted_cogs_value()) / (self.quantity * factor)
 
     def _get_stock_moves(self):
         return self.env['stock.move']


### PR DESCRIPTION
**Issue**:
Partial delivery on sale orders using packaging could lead to wrong COGS value on invoices.

**Steps to reproduce**:
- Create a stored product with perpetual invoicing
- Set "pack of 6" in the product's sales packaging field.
- Create a quotation for 2 packs of 6, unit price 7.
- Validate a partial delivery of 6 units (1 pack), creating a backorder.
- Invoice the first delivery: journal COGS entry is 6*7=42 (correct).
- Invoice the backorder: journal entry is 168 (instead of 42), debit and credit are inverted (incorrect).

**Cause**:
While confirming the second invoice (`action_post`): https://github.com/odoo/odoo/blob/f47ee657b65423788967ae725836af29e93fe6e9/addons/sale/models/account_move.py#L83 the COGS line is generated by `_stock_account_prepare_realtime_out_lines_vals`:
https://github.com/odoo/odoo/blob/f47ee657b65423788967ae725836af29e93fe6e9/addons/stock_account/models/account_move.py#L37 Which needs to compute the unit_price:
https://github.com/odoo/odoo/blob/f47ee657b65423788967ae725836af29e93fe6e9/addons/stock_account/models/account_move.py#L122 https://github.com/odoo/odoo/blob/f47ee657b65423788967ae725836af29e93fe6e9/addons/stock_account/models/account_move_line.py#L74 The computation basically takes the total invoiced value minus the value invoiced previously (`self._get_posted_cogs_value()`) and divides it by the quantity.
The problem is that the total invoiced value does not include the product's UoM factor (here 6 for a pack of 6), whereas the value invoiced before already accounts for the factor: https://github.com/odoo/odoo/blob/f47ee657b65423788967ae725836af29e93fe6e9/addons/sale_stock/models/account_move.py#L173-L175 since it was computed here while confirming the first invoice: https://github.com/odoo/odoo/blob/f47ee657b65423788967ae725836af29e93fe6e9/addons/stock_account/models/account_move.py#L123 https://github.com/odoo/odoo/blob/f47ee657b65423788967ae725836af29e93fe6e9/addons/uom/models/uom_uom.py#L169 This mismatch leads to incorrect COGS for partial deliveries or backorders.

opw-5964399