### PR TITLE
[FIX] website: only set company email if contactus

### DIFF
--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -226,7 +226,8 @@ def add_form_signature(html_fragment, env_sudo):
         email_to_value = form_values['email_to'].attrib.get('value')
         if (not email_to_value
             or (email_to_value == 'info@yourcompany.example.com'
-                and html_fragment.xpath('//span[@data-for="contactus_form"]'))):
+                and html_fragment.xpath('//span[@data-for="contactus_form"]')
+                and html_fragment.xpath('//form[@id="contactus_form"]'))):
             # This means that the mail will be sent to the value of the dataFor
             # which is the company email.
             email_to_value = env_sudo.company.email or ''


### PR DESCRIPTION
Problem: There is a data-for span in the /contactus page that sets specific values on the page's form. If this form is deleted and a new form is added, an error will occur when trying to submit the new form. This is because the value set for website_form_signature will use the email set in the data-for, which will not match with the new form.

Purpose: Modify the code that sets the website_form_signature value to ensure that the original form is present as well if using the data-for values.

Steps to Reproduce in Runbot:

1. Use the Website Editor to delete the form on the /contactus page and create a new one.

2. Attempt to submit the new form.

opw-5956030