### PR TITLE
[IMP] web: allow trailing zeros in widget percentage

### DIFF
--- a/addons/web/static/src/views/fields/formatters.js
+++ b/addons/web/static/src/views/fields/formatters.js
@@ -421,11 +421,13 @@ formatMonetary.extractOptions = ({ options }) => ({
  * @param {number | false} value
  * @param {Object} [options]
  * @param {boolean} [options.noSymbol] if true, doesn't concatenate with "%"
+ * @param {boolean} [options.trailingZeros]
  * @returns {string}
  */
 export function formatPercentage(value, options = {}) {
     value = value || 0;
     options = Object.assign({ trailingZeros: false, thousandsSep: "" }, options);
+    options.trailingZeros = options.trailingZeros === true;
     if (!options.digits && options.field) {
         options.digits = options.field.digits;
     }

--- a/addons/web/static/src/views/fields/percentage/percentage_field.js
+++ b/addons/web/static/src/views/fields/percentage/percentage_field.js
@@ -14,6 +14,12 @@ export class PercentageField extends Component {
         ...standardFieldProps,
         digits: { type: Array, optional: true },
         noSymbol: { type: Boolean, optional: true },
+        trailingZeros: { type: Boolean, optional: true },
+    };
+
+    static defaultProps = {
+        noSymbol: false,
+        trailingZeros: false,
     };
 
     setup() {
@@ -22,6 +28,7 @@ export class PercentageField extends Component {
                 formatPercentage(this.props.record.data[this.props.name], {
                     digits: this.props.digits,
                     noSymbol: true,
+                    trailingZeros: this.props.trailingZeros,
                     field: this.props.record.fields[this.props.name],
                 }),
             refName: "numpadDecimal",
@@ -34,6 +41,7 @@ export class PercentageField extends Component {
         return formatPercentage(this.props.record.data[this.props.name], {
             digits: this.props.digits,
             noSymbol: this.props.noSymbol,
+            trailingZeros: this.props.trailingZeros,
             field: this.props.record.fields[this.props.name],
         });
     }
@@ -53,11 +61,13 @@ export const percentageField = {
             digits = options.digits;
         }
 
-        const noSymbol = options.no_symbol || false;
+        const noSymbol = options.no_symbol;
+        const trailingZeros = options.trailing_zeros;
 
         return {
             digits,
             noSymbol,
+            trailingZeros,
         };
     },
 };

--- a/addons/web/static/tests/views/fields/percentage_field.test.js
+++ b/addons/web/static/tests/views/fields/percentage_field.test.js
@@ -86,3 +86,36 @@ test("PercentageField without no_symbol option shows percentage symbol", async (
     expect(".o_field_widget[name=float_field] span").toHaveCount(1);
     expect(".o_field_widget[name=float_field] span").toHaveText("%");
 });
+
+test("PercentageField with digits option", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: /* xml */ `<form><field name="float_field" widget="percentage" options="{'digits': [3, 2]}"/></form>`,
+        resId: 1,
+    });
+
+    expect(".o_field_widget[name=float_field] input").toHaveValue("44.44");
+});
+
+test("PercentageField with digits option but no trailing_zeros", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: /* xml */ `<form><field name="float_field" widget="percentage" options="{'digits': [3, 8]}"/></form>`,
+        resId: 1,
+    });
+
+    expect(".o_field_widget[name=float_field] input").toHaveValue("44.444");
+});
+
+test("PercentageField with digits option and trailing_zeros", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: /* xml */ `<form><field name="float_field" widget="percentage" options="{'digits': [3, 8], 'trailing_zeros': True}"/></form>`,
+        resId: 1,
+    });
+
+    expect(".o_field_widget[name=float_field] input").toHaveValue("44.44400000");
+});


### PR DESCRIPTION
This adds the option to have trailing zeros in the widget percentage that would
work with the digits option.

Task: 6032743