### PR TITLE
[FIX] calendar: use sudo for attendee company access in notifications

### DIFF
--- a/addons/calendar/models/calendar_alarm_manager.py
+++ b/addons/calendar/models/calendar_alarm_manager.py
@@ -251,5 +251,5 @@ class CalendarAlarm_Manager(models.AbstractModel):
             ('group_ids', 'in', self.env.ref('base.group_user').ids),
         ])
         for user in users:
-            notif = self.with_user(user).with_context(allowed_company_ids=user.company_ids.ids).get_next_notif()
+            notif = self.with_user(user).with_context(allowed_company_ids=user.sudo().company_ids.ids).get_next_notif()
             user._bus_send("calendar.alarm", notif)


### PR DESCRIPTION
[FIX] calendar: use sudo for attendee company access in notifications

Invitations with notification reminders fail if the attendee has access to companies hidden from the organizer.

### Reproduction Steps

1. User A (Company 1) invites User B (Company 1 & 2).
2. Add a "Notification" reminder.
3. Saving the event raises an AccessError on res.company.

### Cause

When preparing notifications, the attendee's company list is fetched while still in the organizer's environment. The `res.company` record rule restricts visible companies to the organizer's own, so the attendee's extra companies are blocked. Since 9a21edd99e7f, `Many2many.read()` uses `_search()` without `bypass_access`, which explicitly checks read access and raises `AccessError` instead of silently filtering at the SQL level.

opw-5916536