### PR TITLE
[FIX] mail: fix read more/less test failure

### DIFF
--- a/addons/mail/static/tests/chatter/web/form_renderer.test.js
+++ b/addons/mail/static/tests/chatter/web/form_renderer.test.js
@@ -263,6 +263,6 @@ test("read more/less should appear only once for the signature", async () => {
     await click(".o-mail-Chatter-sendMessage");
     await insertText(".o-mail-Composer-input", "Example Body");
     await click("[name='open-full-composer']");
-    await contains(".o-mail-Message-body", { text: "Example Body", count: 1 });
+    await contains(".o-mail-Message-body:has(:text('Example Body'))");
     expect(".o-mail-Message .o-signature-container button.o-mail-ellipsis").toHaveCount(1);
 });


### PR DESCRIPTION
Before this commit, test `"read more/less should appear only once for the signature"` failed at the following step:

```
[toBe] expected values to be strictly equal (Failed to find 1 of ".o-mail-Message-body" with text "Example Body" (Timeout of 3 seconds). Found 0 instead.)
```

This happens because message content has "Example Body" in body, but also the "..." of read more/less. "Example Body" is in a text node and it has the "..." button as its sibling, which causes issue with `contains(selector, { text })` helper feature.

This commit fixes the issue by replacing the `{ text }` by equivalent `:has(:text())`, which doesn't struggle with this assertion step.