### PR TITLE
[FIX] l10n_sa_edi: include cash rounding line in payable amount

### DIFF
--- a/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
+++ b/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
@@ -247,8 +247,8 @@ class AccountEdiXmlUBL21Zatca(models.AbstractModel):
         line_extension_amount = vals['vals']['monetary_total_vals']['line_extension_amount']
         tax_inclusive_amount = total_amount
         tax_exclusive_amount = abs(vals['taxes_vals']['base_amount_currency'])
+        payable_rounding_amount = vals['vals']['monetary_total_vals']['payable_rounding_amount'] or 0
         prepaid_amount = 0
-        payable_amount = total_amount
         # - When we calculate the tax values, we filter out taxes and invoice lines linked to downpayments.
         #   As such, when we calculate the TaxInclusiveAmount, it already accounts for the tax amount of the downpayment
         #   Same goes for the TaxExclusiveAmount, and we do not need to add the Tax amount of the downpayment
@@ -259,7 +259,7 @@ class AccountEdiXmlUBL21Zatca(models.AbstractModel):
         if downpayment_vals:
             # - BR-KSA-80: To calculate payable amount, we deduct prepaid amount from total tax inclusive amount
             prepaid_amount = downpayment_vals['total_amount']
-            payable_amount = invoice.currency_id.round(tax_inclusive_amount - prepaid_amount)
+        payable_amount = invoice.currency_id.round(tax_inclusive_amount - prepaid_amount + payable_rounding_amount)
         return {
             'line_extension_amount': line_extension_amount - allowance_total_amount,
             'tax_inclusive_amount': tax_inclusive_amount,

--- a/addons/l10n_sa_edi/tests/common.py
+++ b/addons/l10n_sa_edi/tests/common.py
@@ -264,7 +264,8 @@ class TestSaEdiCommon(AccountEdiTestCommon):
         invoice_date='2025-01-01',
         invoice_date_due='2025-01-01',
         currency_id=None,
-        invoice_line_ids=[]):
+        invoice_line_ids=[],
+        **kwargs):
         """
         Create a draft invoice with the given parameters.
         """
@@ -290,6 +291,7 @@ class TestSaEdiCommon(AccountEdiTestCommon):
             'invoice_line_ids': [
                 _create_invoice_line(line) for line in invoice_line_ids
             ],
+            **kwargs,
         }
         return self.env['account.move'].create(vals)
 

--- a/addons/l10n_sa_edi/tests/test_edi_zatca.py
+++ b/addons/l10n_sa_edi/tests/test_edi_zatca.py
@@ -578,3 +578,37 @@ class TestEdiZatca(TestSaEdiCommon):
 
         for field_name in expected_error_fields:
             self.assertIn(field_name, error_message, f"Error message should contain '{field_name}'")
+
+    def test_invoice_cash_rounding_payable_amount(self):
+        """Test that payable_amount is correctly computed when using cash rounding"""
+        cash_rounding = self.env['account.cash.rounding'].create({
+            'name': 'add_invoice_line',
+            'rounding': 1.00,
+            'strategy': 'add_invoice_line',
+            'profit_account_id': self.company_data['default_account_revenue'].copy().id,
+            'loss_account_id': self.company_data['default_account_expense'].copy().id,
+            'rounding_method': 'UP',
+        })
+
+        move_data = {
+            'name': 'INV/2022/00014',
+            'invoice_date': '2022-09-05',
+            'invoice_date_due': '2022-09-22',
+            'partner_id': self.partner_sa,
+            'invoice_cash_rounding_id': cash_rounding.id,
+            'invoice_line_ids': [{
+                'product_id': self.product_a.id,
+                'price_unit': 99.55,
+                'tax_ids': self.tax_15.ids,
+            }],
+        }
+
+        invoice = self._create_invoice(**move_data)
+        invoice.action_post()
+        xml_content = self.env['account.edi.format']._l10n_sa_generate_zatca_template(invoice)
+        xml_root = etree.fromstring(xml_content)
+        payable_amount = xml_root.xpath(
+            "//cbc:PayableAmount",
+            namespaces=self.env['account.edi.xml.ubl_21.zatca']._l10n_sa_get_namespaces()
+        )[0].text.strip()
+        self.assertEqual(payable_amount, '115.00')


### PR DESCRIPTION
Currently the generated ZATCA XML is not accounting for invoice
cash rounding, leading to an invoice validation issue due to a mismatch
in the calculation of PayableAmount.

Steps to reproduce:
- Have a SA Company setup
- Create a [cash rounding] with strategy 'Add invoice line' and rounding 1.00 (UP)
- Create an invoice for 99.55 + 15% Tax
- Set Cash Rounding Method to [cash rounding]
- Confirm and send xml for validation

Issue:
Validation will issue the following warning
`[202] BR-CO-16 : Amount due for payment (BT-115) = Invoice total amount
with VAT (BT-112) -Pre-Paid amount (BT-113) + Rounding amount (BT-114).`

Analysis:
The ZATCA implementation was calculating the payable amount strictly as
(TaxInclusiveAmount - PrepaidAmount).  This change ensures the rounding
amount is fetched and added to the total payable calculation

opw-5939550