### PR TITLE
[REF] mail: postpone Store method execution until get_result()

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1282,6 +1282,7 @@ class DiscussChannel(models.Model):
         # prefetch in batch, including nested relations (member, guest, ...)
         prefetch_store = Store(bus_channel=res.target.channel, bus_subchannel=res.target.subchannel)
         prefetch_store.add(all_members, "_store_member_fields")
+        prefetch_store.get_result()  # execute the queued operations, which access the nested fields
         # sudo: bus.bus: reading non-sensitive last id
         bus_last_id = self.env["bus.bus"].sudo()._bus_last_id()
         res.attr("avatar_cache_key", predicate=is_channel_or_group)

--- a/addons/mail/tests/test_discuss_tools.py
+++ b/addons/mail/tests/test_discuss_tools.py
@@ -38,14 +38,16 @@ class TestDiscussTools(TransactionCase):
     def test_040_store_invalid(self):
         """Test adding invalid value."""
         store = Store()
+        store.add_model_values("key1", True)
         with self.assertRaises(TypeError):
-            store.add_model_values("key1", True)
+            store.get_result()
 
     def test_042_store_invalid_missing_id(self):
         """Test Thread adding invalid list value."""
         store = Store()
+        store.add_model_values("key1", {"test": True})
         with self.assertRaises(AssertionError):
-            store.add_model_values("key1", {"test": True})
+            store.get_result()
 
     def test_060_store_data_empty_val(self):
         """Test empty values are not present in result."""
@@ -103,14 +105,16 @@ class TestDiscussTools(TransactionCase):
     def test_140_store_store_invalid_bool(self):
         """Test Store adding invalid value."""
         store = Store()
+        store.add_model_values("key1", True)
         with self.assertRaises(TypeError):
-            store.add_model_values("key1", True)
+            store.get_result()
 
     def test_141_store_store_invalid_list(self):
         """Test adding invalid value."""
         store = Store()
+        store.add_model_values("key1", [{"test": True}])
         with self.assertRaises(AssertionError):
-            store.add_model_values("key1", [{"test": True}])
+            store.get_result()
 
     def test_160_store_store_data_empty_val(self):
         """Test Store empty values are not present in result."""
@@ -183,26 +187,30 @@ class TestDiscussTools(TransactionCase):
     def test_240_store_thread_invalid_bool(self):
         """Test Thread adding invalid bool value."""
         store = Store()
+        store.add_model_values("mail.thread", True)
         with self.assertRaises(TypeError):
-            store.add_model_values("mail.thread", True)
+            store.get_result()
 
     def test_241_store_thread_invalid_list(self):
         """Test Thread adding invalid list value."""
         store = Store()
+        store.add_model_values("mail.thread", [True])
         with self.assertRaises(AttributeError):
-            store.add_model_values("mail.thread", [True])
+            store.get_result()
 
     def test_242_store_thread_invalid_missing_id(self):
         """Test Thread adding invalid missing id."""
         store = Store()
+        store.add_model_values("mail.thread", {"model": "res.partner"})
         with self.assertRaises(AssertionError):
-            store.add_model_values("mail.thread", {"model": "res.partner"})
+            store.get_result()
 
     def test_243_store_thread_invalid_missing_model(self):
         """Test Thread adding invalid list value."""
         store = Store()
+        store.add_model_values("mail.thread", {"id": 1})
         with self.assertRaises(AssertionError):
-            store.add_model_values("mail.thread", {"id": 1})
+            store.get_result()
 
     def test_260_store_thread_data_empty_val(self):
         """Test Thread empty values are not present in result."""
@@ -263,6 +271,35 @@ class TestDiscussTools(TransactionCase):
         store.add(user_a, "_store_im_status_fields")
         data2 = store.get_result()
         self.assertEqual(data2["res.partner"][0]["im_status"], "online")
