### PR TITLE
[IMP] website_sale: improve Google Analytics 4 eCommerce event tracking

### DIFF
--- a/addons/website_sale/controllers/cart.py
+++ b/addons/website_sale/controllers/cart.py
@@ -59,6 +59,8 @@ class Cart(PaymentPortal):
             ).unlink()
             values["suggested_products"] = order_sudo._cart_accessories()
             values.update(self._get_express_shop_payment_values(order_sudo))
+            if self.env.website.google_analytics_key:
+                values["cart_tracking_info"] = order_sudo._get_order_tracking_info()
 
         values.update(self.env.website._get_checkout_step_values("/shop/cart"))
         values.update(self._cart_values(**post))
@@ -130,6 +132,7 @@ class Cart(PaymentPortal):
         )
         line_ids = {product_template_id: values["line_id"]}
         added_qty_per_line[values["line_id"]] = values["added_qty"]
+        tracking_info = values.get("tracking_info", [])
         is_combo = product.type == "combo"
         updated_line = (
             values["line_id"]
@@ -189,6 +192,7 @@ class Cart(PaymentPortal):
 
                 line_ids[product_data["product_template_id"]] = product_values["line_id"]
                 added_qty_per_line[product_values["line_id"]] = product_values["added_qty"]
+                tracking_info += product_values.get("tracking_info", [])
 
         warning = values.pop("warning", "")
         if is_combo and (changed_reason := order_sudo._check_combo_quantities(updated_line)):
@@ -229,7 +233,8 @@ class Cart(PaymentPortal):
             "cart_quantity": order_sudo.cart_quantity,
             "notifications": notifications,
             "quantity": values.pop("quantity", 0),
-            "tracking_info": self._get_tracking_information(order_sudo, line_ids.values()),
+            "tracking_info": tracking_info,
+            "currency": order_sudo.currency_id.name,
         }
 
     @route(
@@ -337,6 +342,7 @@ class Cart(PaymentPortal):
         return {
             "cart_has_blocking_alerts": order_sudo._has_blocking_alerts(),
             "cart_quantity": order_sudo.cart_quantity,
+            "currency": order_sudo.currency_id.name,
             "amount": order_sudo.amount_total,
             "minor_amount": payment_utils.to_minor_currency_units(
                 order_sudo.amount_total, order_sudo.currency_id
@@ -491,30 +497,6 @@ class Cart(PaymentPortal):
                 for line in lines
             ],
         }
-
-    def _get_tracking_information(self, order_sudo, line_ids):
-        """Get the tracking information about the sales order lines.
-
-        :param sale.order order: The sales order.
-        :param list[int] line_ids: The ids of the lines to track.
-        :rtype: dict
-        :return: The tracking information.
-        """
-        lines = order_sudo.order_line.filtered(lambda line: line.id in line_ids).with_context(
-            display_default_code=False
-        )
-        return [
-            {
-                "item_id": line.product_id.barcode or line.product_id.id,
-                "item_name": line.product_id.display_name,
-                "item_category": line.product_id.categ_id.name,
-                "currency": line.currency_id.name,
-                "price": line.price_reduce_taxexcl,
-                "discount": line.price_unit - line.price_reduce_taxexcl,
-                "quantity": line.product_uom_qty,
-            }
-            for line in lines
-        ]
 
     def _get_additional_cart_update_values(self, data):
         """Look for extra information in a given dictionary to be included in a `_cart_add` call.

--- a/addons/website_sale/controllers/cart.py
+++ b/addons/website_sale/controllers/cart.py
@@ -70,6 +70,7 @@ class Cart(PaymentPortal):
             ).unlink()
             values["suggested_products"] = order_sudo._cart_accessories()
             values.update(self._get_express_shop_payment_values(order_sudo))
+            values["cart_tracking_info"] = self._get_cart_tracking_info(order_sudo)
 
         values.update(request.website._get_checkout_step_values())
         values.update(self._cart_values(**post))
@@ -334,7 +335,30 @@ class Cart(PaymentPortal):
                 :1
             ].id
 
+        original_line = order_sudo.order_line.filtered(lambda line: line.id == line_id)
+        old_qty = original_line.product_uom_qty if original_line else 0
+
+        tracking_info_before = (
+            self._get_tracking_information(
+                order_sudo,
+                [line_id] if line_id else [],
+                added_qty_per_line={line_id: -old_qty},
+                extra_lines=original_line,
+            )
+            if quantity == 0
+            else None
+        )
+
         values = order_sudo._cart_update_line_quantity(line_id, quantity, **kwargs)
+
+        delta = quantity - old_qty
+        values["tracking_info"] = (
+            tracking_info_before
+            if quantity == 0
+            else self._get_tracking_information(
+                order_sudo, [line_id] if line_id else [], added_qty_per_line={line_id: delta}
+            )
+        )
 
         values["cart_quantity"] = order_sudo.cart_quantity
         values["cart_ready"] = order_sudo._is_cart_ready()
@@ -496,29 +520,64 @@ class Cart(PaymentPortal):
             ],
         }
 
-    def _get_tracking_information(self, order_sudo, line_ids):
+    def _get_tracking_information(
+        self, order_sudo, line_ids, added_qty_per_line=None, extra_lines=None
+    ):
         """Get the tracking information about the sales order lines.
 
-        :param sale.order order: The sales order.
+        :param sale.order order_sudo: The sales order.
         :param list[int] line_ids: The ids of the lines to track.
-        :rtype: dict
+        :param dict added_qty_per_line: Delta quantities per line id (can be negative).
+        :param recordset extra_lines: Extra lines to include (e.g deleted lines no longer in order).
+        :rtype: list[dict]
         :return: The tracking information.
         """
-        lines = order_sudo.order_line.filtered(lambda line: line.id in line_ids).with_context(
-            display_default_code=False
+        added_qty_per_line = added_qty_per_line or {}
+        tracking_line_ids = set(order_sudo._get_order_tracking_lines().ids)
+        lines = order_sudo.order_line.filtered(
+            lambda line: (
+                line.id in set(line_ids) and line.id in tracking_line_ids and line.product_id
+            )
         )
-        return [
-            {
-                "item_id": line.product_id.barcode or line.product_id.id,
-                "item_name": line.product_id.display_name,
-                "item_category": line.product_id.categ_id.name,
-                "currency": line.currency_id.name,
-                "price": line.price_reduce_taxexcl,
-                "discount": line.price_unit - line.price_reduce_taxexcl,
-                "quantity": line.product_uom_qty,
-            }
-            for line in lines
-        ]
+        if extra_lines:
+            lines |= extra_lines.filtered(lambda line: line.product_id)
+        lines = lines.with_context(display_default_code=False)
+
+        show_tax = order_sudo.website_id.show_line_subtotals_tax_selection == "tax_included"
+        result = []
+        for line in lines:
+            delta = added_qty_per_line.get(line.id, line.product_uom_qty)
+            if not delta:
+                continue
+            tracking_data = line.product_id.product_tmpl_id._get_google_analytics_data(
+                line.product_id,
+                {
+                    "display_name": line.product_id.display_name,
+                    "currency": line.currency_id,
+                    "list_price": line.product_id.list_price,
+                },
+            )
+            price = line.price_reduce_taxinc if show_tax else line.price_reduce_taxexcl
+            result.append({
+                **tracking_data,
+                "price": price,
+                "discount": round(line.price_unit - price, 2),
+                "quantity": abs(delta),
+                "delta_quantity": delta,
+            })
+        return result
+
+    def _get_cart_tracking_info(self, order):
+        """Return GA4 tracking data for the begin_checkout event.
+
+        :param sale.order order: The sales order.
+        :rtype: dict
+        """
+        return {
+            "currency": order.currency_id.name,
+            "value": order._get_order_tracking_value(),
+            "items": order._get_order_tracking_items(),
+        }
 
     def _get_additional_cart_update_values(self, data):
         """Look for extra information in a given dictionary to be included in a `_cart_add` call.

--- a/addons/website_sale/controllers/delivery.py
+++ b/addons/website_sale/controllers/delivery.py
@@ -72,7 +72,7 @@ class Delivery(WebsiteSale):
         rendered_tax_lines = self.env.website._render_template(
             "website_sale.order_tax_lines", {"website_sale_order": order}
         )
-        return {
+        result = {
             "success": True,
             "is_free_delivery": not bool(order.amount_delivery),
             "compute_price_after_delivery": order.carrier_id.invoice_policy == "real",
@@ -87,6 +87,12 @@ class Delivery(WebsiteSale):
                 order.amount_total, {"display_currency": currency}
             ),
         }
+        if self.env.website.google_analytics_key and order.carrier_id:
+            result["shipping_tracking_info"] = {
+                **order._get_order_tracking_info(),
+                "shipping_tier": order.carrier_id.name,
+            }
+        return result
 
     @route("/shop/get_delivery_rate", type="jsonrpc", auth="public", methods=["POST"], website=True)
     def shop_get_delivery_rate(self, dm_id):

--- a/addons/website_sale/controllers/delivery.py
+++ b/addons/website_sale/controllers/delivery.py
@@ -73,7 +73,7 @@ class Delivery(WebsiteSale):
         rendered_tax_lines = request.env["ir.ui.view"]._render_template(
             "website_sale.order_tax_lines", {"website_sale_order": order}
         )
-        return {
+        result = {
             "success": True,
             "is_free_delivery": not bool(order.amount_delivery),
             "compute_price_after_delivery": order.carrier_id.invoice_policy == "real",
@@ -88,6 +88,14 @@ class Delivery(WebsiteSale):
                 order.amount_total, {"display_currency": currency}
             ),
         }
+        if request.website.google_analytics_key and order.carrier_id:
+            result["shipping_tracking_info"] = {
+                "currency": order.currency_id.name,
+                "value": order._get_order_tracking_value(),
+                "shipping_tier": order.carrier_id.name,
+                "items": order._get_order_tracking_items(),
+            }
+        return result
 
     @route("/shop/get_delivery_rate", type="jsonrpc", auth="public", methods=["POST"], website=True)
     def shop_get_delivery_rate(self, dm_id):

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -694,6 +694,19 @@ class WebsiteSale(payment_portal.PaymentPortal):
         values["structured_data"] = products.with_context(
             shop_category_id=category.id if category else False
         )._render_jsonld()
+
+        if website.google_analytics_key:
+            if category:
+                item_list_name = category.with_context(lang=False).name
+            elif fuzzy_search_term or search:
+                item_list_name = "Search Results"
+            else:
+                item_list_name = "Shop"
+            # Not translated as they could be used as GA4 aggregation key
+            values["product_tracking_infos"] = products._get_google_analytics_list_data_batch(
+                products_prices, website, item_list_name
+            )
+
         values.update(self._get_additional_shop_values(values, **post))
 
         values["default_expand_filter_sections"] = nb_filter_sections < MAX_EXPANDED_FILTER_SECTIONS
@@ -1730,6 +1743,9 @@ class WebsiteSale(payment_portal.PaymentPortal):
             "order": order,
             "only_services": order.only_services,
             **self.env.website._get_checkout_step_values("/shop/payment"),
+            "payment_tracking_info": (
+                order._get_order_tracking_info() if self.env.website.google_analytics_key else {}
+            ),
         }
         payment_form_values = {
             **sale_portal.CustomerPortal._get_payment_values(
@@ -1844,7 +1860,9 @@ class WebsiteSale(payment_portal.PaymentPortal):
         rendering_values = {
             "order": order,
             "website_sale_order": order,
-            "order_tracking_info": self.order_2_return_dict(order),
+            "order_tracking_info": (
+                order._get_purchase_tracking_info() if self.env.website.google_analytics_key else {}
+            ),
         }
         if (
             self.env["res.users"]._get_signup_invitation_scope() == "b2c"
@@ -2031,36 +2049,6 @@ class WebsiteSale(payment_portal.PaymentPortal):
         if "image" in options:
             image_data = self.env["ir.attachment"].browse(options["image"]).raw
             tag.image = image_data
-
-    def order_lines_2_google_api(self, order_lines):
-        """Transform a list of order lines into a dict for google analytics."""
-        ret = []
-        for line in order_lines.filtered(lambda line: not line.is_delivery):
-            product = line.product_id
-            ret.append({
-                "item_id": product.barcode or product.id,
-                "item_name": product.name or "-",
-                "item_category": product.categ_id.name or "-",
-                "price": line.price_unit,
-                "quantity": line.product_uom_qty,
-            })
-        return ret
-
-    def order_2_return_dict(self, order):
-        """Return the tracking_cart dict of the order for Google analytics basically defined to
-        be inherited."""
-        tracking_cart_dict = {
-            "transaction_id": order.id,
-            "affiliation": order.company_id.name,
-            "value": order.amount_total,
-            "tax": order.amount_tax,
-            "currency": order.currency_id.name,
-            "items": self.order_lines_2_google_api(order.order_line),
-        }
-        delivery_line = order.order_line.filtered("is_delivery")
-        if delivery_line:
-            tracking_cart_dict["shipping"] = delivery_line.price_unit
-        return tracking_cart_dict
 
     # --------------------------------------------------------------------------
     # Products Recently Viewed

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -510,6 +510,14 @@ class WebsiteSale(payment_portal.PaymentPortal):
             attributes = ProductAttribute.browse(attribute_ids).sorted()
 
         products_prices = products._get_sales_prices(website)
+        product_tracking_infos = (
+            products._get_google_analytics_list_data_batch(
+                product_variants, products_prices, website
+            )
+            if website.google_analytics_key
+            else {}
+        )
+
         product_query_params = self._get_product_query_params(**post)
 
         grouped_attributes_values = (
@@ -553,6 +561,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             "previewed_attribute_values": lazy(
                 lambda: products._get_previewed_attribute_values(category, product_query_params)
             ),
+            "product_tracking_infos": product_tracking_infos,
         }
         if filter_by_price_enabled:
             values["min_price"] = min_price or available_min_price
@@ -1624,6 +1633,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             "errors": self._get_shop_payment_errors(order),
             "partner": order.partner_invoice_id,
             "order": order,
+            "payment_tracking_info": self._get_payment_tracking_info(order),
         }
         payment_form_values = {
             **sale_portal.CustomerPortal._get_payment_values(
@@ -2022,35 +2032,36 @@ class WebsiteSale(payment_portal.PaymentPortal):
         if modified_options:
             category.write(modified_options)
 
-    def order_lines_2_google_api(self, order_lines):
-        """Transform a list of order lines into a dict for google analytics."""
-        ret = []
-        for line in order_lines.filtered(lambda line: not line.is_delivery):
-            product = line.product_id
-            ret.append({
-                "item_id": product.barcode or product.id,
-                "item_name": product.name or "-",
-                "item_category": product.categ_id.name or "-",
-                "price": line.price_unit,
-                "quantity": line.product_uom_qty,
-            })
-        return ret
+    def _get_payment_tracking_info(self, order):
+        """Return GA4 tracking data for the add_payment_info event.
+
+        :param sale.order order: The sales order.
+        :rtype: dict
+        """
+        return {
+            "currency": order.currency_id.name,
+            "value": order._get_order_tracking_value(),
+            "items": order._get_order_tracking_items(),
+        }
 
     def order_2_return_dict(self, order):
-        """Return the tracking_cart dict of the order for Google analytics basically defined to
-        be inherited."""
-        tracking_cart_dict = {
-            "transaction_id": order.id,
-            "affiliation": order.company_id.name,
-            "value": order.amount_total,
+        """Return GA4 tracking data for the purchase event.
+
+        :param sale.order order: The sales order.
+        :rtype: dict
+        """
+        tracking_dict = {
+            "transaction_id": order.name,
+            "affiliation": order.website_id.name,
+            "value": order._get_order_tracking_value(),
             "tax": order.amount_tax,
             "currency": order.currency_id.name,
-            "items": self.order_lines_2_google_api(order.order_line),
+            "items": order._get_order_tracking_items(),
         }
         delivery_line = order.order_line.filtered("is_delivery")
         if delivery_line:
-            tracking_cart_dict["shipping"] = delivery_line.price_unit
-        return tracking_cart_dict
+            tracking_dict["shipping"] = delivery_line.price_reduce_taxexcl
+        return tracking_dict
 
     # --------------------------------------------------------------------------
     # Products Recently Viewed

--- a/addons/website_sale/controllers/reorder.py
+++ b/addons/website_sale/controllers/reorder.py
@@ -78,4 +78,5 @@ class CustomerPortal(sale_portal.CustomerPortal):
             values["tracking_info"].extend(cart_values["tracking_info"])
 
         values["cart_quantity"] = order_sudo.cart_quantity
+        values["currency"] = order_sudo.currency_id.name
         return values

--- a/addons/website_sale/controllers/wishlist.py
+++ b/addons/website_sale/controllers/wishlist.py
@@ -37,11 +37,17 @@ class ProductWishlist(Controller):
     @route("/shop/wishlist", type="http", auth="public", website=True, readonly=True, sitemap=False)
     def shop_wishlist(self, **_kw):
         wishes = self.env["product.wishlist"].current()
-
-        return request.render(
-            "website_sale.product_wishlist",
-            {"wishes": wishes.with_context(display_default_code=False)},
-        )
+        values = {"wishes": wishes.with_context(display_default_code=False)}
+        website = self.env.website
+        if website.google_analytics_key and wishes:
+            products = wishes.product_id.product_tmpl_id
+            products_prices = products._get_sales_prices(
+                request.pricelist, request.fiscal_position, website
+            )
+            values["product_tracking_infos"] = products._get_google_analytics_list_data_batch(
+                products_prices, website, "Wishlist"
+            )
+        return request.render("website_sale.product_wishlist", values)
 
     @route("/shop/wishlist/remove/<int:wish_id>", type="jsonrpc", auth="public", website=True)
     def remove_from_wishlist(self, wish_id, **_kw):

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -816,6 +816,7 @@ class ProductTemplate(models.Model):
             combination_info["product_tracking_info"] = self._get_google_analytics_data(
                 product, combination_info
             )
+            combination_info["currency_name"] = combination_info["currency"].name
 
         if (
             self.type == "combo"
@@ -1378,10 +1379,9 @@ class ProductTemplate(models.Model):
     def _get_google_analytics_data(self, product, combination_info):
         self.ensure_one()
         tracking_data = {
-            "item_id": product.barcode or product.id,
-            "item_name": combination_info["display_name"],
+            "item_id": str(product.barcode or product.product_tmpl_id.id),
+            "item_name": self.with_context(display_default_code=False).display_name,
             "item_category": self.categ_id.name,
-            "currency": combination_info["currency"].name,
             "price": combination_info["price"],
         }
 
@@ -1399,6 +1399,36 @@ class ProductTemplate(models.Model):
             key = f"item_{ext_id}" if ext_id == "brand" else ext_id
             tracking_data[key] = value
         return tracking_data
+
+    def _get_google_analytics_list_data_batch(self, products_prices, website, item_list_name):
+        """Compute GA tracking data for all products in batch for list contexts (shop, snippets).
+        Uses already-computed prices to avoid extra queries per product.
+
+        :param dict products_prices: mapping of product.template.id -> price vals
+        :param website: current website record
+        :param str item_list_name: name of the list the products are displayed in (e.g. category
+            name, "Search Results", "Wishlist", snippet name); used to distinguish ``select_item``
+            from ``view_item`` in GA4.
+        :rtype: dict
+        :return: mapping of product.template.id -> GA tracking dict
+        """
+        result = {}
+        currency = website.currency_id
+        for template in self:
+            price_vals = products_prices.get(template.id, {})
+            price = price_vals.get("price_reduce", template.list_price)
+            list_price = price_vals.get("base_price", price)
+            tracking_data = {
+                "item_id": str(template.barcode or template.id),
+                "item_name": template.with_context(display_default_code=False).display_name,
+                "item_category": template.categ_id.name,
+                "item_list_name": item_list_name,
+                "price": price,
+            }
+            if discount := currency.round(list_price - price):
+                tracking_data["discount"] = discount
+            result[template.id] = tracking_data
+        return result
 
     def _get_contextual_pricelist(self):
         """Override to fallback on website current pricelist."""

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -1043,6 +1043,48 @@ class ProductTemplate(models.Model):
             "price": combination_info["list_price"],
         }
 
+    def _get_google_analytics_list_data(self):
+        """Return the Google Analytics tracking data for this product in a list context
+        (shop page, snippets).
+        """
+        self.ensure_one()
+        combination_info = self._get_combination_info()
+        return combination_info.get("product_tracking_info", {})
+
+    def _get_google_analytics_list_data_batch(self, product_variants, products_prices, website):
+        """Compute GA tracking data for all products in batch for list contexts (shop, snippets).
+        Uses already-computed variants and prices to avoid extra queries per product.
+
+        :param dict product_variants: mapping of product.template -> product.product
+        :param dict products_prices: mapping of product.template.id -> price vals
+        :param website: current website record
+        :rtype: dict
+        :return: mapping of product.template.id -> GA tracking dict
+        """
+        result = {}
+        currency = website.currency_id
+        for template in self:
+            variant = product_variants.get(template)
+            price_vals = products_prices.get(template.id, {})
+            price = price_vals.get("price_reduce", template.list_price)
+            list_price = price_vals.get("base_price", price)
+            item_variant = (
+                (variant.product_template_attribute_value_ids._get_combination_name() or None)
+                if variant
+                else None
+            )
+            tracking_data = {
+                "item_id": (variant and (variant.barcode or str(variant.id))) or str(template.id),
+                "item_name": template.with_context(display_default_code=False).display_name,
+                "item_category": template.categ_id.name,
+                "currency": currency.name,
+                "price": price,
+                "discount": round(list_price - price, 2),
+                "item_variant": item_variant,
+            }
+            result[template.id] = tracking_data
+        return result
+
     def _get_contextual_pricelist(self):
         """Override to fallback on website current pricelist."""
         pricelist = super()._get_contextual_pricelist()

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -308,6 +308,127 @@ class SaleOrder(models.Model):
     def _get_amount_total_excluding_delivery(self):
         return sum(self._get_non_delivery_lines().mapped("price_total"))
 
+    def _get_order_tracking_info(self):
+        """Return base GA4 tracking payload for cart, payment, and purchase events.
+
+        :rtype: dict
+        """
+        self.ensure_one()
+        return {
+            "currency": self.currency_id.name,
+            "value": self.currency_id.round(
+                sum(line.price_subtotal for line in self._get_order_tracking_lines())
+            ),
+            "items": self._get_order_tracking_items(),
+        }
+
+    def _get_order_tracking_items(self):
+        """Return GA4 items array for an order.
+
+        :rtype: list[dict]
+        """
+        self.ensure_one()
+        items = []
+        for line in self._get_order_tracking_lines():
+            tracking_data = self._get_order_line_tracking_data(line)
+            items.append({**tracking_data, "quantity": line.product_uom_qty})
+        return items
+
+    def _get_order_tracking_lines(self):
+        """Return order lines to include in GA4 tracking payloads.
+
+        :rtype: sale.order.line recordset
+        """
+        self.ensure_one()
+        return self.order_line.filtered(lambda line: not line.is_delivery and line.product_id)
+
+    def _get_order_line_tracking_data(self, line):
+        """Build a GA4 tracking dict for a single order line.
+
+        :param line: a `sale.order.line` record
+        :rtype: dict
+        """
+        price_unit_taxexcl = line.tax_ids.compute_all(
+            line.price_unit,
+            currency=line.currency_id,
+            quantity=1,
+            product=line.product_id,
+            partner=line.order_id.partner_id,
+        )["total_excluded"]
+        return line.product_id.product_tmpl_id._get_google_analytics_data(
+            line.product_id,
+            {
+                "combination": line.product_id.product_template_attribute_value_ids
+                | line.product_no_variant_attribute_value_ids,
+                "display_name": line.product_id.with_context(
+                    display_default_code=False
+                ).display_name,
+                "currency": line.currency_id,
+                "price": line.price_reduce_taxexcl,
+                "list_price": price_unit_taxexcl,
+            },
+        )
+
+    def _get_cart_lines_tracking_info(self, line_ids, added_qty_per_line=None):
+        """Get GA4 tracking data for specific cart lines with delta quantities.
+
+        :param list[int] line_ids: The ids of the lines to track.
+        :param dict added_qty_per_line: Delta quantities per line id (can be negative).
+        :rtype: list[dict]
+        """
+        self.ensure_one()
+        added_qty_per_line = added_qty_per_line or {}
+        lines = self.env["sale.order.line"].browse(line_ids)
+        result = []
+        for line in lines:
+            delta = added_qty_per_line.get(line.id, line.product_uom_qty)
+            if not delta:
+                continue
+            tracking_data = self._get_order_line_tracking_data(line)
+            # delta_quantity: used by tracking.js to route add_to_cart (positive)
+            # vs remove_from_cart (negative) events, stripped before reaching GA4.
+            result.append({
+                **tracking_data,
+                "quantity": abs(delta),
+                "delta_quantity": delta,
+                "subtotal": line.currency_id.round(line.price_reduce_taxexcl * abs(delta)),
+            })
+        return result
+
+    def _get_purchase_tracking_info(self):
+        """Return GA4 tracking data for the purchase event.
+
+        :rtype: dict
+        """
+        tracking_dict = {
+            **self._get_order_tracking_info(),
+            "transaction_id": self.name,
+            "affiliation": self.website_id.name,
+            "tax": self.amount_tax,
+        }
+
+        delivery_line = self.order_line.filtered("is_delivery")
+        if delivery_line:
+            tracking_dict["shipping"] = delivery_line.price_subtotal
+
+        has_previous = bool(
+            self
+            .env["sale.order"]
+            .sudo()
+            .search_count(
+                [
+                    ("partner_id", "=", self.partner_id.id),
+                    ("state", "=", "sale"),
+                    ("id", "!=", self.id),
+                    ("date_order", ">=", fields.Datetime.now() - relativedelta(days=540)),
+                ],
+                limit=1,
+            )
+        )
+        tracking_dict["customer_type"] = "returning" if has_previous else "new"
+
+        return tracking_dict
+
     def _get_confirmation_template(self):
         """Override of `sale` to use the website specific order confirmation email template if
         set."""
@@ -460,6 +581,14 @@ class SaleOrder(models.Model):
             "line_id": order_line.id,
             "quantity": quantity,
             "warning": warning,
+            "tracking_info": (
+                self._get_cart_lines_tracking_info(
+                    [order_line.id] if order_line else [],
+                    {order_line.id: quantity} if order_line else {},
+                )
+                if self.website_id.google_analytics_key
+                else []
+            ),
         }
 
     def _cart_find_product_line(
@@ -561,15 +690,34 @@ class SaleOrder(models.Model):
             warning = ""
 
         added_qty = quantity - order_line.product_uom_qty  # new_qty - old_qty
+
+        # Capture tracking before deletion since the line will no longer exist after.
+        if quantity <= 0:
+            tracking_info = (
+                self._get_cart_lines_tracking_info(
+                    [order_line.id], {order_line.id: -order_line.product_uom_qty}
+                )
+                if self.website_id.google_analytics_key
+                else []
+            )
+
         order_line = self._cart_update_order_line(order_line, quantity, **kwargs)
         if not self.env.context.get("skip_cart_verification"):
             self._verify_cart_after_update()
+
+        if quantity > 0:
+            tracking_info = (
+                self._get_cart_lines_tracking_info([order_line.id], {order_line.id: added_qty})
+                if self.website_id.google_analytics_key
+                else []
+            )
 
         return {
             "added_qty": added_qty,
             "line_id": order_line.id,
             "quantity": quantity,
             "warning": warning,
+            "tracking_info": tracking_info,
         }
 
     # hook to be overridden

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -276,6 +276,52 @@ class SaleOrder(models.Model):
     def _get_amount_total_excluding_delivery(self):
         return sum(self._get_non_delivery_lines().mapped("price_total"))
 
+    def _get_order_tracking_lines(self):
+        """Return order lines to include in GA4 tracking payloads.
+
+        :rtype: sale.order.line recordset
+        """
+        self.ensure_one()
+        return self.order_line.filtered(lambda line: not line.is_delivery and line.product_id)
+
+    def _get_order_tracking_items(self):
+        """Return GA4 items array for an order.
+
+        :rtype: list[dict]
+        """
+        self.ensure_one()
+        items = []
+        for line in self._get_order_tracking_lines().with_context(display_default_code=False):
+            tracking_data = line.product_id.product_tmpl_id._get_google_analytics_data(
+                line.product_id,
+                {
+                    "display_name": line.product_id.display_name,
+                    "currency": line.currency_id,
+                    "list_price": line.product_id.list_price,
+                },
+            )
+            items.append({
+                **tracking_data,
+                "price": line.price_reduce_taxexcl,
+                "discount": round(line.price_unit - line.price_reduce_taxexcl, 2),
+                "quantity": line.product_uom_qty,
+            })
+        return items
+
+    def _get_order_tracking_value(self):
+        """Return the GA4 event value for the order — sum of item subtotals excluding delivery.
+
+        :rtype: float
+        """
+        self.ensure_one()
+        return round(
+            sum(
+                line.price_reduce_taxexcl * line.product_uom_qty
+                for line in self.order_line.filtered(lambda line: not line.is_delivery)
+            ),
+            2,
+        )
+
     def _get_confirmation_template(self):
         """Override of `sale` to use the website specific order confirmation email template if
         set."""

--- a/addons/website_sale/models/website_snippet_filter.py
+++ b/addons/website_sale/models/website_snippet_filter.py
@@ -151,6 +151,11 @@ class WebsiteSnippetFilter(models.Model):
                         res_product.update(product._get_combination_info())
                     res_product["hide_variants"] = hide_variants
 
+                    if self.env.website.google_analytics_key:
+                        res_product.get("product_tracking_info", {})["item_list_name"] = (
+                            self.with_context(lang=False).name
+                        )
+
                     if records.env.context.get("add2cart_rerender"):
                         res_product["_add2cart_rerender"] = True
                 else:

--- a/addons/website_sale/static/src/interactions/add_to_wishlist.js
+++ b/addons/website_sale/static/src/interactions/add_to_wishlist.js
@@ -49,6 +49,14 @@ export class AddToWishlist extends Interaction {
             saveForLaterButton.classList.add('d-none');
             addedToWishListAlert.classList.remove('d-none');
         }
+
+        const trackingEl = this.el.closest("[data-product-tracking-info]")
+            || document.querySelector("#product_detail[data-product-tracking-info]");
+        if (trackingEl) {
+            const trackingInfo = JSON.parse(trackingEl.dataset.productTrackingInfo);
+            const currency = trackingEl.dataset.productGaCurrency;
+            wSaleUtils.dispatchTrackingEvent("add_to_wishlist_event", { trackingInfo, currency });
+        }
     }
 
     /**

--- a/addons/website_sale/static/src/interactions/cart_line.js
+++ b/addons/website_sale/static/src/interactions/cart_line.js
@@ -63,6 +63,13 @@ export class CartLine extends Interaction {
 
         data['website_sale.cart_lines'] = markup(data['website_sale.cart_lines']);
 
+        if (data.tracking_info?.length) {
+            wSaleUtils.dispatchTrackingEvent("update_cart_event", {
+                currency: data.currency,
+                items: data.tracking_info,
+            });
+        }
+
         if (!data.cart_quantity) {
             // Ensure the last cart removal is recorded.
             browser.sessionStorage.setItem('website_sale_cart_quantity', 0);

--- a/addons/website_sale/static/src/interactions/cart_line.js
+++ b/addons/website_sale/static/src/interactions/cart_line.js
@@ -65,6 +65,12 @@ export class CartLine extends Interaction {
 
         data['website_sale.cart_lines'] = markup(data['website_sale.cart_lines']);
 
+        if (data.tracking_info?.length) {
+            document.querySelector('.oe_website_sale')?.dispatchEvent(
+                new CustomEvent('update_cart_event', { detail: data.tracking_info }),
+            );
+        }
+
         if (!data.cart_quantity) {
             // Ensure the last cart removal is recorded.
             browser.sessionStorage.setItem('website_sale_cart_quantity', 0);

--- a/addons/website_sale/static/src/interactions/checkout.js
+++ b/addons/website_sale/static/src/interactions/checkout.js
@@ -4,6 +4,7 @@ import { _t } from '@web/core/l10n/translation';
 import { rpc } from '@web/core/network/rpc';
 import { setElementContent } from '@web/core/utils/html';
 import { markup } from '@odoo/owl';
+import wSaleUtils from '@website_sale/js/website_sale_utils';
 
 export class Checkout extends Interaction {
     static selector = '#shop_checkout';
@@ -220,6 +221,11 @@ export class Checkout extends Interaction {
         const result = await this.waitFor(this._setDeliveryMethod(radio.dataset.dmId));
         this._updateAmountBadge(radio, result);
         this._updateCartSummaries(result);
+        if (result.shipping_tracking_info) {
+            wSaleUtils.dispatchTrackingEvent(
+                "add_shipping_info_event", result.shipping_tracking_info,
+            );
+        }
     }
 
     /**

--- a/addons/website_sale/static/src/interactions/checkout.js
+++ b/addons/website_sale/static/src/interactions/checkout.js
@@ -312,6 +312,11 @@ export class Checkout extends Interaction {
         const result = await this.waitFor(this._setDeliveryMethod(radio.dataset.dmId));
         this._updateAmountBadge(radio, result);
         this._updateCartSummaries(result);
+        if (result.shipping_tracking_info) {
+            this.el.dispatchEvent(
+                new CustomEvent('add_shipping_info_event', { detail: result.shipping_tracking_info, bubbles: true }),
+            );
+        }
     }
 
     /**

--- a/addons/website_sale/static/src/interactions/product_page.js
+++ b/addons/website_sale/static/src/interactions/product_page.js
@@ -684,9 +684,12 @@ export class ProductPage extends Interaction {
         if ('product_tracking_info' in combination) {
             const product = document.querySelector('#product_detail');
             // Trigger an event to track variant changes in Google Analytics.
-            product.dispatchEvent(new CustomEvent(
-                'view_item_event', { 'detail': combination['product_tracking_info'] }
-            ));
+            product.dataset.productTrackingInfo = JSON.stringify(combination["product_tracking_info"]);
+            product.dataset.productGaCurrency = combination["currency_name"];
+            wSaleUtils.dispatchTrackingEvent("view_item_event", {
+                trackingInfo: combination["product_tracking_info"],
+                currency: combination["currency_name"],
+            });
         }
         const addToCart = parent.querySelector('#add_to_cart_wrap');
         const contactUsButton = parent.closest('#product_details')

--- a/addons/website_sale/static/src/interactions/quick_reorder.js
+++ b/addons/website_sale/static/src/interactions/quick_reorder.js
@@ -141,6 +141,13 @@ export class QuickReorder extends Interaction {
             ...(isCombo && { linked_products: linkedProducts }),
         }));
 
+        if (data.tracking_info?.length) {
+            wSaleUtils.dispatchTrackingEvent("add_to_cart_event", {
+                currency: data.currency,
+                items: data.tracking_info,
+            });
+        }
+
         data['website_sale.shorter_cart_summary'] = markup(
             data['website_sale.shorter_cart_summary']
         );

--- a/addons/website_sale/static/src/interactions/reorder.js
+++ b/addons/website_sale/static/src/interactions/reorder.js
@@ -3,6 +3,7 @@ import { rpc } from '@web/core/network/rpc';
 import { registry } from '@web/core/registry';
 import { redirect } from '@web/core/utils/urls';
 import { Interaction } from '@web/public/interaction';
+import wSaleUtils from "@website_sale/js/website_sale_utils";
 
 export class SaleOrderPortalReorder extends Interaction {
     static selector = '#sale_order_sidebar_button';
@@ -36,26 +37,18 @@ export class SaleOrderPortalReorder extends Interaction {
             // since `website_sale_cart_quantity` updates only via the cart service.
             browser.sessionStorage.setItem('website_sale_cart_quantity', values.cart_quantity);
 
-            this._trackProducts(values.tracking_info);
+            if (values.tracking_info?.length) {
+                wSaleUtils.dispatchTrackingEvent("add_to_cart_event", {
+                    currency: values.currency,
+                    items: values.tracking_info,
+                });
+            }
             redirect('/shop/cart');
         } catch (error) {
             console.error("Error during reordering:", error);
         }
     }
 
-    /**
-     * Track the products added to the cart.
-     *
-     * @private
-     * @param {Object[]} trackingInfo - A list of product tracking information.
-     *
-     * @returns {void}
-     */
-    _trackProducts(trackingInfo) {
-        document.querySelector('.oe_website_sale').dispatchEvent(
-            new CustomEvent('add_to_cart_event', {'detail': trackingInfo})
-        );
-    }
 }
 
 registry

--- a/addons/website_sale/static/src/interactions/tracking.js
+++ b/addons/website_sale/static/src/interactions/tracking.js
@@ -12,7 +12,11 @@ export class Tracking extends Interaction {
         'button[name="o_payment_submit_button"]': { 't-on-click': this.onOrderPayment },
         _root: {
             't-on-view_item_event': (ev) => this.onViewItem(ev),
+            "t-on-select_item_event": (ev) => this.onSelectItem(ev),
             't-on-add_to_cart_event': (ev) => this.onAddToCart(ev),
+            "t-on-update_cart_event": (ev) => this.onUpdateCart(ev),
+            "t-on-add_shipping_info_event": (ev) => this.onAddShippingInfo(ev),
+            "t-on-add_to_wishlist_event": (ev) => this.onAddToWishlist(ev),
         },
     };
 
@@ -21,6 +25,18 @@ export class Tracking extends Interaction {
         if (confirmation) {
             this._vpv('/stats/ecom/order_confirmed/' + confirmation.dataset.orderId);
             this._trackGa('event', 'purchase', JSON.parse(confirmation.dataset.orderTrackingInfo));
+        }
+
+        const cartTrackingEl = this.el.querySelector("#cart_tracking_info");
+        if (cartTrackingEl?.dataset?.cartTrackingInfo) {
+            const cartTrackingData = JSON.parse(cartTrackingEl.dataset.cartTrackingInfo);
+            // coupon added by website_sale_loyalty for begin_checkout; not part of view_cart spec.
+            delete cartTrackingData.coupon;
+            this._trackGa(
+                "event",
+                "view_cart",
+                cartTrackingData,
+            );
         }
     }
 
@@ -42,29 +58,56 @@ export class Tracking extends Interaction {
     }
 
     onViewItem(event) {
-        const productTrackingInfo = event.detail;
-        const trackingInfo = {
-            'currency': productTrackingInfo['currency'],
-            'value': productTrackingInfo['price'],
-            'items': [productTrackingInfo],
-        };
-        this._trackGa('event', 'view_item', trackingInfo);
+        const { trackingInfo, currency } = event.detail;
+        this._trackGa("event", "view_item", {
+            currency,
+            value: trackingInfo.price,
+            items: [trackingInfo],
+        });
+    }
+
+    onSelectItem(event) {
+        const { item_list_name, trackingInfo } = event.detail;
+        this._trackGa("event", "select_item", {
+            item_list_name,
+            items: [trackingInfo],
+        });
+    }
+
+    _trackCartEvent(eventName, currency, items) {
+        this._trackGa("event", eventName, {
+            currency,
+            value: items.reduce((acc, item) => acc + item.subtotal, 0),
+            items: items.map(({ subtotal, ...item }) => item),
+        });
     }
 
     onAddToCart(event) {
-        const productsTrackingInfo = event.detail;
-        const trackingInfo = {
-            'currency': productsTrackingInfo[0]['currency'],
-            'value': productsTrackingInfo.reduce(
-                (acc, val) => acc + val['price'] * val['quantity'], 0
-            ),
-            'items': productsTrackingInfo,
-        };
-        this._trackGa('event', 'add_to_cart', trackingInfo);
+        const { currency, items } = event.detail;
+        if (!items?.length) return;
+        this._trackCartEvent(
+            "add_to_cart",
+            currency,
+            items.map(({ delta_quantity, ...item }) => item),
+        );
+    }
+
+    onUpdateCart(event) {
+        const { currency, items } = event.detail;
+        if (!items?.length) return;
+        const added = items.filter(i => i.delta_quantity > 0).map(({ delta_quantity, ...i }) => i);
+        const removed = items.filter(i => i.delta_quantity < 0).map(({ delta_quantity, ...i }) => i);
+        if (added.length) this._trackCartEvent("add_to_cart", currency, added);
+        if (removed.length) this._trackCartEvent("remove_from_cart", currency, removed);
     }
 
     onCheckoutStart() {
         this._vpv('/stats/ecom/customer_checkout');
+        const cartTrackingEl = this.el.querySelector("#cart_tracking_info");
+        if (!cartTrackingEl?.dataset?.cartTrackingInfo) return;
+        this._trackGa("event", "begin_checkout",
+            JSON.parse(cartTrackingEl.dataset.cartTrackingInfo)
+        );
     }
 
     onCustomerSignin() {
@@ -83,6 +126,32 @@ export class Tracking extends Interaction {
             '#payment_method input[name="o_payment_radio"]:checked'
         )?.parentElement?.querySelector('.o_payment_option_label')?.textContent;
         this._vpv('/stats/ecom/order_payment/' + paymentMethod);
+
+        const paymentTrackingElement = this.el.querySelector("#payment_tracking_info");
+        const trackingInfo = paymentTrackingElement?.dataset?.paymentTrackingInfo
+            ? JSON.parse(paymentTrackingElement.dataset.paymentTrackingInfo)
+            : {};
+
+        this._trackGa("event", "add_payment_info", {
+            ...trackingInfo,
+            payment_type: paymentMethod,
+        });
+    }
+
+    onAddShippingInfo(event) {
+        const shippingInfo = event.detail;
+        if (!shippingInfo) return;
+        this._trackGa("event", "add_shipping_info", shippingInfo);
+    }
+
+    onAddToWishlist(event) {
+        const { trackingInfo, currency } = event.detail;
+        if (!trackingInfo) return;
+        this._trackGa("event", "add_to_wishlist", {
+            currency,
+            value: trackingInfo.price,
+            items: [trackingInfo],
+        });
     }
 }
 

--- a/addons/website_sale/static/src/interactions/tracking.js
+++ b/addons/website_sale/static/src/interactions/tracking.js
@@ -13,6 +13,8 @@ export class Tracking extends Interaction {
         _root: {
             't-on-view_item_event': (ev) => this.onViewItem(ev),
             't-on-add_to_cart_event': (ev) => this.onAddToCart(ev),
+            't-on-update_cart_event': (ev) => this.onUpdateCart(ev),
+            't-on-add_shipping_info_event': (ev) => this.onAddShippingInfo(ev),
         },
     };
 
@@ -21,6 +23,15 @@ export class Tracking extends Interaction {
         if (confirmation) {
             this._vpv('/stats/ecom/order_confirmed/' + confirmation.dataset.orderId);
             this._trackGa('event', 'purchase', JSON.parse(confirmation.dataset.orderTrackingInfo));
+        }
+
+        const cartTrackingEl = this.el.querySelector("#cart_tracking_info");
+        if (cartTrackingEl?.dataset?.cartTrackingInfo) {
+            this._trackGa(
+                "event",
+                "view_cart",
+                JSON.parse(cartTrackingEl.dataset.cartTrackingInfo),
+            );
         }
     }
 
@@ -51,20 +62,46 @@ export class Tracking extends Interaction {
         this._trackGa('event', 'view_item', trackingInfo);
     }
 
+    _trackCartEvent(eventName, items) {
+        this._trackGa('event', eventName, {
+            currency: items[0].currency,
+            value: items.reduce((acc, item) => acc + item.price * item.quantity, 0),
+            items: items
+        });
+    }
+
     onAddToCart(event) {
-        const productsTrackingInfo = event.detail;
-        const trackingInfo = {
-            'currency': productsTrackingInfo[0]['currency'],
-            'value': productsTrackingInfo.reduce(
-                (acc, val) => acc + val['price'] * val['quantity'], 0
-            ),
-            'items': productsTrackingInfo,
-        };
-        this._trackGa('event', 'add_to_cart', trackingInfo);
+        const items = event.detail;
+        if (!items?.length) return;
+        this._trackCartEvent(
+            'add_to_cart',
+            items.map(({ delta_quantity, ...item }) => item),
+        );
+    }
+
+    onUpdateCart(event) {
+        const items = event.detail;
+        if (!items?.length) return;
+
+        const addedItems = items
+            .filter(i => i.delta_quantity > 0)
+            .map(({ delta_quantity, ...item }) => item);
+
+        const removedItems = items
+            .filter(i => i.delta_quantity < 0)
+            .map(({ delta_quantity, ...item }) => item);
+
+        if (addedItems.length) this._trackCartEvent('add_to_cart', addedItems);
+        if (removedItems.length) this._trackCartEvent('remove_from_cart', removedItems);
     }
 
     onCheckoutStart() {
         this._vpv('/stats/ecom/customer_checkout');
+        const cartTrackingEl = this.el.querySelector('#cart_tracking_info');
+        if (!cartTrackingEl?.dataset?.cartTrackingInfo) return;
+        this._trackGa('event', 'begin_checkout',
+            JSON.parse(cartTrackingEl.dataset.cartTrackingInfo)
+        );
     }
 
     onCustomerSignin() {
@@ -83,6 +120,21 @@ export class Tracking extends Interaction {
             '#payment_method input[name="o_payment_radio"]:checked'
         )?.parentElement?.querySelector('.o_payment_option_label')?.textContent;
         this._vpv('/stats/ecom/order_payment/' + paymentMethod);
+
+        const paymentTrackingElement = this.el.querySelector('#payment_tracking_info');
+        const trackingInfo = paymentTrackingElement?.dataset?.paymentTrackingInfo
+            ? JSON.parse(paymentTrackingElement.dataset.paymentTrackingInfo)
+            : {};
+
+        this._trackGa('event', 'add_payment_info', {
+            ...trackingInfo,
+            payment_type: paymentMethod,
+        });
+    }
+    onAddShippingInfo(event) {
+        const shippingInfo = event.detail;
+        if (!shippingInfo) return;
+        this._trackGa('event', 'add_shipping_info', shippingInfo);
     }
 }
 

--- a/addons/website_sale/static/src/interactions/tracking_product_card.js
+++ b/addons/website_sale/static/src/interactions/tracking_product_card.js
@@ -1,0 +1,24 @@
+import { Interaction } from "@web/public/interaction";
+import { registry } from "@web/core/registry";
+import wSaleUtils from "@website_sale/js/website_sale_utils";
+
+export class ProductCardTracking extends Interaction {
+    static selector =
+        "article.oe_product_cart[data-product-tracking-info], div.oe_product_cart[data-product-tracking-info]";
+    dynamicContent = {
+        _root: { "t-on-click": this.onSelectItem },
+    };
+
+    onSelectItem(event) {
+        // Quick-add "Add to Cart" buttons inside cards must not also fire select_item.
+        if (event.target.closest("button")) return;
+        const { item_list_name, ...trackingInfo } = JSON.parse(
+            this.el.dataset.productTrackingInfo
+        );
+        wSaleUtils.dispatchTrackingEvent("select_item_event", { item_list_name, trackingInfo });
+    }
+}
+
+registry
+    .category("public.interactions")
+    .add("website_sale.product_card_tracking", ProductCardTracking);

--- a/addons/website_sale/static/src/interactions/tracking_product_card.js
+++ b/addons/website_sale/static/src/interactions/tracking_product_card.js
@@ -1,0 +1,26 @@
+import { Interaction } from "@web/public/interaction";
+import { registry } from "@web/core/registry";
+
+export class ProductCardTracking extends Interaction {
+    static selector =
+        "article.oe_product_cart[data-product-tracking-info], div.oe_product_cart[data-product-tracking-info]";
+    dynamicContent = {
+        _root: { "t-on-click": this.onSelectItem },
+    };
+
+    onSelectItem(event) {
+        if (event.target.closest("button")) return;
+        this._trackGa("event", "select_item", {
+            items: [JSON.parse(this.el.dataset.productTrackingInfo)],
+        });
+    }
+
+    _trackGa() {
+        const websiteGA = window.gtag || (() => {});
+        websiteGA.apply(this, arguments);
+    }
+}
+
+registry
+    .category("public.interactions")
+    .add("website_sale.product_card_tracking", ProductCardTracking);

--- a/addons/website_sale/static/src/js/cart_service.js
+++ b/addons/website_sale/static/src/js/cart_service.js
@@ -15,6 +15,7 @@ import { redirect } from '@web/core/utils/urls';
 import {
     CartNotificationContainer
 } from '@website_sale/js/cart_notification/cart_notification_container/cart_notification_container';
+import wSaleUtils from "@website_sale/js/website_sale_utils";
 
 const { DateTime } = luxon;
 const AUTOCLOSE_NOTIFICATION_DELAY = 4000;
@@ -493,6 +494,12 @@ export class CartService {
         if (!data) {
             return 0;
         }
+        if (data.quantity && data.tracking_info?.length) {
+            wSaleUtils.dispatchTrackingEvent("add_to_cart_event", {
+                currency: data.currency,
+                items: data.tracking_info,
+            });
+        }
         if (shouldRedirectToCart) {
             redirect('/shop/cart');
             return data.quantity;
@@ -504,9 +511,6 @@ export class CartService {
         };
         for (const notification of data.notifications) {
             this._showCartNotification(notification);
-        }
-        if (data.quantity) {
-            this._trackProducts(data.tracking_info);
         }
         return data.quantity;
     }
@@ -550,21 +554,6 @@ export class CartService {
         setTimeout( () => this.notifications.delete(notification), AUTOCLOSE_NOTIFICATION_DELAY );
     }
 
-    /**
-     * Track the products added to the cart.
-     *
-     * @param {Object[]} trackingInfo - A list of product tracking information.
-     *
-     * @returns {void}
-     */
-    _trackProducts(trackingInfo) {
-        const wrapperEl = document.querySelector('.oe_website_sale');
-        if (wrapperEl) {
-            wrapperEl.dispatchEvent(
-                new CustomEvent('add_to_cart_event', {'detail': trackingInfo})
-            );
-        }
-    }
 }
 
 export const cartService = {

--- a/addons/website_sale/static/src/js/cart_service.js
+++ b/addons/website_sale/static/src/js/cart_service.js
@@ -487,10 +487,6 @@ export class CartService {
         if (!data) {
             return 0;
         }
-        if (shouldRedirectToCart || session.add_to_cart_action === 'go_to_cart') {
-            redirect('/shop/cart');
-            return data.quantity;
-        }
         if (data.cart_quantity && (
             data.cart_quantity !== browser.sessionStorage.getItem('website_sale_cart_quantity')
         )) {
@@ -501,6 +497,10 @@ export class CartService {
         }
         if (data.quantity) {
             this._trackProducts(data.tracking_info);
+        }
+        if (shouldRedirectToCart || session.add_to_cart_action === 'go_to_cart') {
+            redirect('/shop/cart');
+            return data.quantity;
         }
         return data.quantity;
     }

--- a/addons/website_sale/static/src/js/website_sale_utils.js
+++ b/addons/website_sale/static/src/js/website_sale_utils.js
@@ -191,6 +191,19 @@ function clearAttributeValueParams(searchParams) {
     ));
 }
 
+/**
+ * Dispatch a GA4 tracking event to the `.oe_website_sale` element.
+ *
+ * @param {string} eventName
+ * @param {Object} detail
+ * @return {void}
+ */
+function dispatchTrackingEvent(eventName, detail) {
+    document.querySelector(".oe_website_sale")?.dispatchEvent(
+        new CustomEvent(eventName, { detail })
+    );
+}
+
 export default {
     updateCartNavBar: updateCartNavBar,
     getSelectedAttributeValues: getSelectedAttributeValues,
@@ -199,4 +212,5 @@ export default {
     getAttributeValueParams: getAttributeValueParams,
     clearAttributeValueParams: clearAttributeValueParams,
     updateShopContent: updateShopContent,
+    dispatchTrackingEvent: dispatchTrackingEvent,
 };

--- a/addons/website_sale/static/tests/tours/google_analytics.js
+++ b/addons/website_sale/static/tests/tours/google_analytics.js
@@ -9,13 +9,61 @@ function patchTracking() {
     const { Tracking } = odoo.loader.modules.get('@website_sale/interactions/tracking');
     patch(Tracking.prototype, {
         // Don't call super to avoid third party calls (GA).
+        setup() {
+            const cartTrackingEl = document.querySelector("#cart_tracking_info");
+            if (cartTrackingEl?.dataset?.cartTrackingInfo) {
+                document.body.setAttribute("view-cart-event", "1");
+            }
+            const confirmation = this.el.querySelector('div[name="order_confirmation"]');
+            if (confirmation) {
+                document.body.setAttribute("purchase-event", "1");
+                if (sessionStorage.getItem("ga-add-payment-info-fired")) {
+                    document.body.setAttribute("add-payment-info-event", "1");
+                    sessionStorage.removeItem("ga-add-payment-info-fired");
+                }
+            }
+            if (sessionStorage.getItem("ga-begin-checkout-fired")) {
+                document.body.setAttribute("begin-checkout-event", "1");
+                sessionStorage.removeItem("ga-begin-checkout-fired");
+            }
+        },
         onViewItem(event) {
-            const productTrackingInfo = event.detail;
+            const productTrackingInfo = event.detail.trackingInfo;
             document.body.setAttribute("view-event-id", productTrackingInfo.item_id);
+            document.body.setAttribute("view-event-variant", productTrackingInfo.item_variant || "");
+        },
+        onSelectItem(event) {
+            const { trackingInfo } = event.detail;
+            document.body.setAttribute("select-item-event-id", trackingInfo.item_id);
         },
         onAddToCart(event) {
             const productsTrackingInfo = event.detail;
-            document.body.setAttribute("cart-event-id", productsTrackingInfo[0].item_id);
+            if (!productsTrackingInfo.items?.length) return;
+            document.body.setAttribute("cart-event-id", productsTrackingInfo.items[0].item_id);
+        },
+        onUpdateCart(event) {
+            const items = event.detail.items;
+            if (!items?.length) return;
+            const removedItems = items.filter(i => i.delta_quantity < 0);
+            if (removedItems.length) {
+                document.body.setAttribute("remove-from-cart-event-id", removedItems[0].item_id);
+            }
+        },
+        onCheckoutStart() {
+            sessionStorage.setItem("ga-begin-checkout-fired", "1");
+        },
+        onAddShippingInfo(event) {
+            const shippingInfo = event.detail;
+            if (!shippingInfo) return;
+            document.body.setAttribute("shipping-tier", shippingInfo.shipping_tier);
+        },
+        onAddToWishlist(event) {
+            const { trackingInfo } = event.detail;
+            if (!trackingInfo) return;
+            document.body.setAttribute("add-to-wishlist-event-id", trackingInfo.item_id);
+        },
+        onOrderPayment() {
+            sessionStorage.setItem("ga-add-payment-info-fired", "1");
         },
     });
 }
@@ -28,23 +76,21 @@ if (odoo.loader.modules.has('@website_sale/interactions/tracking')) {
     });
 }
 
