### PR TITLE
[IMP] mail: remove redundant member actions from card popover

### DIFF
--- a/addons/hr_holidays/static/src/core/web/avatar_card_popover_patch.xml
+++ b/addons/hr_holidays/static/src/core/web/avatar_card_popover_patch.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-inherit="mail.AvatarCardPopover" t-inherit-mode="extension">
-        <xpath expr="//div[hasclass('o-mail-avatar-card-name-actions')]" position="after">
+        <xpath expr="//span[hasclass('o-mail-avatar-card-name')]" position="after">
             <span t-if="this.partner?.outOfOfficeDateEndText" class="text-warning me-1 smaller fw-bold opacity-75" t-out="this.partner.outOfOfficeDateEndText"/>
         </xpath>
     </t>

--- a/addons/hr_holidays/static/src/core/web/avatar_card_resource_popover.xml
+++ b/addons/hr_holidays/static/src/core/web/avatar_card_resource_popover.xml
@@ -7,7 +7,7 @@
             <!-- Employee is on time off and he is not connected -->
             <i t-if="employee?.hr_icon_display === 'presence_holiday_absent'" class="fa fa-fw fa-plane text-warning me-1" title="On Time Off" role="img" aria-label="On Time Off"/>
         </xpath>
-        <xpath expr="//div[hasclass('o-mail-avatar-card-name-actions')]" position="after">
+        <xpath expr="//span[hasclass('o-mail-avatar-card-name')]" position="after">
             <span t-if="outOfOfficeDateEndText" class="text-warning me-1 small fw-bold" t-out="outOfOfficeDateEndText"/>
         </xpath>
     </t>

--- a/addons/mail/static/src/discuss/core/web/channel_member_patch.js
+++ b/addons/mail/static/src/discuss/core/web/channel_member_patch.js
@@ -18,7 +18,7 @@ patch(ChannelMember.prototype, {
     get attClass() {
         return { ...super.attClass, "o-active": this.state.isAvatarCardOpen };
     },
-    get isClickable(){
+    get isClickable() {
         return this.member.partner_id;
     },
     onClickAvatar(ev) {
@@ -28,8 +28,7 @@ patch(ChannelMember.prototype, {
         if (!this.avatarCard.isOpen) {
             this.avatarCard.open(ev.currentTarget, {
                 id: this.member.partner_id.id,
-                channelMember: this.member,
-                model: "res.partner"
+                model: "res.partner",
             });
             this.state.isAvatarCardOpen = true;
         }

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.js
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.js
@@ -7,7 +7,6 @@ import { useOpenChat } from "@mail/core/web/open_chat_hook";
 import { ImStatus } from "@mail/core/common/im_status";
 import { useDynamicInterval } from "@mail/utils/common/misc";
 import { formatLocalDateTime } from "@mail/utils/common/dates";
-import { useChannelMemberActions } from "@mail/discuss/core/common/channel_member_actions";
 import { ActionList } from "@mail/core/common/action_list";
 import { user } from "@web/core/user";
 
@@ -16,7 +15,6 @@ export class AvatarCardPopover extends Component {
     static components = { ActionList, Dropdown, DropdownItem, ImStatus };
     static props = {
         id: { type: Number, required: true },
-        channelMember: { type: Object, optional: true },
         close: { type: Function, required: true },
         model: {
             type: String,
@@ -37,9 +35,6 @@ export class AvatarCardPopover extends Component {
         this.store.fetchStoreData("avatar_card", {
             id: this.props.id,
             model: this.props.model,
-        });
-        this.chanelMemberActions = useChannelMemberActions({
-            member: () => this.props.channelMember,
         });
         useDynamicInterval(
             (...args) => this.onChangeTz(...args),
@@ -63,9 +58,6 @@ export class AvatarCardPopover extends Component {
         return this.props.model;
     }
 
-    get canOpenSettingMenu() {
-        return this.props.channelMember && this.chanelMemberActions.actions.length;
-    }
     get user() {
         if (this.props.model === "res.users") {
             return this.store["res.users"].get(this.props.id);

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
@@ -14,18 +14,7 @@
                         </span>
                     </span>
                     <div class="d-flex flex-column o_card_user_infos overflow-hidden">
-                        <div class="o-mail-avatar-card-name-actions d-flex align-items-center justify-content-center">
-                            <span class="o-mail-avatar-card-name fw-bold" t-if="this.name" t-out="this.name"/>
-                            <div class="flex-grow-1"/>
-                            <Dropdown t-if="this.canOpenSettingMenu" position="'right-start'">
-                                <button class="btn btn-sm">
-                                    <i class="oi oi-ellipsis-v"/>
-                                </button>
-                                <t t-set-slot="content">
-                                    <ActionList actions="this.chanelMemberActions.actions" dropdown="true"/>
-                                </t>
-                            </Dropdown>
-                        </div>
+                        <span t-if="this.name" class="o-mail-avatar-card-name fw-bold" t-out="this.name"/>
                         <t t-if="this.userInfoTemplate" t-call="{{this.userInfoTemplate}}"/>
                         <a t-if="this.email" t-att-href="'mailto:'+this.email" t-att-title="this.email" class="text-truncate">
                             <i class="fa fa-fw fa-envelope me-1"/><t t-out="this.email"/>


### PR DESCRIPTION
When channel owner / admins was introduced, the member actions were defined in the specific avatar card popover from the members panel.

This was not intuitive to find these actions:
- only this avatar card had this feature, not the other cards
- the feature was hard to find, as we had to click to open avatar, be aware that there's a new "..." button to click and show the member actions.

This made much more sense as a button "..." shown on hover when mouse-hovering the member item in the members panel, which was added shortly after [1].

To follow stable policy, the "..." buttons in card popover have been kept, but in `master` they should be removed as the actions from member item in members panel makes more sense.

[1]: https://github.com/odoo/odoo/pull/244806

Before / After
<img width="571" height="322" alt="Screenshot 2026-03-13 at 17 22 04" src="https://github.com/user-attachments/assets/b455b423-788a-4326-9b70-08cedf58355f" />
<img width="564" height="314" alt="Screenshot 2026-03-13 at 17 21 42" src="https://github.com/user-attachments/assets/5b9294f9-cdc1-4482-92ba-813cdf8193e0" />
