### PR TITLE
[FIX] account_edi_ubl_cii: handle non-string regex

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_move.py
+++ b/addons/account_edi_ubl_cii/models/account_move.py
@@ -127,9 +127,10 @@ class AccountMove(models.Model):
         :return: True if lines look like they're grouped, False otherwise
         """
         self.ensure_one()
+        partner_name = re.escape(self.partner_id.name or _("Unknown partner")) + r' - \d+ - .*'
         return any(
-            re.match(re.escape(self.partner_id.name or _("Unknown partner")) + r' - \d+ - .*', line.name)
-            for line in self.line_ids.filtered(lambda x: x.display_type == 'product')
+            re.match(partner_name, line.name)
+            for line in self.line_ids.filtered(lambda line: line.name and line.display_type == 'product')
         )
 
     @api.model


### PR DESCRIPTION
The issue occurred because a test regex was applied to a non-string value. In some cases the value was False, which caused the operation to fail.

Steps to reproduce:
 - Import a vendor bill
 - Remove the product and the label from one line, then post the bill
 - Import another bill (or the same bill)from the same supplier
 - An error occurs when the regex tries to match a non-string value

This change ensures the regex is only applied to valid strings. It also improves the code by extracting the static part of the regex into a dedicated variable.

opw-6019298
opw-6030364
opw-6033013
opw-6032608
opw-6032546