-let itemId;
-
+let itemVariant;
 
 registry.category("web_tour.tours").add('website_sale.google_analytics_view_item', {
     steps: () => [
-        {
-            content: "select Colored T-Shirt",
-            trigger: '.oe_product_cart a:contains("Colored T-Shirt")',
-            run: "click",
-            expectUnloadPage: true,
-        },
+        ...tourUtils.goToProductPage({
+            productName: "Colored T-Shirt",
+            search: false,
+            expectUnloadPage: true
+        }),
         {
             content: "wait until `_getCombinationInfo()` rpc is done",
             trigger: 'body[view-event-id]',
             timeout: 25000,
             run: () => {
-                itemId = document.body.getAttribute("view-event-id");
+                itemVariant = document.body.getAttribute("view-event-variant");
             }
         },
         {
@@ -55,8 +101,7 @@ registry.category("web_tour.tours").add('website_sale.google_analytics_view_item
         },
         {
             content: 'wait until `_getCombinationInfo()` rpc is done (2)',
-            // a new view event should have been generated, for another variant
-            trigger: `body[view-event-id]:not([view-event-id="${itemId}"])`,
+            trigger: `body[view-event-variant]:not([view-event-variant="${itemVariant}"])`,
             timeout: 25000,
         },
     ]
@@ -64,14 +109,135 @@ registry.category("web_tour.tours").add('website_sale.google_analytics_view_item
 
 registry.category("web_tour.tours").add('website_sale.google_analytics_add_to_cart', {
     steps: () => [
-        ...tourUtils.addToCart({ productName: 'Basic Shirt', search: false, expectUnloadPage: true }),
+        ...tourUtils.goToProductPage({
+            productName: "Basic Shirt",
+            search: false,
+            expectUnloadPage: true
+        }),
         {
-            trigger: "body[cart-event-id]",
+            content: "Add to cart",
+            trigger: '.js_product button[name="add_to_cart"]',
+            run: "click",
         },
         {
-            content: 'check add to cart event',
-            trigger: "a:has(.my_cart_quantity:text(1))",
+            content: "verify add_to_cart event was fired",
+            trigger: "body[cart-event-id]",
             timeout: 25000,
         },
-    ]
+    ],
+});
+
+registry.category("web_tour.tours").add("website_sale.google_analytics_select_item", {
+    steps: () => [
+        {
+            content: "click product card to trigger select_item",
+            trigger: 'article.oe_product_cart[data-product-tracking-info]',
+            run: "click",
+        },
+        {
+            content: "verify select_item event was fired",
+            trigger: "body[select-item-event-id]",
+            timeout: 25000,
+        },
+    ],
+});
+
+registry.category("web_tour.tours").add("website_sale.google_analytics_view_cart", {
+    steps: () => [
+        {
+            content: "verify view_cart event was fired on cart page load",
+            trigger: "body[view-cart-event]",
+            timeout: 25000,
+        },
+    ],
+});
+
+registry.category("web_tour.tours").add("website_sale.google_analytics_begin_checkout", {
+    steps: () => [
+        {
+            content: "verify begin_checkout tracking data is injected on cart page",
+            trigger: "#cart_tracking_info[data-cart-tracking-info]:not(:visible)",
+            timeout: 25000,
+        },
+        tourUtils.goToCheckout(),
+        {
+            content: "verify begin_checkout event was fired",
+            trigger: "body[begin-checkout-event]",
+            timeout: 25000,
+        },
+    ],
+});
+
+registry.category("web_tour.tours").add("website_sale.google_analytics_remove_from_cart", {
+    steps: () => [
+        {
+            content: "decrease cart line quantity",
+            trigger: 'button[name="minus_button"]',
+            run: "click",
+        },
+        {
+            content: "verify remove_from_cart event was fired",
+            trigger: "body[remove-from-cart-event-id]",
+            timeout: 25000,
+        },
+    ],
+});
+
+registry.category("web_tour.tours").add("website_sale.google_analytics_add_shipping_info", {
+    steps: () => [
+        tourUtils.goToCheckout(),
+        tourUtils.selectDeliveryCarrier("Test Delivery"),
+        {
+            content: "verify add_shipping_info event was fired with shipping_tier",
+            trigger: "body[shipping-tier]",
+            timeout: 25000,
+        },
+    ],
+});
+
+registry.category("web_tour.tours").add("website_sale.google_analytics_add_to_wishlist", {
+    steps: () => [
+        ...tourUtils.goToProductPage({
+            productName: "Basic Shirt",
+            search: false,
+            expectUnloadPage: true,
+        }),
+        {
+            content: "wait for product tracking info to be loaded",
+            trigger: "#product_detail[data-product-tracking-info]",
+            timeout: 25000,
+        },
+        {
+            content: "click add to wishlist",
+            trigger: "#product_detail .o_add_wishlist_dyn:not([disabled])",
+            run: "click",
+        },
+        {
+            content: "verify add_to_wishlist event was fired",
+            trigger: "body[add-to-wishlist-event-id]",
+            timeout: 25000,
+        },
+    ],
+});
+
+registry.category("web_tour.tours").add("website_sale.google_analytics_purchase", {
+    steps: () => [
+        tourUtils.goToCheckout(),
+        tourUtils.selectDeliveryCarrier("Test Delivery"),
+        tourUtils.confirmOrder(),
+        {
+            content: "select wire transfer payment",
+            trigger: 'input[name="o_payment_radio"][data-payment-method-code="wire_transfer"]',
+            run: "click",
+        },
+        {
+            trigger: 'input[name="o_payment_radio"][data-payment-method-code="wire_transfer"]:checked',
+        },
+        ...tourUtils.pay({ expectUnloadPage: true }),
+        {
+            content: "verify purchase and add_payment_info events were fired on confirmation page",
+            trigger: "body[purchase-event][add-payment-info-event]",
+            timeout: 30000,
+        },
+    ],
 });

--- a/addons/website_sale/static/tests/tours/google_analytics.js
+++ b/addons/website_sale/static/tests/tours/google_analytics.js
@@ -1,6 +1,5 @@
 import { registry } from "@web/core/registry";
 import { patch } from "@web/core/utils/patch";
-import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
 /**
  * Patch tracking to avoid third party calls during tests.
@@ -9,6 +8,12 @@ function patchTracking() {
     const { Tracking } = odoo.loader.modules.get('@website_sale/interactions/tracking');
     patch(Tracking.prototype, {
         // Don't call super to avoid third party calls (GA).
+        setup() {
+            const cartTrackingEl = document.querySelector("#cart_tracking_info");
+            if (cartTrackingEl?.dataset?.cartTrackingInfo) {
+                document.body.setAttribute("view-cart-event", "1");
+            }
+        },
         onViewItem(event) {
             const productTrackingInfo = event.detail;
             document.body.setAttribute("view-event-id", productTrackingInfo.item_id);
@@ -16,6 +21,38 @@ function patchTracking() {
         onAddToCart(event) {
             const productsTrackingInfo = event.detail;
             document.body.setAttribute("cart-event-id", productsTrackingInfo[0].item_id);
+        },
+        onUpdateCart(event) {
+            const items = event.detail;
+            if (!items?.length) return;
+            const removedItems = items.filter(i => i.delta_quantity < 0);
+            if (removedItems.length) {
+                document.body.setAttribute("remove-from-cart-event-id", removedItems[0].item_id);
+            }
+        },
+        onCheckoutStart() {
+            document.body.setAttribute("begin-checkout-event", "1");
+        },
+        onAddShippingInfo(event) {
+            const shippingInfo = event.detail;
+            if (!shippingInfo) return;
+            document.body.setAttribute("shipping-tier", shippingInfo.shipping_tier);
+        },
+    });
+}
+
+/**
+ * Patch ProductCardTracking to intercept select_item events.
+ */
+function patchProductCardTracking() {
+    const { ProductCardTracking } = odoo.loader.modules.get(
+        '@website_sale/interactions/tracking_product_card'
+    );
+    patch(ProductCardTracking.prototype, {
+        onSelectItem(event) {
+            if (event.target.closest("button")) return;
+            const trackingInfo = JSON.parse(this.el.dataset.productTrackingInfo);
+            document.body.setAttribute("select-item-event-id", trackingInfo.item_id);
         },
     });
 }
@@ -28,8 +65,17 @@ if (odoo.loader.modules.has('@website_sale/interactions/tracking')) {
     });
 }
 
-let itemId;
+if (odoo.loader.modules.has('@website_sale/interactions/tracking_product_card')) {
+    patchProductCardTracking();
+} else {
+    odoo.loader.bus.addEventListener('module-started', (e) => {
+        if (e.detail.moduleName === '@website_sale/interactions/tracking_product_card') {
+            patchProductCardTracking();
+        }
+    });
+}
 
+let itemId;
 
 registry.category("web_tour.tours").add('website_sale.google_analytics_view_item', {
     steps: () => [
@@ -45,7 +91,7 @@ registry.category("web_tour.tours").add('website_sale.google_analytics_view_item
             timeout: 25000,
             run: () => {
                 itemId = document.body.getAttribute("view-event-id");
-            }
+            },
         },
         {
             content: 'select another variant',
@@ -59,19 +105,108 @@ registry.category("web_tour.tours").add('website_sale.google_analytics_view_item
             trigger: `body[view-event-id]:not([view-event-id="${itemId}"])`,
             timeout: 25000,
         },
-    ]
+    ],
 });
 
 registry.category("web_tour.tours").add('website_sale.google_analytics_add_to_cart', {
     steps: () => [
-        ...tourUtils.addToCart({ productName: 'Basic Shirt', search: false, expectUnloadPage: true }),
         {
-            trigger: "body[cart-event-id]",
+            content: "go to Basic Shirt product page",
+            trigger: '.oe_product_cart a:contains("Basic Shirt")',
+            run: "click",
+            expectUnloadPage: true,
         },
         {
-            content: 'check add to cart event',
-            trigger: "a:has(.my_cart_quantity:text(1))",
+            content: "add to cart",
+            trigger: '.js_product button[name="add_to_cart"]',
+            run: "click",
+        },
+        {
+            content: "verify add_to_cart event was fired",
+            trigger: "body[cart-event-id]",
             timeout: 25000,
         },
-    ]
+    ],
+});
+
+registry.category("web_tour.tours").add('website_sale.google_analytics_select_item', {
+    steps: () => [
+        {
+            content: "click product card to trigger select_item",
+            trigger: 'article.oe_product_cart[data-product-tracking-info]',
+            run: "click",
+        },
+        {
+            content: "verify select_item event was fired",
+            trigger: "body[select-item-event-id]",
+            timeout: 25000,
+        },
+    ],
+});
+
+registry.category("web_tour.tours").add('website_sale.google_analytics_view_cart', {
+    steps: () => [
+        {
+            content: "verify view_cart event was fired on cart page load",
+            trigger: "body[view-cart-event]",
+            timeout: 25000,
+        },
+    ],
+});
+
+registry.category("web_tour.tours").add('website_sale.google_analytics_begin_checkout', {
+    steps: () => [
+        {
+            content: "verify begin_checkout tracking data is injected on cart page",
+            trigger: "#cart_tracking_info[data-cart-tracking-info]:not(:visible)",
+            timeout: 25000,
+        },
+        {
+            content: "click checkout to trigger begin_checkout event",
+            trigger: 'a[name="website_sale_main_button"]',
+            run: "click",
+            expectUnloadPage: true,
+        },
+        {
+            content: "verify we reached checkout page",
+            trigger: ".o_website_sale_checkout",
+            timeout: 25000,
+        },
+    ],
+});
+
+registry.category("web_tour.tours").add('website_sale.google_analytics_remove_from_cart', {
+    steps: () => [
+        {
+            content: "decrease cart line quantity",
+            trigger: 'button[name="minus_button"]',
+            run: "click",
+        },
+        {
+            content: "verify remove_from_cart event was fired",
+            trigger: "body[remove-from-cart-event-id]",
+            timeout: 25000,
+        },
+    ],
+});
+
+registry.category("web_tour.tours").add('website_sale.google_analytics_add_shipping_info', {
+    steps: () => [
+        {
+            content: "proceed to checkout",
+            trigger: 'a[name="website_sale_main_button"]',
+            run: "click",
+            expectUnloadPage: true,
+        },
+        {
+            content: "select delivery method",
+            trigger: 'input[name="o_delivery_radio"]',
+            run: "click",
+        },
+        {
+            content: "verify add_shipping_info event was fired with shipping_tier",
+            trigger: "body[shipping-tier]",
+            timeout: 25000,
+        },
+    ],
 });

