### PR TITLE
[FIX] l10n_pl_edi: avoid AttributeError when KSeF rate limit is reached

### DIFF
--- a/addons/l10n_pl_edi/tools/ksef_api_service.py
+++ b/addons/l10n_pl_edi/tools/ksef_api_service.py
@@ -351,7 +351,7 @@ class KsefApiService:
             response = self._make_request('POST', endpoint, json=query_criteria, params=params)
             return response.json()
         except KSeFRateLimitError as e:
-            return {'error': {'retry_after': e.retry_after, 'message': e.message}}
+            return {'error': {'retry_after': e.retry_after, 'message': str(e)}}
 
     def get_invoice_by_ksef_number(self, ksef_number):
         endpoint = f"{self.api_url}/invoices/ksef/{ksef_number}"
@@ -359,4 +359,4 @@ class KsefApiService:
             response = self._make_request('GET', endpoint)
             return {'xml_content': response.content}
         except KSeFRateLimitError as e:
-            return {'error': {'retry_after': e.retry_after, 'message': e.message}}
+            return {'error': {'retry_after': e.retry_after, 'message': str(e)}}


### PR DESCRIPTION
Before this commit:
Steps

1. Create a Polish company
2. Run scheduled action "Polish eInvoice: Download vendor bills from KSeF"
3. If the customer gets 429 Too Many Requests => A traceback error is raised as message isn't an attribute in KSeFRateLimitError object `AttributeError: 'KSeFRateLimitError' object has no attribute 'message'`

This happens because `KSeFRateLimitError` does not define a `message` attribute. The message is only passed to the base Exception and stored in `args`.

After this commit:
Use `str(e)` to properly retrieve the exception message and avoid the AttributeError.

opw-6009380