### PR TITLE
Translation Mode

### DIFF
--- a/addons/test_translation_mode/__init__.py
+++ b/addons/test_translation_mode/__init__.py
@@ -1,0 +1,10 @@
+from . import models
+from . import tools
+
+
+def post_init_hook(env):
+    env['ir.module.module']._update_translations(overwrite=True)
+
+
+def uninstall_hook(env):
+    env['ir.module.module']._update_translations(overwrite=True)

--- a/addons/test_translation_mode/__manifest__.py
+++ b/addons/test_translation_mode/__manifest__.py
@@ -1,0 +1,30 @@
+{
+    'name': 'Translation Mode',
+    'category': 'Hidden',
+    'summary': 'In-context and interactive translation mode to streamline the module translation process using Weblate',
+    'description': """
+The translation mode is available when several languages are installed. Select the language to translate,
+enable the interactive translation mode from the command palette then browse the screens to translate.
+By default, the translate feature redirects to the Odoo official translation project powered by Weblate.
+In the settings, a custom Weblate project can be targeted.""",
+    'depends': ['web'],
+    'data': [
+        'data/config_parameter.xml',
+        'views/translation_mode_settings.xml',
+    ],
+    'assets': {
+        'web.assets_backend': [
+            'test_translation_mode/static/src/**/*',
+        ],
+        'web.assets_frontend': [
+            'test_translation_mode/static/src/**/*',
+        ],
+        'web.assets_unit_tests': [
+            'test_translation_mode/static/tests/**/*',
+        ],
+    },
+    'post_init_hook': 'post_init_hook',
+    'uninstall_hook': 'uninstall_hook',
+    'author': 'Odoo S.A.',
+    'license': 'LGPL-3',
+}

--- a/addons/test_translation_mode/data/config_parameter.xml
+++ b/addons/test_translation_mode/data/config_parameter.xml
@@ -1,0 +1,8 @@
+<odoo>
+    <data noupdate="1">
+        <record model="ir.config_parameter" id="translation_url">
+            <field name="key">test_translation_mode.translation_url</field>
+            <field name="value">https://translate.odoo.com/</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/test_translation_mode/models/__init__.py
+++ b/addons/test_translation_mode/models/__init__.py
@@ -1,0 +1,2 @@
+from . import ir_http
+from . import res_config_settings

--- a/addons/test_translation_mode/models/ir_http.py
+++ b/addons/test_translation_mode/models/ir_http.py
@@ -1,0 +1,8 @@
+from odoo import models
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = 'ir.http'
+
+    def _get_debug_modes(self):
+        return super()._get_debug_modes() | {'translate'}

--- a/addons/test_translation_mode/models/res_config_settings.py
+++ b/addons/test_translation_mode/models/res_config_settings.py
@@ -1,0 +1,17 @@
+from odoo import models, fields
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    user_id = fields.Many2one('res.users', default=lambda self: self.env.user)
+    language = fields.Selection(related='user_id.lang', readonly=False)
+    translation_url = fields.Char(
+        string="Weblate URL",
+        config_parameter='test_translation_mode.translation_url',
+        help="Set the weblate URL where the translations are hosted"
+    )
+
+    def save_and_reload(self):
+        self.set_values()
+        return {'type': 'ir.actions.client', 'tag': 'reload'}

--- a/addons/test_translation_mode/static/src/@types/services.d.ts
+++ b/addons/test_translation_mode/static/src/@types/services.d.ts
@@ -1,0 +1,7 @@
+declare module "services" {
+    import { translationModeServiceFactory } from "../translation_mode_service";
+
+    export interface Services {
+        translation_mode: typeof translationModeServiceFactory;
+    }
+}

--- a/addons/test_translation_mode/static/src/siphash.js
+++ b/addons/test_translation_mode/static/src/siphash.js
@@ -1,0 +1,180 @@
+/**
+ * SipHash 2-4 implementation in JavaScript
+ *
+ * This lib is required to generate specific links to WebLate translations.
+ *
+ * For more details:
+ * @see https://www.aumasson.jp/siphash/siphash.pdf
+ */
+
+/**
+ * @typedef {Uint32Array<[high: Uint32, low: Uint32]>} Uint64Tuple
+ * @typedef {number} Uint32
+ */
+
+/**
+ * @param {Uint64Tuple} a
+ * @param {Uint64Tuple} b
+ */
+function add(a, b) {
+    a[0] = a[0] + b[0] + (((a[1] + b[1]) / 2) >>> 31);
+    a[1] += b[1];
+}
+
+/**
+ * @param {Uint8Array} a
+ * @param {Uint32} offset
+ * @returns {Uint32}
+ */
+function getUint32(a, offset) {
+    return (a[offset + 3] << 24) | (a[offset + 2] << 16) | (a[offset + 1] << 8) | a[offset];
+}
+
+/**
+ * @param {Uint64Tuple} v0
+ * @param {Uint64Tuple} v1
+ * @param {Uint64Tuple} v2
+ * @param {Uint64Tuple} v3
+ */
+function sipRound(v0, v1, v2, v3) {
+    add(v0, v1);
+    add(v2, v3);
+
+    unsignedLeftShift(v1, 13);
+    unsignedLeftShift(v3, 16);
+
+    xor(v1, v0);
+    xor(v3, v2);
+
+    unsignedLeftShift32(v0);
+
+    add(v2, v1);
+    add(v0, v3);
+
+    unsignedLeftShift(v1, 17);
+    unsignedLeftShift(v3, 21);
+
+    xor(v1, v2);
+    xor(v3, v0);
+
+    unsignedLeftShift32(v2);
+}
+
+/**
+ * @param {Uint64Tuple} a
+ * @param {Uint32} n
+ */
+function unsignedLeftShift(a, n) {
+    [a[0], a[1]] = [(a[0] << n) | (a[1] >>> (32 - n)), (a[1] << n) | (a[0] >>> (32 - n))];
+}
+
+/**
+ * @param {Uint64Tuple} a
+ */
+function unsignedLeftShift32(a) {
+    [a[1], a[0]] = [a[0], a[1]];
+}
+
+/**
+ * @param {Uint64Tuple} a
+ * @param {Uint64Tuple} b
+ */
+function xor(a, b) {
+    a[0] ^= b[0];
+    a[0] >>>= 0;
+    a[1] ^= b[1];
+    a[1] >>>= 0;
+}
+
+// Magic numbers dictated by the SipHash algorithm
+/** @type {Uint64Tuple} */
+const N_0 = new Uint32Array([0x736f6d65, 0x70736575]);
+/** @type {Uint64Tuple} */
+const N_1 = new Uint32Array([0x646f7261, 0x6e646f6d]);
+/** @type {Uint64Tuple} */
+const N_2 = new Uint32Array([0x6c796765, 0x6e657261]);
+/** @type {Uint64Tuple} */
+const N_3 = new Uint32Array([0x74656462, 0x79746573]);
+/** @type {Uint64Tuple} */
+const N_255 = new Uint32Array([0, 255]);
+
+const encoder = new TextEncoder();
+
+/**
+ * Main entry point: takes a {@link key}, some {@link data} and returns a hash (string).
+ *
+ * @param {string} key
+ * @param {string} data
+ */
+export function siphash(key, data) {
+    const u8Key = encoder.encode(key);
+    if (u8Key.length !== 16) {
+        throw new Error("SipHash error: 'key' length must be exactly 16 bytes");
+    }
+
+    /** @type {Uint64Tuple} */
+    const v0 = new Uint32Array(2);
+    v0[0] = getUint32(u8Key, 4);
+    v0[1] = getUint32(u8Key, 0);
+
+    /** @type {Uint64Tuple} */
+    const v1 = new Uint32Array(2);
+    v1[0] = getUint32(u8Key, 12);
+    v1[1] = getUint32(u8Key, 8);
+
+    /** @type {Uint64Tuple} */
+    const v2 = new Uint32Array(v0);
+    /** @type {Uint64Tuple} */
+    const v3 = new Uint32Array(v1);
+
+    xor(v0, N_0);
+    xor(v1, N_1);
+    xor(v2, N_2);
+    xor(v3, N_3);
+
+    const u8Data = encoder.encode(data);
+
+    const dataLength = u8Data.length;
+    const dataLengthMin7 = dataLength - 7;
+    /** @type {Uint64Tuple} */
+    const msgInt = new Uint32Array(2);
+    let msgIdx = 0;
+    for (; msgIdx < dataLengthMin7; msgIdx += 8) {
+        msgInt[0] = getUint32(u8Data, msgIdx + 4);
+        msgInt[1] = getUint32(u8Data, msgIdx);
+        xor(v3, msgInt);
+        sipRound(v0, v1, v2, v3);
+        sipRound(v0, v1, v2, v3);
+        xor(v0, msgInt);
+    }
+
+    const buffer = new Uint8Array(8);
+    buffer[7] = dataLength;
+
+    let idxCounter = 0;
+    while (msgIdx < dataLength) {
+        buffer[idxCounter++] = u8Data[msgIdx++];
+    }
+
+    msgInt[0] = (buffer[7] << 24) | (buffer[6] << 16) | (buffer[5] << 8) | buffer[4];
+    msgInt[1] = (buffer[3] << 24) | (buffer[2] << 16) | (buffer[1] << 8) | buffer[0];
+
+    xor(v3, msgInt);
+
+    sipRound(v0, v1, v2, v3);
+    sipRound(v0, v1, v2, v3);
+
+    xor(v0, msgInt);
+    xor(v2, N_255);
+
+    sipRound(v0, v1, v2, v3);
+    sipRound(v0, v1, v2, v3);
+    sipRound(v0, v1, v2, v3);
+    sipRound(v0, v1, v2, v3);
+
+    xor(v0, v1);
+    xor(v0, v2);
+    xor(v0, v3);
+
+    return v0[0].toString(16).padStart(8, "0") + v0[1].toString(16).padStart(8, "0");
+}

