### PR TITLE
[FIX] mass_mailing: fix theme selector flickering

### DIFF
--- a/addons/mail/static/src/scss/convert_inline.scss
+++ b/addons/mail/static/src/scss/convert_inline.scss
@@ -1,0 +1,4 @@
+.o-convert-inline {
+    overflow: hidden;
+    position: relative;
+}

--- a/addons/mass_mailing/static/src/themes/theme_selector/theme_selector.js
+++ b/addons/mass_mailing/static/src/themes/theme_selector/theme_selector.js
@@ -13,6 +13,7 @@ import { useThrottleForAnimation } from "@web/core/utils/timing";
 import { effect } from "@web/core/utils/reactive";
 import { KeepLast } from "@web/core/utils/concurrency";
 import { _t } from "@web/core/l10n/translation";
+import { closestScrollableY } from "@web/core/utils/scrolling";
 
 export class ThemeSelector extends Component {
     static template = "mass_mailing.ThemeSelector";
@@ -73,7 +74,25 @@ export class ThemeSelector extends Component {
             const height = Math.trunc(
                 this.themeSelectorWrapperRef.el.getBoundingClientRect().height
             );
-            iframe.style.height = height + "px";
+
+            // If reducing the size of the frame would cause the scrollable element to become unscrollable,
+            // then we don't resize the frame down to avoid flickering on Chromium-based browsers.
+            const scrollable = closestScrollableY(iframe);
+            const scrollableRange = scrollable
+                ? scrollable.scrollHeight - scrollable.clientHeight
+                : 0;
+            let adjustHeight = true;
+            if (
+                scrollable &&
+                iframe.style.height &&
+                iframe.clientHeight - height >= scrollableRange &&
+                iframe.clientHeight - height - scrollableRange < 20
+            ) {
+                adjustHeight = false;
+            }
+            if (adjustHeight) {
+                iframe.style.height = height + "px";
+            }
         });
         onMounted(() => {
             this.htmlResizeObserver = new ResizeObserver(this.throttledResize);


### PR DESCRIPTION
In Chromium-based browsers, the mass_mailing theme selector attempts
to resize the mass_mailing iframe to match the size of the theme
selector wrapper. This allows the theme selector to take as much screen
space as possible while reducing unnecessary scrollbars.

However, the resizing may cause "scrollbar flickering" issues on
Chromium-based browsers, due to Chromium scrollbars taking up "physical"
width to the right of the scrollable elements. In some instances, a
scrollbar appearing causes the theme selector to scale down from the
lost width just enough that this scrollbar becomes no longer necessary,
causing the theme selector to be resized up, causing the scrollbar to
appear, which causes the theme selector to scale down...

Steps to reproduce:

- On a Chromium-based browser, try to create a new mass_mailing.
- Resize the window's height so that the bottom of the window almost
  touches the bottom of the form.

Fix:

The theme selector will no longer resize itself down if that resize were
to remove scrolling from the form, except in the following edge case:

If the difference between the ranges is larger than 20 pixels
(arbitrary value), we resize anyways, as it's a large enough difference
that it shouldn't trigger flickering.

This prevents occasional oversized empty areas under the theme selector
when a fullscreen window gets sized down

--

10156c10b09dc502a40253d64e2505e817a520bf removed the overflow: hidden; property
away from the body.o_web_client element. As a result, the convert_inline
iframe is able to affect the total height of the page when its height
is higher than the page's height, resulting in the entire page
seeming to have additional padding at the bottom. This is especially
visible when convert_inline has been used at least once, as the iframe
will have a height of 1300px.

This commit adds overflow: hidden; and position: relative; styles to
the convert_inline component div, removing them from view while still
allowing the inlining process to proceed.

Steps to reproduce:
- Create a new mailing
- Select the Events theme
- Reduce window size to below ~1000 px
- Scroll down

task-6002993