### PR TITLE
[PERF] stock_account: use strict valued locations for valuation

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -360,7 +360,7 @@ class ProductProduct(models.Model):
 
     def _with_valuation_context(self):
         valued_locations = self.env['stock.location'].search([('is_valued_internal', '=', True)])
-        return self.with_context(location=valued_locations.ids, owners=[False, self.env.company.partner_id.id])
+        return self.with_context(location=valued_locations.ids, owners=[False, self.env.company.partner_id.id], strict=True)
 
     def _get_remaining_moves(self):
         moves_qty_by_product = {}

--- a/addons/stock_account/tests/test_lot_valuation.py
+++ b/addons/stock_account/tests/test_lot_valuation.py
@@ -297,6 +297,51 @@ class TestLotValuation(TestStockValuationCommon):
         self.assertEqual(lot4.product_qty, 1)
         self.assertEqual(lot4.total_value, 7)
 
+    def test_lot_qty_in_nested_internal_location(self):
+        """Lot/product valuation should include nested valued internal locations."""
+        shelf1 = self.env['stock.location'].create({
+            'name': 'Shelf 1',
+            'usage': 'internal',
+            'location_id': self.stock_location.id,
+            'company_id': self.company.id,
+        })
+
+        self._make_in_move(self.product, 10, 5, lot_ids=[self.lot1], location_dest_id=shelf1.id)
+        self._make_out_move(self.product, 4, lot_ids=[self.lot1], location_id=shelf1.id)
+
+        self.assertEqual(self.product._with_valuation_context().qty_available, 6)
+        self.assertEqual(self.product.total_value, 30)
+        self.assertEqual(self.lot1.product_qty, 6)
+        self.assertEqual(self.lot1.total_value, 30)
+
+    def test_lot_qty_at_date_in_nested_internal_location(self):
+        """Historical lot/product valuation should keep nested internal locations."""
+        shelf1 = self.env['stock.location'].create({
+            'name': 'Shelf 1',
+            'usage': 'internal',
+            'location_id': self.stock_location.id,
+            'company_id': self.company.id,
+        })
+        date_in = fields.Datetime.now() - timedelta(days=2)
+        date_out = fields.Datetime.now() - timedelta(days=1)
+        after_in = fields.Datetime.to_string(date_in + timedelta(seconds=1))
+        after_out = fields.Datetime.to_string(date_out + timedelta(seconds=1))
+
+        with freeze_time(date_in):
+            self._make_in_move(self.product, 10, 5, lot_ids=[self.lot1], location_dest_id=shelf1.id)
+        with freeze_time(date_out):
+            self._make_out_move(self.product, 4, lot_ids=[self.lot1], location_id=shelf1.id)
+
+        self.assertEqual(self.product._with_valuation_context().with_context(to_date=after_in).qty_available, 10)
+        self.assertEqual(self.product.with_context(to_date=after_in).total_value, 50)
+        self.assertEqual(self.lot1.with_context(to_date=after_in).product_qty, 10)
+        self.assertEqual(self.lot1.with_context(to_date=after_in).total_value, 50)
+
+        self.assertEqual(self.product._with_valuation_context().with_context(to_date=after_out).qty_available, 6)
+        self.assertEqual(self.product.with_context(to_date=after_out).total_value, 30)
+        self.assertEqual(self.lot1.with_context(to_date=after_out).product_qty, 6)
+        self.assertEqual(self.lot1.with_context(to_date=after_out).total_value, 30)
+
     def test_change_standard_price(self):
         """ Changing product's standard price will reevaluate all lots """
         self._make_in_move(self.product, 10, 5, lot_ids=[self.lot1, self.lot2])


### PR DESCRIPTION
To compute the inventory valuation report, stock_account builds a valuation context through `_with_valuation_context()` and passes the valued internal/transit locations to stock quantity computation.

Without `strict=True`, stock quantity domains treat these locations as hierarchical anchors and expand them again through the location tree. This is redundant in this specific call site because `_with_valuation_context()` already provides the valued locations to filter on.

On databases with a large location tree, this extra expansion makes the inventory valuation load much slower than necessary.

Using `strict=True` makes quantity computation use the provided valued locations directly.

### Benchmark:
- active products: 5912
- stock moves: ~785k
- internal locations: 4213

| Before  | After  |
|---------|--------|
| 99.285s | 1.853s |

opw-5944584

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
