### PR TITLE
[FIX] base_import: BinaryBytes in URL

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -1299,7 +1299,7 @@ class Base_ImportImport(models.TransientModel):
                                     _("You can not import file via URL, check with your administrator or support for the reason."),
                                     field=name, field_type=field['type']
                                 )
-                            line[index] = base64.b64encode(self._import_file_by_url(line[index], session, name, num))
+                            line[index] = base64.b64encode(self._import_file_by_url(line[index], session, name, num)).decode()
                         elif '.' in line[index]:
                             # Detect if it's a filename
                             pass


### PR DESCRIPTION
When importing from a URL, we keep the data in base64 format. This must stay as a `str` datatype to be able to assign it to a field.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
