### PR TITLE
[FIX] account_edi_ubl_cii: use <cbc:PayableRoundingAmount> for rounding diff

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_ubl.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_ubl.py
@@ -1244,7 +1244,7 @@ class AccountEdiUBL(models.AbstractModel):
         suffix = '_currency' if in_foreign_currency else ''
         tax_details = base_line['tax_details']
 
-        gross_total_excluded = tax_details[f'gross_total_excluded{suffix}']
+        gross_total_excluded = currency.round(tax_details[f'raw_gross_total_excluded{suffix}'])
         for allowance_charge_node in line_node['cac:AllowanceCharge']:
             sign = 1 if allowance_charge_node['cbc:ChargeIndicator']['_text'] == 'true' else -1
             gross_total_excluded += sign * allowance_charge_node['cbc:Amount']['_text']
@@ -1999,27 +1999,28 @@ class AccountEdiUBL(models.AbstractModel):
         }
 
     def _ubl_add_legal_monetary_total_payable_rounding_amount_node_from_cash_rounding(self, vals, in_foreign_currency=True):
+        # DEPRECATED: TO BE REMOVED
+        pass
+
+    def _ubl_add_legal_monetary_total_payable_rounding_amount_node(self, vals):
         AccountTax = self.env['account.tax']
         base_lines = vals['base_lines']
+        currency = vals['currency_id']
         node = vals['legal_monetary_total_node']
-        suffix = '_currency' if in_foreign_currency else ''
-        currency = vals['currency_id'] if in_foreign_currency else vals['company_currency']
+        tax_inclusive_amount = node['cbc:TaxInclusiveAmount']['_text']
 
         base_lines_aggregated_values = AccountTax._aggregate_base_lines_tax_details(
             base_lines=base_lines,
-            grouping_function=lambda base_line, tax_data: self._ubl_is_cash_rounding_base_line(base_line),
+            grouping_function=lambda base_line, tax_data: True,
         )
         values_per_grouping_key = AccountTax._aggregate_base_lines_aggregated_values(base_lines_aggregated_values)
-        payable_rounding_amount = None
-        for grouping_key, values in values_per_grouping_key.items():
-            if not grouping_key:
-                continue
+        expected_tax_inclusive_amount = sum(
+             values['base_amount_currency'] + values['tax_amount_currency']
+             for values in values_per_grouping_key.values()
+        )
 
-            if payable_rounding_amount is None:
-                payable_rounding_amount = 0.0
-            payable_rounding_amount += values[f'total_excluded{suffix}']
-
-        if payable_rounding_amount is None:
+        payable_rounding_amount = expected_tax_inclusive_amount - tax_inclusive_amount
+        if currency.is_zero(payable_rounding_amount):
             node['cbc:PayableRoundingAmount'] = {
                 '_text': None,
                 'currencyID': None,
@@ -2029,9 +2030,6 @@ class AccountEdiUBL(models.AbstractModel):
                 '_text': FloatFmt(payable_rounding_amount, min_dp=currency.decimal_places),
                 'currencyID': currency.name,
             }
-
-    def _ubl_add_legal_monetary_total_payable_rounding_amount_node(self, vals):
-        vals['legal_monetary_total_node']['cbc:PayableRoundingAmount'] = None
 
     def _ubl_add_legal_monetary_total_node(self, vals):
         node = vals['document_node']['cac:LegalMonetaryTotal'] = {}

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -729,9 +729,22 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
     def _ubl_add_legal_monetary_total_payable_rounding_amount_node(self, vals):
         # EXTENDS account.edi.xml.ubl
         super()._ubl_add_legal_monetary_total_payable_rounding_amount_node(vals)
-
-        # Cash rounding lines should not appear as lines but in PayableRoundingAmount.
-        self._ubl_add_legal_monetary_total_payable_rounding_amount_node_from_cash_rounding(vals)
+        tax_withholding_amount = vals['_ubl_values'].get('tax_withholding_amount')
+        node = vals['legal_monetary_total_node']
+        payable_rounding_amount = node['cbc:PayableRoundingAmount']['_text']
+        if tax_withholding_amount and payable_rounding_amount is not None:
+            currency = vals['currency_id']
+            payable_rounding_amount += tax_withholding_amount
+            if currency.is_zero(payable_rounding_amount):
+                node['cbc:PayableRoundingAmount'] = {
+                    '_text': None,
+                    'currencyID': None,
+                }
+            else:
+                node['cbc:PayableRoundingAmount'] = {
+                    '_text': FloatFmt(payable_rounding_amount, min_dp=currency.decimal_places),
+                    'currencyID': currency.name,
+                }
 
     def _ubl_add_legal_monetary_total_prepaid_payable_amount_node(self, vals, in_foreign_currency=True):
         # EXTENDS account.edi.xml.ubl

