### PR TITLE
[FIX] l10n_cl: fix invalid view in l10n_cl

### DIFF
--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -169,7 +169,7 @@
         </xpath>
 
         <td name="td_discount" t-if="display_discount" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" position="after">
-            <td name="td_discount_currency" t-if="display_discount" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" position="after">
+            <td name="td_discount_currency" t-if="display_discount" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
                 <span class="text-nowrap" t-out="line_amounts['total_discount']" t-options="{'widget': 'monetary', 'display_currency': line_amounts['main_currency']}"/>
             </td>
         </td>


### PR DESCRIPTION
There is a broken xpath in l10n_cl.report_invoice_document

When the l10n_cl module is installed, it results in the faulty view being applied to v18 and later versions.
This is particularly annoying because some rolling releases fail because a view with invalid locator is found.

The view won't be disabled after a rolling release upgrade and many developers will be spared from checking the databases manually.