--- a/addons/website_sale/templates/checkout/cart_templates.xml
+++ b/addons/website_sale/templates/checkout/cart_templates.xml
@@ -324,6 +324,12 @@
                     <p t-if="website_sale_order">Please proceed your current cart.</p>
                 </div>
                 <t t-call="website_sale.cart_lines"/>
+                <div
+                    t-if="cart_tracking_info"
+                    id="cart_tracking_info"
+                    class="d-none"
+                    t-att-data-cart-tracking-info="json.dumps(cart_tracking_info)"
+                />
                 <div class="clearfix" />
                 <div class="oe_structure" id="oe_structure_website_sale_cart_1"/>
             </div>

--- a/addons/website_sale/templates/checkout/cart_templates.xml
+++ b/addons/website_sale/templates/checkout/cart_templates.xml
@@ -328,6 +328,12 @@
                     </t>
                 </div>
                 <t t-call="website_sale.cart_lines"/>
+                <div
+                    t-if="cart_tracking_info"
+                    id="cart_tracking_info"
+                    t-att-data-cart-tracking-info="json.dumps(cart_tracking_info)"
+                    style="display:none;"
+                />
                 <div class="clearfix" />
                 <div class="oe_structure" id="oe_structure_website_sale_cart_1"/>
             </div>

