### PR TITLE
[FIX] mail: don't show avatar in composer of chat window

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -388,6 +388,18 @@ export class Composer extends Component {
         }
     }
 
+    get compact() {
+        return this.props.mode === "compact";
+    }
+
+    get normal() {
+        return this.props.mode === "normal";
+    }
+
+    get extended() {
+        return this.props.mode === "extended";
+    }
+
     get CANCEL_OR_SAVE_EDIT_TEXT() {
         const tags = {
             open_samp: markup`<samp>`,

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -2,20 +2,17 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.Composer">
-    <t t-set="isChatterComposer" t-value="extended and !this.props.composer.message"/>
+    <t t-set="isChatterComposer" t-value="this.extended and !this.props.composer.message"/>
     <t t-set="partitionedActions" t-value="this.composerActions.partition"/>
-    <t t-set="compact" t-value="this.props.mode === 'compact'"/>
-    <t t-set="normal" t-value="this.props.mode === 'normal'"/>
-    <t t-set="extended" t-value="this.props.mode === 'extended'"/>
     <t t-set="actionsContainerClass" t-value="'o-mail-Composer-actions d-flex o-rounded-bubble'"/>
     <div t-custom-ref="root">
         <div class="o-mail-Composer d-grid flex-shrink-0 pt-0 position-relative"
                 t-att-class="{
-                    'pb-2': extended and !this.props.composer.message,
-                    'o-extended': extended,
+                    'pb-2': this.extended and !this.props.composer.message,
+                    'o-extended': this.extended,
                     'o-isUiSmall': this.ui.isSmall,
-                    'ps-2 pe-4 pb-2': normal and !this.env.inDiscussApp and !this.env.inMeetingView,
-                    'ps-0 pe-3 pb-2': normal and this.env.inMeetingView,
+                    'ps-2 pe-4 pb-2': this.normal and !this.env.inDiscussApp and !this.env.inMeetingView,
+                    'ps-0 pe-3 pb-2': this.normal and this.env.inMeetingView,
                     'o-hasSelfAvatar': this.showComposerAvatar,
                     'o-focused': this.props.composer.isFocused,
                     'o-editing': this.props.composer.message,
@@ -49,16 +46,16 @@
                     </button>
                 </span>
             </div>
-            <div class="o-mail-Composer-coreMain d-flex flex-nowrap align-items-start flex-grow-1" t-att-class="{ 'flex-column' : extended or this.props.composer.message }">
+            <div class="o-mail-Composer-coreMain d-flex flex-nowrap align-items-start flex-grow-1" t-att-class="{ 'flex-column' : this.extended or this.props.composer.message }">
                 <div class="o-mail-Composer-inputContainer o-mail-Composer-bg d-flex flex-grow-1 border o-rounded-bubble"
                     t-att-class="{
                         'o-iosPwa': this.isIosPwa,
-                        'align-self-stretch' : extended,
+                        'align-self-stretch' : this.extended,
                         'w-100': this.props.composer.message,
                     }"
                     t-custom-ref="input-container"
                 >
-                    <div t-if="!extended" t-attf-class="{{ actionsContainerClass }}">
+                    <div t-if="!this.extended" t-attf-class="{{ actionsContainerClass }}">
                         <Dropdown t-if="partitionedActions.other.length > 0" position="'top-start'" menuClass="this.store.discussDropdownMenuClass(this)">
                             <t t-call="mail.Composer.moreActions"/>
                             <t t-set-slot="content">
@@ -112,7 +109,7 @@
                     t-if="this.props.composer.attachments.length > 0"
                     attachments="this.props.composer.attachments"
                     unlinkAttachment.bind="(...args) => this.attachmentUploader.unlink(...args)"/>
-                <div t-if="!extended and !this.props.composer.message" class="o-mail-Composer-pickerContainer" t-att-class="{ 'o-active': this.composerActions.activePicker and this.ui.isSmall }" t-custom-ref="picker-container">
+                <div t-if="!this.extended and !this.props.composer.message" class="o-mail-Composer-pickerContainer" t-att-class="{ 'o-active': this.composerActions.activePicker and this.ui.isSmall }" t-custom-ref="picker-container">
                     <div t-if="partitionedActions.pickers.length > 1 and this.composerActions.activePicker and this.ui.isSmall" class="o-mail-Composer-pickerSelection btn-group w-100">
                         <button t-foreach="partitionedActions.pickers" t-as="pickerAction" t-key="'PICKER_' + pickerAction.id" class="btn btn-secondary" t-out="pickerAction.pickerName" t-on-click="(ev) => pickerAction.onSelected(ev)" t-att-class="{
                             'active': pickerAction.picker.isOpen
@@ -140,8 +137,8 @@
 <t t-name="mail.Composer.sendButton">
     <button class="o-mail-Composer-send btn"
         t-att-class="{
-            'btn-primary btn-sm': extended,
-            'btn-link rounded-circle p-0': !extended,
+            'btn-primary btn-sm': this.extended,
+            'btn-link rounded-circle p-0': !this.extended,
             'me-2': this.env.inDiscussApp,
             'border-start-0': this.env.inDiscussApp and !this.props.composer.message,
             'border-0': this.props.composer.message,

--- a/addons/mail/static/src/discuss/typing/common/composer_patch.xml
+++ b/addons/mail/static/src/discuss/typing/common/composer_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.Composer" t-inherit-mode="extension">
         <xpath expr="//*[hasclass('o-mail-Composer-coreHeader')]" position="before">
-            <div t-if="this.thread?.channel and !compact and !this.env.inMeetingView" class="o-discuss-Typing d-flex position-absolute top-0 w-100 bg-100 pe-none o-pt-0_5 pe-2 z-1">
+            <div t-if="this.thread?.channel and !this.compact and !this.env.inMeetingView" class="o-discuss-Typing d-flex position-absolute top-0 w-100 bg-100 pe-none o-pt-0_5 pe-2 z-1">
                 <Typing t-if="this.thread.channel.hasOtherMembersTyping" channel="this.thread.channel" size="'medium'"/>
             </div>
         </xpath>

--- a/addons/mail/static/tests/discuss/core/composer.test.js
+++ b/addons/mail/static/tests/discuss/core/composer.test.js
@@ -8,12 +8,15 @@ import {
     insertText,
     onRpcBefore,
     openDiscuss,
+    openFormView,
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
 import { Composer } from "@mail/core/common/composer";
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
-import { getService, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { getService, patchWithCleanup, serverState } from "@web/../tests/web_test_helpers";
+import { deserializeDateTime } from "@web/core/l10n/dates";
+import { getOrigin } from "@web/core/utils/urls";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -120,4 +123,25 @@ test("html composer: send a message in a channel", async () => {
     await click(".o-mail-Composer button[title='Send']:enabled");
     await click(".o-mail-Message[data-persistent]:contains(Hello)");
     await contains(".o-mail-Composer-html.odoo-editor-editable", { textContent: "" });
+});
+
+test("Show self-avatar in composer of Discuss App", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "channel" });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Composer-avatar");
+    const [partner] = pyEnv["res.partner"].read(serverState.partnerId);
+    await contains(
+        `img.o-mail-Composer-avatar[data-src='${getOrigin()}/web/image/res.partner/${
+            serverState.partnerId
+        }/avatar_128?unique=${deserializeDateTime(partner.write_date).ts}']`
+    );
+    // but not in chat window
+    await openFormView("res.partner", serverState.partnerId);
+    await contains(".o-mail-Chatter");
+    await click(".o_menu_systray i[aria-label='Messages']");
+    await click(".o-mail-NotificationItem");
+    await contains(".o-mail-ChatWindow .o-mail-Composer");
+    await contains(".o-mail-ChatWindow .o-mail-Composer-avatar", { count: 0 });
 });


### PR DESCRIPTION
Before this commit, composer of chat window was showing the self-avatar when this shouldn't be present.

This happens since recent PR that prepare for Owl3 and put `this` in template of component, to make distinction of properties of the component and the variables in template [1].

However the change made a mistake: template variables like `compact` were defined in template and were also used in JS methods that were executed with the `this` being the context of template. The getter `showComposerAvatar` was used with implicit `this` that was using the context of template before [1], but was then turned into explicit `this.showComposerAvatar`, making it evaluate `this.compact` in the context of component (outside of template), which was `undefined` even in chat window and thus it mistakenly shows the avatar in the composer of chat window.

This commit fixes the issue by moving properties like `compact` into a getter on the component, so that this can be used even outside of the context of template.

[1]: https://github.com/odoo/odoo/pull/253019

Before / After

<img width="382" height="641" alt="Screenshot 2026-03-12 at 18 37 04" src="https://github.com/user-attachments/assets/14b9865b-0b14-409e-88f0-2bdd3c6205f5" /> <img width="387" height="643" alt="Screenshot 2026-03-12 at 16 45 56" src="https://github.com/user-attachments/assets/e970f37d-477e-4bda-8fa2-77cc1dadc282" />
