### PR TITLE
[IMP] orm: save/restore transaction state

### DIFF
--- a/addons/website/controllers/form.py
+++ b/addons/website/controllers/form.py
@@ -2,7 +2,6 @@
 
 import base64
 import json
-import psycopg2
 
 from markupsafe import Markup
 from psycopg2 import IntegrityError
@@ -39,22 +38,15 @@ class WebsiteForm(http.Controller):
             raise BadRequest('Session expired (invalid CSRF token)')
 
         try:
-            # The except clause below should not let what has been done inside
-            # here be committed. It should not either roll back everything in
-            # this controller method. Instead, we use a savepoint to roll back
-            # what has been done inside the try clause.
-            with request.env.cr.savepoint() as sp:
-                # request.params was modified, update kwargs to reflect the changes
-                kwargs = dict(request.params)
-                kwargs.pop('model_name')
-                res = self._handle_website_form(model_name, **kwargs)
-                # ignore savepoint closing error if the transaction was committed
-                try:
-                    sp.close(rollback=False)
-                except psycopg2.errors.InvalidSavepointSpecification:
-                    sp.closed = True
-                return res
+            # request.params was modified, update kwargs to reflect the changes
+            kwargs = dict(request.params)
+            kwargs.pop('model_name')
+            res = self._handle_website_form(model_name, **kwargs)
+            # try to save here
+            self.env.cr.commit()
+            return res
         except (ValidationError, UserError) as e:
+            self.env.cr.rollback()
             return json.dumps({
                 'error': e.args[0],
             })

--- a/addons/website/tests/test_website_form_editor.py
+++ b/addons/website/tests/test_website_form_editor.py
@@ -102,25 +102,26 @@ class TestWebsiteForm(TransactionCase):
         self.env['ir.model.fields'].formbuilder_whitelist('res.partner', ['name'])
         WebsiteFormController = WebsiteForm()
         original_insert_record = WebsiteFormController.insert_record
-        test_sp = self.env.cr.savepoint()
-        def dummy_insert_record(*args, **kwargs):
-            res = original_insert_record(*args, **kwargs)
-            # delete website_form savepoint by rollbacking to test savepoint
-            self.env.cr.execute('ROLLBACK TO SAVEPOINT "%s"' % test_sp.name)
-            return res
-        WebsiteFormController.insert_record = dummy_insert_record
-        with MockRequest(self.env):
+
+        with (
+            self.enter_registry_test_mode(),
+            self.env.registry.cursor() as test_cr,
+            MockRequest(self.env(cr=test_cr)),
+        ):
+            def dummy_insert_record(*args, **kwargs):
+                res = original_insert_record(*args, **kwargs)
+                test_cr.commit()
+                return res
+            WebsiteFormController.insert_record = dummy_insert_record
             request.params = {
                 'model_name': 'res.partner',
                 'name': 'test partner',
             }
-            with self.assertLogs(level='ERROR'):
-                response = WebsiteFormController.website_form(
-                    **request.params,
-                )
+            response = WebsiteFormController.website_form(
+                **request.params,
+            )
             self.assertEqual(response.status_code, 200)
             self.assertTrue(response.data.startswith(b'{"id":'))
-        test_sp.close(rollback=True)
 
     def test_cannot_delete_field_used_in_website_form(self):
         """

--- a/odoo/orm/environments.py
+++ b/odoo/orm/environments.py
@@ -564,7 +564,8 @@ class Transaction:
     """ A object holding ORM data structures for a transaction. """
     __slots__ = (
         '_Transaction__file_open_tmp_paths',
-        '_cache', '_recent_envs', '_weak_envs',
+        '_cache', '_recent_envs', '_registry_sequence',
+        '_state_stack', '_weak_envs',
         'access_read', 'default_env',
         'field_data', 'field_data_patches', 'field_dirty',
         'protected', 'registry', 'tocompute',
@@ -576,8 +577,12 @@ class Transaction:
         self._recent_envs: deque[Environment] = deque()
         # all environments in order of creation (weak)
         self._weak_envs: list[ReferenceType[Environment]] = []
+
         # default environment (for flushing)
         self.default_env: Environment | None = None
+        self._registry_sequence = registry.registry_sequence
+        # transaction state manipulated by savepoints
+        self._state_stack: list[TransactionState] = []
 
         # cache data {field: cache_data_managed_by_field} often uses a dict
         # to store a mapping from id to a value, but fields may use this field
@@ -726,13 +731,63 @@ class Transaction:
             the registry on all its environments.  This operation is strongly
             recommended after reloading the registry.
         """
+        # get the registry and rebuild the stack of states
         self.registry = Registry(self.registry.db_name)
+        self._registry_sequence = self.registry.registry_sequence
+        self._state_stack = [
+            TransactionState(
+                default_env=state.default_env,
+                registry_sequence=self._registry_sequence,
+            ) for state in self._state_stack]
+
         for env in self.envs:
             reset_cached_properties(env)
         self.access_read.clear()
         # make all environments weak
         self._recent_envs.clear()
         self.clear()
