### PR TITLE
[FIX] hr_recruitment: fix recruitment sample data

### DIFF
--- a/addons/hr_recruitment/data/scenarios/hr_recruitment_scenario.xml
+++ b/addons/hr_recruitment/data/scenarios/hr_recruitment_scenario.xml
@@ -80,7 +80,7 @@
             <field name="priority">2</field>
             <field name="linkedin_profile">www.example.linkedin.com/in/helen.lee</field>
             <field name="job_id" ref="job_marketing" />
-            <field name="user_id" ref="base.user_admin" />
+            <field name="recruiter_id" search="[('user_id', '=', ref('base.user_admin'))]" />
             <field name="medium_id" ref="utm.utm_medium_direct" />
             <field name="department_id" ref="dep_marketing" />
             <field name="salary_expected">3100</field>
@@ -102,7 +102,7 @@
             <field name="priority">2</field>
             <field name="linkedin_profile">www.example.linkedin.com/in/enrique.jones</field>
             <field name="job_id" ref="job_marketing" />
-            <field name="user_id" ref="base.user_admin" />
+            <field name="recruiter_id" search="[('user_id', '=', ref('base.user_admin'))]" />
             <field name="medium_id" ref="utm.utm_medium_direct" />
             <field name="department_id" ref="dep_marketing" />
             <field name="salary_expected">2900</field>
@@ -124,7 +124,7 @@
             <field name="priority">3</field>
             <field name="linkedin_profile">www.example.linkedin.com/in/hannah.glover</field>
             <field name="job_id" ref="job_full_stack_dev" />
-            <field name="user_id" ref="base.user_admin" />
+            <field name="recruiter_id" search="[('user_id', '=', ref('base.user_admin'))]" />
             <field name="medium_id" ref="utm.utm_medium_direct" />
 
             <field name="department_id" ref="dep_rd" />
@@ -147,7 +147,7 @@
             <field name="priority">0</field>
             <field name="linkedin_profile">www.example.linkedin.com/in/simon.jones</field>
             <field name="job_id" ref="job_full_stack_dev" />
-            <field name="user_id" ref="base.user_admin" />
+            <field name="recruiter_id" search="[('user_id', '=', ref('base.user_admin'))]" />
             <field name="medium_id" ref="utm.utm_medium_direct" />
             <field name="department_id" ref="dep_rd" />
             <field name="salary_expected">3000</field>
@@ -173,7 +173,7 @@
             <field name="priority">0</field>
             <field name="linkedin_profile">www.example.linkedin.com/in/maria.rodriguez</field>
             <field name="job_id" ref="job_full_stack_dev" />
-            <field name="user_id" ref="base.user_admin" />
+            <field name="recruiter_id" search="[('user_id', '=', ref('base.user_admin'))]" />
             <field name="medium_id" ref="utm.utm_medium_direct" />
             <field name="department_id" ref="dep_rd" />
             <field name="stage_id" ref="stage_job0" />

--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -418,6 +418,17 @@ class HrJob(models.Model):
     @api.model
     def _action_load_recruitment_scenario(self):
 
+        admin_user = self.env.ref('base.user_admin')
+        employee_admin = self.env['hr.employee'].search([('user_id', '=', admin_user.id)], limit=1)
+
+        if not employee_admin:
+            self.env['hr.employee'].create({
+                'name': admin_user.name,
+                'user_id': admin_user.id,
+                'image_1920': admin_user.image_1920,
+                'structure_type_id': self.env.ref('hr.structure_type_employee').id,
+            })
+
         convert_file(
             self.sudo().env,
             "hr_recruitment",


### PR DESCRIPTION
Currently an error occurs when user tries to load scenario data for recruitment.

Steps to replicate:
- Install `hr_recruitment`.
- Open Recruitment and Click `Load sample Data`.

Error:
```py
ValueError: Invalid field 'user_id' in 'hr.applicant'

odoo.tools.convert.ParseError: while parsing /home/odoo/odoo19/community/addons/hr_recruitment/data/scenarios/hr_recruitment_scenario.xml:72, somewhere inside
<record id='scenario_applicant_macm_helen' model='hr.applicant'>
            <field name=email_from>helenlee@exampe.email.com</field>
            <field name=partner_name>Helen Lee</field>...
```

Cause:
- The field `user_id` was changed to `recruiter_id` from the [PR].
- But the scenario data still had the field `user_id`, this caused the error.

Solution:
- Replace user_id in the sample data with recruiter_id and use an employee as a value instead of a user. One additional detail is that since this is sample data that can potentially be applied on a db that already has some records. There is a case where creating an employee in the sample file and linking them to the admin user, but that can cause an exception if the admin user is already linked to an employee. To circumvent this, we first check if there is an employee linked to the admin user. If not we create a new one and make the sample data use whichever employee that is linked to the admin user.

Backport for the PR: https://github.com/odoo/odoo/pull/246362

[PR]: https://github.com/odoo/odoo/pull/229665

sentry-7324422905
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
