### PR TITLE
[FIX] website_sale: fix video in X2ManyMediaViewer

### DIFF
--- a/addons/website_sale/views/product_image_views.xml
+++ b/addons/website_sale/views/product_image_views.xml
@@ -40,6 +40,8 @@
         <field name="model">product.image</field>
         <field name="arch" type="xml">
             <kanban string="Product Images" default_order="sequence">
+                <!-- We need the hidden video_url to be able to create new `product.image` records with video_url. (see: x2many_media_viewer.js) -->
+                <field name="video_url" invisible="1"/>
                 <field name="sequence" widget="handle"/>
                 <templates>
                     <t t-name="card" class="p-0 border-0">


### PR DESCRIPTION
Since the view cleaning done in #230098,
the `video_url` field infos were not automatically loaded by the JS ORM anymore.

Therefore a traceback was raise when trying to create a new `product.image` record with a video_url field.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