--- a/addons/test_translation_mode/static/src/translate_mode_debug_providers.js
+++ b/addons/test_translation_mode/static/src/translate_mode_debug_providers.js
@@ -1,0 +1,46 @@
+import { router } from "@web/core/browser/router";
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+
+const commandProviderRegistry = registry.category("command_provider");
+
+if (commandProviderRegistry.contains("debug")) {
+    const { provide } = commandProviderRegistry.get("debug");
+
+    commandProviderRegistry.add(
+        "debug",
+        {
+            provide: (env, options) => {
+                const result = provide(env, options);
+                const existingDebugKeys = new Set(env.debug?.split(",").filter(Boolean) || []);
+                if (existingDebugKeys.has("translate")) {
+                    result.unshift({
+                        action() {
+                            existingDebugKeys.delete("translate");
+                            router.pushState(
+                                { debug: [...existingDebugKeys].join(",") },
+                                { reload: true }
+                            );
+                        },
+                        category: "debug",
+                        name: _t("Deactivate interactive translation mode"),
+                    });
+                } else {
+                    result.unshift({
+                        action() {
+                            existingDebugKeys.add("translate");
+                            router.pushState(
+                                { debug: [...existingDebugKeys].join(",") },
+                                { reload: true }
+                            );
+                        },
+                        category: "debug",
+                        name: _t("Activate interactive translation mode"),
+                    });
+                }
+                return result;
+            },
+        },
+        { force: true }
+    );
+}

--- a/addons/test_translation_mode/static/src/translation.patch.js
+++ b/addons/test_translation_mode/static/src/translation.patch.js
@@ -1,0 +1,163 @@
+import { TranslatedString } from "@web/core/l10n/translation";
+import { patch } from "@web/core/utils/patch";
+
+/**
+ * @typedef {{
+ *  context: string;
+ *  isTranslated: boolean;
+ *  source: string;
+ *  translation: string;
+ * }} ContextualizedTranslation
+ *
+ * @typedef {[context: string, source: string, translation?: string]} TranslationMetadata
+ */
+
+/**
+ * @template [T=unknown]
+ * @typedef {import("@web/core/utils/strings").Substitutions<T>} Substitutions
+ */
+
+/**
+ * @param {string} context
+ * @param {string} translation
+ */
+function contextualizeTranslation(context, translation) {
+    if (context === TRANSLATION_MODE_ADDON_NAME) {
+        return translation.replaceAll(RE_CONTEXTUALIZED_TRANSLATION, "");
+    }
+    if (translation.match(RE_CONTEXTUALIZED_TRANSLATION)) {
+        return translation;
+    }
+    // 'isTranslated' is always 0 if it comes from here
+    return encodeTranslation(0, [context, translation], translation);
+}
+
+/**
+ * @param {string} encodedBytes
+ * @param {number} start
+ * @param {number} count
+ */
+function decodeByte(encodedBytes, start, count) {
+    let total = 0;
+    for (let i = 0; i < count; i++) {
+        total |= CT_LOOKUP[encodedBytes[start + i]] << ((count - i - 1) * 4);
+    }
+    return total;
+}
+
+/**
+ * Parameters used to encode and decode contextualized translations (short: 'CT').
+ *
+ * Translation metadata:
+ *
+ * Each translation is preceded by its context, or "metadata", which is a 'list' containing:
+ * - :int: whether the term is translated (0 or 1);
+ * - :string: the (encoded) addon from which the translation originates;
+ * - :string: the (encoded) source term
+ * - :string: (optional the (encoded) translation, attached only if:
+ *     > it exists for the given source (if not, source == translation)
+ *     > the translated term differs from its source
+ *
+ * Encoding:
+ *
+ * This metadata is "encoded" and attached to each translated string. It is encoded
+ * using the following system:
+ * 1. the metadata (list) is stringified;
+ * 2. stringified metadata is converted to bytes array;
+ * 3. each byte is then converted to a tuple of its base-16 integer components;
+ * 4. each integer is then swapped with its corresponding zero-width character.
+ *
+ * Hiding:
+ *
+ * The metadata is encoded in zero-width characters to allow 2 things:
+ * - being properly picked up by the client code with an arrangement of non-conventional characters;
+ * - being invisible in the UI, should the service not work or fail to pick up a translation.
+ *
+ * Encoding happens on the server side; @see {@link addons/test_translation_mode/tools/translate.py}
+ */
+const CT_MAP =
+    "\u200B\u200C\u200D\u200E\u200F\u2060\u2061\u2062\u2063\u2064\uFE00\uFE01\uFE02\uFE03\uFE04\uFE05".split(
+        ""
+    );
+const CT_LOOKUP = Object.fromEntries(CT_MAP.map((char, i) => [char, i]));
+const RE_CONTEXTUALIZED_TRANSLATION = new RegExp(
+    `([${CT_MAP[0]}${CT_MAP[1]}])([${CT_MAP.join("")}]{4,})`,
+    "g"
+);
+const TRANSLATION_MODE_ADDON_NAME = "test_translation_mode";
+
+// Used to encode/decode translation context from strings
+const decoder = new TextDecoder("utf-8");
+const encoder = new TextEncoder();
+
+patch(TranslatedString.prototype, {
+    valueOf() {
+        const translation = super.valueOf();
+        if (isTranslationModeEnabled()) {
+            return contextualizeTranslation(this.context, translation);
+        } else {
+            return translation;
+        }
+    },
+});
+
+/**
+ * @param {0 | 1} isTranslated
+ * @param {TranslationMetadata} metadata
+ * @param {string} translation
+ */
+export function encodeTranslation(isTranslated, metadata, translation) {
+    const strMetadata = JSON.stringify(metadata);
+    const bytesMetadata = encoder.encode(strMetadata);
+    const byteCount = bytesMetadata.length;
+    let encodedMetadata =
+        CT_MAP[isTranslated] +
+        CT_MAP[(byteCount >> 12) & 0xf] +
+        CT_MAP[(byteCount >> 8) & 0xf] +
+        CT_MAP[(byteCount >> 4) & 0xf] +
+        CT_MAP[byteCount & 0xf];
+    for (const charCode of bytesMetadata) {
+        encodedMetadata += CT_MAP[(charCode >> 4) & 0xf] + CT_MAP[charCode & 0xf];
+    }
+    return encodedMetadata + translation;
+}
+
+/**
+ * @param {import("@web/env").OdooEnv} [env]
+ */
+export function isTranslationModeEnabled(env) {
+    const debug = env?.debug ?? odoo.debug ?? "";
+    return debug.includes("translate");
+}
+
+/**
+ * @param {string} text
+ * @returns {[value: string, translations: ContextualizedTranslation[]]}
+ */
+export function parseTranslatedText(text) {
+    /** @type {ContextualizedTranslation[]} */
+    const translations = [];
+    const cleanedText = text.replaceAll(
+        RE_CONTEXTUALIZED_TRANSLATION,
+        (fullMatch, isTranslatedBit, encodedMetadata) => {
+            const byteCount = decodeByte(encodedMetadata, 0, 4);
+            if (!byteCount || 2 * byteCount > encodedMetadata.length - 4) {
+                return fullMatch;
+            }
+            const bytes = new Uint8Array(byteCount);
+            for (let i = 0; i < byteCount; i++) {
+                bytes[i] = decodeByte(encodedMetadata, i * 2 + 4, 2);
+            }
+            const strJsonMetadata = decoder.decode(bytes);
+            const [context, source, translation] = JSON.parse(strJsonMetadata);
+            translations.push({
+                context,
+                isTranslated: isTranslatedBit === CT_MAP[1],
+                source,
+                translation: translation || source,
+            });
+            return "";
+        }
+    );
+    return [cleanedText, translations];
+}