--- a/addons/website_sale/templates/checkout/payment_templates.xml
+++ b/addons/website_sale/templates/checkout/payment_templates.xml
@@ -19,6 +19,12 @@
             oe_structure="oe_structure">
             <div class="oe_structure clearfix" id="oe_structure_website_sale_payment_1"/>
 
+            <div
+                id="payment_tracking_info"
+                class="d-none"
+                t-att-data-payment-tracking-info="json.dumps(payment_tracking_info)"
+            />
+
             <div t-if="not cart_has_blocking_alerts and website_sale_order.amount_total" name="website_sale_non_free_cart">
                 <div id="payment_method" class="o_not_editable mb-3">
                     <t t-call="payment.form"/>

--- a/addons/website_sale/templates/checkout/payment_templates.xml
+++ b/addons/website_sale/templates/checkout/payment_templates.xml
@@ -29,6 +29,8 @@
             </div>
             <div class="oe_structure clearfix" id="oe_structure_website_sale_payment_1"/>
 
+            <div id="payment_tracking_info" t-att-data-payment-tracking-info="json.dumps(payment_tracking_info)" style="display:none;"/>
+
             <div t-if="not errors and website_sale_order.amount_total" name="website_sale_non_free_cart">
                 <div id="payment_method" class="o_not_editable mb-3">
                     <t t-call="payment.form"/>
