### PR TITLE
[FIX] point_of_sale: show product reference on invoices

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1895,7 +1895,13 @@ class PosOrderLine(models.Model):
         is_refund_line = line.qty * line.price_unit < 0
 
         lang = line.order_id.partner_id.lang or self.env.user.lang
-        product_name = line.with_context(lang=lang).full_product_name or line.product_id.with_context(lang=lang).display_name
+        product_name = line.product_id.with_context(lang=lang).display_name
+
+        product_full_name = line.with_context(lang=lang).full_product_name
+        if product_full_name:
+            product_code = f"[{line.with_context(lang=lang).product_id.code}] " if line.product_id.code else ""
+            product_name = product_code + product_full_name
+
         if line.product_id.description_sale:
             product_name += '\n' + line.product_id.with_context(lang=lang).description_sale
         return {

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1874,6 +1874,16 @@ class PosOrderLine(models.Model):
                                         or 0
 
     def _prepare_base_line_for_taxes_computation(self):
+        def get_product_full_name(product_name, display_name, full_product_name):
+            if not full_product_name:
+                return display_name
+            index = display_name.find(product_name)
+            if index == -1:
+                return full_product_name
+            prefix = display_name[:index + len(product_name)]
+            suffix = full_product_name[len(product_name):].strip()
+            return f"{prefix} {suffix}".strip()
+
         self.ensure_one()
         commercial_partner = self.order_id.partner_id.commercial_partner_id
         fiscal_position = self.order_id.fiscal_position_id
@@ -1892,7 +1902,11 @@ class PosOrderLine(models.Model):
         is_refund_line = line.qty * line.price_unit < 0
 
         lang = line.order_id.partner_id.lang or self.env.user.lang
-        product_name = line.with_context(lang=lang).full_product_name or line.product_id.with_context(lang=lang).display_name
+        product_full_name = line.with_context(lang=lang).full_product_name
+        display_name = line.product_id.with_context(lang=lang).display_name
+        name = line.product_id.with_context(lang=lang).name
+
+        product_name = get_product_full_name(name, display_name, product_full_name)
         if line.product_id.description_sale:
             product_name += '\n' + line.product_id.with_context(lang=lang).description_sale
         return {


### PR DESCRIPTION
Currently invoices generated from pos orders do not show the product referense alongside the product name.

Steps to reproduce:
-------------------
* Open shop and select Cabinet with doors
* Add customer to order
* Pay the order
* Wether you selected to invoice or you didn't, does not matter, you can invoice from the backend
> Observe on the invoice that the product does not show the internal reference "Cabinet with Doors"
* Create a sale order for the same product, deliver and invoice
> Observe the invoice, the product shows reference "[E-COM11] Cabinet with Doors"

Why the fix:
------------
After this commit: https://github.com/odoo/odoo/commit/aff477805577cb7ed00fb94440dda5cf2f29cb44
we're using `full_product_name` to set the name on move line name.

We could simply add the reference when computing the product name but the logiq used to computed the display name is a bit more complex than simply adding it always.

Instead we use both display_name and full_product_name to build the final name. This way it has the reference if any and all information about variants are kept as well.

opw-5950016