### PR TITLE
[FIX] event_sale: use the correct exchange rate for event sales

### DIFF
--- a/addons/event_sale/models/event_event.py
+++ b/addons/event_sale/models/event_event.py
@@ -35,9 +35,9 @@ class Event(models.Model):
         )
         event_subtotals_mapping = dict.fromkeys(self._origin, 0)
         for event, currency, sum_price_subtotal in event_subtotals:
-            event_subtotals_mapping[event] += event.currency_id._convert(
+            event_subtotals_mapping[event] += currency._convert(
                 sum_price_subtotal,
-                currency,
+                event.currency_id,
                 event.company_id or self.env.company,
                 date_now,
             )

--- a/addons/event_sale/tests/test_event_sale.py
+++ b/addons/event_sale/tests/test_event_sale.py
@@ -402,6 +402,9 @@ class TestEventSale(TestEventSaleCommon):
             editor.action_make_registration()
 
     def test_ticket_price_with_currency_conversion(self):
+        """ Test that the price of the ticket and the `sale_price_total` are
+        correctly converted when using another currency.
+        """
         def _prepare_currency(self, currency_name):
             currency = self.env['res.currency'].with_context(active_test=False).search(
                 [('name', '=', currency_name)]
@@ -409,8 +412,9 @@ class TestEventSale(TestEventSaleCommon):
             currency.action_unarchive()
             return currency
 
-        currency_VEF = _prepare_currency(self, 'VEF')
         currency_USD = _prepare_currency(self, 'USD')
+        currency_VEF = _prepare_currency(self, 'VEF')
+        currency_VEF.rate_ids.rate = 5.0
 
         company_test = self.env['res.company'].create({
             'name': 'TestCompany',
@@ -419,6 +423,7 @@ class TestEventSale(TestEventSaleCommon):
         })
         self.env.user.company_ids += company_test
         self.env.user.company_id = company_test
+        currency_VEF.rate_ids.company_id = company_test
 
         pricelist_USD = self.env['product.pricelist'].create({
             'name': 'pricelist_USD',
@@ -462,10 +467,26 @@ class TestEventSale(TestEventSaleCommon):
         so.pricelist_id = pricelist_VEF
         so.action_update_prices()
 
+        # Asserting using a fixed value to make sure the conversion is correctly applied
+        # with a value other than 1.0 for the conversion rate between USD and VEF.
+        self.assertEqual(
+            so.amount_total,
+            5000.0,  # 1000 * 5.0 (conversion rate between USD and VEF)
+        )
+
         self.assertAlmostEqual(
             so.amount_total,
             currency_USD._convert(
                 event_ticket.price, currency_VEF, self.env.user.company_id, so.date_order
+            ),
+            delta=1,
+        )
+
+        so.action_confirm()
+        self.assertAlmostEqual(
+            event.sale_price_subtotal,
+            currency_VEF._convert(
+                so.amount_total, currency_USD, self.env.user.company_id, so.date_order
             ),
             delta=1,
         )


### PR DESCRIPTION
Steps to reproduce:
1. Create a currency with a non-1 exchange rate with the company's
currency (e.g. VEF with a rate of 0.000005 against USD).
2. Create a pricelist in that currency.
3. Create an event.
4. Create a sale order with the new pricelist.
5. Add a sale order line with a ticket of the event and confirm
the order.
6. Go to the event's page and check the total sales smart button.
7. Check the total sales of the event: it should be equal to the sale
order's total price converted to the company's currency, but it is not,
because of the wrong conversion (it used the inverse of the correct
exchange rate, which is 200000 instead of 0.000005 in our example).

Problem:
The total sales smart button in an event's page shows wrong totals when
sales are in a currency other than the company's currency.

Cause:
The code converts the sale price from the event's currency (which is the
same as the company's currency) to each sale order's currency, while it
should be the other way around (from each sale order's currency to the
event's currency).
https://github.com/odoo/odoo/blob/3cd709172e997f5a726cf3ae85ffcb9965619fcb/addons/event_sale/models/event_event.py#L38

opw-5494790