### PR TITLE
[IMP] mrp: add tooltips to work center kanban view

### DIFF
--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -397,17 +397,21 @@
                             <field name="name" class="ps-4"/>
                         </div>
                         <div class="o_kanban_workorder_date">
-                            <field name="date_start" invisible="not date_start" class="pe-2"/> - <field name="date_finished" invisible="not date_start" class="ps-2"/>
+                            <span data-tooltip="Scheduled Date">
+                                <field name="date_start" invisible="not date_start" class="pe-2"/> - <field name="date_finished" invisible="not date_start" class="ps-2"/>
+                            </span>
                         </div>
                         <footer>
-                            <div class="o_kanban_workorder_remaining">
+                            <div class="o_kanban_workorder_remaining" data-tooltip="Remaining Time">
                                 <field name="remaining_time" class="mx-1" widget="float_time" options="{'unit': 'minutes', 'show_seconds': True}"/>
                             </div>
                             <div class="d-flex ms-auto">
                                 <field name="last_working_user_id" widget="many2one_avatar_user"/>
-                                <field name="state" widget="mo_view_list_dropdown"
-                                    options="{'no_open': True, 'display': 'bubble'}"
-                                    invisible="production_state == 'draft'"/>
+                                <div data-tooltip="Status">
+                                    <field name="state" widget="mo_view_list_dropdown"
+                                        options="{'no_open': True, 'display': 'bubble'}"
+                                        invisible="production_state == 'draft'"/>
+                                </div>
                             </div>
                         </footer>
                     </t>


### PR DESCRIPTION
To improve clarity and data interpretation in the work center kanban:
- Added "Scheduled Date" tooltip for start and finish date fields.
- Added "Status" tooltip for the state field.
- Added "Remaining Time" tooltip for the remaining_time field.

task-6026150

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
