### PR TITLE
[FIX] website*sale*: tours with translation error

### DIFF
--- a/addons/website_event_booth_sale/static/tests/tours/website_event_booth.js
+++ b/addons/website_event_booth_sale/static/tests/tours/website_event_booth.js
@@ -40,6 +40,11 @@ registry.category("web_tour.tours").add('website_event_booth_tour', {
     total: '220.00',
 }),
 wsTourUtils.goToCheckout(),
+{
+    content: 'Confirm Order page',
+    trigger: 'h3:contains("Confirm order")',
+    isCheck: true,
+},
 ...wsTourUtils.assertCartAmounts({
     taxes: '20.00',
     untaxed: '200.00',

--- a/addons/website_sale_picking/static/tests/tours/onsite_payment_tour.js
+++ b/addons/website_sale_picking/static/tests/tours/onsite_payment_tour.js
@@ -46,6 +46,11 @@ registry.category("web_tour.tours").add('onsite_payment_tour', {
         wsTourUtils.goToCheckout(),
         ...wsTourUtils.fillAdressForm(),
         {
+            content: 'Confirm Order page',
+            trigger: 'h3:contains("Confirm order")',
+            isCheck: true,
+        },
+        {
             content: 'Assert pay on site is NOT an option',
             trigger: 'body:not(:contains("Test Payment Provider"))',
             isCheck: true,

--- a/addons/website_sale_product_configurator/static/tests/tours/website_sale_variants_modal_window.js
+++ b/addons/website_sale_product_configurator/static/tests/tours/website_sale_variants_modal_window.js
@@ -44,18 +44,22 @@
         {
             content: "Check the product is in the cart",
             trigger: 'div>a>h6:contains(Short (TEST))',
+            isCheck: true,
         },
         {
             content: "Check always variant",
             trigger: 'div>a>h6:contains(M always)',
+            isCheck: true,
         },
         {
             content: "Check dynamic variant",
             trigger: 'div>a>h6:contains(M dynamic)',
+            isCheck: true,
         },
         {
             content: "Check never variant",
             trigger: 'div.text-muted>span:contains(Never attribute size: M never)',
+            isCheck: true,
         },
         {
             content: "Check never custom variant",


### PR DESCRIPTION
This commit adds an intermediary step ensuring the proper page has been reached before actually doing the checks and avoiding to let startup requests (like the loading of the translations) pending at the end of the tour (and the eventual stop of the runner browser).

Note: this is most likely due to a timing (indeterministic by nature) change, emphasised by recent Chrome versions (like v145).

runbot-239128