### PR TITLE
[FIX] im_livechat: show livechat button when joined as agent in active livechats

### DIFF
--- a/addons/im_livechat/static/src/embed/common/@types/models.d.ts
+++ b/addons/im_livechat/static/src/embed/common/@types/models.d.ts
@@ -4,6 +4,7 @@ declare module "models" {
     }
     export interface Store {
         activeLivechats: Thread[];
+        activeVisitorLivechats: Thread[];
         guest_token: null;
         livechat_available: boolean;
         livechat_rule: LivechatChannelRule;
@@ -20,5 +21,6 @@ declare module "models" {
         readyToSwapDeferred: Deferred;
         requested_by_operator: boolean;
         storeAsActiveLivechats: Store;
+        storeAsActiveVisitorLivechats: Store;
     }
 }

--- a/addons/im_livechat/static/src/embed/common/autopopup_service.js
+++ b/addons/im_livechat/static/src/embed/common/autopopup_service.js
@@ -18,7 +18,7 @@ export class AutopopupService {
         this.livechatService = livechatService;
         this.ui = ui;
 
-        storeService.isReady.then(() => { 
+        storeService.isReady.then(() => {
             browser.setTimeout(async () => {
                 await storeService.chatHub.initPromise;
                 if (this.allowAutoPopup) {
@@ -35,7 +35,7 @@ export class AutopopupService {
                 !this.ui.isSmall &&
                 this.storeService.livechat_rule?.action === "auto_popup" &&
                 this.storeService.livechat_available &&
-                this.storeService.activeLivechats.length === 0
+                this.storeService.activeVisitorLivechats.length === 0
         );
     }
 }

--- a/addons/im_livechat/static/src/embed/common/livechat_button.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_button.js
@@ -36,6 +36,6 @@ export class LivechatButton extends Component {
     }
 
     get isShown() {
-        return this.store.livechat_available && this.store.activeLivechats.length === 0;
+        return this.store.livechat_available && this.store.activeVisitorLivechats.length === 0;
     }
 }

--- a/addons/im_livechat/static/src/embed/common/store_service_patch.js
+++ b/addons/im_livechat/static/src/embed/common/store_service_patch.js
@@ -10,6 +10,9 @@ const StorePatch = {
     setup() {
         super.setup(...arguments);
         this.activeLivechats = fields.Many("Thread", { inverse: "storeAsActiveLivechats" });
+        this.activeVisitorLivechats = fields.Many("Thread", {
+            inverse: "storeAsActiveVisitorLivechats",
+        });
         expirableStorage.onChange(GUEST_TOKEN_STORAGE_KEY, (value) => (this.guest_token = value));
         this.guest_token = fields.Attr(null, {
             compute() {

--- a/addons/im_livechat/static/src/embed/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/embed/common/thread_model_patch.js
@@ -74,6 +74,16 @@ patch(Thread.prototype, {
                 return this.livechat_active ? this.store : null;
             },
         });
+        this.storeAsActiveVisitorLivechats = fields.One("Store", {
+            /** @this {import("models").Thread} */
+            compute() {
+                return this.livechat_active &&
+                    (this.selfMember?.eq(this.livechatVisitorMember) || this.isTransient)
+                    ? this.store
+                    : null;
+            },
+            inverse: "activeVisitorLivechats",
+        });
         this.requested_by_operator = false;
     },
     /** @returns {boolean} */

--- a/addons/im_livechat/static/tests/embed/livechat_button.test.js
+++ b/addons/im_livechat/static/tests/embed/livechat_button.test.js
@@ -6,13 +6,20 @@ import {
     click,
     contains,
     insertText,
+    setupChatHub,
     start,
     startServer,
     triggerHotkey,
 } from "@mail/../tests/mail_test_helpers";
 import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
 import { describe, test } from "@odoo/hoot";
-import { asyncStep, patchWithCleanup, waitForSteps } from "@web/../tests/web_test_helpers";
+import {
+    asyncStep,
+    Command,
+    patchWithCleanup,
+    serverState,
+    waitForSteps,
+} from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 defineLivechatModels();
@@ -84,4 +91,24 @@ test("clicking on notification opens the chat", async () => {
         text: "Have a Question? Chat with us.",
     });
     await contains(".o-mail-ChatWindow");
+});
+
+test("can start a new live chat when acting as an agent in active live chats", async () => {
+    const pyEnv = await startServer();
+    await loadDefaultEmbedConfig();
+    const guestId = pyEnv["mail.guest"].create({ name: "Visitor" });
+    const channelId = pyEnv["discuss.channel"].create({
+        anonymous_name: "Visitor",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ guest_id: guestId }),
+        ],
+        channel_type: "livechat",
+        livechat_active: true,
+        livechat_operator_id: serverState.partnerId,
+    });
+    setupChatHub({ opened: [channelId] });
+    await start();
+    await contains(".o-mail-ChatWindow");
+    await contains(".o-livechat-LivechatButton");
 });


### PR DESCRIPTION
Previously, users who were part of active livechats as agents could not see the livechat button to start a new conversation. This change ensures the button remains visible so users can start additional livechats as a visitor.

task-[5119098](https://www.odoo.com/odoo/project/1519/tasks/5119098)