+
+    @contextmanager
+    def committing(self):
+        """ Context for committing the connection. """
+        assert not self._state_stack, "Pending savepoints not released, cannot commit!"
+        yield
+        self.clear()
+
+    @contextmanager
+    def rollbacking(self):
+        """ Context for rollbacking the connection. """
+        assert not self._state_stack, "Pending savepoints not released, cannot rollback!"
+        yield
+        self.restore_state()
+
+    def save_state(self):
+        """ Save the current state of the transaction for future restore. """
+        self.flush()
+        self._state_stack.append(TransactionState(
+            default_env=self.default_env,
+            registry_sequence=self._registry_sequence,
+        ))
+
+    def merge_state(self):
+        """ Merge current state into the last saved state. """
+        assert self._state_stack, "no state to pop"
+        self._state_stack.pop()
+
+    def restore_state(self):
+        """ Restore the previously saved state of the transaction after
+        rollback execution (on savepoint or connection). """
+        if self._state_stack:
+            state = self._state_stack[-1]
+            self.default_env = state.default_env
+        if self.registry.registry_sequence != self._registry_sequence:
+            # registry changed, reset the transaction
+            self.reset()
+            return
+
+        self.clear()
+        for env in self.envs:
+            reset_cached_properties(env)
 
     def invalidate_field_data(self) -> None:
         """ Invalidate the cache of all the fields.
@@ -745,6 +800,12 @@ class Transaction:
         # reset Field._get_cache()
         for env in self.envs:
             env.__dict__.pop('_field_cache_memo', None)
+
+
+class TransactionState(typing.NamedTuple):
+    """ The state of the transaction that can be stacked for savepoint operations. """
+    default_env: Environment | None
+    registry_sequence: int
 
 
 # sentinel value for optional parameters

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -16,7 +16,7 @@ import time
 import typing
 import uuid
 import warnings
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from datetime import datetime, timedelta
 from inspect import currentframe
 
@@ -35,7 +35,7 @@ import odoo
 from . import tools
 from .release import MIN_PG_VERSION
 from .tools import SQL, config
-from .tools.func import frame_codeinfo, locked, reset_cached_properties
+from .tools.func import frame_codeinfo, locked
 from .tools.misc import Callbacks, real_time
 
 if typing.TYPE_CHECKING:
@@ -137,29 +137,30 @@ class Savepoint:
 class _FlushingSavepoint(Savepoint):
     def __init__(self, cr: Cursor):
         cr.flush()
+        if cr.transaction is not None:
+            cr.transaction.save_state()
         super().__init__(cr)
-        self._default_env = cr.transaction.default_env if cr.transaction is not None else None
 
     def rollback(self):
         cr = self._cr
         assert isinstance(cr, Cursor)
-        if cr.transaction is not None:
-            cr.transaction.default_env = self._default_env
-            cr.transaction.clear()
-            for env in cr.transaction.envs:
-                reset_cached_properties(env)
         super().rollback()
+        if cr.transaction is not None:
+            cr.transaction.restore_state()
 
     def _close(self, rollback: bool):
-        assert isinstance(self._cr, Cursor)
+        cr = self._cr
+        assert isinstance(cr, Cursor)
         try:
             if not rollback:
-                self._cr.flush()
+                cr.flush()
         except Exception:
             rollback = True
             raise
         finally:
             super()._close(rollback)
+            if cr.transaction is not None:
+                cr.transaction.merge_state()
 
 
 # _CursorProtocol declares the available methods and type information,
@@ -514,10 +515,10 @@ class Cursor(_CursorProtocol):
     def commit(self) -> None:
         """ Commit the current transaction. """
         self.flush()
-        self._cnx.commit()
-        if self.transaction is not None:
-            self.transaction.clear()
-        self._now = None
+        committing = self.transaction.committing() if self.transaction is not None else nullcontext()
+        with committing:
+            self._cnx.commit()
+            self._now = None
         self.prerollback.clear()
         self.postrollback.clear()
         self.postcommit.run()
@@ -527,10 +528,10 @@ class Cursor(_CursorProtocol):
         self.precommit.clear()
         self.postcommit.clear()
         self.prerollback.run()
-        self._cnx.rollback()
-        if self.transaction is not None:
-            self.transaction.clear()
-        self._now = None
+        rollbacking = self.transaction.rollbacking() if self.transaction is not None else nullcontext()
+        with rollbacking:
+            self._cnx.rollback()
+            self._now = None
         self.postrollback.run()
 
     def __getattr__(self, name):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Manage the `Transaction` state from savepoints.
The goal is to be able to support layered state in transactions (such as ormcache) while behaving correctly for the transaction and savepoints.
Committing or rolling back the connection from inside a savepoint makes no sense and is unsupported!

Current behavior before PR:
Some logic replicated to flushing savepoint to try to align the state of the transaction.

Desired behavior after PR is merged:
The transaction is responsible for managing its state. Savepoints just call it.


https://github.com/odoo/enterprise/pull/110666



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
