### PR TITLE
[FIX] mail,im_livechat: mark ended livechat conversations as read

### DIFF
--- a/addons/im_livechat/static/src/core/common/thread_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_patch.js
@@ -30,6 +30,13 @@ patch(Thread.prototype, {
             () => [this.props.thread.livechatVisitorMember?.im_status]
         );
     },
+    /** @override */
+    applyScrollContextually(thread) {
+        super.applyScrollContextually(...arguments);
+        if (thread.composerDisabled && this.isAtBottom && !thread.markedAsUnread && !thread.markingAsRead) {
+            thread.markAsRead();
+        }
+    },
     get showVisitorDisconnected() {
         return (
             this.store.self.notEq(this.props.thread.livechatVisitorMember?.persona) &&

--- a/addons/im_livechat/static/tests/chat_window_patch.test.js
+++ b/addons/im_livechat/static/tests/chat_window_patch.test.js
@@ -212,3 +212,34 @@ test("livechat: non-member can close immediately", async () => {
     await click("[title*='Close Chat Window']");
     await contains(".o-mail-ChatWindow", { count: 0 });
 });
+
+test.tags("desktop", "focus required");
+test("Can mark as read a livechat that has ended", async () => {
+    const pyEnv = await startServer();
+    const guestId = pyEnv["mail.guest"].create({ name: "Visitor" });
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
+        ],
+        channel_type: "livechat",
+    });
+    for (let i = 0; i < 2; i++) {
+        pyEnv["mail.message"].create({
+            author_guest_id: guestId,
+            body: "test message".repeat(10),
+            message_type: "comment",
+            model: "discuss.channel",
+            res_id: channelId,
+        });
+    }
+    await start();
+    setupChatHub({ opened: [channelId] });
+    await contains(".o-mail-ChatWindow .o-mail-Message", { count: 2 });
+    await contains(".o-mail-Thread-banner:has(:text('2 new messages'))");
+    await withGuest(guestId, () =>
+        rpc("/im_livechat/visitor_leave_session", { channel_id: channelId })
+    );
+    await contains("span:text('This livechat conversation has ended.')");
+    await contains(".o-mail-Thread-banner", { count: 0 });
+});

--- a/addons/im_livechat/static/tests/chat_window_patch.test.js
+++ b/addons/im_livechat/static/tests/chat_window_patch.test.js
@@ -4,6 +4,7 @@ import {
     openDiscuss,
     openFormView,
     setupChatHub,
+    scroll,
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
@@ -211,4 +212,38 @@ test("livechat: non-member can close immediately", async () => {
     await contains(".o-mail-ChatWindow");
     await click("[title*='Close Chat Window']");
     await contains(".o-mail-ChatWindow", { count: 0 });
+});
+
+test.tags("desktop");
+test("Mark conversation as read when session ends and agent scrolls to bottom", async () => {
+    const pyEnv = await startServer();
+    const guestId = pyEnv["mail.guest"].create({ name: "Visitor" });
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
+            Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
+        ],
+        channel_type: "livechat",
+    });
+    await start();
+    for (let i = 0; i < 2; i++) {
+        await withGuest(guestId, () =>
+            rpc("/mail/message/post", {
+                post_data: {
+                    body: "test message".repeat(100),
+                    message_type: "comment",
+                    subtype_xmlid: "mail.mt_comment",
+                },
+                thread_id: channelId,
+                thread_model: "discuss.channel",
+            })
+        );
+    }
+    await contains(".o-mail-ChatWindow .o-mail-Message", { count: 2 });
+    await withGuest(guestId, () => rpc("/im_livechat/visitor_leave_session", { channel_id: channelId }));
+    await contains("span", { text: "This livechat conversation has ended." });
+    await contains(".o-mail-Thread-banner", { text: "2 new messages" });
+    await scroll(".o-mail-Thread", "bottom");
+    await contains(".o-mail-Thread", { scroll: "bottom" });
+    await contains(".o-mail-Thread-banner", { count: 0 });
 });

--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -64,6 +64,21 @@ export class ChatWindow extends Component {
         });
     }
 
