### PR TITLE
[FIX] account_edi_ubl_cii: handle case where move lines don't have name

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_move.py
+++ b/addons/account_edi_ubl_cii/models/account_move.py
@@ -128,7 +128,7 @@ class AccountMove(models.Model):
         """
         self.ensure_one()
         return any(
-            re.match(re.escape(self.partner_id.name or _("Unknown partner")) + r' - \d+ - .*', line.name)
+            re.match(re.escape(self.partner_id.name or _("Unknown partner")) + r' - \d+ - .*', line.name or '')
             for line in self.line_ids.filtered(lambda x: x.display_type == 'product')
         )
 


### PR DESCRIPTION
**PROBLEM**
When importing a peppol bill, if the partner have bills with unnamed lines there is a traceback.

**STEP TO REPRODUCE**
1. Download the xml attach to the ticket.
2. Go to Accounting/Vendors/Bills, and upload it.
3. modify the Bill, removing the labels on the line so they are unnamed.
4. Upload the xml one more time, to create a new bill.
5. You should have a traceback.

opw-6022549