### PR TITLE
[FIX] website_crm_partner_assign: portal child contact can post on lead

### DIFF
--- a/addons/website_crm_partner_assign/models/crm_lead.py
+++ b/addons/website_crm_partner_assign/models/crm_lead.py
@@ -351,6 +351,6 @@ class CrmLead(models.Model):
         # controllers and UI
         if operation == 'create' and res_ids and (not model_name or model_name == 'crm.lead'):
             leads = self.browse(res_ids).with_prefetch(self._prefetch_ids)  # force prefetch, lost otherwise with rebrowsing
-            if all(lead.partner_assigned_id == self.env.user.partner_id for lead in leads):
+            if all(lead.partner_assigned_id == self.env.user.commercial_partner_id for lead in leads):
                 return 'read'
         return super()._get_mail_message_access(res_ids, operation, model_name=model_name)

--- a/addons/website_crm_partner_assign/tests/test_partner_assign.py
+++ b/addons/website_crm_partner_assign/tests/test_partner_assign.py
@@ -307,6 +307,42 @@ class TestPartnerLeadPortal(TestCrmCommon, HttpCase):
             }
         )
 
+    def test_portal_post_child_contact(self):
+        child_partner = self.env['res.partner'].create({
+            'name': 'Child Portal Contact',
+            'parent_id': self.user_portal.partner_id.id,
+            'email': 'child.portal@test.example.com',
+        })
+        user_child_portal = mail_new_test_user(
+            self.env, login='user_child_portal',
+            partner_id=child_partner.id,
+            groups='base.group_portal',
+        )
+        self.authenticate(user_child_portal.login, user_child_portal.login)
+        post_url = f"{self.lead_portal.get_base_url()}/mail/chatter_post"
+        res = self.opener.post(
+            url=post_url,
+            json={
+                'params': {
+                    'csrf_token': http.Request.csrf_token(self),
+                    'message': 'Test',
+                    'res_model': self.lead_portal._name,
+                    'res_id': self.lead_portal.id,
+                    'pid': user_child_portal.partner_id.id,
+                },
+            },
+        )
+        res.raise_for_status()
+        self.assertNotIn("error", res.json())
+        message = self.lead_portal.message_ids[0]
+        self.assertMessageFields(
+            message, {
+                'author_id': child_partner,
+                'body': '<p>Test</p>',
+                'message_type': 'comment',
+            }
+        )
+
     def test_route_portal_my_opportunities_as_portal(self):
         """Test that the portal user can access its own opportunities even if
         does not have access to the 'activity_date_deadline' field (needed


### PR DESCRIPTION
When a portal user is set on an individual contact belonging to a company, posting a message on an opportunity assigned to that company fails with an access error.

### Cause

Before creating a mail.message, `_get_mail_message_access` is called to determine the ORM access level the user must hold on the document. The override for `crm.lead` returns `'read'` (sufficient for portal users) when the user is the assigned partner, checking:

    lead.partner_assigned_id == self.env.user.partner_id

`partner_assigned_id` is the company set as the assigned partner. `user.partner_id` is the contact record of the logged-in user. When the portal user is an individual contact whose parent is the assigned company, the two records differ, the condition is False, `'write'` is required, and the portal user does not have it.

### Fix

Replace `user.partner_id` with `user.commercial_partner_id`, which always resolves to the top-level company regardless of whether the user is the company contact or one of its child contacts. This is consistent with `_assert_portal_write_access` in the same file, which already uses `commercial_partner_id` for the same reason.

opw-5913214