### PR TITLE
[FIX] hr_holidays_attendance: display "Extra Hours" on Time Off dashboard

### DIFF
--- a/addons/hr_holidays_attendance/models/hr_leave_type.py
+++ b/addons/hr_holidays_attendance/models/hr_leave_type.py
@@ -45,7 +45,7 @@ class HRLeaveType(models.Model):
                         {
                             'remaining_leaves': 0,
                             'virtual_remaining_leaves': employee.sudo().total_overtime,
-                            'max_leaves': 0,
+                            'max_leaves': employee.sudo().total_overtime,
                             'leaves_taken': 0,
                             'virtual_leaves_taken': 0,
                             'closest_allocation_remaining': 0,

--- a/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
+++ b/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
@@ -81,8 +81,10 @@ class TestHolidaysOvertime(TransactionCase):
             self.new_attendance(check_in=datetime(2021, 1, 2, 8), check_out=datetime(2021, 1, 2, 16))
             self.assertEqual(self.employee.total_overtime, 8, 'Should have 8 hours of overtime')
 
-            overtime_leave_data = self.leave_type_no_alloc.get_allocation_data(self.employee)
-            self.assertEqual(overtime_leave_data[self.employee][0][1]['virtual_remaining_leaves'], 8.0)
+            overtime_leave_data = self.leave_type_no_alloc.with_company(self.company).with_context(employee_id=self.employee.id).get_allocation_data_request()
+            self.assertEqual(overtime_leave_data[0][0], "Extra Hours")
+            self.assertEqual(overtime_leave_data[0][1]['virtual_remaining_leaves'], 8.0)
+            self.assertEqual(overtime_leave_data[0][1]['max_leaves'], 8.0)
 
             leave = self.env['hr.leave'].create({
                 'name': 'no overtime',


### PR DESCRIPTION
### Issue:
When an employee has Extra Hours, they are not shown in the dashboard.

### Steps to reproduce:
- Install Attendance and Time off apps
- Create some attendance with extra hours for the employee
- Go to the employee's time off dashboard
- Notice Extra Hours allocation is not shown

## Cause:
The extra hours are added in [`get_allocation_data()`](https://github.com/odoo/odoo/blob/5c3deb11627f4d6762c4994207bd582afb96f064/addons/hr_holidays_attendance/models/hr_leave_type.py#L35-L66), but then they are removed in [`get_allocation_data_request()`](https://github.com/odoo/odoo/blob/5c3deb11627f4d6762c4994207bd582afb96f064/addons/hr_holidays/models/hr_leave_type.py#L489) just before returning because `max_leaves` is zero.

### Solution:
We also set `max_leaves` to `employee.total_overtime`. If the employee doesn't have any extra hours, then it will not display.

opw-5925258