### PR TITLE
[IMP] mrp: remove manual consumption logic

### DIFF
--- a/addons/mrp/__init__.py
+++ b/addons/mrp/__init__.py
@@ -9,11 +9,10 @@ from . import controller
 
 def _pre_init_mrp(env):
     """ Allow installing MRP in databases with large stock.move table (>1M records)
-        - Creating the computed stored fields `stock_move` `unit_factor` and `manual_consumption`
+        - Creating the computed stored fields `stock_move` and `unit_factor`
         is terribly slow with the ORM and leads to "Out of Memory" crashes.
     """
     env.cr.execute("""ALTER TABLE "stock_move" ADD COLUMN "unit_factor" double precision NOT NULL DEFAULT 1;""")
-    env.cr.execute("""ALTER TABLE "stock_move" ADD COLUMN "manual_consumption" boolean NOT NULL DEFAULT FALSE;""")
 
 def _create_warehouse_data(env):
     """ This hook is used to add a default manufacture_pull_id, manufacture

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1433,7 +1433,6 @@ class MrpProduction(models.Model):
             'warehouse_id': source_location.warehouse_id.id,
             'reference_ids': self.reference_ids.ids,
             'propagate_cancel': self.propagate_cancel,
-            'manual_consumption': self.env['stock.move']._determine_is_manual_consumption(bom_line),
         }
         return data
 
@@ -1447,7 +1446,7 @@ class MrpProduction(models.Model):
     def _mark_byproducts_as_produced(self):
         self.move_byproduct_ids.picked = True
 
-    def _set_qty_producing(self, pick_manual_consumption_moves=True):
+    def _set_qty_producing(self, mark_moves_picked=True):
         if self.product_id.tracking == 'serial':
             qty_producing_uom = self.uom_id._compute_quantity(self.qty_producing, self.product_id.uom_id, rounding_method='HALF-UP')
             qty_production_uom = self.uom_id._compute_quantity(self.product_qty, self.product_id.uom_id, rounding_method='HALF-UP')
@@ -1463,17 +1462,14 @@ class MrpProduction(models.Model):
             | self.move_finished_ids.filtered(lambda m: m.product_id != self.product_id or m.product_id.tracking == 'serial')
         ):
             is_byproduct = move in self.move_byproduct_ids
-            # Never update already produced by-product moves.
-            if move.picked and (is_byproduct or move.manual_consumption):
-                continue
-
+            # Never update already picked moves.
             # sudo needed for portal users
-            if move.sudo()._should_bypass_set_qty_producing():
+            if move.picked or move.sudo()._should_bypass_set_qty_producing():
                 continue
 
             new_qty = move.uom_id.round((self.qty_producing - self.qty_produced) * move.unit_factor)
             move._set_quantity_done(new_qty)
-            if (not move.manual_consumption or pick_manual_consumption_moves) \
+            if mark_moves_picked \
                     and move.quantity \
                     and not is_byproduct \
                     and (move.raw_material_production_id or move.product_id.tracking != 'serial'):
@@ -1869,7 +1865,8 @@ class MrpProduction(models.Model):
                 elif line := move.bom_line_id:
                     expected_qty = line.uom_id._compute_quantity(
                         line.product_qty * bom_factors[line.bom_id.id], move.uom_id)
-                picked_qty = move._get_picked_quantity()
+                picked_qty = sum(ml.uom_id._compute_quantity(ml.quantity, move.uom_id, round=False)
+                    for ml in move.move_line_ids)
                 if move.uom_id.compare(picked_qty, expected_qty):
                     issues.append((order, move.product_id, move.uom_id, move, picked_qty, expected_qty))
             # Once we've matched every orphaned BoM line we could match with orphaned moves, we consider
@@ -2304,6 +2301,9 @@ class MrpProduction(models.Model):
         backorders = productions_to_backorder and productions_to_backorder._split_productions()
         backorders = backorders - productions_to_backorder
 
+        for production in self.filtered(lambda p: not p.uom_id.is_zero(production.qty_producing)):
+            production.move_raw_ids.filtered(lambda m: not m.picked).picked = True
+
         productions_not_to_backorder._post_inventory(cancel_backorder=True)
         productions_to_backorder._post_inventory(cancel_backorder=True)
 
@@ -2413,12 +2413,7 @@ class MrpProduction(models.Model):
         self._button_mark_done_sanity_checks()
         production_auto_ids = set()
         for production in self:
-            if not production.uom_id.is_zero(production.qty_producing):
-                production.move_raw_ids.filtered(
-                    lambda move: move.manual_consumption and not move.picked
-                ).picked = True
-                continue
-            if production._auto_production_checks():
+            if production.uom_id.is_zero(production.qty_producing) and production._auto_production_checks():
                 production_auto_ids.add(production.id)
 
         productions_auto = self.env['mrp.production'].browse(production_auto_ids)
@@ -2790,7 +2785,6 @@ class MrpProduction(models.Model):
                 if move_raw.operation_id != bom_line.operation_id:
                     move_raw.operation_id = bom_line.operation_id
                     move_raw.workorder_id = self.workorder_ids.filtered(lambda wo: wo.operation_id == move_raw.operation_id)
-                move_raw.manual_consumption = move_raw._determine_is_manual_consumption(bom_line)
             elif not bom_line:
                 moves_to_unlink |= move_raw
         # Creates a raw moves for each remaining BoM's lines.
@@ -3019,9 +3013,9 @@ class MrpProduction(models.Model):
         for move in self.move_raw_ids:
             if move.state in ('done', 'cancel') or not move.product_uom_qty:
                 continue
-            if move.manual_consumption:
-                if move.has_tracking in ('serial', 'lot') and (not move.picked or any(not line.lot_id for line in move.move_line_ids if line.quantity and line.picked)):
-                    missing_lot_id_products += "\n  - %s" % move.product_id.display_name
+            if move.picked and move.has_tracking in ('serial', 'lot') and \
+                any(not line.lot_id for line in move.move_line_ids if line.quantity and line.picked):
+                missing_lot_id_products += "\n  - %s" % move.product_id.display_name
         if missing_lot_id_products:
             error_msg = _(
                 "You need to supply Lot/Serial Number for products and 'consume' them: %(missing_products)s",

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -57,10 +57,6 @@ class StockMove(models.Model):
         help="The percentage of the final production cost for this by-product. The total of all by-products' cost share must be smaller or equal to 100.")
     product_qty_available = fields.Float('Product On Hand Quantity', related='product_id.qty_available', depends=['product_id'])
     product_virtual_available = fields.Float('Product Forecasted Quantity', related='product_id.virtual_available', depends=['product_id'])
-    manual_consumption = fields.Boolean(
-        'Manual Consumption', compute='_compute_manual_consumption', store=True, readonly=False,
-        help="When activated, then the registration of consumption for that component is recorded manually exclusively.\n"
-             "If not activated, and any of the components consumption is edited manually on the manufacturing order, Odoo assumes manual consumption also.")
 
     @api.depends('product_id.bom_ids', 'product_id.bom_ids.uom_id')
     def _compute_allowed_uom_ids(self):
@@ -74,15 +70,6 @@ class StockMove(models.Model):
         for move in self:
             if move.production_id:
                 move.packaging_uom_id = move.production_id.uom_id
-
-    @api.depends('product_id')
-    def _compute_manual_consumption(self):
-        for move in self:
-            # when computed for new_id in onchange, use value from _origin
-            if move != move._origin:
-                move.manual_consumption = move._origin.manual_consumption
-            elif not move.manual_consumption:
-                move.manual_consumption = move._is_manual_consumption()
 
     @api.depends('raw_material_production_id.location_src_id', 'production_id.location_src_id')
     def _compute_location_id(self):
@@ -215,16 +202,17 @@ class StockMove(models.Model):
     def _onchange_product_uom_qty(self):
         if self.uom_id and self.raw_material_production_id \
             and (self.has_tracking not in ['lot', 'serial']) \
-            and self.state not in ('draft', 'cancel', 'done'):
+            and self.state not in ('draft', 'cancel', 'done') and not self.picked:
             mo = self.raw_material_production_id
             new_qty = self.uom_id.round((mo.qty_producing - mo.qty_produced) * self.unit_factor)
+            self.env = self.env(context=dict(self.env.context, skip_mark_picked=True))
             self.quantity = new_qty
 
-    @api.onchange('quantity', 'uom_id', 'picked')
+    @api.onchange('quantity')
     def _onchange_quantity(self):
         if self.raw_material_production_id and self.uom_id and \
-            not self.uom_id.is_zero(self.quantity) and self.uom_id.compare(self.product_uom_qty, self.quantity) != 0:
-            self.manual_consumption = True
+            not self.env.context.get('skip_mark_picked') \
+            and self.uom_id.compare(self.product_uom_qty, self.quantity) != 0:
             self.picked = True
 
     @api.constrains('quantity', 'raw_material_production_id')
@@ -240,10 +228,8 @@ class StockMove(models.Model):
         - Moves from a copied MO
         - Backorders
         """
