### PR TITLE
[FIX] website_sale: avoid changing function signature

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -498,7 +498,7 @@ class SaleOrder(models.Model):
                 order_line,
                 order_line.product_id.id,
                 quantity,
-                order_line.product_uom_id.id,
+                uom_id=order_line.product_uom_id.id,
                 **kwargs,
             )
         else:
@@ -522,7 +522,7 @@ class SaleOrder(models.Model):
         }
 
     # hook to be overridden
-    def _verify_updated_quantity(self, _order_line, _product_id, new_qty, _uom_id, **_kwargs):  # noqa: PLR6301
+    def _verify_updated_quantity(self, order_line, product_id, new_qty, uom_id, **_kwargs):  # noqa: ARG002, PLR6301
         return new_qty, ""
 
     def _cart_update_order_line(self, order_line, quantity, **kwargs):
@@ -554,7 +554,7 @@ class SaleOrder(models.Model):
                             item_line,
                             item_line.product_id.id,
                             quantity,
-                            item_line.product_uom_id.id,
+                            uom_id=item_line.product_uom_id.id,
                             **kwargs,
                         )
                         combo_quantity = min(combo_quantity, combo_item_quantity)


### PR DESCRIPTION
Partial revert of commit 18a2407a311302eba0623bb0eeded0a4022eddf5, to avoid changing the signature of '_verify_updated_quantity'



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
