### PR TITLE
[IMP] account: hash cash journal on reco

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -108,12 +108,20 @@ class AccountBankStatement(models.Model):
         bypass_search_access=True,
     )
 
+    is_statement_posted = fields.Boolean(compute='_compute_is_statement_posted', store=True)
+    journal_type = fields.Selection(string="Journal Type", related='journal_id.type')
+
     _journal_id_date_desc_id_desc_idx = models.Index("(journal_id, date DESC, id DESC)")
     _first_line_index_idx = models.Index("(journal_id, first_line_index)")
 
     # -------------------------------------------------------------------------
     # COMPUTE METHODS
     # -------------------------------------------------------------------------
+    @api.depends('journal_type')
+    def _compute_is_statement_posted(self):
+        for record in self:
+            # By default when a cash statement is created he is not posted
+            record.is_statement_posted = record.journal_type != 'cash'
 
     @api.depends('create_date')
     def _compute_name(self):
@@ -166,10 +174,10 @@ class AccountBankStatement(models.Model):
 
             stmt.balance_start = balance_start
 
-    @api.depends('balance_start', 'line_ids.amount', 'line_ids.state')
+    @api.depends('balance_start', 'line_ids.amount', 'line_ids.state', 'journal_type')
     def _compute_balance_end(self):
         for stmt in self:
-            lines = stmt.line_ids.filtered(lambda x: x.state == 'posted')
+            lines = stmt.line_ids if stmt.journal_type == 'cash' else stmt.line_ids.filtered(lambda x: x.state == 'posted')
             stmt.balance_end = stmt.balance_start + sum(lines.mapped('amount'))
 
     @api.depends('balance_start')
@@ -190,8 +198,7 @@ class AccountBankStatement(models.Model):
     @api.depends('balance_end', 'balance_end_real', 'line_ids.amount', 'line_ids.state')
     def _compute_is_complete(self):
         for stmt in self:
-            stmt.is_complete = stmt.line_ids.filtered(lambda l: l.state == 'posted') and stmt.currency_id.compare_amounts(
-                stmt.balance_end, stmt.balance_end_real) == 0
+            stmt.is_complete = not stmt.is_statement_posted or (stmt.line_ids.filtered(lambda l: l.state == 'posted') and stmt.currency_id.compare_amounts(stmt.balance_end, stmt.balance_end_real) == 0)
 
     @api.depends('balance_end', 'balance_end_real')
     def _compute_is_valid(self):
@@ -237,7 +244,7 @@ class AccountBankStatement(models.Model):
             limit=1,
             order='first_line_index DESC',
         )
-        return not previous or self.currency_id.compare_amounts(self.balance_start, previous.balance_end_real) == 0
+        return not self.is_statement_posted or not previous or self.currency_id.compare_amounts(self.balance_start, previous.balance_end_real) == 0
 
     def _get_invalid_statement_ids(self, all_statements=None):
         """ Returns the statements that are invalid for _compute and _search methods."""
@@ -254,12 +261,14 @@ class AccountBankStatement(models.Model):
                                 PARTITION BY st.journal_id
                                     ORDER BY st.first_line_index
                             ) AS prev_balance_end_real,
-                            currency.decimal_places
+                            currency.decimal_places,
+                            st.is_statement_posted
                        FROM account_bank_statement st
                   LEFT JOIN res_company co ON st.company_id = co.id
                   LEFT JOIN account_journal j ON st.journal_id = j.id
                   LEFT JOIN res_currency currency ON COALESCE(j.currency_id, co.currency_id) = currency.id
                       WHERE st.first_line_index IS NOT NULL
+                        AND st.is_statement_posted = TRUE
                       {"" if all_statements else "AND st.journal_id IN %(journal_ids)s"}
                   )
            SELECT id

--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -108,12 +108,25 @@ class AccountBankStatement(models.Model):
         bypass_search_access=True,
     )
 
