### PR TITLE
[FIX] sale: allow `sale_ok` products to be reinvoiced

### DIFF
--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -90,11 +90,11 @@ class ProductTemplate(models.Model):
         super()._compute_service_tracking()
         self.filtered(lambda pt: not pt.sale_ok).service_tracking = 'no'
 
-    @api.depends('purchase_ok')
+    @api.depends('purchase_ok', 'sale_ok')
     def _compute_visible_expense_policy(self):
-        visibility = self.env.user.has_group('analytic.group_analytic_accounting')
-        for product_template in self:
-            product_template.visible_expense_policy = visibility and product_template.purchase_ok
+        self.visible_expense_policy = False
+        if self.env.user.has_group('analytic.group_analytic_accounting'):
+            self.filtered(lambda pt: pt.purchase_ok or pt.sale_ok).visible_expense_policy = True
 
     @api.depends('sale_ok')
     def _compute_expense_policy(self):


### PR DESCRIPTION
This commit fixes an issue where the reinvoicing policy option was only available for `purchase_ok` products. The `expense_policy` field was originally limited to expense-related use cases, which is why it was not shown for `sale_ok` products.

However, with the introduction of the new Services and Materials upselling flow in Sales, this restriction is no longer valid. The reinvoicing policy should therefore also be available for `sale_ok` products.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
