### PR TITLE
[FIX] pos_restaurant: fix tour for updating data

### DIFF
--- a/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
@@ -95,6 +95,7 @@ registry.category("web_tour.tours").add("test_sync_lines_qty_update_ticket_scree
             ProductScreen.clickOrderline("Coca-Cola", "1"),
             ProductScreen.clickNumpad("3"),
             ProductScreen.selectedOrderlineHas("Coca-Cola", "3"),
+            Chrome.waitForOrdersSync(),
             Chrome.clickOrders(),
             TicketScreen.selectOrder("001"),
             Order.hasLine({


### PR DESCRIPTION
The crash occurs due to the test case introduced in PR https://github.com/odoo/odoo/pull/240366. The data is not fully synced with the backend when the tour execution completes, which leads to a crash.

This commit introduces a delay to ensure that the data is properly synchronized with the backend before the tour finishes.

Runbot-241918
