### PR TITLE
[FIX] html_editor: fix hint blinking when selection updates

### DIFF
--- a/addons/html_editor/static/src/main/hint_plugin.js
+++ b/addons/html_editor/static/src/main/hint_plugin.js
@@ -50,8 +50,10 @@ export class HintPlugin extends Plugin {
         this.updateHints();
     }
 
-    triggerDebouncedUpdateHints() {
-        this.clearHints();
+    triggerDebouncedUpdateHints(selectionData = this.dependencies.selection.getSelectionData()) {
+        if (selectionData.documentSelectionIsInEditable) {
+            this.clearHints();
+        }
         this.debouncedUpdateHints();
     }
 


### PR DESCRIPTION
Problem:
When the selection is updating, the hint is blinking in the editable.

Cause:
After 9df2662cc79c2d8277211f7ce0bdb389f783f933, `triggerDebouncedUpdateHints` clears the hint immediately and adds it back using a debounced version of `updateHints` which runs after a few seconds, thus causing this blink.

Solution:
We only update hint if the selection inside the editable.

Steps to reproduce:
- Create a new Todo.
- Keep the editable empty.
- Update the Todo title.
- Observe the editable hint blinking.

task-6025534

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
