### PR TITLE
[FIX] point_of_sale: allow simultaneous order to be saved

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1149,6 +1149,9 @@ class PosOrder(models.Model):
     def is_already_paid(self):
         return self.state == "paid"
 
+    def get_draft_orders(self):
+        return self.filtered(lambda order: order.state == "draft").ids
+
     @api.model
     def remove_from_ui(self, server_ids):
         """ Remove orders from the frontend PoS application

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -645,6 +645,35 @@ export class PosStore extends Reactive {
             return order;
         }
     }
+
+    /**
+     * Some locally stored orders may have already been processed by another trusted POS.
+     * Keep orders without a server_id and orders whose server_id is still in draft on the server
+     */
+    async _getValidDraftOrders(localJsonOrders) {
+        try {
+            const ids = localJsonOrders
+                .filter((json) => json.server_id)
+                .map((json) => json.server_id);
+            const validIds = ids.length
+                ? await this.orm.call("pos.order", "get_draft_orders", [ids])
+                : [];
+
+            const validJsonOrders = [];
+            for (const order of localJsonOrders) {
+                if (!order.server_id || validIds.includes(order.server_id)) {
+                    validJsonOrders.push(order);
+                } else {
+                    this.db.remove_unpaid_order(order);
+                }
+            }
+            return validJsonOrders;
+        } catch (error) {
+            console.error("There was an error while validating draft orders", error);
+            return localJsonOrders;
+        }
+    }
+
     /**
      * Load the locally saved unpaid orders for this PoS Config.
      *
@@ -657,6 +686,7 @@ export class PosStore extends Reactive {
         var jsons = this.db.get_unpaid_orders();
         await this._loadMissingProducts(jsons);
         await this._loadMissingPartners(jsons);
+        jsons = await this._getValidDraftOrders(jsons);
         var orders = [];
 
         for (const json of jsons) {

--- a/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
@@ -8,6 +8,7 @@ import { registry } from "@web/core/registry";
 import * as Order from "@point_of_sale/../tests/tours/helpers/generic_components/OrderWidgetMethods";
 import { inLeftSide, scan_barcode } from "@point_of_sale/../tests/tours/helpers/utils";
 import * as ProductConfiguratorPopup from "@point_of_sale/../tests/tours/helpers/ProductConfiguratorTourMethods";
+import * as TicketScreen from "@point_of_sale/../tests/tours/helpers/TicketScreenTourMethods";
 
 registry.category("web_tour.tours").add("ProductScreenTour", {
     test: true,
@@ -288,5 +289,47 @@ registry.category("web_tour.tours").add("test_products_variants_attribute_value_
             ProductScreen.clickProductInfoAttributeValue("Size", "Medium"),
             ProductScreen.checkProductsNumber(1),
             ProductScreen.productIsDisplayed("Small Shelf (Medium)"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_only_unpaid_orders_are_loaded", {
+    test: true,
+    steps: () =>
+        [
+            // open pos "shop"
+            {
+                content: "start new session",
+                trigger: ".o_kanban_primary_left button:contains('New Session')",
+            },
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.addOrderline("Desk Pad", "1"),
+            ProductScreen.saveOrder(),
+            Chrome.clickMenuButton(),
+            {
+                content: "click backend button",
+                trigger: "li.backend-button",
+            },
+            // open pos "shop2"
+            {
+                content: "start another new session",
+                trigger: ".o_kanban_primary_left button:contains('New Session')",
+            },
+            Chrome.clickMenuButton(),
+            Chrome.clickTicketButton(),
+            TicketScreen.selectOrder("-0001"),
+            TicketScreen.loadSelectedOrder(),
+            ProductScreen.isShown(),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            Chrome.closeSession(),
+            // reopen pos "shop"
+            {
+                content: "open session",
+                trigger: ".o_kanban_primary_left button:contains('Continue Selling')",
+            },
+            // there should not be any order
+            ProductScreen.orderIsEmpty(),
         ].flat(),
 });

--- a/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
@@ -571,3 +571,19 @@ export function doubleClickOrder(name) {
         },
     ];
 }
+
+export function saveOrder() {
+    return inLeftSide(
+        [
+            {
+                content: "click more button",
+                trigger: ".mobile-more-button",
+                mobile: true,
+            },
+            {
+                content: "click save button",
+                trigger: '.control-buttons .control-button:contains("Save")',
+            },
+        ].flat()
+    );
+}

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1433,6 +1433,12 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_products_variants_attribute_value_filtering', login="pos_user")
 
+    def test_only_unpaid_orders_are_loaded(self):
+        other_pos = self.main_pos_config.copy({"name": "shop2"})
+        self.main_pos_config.trusted_config_ids += other_pos
+        other_pos.trusted_config_ids += self.main_pos_config
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_only_unpaid_orders_are_loaded', login="pos_admin")
+
 
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):


### PR DESCRIPTION
Step to reproduce:
- have two pos, both trust each other, pos  A and B
- open pos A , create a order and save it
- go to backend , open pos B
- process the order, go to backend
- open pos A (notice, last save order is still loaded)
- removed older lines, and add new ones and save this again
- go to backend and open pos B
- notice that order is not loaded in other pos

Cause:
- Draft orders are stored in local storage.
- When shared with another POS, `pos.order` is created via `create_from_ui` and receives a `server_id`.
- If that order is later processed from another POS, the backend state changes.
- When the original POS is reopened, the local data still treats the order as draft.
- Saving the order again does not create a new order because it already has a `server_id`.
- This causes inconsistency with the backend and prevents the order from appearing in other POS sessions.

Fix:
- Before loading orders from JSON, verify that orders with `server_id` are still in `draft` state on the server.
- Discard orders whose backend state is no longer `draft`. 
 
opw-5946355

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
