### PR TITLE
[FIX] project: Allows users to view sub-tasks in kanban mobile view

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -690,6 +690,7 @@
                     <field name="subtask_count"/>
                     <field name="is_template"/>
                     <field name="has_project_template"/>
+                    <field name="parent_id"/>
                     <progressbar field="state" colors='{"1_done": "success-done", "1_canceled": "danger", "03_approved": "success", "02_changes_requested": "warning", "04_waiting_normal": "info", "01_in_progress": "200" }'/>
                     <templates>
                         <t t-name="menu" t-if="!selection_mode" groups="base.group_user">


### PR DESCRIPTION
Example of steps:
- Install `industry_fsm`
- Create a task with a subtask
- Enable mobile view with devtools
- Open a task
- Navigate to sub-tasks tab
- Traceback

```
TypeError: undefined is not an object (evaluating 'ctx['record'].parent_id.raw_value')
```

parent_id was missing from "view_task_kanban"

opw-5981990