### PR TITLE
[FIX] pos_bancontact_pay: mute_logger translate not needed

### DIFF
--- a/addons/pos_bancontact_pay/errors/http.py
+++ b/addons/pos_bancontact_pay/errors/http.py
@@ -1,6 +1,3 @@
-from json import JSONDecodeError
-
-from odoo import _
 from odoo.exceptions import (
     AccessDenied,
     AccessError,
@@ -8,57 +5,42 @@ from odoo.exceptions import (
     UserError,
     ValidationError,
 )
+from odoo.tools.translate import LazyTranslate
+
+_lt = LazyTranslate(__name__)
 
 
-def assert_bancontact_http_success(response, extra_errors=None):
-    errors = {
-        400: (
-            _("The action could not be completed. Please try again or contact support."),
-            MissingError,
-        ),
-        401: (
-            _("Authentication with Bancontact failed. Please verify your API key."),
-            AccessDenied,
-        ),
-        403: (
-            _("Access denied. Please check your Bancontact permissions."),
-            AccessDenied,
-        ),
-        404: (
-            _("Merchant profile not found on Bancontact. Please check your Payment Profile ID (ppid)."),
-            UserError,
-        ),
-        422: (
-            _("Unable to process the request. Please verify your configuration or try again later."),
-            ValidationError,
-        ),
-        429: (
-            _("Rate limit reached with Bancontact. Please wait and try again."),
-            AccessDenied,
-        ),
-        500: (
-            _("Bancontact is currently unavailable. Please try again later."),
-            AccessError,
-        ),
-        503: (
-            _("Bancontact is currently unavailable. Please try again later."),
-            AccessError,
-        ),
-        **(extra_errors or {}),
-    }
-
-    if response.status_code in errors:
-        error_message, exception_class = errors[response.status_code]
-        try:
-            error_data = response.json()
-        except JSONDecodeError:
-            error_data = {}
-        code = error_data.get("code", "")
-
-        exception_msg = f"{error_message} (ERR: {response.status_code}"
-        if code:
-            exception_msg += f" - {code}"
-        exception_msg += ")"
-        raise exception_class(exception_msg)
-
-    response.raise_for_status()
+HTTP_ERRORS = {
+    400: (
+        _lt("The action could not be completed. Please try again or contact support."),
+        MissingError,
+    ),
+    401: (
+        _lt("Authentication with Bancontact failed. Please verify your API key."),
+        AccessDenied,
+    ),
+    403: (
+        _lt("Access denied. Please check your Bancontact permissions."),
+        AccessDenied,
+    ),
+    404: (
+        _lt("Merchant profile not found on Bancontact. Please check your Payment Profile ID (ppid)."),
+        UserError,
+    ),
+    422: (
+        _lt("Unable to process the request. Please verify your configuration or try again later."),
+        ValidationError,
+    ),
+    429: (
+        _lt("Rate limit reached with Bancontact. Please wait and try again."),
+        AccessDenied,
+    ),
+    500: (
+        _lt("Bancontact is currently unavailable. Please try again later."),
+        AccessError,
+    ),
+    503: (
+        _lt("Bancontact is currently unavailable. Please try again later."),
+        AccessError,
+    ),
+}

--- a/addons/pos_bancontact_pay/models/pos_payment_method.py
+++ b/addons/pos_bancontact_pay/models/pos_payment_method.py
@@ -1,3 +1,4 @@
+from json import JSONDecodeError
 from urllib.parse import urlencode
 
 import requests
@@ -7,7 +8,7 @@ from odoo.exceptions import ValidationError
 from odoo.tools.sql import column_exists, create_column
 
 from odoo.addons.pos_bancontact_pay import const
-from odoo.addons.pos_bancontact_pay.errors.http import assert_bancontact_http_success
+from odoo.addons.pos_bancontact_pay.errors.http import HTTP_ERRORS
 
 
 class PosPaymentMethod(models.Model):
@@ -128,7 +129,7 @@ class PosPaymentMethod(models.Model):
             }
             url, payload = self._prepare_bancontact_payment_request(**kwargs)
             response = requests.post(url, json=payload, headers=headers, timeout=5)
-            assert_bancontact_http_success(response)
+            self._assert_bancontact_http_success(response)
             bancontact_data = response.json()
 
             pos_payment.bancontact_id = bancontact_data["paymentId"]
@@ -156,7 +157,7 @@ class PosPaymentMethod(models.Model):
                 "Content-Type": "application/json",
             }
             response = requests.delete(url, headers=headers, timeout=5)
