### PR TITLE
[FIX] point_of_sale: load preparation categories

### DIFF
--- a/addons/point_of_sale/models/pos_category.py
+++ b/addons/point_of_sale/models/pos_category.py
@@ -40,13 +40,16 @@ class PosCategory(models.Model):
     def _load_pos_data_domain(self, data, config):
         domain = []
         if config.limit_categories:
-            preparation_categories = [printer['product_categories_ids'] for printer in data['pos.printer']]
-            flattened_preparation_categories = [item for sublist in preparation_categories for item in sublist]
-            domain += [('id', 'in', flattened_preparation_categories + config.iface_available_categ_ids.ids)]
+            additional_categories_ids = self._load_pos_data_additional_categories_ids(data, config)
+            domain += [('id', 'in', additional_categories_ids + config.iface_available_categ_ids.ids)]
         return domain
 
     @api.model
-    def _load_pos_data_fields(self, config):
+    def _load_pos_data_additional_categories_ids(self, data, config):
+        return config.printer_ids.product_categories_ids._get_descendants().ids
+
+    @api.model
+    def _load_pos_data_fields(self, config_id):
         return ['id', 'name', 'parent_id', 'child_ids', 'write_date', 'has_image', 'color', 'sequence', 'hour_until', 'hour_after']
 
     def _get_hierarchy(self) -> List[str]:

