### PR TITLE
[FIX] pos_self_order: register preset phone input

### DIFF
--- a/addons/pos_self_order/static/src/app/models/pos_order.js
+++ b/addons/pos_self_order/static/src/app/models/pos_order.js
@@ -65,6 +65,9 @@ patch(PosOrder.prototype, {
     },
     serializeForORM(opts = {}) {
         const data = super.serializeForORM(opts);
+        if (this.mobile && !data.mobile) {
+            data.mobile = this.mobile;
+        }
         if (this.email && !data.email) {
             data.email = this.email;
         }

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
@@ -140,6 +140,8 @@ export class CartPage extends Component {
     async proceedInfos(state) {
         this.state.fillInformations = false;
         if (state) {
+            this.selfOrder.currentOrder.mobile =
+                this.selfOrder.currentOrder.partner_id?.phone || state.phone;
             this.selfOrder.currentOrder.email =
                 this.selfOrder.currentOrder.partner_id?.email || state.email;
             await this.pay();

--- a/addons/pos_self_order/static/tests/tours/self_order_preset_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_preset_tour.js
@@ -112,6 +112,7 @@ registry.category("web_tour.tours").add("test_preset_takeaway_email_tour", {
         Utils.clickBtn("Order"),
         CartPage.fillInput("Name", "Public user"),
         CartPage.fillInput("Email", "public.user@test.com"),
+        CartPage.fillInput("Phone", "+32000111222"),
         Utils.clickBtn("Continue"),
         // Waiting for mail to be sent
         {

--- a/addons/pos_self_order/tests/test_takeaway_preset_mail.py
+++ b/addons/pos_self_order/tests/test_takeaway_preset_mail.py
@@ -14,7 +14,10 @@ class TestTakeawayMail(MailCase, TestSelfOrderPreset):
 
         with self.mock_mail_gateway():
             self.start_tour(self_route, "test_preset_takeaway_email_tour")
-        self.assertEqual("Public user", self.env["pos.order"].search([], limit=1, order="id desc").floating_order_name)
+        order = self.pos_config.current_session_id.order_ids
+        self.assertEqual(len(order), 1)
+        self.assertTrue(bool("Public user" in self.pos_config.current_session_id.order_ids.floating_order_name))
+        self.assertEqual(order.mobile, "+32000111222")
 
         # Message is posted and mail is sent on time
         self.assertEqual(len(self._new_mails), 1)


### PR DESCRIPTION
Currently, when using the takeaway preset, the phone information filled in is not registered on the order.

Steps to reproduce:
-------------------
* Change restaurant setting to enable self order
* Open mobile menu (make sure session is opened prior)
* Select takeout preset
* Place an order
* Fill in all information, time, name, email & phone
* Validate order
* Go to the orders in the backend
> Observe that the contact info does not register the phone (mobile)

Why the fix:
------------
Nothing was done with the phone information so we now register it on the order.

opw-6014340