--- a/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_BR_E_08_line_extension_amount.xml
+++ b/addons/account_edi_ubl_cii/tests/test_files/export/bis3/invoice/be/test_invoice_BR_E_08_line_extension_amount.xml
@@ -104,13 +104,25 @@
 		</cac:PayeeFinancialAccount>
 	</cac:PaymentMeans>
 	<cac:TaxTotal>
-		<cbc:TaxAmount currencyID="EUR">210.67</cbc:TaxAmount>
+		<cbc:TaxAmount currencyID="EUR">0.18</cbc:TaxAmount>
 		<cac:TaxSubtotal>
-			<cbc:TaxableAmount currencyID="EUR">1003.21</cbc:TaxableAmount>
-			<cbc:TaxAmount currencyID="EUR">210.67</cbc:TaxAmount>
+			<cbc:TaxableAmount currencyID="EUR">90.30</cbc:TaxableAmount>
+			<cbc:TaxAmount currencyID="EUR">0.00</cbc:TaxAmount>
+			<cac:TaxCategory>
+				<cbc:ID>E</cbc:ID>
+				<cbc:Percent>0.0</cbc:Percent>
+				<cbc:TaxExemptionReason>Exempt from tax</cbc:TaxExemptionReason>
+				<cac:TaxScheme>
+					<cbc:ID>VAT</cbc:ID>
+				</cac:TaxScheme>
+			</cac:TaxCategory>
+		</cac:TaxSubtotal>
+		<cac:TaxSubtotal>
+			<cbc:TaxableAmount currencyID="EUR">3.06</cbc:TaxableAmount>
+			<cbc:TaxAmount currencyID="EUR">0.18</cbc:TaxAmount>
 			<cac:TaxCategory>
 				<cbc:ID>S</cbc:ID>
-				<cbc:Percent>21.0</cbc:Percent>
+				<cbc:Percent>6.0</cbc:Percent>
 				<cac:TaxScheme>
 					<cbc:ID>VAT</cbc:ID>
 				</cac:TaxScheme>
@@ -118,144 +130,68 @@
 		</cac:TaxSubtotal>
 	</cac:TaxTotal>
 	<cac:LegalMonetaryTotal>
-		<cbc:LineExtensionAmount currencyID="EUR">1003.21</cbc:LineExtensionAmount>
-		<cbc:TaxExclusiveAmount currencyID="EUR">1003.21</cbc:TaxExclusiveAmount>
-		<cbc:TaxInclusiveAmount currencyID="EUR">1213.88</cbc:TaxInclusiveAmount>
+		<cbc:LineExtensionAmount currencyID="EUR">93.36</cbc:LineExtensionAmount>
+		<cbc:TaxExclusiveAmount currencyID="EUR">93.36</cbc:TaxExclusiveAmount>
+		<cbc:TaxInclusiveAmount currencyID="EUR">93.54</cbc:TaxInclusiveAmount>
 		<cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
-		<cbc:PayableRoundingAmount currencyID="EUR">-0.02</cbc:PayableRoundingAmount>
-		<cbc:PayableAmount currencyID="EUR">1213.86</cbc:PayableAmount>
+		<cbc:PayableRoundingAmount currencyID="EUR">0.01</cbc:PayableRoundingAmount>
+		<cbc:PayableAmount currencyID="EUR">93.55</cbc:PayableAmount>
 	</cac:LegalMonetaryTotal>
 	<cac:InvoiceLine>
 		<cbc:ID>___ignore___</cbc:ID>
 		<cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
-		<cbc:LineExtensionAmount currencyID="EUR">0.46</cbc:LineExtensionAmount>
+		<cbc:LineExtensionAmount currencyID="EUR">90.30</cbc:LineExtensionAmount>
 		<cac:Item>
 			<cbc:Description>Test Product</cbc:Description>
 			<cbc:Name>Test Product</cbc:Name>
 			<cac:ClassifiedTaxCategory>
-				<cbc:ID>S</cbc:ID>
-				<cbc:Percent>21.0</cbc:Percent>
+				<cbc:ID>E</cbc:ID>
+				<cbc:Percent>0.0</cbc:Percent>
 				<cac:TaxScheme>
 					<cbc:ID>VAT</cbc:ID>
 				</cac:TaxScheme>
 			</cac:ClassifiedTaxCategory>
 		</cac:Item>
 		<cac:Price>
-			<cbc:PriceAmount currencyID="EUR">0.4567</cbc:PriceAmount>
+			<cbc:PriceAmount currencyID="EUR">90.3</cbc:PriceAmount>
 		</cac:Price>
 	</cac:InvoiceLine>
 	<cac:InvoiceLine>
 		<cbc:ID>___ignore___</cbc:ID>
