### PR TITLE
[FIX] l10n_sa:  Tax adjustments

### DIFF
--- a/addons/l10n_sa/data/template/account.tax-sa.csv
+++ b/addons/l10n_sa/data/template/account.tax-sa.csv
@@ -3,14 +3,6 @@
 ,,,,,,,,,"tax","invoice","1(T)","sa_account_201017",,,,,,,,,,,
 ,,,,,,,,,"base","refund","1(B)",,,,,,,,,,,,
 ,,,,,,,,,"tax","refund","1(T)","sa_account_201017",,,,,,,,,,,
-"sa_ph_pe_hs_tax_15","15% PH PE HS","sale","15.0","percent","Private Healthcare / Private Education / First house sales to citizens","15%","sa_tax_group_taxes_vat",,"base","invoice","2(B)",,,"المبيعات الخاضعة للنسبة الأساسية %15",l10n_sa_account_fiscal_position_ksa,,,,,,,
-,,,,,,,,,"tax","invoice",,"sa_account_201017",,,,,,,,,,,
-,,,,,,,,,"base","refund","2(B)",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,"sa_account_201017",,,,,,,,,,,
-"sa_local_sales_tax_0","0%","sale","0.0","percent","Not Subject to VAT","0%","sa_tax_group_taxes_vat",,"base","invoice","3(B)",,,"غير خاضعة لضريبة القيمة المضافة.","l10n_sa_account_fiscal_position_ksa,l10n_sa_account_fiscal_position_gcc",,,,,,,,,"Not Subject to VAT."
-,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
-,,,,,,,,,"base","refund","3(B)",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,,,,,,,,,,,,
 "sa_international_transport_passengers_tax_0","0% ITP","sale","0.0","percent","The International transport of Passengers","0%","sa_tax_group_taxes_vat",,"base","invoice","3(B)",,,"المواصلات الدولية للركاب.",l10n_sa_account_fiscal_position_ksa,,"False",,,,,,,"The International transport of Passengers."
 ,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
 ,,,,,,,,,"base","refund","3(B)",,,,,,,,,,,,
@@ -19,7 +11,7 @@
 ,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
 ,,,,,,,,,"base","refund","3(B)",,,,,,,,,,,,
 ,,,,,,,,,"tax","refund",,,,,,,,,,,,,
-"sa_qualifying_transport_tax_0","0% QT","sale","0.0","percent","Supply of a qualifying means of transport","0%","sa_tax_group_taxes_vat",,"base","invoice","3(B)",,,"التزويد بوسائل نقل مؤهلة.",l10n_sa_account_fiscal_position_ksa,,,,,,,,,"Supply of a qualifying means of transport."
+"sa_qualifying_transport_tax_0","0% QT","sale","0.0","percent","Supply of a qualifying means of transport","0%","sa_tax_group_taxes_vat",,"base","invoice","3(B)",,,"التزويد بوسائل نقل مؤهلة.",l10n_sa_account_fiscal_position_ksa,,"False",,,,,,,"Supply of a qualifying means of transport."
 ,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
 ,,,,,,,,,"base","refund","3(B)",,,,,,,,,,,,
 ,,,,,,,,,"tax","refund",,,,,,,,,,,,,
@@ -35,15 +27,15 @@
 ,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
 ,,,,,,,,,"base","refund","3(B)",,,,,,,,,,,,
 ,,,,,,,,,"tax","refund",,,,,,,,,,,,,
-"sa_private_education_tax_0","0% PE","sale","0.0","percent","Private education to citizen","0%","sa_tax_group_taxes_vat",,"base","invoice","3(B)",,,"تعليم خاص للمواطن.",l10n_sa_account_fiscal_position_ksa,,"False",,,,,,,"Private education to citizen."
+"sa_private_education_tax_0","0% PE","sale","0.0","percent","Private education to citizen","0%","sa_tax_group_taxes_vat",,"base","invoice","2(B)",,,"تعليم خاص للمواطن.",l10n_sa_account_fiscal_position_ksa,,"False",,,,,,,"Private education to citizen."
 ,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
-,,,,,,,,,"base","refund","3(B)",,,,,,,,,,,,
+,,,,,,,,,"base","refund","2(B)",,,,,,,,,,,,
 ,,,,,,,,,"tax","refund",,,,,,,,,,,,,
-"sa_private_healthcare_tax_0","0% PH","sale","0.0","percent","Private healthcare to citizen","0%","sa_tax_group_taxes_vat",,"base","invoice","3(B)",,,"رعاية صحية خاصة للمواطن.",l10n_sa_account_fiscal_position_ksa,,"False",,,,,,,"Private healthcare to citizen."
+"sa_private_healthcare_tax_0","0% PH","sale","0.0","percent","Private healthcare to citizen","0%","sa_tax_group_taxes_vat",,"base","invoice","2(B)",,,"رعاية صحية خاصة للمواطن.",l10n_sa_account_fiscal_position_ksa,,"False",,,,,,,"Private healthcare to citizen."
 ,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
-,,,,,,,,,"base","refund","3(B)",,,,,,,,,,,,
+,,,,,,,,,"base","refund","2(B)",,,,,,,,,,,,
 ,,,,,,,,,"tax","refund",,,,,,,,,,,,,
-"sa_international_transport_goods_tax_0","0% IT G","sale","0.0","percent","The International transport of Goods","0%","sa_tax_group_taxes_vat","consu","base","invoice","3(B)",,,"الشحن الدولي للبضائع.",l10n_sa_account_fiscal_position_ksa,,,,,,,,,"The International transport of Goods."
+"sa_international_transport_goods_tax_0","0% IT G","sale","0.0","percent","The International transport of Goods","0%","sa_tax_group_taxes_vat","consu","base","invoice","3(B)",,,"الشحن الدولي للبضائع.",l10n_sa_account_fiscal_position_ksa,,"False",,,,,,,"The International transport of Goods."
 ,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
 ,,,,,,,,,"base","refund","3(B)",,,,,,,,,,,,
 ,,,,,,,,,"tax","refund",,,,,,,,,,,,,
@@ -66,6 +58,10 @@
 "sa_exempt_real_estate_tax_0","0% EXT RE","sale","0.0","percent","Exempt - Real estate transaction mentioned in Article 30 of the VAT Regulations","Exempt","sa_tax_group_taxes_vat",,"base","invoice","5(B)",,,"المعاملات العقارية المذكورة في القانون 30 في لوائح ضريبة القيمة المضافة","l10n_sa_account_fiscal_position_ksa,l10n_sa_account_fiscal_position_gcc",,"False",,,,,,,"Real estate transaction mentioned in Article 30 of the VAT Regulations."
 ,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
 ,,,,,,,,,"base","refund","5(B)",,,,,,,,,,,,
+,,,,,,,,,"tax","refund",,,,,,,,,,,,,
+"sa_local_sales_tax_0","0%","sale","0.0","percent","Not Subject to VAT","0%","sa_tax_group_taxes_vat",,"base","invoice",,,,"غير خاضعة لضريبة القيمة المضافة.","l10n_sa_account_fiscal_position_ksa,l10n_sa_account_fiscal_position_gcc",,"False",,,,,,,"Not Subject to VAT."
+,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
+,,,,,,,,,"base","refund",,,,,,,,,,,,,
 ,,,,,,,,,"tax","refund",,,,,,,,,,,,,
 "sa_purchase_tax_15","15%","purchase","15.0","percent",,"15%","sa_tax_group_taxes_vat",,"base","invoice","7(B)",,,"المشتريات الخاضعة للنسبة الأساسية %15",l10n_sa_account_fiscal_position_ksa,,,,,,,
 ,,,,,,,,,"tax","invoice","7(T)","sa_account_104041",,,,,,,,,,,

