### PR TITLE
[IMP] stock: change order of tracking options on product

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -793,9 +793,9 @@ class ProductTemplate(models.Model):
         'Customer Lead Time', default=0, company_dependent=True,
         help="Delivery lead time, in days. It's the number of days, promised to the customer, between the confirmation of the sales order and the delivery.")
     tracking = fields.Selection([
-        ('serial', 'By Unique Serial Number'),
+        ('none', 'By Quantity'),
         ('lot', 'By Lots'),
-        ('none', 'By Quantity')],
+        ('serial', 'By Unique Serial Number')],
         string="Tracking",
         compute='_compute_tracking', inverse='_set_tracking', store=True, readonly=False, precompute=True,
         help="Ensure the traceability of a storable product in your warehouse.")


### PR DESCRIPTION
Purpose: Tracking by quantity is more frequent than tracking by lot or serial number so it should be first in the list.

The order in the dropdown will now be:
- By Quantity
- By Lots
- By Unique Serial Number

task-6025784