+    get autofocusComposer() {
+        if (this.isMobileOS || this.thread.composerDisabled) {
+            return undefined;
+        }
+        return this.props.chatWindow.autofocus;
+    }
+
+    get autofocusThread() {
+        const autofocus = this.props.chatWindow.autofocus;
+        if (this.isMobileOS) {
+            return autofocus + (this.thread.composerDisabled ? 1 : 0);
+        }
+        return this.thread.composerDisabled ? autofocus + 1 : undefined;
+    }
+
     get composerType() {
         if (this.thread.model !== "discuss.channel") {
             return "note";

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -68,9 +68,9 @@
                     <t t-component="threadActions.activeAction.actionPanelComponent" t-props="{ ...threadActions.activeAction.actionPanelComponentProps, thread }"/>
                 </div>
                 <t t-elif="thread">
-                    <Thread autofocus="isMobileOS ? props.chatWindow.autofocus : undefined" isInChatWindow="true" thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent" jumpToNewMessage="props.chatWindow.jumpToNewMessage"/>
+                    <Thread autofocus="autofocusThread" isInChatWindow="true" thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent" jumpToNewMessage="props.chatWindow.jumpToNewMessage"/>
                     <t t-call="mail.ChatWindow.memberTyping"/>
-                    <Composer composer="thread.composer" autofocus="isMobileOS ? undefined : props.chatWindow.autofocus" mode="'compact'" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="composerType"/>
+                    <Composer composer="thread.composer" autofocus="autofocusComposer" mode="'compact'" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="composerType"/>
                 </t>
             </t>
         </div>

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -165,6 +165,11 @@ export class Thread extends Record {
         },
     });
     isDisplayedOnUpdate() {}
+
+    get composerDisabled() {
+        return false;
+    }
+
     get isFocused() {
         return this.isFocusedCounter !== 0;
     }

--- a/addons/mail/static/src/core/public_web/discuss_content.xml
+++ b/addons/mail/static/src/core/public_web/discuss_content.xml
@@ -68,8 +68,8 @@
                 <t name="core-content">
                     <t t-if="thread">
                         <div t-if="!ui.isSmall or !threadActions.activeAction?.actionPanelComponentCondition" class="d-flex flex-column flex-grow-1 bg-inherit o-min-width-0">
-                            <t name="thread"><Thread thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent"/></t>
-                            <Composer t-if="thread.model !== 'mail.box' or thread.composer.replyToMessage" t-key="thread.localId" composer="thread.composer" autofocus="true" onDiscardCallback="() => (thread.composer.replyToMessage = undefined)" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="root" type="thread.composer.replyToMessage ? (thread.composer.replyToMessage.isNote ? 'note' : 'message') : undefined"/>
+                            <t name="thread"><Thread thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent" autofocus="thread.composerDisabled"/></t>
+                            <Composer t-if="thread.model !== 'mail.box' or thread.composer.replyToMessage" t-key="thread.localId" composer="thread.composer" autofocus="!thread.composerDisabled" onDiscardCallback="() => (thread.composer.replyToMessage = undefined)" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="root" type="thread.composer.replyToMessage ? (thread.composer.replyToMessage.isNote ? 'note' : 'message') : undefined"/>
                         </div>
                         <div t-if="threadActions.activeAction?.actionPanelComponentCondition" t-attf-class="{{ threadActions.activeAction.panelOuterClass }}" class="o-mail-DiscussContent-panelContainer o-mail-discussSidebarBgColor h-100 border-start border-secondary flex-shrink-0" t-att-class="{ 'w-100': ui.isSmall }">
                             <t t-component="threadActions.activeAction.actionPanelComponent" thread="thread" t-props="threadActions.activeAction.actionPanelComponentProps"/>


### PR DESCRIPTION
**Description of the issue this PR addresses:**
Previously, when a livechat conversation ended, it was never automatically 
marked as read. The existing `mark_as_read` mechanism depends on the 
composer being focused, but ended livechat conversations hides the composer, 
and the chat window does not focus the thread automatically 
(focus only happens on explicit click).

This made it impossible for the read state to be triggered through the normal 
path, leaving agents with persistent unread indicators on closed livechat 
conversations.

**Desired behavior after PR is merged:**
- Focus the composer when present.
- Focus the conversation otherwise.

This ensures the read state is correctly triggered when the conversation
is effectively in focus.

task-[5900038](https://www.odoo.com/odoo/project/1519/tasks/5900038)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
