### PR TITLE
[FIX] point_of_sale, pos_self_order: disable darkreader

### DIFF
--- a/addons/point_of_sale/views/pos_assets_index.xml
+++ b/addons/point_of_sale/views/pos_assets_index.xml
@@ -6,7 +6,7 @@
 <html>
     <head>
         <title>Odoo POS</title>
-
+        <meta name="darkreader-lock"/>
         <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
         <meta http-equiv="content-type" content="text/html, charset=utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, interactive-widget=resizes-content"/>

--- a/addons/pos_self_order/views/pos_self_order.index.xml
+++ b/addons/pos_self_order/views/pos_self_order.index.xml
@@ -4,6 +4,7 @@
         <html t-att-lang="lang and lang.replace('_', '-')">
             <head>
                 <title>Odoo Self Order</title>
+                <meta name="darkreader-lock"/>
                 <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
                 <meta http-equiv="content-type" content="text/html, charset=utf-8" />
                 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"/>


### PR DESCRIPTION

Users who have enabled the dark mode option in Brave that automatically modifies website colors may experience usability issues with the self-order and point_of faile.

To avoid this, a meta tag has been added to disable Dark Reader modifications .

Task.6037294


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