--- a/addons/point_of_sale/static/src/app/components/category_selector/category_selector.js
+++ b/addons/point_of_sale/static/src/app/components/category_selector/category_selector.js
@@ -15,10 +15,11 @@ export class CategorySelector extends Component {
     getCategoriesList(list, allParents, depth) {
         const categoriesList = [...list];
         list.forEach((item) => {
-            if (item.id === allParents[depth]?.id && item.child_ids?.length) {
-                categoriesList.push(
-                    ...this.getCategoriesList(item.child_ids, allParents, depth + 1)
-                );
+            if (item.id === allParents[depth]?.id) {
+                const children = this.getChildren(item);
+                if (children.length) {
+                    categoriesList.push(...this.getCategoriesList(children, allParents, depth + 1));
+                }
             }
         });
         return categoriesList;
@@ -26,29 +27,39 @@ export class CategorySelector extends Component {
 
     getCategoriesAndSub() {
         const { limit_categories, iface_available_categ_ids } = this.pos.config;
-        let rootCategories = this.pos.models["pos.category"].getAll();
+        let displayableCategories;
         if (limit_categories && iface_available_categ_ids.length > 0) {
-            rootCategories = iface_available_categ_ids;
+            displayableCategories = iface_available_categ_ids;
+            const allowedIdSet = new Set(displayableCategories.map((c) => c.id));
+            this.isAllowedCategory = (category) => allowedIdSet.has(category.id);
+        } else {
+            displayableCategories = this.pos.models["pos.category"].getAll();
+            this.isAllowedCategory = () => true;
         }
-        rootCategories = rootCategories
-            .filter((category) => !category.parent_id)
+
+        const rootCategories = displayableCategories
+            .filter(
+                (category) => !category.parent_id || !this.isAllowedCategory(category.parent_id)
+            )
             .sort((a, b) => a.sequence - b.sequence);
         const selected = this.pos.selectedCategory ? [this.pos.selectedCategory] : [];
-        const allParents = selected.concat(this.pos.selectedCategory?.allParents || []).reverse();
-        return this.getCategoriesList(rootCategories, allParents, 0)
+        const allParents = selected.concat(this.getAllParents(this.pos.selectedCategory)).reverse();
+        const result = this.getCategoriesList(rootCategories, allParents, 0)
             .flat(Infinity)
             .filter((c) => c.hasProductsToShow)
-            .map(this.getChildCategoriesInfo, this);
+            .map((c) => this.getChildCategoriesInfo(c, rootCategories));
+        this.isAllowedCategory = null;
+        return result;
     }
 
     getAncestorsAndCurrent() {
         const selectedCategory = this.pos.selectedCategory;
         return selectedCategory
-            ? [undefined, ...selectedCategory.allParents, selectedCategory]
+            ? [undefined, ...this.getAllParents(selectedCategory), selectedCategory]
             : [selectedCategory];
     }
 
-    getChildCategoriesInfo(category) {
+    getChildCategoriesInfo(category, rootCategories) {
         return {
             ...pick(category, "id", "name", "color"),
             imgSrc:
@@ -56,14 +67,26 @@ export class CategorySelector extends Component {
                     ? `/web/image?model=pos.category&field=image_128&id=${category.id}`
                     : undefined,
             isSelected: this.getAncestorsAndCurrent().includes(category),
-            isChildren: this.getChildCategories(this.pos.selectedCategory).includes(category),
+            isChildren: this.getChildCategories(this.pos.selectedCategory, rootCategories).includes(
+                category
+            ),
         };
     }
 
-    getChildCategories(selectedCategory) {
-        return selectedCategory
-            ? [...selectedCategory.child_ids]
-            : this.pos.models["pos.category"].filter((category) => !category.parent_id);
+    getChildCategories(selectedCategory, rootCategories) {
+        return selectedCategory ? this.getChildren(selectedCategory) : rootCategories;
+    }
+
+    getChildren(category) {
+        return (
+            category.child_ids
+                ?.filter((child) => this.isAllowedCategory(child))
+                .sort((a, b) => a.sequence - b.sequence) || []
+        );
+    }
+
+    getAllParents(category) {
+        return category?.allParents.filter((cat) => this.isAllowedCategory(cat)) || [];
     }
 
     getAllSelected() {

--- a/addons/point_of_sale/static/tests/pos/tours/utils/preparation_receipt_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/preparation_receipt_util.js
@@ -76,6 +76,12 @@ export function checkPreparationTicketData(
         const lines = tickets[0].querySelectorAll(".orderline");
         const lineNames = [];
 
+        if (data.length !== lines.length) {
+            throw new Error(
+                `Ticket data mismatch: expected ${data.length} lines, but printed ${lines.length}.`
+            );
+        }
+
         let idx = 0;
         for (const line of lines) {
             const name = line.firstChild.children[1].innerHTML;

--- a/addons/point_of_sale/static/tests/unit/components/category_selector.test.js
+++ b/addons/point_of_sale/static/tests/unit/components/category_selector.test.js
@@ -1,0 +1,363 @@
+import { expect, test, describe, beforeEach } from "@odoo/hoot";
+
+import { setupPosEnv } from "../utils";
+import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { CategorySelector } from "@point_of_sale/app/components/category_selector/category_selector";
+import { PosCategory } from "../data/pos_category.data";
+import { definePosModels } from "../data/generate_model_definitions";
+import { ProductTemplate } from "../data/product_template.data";
+import { PosConfig } from "../data/pos_config.data";
+
+definePosModels();
+
+describe("With restricted categories", () => {
+    describe("Without child categories", () => {
+        beforeEach(async () => {
+            const catDrink = addCategory({ name: "Drinks", sequence: 2 });
+            const catFood = addCategory({ name: "Food", sequence: 1 });
+            const posConfig = PosConfig._records[0];
+            posConfig.iface_available_categ_ids = [catDrink.id, catFood.id];
+            posConfig.limit_categories = true;
+            addProduct({ name: "Water", pos_categ_id: catDrink.id });
+            addProduct({ name: "Burger", pos_categ_id: catFood.id });
+            this.pos = await setupPosEnv();
+
+            this.catDrink = this.pos.models["pos.category"].get(catDrink.id);
+            this.catFood = this.pos.models["pos.category"].get(catFood.id);
+
+            expect(this.pos.models["pos.category"].getAll().length).toBeGreaterThan(
+                this.pos.config.iface_available_categ_ids.length
+            ); // All cats are loaded
+        });
+
+        test("return root categories sorted by sequence", async () => {
+            const comp = await mountWithCleanup(CategorySelector, {});
+            const categories = comp.getCategoriesAndSub(this.pos);
+            assertCategories(categories, [
+                {
+                    id: this.catFood.id,
+                    name: this.catFood.name,
+                    isChildren: true,
+                    isSelected: false,
+                },
+                {
+                    id: this.catDrink.id,
+                    name: this.catDrink.name,
+                    isChildren: true,
+                    isSelected: false,
+                },
+            ]);
+        });
+
+        test("mark category as selected", async () => {
+            const comp = await mountWithCleanup(CategorySelector, {});
+            this.pos.selectedCategory = this.catDrink;
+            const categories = comp.getCategoriesAndSub(this.pos);
+            assertCategories(categories, [
+                {
+                    id: this.catFood.id,
+                    name: this.catFood.name,
+                    isChildren: false,
+                    isSelected: false,
+                },
+                {
+                    id: this.catDrink.id,
+                    name: this.catDrink.name,
+                    isChildren: false,
+                    isSelected: true,
+                },
+            ]);
+        });
+
+        test("update selection state when switching between categories", async () => {
+            const comp = await mountWithCleanup(CategorySelector, {});
+            this.pos.selectedCategory = this.catDrink;
+            comp.getCategoriesAndSub(this.pos);
+            this.pos.selectedCategory = this.catFood;
+            const categories = comp.getCategoriesAndSub(this.pos);
+
+            assertCategories(categories, [
+                {
+                    id: this.catFood.id,
+                    name: this.catFood.name,
+                    isChildren: false,
+                    isSelected: true,
+                },
+                {
+                    id: this.catDrink.id,
+                    name: this.catDrink.name,
+                    isChildren: false,
+                    isSelected: false,
+                },
+            ]);
+        });
+
+        test("reset to default state when category is unselected", async () => {
+            const comp = await mountWithCleanup(CategorySelector, {});
+            this.pos.selectedCategory = this.catFood;
+            comp.getCategoriesAndSub(this.pos);
+
+            this.pos.selectedCategory = null;
+            const categories = comp.getCategoriesAndSub(this.pos);
+
+            assertCategories(categories, [
+                {
+                    id: this.catFood.id,
+                    name: this.catFood.name,
+                    isChildren: true,
+                    isSelected: false,
+                },
+                {
+                    id: this.catDrink.id,
+                    name: this.catDrink.name,
+                    isChildren: true,
+                    isSelected: false,
+                },
+            ]);
+        });
+    });
+
+    describe('With child categories"', () => {
+        beforeEach(async () => {
+            // Food hierarchy: Food > Burger > Best Burger
+            const catFood = addCategory({ name: "Food", sequence: 1 });
+            const catBurger = addCategory({ name: "Burger", sequence: 2 });
+            const catBestBurger = addCategory({ name: "Best Burger", sequence: 3 });
+            const catBestBurgerHidden = addCategory({ name: "Best Burger Hidden", sequence: 3 });
+            catFood.child_ids = [catBurger.id];
+            catBurger.parent_id = catFood.id;
+            catBurger.child_ids = [catBestBurger.id, catBestBurgerHidden.id];
+            catBestBurger.parent_id = catBurger.id;
+            catBestBurgerHidden.parent_id = catBurger.id;
+
+            // Drinks hierarchy: Drinks > [Soft, Cocktail]
+            const catDrink = addCategory({ name: "Drinks", sequence: 4 });
+            const catSoft = addCategory({ name: "Soft", sequence: 6 });
+            const catCocktail = addCategory({ name: "Cocktail", sequence: 7 });
+            catDrink.child_ids = [catCocktail.id, catSoft.id]; // Unordered on purpose
+            catSoft.parent_id = catDrink.id;
+            catCocktail.parent_id = catDrink.id;
+            const product = addProduct({ name: "Demo" });
+            product.pos_categ_ids = [
+                catFood.id,
+                catBurger.id,
+                catBestBurger.id,
+                catBestBurgerHidden.id,
+                catDrink.id,
+                catSoft.id,
+                catCocktail.id,
+            ];
+            const posConfig = PosConfig._records[0];
+            posConfig.iface_available_categ_ids = [
+                catFood.id,
+                catBurger.id,
+                catBestBurger.id,
+                catDrink.id,
+                catSoft.id,
+                catCocktail.id,
+            ]; //exclude catBestBurgerHidden
+
+            posConfig.limit_categories = true;
+            this.pos = await setupPosEnv();
+
+            this.catFood = this.pos.models["pos.category"].get(catFood.id);
+            this.catBurger = this.pos.models["pos.category"].get(catBurger.id);
+            this.catBestBurger = this.pos.models["pos.category"].get(catBestBurger.id);
+
+            this.catDrink = this.pos.models["pos.category"].get(catDrink.id);
+            this.catSoft = this.pos.models["pos.category"].get(catSoft.id);
+            this.catCocktail = this.pos.models["pos.category"].get(catCocktail.id);
+        });
+
+        test("return only root categories when no category is selected", async () => {
+            const comp = await mountWithCleanup(CategorySelector, {});
+            const categories = comp.getCategoriesAndSub();
+            assertCategories(categories, [
+                { id: this.catFood.id, name: "Food", isChildren: true, isSelected: false },
+                { id: this.catDrink.id, name: "Drinks", isChildren: true, isSelected: false },
+            ]);
+        });
+
+        test("show immediate children when root category is selected", async () => {
+            const comp = await mountWithCleanup(CategorySelector, {});
+            this.pos.selectedCategory = this.catFood;
+            const categories = comp.getCategoriesAndSub();
+
+            assertCategories(categories, [
+                { id: this.catFood.id, name: "Food", isChildren: false, isSelected: true },
+                { id: this.catDrink.id, name: "Drinks", isChildren: false, isSelected: false },
+                { id: this.catBurger.id, name: "Burger", isChildren: true, isSelected: false },
+            ]);
+        });
+
+        test("show parent categories when second-level category is selected", async () => {
+            const comp = await mountWithCleanup(CategorySelector, {});
+            this.pos.selectedCategory = this.catBurger;
+            const categories = comp.getCategoriesAndSub();
+
+            assertCategories(categories, [
+                { id: this.catFood.id, name: "Food", isChildren: false, isSelected: true },
+                { id: this.catDrink.id, name: "Drinks", isChildren: false, isSelected: false },
+                { id: this.catBurger.id, name: "Burger", isChildren: false, isSelected: true },
+                {
+                    id: this.catBestBurger.id,
+                    name: "Best Burger",
+                    isChildren: true,
+                    isSelected: false,
+                },
+            ]);
+        });
+
+        test("show parent categories when third-level category is selected", async () => {
+            const comp = await mountWithCleanup(CategorySelector, {});
+            this.pos.selectedCategory = this.catBestBurger;
+            const categories = comp.getCategoriesAndSub();
+
+            assertCategories(categories, [
+                { id: this.catFood.id, name: "Food", isChildren: false, isSelected: true },
+                { id: this.catDrink.id, name: "Drinks", isChildren: false, isSelected: false },
+                { id: this.catBurger.id, name: "Burger", isChildren: false, isSelected: true },
+                {
+                    id: this.catBestBurger.id,
+                    name: "Best Burger",
+                    isChildren: false,
+                    isSelected: true,
+                },
+            ]);
+        });
+
+        test("show children sorted by sequence when parent is selected", async () => {
+            const comp = await mountWithCleanup(CategorySelector, {});
+            this.pos.selectedCategory = this.catDrink;
+            const categories = comp.getCategoriesAndSub();
+
+            // Soft (sequence: 6) should come before Cocktail (sequence: 7)
+            expect(this.catSoft.sequence).toBeLessThan(this.catCocktail.sequence);
+            assertCategories(categories, [
+                { id: this.catFood.id, name: "Food", isChildren: false, isSelected: false },
+                { id: this.catDrink.id, name: "Drinks", isChildren: false, isSelected: true },
+                { id: this.catSoft.id, name: "Soft", isChildren: true, isSelected: false },
+                { id: this.catCocktail.id, name: "Cocktail", isChildren: true, isSelected: false },
+            ]);
+        });
+
+        test("switch to different category", async () => {
+            const comp = await mountWithCleanup(CategorySelector, {});
+            this.pos.selectedCategory = this.catCocktail;
+            const categories = comp.getCategoriesAndSub();
+
+            assertCategories(categories, [
+                { id: this.catFood.id, name: "Food", isChildren: false, isSelected: false },
+                { id: this.catDrink.id, name: "Drinks", isChildren: false, isSelected: true },
+                { id: this.catSoft.id, name: "Soft", isChildren: false, isSelected: false },
+                { id: this.catCocktail.id, name: "Cocktail", isChildren: false, isSelected: true },
+            ]);
+        });
+    });
+});
+
+describe("Without restricted categories", () => {
+    beforeEach(async () => {
+        const posConfig = PosConfig._records[0];
+        posConfig.iface_available_categ_ids = false;
+        posConfig.limit_categories = true;
+
+        const catFood = addCategory({ name: "Food", sequence: 1 });
+        const catBurger = addCategory({ name: "Burger", sequence: 2 });
+        catFood.child_ids = [catBurger.id];
+        catBurger.parent_id = catFood.id;
+
+        const product = addProduct({ name: "Demo" });
+        product.pos_categ_ids = [catBurger.id, catFood.id];
+        this.pos = await setupPosEnv();
+
+        this.catFood = this.pos.models["pos.category"].get(catFood.id);
+        this.catBurger = this.pos.models["pos.category"].get(catBurger.id);
+    });
+
+    test("root categories", async () => {
+        const comp = await mountWithCleanup(CategorySelector, {});
+        const categories = comp
+            .getCategoriesAndSub()
+            .filter((c) => c.id === this.catFood.id || c.id === this.catBurger.id);
+        expect(categories.length).toBe(1);
+
+        assertCategories(categories, [
+            { id: this.catFood.id, name: "Food", isChildren: true, isSelected: false },
+        ]);
+    });
+
+    test("select parent category", async () => {
+        const comp = await mountWithCleanup(CategorySelector, {});
+        this.pos.selectedCategory = this.catFood;
+        const categories = comp
+            .getCategoriesAndSub()
+            .filter((c) => c.id === this.catFood.id || c.id === this.catBurger.id);
+
+        assertCategories(categories, [
+            { id: this.catFood.id, name: "Food", isChildren: false, isSelected: true },
+            { id: this.catBurger.id, name: "Burger", isChildren: true, isSelected: false },
+        ]);
+    });
+
+    test("select child category", async () => {
+        const comp = await mountWithCleanup(CategorySelector, {});
+        this.pos.selectedCategory = this.catBurger;
+        const categories = comp
+            .getCategoriesAndSub()
+            .filter((c) => c.id === this.catFood.id || c.id === this.catBurger.id);
+
+        assertCategories(categories, [
+            { id: this.catFood.id, name: "Food", isChildren: false, isSelected: true },
+            { id: this.catBurger.id, name: "Burger", isChildren: false, isSelected: true },
+        ]);
+    });
+});
+
+// Helper functions
+function assertCategory(category, expected) {
+    expect(category.id).toBe(expected.id);
+    expect(category.name).toBe(expected.name);
+    expect(category.isChildren).toBe(expected.isChildren);
+    expect(category.isSelected).toBe(expected.isSelected);
+}
+
+function assertCategories(categories, expectedCategories) {
+    expect(categories.length).toBe(expectedCategories.length);
+    expectedCategories.forEach((expected, index) => {
+        assertCategory(categories[index], expected);
+    });
+}
+
+let productId = 900;
+
+function addProduct({ name, pos_categ_id, price = 10 }) {
+    const record = {
+        id: productId++,
+        name: name,
+        display_name: name,
+        list_price: price,
+        standard_price: price,
+        type: "consu",
+        pos_categ_ids: [pos_categ_id],
+        available_in_pos: true,
+        active: true,
+    };
+
+    ProductTemplate._records.push(record);
+    return record;
+}
+
+let catId = 100;
+function addCategory({ name, parent_id = false, child_ids = [], sequence = 1 }) {
+    const record = {
+        id: catId++,
+        name: name,
+        sequence: sequence,
+        parent_id: parent_id,
+        child_ids: child_ids,
+        has_image: false,
+    };
+    PosCategory._records.push(record);
+    return record;
+}

--- a/addons/point_of_sale/tests/common_setup_methods.py
+++ b/addons/point_of_sale/tests/common_setup_methods.py
@@ -113,6 +113,7 @@ def setup_product_combo_items(self):
             "pos_categ_ids": [(6, 0, [pos_category_2.id])],
         }
     )
+    self.combo_product_5 = combo_product_5
 
     self.desks_combo = self.env["product.combo"].create(
         {

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1597,6 +1597,56 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_printer_not_linked_to_any_combo_category', login="pos_user")
 
+    def test_printer_with_not_limited_category(self):
+        """  This test ensures that if a printer has a category that is not in the limited categories of the POS,
+             the products of this category are still printed in the preparation ticket """
+
+        setup_product_combo_items(self)
+        initial_cats_ids = self.env['pos.category'].search([]).ids
+        new_category = self.env['pos.category'].create({
+            'name': 'Not visible',
+        })
+        self.printer.write({
+            'product_categories_ids': [Command.set([new_category.id])],
+        })
+        self.combo_product_5.pos_categ_ids = [Command.set([new_category.id])]
+        self.main_pos_config.write({
+            'is_order_printer': True,
+            'printer_ids': [Command.set(self.printer.ids)],
+            'limit_categories': True,
+            'iface_available_categ_ids': [Command.set(initial_cats_ids)],
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_printer_restricts_to_allowed_categories_for_combo', login="pos_user")
+
+    def test_printer_with_not_limited_category_child(self):
+        """  This test ensures that if a printer has a category that is not in the limited categories of the POS,
+             the products with a child category of the printer's category (also not in the limited categories)
+             are still printed in the preparation ticket """
+
+        setup_product_combo_items(self)
+        initial_cats_ids = self.env['pos.category'].search([]).ids
+
+        new_category = self.env['pos.category'].create({
+            'name': 'Not Limited',
+        })
+        self.printer.write({
+            'product_categories_ids': [Command.set([new_category.id])],
+        })
+        new_child_category = self.env['pos.category'].create({
+            'name': 'Not Limited child',
+            'parent_id': new_category.id,
+        })
+        self.combo_product_5.pos_categ_ids = [Command.set([new_child_category.id])]
+        self.main_pos_config.write({
+            'is_order_printer': True,
+            'limit_categories': True,
+            'iface_available_categ_ids': [Command.set(initial_cats_ids)],
+            'printer_ids': [Command.set(self.printer.ids)],
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_printer_restricts_to_allowed_categories_for_combo', login="pos_user")
+
     def test_multi_product_options(self):
         self.pos_user.write({
             'group_ids': [

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -504,7 +504,7 @@ registry.category("web_tour.tours").add("test_course_restaurant_preparation_tour
             Dialog.confirm(),
             FloorScreen.clickTable("5"),
             ProductScreen.selectCourseLine("Course 3"),
-            checkPreparationTicketData([{ name: "Product Test", qty: 1, attribute: ["Value 1"] }], {
+            checkPreparationTicketData([], {
                 visibleInDom: ["Course 3"],
                 invisibleInDom: ["DUPLICATA!"],
                 fireCourse: true,

--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.js
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.js
@@ -31,7 +31,9 @@ export class ProductListPage extends Component {
             this.selfOrder.computeAvailableCategories();
         }
         const availableCategories = this.selfOrder.availableCategories;
-        const topCategories = availableCategories.filter((category) => !category.parent_id);
+        const topCategories = availableCategories.filter((category) =>
+            this.isRootCategory(category)
+        );
         const selectedCategory =
             initCategories && topCategories.length > 0
                 ? topCategories[0]
@@ -91,10 +93,17 @@ export class ProductListPage extends Component {
         });
     }
 
+    isRootCategory(category) {
+        if (!category) {
+            return false;
+        }
+        return !category.parent_id || !this.selfOrder.isVisibleCategory(category.parent_id);
+    }
+
     selectCategory(category) {
         this.state.selectedCategory = category;
         if (this.selfOrder.kioskMode) {
-            if (!category.parent_id) {
+            if (this.isRootCategory(category)) {
                 this.toggleSubCategoryPanel();
             }
             this.ensureCategoryVisible();
@@ -116,6 +125,13 @@ export class ProductListPage extends Component {
         );
     }
 
+    isProductVisible(product) {
+        if (product.pos_categ_ids.length === 0) {
+            return true;
+        }
+        return product.pos_categ_ids.some((cat) => this.selfOrder.isVisibleCategory(cat));
+    }
+
     isProductAvailable(product) {
         if (product.pos_categ_ids.length === 0) {
             return true;
@@ -124,7 +140,13 @@ export class ProductListPage extends Component {
     }
 
     get topSelectedCategory() {
-        return this.selectedCategory?.parent_id || this.selectedCategory;
+        if (this.selectedCategory) {
+            const parentCat = this.selectedCategory.parent_id;
+            if (parentCat && this.selfOrder.isVisibleCategory(parentCat)) {
+                return parentCat;
+            }
+        }
+        return this.selectedCategory;
     }
 
     get selectedCategory() {
@@ -140,10 +162,19 @@ export class ProductListPage extends Component {
         if (!currentCategory) {
             return [];
         }
-        if (currentCategory.parent_id) {
-            return currentCategory.parent_id.child_ids;
+        const parent =
+            currentCategory.parent_id && this.selfOrder.isVisibleCategory(currentCategory.parent_id)
+                ? currentCategory.parent_id
+                : currentCategory;
+
+        return this.filterVisibleCategories(parent.child_ids || []);
+    }
+
+    filterVisibleCategories(categories) {
+        if (!categories) {
+            return categories;
         }
-        return currentCategory.child_ids || [];
+        return categories.filter((c) => this.selfOrder.isVisibleCategory(c));
     }
 
     get productCategories() {

--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
@@ -56,7 +56,7 @@
                          <div class="fs-2 fw-bold ps-3 ps-sm-0 py-2 py-sm-3 py-lg-4" t-esc="category.name" t-if="!selfOrder.kioskMode"/>
                          <t t-set="productList" t-value="getProducts(category)"/>
                          <div class="product_list grid" t-att-class="{'pt-sm-3 pt-lg-4': selfOrder.kioskMode, 'pb-2': !selfOrder.kioskMode}">
-                            <div t-foreach="productList" t-as="product" t-key="product.id" class="o_self_product_box g-col-12 g-col-md-6 g-col-lg-3 rounded-4 p-3 p-lg-0 shadow-sm shadow-lg-none" t-att-class="{'g-col-kiosk-p-4': productList.length &lt;= 9 , 'g-col-kiosk-p-3': productList.length &gt; 9 }">
+                            <div t-foreach="productList" t-as="product" t-if="isProductVisible(product)" t-key="product.id" class="o_self_product_box g-col-12 g-col-md-6 g-col-lg-3 rounded-4 p-3 p-lg-0 shadow-sm shadow-lg-none" t-att-class="{'g-col-kiosk-p-4': productList.length &lt;= 9 , 'g-col-kiosk-p-3': productList.length &gt; 9 }">
                                 <t t-set="not_available" t-value="!product.self_order_available || !isProductAvailable(product)" />
                                 <article role="button" t-on-click="(evt) => this.selectProduct(product, evt.target)" class="position-relative d-flex flex-row-reverse flex-lg-column align-items-start cursor-pointer" t-att-class="{'opacity-50' : not_available}">
                                     <div class="product_img ratio ratio-1x1 w-lg-100 flex-shrink-0 ms-2 ms-lg-0">

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -439,9 +439,13 @@ export class SelfOrder extends Reactive {
     }
 
     initProducts() {
-        this.productCategories = this.config.limit_categories
-            ? this.config.iface_available_categ_ids
-            : this.models["pos.category"].getAll();
+        if (this.config.limit_categories) {
+            this.productCategories = this.config.iface_available_categ_ids;
+            this.limitedCategoryIdsSet = new Set(this.productCategories.map((c) => c.id));
+        } else {
+            this.limitedCategoryIdsSet = null;
+            this.productCategories = this.models["pos.category"].getAll();
+        }
         this.productByCategIds = this.models["product.template"].getAllBy("pos_categ_ids");
 
         const excludedProductTemplateIds = new Set(
@@ -468,6 +472,16 @@ export class SelfOrder extends Reactive {
             });
             this.productByCategIds["0"] = productWoCat;
         }
+    }
+
+    isVisibleCategory(category) {
+        if (!category) {
+            return false;
+        }
+        if (this.limitedCategoryIdsSet) {
+            return this.limitedCategoryIdsSet.has(category.id);
+        }
+        return true;
     }
 
     initData() {

--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -271,3 +271,31 @@ registry.category("web_tour.tours").add("test_self_order_parent_category", {
         Utils.clickBtn("Close"),
     ],
 });
+
+registry.category("web_tour.tours").add("test_self_order_limited_cat", {
+    steps: () => [
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickCategory("Miscellaneous"),
+        Utils.negateStep(ProductPage.checkRootCategoryDisplayed("Hidden root")),
+        ProductPage.checkProductDisplayed("Fanta"),
+        Utils.negateStep(ProductPage.checkProductDisplayed("Coca-Cola")),
+        ProductPage.checkChildCategoryDisplayed("Child2"),
+        Utils.negateStep(ProductPage.checkChildCategoryDisplayed("Hidden child")),
+        ProductPage.clickChildCategory("Child2"),
+        ProductPage.checkProductDisplayed("Fanta"),
+        ProductPage.clickCategory("Visible Root"),
+        ProductPage.checkProductDisplayed("Ketchup"),
+        ProductPage.clickCategory("Category 2"),
+        ProductPage.clickProduct("Office Combo"),
+        ProductPage.clickComboProduct("Combo Product 5"),
+        Utils.clickBtn("Add to cart"),
+
+        Utils.clickBtn("Checkout"),
+        Utils.clickBtn("Order"),
+        Utils.clickBtn("Close"),
+        {
+            content: `Check prep change printed'`,
+            trigger: `.pos-receipt-print:contains('Combo Product 5')`,
+        },
+    ],
+});

--- a/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
@@ -206,3 +206,24 @@ export function isShown() {
         trigger: ".o_self_product_list_page",
     };
 }
+
+export function checkProductDisplayed(productName) {
+    return {
+        content: `Check if product '${productName}' is displayed`,
+        trigger: `.o_self_product_box span:contains('${productName}')`,
+    };
+}
+
+export function checkRootCategoryDisplayed(categoryName) {
+    return {
+        content: `Check if root category '${categoryName}' is displayed`,
+        trigger: `.category_btn:contains('${categoryName}')`,
+    };
+}
+
+export function checkChildCategoryDisplayed(categoryName) {
+    return {
+        content: `Check if child category '${categoryName}' is displayed`,
+        trigger: `.child_category_btn:contains('${categoryName}')`,
+    };
+}

--- a/addons/pos_self_order/tests/test_self_order_kiosk.py
+++ b/addons/pos_self_order/tests/test_self_order_kiosk.py
@@ -344,3 +344,77 @@ class TestSelfOrderKiosk(SelfOrderCommonTest):
         self.pos_config.current_session_id.set_opening_control(0, "")
         self_route = self.pos_config._get_self_order_route()
         self.start_tour(self_route, "test_self_order_parent_category")
+
+    def test_self_order_limited_cat(self):
+        setup_product_combo_items(self)
+        self.office_combo.write({
+            "combo_ids": [
+                Command.unlink(c.id)
+                for c in self.office_combo.combo_ids
+                if c.id != self.desks_combo.id
+            ],
+        })
+
+        limited_cats_ids = self.env['pos.category'].search([]).ids
+        parent_cat = self.cola.pos_categ_ids[0]
+        hidden_child_category = self.env['pos.category'].create({
+            'name': 'Hidden child',
+            'parent_id': parent_cat.id,
+        })
+        visible_child_category = self.env['pos.category'].create({
+            'name': 'Child2',
+            'parent_id': parent_cat.id,
+        })
+        limited_cats_ids += [visible_child_category.id]
+        self.fanta.pos_categ_ids = [Command.link(visible_child_category.id)]
+
+        # Set the child category on this product. The category is loaded because it is a preparation category.
+        # However, the product should not be displayed and the subcategory should be hidden in the frontend
+        # because it is not a limited category.
+        self.cola.pos_categ_ids = [Command.set([hidden_child_category.id])]
+
+        # Hidden root category loaded because it is a preparation category.
+        hidden_root_category = self.env['pos.category'].create({
+            'name': 'Hidden root',
+        })
+
+        # This category is child of a hidden category -> displayed as root
+        visible_root_category = self.env['pos.category'].create({
+            'name': 'Visible Root',
+            'parent_id': hidden_child_category.id,
+        })
+        limited_cats_ids += [visible_root_category.id]
+
+        self.ketchup.pos_categ_ids = [Command.link(hidden_root_category.id), Command.link(visible_root_category.id)]
+
+        # The combo product to sent to the printer
+        self.combo_product_5.pos_categ_ids = [Command.link(hidden_child_category.id)]
+
+        printer = self.env['pos.printer'].create({
+            'name': 'Printer',
+            'printer_type': 'epson_epos',
+            'epson_printer_ip': '0.0.0.0',
+        })
+
+        printer.write({
+            'product_categories_ids': [Command.set([hidden_child_category.id, hidden_root_category.id])],
+        })
+
+        self.pos_config.write({
+            'self_ordering_mode': 'kiosk',
+            'self_ordering_pay_after': 'each',
+            'is_order_printer': True,
+            'limit_categories': True,
+            'iface_available_categ_ids': [Command.set(limited_cats_ids)],
+            'printer_ids': [Command.set(printer.ids)],
+            'use_presets': False,
+            'default_preset_id': False,
+            'available_preset_ids': [Command.clear()],
+        })
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+        loaded_category_ids = [cat['id'] for cat in self.pos_config.load_self_data()['pos.category']]
+        self.assertTrue(all(cid in loaded_category_ids for cid in [hidden_root_category.id, hidden_child_category.id]))
+        self_route = self.pos_config._get_self_order_route()
+
+        self.start_tour(self_route, "test_self_order_limited_cat")


### PR DESCRIPTION
Since this PR https://github.com/odoo/odoo/pull/225658, if the POS category of a combo item product was not listed under the restricted categories but was assigned to a preparation printer, the item would not be printed by the preparation printer.

This commit ensures that preparation categories are loaded, preventing any used category from being missed.

Enterprise PR: https://github.com/odoo/enterprise/pull/110638