--- a/addons/test_translation_mode/static/src/translation_mode.css
+++ b/addons/test_translation_mode/static/src/translation_mode.css
@@ -1,0 +1,71 @@
+.o-body-with-translate-side-panel {
+    --translate-side-panel-width: clamp(25rem, 30vw, 30rem);
+
+    width: calc(100vw - var(--translate-side-panel-width));
+}
+
+.o-translation-pointer {
+    --_rgb: var(--info-rgb);
+
+    border: 2px solid rgb(var(--_rgb));
+    box-shadow: 0 0 0.5rem 2px rgb(var(--_rgb));
+    border-radius: 0.25rem;
+    position: fixed;
+    z-index: 9999;
+    left: var(--_x, 0);
+    top: var(--_y, 0);
+    width: var(--_w, 0);
+    height: var(--_h, 0);
+    pointer-events: none;
+
+    animation: o-translation-pointer-animation 500ms infinite ease-in-out;
+}
+
+.o-translate-side-panel {
+    /* Dark */
+    --_highlight-bg-rgb: 209, 236, 241;
+
+    height: 100vh;
+    width: var(--translate-side-panel-width);
+    z-index: 2000;
+
+    .o-translate-card {
+        cursor: pointer;
+
+        &:hover {
+            background-color: rgba(var(--_highlight-bg-rgb), 0.5);
+        }
+
+        &:focus,
+        &:focus-within {
+            background-color: rgba(var(--_highlight-bg-rgb), 1);
+        }
+    }
+
+    .o-translation-flag {
+        object-fit: contain;
+        max-width: 1.5rem;
+    }
+}
+
+/* TODO: use bundle system */
+@media (prefers-color-scheme: dark) {
+    .o-translate-side-panel {
+        --_highlight-bg-rgb: 32, 54, 75;
+    }
+}
+
+@keyframes o-translation-pointer-animation {
+    from {
+        background-color: rgba(var(--_rgb), 0.05);
+        box-shadow: 0 0 2px 0 rgb(var(--_rgb));
+    }
+    50% {
+        background-color: rgba(var(--_rgb), 0.25);
+        box-shadow: 0 0 1rem 2px rgb(var(--_rgb));
+    }
+    to {
+        background-color: rgba(var(--_rgb), 0.05);
+        box-shadow: 0 0 2px 0 rgb(var(--_rgb));
+    }
+}

