### PR TITLE
[FIX] point_of_sale: wait for orders to render in nbOrdersIs

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/utils/ticket_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/ticket_screen_util.js
@@ -5,13 +5,7 @@ import { isSyncStatusConnected } from "@point_of_sale/../tests/pos/tours/utils/c
 export function nbOrdersIs(nb) {
     return [
         {
-            trigger: `.ticket-screen`,
-            run: () => {
-                const orders = document.querySelectorAll(".ticket-screen .order-row");
-                if (orders.length !== nb) {
-                    throw new Error(`Expected ${nb} orders, but found ${orders.length}`);
-                }
-            },
+            trigger: `.ticket-screen .order-row:count(${nb})`,
         },
     ];
 }


### PR DESCRIPTION
Updated the assertion to use the :count() pseudo-selector directly in the trigger. Instead of synchronously throwing an error as soon as .ticket-screen mounts, the framework will now correctly wait for the exact number of .order-row elements to render, resolving timing issues with pending requests or UI animations.

build_error-241246