### PR TITLE
[FIX] pos_sale: fix lot quantities when settling SO with Pick then Deliver

### DIFF
--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -125,11 +125,22 @@ class SaleOrderLine(models.Model):
                 sale_line_uom = sale_line.product_uom
                 item = sale_line.read(field_names, load=False)[0]
                 if sale_line.product_id.tracking != 'none':
-                    move_lines = sale_line.move_ids.move_line_ids.filtered(lambda ml: ml.product_id.id == sale_line.product_id.id)
+                    candidates = self.env['stock.move.line'].search([
+                        ('picking_id', 'in', sale_line.order_id.picking_ids.ids),
+                        ('product_id', '=', sale_line.product_id.id),
+                        ('move_id.sale_line_id', '=', sale_line.id),
+                        ('move_id.is_inventory', '=', False),
+                    ], order='picking_id, id')
+                    if candidates:
+                        first_picking = candidates[:1].picking_id
+                        move_lines = candidates.filtered(lambda ml: ml.picking_id == first_picking)
+                    else:
+                        move_lines = self.env['stock.move.line']
                     item['lot_names'] = move_lines.lot_id.mapped('name')
                     lot_qty_by_name = {}
                     for line in move_lines:
-                        lot_qty_by_name[line.lot_id.name] = lot_qty_by_name.get(line.lot_id.name, 0.0) + line.quantity
+                        if line.lot_id:
+                            lot_qty_by_name[line.lot_id.name] = lot_qty_by_name.get(line.lot_id.name, 0.0) + line.quantity
                     item['lot_qty_by_name'] = lot_qty_by_name
                 if product_uom == sale_line_uom:
                     results.append(item)

--- a/addons/pos_sale/tests/test_pos_sale_lot.py
+++ b/addons/pos_sale/tests/test_pos_sale_lot.py
@@ -98,3 +98,72 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
 
         order = self.env['pos.order'].sync_from_ui([pos_order])
         self.assertEqual(self.env['pos.order'].browse(order['pos.order'][0]['id']).picking_ids.move_line_ids.lot_id, lot1)
+
+    def test_read_converted_lot_quantities_pick_then_deliver(self):
+        """
+        Test that read_converted returns correct lot quantities with 2-step
+        "Pick then Deliver" after delivery is validated (no double-counting).
+        """
+        warehouse = self.env['stock.warehouse'].search(
+            [('company_id', '=', self.env.company.id)], limit=1
+        )
+        warehouse.delivery_steps = 'pick_ship'
+        stock_location = warehouse.lot_stock_id
+
+        product = self.env['product.product'].create({
+            'name': 'Product Lot Tracked',
+            'tracking': 'lot',
+            'is_storable': True,
+            'available_in_pos': True,
+            'lst_price': 10,
+            'categ_id': self.env.ref('product.product_category_all').id,
+        })
+
+        lots = self.env['stock.lot'].create([
+            {'name': 'LOT-1', 'product_id': product.id, 'company_id': self.env.company.id},
+            {'name': 'LOT-2', 'product_id': product.id, 'company_id': self.env.company.id},
+        ])
+        for lot in lots:
+            self.env['stock.quant'].with_context(inventory_mode=True).create({
+                'product_id': product.id,
+                'inventory_quantity': 1,
+                'location_id': stock_location.id,
+                'lot_id': lot.id,
+            }).action_apply_inventory()
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.env['res.partner'].create({'name': 'Test'}).id,
+            'warehouse_id': warehouse.id,
+            'order_line': [(0, 0, {
+                'product_id': product.id,
+                'name': product.name,
+                'product_uom_qty': 2,
+                'product_uom': product.uom_id.id,
+                'price_unit': product.lst_price,
+            })],
+        })
+        sale_order.action_confirm()
+
+        pick_picking = sale_order.picking_ids.filtered(
+            lambda p: p.picking_type_code != 'outgoing'
+        )
+        pick_picking.action_assign()
+        mls = pick_picking.move_line_ids.filtered(lambda ml: ml.product_id == product)
+        for ml, lot in zip(mls[:2], lots):
+            ml.write({'lot_id': lot.id, 'quantity': 1})
+        for ml in mls[2:]:
+            ml.unlink()
+        pick_picking.move_ids.picked = True
+        pick_picking._action_done()
+
+        delivery_picking = sale_order.picking_ids.filtered(
+            lambda p: p.picking_type_code == 'outgoing'
+        )
+        delivery_picking.action_assign()
+        delivery_picking.move_ids.picked = True
+        delivery_picking._action_done()
+
+        [conv] = sale_order.order_line.read_converted()
+        self.assertEqual(conv['product_uom_qty'], 2)
+        lot_qty_sum = sum(conv.get('lot_qty_by_name', {}).values())
+        self.assertEqual(lot_qty_sum, 2)


### PR DESCRIPTION
When settling a sale order in POS after validating the delivery, quantities and lots were wrong for lot-tracked products with warehouse "Pick then Deliver (2 steps)": quantity doubled when loading SN/Lots.

Steps to reproduce:
-------------------
* Create a product with Tracking by lots
* In Inventory, set warehouse Outgoing Shipments to "Pick then Deliver (2 steps)"
* Create a quotation with the product and confirm it
* Validate the delivery
* In POS, settle the sale order from Quotation/Order
* When asked "Do you want to load the SN/Lots linked to the Sales Order?", click Yes

> Observation:
Quantity doubled.

Why the fix:
------------
read_converted() used move_line_ids from all moves linked to the sale line. With 2-step, both pick and delivery moves have move_line_ids with the same lots, so quantities were counted twice.
We now use move lines from exactly one picking and filter by sale_line_id.

opw-6001585