### PR TITLE
[FIX] html_editor: prevent editable scrolling when refocus by clicking

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -233,6 +233,14 @@ export class SelectionPlugin extends Plugin {
             }
         });
         this.preservedCursors = [];
+        // Calling the native `focus` method of the editable element, even with
+        // `preventScroll: true`, would reset the selection at the start of the
+        // editable. This would, in turn, trigger a selectionchange event and,
+        // down the line, a scroll to the position of the selection, so to the
+        // top of the document. Calling focusEditable instead will restore the
+        // correct editable selection and prevent scrolling when not needed.
+        this.editableOriginalFocus = this.editable.focus;
+        this.editable.focus = () => this.focusEditable();
     }
 
     selectAll() {
@@ -1097,7 +1105,8 @@ export class SelectionPlugin extends Plugin {
         }
 
         // Manualy focusing the editable is necessary to avoid some non-deterministic error in the HOOT unit tests.
-        this.editable.focus({ preventScroll: true });
+        // Use the copy of the original focus but prevent scrolling.
+        this.editableOriginalFocus.call(this.editable, { preventScroll: true });
 
         if (!documentSelectionIsInEditable) {
             // Selection is outside the editor — restore it.

--- a/addons/html_editor/static/src/core/shortcut_plugin.js
+++ b/addons/html_editor/static/src/core/shortcut_plugin.js
@@ -58,6 +58,7 @@ export class ShortCutPlugin extends Plugin {
     }
 
     destroy() {
+        super.destroy();
         this.removeEditorCommandPalette();
     }
 


### PR DESCRIPTION
Before this commit: the editable area scrolls to the top when the command palette is closed by clicking the gray zone

After this commit: we override the focus function of the editable and use focusEditable instead, which keeps the selection. Note it's a succession fix of https://github.com/odoo/odoo/pull/250624 and both of them are a workaround without touching the ui_service and command palette. Also added super.destroy() in the previous fix till 18.4.

task-6034339


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
