### PR TITLE
[IMP] html_editor: use CSSOM to remove transform styles on image reset

### DIFF
--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -349,10 +349,15 @@ export class ImagePlugin extends Plugin {
     }
 
     resetImageTransformation(image) {
-        image.setAttribute(
-            "style",
-            (image.getAttribute("style") || "").replace(/[^;]*transform[\w:]*;?/g, "")
-        );
+        const stylePropertiesToRemove = [
+            "transform",
+            "transform-box",
+            "transform-origin",
+            "transform-style",
+        ];
+        for (const styleProperty of stylePropertiesToRemove) {
+            image.style.removeProperty(styleProperty);
+        }
         this.dependencies.history.addStep();
     }
 


### PR DESCRIPTION
__Before commit__
Transform-related CSS properties are removed from an image element by manipulating the raw `style` attribute string with a regex which is fragile and costly in performance.

__Steps to reproduce (saas-19.2)__
This regex was added in [18.0][1] but is only a real issue since `resetImageTransformation` was called in
`on_will_save_media_dialog_handlers` in [saas-19.2][2]:
1. Add a section block.
2. Add a background image.
3. Open the media dialog and replace the background image. => The website will hang for a while.

__Fix:__
Use `.style.removeProperty()` instead to speed up the process and to make it less error prone.

[1]: https://github.com/odoo/odoo/commit/85698bf4f591fc9280f054b9a255a7d
[2]: https://github.com/odoo/odoo/commit/781c0ae77de01f0df8667e0191f6c34