### PR TITLE
[FIX] stock_account: initial demand click redirect to useful data

### DIFF
--- a/addons/stock_account/report/stock_valuation_report.py
+++ b/addons/stock_account/report/stock_valuation_report.py
@@ -47,7 +47,6 @@ class StockValuationReport(models.AbstractModel):
             'value': 0,
             'lines_by_account_id': defaultdict(lambda: {
                 'value': 0,
-                'accounts': [],
             }),
         }
         ending_stock = {
@@ -55,7 +54,6 @@ class StockValuationReport(models.AbstractModel):
             'value': 0,
             'lines_by_account_id': defaultdict(lambda: {
                 'value': 0,
-                'accounts': [],
             }),
         }
 

--- a/addons/stock_account/static/src/stock_valuation/controller.js
+++ b/addons/stock_account/static/src/stock_valuation/controller.js
@@ -44,7 +44,6 @@ export class StockValuationReportController {
         }
         // Prepare the "Initial Balance" lines.
         this.data.initial_balance.lines = [];
-        this.data.initial_balance.accounts = [];
         for (let [accountId, data] of Object.entries(this.data.initial_balance.lines_by_account_id)) {
             const account = this.data.accounts_by_id[accountId];
             this.data.initial_balance.lines.push({
@@ -52,11 +51,9 @@ export class StockValuationReportController {
                 value: data.value,
                 account_id: accountId,
             });
-            this.data.initial_balance.accounts.push(...data.accounts);
         }
         // Prepare the "Ending Stock" lines.
         this.data.ending_stock.lines = [];
-        this.data.ending_stock.accounts = [];
         for (let [accountId, data] of Object.entries(this.data.ending_stock.lines_by_account_id)) {
             const account = this.data.accounts_by_id[accountId];
             this.data.ending_stock.lines.push({
@@ -64,7 +61,6 @@ export class StockValuationReportController {
                 value: data.value,
                 account_id: accountId,
             });
-            this.data.ending_stock.accounts.push(...data.accounts);
         }
     }
 

--- a/addons/stock_account/static/src/stock_valuation/line/line.js
+++ b/addons/stock_account/static/src/stock_valuation/line/line.js
@@ -23,6 +23,11 @@ export class StockValuationReportLine extends Component {
     }
 
     // Getters -----------------------------------------------------------------
+    get accounts() {
+        if (! this.hasSublines) { return []; }
+        return this.props.sublines.map(line => parseInt(line.account_id));
+    }
+
     get credit() {
         if (this.props.line?.credit) {
             return this.env.formatMonetary(this.props.line.credit);
@@ -73,7 +78,7 @@ export class StockValuationReportLine extends Component {
 
     // On Click Methods --------------------------------------------------------
     onClick() {
-        this.props.onClickMethod && this.props.onClickMethod(this.props.line);
+        this.props.onClickMethod && this.props.onClickMethod(this.accounts);
     }
 
     onClickToggle() {

--- a/addons/stock_account/static/src/stock_valuation/stock_valuation_report.js
+++ b/addons/stock_account/static/src/stock_valuation/stock_valuation_report.js
@@ -4,6 +4,8 @@ import { useService } from "@web/core/utils/hooks";
 import { ControlPanel } from "@web/search/control_panel/control_panel";
 import { formatMonetary } from "@web/views/fields/formatters";
 import { standardActionServiceProps } from "@web/webclient/actions/action_service";
+import { serializeDate } from "@web/core/l10n/dates";
+const { DateTime } = luxon;
 
 import { Component, onWillStart, useChildSubEnv, useState } from "@odoo/owl";
 
@@ -79,20 +81,22 @@ export class StockValuationReport extends Component {
     }
 
     // On Click Methods --------------------------------------------------------
-    openAccountMoves(accountMoves=false) {
-        const additionalContext = {};
-        const domain = [];
-        if (accountMoves) {
-            const ids = accountMoves.map((am) => am.id);
-            const names = accountMoves.map((am) => am.name);
-            additionalContext.search_default_name = names;
-            additionalContext.search_default_ids = ids;
-            domain.push(["id", "in", ids])
+    async openAccountMoves(accountIds=false) {
+        const action = await this.actionService.loadAction("account.action_account_moves_all");
+        const domain = [...(action.domain || [])];
+        if (accountIds) {
+            domain.push(['account_id', 'in', accountIds]);
         }
-        return this.actionService.doAction(
-            "account.action_move_journal_line",
-            { additionalContext, domain }
-        );
+        if (serializeDate(this.controller.state.date) !== serializeDate(DateTime.now())) {
+            domain.push(['date', '<=', serializeDate(this.controller.state.date)]);
+        }
+        action.domain = domain;
+        action.context = {
+            ...action.context,
+            search_default_group_by_account: 1,
+            search_default_groupby_date: 'month',
+        };
+        return this.actionService.doAction(action);
     }
 
     openStockMoveView(title, usage) {

--- a/addons/stock_account/static/src/stock_valuation/stock_valuation_report.xml
+++ b/addons/stock_account/static/src/stock_valuation/stock_valuation_report.xml
@@ -43,9 +43,10 @@
         <StockValuationReportLine
             label.translate="Initial Balance"
             level="0"
-            onClickMethod.bind="openAccountMoves"
+            onClickMethod="data.initial_balance.lines.length ? openAccountMoves.bind(this) : undefined"
             sublines="data.initial_balance.lines"
-            value="data.initial_balance.value"/>
+            value="data.initial_balance.value"
+        />
         <t t-call="stock_account.StockValuationReport.EmptyLine"/>
     </t>
 
@@ -63,7 +64,7 @@
         <StockValuationReportLine
             label.translate="Ending Stock"
             level="0"
-            onClickMethod.bind="openStockReport"
+            onClickMethod="data.ending_stock.lines.length ? openStockReport.bind(this) : undefined"
             sublines="data.ending_stock.lines"
             value="data.ending_stock.value"/>
         <t t-call="stock_account.StockValuationReport.EmptyLine"/>


### PR DESCRIPTION
Currently the initial demand click will open the account.move view without filter. So you don't know what is related to the initial balance or not.

This commit updates the action to use a domain on the accounts used by inventory valuation. Also it shows the account.move.line instead.

It also add a date if needed to be concistent with the reprot.

Task: 6024514

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
