### PR TITLE
[FIX] pos_discount: correctly format the starting value of the discount

### DIFF
--- a/addons/pos_discount/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/pos_discount/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -7,7 +7,7 @@ patch(ControlButtons.prototype, {
     async clickDiscount() {
         this.dialog.add(NumberPopup, {
             title: _t("Discount Percentage"),
-            startingValue: this.pos.config.discount_pc,
+            startingValue: this.env.utils.formatCurrency(this.pos.config.discount_pc, false),
             getPayload: (num) => {
                 const percent = Math.max(
                     0,


### PR DESCRIPTION
Before this commit, if the decimal separator was different than the dot, the starting value of the discount was not correctly formatted in the discount popup. This caused incorrect default discount values to be applied when the user clicked on the discount button without changing the value.

opw-6018555

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