-        if self.env.context.get('force_manual_consumption'):
+        if self.env.context.get('force_move_picked'):
             for vals in vals_list:
-                if 'quantity' in vals:
-                    vals['manual_consumption'] = True
                 vals['picked'] = True
         mo_id_to_mo = defaultdict(lambda: self.env['mrp.production'])
         product_id_to_product = defaultdict(lambda: self.env['product.product'])
@@ -282,7 +268,7 @@ class StockMove(models.Model):
 
     def write(self, vals):
         moves_to_update = False
-        if self.env.context.get('force_manual_consumption') and 'quantity' in vals:
+        if self.env.context.get('force_move_picked') and 'quantity' in vals:
             moves_to_update = self.filtered(lambda move: move.product_uom_qty != vals['quantity'])
         if 'product_uom_qty' in vals and 'move_line_ids' in vals:
             # first update lines then product_uom_qty as the later will unreserve
@@ -292,7 +278,7 @@ class StockMove(models.Model):
         old_demand = {move.id: move.product_uom_qty for move in self}
         res = super().write(vals)
         if moves_to_update:
-            moves_to_update.write({'manual_consumption': True, 'picked': True})
+            moves_to_update.write({'picked': True})
         if 'product_uom_qty' in vals and not self.env.context.get('no_procurement', False):
             # when updating consumed qty need to update related pickings
             # context no_procurement means we don't want the qty update to modify stock i.e create new pickings
@@ -328,8 +314,34 @@ class StockMove(models.Model):
         if procurements:
             self.env['stock.rule'].run(procurements)
 
+    def _do_unreserve(self):
+        # Moves with a quantity should be protected from unreservation (similar to picked).
+        # This override is to do that for moves which got updated from updating qty_producing as
+        # they are not marked as picked any more
+        if not self.env.context.get('skip_mo_check'):
+            protected = self.filtered(
+                lambda m: m.raw_material_production_id
+                and not m.picked
+                and m.quantity
+                and m.raw_material_production_id.qty_producing > 0
+            )
+            return super(StockMove, self - protected)._do_unreserve()
+        return super()._do_unreserve()
+
     def _action_assign(self, force_qty=False):
