### PR TITLE
 [FIX] tools: trust function `Headers.get` in `safe_eval`

### DIFF
--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -1083,4 +1083,5 @@ def _initialize_safe_whitelist():
     safe_whitelist.add_class('werkzeug.exceptions.Unauthorized')
     safe_whitelist.add_instance('werkzeug.datastructures.file_storage.FileStorage')
     safe_whitelist.add_instance('werkzeug.local.LocalProxy')
+    safe_whitelist.add_function('werkzeug.datastructures.headers.Headers.get')
     safe_whitelist.add_function('werkzeug.datastructures.structures.TypeConversionDict.*')


### PR DESCRIPTION
It is safe to retrieve a header value using the `Headers.get` function.

Task-6036768
