### PR TITLE
[FIX] hr_livechat: update My Team filter in Live Chat reports

### DIFF
--- a/addons/hr_livechat/views/discuss_channel_views.xml
+++ b/addons/hr_livechat/views/discuss_channel_views.xml
@@ -7,7 +7,11 @@
             <field name="inherit_id" ref="im_livechat.discuss_channel_view_search"/>
             <field name="arch" type="xml">
                 <xpath expr="//*[@name='filter_my_sessions']" position="after">
-                    <filter name="filter_my_team" domain="[('channel_member_ids.partner_id.user_ids.employee_id.member_of_department', '=', True)]" string="My Team"/>
+                    <filter
+                       name="filter_my_team"
+                       domain="['|', ('channel_member_ids.partner_id.user_ids', '=', uid), ('channel_member_ids.partner_id.employee_ids.parent_id.user_id', '=', uid)]"
+                       string="My Team"
+                    />
                 </xpath>
             </field>
         </record>

--- a/addons/hr_livechat/views/im_livechat_report_channel_views.xml
+++ b/addons/hr_livechat/views/im_livechat_report_channel_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="im_livechat.im_livechat_report_channel_view_search"/>
         <field name="arch" type="xml">
             <xpath expr="//*[@name='my_session']" position="after">
-                <filter name="my_team" domain="[('partner_id.user_ids.employee_id.member_of_department', '=', True)]" string="My Team"/>
+                <filter name="my_team" domain="['|', ('partner_id.user_ids', '=', uid), ('partner_id.employee_ids.parent_id.user_id', '=', uid)]" string="My Team"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Replace the department-based domain with a hierarchy-based domain in livechat reports. The new filter includes the current user's records and the records of employees whose manager is the current user.

task-6030147


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