--- a/addons/test_translation_mode/static/src/translation_mode_service.js
+++ b/addons/test_translation_mode/static/src/translation_mode_service.js
@@ -1,0 +1,733 @@
+import { onMounted, onWillUnmount, reactive } from "@odoo/owl";
+import { localization } from "@web/core/l10n/localization";
+import { registry } from "@web/core/registry";
+import { patch } from "@web/core/utils/patch";
+import { debounce } from "@web/core/utils/timing";
+import { session } from "@web/session";
+import { siphash } from "./siphash";
+import { isTranslationModeEnabled, parseTranslatedText } from "./translation.patch";
+import {
+    TRANSLATABLE_PROPERTY_LABELS,
+    TranslationModeSidePanel,
+} from "./translation_mode_side_panel";
+
+/**
+ * @typedef {import("./translation.patch").ContextualizedTranslation} ContextualizedTranslation
+ *
+ * @typedef {[position: string, translations: ContextualizedTranslation[]]} PositionTranslations
+ *
+ * @typedef {ContextualizedTranslation & {
+ *  link: string;
+ *  targets: [HTMLElement, string][];
+ * }} TargetedTranslation
+ */
+
+function getLang() {
+    if (!urlParams.lang) {
+        const code = localization.code;
+        if (code === "en_US") {
+            urlParams.lang = "en";
+        } else {
+            urlParams.lang = WEBLATE_LANG_MAPPING[code] || code;
+        }
+    }
+    return urlParams.lang;
+}
+
+/**
+ * @param {CSSStyleDeclaration} style
+ * @param {string} property
+ */
+function getPxValue(style, property) {
+    return Number(style.getPropertyValue(property).replaceAll(/[^\d.]+/g, "")) || 0;
+}
+
+/**
+ * @param {string} source
+ * @param {string} context
+ */
+function getTranslationLink(source, context) {
+    const lang = getLang();
+    const version = getVersion();
+    if (!termHashes.has(source)) {
+        termHashes.set(source, siphash(WEBLATE_SIPHASH_KEY, source));
+    }
+    const checksum = termHashes.get(source);
+    return `${BASE_TRANSLATE_URL}${version}/${context}/${lang}/?checksum=${checksum}`;
+}
+
+function getVersion() {
+    if (!urlParams.version) {
+        const versionInfo = session.server_version_info;
+        urlParams.version = String(versionInfo[0]);
+        if (versionInfo[1]) {
+            const majorVersion = urlParams.version.split(/[~-]/g).at(-1);
+            urlParams.version = `s${majorVersion}-${versionInfo[1]}`;
+        }
+    }
+    return urlParams.version;
+}
+
+/**
+ * @param {CSSStyleDeclaration} style
+ * @param {string} property
+ * @param {number} value
+ */
+function setPxValue(style, property, value) {
+    style.setProperty(property, `${value}px`);
+}
+
+/**
+ * @param {HTMLElement} target
+ * @param {HTMLDivElement} pointer
+ */
+function updateTranslationPointer(target, pointer) {
+    const rect = target.getBoundingClientRect();
+    if (
+        !rect.width ||
+        !rect.height ||
+        rect.x + rect.width < 0 ||
+        rect.x > window.innerWidth ||
+        rect.y + rect.height < 0 ||
+        rect.y > window.innerHeight
+    ) {
+        pointer.remove();
+        return;
+    }
+
+    const style = getComputedStyle(target);
+    const xBorderWidth =
+        getPxValue(style, "border-left-width") && getPxValue(style, "border-right-width");
+    const yBorderWidth =
+        getPxValue(style, "border-top-width") && getPxValue(style, "border-bottom-width");
+
+    const width = Math.max(rect.width, POINTER_MIN_SIZE);
+    const wDiff = rect.width < POINTER_MIN_SIZE ? width - rect.width : 0;
+    const wMargin = xBorderWidth || rect.width < POINTER_MIN_SIZE ? 0 : POINTER_MARGIN;
+    setPxValue(pointer.style, "--_x", rect.x - wDiff / 2 - wMargin);
+    setPxValue(pointer.style, "--_w", width + wMargin * 2);
+
+    const height = Math.max(rect.height, POINTER_MIN_SIZE);
+    const hDiff = rect.height < POINTER_MIN_SIZE ? height - rect.height : 0;
+    const hMargin = yBorderWidth || rect.height < POINTER_MIN_SIZE ? 0 : POINTER_MARGIN;
+    setPxValue(pointer.style, "--_y", rect.y - hDiff / 2 - hMargin);
+    setPxValue(pointer.style, "--_h", height + hMargin * 2);
+
+    if (!pointer.isConnected) {
+        target.ownerDocument.body.appendChild(pointer);
+    }
+}
+
+class TranslationScanner {
+    /** @type {Set<HTMLIFrameElement>} */
+    addedIframes = new Set();
+    /**
+     * @private
+     * @type {Map<Element, PositionTranslations[]>}
+     */
+    elementTranslations = new Map();
+
+    /**
+     * @param {Iterable<Node>} nodes
+     * @param {boolean} [highlightsEnabled]
+     */
+    constructor(nodes, highlightsEnabled) {
+        this.highlightsEnabled = highlightsEnabled;
+        for (const node of nodes) {
+            this._translateNode(node);
+        }
+    }
+
+    getGroupedTranslations() {
+        /** @type {Record<string, TargetedTranslation>} */
+        const translationsBySources = {};
+        for (const [el, translations] of this.elementTranslations) {
+            for (const [position, positionTranslations] of translations) {
+                for (const translation of positionTranslations) {
+                    translationsBySources[translation.source] ||= {
+                        targets: [],
+                        link: getTranslationLink(translation.source, translation.context),
+                        ...translation,
+                    };
+                    translationsBySources[translation.source].targets.push([el, position]);
+                }
+            }
+        }
+        return translationsBySources;
+    }
+
+    /**
+     * @private
+     * @param {Node} node
+     * @param {PositionTranslations} positionTranslations
+     */
+    _addNodeTranslations(node, positionTranslations) {
+        if (!this.highlightsEnabled) {
+            return;
+        }
+        const el = node.nodeType === Node.ELEMENT_NODE ? node : node.parentElement;
+        if (!el) {
+            return;
+        }
+        /** @type {PositionTranslations[]} */
+        const info = [];
+        for (const [root, rootTranslations] of this.elementTranslations) {
+            if (root === el || root.contains(el)) {
+                // Element *is contained* within an existing element:
+                // -> return the parent info
+                rootTranslations.push(...info, positionTranslations);
+                return;
+            }
+            if (el.contains(root)) {
+                // Element *contains* an existing element:
+                // -> replace that element with the given one and retrieve the existing
+                //  info
+                this.elementTranslations.delete(root);
+                info.push(...rootTranslations);
+            }
+        }
+        info.push(positionTranslations);
+
+        this.elementTranslations.set(el, info);
+    }
+
+    /**
+     * @private
+     * @param {Node} node
+     * @param {Attr} attribute
+     */
+    _translateAttribute(node, attribute) {
+        const [value, translations] = parseTranslatedText(attribute.value);
+        if (!translations.length) {
+            return;
+        }
+
+        attribute.value = value;
+
+        this._addNodeTranslations(node, [attribute.name, translations]);
+    }
+
+    /**
+     * @private
+     * @param {HTMLCanvasElement} canvas
+     * @param {string} text
+     */
+    _translateCanvasText(canvas, text) {
+        const [value, translations] = parseTranslatedText(text);
+        if (!translations.length) {
+            return text;
+        }
+
+        this._addNodeTranslations(canvas, ["canvas", translations]);
+
+        return value;
+    }
+
+    /**
+     * @private
+     * @param {Node} node
+     */
+    _translateNode(node) {
+        switch (node.nodeType) {
+            case Node.ELEMENT_NODE: {
+                if (node.closest(IGNORE_SELECTOR)) {
+                    return;
+                }
+                if (node.nodeName === "IFRAME") {
+                    this.addedIframes.add(node);
+                } else if (node.nodeName === "TITLE") {
+                    this._translateProperty(node, "textContent", false);
+                    return;
+                }
+                break;
+            }
+            case Node.TEXT_NODE: {
+                const parent = node.parentElement;
+                if (parent) {
+                    this._translateProperty(node, "textContent");
+                }
+                return;
+            }
+            default: {
+                return;
+            }
+        }
+
+        // Scan children first to replace translated string on the deepest possible
+        // level
+        for (const childNode of node.childNodes) {
+            this._translateNode(childNode);
+        }
+
+        // Replace and highlight element translated attributes
+        for (const attribute of node.attributes) {
+            this._translateAttribute(node, attribute);
+        }
+
+        // Replace and highlight translated properties
+        for (const propertyName in TRANSLATABLE_PROPERTY_LABELS) {
+            this._translateProperty(node, propertyName);
+        }
+    }
+
+    /**
+     * @private
+     * @param {Node} node
+     * @param {string} property
+     */
+    _translateProperty(node, property) {
+        const rawValue = node[property];
+        if (typeof rawValue !== "string" || !rawValue) {
+            return;
+        }
+
+        const [value, translations] = parseTranslatedText(rawValue);
+        if (!translations.length) {
+            return;
+        }
+
+        node[property] = value;
+
+        this._addNodeTranslations(node, [property, translations]);
+    }
+}
+
+const CAPTURE = { capture: true };
+const IGNORE_SELECTOR = [`[data-translation-highlight]`].join(",");
+/**
+ * !TODO: replace by a parser... JS does not support (?R) recursion in regexes so this is not possible
+ * Translate URL is constructed based on the following pattern:
+ *
+ * <ORIGIN>/translate/odoo-<VERSION_NUMBER>/<LANGUAGE>/?checksum=<TERM_HASH>
+ *
+ * Where:
+ * - ORIGIN = translate.odoo.com
+ * - VERSION_NUMBER = current stable version
+ * - LANGUAGE = language code ("en", "fr", etc.)
+ * - TERM_HASH = SipHash 2-4 representation of the given term, using {@link WEBLATE_SIPHASH_KEY}
+ */
+const BASE_TRANSLATE_URL = "translate/odoo-";
+/**
+ * Hard-coded hash key used to generate SipHash 2-4 hexadecimal hash reprenstation
+ * of translated terms.
+ *
+ * This has been extracted directly from the official Weblate repository:
+ * @see https://github.com/WeblateOrg/weblate/blob/main/weblate/utils/hash.py#L23
+ */
+const WEBLATE_SIPHASH_KEY = "Weblate Sip Hash";
+const WEBLATE_LANG_MAPPING = {
+    ar_001: "ar",
+    ku: "ckb",
+    "sr@latin": "sr_Latn",
+    nb: "nb_NO",
+    tl: "fil",
+};
+const POINTER_MARGIN = 5;
+const POINTER_MIN_SIZE = 32;
+
+/** @type {Map<string, string>} */
+const termHashes = new Map();
+
+export class TranslationModeService {
+    /** @type {TargetedTranslation[]} */
+    currentTranslations = reactive([]);
+    /** @type {Set<Node>} */
+    observedNodes = new Set();
+    observer = new MutationObserver(this._onMutation.bind(this));
+    started = false;
+    /** @type {Map<HTMLElement, HTMLDivElement>} */
+    translationPointers = new Map();
+
+    /**
+     * @private
+     * @type {TranslationModeService["_onKeyDown"]}
+     */
+    _boundOnKeyDown = this._onKeyDown.bind(this);
+    /**
+     * @private
+     * @type {TranslationModeService["_onPointerDown"]}
+     */
+    _boundOnPointerDown = this._onPointerDown.bind(this);
+    /**
+     * @private
+     * @type {TranslationModeService["_onWindowScroll"]}
+     */
+    _debouncedOnWindowScroll = debounce(this._onWindowScroll.bind(this), "animationFrame");
+
+    // Lifecycle
+
+    /**
+     * @param {import("@web/env").OdooEnv} _env
+     * @param {import("services").Services} services
+     */
+    setup(_env, { localization }) {
+        if (this.started) {
+            return;
+        }
+        this.started = true;
+
+        this.highlightsEnabled = localization.code !== "en_US";
+        if (this.highlightsEnabled) {
+            console.debug(`Interactive translation mode is active with translation highlighting.`);
+        } else {
+            console.log(
+                `Interactive translation mode is active, but translation highlighting has been disabled for language "${localization.code}".`
+            );
+        }
+
+        for (const title of document.head.getElementsByTagName("title")) {
+            this.addObservedNode(title);
+        }
+        this.addObservedNode(document.body, true);
+
+        // Initial scan
+        const scanner = new TranslationScanner([document.body], this.highlightsEnabled);
+        for (const iframe of scanner.addedIframes) {
+            this.addObservedNode(iframe);
+        }
+        this._registerTranslations(scanner.getGroupedTranslations());
+
+        // Start observing mutations immediatly
+        this._observe();
+
+        // Observe canvas text rendering as well
+        patch(CanvasRenderingContext2D.prototype, {
+            fillText(text, ...args) {
+                return super.fillText(scanner._translateCanvasText(this.canvas, text), ...args);
+            },
+            strokeText(text, ...args) {
+                return super.strokeText(scanner._translateCanvasText(this.canvas, text), ...args);
+            },
+        });
+    }
+
+    destroy() {
+        this._disconnect();
+
+        registry.category("main_components").remove("translation-mode-side-panel");
+
+        for (const node of this.observedNodes) {
+            node.removeEventListener("keydown", this._boundOnKeyDown, CAPTURE);
+            node.removeEventListener("pointerdown", this._boundOnPointerDown, CAPTURE);
+        }
+        this.observedNodes.clear();
+
+        window.removeEventListener("scroll", this._debouncedOnWindowScroll, CAPTURE);
+
+        this._clearTranslationPointers();
+    }
+
+    // Public
+
+    /**
+     * @param {Node} node
+     * @param {boolean} [options]
+     */
+    addObservedNode(node, withListeners) {
+        if (this.observedNodes.has(node)) {
+            return;
+        }
+        this.observedNodes.add(node);
+        if (withListeners) {
+            node.addEventListener("keydown", this._boundOnKeyDown, CAPTURE);
+            node.addEventListener("pointerdown", this._boundOnPointerDown, CAPTURE);
+        }
+    }
+
+    getTranslations() {
+        /** @type {TargetedTranslation[]} */
+        const translated = [];
+        /** @type {TargetedTranslation[]} */
+        const untranslated = [];
+        for (const translation of this.currentTranslations) {
+            if (translation.translated) {
+                translated.push(translation);
+            } else {
+                untranslated.push(translation);
+            }
+        }
+        return { translated, untranslated };
+    }
+
+    /**
+     * @param {TargetedTranslation} translation
+     * @param {boolean} keepHighlighted
+     */
+    highlightTranslation(translation, keepHighlighted) {
+        this._handleMutations(this._disconnect());
+
+        if (!keepHighlighted) {
+            this._clearTranslationPointers();
+        }
+        for (const [el] of translation.targets) {
+            this._createTranslationPointer(el, translation.isTranslated);
+        }
+
+        this._observe();
+    }
+
+    registerSidePanel() {
+        registry.category("main_components").add("translation-mode-side-panel", {
+            Component: TranslationModeSidePanel,
+            props: {
+                translations: this.currentTranslations,
+            },
+        });
+
+        window.addEventListener("scroll", this._debouncedOnWindowScroll, CAPTURE);
+    }
+
+    useBodyClass(className) {
+        onMounted(() => {
+            this._handleMutations(this._disconnect());
+
+            document.body.classList.add(className);
+
+            this._observe();
+        });
+        onWillUnmount(() => {
+            this._handleMutations(this._disconnect());
+
+            document.body.classList.remove(className);
+
+            this._observe();
+        });
+    }
+
+    // Private
+
+    /**
+     * @private
+     */
+    _clearTranslationPointers() {
+        for (const pointer of this.translationPointers.values()) {
+            pointer.remove();
+        }
+        this.translationPointers.clear();
+    }
+
+    /**
+     * @private
+     * @param {HTMLElement} target
+     * @param {boolean} isTranslated
+     */
+    _createTranslationPointer(target, isTranslated) {
+        if (this.translationPointers.has(target)) {
+            return;
+        }
+
+        const rgbColor = isTranslated ? "success" : "danger";
+        const pointer = document.createElement("div");
+        pointer.classList.add("o-translation-pointer");
+        pointer.style.setProperty("--_rgb", `var(--${rgbColor}-rgb)`);
+
+        this.translationPointers.set(target, pointer);
+
+        updateTranslationPointer(target, pointer);
+    }
+
+    /**
+     * @private
+     */
+    _disconnect() {
+        const remainingMutations = this.observer.takeRecords();
+        this.observer.disconnect();
+
+        return remainingMutations;
+    }
+
+    /**
+     * @private
+     * @param {MutationRecord[]} mutations
+     */
+    _handleMutations(mutations) {
+        if (!mutations.length) {
+            return;
+        }
+        /**
+         * Use a set to eliminate:
+         *  - duplicate nodes;
+         *  - children of nodes already contained in the set.
+         * @type {Set<Node>}
+         */
+        const targets = new Set();
+        for (const mutation of mutations) {
+            if (!mutation.target) {
+                continue;
+            }
+            let assigned = false;
+            for (const otherTarget of targets) {
+                if (mutation.target.contains(otherTarget)) {
+                    targets.delete(otherTarget);
+                    break;
+                } else if (otherTarget.contains(mutation.target)) {
+                    assigned = true;
+                    break;
+                }
+            }
+            if (!assigned) {
+                targets.add(mutation.target);
+            }
+        }
+
+        const scanner = new TranslationScanner(targets, this.highlightsEnabled);
+        for (const iframe of scanner.addedIframes) {
+            this.addObservedNode(iframe);
+        }
+        this._registerTranslations(scanner.getGroupedTranslations());
+    }
+
+    /**
+     * @private
+     */
+    _observe() {
+        for (let node of this.observedNodes) {
+            if (!node.isConnected) {
+                this.observedNodes.delete(node);
+                continue;
+            }
+            if (node.nodeName === "IFRAME") {
+                const document = node.contentDocument;
+                if (document?.body?.isConnected) {
+                    node = document.body;
+
+                    // Remove existing event listeners (if any)
+                    node.removeEventListener("keydown", this._boundOnKeyDown, CAPTURE);
+                    node.removeEventListener("pointerdown", this._boundOnPointerDown, CAPTURE);
+
+                    // Add them back
+                    node.addEventListener("keydown", this._boundOnKeyDown, CAPTURE);
+                    node.addEventListener("pointerdown", this._boundOnPointerDown, CAPTURE);
+                } else {
+                    this.observedNodes.delete(node);
+                    continue;
+                }
+            }
+            this.observer.observe(node, {
+                attributes: true,
+                characterData: true,
+                childList: true,
+                subtree: true,
+            });
+        }
+    }
+
+    /**
+     * @private
+     * @param {KeyboardEvent} ev
+     */
+    _onKeyDown(ev) {
+        if (ev.key === "Escape") {
+            this._clearTranslationPointers();
+        }
+    }
+
+    /**
+     * @private
+     * @type {MutationCallback}
+     */
+    _onMutation(mutations) {
+        const startTime = performance.now();
+
+        mutations.push(...this._disconnect());
+        this._handleMutations(mutations);
+        this._observe();
+
+        console.debug(
+            "[TRANSLATION SERVICE] scan took",
+            Number((performance.now() - startTime).toFixed(3)),
+            "ms"
+        );
+    }
+
+    /**
+     * @private
+     * @param {PointerEvent} ev
+     */
+    _onPointerDown(ev) {
+        if (!ev.ctrlKey) {
+            this._clearTranslationPointers();
+        }
+    }
+
+    /**
+     * @private
+     * @param {Event} ev
+     */
+    _onWindowScroll(ev) {
+        if (
+            ev.target.nodeType === Node.ELEMENT_NODE &&
+            ev.target.closest(".o-translate-side-panel")
+        ) {
+            return;
+        }
+        for (const [target, pointer] of this.translationPointers) {
+            updateTranslationPointer(target, pointer);
+        }
+    }
+
+    /**
+     * @private
+     * @param {Record<string, TargetedTranslation>} newTranslations
+     */
+    _registerTranslations(newTranslations) {
+        const oldTranslations = new Map(this.currentTranslations.map((t) => [t.source, t]));
+        for (const translation of Object.values(newTranslations)) {
+            const existingTranslation = oldTranslations.get(translation.source);
+            if (existingTranslation) {
+                const nextTargets = new Set();
+                for (const target of existingTranslation.targets) {
+                    if (target[0].isConnected) {
+                        nextTargets.add(target);
+                    }
+                }
+                for (const newTarget of translation.targets) {
+                    nextTargets.add(newTarget);
+                }
+                if (nextTargets.size) {
+                    translation.targets = [...nextTargets];
+                    oldTranslations.delete(translation.source);
+                }
+            } else {
+                this.currentTranslations.push(translation);
+            }
+        }
+        for (const translation of oldTranslations.values()) {
+            const nextTargets = new Set();
+            for (const target of translation.targets) {
+                if (target[0].isConnected) {
+                    nextTargets.add(target);
+                }
+            }
+            if (nextTargets.size) {
+                translation.targets = [...nextTargets];
+            } else {
+                const index = this.currentTranslations.indexOf(translation);
+                this.currentTranslations.splice(index, 1);
+            }
+        }
+    }
+}
+
+export const translationModeServiceFactory = {
+    dependencies: ["localization"],
+    start(env, dependencies) {
+        const service = new TranslationModeService();
+        service.setup(env, dependencies);
+        if (isTranslationModeEnabled(env)) {
+            service.registerSidePanel();
+        }
+        return service;
+    },
+};
+
+export const urlParams = {
+    lang: "",
+    version: "",
+};
+
+// Service should only be registered at top level, as it will look for translations
+// in iframes.
+if (window === window.top) {
+    registry.category("services").add("translation_mode", translationModeServiceFactory);
+}