-            assert_bancontact_http_success(response,
+            self._assert_bancontact_http_success(response,
                 {422: (_("Unable to cancel payment. The payment may not be in a cancellable state."), ValidationError)},
             )
 
@@ -220,3 +221,21 @@ class PosPaymentMethod(models.Model):
         """Return the Bancontact endpoint URL for the current environment."""
         environment = "preprod" if self.bancontact_test_mode else "production"
         return const.API_URLS[environment][target]
+
+    def _assert_bancontact_http_success(self, response, extra_errors=None):
+        errors = {**HTTP_ERRORS, **(extra_errors or {})}
+        if response.status_code in errors:
+            error_message, exception_class = errors[response.status_code]
+            try:
+                error_data = response.json()
+            except JSONDecodeError:
+                error_data = {}
+            code = error_data.get("code", "")
+
+            exception_msg = f"{error_message} (ERR: {response.status_code}"
+            if code:
+                exception_msg += f" - {code}"
+            exception_msg += ")"
+            raise exception_class(exception_msg)
+
+        response.raise_for_status()

--- a/addons/pos_bancontact_pay/tests/test_models.py
+++ b/addons/pos_bancontact_pay/tests/test_models.py
@@ -14,7 +14,6 @@ from odoo.exceptions import (
     ValidationError,
 )
 from odoo.tests.common import tagged
-from odoo.tools import mute_logger
 
 from odoo.addons.point_of_sale.tests.common import CommonPosTest
 from odoo.addons.pos_bancontact_pay import const
@@ -133,12 +132,11 @@ class TestModels(TestBancontactPay, CommonPosTest):
     # --------------------------------------
     # Create Bancontact Payment
     # --------------------------------------
-    @mute_logger("odoo.tools.translate")
+
     def test_create_bancontact_payment_not_found(self):
         with (self.assertRaises(ValidationError)):
             self.payment_method_display.create_bancontact_payment(payment_id=9999)
 
-    @mute_logger("odoo.tools.translate")
     def test_create_bancontact_payment_success(self):
         payment = self._init_bancontact_pos_payment()
         generated_bancontact_id = self._generate_bancontact_id()
@@ -152,7 +150,6 @@ class TestModels(TestBancontactPay, CommonPosTest):
             self.assertEqual(payment.bancontact_id, generated_bancontact_id)
             self.assertEqual(payment.qr_code, generated_qr_code)
 
-    @mute_logger("odoo.tools.translate")
     def test_create_bancontact_payment_already_exists_not_processing(self):
         existing_bancontact_id = "__bancontact_existing_id__"
         existing_qr_code = "__bancontact_existing_qr_code__"
@@ -173,7 +170,6 @@ class TestModels(TestBancontactPay, CommonPosTest):
             self.assertEqual(payment.bancontact_id, generated_bancontact_id)
             self.assertEqual(payment.qr_code, generated_qr_code)
 
-    @mute_logger("odoo.tools.translate")
     def test_create_bancontact_payment_already_exists_processing(self):
         existing_bancontact_id = "__bancontact_existing_id__"
         existing_qr_code = "__bancontact_existing_qr_code__"
@@ -194,7 +190,6 @@ class TestModels(TestBancontactPay, CommonPosTest):
             self.assertEqual(payment.bancontact_id, existing_bancontact_id)
             self.assertEqual(payment.qr_code, existing_qr_code)
 
-    @mute_logger("odoo.tools.translate")
     def test_create_bancontact_payment_api_error(self):
         codes = [(400, MissingError), (401, AccessDenied), (403, AccessDenied),
                  (404, UserError), (422, ValidationError), (429, AccessDenied),
@@ -208,12 +203,11 @@ class TestModels(TestBancontactPay, CommonPosTest):
     # --------------------------------------
     # Cancel Bancontact Payment
     # --------------------------------------
-    @mute_logger("odoo.tools.translate")
+
     def test_cancel_bancontact_payment_not_found(self):
         with (self.assertRaises(ValidationError)):
             self.payment_method_display.cancel_bancontact_payment(payment_id=9999)
 
-    @mute_logger("odoo.tools.translate")
     def test_cancel_bancontact_payment_success(self):
         bancontact_id = self._generate_bancontact_id()
         qr_code = self._generate_qr_code()
@@ -226,7 +220,6 @@ class TestModels(TestBancontactPay, CommonPosTest):
             self.assertFalse(payment.bancontact_id)
             self.assertFalse(payment.qr_code)
 
-    @mute_logger("odoo.tools.translate")
     def test_cancel_bancontact_payment_no_bancontact_id(self):
         payment = self._init_bancontact_pos_payment(payment_status="waitingScan", qr_code="some_qr_code")
         with self.mock_bancontact_call():
@@ -237,7 +230,6 @@ class TestModels(TestBancontactPay, CommonPosTest):
             self.assertFalse(payment.bancontact_id)
             self.assertEqual(payment.qr_code, "some_qr_code")
 
-    @mute_logger("odoo.tools.translate")
     def test_cancel_bancontact_payment_api_error(self):
         codes = [(400, MissingError), (401, AccessDenied), (403, AccessDenied),
                  (404, UserError), (422, ValidationError), (429, AccessDenied),


### PR DESCRIPTION
No need to mute the whole `odoo.tools.translate` module, when it could be avoided.
