### PR TITLE
[REF] portal: move /portal/chatter_init into /mail/data

### DIFF
--- a/addons/portal/controllers/thread.py
+++ b/addons/portal/controllers/thread.py
@@ -1,6 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import http
 from odoo.fields import Domain
 from odoo.http import request
 from odoo.addons.mail.controllers.thread import ThreadController
@@ -10,64 +9,6 @@ from odoo.addons.portal.utils import get_portal_partner
 
 
 class PortalThreadController(ThreadController):
-    @http.route("/portal/chatter_init", type="jsonrpc", auth="public", website=True)
-    def portal_chatter_init(self, thread_model, thread_id, **kwargs):
-        store = Store().add_global_values(request.env.user.sudo(False)._store_init_global_fields)
-        if request.env.user.has_group("website.group_website_restricted_editor"):
-            store.add(request.env.user.partner_id, {"is_user_publisher": True})
-        if thread := self._get_thread_with_access(thread_model, thread_id, mode="read", **kwargs):
-            store.add(
-                thread,
-                lambda res: self._store_portal_thread_fields(res, **kwargs),
-                as_thread=True,
-            )
-        return store.get_result()
-
-    @classmethod
-    def _store_portal_thread_fields(cls, res: Store.FieldList, **kwargs):
-        portal_partner_by_thread = {
-            thread: get_portal_partner(
-                # need to use sudo because portal users might not have the right to read the portal partner
-                thread.sudo(), kwargs.get("hash"), kwargs.get("pid"), kwargs.get("token"),
-            ) for thread in res.records
-        }
-
-        def can_react(thread):
-            thread_mode = False
-            # sudo: mail.thread - can read thread to build _mail_get_operation_for_mail_message_operation
-            for domain, operation in thread.sudo()._mail_get_operation_for_mail_message_operation(
-                getattr(thread, "_mail_message_reaction_access", "create"),
-            ):
-                # sudo: mail.thread - can read thread to filter on access domain
-                if thread.sudo().filtered_domain(domain):
-                    thread_mode = operation
-                    break
-            if not thread_mode:
-                return False
-            has_access = cls._get_thread_with_access(
-                thread._name,
-                thread.id,
-                mode=thread_mode,
-                **kwargs,
-            )
-            if request.env.user._is_public():
-                return bool(has_access and portal_partner_by_thread.get(thread))
-            return bool(has_access)
-
-        res.attr("can_react", can_react)
-        res.attr("hasReadAccess", lambda t: t.sudo(False).has_access("read"))
-        res.one(
-            "portal_partner",
-            lambda res: (
-                res.attr("active"),
-                res.one("main_user_id", ["partner_id", "share"]),
-                res.attr("name"),
-                res.from_method("_store_avatar_fields"),
-            ),
-            predicate=lambda t: t in portal_partner_by_thread,
-            value=portal_partner_by_thread.get,
-        )
-
     def _prepare_message_data(self, post_data, *, thread, **kwargs):
         post_data = super()._prepare_message_data(post_data, thread=thread, **kwargs)
         if kwargs.get("from_create") and request.env.user._is_public():
@@ -133,6 +74,71 @@ class PortalWebClientController(WebclientController):
             )
             for message_data in messages.portal_message_format(options=params):
                 store.add_model_values("mail.message", message_data)
+        if name == "/portal/chatter_init":
+            access_params = params.get("access_params", {})
+            store.add_global_values(request.env.user.sudo(False)._store_init_global_fields)
+            if request.env.user.has_group("website.group_website_restricted_editor"):
+                store.add(request.env.user.partner_id, {"is_user_publisher": True})
+            if thread := self._get_thread_with_access(
+                params["thread_model"],
+                params["thread_id"],
+                mode="read",
+                **access_params,
+            ):
+                store.add(
+                    thread,
+                    lambda res: self._store_portal_thread_fields(res, access_params),
+                    as_thread=True,
+                )
+
+    @classmethod
+    def _store_portal_thread_fields(cls, res: Store.FieldList, access_params):
+        portal_partner_by_thread = {
+            thread: get_portal_partner(
+                # need to use sudo because portal users might not have the right to read the portal partner
+                thread.sudo(),
+                access_params.get("hash"),
+                access_params.get("pid"),
+                access_params.get("token"),
+            )
+            for thread in res.records
+        }
+
+        def can_react(thread):
+            thread_mode = False
+            # sudo: mail.thread - can read thread to build _mail_get_operation_for_mail_message_operation
+            for domain, operation in thread.sudo()._mail_get_operation_for_mail_message_operation(
+                getattr(thread, "_mail_message_reaction_access", "create"),
+            ):
+                # sudo: mail.thread - can read thread to filter on access domain
+                if thread.sudo().filtered_domain(domain):
+                    thread_mode = operation
+                    break
+            if not thread_mode:
+                return False
+            has_access = cls._get_thread_with_access(
+                thread._name,
+                thread.id,
+                mode=thread_mode,
+                **access_params,
+            )
+            if request.env.user._is_public():
+                return bool(has_access and portal_partner_by_thread.get(thread))
+            return bool(has_access)
+
+        res.attr("can_react", can_react)
+        res.attr("hasReadAccess", lambda t: t.sudo(False).has_access("read"))
+        res.one(
+            "portal_partner",
+            lambda res: (
+                res.attr("active"),
+                res.one("main_user_id", ["partner_id", "share"]),
+                res.attr("name"),
+                res.from_method("_store_avatar_fields"),
+            ),
+            predicate=lambda t: t in portal_partner_by_thread,
+            value=portal_partner_by_thread.get,
+        )
 
     @classmethod
     def _get_non_empty_message_domain(self):

--- a/addons/portal/static/src/chatter/portal/portal_chatter_service.js
+++ b/addons/portal/static/src/chatter/portal/portal_chatter_service.js
@@ -1,7 +1,6 @@
 import { PortalChatter } from "@portal/chatter/portal/portal_chatter";
 import { App } from "@odoo/owl";
 import { registry } from "@web/core/registry";
-import { rpc } from "@web/core/network/rpc";
 import { session } from "@web/session";
 import { appTranslateFn } from "@web/core/l10n/translation";
 import { getTemplate } from "@web/core/templates";
@@ -54,16 +53,15 @@ export class PortalChatterService {
             hash: chatterEl.getAttribute("data-hash"),
             pid: parseInt(chatterEl.getAttribute("data-pid")),
         });
-        const data = await rpc(
+        await this.store.fetchStoreData(
             "/portal/chatter_init",
             {
-                thread_model: props.resModel,
+                access_params: thread.rpcParams,
                 thread_id: props.resId,
-                ...thread.rpcParams,
+                thread_model: props.resModel,
             },
-            { silent: true }
+            { readonly: false }
         );
-        this.store.insert(data);
         odoo.portalChatterReady.resolve(true);
     }
 }


### PR DESCRIPTION
Make `/portal/chatter_init` route part of `/mail/data` so we don't need to manually do the store insert.

task-6032947

