### PR TITLE
[FIX] account: Changed Hebrew translations for INV and BILL to prevent overlap

### DIFF
--- a/addons/account/i18n/he.po
+++ b/addons/account/i18n/he.po
@@ -4369,7 +4369,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/account/models/chart_template.py:0
 msgid "BILL"
-msgstr "חשבוניות רכש"
+msgstr "BILL"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.view_account_reconcile_model_form
@@ -9630,7 +9630,7 @@ msgstr "מזהה"
 #. odoo-python
 #: code:addons/account/models/chart_template.py:0
 msgid "INV"
-msgstr "חשבונית"
+msgstr "INV"
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.report_invoice_document


### PR DESCRIPTION
When doing a fresh install of accounting with your company language set to Hebrew, you will receive an error violating a constraint on the account_journal table due to the code column being Varchar(5) and the Hebrew translations of "INV" and "BILL" having the same first 5 characters.

This commit will allow users to install Accounting when their language is set to Hebrew or switch to the l10n_il with no journals in their database and their language set to Hebrew. 

Reproduction steps:
 - Uninstall Accounting + Invoice
 - Set company language to Hebrew
 - Install accounting (which will install Invoice)

opw-6001568
