### PR TITLE
[FIX] im_livechat: disable @mentions for visitors in livechat

### DIFF
--- a/addons/im_livechat/static/src/core/common/suggestion_service_patch.js
+++ b/addons/im_livechat/static/src/core/common/suggestion_service_patch.js
@@ -1,0 +1,13 @@
+import { SuggestionService } from "@mail/core/common/suggestion_service";
+
+import { patch } from "@web/core/utils/patch";
+
+patch(SuggestionService.prototype, {
+    /** @override */
+    getSupportedDelimiters(thread) {
+        const res = super.getSupportedDelimiters(...arguments);
+        return thread?.channel_type === "livechat" && !this.store.self.isInternalUser
+            ? res.filter((delimiter) => delimiter.at(0) !== "@")
+            : res;
+    },
+});

--- a/addons/im_livechat/static/tests/embed/suggestion.test.js
+++ b/addons/im_livechat/static/tests/embed/suggestion.test.js
@@ -1,0 +1,30 @@
+import { LivechatButton } from "@im_livechat/embed/common/livechat_button";
+import {
+    defineLivechatModels,
+    loadDefaultEmbedConfig,
+} from "@im_livechat/../tests/livechat_test_helpers";
+import { SuggestionService } from "@mail/core/common/suggestion_service";
+import { click, contains, insertText, start } from "@mail/../tests/mail_test_helpers";
+import { describe, expect, test } from "@odoo/hoot";
+import { mountWithCleanup, patchWithCleanup } from "@web/../tests/web_test_helpers";
+
+describe.current.tags("desktop");
+defineLivechatModels();
+
+test("Visitor cannot use @ mentions in livechat", async () => {
+    await loadDefaultEmbedConfig();
+    await start({ authenticateAs: false });
+    await mountWithCleanup(LivechatButton);
+    await click(".o-livechat-LivechatButton");
+    await contains(".o-mail-Message", { text: "Hello, how may I help you?" });
+    patchWithCleanup(SuggestionService.prototype, {
+        getSupportedDelimiters() {
+            const delimiters = super.getSupportedDelimiters(...arguments);
+            expect.step(delimiters.map((d) => d[0]).join(","));
+            return delimiters;
+        },
+    });
+    await insertText(".o-mail-Composer-input", "@");
+    await expect.waitForSteps(["#,:,/"]);
+    await contains(".o-mail-Composer-suggestion", { count: 0 });
+});

--- a/addons/im_livechat/static/tests/embed/suggestion.test.js
+++ b/addons/im_livechat/static/tests/embed/suggestion.test.js
@@ -1,0 +1,25 @@
+import { LivechatButton } from "@im_livechat/embed/common/livechat_button";
+import {
+    defineLivechatModels,
+    loadDefaultEmbedConfig,
+} from "@im_livechat/../tests/livechat_test_helpers";
+import { describe, test } from "@odoo/hoot";
+import { animationFrame } from "@odoo/hoot-mock";
+import { click, contains, insertText, start } from "@mail/../tests/mail_test_helpers";
+import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+
+describe.current.tags("desktop");
+defineLivechatModels();
+
+test("Visitor cannot use @ mentions in livechat", async () => {
+    await loadDefaultEmbedConfig();
+    await start({ authenticateAs: false });
+    await mountWithCleanup(LivechatButton);
+    await click(".o-livechat-LivechatButton");
+    await contains(".o-mail-Message", { text: "Hello, how may I help you?" });
+    await insertText(".o-mail-Composer-input", "@");
+    await animationFrame();
+    await animationFrame();
+    await animationFrame();
+    await contains(".o-mail-Composer-suggestion", { count: 0 });
+});


### PR DESCRIPTION
**Description of the issue this PR addresses:**
----------------------------------------------
Visitors in livechat can trigger partner mention suggestions by typing the @ delimiter in the composer. However, visitors can only mention themselves or odoobot, which does not provide meaningful functionality in the context of a livechat conversation.

**Current behavior before PR:**
----------------------------------------------
- Visitors can type @ in the livechat composer and trigger partner mention suggestions.
- The suggestions only include the visitor themselves or odoobot.

**Desired behavior after PR is merged:**
----------------------------------------------
- The @ delimiter is disabled for visitors in livechat threads.
- Partner mention suggestions are no longer triggered for visitors.
- Internal users (operators) can still use @ mentions normally.

Task-5119068

----------------------------------------------
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