--- a/addons/test_translation_mode/static/src/translation_mode_side_panel.js
+++ b/addons/test_translation_mode/static/src/translation_mode_side_panel.js
@@ -1,0 +1,239 @@
+import { Component, onWillDestroy, useRef, useState } from "@odoo/owl";
+import { normalizedMatch } from "@web/core/l10n/utils";
+import { useService } from "@web/core/utils/hooks";
+import { isVisible } from "@web/core/utils/ui";
+
+/**
+ * @typedef {import("./translation_mode_service").TargetedTranslation} TargetedTranslation
+ */
+
+/**
+ * @param {TargetedTranslation} translation
+ */
+function isMissingSource(translation) {
+    return !translation.source || RE_MISSING_SOURCE.test(translation.source);
+}
+
+/**
+ * @param {TargetedTranslation} translation
+ */
+function isMissingTranslation(translation) {
+    return !translation.isTranslated;
+}
+
+/**
+ * @param {string} filter
+ * @param {TargetedTranslation} translation
+ */
+function matchFilter(filter, translation) {
+    if (!filter) {
+        return true;
+    }
+    if (!isMissingSource(translation) && normalizedMatch(translation.source, filter).match) {
+        return true;
+    }
+    if (
+        !isMissingTranslation(translation) &&
+        normalizedMatch(translation.translation, filter).match
+    ) {
+        return true;
+    }
+    return false;
+}
+
+const DEFAULT_LANG_DISPLAY_NAME = "English (US)";
+const DEFAULT_LANG_FLAG_URL = "/base/static/img/country_flags/us.png";
+
+const RE_MISSING_SOURCE = /^MISSING_SOURCE_\d{8}$/;
+
+export class TranslationModeSidePanel extends Component {
+    static props = {
+        translations: {
+            type: Array,
+            element: {
+                type: Object,
+                shape: {
+                    context: String,
+                    link: String,
+                    source: String,
+                    targets: {
+                        type: Array,
+                        element: {
+                            type: Array,
+                            element: {
+                                validate: (el) =>
+                                    typeof el === "string" || el?.nodeType === Node.ELEMENT_NODE,
+                            },
+                        },
+                    },
+                    isTranslated: Boolean,
+                    translation: String,
+                },
+            },
+        },
+    };
+    static template = "test_translation_mode.TranslationModeSidePanel";
+
+    isMissingSource = isMissingSource;
+    isMissingTranslation = isMissingTranslation;
+
+    defaultLangDisplayName = DEFAULT_LANG_DISPLAY_NAME;
+    defaultLangFlagUrl = DEFAULT_LANG_FLAG_URL;
+    /**
+     * Internal set recomputed on each render keeping track of which translations
+     * are only bound to hidden targets.
+     * @type {Set<TargetedTranslation>}
+     */
+    hiddenTranslations = new Set();
+
+    setup() {
+        this.actionService = useService("action");
+        this.localization = useService("localization");
+        this.orm = useService("orm");
+        this.translationMode = useService("translation_mode");
+
+        this.translationMode.useBodyClass("o-body-with-translate-side-panel");
+
+        this.rootRef = useRef("root");
+        this.collapsedCategories = useState(new Set());
+        this.state = useState({
+            filter: "",
+            currentLangDisplayName: this.localization.code,
+            currentLangFlagUrl: "",
+            translationUrl: null,
+        });
+
+        this.onPointerDown = this.onPointerDown.bind(this);
+        window.addEventListener("pointerdown", this.onPointerDown, { capture: true });
+        onWillDestroy(() =>
+            window.removeEventListener("pointerdown", this.onPointerDown, { capture: true })
+        );
+
+        this.orm
+            .call("ir.config_parameter", "get_str", ["test_translation_mode.translation_url"])
+            .then((translationUrl) => {
+                this.state.translationUrl = translationUrl || "";
+                if (!this.state.translationUrl.endsWith("/")) {
+                    this.state.translationUrl += "/";
+                }
+            });
+        this.orm
+            .webSearchRead("res.lang", [["code", "=", this.localization.code]], {
+                specification: {
+                    display_name: {},
+                    flag_image_url: {},
+                },
+            })
+            .then(({ records }) => {
+                this.state.currentLangDisplayName = records[0].display_name;
+                this.state.currentLangFlagUrl = records[0].flag_image_url;
+            });
+    }
+
+    /**
+     * @param {[target: HTMLElement, position: string]} targets
+     */
+    formatTarget(targets) {
+        const resultSet = new Set();
+        for (const [, position] of targets) {
+            if (TRANSLATABLE_ATTRIBUTE_LABELS[position]) {
+                resultSet.add(TRANSLATABLE_ATTRIBUTE_LABELS[position]);
+            } else if (TRANSLATABLE_PROPERTY_LABELS[position]) {
+                resultSet.add(TRANSLATABLE_PROPERTY_LABELS[position]);
+            } else {
+                resultSet.add(position);
+            }
+        }
+        return [...resultSet].join(" / ");
+    }
+
+    getTranslationCategories() {
+        /** @type {TargetedTranslation[]} */
+        const translated = [];
+        /** @type {TargetedTranslation[]} */
+        const untranslated = [];
+        this.hiddenTranslations.clear();
+        const filter = this.state.filter.toLowerCase().trim();
+        for (const translation of this.props.translations) {
+            if (!matchFilter(filter, translation)) {
+                continue;
+            }
+            if (!translation.targets.some(([el]) => isVisible(el, { css: true, viewPort: true }))) {
+                this.hiddenTranslations.add(translation);
+            }
+            if (translation.isTranslated) {
+                translated.push(translation);
+            } else {
+                untranslated.push(translation);
+            }
+        }
+        const categories = [];
+        if (untranslated.length) {
+            categories.push({
+                id: "untranslated",
+                label: `Untranslated`,
+                translations: untranslated,
+            });
+        }
+        if (translated.length) {
+            categories.push({
+                id: "translated",
+                label: `Translated`,
+                translations: translated,
+            });
+        }
+        return categories;
+    }
+
+    /**
+     * @param {TargetedTranslation} translation
+     * @param {PointerEvent} ev
+     */
+    onCardClick(translation, ev) {
+        this.translationMode.highlightTranslation(translation, ev.ctrlKey);
+    }
+
+    /**
+     * @param {Event} ev
+     */
+    onPointerDown(ev) {
+        if (ev.composedPath().includes(this.rootRef.el)) {
+            // Stop all pointer events from within the side panel.
+            // This is done to avoid dropdowns closing when focusing translations
+            ev.stopImmediatePropagation();
+            ev.stopPropagation();
+        }
+    }
+
+    openSettings() {
+        this.actionService.doAction("test_translation_mode.translation_mode_settings_action");
+    }
+
+    toggleCategory(category) {
+        if (this.collapsedCategories.has(category.id)) {
+            this.collapsedCategories.delete(category.id);
+        } else {
+            this.collapsedCategories.add(category.id);
+        }
+    }
+}
+
+export const TRANSLATABLE_ATTRIBUTE_LABELS = {
+    "aria-label": `Aria label`,
+    "aria-placeholder": `Aria placeholder`,
+    "aria-roledescription": `Aria role description`,
+    "aria-valuetext": `Aria value text`,
+    "data-tooltip-info": `Tooltip info data`,
+    "data-tooltip": `Tooltip data`,
+    "o-we-hint-text": `Web editor text hint`,
+    alt: `Alternate text`,
+    label: `Label`,
+    name: `Name`,
+    placeholder: `Placeholder`,
+    searchabletext: `Searchable text`,
+    title: `Title`,
+};
+export const TRANSLATABLE_PROPERTY_LABELS = {
+    textContent: `Text`,
+    value: `Value`,
+};

