### PR TITLE
Restore previews in `ButtonStyleOption`

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.scss
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.scss
@@ -101,7 +101,7 @@
     }
 
     .o-hb-edit-color-combination {
-        color: $o-we-item-clickable-color;
+        color: $o-we-color-global;
         border: none;
 
         &:hover {

--- a/addons/html_builder/static/src/plugins/border_configurator_option.js
+++ b/addons/html_builder/static/src/plugins/border_configurator_option.js
@@ -10,6 +10,7 @@ export class BorderConfigurator extends BaseOptionComponent {
         withRoundCorner: { type: Boolean, optional: true },
         withBSClass: { type: Boolean, optional: true },
         action: { type: String, optional: true },
+        level: { type: Number, optional: true },
     };
     static defaultProps = {
         withRoundCorner: true,

--- a/addons/html_builder/static/src/plugins/border_configurator_option.xml
+++ b/addons/html_builder/static/src/plugins/border_configurator_option.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="html_builder.BorderConfiguratorOption">
-    <BuilderRow label="this.props.label">
+    <BuilderRow label="this.props.label" level="this.props.level">
         <BuilderNumberInput action="this.props.action" actionParam="{ mainParam: this.getStyleActionParam('width'), extraClass: this.props.withBSClass and 'border' }" unit="'px'" min="0" composable="true"/>
         <BuilderSelect action="this.props.action" actionParam="this.getStyleActionParam('style')" t-if="this.state.hasBorder">
             <BuilderSelectItem title.translate="Solid" actionValue="'solid'"><div class="o-hb-border-preview" style="border-style: solid;"/></BuilderSelectItem>
@@ -17,7 +17,7 @@
     </BuilderRow>
 
     <!-- TODO: handle the dependency with border_width_opt bg_color_opt-->
-    <BuilderRow t-if="this.props.withRoundCorner and this.state.hasBorder" label.translate="Round Corners">
+    <BuilderRow t-if="this.props.withRoundCorner and this.state.hasBorder" label.translate="Round Corners" level="this.props.level">
         <BuilderNumberInput action="this.props.action" actionParam="{ mainParam: this.getStyleActionParam('radius'), extraClass: this.props.withBSClass and 'rounded' }" unit="'px'" min="0" composable="true"/>
     </BuilderRow>
 </t>

--- a/addons/html_builder/static/src/plugins/button_style_option.js
+++ b/addons/html_builder/static/src/plugins/button_style_option.js
@@ -36,6 +36,7 @@ export class ButtonStyleOption extends BaseOptionComponent {
         BuilderNumberInput,
         BorderConfigurator,
     };
+    static dependencies = ["history"];
 
     buttonSizesData = BUTTON_SIZES;
     buttonShapesData = BUTTON_SHAPES;
@@ -43,16 +44,102 @@ export class ButtonStyleOption extends BaseOptionComponent {
 
     setup() {
         super.setup();
+        this.state = useDomState(async (el) => {
+            const buttonType = getButtonType(el);
+            const buttonStyles = await this.getButtonStyles(el);
+            const state = {
+                buttonStyles: buttonStyles,
+                buttonCombinationClass: this.findColorCombination(el),
+                currentButtonType: buttonType,
+                currentButtonTypeData: this.buttonTypesData.find((btn) => btn.type == buttonType),
+            };
+            return state;
+        });
+    }
 
-        const editingElement = this.env.getEditingElement();
-        const computedStyle =
-            editingElement.ownerDocument.defaultView.getComputedStyle(editingElement);
-        this.state = useDomState((el) => ({
-            type: getButtonType(el),
-            textColor: computedStyle.color,
-            fillColor: computedStyle.backgroundColor,
-            border: computedStyle.border,
-        }));
+    goToThemeTab() {
+        this.env.editColorCombination(
+            parseInt(this.state.buttonCombinationClass.replace("o_cc", ""))
+        );
+    }
+
+    async getButtonStyles(el) {
+        // Button variant styles depend on user-customized theme settings
+        // and on where the builder is running (website or mass mailing). The
+        // cleanest approach to generate a preview is to add a temporary button
+        // to the DOM and copy its computed styles. See commit message for more.
+        const buttonVariants = {
+            primary: "btn-primary",
+            secondary: "btn-secondary",
+        };
+        const previewVariables = [
+            "background-color",
+            "border",
+            "border-radius",
+            "color",
+            "font-family",
+            "font-weight",
+            "text-transform",
+        ];
+
+        const buttonContainerEl = el.parentElement;
+        const iframeDocument = el.ownerDocument;
+        const styles = {
+            primary: "",
+            secondary: "",
+            custom: "",
+        };
+        for (const [variantName, variantClass] of Object.entries(buttonVariants)) {
+            const tempButtonEl = iframeDocument.createElement("a");
+            tempButtonEl.className = `btn ${variantClass}`;
+            this.dependencies.history.ignoreDOMMutations(() =>
+                buttonContainerEl.appendChild(tempButtonEl)
+            );
+            const computedStyle = getComputedStyle(tempButtonEl);
+            for (const style of previewVariables) {
+                const value = computedStyle.getPropertyValue(style);
+                if (value) {
+                    styles[variantName] += `${style}: ${value};`;
+                }
+            }
+            this.dependencies.history.ignoreDOMMutations(() => tempButtonEl.remove());
+        }
+
+        // The style for btn-custom is always a copy of the current button style.
+        // This way, if a custom button is currently in use, the customization is
+        // correctly represented in the button preview. Otherwise, the custom
+        // button style represents the style that the button would adopt once
+        // the customization begins.
+
+        // requestAnimationFrame is a temporary workaround necessary because
+        // the change of color seems to be animated even if it should not (see
+        // `withoutTransition` in `StyleAction.apply`). This should be removed
+        // once the transition problem is fixed.
+        await new Promise((resolve) => {
+            requestAnimationFrame(() => {
+                const computedStyle = getComputedStyle(el);
+                for (const style of previewVariables) {
+                    const value = computedStyle.getPropertyValue(style);
+                    if (value) {
+                        styles.custom += `${style}: ${value};`;
+                    }
+                }
+                resolve();
+            });
+        });
+        return styles;
+    }
+
+    findColorCombination(el) {
+        // Crawl the DOM upwards until a cc class is found, otherwise return cc1
+        const ccClasses = ["o_cc1", "o_cc2", "o_cc3", "o_cc4", "o_cc5"];
+        const ccSelector = ccClasses.map((cls) => `.${cls}`).join(",");
+        const ccElement = el.closest(ccSelector);
+        if (!ccElement) {
+            return ccClasses[0];
+        }
+        const matchedClass = ccClasses.find((cls) => ccElement.classList?.contains(cls));
+        return matchedClass;
     }
 }
 

--- a/addons/html_builder/static/src/plugins/button_style_option.scss
+++ b/addons/html_builder/static/src/plugins/button_style_option.scss
@@ -1,0 +1,10 @@
+.o-hb-button-style-preview {
+    height: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.o-hb-button-style-btn-edit {
+    color: $o-we-color-global;
+}

--- a/addons/html_builder/static/src/plugins/button_style_option.xml
+++ b/addons/html_builder/static/src/plugins/button_style_option.xml
@@ -4,22 +4,35 @@
 <t t-name="html_builder.ButtonStyleOption">
     <BuilderRow label.translate="Type">
         <BuilderSelect action="'buttonStyleAction'" actionParam="'type'">
+            <t t-set-slot="fixedButton">
+                <div class="btn flex-grow-1 my-2 w-100"
+                    t-attf-class="o-hb-button-style-preview o-hb-button-style-preview-{{this.state.currentButtonType}}"
+                    t-att-style="this.state.buttonStyles[this.state.currentButtonType]"
+                    t-out="this.state.currentButtonTypeData.label"/>
+            </t>
             <t t-foreach="this.buttonTypesData.slice(1)" t-as="opt" t-key="opt.type">
                 <BuilderSelectItem actionValue="opt.type" preview="opt.type !== 'custom'">
-                    <t t-out="opt.label"/>
+                    <div class="btn flex-grow-1 my-2 w-100"
+                        t-att-class="opt.className"
+                        t-attf-class="o-hb-button-style-preview o-hb-button-style-preview-{{opt.type}}"
+                        t-att-style="this.state.buttonStyles[opt.type]"
+                        t-out="opt.label"/>
                 </BuilderSelectItem>
             </t>
         </BuilderSelect>
+        <a class="fa fa-pencil btn o-hb-button-style-btn-edit"
+            title="Edit Color Combination"
+            t-on-click="this.goToThemeTab"/>
     </BuilderRow>
 
-    <t t-if="this.state.type === 'custom'">
+    <t t-if="this.state.currentButtonType === 'custom'">
         <BuilderRow label.translate="Text" level="1">
             <BuilderColorPicker styleAction="'color'" enabledTabs="['solid', 'custom']" />
         </BuilderRow>
         <BuilderRow label.translate="Fill" level="1">
             <BuilderColorPicker action="'buttonFillColorAction'" actionParam="{ mainParam: 'background-color', allowImportant: false }" enabledTabs="['solid', 'custom', 'gradient']" />
         </BuilderRow>
-        <BorderConfigurator label.translate="Border" withRoundCorner="false" withBSClass="false" />
+        <BorderConfigurator label.translate="Border" withRoundCorner="false" withBSClass="false" level="1"/>
     </t>
 
     <BuilderRow label.translate="Size">

--- a/addons/html_builder/static/tests/options/button_style_option.test.js
+++ b/addons/html_builder/static/tests/options/button_style_option.test.js
@@ -1,6 +1,7 @@
 import { contains } from "@web/../tests/web_test_helpers";
 import { setupHTMLBuilder } from "@html_builder/../tests/helpers";
 import { expect, test, queryOne, describe } from "@odoo/hoot";
+import { animationFrame } from "@odoo/hoot-dom";
 
 describe.current.tags("desktop");
 
@@ -65,6 +66,8 @@ test("should load the current custom style correctly", async () => {
         '<p><a href="https://test.com/" class="btn btn-custom" style="color: rgb(0, 255, 0); background-color: rgb(0, 0, 255); border-width: 4px; border-color: rgb(255, 0, 0); border-style: dotted;">Link label</a></p>'
     );
     await contains(":iframe p > a").click();
+    // Necessary because of the requestAnimationFrame in ButtonStyleOption.getButtonStyle
+    await animationFrame();
 
     expect("[data-label=Type] .o-hb-select-toggle").toHaveText("Custom");
     expect("[data-label=Text] .o_we_color_preview").toHaveStyle("background-color: rgb(0, 255, 0)");
@@ -152,6 +155,8 @@ test("border works even if current border style is none", async () => {
 
     await contains("[data-label=Type] .o-hb-select-toggle").click();
     await contains(".o_popover .dropdown-item:contains('Custom')").click();
+    // Necessary because of the requestAnimationFrame in ButtonStyleOption.getButtonStyle
+    await animationFrame();
 
     expect("[data-label=Border] .o-hb-input-number").toHaveValue("0");
 

--- a/addons/website/static/tests/builder/options/button_style_option.test.js
+++ b/addons/website/static/tests/builder/options/button_style_option.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, queryFirst, queryOne, test } from "@odoo/hoot";
+import { animationFrame, describe, expect, queryFirst, queryOne, test } from "@odoo/hoot";
 import {
     defineWebsiteModels,
     setupWebsiteBuilder,
@@ -18,6 +18,8 @@ test("fill color preview shows the hover fill color in outline mode", async () =
     // Set a background color
     await contains("[data-label=Fill] .o_we_color_preview").click();
     await contains(".o_color_button[data-color='#0000FF']").click();
+    // Necessary because of the requestAnimationFrame in ButtonStyleOption.getButtonStyle
+    await animationFrame();
 
     expect(":iframe p > a").toHaveStyle(
         "background-color: rgba(0, 0, 0, 0); background-image: none",
@@ -38,6 +40,8 @@ test("fill color preview shows the hover fill color in outline mode", async () =
     const gradientButton = queryFirst(".o_gradient_color_button");
     const gradient = gradientButton.dataset.color;
     await contains(gradientButton).click();
+    // Necessary because of the requestAnimationFrame in ButtonStyleOption.getButtonStyle
+    await animationFrame();
 
     expect(":iframe p > a").toHaveStyle(
         "background-color: rgba(0, 0, 0, 0); background-image: none",
@@ -72,4 +76,53 @@ test("keep current style when switching from button", async () => {
 
     expect(":iframe p > a").toHaveClass("btn btn-custom");
     expect(":iframe p > a").toHaveStyle(buttonSecondaryStyles, { inline: true });
+});
+
+test("should preview button styles in dropdown", async () => {
+    await setupWebsiteBuilder(
+        `<p>
+            <a href="#" class="btn btn-primary test-target">clickme</a>
+            <a href="#" class="btn btn-secondary test-target">clickme</a>
+        </p>`,
+        {
+            loadIframeBundles: true,
+        }
+    );
+
+    await contains(":iframe p > a.test-target").click();
+    // primary count=2 because it's shown both in dropdown list and trigger
+    expect(".o-hb-button-style-preview-primary").toHaveCount(2);
+    expect(".o-hb-button-style-preview-secondary").toHaveCount(1);
+    expect(".o-hb-button-style-preview-custom").toHaveCount(1);
+
+    const primaryStyle = getComputedStyle(queryOne(":iframe .btn-primary.test-target"));
+    const secondaryStyle = getComputedStyle(queryOne(":iframe .btn-secondary.test-target"));
+    const previewVariables = [
+        "background-color",
+        "border",
+        "border-radius",
+        "color",
+        "font-family",
+        "font-weight",
+        "text-transform",
+    ];
+
+    previewVariables.forEach((v) => {
+        expect(".o-hb-button-style-preview-primary").toHaveStyle(`${v}: ${primaryStyle[v]}`);
+        expect(".o-hb-button-style-preview-secondary").toHaveStyle(`${v}: ${secondaryStyle[v]}`);
+    });
+});
+
+test("should have a button linking to theme tab", async () => {
+    await setupWebsiteBuilder(
+        '<p><a href="#" class="btn btn-primary test-target">clickme</a></p>',
+        {
+            loadIframeBundles: true,
+        }
+    );
+
+    await contains(":iframe p > a.test-target").click();
+    await contains("a.o-hb-button-style-btn-edit").click();
+    await animationFrame();
+    expect("button[data-name='theme']").toHaveClass("active");
 });


### PR DESCRIPTION
This PR enhances `ButtonStyleOption` by introducing visual previews in the “Type” dropdown, adding a direct link to the theme’s color combination settings, and fixing option indentation. Moreover, it sets the color scheme of all “go-to-theme” buttons to the theme tab’s yellow styling.

task-5346631