### PR TITLE
[IMP] mail: sync discuss sidebar item hover effect with name highlight

### DIFF
--- a/addons/im_livechat/static/src/core/web/discuss_app/sidebar/category_patch.scss
+++ b/addons/im_livechat/static/src/core/web/discuss_app/sidebar/category_patch.scss
@@ -17,12 +17,6 @@
             );
     }
 
-    .o-mail-DiscussSidebarChannel.o-active &,
-    .o-mail-DiscussSidebarChannel &:hover,
-    .o-mail-DiscussSidebarChannel &:focus-visible {
-        --bg-opacity: 1;
-    }
-
     .o-mail-DiscussSidebarChannel.o-active & {
         --border-opacity: .75;
     }

--- a/addons/mail/static/src/core/public_web/discuss_app/sidebar/sidebar.scss
+++ b/addons/mail/static/src/core/public_web/discuss_app/sidebar/sidebar.scss
@@ -57,8 +57,12 @@
         outline-color: var(--mail-DiscussSidebar-itemActiveOutlineColor, mix($o-view-background-color, $o-action, 50%)) !important;
     }
 
+    &:not(:hover):not(.o-unread):not(.o-active) .o-mail-DiscussSidebar-itemName {
+        opacity: 75%;
+    }
+
     &.o-active, &:hover {
-        .o-mail-DiscussSidebarChannel-itemName {
+        .o-mail-DiscussSidebar-itemName {
             filter: brightness(1.1);
         }
     }

--- a/addons/mail/static/src/core/web/discuss_app/sidebar/mailboxes.xml
+++ b/addons/mail/static/src/core/web/discuss_app/sidebar/mailboxes.xml
@@ -38,7 +38,7 @@
         >
             <ThreadIcon className="'bg-inherit opacity-75 justify-content-center ' + (this.store.discuss.isSidebarCompact ? '' : 'o-ms-1_5 me-2 pt-1')" thread="this.mailbox" size="this.store.discuss.isSidebarCompact ? 'large' : 'medium'"/>
             <t t-if="!this.store.discuss.isSidebarCompact">
-                <div class="me-2 text-truncate small opacity-75 opacity-100-hover" t-out="this.mailbox.display_name"/>
+                <div class="o-mail-DiscussSidebar-itemName me-2 text-truncate small" t-out="this.mailbox.display_name"/>
                 <div t-attf-class="flex-grow-1 {{ this.mailbox.counter === 0 ? 'me-3': '' }}"/>
             </t>
             <t t-if="this.mailbox.counter > 0" t-call="mail.discuss_badge">

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.js
@@ -94,9 +94,6 @@ export class DiscussSidebarChannel extends Component {
             "o-unread o-fw-600":
                 this.channel.self_member_id?.message_unread_counter > 0 &&
                 !this.channel.self_member_id?.mute_until_dt,
-            "opacity-75 opacity-100-hover":
-                this.channel.self_member_id?.message_unread_counter === 0 ||
-                this.channel.self_member_id?.mute_until_dt,
         };
     }
 

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/channel.xml
@@ -34,7 +34,7 @@
                 <div class="position-relative d-flex flex-shrink-0 o-my-0_5 rounded-2" name="threadAvatar" t-att-class="{ 'ms-2': !this.store.discuss.isSidebarCompact }">
                     <DiscussAvatar channel="this.channel" size="26"/>
                 </div>
-                <div t-if="!this.store.discuss.isSidebarCompact" class="o-mail-DiscussSidebarChannel-itemName overflow-hidden ms-2 text-start flex-grow-1 z-1" t-att-class="this.itemNameAttClass">
+                <div t-if="!this.store.discuss.isSidebarCompact" class="o-mail-DiscussSidebarChannel-itemName o-mail-DiscussSidebar-itemName overflow-hidden ms-2 text-start flex-grow-1 z-1" t-att-class="this.itemNameAttClass">
                     <div class="d-flex align-items-baseline o-min-width-0 gap-2">
                         <span class="text-truncate" t-out="this.channel.displayName" t-custom-ref="displayName"/>
                         <div class="d-flex gap-2 ms-auto" t-custom-ref="displayNameAdditionalContent"/>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/subchannel.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app/sidebar/subchannel.xml
@@ -34,9 +34,8 @@
                 'o-unread': this.channel.self_member_id?.message_unread_counter > 0 and !this.channel.self_member_id?.mute_until_dt,
                 'opacity-50': this.channel.self_member_id?.mute_until_dt,
             }">
-                <span class="text-truncate" t-out="this.channel.displayName" t-att-class="{
-                    'o-fw-600': this.channel.self_member_id?.message_unread_counter > 0,
-                    'opacity-75 opacity-100-hover': !(this.channel.self_member_id?.message_unread_counter > 0 and !this.channel.self_member_id?.mute_until_dt),
+                <span class="o-mail-DiscussSidebar-itemName text-truncate" t-out="this.channel.displayName" t-att-class="{
+                    'o-fw-600': this.channel.self_member_id?.message_unread_counter > 0 and !this.channel.self_member_id?.mute_until_dt,
                 }" t-att-style="this.store.discuss.isSidebarCompact ? 'text-overflow: clip;' : ''"/>
                 <span class="flex-grow-1"/>
                 <t t-if="!this.store.discuss.isSidebarCompact" t-call="mail.DiscussSidebarChannel.actions"/>


### PR DESCRIPTION
Before this commit, hover effect on discuss sidebar item looked weird:

- item had hover effect even when active, which gives wrong impression this item is not active yet.
- triggers of item hover and its name highlighting were different, which gives the wrong impression the name has different interaction than click on item

This commit fixes both problems:
- hover on active item doesn't change its visual (other than showing the "..." more actions)
- hover effect on non-active item highlights the name consistently.

Before / After
("Administrators" is active, mouse-hover on "General" on the bottom as to not hover the "name" part)
<img width="295" height="830" alt="Screenshot 2026-03-12 at 15 44 06" src="https://github.com/user-attachments/assets/ba358896-fdbc-4761-ad71-8bd5ecaaa1a0" /> <img width="299" height="818" alt="Screenshot 2026-03-12 at 15 43 44" src="https://github.com/user-attachments/assets/2313cb3a-d4f2-4937-94b5-96ccec7f0531" />
