### PR TITLE
[IMP] point_of_sale: reorder products in config

### DIFF
--- a/addons/point_of_sale/models/product_template.py
+++ b/addons/point_of_sale/models/product_template.py
@@ -49,6 +49,13 @@ class ProductTemplate(models.Model):
         copy=False,
     )
 
+    @api.model
+    def set_pos_sequence(self, sequence_by_id):
+        for tmpl_id, sequence in sequence_by_id.items():
+            product_tmpl = self.browse(int(tmpl_id))
+            if product_tmpl.exists():
+                product_tmpl.pos_sequence = sequence
+
     def write(self, vals):
         # Clear empty public description content to avoid side-effects on product page
         # when there is no content to display anyway.

--- a/addons/point_of_sale/static/src/app/components/product_card/product_card.xml
+++ b/addons/point_of_sale/static/src/app/components/product_card/product_card.xml
@@ -4,10 +4,11 @@
     <t t-name="point_of_sale.ProductCard">
         <article tabindex="0"
             role="button"
-            t-attf-class="{{this.props.class}} {{this.props.color ? `o_colorlist_item_color_transparent_${this.props.color}` : ''}} product position-relative btn btn-light d-flex align-items-stretch p-0 rounded-3 text-start cursor-pointer {{ this.props.imgUrl ? 'd-flex align-items-stretch' : ''}} {{ this.props.available ? '' : 'opacity-50' }}"
+            t-attf-class="{{this.props.class}} {{this.props.color ? `o_colorlist_item_color_transparent_${this.props.color}` : ''}} product-sortable product position-relative btn btn-light d-flex align-items-stretch p-0 rounded-3 text-start cursor-pointer {{ this.props.imgUrl ? 'd-flex align-items-stretch' : ''}} {{ this.props.available ? '' : 'opacity-50' }}"
             t-on-keypress="(event) => event.code === 'Space' ? this.props.onClick(event) : ()=>{}"
             t-on-click.stop="this.props.onClick"
             t-att-data-product-id="this.props.productId"
+            t-att-data-pos_sequence="this.props.product.pos_sequence"
             t-attf-aria-labelledby="article_product_{{this.props.productId}}">
             <div t-if="this.props.imageUrl" class="product-img ratio ratio-4x3 rounded-top rounded-3">
                 <img class="w-100 object-fit-cover bg-200 pe-none" t-att-src="this.props.imageUrl" t-att-alt="this.props.name" draggable="false"/>
@@ -33,3 +34,4 @@
         </article>
     </t>
 </templates>
+

--- a/addons/point_of_sale/static/src/app/hooks/long_press_hook.js
+++ b/addons/point_of_sale/static/src/app/hooks/long_press_hook.js
@@ -1,12 +1,12 @@
-import { LONG_PRESS_DURATION } from "@point_of_sale/utils";
+import { LONG_PRESS_DURATION, TOUCH_DELAY } from "@point_of_sale/utils";
 
 export function useLongPress(callback, delay = LONG_PRESS_DURATION) {
     let timer = null;
 
-    function startLongPress(params) {
+    function startLongPress(params, offset = 0) {
         timer = setTimeout(() => {
             callback(params);
-        }, delay);
+        }, delay + offset);
     }
 
     function cancelLongPress() {
@@ -24,7 +24,7 @@ export function useLongPress(callback, delay = LONG_PRESS_DURATION) {
         },
         onMouseUp: cancelLongPress,
         onTouchStart(params) {
-            startLongPress(params);
+            startLongPress(params, TOUCH_DELAY);
         },
         onTouchEnd: cancelLongPress,
         onScroll: cancelLongPress,

--- a/addons/point_of_sale/static/src/app/models/related_models/index.js
+++ b/addons/point_of_sale/static/src/app/models/related_models/index.js
@@ -279,6 +279,7 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
          **/
         toRaw() {
             this.length; // Ensure reactivity when the record map of this model is updated
+            this.lastUpdateDate; // Ensure reactivity when the record fields of this model is updated
             return toRaw(this);
         }
 
@@ -549,6 +550,8 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
                 this[STORE_SYMBOL].remove(record);
                 this[STORE_SYMBOL].add(record);
             }
