### PR TITLE
[FIX] hr_holidays: prevent error when selecting the time off type

### DIFF
--- a/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard.py
+++ b/addons/hr_holidays/wizard/hr_leave_allocation_generate_multi_wizard.py
@@ -24,7 +24,6 @@ class HrLeaveAllocationGenerateMultiWizard(models.TransientModel):
 
     def _domain_work_entry_type_id(self):
         domain = [
-            ('company_id', 'in', self.env.companies.ids + [False]),
             ('requires_allocation', '=', True),
         ]
         if self.env.user.has_group('hr_holidays.group_hr_holidays_user'):


### PR DESCRIPTION
This error occurs when selecting the `Time Off Type` in the `New Group Allocation` wizard.

Steps to reproduce:
- Install `hr_holidays` module
- Time Off > Management > Allocations > `New Group Allocation`
- Try to select `Time Off Type`

Traceback:
`ValueError: Invalid field hr.work.entry.type.company_id in condition ('company_id', 'in', [1, False])`

In this [commit], the `company_id` field was removed from the `hr.work.entry.type` model; however, it is still referenced in the `_domain_work_entry_type_id` domain.

[commit]: https://github.com/odoo/odoo/commit/d37cf89a6ff134988b4a7c001a97973cd95a2ea8#diff-5cda5340aaeaddd073ac083c1909e0e52d6cbc48cb8d9c8f93ad48fd8a04f00dL68-L69

sentry-7328870622