--- a/addons/l10n_sa/data/template/account.tax-sa.csv
+++ b/addons/l10n_sa/data/template/account.tax-sa.csv
@@ -1,171 +1,171 @@
-"id","name","type_tax_use","amount","amount_type","description","invoice_label","tax_group_id","tax_scope","repartition_line_ids/repartition_type","repartition_line_ids/document_type","repartition_line_ids/tag_ids","repartition_line_ids/account_id","repartition_line_ids/factor_percent","description@ar","fiscal_position_ids","original_tax_ids","active","tax_exigibility","repartition_line_ids/use_in_tax_closing","price_include_override",include_base_amount,cash_basis_transition_account_id,is_withholding_tax_on_payment,"invoice_legal_notes"
-"sa_sales_tax_15","15%","sale","15.0","percent",,"15%","sa_tax_group_taxes_vat",,"base","invoice","1(B)",,,"المبيعات الخاضعة للنسبة الأساسية %15",l10n_sa_account_fiscal_position_ksa,,,,,,,
-,,,,,,,,,"tax","invoice","1(T)","sa_account_201017",,,,,,,,,,,
-,,,,,,,,,"base","refund","1(B)",,,,,,,,,,,,
-,,,,,,,,,"tax","refund","1(T)","sa_account_201017",,,,,,,,,,,
-"sa_international_transport_passengers_tax_0","0% ITP","sale","0.0","percent","The International transport of Passengers","0%","sa_tax_group_taxes_vat",,"base","invoice","3(B)",,,"المواصلات الدولية للركاب.",l10n_sa_account_fiscal_position_ksa,,"False",,,,,,,"The International transport of Passengers."
-,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
-,,,,,,,,,"base","refund","3(B)",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,,,,,,,,,,,,
-"sa_international_transport_passengers_services_tax_0","0% S IPT","sale","0.0","percent","Services directly connected and incidental to a Supply of international passenger transport","0%","sa_tax_group_taxes_vat",,"base","invoice","3(B)",,,"الخدمات المتصلة مباشرة وعرضاً بوسيلة مواصلات الركاب الدولية.",l10n_sa_account_fiscal_position_ksa,,"False",,,,,,,"Services directly connected with international passenger transport."
-,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
-,,,,,,,,,"base","refund","3(B)",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,,,,,,,,,,,,
-"sa_qualifying_transport_tax_0","0% QT","sale","0.0","percent","Supply of a qualifying means of transport","0%","sa_tax_group_taxes_vat",,"base","invoice","3(B)",,,"التزويد بوسائل نقل مؤهلة.",l10n_sa_account_fiscal_position_ksa,,"False",,,,,,,"Supply of a qualifying means of transport."
-,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
-,,,,,,,,,"base","refund","3(B)",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,,,,,,,,,,,,
-"sa_any_goods_passengers_transport_tax_0","0% GPT","sale","0.0","percent","Any services relating to Goods or passenger transportation, as defined in article twenty five of these Regulations","0%","sa_tax_group_taxes_vat",,"base","invoice","3(B)",,,"أي خدمة متعلقة بنقل الركاب أو البضائع، كما هو محدد في القانون خمسة وعشرين في تلك اللوائح.",l10n_sa_account_fiscal_position_ksa,,"False",,,,,,,"Any services relating to Goods or passenger transportation, as defined in article twenty five of these Regulations."
-,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
-,,,,,,,,,"base","refund","3(B)",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,,,,,,,,,,,,
-"sa_medicines_tax_0","0% MME","sale","0.0","percent","Medicines and medical equipment","0%","sa_tax_group_taxes_vat",,"base","invoice","3(B)",,,"الأدوية والمعدات الطبية.",l10n_sa_account_fiscal_position_ksa,,"False",,,,,,,"Medicines and medical equipment."
-,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
-,,,,,,,,,"base","refund","3(B)",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,,,,,,,,,,,,
-"sa_qualifying_metals_tax_0","0% QM","sale","0.0","percent","Qualifying metals","0%","sa_tax_group_taxes_vat",,"base","invoice","3(B)",,,"المعادن المؤهلة.",l10n_sa_account_fiscal_position_ksa,,"False",,,,,,,"Qualifying metals."
-,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
-,,,,,,,,,"base","refund","3(B)",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,,,,,,,,,,,,
-"sa_private_education_tax_0","0% PE","sale","0.0","percent","Private education to citizen","0%","sa_tax_group_taxes_vat",,"base","invoice","2(B)",,,"تعليم خاص للمواطن.",l10n_sa_account_fiscal_position_ksa,,"False",,,,,,,"Private education to citizen."
-,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
-,,,,,,,,,"base","refund","2(B)",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,,,,,,,,,,,,
-"sa_private_healthcare_tax_0","0% PH","sale","0.0","percent","Private healthcare to citizen","0%","sa_tax_group_taxes_vat",,"base","invoice","2(B)",,,"رعاية صحية خاصة للمواطن.",l10n_sa_account_fiscal_position_ksa,,"False",,,,,,,"Private healthcare to citizen."
-,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
-,,,,,,,,,"base","refund","2(B)",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,,,,,,,,,,,,
-"sa_international_transport_goods_tax_0","0% IT G","sale","0.0","percent","The International transport of Goods","0%","sa_tax_group_taxes_vat","consu","base","invoice","3(B)",,,"الشحن الدولي للبضائع.",l10n_sa_account_fiscal_position_ksa,,"False",,,,,,,"The International transport of Goods."
-,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
-,,,,,,,,,"base","refund","3(B)",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,,,,,,,,,,,,
-"sa_export_sales_tax_0","0% EX G","sale","0.0","percent","Zero-rated exports - Export of Goods","0% Export","sa_tax_group_taxes_vat","consu","base","invoice","4(B)",,,"تصدير البضائع.",l10n_sa_account_fiscal_position_gcc,sa_sales_tax_15,,,,,,,,"Export of Goods."
-,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
-,,,,,,,,,"base","refund","4(B)",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,,,,,,,,,,,,
-"sa_export_services_tax_0","0% EX S","sale","0.0","percent","Zero-rated exports - Export of Services","0% Export","sa_tax_group_taxes_vat","service","base","invoice","4(B)",,,"تصدير الخدمات.",l10n_sa_account_fiscal_position_gcc,,,,,,,,,"Export of Services."
-,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
-,,,,,,,,,"base","refund","4(B)",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,,,,,,,,,,,,
-"sa_exempt_sales_tax_0","0% EXT FS","sale","0.0","percent","Exempt - Financial services mentioned in Article 29 of the VAT Regulations","Exempt","sa_tax_group_taxes_vat",,"base","invoice","5(B)",,,"الخدمات المالية المذكورة في القانون 29 في لوائح ضريبة القيمة المضافة","l10n_sa_account_fiscal_position_ksa,l10n_sa_account_fiscal_position_gcc",,"False",,,,,,,"Financial services mentioned in Article 29 of the VAT Regulations."
-,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
-,,,,,,,,,"base","refund","5(B)",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,,,,,,,,,,,,
-"sa_exempt_life_insurance_tax_0","0% EXT LI","sale","0.0","percent","Exempt - Life Insurance Services mentioned in Article 29 of the VAT Regulations","Exempt","sa_tax_group_taxes_vat",,"base","invoice","5(B)",,,"خدمات التأمين على الحياة المذكورة في القانون 29 لضريبة القيمة المضافة","l10n_sa_account_fiscal_position_ksa,l10n_sa_account_fiscal_position_gcc",,"False",,,,,,,"Life insurance services mentioned in Article 29 of the VAT Regulations."
-,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
-,,,,,,,,,"base","refund","5(B)",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,,,,,,,,,,,,
-"sa_exempt_real_estate_tax_0","0% EXT RE","sale","0.0","percent","Exempt - Real estate transaction mentioned in Article 30 of the VAT Regulations","Exempt","sa_tax_group_taxes_vat",,"base","invoice","5(B)",,,"المعاملات العقارية المذكورة في القانون 30 في لوائح ضريبة القيمة المضافة","l10n_sa_account_fiscal_position_ksa,l10n_sa_account_fiscal_position_gcc",,"False",,,,,,,"Real estate transaction mentioned in Article 30 of the VAT Regulations."
-,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
-,,,,,,,,,"base","refund","5(B)",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,,,,,,,,,,,,
-"sa_local_sales_tax_0","0%","sale","0.0","percent","Not Subject to VAT","0%","sa_tax_group_taxes_vat",,"base","invoice",,,,"غير خاضعة لضريبة القيمة المضافة.","l10n_sa_account_fiscal_position_ksa,l10n_sa_account_fiscal_position_gcc",,"False",,,,,,,"Not Subject to VAT."
-,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
-,,,,,,,,,"base","refund",,,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,,,,,,,,,,,,
-"sa_purchase_tax_15","15%","purchase","15.0","percent",,"15%","sa_tax_group_taxes_vat",,"base","invoice","7(B)",,,"المشتريات الخاضعة للنسبة الأساسية %15",l10n_sa_account_fiscal_position_ksa,,,,,,,
-,,,,,,,,,"tax","invoice","7(T)","sa_account_104041",,,,,,,,,,,
-,,,,,,,,,"base","refund","7(B)",,,,,,,,,,,,
-,,,,,,,,,"tax","refund","7(T)","sa_account_104041",,,,,,,,,,,
-"sa_rcp_tax_15","15% R C","purchase","15.0","percent",,"15% Reverse charge","sa_tax_group_taxes_vat","service","base","invoice","9(B)",,,"الاستيرادات الخاضعة لضريبة القيمة المضافة التي تُطبق عليها آلية الاحتساب العكسي %15",l10n_sa_account_fiscal_position_gcc,,,,,,,
-,,,,,,,,,"tax","invoice","9(T)","sa_account_104043",,,,,,,,,,,
-,,,,,,,,,"tax","invoice","9(T)","sa_account_201017","-100",,,,,,,,,,
-,,,,,,,,,"base","refund","9(B)",,,,,,,,,,,,
-,,,,,,,,,"tax","refund","9(T)","sa_account_104043",,,,,,,,,,,
-,,,,,,,,,"tax","refund","9(T)","sa_account_201017","-100",,,,,,,,,,
-"sa_import_tax_paid_15_paid_to_customs","15% EX ONLY B","purchase","0.0","percent","Imports - Only Base","15% Import - Base","sa_tax_group_taxes_import_15",,"base","invoice","8(B)",,,"الاستيرادات الخاضعة لضريبة القيمة المضافة بالنسبة الأساسية و التي تدفع في الجمارك %15",l10n_sa_account_fiscal_position_gcc,,,,,,,
-,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
-,,,,,,,,,"base","refund","8(B)",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,,,,,,,,,,,,
-"sa_import_tax_paid_15_paid_to_customs_vat","15% EX ONLY","purchase","100.0","division","Imports - Only VAT","15% Import","sa_tax_group_taxes_import_15",,"base","invoice",,,,"الاستيرادات الخاضعة لضريبة القيمة المضافة بالنسبة الأساسية و التي تدفع في الجمارك %15",l10n_sa_account_fiscal_position_gcc,,,,,tax_included,True,
-,,,,,,,,,"tax","invoice","8(T)","sa_account_101060",,,,,,,,,,,
-,,,,,,,,,"base","refund",,,,,,,,,,,,,
-,,,,,,,,,"tax","refund","8(T)","sa_account_101060",,,,,,,,,,,
-"sa_purchases_tax_0","0%","purchase","0.0","percent",,"0%","sa_tax_group_taxes_vat",,"base","invoice","10(B)",,,"المشتريات الخاضعة لنسبة %0",l10n_sa_account_fiscal_position_ksa,,,,,,,
-,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
-,,,,,,,,,"base","refund","10(B)",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,,,,,,,,,,,,
-"sa_exempt_purchases_tax","0% EXT","purchase","0.0","percent","Exempt","Exempt","sa_tax_group_taxes_vat",,"base","invoice","11(B)",,,"المشتريات المعفاة من الضريبة","l10n_sa_account_fiscal_position_ksa,l10n_sa_account_fiscal_position_gcc",,,,,,,
-,,,,,,,,,"tax","invoice",,,,,,,,,,,,,
-,,,,,,,,,"base","refund","11(B)",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,,,,,,,,,,,,
-"sa_withholding_tax_5_rental","5% WH R G","purchase","5.0","division","Gross Withholding on Payment - Rent","5% Withholding","sa_tax_group_taxes_withholding_5","service","base","invoice","1(B)_W_G",,,"استقطاع الضريبة 5 % (إيجار)",l10n_sa_account_fiscal_position_gcc,,,"on_payment",,tax_excluded,,sa_account_201035,
-,,,,,,,,,"tax","invoice",,"sa_account_400073",,,,,,,,,,,
-,,,,,,,,,"tax","invoice","1(T)_W_G","sa_account_201020","-100",,,,,,,,,,
-,,,,,,,,,"base","refund","1(B)_W_G",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,"sa_account_400073",,,,,,,,,,,
-,,,,,,,,,"tax","refund","1(T)_W_G","sa_account_201020","-100",,,,,,,,,,
-"sa_withholding_tax_5_tickets_or_air_freight","5% WH AT AF MF G","purchase","5.0","division","Gross Withholding on Payment - Air tickets, Air freight and Maritime freight for International travel departing from Saudi Arabia","5% Withholding","sa_tax_group_taxes_withholding_5","service","base","invoice","2(B)_W_G",,,"استقطاع الضريبة 5 % (تذاكر طيران أو شحن جوي)",l10n_sa_account_fiscal_position_gcc,,,"on_payment",,tax_excluded,,sa_account_201035,
-,,,,,,,,,"tax","invoice",,"sa_account_400073",,,,,,,,,,,
-,,,,,,,,,"tax","invoice","2(T)_W_G","sa_account_201020","-100",,,,,,,,,,
-,,,,,,,,,"base","refund","2(B)_W_G",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,"sa_account_400073",,,,,,,,,,,
-,,,,,,,,,"tax","refund","2(T)_W_G","sa_account_201020","-100",,,,,,,,,,
-"sa_withholding_tax_5_international_telecommunication","5% WH TC ICS G","purchase","5.0","division","Gross Withholding on Payment - Technical and consulting services and international telecommunication services (for related and unrelated parties)","5% Withholding","sa_tax_group_taxes_withholding_5","service","base","invoice","3(B)_W_G",,,"استقطاع الضريبة 5 % (خدمات اتصاالت هاتفية دولية)",l10n_sa_account_fiscal_position_gcc,,,"on_payment",,tax_excluded,,sa_account_201035,
-,,,,,,,,,"tax","invoice",,"sa_account_400073",,,,,,,,,,,
-,,,,,,,,,"tax","invoice","3(T)_W_G","sa_account_201020","-100",,,,,,,,,,
-,,,,,,,,,"base","refund","3(B)_W_G",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,"sa_account_400073",,,,,,,,,,,
-,,,,,,,,,"tax","refund","3(T)_W_G","sa_account_201020","-100",,,,,,,,,,
-"sa_withholding_tax_5_distributed_profits","5% WH D G","purchase","5.0","division","Gross Withholding on Payment - Dividends","5% Withholding","sa_tax_group_taxes_withholding_5","service","base","invoice","4(B)_W_G",,,"استقطاع الضريبة 5 % (أرباح موزعة)",l10n_sa_account_fiscal_position_gcc,,,"on_payment",,tax_excluded,,sa_account_201035,
-,,,,,,,,,"tax","invoice",,"sa_account_400073",,,,,,,,,,,
-,,,,,,,,,"tax","invoice","4(T)_W_G","sa_account_201020","-100",,,,,,,,,,
-,,,,,,,,,"base","refund","4(B)_W_G",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,"sa_account_400073",,,,,,,,,,,
-,,,,,,,,,"tax","refund","4(T)_W_G","sa_account_201020","-100",,,,,,,,,,
-"sa_withholding_tax_5_insurance_amd_reinsurance","5% WH IL IRP G ","purchase","5.0","division","Gross Withholding on Payment - Interest on loan, insurance and reinsurance premium","5% Withholding","sa_tax_group_taxes_withholding_5","service","base","invoice","5(B)_W_G",,,"استقطاع الضريبة 5 % (قسط تأمين أو إعادة تأمين)",l10n_sa_account_fiscal_position_gcc,,,"on_payment",,tax_excluded,,sa_account_201035,
-,,,,,,,,,"tax","invoice",,"sa_account_400073",,,,,,,,,,,
-,,,,,,,,,"tax","invoice","5(T)_W_G","sa_account_201020","-100",,,,,,,,,,
-,,,,,,,,,"base","refund","5(B)_W_G",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,"sa_account_400073",,,,,,,,,,,
-,,,,,,,,,"tax","refund","5(T)_W_G","sa_account_201020","-100",,,,,,,,,,
-"sa_withholding_tax_15_royalties","15% WH R G","purchase","15.0","division","Gross Withholding on Payment - Royalty","15% Withholding","sa_tax_group_taxes_withholding_15","service","base","invoice","6(B)_W_G",,,"استقطاع الضريبة 15 % (أتاوة أو ريع)",l10n_sa_account_fiscal_position_gcc,,,"on_payment",,tax_excluded,,sa_account_201035,
-,,,,,,,,,"tax","invoice",,"sa_account_400073",,,,,,,,,,,
-,,,,,,,,,"tax","invoice","6(T)_W_G","sa_account_201020","-100",,,,,,,,,,
-,,,,,,,,,"base","refund","6(B)_W_G",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,"sa_account_400073",,,,,,,,,,,
-,,,,,,,,,"tax","refund","6(T)_W_G","sa_account_201020","-100",,,,,,,,,,
-"sa_withholding_tax_15_others","15% WH O G","purchase","15.0","division","Gross Withholding on Payment - Any other payments","15% Withholding","sa_tax_group_taxes_withholding_15","service","base","invoice","7(B)_W_G",,,"استقطاع الضريبة 15 % (لأي دفعات أخرى)",l10n_sa_account_fiscal_position_gcc,,,"on_payment",,tax_excluded,,sa_account_201035,
-,,,,,,,,,"tax","invoice",,"sa_account_400073",,,,,,,,,,,
-,,,,,,,,,"tax","invoice","7(T)_W_G","sa_account_201020","-100",,,,,,,,,,
-,,,,,,,,,"base","refund","7(B)_W_G",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,"sa_account_400073",,,,,,,,,,,
-,,,,,,,,,"tax","refund","7(T)_W_G","sa_account_201020","-100",,,,,,,,,,
-"sa_withholding_tax_20_managerial","20% WH MF G","purchase","20.0","division","Gross Withholding on Payment - Management Fees","20% Withholding","sa_tax_group_taxes_withholding_20","service","base","invoice","8(B)_W_G",,,"استقطاع الضريبة 20 % (أتعاب إدارة)",l10n_sa_account_fiscal_position_gcc,,,"on_payment",,tax_excluded,,sa_account_201035,
-,,,,,,,,,"tax","invoice",,"sa_account_400073",,,,,,,,,,,
-,,,,,,,,,"tax","invoice","8(T)_W_G","sa_account_201020","-100",,,,,,,,,,
-,,,,,,,,,"base","refund","8(B)_W_G",,,,,,,,,,,,
-,,,,,,,,,"tax","refund",,"sa_account_400073",,,,,,,,,,,
-,,,,,,,,,"tax","refund","8(T)_W_G","sa_account_201020","-100",,,,,,,,,,
-"sa_withholding_tax_5_rental_d","5% WH R D","purchase","-5.0","percent","Deducted Withholding on Payment - Rent","5% Withholding","sa_tax_group_taxes_withholding_5","service","base","invoice","1(B)_W_D",,,"استقطاع الضريبة 5 % (إيجار)",l10n_sa_account_fiscal_position_gcc,,"False",,,,,,True
-,,,,,,,,,"tax","invoice","1(T)_W_D","sa_account_201020",,,,,,,,,,,
-,,,,,,,,,"base","refund","1(B)_W_D",,,,,,,,,,,,
-,,,,,,,,,"tax","refund","1(T)_W_D","sa_account_201020",,,,,,,,,,,
-"sa_withholding_tax_5_tickets_or_air_freight_d","5% WH AT AF MF D","purchase","-5.0","percent","Deducted Withholding on Payment - Air tickets, Air freight and Maritime freight for International travel departing from Saudi Arabia","5% Withholding","sa_tax_group_taxes_withholding_5","service","base","invoice","2(B)_W_D",,,"استقطاع الضريبة 5 % (تذاكر طيران أو شحن جوي)",l10n_sa_account_fiscal_position_gcc,,"False",,,,,,True
-,,,,,,,,,"tax","invoice","2(T)_W_D","sa_account_201020",,,,,,,,,,,
-,,,,,,,,,"base","refund","2(B)_W_D",,,,,,,,,,,,
-,,,,,,,,,"tax","refund","2(T)_W_D","sa_account_201020",,,,,,,,,,,
-"sa_withholding_tax_5_international_telecommunication_d","5% WH TC ICS D","purchase","-5.0","percent","Deducted Withholding on Payment - Technical and consulting services and international telecommunication services (for related and unrelated parties)","5% Withholding","sa_tax_group_taxes_withholding_5","service","base","invoice","3(B)_W_D",,,"استقطاع الضريبة 5 % (خدمات اتصاالت هاتفية دولية)",l10n_sa_account_fiscal_position_gcc,,"False",,,,,,True
-,,,,,,,,,"tax","invoice","3(T)_W_D","sa_account_201020",,,,,,,,,,,
-,,,,,,,,,"base","refund","3(B)_W_D",,,,,,,,,,,,
-,,,,,,,,,"tax","refund","3(T)_W_D","sa_account_201020",,,,,,,,,,,
-"sa_withholding_tax_5_distributed_profits_d","5% WH D D","purchase","-5.0","percent","Deducted Withholding on Payment - Dividends","5% Withholding","sa_tax_group_taxes_withholding_5","service","base","invoice","4(B)_W_D",,,"استقطاع الضريبة 5 % (أرباح موزعة)",l10n_sa_account_fiscal_position_gcc,,"False",,,,,,True
-,,,,,,,,,"tax","invoice","4(T)_W_D","sa_account_201020",,,,,,,,,,,
-,,,,,,,,,"base","refund","4(B)_W_D",,,,,,,,,,,,
-,,,,,,,,,"tax","refund","4(T)_W_D","sa_account_201020",,,,,,,,,,,
-"sa_withholding_tax_5_insurance_amd_reinsurance_d","5% WH IL IRP D","purchase","-5.0","percent","Deducted Withholding on Payment - Interest on loan, insurance and reinsurance premium","5% Withholding","sa_tax_group_taxes_withholding_5","service","base","invoice","5(B)_W_D",,,"استقطاع الضريبة 5 % (قسط تأمين أو إعادة تأمين)",l10n_sa_account_fiscal_position_gcc,,"False",,,,,,True
-,,,,,,,,,"tax","invoice","5(T)_W_D","sa_account_201020",,,,,,,,,,,
-,,,,,,,,,"base","refund","5(B)_W_D",,,,,,,,,,,,
-,,,,,,,,,"tax","refund","5(T)_W_D","sa_account_201020",,,,,,,,,,,
-"sa_withholding_tax_15_royalties_d","15% WH R D","purchase","-15.0","percent","Deducted Withholding on Payment - Royalty","15% Withholding","sa_tax_group_taxes_withholding_15","service","base","invoice","6(B)_W_D",,,"استقطاع الضريبة 15 % (أتاوة أو ريع)",l10n_sa_account_fiscal_position_gcc,,"False",,,,,,True
-,,,,,,,,,"tax","invoice","6(T)_W_D","sa_account_201020",,,,,,,,,,,
-,,,,,,,,,"base","refund","6(B)_W_D",,,,,,,,,,,,
-,,,,,,,,,"tax","refund","6(T)_W_D","sa_account_201020",,,,,,,,,,,
-"sa_withholding_tax_15_others_d","15% WH O D","purchase","-15.0","percent","Deducted Withholding on Payment - Any other payments","15% Withholding","sa_tax_group_taxes_withholding_15","service","base","invoice","7(B)_W_D",,,"استقطاع الضريبة 15 % (لأي دفعات أخرى)",l10n_sa_account_fiscal_position_gcc,,"False",,,,,,True
-,,,,,,,,,"tax","invoice","7(T)_W_D","sa_account_201020",,,,,,,,,,,
-,,,,,,,,,"base","refund","7(B)_W_D",,,,,,,,,,,,
-,,,,,,,,,"tax","refund","7(T)_W_D","sa_account_201020",,,,,,,,,,,
-"sa_withholding_tax_20_managerial_d","20% WH MF D","purchase","-20.0","percent","Deducted Withholding on Payment - Management Fees","20% Withholding","sa_tax_group_taxes_withholding_20","service","base","invoice","8(B)_W_D",,,"استقطاع الضريبة 20 % (أتعاب إدارة)",l10n_sa_account_fiscal_position_gcc,,"False",,,,,,True
-,,,,,,,,,"tax","invoice","8(T)_W_D","sa_account_201020",,,,,,,,,,,
-,,,,,,,,,"base","refund","8(B)_W_D",,,,,,,,,,,,
-,,,,,,,,,"tax","refund","8(T)_W_D","sa_account_201020",,,,,,,,,,,
+"id","name","type_tax_use","amount","amount_type","description","invoice_label","tax_group_id","tax_scope","repartition_line_ids/repartition_type","repartition_line_ids/document_type","repartition_line_ids/tag_ids","repartition_line_ids/account_id","repartition_line_ids/factor_percent","description@ar","fiscal_position_ids","original_tax_ids","active","tax_exigibility","repartition_line_ids/use_in_tax_closing","price_include_override","include_base_amount","cash_basis_transition_account_id","is_withholding_tax_on_payment","invoice_legal_notes"
+"sa_sales_tax_15","15%","sale","15.0","percent","","15%","sa_tax_group_taxes_vat","","base","invoice","1(B)","","","المبيعات الخاضعة للنسبة الأساسية %15","l10n_sa_account_fiscal_position_ksa","","","","","","","","",""
+"","","","","","","","","","tax","invoice","1(T)","sa_account_201017","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","1(B)","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","1(T)","sa_account_201017","","","","","","","","","","","",""
+"sa_international_transport_passengers_tax_0","0% ITP","sale","0.0","percent","The International transport of Passengers","0%","sa_tax_group_taxes_vat","","base","invoice","3(B)","","","المواصلات الدولية للركاب.","l10n_sa_account_fiscal_position_ksa","","False","","","","","","","The International transport of Passengers."
+"","","","","","","","","","tax","invoice","","","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","3(B)","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","","","","","","","","","","","","","",""
+"sa_international_transport_passengers_services_tax_0","0% S IPT","sale","0.0","percent","Services directly connected and incidental to a Supply of international passenger transport","0%","sa_tax_group_taxes_vat","","base","invoice","3(B)","","","الخدمات المتصلة مباشرة وعرضاً بوسيلة مواصلات الركاب الدولية.","l10n_sa_account_fiscal_position_ksa","","False","","","","","","","Services directly connected with international passenger transport."
+"","","","","","","","","","tax","invoice","","","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","3(B)","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","","","","","","","","","","","","","",""
+"sa_qualifying_transport_tax_0","0% QT","sale","0.0","percent","Supply of a qualifying means of transport","0%","sa_tax_group_taxes_vat","","base","invoice","3(B)","","","التزويد بوسائل نقل مؤهلة.","l10n_sa_account_fiscal_position_ksa","","False","","","","","","","Supply of a qualifying means of transport."
+"","","","","","","","","","tax","invoice","","","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","3(B)","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","","","","","","","","","","","","","",""
+"sa_any_goods_passengers_transport_tax_0","0% GPT","sale","0.0","percent","Any services relating to Goods or passenger transportation, as defined in article twenty five of these Regulations","0%","sa_tax_group_taxes_vat","","base","invoice","3(B)","","","أي خدمة متعلقة بنقل الركاب أو البضائع، كما هو محدد في القانون خمسة وعشرين في تلك اللوائح.","l10n_sa_account_fiscal_position_ksa","","False","","","","","","","Any services relating to Goods or passenger transportation, as defined in article twenty five of these Regulations."
+"","","","","","","","","","tax","invoice","","","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","3(B)","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","","","","","","","","","","","","","",""
+"sa_medicines_tax_0","0% MME","sale","0.0","percent","Medicines and medical equipment","0%","sa_tax_group_taxes_vat","","base","invoice","3(B)","","","الأدوية والمعدات الطبية.","l10n_sa_account_fiscal_position_ksa","","False","","","","","","","Medicines and medical equipment."
+"","","","","","","","","","tax","invoice","","","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","3(B)","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","","","","","","","","","","","","","",""
+"sa_qualifying_metals_tax_0","0% QM","sale","0.0","percent","Qualifying metals","0%","sa_tax_group_taxes_vat","","base","invoice","3(B)","","","المعادن المؤهلة.","l10n_sa_account_fiscal_position_ksa","","False","","","","","","","Qualifying metals."
+"","","","","","","","","","tax","invoice","","","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","3(B)","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","","","","","","","","","","","","","",""
+"sa_private_education_tax_0","0% PE","sale","0.0","percent","Private education to citizen","0%","sa_tax_group_taxes_vat","","base","invoice","2(B)","","","تعليم خاص للمواطن.","l10n_sa_account_fiscal_position_ksa","","False","","","","","","","Private education to citizen."
+"","","","","","","","","","tax","invoice","","","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","2(B)","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","","","","","","","","","","","","","",""
+"sa_private_healthcare_tax_0","0% PH","sale","0.0","percent","Private healthcare to citizen","0%","sa_tax_group_taxes_vat","","base","invoice","2(B)","","","رعاية صحية خاصة للمواطن.","l10n_sa_account_fiscal_position_ksa","","False","","","","","","","Private healthcare to citizen."
+"","","","","","","","","","tax","invoice","","","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","2(B)","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","","","","","","","","","","","","","",""
+"sa_international_transport_goods_tax_0","0% IT G","sale","0.0","percent","The International transport of Goods","0%","sa_tax_group_taxes_vat","consu","base","invoice","3(B)","","","الشحن الدولي للبضائع.","l10n_sa_account_fiscal_position_ksa","","False","","","","","","","The International transport of Goods."
+"","","","","","","","","","tax","invoice","","","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","3(B)","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","","","","","","","","","","","","","",""
+"sa_export_sales_tax_0","0% EX G","sale","0.0","percent","Zero-rated exports - Export of Goods","0% Export","sa_tax_group_taxes_vat","consu","base","invoice","4(B)","","","تصدير البضائع.","l10n_sa_account_fiscal_position_gcc","sa_sales_tax_15","","","","","","","","Export of Goods."
+"","","","","","","","","","tax","invoice","","","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","4(B)","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","","","","","","","","","","","","","",""
+"sa_export_services_tax_0","0% EX S","sale","0.0","percent","Zero-rated exports - Export of Services","0% Export","sa_tax_group_taxes_vat","service","base","invoice","4(B)","","","تصدير الخدمات.","l10n_sa_account_fiscal_position_gcc","","","","","","","","","Export of Services."
+"","","","","","","","","","tax","invoice","","","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","4(B)","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","","","","","","","","","","","","","",""
+"sa_exempt_sales_tax_0","0% EXT FS","sale","0.0","percent","Exempt - Financial services mentioned in Article 29 of the VAT Regulations","Exempt","sa_tax_group_taxes_vat","","base","invoice","5(B)","","","الخدمات المالية المذكورة في القانون 29 في لوائح ضريبة القيمة المضافة","l10n_sa_account_fiscal_position_ksa,l10n_sa_account_fiscal_position_gcc","","False","","","","","","","Financial services mentioned in Article 29 of the VAT Regulations."
+"","","","","","","","","","tax","invoice","","","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","5(B)","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","","","","","","","","","","","","","",""
+"sa_exempt_life_insurance_tax_0","0% EXT LI","sale","0.0","percent","Exempt - Life Insurance Services mentioned in Article 29 of the VAT Regulations","Exempt","sa_tax_group_taxes_vat","","base","invoice","5(B)","","","خدمات التأمين على الحياة المذكورة في القانون 29 لضريبة القيمة المضافة","l10n_sa_account_fiscal_position_ksa,l10n_sa_account_fiscal_position_gcc","","False","","","","","","","Life insurance services mentioned in Article 29 of the VAT Regulations."
+"","","","","","","","","","tax","invoice","","","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","5(B)","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","","","","","","","","","","","","","",""
+"sa_exempt_real_estate_tax_0","0% EXT RE","sale","0.0","percent","Exempt - Real estate transaction mentioned in Article 30 of the VAT Regulations","Exempt","sa_tax_group_taxes_vat","","base","invoice","5(B)","","","المعاملات العقارية المذكورة في القانون 30 في لوائح ضريبة القيمة المضافة","l10n_sa_account_fiscal_position_ksa,l10n_sa_account_fiscal_position_gcc","","False","","","","","","","Real estate transaction mentioned in Article 30 of the VAT Regulations."
+"","","","","","","","","","tax","invoice","","","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","5(B)","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","","","","","","","","","","","","","",""
+"sa_local_sales_tax_0","0%","sale","0.0","percent","Not Subject to VAT","0%","sa_tax_group_taxes_vat","","base","invoice","","","","غير خاضعة لضريبة القيمة المضافة.","l10n_sa_account_fiscal_position_ksa,l10n_sa_account_fiscal_position_gcc","","False","","","","","","","Not Subject to VAT."
+"","","","","","","","","","tax","invoice","","","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","","","","","","","","","","","","","",""
+"sa_purchase_tax_15","15%","purchase","15.0","percent","","15%","sa_tax_group_taxes_vat","","base","invoice","7(B)","","","المشتريات الخاضعة للنسبة الأساسية %15","l10n_sa_account_fiscal_position_ksa","","","","","","","","",""
+"","","","","","","","","","tax","invoice","7(T)","sa_account_104041","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","7(B)","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","7(T)","sa_account_104041","","","","","","","","","","","",""
+"sa_rcp_tax_15","15% R C","purchase","15.0","percent","","15% Reverse charge","sa_tax_group_taxes_vat","service","base","invoice","9(B)","","","الاستيرادات الخاضعة لضريبة القيمة المضافة التي تُطبق عليها آلية الاحتساب العكسي %15","l10n_sa_account_fiscal_position_gcc","","","","","","","","",""
+"","","","","","","","","","tax","invoice","9(T)","sa_account_104043","","","","","","","","","","","",""
+"","","","","","","","","","tax","invoice","9(T)","sa_account_201017","-100","","","","","","","","","","",""
+"","","","","","","","","","base","refund","9(B)","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","9(T)","sa_account_104043","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","9(T)","sa_account_201017","-100","","","","","","","","","","",""
+"sa_import_tax_paid_15_paid_to_customs","15% EX ONLY B","purchase","0.0","percent","Imports - Only Base","15% Import - Base","sa_tax_group_taxes_import_15","","base","invoice","8(B)","","","الاستيرادات الخاضعة لضريبة القيمة المضافة بالنسبة الأساسية و التي تدفع في الجمارك %15","l10n_sa_account_fiscal_position_gcc","","","","","","","","",""
+"","","","","","","","","","tax","invoice","","","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","8(B)","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","","","","","","","","","","","","","",""
+"sa_import_tax_paid_15_paid_to_customs_vat","15% EX ONLY","purchase","100.0","division","Imports - Only VAT","15% Import","sa_tax_group_taxes_import_15","","base","invoice","","","","الاستيرادات الخاضعة لضريبة القيمة المضافة بالنسبة الأساسية و التي تدفع في الجمارك %15","l10n_sa_account_fiscal_position_gcc","","","","","tax_included","True","","",""
+"","","","","","","","","","tax","invoice","8(T)","sa_account_101060","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","8(T)","sa_account_101060","","","","","","","","","","","",""
+"sa_purchases_tax_0","0%","purchase","0.0","percent","","0%","sa_tax_group_taxes_vat","","base","invoice","10(B)","","","المشتريات الخاضعة لنسبة %0","l10n_sa_account_fiscal_position_ksa","","","","","","","","",""
+"","","","","","","","","","tax","invoice","","","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","10(B)","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","","","","","","","","","","","","","",""
+"sa_exempt_purchases_tax","0% EXT","purchase","0.0","percent","Exempt","Exempt","sa_tax_group_taxes_vat","","base","invoice","11(B)","","","المشتريات المعفاة من الضريبة","l10n_sa_account_fiscal_position_ksa,l10n_sa_account_fiscal_position_gcc","","","","","","","","",""
+"","","","","","","","","","tax","invoice","","","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","11(B)","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","","","","","","","","","","","","","",""
+"sa_withholding_tax_5_rental","5% WH R G","purchase","5.0","division","Gross Withholding on Payment - Rent","5% Withholding","sa_tax_group_taxes_withholding_5","service","base","invoice","1(B)_W_G","","","استقطاع الضريبة 5 % (إيجار)","l10n_sa_account_fiscal_position_gcc","","","on_payment","","tax_excluded","","sa_account_201035","",""
+"","","","","","","","","","tax","invoice","","sa_account_400073","","","","","","","","","","","",""
+"","","","","","","","","","tax","invoice","1(T)_W_G","sa_account_201020","-100","","","","","","","","","","",""
+"","","","","","","","","","base","refund","1(B)_W_G","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","","sa_account_400073","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","1(T)_W_G","sa_account_201020","-100","","","","","","","","","","",""
+"sa_withholding_tax_5_tickets_or_air_freight","5% WH AT AF MF G","purchase","5.0","division","Gross Withholding on Payment - Air tickets, Air freight and Maritime freight for International travel departing from Saudi Arabia","5% Withholding","sa_tax_group_taxes_withholding_5","service","base","invoice","2(B)_W_G","","","استقطاع الضريبة 5 % (تذاكر طيران أو شحن جوي)","l10n_sa_account_fiscal_position_gcc","","","on_payment","","tax_excluded","","sa_account_201035","",""
+"","","","","","","","","","tax","invoice","","sa_account_400073","","","","","","","","","","","",""
+"","","","","","","","","","tax","invoice","2(T)_W_G","sa_account_201020","-100","","","","","","","","","","",""
+"","","","","","","","","","base","refund","2(B)_W_G","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","","sa_account_400073","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","2(T)_W_G","sa_account_201020","-100","","","","","","","","","","",""
+"sa_withholding_tax_5_international_telecommunication","5% WH TC ICS G","purchase","5.0","division","Gross Withholding on Payment - Technical and consulting services and international telecommunication services (for related and unrelated parties)","5% Withholding","sa_tax_group_taxes_withholding_5","service","base","invoice","3(B)_W_G","","","استقطاع الضريبة 5 % (خدمات اتصاالت هاتفية دولية)","l10n_sa_account_fiscal_position_gcc","","","on_payment","","tax_excluded","","sa_account_201035","",""
+"","","","","","","","","","tax","invoice","","sa_account_400073","","","","","","","","","","","",""
+"","","","","","","","","","tax","invoice","3(T)_W_G","sa_account_201020","-100","","","","","","","","","","",""
+"","","","","","","","","","base","refund","3(B)_W_G","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","","sa_account_400073","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","3(T)_W_G","sa_account_201020","-100","","","","","","","","","","",""
+"sa_withholding_tax_5_distributed_profits","5% WH D G","purchase","5.0","division","Gross Withholding on Payment - Dividends","5% Withholding","sa_tax_group_taxes_withholding_5","service","base","invoice","4(B)_W_G","","","استقطاع الضريبة 5 % (أرباح موزعة)","l10n_sa_account_fiscal_position_gcc","","","on_payment","","tax_excluded","","sa_account_201035","",""
+"","","","","","","","","","tax","invoice","","sa_account_400073","","","","","","","","","","","",""
+"","","","","","","","","","tax","invoice","4(T)_W_G","sa_account_201020","-100","","","","","","","","","","",""
+"","","","","","","","","","base","refund","4(B)_W_G","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","","sa_account_400073","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","4(T)_W_G","sa_account_201020","-100","","","","","","","","","","",""
+"sa_withholding_tax_5_insurance_amd_reinsurance","5% WH IL IRP G","purchase","5.0","division","Gross Withholding on Payment - Interest on loan, insurance and reinsurance premium","5% Withholding","sa_tax_group_taxes_withholding_5","service","base","invoice","5(B)_W_G","","","استقطاع الضريبة 5 % (قسط تأمين أو إعادة تأمين)","l10n_sa_account_fiscal_position_gcc","","","on_payment","","tax_excluded","","sa_account_201035","",""
+"","","","","","","","","","tax","invoice","","sa_account_400073","","","","","","","","","","","",""
+"","","","","","","","","","tax","invoice","5(T)_W_G","sa_account_201020","-100","","","","","","","","","","",""
+"","","","","","","","","","base","refund","5(B)_W_G","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","","sa_account_400073","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","5(T)_W_G","sa_account_201020","-100","","","","","","","","","","",""
+"sa_withholding_tax_15_royalties","15% WH R G","purchase","15.0","division","Gross Withholding on Payment - Royalty","15% Withholding","sa_tax_group_taxes_withholding_15","service","base","invoice","6(B)_W_G","","","استقطاع الضريبة 15 % (أتاوة أو ريع)","l10n_sa_account_fiscal_position_gcc","","","on_payment","","tax_excluded","","sa_account_201035","",""
+"","","","","","","","","","tax","invoice","","sa_account_400073","","","","","","","","","","","",""
+"","","","","","","","","","tax","invoice","6(T)_W_G","sa_account_201020","-100","","","","","","","","","","",""
+"","","","","","","","","","base","refund","6(B)_W_G","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","","sa_account_400073","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","6(T)_W_G","sa_account_201020","-100","","","","","","","","","","",""
+"sa_withholding_tax_15_others","15% WH O G","purchase","15.0","division","Gross Withholding on Payment - Any other payments","15% Withholding","sa_tax_group_taxes_withholding_15","service","base","invoice","7(B)_W_G","","","استقطاع الضريبة 15 % (لأي دفعات أخرى)","l10n_sa_account_fiscal_position_gcc","","","on_payment","","tax_excluded","","sa_account_201035","",""
+"","","","","","","","","","tax","invoice","","sa_account_400073","","","","","","","","","","","",""
+"","","","","","","","","","tax","invoice","7(T)_W_G","sa_account_201020","-100","","","","","","","","","","",""
+"","","","","","","","","","base","refund","7(B)_W_G","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","","sa_account_400073","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","7(T)_W_G","sa_account_201020","-100","","","","","","","","","","",""
+"sa_withholding_tax_20_managerial","20% WH MF G","purchase","20.0","division","Gross Withholding on Payment - Management Fees","20% Withholding","sa_tax_group_taxes_withholding_20","service","base","invoice","8(B)_W_G","","","استقطاع الضريبة 20 % (أتعاب إدارة)","l10n_sa_account_fiscal_position_gcc","","","on_payment","","tax_excluded","","sa_account_201035","",""
+"","","","","","","","","","tax","invoice","","sa_account_400073","","","","","","","","","","","",""
+"","","","","","","","","","tax","invoice","8(T)_W_G","sa_account_201020","-100","","","","","","","","","","",""
+"","","","","","","","","","base","refund","8(B)_W_G","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","","sa_account_400073","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","8(T)_W_G","sa_account_201020","-100","","","","","","","","","","",""
+"sa_withholding_tax_5_rental_d","5% WH R D","purchase","-5.0","percent","Deducted Withholding on Payment - Rent","5% Withholding","sa_tax_group_taxes_withholding_5","service","base","invoice","1(B)_W_D","","","استقطاع الضريبة 5 % (إيجار)","l10n_sa_account_fiscal_position_gcc","","False","","","","","","True",""
+"","","","","","","","","","tax","invoice","1(T)_W_D","sa_account_201020","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","1(B)_W_D","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","1(T)_W_D","sa_account_201020","","","","","","","","","","","",""
+"sa_withholding_tax_5_tickets_or_air_freight_d","5% WH AT AF MF D","purchase","-5.0","percent","Deducted Withholding on Payment - Air tickets, Air freight and Maritime freight for International travel departing from Saudi Arabia","5% Withholding","sa_tax_group_taxes_withholding_5","service","base","invoice","2(B)_W_D","","","استقطاع الضريبة 5 % (تذاكر طيران أو شحن جوي)","l10n_sa_account_fiscal_position_gcc","","False","","","","","","True",""
+"","","","","","","","","","tax","invoice","2(T)_W_D","sa_account_201020","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","2(B)_W_D","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","2(T)_W_D","sa_account_201020","","","","","","","","","","","",""
+"sa_withholding_tax_5_international_telecommunication_d","5% WH TC ICS D","purchase","-5.0","percent","Deducted Withholding on Payment - Technical and consulting services and international telecommunication services (for related and unrelated parties)","5% Withholding","sa_tax_group_taxes_withholding_5","service","base","invoice","3(B)_W_D","","","استقطاع الضريبة 5 % (خدمات اتصاالت هاتفية دولية)","l10n_sa_account_fiscal_position_gcc","","False","","","","","","True",""
+"","","","","","","","","","tax","invoice","3(T)_W_D","sa_account_201020","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","3(B)_W_D","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","3(T)_W_D","sa_account_201020","","","","","","","","","","","",""
+"sa_withholding_tax_5_distributed_profits_d","5% WH D D","purchase","-5.0","percent","Deducted Withholding on Payment - Dividends","5% Withholding","sa_tax_group_taxes_withholding_5","service","base","invoice","4(B)_W_D","","","استقطاع الضريبة 5 % (أرباح موزعة)","l10n_sa_account_fiscal_position_gcc","","False","","","","","","True",""
+"","","","","","","","","","tax","invoice","4(T)_W_D","sa_account_201020","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","4(B)_W_D","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","4(T)_W_D","sa_account_201020","","","","","","","","","","","",""
+"sa_withholding_tax_5_insurance_amd_reinsurance_d","5% WH IL IRP D","purchase","-5.0","percent","Deducted Withholding on Payment - Interest on loan, insurance and reinsurance premium","5% Withholding","sa_tax_group_taxes_withholding_5","service","base","invoice","5(B)_W_D","","","استقطاع الضريبة 5 % (قسط تأمين أو إعادة تأمين)","l10n_sa_account_fiscal_position_gcc","","False","","","","","","True",""
+"","","","","","","","","","tax","invoice","5(T)_W_D","sa_account_201020","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","5(B)_W_D","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","5(T)_W_D","sa_account_201020","","","","","","","","","","","",""
+"sa_withholding_tax_15_royalties_d","15% WH R D","purchase","-15.0","percent","Deducted Withholding on Payment - Royalty","15% Withholding","sa_tax_group_taxes_withholding_15","service","base","invoice","6(B)_W_D","","","استقطاع الضريبة 15 % (أتاوة أو ريع)","l10n_sa_account_fiscal_position_gcc","","False","","","","","","True",""
+"","","","","","","","","","tax","invoice","6(T)_W_D","sa_account_201020","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","6(B)_W_D","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","6(T)_W_D","sa_account_201020","","","","","","","","","","","",""
+"sa_withholding_tax_15_others_d","15% WH O D","purchase","-15.0","percent","Deducted Withholding on Payment - Any other payments","15% Withholding","sa_tax_group_taxes_withholding_15","service","base","invoice","7(B)_W_D","","","استقطاع الضريبة 15 % (لأي دفعات أخرى)","l10n_sa_account_fiscal_position_gcc","","False","","","","","","True",""
+"","","","","","","","","","tax","invoice","7(T)_W_D","sa_account_201020","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","7(B)_W_D","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","7(T)_W_D","sa_account_201020","","","","","","","","","","","",""
+"sa_withholding_tax_20_managerial_d","20% WH MF D","purchase","-20.0","percent","Deducted Withholding on Payment - Management Fees","20% Withholding","sa_tax_group_taxes_withholding_20","service","base","invoice","8(B)_W_D","","","استقطاع الضريبة 20 % (أتعاب إدارة)","l10n_sa_account_fiscal_position_gcc","","False","","","","","","True",""
+"","","","","","","","","","tax","invoice","8(T)_W_D","sa_account_201020","","","","","","","","","","","",""
+"","","","","","","","","","base","refund","8(B)_W_D","","","","","","","","","","","","",""
+"","","","","","","","","","tax","refund","8(T)_W_D","sa_account_201020","","","","","","","","","","","",""


