### PR TITLE
[FIX] stock: restore table borders in picking operations report

### DIFF
--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -7,7 +7,7 @@
                 <div class="article o_report_layout_standard">
                     <t t-foreach="docs" t-as="o">
                         <t t-set="address" t-value="None"/>
-                        <div class="page o_report_stockpicking_operations">
+                        <div class="page">
                             <div class="row justify-content-between">
                                 <div class="col-4">
                                     <h3 t-field="o.picking_type_id.code"></h3>
@@ -104,7 +104,7 @@
                                 then we then loop over indvidual move lines and print a breakdown of them
                                 4. If a move contains only one move line, the move is summarized in the heading only
                             -->
-                            <table class="table table-sm o_main_table" t-if="o.move_line_ids and o.move_ids.move_line_ids.filtered(lambda ml: not ml.is_entire_pack)" style="table-layout: fixed; width: 100%">
+                            <table class="table o_main_table" t-if="o.move_line_ids and o.move_ids.move_line_ids.filtered(lambda ml: not ml.is_entire_pack)" style="table-layout: fixed; width: 100%">
                                 <t t-set="picking_has_barcode" t-value="any(move_line.product_id and move_line.product_id.barcode for move_line in o.move_line_ids)"/>
                                 <t t-set="picking_has_serial_number" t-value="any(move_line.lot_id or move_line.lot_name for move_line in o.move_line_ids)" groups="stock.group_production_lot"/>
                                 <t t-set="barcode_col_exists" t-value="picking_has_barcode or picking_has_serial_number"/>

--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -7,7 +7,7 @@
                 <div class="article o_report_layout_standard">
                     <t t-foreach="docs" t-as="o">
                         <t t-set="address" t-value="None"/>
-                        <div class="page o_report_stockpicking_operations">
+                        <div class="page">
                             <div class="row justify-content-between">
                                 <div class="col-4">
                                     <h3 t-field="o.picking_type_id.code"></h3>
@@ -104,7 +104,7 @@
                                 then we then loop over indvidual move lines and print a breakdown of them
                                 4. If a move contains only one move line, the move is summarized in the heading only
                             -->
-                            <table class="table table-sm o_main_table" t-if="o.move_line_ids and o.move_ids.move_line_ids.filtered(lambda ml: not ml.is_entire_pack)" style="table-layout: fixed; width: 100%">
+                            <table class="table" t-if="o.move_line_ids and o.move_ids.move_line_ids.filtered(lambda ml: not ml.is_entire_pack)" style="table-layout: fixed; width: 100%">
                                 <t t-set="picking_has_barcode" t-value="any(move_line.product_id and move_line.product_id.barcode for move_line in o.move_line_ids)"/>
                                 <t t-set="picking_has_serial_number" t-value="any(move_line.lot_id or move_line.lot_name for move_line in o.move_line_ids)" groups="stock.group_production_lot"/>
                                 <t t-set="barcode_col_exists" t-value="picking_has_barcode or picking_has_serial_number"/>

--- a/addons/stock/static/src/scss/report_stockpicking_operations.scss
+++ b/addons/stock/static/src/scss/report_stockpicking_operations.scss
@@ -1,9 +1,3 @@
-.o_report_stockpicking_operations table {
-    thead, tbody, td, th, tr {
-        border: 0;
-    }
-}
-
 /*
  * Before this PR, col-auto was the closest thing to flex box support.
  * However, an issue arised at the time of testing: when one of the


### PR DESCRIPTION
Issue before this commit:
=========================
The picking operations report displays the operations table without borders, 
making it difficult to read and distinguish between rows and columns.

Steps to Reproduce:
=========================
- Install the stock module
- Create a delivery order with products
- Print the picking operations report

Cause of the issue:
=========================
In this commit (https://github.com/odoo/odoo/commit/21cd7e6), the `o_report_stockpicking_operations` class was added 
to a div, which removed the table borders.

After This Commit:
=========================
This change restores the table borders in the operations report, improving readability.

Before: 
<img width="796" height="523" alt="2026-04-17_16-30" src="https://github.com/user-attachments/assets/084861e9-3c5b-4ca7-a237-32a56bf2267d" />

After:
<img width="795" height="596" alt="2026-04-17_16-30_1" src="https://github.com/user-attachments/assets/e43ed341-8e8b-47c9-9820-66a53823b26c" />

Task: 5462122