-        res = super(StockMove, self)._action_assign(force_qty=force_qty)
+        # Moves with a quantity should be protected from re-assignation (similar to picked).
+        # This override is to do that for moves which got updated from updating qty_producing as
+        # they are not marked as picked any more
+        if not self.env.context.get('skip_mo_check'):
+            protected = self.filtered(
+                lambda m: m.raw_material_production_id
+                and not m.picked
+                and m.quantity
+                and m.raw_material_production_id.qty_producing > 0
+            )
+            res = super(StockMove, self - protected)._action_assign(force_qty=force_qty)
+        else:
+            res = super()._action_assign(force_qty=force_qty)
         for move in self.filtered(lambda x: x.production_id or x.raw_material_production_id):
             if move.move_line_ids:
                 move.move_line_ids.write({'production_id': move.raw_material_production_id.id,
@@ -394,7 +406,7 @@ class StockMove(models.Model):
             action['name'] = _("Components")
             action['views'] = [(self.env.ref('mrp.view_stock_move_operations_raw').id, 'form')]
             action['context']['show_destination_location'] = False
-            action['context']['force_manual_consumption'] = True
+            action['context']['force_move_picked'] = True
             action['context']['active_mo_id'] = self.raw_material_production_id.id
         elif self.production_id:
             action['name'] = _("Move Byproduct")
@@ -499,7 +511,6 @@ class StockMove(models.Model):
             'state': 'draft' if self.state == 'draft' else 'confirmed',
             'reservation_date': self.reservation_date,
             'date_deadline': self.date_deadline,
-            'manual_consumption': self._is_manual_consumption(),
             'move_orig_ids': [Command.link(m.id) for m in self.mapped('move_orig_ids')],
             'move_dest_ids': [Command.link(m.id) for m in self.mapped('move_dest_ids')],
             'procure_method': self.procure_method,
@@ -647,20 +658,12 @@ class StockMove(models.Model):
             }
         return res
 
-    def _is_manual_consumption(self):
-        self.ensure_one()
-        return self._determine_is_manual_consumption(self.bom_line_id)
-
-    @api.model
-    def _determine_is_manual_consumption(self, bom_line):
-        return bom_line and bom_line.operation_id
-
     def _get_relevant_state_among_moves(self):
         res = super()._get_relevant_state_among_moves()
         if res == 'partially_available'\
                 and self.raw_material_production_id\
                 and all(move.should_consume_qty and move.uom_id.compare(move.quantity, move.should_consume_qty) >= 0
-                        or (move.uom_id.compare(move.quantity, move.product_uom_qty) >= 0 or (move.manual_consumption and move.picked))
+                        or (move.uom_id.compare(move.quantity, move.product_uom_qty) >= 0 or move.picked)
                         for move in self):
             res = 'assigned'
         return res

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -2297,8 +2297,6 @@ class TestBoM(TestMrpCommon):
         mo = mo_form.save()
         mo.action_confirm()
 
-        move_consumed_in_op = mo.move_raw_ids.filtered(lambda m: m.bom_line_id == self.bom_2.bom_line_ids[0])
-        self.assertTrue(move_consumed_in_op.manual_consumption)
         self.bom_2.write({
             'bom_line_ids': [
                 Command.update(self.bom_2.bom_line_ids[0].id, {'operation_id': self.env['mrp.routing.workcenter'].id}),
@@ -2306,7 +2304,6 @@ class TestBoM(TestMrpCommon):
         })
         self.assertTrue(mo.is_outdated_bom)
         mo.action_update_bom()
-        self.assertFalse(move_consumed_in_op.manual_consumption)
 
         self.bom_2.operation_ids.write({
             'name': 'Painting',

--- a/addons/mrp/tests/test_byproduct.py
+++ b/addons/mrp/tests/test_byproduct.py
@@ -91,7 +91,7 @@ class TestMrpByProduct(common.TransactionCase):
         self.assertEqual(consume_move_c.product_uom_qty, 4, "Wrong consumed quantity of product c.")
         self.assertEqual(by_product_move.product_uom_qty, 2, "Wrong produced quantity of sub product.")
 
-        mnf_product_a._post_inventory()
+        mnf_product_a.button_mark_done()
 
         # I see that stock moves of External Hard Disk including Headset USB are done now.
         self.assertFalse(any(move.state != 'done' for move in moves), 'Moves are not done!')
@@ -351,7 +351,7 @@ class TestMrpByProduct(common.TransactionCase):
         mo_form.qty_producing = 2.00
         mo = mo_form.save()
 
-        mo._post_inventory()
+        mo.button_mark_done()
         byproduct_move_line = mo.move_byproduct_ids.move_line_ids
         finished_move_line = mo.move_finished_ids.filtered(lambda m: m.product_id == self.product_a).move_line_ids
         self.assertEqual(byproduct_move_line.location_dest_id, shelf2_location)

--- a/addons/mrp/tests/test_cancel_mo.py
+++ b/addons/mrp/tests/test_cancel_mo.py
@@ -43,35 +43,6 @@ class TestMrpCancelMO(TestMrpCommon):
         self.assertEqual(manufacturing_order.move_finished_ids.state, 'cancel',
             "Cancelled MO finished move must be cancelled as well.")
 
-    def test_cancel_mo_without_routing_3(self):
-        """ Cancel a Manufacturing Order with no routing but some productions
-        after post inventory.
-        """
-        # Create MO
-        manufacturing_order = self.generate_mo()[0]
-        # Produce some quantity (not all to avoid to done the MO when post inventory)
-        mo_form = Form(manufacturing_order)
-        mo_form.qty_producing = 2
-        manufacturing_order = mo_form.save()
-        # Post Inventory
-        manufacturing_order._post_inventory()
-        # Cancel the MO
-        manufacturing_order.action_cancel()
-        # Check MO is marked as done and its SML are done or cancelled
-        self.assertEqual(manufacturing_order.state, 'done', "MO should be in done state.")
-        self.assertEqual(manufacturing_order.move_raw_ids[0].state, 'done',
-            "Due to 'post_inventory', some move raw must stay in done state")
-        self.assertEqual(manufacturing_order.move_raw_ids[1].state, 'done',
-            "Due to 'post_inventory', some move raw must stay in done state")
-        self.assertEqual(manufacturing_order.move_raw_ids[2].state, 'cancel',
-            "The other move raw are cancelled like their MO.")
-        self.assertEqual(manufacturing_order.move_raw_ids[3].state, 'cancel',
-            "The other move raw are cancelled like their MO.")
-        self.assertEqual(manufacturing_order.move_finished_ids[0].state, 'done',
-            "Due to 'post_inventory', a move finished must stay in done state")
-        self.assertEqual(manufacturing_order.move_finished_ids[1].state, 'cancel',
-            "The other move finished is cancelled like its MO.")
-
     def test_unlink_mo(self):
         """ Try to unlink a Manufacturing Order, and check it's possible or not
         depending of the MO state (must be in cancel state to be unlinked, but
@@ -91,10 +62,11 @@ class TestMrpCancelMO(TestMrpCommon):
         mo_form = Form(manufacturing_order)
         mo_form.qty_producing = 2
         manufacturing_order = mo_form.save()
-        # Post Inventory
-        manufacturing_order._post_inventory()
+        backorder_action = manufacturing_order.button_mark_done()
+        backorder = Form(self.env['mrp.production.backorder'].with_context(**backorder_action['context']))
+        backorder.save().action_backorder()
         # Unlink the MO must raises an UserError since it cannot be really cancelled
-        self.assertEqual(manufacturing_order.exists().state, 'progress')
+        self.assertEqual(manufacturing_order.exists().state, 'done')
         with self.assertRaises(UserError):
             manufacturing_order.unlink()
 

--- a/addons/mrp/tests/test_consume_component.py
+++ b/addons/mrp/tests/test_consume_component.py
@@ -248,8 +248,20 @@ class TestConsumeComponent(TestConsumeComponentCommon):
         self.executeConsumptionTriggers(mo_serial)
         self.executeConsumptionTriggers(mo_none)
         self.executeConsumptionTriggers(mo_lot)
-        for mov in mo_all.move_raw_ids:
-            self.assertTrue(mov.picked, "All components should be picked")
+
+        # updating qty_producing by _on_change_producing() or action_generate_serial()
+        # doesn't mark moves as picked but only qty_done to match the qty_consumed
+        should_be_picked_moves = mo_serial[2].move_raw_ids | mo_none[1].move_raw_ids | mo_lot[1].move_raw_ids
+        should_not_be_picked_moves = mo_all.move_raw_ids - should_be_picked_moves
+
+        for move in should_be_picked_moves:
+            self.assertTrue(move.picked)
+
+        for move in should_not_be_picked_moves:
+            self.assertFalse(move.picked)
+
+        for move in mo_all.move_raw_ids:
+            self.assertEqual(move.product_qty, move.quantity)
 
     def test_option_enabled_and_qty_not_available(self):
         """Option enabled, qty not available
@@ -274,10 +286,7 @@ class TestConsumeComponent(TestConsumeComponentCommon):
         self.executeConsumptionTriggers(mo_lot)
 
         for mov in mo_all.move_raw_ids:
-            if mov.has_tracking not in ['lot', 'serial']:
-                self.assertTrue(mov.picked, "components should be picked even without no quantity reserved")
-            else:
-                self.assertEqual(mov.product_qty, mov.quantity, "Done quantity shall be equal to To Consume quantity.")
+            self.assertEqual(mov.product_qty, mov.quantity, "Done quantity should be equal to To Consume quantity.")
 
     def test_option_enabled_and_qty_partially_available(self):
         """Option enabled, qty partially available
@@ -315,15 +324,17 @@ class TestConsumeComponent(TestConsumeComponentCommon):
                 self.executeConsumptionTriggers(mo)
             elif serialTrigger == 1:
                 mo.qty_producing = 1
-                mo._set_qty_producing(False)
+                mo._set_qty_producing()
             elif serialTrigger == 2:
                 mo.action_generate_serial()
 
             for mov in mo.move_raw_ids:
                 if mov.has_tracking not in ['lot', 'serial']:
-                    self.assertTrue(mov.picked, "non tracked components should be picked")
-                else:
-                    self.assertEqual(mov.product_qty, mov.quantity, "Done quantity shall be equal to To Consume quantity.")
+                    if serialTrigger in (None, 2):
+                        self.assertFalse(mov.picked, "components should not be auto-picked via qty_producing or action_generate_serial")
+                    else:
+                        self.assertTrue(mov.picked)
+                self.assertEqual(mov.product_qty, mov.quantity, "Done quantity should be equal to To Consume quantity.")
             mo.action_cancel()
 
         testUnit(self.mo_none_tmpl)
@@ -368,14 +379,14 @@ class TestConsumeComponent(TestConsumeComponentCommon):
         ])
         mo.action_generate_serial()
         self.assertRecordValues(mo.move_raw_ids, [
-            {'should_consume_qty': 3.0, 'quantity': 3.0, 'picked': True, 'lot_ids': []},
+            {'should_consume_qty': 3.0, 'quantity': 3.0, 'picked': False, 'lot_ids': []},
             {'should_consume_qty': 2.0, 'quantity': 0.0, 'picked': False, 'lot_ids': []},
             {'should_consume_qty': 1.0, 'quantity': 0.0, 'picked': False, 'lot_ids': []},
         ])
         self.assertTrue(mo.lot_producing_ids)
         mo.picking_ids.button_validate()
         self.assertRecordValues(mo.move_raw_ids, [
-            {'quantity': 3.0, 'picked': True, 'lot_ids': []},
+            {'quantity': 3.0, 'picked': False, 'lot_ids': []},
             {'quantity': 2.0, 'picked': False, 'lot_ids': lot_1.ids},
             {'quantity': 1.0, 'picked': False, 'lot_ids': lot_2.ids},
         ])
@@ -426,7 +437,7 @@ class TestConsumeComponent(TestConsumeComponentCommon):
         with Form(mo) as mo_form:
             mo_form.qty_producing = 1.0
         self.assertRecordValues(mo.move_raw_ids, [
-            {'should_consume_qty': 1.0, 'quantity': 1.0, 'picked': True},
+            {'should_consume_qty': 1.0, 'quantity': 1.0, 'picked': False},
         ])
         move = self.env['stock.move'].create({
             'product_id': compo2.id,
@@ -438,7 +449,7 @@ class TestConsumeComponent(TestConsumeComponentCommon):
         move.quantity = 1
         move._action_assign()
         self.assertRecordValues(mo.move_raw_ids, [
-            {'should_consume_qty': 1.0, 'quantity': 1.0, 'picked': True},
+            {'should_consume_qty': 1.0, 'quantity': 1.0, 'picked': False},
             {'should_consume_qty': 1.0, 'quantity': 1.0, 'picked': True},
         ])
 

--- a/addons/mrp/tests/test_manual_consumption.py
+++ b/addons/mrp/tests/test_manual_consumption.py
@@ -40,14 +40,12 @@ class TestTourManualConsumption(HttpCase):
 
         self.assertEqual(mo.state, 'confirmed')
         move_nt = mo.move_raw_ids
-        self.assertEqual(move_nt.manual_consumption, False)
         self.assertEqual(move_nt.quantity, 0)
         self.assertFalse(move_nt.picked)
 
         url = f"/odoo/action-mrp.mrp_production_action/{mo.id}"
         self.start_tour(url, "test_mrp_manual_consumption_02", login="admin", timeout=100)
 
-        self.assertEqual(move_nt.manual_consumption, True)
         self.assertEqual(move_nt.picked, True)
         self.assertEqual(move_nt.quantity, 16.0)
 
@@ -84,7 +82,6 @@ class TestManualConsumption(TestMrpCommon):
         component.standard_price = 20
         mo.move_raw_ids.quantity = 2.0
         mo.move_raw_ids.picked = True
-        mo.move_raw_ids.manual_consumption = True
         self.assertEqual(mo.state, 'progress')
         action = mo.button_mark_done()
         consumption_warning = Form(self.env['mrp.consumption.warning'].with_context(**action['context']))
@@ -94,9 +91,9 @@ class TestManualConsumption(TestMrpCommon):
 
     def test_manual_consumption_quantity_change(self):
         """Test manual consumption mechanism.
-        1. Test when a move is manual consumption but NOT picked, quantity will be updated automatically.
-        2. Test when a move is manual consumption but IS picked, quantity will not be updated automatically.
-        3. Test when create backorder, the manual consumption should be set according to the bom.
+        1. Test when a move is NOT picked, quantity will be updated automatically.
+        2. Test when a move is picked, quantity will not be updated automatically.
+        3. Test when create backorder, the moves are not picked (auto updated normally).
         """
         Product = self.env['product.product']
         product_finish = Product.create({
@@ -135,28 +132,29 @@ class TestManualConsumption(TestMrpCommon):
         mo.action_confirm()
         mo.action_assign()
 
-        # After updating qty_producing, quantity changes for both moves, but manual move will remain not picked
+        # After updating qty_producing, None of the moves are picked
         mo_form = Form(mo)
         mo_form.qty_producing = 5
         mo = mo_form.save()
         move_auto, move_manual = get_moves(mo)
-        self.assertEqual(move_auto.manual_consumption, False)
         self.assertEqual(move_auto.quantity, 5)
-        self.assertTrue(move_auto.picked)
-        self.assertEqual(move_manual.manual_consumption, False)
+        self.assertFalse(move_auto.picked)
         self.assertEqual(move_manual.quantity, 5)
-        self.assertTrue(move_manual.picked)
+        self.assertFalse(move_manual.picked)
 
         move_manual.quantity = 6
         move_manual._onchange_quantity()
 
-        # Now we change quantity to 7. Automatic move will change quantity, but manual move will still be 5 because it has been already picked.
+        # Now we change quantity to 7. Automatic move (not picked) will change quantity,
+        # but manual move (picked) will still be 6 because it has been already picked.
         mo_form = Form(mo)
         mo_form.qty_producing = 7
         mo = mo_form.save()
 
         self.assertEqual(move_auto.quantity, 7)
+        self.assertFalse(move_auto.picked)
         self.assertEqual(move_manual.quantity, 6)
+        self.assertTrue(move_manual.picked)
 
         # Bypass consumption issues wizard and create backorders
         action = mo.button_mark_done()
@@ -167,14 +165,14 @@ class TestManualConsumption(TestMrpCommon):
         backorder_form.save().action_backorder()
         backorder = mo.production_group_id.production_ids - mo
 
-        # Check that backorders move have the same manual consumption values as BoM
+        # Check that backorder moves are not picked (not yet consumed)
         move_auto, move_manual = get_moves(backorder)
-        self.assertEqual(move_auto.manual_consumption, False)
-        self.assertEqual(move_manual.manual_consumption, False)
+        self.assertFalse(move_auto.picked)
+        self.assertFalse(move_manual.picked)
 
     def test_update_manual_consumption_00(self):
         """
-        Check that the manual consumption is set to true when the quantity is manualy set.
+        Check that move.picked is set to true when the quantity is manualy set.
         """
         bom = self.bom_1
         components = bom.bom_line_ids.product_id
@@ -184,13 +182,11 @@ class TestManualConsumption(TestMrpCommon):
         mo_form.product_qty = 4
         mo = mo_form.save()
         mo.action_confirm()
-        self.assertEqual(mo.move_raw_ids.mapped('manual_consumption'), [False, False])
         self.assertEqual(components[0].stock_quant_ids.reserved_quantity, 2.0)
         with Form(mo) as fmo:
             with fmo.move_raw_ids.edit(0) as line_0:
                 line_0.quantity = 3.0
                 line_0.picked = True
-        self.assertEqual(mo.move_raw_ids.mapped('manual_consumption'), [True, False])
         self.assertEqual(components[0].stock_quant_ids.reserved_quantity, 3.0)
         mo.button_mark_done()
         self.assertRecordValues(mo.move_raw_ids, [{'quantity': 3.0, 'picked': True}, {'quantity': 4.0, 'picked': True}])
@@ -208,16 +204,14 @@ class TestManualConsumption(TestMrpCommon):
         mo_form.product_qty = 4
         mo = mo_form.save()
         mo.action_confirm()
-        self.assertEqual(mo.move_raw_ids.mapped('manual_consumption'), [False, False])
         self.assertEqual(components[0].stock_quant_ids.reserved_quantity, 2.0)
         with Form(mo) as fmo:
             with fmo.move_raw_ids.edit(0) as line_0:
                 line_0.quantity = 3.0
                 line_0.picked = True
             fmo.qty_producing = 2.0
-        self.assertEqual(mo.move_raw_ids.mapped('manual_consumption'), [True, False])
         self.assertEqual(components[0].stock_quant_ids.reserved_quantity, 3.0)
-        self.assertRecordValues(mo.move_raw_ids, [{'quantity': 3.0, 'picked': True}, {'quantity': 2.0, 'picked': True}])
+        self.assertRecordValues(mo.move_raw_ids, [{'quantity': 3.0, 'picked': True}, {'quantity': 2.0, 'picked': False}])
 
     def test_reservation_state_with_manual_consumption(self):
         """
@@ -251,7 +245,7 @@ class TestManualConsumption(TestMrpCommon):
         of a component move line/quant (without changing the quantity) does not mark it as consumed.
 
         The wizard (opened via 'action_show_details' on move) should only set
-        'manual_consumption' and 'picked' to True when the done quantity(quantity)
+        'picked' to True when the done quantity(quantity)
         differs from the demanded quantity(product_uom_qty).
         """
         bom = self.bom_4
@@ -279,7 +273,7 @@ class TestManualConsumption(TestMrpCommon):
 
         # Initially: not consumed.
         self.assertRecordValues(mo.move_raw_ids, [
-            {"manual_consumption": False, "picked": False, "lot_ids": lots[0].ids},
+            {"picked": False, "lot_ids": lots[0].ids},
         ])
 
         # Change only the lot in the 'Details' wizard, keep quantity unchanged.
@@ -288,9 +282,9 @@ class TestManualConsumption(TestMrpCommon):
                 move_line.lot_id = lots[1]
             wiz_form.save()
 
-        # Still it should not consumed.
+        # Still not consumed since quantity unchanged.
         self.assertRecordValues(mo.move_raw_ids, [
-            {"manual_consumption": False, "picked": False, "lot_ids": lots[1].ids},
+            {"picked": False, "lot_ids": lots[1].ids},
         ])
 
         # Change the quantity in the 'Details' wizard.
@@ -301,7 +295,7 @@ class TestManualConsumption(TestMrpCommon):
 
         # Now it should be marked as consumed, since the done quantity differs from the demand.
         self.assertRecordValues(mo.move_raw_ids, [
-            {"manual_consumption": True, "picked": True, "lot_ids": lots[1].ids},
+            {"picked": True, "lot_ids": lots[1].ids},
         ])
 
     def test_consumption_on_new_move_lines(self):
@@ -323,7 +317,7 @@ class TestManualConsumption(TestMrpCommon):
         mo.action_confirm()
 
         self.assertRecordValues(mo.move_raw_ids, [
-            {"manual_consumption": False, "picked": False},
+            {"picked": False},
         ])
 
         with Form.from_action(self.env, mo.move_raw_ids[0].action_show_details()) as wiz_form:
@@ -333,12 +327,12 @@ class TestManualConsumption(TestMrpCommon):
             wiz_form.save()
 
         self.assertRecordValues(mo.move_raw_ids, [
-            {"manual_consumption": True, "picked": True},
+            {"picked": True},
         ])
 
     def test_manual_consumption_is_false_if_quantity_was_unchanged(self):
         """
-        Check that a move's `manual_consumption` field is only set if the
+        Check that a move is only marked as picked if the
         quantity of the move line was modified.
         """
         product_lot = self.env['product.product'].create({
@@ -374,13 +368,13 @@ class TestManualConsumption(TestMrpCommon):
         with details_form.move_line_ids.edit(0) as move_line:
             move_line.lot_id = lot_2
         move = details_form.save()
-        # Since quantity was unchanged, `manual_consumption` should not be set
-        self.assertFalse(move.manual_consumption)
+        # Since quantity was unchanged, the move should not be picked
+        self.assertFalse(move.picked)
 
         # Use the form again, this time changing the lot and the quantity
         with details_form.move_line_ids.edit(0) as move_line:
             move_line.lot_id = lot_1
             move_line.quantity = 1
         move = details_form.save()
-        # Quantity was modified, so `manual_consumption` should be set
-        self.assertTrue(move.manual_consumption)
+        # Quantity was modified, so the move should be picked
+        self.assertTrue(move.picked)

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -726,76 +726,6 @@ class TestMrpOrder(TestMrpCommon, MailCase):
         with details_operation_form.move_line_ids.edit(0) as ml:
             self.assertEqual(ml.lot_id, remaining_lot)
 
-    def test_product_produce_3(self):
-        """ Checks that, for a BOM where one of the components is tracked by lot and the other is
-        not tracked, when creating a manufacturing order for 1 finished product and reserving, the
-        reserved lines are displayed. Then, over-consume by creating new line.
-        """
-        mo, _, p_final, p1, p2 = self.generate_mo(tracking_base_1='lot', qty_base_1=10, qty_final=1)
-
-        # Required for `lot_producing_ids` to be visible in the view
-        # <field name="lot_producing_ids" invisible="product_tracking in ('none', False)"/>
-        p_final.tracking = 'lot'
-
-        self.assertEqual(len(mo), 1, 'MO should have been created')
-
-        first_lot_for_p1 = self.env['stock.lot'].create({
-            'name': 'lot1',
-            'product_id': p1.id,
-        })
-        second_lot_for_p1 = self.env['stock.lot'].create({
-            'name': 'lot2',
-            'product_id': p1.id,
-        })
-
-        final_product_lot = self.env['stock.lot'].create({
-            'name': 'lot1',
-            'product_id': p_final.id,
-        })
-
-        self.env['stock.quant']._update_available_quantity(p1, self.shelf_1, 3, lot_id=first_lot_for_p1)
-        self.env['stock.quant']._update_available_quantity(p1, self.shelf_2, 3, lot_id=first_lot_for_p1)
-        self.env['stock.quant']._update_available_quantity(p1, self.stock_location, 8, lot_id=second_lot_for_p1)
-        self.env['stock.quant']._update_available_quantity(p2, self.stock_location, 5)
-
-        mo.action_assign()
-        mo_form = Form(mo)
-        mo_form.qty_producing = 1.0
-        mo_form.lot_producing_ids.set(final_product_lot)
-        mo = mo_form.save()
-        # p2
-        details_operation_form = Form(mo.move_raw_ids[0], view=self.env.ref('stock.view_stock_move_operations'))
-        with details_operation_form.move_line_ids.new() as line:
-            line.quantity = 1
-        details_operation_form.save()
-
-        # p1
-        details_operation_form = Form(mo.move_raw_ids[1], view=self.env.ref('stock.view_stock_move_operations'))
-        with details_operation_form.move_line_ids.new() as line:
-            line.quantity = 2
-            line.lot_id = first_lot_for_p1
-        with details_operation_form.move_line_ids.new() as line:
-            line.quantity = 1
-            line.lot_id = second_lot_for_p1
-        details_operation_form.save()
-
-        move_1 = mo.move_raw_ids.filtered(lambda m: m.product_id == p1)
-        # quantity/reserved_uom_qty lot
-        # 3/3 lot 1 shelf 1
-        # 1/1 lot 1 shelf 2
-        # 2/2 lot 1 shelf 2
-        # 2/0 lot 1 other
-        # 5/4 lot 2
-        ml_to_shelf_1 = move_1.move_line_ids.filtered(lambda ml: ml.lot_id == first_lot_for_p1 and ml.location_id == self.shelf_1)
-        ml_to_shelf_2 = move_1.move_line_ids.filtered(lambda ml: ml.lot_id == first_lot_for_p1 and ml.location_id == self.shelf_2)
-
-        self.assertEqual(sum(ml_to_shelf_1.mapped('quantity')), 3.0, '3 units should be took from shelf1 as reserved.')
-        self.assertEqual(sum(ml_to_shelf_2.mapped('quantity')), 3.0, '3 units should be took from shelf2 as reserved.')
-        self.assertEqual(move_1.quantity, 13, 'You should have used the tem units.')
-
-        mo.button_mark_done()
-        self.assertEqual(mo.state, 'done', "Production order should be in done state.")
-
     def test_product_produce_4(self):
         """ Possibility to produce with a given raw material in multiple locations. """
         mo, _, p_final, p1, p2 = self.generate_mo(qty_final=1, qty_base_1=5)
@@ -823,51 +753,6 @@ class TestMrpOrder(TestMrpCommon, MailCase):
 
         mo.button_mark_done()
         self.assertEqual(mo.state, 'done', "Production order should be in done state.")
-
-    def test_product_produce_6(self):
-        """ Plan 5 finished products, reserve and produce 3. Post the current production.
-        Simulate an unlock and edit and, on the opened moves, set the consumed quantity
-        to 3. Now, try to update the quantity to mo2 to 3. It should fail since there
-        are consumed quantities. Unlock and edit, remove the consumed quantities and
-        update the quantity to produce to 3."""
-        mo, bom, p_final, p1, p2 = self.generate_mo()
-        self.assertEqual(len(mo), 1, 'MO should have been created')
-
-        self.env['stock.quant']._update_available_quantity(p1, self.stock_location, 20)
-
-        self.env['stock.quant']._update_available_quantity(p2, self.stock_location, 5)
-        mo.action_assign()
-
-        mo_form = Form(mo)
-        mo_form.qty_producing = 3
-        mo = mo_form.save()
-
-        mo._post_inventory()
-        self.assertEqual(len(mo.move_raw_ids), 4)
-
-        mo.move_raw_ids.filtered(lambda m: m.state != 'done')[0].quantity = 3
-
-        update_quantity_wizard = self.env['change.production.qty'].create({
-            'mo_id': mo.id,
-            'product_qty': 3,
-        })
-
-        mo.move_raw_ids.filtered(lambda m: m.state != 'done')[0].quantity = 0
-        update_quantity_wizard.change_prod_qty()
-
-        self.assertEqual(len(mo.move_raw_ids), 4)
-
-        mo.move_raw_ids.picked = True
-        action = mo.button_mark_done()
-
-        warning = Form(self.env['mrp.consumption.warning'].with_context(**action['context'])).save()
-        self.assertRecordValues(warning.mrp_consumption_warning_line_ids, [
-            {'product_consumed_qty_uom': 0, 'product_expected_qty_uom':  3},
-            {'product_consumed_qty_uom': 0, 'product_expected_qty_uom': 12},
-        ])
-        warning.action_confirm()
-
-        self.assertTrue(all(s in ['done', 'cancel'] for s in mo.move_raw_ids.mapped('state')))
 
     def test_product_produce_7(self):
         """ Plan 2 finished products, reserve and produce 3. Post the current production.
@@ -920,7 +805,6 @@ class TestMrpOrder(TestMrpCommon, MailCase):
         details_operation_form = Form(mo.move_raw_ids[-1], view=self.env.ref('stock.view_stock_move_operations'))
         with details_operation_form.move_line_ids.new() as ml:
             ml.quantity = 1
-            ml.picked = True
         details_operation_form.save()
 
         # Won't accept to be done, instead return a wizard
@@ -2328,6 +2212,7 @@ class TestMrpOrder(TestMrpCommon, MailCase):
         mo = mo_form.save()
         mo.move_raw_ids[0].quantity = 90
         mo.move_raw_ids[1].quantity = 70
+        mo.move_raw_ids.picked = True
         action = mo.button_mark_done()
         warning = Form(self.env['mrp.consumption.warning'].with_context(**action['context'])).save()
         self.assertRecordValues(warning.mrp_consumption_warning_line_ids, [

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -485,15 +485,12 @@
                                     <field name="forecast_expected_date" column_invisible="True"/>
                                     <field name="quantity" string="Consumed"
                                         decoration-success="(state not in ['done', 'cancel']) and (quantity - (should_consume_qty if parent.qty_producing else product_uom_qty) == 0)"
-                                        decoration-warning="(state not in ['done', 'cancel']) and (quantity - (should_consume_qty if parent.qty_producing else product_uom_qty) &gt; 0.0001)"
+                                        decoration-danger="(state not in ['done', 'cancel']) and (quantity - (should_consume_qty if parent.qty_producing else product_uom_qty) &gt; 0)"
+                                        decoration-warning="(state not in ['done', 'cancel']) and (quantity - (should_consume_qty if parent.qty_producing else product_uom_qty) &lt; 0)"
                                         column_invisible="parent.state == 'draft'"
-                                        decoration-info="manual_consumption"
-                                        decoration-muted="not manual_consumption"
-                                        decoration-bf="manual_consumption"
                                         force_save="1"/>
                                     <field name="uom_id" readonly="state != 'draft' and id" options="{'no_open': True, 'no_create': True}" groups="uom.group_uom" widget="many2one_uom"/>
-                                    <field name="picked" column_invisible="True"/>
-                                    <field name="manual_consumption" column_invisible="True" force_save="1"/>
+                                    <field name="picked" optional="hide"/>
                                     <field name="show_details_visible" column_invisible="True"/>
                                     <field name="lot_ids" widget="many2many_tags"
                                         optional="hide"

--- a/addons/mrp/wizard/change_production_qty.py
+++ b/addons/mrp/wizard/change_production_qty.py
@@ -78,7 +78,7 @@ class ChangeProductionQty(models.TransientModel):
             production.write({'product_qty': new_production_qty})
             if not production.uom_id.is_zero(production.qty_producing) and not production.workorder_ids:
                 production.qty_producing = new_production_qty
-                production._set_qty_producing()
+                production._set_qty_producing(False)
 
             for wo in production.workorder_ids:
                 quantity = wo.qty_production - wo.qty_produced

--- a/addons/mrp_account/tests/test_mrp_account.py
+++ b/addons/mrp_account/tests/test_mrp_account.py
@@ -222,6 +222,7 @@ class TestMrpAccountWorkorder(TestBomPriceOperationCommon):
         """
         self.glass.qty_available = 2
         mo = self._create_mo(self.bom_1, 1, confirm=False)
+        mo.move_raw_ids.workorder_id = mo.workorder_ids[0]
 
         # post a WIP for an invalid MO, i.e. draft/cancelled/done results in a "Manual Entry"
         wizard = Form(self.env['mrp.account.wip.accounting'].with_context({'active_ids': [mo.id]}))
@@ -441,7 +442,6 @@ class TestMrpAccountWorkorder(TestBomPriceOperationCommon):
         self.assertEqual(mo.workorder_ids._cal_cost(), 600)
 
         # Cost should stay the same for a done MO if nothing else is changed
-        mo.move_raw_ids.picked = True
         mo.button_mark_done()
         self.workcenter.costs_hour = 333
         self.assertEqual(mo.workorder_ids._cal_cost(), 600)
@@ -454,8 +454,6 @@ class TestMrpAccountWorkorder(TestBomPriceOperationCommon):
         self.assertEqual(workorder._cal_cost(), 600)
         # Simulate missing finished moves
         mo.move_finished_ids.unlink()
-        # Post inventory and complete MO
-        mo.move_raw_ids.picked = True
         mo.button_mark_done()
         self.assertEqual(mo.state, 'done')
 

--- a/addons/mrp_account/tests/test_valuation_layers.py
+++ b/addons/mrp_account/tests/test_valuation_layers.py
@@ -146,14 +146,13 @@ class TestMrpValuationStandard(TestBomPriceCommon):
         self._make_in_move(self.glass, 1, 20)
         mo = self._create_mo(self.bom_1, 2)
         self._produce(mo, 1)
-        mo._post_inventory()
+        action = mo.button_mark_done()
+        backorder = Form(self.env['mrp.production.backorder'].with_context(**action['context']))
+        backorder.save().action_backorder()
+        mo = mo.production_group_id.production_ids[-1]
         self.assertEqual(self.glass.total_value, 20)
         self.assertEqual(self.dining_table.total_value, 8.8)
-        self._produce(mo)
-        warning = Form.from_action(self.env, mo.button_mark_done()).save()
-        for warning_line in warning.mrp_consumption_warning_line_ids:
-            self.assertEqual(warning_line.product_expected_qty_uom, 2 * warning_line.product_consumed_qty_uom)
-        warning.action_confirm()
+        mo.button_mark_done()
         self.assertEqual(self.glass.total_value, 0)
         self.assertEqual(self.dining_table.total_value, 8.8 * 2)
 
@@ -180,14 +179,14 @@ class TestMrpValuationStandard(TestBomPriceCommon):
         self._make_in_move(self.glass, 1)
         mo = self._create_mo(self.bom_1, 2)
         self._produce(mo, 1)
-        mo._post_inventory()
+        action = mo.button_mark_done()
+        backorder = Form(self.env['mrp.production.backorder'].with_context(**action['context']))
+        backorder.save().action_backorder()
+        mo = mo.production_group_id.production_ids[-1]
         self.assertEqual(self.glass.total_value, 100)
         self.assertEqual(self.dining_table.total_value, PRICE + 100)
         self._produce(mo)
-        warning = Form.from_action(self.env, mo.button_mark_done()).save()
-        for warning_line in warning.mrp_consumption_warning_line_ids:
-            self.assertEqual(warning_line.product_expected_qty_uom, 2 * warning_line.product_consumed_qty_uom)
-        warning.action_confirm()
+        mo.button_mark_done()
         self.assertEqual(self.glass.total_value, 0)
         self.assertEqual(self.dining_table.total_value, 2 * (PRICE + 100))
 
@@ -225,14 +224,14 @@ class TestMrpValuationStandard(TestBomPriceCommon):
         self._make_in_move(self.glass, 1)
         mo = self._create_mo(self.bom_1, 2)
         self._produce(mo, 1)
-        mo._post_inventory()
+        action = mo.button_mark_done()
+        backorder = Form(self.env['mrp.production.backorder'].with_context(**action['context']))
+        backorder.save().action_backorder()
+        mo = mo.production_group_id.production_ids[-1]
         self.assertEqual(self.glass.total_value, 100)
         self.assertEqual(self.dining_table.total_value, 1000)
         self._produce(mo)
-        warning = Form.from_action(self.env, mo.button_mark_done()).save()
-        for warning_line in warning.mrp_consumption_warning_line_ids:
-            self.assertEqual(warning_line.product_expected_qty_uom, 2 * warning_line.product_consumed_qty_uom)
-        warning.action_confirm()
+        mo.button_mark_done()
         self.assertEqual(self.glass.total_value, 0)
         self.assertEqual(self.dining_table.total_value, 2000)
 
@@ -258,14 +257,14 @@ class TestMrpValuationStandard(TestBomPriceCommon):
         self._make_in_move(self.glass, 1, 20)
         mo = self._create_mo(self.bom_1, 2)
         self._produce(mo, 1)
-        mo._post_inventory()
+        action = mo.button_mark_done()
+        backorder = Form(self.env['mrp.production.backorder'].with_context(**action['context']))
+        backorder.save().action_backorder()
+        mo = mo.production_group_id.production_ids[-1]
         self.assertEqual(self.glass.total_value, 15)
         self.assertEqual(self.dining_table.total_value, PRICE + 15)
         self._produce(mo)
-        warning = Form.from_action(self.env, mo.button_mark_done()).save()
-        for warning_line in warning.mrp_consumption_warning_line_ids:
-            self.assertEqual(warning_line.product_expected_qty_uom, 2 * warning_line.product_consumed_qty_uom)
-        warning.action_confirm()
+        mo.button_mark_done()
         self.assertEqual(self.glass.total_value, 0)
         self.assertEqual(self.dining_table.total_value, 2 * PRICE + 30)
 

--- a/addons/project_mrp_account/tests/test_analytic_account.py
+++ b/addons/project_mrp_account/tests/test_analytic_account.py
@@ -83,6 +83,10 @@ class TestAnalyticAccount(TestMrpAnalyticAccount):
         mo_form = Form(mo)
         mo_form.qty_producing = 5.0
         mo_form.save()
+        # Setting the move as picked to trigger analytic account lines calculations and
+        # setting it to False again to enable changing move.quantity when changing mo.qty_producing
+        mo.move_raw_ids.picked = True
+        mo.move_raw_ids.picked = False
         self.assertEqual(mo.state, 'progress')
         self.assertEqual(mo.move_raw_ids.analytic_account_line_ids.amount, -50.0)
 
@@ -90,6 +94,10 @@ class TestAnalyticAccount(TestMrpAnalyticAccount):
         mo_form = Form(mo)
         mo_form.qty_producing = 10.0
         mo_form.save()
+        # Setting the move as picked to trigger analytic account lines calculations and
+        # setting it to False again to enable changing move.quantity when changing mo.qty_producing
+        mo.move_raw_ids.picked = True
+        mo.move_raw_ids.picked = False
         mo.workorder_ids.button_finish()
         self.assertEqual(mo.state, 'to_close')
         self.assertEqual(mo.move_raw_ids.analytic_account_line_ids.amount, -100.0)
@@ -117,6 +125,10 @@ class TestAnalyticAccount(TestMrpAnalyticAccount):
         mo_form = Form(mo)
         mo_form.qty_producing = 5.0
         mo_form.save()
+        # Setting the move as picked to trigger analytic account lines calculations and
+        # setting it to False again to enable changing move.quantity when changing mo.qty_producing
+        mo.move_raw_ids.picked = True
+        mo.move_raw_ids.picked = False
         self.assertEqual(mo.state, 'progress')
         self.assertEqual(mo.move_raw_ids.analytic_account_line_ids.amount, -50.0)
 
@@ -360,6 +372,10 @@ class TestAnalyticAccount(TestMrpAnalyticAccount):
         mo_form.qty_producing = 5.0
         mo_form.save()
         self.assertEqual(mo.state, 'progress')
+        # Setting the move as picked to trigger analytic account lines calculations and
+        # setting it to False again to enable changing move.quantity when changing mo.qty_producing
+        mo.move_raw_ids.picked = True
+        mo.move_raw_ids.picked = False
         aal = mo.move_raw_ids.analytic_account_line_ids
         self.assertEqual(len(aal), 1)
         self.assertEqual(sum(aal.mapped('amount')), -50.00)
@@ -368,6 +384,10 @@ class TestAnalyticAccount(TestMrpAnalyticAccount):
         mo_form = Form(mo)
         mo_form.qty_producing = 10.0
         mo_form.save()
+        # Setting the move as picked to trigger analytic account lines calculations and
+        # setting it to False again to enable changing move.quantity when changing mo.qty_producing
+        mo.move_raw_ids.picked = True
+        mo.move_raw_ids.picked = False
         mo.workorder_ids.button_finish()
         aal = mo.move_raw_ids.analytic_account_line_ids
 
@@ -416,6 +436,10 @@ class TestAnalyticAccount(TestMrpAnalyticAccount):
         mo_form = Form(mo)
         mo_form.qty_producing = 5.0
         mo_form.save()
+        # Setting the move as picked to trigger analytic account lines calculations and
+        # setting it to False again to enable changing move.quantity when changing mo.qty_producing
+        mo.move_raw_ids.picked = True
+        mo.move_raw_ids.picked = False
         self.assertEqual(mo.state, 'progress')
         self.assertEqual(self.analytic_account.balance, -50.0)
 
@@ -423,6 +447,8 @@ class TestAnalyticAccount(TestMrpAnalyticAccount):
         mo_form = Form(mo)
         mo_form.qty_producing = 0.0
         mo_form.save()
+        # Setting the move as picked to trigger analytic account lines calculations and
+        mo.move_raw_ids.picked = True
         self.assertEqual(mo.state, 'progress')
         self.assertEqual(self.analytic_account.balance, 0.0)
 

--- a/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
+++ b/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
@@ -334,7 +334,6 @@ class TestAngloSaxonValuationPurchaseMRP(TestStockValuationCommon):
             mo_form = Form(production)
             mo_form.qty_producing = 1
             production = mo_form.save()
-            production._post_inventory()
             production.button_mark_done()
             return production
 

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -457,7 +457,7 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
         mo_form = Form(mnf_product_a)
         mo_form.qty_producing = mo_form.product_qty
         mnf_product_a = mo_form.save()
-        mnf_product_a._post_inventory()
+        mnf_product_a.button_mark_done()
         # Check state of manufacturing order product A.
         self.assertEqual(mnf_product_a.state, 'done', 'Manufacturing order should still be in the progress state.')
         # Check product A avaialble quantity should be 120.


### PR DESCRIPTION
This PR removes the technical field `manual_consumption` logic from mrp.

Before this PR:
If a move is marked as `manual_consumption=True`, its consumed quantity is not automatically updated on the MO. `manual_consumption` logic basically depended on the move being linked to an operation on the bom_line_id.

After this PR: 
No more `manual_consumption` field. A move's consumed quantity is not automatically updated if it's picked. How the move is being picked is the same which is by marking a move as consumed in the shopfloor app, marking a work order that has component moves as done or simply editing the consumed quantity on the MO form or barcode.

Changes in behavior:
- If the move is marked as picked => it's no longer automatically updated.
- Using barcode for mrp: When updating the qty_producing on the finished product, exiting the barcode and entering again => the quantity on the move lines reflect the new changed qty_producing and no more unpicked split move lines are created. However, changing the quantity on the move Lines (instead of the qty_producing) causes the move lines to split as expected [this is not necessarily a limitation but it can be improved if needed].

Enterprise PR: https://github.com/odoo/enterprise/pull/110503
Upgrade PR: https://github.com/odoo/upgrade/pull/9794
Task: 5882264