### PR TITLE
[FIX] base: do not rotate session from websocket closed route

### DIFF
--- a/addons/bus/tests/test_websocket_controller.py
+++ b/addons/bus/tests/test_websocket_controller.py
@@ -66,7 +66,7 @@ class TestWebsocketController(HttpCaseWithUserDemo):
                 'is_first_poll': False,
             })
 
-    def test_do_not_rotate_session_when_peeking_notifications(self):
+    def test_do_not_rotate_session(self):
         self.authenticate('admin', 'admin')
         self.url_open('/odoo')
         original_session = self.opener.cookies['session_id']
@@ -81,3 +81,9 @@ class TestWebsocketController(HttpCaseWithUserDemo):
         self.assertEqual(self.opener.cookies['session_id'], original_session)
         self.url_open("/odoo")
         self.assertNotEqual(self.opener.cookies['session_id'], original_session)
+        original_session = self.opener.cookies['session_id']
+        original_session_obj = root.session_store.get(original_session)
+        original_session_obj['create_time'] -= SESSION_ROTATION_INTERVAL
+        root.session_store.save(original_session_obj)
+        self.make_jsonrpc_request('/websocket/on_closed')
+        self.assertEqual(self.opener.cookies['session_id'], original_session)

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -313,6 +313,7 @@ SESSION_ROTATION_INTERVAL = 60 * 60 * 3
 
 # URL paths for which automatic session rotation is disabled.
 SESSION_ROTATION_EXCLUDED_PATHS = (
+    '/websocket/on_closed',
     '/websocket/peek_notifications',
     '/websocket/update_bus_presence',
 )


### PR DESCRIPTION
In [1], session rotation was disabled for websocket routes. However, the `/websocket/on_closed` route was forgotten.

This commit ensures session rotation is also disabled for this route.

[1]: https://github.com/odoo/odoo/pull/250826

opw-5445323

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
