### PR TITLE
[FIX] point_of_sale: add company constraint on payment method

### DIFF
--- a/addons/point_of_sale/models/pos_payment_method.py
+++ b/addons/point_of_sale/models/pos_payment_method.py
@@ -211,6 +211,12 @@ class PosPaymentMethod(models.Model):
                 if error_msg:
                     raise ValidationError(error_msg)
 
+    @api.constrains('config_ids')
+    def _check_company_config(self):
+        for payment in self:
+            if self.env['pos.config'].search_count([('id', 'in', payment.config_ids.ids), ('company_id', '!=', payment.company_id.id)]):
+                raise ValidationError(_("The points of sale for the payment method %s must belong to its company.", payment.name))
+
     @api.depends('payment_method_type', 'journal_id')
     def _compute_qr(self):
         for pm in self:

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -1161,6 +1161,28 @@ class TestPointOfSaleFlow(CommonPosTest):
         sub_pos_config.current_session_id.action_pos_session_closing_control()
         self.assertEqual(current_session.state, 'closed', msg='State of current session should be closed.')
 
+    def test_pos_branch_payment_method_config(self):
+        """ This test checks that we don't set a config on a payment
+        method that have different companies.
+        """
+        branch = self.env['res.company'].create({
+            'name': 'Sub Company',
+            'parent_id': self.env.company.id,
+            'chart_template': self.env.company.chart_template,
+            'country_id': self.env.company.country_id.id,
+        })
+        self.env.cr.precommit.run()
+        self.env.user.group_ids += self.env.ref('point_of_sale.group_pos_manager')
+        bank_payment_method = self.bank_payment_method.copy()
+        sub_pos_config = self.env['pos.config'].with_company(branch).create({
+            'name': 'Main',
+            'journal_id': self.company_data['default_journal_sale'].id,
+            'invoice_journal_id': self.company_data['default_journal_sale'].id,
+        })
+
+        with self.assertRaises(ValidationError, msg="The points of sale for the payment method Bank must belong to its company."):
+            bank_payment_method.write({"config_ids": sub_pos_config.ids})
+
     def test_order_unexisting_lots(self):
         self.ten_dollars_with_10_incl.product_variant_id.write({
             'tracking': 'lot',


### PR DESCRIPTION
Steps to reproduce:
-------------------
* Let's say you're on company A, create a pos payment method
* Don't assign a pos yet
* Create a branch company sub_A
* Switch to that branch company
* Create a pos
* Now switch to company A but also select sub_A
* In the config of the pos from sub_A, try to add the new payment method and save
> Validation error -> Normal
* Now instead go to the payment method form
* In the point of sales select the pos sub_A
* Save
> No error
* Try opening the pos sub_A
> Validation error, same as the first one -> Normal

Why the fix:
------------
We already have a contraint on the pos config model checking that the companies match.
https://github.com/odoo/odoo/blob/88df50bc96448dfaff28bd37e970ffd18bf8d554/addons/point_of_sale/models/pos_config.py#L469-L473

However when writing on the model pos payment there is no constraint and the ORM currently does not trigger constraints on comodel of the field we're modifying so we need to add this constraint on the pos payment method model as well

opw-6000206