### PR TITLE
[FIX] point_of_sale: handle IndexedDB connection loss on iOS/Safari

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service.js
+++ b/addons/point_of_sale/static/src/app/models/data_service.js
@@ -16,16 +16,17 @@ const INDEXED_DB_VERSION = 1;
 
 export class PosData extends Reactive {
     static modelToLoad = []; // When empty all models are loaded
-    static serviceDependencies = ["orm", "bus_service"];
+    static serviceDependencies = ["orm", "bus_service", "dialog"];
 
     constructor() {
         super();
         this.ready = this.setup(...arguments).then(() => this);
     }
 
-    async setup(env, { orm, bus_service }) {
+    async setup(env, { orm, bus_service, dialog }) {
         this.orm = orm;
         this.bus = bus_service;
+        this.dialog = dialog;
         this.relations = [];
         this.custom = {};
         this.syncInProgress = false;
@@ -107,7 +108,7 @@ export class PosData extends Reactive {
             data.key,
             name,
         ]);
-        this.indexedDB = new IndexedDB(this.databaseName, INDEXED_DB_VERSION, models);
+        this.indexedDB = new IndexedDB(this.databaseName, INDEXED_DB_VERSION, models, this.dialog);
     }
 
     deleteDataIndexedDB(model, uuid) {

--- a/addons/point_of_sale/static/src/app/models/utils/indexed_db.js
+++ b/addons/point_of_sale/static/src/app/models/utils/indexed_db.js
@@ -1,12 +1,16 @@
 import { _t } from "@web/core/l10n/translation";
+import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 
 export default class IndexedDB {
-    constructor(dbName, dbVersion, dbStores) {
+    constructor(dbName, dbVersion, dbStores, dialog) {
         this.db = null;
         this.dbName = dbName;
         this.dbVersion = dbVersion;
         this.dbStores = dbStores;
         this.dbInstance = null;
+        this.dialog = dialog;
+        this._isReconnecting = false;
+        this._reloadDialogShown = false;
         this.databaseEventListener();
     }
 
@@ -25,11 +29,21 @@ export default class IndexedDB {
         this.dbInstance = indexedDB;
         const dbInstance = indexedDB.open(this.dbName, this.dbVersion);
         dbInstance.onerror = (event) => {
-            console.error("Database error: " + event.target.errorCode);
+            const err = event.target.error;
+            console.error("Database error:", err);
+            // Known iOS/Safari WebKit bug: the IDB server process was killed by the OS.
+            // No reconnect will succeed — only a page reload restores the daemon.
+            if (
+                err?.name === "UnknownError" &&
+                err.message.includes("Connection to Indexed Database server lost")
+            ) {
+                this._showReloadDialog();
+            }
         };
         dbInstance.onsuccess = (event) => {
             this.db = event.target.result;
             console.info(`IndexedDB ${this.dbVersion} Ready`);
+            this._setupVisibilityProbe();
         };
         dbInstance.onupgradeneeded = (event) => {
             for (const [id, storeName] of this.dbStores) {
@@ -91,8 +105,64 @@ export default class IndexedDB {
             return this.db.transaction(dbStore, "readwrite");
         } catch (e) {
             console.info("DATABASE is not ready yet", e);
+            if (e.name === "InvalidStateError") {
+                this.db = null;
+                this._attemptReconnect();
+            }
             return false;
         }
+    }
+
+    _attemptReconnect() {
+        if (this._isReconnecting) {
+            return;
+        }
+        this._isReconnecting = true;
+        setTimeout(() => {
+            if (this.db) {
+                try {
+                    this.db.close();
+                } catch {
+                    // already closed
+                }
+                this.db = null;
+            }
+            this.databaseEventListener();
+            this._isReconnecting = false;
+        }, 3000);
+    }
+
+    _setupVisibilityProbe() {
+        if (this._visibilityProbeAttached) {
+            return;
+        }
+        this._visibilityProbeAttached = true;
+        document.addEventListener("visibilitychange", () => {
+            if (document.visibilityState !== "visible" || !this.db) {
+                return;
+            }
+            try {
+                this.db.transaction([this.dbStores[0][1]], "readonly").abort();
+            } catch {
+                this.db = null;
+                this._attemptReconnect();
+            }
+        });
+    }
+
+    _showReloadDialog() {
+        if (!this.dialog || this._reloadDialogShown) {
+            return;
+        }
+        this._reloadDialogShown = true;
+        this.dialog.add(AlertDialog, {
+            title: _t("Database Connection Lost"),
+            body: _t(
+                "The connection to the local database was lost. Reloading the page will restore it and prevent any loss of unsaved orders."
+            ),
+            confirmLabel: _t("Reload"),
+            confirm: () => window.location.reload(),
+        });
     }
 
     reset() {


### PR DESCRIPTION
On iOS/Safari, the WebKit IDB server process can be killed by the OS (e.g. due to memory pressure when the app is backgrounded), resulting in an UnknownError: "Connection to Indexed Database server lost". Additionally, returning from background can leave the connection in an InvalidStateError "closing" state while this.db remains non-null.

opw-5121896

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
