### PR TITLE
[FIX] web: menu_toggle SVG missing unit

### DIFF
--- a/addons/web/static/src/webclient/navbar/navbar.scss
+++ b/addons/web/static/src/webclient/navbar/navbar.scss
@@ -50,7 +50,7 @@
 
                 &:first-child {
                     transform: translate(12%,0) #{"/* rtl:translate(-6%, 0) */"};
-                    rx: 1;
+                    rx: 100%;
                 }
             }
 


### PR DESCRIPTION
Before this commit, some browsers showed a warning or, even worse, dropped this CSS rule because the unit was missing.

This line ensures that the tip of the arrow is rounded instead of truncated.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
