### PR TITLE
[FIX] web: apply readonly visual style to all fields on non-editable …

### DIFF
--- a/addons/web/static/src/views/fields/field.js
+++ b/addons/web/static/src/views/fields/field.js
@@ -149,7 +149,10 @@ export function getFieldFromRegistry(fieldType, widget, viewType, jsClass) {
 }
 
 export function fieldVisualFeedback(field, record, fieldName, fieldInfo) {
-    const readonly = evaluateBooleanExpr(fieldInfo.readonly, record.evalContextWithVirtualIds);
+    const readonly =
+        fieldInfo.viewType === "form" && !record.isInEdition
+            ? true
+            : evaluateBooleanExpr(fieldInfo.readonly, record.evalContextWithVirtualIds);
     const required = evaluateBooleanExpr(fieldInfo.required, record.evalContextWithVirtualIds);
     const inEdit = record.isInEdition;
 

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -11228,6 +11228,22 @@ test(`form view with edit='0' but create='1', new record`, async () => {
     expect(`.o_form_editable`).toHaveCount(1);
 });
 
+test(`form view with edit='0': all fields should be readonly`, async () => {
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `<form edit="0"><group><field name="foo"/></group></form>`,
+        resId: 1,
+    });
+    expect(`.o_form_editable`).toHaveCount(0);
+    expect(`.o_form_readonly`).toHaveCount(1);
+
+    expect(`label[for=foo_0].o_form_label_readonly`).toHaveCount(1);
+    expect(`.o_field_widget[name=foo].o_readonly_modifier`).toHaveCount(1);
+
+    expect(`input`).toHaveCount(0);
+});
+
 test(`save a form view with an invisible required field`, async () => {
     Partner._fields.text = fields.Text({ required: 1 });
 


### PR DESCRIPTION
…forms

Before this commit, some input boxes were not styled correctly. We found that `o_form_label_readonly` and `o_readonly_modifier` were not applied to labels and fields when a view had its `edit` attribute set to `false`.

As a result, fields appeared visually editable even though they were not.

This change is only applied to forms because we do not want kanban records to have unnecessary classes.

This issue is already present in older versions, but it is now more visually problematic with the new "Input Boxes" mobile design.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
