### PR TITLE
[FIX] pos_self_order: register sequence number

### DIFF
--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -26,6 +26,7 @@ class PosSelfOrderController(http.Controller):
                 sequence_number = re.findall(r'\d+', ir_sequence_session)[0]
             order_reference = self._generate_unique_id(pos_session.id, pos_config.id, sequence_number, device_type)
             order['pos_reference'] = order_reference
+            order['sequence_number'] = sequence_number
             order['name'] = order_reference
 
         # Create a safe copy of the order with only the necessary fields for order creation to


### PR DESCRIPTION
Currently, all self order orders are showing the same tracking number.

Steps to reproduce:
-------------------
* Open restaurant config and enable self ordering
* Open self in a first private navigator, place an order
> Tracking number shows 500
* Close navigator and open a new one
* Open self, place an order
> Tracking number shows 500

Why the fix:
------------
The line re-introduced was removed here https://github.com/odoo/odoo/commit/f6e94c794c1ac685f1229835279ded5ea686cfad by accident, as the upper versions of the commit are still using it.

opw-6022132