### PR TITLE
[IMP] payment_redsys: tokenization support

### DIFF
--- a/addons/payment_redsys/README.md
+++ b/addons/payment_redsys/README.md
@@ -11,15 +11,17 @@ submission provided by the `payment` module.
 
 - Payment with redirection flow
 - Webhook notifications
+- [Tokenization](https://pagosonline.redsys.es/desarrolladores-inicio/documentacion-funcionalidades-avanzadas/tokenizacion/)
 
 ## Not implemented features
 
-- [Tokenization](https://pagosonline.redsys.es/desarrolladores-inicio/documentacion-funcionalidades-avanzadas/tokenizacion/)
 - [Manual capture](https://pagosonline.redsys.es/desarrolladores-inicio/documentacion-operativa/preautorizaciones-y-confirmaciones/)
 - [Refunds](https://pagosonline.redsys.es/desarrolladores-inicio/documentacion-operativa/devolver-o-anular-un-pago/)
 
 ## Module history
 
+- `saas-19.3`
+  - Support for tokenization is added. odoo/odoo#253606.
 - `19.0`
   - Integration with the Redirection API. odoo/odoo#205135.
 
@@ -30,4 +32,5 @@ submission provided by the `payment` module.
 ### VISA
 
 **Card Number**: `4548810000000003`
+**Expiry Date**: any future date
 **CVV**: `123`

--- a/addons/payment_redsys/data/payment_provider_data.xml
+++ b/addons/payment_redsys/data/payment_provider_data.xml
@@ -4,6 +4,7 @@
     <record id="payment.payment_provider_redsys" model="payment.provider">
         <field name="code">redsys</field>
         <field name="redirect_form_view_id" ref="payment.generic_redirect_form"/>
+        <field name="allow_tokenization">True</field>
     </record>
 
 </odoo>

--- a/addons/payment_redsys/models/payment_provider.py
+++ b/addons/payment_redsys/models/payment_provider.py
@@ -3,6 +3,7 @@
 import base64
 import hashlib
 import hmac
+import json
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import Cipher, modes
@@ -15,6 +16,7 @@ except ImportError:
     from cryptography.hazmat.primitives.ciphers.algorithms import TripleDES
 
 from odoo import fields, models
+from odoo.tools.urls import urljoin
 
 from odoo.addons.payment_redsys import const
 
@@ -38,6 +40,13 @@ class PaymentProvider(models.Model):
         groups="base.group_system",
     )
 
+    # === COMPUTED METHODS === #
+
+    def _compute_feature_support_fields(self):
+        """Override of `payment` to enable additional features."""
+        super()._compute_feature_support_fields()
+        self.filtered(lambda p: p.code == "redsys").support_tokenization = True
+
     # === CRUD METHODS === #
 
     def _get_default_payment_method_codes(self):
@@ -47,14 +56,18 @@ class PaymentProvider(models.Model):
             return super()._get_default_payment_method_codes()
         return const.DEFAULT_PAYMENT_METHOD_CODES
 
-    # === BUSINESS METHODS === #
+    # === REQUEST HELPERS === #
 
-    def _redsys_get_api_url(self):
+    def _build_request_url(self, endpoint, **kwargs):
+        """Override of `payment` to build the request URL."""
+        if self.code != "redsys":
+            return super()._build_request_url(endpoint, **kwargs)
+
         if self.state == "enabled":
-            api_url = "https://sis.redsys.es/sis/realizarPago"
+            base = "https://sis.redsys.es/sis"
         else:  # 'test'
-            api_url = "https://sis-t.redsys.es:25443/sis/realizarPago"
-        return api_url
+            base = "https://sis-t.redsys.es:25443/sis"
+        return urljoin(base, endpoint)
 
     def _redsys_calculate_signature(self, merchant_parameters, reference, secret_key):
         """Calculate the signature for the provided data.
@@ -71,11 +84,17 @@ class PaymentProvider(models.Model):
         decoded_key = base64.b64decode(secret_key)
         # 2. Derive the signature key by 3DES-encrypting the transaction (Ds_Merchant_Order).
         encoded_order = reference.encode().ljust(16, b"\x00")
-        cipher = Cipher(
-            TripleDES(decoded_key), modes.CBC(b"\x00" * 8), backend=default_backend()
-        )
+        cipher = Cipher(TripleDES(decoded_key), modes.CBC(b"\x00" * 8), backend=default_backend())
         derived_key = cipher.encryptor().update(encoded_order) + cipher.encryptor().finalize()
         # 3. Create HMAC-SHA256 using the derived key and merchant parameters.
         hmac_obj = hmac.new(derived_key, merchant_parameters.encode(), hashlib.sha256)
         # 4. Encode the HMAC result in Base64.
         return base64.urlsafe_b64encode(hmac_obj.digest()).decode()
+
+    def _parse_response_content(self, response, **kwargs):
+        """Override of `payment` to parse the response content."""
+        if self.code != "redsys":
+            return super()._parse_response_content(response, **kwargs)
+
+        merchant_params = response.json().get("Ds_MerchantParameters")
+        return json.loads(base64.b64decode(merchant_params).decode())

--- a/addons/payment_redsys/models/payment_transaction.py
+++ b/addons/payment_redsys/models/payment_transaction.py
@@ -62,6 +62,27 @@ class PaymentTransaction(models.Model):
         if self.provider_code != "redsys":
             return super()._get_specific_rendering_values(processing_values)
 
+        return {
+            "api_url": self.provider_id._build_request_url("/realizarPago"),
+            "url_params": self._redsys_prepare_request_payload(),
+        }
+
+    def _send_payment_request(self):
+        """Override of `payment` to send a payment request to Redsys."""
+        if self.provider_code != "redsys":
+            return super()._send_payment_request()
+
+        payment_data = self._send_api_request(
+            "POST", "/rest/trataPeticionREST", json=self._redsys_prepare_request_payload()
+        )
+        self._process("redsys", payment_data)
+
+    def _redsys_prepare_request_payload(self):
+        """Prepare the Redsys request payload with encoded merchant parameters and signature.
+
+        :return: The payload to be sent to Redsys.
+        :rtype: dict
+        """
         merchant_parameters = self._redsys_prepare_merchant_parameters()
         encoded_merchant_parameters = base64.b64encode(
             json.dumps(merchant_parameters).encode()
@@ -70,12 +91,9 @@ class PaymentTransaction(models.Model):
             encoded_merchant_parameters, self.reference, self.provider_id.redsys_secret_key
         )
         return {
-            "api_url": self.provider_id._redsys_get_api_url(),
-            "url_params": {
-                "Ds_MerchantParameters": encoded_merchant_parameters,
-                "Ds_Signature": signature,
-                "Ds_SignatureVersion": "HMAC_SHA256_V1",
-            },
+            "Ds_MerchantParameters": encoded_merchant_parameters,
+            "Ds_Signature": signature,
+            "Ds_SignatureVersion": "HMAC_SHA256_V1",
         }
 
     def _redsys_prepare_merchant_parameters(self):
@@ -88,7 +106,7 @@ class PaymentTransaction(models.Model):
         base_url = self.provider_id.get_base_url()
         return_url = urljoin(base_url, RedsysController._return_url)
         webhook_url = urljoin(base_url, RedsysController._webhook_url)
-        return {
+        merchant_parameters = {
             "DS_MERCHANT_AMOUNT": str(converted_amount),
             "DS_MERCHANT_CURRENCY": self.currency_id.iso_numeric,
             "DS_MERCHANT_MERCHANTCODE": self.provider_id.redsys_merchant_code,
@@ -111,6 +129,20 @@ class PaymentTransaction(models.Model):
                 "email": self.partner_email,
             },
         }
+        if self.tokenize:
+            merchant_parameters.update({
+                "DS_MERCHANT_COF_INI": "S",
+                "DS_MERCHANT_COF_TYPE": "R",
+                "DS_MERCHANT_IDENTIFIER": "REQUIRED",
+            })
+        elif self.token_id:
+            merchant_parameters.update({
+                "DS_MERCHANT_COF_TYPE": "R",
+                "DS_MERCHANT_DIRECTPAYMENT": "true",
+                "DS_MERCHANT_EXCEP_SCA": "MIT",
+                "DS_MERCHANT_IDENTIFIER": self.token_id.provider_ref,
+            })
+        return merchant_parameters
 
     @api.model
     def _extract_reference(self, provider_code, payment_data):
@@ -164,3 +196,13 @@ class PaymentTransaction(models.Model):
         else:
             _logger.warning("Received invalid payment status (%s).", status_code)
             self._set_error(_("Unknown status code: %s", status_code))
+
+    def _extract_token_values(self, payment_data):
+        """Override of `payment` to return token data based on Redsys payment data."""
+        if self.provider_code != "redsys":
+            return super()._extract_token_values(payment_data)
+
+        return {
+            "provider_ref": payment_data.get("Ds_Merchant_Identifier"),
+            "payment_details": payment_data.get("Ds_Card_Number", "")[-4:],
+        }

--- a/addons/payment_redsys/tests/common.py
+++ b/addons/payment_redsys/tests/common.py
@@ -33,3 +33,9 @@ class RedsysCommon(PaymentCommon):
             "Ds_MerchantParameters": cls.encoded_merchant_parameter,
             "Ds_Signature": "upzUj96lLgOEUP5lvaj7lz0Se4MXmc5_GoJ32ACqZ3A=",
         }
+        cls.provider_ref = "test_identifier_123"
+        cls.token_merchant_data = {
+            **cls.merchant_parameters,
+            "Ds_Merchant_Identifier": cls.provider_ref,
+            "Ds_Card_Number": "454881******0003",
+        }

--- a/addons/payment_redsys/tests/test_payment_transaction.py
+++ b/addons/payment_redsys/tests/test_payment_transaction.py
@@ -29,6 +29,26 @@ class TestPaymentTransaction(RedsysCommon):
         self.assertEqual(merchant_parameters["DS_MERCHANT_PAYMETHODS"], "C")  # credit card
         self.assertTrue("DS_MERCHANT_EMV3DS" in merchant_parameters)
 
+    def test_no_item_missing_from_merchant_parameters_for_tokenization(self):
+        """Test that all important items are present in the merchant parameters when the transaction
+        is tokenized."""
+        tx = self._create_transaction("redirect", tokenize=True)
+        payload = tx._redsys_prepare_merchant_parameters()
+        self.assertEqual(payload["DS_MERCHANT_COF_INI"], "S")
+        self.assertEqual(payload["DS_MERCHANT_COF_TYPE"], "R")
+        self.assertEqual(payload["DS_MERCHANT_IDENTIFIER"], "REQUIRED")
+
+    def test_no_item_missing_from_merchant_parameters_for_token_payments(self):
+        """Test that all important items are present in the merchant parameters when payment by
+        token."""
+        token = self._create_token(provider_ref=self.provider_ref)
+        tx = self._create_transaction("redirect", token_id=token.id)
+        payload = tx._redsys_prepare_merchant_parameters()
+        self.assertEqual(payload["DS_MERCHANT_COF_TYPE"], "R")
+        self.assertEqual(payload["DS_MERCHANT_DIRECTPAYMENT"], "true")
+        self.assertEqual(payload["DS_MERCHANT_EXCEP_SCA"], "MIT")
+        self.assertEqual(payload["DS_MERCHANT_IDENTIFIER"], tx.token_id.provider_ref)
+
     def test_search_by_reference_returns_tx(self):
         """Test that the transaction is returned from the payment data."""
         tx = self._create_transaction("redirect")
@@ -59,3 +79,10 @@ class TestPaymentTransaction(RedsysCommon):
         tx = self._create_transaction("redirect")
         tx._apply_updates(self.merchant_parameters)
         self.assertEqual(tx.state, "done")
+
+    def test_extract_token_values_maps_fields_correctly(self):
+        """Test that the token values are extracted correctly from the payment data."""
+        tx = self._create_transaction(flow="redirect")
+        token_values = tx._extract_token_values(self.token_merchant_data)
+        self.assertEqual(token_values["provider_ref"], "test_identifier_123")
+        self.assertEqual(token_values["payment_details"], "0003")


### PR DESCRIPTION
Implement Redsys tokenization using the merchant-managed integration.
Store the merchant identifier returned by Redsys and use it for
subsequent payments through the REST API without redirect.

This allows automatic payments (e.g., subscriptions) to work correctly.

Note: Merchants must request this configuration from their acquiring bank
during the onboarding process, as it is not enabled by default.

task-5930122