### PR TITLE
[FIX] website: use root height in parallax preview

### DIFF
--- a/addons/website/static/src/interactions/parallax/parallax.preview.js
+++ b/addons/website/static/src/interactions/parallax/parallax.preview.js
@@ -91,7 +91,9 @@ const ParallaxPreview = (I) =>
         updateParallaxPosition = () => {
             const clamp = (value) => Math.min(1, Math.max(0, value));
             const rect = this.el.getBoundingClientRect();
-            const viewportHeight = this.previewContainerEl.clientHeight;
+            // Do not use `body.clientHeight` here. Inside a scaled iframe,
+            // Firefox and Chrome can return different values for "clientHeight".
+            const viewportHeight = this.el.ownerDocument.documentElement.clientHeight;
             const relativeScrollProgress = viewportHeight ? rect.top / viewportHeight : 0;
 
             const parallaxShift = relativeScrollProgress * this.PARALLAX_RATE * 100;


### PR DESCRIPTION
Steps to reproduce:
- Open the website editor.
- Open the snippet dialog.
- Scroll through a parallax snippet preview in Firefox and Chrome. => The preview animation does not move the same way.

Before this commit, the parallax preview used `body.clientHeight` inside the scaled snippet preview iframe. Firefox and Chrome can return different values there, so the preview animation was inconsistent.

After this commit, the preview reads
`document.documentElement.clientHeight` instead, which gives a stable iframe viewport height across browsers.