### PR TITLE
[FIX] mrp: Unable to validate a production with lot consumed in opera…

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2308,12 +2308,7 @@ class MrpProduction(models.Model):
         for production in productions_auto:
             production._set_quantities()
 
-        for production in self:
-            if not production.product_uom_id.is_zero(production.qty_producing):
-                production.move_raw_ids.filtered(
-                    lambda move: move.manual_consumption and not move.picked
-                ).picked = True
-                continue
+        self.move_raw_ids.filtered(lambda m: m.manual_consumption and not m.picked).picked = True
 
         # Produce by-products also for not auto productions.
         (self - productions_auto)._mark_byproducts_as_produced()
@@ -2900,19 +2895,6 @@ class MrpProduction(models.Model):
             self._set_qty_producing()
 
         self._mark_byproducts_as_produced()
-
-        for move in self.move_raw_ids:
-            if move.state in ('done', 'cancel') or not move.product_uom_qty:
-                continue
-            if move.manual_consumption:
-                if move.has_tracking in ('serial', 'lot') and (not move.picked or any(not line.lot_id for line in move.move_line_ids if line.quantity and line.picked)):
-                    missing_lot_id_products += "\n  - %s" % move.product_id.display_name
-        if missing_lot_id_products:
-            error_msg = _(
-                "You need to supply Lot/Serial Number for products and 'consume' them: %(missing_products)s",
-                missing_products=missing_lot_id_products,
-            )
-            raise UserError(error_msg)
 
     def _get_autoprint_done_report_actions(self):
         """ Reports to auto-print when MO is marked as done


### PR DESCRIPTION
…tion

Steps:
- Create a BoM with 2 operations
- Add a component tracked by lot and consumed in first operation
- Add enough quantity in stock
- Create a MO with the BoM and validate

Current behavior:
- You are locked and it's not possible to validate the MO since it's says you need to consume a lot for the component (despite the reservation and a lot is already set)

Expected behavior:
- Everything is validated

It happens due to commit ab432cf77311ba852c59ae8675ad4c2dab3bfdf4
In this particular case, the move is never set to picked and it crash after. We remove the first if condition since at this step, everything should have a qty_producing.
We also removed the UserError during set_quantity to prevent an early mistake since it would block at validation anyway
