### PR TITLE
[FIX] web: lower specificity of default field width rule

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -456,7 +456,7 @@
     }
 
     
-    .o_form_sheet .o_field_widget:not(.o_input_box_overlay_start, .o_input_box_overlay_end, .o_field_widget .o_field_widget, .o_field_event_state_selection, .o_field_state_selection, .o_field_boolean_favorite, .o_field_priority, .o_field_contact_image, .oe_avatar), .o_input_box:not(.o_input_box .o_input_box) {
+    .o_form_sheet :where(.o_field_widget:not(.o_input_box_overlay_start, .o_input_box_overlay_end, .o_field_widget .o_field_widget, .o_field_event_state_selection, .o_field_state_selection, .o_field_boolean_favorite, .o_field_priority, .o_field_contact_image, .oe_avatar)), :where(.o_input_box:not(.o_input_box .o_input_box)) {
         width: 100%;
     }
 


### PR DESCRIPTION
**Issue:** 
odoo/odoo#250051 consolidated multiple `width: 100%` rules into a single broad selector:

    .o_form_view .o_form_sheet .o_field_widget:not(…) { width: 100% }

This broadened scope from `.o_group/.o_inner_group` to the entire `.o_form_sheet`, which was needed for the new `o_input_box` overlay system. However, the high specificity (0,4,0) now overrides any module-specific rule with lower specificity, such as setting.scss's `width: 50%` rule (0,3,0) for `<setting>` blocks.

This broke settings panels: field widgets stretched to 100% width instead of 50%, causing overflow in layouts like the helpdesk team email alias row.

**Fix:**  
wrap the field widget portion of the selector in `:where()`.

The `:where()` CSS pseudo-class works identically to `:is()` in terms of what it matches, but always contributes zero specificity.

(ref: https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity)
(ref: https://developer.mozilla.org/en-US/docs/Web/CSS/:where)

```
Before (A=0, B=4, C=0):
    .o_form_view .o_form_sheet .o_field_widget:not(…)
    ↑(0,1,0)    ↑(0,1,0)     ↑(0,1,0)      ↑(0,1,0)

After (A=0, B=2, C=0):
    .o_form_view .o_form_sheet :where(.o_field_widget:not(…))
    ↑(0,1,0)    ↑(0,1,0)     ↑(0,0,0) ← :where zeroes this
```

The rule still matches every field widget in the form sheet, but now any component-specific override (settings, helpdesk, custom views) wins naturally without needing specificity hacks.

CSS specificity tiebreaker order:
```
    A: inline styles > B: IDs > C: classes/attrs/pseudo-classes
    Equal specificity → last rule in source order wins
```

task-6005002

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
