### PR TITLE
[FIX] pos_self_order: optimize partner data loading for self-ordering

### DIFF
--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -61,7 +61,6 @@ class PosSelfOrderController(http.Controller):
     def _generate_return_values(self, order, config_id):
         return {
             'pos.order': order.read(order._load_pos_data_fields(config_id.id), load=False),
-            'res.partner': order.partner_id.read(order.partner_id._load_pos_data_fields(config_id.id), load=False),
             'pos.order.line': order.lines.read(order._load_pos_data_fields(config_id.id), load=False),
             'pos.payment': order.payment_ids.read(order.payment_ids._load_pos_data_fields(order.config_id.id), load=False),
             'pos.payment.method': order.payment_ids.mapped('payment_method_id').read(order.env['pos.payment.method']._load_pos_data_fields(order.config_id.id), load=False),
@@ -78,7 +77,7 @@ class PosSelfOrderController(http.Controller):
 
         if existing_partner and existing_partner.exists():
             return {
-                'res.partner': existing_partner.read(existing_partner._load_pos_data_fields(pos_config.id), load=False),
+                'res.partner': existing_partner.read(['id'], load=False),
             }
 
         state_id = pos_config.env['res.country.state'].browse(int(state_id)) if state_id else False
@@ -95,7 +94,7 @@ class PosSelfOrderController(http.Controller):
         })
 
         return {
-            'res.partner': partner_sudo.read(partner_sudo._load_pos_data_fields(pos_config.id), load=False),
+            'res.partner': partner_sudo.read(['id'], load=False),
         }
 
     @http.route('/pos-self-order/remove-order', auth='public', type='jsonrpc', website=True)

--- a/addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.js
+++ b/addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.js
@@ -10,16 +10,20 @@ export class PresetInfoPopup extends Component {
 
     setup() {
         this.selfOrder = useSelfOrder();
+        const partner = this.selfOrder.currentOrder.partner_id;
+        const companyStateId = this.selfOrder.config.company_id.country_id.state_ids[0]?.id;
+        const companyCountryId = this.selfOrder.config.company_id.country_id.id;
+
         this.state = useState({
             selectedSlot: null,
-            selectedPartnerId: null,
-            name: "",
-            phone: "",
-            street: "",
-            countryId: this.selfOrder.config.company_id.country_id.id,
-            stateId: this.selfOrder.config.company_id.country_id.state_ids[0]?.id || null,
-            city: "",
-            zip: "",
+            selectedPartnerId: partner?.id || null,
+            name: partner?.name || "",
+            phone: partner?.phone || "",
+            street: partner?.street || "",
+            countryId: partner?.country_id?.id || companyCountryId || null,
+            stateId: partner?.state_id?.id || companyStateId || null,
+            city: partner?.city || "",
+            zip: partner?.zip || "",
         });
 
         onWillStart(async () => {
@@ -40,7 +44,27 @@ export class PresetInfoPopup extends Component {
                 state_id: this.state.stateId,
                 zip: this.state.zip,
             });
-            const partner = this.selfOrder.models.loadData(result);
+
+            const partnerId = result?.["res.partner"]?.[0]?.id;
+            if (!partnerId) {
+                return;
+            }
+
+            const partner = this.selfOrder.models.loadData({
+                "res.partner": [
+                    {
+                        id: partnerId,
+                        name: this.state.name,
+                        phone: this.state.phone,
+                        street: this.state.street,
+                        city: this.state.city,
+                        country_id: this.state.countryId,
+                        state_id: this.state.stateId,
+                        zip: this.state.zip,
+                    },
+                ],
+            });
+
             this.selfOrder.currentOrder.floating_order_name = `${this.preset.name} - ${partner["res.partner"][0].name}`;
             this.selfOrder.currentOrder.partner_id = partner["res.partner"][0];
         } else {
@@ -56,17 +80,10 @@ export class PresetInfoPopup extends Component {
         this.props.callback(true);
     }
 
-    selectExistingPartner(event) {
-        const partner = this.selfOrder.models["res.partner"].get(event.target.value);
-        this.state.name = partner?.name || "";
-        this.state.phone = partner?.phone || "";
-        this.state.street = partner?.street || "";
-        this.state.city = partner?.city || "";
-        this.state.countryId = partner?.country_id?.id || null;
-        this.state.stateId = partner?.state_id?.id || null;
-        this.state.zip = partner?.zip || "";
-    }
+    // TODO: remove in master
+    selectExistingPartner(event) {}
 
+    // TODO: remove in master
     get existingPartners() {
         return this.selfOrder.models["res.partner"].getAll();
     }

--- a/addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.xml
+++ b/addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.xml
@@ -21,17 +21,6 @@
                         t-esc="s.datetime.toFormat('HH:mm')" />
                 </t>
             </select>
-            <select t-if="preset.needsPartner and existingPartners.length"
-                class="partner-select form-select mb-3"
-                t-on-change="selectExistingPartner"
-                t-model="state.selectedPartnerId">
-                <option value="">
-                    Select your address
-                </option>
-                <t t-foreach="existingPartners" t-as="partner" t-key="partner.id">
-                    <option t-att-value="partner.id" t-esc="partner.name + ' ' + partner.pos_contact_address" />
-                </t>
-            </select>
             <input t-if="preset.needsName || preset.needsPartner"
                 type="text"
                 class="form-control mb-3"

--- a/addons/pos_self_order/static/tests/tours/self_order_preset_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_preset_tour.js
@@ -49,18 +49,6 @@ registry.category("web_tour.tours").add("self_order_preset_delivery_tour", {
         CartPage.fillInput("City", "New York"),
         Utils.clickBtn("Continue"),
         Utils.clickBtn("Ok"),
-
-        // Check if the partner is available in cache
-        Utils.checkIsNoBtn("My Order"),
-        Utils.clickBtn("Order Now"),
-        LandingPage.selectLocation("Delivery"),
-        ProductPage.clickProduct("Free"),
-        Utils.clickBtn("Order"),
-        CartPage.checkProduct("Free", "0", "1"),
-        Utils.clickBtn("Pay"),
-        CartPage.selectRandomValueInInput(".partner-select"),
-        Utils.clickBtn("Continue"),
-        Utils.clickBtn("Ok"),
     ],
 });
 


### PR DESCRIPTION
Partner data loading for self-ordering was not optimized, leading to performance issues when the partner had a lot of data.

This commit optimizes the partner data loading by only loading the necessary fields for self-ordering.
