### PR TITLE
[FIX] mail: 'muted' call action should be red instead of pink.

### DIFF
--- a/addons/mail/static/src/core/common/action_list.scss
+++ b/addons/mail/static/src/core/common/action_list.scss
@@ -97,10 +97,15 @@
                     }
                 }
             }
-            &.o-inline.btn-#{$status}:not(.o-tag-JOIN_LEAVE_CALL):not(.o-hasBtnBg) {
-                color: var(--o-mail-ActionList-#{$status}NoBgColor, #{$color});
-                &:active {
-                    background-color: inherit;
+            &.o-inline.btn-#{$status}:not(.o-tag-JOIN_LEAVE_CALL) {
+                &.o-hasBtnBg {
+                    --btn-active-bg: var(--btn-bg);
+                }
+                &:not(.o-hasBtnBg) {
+                    color: var(--o-mail-ActionList-#{$status}NoBgColor, #{$color});
+                    &:active {
+                        background-color: inherit;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Before this commit, when in discuss call and current user has microphone muted, the icon has light red / pink background color on muted instead of red.

The color should be the same as the one from "disconnect", but the difference comes from `btn-danger` with or without `.active` that has different shade of red for background: the `.active` version is lighter like in the mute button when active.

`.active` classname is preferred to keep so that the visual is consistent for most discuss actions, including the ones without success / danger which a majority of these buttons have. However, the buttons with danger / success style are intended to preserve their color unchanged as the `.active` aspect is meant to tell whether the button is active or not and the slight change of color shade is not desirable in the context of discuss action list.

This commit uses the same background color for danger / success / primary inline button. Other styles line dropdown and inline buttons without background had already the same colors, so this commit fixes the only case that was missing.

Task-5436990

Before / After

<img width="283" height="38" alt="Screenshot 2026-03-13 at 15 21 22" src="https://github.com/user-attachments/assets/3ebba48c-5b22-43e9-a915-e18a5531e660" /> <img width="270" height="41" alt="Screenshot 2026-03-13 at 15 21 45" src="https://github.com/user-attachments/assets/586d05a4-2a6c-48e0-89c6-bffa85a86e59" />
