### PR TITLE
[FIX] html_editor: make sure link preview's button's text doesn't stack

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.scss
+++ b/addons/html_editor/static/src/main/link/link_popover.scss
@@ -34,6 +34,10 @@
 
     .o_we_link_preview {
         width: 300px;
+
+        .btn {
+            white-space: nowrap;
+        }
     }
 }
 


### PR DESCRIPTION
Before this commit: the Edit Menu button's text stacks when the url's
preview is loaded.

After this commit: we make sure the button isn't wrapped for all the
buttons inside the link preview.

task-6036771


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