### PR DESCRIPTION
This commit aims to make the invoice line tax drop-down cleaner and more
straightforward.
The tax `15% PH PE HS` is already handled through the `0% PE` and `0% PH` taxes
and `0% Not Subject to VAT` is visible with the other `0%` taxes such as
`0% EX G`, etc. The users were incorrectly selecting the `0% Not Subject to VAT`
instead of the actual `0%` taxes according to the characteristics of the supply;
leading to non-compliance with the ZATCA rules.

Before this commit:
- `15% PH PE HS` tax had `amount = 15%` and was `active`.
- `0% PE & 0% PH` had distribution for invoices: `base tax grid = 3(B)` and
  distribution for refunds: `base tax grid = 3(B)`.
- `0% Not Subject to VAT` tax was `active` and had distribution for invoice:
  `base tax grid = 3(B)` and distribution for refunds: `base tax grid 3(B)`
- `0% IT G and 0% QT` taxes were `active`.

After this commit:
- `15% PH PE HS` tax has been removed.
- `0% PE & 0% PH` taxes have distribution for invoices: 'base tax grid = 2(B)`
  and distribution for refunds: `base tax grid = 2(B)`
- `0% Not Subject to VAT` tax is set to `inactive`, `sequence = 17` and tax grid
  has been removed.
- `0% IT G and 0% QT` taxes have been set to `inactive`.

task-5959979