### PR TITLE
[FIX] account_edi_ubl_cii: Hungary cannot send invoices to NAV

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -1330,14 +1330,18 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
         commercial_partner = partner.commercial_partner_id
 
         if commercial_partner.vat and commercial_partner.vat != '/':
+            vat = commercial_partner.vat
             country_code = commercial_partner.country_id.code
             if country_code in GST_COUNTRY_CODES:
                 tax_scheme_id = 'GST'
             else:
                 tax_scheme_id = 'VAT'
 
+            if country_code == 'HU' and not vat.upper().startswith('HU'):
+                vat = 'HU' + vat[:8]
+
             nodes.append({
-                'cbc:CompanyID': {'_text': commercial_partner.vat},
+                'cbc:CompanyID': {'_text': vat},
                 'cac:TaxScheme': {
                     'cbc:ID': {'_text': tax_scheme_id},
                 },


### PR DESCRIPTION
Problem
---------
When building the UBL, invoices with Hungarian partners get hit with the following constains: "The VAT of the [role] should be prefixed by the country code". However, Hungary allows for VAT numbers that do no start with the country code. Every Hungarian business is assigned a Tax Number (Adószám) that follows a fixed 11-digit format: NNNNNNNN-Y-CC.

Solution
---------
Build the VAT number from the Domestic Tax Number if it is not the case.

no-task

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