+
+    def test_393_delayed_add(self):
+        """Test that delayed store.add() postpones reading fields until get_result()."""
+        user_a = new_test_user(self.env, "test_user_390@example.com")
+        store = Store()
+        store.add(user_a, "_store_im_status_fields")
+        self.assertEqual(user_a.partner_id.im_status, "offline")
+        self.env["mail.presence"]._update_presence(user_a)
+        data = store.get_result()
+        self.assertEqual(data["res.partner"][0]["im_status"], "online")
+
+    def test_395_delayed_add_ignores_deleted_record(self):
+        """Test that delayed store.add() ignores deleted records."""
+        user_a = new_test_user(self.env, "test_user_390@example.com")
+        store = Store()
+        store.add(user_a, ["name"])
+        user_a.unlink()
+        data = store.get_result()
+        self.assertFalse(data)
+
+    def test_397_delayed_delete_keeps_deleted_record(self):
+        """Test that delayed store.delete() keeps deleted records."""
+        user_a = new_test_user(self.env, "test_user_390@example.com")
+        store = Store()
+        user_a.unlink()
+        store.add(user_a, ["name"])
+        store.delete(user_a)
+        data = store.get_result()
+        self.assertEqual({"res.users": [{"id": user_a.id, "_DELETE": True}]}, data)
 
     # 4xx Tests many command modes
 

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -257,6 +257,21 @@ ids_by_model.update(
 NO_VALUE = object()
 
 
+def store_enqueue(func):
+    """Wraps a Store method to postpone its execution until get_result()."""
+
+    @wraps(func)
+    def store_enqueue__wrapper(store, *args, **kwargs):
+        if func.__name__ == "resolve_data_request" and "data_id" not in kwargs:
+            kwargs["data_id"] = store.data_id
+        if not store.is_executing_operation_queue:
+            store.operation_queue.append(lambda: func(store, *args, **kwargs))
+            return store
+        return func(store, *args, **kwargs)
+
+    return store_enqueue__wrapper
+
+
 class Store:
     """Helper to build a dict of data for sending to web client.
     It supports merging of data from multiple sources, either through list extend or dict update.
@@ -268,8 +283,11 @@ class Store:
         self.already_done = set()
         self.data = {}
         self.data_id = None
+        self.is_executing_operation_queue = False
+        self.operation_queue = []
         self.target = Store.Target(bus_channel, bus_subchannel)
 
+    @store_enqueue
     def add(self, records, fields, *, as_thread=False, fields_params=None):
         """Add records to the store. Data is coming from _to_store() method of the model if it is
         defined, and fallbacks to _read_format() otherwise.
@@ -306,6 +324,7 @@ class Store:
             if self.add_depth == 0:
                 self.already_done.clear()
 
+    @store_enqueue
     def add_global_values(self, field_fn=None, /, **values):
         """Add global values to the store. Global values are stored in the Store singleton
         (mail.store service) in the client side.
@@ -315,6 +334,7 @@ class Store:
         self.add_singleton_values("Store", field_fn or values)
         return self
 
+    @store_enqueue
     def add_model_values(self, model_name, values):
         """Add values to a model in the store.
 
@@ -333,6 +353,7 @@ class Store:
             del self.data[model_name][index]["_DELETE"]
         return self
 
+    @store_enqueue
     def add_records_fields(self, field_list, as_thread=False):
         """Same as Store.add() but without calling _to_store().
 
@@ -351,6 +372,7 @@ class Store:
                     self.add_model_values(record._name, {"id": record.id, **record_data})
         return self
 
+    @store_enqueue
     def add_singleton_values(self, model_name, values):
         """Add values to the store for a singleton model."""
         if not values:
@@ -365,6 +387,7 @@ class Store:
             self._add_values(data, model_name)
         return self
 
+    @store_enqueue
     def delete(self, records, as_thread=False):
         """Delete records from the store."""
         if not records:
@@ -394,6 +417,13 @@ class Store:
 
     def get_result(self):
         """Gets resulting data built from adding all data together."""
+        self.is_executing_operation_queue = True
+        try:
+            for func in self.operation_queue:
+                func()
+            self.operation_queue.clear()
+        finally:
+            self.is_executing_operation_queue = False
         res = Store.Result()
         for model_name, records in sorted(self.data.items()):
             if not ids_by_model[model_name]:  # singleton
@@ -409,16 +439,17 @@ class Store:
         if res := self.get_result():
             self.target.channel._bus_send(notification_type, res, subchannel=self.target.subchannel)
 
-    def resolve_data_request(self, values=None):
+    @store_enqueue
+    def resolve_data_request(self, values=None, *, data_id=None):
         """Add values to the store for the current data request.
 
         Use case: resolve a specific data request from a client."""
-        if not self.data_id:
+        if not data_id:
             return self
         data_list = []
         self._add_abstract_fields_value(self._format_fields(values or [{}]), data_list)
         for data in data_list:
-            self.add_model_values("DataResponse", {"id": self.data_id, "_resolve": True, **data})
+            self.add_model_values("DataResponse", {"id": data_id, "_resolve": True, **data})
         return self
 
     def _add_values(self, values, model_name, index=None):


### PR DESCRIPTION
Adding fields into Store is not necessary until get_result() is called. This is a slight optimization, but normally get_result() should always be called, otherwise building the Store was unnecessary in the first place.

The main advantage of this change is to ensure Store gets the value of the fields as late as possible in the transaction, which means it will contain values as up to date as possible.

https://github.com/odoo/enterprise/pull/110943