### PR TITLE
[FIX] website: fix video snippet in edit mode

### DIFF
--- a/addons/test_website/static/tests/tours/website_field_sanitize.js
+++ b/addons/test_website/static/tests/tours/website_field_sanitize.js
@@ -19,17 +19,17 @@ registry.category("web_tour.tours").add("website_designer_iframe_video", {
         {
             content: "Add a YouTube video",
             trigger: ".o_select_media_dialog #o_video_text",
-            run: "text //www.youtube.com/embed/G8b4UZIcTfg",
+            run: "text //www.youtube.com/embed/nbso3NVz3p8",
         },
         {
             content: "Save and close the media dialog",
-            extra_trigger: ".modal .o_video_preview .media_iframe_video iframe[src*='G8b4UZIcTfg']",
+            extra_trigger: ".modal .o_video_preview .media_iframe_video iframe[src*='nbso3NVz3p8']",
             trigger: ".modal-footer .btn-primary",
         },
         ...wTourUtils.clickOnSave(),
         {
             content: "Check that the video was correctly saved",
-            trigger: "iframe .media_iframe_video[data-oe-expression*='G8b4UZIcTfg']",
+            trigger: "iframe .media_iframe_video[data-oe-expression*='nbso3NVz3p8']",
             run: () => {},
         },
     ],
@@ -43,7 +43,7 @@ registry.category("web_tour.tours").add("website_restricted_editor_iframe_video"
         {
             content: "Check that the video iframe was correctly restored after saving the changes",
             trigger:
-                "iframe [data-oe-field]:not([data-oe-sanitize-prevent-edition]) .media_iframe_video[data-oe-expression*='G8b4UZIcTfg']",
+                "iframe [data-oe-field]:not([data-oe-sanitize-prevent-edition]) .media_iframe_video[data-oe-expression*='nbso3NVz3p8']",
             run: () => {},
         },
         {

--- a/addons/website/views/snippets/s_video.xml
+++ b/addons/website/views/snippets/s_video.xml
@@ -2,10 +2,10 @@
 <odoo>
 
 <template id="s_video" name="Video">
-    <div class="media_iframe_video o_snippet_drop_in_only" data-oe-expression="//www.youtube.com/embed/G8b4UZIcTfg?rel=0&amp;autoplay=0">
+    <div class="media_iframe_video o_snippet_drop_in_only" data-oe-expression="//www.youtube.com/embed/nbso3NVz3p8?rel=0&amp;autoplay=0">
         <div class="css_editable_mode_display"></div>
         <div class="media_iframe_video_size"></div>
-        <iframe src="//www.youtube.com/embed/G8b4UZIcTfg?rel=0&amp;autoplay=0"
+        <iframe src="//www.youtube.com/embed/nbso3NVz3p8?rel=0&amp;autoplay=0"
             frameborder="0" allowfullscreen="allowfullscreen" aria-label="Video"></iframe>
     </div>
 </template>


### PR DESCRIPTION

Specification:
- The previously embedded video used by the "s_video" snippet
(id=G8b4UZIcTfg) is no longer publicly available.

After this commit:
- This commit replaces the default video with a new publicly available
one (id=nbso3NVz3p8).

task-6034987


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