@@ -44,14 +46,14 @@
     </template>
 
     <template id="website_sale.submit_button" inherit_id="payment.submit_button">
-        <div name="o_payment_default_submit_labels" position="replace">    
+        <div name="o_payment_default_submit_labels" position="replace">
             <t t-if="website_sale_order and not website_sale_order.amount_total">
                 <span name="o_free_order_label" t-field="res_company.free_order_label"/>
             </t>
-            <t t-else=""> 
+            <t t-else="">
                 <t>$0</t>
             </t>
         </div>
     </template>
-    
+
 </odoo>

--- a/addons/website_sale/templates/product_tile_templates.xml
+++ b/addons/website_sale/templates/product_tile_templates.xml
@@ -43,6 +43,8 @@
         t-attf-class="oe_product_cart h-100 d-flex {{ptavs_classes}}"
         t-att-data-publish="product.website_published and 'on' or 'off'"
         t-att-aria-label="product.name"
+        t-att-data-product-tracking-info="json.dumps((product_tracking_infos or {}).get(product.id, {}))"
+        t-att-data-product-ga-currency="website.currency_id.name"
     >
         <t t-if="not product.website_published" t-call="website.unpublished_badge" badge_position="'left'"/>
         <t t-call="website_sale.product_image_and_ribbon" product_image_title="product.name"/>