-		<cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
-		<cbc:LineExtensionAmount currencyID="EUR">0.46</cbc:LineExtensionAmount>
+		<cbc:InvoicedQuantity unitCode="C62">0.45</cbc:InvoicedQuantity>
+		<cbc:LineExtensionAmount currencyID="EUR">1.14</cbc:LineExtensionAmount>
 		<cac:Item>
 			<cbc:Description>Test Product</cbc:Description>
 			<cbc:Name>Test Product</cbc:Name>
 			<cac:ClassifiedTaxCategory>
 				<cbc:ID>S</cbc:ID>
-				<cbc:Percent>21.0</cbc:Percent>
+				<cbc:Percent>6.0</cbc:Percent>
 				<cac:TaxScheme>
 					<cbc:ID>VAT</cbc:ID>
 				</cac:TaxScheme>
 			</cac:ClassifiedTaxCategory>
 		</cac:Item>
 		<cac:Price>
-			<cbc:PriceAmount currencyID="EUR">0.4567</cbc:PriceAmount>
+			<cbc:PriceAmount currencyID="EUR">2.54</cbc:PriceAmount>
 		</cac:Price>
 	</cac:InvoiceLine>
 	<cac:InvoiceLine>
 		<cbc:ID>___ignore___</cbc:ID>
-		<cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
-		<cbc:LineExtensionAmount currencyID="EUR">0.46</cbc:LineExtensionAmount>
+		<cbc:InvoicedQuantity unitCode="C62">0.28</cbc:InvoicedQuantity>
+		<cbc:LineExtensionAmount currencyID="EUR">1.92</cbc:LineExtensionAmount>
 		<cac:Item>
 			<cbc:Description>Test Product</cbc:Description>
 			<cbc:Name>Test Product</cbc:Name>
 			<cac:ClassifiedTaxCategory>
 				<cbc:ID>S</cbc:ID>
-				<cbc:Percent>21.0</cbc:Percent>
+				<cbc:Percent>6.0</cbc:Percent>
 				<cac:TaxScheme>
 					<cbc:ID>VAT</cbc:ID>
 				</cac:TaxScheme>
 			</cac:ClassifiedTaxCategory>
 		</cac:Item>
 		<cac:Price>
-			<cbc:PriceAmount currencyID="EUR">0.4567</cbc:PriceAmount>
-		</cac:Price>
-	</cac:InvoiceLine>
-	<cac:InvoiceLine>
-		<cbc:ID>___ignore___</cbc:ID>
-		<cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
-		<cbc:LineExtensionAmount currencyID="EUR">0.46</cbc:LineExtensionAmount>
-		<cac:Item>
-			<cbc:Description>Test Product</cbc:Description>
-			<cbc:Name>Test Product</cbc:Name>
-			<cac:ClassifiedTaxCategory>
-				<cbc:ID>S</cbc:ID>
-				<cbc:Percent>21.0</cbc:Percent>
-				<cac:TaxScheme>
-					<cbc:ID>VAT</cbc:ID>
-				</cac:TaxScheme>
-			</cac:ClassifiedTaxCategory>
-		</cac:Item>
-		<cac:Price>
-			<cbc:PriceAmount currencyID="EUR">0.4567</cbc:PriceAmount>
-		</cac:Price>
-	</cac:InvoiceLine>
-	<cac:InvoiceLine>
-		<cbc:ID>___ignore___</cbc:ID>
-		<cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
-		<cbc:LineExtensionAmount currencyID="EUR">0.46</cbc:LineExtensionAmount>
-		<cac:Item>
-			<cbc:Description>Test Product</cbc:Description>
-			<cbc:Name>Test Product</cbc:Name>
-			<cac:ClassifiedTaxCategory>
-				<cbc:ID>S</cbc:ID>
-				<cbc:Percent>21.0</cbc:Percent>
-				<cac:TaxScheme>
-					<cbc:ID>VAT</cbc:ID>
-				</cac:TaxScheme>
-			</cac:ClassifiedTaxCategory>
-		</cac:Item>
-		<cac:Price>
-			<cbc:PriceAmount currencyID="EUR">0.4567</cbc:PriceAmount>
-		</cac:Price>
-	</cac:InvoiceLine>
-	<cac:InvoiceLine>
-		<cbc:ID>___ignore___</cbc:ID>
-		<cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
-		<cbc:LineExtensionAmount currencyID="EUR">0.46</cbc:LineExtensionAmount>
-		<cac:Item>
-			<cbc:Description>Test Product</cbc:Description>
-			<cbc:Name>Test Product</cbc:Name>
-			<cac:ClassifiedTaxCategory>
-				<cbc:ID>S</cbc:ID>
-				<cbc:Percent>21.0</cbc:Percent>
-				<cac:TaxScheme>
-					<cbc:ID>VAT</cbc:ID>
-				</cac:TaxScheme>
-			</cac:ClassifiedTaxCategory>
-		</cac:Item>
-		<cac:Price>
-			<cbc:PriceAmount currencyID="EUR">0.4567</cbc:PriceAmount>
-		</cac:Price>
-	</cac:InvoiceLine>
-	<cac:InvoiceLine>
-		<cbc:ID>___ignore___</cbc:ID>
-		<cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
-		<cbc:LineExtensionAmount currencyID="EUR">1000.45</cbc:LineExtensionAmount>
-		<cac:Item>
-			<cbc:Description>Test Product</cbc:Description>
-			<cbc:Name>Test Product</cbc:Name>
-			<cac:ClassifiedTaxCategory>
-				<cbc:ID>S</cbc:ID>
-				<cbc:Percent>21.0</cbc:Percent>
-				<cac:TaxScheme>
-					<cbc:ID>VAT</cbc:ID>
-				</cac:TaxScheme>
-			</cac:ClassifiedTaxCategory>
-		</cac:Item>
-		<cac:Price>
-			<cbc:PriceAmount currencyID="EUR">1000.45</cbc:PriceAmount>
+			<cbc:PriceAmount currencyID="EUR">6.87</cbc:PriceAmount>
 		</cac:Price>
 	</cac:InvoiceLine>
 </Invoice>

