### PR TITLE
[FIX] l10n_hu: Fix 0% EU G fiscal position

### DIFF
--- a/addons/l10n_hu/data/template/account.tax-hu.csv
+++ b/addons/l10n_hu/data/template/account.tax-hu.csv
@@ -31,7 +31,7 @@
 "","","","","","","","","","100","tax","invoice","","","","","","",""
 "","","","","","","","","","100","base","refund","base_pay_intra","","","","","",""
 "","","","","","","","","","100","tax","refund","","","","","","",""
-"FEUT","81","0% EU G","0% Goods Intra-community Deliveries","0%","0.0","percent","sale","tax_group_afa_0","100","base","invoice","base_pay_intra","","0% EU termékértékesítés, adómentes","0%","fiscal_position_hu_eu_out,fiscal_position_hu_eu","F5,F27,F18","Exempt intra-community supplies - Article 138 of the Directive 2006/112/EC"
+"FEUT","81","0% EU G","0% Goods Intra-community Deliveries","0%","0.0","percent","sale","tax_group_afa_0","100","base","invoice","base_pay_intra","","0% EU termékértékesítés, adómentes","0%","fiscal_position_hu_eu","F5,F27,F18","Exempt intra-community supplies - Article 138 of the Directive 2006/112/EC"
 "","","","","","","","","","100","tax","invoice","","","","","","",""
 "","","","","","","","","","100","base","refund","base_pay_intra","","","","","",""
 "","","","","","","","","","100","tax","refund","","","","","","",""


### PR DESCRIPTION
In Hungary, the 0% Goods Intra-community tax is mapped with the
EU partner & Partner outside the EU, which doesn't make sense.
Intra-community taxes should only be mapped with the EU partner
fiscal position.

This commit removes the outside EU position from this task.

no-task