--- a/addons/website_sale/templates/product_tile_templates.xml
+++ b/addons/website_sale/templates/product_tile_templates.xml
@@ -43,6 +43,7 @@
         t-attf-class="oe_product_cart h-100 d-flex {{ptavs_classes}}"
         t-att-data-publish="product.website_published and 'on' or 'off'"
         t-att-aria-label="product.name"
+        t-att-data-product-tracking-info="json.dumps((product_tracking_infos or {}).get(product.id, {}))"
     >
         <t t-if="not product.website_published" t-call="website.unpublished_badge" badge_position="'left'"/>
         <div t-attf-class="oe_product_image position-relative flex-grow-0 overflow-hidden">

--- a/addons/website_sale/templates/snippets/product_snippet_template_data.xml
+++ b/addons/website_sale/templates/snippets/product_snippet_template_data.xml
@@ -48,6 +48,8 @@
                     t-att-aria-label="product.display_name"
                     t-att-data-add2cart-rerender="data.get('_add2cart_rerender')"
                     t-att-data-publish="product.website_published and 'on' or 'off'"
+                    t-att-data-product-tracking-info="json.dumps(data.get('product_tracking_info', {}))"
+                    t-att-data-product-ga-currency="website.currency_id.name"
                 >
                     <t
                         t-set="ribbon"

