### PR TITLE
[FIX] calendar: avoid advancing Microsoft sync date before sync completes

### DIFF
--- a/addons/microsoft_calendar/models/res_users.py
+++ b/addons/microsoft_calendar/models/res_users.py
@@ -78,7 +78,6 @@ class ResUsers(models.Model):
 
     def _sync_microsoft_calendar(self):
         self.ensure_one()
-        self.sudo().microsoft_last_sync_date = datetime.now()
         if self._get_microsoft_sync_status() != "sync_active":
             return False
 

--- a/doc/cla/individual/hadigital24.md
+++ b/doc/cla/individual/hadigital24.md
@@ -1,0 +1,9 @@
+Germany, 2026-03-12
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Hamza Afadar hamza@digitalstarten.de https://github.com/hadigital24


### PR DESCRIPTION
Current behavior
----------------
In `_sync_microsoft_calendar`, `microsoft_last_sync_date` is updated at the very
beginning of the synchronization flow.

This advances the sync baseline too early.

Problem
-------
When token refresh/recovery happens before the synchronization has fully
completed, pending older records can be skipped permanently because the sync
window is already moved to "now".

This is especially reproducible when the Microsoft token is expired and the sync
is triggered again.

Steps to reproduce
------------------
1. Configure Microsoft calendar sync for a user.
2. Let the Microsoft token expire.
3. Make sure there are pending calendar changes older than "now" but newer than
   the previous `microsoft_last_sync_date`.
4. Trigger synchronization.
5. Observe that `microsoft_last_sync_date` is updated before the full sync flow
   is completed.
6. Observe that older changes may be skipped permanently.

Expected behavior
-----------------
`microsoft_last_sync_date` should only be updated after the synchronization flow
has completed successfully.

Solution
--------
Remove the initial write of `microsoft_last_sync_date` and keep only the final
update after all synchronization steps have completed.