### PR TITLE
[FIX] memory: change tracemalloc to psutil and heuristic

### DIFF
--- a/addons/web/controllers/profiling.py
+++ b/addons/web/controllers/profiling.py
@@ -31,7 +31,21 @@ class Profiling(Controller):
         if not profiles:
             raise request.not_found()
         params = kwargs or profiles._default_profile_params()
-        speedscope_result = profiles._generate_speedscope(profiles._parse_params(params))
+        parsed_params = profiles._parse_params(params)
+
+        # Memory profile: render the memory visualization template
+        if parsed_params.get('memory_profile') and action not in ('speedscope_download_json', 'speedscope_download_html'):
+            speedscope_result = profiles._generate_speedscope(parsed_params)
+            icp = request.env['ir.config_parameter']
+            memory_data = profiles._get_memory_data()
+            context = {
+                'speedscope_base64': base64.b64encode(speedscope_result).decode('utf-8'),
+                'memory_data': base64.b64encode(json.dumps(memory_data).encode()).decode(),
+                'cdn': icp.sudo().get_param('speedscope_cdn', "https://cdn.jsdelivr.net/npm/speedscope@1.13.0/dist/release/"),
+            }
+            return request.render('web.view_memory', context)
+
+        speedscope_result = profiles._generate_speedscope(parsed_params)
         if action == 'speedscope_download_json':
             headers = [
                 ('Content-Type', 'application/json'),
@@ -61,15 +75,6 @@ class Profiling(Controller):
         profiles = request.env['ir.profile'].browse(int(p) for p in profile_str.split(',')).exists()
         if not profiles:
             raise request.not_found()
-
-        if action == 'memory_open':
-            memory_profile = profiles._generate_memory_profile(profiles._parse_params(kwargs))
-            encoded_memory_profile = json.dumps(memory_profile).encode('utf_8')
-            context = {
-                'profile': profiles,
-                'memory_graph': base64.b64encode(encoded_memory_profile).decode('utf-8'),
-                }
-            return request.render('web.view_memory', context)
 
         context = {
             'default_params': profiles._default_profile_params(),

--- a/addons/web/static/src/webclient/debug/profiling/profiling_item.js
+++ b/addons/web/static/src/webclient/debug/profiling/profiling_item.js
@@ -18,7 +18,7 @@ export class ProfilingItem extends Component {
         this.profiling.setParam(param, ev.target.value);
     }
     toggleParam(param) {
-        const value = this.profiling.state.params.execution_context_qweb;
+        const value = this.profiling.state.params[param];
         this.profiling.setParam(param, !value);
     }
     openProfiles() {

--- a/addons/web/static/src/webclient/debug/profiling/profiling_item.xml
+++ b/addons/web/static/src/webclient/debug/profiling/profiling_item.xml
@@ -38,21 +38,12 @@
                                 <input type="number" class="form-control" t-on-click.stop.prevent="" t-on-change="(ev) => this.changeParam('time_limit', ev)" t-att-value="profiling.state.params.time_limit || '0'" placeholder="None"/>
                             </div>
                         </div>
-                        <span class="o_profiling_switch form-check form-switch mt-2" t-on-click.stop.prevent="() => this.profiling.toggleCollector('memory')">
-                            <input type="checkbox" class="form-check-input" id="profile_memory"
-                                t-att-checked="profiling.isCollectorEnabled('memory')"/>
-                            <label class="form-check-label" for="profile_memory">Record memory</label>
-                        </span>
-                        <div t-if="profiling.isCollectorEnabled('memory')" class="input-group input-group-sm mt-2" t-on-click.stop.prevent="">
-                            <div class="input-group-text">Interval</div>
-                            <select class="profile_param form-select" t-on-change="(ev) => this.changeParam('memory_interval', ev)">
-                                <t t-set="interval" t-value="profiling.state.params.memory_interval"/>
-                                <option value="">Default</option>
-                                <option value="0.01" t-att-selected="interval === '0.01'">0.01</option>
-                                <option value="0.1" t-att-selected="interval === '0.1'">0.1</option>
-                                <option value="1" t-att-selected="interval === '1'">1</option>
-                                <option value="5" t-att-selected="interval === '5'">5</option>
-                            </select>
+                        <div t-if="profiling.isCollectorEnabled('traces_async')" class="input-group input-group-sm mt-2" t-on-click.stop.prevent="">
+                            <span class="o_profiling_switch form-check form-switch mt-2" t-on-click.stop.prevent="() => this.toggleParam('memory_profile')">
+                                <input type="checkbox" class="form-check-input" id="memory_profile"
+                                    t-att-checked="profiling.state.params.memory_profile"/>
+                                <label class="form-check-label" for="memory_profile">Record memory</label>
+                            </span>
                         </div>
                         <div class="input-group input-group-sm mt-2">
                             <div class="input-group-text">Entry Count</div>

--- a/addons/web/static/src/webclient/debug/profiling/profiling_item.xml
+++ b/addons/web/static/src/webclient/debug/profiling/profiling_item.xml
@@ -34,22 +34,6 @@
                                 <option value="1" t-att-selected="interval === '1'">1</option>
                             </select>
                         </div>
-                        <span class="o_profiling_switch form-check form-switch mt-2" t-on-click.stop.prevent="() => this.profiling.toggleCollector('memory')">
-                            <input type="checkbox" class="form-check-input" id="profile_memory"
-                                t-att-checked="profiling.isCollectorEnabled('memory')"/>
-                            <label class="form-check-label" for="profile_memory">Record memory</label>
-                        </span>
-                        <div t-if="profiling.isCollectorEnabled('memory')" class="input-group input-group-sm mt-2" t-on-click.stop.prevent="">
-                            <div class="input-group-text">Interval</div>
-                            <select class="profile_param form-select" t-on-change="(ev) => this.changeParam('memory_interval', ev)">
-                                <t t-set="interval" t-value="profiling.state.params.memory_interval"/>
-                                <option value="">Default</option>
-                                <option value="0.01" t-att-selected="interval === '0.01'">0.01</option>
-                                <option value="0.1" t-att-selected="interval === '0.1'">0.1</option>
-                                <option value="1" t-att-selected="interval === '1'">1</option>
-                                <option value="5" t-att-selected="interval === '5'">5</option>
-                            </select>
-                        </div>
                         <div class="input-group input-group-sm mt-2">
                             <div class="input-group-text">Entry Count</div>
                             <input type="number" class="form-control" t-on-click.stop.prevent="" t-on-change="(ev) => this.changeParam('entry_count_limit', ev)" t-att-value="profiling.state.params.entry_count_limit || '0'" placeholder="None"/>

--- a/addons/web/views/memory_template.xml
+++ b/addons/web/views/memory_template.xml
@@ -8,384 +8,146 @@
             <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
             <title>Memory Usage Visualization</title>
             <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-            <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels"></script>
             <style>
-                /* General body and layout styles */
+                * { box-sizing: border-box; margin: 0; padding: 0; }
                 body {
                     font-family: Arial, sans-serif;
-                    margin: 20px;
                     background-color: #f9f9f9;
-                }
-                .container {
+                    height: 100vh;
                     display: flex;
                     flex-direction: column;
-                    gap: 20px;
                 }
-
-                /* Row definitions for the new layout */
-                .top-row {
-                    height: 40vh; /* Line graph takes 40% of the viewport height */
+                .chart-row {
+                    height: 30vh;
+                    min-height: 200px;
+                    padding: 10px;
+                    flex-shrink: 0;
                 }
-                .bottom-row {
-                    display: flex;
-                    gap: 20px;
-                    /* The height of this row will be determined by its content */
-                }
-
-                /* Chart container styles */
                 .chart-container {
                     position: relative;
                     background: #fff;
                     border: 1px solid #ddd;
                     border-radius: 5px;
-                    padding: 15px;
+                    padding: 10px;
                     height: 100%;
                     width: 100%;
                 }
-                
-                /* Specific styling for the bottom row elements */
-                .bar-chart-wrapper {
-                    flex: 2; /* Bar chart takes 2/3 of the width */
-                    min-height: 400px; /* Minimum height for the bar chart */
+                .speedscope-row {
+                    flex: 1;
+                    min-height: 0;
+                    padding: 0 10px 10px;
                 }
-                .traceback-panel {
-                    flex: 1; /* Traceback panel takes 1/3 of the width */
-                    background: #f5f5f5;
+                .speedscope-row iframe {
+                    width: 100%;
+                    height: 100%;
                     border: 1px solid #ddd;
                     border-radius: 5px;
-                    padding: 15px;
-                    overflow-y: auto;
-                    min-height: 400px; /* Match min-height for alignment */
-                    height: fit-content; /* Adjust height to content */
-                }
-
-                /* Traceback panel content styling */
-                .traceback-header {
-                    font-weight: bold;
-                    margin-bottom: 10px;
-                    color: #333;
-                }
-                .traceback-item {
-                    background: white;
-                    margin: 5px 0;
-                    padding: 8px;
-                    border-radius: 3px;
-                    border-left: 3px solid #007acc;
-                    font-family: monospace;
-                    font-size: 12px;
-                }
-                .traceback-file {
-                    color: #007acc;
-                    font-weight: bold;
-                }
-                .copyable {
-                    cursor: pointer;
-                    user-select: all;
-                    padding: 2px 4px;
-                    border-radius: 3px;
-                    transition: background-color 0.2s;
-                }
-                .copyable:hover {
-                    background-color: #e8f4f8;
-                }
-                .traceback-line {
-                    color: #666;
-                }
-                .no-selection {
-                    color: #999;
-                    font-style: italic;
-                    text-align: center;
-                    padding-top: 50px;
                 }
             </style>
         </head>
         <body>
-            <div class="container">
-                <!-- Top row for the full-width line chart -->
-                <div class="top-row">
-                    <div class="chart-container">
-                        <canvas id="totalMemoryChart"></canvas>
-                    </div>
+            <div class="chart-row">
+                <div class="chart-container">
+                    <canvas id="memoryChart"></canvas>
                 </div>
-                <!-- Bottom row for the bar chart and traceback panel -->
-                <div class="bottom-row">
-                    <div class="bar-chart-wrapper chart-container" id="memoryChartContainer">
-                        <canvas id="memoryChart"></canvas>
-                    </div>
-                    <div class="traceback-panel" id="tracebackPanel">
-                        <div class="no-selection">Click a point on the top chart, then a bar below to see details.</div>
-                    </div>
-                </div>
+            </div>
+            <div class="speedscope-row">
+                <iframe id="speedscopeFrame" sandbox="allow-scripts allow-same-origin"></iframe>
             </div>
 
             <script>
-                // Get data from Odoo template
-                const rawData = JSON.parse(atob('<t t-esc="memory_graph"/>'));
+                // --- DATA FROM SERVER ---
+                const memoryData = JSON.parse(atob('<t t-esc="memory_data"/>'));
+                const fullSpeedscopeBase64 = '<t t-esc="speedscope_base64"/>';
+                const cdn = '<t t-esc="cdn"/>';
+                const points = memoryData.points;
 
-                // --- UTILITY FUNCTIONS ---
+                // --- UTILITY ---
                 function formatBytes(bytes) {
                     if (bytes === 0) return '0 B';
                     const k = 1024;
                     const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
                     const i = Math.floor(Math.log(Math.abs(bytes)) / Math.log(k));
-                    const value = bytes / Math.pow(k, i);
-                    return `${value.toFixed(1)} ${sizes[i]}`;
+                    const sign = bytes &lt; 0 ? '-' : '';
+                    return sign + (Math.abs(bytes) / Math.pow(k, i)).toFixed(1) + ' ' + sizes[i];
                 }
 
-                function formatTimestamp(timestamp) {
-                    const date = new Date(timestamp * 1000);
-                    return date.toLocaleString();
+                function formatTimestamp(ts) {
+                    return new Date(ts * 1000).toLocaleTimeString();
                 }
 
-                function getLastFileFromTraceback(traceback) {
-                    if (!traceback || traceback.length === 0) return "unknown:0";
-                    const lastFrame = traceback[traceback.length - 1];
-                    return `${lastFrame[0]}:${lastFrame[1]}`;
-                }
-                
-                function getFullTracebackKey(traceback) {
-                    if (!traceback || traceback.length === 0) return "unknown";
-                    return traceback.map(frame => `${frame[0]}:${frame[1]}`).join(' -> ');
-                }
+                // --- SPEEDSCOPE IFRAME ---
+                let currentBlobUrl = null;
 
-                // --- DYNAMIC UI UPDATES ---
-                function updateChartHeight(chart, dataLength) {
-                    const container = document.getElementById('memoryChartContainer');
-                    if (dataLength === 0) {
-                        container.style.height = '400px'; // Reset to min-height
-                        chart.resize();
-                        return;
-                    }
-                    
-                    const minBarHeight = 35; // Minimum height per bar for readability
-                    const padding = 100; // Extra space for axes and labels
-                    const newHeight = Math.max(400, (dataLength * minBarHeight) + padding);
-                    
-                    container.style.height = newHeight + 'px';
-                    chart.resize();
+                function loadSpeedscopeInIframe(base64Data) {
+                    if (currentBlobUrl) URL.revokeObjectURL(currentBlobUrl);
+
+                    const html = '\x3c!DOCTYPE html\x3e' +
+                        '\x3chtml\x3e\x3chead\x3e' +
+                        '\x3cscript\x3ewindow.location.hash="#localProfilePath=1";\x3c/script\x3e' +
+                        '\x3clink href="https://fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet"/\x3e' +
+                        '\x3clink rel="stylesheet" href="' + cdn + 'reset.8c46b7a1.css"/\x3e' +
+                        '\x3c/head\x3e\x3cbody\x3e' +
+                        '\x3cscript src="' + cdn + 'speedscope.026f36b0.js"\x3e\x3c/script\x3e' +
+                        '\x3cscript\x3e' +
+                        'document.addEventListener("DOMContentLoaded", function() {' +
+                        '  speedscope.loadFileFromBase64("Profile", "' + base64Data + '");' +
+                        '});' +
+                        '\x3c/script\x3e' +
+                        '\x3c/body\x3e\x3c/html\x3e';
+
+                    const blob = new Blob([html], {type: 'text/html'});
+                    currentBlobUrl = URL.createObjectURL(blob);
+                    document.getElementById('speedscopeFrame').src = currentBlobUrl;
                 }
 
-                function showTraceback(traceback, size, fullTracebackKey) {
-                    const panel = document.getElementById('tracebackPanel');
-                    if (!traceback || traceback.length === 0) {
-                        panel.innerHTML = '<div class="no-selection">No traceback available</div>';
-                        return;
-                    }
+                // --- CHART (hover-only, no click interaction) ---
+                const labels = points.map(p => formatTimestamp(p.timestamp));
+                const memValues = points.map(p => p.memory);
 
-                    let html = `<div class="traceback-header">Traceback (${formatBytes(size)})</div>`;
-
-                    if (fullTracebackKey) {
-                        html += `
-                            <div style="margin-bottom: 10px; padding: 8px; background: #e8f4f8; border-radius: 3px; font-size: 11px; color: #555;">
-                                <strong>Full Path:</strong> <span class="copyable" title="Click to select for copying">${fullTracebackKey}</span>
-                            </div>
-                        `;
-                    }
-
-                    traceback.forEach(frame => {
-                        const [filename, lineNo, functionName, code] = frame;
-                        html += `
-                            <div class="traceback-item">
-                                <div class="traceback-file copyable" title="Click to select for copying">${filename}:${lineNo}</div>
-                                <div>in <strong>${functionName || 'unknown'}</strong></div>
-                                ${code ? `<div class="traceback-line">${code}</div>` : ''}
-                            </div>
-                        `;
-                    });
-
-                    panel.innerHTML = html;
-                }
-
-                // --- CHART LOGIC ---
-                const totalSizes = rawData.map(entry =>
-                    entry.samples.reduce((sum, sample) => sum + sample.size, 0)
-                );
-                const lineLabels = rawData.map(entry => formatTimestamp(entry.start));
-
-                let selectedIndexes = [];
-                let currentBreakdownData = [];
-
-                const updateBarChart = () => {
-                    if (selectedIndexes.length === 1) {
-                        const entry = rawData[selectedIndexes[0]];
-                        const groupedData = {};
-                        entry.samples.forEach(sample => {
-                            const key = getLastFileFromTraceback(sample.traceback);
-                            if (!groupedData[key]) {
-                                groupedData[key] = { size: 0, traceback: sample.traceback, samples: [] };
-                            }
-                            groupedData[key].size += sample.size;
-                            groupedData[key].samples.push(sample);
-                        });
-
-                        currentBreakdownData = Object.entries(groupedData).map(([key, data]) => ({
-                            label: key,
-                            size: data.size,
-                            traceback: data.traceback,
-                            samples: data.samples
-                        })).sort((a, b) => b.size - a.size);
-
-                        breakdownChart.data.labels = currentBreakdownData.map(item => item.label);
-                        breakdownChart.data.datasets = [{
-                            label: `Memory Usage`,
-                            data: currentBreakdownData.map(item => item.size),
-                            backgroundColor: 'rgba(54, 162, 235, 0.6)',
-                            borderColor: 'rgba(54, 162, 235, 1)',
-                            borderWidth: 1
-                        }];
-                        breakdownChart.options.plugins.title.text = `Memory Breakdown for ${formatTimestamp(entry.start)}`;
-
-                    } else if (selectedIndexes.length === 2) {
-                        const [idx1, idx2] = selectedIndexes.sort((a, b) => a - b);
-                        const entry1 = rawData[idx1];
-                        const entry2 = rawData[idx2];
-
-                        const groupDataByFullTraceback = (entry) => {
-                            const grouped = {};
-                            entry.samples.forEach(sample => {
-                                const key = getFullTracebackKey(sample.traceback);
-                                if (!grouped[key]) {
-                                    grouped[key] = { size: 0, traceback: sample.traceback, lastFile: getLastFileFromTraceback(sample.traceback) };
-                                }
-                                grouped[key].size += sample.size;
-                            });
-                            return grouped;
-                        };
-
-                        const data1 = groupDataByFullTraceback(entry1);
-                        const data2 = groupDataByFullTraceback(entry2);
-                        const labelSet = new Set([...Object.keys(data1), ...Object.keys(data2)]);
-                        
-                        let diffData = [];
-                        labelSet.forEach(fullTracebackKey => {
-                            const size1 = data1[fullTracebackKey]?.size || 0;
-                            const size2 = data2[fullTracebackKey]?.size || 0;
-                            const diff = size2 - size1;
-                            if (diff !== 0) {
-                                const item = data2[fullTracebackKey] || data1[fullTracebackKey];
-                                diffData.push({ 
-                                    label: item.lastFile,
-                                    diff: diff,
-                                    traceback: item.traceback,
-                                    fullTracebackKey: fullTracebackKey
-                                });
-                            }
-                        });
-
-                        currentBreakdownData = diffData.sort((a, b) => b.diff - a.diff);
-
-                        breakdownChart.data.labels = currentBreakdownData.map(item => item.label);
-                        breakdownChart.data.datasets = [{
-                            label: `Difference`,
-                            data: currentBreakdownData.map(item => item.diff),
-                            backgroundColor: item => item.raw >= 0 ? 'rgba(75, 192, 192, 0.6)' : 'rgba(255, 99, 132, 0.6)',
-                            borderColor: item => item.raw >= 0 ? 'rgba(75, 192, 192, 1)' : 'rgba(255, 99, 132, 1)',
-                            borderWidth: 1
-                        }];
-                        breakdownChart.options.plugins.title.text = `Memory Difference: ${formatTimestamp(entry2.start)} vs ${formatTimestamp(entry1.start)}`;
-
-                    } else {
-                        currentBreakdownData = [];
-                        breakdownChart.data.labels = [];
-                        breakdownChart.data.datasets = [];
-                        breakdownChart.options.plugins.title.text = 'Memory Breakdown';
-                        document.getElementById('tracebackPanel').innerHTML = 
-                            '<div class="no-selection">Click a point on the top chart, then a bar below to see details.</div>';
-                    }
-                    
-                    updateChartHeight(breakdownChart, currentBreakdownData.length);
-                    breakdownChart.update();
-                    totalChart.update();
-                };
-
-                // --- CHART INSTANTIATION ---
-                const totalChart = new Chart(document.getElementById('totalMemoryChart'), {
+                new Chart(document.getElementById('memoryChart'), {
                     type: 'line',
                     data: {
-                        labels: lineLabels,
+                        labels: labels,
                         datasets: [{
-                            label: 'Total Memory Usage',
-                            data: totalSizes,
-                            fill: false,
+                            label: 'RSS Memory (baselined)',
+                            data: memValues,
+                            fill: true,
+                            backgroundColor: 'rgba(75, 192, 192, 0.1)',
                             borderColor: 'rgba(75, 192, 192, 1)',
                             tension: 0.1,
-                            pointBackgroundColor: ctx => selectedIndexes.includes(ctx.dataIndex) ? 'rgba(255, 99, 132, 1)' : 'rgba(75, 192, 192, 1)',
-                            pointRadius: ctx => selectedIndexes.includes(ctx.dataIndex) ? 7 : 4,
-                            pointBorderWidth: ctx => selectedIndexes.includes(ctx.dataIndex) ? 3 : 1
+                            pointRadius: 2,
+                            pointBackgroundColor: 'rgba(75, 192, 192, 1)',
                         }]
                     },
                     options: {
                         responsive: true,
                         maintainAspectRatio: false,
                         plugins: {
-                            title: { display: true, text: 'Total Memory Usage Over Time (Click to select, Shift+Click to compare)' },
-                            tooltip: { callbacks: { label: context => `Total: ${formatBytes(context.raw)}` } }
-                        },
-                        onClick: (evt, elements) => {
-                            if (elements.length > 0) {
-                                const idx = elements[0].index;
-                                const isSelected = selectedIndexes.includes(idx);
-                                if (evt.native.shiftKey) {
-                                    if (isSelected) {
-                                        selectedIndexes = selectedIndexes.filter(i => i !== idx);
-                                    } else {
-                                        selectedIndexes.push(idx);
-                                        if (selectedIndexes.length > 2) selectedIndexes.shift();
-                                    }
-                                } else {
-                                    selectedIndexes = isSelected &amp;&amp; selectedIndexes.length === 1 ? [] : [idx];
+                            title: { display: true, text: 'RSS Memory Over Time' },
+                            tooltip: {
+                                callbacks: {
+                                    label: ctx => 'Δ ' + formatBytes(ctx.raw),
+                                    afterLabel: ctx => 'Absolute: ' + formatBytes(points[ctx.dataIndex].abs_memory),
                                 }
-                            } else {
-                                selectedIndexes = [];
-                            }
-                            updateBarChart();
+                            },
+                            legend: { display: false },
                         },
                         scales: {
-                            y: { beginAtZero: true, ticks: { callback: formatBytes }, title: { display: true, text: 'Total Memory' } },
-                            x: { title: { display: true, text: 'Time' } }
+                            y: {
+                                title: { display: true, text: 'Memory (Δ from baseline)' },
+                                ticks: { callback: v => formatBytes(v) },
+                            },
+                            x: {
+                                title: { display: true, text: 'Time' },
+                                ticks: { maxTicksLimit: 20 },
+                            }
                         }
                     }
                 });
 
-                const breakdownChart = new Chart(document.getElementById('memoryChart'), {
-                    type: 'bar',
-                    data: { labels: [], datasets: [] },
-                    options: {
-                        indexAxis: 'y',
-                        responsive: true,
-                        maintainAspectRatio: false,
-                        layout: { padding: { right: 120 } },
-                        plugins: {
-                            legend: { display: false },
-                            title: { display: true, text: 'Memory Breakdown' },
-                            tooltip: { callbacks: { label: context => `${formatBytes(context.raw)}` } },
-                            datalabels: {
-                                anchor: 'end',
-                                align: 'right',
-                                color: '#000',
-                                font: { weight: 'bold', size: 11 },
-                                formatter: (value) => formatBytes(value),
-                                display: true,
-                                clip: false
-                            }
-                        },
-                        onClick: (evt, elements) => {
-                            if (elements.length > 0 &amp;&amp; currentBreakdownData.length > 0) {
-                                const item = currentBreakdownData[elements[0].index];
-                                const fullKey = item.fullTracebackKey || getFullTracebackKey(item.traceback);
-                                showTraceback(item.traceback, Math.abs(item.diff || item.size), fullKey);
-                            }
-                        },
-                        scales: {
-                            x: { beginAtZero: false, ticks: { callback: formatBytes }, title: { display: true, text: 'Memory Usage / Difference' } },
-                            y: { title: { display: true, text: 'File:Line' }, ticks: { maxRotation: 0, font: { size: 11 } } }
-                        }
-                    },
-                    plugins: [ChartDataLabels]
-                });
-
-                // Initial render
-                updateBarChart();
+                // Load full memory speedscope
+                loadSpeedscopeInIframe(fullSpeedscopeBase64);
             </script>
         </body>
         </html>

--- a/addons/web/views/speedscope_config_wizard.xml
+++ b/addons/web/views/speedscope_config_wizard.xml
@@ -6,24 +6,6 @@
         <div class="container-md p-0">
             <div class="o_form_view align-items-center">
                 <div class="row">
-                    <div class="col" t-if="profiles._compute_has_memory()">
-                        <div class="o_form_sheet">
-                            <form method="get" t-attf-action="/web/profile_config/{{profile_str}}">
-                                <h4>Memory profile</h4>
-                                <div class="mt-3">
-                                    <label for="memory_limit">Memory limit (in bytes)</label>
-                                    <input type="number" id="memory_limit" name="memory_limit" class="form-control" value="1000"/>
-                                </div>
-
-                                <input type="hidden" name="profile_id" t-att-value="profile_str" />
-                                
-                                <div class="mt-3">
-                                    <button type="submit" class="btn btn-primary" name="action" value="memory_open">open</button>
-                                </div>
-                            </form>
-                        </div>
-                    </div>
-
                     <div class="col">
                         <div class="o_form_sheet">
                             <!-- Single Form -->
@@ -77,6 +59,10 @@
                                 <div class="form-check" t-if="has_traces">
                                     <input type="checkbox" class="form-check-input" id="frames_profile" name="frames_profile" value="True" t-att-checked="default_params.get('frames_profile')"/>
                                     <label class="form-check-label" for="frames_profile">Frames</label>
+                                </div>
+                                <div class="form-check" t-if="has_traces and profiles._has_memory_traces()">
+                                    <input type="checkbox" class="form-check-input" id="memory_profile" name="memory_profile" value="True" t-att-checked="default_params.get('memory_profile')"/>
+                                    <label class="form-check-label" for="memory_profile">Memory (heuristic)</label>
                                 </div>
 
                                 <input type="hidden" name="profile_id" t-att-value="profile_str" />

--- a/odoo/addons/base/models/ir_profile.py
+++ b/odoo/addons/base/models/ir_profile.py
@@ -57,27 +57,35 @@ class IrProfile(models.Model):
         records.unlink()
         return len(records), len(records) == GC_UNLINK_LIMIT  # done, remaining
 
-    def _compute_has_memory(self):
+    def _has_memory_traces(self):
+        """Return True if all profiles have RSS memory measurements in traces_async."""
         for profile in self:
-            if not bool(profile.others and json.loads(profile.others).get("memory")):
+            if not profile.traces_async:
+                return False
+            entries = json.loads(profile.traces_async)
+            if not entries or entries[0].get('memory') is None:
                 return False
         return True
 
-    def _generate_memory_profile(self, params):
-        memory_graph = []
-        memory_limit = params.get('memory_limit', 0)
+    def _get_memory_data(self):
+        """Return baselined RSS memory data points for the chart."""
+        points = []
+        baseline = None
         for profile in self:
-            if profile.others:
-                memory = json.loads(profile.others).get("memory", "[{}]")
-                memory_tracebacks = json.loads(memory)[:-1]
-                for entry in memory_tracebacks:
-                    memory_graph.append({
-                        "samples": [
-                            sample for sample in entry["memory_tracebacks"]
-                            if sample.get("size", False) >= memory_limit
-                        ]
-                    , "start": entry["start"]})
-        return memory_graph
+            if not profile.traces_async:
+                continue
+            for entry in json.loads(profile.traces_async):
+                mem = entry.get('memory')
+                if mem is None:
+                    continue
+                if baseline is None:
+                    baseline = mem
+                points.append({
+                    'timestamp': entry['start'],
+                    'memory': mem - baseline,
+                    'abs_memory': mem,
+                })
+        return {'points': points}
 
     def _compute_config_url(self):
         for profile in self:
@@ -94,11 +102,13 @@ class IrProfile(models.Model):
     def _default_profile_params(self):
         has_sql = any(profile.sql for profile in self)
         has_traces = any(profile.traces_async for profile in self)
+        has_memory = self._has_memory_traces()
         return {
             'combined_profile': has_sql and has_traces,
             'sql_no_gap_profile': has_sql and not has_traces,
             'sql_density_profile': False,
             'frames_profile': has_traces and not has_sql,
+            'memory_profile': has_memory,
         }
 
     def _parse_params(self, params):
@@ -110,8 +120,8 @@ class IrProfile(models.Model):
             'sql_no_gap_profile': str2bool(params.get('sql_no_gap_profile', False)),
             'sql_density_profile': str2bool(params.get('sql_density_profile', False)),
             'frames_profile': str2bool(params.get('frames_profile', False)),
+            'memory_profile': str2bool(params.get('memory_profile', False)),
             'profile_aggregation_mode': params.get('profile_aggregation_mode', 'tabs'),
-            'memory_limit': int(params.get('memory_limit', 0)),
         }
 
     def _generate_speedscope(self, params):
@@ -123,7 +133,7 @@ class IrProfile(models.Model):
         for profile in self:
             if (params['sql_no_gap_profile'] or params['sql_density_profile'] or params['combined_profile']) and profile.sql:
                 sp.add(f'sql {profile.id}', json.loads(profile.sql))
-            if (params['frames_profile'] or params['combined_profile']) and profile.traces_async:
+            if (params['frames_profile'] or params['combined_profile'] or params['memory_profile']) and profile.traces_async:
                 sp.add(f'frames {profile.id}', json.loads(profile.traces_async))
             if params['profile_aggregation_mode'] == 'tabs':
                 profile._add_outputs(sp, f'{profile.id} {profile.name}' if len(self) > 1 else '', params)
@@ -142,9 +152,11 @@ class IrProfile(models.Model):
         if params['sql_no_gap_profile']:
             sp.add_output(sql, hide_gaps=True, display_name=f'Sql (no gap) {suffix}', **params)
         if params['sql_density_profile']:
-            sp.add_output(sql , continuous=False, complete=False, display_name=f'Sql (density) {suffix}',**params)
+            sp.add_output(sql, continuous=False, complete=False, display_name=f'Sql (density) {suffix}', **params)
         if params['frames_profile']:
-            sp.add_output(frames, display_name=f'Frames {suffix}',**params)
+            sp.add_output(frames, display_name=f'Frames {suffix}', **params)
+        if params['memory_profile']:
+            sp.add_memory_output(frames, display_name=f'Memory {suffix}', **params)
 
     @api.depends('speedscope')
     def _compute_speedscope_url(self):

--- a/odoo/addons/base/tests/test_profiler.py
+++ b/odoo/addons/base/tests/test_profiler.py
@@ -709,5 +709,24 @@ class TestSyncRecorder(BaseCase):
 @tagged('-standard', 'profiling_memory')
 class TestMemoryProfiler(HttpCase):
     def test_memory_profiler(self):
-        with Profiler(collectors=['memory'], db=None):
+        """Memory measurements are now embedded in each traces_async entry."""
+        with Profiler(collectors=['traces_async'], db=None) as p:
             self.env['base.module.update'].create({}).update_module()
+
+        entries = p.collectors[0].entries
+        self.assertTrue(entries, "Expected profiling entries")
+        # Each entry should carry a 'memory' key with a non-negative integer
+        for entry in entries:
+            if entry.get('stack'):  # skip the empty closing entry
+                self.assertIn('memory', entry)
+                self.assertIsInstance(entry['memory'], int)
+                self.assertGreaterEqual(entry['memory'], 0)
+
+        # Verify the speedscope memory output can be constructed from these entries
+        sp = Speedscope(init_stack_trace=[])
+        sp.add('frames', entries)
+        sp.add_memory_output(['frames'], display_name='Memory')
+        result = sp.make()
+        # If any positive memory diffs were found, a sampled memory profile is present
+        memory_profiles = [prof for prof in result['profiles'] if prof.get('type') == 'sampled']
+        self.assertTrue(memory_profiles, "Expected at least one sampled memory profile")

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -60,6 +60,7 @@ from odoo.release import nt_service_name
 from odoo.tools import config, gc, osutil, OrderedSet, profiler
 from odoo.tools.cache import log_ormcache_stats
 from odoo.tools.misc import stripped_sys_argv, dumpstacks
+from odoo.tools.osutil import memory_info
 from .db import list_dbs
 
 _logger = logging.getLogger(__name__)
@@ -72,18 +73,6 @@ thread_local = threading.local()
 
 # the model and method name that was called via rpc, for logging
 thread_local.rpc_model_method = ''
-
-
-def memory_info(process):
-    """
-    :return: the relevant memory usage according to the OS in bytes.
-    """
-    # psutil < 2.0 does not have memory_info, >= 3.0 does not have get_memory_info
-    pmem = (getattr(process, 'memory_info', None) or process.get_memory_info)()
-    # MacOSX allocates very large vms to all processes so we only monitor the rss usage.
-    if platform.system() == 'Darwin':
-        return pmem.rss
-    return pmem.vms
 
 
 def set_limit_memory_hard():

--- a/odoo/tools/osutil.py
+++ b/odoo/tools/osutil.py
@@ -5,8 +5,11 @@
 Some functions related to the os and os.path module
 """
 import os
+import platform
 import re
 import zipfile
+
+system_name = platform.system()
 
 
 WINDOWS_RESERVED = re.compile(r'''
@@ -71,6 +74,17 @@ def zip_dir(path, stream, include_dir=True, fnct_sort=None):      # TODO add ign
                     real_fpath = os.path.realpath(fpath)
                     if os.path.isfile(real_fpath) and os.path.commonpath([dir_root_path, real_fpath]) == dir_root_path:
                         zipf.write(real_fpath, fpath[len_prefix:])
+
+
+def memory_info(process):
+    """
+    :return: the relevant memory usage according to the OS in bytes.
+    """
+    pmem = process.memory_info()
+    # MacOSX allocates very large vms to all processes so we only monitor the rss usage.
+    if system_name == 'Darwin':
+        return pmem.rss
+    return pmem.vms
 
 
 if os.name != 'nt':

--- a/odoo/tools/profiler.py
+++ b/odoo/tools/profiler.py
@@ -4,12 +4,12 @@ from contextlib import nullcontext, ExitStack
 from datetime import datetime
 import json
 import logging
-import sys
-import time
-import threading
 import re
-import tracemalloc
+import sys
+import threading
+import time
 
+import psutil
 from psycopg2 import OperationalError
 
 from odoo import tools
@@ -250,6 +250,11 @@ class PeriodicCollector(_BasePeriodicCollector):
 
     name = 'traces_async'
 
+    def start(self):
+        self._memory_profile = self.profiler.memory_profile
+        self._process = self.profiler.process
+        super().start()
+
     def add(self, entry=None, frame=None):
         """ Add an entry (dict) to this collector. """
         if self.last_frame:
@@ -270,43 +275,9 @@ class PeriodicCollector(_BasePeriodicCollector):
             # maybe modify the last entry to add a last seen?
             return
         self.last_frame = frame
+        if self._memory_profile:
+            entry = {'memory': self._process.memory_info().rss, **(entry or {})}
         super().add(entry=entry, frame=frame)
-
-
-_lock = threading.Lock()
-
-
-class MemoryCollector(_BasePeriodicCollector):
-
-    name = 'memory'
-    _store = 'others'
-    _min_interval = 0.01  # minimum interval allowed
-    _default_interval = 1
-
-    def start(self):
-        _lock.acquire()
-        tracemalloc.start()
-        super().start()
-
-    def add(self, entry=None, frame=None):
-        """ Add an entry (dict) to this collector. """
-        self._entries.append({
-            'start': real_time(),
-            'memory': tracemalloc.take_snapshot(),
-        })
-
-    def stop(self):
-        super().stop()
-        _lock.release()
-        tracemalloc.stop()
-
-    def post_process(self):
-        for i, entry in enumerate(self._entries):
-            if entry.get("memory", False):
-                entry_statistics = entry["memory"].statistics('traceback')
-                modified_entry_statistics = [{'traceback': list(statistic.traceback._frames),
-                                            'size': statistic.size} for statistic in entry_statistics]
-                self._entries[i] = {"memory_tracebacks": modified_entry_statistics, "start": entry['start']}
 
 
 class SyncCollector(Collector):
@@ -570,6 +541,8 @@ class Profiler:
         self.time_limit = int(self.params.get("time_limit", 0))
         self.done = False
         self.exit_stack = ExitStack()
+        self.process = psutil.Process()
+        self.memory_profile = self.params.get("memory_profile", False)
         self.counter = 0
 
         if db is ...:

--- a/odoo/tools/profiler.py
+++ b/odoo/tools/profiler.py
@@ -8,7 +8,7 @@ import sys
 import time
 import threading
 import re
-import tracemalloc
+import psutil
 
 from psycopg2 import OperationalError
 
@@ -19,6 +19,7 @@ from .gc import disabling_gc
 
 
 _logger = logging.getLogger(__name__)
+_process = psutil.Process()
 
 # ensure we have a non patched time for profiling times when using freezegun
 real_datetime_now = datetime.now
@@ -258,43 +259,7 @@ class PeriodicCollector(_BasePeriodicCollector):
             # maybe modify the last entry to add a last seen?
             return
         self.last_frame = frame
-        super().add(entry=entry, frame=frame)
-
-
-_lock = threading.Lock()
-
-
-class MemoryCollector(_BasePeriodicCollector):
-
-    name = 'memory'
-    _store = 'others'
-    _min_interval = 0.01  # minimum interval allowed
-    _default_interval = 1
-
-    def start(self):
-        _lock.acquire()
-        tracemalloc.start()
-        super().start()
-
-    def add(self, entry=None, frame=None):
-        """ Add an entry (dict) to this collector. """
-        self._entries.append({
-            'start': real_time(),
-            'memory': tracemalloc.take_snapshot(),
-        })
-
-    def stop(self):
-        super().stop()
-        _lock.release()
-        tracemalloc.stop()
-
-    def post_process(self):
-        for i, entry in enumerate(self._entries):
-            if entry.get("memory", False):
-                entry_statistics = entry["memory"].statistics('traceback')
-                modified_entry_statistics = [{'traceback': list(statistic.traceback._frames),
-                                            'size': statistic.size} for statistic in entry_statistics]
-                self._entries[i] = {"memory_tracebacks": modified_entry_statistics, "start": entry['start']}
+        super().add(entry={'memory': _process.memory_info().rss, **(entry or {})}, frame=frame)
 
 
 class SyncCollector(Collector):

--- a/odoo/tools/speedscope.py
+++ b/odoo/tools/speedscope.py
@@ -95,6 +95,66 @@ class Speedscope:
         })
         return self
 
+    def add_memory_output(self, names, display_name=None, use_context=True, **params):
+        """
+        Add a memory-based sampled profile output.
+
+        For each pair of consecutive entries in ``names``, the diff in RSS
+        memory is computed.  Positive diffs (allocations) are attributed as a
+        heuristic to *both* the previous and the current stack trace, since the
+        allocation happened somewhere in the interval between the two samples.
+
+        :param names: list of keys previously added via :meth:`add`
+        :param display_name: tab name for this output
+        :param use_context: include execution context frames
+        """
+        entries = []
+        display_name = display_name or f'Memory {",".join(names)}'
+        for name in names:
+            raw = self.profiles_raw.get(name)
+            if not raw:
+                continue
+            entries += raw
+        entries.sort(key=lambda e: e['start'])
+
+        samples = []
+        weights = []
+        total_weight = 0
+        init_ids = self.stack_to_ids(self.init_stack_trace, None)
+
+        for i in range(len(entries) - 1):
+            current = entries[i]
+            nxt = entries[i + 1]
+            current_mem = current.get('memory')
+            nxt_mem = nxt.get('memory')
+            if current_mem is None or nxt_mem is None:
+                continue
+            diff = nxt_mem - current_mem
+            if diff <= 0:
+                continue
+            stack = current.get('stack') or []
+            context = use_context and current.get('exec_context')
+            stack_ids = self.stack_to_ids(stack, context, False, self.init_stack_trace_level)
+            full_ids = init_ids + stack_ids
+            if full_ids:
+                samples.append(full_ids)
+                weights.append(diff)
+                total_weight += diff
+
+        if not samples:
+            return self
+
+        self.profiles.append({
+            "name": display_name,
+            "type": "sampled",
+            "unit": "bytes",
+            "startValue": 0,
+            "endValue": total_weight,
+            "samples": samples,
+            "weights": weights,
+        })
+        return self
+
     def add_default(self,**params):
         if len(self.profiles_raw) > 1:
             if params['combined_profile']:


### PR DESCRIPTION
The previous memory profiler was causing a lot of performance issues.
This is because tracemalloc tracks the allocations that happens at the
python interpreter level by attaching to the cpython allocators. This
first meant each allocation that happens through python has to go
through a callstack while holding the GIL and preventing the thread and
other threads from operating. This callstack does multiple things,
first is walking the allocation back from the current frame up until
the specified frame depth at the start of collection. The other is
updating the internal object that keeps track of the allocations and
what cause them up until now which degrades the performance even more
when the allocator keeps running for a long time. Increasing the frame
depth also means the partitioning becomes even more fragmented in the
internal object and leads to higher memory usage. This in turns means
lower performance as well. The issue becomes more evident when the
overhead of tracemalloc blocks any execution even turning it off
because the gil cannot be released until the full allocation execution
happens.

Currently this would happen on long enough requests or a high enough
depth.

Two PRs were made to try to address this issue.

1- https://github.com/odoo/odoo/pull/251950 : This PR tries the
solution of having a lower frame depth but matching the frames based on
a window of frames so that we can reconstruct an approximation of the
flamegraph, for example: matching window of 2 frames
1 - > 2 - > 3 - > 4
2 - > 3 - > 4 - > 5
would mean that we would match frames 2 and 3 in both stack traces and
append the first frame to the second callstack which would look like
1 - > 2 - > 3 - > 4 - > 5
Neverthless this was deemed to have too big of an assumption in the
building heuristic.

2- https://github.com/odoo/odoo/pull/253120: This PR was supposed to be
introducing memray as a profiler. Memray is the best tool for this
usecase. First because it attaches on the native system allocation
calls, and uses a file to append to on allocations. This solves both of
the issues that we had in the beginning but the issue with memray is
that it's an external tool that was deemed unnecessary to add.

The final solution is this PR:
The PR assumes a heuristic that in worker mode, a single worker handles
one thread which mean that the process memory can be fully attributed
to the request. The heuristic is also based that on a high enough
sampling rate, the delta can be fully attributed to the current frame.
This is a close enough approximation to know where to look but not what
is the actual memory usage by line.