### PR TITLE
[FIX] l10n_my_edi_pos: unlink prepayment on consolidated invoices

### DIFF
--- a/addons/l10n_my_edi_pos/models/account_edi_xml_ubl_my.py
+++ b/addons/l10n_my_edi_pos/models/account_edi_xml_ubl_my.py
@@ -406,7 +406,7 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
         self._add_document_monetary_total_nodes(document_node, vals)
         currency_suffix = vals['currency_suffix']
 
-        amount_paid = vals[f'total_paid_amount{currency_suffix}']
+        amount_paid = 0.0
         document_node['cac:PrepaidPayment'] = {
             'cbc:PaidAmount': {
                 '_text': self.format_float(amount_paid, vals['currency_dp']),

--- a/addons/l10n_my_edi_pos/tests/expected_xmls/consolidated_invoice.xml
+++ b/addons/l10n_my_edi_pos/tests/expected_xmls/consolidated_invoice.xml
@@ -153,7 +153,7 @@
         </cac:Party>
     </cac:AccountingCustomerParty>
     <cac:PrepaidPayment>
-        <cbc:PaidAmount currencyID="USD">1768.00</cbc:PaidAmount>
+        <cbc:PaidAmount currencyID="USD">0.00</cbc:PaidAmount>
     </cac:PrepaidPayment>
     <cac:TaxExchangeRate>
         <cbc:SourceCurrencyCode>USD</cbc:SourceCurrencyCode>
@@ -192,7 +192,7 @@
         <cbc:TaxExclusiveAmount currencyID="USD">1680.00</cbc:TaxExclusiveAmount>
         <cbc:TaxInclusiveAmount currencyID="USD">1768.00</cbc:TaxInclusiveAmount>
         <cbc:PrepaidAmount currencyID="USD">0.00</cbc:PrepaidAmount>
-        <cbc:PayableAmount currencyID="USD">0.00</cbc:PayableAmount>
+        <cbc:PayableAmount currencyID="USD">1768.00</cbc:PayableAmount>
     </cac:LegalMonetaryTotal>
     <cac:InvoiceLine>
         <cbc:ID>1</cbc:ID>

--- a/addons/l10n_my_edi_pos/tests/expected_xmls/consolidated_invoice_tax_included.xml
+++ b/addons/l10n_my_edi_pos/tests/expected_xmls/consolidated_invoice_tax_included.xml
@@ -150,7 +150,7 @@
         </cac:Party>
     </cac:AccountingCustomerParty>
     <cac:PrepaidPayment>
-        <cbc:PaidAmount currencyID="MYR">110.00</cbc:PaidAmount>
+        <cbc:PaidAmount currencyID="MYR">0.00</cbc:PaidAmount>
     </cac:PrepaidPayment>
     <cac:TaxTotal>
         <cbc:TaxAmount currencyID="MYR">10.00</cbc:TaxAmount>
@@ -172,7 +172,7 @@
         <cbc:TaxExclusiveAmount currencyID="MYR">100.00</cbc:TaxExclusiveAmount>
         <cbc:TaxInclusiveAmount currencyID="MYR">110.00</cbc:TaxInclusiveAmount>
         <cbc:PrepaidAmount currencyID="MYR">0.00</cbc:PrepaidAmount>
-        <cbc:PayableAmount currencyID="MYR">0.00</cbc:PayableAmount>
+        <cbc:PayableAmount currencyID="MYR">110.00</cbc:PayableAmount>
     </cac:LegalMonetaryTotal>
     <cac:InvoiceLine>
         <cbc:ID>1</cbc:ID>

--- a/addons/l10n_my_edi_pos/tests/expected_xmls/consolidated_invoice_tax_included_with_discount.xml
+++ b/addons/l10n_my_edi_pos/tests/expected_xmls/consolidated_invoice_tax_included_with_discount.xml
@@ -150,7 +150,7 @@
         </cac:Party>
     </cac:AccountingCustomerParty>
     <cac:PrepaidPayment>
-        <cbc:PaidAmount currencyID="MYR">88.00</cbc:PaidAmount>
+        <cbc:PaidAmount currencyID="MYR">0.00</cbc:PaidAmount>
     </cac:PrepaidPayment>
     <cac:TaxTotal>
         <cbc:TaxAmount currencyID="MYR">8.00</cbc:TaxAmount>
@@ -172,7 +172,7 @@
         <cbc:TaxExclusiveAmount currencyID="MYR">80.00</cbc:TaxExclusiveAmount>
         <cbc:TaxInclusiveAmount currencyID="MYR">88.00</cbc:TaxInclusiveAmount>
         <cbc:PrepaidAmount currencyID="MYR">0.00</cbc:PrepaidAmount>
-        <cbc:PayableAmount currencyID="MYR">0.00</cbc:PayableAmount>
+        <cbc:PayableAmount currencyID="MYR">88.00</cbc:PayableAmount>
     </cac:LegalMonetaryTotal>
     <cac:InvoiceLine>
         <cbc:ID>1</cbc:ID>

--- a/addons/l10n_my_edi_pos/tests/test_myinvois_pos.py
+++ b/addons/l10n_my_edi_pos/tests/test_myinvois_pos.py
@@ -204,6 +204,32 @@ class TestMyInvoisPoS(TestPoSCommon):
                 self.assertEqual(len(consolidated_invoice), 2)  # Two consolidated invoices of a single line due to the MAX_LINE_COUNT_PER_INVOICE
 
     @mute_logger('odoo.addons.point_of_sale.models.pos_order')
+    def test_consolidate_invoices_prepayment_unlink(self):
+        """Ensure that consolidated invoices have a PaidAmount of 0.00 and the correct PayableAmount."""
+        with freeze_time("2025-01-01"):
+            with self.with_pos_session():
+                first_order = self._create_order({'pos_order_lines_ui_args': [(self.product_one, 1.0)]})
+                second_order = self._create_order({'pos_order_lines_ui_args': [(self.product_two, 1.0)]})
+
+            wizard = self.env['myinvois.consolidate.invoice.wizard'].create({
+                'date_from': '2025-01-01',
+                'date_to': '2025-01-31',
+            })
+            wizard.button_consolidate_orders()
+
+            consolidated_invoice = (first_order | second_order).consolidated_invoice_ids
+            self.assertEqual(len(consolidated_invoice), 1)
+
+            consolidated_invoice.action_generate_xml_file()
+            xml_tree = etree.fromstring(consolidated_invoice.myinvois_file_id.raw)
+            tax_inclusive_node = xml_tree.xpath("cac:LegalMonetaryTotal/cbc:TaxInclusiveAmount", namespaces=NS_MAP)
+            self.assertTrue(tax_inclusive_node, "TaxInclusiveAmount node is missing from the XML.")
+            expected_total = tax_inclusive_node[0].text
+
+            self._assert_node_values(xml_tree, "cac:PrepaidPayment/cbc:PaidAmount", '0.00')
+            self._assert_node_values(xml_tree, "cac:LegalMonetaryTotal/cbc:PayableAmount", expected_total)
+
+    @mute_logger('odoo.addons.point_of_sale.models.pos_order')
     def test_send_consolidated_invoice(self):
         with freeze_time("2025-01-01"):
             # Create the orders


### PR DESCRIPTION
For POS consolidated invoices, the PrePayment Amount was mapped to the payment linked to the document. This incorrectly decreased the Total Amount Payable to 0, since POS orders are already paid at the counter.

MyInvois tax officer and helpdesk requires that the Total Amount Payable (cbc:PayableAmount) to reflect the total amount of the issued e-document , regardless of prior payments.

This commit forces the PaidAmount to 0 for consolidated documents, ensuring the PayableAmount correctly matches the TaxInclusiveAmount as expected by the MyInvois API.

task-[6021698](https://www.odoo.com/odoo/all-tasks/6021698)