+    state = fields.Selection(
+        selection=[
+            ('draft', "Draft"),
+            ('posted', "Posted")
+        ],
+        compute='_compute_state', store=True,
+    )
+    journal_type = fields.Selection(string="Journal Type", related='journal_id.type')
+
     _journal_id_date_desc_id_desc_idx = models.Index("(journal_id, date DESC, id DESC)")
     _first_line_index_idx = models.Index("(journal_id, first_line_index)")
 
     # -------------------------------------------------------------------------
     # COMPUTE METHODS
     # -------------------------------------------------------------------------
+    @api.depends('journal_type')
+    def _compute_state(self):
+        for record in self:
+            record.state = "draft" if record.journal_type == "cash" else "posted"
 
     @api.depends('create_date')
     def _compute_name(self):
@@ -139,37 +152,47 @@ class AccountBankStatement(models.Model):
 
     @api.depends('create_date')
     def _compute_balance_start(self):
+        statement_per_journal = dict(self.env['account.bank.statement']._read_group(
+            domain=[('state', '=', 'posted')],
+            groupby=['journal_id'],
+            aggregates=['id:recordset']
+        ))
+
         for stmt in self.sorted(lambda x: x.first_line_index or '0'):
             journal_id = stmt.journal_id.id or stmt.line_ids.journal_id.id
-            previous_line_with_statement = self.env['account.bank.statement.line'].search([
-                ('internal_index', '<', stmt.first_line_index),
-                ('journal_id', '=', journal_id),
-                ('state', '=', 'posted'),
-                ('statement_id', '!=', False),
-            ], limit=1)
-            balance_start = previous_line_with_statement.statement_id.balance_end_real
+            if stmt.journal_type == 'cash':
+                statements = statement_per_journal.get(stmt.journal_id, self.env['account.bank.statement']).sorted(key=lambda s: (s.date, s.id), reverse=True)
+                balance_start = statements[0].balance_end_real if statements else 0
+            else:
+                previous_line_with_statement = self.env['account.bank.statement.line'].search([
+                    ('internal_index', '<', stmt.first_line_index),
+                    ('journal_id', '=', journal_id),
+                    ('state', '=', 'posted'),
+                    ('statement_id', '!=', False),
+                ], limit=1)
+                balance_start = previous_line_with_statement.statement_id.balance_end_real
 
-            lines_in_between_domain = [
-                ('internal_index', '<', stmt.first_line_index),
-                ('journal_id', '=', journal_id),
-                ('state', '=', 'posted'),
-            ]
-            if previous_line_with_statement:
-                lines_in_between_domain.append(('internal_index', '>', previous_line_with_statement.internal_index))
-                # remove lines from previous statement (when multi-editing a line already in another statement)
-                previous_st_lines = previous_line_with_statement.statement_id.line_ids
-                lines_in_common = previous_st_lines.filtered(lambda l: l.id in stmt.line_ids._origin.ids)
-                balance_start -= sum(lines_in_common.mapped('amount'))
+                lines_in_between_domain = [
+                    ('internal_index', '<', stmt.first_line_index),
+                    ('journal_id', '=', journal_id),
+                    ('state', '=', 'posted'),
+                ]
+                if previous_line_with_statement:
+                    lines_in_between_domain.append(('internal_index', '>', previous_line_with_statement.internal_index))
+                    # remove lines from previous statement (when multi-editing a line already in another statement)
+                    previous_st_lines = previous_line_with_statement.statement_id.line_ids
+                    lines_in_common = previous_st_lines.filtered(lambda l: l.id in stmt.line_ids._origin.ids)
+                    balance_start -= sum(lines_in_common.mapped('amount'))
 
-            lines_in_between = self.env['account.bank.statement.line'].search(lines_in_between_domain)
-            balance_start += sum(lines_in_between.mapped('amount'))
+                lines_in_between = self.env['account.bank.statement.line'].search(lines_in_between_domain)
+                balance_start += sum(lines_in_between.mapped('amount'))
 
             stmt.balance_start = balance_start
 
-    @api.depends('balance_start', 'line_ids.amount', 'line_ids.state')
+    @api.depends('balance_start', 'line_ids.amount', 'line_ids.state', 'journal_type')
     def _compute_balance_end(self):
         for stmt in self:
