### PR TITLE
[FIX] web: leftover temporary report files (for real this time)

### DIFF
--- a/addons/web/tests/test_reports.py
+++ b/addons/web/tests/test_reports.py
@@ -115,7 +115,7 @@ class TestReports(odoo.tests.HttpCase):
         with (MockRequest(report.env) as mock_request,
             patch('subprocess.Popen') as mock_popen,
             patch.object(root.session_store, 'delete') as mock_delete,
-            patch.object(os, 'unlink') as mock_unlink):
+            patch.object(os, 'unlink', wraps=os.unlink) as mock_unlink):
 
             mock_request.session = self.authenticate(admin.login, admin.login)
 


### PR DESCRIPTION
Followup to #253053 which assumed it was some sort of race in the report code which would sometimes fail to cleanup the temp files, but after hitting a test failure in #253816 the true culprit was revealed: it was the test #186547 added all along and I didn't even think to run it!

Because `test_report_error_cleanup` mocks the `os.unlink` call the `os.unlink` call never happens during that test, so none of the temporary files get deleted, and this is what added a full set of report files to my /tmp every day as I'd run the entire test suite in the morning.

To be clear the race was still there and resolving it was reasonable it, but that was not the cause of the leftover temporary files, or if so extremely rarely.
