### PR TITLE
[REV] mrp: validate MO with tracked comp consumed in WO

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2294,6 +2294,11 @@ class MrpProduction(models.Model):
         production_auto_ids = set()
         production_missing_lot_ids = set()
         for production in self:
+            if not production.product_uom_id.is_zero(production.qty_producing):
+                production.move_raw_ids.filtered(
+                    lambda move: move.manual_consumption and not move.picked
+                ).picked = True
+                continue
             if production._auto_production_checks():
                 production_auto_ids.add(production.id)
             elif not production.lot_producing_ids:
@@ -2307,14 +2312,6 @@ class MrpProduction(models.Model):
         productions_auto = self.env['mrp.production'].browse(production_auto_ids)
         for production in productions_auto:
             production._set_quantities()
-
-        for production in self:
-            if not production.product_uom_id.is_zero(production.qty_producing):
-                production.move_raw_ids.filtered(
-                    lambda move: move.manual_consumption and not move.picked
-                ).picked = True
-                continue
-
         # Produce by-products also for not auto productions.
         (self - productions_auto)._mark_byproducts_as_produced()
 
@@ -2894,11 +2891,8 @@ class MrpProduction(models.Model):
         missing_lot_id_products = ""
         if self.product_tracking in ('lot', 'serial') and not self.lot_producing_ids:
             self.action_generate_serial()
-
-        if not self.qty_producing:
-            self.qty_producing = self.product_qty - self.qty_produced
-            self._set_qty_producing()
-
+        self.qty_producing = self.product_qty - self.qty_produced
+        self._set_qty_producing()
         self._mark_byproducts_as_produced()
 
         for move in self.move_raw_ids:


### PR DESCRIPTION
This revert [1]

It is currently impossible to process a MO if there is at least one raw SM
with tracked component and in manual consumption.

Case example:
1. Create two product P_finished, P_compo
   - P_compo is tracked by lot
2. Apply an on-hand qty for P_compo
3. Create a BoM with the products
   - P_compo must be consumed in an operation
4. Create, confirm and produce the MO

Error: an error message is displayed and blocks the MO validation: "You need
to supply Lot/Serial Number for products and 'consume' them [...]"

A raw SM linked to an operation is in manual consumption mode:
https://github.com/odoo/odoo/blob/0432a982dfea6e68419f137502c018c0a9241181/addons/mrp/models/stock_move.py#L632-L638
When processing the MO, we first run the `pre_button_mark_done` where we
call `_set_quantities`. There, an error in raised if a raw SM tracked and in
manual consumption isn't picked:
https://github.com/odoo/odoo/blob/6d4d506fdd6496ddcba87fa06411bad7d5bb9b8e/addons/mrp/models/mrp_production.py#L2904-L2909
And here is the issue: before [1], we flagged `picked` before
`_set_quantities`, so it was ok. But with the commit, we flag it after. This is
the reason why we reach the raised error.

Commit [1] was covering an important but not blocking use case. However, the
consequence is that some people are now blocked. As a quick reaction, we
therefore revert the commit and later will we look for a better possible
solution.

[1] https://github.com/odoo/odoo/commit/ab432cf77311ba852c59ae8675ad4c2dab3bfdf4

opw-5939156