--- a/addons/website_sale/templates/snippets/product_snippet_template_data.xml
+++ b/addons/website_sale/templates/snippets/product_snippet_template_data.xml
@@ -21,6 +21,7 @@
                     t-att-aria-label="product.display_name"
                     t-att-data-add2cart-rerender="data.get('_add2cart_rerender')"
                     t-att-data-publish="product.website_published and 'on' or 'off'"
+                    t-att-data-product-tracking-info="json.dumps(product.product_tmpl_id._get_google_analytics_list_data() if product.is_product_variant else product._get_google_analytics_list_data())"
                 >
                     <!-- Image -->
                     <div t-attf-class="oe_product_image position-relative flex-grow-0 overflow-hidden">

--- a/addons/website_sale/tests/__init__.py
+++ b/addons/website_sale/tests/__init__.py
@@ -20,6 +20,7 @@ from . import (
     test_ecommerce_access,
     test_express_checkout_flows,
     test_fuzzy,
+    test_google_analytics,
     test_google_merchant_center,
     test_mail,
     test_main_controller,

--- a/addons/website_sale/tests/test_google_analytics.py
+++ b/addons/website_sale/tests/test_google_analytics.py
@@ -1,0 +1,104 @@
+from odoo.fields import Command
+from odoo.tests import HttpCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestGoogleAnalytics(HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        attribute = cls.env["product.attribute"].create({
+            "name": "Color",
+            "sequence": 10,
+            "display_type": "color",
+            "value_ids": [Command.create({"name": "Red"}), Command.create({"name": "Pink"})],
+        })
+        cls.env["product.template"].create({
+            "name": "Colored T-Shirt",
+            "standard_price": 500,
+            "list_price": 750,
+            "type": "consu",
+            "website_published": True,
+            "attribute_line_ids": [
+                Command.create({"attribute_id": attribute.id, "value_ids": attribute.value_ids})
+            ],
+        })
+        cls.basic_shirt = cls.env["product.template"].create({
+            "name": "Basic Shirt",
+            "standard_price": 500,
+            "list_price": 750,
+            "type": "consu",
+            "website_published": True,
+        })
+        cls.env["delivery.carrier"].create({
+            "name": "Test Delivery",
+            "product_id": cls.env.ref("delivery.product_product_delivery").id,
+            "website_published": True,
+        })
+        cls.env.ref("base.default_website").write({"google_analytics_key": "G-XXXXXXXXXXX"})
+        cls.env.ref("base.partner_admin").write({
+            "street": "215 Vine St",
+            "city": "Scranton",
+            "zip": "18503",
+            "country_id": cls.env.ref("base.us").id,
+            "state_id": cls.env["ir.model.data"]._xmlid_to_res_id("base.state_us_39"),
+            "phone": "+1 555-555-5555",
+            "email": "admin@yourcompany.example.com",
+        })
+        if cls.env["ir.module.module"]._get("payment_custom").state == "installed":
+            transfer_provider = cls.env.ref("payment.payment_provider_transfer")
+            transfer_provider.is_published = True
+
+    def _create_test_cart(self):
+        return self.env["sale.order"].create({
+            "partner_id": self.env.ref("base.partner_admin").id,
+            "website_id": self.env.ref("base.default_website").id,
+            "order_line": [
+                Command.create({
+                    "product_id": self.basic_shirt.product_variant_id.id,
+                    "product_uom_qty": 2,
+                })
+            ],
+        })
+
+    def test_view_item(self):
+        self.start_tour("/shop?search=Colored T-Shirt", "website_sale.google_analytics_view_item")
+
+    def test_add_to_cart(self):
+        self.start_tour("/shop?search=Basic Shirt", "website_sale.google_analytics_add_to_cart")
+
+    def test_select_item(self):
+        self.start_tour("/shop?search=Basic Shirt", "website_sale.google_analytics_select_item")
+
+    def test_view_cart(self):
+        self._create_test_cart()
+        self.start_tour("/shop/cart", "website_sale.google_analytics_view_cart", login="admin")
+
+    def test_begin_checkout(self):
+        self._create_test_cart()
+        self.start_tour("/shop/cart", "website_sale.google_analytics_begin_checkout", login="admin")
+
+    def test_remove_from_cart(self):
+        self._create_test_cart()
+        self.start_tour(
+            "/shop/cart", "website_sale.google_analytics_remove_from_cart", login="admin"
+        )
+
+    def test_add_shipping_info(self):
+        self._create_test_cart()
+        self.start_tour(
+            "/shop/cart", "website_sale.google_analytics_add_shipping_info", login="admin"
+        )
+
+    def test_add_to_wishlist(self):
+        self.start_tour(
+            "/shop?search=Basic Shirt",
+            "website_sale.google_analytics_add_to_wishlist",
+            login="admin",
+        )
+
+    def test_purchase(self):
+        if self.env["ir.module.module"]._get("payment_custom").state != "installed":
+            self.skipTest("Transfer provider is not installed")
+        self._create_test_cart()
+        self.start_tour("/shop/cart", "website_sale.google_analytics_purchase", login="admin")

--- a/addons/website_sale/tests/test_sale_process.py
+++ b/addons/website_sale/tests/test_sale_process.py
@@ -129,35 +129,6 @@ class TestSaleProcess(HttpCaseWithUserDemo, WebsiteSaleCommon, HttpCaseWithWebsi
         )
         self.start_tour("/shop/cart", "website_sale.complete_flow_2", login="admin")
 
-    def test_05_google_analytics_tracking(self):
-        # Data for google_analytics_view_item
-        attribute = self.env["product.attribute"].create({
-            "name": "Color",
-            "sequence": 10,
-            "display_type": "color",
-            "value_ids": [Command.create({"name": "Red"}), Command.create({"name": "Pink"})],
-        })
-        self.env["product.template"].create({
-            "name": "Colored T-Shirt",
-            "standard_price": 500,
-            "list_price": 750,
-            "type": "consu",
-            "website_published": True,
-            "attribute_line_ids": [
-                Command.create({"attribute_id": attribute.id, "value_ids": attribute.value_ids})
-            ],
-        })
-        self.env.ref("base.default_website").write({"google_analytics_key": "G-XXXXXXXXXXX"})
-        self.start_tour("/shop?search=Colored T-Shirt", "website_sale.google_analytics_view_item")
-        # Data for google_analytics_add_to_cart
-        self.env["product.template"].create({
-            "name": "Basic Shirt",
-            "standard_price": 500,
-            "type": "consu",
-            "website_published": True,
-        })
-        self.start_tour("/shop?search=Basic Shirt", "website_sale.google_analytics_add_to_cart")
-
     def test_06_public_user_shop_repair(self):
         """Public user purchasing repair service products in website shop."""
         if self.env["ir.module.module"]._get("repair").state != "installed":

--- a/addons/website_sale/tests/test_sale_process.py
+++ b/addons/website_sale/tests/test_sale_process.py
@@ -128,8 +128,17 @@ class TestSaleProcess(HttpCaseWithUserDemo, WebsiteSaleCommon, HttpCaseWithWebsi
         )
         self.start_tour("/shop/cart", "website_sale.complete_flow_2", login="admin")
 
+    def _create_test_cart(self, product):
+        """Create a cart with one product for GA tour tests."""
+        return self.env["sale.order"].create({
+            "partner_id": self.env.ref("base.partner_admin").id,
+            "website_id": 1,
+            "order_line": [
+                Command.create({"product_id": product.product_variant_id.id, "product_uom_qty": 2})
+            ],
+        })
+
     def test_05_google_analytics_tracking(self):
-        # Data for google_analytics_view_item
         attribute = self.env["product.attribute"].create({
             "name": "Color",
             "sequence": 10,
@@ -148,14 +157,37 @@ class TestSaleProcess(HttpCaseWithUserDemo, WebsiteSaleCommon, HttpCaseWithWebsi
         })
         self.env["website"].browse(1).write({"google_analytics_key": "G-XXXXXXXXXXX"})
         self.start_tour("/shop?search=Colored T-Shirt", "website_sale.google_analytics_view_item")
-        # Data for google_analytics_add_to_cart
-        self.env["product.template"].create({
+
+        product = self.env["product.template"].create({
             "name": "Basic Shirt",
             "standard_price": 500,
+            "list_price": 750,
             "type": "consu",
             "website_published": True,
         })
+        self.env["delivery.carrier"].create({
+            "name": "Test Delivery",
+            "product_id": self.env.ref("delivery.product_product_delivery").id,
+            "website_published": True,
+        })
         self.start_tour("/shop?search=Basic Shirt", "website_sale.google_analytics_add_to_cart")
+        self.start_tour("/shop?search=Basic Shirt", "website_sale.google_analytics_select_item")
+
+        self._create_test_cart(product)
+        self.start_tour("/shop/cart", "website_sale.google_analytics_view_cart", login="admin")
+
+        self._create_test_cart(product)
+        self.start_tour("/shop/cart", "website_sale.google_analytics_begin_checkout", login="admin")
+
+        self._create_test_cart(product)
+        self.start_tour(
+            "/shop/cart", "website_sale.google_analytics_remove_from_cart", login="admin"
+        )
+
+        self._create_test_cart(product)
+        self.start_tour(
+            "/shop/cart", "website_sale.google_analytics_add_shipping_info", login="admin"
+        )
 
     def test_06_public_user_shop_repair(self):
         """Public user purchasing repair service products in website shop."""

--- a/addons/website_sale_loyalty/controllers/cart.py
+++ b/addons/website_sale_loyalty/controllers/cart.py
@@ -18,3 +18,9 @@ class Cart(WebsiteSaleCart):
         product = self.env["product.product"].browse(int(kwargs["trigger_product_id"]))
         self.add_to_cart(product.product_tmpl_id.id, product.id, 1)
         return request.redirect("/shop/cart")
+
+    def _get_cart_tracking_info(self, order):
+        result = super()._get_cart_tracking_info(order)
+        if coupon := order._get_applied_coupon_codes():
+            result["coupon"] = coupon
+        return result

--- a/addons/website_sale_loyalty/controllers/main.py
+++ b/addons/website_sale_loyalty/controllers/main.py
@@ -125,3 +125,15 @@ class WebsiteSale(main.WebsiteSale):
             else:
                 order._remove_delivery_line()
         return True
+
+    def _get_payment_tracking_info(self, order):
+        result = super()._get_payment_tracking_info(order)
+        if coupon := order._get_applied_coupon_codes():
+            result["coupon"] = coupon
+        return result
+
+    def order_2_return_dict(self, order):
+        result = super().order_2_return_dict(order)
+        if coupon := order._get_applied_coupon_codes():
+            result["coupon"] = coupon
+        return result

--- a/addons/website_sale_loyalty/models/sale_order.py
+++ b/addons/website_sale_loyalty/models/sale_order.py
@@ -209,6 +209,24 @@ class SaleOrder(models.Model):
         lines = super()._get_no_effect_on_threshold_lines()
         return lines + self.order_line.filtered("is_donation")
 
+    def _get_order_tracking_info(self):
+        result = super()._get_order_tracking_info()
+        if coupon := self._get_applied_coupon_codes():
+            result["coupon"] = coupon
+        return result
+
+    def _get_applied_coupon_codes(self):
+        """Return applied coupon/promotion codes as a comma-separated string for GA4 tracking.
+
+        :rtype: str
+        """
+        self.ensure_one()
+        return ",".join(self.order_line.coupon_id.mapped("code"))
+
+    def _get_order_tracking_lines(self):
+        """Override to exclude loyalty reward lines from GA4 tracking."""
+        return super()._get_order_tracking_lines().filtered(lambda line: not line.is_reward_line)
+
     def _allow_nominative_programs(self):
         website = self.env.website
         if not website:

--- a/addons/website_sale_loyalty/models/sale_order.py
+++ b/addons/website_sale_loyalty/models/sale_order.py
@@ -207,6 +207,25 @@ class SaleOrder(models.Model):
         self.ensure_one()
         return self.order_line.filtered(lambda line: line.reward_id.reward_type == "shipping")
 
+    def _get_order_tracking_lines(self):
+        """Override to exclude loyalty reward lines from GA4 tracking."""
+        return super()._get_order_tracking_lines().filtered(lambda line: not line.is_reward_line)
+
+    def _get_applied_coupon_codes(self):
+        """Return applied coupon/promotion codes as a comma-separated string for GA4 tracking.
+
+        :rtype: str or None
+        """
+        self.ensure_one()
+        codes = (
+            self.order_line
+            .filtered("is_reward_line")
+            .filtered("coupon_id")
+            .mapped("coupon_id.code")
+        )
+        codes = list(dict.fromkeys(codes))  # deduplicate, preserve order
+        return ",".join(codes) if codes else None
+
     def _allow_nominative_programs(self):
         if not request or not hasattr(request, "website"):
             return super()._allow_nominative_programs()


### PR DESCRIPTION
Improve GA4 eCommerce tracking coverage and data quality for website_sale.

Previously, only basic events were tracked (add_to_cart on product page, purchase with incomplete data). This commit adds missing events and improves existing ones to fully comply with GA4's eCommerce specification.

- `select_item`: added - fires when a product card is clicked on /shop or in product snippets.
- `add_to_cart`: improved - now fires on all surfaces (shop page,snippets, product page, quick add).
- `remove_from_cart`: added - fires when a cart line quantity is decreased or deleted.
- `view_cart`: added - fires when the cart page is loaded.
- `begin_checkout`: added - fires when the user proceeds to checkout from the cart page.
- `add_shipping_info`: added - fires when a delivery method is selected on the checkout page.
- `add_payment_info`: added - fires when the payment form is submitted.
- `purchase`: improved - added transaction_id, value (pre-tax), affiliation, item data quality and customer_type.
- `add_to_wishlist`: added - fires when a product is added to the wishlist from any surface.
- `coupon`: added - applied coupon/promotion codes are included in begin_checkout, add_payment_info, and purchase events when website_sale_loyalty is installed.

task-5417090
