### PR TITLE
[FIX] html_builder: filter options for access right earlier

### DIFF
--- a/addons/html_builder/static/src/sidebar/option_container.js
+++ b/addons/html_builder/static/src/sidebar/option_container.js
@@ -49,16 +49,17 @@ export class OptionsContainer extends BaseOptionComponent {
 
         this.callOperation = useOperation();
 
+        this.options = [];
         this.hasGroup = {};
         onWillStart(async () => {
-            await this.updateAccessGroup(this.props.options);
+            this.options = await this.filterAccessGroup(this.props.options);
         });
         onWillUpdateProps(async (nextProps) => {
-            await this.updateAccessGroup(nextProps.options);
+            this.options = await this.filterAccessGroup(nextProps.options);
         });
     }
 
-    async updateAccessGroup(options) {
+    async filterAccessGroup(options) {
         const proms = [];
         const groups = [...new Set(options.flatMap((o) => o.groups || []))];
         for (const group of groups) {
@@ -69,6 +70,7 @@ export class OptionsContainer extends BaseOptionComponent {
             );
         }
         await Promise.all(proms);
+        return options.filter((option) => this.hasAccess(option.groups));
     }
 
     hasAccess(groups) {
@@ -80,7 +82,7 @@ export class OptionsContainer extends BaseOptionComponent {
 
     get title() {
         let title;
-        for (const option of this.props.options) {
+        for (const option of this.options) {
             if (option.getSnippetTitle) {
                 title = option.getSnippetTitle.call(this);
                 continue;

--- a/addons/html_builder/static/src/sidebar/option_container.xml
+++ b/addons/html_builder/static/src/sidebar/option_container.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="html_builder.OptionsContainer">
-    <div t-if="props.options.length"
+    <div t-if="this.options.length"
          class="options-container mb-1" t-ref="root" t-att-data-container-title="title"
          t-on-pointerenter="onPointerEnter" t-on-pointerleave="onPointerLeave">
         <div class="options-container-header d-flex align-items-center justify-content-between">
@@ -61,8 +61,8 @@
             </div>
         </div>
         <div t-if="!this.props.folded" class="we-bg-options-container pb-3" t-ref="content">
-            <t t-foreach="props.options" t-as="OptionClass" t-key="OptionClass.name + '-' + OptionClass.template">
-                <BuilderContext applyTo="OptionClass.applyTo" t-if="hasAccess(OptionClass.groups)">
+            <t t-foreach="this.options" t-as="OptionClass" t-key="OptionClass.name + '-' + OptionClass.template">
+                <BuilderContext applyTo="OptionClass.applyTo">
                     <t t-component="OptionClass"></t>
                 </BuilderContext>
             </t>

--- a/addons/html_builder/static/tests/custom_tab/misc.test.js
+++ b/addons/html_builder/static/tests/custom_tab/misc.test.js
@@ -16,7 +16,7 @@ import { withSequence } from "@html_editor/utils/resource";
 import { describe, expect, test } from "@odoo/hoot";
 import { animationFrame, queryAllTexts, queryFirst } from "@odoo/hoot-dom";
 import { Component, onWillStart, xml } from "@odoo/owl";
-import { contains, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { contains, onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 
@@ -266,6 +266,55 @@ test("last container with options is unfolded regardless of containers without o
     await contains(":iframe .test-options-child").click();
     expect(".options-container-header i.fa-caret-right").toHaveCount(0);
     expect(".options-container-header i.fa-caret-down").toHaveCount(1);
+});
+
+test("options restricted to groups excluding current user do not make an empty folded group appear", async () => {
+    onRpc("res.users", "has_group", ({ args: [_, group] }) => {
+        if (group === "another_group") {
+            return false;
+        }
+    });
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static selector = ".test-options-target";
+            static template = xml`<BuilderRow label="'Row 1'">A</BuilderRow>`;
+            static groups = ["another_group"];
+        }
+    );
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static selector = ".test-options-child";
+            static template = xml`<BuilderRow label="'Row 2'">A</BuilderRow>`;
+        }
+    );
+    await setupHTMLBuilder(
+        `<section class="test-options-target" data-name="Target">
+            <div class="test-options-child" data-name="Child">
+                Text
+            </div>
+        </section>`
+    );
+    await contains(":iframe .test-options-child").click();
+    expect(".options-container-header:contains(Target)").toHaveCount(0);
+    expect(".options-container-header i.fa-caret-down").toHaveCount(1);
+});
+
+test("option with groups restriction not available to user", async () => {
+    onRpc("res.users", "has_group", ({ args: [_, group] }) => {
+        if (group === "another_group") {
+            return false;
+        }
+    });
+    addBuilderOption(
+        class extends BaseOptionComponent {
+            static selector = ".test-target";
+            static template = xml`<BuilderRow label="'Row'">Test</BuilderRow>`;
+            static groups = ["another_group"];
+        }
+    );
+    await setupHTMLBuilder(`<div class="test-target">Hello</div>`);
+    await contains(":iframe .test-target").click();
+    expect(".options-container").toHaveCount(0);
 });
 
 test("option that matches several elements", async () => {


### PR DESCRIPTION
Since the [website builder refactor], the `OptionContainer` component filters the option based on access right when rendering the list of options, and hides itself if there is no options visible when rendered. With [folding of options], the options are rendered only when the group is unfolded. Thus the component can hide itself only if unfolded. Generally, there is at least one option visible when a group is rendered, which appears when the group is unfolded. But when options are filtered because of access right, the filtered list is often empty, and the group disappears when unfolded.

This commit moves the filtering slightly earlier, so the options are filtered before rendering. If the filtered list of options is empty, the component shows nothing at all as it knows it has zero options, instead of a folded group.

Steps to reproduce:
- With a user with only the "restricted editor" access right (and not "editor and designer")
- Open website builder on /blog
- Click in the title in the cover
- Bug: the "Blog Page" options group appears (but it is empty, and disappears when opened)

[website builder refactor]: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
[folding of options]: 64d35ccd6fade9e0473686b8484f561b5f4215ce

task-6032728
