### PR TITLE
[FIX] website_sale: archive guests only for automatic invoices

### DIFF
--- a/addons/website_sale/models/payment_transaction.py
+++ b/addons/website_sale/models/payment_transaction.py
@@ -6,8 +6,9 @@ from odoo import models
 class PaymentTransaction(models.Model):
     _inherit = 'payment.transaction'
 
-    def _check_amount_and_confirm_order(self):
+    def _send_invoice(self):
         """Override of `sale` to archive guest contacts."""
-        confirmed_orders = super()._check_amount_and_confirm_order()
-        confirmed_orders.filtered('website_id')._archive_partner_if_no_user()
-        return confirmed_orders
+        super()._send_invoice()
+        self.sale_order_ids.filtered(
+            lambda so: so.state == "sale" and so.website_id
+        )._archive_partner_if_no_user()

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -915,13 +915,29 @@ class SaleOrder(models.Model):
         self._recompute_prices()
 
     def _validate_order(self):
-        self.filtered('website_id')._archive_partner_if_no_user()
         super()._validate_order()
+        # After SO confirmation and email sending, archive customers without accounts
+        self.filtered('website_id')._archive_partner_if_no_user()
 
     def _archive_partner_if_no_user(self):
+        """Archive SO customer if it has no linked users."""
+        if (
+            not self
+            .env["ir.config_parameter"]
+            .sudo()
+            .get_bool("website_sale.automatic_archiving_of_guest_contacts", True)
+        ):
+            return
         partners_to_archive = self.env['res.partner']
         for order in self:
-            if not (commercial_partner := order.partner_id).user_ids:
-                partners_to_archive |= commercial_partner + commercial_partner.child_ids
+            if (
+                not (customer := order.partner_id.user_ids)
+                and not (commercial_partner := order.partner_id.commercial_partner_id).user_ids
+            ):
+                partners_to_archive |= (
+                    commercial_partner
+                    | commercial_partner.child_ids
+                    | customer.child_ids
+                )
 
         partners_to_archive.active = False

--- a/addons/website_sale/tests/test_cart_payment.py
+++ b/addons/website_sale/tests/test_cart_payment.py
@@ -24,7 +24,7 @@ class WebsiteSaleCartPayment(PaymentHttpCommon, WebsiteSaleCommon):
             'provider_id': cls.provider.id,
             'reference': cls.reference,
             'operation': 'online_redirect',
-            'partner_id': cls.partner.id,
+            'partner_id': cls.cart.partner_id.id,
         })
         cls.cart.write({'transaction_ids': [Command.set([cls.tx.id])]})
 
@@ -80,3 +80,23 @@ class WebsiteSaleCartPayment(PaymentHttpCommon, WebsiteSaleCommon):
                 salesperson,
                 "Salesperson should get assigned when sending payment confirmation mail",
             )
+
+    def test_payment_archives_customer_if_automatic_invoice(self):
+        # Async emails must be disabled otherwise invoice (and partner archiving) will be handled in
+        # a cron.
+        self.env["ir.config_parameter"].set_bool("sale.async_emails", False)
+        self.env["ir.config_parameter"].set_bool("sale.automatic_invoice", True)
+        self.tx._set_done()
+        self.tx._post_process()
+        self.assertFalse(self.cart.partner_id.active)
+
+    def test_payment_doesnt_archive_partner_if_manual_invoicing(self):
+        """Customers shouldn't be archived if automatic invoice is disabled, otherwise their address
+        won't be considered when sending the invoice later on."""
+        # Async emails must be disabled otherwise invoice (and partner archiving) will be handled in
+        # a cron.
+        self.env["ir.config_parameter"].set_bool("sale.async_emails", False)
+        self.env["ir.config_parameter"].set_bool("sale.automatic_invoice", False)
+        self.tx._set_done()
+        self.tx._post_process()
+        self.assertTrue(self.cart.partner_id.active)

--- a/addons/website_sale/tests/test_sale_order.py
+++ b/addons/website_sale/tests/test_sale_order.py
@@ -63,3 +63,43 @@ class TestSaleOrder(WebsiteSaleCommon):
             self.cart.website_id,
             invoice.website_id,
         )
+
+    def test_unregistered_customer_archiving(self):
+        self.cart._archive_partner_if_no_user()
+        self.assertFalse(self.cart.partner_id.active)
+
+        # Customers with parent company record (if a parent_name is provided)
+        customer = self.env["res.partner"].create({"parent_name": "Company", "name": "Cuzco"})
+        billing = self.env["res.partner"].create({
+            "parent_id": customer.parent_id.id,
+            "type": "invoice",
+            "name": "Cuzco Billing",
+        })
+        cart = self._create_so(partner_id=customer.id)
+        self.assertEqual(cart.partner_invoice_id, billing)
+
+        cart._archive_partner_if_no_user()
+        self.assertFalse(customer.active)
+        self.assertFalse(billing.active)
+        self.assertFalse(customer.parent_id.active)
+
+        # Customers without a parent company.
+        customer = self.env["res.partner"].create({"name": "Simple"})
+        billing = self.env["res.partner"].create({
+            "parent_id": customer.id,
+            "type": "invoice",
+            "name": "Simple Billing",
+        })
+        cart = self._create_so(partner_id=customer.id)
+        self.assertEqual(cart.partner_invoice_id, billing)
+
+        cart._archive_partner_if_no_user()
+        self.assertFalse(customer.active)
+        self.assertFalse(billing.active)
+
+    def test_customer_archiving_if_has_user(self):
+        self._create_new_portal_user(login="whatever", partner_id=self.cart.partner_id.id)
+        self.cart._archive_partner_if_no_user()
+        self.assertTrue(
+            self.cart.partner_id.active, "Registered customers shouldn't be archived on payment"
+        )


### PR DESCRIPTION
Before this fix, when automatic invoicing was disabled, manually sending an invoice by email resulted in an empty "Send To" field because the guest contact had already been archived.

To prevent this issue, guest archiving is now triggered only when automatic invoicing is enabled.

Additionally, to avoid problems with email delivery, the guest is archived only after the invoice has been sent. This ensures that the email generation process sees the guest as active. If the guest were archived immediately after the Sales Order confirmation, the email generation logic in `mail_thread.py` would skip the archived partner (`pdata['active'] is False`), preventing the invoice email from being sent.