### PR TITLE
[IMP] calendar,microsoft_calendar: prevent editing recurring events synced from Outlook

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -240,8 +240,8 @@
                                     <field name="rrule_type_ui" invisible="not recurrency" required="recurrency" readonly="not user_can_edit"/>
                                     <label for="interval" class="fw-bold text-900" invisible="not recurrency or rrule_type_ui != 'custom'"/>
                                     <div class="d-flex gap-1" invisible="not recurrency or rrule_type_ui != 'custom'">
-                                        <field name="interval" string="Repeat every" class="oe_inline w-auto o_input_5ch" />
-                                        <field name="rrule_type" nolabel="1" class="oe_inline" required="rrule_type_ui == 'custom'"/>
+                                        <field name="interval" string="Repeat every" class="oe_inline w-auto o_input_5ch" readonly="not user_can_edit"/>
+                                        <field name="rrule_type" nolabel="1" class="oe_inline" required="rrule_type_ui == 'custom'" readonly="not user_can_edit"/>
                                     </div>
                                     <span class="fw-bold text-nowrap" invisible="rrule_type_ui not in ['weekly', 'custom'] or (rrule_type_ui == 'custom' and rrule_type != 'weekly')">Repeat on</span>
                                     <div invisible="rrule_type_ui not in ['weekly', 'custom'] or (rrule_type_ui == 'custom' and rrule_type != 'weekly')" ><widget name="calendar_week_days" readonly="not user_can_edit"/></div>

--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -40,6 +40,23 @@ class CalendarEvent(models.Model):
     _inherit = ['calendar.event', 'microsoft.calendar.sync']
 
     microsoft_recurrence_master_id = fields.Char('Microsoft Recurrence Master Id')
+    microsoft_sync_active = fields.Boolean('Microsoft Sync Active', compute='_compute_microsoft_sync_active')
+
+    @api.depends('user_id.microsoft_calendar_rtoken', 'user_id.microsoft_synchronization_stopped')
+    def _compute_microsoft_sync_active(self):
+        # Check token and sync status manually to avoid calling
+        # _check_microsoft_sync_status, which may trigger a token refresh
+        for event in self:
+            sync_active = (
+                bool(event.user_id.sudo().microsoft_calendar_rtoken)
+                and not event.user_id.sudo().microsoft_synchronization_stopped
+            )
+            event.microsoft_sync_active = sync_active
+
+    @api.depends('microsoft_sync_active', 'recurrency')
+    def _compute_user_can_edit(self):
+        super()._compute_user_can_edit()
+        self.filtered(lambda e: e.microsoft_sync_active and e.recurrency).user_can_edit = False
 
     def _get_organizer(self):
         return self.user_id

--- a/addons/microsoft_calendar/views/microsoft_calendar_views.xml
+++ b/addons/microsoft_calendar/views/microsoft_calendar_views.xml
@@ -10,4 +10,38 @@
             </field>
         </field>
     </record>
+
+    <record id="view_microsoft_calendar_event_form" model="ir.ui.view">
+        <field name="name">microsoft_calendar.event.form</field>
+        <field name="model">calendar.event</field>
+        <field name="inherit_id" ref="calendar.view_calendar_event_form"/>
+        <field name="arch" type="xml">
+            <xpath
+                expr="//div[./field[@name='recurrence_update']][@role='status']"
+                position="attributes">
+                <attribute name="invisible" add="microsoft_sync_active" separator="or"/>
+            </xpath>
+
+            <xpath
+                expr="//div[./field[@name='recurrence_update']][@role='status']"
+                position="after">
+                <div invisible="not (microsoft_sync_active and recurrency)" class="alert alert-info"
+                    role="alert">
+                    Recurring events can only be edited from Outlook.
+                </div>
+            </xpath>
+
+            <xpath expr="//field[@name='recurrency']" position="attributes">
+                <attribute name="readonly" add="microsoft_sync_active" separator="or"/>
+            </xpath>
+
+            <xpath expr="//field[@name='recurrency']" position="after">
+                <div invisible="recurrency or not microsoft_sync_active"
+                    class="alert alert-info" role="alert"
+                    colspan="2">
+                    Recurring events must be created directly in Outlook Calendar.
+                </div>
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
Before this commit:

- Users could attempt to edit recurring events or toggle the recurrency checkbox when Outlook sync was active, but these actions would fail with a backend error.

After this commit:

- Recurring events are now visually read-only when the owner is sync to Outlook, and a banner indicates they can only be edited from Outlook.
- The recurrency checkbox is readonly when Outlook sync is active, with an info message telling users that recurring events must be created directly in Outlook Calendar.

opw-4374503