### PR TITLE
[PERF] l10n_sa_edi_pos: defer PDF generation

### DIFF
--- a/addons/l10n_sa_edi_pos/models/account_move.py
+++ b/addons/l10n_sa_edi_pos/models/account_move.py
@@ -4,5 +4,21 @@ from odoo import models
 class AccountMove(models.Model):
     _inherit = 'account.move'
 
+    def l10n_sa_pos_ensure_invoice_pdf(self):
+        """Generate the invoice PDF on demand for SA POS.
+
+        ZATCA clearance/reporting is already processed at checkout time.
+        This generates only the PDF (no ZATCA re-submission, no email) so
+        that "Reprint Invoice" serves the real signed invoice rather than a
+        proforma.
+        """
+        self.ensure_one()
+        if not self.invoice_pdf_report_id:
+            # sending_methods={} skips email; ZATCA is already 'sent' so
+            # _is_sa_edi_applicable returns False and it is not re-submitted.
+            self.env['account.move.send']._generate_and_send_invoices(
+                self, sending_methods={}
+            )
+
     def _l10n_sa_check_refund_reason(self):
         return super()._l10n_sa_check_refund_reason() or (self.pos_order_ids and self.pos_order_ids[0].refunded_orders_count > 0 and self.ref)

--- a/addons/l10n_sa_edi_pos/models/pos_order.py
+++ b/addons/l10n_sa_edi_pos/models/pos_order.py
@@ -6,3 +6,22 @@ class PosOrder(models.Model):
 
     l10n_sa_invoice_qr_code_str = fields.Char(related="account_move.l10n_sa_qr_code_str", string="ZATCA QR Code")
     l10n_sa_invoice_edi_state = fields.Selection(related="account_move.edi_state", string="Electronic invoicing")
+
+    def _generate_pos_order_invoice(self):
+        # When generate_pdf=False (set by the SA ZATCA POS UI to avoid blocking checkout
+        # on wkhtmltopdf), super() skips _generate_and_send entirely — including ZATCA.
+        # We restore ZATCA EDI processing here since it is legally required to run synchronously.
+        # PDF is left for on-demand generation when the invoice is first viewed or downloaded.
+        if self.env.context.get('generate_pdf', True) or self.company_id.country_id.code != 'SA':
+            return super()._generate_pos_order_invoice()
+
+        orders_needing_invoice = self.filtered(lambda o: not o.account_move)
+        result = super()._generate_pos_order_invoice()
+
+        for order in orders_needing_invoice:
+            if order.account_move:
+                order.account_move.edi_document_ids.filtered(
+                    lambda d: d.state == 'to_send' and d.edi_format_id._needs_web_services()
+                )._process_documents_web_services(with_commit=False)
+
+        return result

--- a/addons/l10n_sa_edi_pos/static/src/overrides/components/invoice_button/invoice_button.js
+++ b/addons/l10n_sa_edi_pos/static/src/overrides/components/invoice_button/invoice_button.js
@@ -1,0 +1,22 @@
+import { InvoiceButton } from "@point_of_sale/app/screens/ticket_screen/invoice_button/invoice_button";
+import { patch } from "@web/core/utils/patch";
+
+patch(InvoiceButton.prototype, {
+    async _downloadInvoice(orderId) {
+        if (this.pos.company.country_id?.code === "SA") {
+            // PDF was deferred at checkout to avoid blocking on wkhtmltopdf.
+            // Generate it now on demand before downloading so the user gets
+            // the real signed invoice and not the proforma fallback.
+            const orderData = (
+                await this.pos.data.read("pos.order", [orderId], [], { load: false })
+            )[0];
+            const accountMoveId = orderData?.raw?.account_move;
+            if (accountMoveId) {
+                await this.pos.data.call("account.move", "l10n_sa_pos_ensure_invoice_pdf", [
+                    accountMoveId,
+                ]);
+            }
+        }
+        return super._downloadInvoice(...arguments);
+    },
+});

--- a/addons/l10n_sa_edi_pos/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/l10n_sa_edi_pos/static/src/overrides/components/payment_screen/payment_screen.js
@@ -6,6 +6,16 @@ import { markup } from "@odoo/owl";
 
 patch(PaymentScreen.prototype, {
     //@Override
+    shouldDownloadInvoice() {
+        // For SA companies the PDF is deferred (generated on demand). Skip the
+        // automatic post-checkout download so the cashier is never presented
+        // with a proforma instead of the real invoice.
+        if (this.currentOrder?.isSACompany) {
+            return false;
+        }
+        return super.shouldDownloadInvoice();
+    },
+    //@Override
     async _finalizeValidation() {
         await super._finalizeValidation(...arguments);
         const order = this.currentOrder;

--- a/addons/l10n_sa_edi_pos/static/src/overrides/models/pos_store.js
+++ b/addons/l10n_sa_edi_pos/static/src/overrides/models/pos_store.js
@@ -12,4 +12,14 @@ patch(PosStore.prototype, {
         }
         return result;
     },
+
+    getSyncAllOrdersContext() {
+        const context = super.getSyncAllOrdersContext(...arguments);
+        // For SA companies, defer PDF generation to avoid blocking checkout on wkhtmltopdf.
+        // ZATCA EDI (clearance/reporting) is still processed synchronously on the server.
+        if (this.company.country_id?.code === "SA") {
+            context.generate_pdf = false;
+        }
+        return context;
+    },
 });


### PR DESCRIPTION
For SA companies, wkhtmltopdf PDF generation was accounting for ~47% of the sync_from_ui response time (~3.1s out of ~6.5s total), blocking the cashier at every order.

The PDF is not needed during checkout: ZATCA requires only the signed XML and returns the QR code. The PDF can be generated on demand when the invoice is first viewed or downloaded.

opw-6019994


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