--- a/addons/test_translation_mode/static/src/translation_mode_side_panel.xml
+++ b/addons/test_translation_mode/static/src/translation_mode_side_panel.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0"?>
+<templates>
+
+    <t t-name="test_translation_mode.TranslationModeSidePanel">
+        <t t-set="highlightsEnabled" t-value="this.translationMode.highlightsEnabled" />
+        <t t-set="categories" t-value="this.getTranslationCategories()" />
+        <aside
+            class="o-translate-side-panel d-flex flex-column position-fixed top-0 end-0 bg-view shadow"
+            data-translation-highlight="off"
+            t-ref="root"
+            t-translation="off"
+        >
+            <header class="d-flex flex-column p-2 gap-2">
+                <div class="d-flex align-items-center gap-1">
+                    <search class="o_searchview form-control d-flex align-items-center gap-2">
+                        <i class="oi oi-search text-muted" />
+                        <div class="o_searchview_input_container d-flex flex-grow-1">
+                            <input
+                                name="filter-translations"
+                                type="text"
+                                class="o_searchview_input flex-grow-1 border-0 p-0 bg-transparent"
+                                placeholder="Search…"
+                                t-att-disabled="!highlightsEnabled"
+                                t-model="this.state.filter"
+                            />
+                        </div>
+                    </search>
+                    <button
+                        class="btn border-0 py-1 px-2"
+                        title="Settings"
+                        aria-label="Open settings"
+                        t-on-click="this.openSettings"
+                    >
+                        <i class="fa fa-cog" aria-hidden="true" />
+                    </button>
+                </div>
+            </header>
+            <t t-if="!highlightsEnabled">
+                <h5 class="text-muted fw-bold fst-italic text-center p-4">
+                    Translation highlighting has been disabled for this language.
+                </h5>
+            </t>
+            <div class="d-flex flex-column overflow-auto h-100">
+                <t t-foreach="categories" t-as="category" t-key="category.id">
+                    <t t-set="isOpen" t-value="!this.collapsedCategories.has(category.id)" />
+                    <details t-att-open="isOpen">
+                        <summary
+                            class="d-flex justify-content-between p-2 user-select-none"
+                            t-on-click="() => this.toggleCategory(category)"
+                        >
+                            <h4 class="d-flex gap-2 align-items-center m-0">
+                                <i
+                                    class="fa fa-caret-right transition-base"
+                                    t-att-class="{ 'fa-rotate-90': isOpen }"
+                                />
+                                <strong t-out="category.label" />
+                            </h4>
+                            <strong class="fs-4" t-out="category.translations.length" />
+                        </summary>
+                        <ul class="list-unstyled m-0 d-flex flex-column overflow-y-auto">
+                            <t t-foreach="category.translations" t-as="translation" t-key="translation.source">
+                                <li
+                                    t-attf-class="border-2 border-start border-{{ translation.isTranslated ? 'success' : 'danger' }}"
+                                >
+                                    <div
+                                        class="o-translate-card card card-body gap-2 p-2"
+                                        tabindex="0"
+                                        t-on-click="(ev) => this.onCardClick(translation, ev)"
+                                    >
+                                        <div class="d-flex justify-content-between align-items-center">
+                                            <h5 class="d-flex gap-2 align-items-center m-0">
+                                                <span t-out="formatTarget(translation.targets)" />
+                                                <t t-if="this.hiddenTranslations.has(translation)">
+                                                    <i
+                                                        class="fa fa-eye-slash text-muted"
+                                                        title="These elements are hidden in the current user interface"
+                                                    />
+                                                </t>
+                                            </h5>
+                                            <t t-if="this.state.translationUrl === null">
+                                                <a class="small fst-italic">
+                                                    Loading…
+                                                </a>
+                                            </t>
+                                            <t t-else="">
+                                                <a
+                                                    class="d-flex gap-1 align-items-center user-select-none"
+                                                    target="_blank"
+                                                    t-att-href="this.state.translationUrl + translation.link"
+                                                    title="Edit translation on Weblate"
+                                                    aria-label="Edit translation on Weblate"
+                                                >
+                                                    <i class="fa fa-external-link" aria-hidden="true" />
+                                                    Translate
+                                                </a>
+                                            </t>
+                                        </div>
+                                        <div class="d-flex gap-2">
+                                            <img
+                                                class="o-translation-flag user-select-none"
+                                                t-att-src="this.defaultLangFlagUrl"
+                                                t-att-alt="this.defaultLangDisplayName"
+                                            />
+                                            <t t-if="this.isMissingSource(translation)">
+                                                <span class="text-muted">
+                                                    No source term
+                                                </span>
+                                            </t>
+                                            <t t-else="">
+                                                <span class="text-wrap" t-out="translation.source" />
+                                            </t>
+                                        </div>
+                                        <div class="d-flex gap-2">
+                                            <img
+                                                class="o-translation-flag user-select-none"
+                                                t-att-src="this.state.currentLangFlagUrl"
+                                                t-att-alt="this.state.currentLangDisplayName"
+                                            />
+                                            <t t-if="this.isMissingTranslation(translation)">
+                                                <span class="text-muted">
+                                                    Missing translation
+                                                </span>
+                                            </t>
+                                            <t t-else="">
+                                                <span class="text-wrap" t-out="translation.translation" />
+                                            </t>
+                                        </div>
+                                    </div>
+                                </li>
+                            </t>
+                        </ul>
+                    </details>
+                </t>
+            </div>
+        </aside>
+    </t>
+
+</templates>