--- a/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_export_bis3_be.py
@@ -802,3 +802,27 @@ class TestUblExportBis3BE(TestUblBis3Common, TestUblCiiBECommon):
             partner=self.partner_nl,
             test_file='test_invoice_customer_party_identifiers_partner_nl_vat_eas_oin_company_registry',
         )
+
+    def test_invoice_BR_E_08_line_extension_amount(self):
+        """ [BR-E-08] In a VAT breakdown (BG-23) where the VAT category code (BT-118) is "Exempt from VAT"
+            the VAT category taxable amount (BT-116) shall equal the sum of Invoice line net amounts (BT-131)
+            minus the sum of Document level allowance amounts (BT-92) plus the sum of Document level charge
+            amounts (BT-99) where the VAT category codes (BT-151, BT-95, BT-102) are "Exempt from VAT".
+        """
+        tax_0 = self.percent_tax(0.0)
+        tax_6 = self.percent_tax(6.0)
+        product_1 = self._create_product(lst_price=90.30, taxes_id=tax_0)
+        product_2 = self._create_product(lst_price=2.54, taxes_id=tax_6)
+        product_3 = self._create_product(lst_price=6.87, taxes_id=tax_6)
+        invoice = self._create_invoice(
+            partner_id=self.partner_be,
+            invoice_line_ids=[
+                self._prepare_invoice_line(product_id=product_1),
+                self._prepare_invoice_line(product_id=product_2, quantity=0.45),
+                self._prepare_invoice_line(product_id=product_3, quantity=0.28),
+            ],
+            post=True,
+        )
+
+        self._generate_invoice_ubl_file(invoice)
+        self._assert_invoice_ubl_file(invoice, 'test_invoice_BR_E_08_line_extension_amount')


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting and l10n_be
- Switch to a Belgian company (e.g. BE Company CoA)
- In Accounting settings:
  * activate Peppol
  * set "Rounding Method" to "Round Globally"

- Create an invoice:
  * Customer: [a Belgian customer with a VAT]
  * Invoice Lines:

    | Label | Quantity | Price | Taxes | 
    | ------- | ---------- | ------- | ------- |
    |  Line 1   |   1.0    | 90.30 |   0%  |
    |  Line 2   |   0.45   |  2.54 |   6%  |
    |  Line 3   |   0.28   |  6.87 |   6%  |

- Confirm the invoice
- Send the invoice to Peppol

**Issue:**
The generated XML has a line with `<cbc:LineExtensionAmount>` set to 90.31, `<cbc:InvoicedQuantity>` set to 1.0 and `<cbc:PriceAmount>` set to 90.30, which fails the validation with the following error:

`[BR-E-08]-In a VAT breakdown (BG-23) where the VAT category code (BT-118) is "Exempt from VAT" the VAT category taxable amount (BT-116) shall equal the sum of Invoice line net amounts (BT-131) minus the sum of Document level allowance amounts (BT-92) plus the sum of Document level charge amounts (BT-99) where the VAT category codes (BT-151, BT-95, BT-102) are "Exempt from VAT".`

**Cause:**
The use of decimal number in quantity generates a 0.01 rounding difference in the base amounts.
The extra cent is dispatched in one of the `<cbc:LineExtensionAmount>` node.

**Solution:**
There is no easy solution to handle these rounding cases. The solution used in this fix is to handle the extra cents as if they are cash rounding amount and declare them in `<cbc:PayableRoundingAmount>` node.

opw-5933545




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
