### PR TITLE
[FIX] stock: increment subsequences by date_range on lot generation

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1100,10 +1100,19 @@ Please change the quantity done or the rounding precision in your settings.""",
                         'id': value,
                         'display_name': self.env['stock.move.line'][key].browse(value).display_name
                     }
-        if product.lot_sequence_id:
-            first_number = product.lot_sequence_id.number_next_actual - product.lot_sequence_id.number_increment
-            if (first_lot and first_lot == product.lot_sequence_id.get_next_char(first_number)):
-                product.lot_sequence_id.sudo().write({'number_next_actual': first_number + len(lot_qties)})
+        if product.lot_sequence_id and first_lot:
+            current_sequence = product.lot_sequence_id._get_current_sequence()
+            increment = product.lot_sequence_id.number_increment
+            first_number = current_sequence.number_next_actual - increment
+            final_number = first_number
+            # Since the value might have been incremented by the "New" button of the "Generate Serial Numbers" wizard
+            # we need to consider both the decremented and the current value of the sequence
+            if first_lot == product.lot_sequence_id.get_next_char(first_number):
+                final_number = first_number + len(lot_qties)
+            elif first_lot == product.lot_sequence_id.get_next_char(first_number + increment):
+                final_number = first_number + increment + len(lot_qties)
+            if first_number != final_number:
+                current_sequence.sudo().write({'number_next_actual': final_number})
         return vals_list
 
     def _push_apply(self):

--- a/addons/stock/tests/test_generate_serial_numbers.py
+++ b/addons/stock/tests/test_generate_serial_numbers.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from freezegun import freeze_time
 
 from odoo import Command
 from odoo.exceptions import ValidationError
@@ -506,3 +507,97 @@ class StockGenerateCommon(TransactionCase):
                 'default_quantity': 0,
             }, "generate", "", 3, "test")
         self.assert_move_line_vals_values(move_line_vals, [])
+
+    @freeze_time('2020-11-12')
+    def test_serial_numbers_sequence_use_date_range(self):
+        """
+        In case the serial/lot sequence is date_range specific, check that
+        the associated subsequence is incremented accordingly.
+        """
+        product = self.product_serial
+        serial_sequence = product.lot_sequence_id
+        serial_sequence.write({
+            'use_date_range': True,
+            'date_range_ids': [
+                Command.create({
+                    'date_from': '2020-01-01',
+                    'date_to': '2020-09-30',
+                    'number_next_actual': 12,
+                }),
+                Command.create({
+                    'date_from': '2020-10-01',
+                    'date_to': '2020-12-31',
+                    'number_next_actual': 33,
+                }),
+                Command.create({
+                    'date_from': '2021-01-01',
+                    'date_to': '2022-12-31',
+                    'number_next_actual': 5,
+                }),
+            ]
+        })
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        receipt = self.env['stock.picking'].create({
+            'picking_type_id': warehouse.in_type_id.id,
+            'location_id': self.ref('stock.stock_location_suppliers'),
+            'location_dest_id': warehouse.lot_stock_id.id,
+            'move_ids': [Command.create({
+                'product_id': product.id,
+                'product_uom_qty': 3,
+                'location_id': self.ref('stock.stock_location_suppliers'),
+                'location_dest_id': warehouse.lot_stock_id.id,
+            })],
+        })
+        receipt.action_confirm()
+        # Mimic the flow of clicking on the "New" button of the generating wizzard which performs a `next_by_id`
+        # incrementing the sequence prior to the lot_name's generation.
+        move_line_vals = receipt.move_ids.action_generate_lot_line_vals(
+            {
+                'default_company_id': self.env.company.id,
+                'default_date': '2020-11-12 12:00:00',
+                'default_tracking': 'serial',
+                'default_product_id': product.id,
+                'default_picking_id': receipt.id,
+                'default_picking_type_id': warehouse.in_type_id.id,
+                'default_location_id': self.ref('stock.stock_location_suppliers'),
+                'default_location_dest_id': warehouse.lot_stock_id.id,
+                'default_quantity': 3,
+        }, 'generate', serial_sequence.next_by_id(), 3, 'test')
+        self.assertEqual([val.get('lot_name') for val in move_line_vals], ['0000033', '0000034', '0000035'])
+        # Check that the appropriate sub-sequence has been updated accordingly
+        self.assertEqual(serial_sequence._get_current_sequence().number_next_actual, 36)
+
+        # Mimic the flow of manually entering the appropriate next value without clicking on the "New" button
+        # In particular, without calling the `next_by_id` prior the lot_name's generation.
+        move_line_vals = receipt.move_ids.action_generate_lot_line_vals(
+            {
+                'default_company_id': self.env.company.id,
+                'default_date': '2020-11-12 12:00:00',
+                'default_tracking': 'serial',
+                'default_product_id': product.id,
+                'default_picking_id': receipt.id,
+                'default_picking_type_id': warehouse.in_type_id.id,
+                'default_location_id': self.ref('stock.stock_location_suppliers'),
+                'default_location_dest_id': warehouse.lot_stock_id.id,
+                'default_quantity': 3,
+        }, 'generate', '0000036', 3, 'test')
+        self.assertEqual([val.get('lot_name') for val in move_line_vals], ['0000036', '0000037', '0000038'])
+        # Check that the appropriate sub-sequence has been updated accordingly
+        self.assertEqual(serial_sequence._get_current_sequence().number_next_actual, 39)
+
+        # Mimic the flow of entering an arbitrary number unrelated to the current sequence
+        move_line_vals = receipt.move_ids.action_generate_lot_line_vals(
+            {
+                'default_company_id': self.env.company.id,
+                'default_date': '2020-11-12 12:00:00',
+                'default_tracking': 'serial',
+                'default_product_id': product.id,
+                'default_picking_id': receipt.id,
+                'default_picking_type_id': warehouse.in_type_id.id,
+                'default_location_id': self.ref('stock.stock_location_suppliers'),
+                'default_location_dest_id': warehouse.lot_stock_id.id,
+                'default_quantity': 3,
+        }, "generate", 'SN52', 3, "test")
+        self.assertEqual([val.get('lot_name') for val in move_line_vals], ['SN52', 'SN53', 'SN54'])
+        # Check that the asequence was not updated
+        self.assertEqual(serial_sequence.next_by_id(), '0000039')


### PR DESCRIPTION
### Steps to reproduce:

- In the settings enable: Lots & Serial Numbers and Multi-Step routes
- Settings > Technical > Sequences & Identifiers > Sequences
- On the stock.lot.serial sequence enable: `Use subsequences per date_range`, add a range date containing today
- Create a product tracked by Serial numbers
- Create and confirm a receipt for 3 units of your product
- Detailed of the move > Generate Serials/Lots > New > Generate
#### > 3 serial numbers were created but the date specific sequence has only been updated once. This can be checked by creating a new receipt and processing the same exact flow.

### Cause of the issue:

Generating the serial numbers will call the
`action_generate_lot_line_vals`. However, this method is not tailored to deal with the `use_date_range` and increments the main sequence rather than the actual subsequence:
https://github.com/odoo/odoo/blob/441a6d1b928a44b9a760f926180a925159edff3e/addons/stock/models/stock_move.py#L1103-L1106

### Fix:

We rely on the apparently unused `_get_current_sequence` method to recover the appropriate sequence by date range to update: https://github.com/odoo/odoo/blob/441a6d1b928a44b9a760f926180a925159edff3e/odoo/addons/base/models/ir_sequence.py#L114-L128 This method has been introduced in an accounting naming IMP: 915aa9e4db3169a4767617b5310721f0d9c16812 and is unused since the accounting is no more relying on name sequences:
dfd01b8c5c7e1177f37bf199790a0732a61eed78

In addition, we fine tune the current version of the code updating the serial sequence on lot generation since it is currently updating the sequence only if the first generated lot has been set via the`New` button and hence has incremented the sequence via a `next_by_id` call: https://github.com/odoo/odoo/blob/ec9343376597a4bffe9d2fd2f68777fe11b93267/addons/stock/static/src/widgets/lots_dialog.xml#L33 https://github.com/odoo/odoo/blob/ec9343376597a4bffe9d2fd2f68777fe11b93267/addons/stock/static/src/widgets/generate_serial.js#L48-L56 https://github.com/odoo/odoo/blob/ec9343376597a4bffe9d2fd2f68777fe11b93267/odoo/addons/base/models/ir_sequence.py#L261-L275 https://github.com/odoo/odoo/blob/ec9343376597a4bffe9d2fd2f68777fe11b93267/odoo/addons/base/models/ir_sequence.py#L335-L337 https://github.com/odoo/odoo/blob/ec9343376597a4bffe9d2fd2f68777fe11b93267/odoo/addons/base/models/ir_sequence.py#L53-L55 While if the value of first lot is given manually to the wizzard is given manually to the wizzard, the sequence does not get incremented by the nextval.

opw-5931056

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