--- a/addons/test_translation_mode/static/tests/translation.patch.test.js
+++ b/addons/test_translation_mode/static/tests/translation.patch.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { encodeTranslation, parseTranslatedText } from "../src/translation.patch";
+
+describe.current.tags("headless");
+
+test("encodeTranslation", () => {
+    const metadata = ["web", "Component"];
+    const translation = "Component";
+
+    const encoded = encodeTranslation(0, metadata, translation);
+
+    expect(encoded).toHaveLength(
+        1 + // translated bit
+            4 + // byte count
+            JSON.stringify(metadata).length * 2 + // encoded metadata
+            translation.length // translation
+    );
+    expect(encoded).toMatch(/Component$/);
+});
+
+test("parseTranslatedText", () => {
+    expect(parseTranslatedText(encodeTranslation(0, ["web", "Component"], "Component"))).toEqual([
+        "Component",
+        [
+            {
+                context: "web",
+                isTranslated: false,
+                source: "Component",
+                translation: "Component",
+            },
+        ],
+    ]);
+    expect(
+        parseTranslatedText(/* xml */ `
+            <span>\u200E${encodeTranslation(1, ["website", "Website", "Site Web"], "Site Web")}\u200E</span>
+            <div>\u200D${encodeTranslation(0, ["web", "Menu"], "Menu")}</div>
+        `)
+    ).toEqual([
+        /* xml */ `
+            <span>\u200ESite Web\u200E</span>
+            <div>\u200DMenu</div>
+        `,
+        [
+            {
+                context: "website",
+                isTranslated: true,
+                source: "Website",
+                translation: "Site Web",
+            },
+            {
+                context: "web",
+                isTranslated: false,
+                source: "Menu",
+                translation: "Menu",
+            },
+        ],
+    ]);
+});

--- a/addons/test_translation_mode/static/tests/translation_mode_side_panel.test.js
+++ b/addons/test_translation_mode/static/tests/translation_mode_side_panel.test.js
@@ -1,0 +1,146 @@
+import {
+    afterEach,
+    animationFrame,
+    clear,
+    click,
+    describe,
+    expect,
+    fill,
+    queryAll,
+    test,
+} from "@odoo/hoot";
+import {
+    defineModels,
+    makeMockEnv,
+    models,
+    mountWithCleanup,
+    serverState,
+} from "@web/../tests/web_test_helpers";
+import { encodeTranslation } from "../src/translation.patch";
+import { urlParams } from "../src/translation_mode_service";
+
+class IrConfigParameter extends models.ServerModel {
+    _name = "ir.config_parameter";
+    _records = [{ key: "test_translation_mode.translation_url", value: "www.example.com" }];
+
+    /**
+     * @param {string} key
+     */
+    get_str(key) {
+        return this._filter([["key", "=", key]])[0]?.value ?? null;
+    }
+}
+
+class ResLang extends models.ServerModel {
+    _name = "res.lang";
+    _records = [
+        {
+            code: "en_US",
+            display_name: "English",
+            flag_image_url: "",
+        },
+        {
+            code: "fr_FR",
+            display_name: "French",
+            flag_image_url: "",
+        },
+    ];
+}
+
+defineModels({ IrConfigParameter, ResLang });
+afterEach(() => {
+    for (const key in urlParams) {
+        delete urlParams[key];
+    }
+});
+describe.current.tags("desktop");
+
+/**
+ * @param {string} source
+ * @param {string} [translation]
+ */
+function mockEncodedTranslation(source, translation) {
+    const metadata = ["web", source];
+    if (translation) {
+        metadata.push(translation);
+    }
+    return encodeTranslation(translation ? 1 : 0, metadata, translation || source);
+}
+
+test("side panel is not rendered by default", async () => {
+    await mountWithCleanup(/* xml */ `
+        <div class="sample-element">
+            ${mockEncodedTranslation("Component")}
+        </div>
+    `);
+
+    expect(".sample-element:only").toHaveText("Component");
+    expect(".o-translate-side-panel").not.toHaveCount();
+});
+
+test("side panel with no translation", async () => {
+    serverState.lang = "en_US";
+
+    expect(document.body).not.toHaveClass("o-body-with-translate-side-panel");
+
+    await makeMockEnv({ debug: "translate" });
+    await mountWithCleanup(/* xml */ `
+        <div class="sample-element">
+            ${mockEncodedTranslation("Component", "Component")}
+        </div>
+    `);
+
+    expect(document.body).toHaveClass("o-body-with-translate-side-panel");
+
+    expect(".sample-element:only").toHaveText("Component");
+    expect(".o-translate-side-panel:only").toHaveText(
+        "Translation highlighting has been disabled for this language."
+    );
+    expect(".o-translate-side-panel .o-translate-card").not.toHaveCount();
+});
+
+test("side panel with translations", async () => {
+    serverState.lang = "fr_FR";
+    serverState.serverVersion = [3, 0, 0, "final", 0, ""];
+
+    expect(document.body).not.toHaveClass("o-body-with-translate-side-panel");
+
+    await makeMockEnv({ debug: "translate" });
+    await mountWithCleanup(/* xml */ `
+        <div class="sample-element">
+            ${mockEncodedTranslation("Component", "Composant")}
+        </div>
+    `);
+
+    expect(document.body).toHaveClass("o-body-with-translate-side-panel");
+
+    expect(".sample-element:only").toHaveText("Composant");
+    expect(".o-translate-side-panel:only .o-translate-card:only").toHaveText(
+        ["Text", "Translate", "Component", "Composant"].join("\n")
+    );
+    expect(".o-translate-side-panel .o-translate-card a[href]").toHaveAttribute(
+        "href",
+        "www.example.com/translate/odoo-3/web/fr_FR/?checksum=25c3e74edddbe2ff"
+    );
+    expect(queryAll(".o-translation-pointer", { root: document.body })).not.toHaveCount();
+
+    await click(".o-translate-card");
+
+    expect(queryAll(".o-translation-pointer", { root: document.body })).toHaveCount(1);
+
+    await click(".sample-element");
+
+    expect(queryAll(".o-translation-pointer", { root: document.body })).not.toHaveCount();
+
+    await click("[name='filter-translations']");
+    await fill("aaaa");
+    await animationFrame();
+
+    expect(".o-translate-side-panel .o-translate-card").not.toHaveCount();
+
+    await clear();
+    await fill("comp");
+    await animationFrame();
+
+    expect(".o-translate-side-panel .o-translate-card").toHaveCount(1);
+});

--- a/addons/test_translation_mode/tools/__init__.py
+++ b/addons/test_translation_mode/tools/__init__.py
@@ -1,0 +1,1 @@
+from . import translate

