### PR TITLE
[FIX] account: enable template reply_to on account wizard

### DIFF
--- a/addons/account/models/account_move_send.py
+++ b/addons/account/models/account_move_send.py
@@ -90,6 +90,8 @@ class AccountMoveSend(models.AbstractModel):
                 'mail_subject': get_setting('mail_subject', default_value=self._get_default_mail_subject(move, mail_template, mail_lang)),
                 'mail_partner_ids': get_setting('mail_partner_ids', default_value=self._get_default_mail_partner_ids(move, mail_template, mail_lang).ids),
             })
+            if reply_to := get_setting('reply_to', default_value=self._get_default_mail_reply_to(move, mail_template, mail_lang)):
+                vals['reply_to'] = reply_to
         # Add mail attachments if sending methods support them
         if self._display_attachments_widget(vals['invoice_edi_format'], vals['sending_methods']):
             mail_attachments_widget = self._get_default_mail_attachments_widget(
@@ -218,6 +220,15 @@ class AccountMoveSend(models.AbstractModel):
             partner_ids = mail_template._parse_partner_to(partner_to)
             partners |= self.env['res.partner'].sudo().browse(partner_ids).exists()
         return partners if self.env.context.get('allow_partners_without_mail') else partners.filtered('email')
+
+    @api.model
+    def _get_default_mail_reply_to(self, move, mail_template, mail_lang):
+        return self._get_mail_default_field_value_from_template(
+            mail_template,
+            mail_lang,
+            move,
+            'reply_to',
+        )
 
     # -------------------------------------------------------------------------
     # ATTACHMENTS
@@ -659,6 +670,8 @@ class AccountMoveSend(models.AbstractModel):
             mail_template = move_data['mail_template']
             mail_lang = move_data['mail_lang']
             mail_params = self._get_mail_params(move, move_data)
+            if reply_to := move_data.get('reply_to'):
+                mail_params['reply_to'] = reply_to
             if not mail_params:
                 continue
 

--- a/addons/account/tests/test_mail_tracking_value.py
+++ b/addons/account/tests/test_mail_tracking_value.py
@@ -96,3 +96,78 @@ class TestTracking(AccountTestInvoicingCommon, MailCase):
                     self._new_msgs[0],
                     [{'partner': partner_admin, 'type': 'inbox', 'is_read': False}]
                 )
+
+    def test_invoice_template_reply_to(self):
+        self.partner_a.email = 'partner_a@example.com'
+        self.partner_a.invoice_sending_method = 'email'
+        self.partner_b.email = 'partner_b@example.com'
+        self.partner_b.invoice_sending_method = 'email'
+        invoice_1 = self._create_invoice(post=True, partner_id=self.partner_a)
+        invoice_2 = self._create_invoice(post=True, partner_id=self.partner_b)
+        mail_template = invoice_1._get_mail_template()
+        wizard = self._create_account_move_send_wizard_single(
+            invoice_1,
+            sending_methods=['email'],
+            template_id=mail_template.id
+        )
+        wizard_multi = self._create_account_move_send_wizard_multi(
+            invoice_1 | invoice_2,
+        )
+
+        test_cases_single = [
+            ('test_reply_to@example.com', 'test_reply_to@example.com'),
+            ('{{ object.user_id.email_formatted }}', self.env.user.email_formatted),
+            (False, self.env.user.email_formatted),
+        ]
+        for input_reply_to, expected_reply_to in test_cases_single:
+            mail_template.reply_to = input_reply_to
+
+            with self.mock_mail_gateway(mail_unlink_sent=False), self.mock_mail_app():
+                wizard.action_send_and_print()
+                self.env.cr.flush()  # force tracking message
+
+            self.assertMailMail(
+                self.partner_a,
+                'sent',
+                author=self.env.user.partner_id,
+                email_values={
+                    'reply_to': expected_reply_to,
+                },
+                fields_values={
+                    'reply_to': expected_reply_to,
+                },
+            )
+
+        test_cases_multi = [
+            ('test_reply_to@example.com', 'test_reply_to@example.com', 'test_reply_to@example.com'),
+            ('{{ object.partner_id.email_formatted }}', self.partner_a.email_formatted, self.partner_b.email_formatted),
+            (False, self.env.user.email_formatted, self.env.user.email_formatted),
+        ]
+        for input_reply_to, expected_reply_to_a, expected_reply_to_b in test_cases_multi:
+            mail_template.reply_to = input_reply_to
+
+            with self.mock_mail_gateway(mail_unlink_sent=False), self.mock_mail_app():
+                wizard_multi.action_send_and_print(force_synchronous=True)
+
+            self.assertMailMail(
+                self.partner_a,
+                'sent',
+                author=self.env.user.partner_id,
+                email_values={
+                    'reply_to': expected_reply_to_a,
+                },
+                fields_values={
+                    'reply_to': expected_reply_to_a,
+                },
+            )
+            self.assertMailMail(
+                self.partner_b,
+                'sent',
+                author=self.env.user.partner_id,
+                email_values={
+                    'reply_to': expected_reply_to_b,
+                },
+                fields_values={
+                    'reply_to': expected_reply_to_b,
+                },
+            )

--- a/addons/account/wizard/account_move_send_wizard.py
+++ b/addons/account/wizard/account_move_send_wizard.py
@@ -365,6 +365,8 @@ class AccountMoveSendWizard(models.TransientModel):
                 'mail_subject': self.subject,
                 'mail_partner_ids': self.mail_partner_ids.ids,
             })
+            if reply_to := self._get_default_mail_reply_to(self.move_id, self.template_id, self.lang):
+                send_settings['reply_to'] = reply_to
         if self.display_attachments_widget:
             send_settings['mail_attachments_widget'] = self.mail_attachments_widget
         return send_settings


### PR DESCRIPTION
**Steps to reproduce:**
- Install Invoice app
- Go to Settings > Technical > Email Templates
- Go to "Invoice: Sending" template
- Change the Reply To in its settings
- Send an Invoice
- Default reply-to is applied on the outgoing mail

**Issue:**
Accounting/Invoicing uses a separate email wizard that handles messages differently from the standard mail composer, which doesn't take into account some template features such as its reply_to field.
(`mail.compose.message` vs `account.move.send.wizard`)

**Fix:**
Try to add the reply_to (if provided in the template) to the mail when sending invoices, default to the existing behavior if not.

Might have been deliberately prevented previously due to some accounting-specific or performance constraints.

opw-5982926