### PR TITLE
[FIX] web: increase test_unit_desktop suite timeout

### DIFF
--- a/addons/web/tests/test_js.py
+++ b/addons/web/tests/test_js.py
@@ -145,7 +145,7 @@ class WebSuite(QunitCommon, HOOTCommon):
     @odoo.tests.no_retry
     def test_unit_desktop(self):
         # Unit tests suite (desktop)
-        self.browser_js(f'/web/tests?headless&loglevel=2&preset=desktop&timeout=15000{self.hoot_filters}', "", "", login='admin', timeout=3000, success_signal="[HOOT] Test suite succeeded", error_checker=unit_test_error_checker)
+        self.browser_js(f'/web/tests?headless&loglevel=2&preset=desktop&timeout=15000{self.hoot_filters}', "", "", login='admin', timeout=3600, success_signal="[HOOT] Test suite succeeded", error_checker=unit_test_error_checker)
 
     @odoo.tests.no_retry
     def test_hoot(self):


### PR DESCRIPTION
Lately, the main unit test suite started a timeout on a regular basis. After a bit of inverstigation, no specific culprit could be identified. In particular, there's no memory consumption difference between now and a month ago, when the suite was less likely to time out. The reason might simply be the number of tests that keeps growing, and the overall required time for the suite to complete flirting more and more with the limit, hence causing timeouts when the runbot is particularily loaded.

This commit thus extends the limit from 50 minutes to 1 hour.

Note that this is only required in 19.0, as from 19.1, the suite is split by sub-builds, each one running the unit tests of the tested addons only (instead of a single run in the web sub-build that executes all unit tests).

runbot error~238424

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
