### PR TITLE
[FIX] web: improve some spacing issues in o_input_box elements

### DIFF
--- a/addons/project/static/src/scss/project_form.scss
+++ b/addons/project/static/src/scss/project_form.scss
@@ -36,7 +36,7 @@
     }
     &.o_field_CopyClipboardChar span:not(.fa-clipboard) {
         white-space: unset;
-        width: calc(100% - var(--inputbox-overlay-padding-suffix));
+        width: calc(100% - var(--inputbox-overlay-end-size));
         display: block;
         overflow: hidden;
         text-wrap: nowrap;

--- a/addons/web/static/src/core/input_box/input_box.js
+++ b/addons/web/static/src/core/input_box/input_box.js
@@ -29,7 +29,7 @@ function _positionInputBoxOverlay(target) {
         startOverlays[i].style["inset-inline-start"] = `calc((1.5 * var(--inputbox-overlay-padding-x)) ${offset})`;
         startPadding += startOverlays[i].clientWidth + gap;
     };
-    closestInputBox.style.setProperty("--inputbox-overlay-padding-prefix", startPadding + "px");
+    closestInputBox.style.setProperty("--inputbox-overlay-start-size", startPadding + "px");
     for (let i = endOverlays.length; i > 0; i--) {
         const overlay = endOverlays[i - 1];
         if (_hasTouch && overlay.classList.contains("btn-link")) {
@@ -40,7 +40,7 @@ function _positionInputBoxOverlay(target) {
         overlay.style["inset-inline-end"] = `calc(var(--inputbox-overlay-padding-x) ${offset})`;
         endPadding += overlay.clientWidth + gap;
     }
-    closestInputBox.style.setProperty("--inputbox-overlay-padding-suffix", endPadding + "px");
+    closestInputBox.style.setProperty("--inputbox-overlay-end-size", endPadding + "px");
     const inlineEl = closestInputBox.querySelector(".o_input_box_overlay_inline");
     if (inlineEl) {
         const inputEl = closestInputBox.querySelector(

--- a/addons/web/static/src/core/input_box/input_box.scss
+++ b/addons/web/static/src/core/input_box/input_box.scss
@@ -8,26 +8,21 @@
     --inputbox-overlay-padding-x: 0px;
     --inputbox-overlay-padding-y: 0px;
     --inputbox-overlay-padding-toggler: 0px;
-    --inputbox-overlay-padding-prefix: 0px;
-    --inputbox-overlay-padding-suffix: 0px;
+    --inputbox-overlay-start-size: 0px;
+    --inputbox-overlay-end-size: 0px;
     // STORE THE COMPUTED VALUE IN REUSABLE VARIABLES
-    --inputbox-inner-padding-start: calc((1.5 * var(--inputbox-overlay-padding-x)) + var(--inputbox-overlay-padding-prefix));
-    --inputbox-inner-padding-end: calc(var(--inputbox-overlay-padding-x) + var(--inputbox-overlay-padding-suffix) + var(--inputbox-overlay-padding-toggler));
-
-    &:is(.o_touch_device .o_input_box) {
-        --inputbox-overlay-padding-x: var(--inputbox-spacing-unit);
-        --inputbox-overlay-padding-y: calc(var(--border-width) + 2.25 * var(--inputbox-spacing-unit) - var(--inputbox-overlay-size) / 2);
-    }
+    --inputbox-inner-padding-start: calc((1.5 * var(--inputbox-overlay-padding-x)) + var(--inputbox-overlay-start-size));
+    --inputbox-inner-padding-end: calc(var(--inputbox-overlay-padding-x) + var(--inputbox-overlay-end-size) + var(--inputbox-overlay-padding-toggler));
 
     &:has(.o_dropdown_button) {
         --inputbox-overlay-padding-toggler: calc(var(--inputbox-overlay-padding-x) + (2 * var(--inputbox-spacing-unit)));
 
         .o_dropdown_button {
-            inset-inline-end: var(--inputbox-overlay-padding-suffix) !important;
+            inset-inline-end: var(--inputbox-overlay-end-size) !important;
         }
     }
 
-    .o_input:not(.o_input .o_input) {
+    .o_input:not(.o_input .o_input), &:not(:has(.o_input)) {
         padding-inline-start: var(--inputbox-inner-padding-start) !important;
         padding-inline-end: var(--inputbox-inner-padding-end) !important;
     }

--- a/addons/web/static/src/views/fields/fields.scss
+++ b/addons/web/static/src/views/fields/fields.scss
@@ -51,8 +51,8 @@
             padding-right: var(--inputbox-inner-padding-end);
         }
         &:is(.o_touch_device *) {
-            padding-top: var(--inputbox-spacing-unit);
-            padding-bottom: var(--inputbox-spacing-unit);
+            padding-top: var(--inputbox-overlay-padding-y);
+            padding-bottom: var(--inputbox-overlay-padding-y);
         }
     }
 }

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -456,7 +456,7 @@
     }
 
     
-    .o_form_sheet .o_field_widget:not(.o_input_box_overlay_start, .o_input_box_overlay_end, .o_field_event_state_selection, .o_field_state_selection, .o_field_boolean_favorite, .o_field_priority, .o_field_contact_image, .oe_avatar), .o_input_box:not(.o_input_box .o_input_box) {
+    .o_form_sheet .o_field_widget:not(.o_input_box_overlay_start, .o_input_box_overlay_end, .o_field_widget .o_field_widget, .o_field_event_state_selection, .o_field_state_selection, .o_field_boolean_favorite, .o_field_priority, .o_field_contact_image, .oe_avatar), .o_input_box:not(.o_input_box .o_input_box) {
         width: 100%;
     }
 
@@ -1184,21 +1184,21 @@
 
 // General InputBox rules
 .o_form_view {
-        .o_field_widget:not(.o_list_view .o_field_widget):not(.o_field_one2many):not(.o_input_box_overlay_start, .o_input_box_overlay_end), .o_input_box:has(.o_field_widget) {
-            &:has(.o_input, textarea, select, [contenteditable]) {
-                position: relative;
+    .o_field_widget:not(.o_list_view .o_field_widget):not(.o_field_one2many):not(.o_input_box_overlay_start, .o_input_box_overlay_end), .o_input_box:has(.o_field_widget) {
+        &:has(.o_input, textarea, select, [contenteditable]) {
+            position: relative;
 
-                .o_input_dropdown {
-                    position: static;
-                }
+            .o_input_dropdown {
+                position: static;
             }
         }
-        .o_input_box:has(.o_field_widget):not(.o_input_box .o_input_box):not(.o_field_widget .o_input_box) {
-            margin-bottom: var(--fieldWidget-margin-bottom);
-        }
-        .o_input_box .o_field_widget {
-            --fieldWidget-margin-bottom: 0;
-        }
+    }
+    .o_input_box:has(.o_field_widget):not(.o_input_box .o_input_box):not(.o_field_widget .o_input_box) {
+        margin-bottom: var(--fieldWidget-margin-bottom);
+    }
+    .o_input_box .o_field_widget {
+        --fieldWidget-margin-bottom: 0;
+    }
 }
 
 // TOUCH ONLY INPUTBOX RULES
@@ -1218,7 +1218,11 @@
         outline: var(--fieldWidget-outline-width) solid var(--border-color);
     }
 
-    .o_field_widget:not(.o_field_widget .o_field_widget):not(.o_list_view .o_field_widget):not(.o_field_one2many):not(.o_field_domain):not(.o_form_label .o_field_widget), .o_input_box:has(.o_field_widget) {
+    .o_field_widget:not(.o_field_widget .o_field_widget):not(.o_field_one2many):not(.o_field_domain):not(.o_form_label .o_field_widget), .o_input_box:has(.o_field_widget) {
+        &.o_input_box, .o_input_box {
+            --inputbox-overlay-padding-x: var(--inputbox-spacing-unit);
+            --inputbox-overlay-padding-y: calc(var(--border-width) + 2.25 * var(--inputbox-spacing-unit) - var(--inputbox-overlay-size) / 2);
+        }
         &:not(.o_input_box *) {
             &:has(.o_input, textarea, select, [contenteditable], .o_colorlist), &:is(.o_cell > .o_readonly_modifier, .o_cell .o_input_box:has(.o_readonly_modifier)):not(:has(input)) {
                 outline: var(--fieldWidget-outline-width) solid var(--o-input-border-color);
@@ -1313,9 +1317,6 @@ body:not(.o_touch_device) .o_form_view {
         .o_field_char.o_readonly_modifier {
             margin-bottom: 0;
         }
-    }
-    .o_form_label {
-        font-size: var(--fieldWidget-label-height);
     }
     .o_label_active {
         color: $o-action;

--- a/addons/web/static/tests/core/input_box.test.js
+++ b/addons/web/static/tests/core/input_box.test.js
@@ -35,7 +35,7 @@ describe("InputBox Component", () => {
         expect(".o_input_box .btn .fa-building").not.toBeVisible();
         expect(".o_input_box .btn .fa-trash").not.toBeVisible();
         const overlayPadding = queryFirst(".o_input_box_overlay_end").clientWidth + INPUTBOX_SPACING_UNIT;
-        expect(".o_input_box").toHaveStyle({"--inputbox-overlay-padding-prefix": "0px", "--inputbox-overlay-padding-suffix": 2 * overlayPadding + "px"});
+        expect(".o_input_box").toHaveStyle({"--inputbox-overlay-start-size": "0px", "--inputbox-overlay-end-size": 2 * overlayPadding + "px"});
         expect(".o_input_box .o_input_box_overlay_end:eq(0)").toHaveStyle({"inset-inline-end": overlayPadding + "px"});
         expect(".o_input_box .o_input_box_overlay_end:eq(1)").toHaveStyle({"inset-inline-end": "0px"});
         await contains(".o_input_box input").click();
@@ -75,7 +75,7 @@ describe("InputBox Component", () => {
         await animationFrame();
         expect(".o_input_box .btn .oi-ellipsis-v").toBeVisible();
         const overlayPadding = queryFirst(".o_input_box_overlay_end").clientWidth + INPUTBOX_SPACING_UNIT;
-        expect(".o_input_box").toHaveStyle({"--inputbox-overlay-padding-prefix": "0px", "--inputbox-overlay-padding-suffix": overlayPadding + "px"});
+        expect(".o_input_box").toHaveStyle({"--inputbox-overlay-start-size": "0px", "--inputbox-overlay-end-size": overlayPadding + "px"});
         await contains(".o_input_box .btn .oi-ellipsis-v").click();
         await animationFrame();
         expect(".o_bottom_sheet").toHaveCount(1);
@@ -108,7 +108,7 @@ describe("Elements with o_input_box classname", () => {
         expect(".o_input_box .fa").toHaveCount(2);
         const overlayPaddingStart = queryFirst(".o_input_box_overlay_start").clientWidth + INPUTBOX_SPACING_UNIT;
         const overlayPaddingEnd = queryFirst(".o_input_box_overlay_end").clientWidth + INPUTBOX_SPACING_UNIT;
-        expect(".o_input_box:not(.o_input_box .o_input_box").toHaveAttribute("style",`--inputbox-overlay-padding-prefix: ${overlayPaddingStart}px; --inputbox-overlay-padding-suffix: ${overlayPaddingEnd}px;`);
+        expect(".o_input_box:not(.o_input_box .o_input_box").toHaveAttribute("style",`--inputbox-overlay-start-size: ${overlayPaddingStart}px; --inputbox-overlay-end-size: ${overlayPaddingEnd}px;`);
         expect(".o_input_box .o_input_box").not.toHaveAttribute("style");
         expect(".o_input_box .fa-phone").toBeVisible();
     });
@@ -132,7 +132,42 @@ describe("Elements with o_input_box classname", () => {
         positionInputBoxOverlay(getFixture());
         await animationFrame();
         const overlayPaddingEnd = queryFirst(".o_input_box_overlay_end").clientWidth + INPUTBOX_SPACING_UNIT;
-        expect(".o_input_box:not(.o_input_box .o_input_box").toHaveAttribute("style",`--inputbox-overlay-padding-prefix: 0px; --inputbox-overlay-padding-suffix: ${overlayPaddingEnd}px;`);
+        expect(".o_input_box:not(.o_input_box .o_input_box").toHaveAttribute("style",`--inputbox-overlay-start-size: 0px; --inputbox-overlay-end-size: ${overlayPaddingEnd}px;`);
         expect(".o_input_box .fa-phone").not.toBeVisible();
+    });
+
+    test("Multiple and different overlay items can be present", async () => {
+        const CUSTOM_PADDING_AROUND = 5;
+        // In this test, we use the --inputbox-overlay-padding-x variable to add horizontal padding around the inputbox element.
+        // This is the implementation used by the form view on touch devices to add spacing around the entire box.
+        const item_a_w = 24;
+        const item_b_w = 35;
+        const item_c_w = 50;
+        class Root extends Component {
+            static components = {};
+            static props = {};
+            static template = xml`
+                <div class="o_input_box" style="--inputbox-overlay-padding-x: ${CUSTOM_PADDING_AROUND}px;">
+                    <div class="o_input_box_overlay_start" style="width: ${item_a_w}px;"/>
+                    <div class="o_input_box">
+                        <span>Hello Guys</span>
+                        <div id="b" class="o_input_box_overlay_end" style="width: ${item_b_w}px;"/>
+                        <div id="c" class="o_input_box_overlay_end" style="width: ${item_c_w}px;"/>
+                    </div>
+                </div>
+            `;
+        }
+        await mountWithCleanup(Root);
+        // Component with o_input_box class having o_input_box_overlay elements must call the positioning function after the render
+        positionInputBoxOverlay(getFixture());
+        await animationFrame();
+        expect(".o_input_box .o_input_box_overlay_start").toHaveCount(1);
+        expect(".o_input_box .o_input_box_overlay_end").toHaveCount(2);
+        const overlayPaddingStart = queryFirst(".o_input_box_overlay_start").clientWidth + INPUTBOX_SPACING_UNIT;
+        const overlayPaddingEnd = queryFirst(".o_input_box_overlay_end#b").clientWidth + 2 * INPUTBOX_SPACING_UNIT + queryFirst(".o_input_box_overlay_end#c").clientWidth;
+        expect(".o_input_box:not(.o_input_box .o_input_box").toHaveAttribute("style",`--inputbox-overlay-padding-x: ${CUSTOM_PADDING_AROUND}px; --inputbox-overlay-start-size: ${overlayPaddingStart}px; --inputbox-overlay-end-size: ${overlayPaddingEnd}px;`);
+        expect(".o_input_box .o_input_box").not.toHaveAttribute("style");
+        expect(getComputedStyle(queryFirst(".o_input_box")).paddingInlineStart).toBe(`${overlayPaddingStart + 1.5 * CUSTOM_PADDING_AROUND}px`);
+        expect(getComputedStyle(queryFirst(".o_input_box")).paddingInlineEnd).toBe(`${overlayPaddingEnd + CUSTOM_PADDING_AROUND}px`);
     });
 });


### PR DESCRIPTION
This commit reduces some padding unnecessary when elements with the o_input_box class is present outside of the form view. This reduces for example the space between the first overlay icon and the field content in the datetime field on kanban cards. A test has been introduced to make sure the right padding value is calculated to set the padding around elements in fields, with custom overlays width and a general padding set around them (as it is the case for the mobile form view).

Also, the vertical padding is only applied on form views on touch devices, where the inputbox is designed to be used with more padding around the elements, and no longer inside list/kanban views contained inside a form view.

Some css variables have been renamed to have a better knowledge of what they mean.

Finally, a redundant css rule for labels has been removed, since we don't want to select radio/checkbox o_form_label elements.

task-6011668
task-6011616
task-6012417