### PR TITLE
[FIX] website{,_sale}: prevent team_id recompute on cart confirm

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -325,6 +325,7 @@ class SaleOrder(models.Model):
         compute='_compute_has_active_pricelist')
     show_update_pricelist = fields.Boolean(
         string="Has Pricelist Changed", store=False)  # True if the pricelist was changed
+    skip_team_recompute = fields.Boolean(store=False, default=False)
 
     _date_order_id_idx = models.Index("(date_order desc, id desc)")
 
@@ -490,6 +491,9 @@ class SaleOrder(models.Model):
     def _compute_team_id(self):
         cached_teams = {}
         for order in self:
+            if order.skip_team_recompute and order.team_id:
+                order.skip_team_recompute = False
+                continue
             default_team_id = order._default_team_id()
             user_id = order.user_id.id
             company_id = order.company_id.id

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -155,6 +155,8 @@ class SaleOrder(models.Model):
                 # It'll be assigned on confirmation (see action_confirm)
                 continue
             if not order.user_id:
+                if order.env.context.get('skip_team_recompute'):
+                    order.skip_team_recompute = True
                 order.user_id = (
                     order.website_id.salesperson_id
                     or order.partner_id.user_id.id
@@ -252,7 +254,9 @@ class SaleOrder(models.Model):
             carts = carts.with_user(SUPERUSER_ID)
         # Assign the salesman to carts on confirmation, as SUPERUSER to send the
         # 'You have been assigned to SOOOO' with OdooBot (and not public/logged in user).
-        carts.with_context(force_user_recomputation=True)._compute_user_id()
+        carts.with_context(
+            force_user_recomputation=True, skip_team_recompute=True
+        )._compute_user_id()
         return super().action_confirm()
 
     def _send_payment_succeeded_for_order_mail(self):

--- a/addons/website_sale/tests/__init__.py
+++ b/addons/website_sale/tests/__init__.py
@@ -40,6 +40,7 @@ from . import test_website_sale_settings
 from . import test_website_sale_shop_redirects
 from . import test_website_sale_show_compare_list_price
 from . import test_website_sale_snippets
+from . import test_website_sale_team
 from . import test_website_sale_visitor
 from . import test_website_sale_technical_page
 from . import test_website_sequence

--- a/addons/website_sale/tests/test_website_sale_team.py
+++ b/addons/website_sale/tests/test_website_sale_team.py
@@ -1,0 +1,8 @@
+from odoo.addons.website_sale.tests.common import WebsiteSaleCommon
+
+
+class WebsiteSaleTeam(WebsiteSaleCommon):
+    def test_website_sale_cart_confirmation_does_not_change_team(self):
+        website_team = self.cart.team_id
+        self.cart.action_confirm()
+        self.assertEqual(self.cart.team_id, website_team)


### PR DESCRIPTION
Issue:
---
Confirming a website SO causes `team_id` to be recomputed to unexpected value.

#### Steps to reproduce (using demo data):
1- In shop, add a product to cart and checkout.
2- Confirm and pay the order.
3- In the backend, open the sale order and check the `team_id`.

As you see the `team_id` is set to `Sale`, which is not expected. It's expected to be `Website`.

Cause:
---
#195810 replaced the `team_id` override of `website_sale` compute with `_default_team_id`.
This allows `team_id` to be recomputed when `user_id` is manually changed, but also means that setting `user_id` in `website_sale.action_confirm` triggers a recomputation.
Although the website team was passed as a default context in `_get_default_team_id`, it is ignored if the current user already has a team:
https://github.com/odoo/odoo/blob/10c23e3ca5f931f09110a541cbe2ba777eff25dd/addons/sales_team/models/crm_team.py#L73-L75

opw-6008950