+
+            this.lastUpdateDate = Date.now();
 
             aggregatedUpdates.fireEventAndDirty({
                 silentModels: opts.silent ? [record.model.name] : [],

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -1,4 +1,4 @@
-import { onWillRender, useLayoutEffect, useState } from "@web/owl2/utils";
+import { onWillRender, useLayoutEffect, useRef, useState } from "@web/owl2/utils";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { useTrackedAsync } from "@point_of_sale/app/hooks/hooks";
@@ -6,6 +6,7 @@ import { useLongPress } from "@point_of_sale/app/hooks/long_press_hook";
 import { useBarcodeReader } from "@point_of_sale/app/hooks/barcode_reader_hook";
 import { _t } from "@web/core/l10n/translation";
 import { usePos } from "@point_of_sale/app/hooks/pos_hook";
+import { user } from "@web/core/user";
 import { Component, onMounted, onWillUnmount } from "@odoo/owl";
 import { CategorySelector } from "@point_of_sale/app/components/category_selector/category_selector";
 import { Input } from "@point_of_sale/app/components/inputs/input/input";
@@ -29,6 +30,7 @@ import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { OptionalProductPopup } from "@point_of_sale/app/components/popups/optional_products_popup/optional_products_popup";
 import { useRouterParamsChecker } from "@point_of_sale/app/hooks/pos_router_hook";
 import { debounce } from "@web/core/utils/timing";
+import { useSortable } from "@web/core/utils/sortable_owl";
 
 const { DateTime } = luxon;
 
@@ -125,13 +127,79 @@ export class ProductScreen extends Component {
             },
             () => [this.currentOrder, this.currentOrder.totalQuantity]
         );
+
+        this.canReorderProducts = false;
+        Promise.resolve(user.checkAccessRight("product.template", "write")).then((hasAccess) => {
+            this.canReorderProducts = hasAccess;
+        });
+
+        useSortable({
+            ref: useRef("productsRoot"),
+            elements: ".product-sortable",
+            cursor: "move",
+            tolerance: 10,
+            connectGroups: false,
+            enable: () => this.canReorderProducts,
+            preventDrag: (element) => isNaN(Number(element.dataset.productId)),
+            onDragStart: () => {
+                this.longPressHandlers.onMouseUp();
+                this.longPressHandlers.onTouchEnd();
+            },
+            onDrop: async (params) => this._sortDrop(params),
+        });
     }
 
