### PR TITLE
[FIX] product: return newly created products with original context

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -719,7 +719,11 @@ class ProductProduct(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        return super(ProductProduct, self.with_context(create_product_product=False)).create(vals_list)
+        products = super(ProductProduct, self.with_context(create_product_product=False)).create(
+            vals_list
+        )
+        # Make sure the `create_product_product` context is not kept, unless it was already set.
+        return products.with_env(self.env)
 
     def action_archive(self):
         records = self.filtered('active')

--- a/addons/product/tests/test_variants.py
+++ b/addons/product/tests/test_variants.py
@@ -247,6 +247,12 @@ class TestVariants(ProductVariantsCommon):
         self.assertEqual(variant_copy.name, 'Test Copy (copy) (copy)')
         self.assertEqual(len(variant_copy.product_variant_ids), 2)
 
+        # test copy of variant from variant
+        variant = self.env['product.product'].create({'name': 'Test Copy Variant'})
+        variant_copy = variant.copy()
+        self.assertTrue(variant_copy.exists())
+        self.assertEqual(variant_copy.name, 'Test Copy Variant (copy)')
+
     def test_dynamic_variants_copy(self):
         self.color_attr = self.env['product.attribute'].create({'name': 'Color', 'create_variant': 'dynamic'})
         self.color_attr_value_r = self.env['product.attribute.value'].create({'name': 'Red', 'attribute_id': self.color_attr.id})
@@ -265,10 +271,6 @@ class TestVariants(ProductVariantsCommon):
         self.assertEqual(template_dyn.name, 'Test Dynamical')
 
         variant_dyn = template_dyn._create_product_variant(template_dyn._get_first_possible_combination())
-        if 'create_product_product' in variant_dyn.env.context:
-            new_context = dict(variant_dyn.env.context)
-            new_context.pop('create_product_product')
-            variant_dyn = variant_dyn.with_context(new_context)
         self.assertEqual(len(template_dyn.product_variant_ids), 1)
 
         variant_dyn_copy = variant_dyn.copy()


### PR DESCRIPTION
Ensure that the returned records context is not polluted with keys added from create (like `create_product_product`)

Fixes #247624