### PR TITLE
[FIX] l10n_lu: correct type account of 142

### DIFF
--- a/addons/l10n_lu/data/template/account.account-lu.csv
+++ b/addons/l10n_lu/data/template/account.account-lu.csv
@@ -72,7 +72,7 @@
 "lu_2020_account_138232","138232","Temporarily not taxable capital gains reinvested","equity","","False","","Sonderposten mit Rücklageanteil, wiederangelegt","Plus-values immunisées réinvesties"
 "lu_2020_account_13828","13828","Reserves not available for distribution not mentioned above","equity","","False","","Gebundene Rücklagen welche nicht oben aufgelistet wurden","Réserves non disponibles non visées ci-dessus"
 "lu_2020_account_1411","1411","Results brought forward in the process of assignment","equity","","False","","Ergebnisvorträge in Zuweisung","Résultats reportés en instance d'affectation"
-"lu_2020_account_1412","1412","Results brought forward (assigned)","equity","","False","","Ergebnisvorträge (zugewiesen)","Résultats reportés (affectés)"
+"lu_2020_account_1412","1412","Results brought forward (assigned)","equity_unaffected","","False","","Ergebnisvorträge (zugewiesen)","Résultats reportés (affectés)"
 "lu_2011_account_142","142","Result for the financial year","equity_unaffected","","False","","Ergebnis des Geschäftsjahres","Résultat de l'exercice"
 "lu_2011_account_15","15","Interim dividends","equity","","False","","Vorabdividenden","Acomptes sur dividendes"
 "lu_2020_account_1611","1611","Development costs","equity","","False","","Entwicklungskosten","Frais de développement"


### PR DESCRIPTION
Steps to reproduce:
- Use a Luxembourg company
- Post a P&L result for the year and do the year-end affectation (Dr 142 / Cr 1412)
- Open the Luxembourg balance sheet (full or abbreviated)

Issue:
Line "V. Profit or loss brought forward" shows incorrect values.

Cause:
The `accounts` expression for that line used `account_codes` engine with formula `-14`,
which only sums accounts by code prefix. Account 1412 ("Results brought forward (assigned)")
was typed as `equity`, so its balance was carried forward as an initial balance instead of
being captured as retained earnings in the formula.

Solution:
- Set account 1412 to `equity_unaffected`, consistent with account 142.
- Change the `accounts` expression of Line V in both the full and abbreviated balance sheet
  to use the `domain` engine:
  `['|', ('account_id.code', '=like', '14%'), ('account_id.account_type', '=', 'equity_unaffected')]`
  with subformula `-sum`.
  This correctly captures the balance of all 14x accounts and any `equity_unaffected` accounts,
  which covers the standard year-end affectation workflow.

opw-5883505