### PR TITLE
[FIX] web_tour: restore onboarding tour launch from list view

### DIFF
--- a/addons/web_tour/__manifest__.py
+++ b/addons/web_tour/__manifest__.py
@@ -40,6 +40,7 @@ Odoo Web tours.
             ('include', 'web_tour.recorder'),
             ('include', 'web_tour.automatic'),
             ('include', 'web_tour.interactive'),
+            'web_tour/static/tests/tour_models.js',
             'web_tour/static/tests/*.test.js',
         ],
         "web.assets_tests": [

--- a/addons/web_tour/static/src/js/tour_service.js
+++ b/addons/web_tour/static/src/js/tour_service.js
@@ -81,7 +81,7 @@ export class TourService {
 
         const paramsTourName = new URLSearchParams(browser.location.search).get("tour");
         if (paramsTourName) {
-            this.startTour(paramsTourName, { mode: "manual", fromDB: true });
+            this.startTour(paramsTourName, { mode: "manual" });
         }
 
         if (tourState.getCurrentTour()) {
@@ -159,35 +159,38 @@ export class TourService {
      * @param {string} name The name of the tour
      */
     async getTour(name, options) {
-        if (options.mode !== "manual") {
-            await this.waitUntilTourRegistered(name);
-        }
-        let tour = tourRegistry.get(name, null);
-        if (options.mode === "manual" && options.fromDB) {
-            tour = await this.orm.call("web_tour.tour", "get_tour_json_by_name", [name]);
+        // Onboarding tour (come from database (.xml files))
+        if (options.mode === "manual") {
+            const tour = await this.orm.call("web_tour.tour", "get_tour_json_by_name", [name]);
             if (!tour) {
                 throw new Error(`Tour '${name}' is not found in the database.`);
             }
-
             if (!tour.steps.length && tourRegistry.contains(tour.name)) {
                 tour.steps = tourRegistry.get(tour.name).steps;
             }
+            return {
+                ...tour,
+                steps:
+                    typeof tour.steps === "function"
+                        ? tour.steps()
+                        : Array.isArray(tour.steps)
+                        ? tour.steps
+                        : [],
+            };
         }
-        if (!tour) {
-            return undefined;
+        // Automatic tour (come from registry)
+        else {
+            await this.waitUntilTourRegistered(name);
+            const tour = tourRegistry.get(name, null);
+            if (!tour) {
+                throw new Error(`Tour '${name}' is not found in registry 'web_tour.tours'.`);
+            }
+            return {
+                ...tour,
+                name,
+                steps: tour.steps(),
+            };
         }
-        const url = options.fromDB ? options.url : tour.url;
-        return {
-            ...tour,
-            name,
-            url,
-            steps:
-                typeof tour.steps === "function"
-                    ? tour.steps()
-                    : Array.isArray(tour.steps)
-                    ? tour.steps
-                    : [],
-        };
     }
 
     /**
@@ -222,9 +225,6 @@ export class TourService {
         const tourName = tourState.getCurrentTour();
         const tourConfig = tourState.getCurrentConfig();
         const tour = await this.getTour(tourName, tourConfig);
-        if (!tour) {
-            return;
-        }
 
         tour.steps.forEach((step) => this.validateStep(step));
 
@@ -245,7 +245,6 @@ export class TourService {
                 TourPointer,
                 {
                     pointerState,
-                    bounce: !(tourConfig.mode === "auto" && tourConfig.keepWatchBrowser),
                 },
                 {
                     sequence: 1100, // sequence based on bootstrap z-index values.
@@ -281,16 +280,11 @@ export class TourService {
 
     /**
      * Starts manual or automatic tour.
-     * This retrieves a tour from the internal registry or from the database
-     * if `options.fromDB` is set.
-     *
      * @param {string} name - The name of the tour to start.
      * @param {Object} [options={}] - Options to customize the tour start.
-     * @param {boolean} [options.fromDB=false] - Whether the tour should be loaded from the database.
      * @param {string} [options.url] - URL to start the tour.
      * @param {"auto"|"manual"} [options.mode="auto"] - Tour start mode ("auto" or "manual").
      * @param {number} [options.stepDelay=0] - Delay between each tour step.
-     * @param {boolean} [options.keepWatchBrowser=false] - Whether to keep watching the browser continuously.
      * @param {number} [options.showPointerDuration=0] - Duration to show the pointer on each step.
      * @param {boolean} [options.debug=false] - Enables debug mode for the tour.
      * @param {boolean} [options.redirect=true] - Whether to redirect to `tour.url` if necessary.
@@ -299,9 +293,7 @@ export class TourService {
         this.removePointer();
         this.removeTourRecorder();
         const tour = await this.getTour(name, options);
-        if (!tour) {
-            return;
-        }
+
         if (!session.is_public && !this.toursEnabled && options.mode === "manual") {
             this.toursEnabled = await this.orm.call("res.users", "switch_tour_enabled", [
                 !this.toursEnabled,
@@ -310,7 +302,6 @@ export class TourService {
 
         const tourConfig = {
             stepDelay: 0,
-            keepWatchBrowser: false,
             mode: "auto",
             showPointerDuration: 0,
             debug: false,
@@ -323,7 +314,7 @@ export class TourService {
         tourState.setCurrentTour(name);
         tourState.setCurrentIndex(0);
 
-        if (tour.url && tourConfig.startUrl != tour.url && tourConfig.redirect) {
+        if (tourConfig.mode === "manual" && tour.url && tourConfig.redirect) {
             redirect(tour.url);
         } else {
             await this.resumeTour();

--- a/addons/web_tour/static/tests/tour_interactive.test.js
+++ b/addons/web_tour/static/tests/tour_interactive.test.js
@@ -20,6 +20,7 @@ import { registry } from "@web/core/registry";
 import { session } from "@web/session";
 import { WebClient } from "@web/webclient/webclient";
 import { TourInteractive } from "@web_tour/js/tour_interactive/tour_interactive";
+import { Tour, TourStep } from "./tour_models";
 
 describe.current.tags("desktop");
 
@@ -43,7 +44,7 @@ class Product extends models.Model {
     _records = [{ name: "A" }, { name: "B" }];
 }
 
-defineModels([Partner, Product]);
+defineModels([Partner, Product, Tour, TourStep]);
 
 class Counter extends Component {
     static props = ["*"];
@@ -85,13 +86,6 @@ beforeEach(() => {
         return (nextTour && { name: nextTour.at(0) }) || false;
     });
     onRpc("res.users", "switch_tour_enabled", () => true);
-    onRpc("web_tour.tour", "get_tour_json_by_name", () => ({
-        name: "tour1",
-        steps: [
-            { trigger: "button.foo", run: "click" },
-            { trigger: "button.bar", run: "click" },
-        ],
-    }));
 });
 
 after(() => {
@@ -99,6 +93,7 @@ after(() => {
 });
 
 test("registering test tour after service is started doesn't auto-start the tour", async () => {
+    Tour._records = [{ name: "tour1" }];
     patchWithCleanup(session, { tour_enabled: true });
     class Root extends Component {
         static components = { Counter };
@@ -126,6 +121,7 @@ test("registering test tour after service is started doesn't auto-start the tour
 });
 
 test("perform edit on next step", async () => {
+    Tour._records = [{ name: "giro_d_italia" }];
     registry.category("web_tour.tours").add("giro_d_italia", {
         steps: () => [
             {
@@ -162,6 +158,7 @@ test("perform edit on next step", async () => {
 });
 
 test("manual tour with inactive steps", async () => {
+    Tour._records = [{ name: "tour_de_wallonie" }];
     registry.category("web_tour.tours").add("tour_de_wallonie", {
         steps: () => [
             {
@@ -229,26 +226,34 @@ test("manual tour with alternative trigger", async () => {
             !s.includes("═") ? expect.step(s) : "";
         },
     });
-    registry.category("web_tour.tours").add("tour_des_flandres_2", {
-        steps: () => [
-            {
-                trigger: ".button1, .button2",
-                run: "click",
-            },
-            {
-                trigger: "body:not(:visible), .button4, .button3",
-                run: "click",
-            },
-            {
-                trigger: ".interval1, .interval2, .button5",
-                run: "click",
-            },
-            {
-                trigger: "button:contains(0, hello):enabled, button:contains(2, youpi)",
-                run: "click",
-            },
-        ],
-    });
+    TourStep._records = [
+        {
+            tour_id: 1,
+            trigger: ".button1, .button2",
+            run: "click",
+        },
+        {
+            tour_id: 1,
+            trigger: "body:not(:visible), .button4, .button3",
+            run: "click",
+        },
+        {
+            tour_id: 1,
+            trigger: ".interval1, .interval2, .button5",
+            run: "click",
+        },
+        {
+            tour_id: 1,
+            trigger: "button:contains(0, hello):enabled, button:contains(2, youpi)",
+            run: "click",
+        },
+    ];
+    Tour._records = [
+        {
+            id: 1,
+            name: "tour_des_flandres_2",
+        },
+    ];
     class Root extends Component {
         static components = {};
         static template = xml/*html*/ `
@@ -275,6 +280,7 @@ test("manual tour with alternative trigger", async () => {
 });
 
 test("Tour backward when the pointed element disappear", async () => {
+    Tour._records = [{ name: "tour1" }];
     registry.category("web_tour.tours").add("tour1", {
         steps: () => [
             { trigger: "button.foo", run: "click" },
@@ -317,6 +323,17 @@ test("Tour backward when the pointed element disappear", async () => {
 });
 
 test("Tour backward when the pointed element disappear and ignore warn step", async () => {
+    Tour._records = [
+        {
+            id: 1,
+            name: "tour1",
+        },
+    ];
+    TourStep._records = [
+        { trigger: "button.foo", run: "click", tour_id: 1 },
+        { trigger: "button.foo", tour_id: 1 },
+        { trigger: "button.bar", run: "click", tour_id: 1 },
+    ];
     patchWithCleanup(console, {
         warn: (msg) => expect.step(msg),
     });
@@ -365,6 +382,17 @@ test("Tour backward when the pointed element disappear and ignore warn step", as
 });
 
 test("Tour started by the URL", async () => {
+    Tour._records = [
+        {
+            id: 1,
+            name: "tour1",
+        },
+    ];
+    TourStep._records = [
+        { trigger: "button.foo", run: "click", tour_id: 1 },
+        { trigger: "button.foo", tour_id: 1 },
+        { trigger: "button.bar", run: "click", tour_id: 1 },
+    ];
     browser.location.href = `${browser.location.origin}?tour=tour1`;
 
     class Dummy extends Component {
@@ -392,10 +420,10 @@ test("Tour started by the URL", async () => {
 });
 
 test("Log a warning if step ignored", async () => {
+    Tour._records = [{ name: "tour1" }];
     patchWithCleanup(console, {
         warn: (msg) => expect.step(msg),
     });
-
     registry.category("web_tour.tours").add("tour1", {
         steps: () => [
             { trigger: "button.foo", run: "click" },
@@ -432,6 +460,7 @@ test("Log a warning if step ignored", async () => {
 });
 
 test("check alternative trigger that appear after the initial trigger", async () => {
+    Tour._records = [{ name: "rainbow_tour" }];
     registry.category("web_tour.tours").add("rainbow_tour", {
         steps: () => [
             {
@@ -464,6 +493,7 @@ test("check alternative trigger that appear after the initial trigger", async ()
 });
 
 test("validating edit step on autocomplete by selecting autocomplete item", async () => {
+    Tour._records = [{ name: "rainbow_tour" }];
     registry.category("web_tour.tours").add("rainbow_tour", {
         steps: () => [
             {
@@ -498,6 +528,7 @@ test("validating edit step on autocomplete by selecting autocomplete item", asyn
 });
 
 test("validating edit step on autocomplete by selecting autocomplete item (validate automatically autocomplete item step)", async () => {
+    Tour._records = [{ name: "rainbow_tour" }];
     registry.category("web_tour.tours").add("rainbow_tour", {
         steps: () => [
             {
@@ -536,6 +567,7 @@ test("validating edit step on autocomplete by selecting autocomplete item (valid
 });
 
 test("validating click on autocomplete item by pressing Enter", async () => {
+    Tour._records = [{ name: "rainbow_tour" }];
     registry.category("web_tour.tours").add("rainbow_tour", {
         steps: () => [
             {
@@ -575,6 +607,7 @@ test("validating click on autocomplete item by pressing Enter", async () => {
 });
 
 test("Tour don't backward when dropdown loading", async () => {
+    Tour._records = [{ name: "rainbow_tour" }];
     Product._records = [{ name: "Harry test 1" }, { name: "Harry test 2" }];
     registry.category("web_tour.tours").add("rainbow_tour", {
         steps: () => [
@@ -636,6 +669,7 @@ test("Tour don't backward when dropdown loading", async () => {
 });
 
 test("Don't backward when action manager is busy", async () => {
+    Tour._records = [{ name: "tour1" }];
     registry.category("web_tour.tours").add("tour1", {
         steps: () => [
             { trigger: "button.foo", run: "click" },
@@ -692,6 +726,7 @@ test("Don't backward when action manager is busy", async () => {
 });
 
 test("check rainbowManMessage", async () => {
+    Tour._records = [{ name: "rainbow_tour" }];
     registry.category("web_tour.tours").add("rainbow_tour", {
         steps: () => [
             {
@@ -736,6 +771,7 @@ test("check rainbowManMessage", async () => {
 });
 
 test("pointer hidden when trigger is behind overlay", async () => {
+    Tour._records = [{ name: "tour1" }];
     registry.category("web_tour.tours").add("tour1", {
         steps: () => [{ trigger: "button.foo", run: "click" }],
     });

--- a/addons/web_tour/static/tests/tour_models.js
+++ b/addons/web_tour/static/tests/tour_models.js
@@ -1,0 +1,29 @@
+import { models, fields } from "@web/../tests/web_test_helpers";
+
+export class TourStep extends models.Model {
+    _name = "web_tour.tour.step";
+    trigger = fields.Char();
+    content = fields.Char();
+    run = fields.Char();
+    tour_id = fields.Many2one({ relation: "web_tour.tour" });
+}
+
+export class Tour extends models.Model {
+    _name = "web_tour.tour";
+    name = fields.Char();
+    step_ids = fields.One2many({ relation: "web_tour.tour.step", relation_field: "tour_id" });
+    url = fields.Char({ string: "Starting URL" });
+    get_tour_json_by_name(name) {
+        const tourModel = this.env["web_tour.tour"];
+        const stepModel = this.env["web_tour.tour.step"];
+        const tourIds = tourModel.search([["name", "=", name]]);
+        if (!tourIds.length) {
+            return false;
+        }
+        const tourData = tourModel.read(tourIds, ["name", "url"])[0];
+        const stepIds = stepModel.search([["tour_id", "=", tourData.id]]);
+        const steps = stepModel.read(stepIds, ["trigger", "content", "run"]);
+        tourData.steps = steps;
+        return tourData;
+    }
+}

--- a/addons/web_tour/static/tests/tour_pointer.test.js
+++ b/addons/web_tour/static/tests/tour_pointer.test.js
@@ -11,6 +11,7 @@ import {
 import { Component, useState, xml } from "@odoo/owl";
 import {
     contains,
+    defineModels,
     getService,
     mountWithCleanup,
     onRpc,
@@ -19,6 +20,7 @@ import {
 import { Dialog } from "@web/core/dialog/dialog";
 import { registry } from "@web/core/registry";
 import { TourInteractive } from "@web_tour/js/tour_interactive/tour_interactive";
+import { Tour, TourStep } from "./tour_models";
 
 describe.current.tags("desktop");
 
@@ -68,9 +70,11 @@ after(() => {
     TourInteractive.observer.disconnect();
 });
 
+defineModels([Tour, TourStep]);
+
 test("scrolling to next step should update the pointer's height", async (assert) => {
     disableAnimations();
-
+    Tour._records = [{ name: "tour_de_france" }];
     const content = "Click this pretty button to increment this magnificent counter !";
     registry.category("web_tour.tours").add("tour_de_france", {
         steps: () => [
@@ -144,6 +148,7 @@ test("scrolling to next step should update the pointer's height", async (assert)
 });
 
 test("should show only 1 pointer at a time", async () => {
+    Tour._records = [{ name: "milan_sanremo" }, { name: "paris_roubaix" }];
     registry.category("web_tour.tours").add("milan_sanremo", {
         steps: () => [
             {
@@ -184,6 +189,7 @@ test("should show only 1 pointer at a time", async () => {
 });
 
 test("hovering to the anchor element should show the content and not when content empty", async () => {
+    Tour._records = [{ name: "la_vuelta" }];
     registry.category("web_tour.tours").add("la_vuelta", {
         steps: () => [
             {
@@ -232,12 +238,19 @@ test("hovering to the anchor element should show the content and not when conten
 });
 
 test("pointer is added on top of overlay's stack", async () => {
-    registry.category("web_tour.tours").add("tour1", {
-        steps: () => [
-            { trigger: ".modal .a", run: "click" },
-            { trigger: ".modal .btn-close", run: "click" },
-        ],
-    });
+    TourStep._records = [
+        {
+            tour_id: 1,
+            trigger: ".modal .a",
+            run: "click",
+        },
+        {
+            tour_id: 1,
+            trigger: ".modal .btn-close",
+            run: "click",
+        },
+    ];
+    Tour._records = [{ name: "tour1" }];
     class DummyDialog extends Component {
         static props = ["*"];
         static components = { Dialog };
@@ -275,6 +288,7 @@ test("pointer is added on top of overlay's stack", async () => {
 });
 
 test("next step with new anchor at same position", async () => {
+    Tour._records = [{ name: "tour1" }];
     tourRegistry.add("tour1", {
         steps: () => [
             { trigger: "button.foo", run: "click" },
@@ -332,6 +346,7 @@ test("next step with new anchor at same position", async () => {
 });
 
 test("points to next step", async () => {
+    Tour._records = [{ name: "tour1" }];
     tourRegistry.add("tour1", {
         steps: () => [
             {
@@ -359,6 +374,7 @@ test("points to next step", async () => {
 });
 
 test("scroller pointer to reach next step", async () => {
+    Tour._records = [{ name: "tour_des_flandres" }];
     disableAnimations();
 
     registry.category("web_tour.tours").add("tour_des_flandres", {
@@ -411,6 +427,7 @@ test("scroller pointer to reach next step", async () => {
 });
 
 test("scroller pointer to reach next step (X axis)", async () => {
+    Tour._records = [{ name: "tour_des_flandres" }];
     disableAnimations();
     patchWithCleanup(Element.prototype, {
         scrollIntoView(options) {
@@ -467,6 +484,7 @@ test("scroller pointer to reach next step (X axis)", async () => {
 });
 
 test("check tooltip position", async () => {
+    Tour._records = [{ name: "tour_des_tooltip" }];
     registry.category("web_tour.tours").add("tour_des_tooltip", {
         steps: () => [
             {
@@ -564,6 +582,7 @@ test("check tooltip position", async () => {
 });
 
 test("check drop zone", async () => {
+    Tour._records = [{ name: "tour_des_drag_and_drop" }];
     registry.category("web_tour.tours").add("tour_des_drag_and_drop", {
         steps: () => [
             {

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -2637,9 +2637,7 @@ class HttpCase(TransactionCase):
         `browser_js` can be passed as keyword arguments."""
         options = {
             'stepDelay': step_delay or 0,
-            'keepWatchBrowser': kwargs.get('watch', False),
             'debug': kwargs.get('debug', False),
-            'startUrl': url_path,
         }
         code = kwargs.pop('code', f"odoo.startTour({tour_name!r}, {json.dumps(options)})")
         ready = kwargs.pop('ready', f"odoo.isTourReady({tour_name!r})")


### PR DESCRIPTION
Fix an issue where onboarding tours could no longer be launched from the tour list view. The launch mechanism was retrieving the URL from the tour registry, although onboarding tours no longer define their URL there.

The fix retrieves onboarding tours from the database instead, while still falling back to the registry for steps that are not defined in the database.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
