### PR TITLE
[FIX] hr_holidays: UI Bug on time off smartbutton

### DIFF
--- a/addons/hr_holidays/views/hr_views.xml
+++ b/addons/hr_holidays/views/hr_views.xml
@@ -132,8 +132,8 @@
                         groups="base.group_user"
                         help="Remaining leaves">
                     <div class="o_field_widget o_stat_info">
-                        <span class="o_stat_value" invisible="allocation_display == '0'">
-                            <field name="allocation_remaining_display"/>/<field name="allocation_display"/> Days
+                        <span class="o_stat_value d-flex" invisible="allocation_display == '0'">
+                            <field name="allocation_remaining_display"/>/<field name="allocation_display" class='me-1'/>Days
                         </span>
                         <span class="o_stat_text">
                             Time Off


### PR DESCRIPTION
Version:
**master**

Fix the Time Off smart button UI on the Employee form, when the leave balance exists. 

**task-6008045**
