### PR TITLE
[IMP] payment_xendit: support PayNow, SGD, USD, and more card brands

### DIFF
--- a/addons/payment/data/payment_provider_data.xml
+++ b/addons/payment/data/payment_provider_data.xml
@@ -454,6 +454,7 @@
                    ref('payment.payment_method_mandiri'),
                    ref('payment.payment_method_maya'),
                    ref('payment.payment_method_ovo'),
+                   ref('payment.payment_method_paynow'),
                    ref('payment.payment_method_promptpay'),
                    ref('payment.payment_method_qris'),
                    ref('payment.payment_method_scb'),

--- a/addons/payment_xendit/const.py
+++ b/addons/payment_xendit/const.py
@@ -5,7 +5,9 @@ SUPPORTED_CURRENCIES = [
     'IDR',
     'MYR',
     'PHP',
+    'SGD',
     'THB',
+    'USD',
     'VND',
 ]
 
@@ -15,7 +17,9 @@ CURRENCY_DECIMALS = {
     'IDR': 0,
     'MYR': 0,
     'PHP': 0,
+    'SGD': 0,
     'THB': 0,
+    'USD': 0,
     'VND': 0,
 }
 
@@ -37,11 +41,15 @@ DEFAULT_PAYMENT_METHOD_CODES = {
     # VN
     'appota',
     'zalopay',
-    'vnptwallet'
+    'vnptwallet',
+    # SG
+    'paynow',
 
     # Brand payment methods.
     'visa',
     'mastercard',
+    'jcb',
+    'amex',
 }
 
 # FPX is an online payment method in Malaysia that allows customers to make payments directly from their bank accounts.
@@ -103,6 +111,7 @@ PAYMENT_METHODS_MAPPING = {
     'krungthai_bank': 'DD_KTB_MB',
     'bangkok_bank': 'DD_BBL_MB',
     'touch_n_go': 'TOUCHNGO',
+    'paynow': 'SGQR',
     **{method: 'fpx' for method in FPX_METHODS}
 }
 

--- a/addons/payment_xendit/models/payment_transaction.py
+++ b/addons/payment_xendit/models/payment_transaction.py
@@ -40,7 +40,8 @@ class PaymentTransaction(models.Model):
         rounded_amount = float_round(self.amount, rounding, rounding_method='DOWN')
         return {
             'rounded_amount': rounded_amount,
-            'access_token': payment_utils.generate_access_token(self.reference)
+            'access_token': payment_utils.generate_access_token(self.reference),
+            'currency': self.currency_id.name,
         }
 
     def _get_specific_rendering_values(self, processing_values):

--- a/addons/payment_xendit/models/payment_transaction.py
+++ b/addons/payment_xendit/models/payment_transaction.py
@@ -39,7 +39,8 @@ class PaymentTransaction(models.Model):
             rounding = self.currency_id.decimal_places
         rounded_amount = float_round(self.amount, rounding, rounding_method='DOWN')
         return {
-            'rounded_amount': rounded_amount
+            'rounded_amount': rounded_amount,
+            'currency': self.currency_id.name,
         }
 
     def _get_specific_rendering_values(self, processing_values):

--- a/addons/payment_xendit/static/src/js/payment_form.js
+++ b/addons/payment_xendit/static/src/js/payment_form.js
@@ -122,6 +122,7 @@ paymentForm.include({
                 // Allow reusing tokens when the transaction should be tokenized.
                 is_multiple_use: processingValues['should_tokenize'],
                 amount: processingValues['rounded_amount'],
+                currency: processingValues['currency'],
             },
             (err, token) =>  
                 {
@@ -134,6 +135,7 @@ paymentForm.include({
                     if (processingValues['should_tokenize']) {
                         Xendit.card.createAuthentication({
                             amount: processingValues['rounded_amount'],
+                            currency: processingValues['currency'],
                             token_id: token.id
                         }, (err, result) => {
                             this._xenditHandleResponse(err, result, processingValues, 'auth')


### PR DESCRIPTION
This commit expands Xendit support to include the Singaporean market and
additional card brands.

The following changes were made:
- Added support for the PayNow (SGQR) payment method.
- Added SGD and USD to the list of supported currencies.
- Added JCB and AMEX to the supported card brands (available for some markets).
- Updated the base payment provider data for Xendit to include PayNow.

Task-5964309

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
