### PR TITLE
[IMP] purchase: Include non-deductible VAT in Budget

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -222,6 +222,7 @@ class AccountTax(models.Model):
     # Technical field depicting if the tax has at least one repartition line with a percentage below 0.
     # Used for the taxes computation to manage the reverse charge taxes having a repartition +100 -100.
     has_negative_factor = fields.Boolean(compute='_compute_has_negative_factor')
+    non_deductible_amount = fields.Float(compute='_compute_non_deductible_amount')
 
     @api.constrains('company_id', 'name', 'type_tax_use', 'tax_scope', 'country_id')
     def _constrains_name(self):
@@ -708,6 +709,19 @@ class AccountTax(models.Model):
     def _compute_tax_label(self):
         for tax in self:
             tax.tax_label = tax.invoice_label or tax.name
+
+    @api.depends(
+        'invoice_repartition_line_ids.repartition_type',
+        'invoice_repartition_line_ids.use_in_tax_closing',
+        'invoice_repartition_line_ids.factor_percent',
+    )
+    def _compute_non_deductible_amount(self):
+        for tax in self:
+            tax.non_deductible_amount = sum(
+                rep_line.factor_percent / 100.0
+                for rep_line in tax.invoice_repartition_line_ids
+                if rep_line.repartition_type == 'tax' and not rep_line.use_in_tax_closing
+            )
 
     @api.onchange('amount')
     def onchange_amount(self):

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -45,6 +45,7 @@ class PurchaseOrderLine(models.Model):
     price_subtotal = fields.Monetary(compute='_compute_amount', string='Subtotal', store=True)
     price_total = fields.Monetary(compute='_compute_amount', string='Total', store=True)
     price_tax = fields.Float(compute='_compute_amount', string='Tax', store=True)
+    non_deductible_tax = fields.Float(compute='_compute_amount', store=True)
 
     order_id = fields.Many2one('purchase.order', string='Order Reference', index=True, required=True, ondelete='cascade')
 
@@ -123,6 +124,10 @@ class PurchaseOrderLine(models.Model):
             line.price_subtotal = base_line['tax_details']['total_excluded_currency']
             line.price_total = base_line['tax_details']['total_included_currency']
             line.price_tax = line.price_total - line.price_subtotal
+            line.non_deductible_tax = sum(
+                tax_data['tax_amount_currency'] * tax_data['tax'].non_deductible_amount
+                for tax_data in base_line['tax_details']['taxes_data']
+            )
 
     def _prepare_base_line_for_taxes_computation(self):
         """ Convert the current record to a dictionary in order to use the generic taxes computation method


### PR DESCRIPTION
In the cultural industry and/or training (formations) industry namely but not only, users often do not have right to deduct VAT. Though, they receive bills issued by their customer, where VAT is explicitly set. Our users want to fetch the bills (import, Peppol, whatever) and post them quickly. Hence why even though they don't deduct VAT, they manipulate taxes.

By doing so, they adapt their taxes:
adapting the tax grids
removing the account on the tax repartition line (or setting a distinct P&L account) >> this is how you can deduct if a tax is deductible or not The issue is that in budgets, before the bill is recorded, the committed account forgets to compute the non-deductible tax contribution. And the user is temporarily mislead because if the amounts have already been committed, the budget suggests that they have not yet been committed. Only when the bill is registered, then the committed amount is adapted to the bills.

Adapt the computations of the budget so that the committed amount takes into account the non-deductible VAT.

task-5993281

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
