### PR TITLE
[FIX] account: dashboard access error when a journal currency is set …

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -408,7 +408,7 @@ class AccountJournal(models.Model):
             dashboard_data[journal.id] = {
                 'currency_id': journal.currency_id.id or journal.company_id.sudo().currency_id.id,
                 'show_company': len(self.env.companies) > 1 or journal.company_id.id != self.env.company.id,
-                'company_name': journal.company_id.name,
+                'company_name': journal.company_id.sudo().name,
             }
         self._fill_bank_cash_dashboard_data(dashboard_data)
         self._fill_sale_purchase_dashboard_data(dashboard_data)


### PR DESCRIPTION
Issue before this commit:
Opening the Accounting Dashboard from a child company as a non-admin user raises an  Access Error when the journal has a currency_id set. The error occurs with journal items which currency id is set

Steps to Reproduce ([video](https://drive.google.com/file/d/1Spt5zruNAVAvSdQYk-RuifzynyIfBOLK/view?usp=drive_link
)):
- Install the account module.
- Create child company
- Create journal journal with a currency set
- Log in as a non-admin user.
- Select only the child company
- Open Accounting (Dashboard)

Cause of the Issue:
When the journal does not have currency_id, the system reads company data using
 sudo(), so no access issue occurs.
When the journal has currency_id, sudo() is not used, and reading the company name triggers an Access Error.

With This Commit:
Bypass record rules when reading the company name if the journal has a currency_id.

opw-6017296