-    onMouseDown(event, product) {
-        this.longPressHandlers.onMouseDown(event, product);
+    async _sortDrop({ element, previous, next }) {
+        const elementId = Number(element.dataset.productId);
+        if (isNaN(elementId)) {
+            return;
+        }
+        let currentSeq = 0;
+        while (previous) {
+            if (previous.dataset.pos_sequence) {
+                currentSeq = Number(previous.dataset.pos_sequence) + 1;
+                break;
+            }
+            previous = previous.previousElementSibling;
+        }
+        if (!currentSeq) {
+            currentSeq = 1;
+        }
+
+        const sequenceById = { [elementId]: currentSeq };
+
+        while (next) {
+            if (next == element) {
+                next = next.nextElementSibling;
+            }
+            const nextSeq = Number(next.dataset.pos_sequence);
+            if (nextSeq > currentSeq) {
+                break;
+            }
+            currentSeq += 1;
+            const nextId = Number(next.dataset.productId);
+            if (!isNaN(nextId)) {
+                sequenceById[nextId] = currentSeq;
+            }
+            next = next.nextElementSibling;
+        }
+
+        // Force a rerender on the screen
+        for (const [id, seq] of Object.entries(sequenceById)) {
+            const record = this.pos.models["product.template"].get(Number(id));
+            record?.update({ pos_sequence: seq });
+        }
+        await this.pos.data.call("product.template", "set_pos_sequence", [sequenceById]);
     }
 
-    onTouchStart(product) {
+    onPointerDown(event, product) {
+        if (isNaN(Number(product.id))) {
+            return;
+        }
+        if (event.pointerType == "mouse") {
+            this.longPressHandlers.onMouseDown(event, product);
+            return;
+        }
         this.longPressHandlers.onTouchStart(product);
     }
 

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
@@ -26,7 +26,7 @@
                 <div class="position-relative d-flex flex-column flex-grow-1 overflow-hidden">
                     <CategorySelector t-if="this.pos.productToDisplayByCateg.length > 0 and (!this.ui.isSmall || !this.pos.scanning)" />
                     <BarcodeVideoScanner t-if="this.pos.scanning" t-props="this.barcodeVideoScannerProps" />
-                    <div t-elif="this.pos.productToDisplayByCateg.length > 0" class="overflow-y-auto" t-on-scroll="this.onScroll">
+                    <div t-elif="this.pos.productToDisplayByCateg.length > 0" t-ref="productsRoot" class="overflow-y-auto" t-on-scroll="this.onScroll">
                         <div t-foreach="this.pos.productToDisplayByCateg" t-as="productCateg" t-key="productCateg[0]" class="product-list d-grid gap-1 gap-lg-2 px-2 py-2">
                             <ProductCard
                                 t-foreach="productCateg[1]" t-as="product" t-key="product.id"
@@ -38,10 +38,8 @@
                                 color="product.color || product.pos_categ_ids?.at(-1)?.color"
                                 imageUrl="this.pos.config.show_product_images and this.getProductImage(product)"
                                 onClick.bind="() => this.addProductToOrder(product)"
-                                t-on-mousedown="(event) => this.onMouseDown(event, product)"
-                                t-on-mouseup="this.longPressHandlers.onMouseUp"
-                                t-on-touchstart="(event) => this.onTouchStart(product)"
-                                t-on-touchend="this.longPressHandlers.onTouchEnd"
+                                t-on-pointerdown="(event) => this.onPointerDown(event, product)"
+                                t-on-pointerup="longPressHandlers.onMouseUp"
                                 productCartQty="this.state.quantityByProductTmplId[product.id]" />
                         </div>
                     </div>

--- a/addons/point_of_sale/static/src/utils.js
+++ b/addons/point_of_sale/static/src/utils.js
@@ -175,6 +175,7 @@ export function isValidEmail(email) {
 }
 
 export const LONG_PRESS_DURATION = session.test_mode ? 100 : 500;
+export const TOUCH_DELAY = session.test_mode ? 50 : 300;
 
 export async function getImageDataUrl(imageUrl) {
     const res = await fetch(imageUrl);

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
@@ -1017,8 +1017,8 @@ export function longPressProduct(productName) {
             content: `Long pressing product "${productName}"...`,
             trigger: `.product-list .product-name:contains("${productName}")`,
             run: async (el) => {
-                const mouseDown = new MouseEvent("mousedown", { bubbles: true });
-                const mouseUp = new MouseEvent("mouseup", { bubbles: true });
+                const mouseDown = new MouseEvent("pointerdown", { bubbles: true });
+                const mouseUp = new MouseEvent("pointerup", { bubbles: true });
                 el.anchor.dispatchEvent(mouseDown);
                 await new Promise((resolve) => setTimeout(resolve, LONG_PRESS_DURATION + 50));
                 el.anchor.dispatchEvent(mouseUp);

--- a/addons/point_of_sale/static/tests/unit/components/product_screen.test.js
+++ b/addons/point_of_sale/static/tests/unit/components/product_screen.test.js
@@ -1,34 +1,44 @@
 import { test, expect } from "@odoo/hoot";
-import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { pointerDown, pointerUp, queryAll, queryOne } from "@odoo/hoot-dom";
+import { advanceTime, animationFrame } from "@odoo/hoot-mock";
+import {
+    contains,
+    mountWithCleanup,
+    onRpc,
+    patchWithCleanup,
+} from "@web/../tests/web_test_helpers";
 import { setupPosEnv } from "../utils";
 import { ProductScreen } from "@point_of_sale/app/screens/product_screen/product_screen";
 import { definePosModels } from "../data/generate_model_definitions";
+import { LONG_PRESS_DURATION, TOUCH_DELAY } from "@point_of_sale/utils";
 
 definePosModels();
 
-test("_getProductByBarcode", async () => {
+async function mountProductScreen() {
     const store = await setupPosEnv();
     store.addNewOrder();
     const order = store.getOrder();
-    const comp = await mountWithCleanup(ProductScreen, { props: { orderUuid: order.uuid } });
-    await comp.addProductToOrder(store.models["product.template"].get(5));
+    const productScreen = await mountWithCleanup(ProductScreen, {
+        props: { orderUuid: order.uuid },
+    });
+    return { store, order, productScreen };
+}
+
+test("_getProductByBarcode", async () => {
+    const { store, order, productScreen } = await mountProductScreen();
+    await productScreen.addProductToOrder(store.models["product.template"].get(5));
 
     expect(order.displayPrice).toBe(3.45);
-    expect(comp.total).toBe("$\u00a03.45");
-    expect(comp.items).toBe("1");
+    expect(productScreen.total).toBe("$\u00a03.45");
+    expect(productScreen.items).toBe("1");
 
-    const productByBarcode = await comp._getProductByBarcode({ base_code: "test_test" });
+    const productByBarcode = await productScreen._getProductByBarcode({ base_code: "test_test" });
     expect(productByBarcode.id).toEqual(5);
 });
 
 test("fastValidate", async () => {
-    const store = await setupPosEnv();
-    store.addNewOrder();
-    const order = store.getOrder();
+    const { store, order, productScreen } = await mountProductScreen();
     const fastPaymentMethod = order.config.fast_payment_method_ids[0];
-    const productScreen = await mountWithCleanup(ProductScreen, {
-        props: { orderUuid: order.uuid },
-    });
     await productScreen.addProductToOrder(store.models["product.template"].get(5));
 
     expect(order.displayPrice).toBe(3.45);
@@ -40,4 +50,82 @@ test("fastValidate", async () => {
     expect(order.payment_ids[0].payment_method_id).toEqual(fastPaymentMethod);
     expect(order.state).toBe("paid");
     expect(order.amount_paid).toBe(3.45);
+});
+
+test("long press on a product opens the product info popup", async () => {
+    const { store } = await mountProductScreen();
+
+    patchWithCleanup(store, {
+        async onProductInfoClick(product) {
+            expect.step(`product-info:${product.id}`);
+        },
+    });
+
+    const product = queryOne('.product-sortable[data-product-id="5"]');
+    await pointerDown(product);
+    await advanceTime(LONG_PRESS_DURATION + TOUCH_DELAY + 5);
+    await pointerUp(product);
+    expect.verifySteps(["product-info:5"]);
+});
+
+test("simple click on a product adds it to the cart", async () => {
+    const { store, order } = await mountProductScreen();
+
+    patchWithCleanup(store, {
+        async onProductInfoClick(product) {
+            expect.step(`product-info:${product.id}`);
+        },
+    });
+
+    await contains('.product-sortable[data-product-id="5"]').click();
+
+    expect(order.lines).toHaveLength(1);
+    expect(order.lines[0].product_id.product_tmpl_id.id).toBe(5);
+    expect.verifySteps([]);
+});
+
+test("drag and drop reorders products", async () => {
+    const getRenderedProductIds = () =>
+        queryAll(".product-sortable").map((product) => Number(product.dataset.productId));
+
+    const { store } = await mountProductScreen();
+    const products = store.models["product.template"];
+    const categoryTwoProducts = products
+        .getAll()
+        .filter((product) => product.pos_categ_ids.some((category) => category.id === 2));
+
+    for (const [index, product] of categoryTwoProducts.entries()) {
+        product.update({ is_favorite: false, pos_sequence: 100 + index });
+    }
+    products.get(6).update({ pos_sequence: 10 });
+    products.get(8).update({ pos_sequence: 20 });
+    products.get(9).update({ pos_sequence: 30 });
+    products.get(7).update({ pos_sequence: 40 });
+    store.setSelectedCategory(2);
+    await animationFrame();
+
+    onRpc("product.template", "set_pos_sequence", (params) => {
+        const sequenceById = params.args[0];
+        for (const [id, seq] of Object.entries(sequenceById)) {
+            expect.step(`product.template:${id}:${seq}`);
+        }
+        return true;
+    });
+
+    const initialRenderedIds = getRenderedProductIds();
+    expect(initialRenderedIds.indexOf(6)).toBeLessThan(initialRenderedIds.indexOf(8));
+    expect(initialRenderedIds.indexOf(8)).toBeLessThan(initialRenderedIds.indexOf(9));
+    expect(initialRenderedIds.indexOf(9)).toBeLessThan(initialRenderedIds.indexOf(7));
+
+    await contains('.product-sortable[data-product-id="6"]').dragAndDrop(
+        '.product-sortable[data-product-id="8"]'
+    );
+    await animationFrame();
+
+    expect.verifySteps(["product.template:6:21"]);
+    const reorderedIds = getRenderedProductIds();
+    expect(reorderedIds.indexOf(8)).toBeLessThan(reorderedIds.indexOf(6));
+    expect(reorderedIds.indexOf(6)).toBeLessThan(reorderedIds.indexOf(9));
+    expect(reorderedIds.indexOf(9)).toBeLessThan(reorderedIds.indexOf(7));
+    expect(products.get(6).pos_sequence).toBe(21);
 });

--- a/addons/point_of_sale/static/tests/unit/utils.js
+++ b/addons/point_of_sale/static/tests/unit/utils.js
@@ -32,8 +32,10 @@ export const setupPosEnv = async () => {
     store.setCashier(store.user);
     patchWithCleanup(user, {
         // Needed for the allowProductCreation method
+        // and for product reorder in the frontend
         checkAccessRight: (model, operation) =>
-            operation === "create" && model === "product.product",
+            (operation === "create" && model === "product.product") ||
+            (operation === "write" && model === "product.template"),
     });
     return store;
 };


### PR DESCRIPTION
The only way to order products on the POS right now is through going on the product list view and dragging the sequence there.

This commit will add the possibility to click and drag products directly on the config front end to reorder them.

Task-[6010096](https://www.odoo.com/odoo/project/1737/tasks/6010096)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
