### PR TITLE
[FIX] tools: make sure design themes are not count in cloc

### DIFF
--- a/odoo/tools/cloc.py
+++ b/odoo/tools/cloc.py
@@ -21,7 +21,7 @@ DEFAULT_EXCLUDE = [
     "upgrades/**/*",
 ]
 
-STANDARD_MODULES = ['web', 'web_enterprise', 'theme_common', 'base']
+STANDARD_MODULES = ['web', 'web_enterprise', 'test_themes', 'base']
 MAX_FILE_SIZE = 25 * 2**20 # 25 MB
 MAX_LINE_SIZE = 100000
 VALID_EXTENSION = ['.py', '.js', '.xml', '.css', '.scss']


### PR DESCRIPTION
In saas-19.2 the module theme_common was remove, this module was use by the cloc to ignore the addons in the same folder.

Since it has been remove, all the themes installed count as custom modules.

Of course we want to avoid that, so we need a new beacon modules: test_themes sounds good.

opw: 6036549, 6035869, 6035726, 6035293, 6031718, ....

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