-            lines = stmt.line_ids.filtered(lambda x: x.state == 'posted')
+            lines = stmt.line_ids if stmt.journal_type == 'cash' else stmt.line_ids.filtered(lambda x: x.state == 'posted')
             stmt.balance_end = stmt.balance_start + sum(lines.mapped('amount'))
 
     @api.depends('balance_start')
@@ -190,8 +213,7 @@ class AccountBankStatement(models.Model):
     @api.depends('balance_end', 'balance_end_real', 'line_ids.amount', 'line_ids.state')
     def _compute_is_complete(self):
         for stmt in self:
-            stmt.is_complete = stmt.line_ids.filtered(lambda l: l.state == 'posted') and stmt.currency_id.compare_amounts(
-                stmt.balance_end, stmt.balance_end_real) == 0
+            stmt.is_complete = stmt.state == 'draft' or (stmt.line_ids.filtered(lambda l: l.state == 'posted') and stmt.currency_id.compare_amounts(stmt.balance_end, stmt.balance_end_real) == 0)
 
     @api.depends('balance_end', 'balance_end_real')
     def _compute_is_valid(self):
@@ -237,7 +259,7 @@ class AccountBankStatement(models.Model):
             limit=1,
             order='first_line_index DESC',
         )
-        return not previous or self.currency_id.compare_amounts(self.balance_start, previous.balance_end_real) == 0
+        return self.state == 'draft' or not previous or self.currency_id.compare_amounts(self.balance_start, previous.balance_end_real) == 0
 
     def _get_invalid_statement_ids(self, all_statements=None):
         """ Returns the statements that are invalid for _compute and _search methods."""
@@ -254,12 +276,14 @@ class AccountBankStatement(models.Model):
                                 PARTITION BY st.journal_id
                                     ORDER BY st.first_line_index
                             ) AS prev_balance_end_real,
-                            currency.decimal_places
+                            currency.decimal_places,
+                            st.state
                        FROM account_bank_statement st
                   LEFT JOIN res_company co ON st.company_id = co.id
                   LEFT JOIN account_journal j ON st.journal_id = j.id
                   LEFT JOIN res_currency currency ON COALESCE(j.currency_id, co.currency_id) = currency.id
                       WHERE st.first_line_index IS NOT NULL
+                        AND st.state = 'posted'
                       {"" if all_statements else "AND st.journal_id IN %(journal_ids)s"}
                   )
            SELECT id

--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -412,7 +412,7 @@ class AccountBankStatementLine(models.Model):
         self.env.remove_to_compute(self.env['account.move']._fields['narration'], st_lines.move_id)
 
         # No need for the user to manage their status (from 'Draft' to 'Posted')
-        st_lines.move_id.action_post()
+        st_lines.filtered(lambda st_line: st_line.journal_id.type != "cash").move_id.action_post()
         return st_lines.with_env(self.env)  # clear the context
 
     def write(self, vals):
