### PR TITLE
[IMP] core: preserve cache-only field values after create

### DIFF
--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -314,6 +314,28 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
         record = self.env['test_orm.mixed'].create({})
         self.assertTrue(record.now)
 
+    def test_10_non_stored_cache_only(self):
+        """Test create and write behavior for fields.Char(store=False).
+
+        cache_only fields are non-stored, non-computed fields, whose values
+        are lost after invalidation. Usually they are used as a hack.
+        """
+        Category = self.env['test_orm.category']
+        self.assertFalse(Category._fields['dummy'].store)
+        self.assertFalse(Category._fields['dummy'].compute)
+
+        # Create: cache_only field value should be in cache
+        cat = Category.create({'name': 'CacheOnlyTest', 'dummy': 'create_value'})
+        self.assertEqual(cat.dummy, 'create_value')
+        cat.invalidate_recordset()
+        self.assertFalse(cat.dummy)
+
+        # Write: cache_only field value should be updated in cache
+        cat.write({'dummy': 'write_value'})
+        self.assertEqual(cat.dummy, 'write_value')
+        cat.invalidate_recordset()
+        self.assertFalse(cat.dummy)
+
     def test_11_stored(self):
         """ test stored fields """
         def check_stored(disc):

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -3969,6 +3969,7 @@ class BaseModel(metaclass=MetaModel):
             data = {}
             data['stored'] = stored = {}
             data['inversed'] = inversed = {}
+            data['cached_only'] = cached_only = {}
             data['inherited'] = inherited = defaultdict(dict)
             data['protected'] = protected = set()
             for key, val in vals.items():
@@ -3982,9 +3983,12 @@ class BaseModel(metaclass=MetaModel):
                 elif field.inverse and field not in precomputed:
                     inversed[key] = val
                     determine_inverses[field.inverse].add(field)
+                elif not field.store and not field.compute:
+                    # cache only fields with `field.inverse` will be handed by `inversed` correctly
+                    cached_only[key] = val
                 # protect editable computed fields and precomputed fields
                 # against (re)computation
-                if field.compute and (not field.readonly or field.precompute):
+                if (field.compute and (not field.readonly or field.precompute)) or key in cached_only:
                     protected.update(self.pool.field_computed.get(field, [field]))
 
             data_list.append(data)
@@ -4013,6 +4017,10 @@ class BaseModel(metaclass=MetaModel):
         # protect fields being written against recomputation
         protected_fields = [(data['protected'], data['record']) for data in data_list]
         with self.env.protecting(protected_fields):
+            # fill cached_only fields
+            for data in data_list:
+                if vals := data['cached_only']:
+                    data['record']._update_cache(vals)
             # call inverse method for each group of fields
             for fields in determine_inverses.values():
                 # determine which records to inverse for those fields


### PR DESCRIPTION
Cache-only fields are non-stored, non-computed fields whose values are lost after invalidation. Previously, their values were preserved after write() but not after create(), causing inconsistent behavior.

Preserve cache-only field values after create() to align with write().

enterprise https://github.com/odoo/enterprise/pull/110645

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
