### PR TITLE
[FIX] tools: trust `ZoneInfo` in `safe_eval`

### DIFF
--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -969,7 +969,7 @@ def _initialize_safe_whitelist():
     safe_whitelist.add_function('OrderedDict.*')
     safe_whitelist.add_function('_functools.reduce')
     # Monkey patches
-    safe_whitelist.add_instance('odoo._monkeypatches.zoneinfo.ZoneInfo')
+    safe_whitelist.add_class('odoo._monkeypatches.zoneinfo.ZoneInfo')
     safe_whitelist.add_function('odoo._monkeypatches.*')
     # Core
     safe_whitelist.add_class('odoo.addons.*')  # TODO: Restrict addons


### PR DESCRIPTION
The API to use in the evaluation context to obtain a timezone info is the `ZoneInfo` class.

This class is exposed via `dateutil.tz.gettz`.

It is necessary to trust this class in order to create timezone info objects (and not just use them).

Task-6033011