### PR TITLE
[FIX] translate.py: translate t-attf- in OWL templates

### DIFF
--- a/odoo/addons/test_tools/tests/test_translate.py
+++ b/odoo/addons/test_tools/tests/test_translate.py
@@ -11,7 +11,7 @@ import io
 
 from odoo.exceptions import UserError
 from odoo.tools import sql
-from odoo.tools.translate import quote, unquote, xml_translate, html_translate, TranslationImporter, TranslationModuleReader
+from odoo.tools.translate import quote, unquote, xml_translate, html_translate, TranslationImporter, TranslationModuleReader, babel_extract_qweb
 from odoo.tests.common import TransactionCase, BaseCase, new_test_user, tagged
 
 _stats_logger = logging.getLogger('odoo.tests.stats')
@@ -410,6 +410,19 @@ class TranslationToolsTestCase(BaseCase):
 
                         <div data-stuff.translate="dog"/>
                     </t>""")
+
+    def test_translate_xml_fstring_in_js(self):
+        file_obj = io.StringIO("""
+        <t t-name="some_owl_template">
+            <img t-attf-title="  Some {{ this.expr1 }} text {{ this.expr2 }}  " />
+            <div t-attf-data-nope="Not translated" title="translated verbatim" />
+        </t>
+        """)
+        results = babel_extract_qweb(file_obj, [], [], {})
+        self.assertEqual(results, [
+            (3, None, 'Some {{0}} text {{1}}', []),
+            (4, None, 'translated verbatim', [])
+        ])
 
     def test_translate_html(self):
         """ Test html_translate(). """

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -140,6 +140,7 @@ OWL_TRANSLATED_ATTRS = {
     "placeholder",
     "title",
 }
+OWL_TRANSLATED_ATTRS.update({f't-attf-{attr}' for attr in OWL_TRANSLATED_ATTRS})
 
 avoid_pattern = re.compile(r"\s*<!DOCTYPE", re.IGNORECASE | re.MULTILINE | re.UNICODE)
 space_pattern = re.compile(r"[\s\uFEFF]*")  # web_editor uses \uFEFF as ZWNBSP
@@ -1114,7 +1115,12 @@ def _extract_translatable_qweb_terms(element, callback):
             is_component = el.tag[0].isupper() or "t-component" in el.attrib or "t-set-slot" in el.attrib
             for attr in el.attrib:
                 if (not is_component and attr in OWL_TRANSLATED_ATTRS) or (is_component and attr.endswith(".translate")):
-                    _push(callback, el.attrib[attr], el.sourceline)
+                    if attr.startswith("t-attf-") and attr in OWL_TRANSLATED_ATTRS:
+                        val = []
+                        translate_format_string_expression(el.attrib[attr], val.append)
+                        _push(callback, val[0], el.sourceline)
+                    else:
+                        _push(callback, el.attrib[attr], el.sourceline)
             _extract_translatable_qweb_terms(el, callback)
         _push(callback, el.tail, el.sourceline)
 


### PR DESCRIPTION
Before this commit, t-attf attributes were not translated in owl templates In odoo, they are since odoo/odoo#201511 (in qweb python that is).

This commit allows for collecting those expression in the translations.

As for the python, expressions are slightly modified. `t-attf-title="Some {{ this.object }} View {{ this.viewId }}"` is transformed into `"Some {{0}} View {{1}}"`

That way, expressions cannot be mistakenly translated in the string received from the translation function.

owl-pr: odoo/owl#1807
task-6033548

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
