### PR TITLE
[FIX] point_of_sale: remove undeterministicTour key

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -248,7 +248,6 @@ registry.category("web_tour.tours").add("test_tax_control_button_visiblity", {
 });
 
 registry.category("web_tour.tours").add("test_reuse_empty_floating_order", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -1169,7 +1168,6 @@ registry.category("web_tour.tours").add("test_only_existing_lots", {
 });
 
 registry.category("web_tour.tours").add("test_delete_line", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -1190,6 +1188,9 @@ registry.category("web_tour.tours").add("test_delete_line", {
                     content: "Click 0",
                     trigger: ".modal " + Numpad.buttonTriger("0"),
                     run: "click",
+                },
+                {
+                    trigger: ".modal .popup-input .input-value:contains(0)",
                 },
                 ...Chrome.confirmPopup(),
             ]),

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
@@ -86,30 +86,12 @@ export function checkFloatingOrderCount(expectedCount) {
         {
             isActive: ["mobile"],
             content: `check there are ${expectedCount} floating order`,
-            trigger: ".modal-dialog .list-container-items .btn",
-            run: () => {
-                const btns = document.querySelectorAll(".modal-dialog .list-container-items .btn");
-                if (btns.length !== expectedCount) {
-                    throw new Error(
-                        `Expected ${expectedCount} floating order buttons, found ${btns.length}`
-                    );
-                }
-            },
+            trigger: `.modal-dialog .list-container-items:has(.btn:count(${expectedCount}))`,
         },
         {
             isActive: ["desktop"],
             content: `check there are ${expectedCount} floating order`,
-            trigger: ".list-container-items",
-            run: () => {
-                const btns = document.querySelectorAll(
-                    ".list-container-items .floating-order-container .btn"
-                );
-                if (btns.length !== expectedCount) {
-                    throw new Error(
-                        `Expected ${expectedCount} floating order buttons, found ${btns.length}`
-                    );
-                }
-            },
+            trigger: `.list-container-items:has(.floating-order-container:has(.btn):count(${expectedCount}))`,
         },
         {
             isActive: ["mobile"],


### PR DESCRIPTION
Fix undeterministic tours by making some triggers more precise in a few steps to ensure the tour take the good way.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
