### PR TITLE
[FIX] web: form: allow to create even if edit="0"

### DIFF
--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -150,6 +150,7 @@ export class FormController extends Component {
     static defaultProps = {
         preventCreate: false,
         preventEdit: false,
+        readonly: false,
         updateActionState: () => {},
     };
 
@@ -373,7 +374,7 @@ export class FormController extends Component {
                 fields: this.props.fields,
                 activeFields: {}, // will be generated after loading sub views (see willStart)
                 isMonoRecord: true,
-                mode: this.props.readonly ? "readonly" : "edit",
+                mode: !this.props.readonly && this.canEdit ? "edit" : "readonly",
                 context: this.props.context,
             },
             state: this.props.state?.modelState,

--- a/addons/web/static/src/views/form/form_controller.xml
+++ b/addons/web/static/src/views/form/form_controller.xml
@@ -38,7 +38,7 @@
                         </t>
                     </t>
 
-                    <t t-component="props.Renderer" record="model.root" Compiler="props.Compiler" readonly="props.readonly" archInfo="archInfo" translateAlert="translateAlert" onNotebookPageChange.bind="onNotebookPageChange" activeNotebookPages="props.state and props.state.activeNotebookPages"/>
+                    <t t-component="props.Renderer" record="model.root" Compiler="props.Compiler" readonly="(this.props.readonly or !this.canEdit) and !model.root.isNew" archInfo="archInfo" translateAlert="translateAlert" onNotebookPageChange.bind="onNotebookPageChange" activeNotebookPages="props.state and props.state.activeNotebookPages"/>
                 </Layout>
             </div>
         </div>

--- a/addons/web/static/src/views/form/form_view.js
+++ b/addons/web/static/src/views/form/form_view.js
@@ -23,9 +23,6 @@ export const formView = {
 
         return {
             ...genericProps,
-            readonly:
-                genericProps.readonly ||
-                (archInfo.activeActions?.edit === false && genericProps.resId !== false),
             Model: view.Model,
             Renderer: view.Renderer,
             buttonTemplate: genericProps.buttonTemplate || view.buttonTemplate,

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -11214,9 +11214,11 @@ test(`form view with edit='0' but create='1', existing record`, async () => {
         resId: 1,
     });
     expect(`.o_form_readonly`).toHaveCount(1);
+    expect(`.o_field_widget[name=foo] span`).toHaveText("yop");
 
     await contains(`.o_form_button_create`).click();
     expect(`.o_form_editable`).toHaveCount(1);
+    expect(`.o_field_widget[name=foo] input`).toHaveValue("My little Foo Value");
 });
 
 test(`form view with edit='0' but create='1', new record`, async () => {
@@ -11226,6 +11228,7 @@ test(`form view with edit='0' but create='1', new record`, async () => {
         arch: `<form edit="0"><field name="foo"/></form>`,
     });
     expect(`.o_form_editable`).toHaveCount(1);
+    expect(`.o_field_widget[name=foo] input`).toHaveValue("My little Foo Value");
 });
 
 test(`save a form view with an invisible required field`, async () => {


### PR DESCRIPTION
Have a form view with `edit="0"` on its root node in the arch (but no restriction for the creation). Open an existing record, it is readonly as expected. Click "New", an empty new record opens, but it is readonly as well, thus preventing the user from actually creating.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
