### PR TITLE
[FIX] account_edi_ubl_cii: add export XML button for non default format

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_move.py
+++ b/addons/account_edi_ubl_cii/models/account_move.py
@@ -59,10 +59,11 @@ class AccountMove(models.Model):
             elif allow_fallback:
                 if (
                     self.partner_id
-                    and (suggested_edi_format := self.commercial_partner_id._get_suggested_ubl_cii_edi_format())
-                    and self._need_ubl_cii_xml(suggested_edi_format)
+                    and (edi_format := self.commercial_partner_id.with_company(self.company_id)
+                        ._get_ubl_cii_edi_format())
+                    and self._need_ubl_cii_xml(edi_format)
                 ):
-                    builder = self.env['res.partner']._get_edi_builder(suggested_edi_format)
+                    builder = self.env['res.partner']._get_edi_builder(edi_format)
                     xml_content, errors = builder._export_invoice(self)
                     filename = builder._export_invoice_filename(self)
                     return {
@@ -76,12 +77,13 @@ class AccountMove(models.Model):
     def get_extra_print_items(self):
         print_items = super().get_extra_print_items()
         posted_moves = self.filtered(lambda move: move.state == 'posted')
-        suggested_edi_formats = {
-            suggested_format
-            for partner in posted_moves.commercial_partner_id
-            if (suggested_format := partner._get_suggested_ubl_cii_edi_format())
+        edi_formats = {
+            edi_format
+            for move in posted_moves
+            if (edi_format := move.commercial_partner_id.with_company(move.company_id)
+                    ._get_ubl_cii_edi_format())
         }
-        if posted_moves.ubl_cii_xml_id or suggested_edi_formats:
+        if posted_moves.ubl_cii_xml_id or edi_formats:
             print_items.append({
                 'key': 'download_ubl',
                 'description': _('Export XML'),

--- a/addons/account_edi_ubl_cii/models/res_partner.py
+++ b/addons/account_edi_ubl_cii/models/res_partner.py
@@ -206,6 +206,10 @@ class ResPartner(models.Model):
                 return min(formats_by_country, key=lambda e: formats_info[e].get('sequence', 100))  # we use a sequence of 100 by default
         return False
 
+    def _get_ubl_cii_edi_format(self):
+        self.ensure_one()
+        return self.invoice_edi_format or self._get_suggested_ubl_cii_edi_format()
+
     def _get_suggested_peppol_edi_format(self):
         self.ensure_one()
         suggested_format = self.commercial_partner_id._get_suggested_ubl_cii_edi_format()

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -512,6 +512,38 @@ comment-->1000.0</TaxExclusiveAmount></xpath>"""
                 (invoices[:2]).ubl_cii_xml_id.mapped('name'),
             )
 
+    def test_export_xml(self):
+        partners = self.env['res.partner'].create([{
+            'name': 'Partner',
+            'country_id': country_id,
+            'invoice_edi_format': edi_format,
+        } for edi_format, country_id in [
+            ('ubl_bis3', self.env.ref('base.hu').id),
+            (False, self.env.ref('base.hu').id),  # HU has no default format
+            (False, self.env.ref('base.nl').id),  # NL should have 'nlcius' as suggested format
+        ]])
+        invoices = [self._create_invoice(partner_id=partner.id, post=True, invoice_line_ids=[
+            self._prepare_invoice_line(product_id=self.product_a.id, price_unit=100)])
+            for partner in partners]
+        print_items = invoices[1].get_extra_print_items()
+        self.assertEqual(print_items, [])
+        print_items = invoices[0].get_extra_print_items()
+        self.assertEqual(
+            print_items[0]['url'],
+            f'/account/download_invoice_documents/{invoices[0].id}/ubl?allow_fallback=true',
+        )
+
+        xml_content = invoices[0]._get_invoice_legal_documents('ubl', allow_fallback=True)
+        xml_etree = self.get_xml_tree_from_string(xml_content['content'].decode()[39:])
+
+        self.assertEqual(
+            xml_etree.find('{*}CustomizationID').text,
+            'urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0',
+        )
+        formats = [move.commercial_partner_id.with_company(move.company_id)
+                    ._get_ubl_cii_edi_format() for move in invoices]
+        self.assertListEqual(formats, ['ubl_bis3', False, 'nlcius'])
+
     def test_payment_means_code_in_facturx_xml(self):
         bank_ing = self.env['res.bank'].create({'name': 'ING', 'bic': 'BBRUBEBB'})
         partner_bank = self.env['res.partner.bank'].create({


### PR DESCRIPTION
Issue:
Export XML button doesn't produce the same file as the send button.

Steps to reproduce:
- Company in Spain with Peppol (work with any Peppol country)
- Partner in Croatia
- Select eInvoice Type as "EU Standard (Peppol Bis 3.0)"
- Create an invoice
- Confirm it
- Click on the Wheel -> Download

Current behavior:
- without l10n_hr_edi: only "PDF" and "PDF without Payment"
- with l10n_hr_edi: "Export XML" appear, but try to create an "ubl_hr" file

Cause:
"Export XML" button appear only if:
- there is a default ubl option for the partner country
- there is an XML attached to the invoice when clicked it exports the corresponding one.

Whereas, the 'send' button rely on:
1) the partner defined edi format,
2) the default ubl option for the partner country
3) "ubl_bis3"

To be noted:
The route to download the XML doesn't keep the context of the active company and fallback to the first allowed company. As invoice_edi_format is company dependent it needs to be exported in the format defined for the company of the invoice.

opw-5943500

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
