### PR TITLE
[IMP] account_edi_ubl_cii: make ZUGFeRD attachment filename configurable

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_move_send.py
+++ b/addons/account_edi_ubl_cii/models/account_move_send.py
@@ -190,7 +190,9 @@ class AccountMoveSend(models.AbstractModel):
 
         attachment_name = 'factur-x.xml'
         if invoice.commercial_partner_id.country_code == 'DE' and invoice.commercial_partner_id.peppol_eas != '0204':
-            attachment_name = 'zugferd.xml'
+            attachment_name = self.env['ir.config_parameter'].sudo().get_param(
+                'account_edi_ubl_cii.zugferd_filename'
+            ) or 'zugferd.xml'
 
         writer.addAttachment(attachment_name, xml_facturx, subtype='text/xml')
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Some EDI validators require specific attachment filenames for embedded ZUGFeRD XML in PDF/A-3 (e.g. 'zugferd-invoice.xml') instead of the current hardcoded 'zugferd.xml'.

Current behavior before PR:
Currently, the filename for ZUGFeRD in Odoo is hardcoded in the PDF embedding logic.

Desired behavior after PR is merged:
This change introduces a system parameter allowing administrators to override the filename:
- account_edi_ubl_cii.zugferd_filename

Default value remains 'zugferd.xml' to preserve existing behavior and ensure all tests continue to pass. Factur-X filenames (factur-x.xml) are unaffected.

This makes the attachment filename flexible for organizations with validator requirements without breaking backward compatibility.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
