### PR TITLE
[FIX] account_journal: Prevent overlap in other languages

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -86,7 +86,7 @@ class AccountJournal(models.Model):
     name_placeholder = fields.Char(compute='_compute_name_placeholder')
     code = fields.Char(
         string='Sequence Prefix',
-        size=5,
+        size=7,
         compute='_compute_code', readonly=False, store=True,
         required=True, precompute=True,
         help="Shorter name used for display. "
@@ -1010,7 +1010,7 @@ class AccountJournal(models.Model):
                 vals['default_account_id'] = default_account_id
 
         if is_import and not vals.get('code'):
-            code = vals['name'][:5]
+            code = vals['name'][:self._fields['code'].size]
             vals['code'] = code if not protected_codes or code not in protected_codes else self._get_next_journal_default_code(journal_type, company, protected_codes)
             if not vals['code']:
                 raise UserError(_("Cannot generate an unused journal code. Please change the name for journal %s.", vals['name']))

--- a/addons/account/tests/test_account_journal.py
+++ b/addons/account/tests/test_account_journal.py
@@ -133,7 +133,7 @@ class TestAccountJournal(AccountTestInvoicingCommon, HttpCase):
             {"name": "OD_BLABLU"},
         ])
 
-        self.assertEqual(sorted(new_journals.mapped("code")), ["MISC1", "OD_BL"], "The journals should be set correctly")
+        self.assertEqual(sorted(new_journals.mapped("code")), ["MISC1", "OD_BLAB"], "The journals should be set correctly")
 
     def test_archive_used_journal(self):
         journal = self.env['account.journal'].create({


### PR DESCRIPTION
When generating journals with some languages, such as Hebrew, codes overlap violating the constraint _code_company_uniq. This commit will prevent that from happening by increasing the 5 character constraint to 7.

Also removed the "magic number" to be used dynamically.

Reproduction steps:
 - Create a fresh database
 - Set company language to Hebrew
 - Attempt to install accounting

Enterprise PR: odoo/enterprise#110710
Ticket [link](https://www.odoo.com/odoo/project.task/6001568)
opw-6001568