--- a/addons/test_translation_mode/tools/translate.py
+++ b/addons/test_translation_mode/tools/translate.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+import re
+
+import odoo.tools.translate as translate
+
+
+"""
+Parameters used to encode and decode contextualized translations (short: 'CT').
+
+Translation metadata:
+
+Each translation is preceded by its context, or "metadata", which is a 'list' containing:
+- :int: whether the term is translated (0 or 1);
+- :string: the (encoded) addon from which the translation originates;
+- :string: the (encoded) source term
+- :string: (optional the (encoded) translation, attached only if:
+    > it exists for the given source (if not, source == translation)
+    > the translated term differs from its source
+
+Encoding:
+
+This metadata is "encoded" and attached to each translated string. It is encoded
+using the following system:
+1. the metadata (list) is stringified;
+2. stringified metadata is converted to bytes array;
+3. each byte is then converted to a tuple of its base-16 integer components;
+4. each integer is then swapped with its corresponding zero-width character.
+
+Hiding:
+
+The metadata is encoded in zero-width characters to allow 2 things:
+- being properly picked up by the client code with an arrangement of non-conventional characters;
+- being invisible in the UI, should the service not work or fail to pick up a translation.
+
+Decoding happens on the client side; see: <addons/test_translation_mode/static/src/translation.patch.js>
+"""
+CT_MAP = tuple('\u200B\u200C\u200D\u200E\u200F\u2060\u2061\u2062\u2063\u2064\uFE00\uFE01\uFE02\uFE03\uFE04\uFE05')
+RE_CONTEXTUALIZED_TRANSLATION = re.compile(
+    f"[{CT_MAP[0]}{CT_MAP[1]}][{''.join(CT_MAP)}]+"
+)
+
+
+original_CSVFileReader__iter__ = translate.CSVFileReader.__iter__
+original_PoFileReader__iter__ = translate.PoFileReader.__iter__
+original_XMLDataFileReader__iter__ = translate.XMLDataFileReader.__iter__
+
+
+def contextualize_entry(entry: str):
+    translation = entry.get('value', "")
+    if translation and RE_CONTEXTUALIZED_TRANSLATION.match(translation):
+        return entry
+
+    source = entry.get('src', "")
+    final_translation = translation or source
+    metadata = [entry.get('module', "base"), source]
+    if source != final_translation:
+        metadata.append(translation)
+
+    # Encoding
+    str_metadata = json.dumps(metadata)
+    bytes_metadata = str_metadata.encode('utf-8')
+    byte_count = encode_word(len(bytes_metadata))  # supports lengths up to 2^16
+    encoded_metadata = ''.join(encode_byte(byte) for byte in bytes_metadata)
+    is_translated_bit = CT_MAP[1 if translation else 0]
+
+    entry['value'] = is_translated_bit + byte_count + encoded_metadata + final_translation
+    return entry
+
+
+def encode_byte(byte: int):
+    return CT_MAP[(byte >> 4) & 0xF] + CT_MAP[byte & 0xF]
+
+
+def encode_word(word: int):
+    return CT_MAP[(word >> 12) & 0xF] + CT_MAP[(word >> 8) & 0xF] + CT_MAP[(word >> 4) & 0xF] + CT_MAP[word & 0xF]
+
+
+def CSVFileReader__iter__(self):
+    for entry in original_CSVFileReader__iter__(self):
+        yield contextualize_entry(entry)
+
+
+def PoFileReader__iter__(self):
+    for entry in original_PoFileReader__iter__(self):
+        yield contextualize_entry(entry)
+
+
+def XMLDataFileReader__iter__(self):
+    for entry in original_XMLDataFileReader__iter__(self):
+        yield contextualize_entry(entry)
+
+
+translate.CSVFileReader.__iter__ = CSVFileReader__iter__
+translate.PoFileReader.__iter__ = PoFileReader__iter__
+translate.XMLDataFileReader.__iter__ = XMLDataFileReader__iter__
+
+# Reset cached translations
+translate.code_translations.python_translations.clear()
+translate.code_translations.web_translations.clear()

--- a/addons/test_translation_mode/views/translation_mode_settings.xml
+++ b/addons/test_translation_mode/views/translation_mode_settings.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="translation_mode_settings_form" model="ir.ui.view">
+        <field name="name">test_translation_mode.settings.form</field>
+        <field name="model">res.config.settings</field>
+        <field name="arch" type="xml">
+            <form>
+                <group>
+                    <label for="language" />
+                    <div class="o_row">
+                        <field name="language" required="1" />
+                        <button
+                            type="action"
+                            name="%(base.action_view_base_language_install)d"
+                            class="btn btn-link fa fa-globe"
+                            groups="base.group_system"
+                            aria-label="Add a language"
+                            title="Add a language"
+                        />
+                    </div>
+                    <field name="translation_url" />
+                </group>
+                <footer>
+                    <button class="btn btn-primary" type="object" name="save_and_reload" string="Save" />
+                    <button special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="translation_mode_settings_action" model="ir.actions.act_window">
+        <field name="res_model">res.config.settings</field>
+        <field name="name">Settings</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="translation_mode_settings_form"/>
+        <field name="target">new</field>
+        <field name="context">{'dialog_size': 'medium'}</field>
+    </record>
+</odoo>

--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -7,22 +7,6 @@ from odoo.tools import config
 from odoo.tools.func import deprecated
 from odoo.tools.misc import hmac, str2bool
 
-"""
-Debug mode is stored in session and should always be a string.
-It can be activated with an URL query string `debug=<mode>` where mode
-is either:
-- 'tests' to load tests assets
-- 'assets' to load assets non minified
-- any other truthy value to enable simple debug mode (to show some
-  technical feature, to show complete traceback in frontend error..)
-- any falsy value to disable debug mode
-
-You can use any truthy/falsy value from `str2bool` (eg: 'on', 'f'..)
-Multiple debug modes can be activated simultaneously, separated with a
-comma (eg: 'tests, assets').
-"""
-ALLOWED_DEBUG_MODES = ['', '1', 'assets', 'tests']
-
 
 class IrHttp(models.AbstractModel):
     _inherit = 'ir.http'
@@ -42,12 +26,29 @@ class IrHttp(models.AbstractModel):
         if cids := cookies.get('cids'):
             cookies['cids'] = '-'.join(cids.split(','))
 
+    def _get_debug_modes(self):
+        """
+        Debug mode is stored in session and should always be a string.
+        It can be activated with an URL query string `debug=<mode>` where mode
+        is either:
+        - 'tests' to load tests assets
+        - 'assets' to load assets non minified
+        - any other truthy value to enable simple debug mode (to show some
+        technical feature, to show complete traceback in frontend error..)
+        - any falsy value to disable debug mode
+
+        You can use any truthy/falsy value from `str2bool` (eg: 'on', 'f'..)
+        Multiple debug modes can be activated simultaneously, separated with a
+        comma (eg: 'tests, assets').
+        """
+        return {'', '1', 'assets', 'tests'}
+
     @classmethod
     def _handle_debug(cls):
         debug = request.httprequest.args.get('debug')
         if debug is not None:
             request.session.debug = ','.join(
-                     mode if mode in ALLOWED_DEBUG_MODES
+                     mode if mode in request.env['ir.http']._get_debug_modes()
                 else '1' if str2bool(mode, mode)
                 else ''
                 for mode in (debug or '').split(',')

--- a/odoo/tests/runbot/parallel_testing.json
+++ b/odoo/tests/runbot/parallel_testing.json
@@ -1,7 +1,7 @@
 {
     "name": "Parallel testing",
     "vars": {
-        "module_filter": "*,-hw_*,-*l10n_*,-theme_*,-account_bacs,-account_reports_cash_basis,-auth_ldap,-base_gengo,-document_ftp,-iot_drivers,-note_pad,-odoo_referral,-odoo_referral_portal,-pad,-pad_project,-pos_blackbox_be,-pos_cache,-pos_six,-social_demo,-website_gengo,-website_instantclick,test_l10n_be_hr_payroll_account,test_l10n_us_hr_payroll_account"
+        "module_filter": "*,-hw_*,-*l10n_*,-theme_*,-account_bacs,-account_reports_cash_basis,-auth_ldap,-base_gengo,-document_ftp,-iot_drivers,-note_pad,-odoo_referral,-odoo_referral_portal,-pad,-pad_project,-pos_blackbox_be,-pos_cache,-pos_six,-social_demo,-website_gengo,-website_instantclick,test_l10n_be_hr_payroll_account,test_l10n_us_hr_payroll_account,-test_translation_mode"
     },
     "steps": [
         {


### PR DESCRIPTION
### [ADD] translation_mode: UI translation addon

This commit introduces a 'translation_mode' addon to help translators
correct all displayed translations quickly.

This addon consists of 3 main features:

- a server-side formatter, which wraps every translation in a special
format in order to keep: the context (= addon), whether it has a
translation, the source string and finally the translation itself. This
wrapping is needed since translations can be built at any point, from
the DB or statically, on the server or the client, and there is no
single route to convey them all. The solution applied here is to
override the translation files readers (PO, CSV and XML) and to apply
the wrapping ASAP.

- a client-side service, which parses all wrapped translated strings.
This one may not cover *all* grounds since it relies on a fixed list of
features (i.e. DOM nodes & document title), so there may be times where
a wrapped string passes through unwrapped and may be displayed on the
client.

- an additional debug mode ("debug=translate"), which will display a
global side bar on every screen and will show the list of currently
displayed translations.

As this addon's strategy is **very aggressive**, it will require an
exclusion from CI to allow tests from other addons to pass.

Task [5989557](<https://www.odoo.com/odoo/project/133/tasks/5989557>)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr