### PR TITLE
[FIX] mail: keep next activity fields consistent in list views

### DIFF
--- a/addons/crm/models/res_partner.py
+++ b/addons/crm/models/res_partner.py
@@ -54,9 +54,8 @@ class ResPartner(models.Model):
             'search_default_filter_won': 1,
             'search_default_filter_ongoing': 1,
             'search_default_filter_lost': 1,
-            'active_test': False,
         }
         # we want the list view first
         action['views'] = sorted(action['views'], key=lambda view: view[1] != 'list')
-        action['domain'] = self._get_contact_opportunities_domain()
+        action['domain'] = self._get_contact_opportunities_domain() + [('active', 'in', [True, False])]
         return action


### PR DESCRIPTION
Steps to reproduce
1. Install crm, contact
1. Contacts → open a contact with an opportunity, if not present, create it.
2. From the Opportunities list view, add Studio fields “Next Activity Summary” and “Next Activity Type”.
3. In the opportunity, create an activity and see the list view of opportunity now from Contacts → opportunity.
4. Mark the current activity as done and create a new activity.
5. Observe the list view again: it still shows the old activity summary/type.

Issue
- When opening Opportunities from a Contact, archived (done) activities are included in activity-related fields, so “Next Activity” fields can point to old activities.

Root cause
- Done activity records are now set to archived. The Contact → Opportunities action sets `active_test=False`.  https://github.com/odoo/odoo/blob/9b071683e0eb270811302a4dd0ad10e0baaa0834/addons/crm/models/res_partner.py#L57
Since `activity_ids` had no domain, it included inactive activities, and related fields (`activity_summary`, `activity_type_id`) resolve to archived records.
https://github.com/odoo/odoo/blob/9b071683e0eb270811302a4dd0ad10e0baaa0834/addons/mail/models/mail_activity_mixin.py#L49

Solution
- Instead of passing active_test in context we will pass the domain to prevent the context interfear with activity fields.

opw-5942696