### PR TITLE
[FIX] point_of_sale, pos_safaricom: display payment integration field labels

### DIFF
--- a/addons/pos_safaricom/views/pos_payment_method_views.xml
+++ b/addons/pos_safaricom/views/pos_payment_method_views.xml
@@ -5,7 +5,7 @@
         <field name="model">pos.payment.method</field>
         <field name="inherit_id" ref="point_of_sale.pos_payment_method_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='use_payment_terminal']" position="after">
+            <xpath expr="//group[@name='Payment methods']/div/group" position="after">
                 <!-- Safaricom M-Pesa -->
                 <group colspan="2" col="2" invisible="use_payment_terminal != 'safaricom'">
                     <group>


### PR DESCRIPTION
Steps to Reproduce:
------------------------
- Install the Point of Sale module and the pos_safaricom module.
- Configure a payment terminal for any payment method.

Issue:
-------
- The labels of the payment method integration fields are not visible.

Cause:
---------
- In pos_safaricom, a `<group>` tag was inserted using an `<xpath>` after a field element.
- This caused the fields at that level to lose their labels due to the altered view structure

Fix:
----
- Updated the `<xpath>` to target the group level instead of inserting a `<group>` after a field.
- This preserves the correct form view hierarchy and ensures that field labels are displayed properly

task: 6030960