### PR TITLE
[FIX] l10n_it_edi: update PA status after SDI validation

### DIFF
--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -108,6 +108,9 @@ class AccountMove(models.Model):
         help="Public Investment Unique Identifier")
     # Technical field for showing the above fields or not
     l10n_it_partner_pa = fields.Boolean(compute='_compute_l10n_it_partner_pa')
+    l10n_it_partner_is_public_administration = fields.Boolean(compute='_compute_l10n_it_partner_is_public_administration',
+        help='Only partners that have a 6-chars long l10n_it_pa_index actually belong to the Public Administration'
+    )
 
     # -------------------------------------------------------------------------
     # Computes
@@ -118,6 +121,12 @@ class AccountMove(models.Model):
         for move in self:
             partner = move.commercial_partner_id
             move.l10n_it_partner_pa = partner and (partner._l10n_it_edi_is_public_administration() or len(partner.l10n_it_pa_index or '') == 7)
+
+    @api.depends('commercial_partner_id.l10n_it_pa_index', 'company_id')
+    def _compute_l10n_it_partner_is_public_administration(self):
+        for move in self:
+            partner = move.commercial_partner_id
+            move.l10n_it_partner_is_public_administration = partner and partner._l10n_it_edi_is_public_administration()
 
     @api.depends('move_type', 'line_ids.tax_tag_ids')
     def _compute_l10n_it_edi_is_self_invoice(self):
@@ -243,7 +252,13 @@ class AccountMove(models.Model):
 
     def action_check_l10n_it_edi(self):
         self.ensure_one()
-        if not self.l10n_it_edi_transaction and self.l10n_it_edi_state not in WAITING_STATES:
+        if (
+            not self.l10n_it_edi_transaction
+            and self.l10n_it_edi_state not in WAITING_STATES
+        ) or (
+            self.l10n_it_edi_state == 'forwarded'
+            and not self.l10n_it_partner_is_public_administration
+        ):
             raise UserError(_("This move is not waiting for updates from the SdI."))
         if self.l10n_it_edi_state == 'being_sent':
             return {'type': 'ir.actions.client', 'tag': 'reload'}
@@ -896,7 +911,15 @@ class AccountMove(models.Model):
                 moves_to_check = self.search([
                     ('company_id', '=', proxy_user.company_id.id),
                     ('l10n_it_edi_transaction', '!=', False),
-                    ('l10n_it_edi_state', 'in', WAITING_STATES)
+                    *expression.OR(
+                        [[('l10n_it_edi_state', 'in', WAITING_STATES)],
+                        expression.AND(
+                            [
+                                [('l10n_it_edi_state', '=', 'forwarded')],
+                                [('commercial_partner_id.l10n_it_pa_index', '=ilike', '_' * 6)],
+                            ]
+                        )]
+                    )
                 ])
                 if moves_to_check:
                     moves_to_check._l10n_it_edi_update_send_state()

--- a/addons/l10n_it_edi/tests/test_account_move_send.py
+++ b/addons/l10n_it_edi/tests/test_account_move_send.py
@@ -188,6 +188,47 @@ class TestItAccountMoveSend(TestItEdi, TestAccountMoveSendCommon):
             self.assertEqual(invoice.l10n_it_edi_state, "processing")
             self.assertEqual(invoice.l10n_it_edi_transaction, success['id_transaction'])
 
+    def test_pa_state_keeps_updating_after_sdi_validation(self):
+        """
+        Ensure that the PA state is fetched from the server even when the SDI validation is passed
+        """
+        invoice = self.init_invoice(self.italian_partner_b)
+        self.assertTrue(invoice.l10n_it_partner_is_public_administration)
+        invoice.l10n_it_origin_document_type = 'purchase_order'
+        self.generate_l10n_it_edi_send_attachments(invoice)
+        success = {
+            'id_transaction': "SDI ID 1",
+            'signed': False,
+            'signed_data': False,
+        }
+        l10n_it_move = 'odoo.addons.l10n_it_edi.models.account_move.AccountMove'
+        with patch(f'{l10n_it_move}._l10n_it_edi_upload_single', return_value=success) as mock_check:
+            attachments_vals = {invoice: {'name': invoice.l10n_it_edi_attachment_id.name, 'raw': invoice.l10n_it_edi_attachment_file}}
+            results = invoice._l10n_it_edi_send(attachments_vals)
+
+            self.assertEqual(mock_check.call_count, 1)
+            self.assertEqual(results, {invoice.l10n_it_edi_attachment_id.name: success})
+            self.assertEqual(invoice.l10n_it_edi_state, "processing")
+            self.assertEqual(invoice.l10n_it_edi_transaction, success['id_transaction'])
+
+            invoice.l10n_it_edi_state = 'forwarded'
+            self.assertRecordValues(invoice, [
+                {
+                    'l10n_it_edi_state': 'forwarded',
+                    'l10n_it_partner_is_public_administration': True,
+                },
+            ])
+
+            with (
+                patch(f'{l10n_it_move}._l10n_it_edi_update_send_state', autospec=True) as update_send_state,
+                patch(f'{l10n_it_move}._l10n_it_edi_download_invoices')
+            ):
+                invoice.action_check_l10n_it_edi()
+                update_send_state.assert_called_once()
+
+                invoice.cron_l10n_it_edi_download_and_update()
+                self.assertEqual(update_send_state.call_count, 2)
+
     def test_l10n_it_edi_send_proxy_error(self):
         invoice = self.init_invoice(self.italian_partner_a)
         self.generate_l10n_it_edi_send_attachments(invoice)

--- a/addons/l10n_it_edi/views/l10n_it_view.xml
+++ b/addons/l10n_it_edi/views/l10n_it_view.xml
@@ -134,7 +134,8 @@
                         string="Check Sending"
                         class="oe_highlight"
                         data-hotkey="shift+K"
-                        invisible="l10n_it_edi_state not in ('being_sent', 'processing', 'forward_attempt')"
+                        invisible="l10n_it_edi_state not in ('being_sent', 'processing', 'forward_attempt', 'forwarded')
+                                   or (l10n_it_edi_state == 'forwarded' and not l10n_it_partner_is_public_administration)"
                     />
                 </xpath>
                 <xpath expr="//page[@name='other_info']" position="after">


### PR DESCRIPTION
### Issue:
After the SDI validation, the state was never updated to match the PA state, resulting in a mismatch with the actual status

### Cause:
When `l10n_it_edi_state` is set to `forwarded`, the cron `cron_l10n_it_edi_download_and_update` doesn't consider that a new state could occur
However, invoices sent to Public Administration can still be rejected after being forwarded

It is not possible to reproduce the issue with the demo system, as it only sets the state to `forwarded`

Ticket [link](https://www.odoo.com/odoo/project.task/5391891)
opw-5391891