### PR TITLE
[FIX] hr_recruitment_survey: fix missing type

### DIFF
--- a/addons/hr_recruitment_survey/models/survey_survey.py
+++ b/addons/hr_recruitment_survey/models/survey_survey.py
@@ -16,7 +16,7 @@ class SurveySurvey(models.Model):
         if self.env.user.has_group('hr_recruitment.group_hr_recruitment_interviewer') or \
                 self.env.user.has_group('survey.group_survey_user'):
             for survey in self:
-                survey.allowed_survey_types.append('recruitment')
+                survey.allowed_survey_types = [*survey.allowed_survey_types, 'recruitment']
 
     def _compute_job_count(self):
         job_read_group = self.env['hr.job']._read_group(


### PR DESCRIPTION
How to reproduce:
- install hr_recruitment_survey
- log in as admin and create a new survey The selection for "Recruitment" survey type is missing in the survey form.

We solve the issue by replacing the "append" in the compute method by an affectation.

Task-6009719