### PR TITLE
[FIX] html_editor: make files uploaded as link URLs publicly accessible

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -175,6 +175,7 @@ export class Builder extends Component {
                 getAnimateTextConfig: () => ({ editor: this.editor, editorBus: this.editorBus }),
                 cleanEmptyStructuralContainers: false,
                 isEditableRTL: false,
+                publicAttachments: true,
             },
             this.env.services
         );

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -1271,7 +1271,10 @@ export class LinkPlugin extends Plugin {
                     }
                 ),
                 isAvailable: link_popover.isAvailable,
-                getProps: link_popover.getProps,
+                getProps: (...args) => ({
+                    ...link_popover.getProps(...args),
+                    publicAttachments: this.config.publicAttachments,
+                }),
             });
         });
     }

--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -47,6 +47,7 @@ export class LinkPopover extends Component {
         allowCustomStyle: { type: Boolean, optional: true },
         allowTargetBlank: { type: Boolean, optional: true },
         allowStripDomain: { type: Boolean, optional: true },
+        publicAttachments: { type: Boolean, optional: true },
         formatColor: { type: Function, optional: true },
     };
     static defaultProps = {
@@ -619,8 +620,8 @@ export class LinkPopover extends Component {
 
     async uploadFile() {
         const { upload, getURL } = this.uploadService;
-        const { resModel, resId } = this.props.recordInfo;
-        const [attachment] = await upload({ resModel, resId, accessToken: true });
+        const uploadParams = this.props.publicAttachments ? {} : { ...this.props.recordInfo };
+        const [attachment] = await upload({ ...uploadParams }, { accessToken: true });
         if (!attachment) {
             // No file selected or upload failed
             return;

--- a/addons/html_editor/static/src/main/media/file_plugin.js
+++ b/addons/html_editor/static/src/main/media/file_plugin.js
@@ -153,7 +153,8 @@ export class FilePlugin extends Plugin {
 
     async uploadAndInsertFiles() {
         // Upload
-        const attachments = await this.services.uploadLocalFiles.upload(this.recordInfo, {
+        const uploadParams = this.config.publicAttachments ? {} : { ...this.recordInfo };
+        const attachments = await this.services.uploadLocalFiles.upload(uploadParams, {
             multiple: true,
             accessToken: true,
         });


### PR DESCRIPTION
Problem:
On Website Events, when uploading a file as a URL in a link on a public page, portal users cannot download the file.

Cause:
The upload process attaches the current `res_model` to the file. As a result, access to the file depends on model permissions. Even if users can view the page, they may not have the rights required to download the attachment.

Solution:
Files uploaded through link URLs should be public by default, without `access_token`, `res_model`, or `res_id`, similar to the behavior in `web_editor`.

Steps to reproduce:
- Go to Website > Events.
- Upload a file as a URL in a link.
- Save the page.
- Open the page in a new unauthenticated session.
- The page and link are visible, but the file cannot be downloaded.

opw-5993708

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