@@ -472,7 +472,7 @@ class AccountBankStatementLine(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _check_allow_unlink(self):
-        if self.statement_id.filtered(lambda stmt: stmt.is_valid and stmt.is_complete):
+        if self.statement_id.filtered(lambda stmt: stmt.is_statement_posted and stmt.is_valid and stmt.is_complete):
             raise UserError(_("You can not delete a transaction from a valid statement.\n"
                               "If you want to delete it, please remove the statement first."))
 

--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -412,7 +412,7 @@ class AccountBankStatementLine(models.Model):
         self.env.remove_to_compute(self.env['account.move']._fields['narration'], st_lines.move_id)
 
         # No need for the user to manage their status (from 'Draft' to 'Posted')
-        st_lines.move_id.action_post()
+        st_lines.filtered(lambda st_line: st_line.journal_id.type != "cash").move_id.action_post()
         return st_lines.with_env(self.env)  # clear the context
 
     def write(self, vals):
@@ -472,7 +472,7 @@ class AccountBankStatementLine(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _check_allow_unlink(self):
-        if self.statement_id.filtered(lambda stmt: stmt.is_valid and stmt.is_complete):
+        if self.statement_id.filtered(lambda stmt: stmt == 'posted' and stmt.is_valid and stmt.is_complete):
             raise UserError(_("You can not delete a transaction from a valid statement.\n"
                               "If you want to delete it, please remove the statement first."))
 

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3977,7 +3977,8 @@ class AccountMove(models.Model):
 
                 if vals.get('state') == 'posted':
                     self.flush_recordset()  # Ensure that the name is correctly computed
-                    self._hash_moves()
+                    if move_to_hash := self.filtered(lambda move: move.journal_id.type != 'cash'):
+                        move_to_hash._hash_moves()
                 super(AccountMove, self.browse(move_ids_review_done)).write({'review_state': 'reviewed'})
                 super(AccountMove, self.browse(move_ids_review_todo)).write({'review_state': 'todo'})
 

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4076,7 +4076,8 @@ class AccountMove(models.Model):
 
                 if vals.get('state') == 'posted':
                     self.flush_recordset()  # Ensure that the name is correctly computed
-                    self._hash_moves()
+                    if move_to_hash := self.filtered(lambda move: move.journal_id.type != 'cash'):
+                        move_to_hash._hash_moves()
                 super(AccountMove, self.browse(move_ids_review_done)).write({'review_state': 'reviewed'})
                 super(AccountMove, self.browse(move_ids_review_todo)).write({'review_state': 'todo'})
 

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -884,7 +884,8 @@ class AccountChartTemplate(models.AbstractModel):
         xmlid = self._get_account_parent_xmlid(code_prefix, template_code)
         return xmlid and (parent := self.ref(xmlid, raise_if_not_found=False)) and parent.id
 
-    def _get_accounts_data_values(self, company, template_data, bank_prefix='', code_digits=0):
+    def _get_accounts_data_values(self, company, template_data, bank_prefix='', cash_prefix='', code_digits=0):
+        cash_prefix = cash_prefix or company.cash_account_code_prefix
         bank_prefix = bank_prefix or company.bank_account_code_prefix
         code_digits = code_digits or int(template_data.get('code_digits', 6))
         return {
@@ -892,6 +893,12 @@ class AccountChartTemplate(models.AbstractModel):
                 'name': _("Bank Suspense Account"),
                 'parent_id': self._get_account_parent_id(bank_prefix),
                 'prefix': bank_prefix,
+                'code_digits': code_digits,
+                'account_type': 'asset_current',
+            },
+            'account_journal_cash_suspense_account_id': {
+                'name': _("Cash Suspense Account"),
+                'prefix': cash_prefix,
                 'code_digits': code_digits,
                 'account_type': 'asset_current',
             },
@@ -942,8 +949,9 @@ class AccountChartTemplate(models.AbstractModel):
         """
         # Create utility bank_accounts
         bank_prefix = company.bank_account_code_prefix
+        cash_prefix = company.cash_account_code_prefix
         code_digits = int(template_data.get('code_digits', 6))
-        accounts_data = self._get_accounts_data_values(company, template_data, bank_prefix=bank_prefix, code_digits=code_digits)
+        accounts_data = self._get_accounts_data_values(company, template_data, bank_prefix=bank_prefix, cash_prefix=cash_prefix, code_digits=code_digits)
         for fname in list(accounts_data):
             if company[fname]:
                 del accounts_data[fname]

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -120,6 +120,7 @@ class ResCompany(models.Model):
     default_cash_difference_income_account_id = fields.Many2one('account.account', string="Cash Difference Income", check_company=True)
     default_cash_difference_expense_account_id = fields.Many2one('account.account', string="Cash Difference Expense", check_company=True)
     account_journal_suspense_account_id = fields.Many2one('account.account', string='Journal Suspense Account', check_company=True)
+    account_journal_cash_suspense_account_id = fields.Many2one('account.account', string='Journal Cash Suspense Account', check_company=True)
     account_journal_early_pay_discount_gain_account_id = fields.Many2one(comodel_name='account.account', string='Cash Discount Write-Off Gain Account', check_company=True)
     account_journal_early_pay_discount_loss_account_id = fields.Many2one(comodel_name='account.account', string='Cash Discount Write-Off Loss Account', check_company=True)
     transfer_account_code_prefix = fields.Char(string='Prefix of the transfer accounts')

--- a/addons/account/tests/test_account_bank_statement.py
+++ b/addons/account/tests/test_account_bank_statement.py
@@ -1234,7 +1234,9 @@ class TestAccountBankStatementLine(AccountTestInvoicingCommon):
             'date': fields.Date.from_string(line3.date),
         }])
         # test split with canceled/draft lines
-        statement2 = self.env['account.bank.statement'].with_context({'split_line_id': line2.id}).create({})
+        statement2 = self.env['account.bank.statement'].with_context({'split_line_id': line2.id}).create({
+            'date': fields.Date.from_string(line2.date),
+        })
         self.assertRecordValues(statement1 + statement2, [{
             'is_complete': False,
             'balance_end': 2,

--- a/addons/account/tests/test_account_bank_statement.py
+++ b/addons/account/tests/test_account_bank_statement.py
@@ -1236,7 +1236,9 @@ class TestAccountBankStatementLine(AccountTestInvoicingCommon):
             'date': fields.Date.from_string(line3.date),
         }])
         # test split with canceled/draft lines
-        statement2 = self.env['account.bank.statement'].with_context({'split_line_id': line2.id}).create({})
+        statement2 = self.env['account.bank.statement'].with_context({'split_line_id': line2.id}).create({
+            'date': fields.Date.from_string(line2.date),
+        })
         self.assertRecordValues(statement1 + statement2, [{
             'is_complete': False,
             'balance_end': 2,

--- a/addons/account/views/account_bank_statement_views.xml
+++ b/addons/account/views/account_bank_statement_views.xml
@@ -68,8 +68,7 @@
             <field name="name">Bank Statements</field>
             <field name="res_model">account.bank.statement</field>
             <field name="view_mode">list,kanban,pivot,graph,form</field>
-            <field name="domain">[('journal_id.type', '=', 'bank')]</field>
-            <field name="context">{'journal_type':'bank'}</field>
+            <field name="domain">[('journal_id', '=', active_id)]</field>
             <field name="search_view_id" ref="view_bank_statement_search"/>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">

--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -92,6 +92,12 @@
                                                required="type in ('bank', 'cash', 'credit')"
                                                options="{'no_quick_create': True}"
                                                groups="account.group_account_readonly"/>
+                                        <field name="cash_suspense_account_id"
+                                               groups="account.group_account_readonly"
+                                               invisible="type != 'cash'"
+                                               required="type == 'cash'"
+                                               options="{'no_quick_create': True}"
+                                        />
                                         <field name="non_deductible_account_id"
                                                invisible="type != 'purchase'"
                                                options="{'no_quick_create': True}"
@@ -154,10 +160,10 @@
                                     <field name="selected_payment_method_codes" invisible="1"/>
                                     <group name="outgoing_payment" />
                             </page>
-                            <page name="advanced_settings" string="Advanced Settings" invisible="type in ['bank', 'cash']">
+                            <page name="advanced_settings" string="Advanced Settings" invisible="type == 'bank'">
                                 <group>
                                     <group string="Automation" groups="account.group_account_manager">
-                                        <field name="restrict_mode_hash_table" groups="account.group_account_readonly" invisible="type not in ['sale', 'purchase', 'general']"
+                                        <field name="restrict_mode_hash_table" groups="account.group_account_readonly" invisible="type not in ['sale', 'purchase', 'general', 'cash']"
                                         />
                                         <field name="is_self_billing" invisible="type != 'purchase'"/>
                                     </group>

--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -158,10 +158,10 @@
                                     <field name="selected_payment_method_codes" invisible="1"/>
                                     <group name="outgoing_payment" />
                             </page>
-                            <page name="advanced_settings" string="Advanced Settings" invisible="type in ['bank', 'cash']">
+                            <page name="advanced_settings" string="Advanced Settings" invisible="type == 'bank'">
                                 <group>
                                     <group string="Automation" groups="account.group_account_manager">
-                                        <field name="restrict_mode_hash_table" groups="account.group_account_readonly" invisible="type not in ['sale', 'purchase', 'general']"
+                                        <field name="restrict_mode_hash_table" groups="account.group_account_readonly" invisible="type not in ['sale', 'purchase', 'general', 'cash']"
                                         />
                                         <field name="is_self_billing" invisible="type != 'purchase'"/>
                                     </group>

--- a/addons/l10n_ar/models/template_ar_base.py
+++ b/addons/l10n_ar/models/template_ar_base.py
@@ -87,8 +87,8 @@ class AccountChartTemplate(models.AbstractModel):
             },
         }
 
-    def _get_accounts_data_values(self, company, template_data, bank_prefix='', code_digits=0):
-        accounts_data = super()._get_accounts_data_values(company, template_data, bank_prefix=bank_prefix, code_digits=code_digits)
+    def _get_accounts_data_values(self, company, template_data, bank_prefix='', cash_prefix='', code_digits=0):
+        accounts_data = super()._get_accounts_data_values(company, template_data, bank_prefix=bank_prefix, cash_prefix=cash_prefix, code_digits=code_digits)
         if company.account_fiscal_country_id.code == 'AR':
             accounts_data['default_cash_difference_expense_account_id'].update({
                 'description': self.env._('Cash count differences recognized as loss.'),

--- a/addons/l10n_ca/models/template_ca.py
+++ b/addons/l10n_ca/models/template_ca.py
@@ -57,8 +57,8 @@ class AccountChartTemplate(models.AbstractModel):
             },
         }
 
-    def _get_accounts_data_values(self, company, template_data, bank_prefix='', code_digits=0):
-        accounts_data = super()._get_accounts_data_values(company, template_data, bank_prefix=bank_prefix, code_digits=code_digits)
+    def _get_accounts_data_values(self, company, template_data, bank_prefix='', cash_prefix='', code_digits=0):
+        accounts_data = super()._get_accounts_data_values(company, template_data, bank_prefix=bank_prefix, cash_prefix=cash_prefix, code_digits=code_digits)
         if company.account_fiscal_country_id.code == 'CA':
             accounts_data['default_cash_difference_expense_account_id'].update({
                 'description': self.env._('Losses resulting from discrepancies in cash balances or reconciliations'),

--- a/addons/l10n_mx/models/template_mx.py
+++ b/addons/l10n_mx/models/template_mx.py
@@ -72,8 +72,8 @@ class AccountChartTemplate(models.AbstractModel):
             },
         }
 
-    def _get_accounts_data_values(self, company, template_data, bank_prefix='', code_digits=0):
-        accounts_data = super()._get_accounts_data_values(company, template_data, bank_prefix=bank_prefix, code_digits=code_digits)
+    def _get_accounts_data_values(self, company, template_data, bank_prefix='', cash_prefix='', code_digits=0):
+        accounts_data = super()._get_accounts_data_values(company, template_data, bank_prefix=bank_prefix, cash_prefix=cash_prefix, code_digits=code_digits)
         if company.account_fiscal_country_id.code == 'MX':
             accounts_data.update({
                 'default_cash_difference_income_account_id': {

--- a/addons/l10n_us_account/models/template_us.py
+++ b/addons/l10n_us_account/models/template_us.py
@@ -93,8 +93,8 @@ class AccountChartTemplate(models.AbstractModel):
             },
         }
 
-    def _get_accounts_data_values(self, company, template_data, bank_prefix='', code_digits=0):
-        accounts_data = super()._get_accounts_data_values(company, template_data, bank_prefix=bank_prefix, code_digits=code_digits)
+    def _get_accounts_data_values(self, company, template_data, bank_prefix='', cash_prefix='', code_digits=0):
+        accounts_data = super()._get_accounts_data_values(company, template_data, bank_prefix=bank_prefix, cash_prefix=cash_prefix, code_digits=code_digits)
         if company.account_fiscal_country_id.code == 'US':
             accounts_data['transfer_account_id'].update({
                 'name': self.env._('Funds in Transit'),


### PR DESCRIPTION
The mechanism for securing accounting entries already exists in most of our journals. However, it has not yet been implemented for ‘Cash’ journals.

This commit will allow users to check the "Secure Posted Entries with Hash" field. Now when this is checked, and the entry is reconciled. The entry will be hashed.

For cash journal only, we can have draft statement.

Also adding a cash suspense account, on posting if a statement line (in a statement) has no account, we will set this one.

Invalid statement only occurs when posting the statement

task-5170039




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
