### PR TITLE
[REF] html_builder, website: align addBuilderOption with XML-based API

### DIFF
--- a/addons/html_builder/static/tests/background_shape_color.test.js
+++ b/addons/html_builder/static/tests/background_shape_color.test.js
@@ -107,9 +107,9 @@ async function updateBgColor(selector, bgColor, waitSidebarUpdated) {
 }
 
 beforeEach(async () => {
-    addBuilderOption(
-        class TestBackgroundOption extends BackgroundOption {
-            static selector = "section";
+    addBuilderOption({
+        selector: "section",
+        Component: class TestBackgroundOption extends BackgroundOption {
             static props = {
                 ...BackgroundOption.props,
                 withColors: { type: Boolean, optional: true },
@@ -122,8 +122,8 @@ beforeEach(async () => {
                 withShapes: true,
                 withColorCombinations: false,
             };
-        }
-    );
+        },
+    });
 });
 
 test("Connections shape takes neighbor element's background color", async () => {

--- a/addons/html_builder/static/tests/builder_action.test.js
+++ b/addons/html_builder/static/tests/builder_action.test.js
@@ -38,12 +38,10 @@ beforeEach(() => {
 });
 
 test("apply is called if clean is not defined", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".s_test";
-            static template = xml`<BuilderButton action="'testAction'">Click</BuilderButton>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".s_test",
+        template: xml`<BuilderButton action="'testAction'">Click</BuilderButton>`,
+    });
     await setupHTMLBuilder(`<section class="s_test">Test</section>`);
     await contains(":iframe .s_test").click();
     await contains("[data-action-id='testAction']").click();
@@ -55,12 +53,10 @@ test("apply is called if clean is not defined", async () => {
 });
 
 test("custom action and shorthand action: clean actions are independent, apply is called on custom action if clean is not defined", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".s_test";
-            static template = xml`<BuilderButton action="'testAction'" classAction="'custom-class'">Click</BuilderButton>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".s_test",
+        template: xml`<BuilderButton action="'testAction'" classAction="'custom-class'">Click</BuilderButton>`,
+    });
     await setupHTMLBuilder(`<section class="s_test">Test</section>`);
     await contains(":iframe .s_test").click();
     await contains("[data-action-id='testAction']").click();
@@ -77,8 +73,6 @@ test("Prepare is triggered on props updated", async () => {
     prepareDeferred.resolve();
     class TestOption extends BaseOptionComponent {
         static template = xml`<BuilderCheckbox action="'customAction'" actionParam="state.param"/>`;
-        static selector = ".test-options-target";
-        static props = {};
         setup() {
             super.setup();
             this.state = useState({ param: "old param" });
@@ -98,7 +92,10 @@ test("Prepare is triggered on props updated", async () => {
     addBuilderAction({
         CustomAction,
     });
-    addBuilderOption(TestOption);
+    addBuilderOption({
+        selector: ".test-options-target",
+        Component: TestOption,
+    });
     await setupHTMLBuilder(`<section class="test-options-target">Homepage</section>`);
     await contains(":iframe .test-options-target").click();
     expect.verifySteps(["prepare"]);
@@ -113,12 +110,10 @@ test("Prepare is triggered on props updated", async () => {
 });
 
 test("Data Attribute action works with non string values", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".s_test";
-            static template = xml`<BuilderButton dataAttributeAction="'customerOrderIds'" dataAttributeActionValue="[100, 200]">Click</BuilderButton>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".s_test",
+        template: xml`<BuilderButton dataAttributeAction="'customerOrderIds'" dataAttributeActionValue="[100, 200]">Click</BuilderButton>`,
+    });
     await setupHTMLBuilder(`<section class="s_test">Test</section>`);
     await contains(":iframe .s_test").click();
     await contains(".we-bg-options-container button:contains('Click')").click();
@@ -155,12 +150,10 @@ describe("isPreviewing is passed to action's apply and clean", () => {
     });
 
     test("useClickableBuilderComponent", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderButton action="'isPreviewing'" actionValue="true">Toggle</BuilderButton>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderButton action="'isPreviewing'" actionValue="true">Toggle</BuilderButton>`,
+        });
         await setupHTMLBuilder(`<section class="test-options-target">Homepage</section>`);
         await contains(":iframe .test-options-target").click();
 
@@ -177,12 +170,10 @@ describe("isPreviewing is passed to action's apply and clean", () => {
     });
 
     test("useInputBuilderComponent", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderTextInput action="'isPreviewing'"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderTextInput action="'isPreviewing'"/>`,
+        });
         await setupHTMLBuilder(`<section class="test-options-target">Homepage</section>`);
         await contains(":iframe .test-options-target").click();
 
@@ -192,12 +183,10 @@ describe("isPreviewing is passed to action's apply and clean", () => {
     });
 
     test("useColorPickerBuilderComponent", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderColorPicker action="'isPreviewing'"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderColorPicker action="'isPreviewing'"/>`,
+        });
         await setupHTMLBuilder(`<section class="test-options-target">Homepage</section>`);
         await contains(":iframe .test-options-target").click();
 
@@ -226,12 +215,10 @@ describe("isPreviewing is passed to action's apply and clean", () => {
 
         defineModels([Test]);
 
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderMany2One action="'isPreviewing'" model="'test'" limit="10" allowUnselect="true"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderMany2One action="'isPreviewing'" model="'test'" limit="10" allowUnselect="true"/>`,
+        });
         await setupHTMLBuilder(`<section class="test-options-target">Homepage</section>`);
         await contains(":iframe .test-options-target").click();
 
@@ -294,12 +281,10 @@ test("reload action: apply, clean save and reload are called in the right order 
         },
     });
 
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButton action="'testReload'">Click</BuilderButton>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton action="'testReload'">Click</BuilderButton>`,
+    });
     await setupHTMLBuilder(`<section class="test-options-target">Test</section>`);
     await contains(":iframe .test-options-target").click();
 
@@ -334,12 +319,10 @@ test("shows notification when a BuilderAction.apply times out", async () => {
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButton action="'timeoutAction'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton action="'timeoutAction'"/>`,
+    });
 
     await setupHTMLBuilder(`<div class="test-options-target">TEST</div>`);
     await contains(":iframe .test-options-target").click();

--- a/addons/html_builder/static/tests/builder_option.test.js
+++ b/addons/html_builder/static/tests/builder_option.test.js
@@ -5,7 +5,6 @@ import {
     setupHTMLBuilder,
 } from "@html_builder/../tests/helpers";
 import { BuilderAction } from "@html_builder/core/builder_action";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 import { Plugin } from "@html_editor/plugin";
 import { expect, test, describe } from "@odoo/hoot";
 import { animationFrame } from "@odoo/hoot-dom";
@@ -23,12 +22,10 @@ test("Undo/Redo correctly restores the stored container target", async () => {
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButton action="'customAction'">Test</BuilderButton>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton action="'customAction'">Test</BuilderButton>`,
+    });
     await setupHTMLBuilder(`
         <div data-name="Target 1" class="test-options-target target1">
             Homepage
@@ -60,12 +57,10 @@ test("Undo/Redo multiple actions always restores the action container target", a
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButton action="'customAction'">Test</BuilderButton>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton action="'customAction'">Test</BuilderButton>`,
+    });
     await setupHTMLBuilder(`
         <div data-name="Target 1" class="test-options-target target1">
             Homepage
@@ -108,12 +103,10 @@ test("Undo/Redo an action that activates another target restores the old one on 
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButton action="'customAction'">Test</BuilderButton>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton action="'customAction'">Test</BuilderButton>`,
+    });
     const { getEditor } = await setupHTMLBuilder(`
         <div data-name="Target 1" class="test-options-target target1">
             Homepage
@@ -147,12 +140,10 @@ test("Undo/Redo an action that deactivates the containers restores the old one o
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButton action="'customAction'">Test</BuilderButton>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton action="'customAction'">Test</BuilderButton>`,
+    });
     const { getEditor } = await setupHTMLBuilder(`
         <div data-name="Target 1" class="test-options-target target1">
             Homepage
@@ -188,18 +179,14 @@ test("Containers fallback to a valid ancestor if the target disappears and resto
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButton action="'targetAction'">Test</BuilderButton>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-ancestor";
-            static template = xml`<BuilderButton action="'ancestorAction'">Ancestor selected</BuilderButton>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton action="'targetAction'">Test</BuilderButton>`,
+    });
+    addBuilderOption({
+        selector: ".test-ancestor",
+        template: xml`<BuilderButton action="'ancestorAction'">Ancestor selected</BuilderButton>`,
+    });
     await setupHTMLBuilder(`
         <div data-name="Ancestor" class="test-ancestor">
             Hey I'm an ancestor
@@ -224,12 +211,10 @@ test("Containers fallback to a valid ancestor if the target disappears and resto
 });
 
 test("Do not activate/update containers if the element clicked is excluded", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButton classAction="'test'">Test</BuilderButton>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton classAction="'test'">Test</BuilderButton>`,
+    });
     await setupHTMLBuilder(`
         <div data-name="Target 1" class="test-options-target target1 o_we_no_overlay">
             Homepage
@@ -257,24 +242,18 @@ test("Do not show parent container for no_parent_containers targets", async () =
         };
     }
     addBuilderPlugin(TestPlugin);
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-parent-target";
-            static template = xml`<BuilderButton classAction="'test'">Test</BuilderButton>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-child-target";
-            static template = xml`<BuilderButton classAction="'test'">Test</BuilderButton>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-grand-child-target";
-            static template = xml`<BuilderButton classAction="'test'">Test</BuilderButton>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-parent-target",
+        template: xml`<BuilderButton classAction="'test'">Test</BuilderButton>`,
+    });
+    addBuilderOption({
+        selector: ".test-child-target",
+        template: xml`<BuilderButton classAction="'test'">Test</BuilderButton>`,
+    });
+    addBuilderOption({
+        selector: ".test-grand-child-target",
+        template: xml`<BuilderButton classAction="'test'">Test</BuilderButton>`,
+    });
     await setupHTMLBuilder(`
         <div data-name="Parent" class="test-parent-target">
             Parent
@@ -302,12 +281,6 @@ test("Do not show parent container for no_parent_containers targets", async () =
 });
 
 test("Option containers should update reactively", async () => {
-    class Option extends BaseOptionComponent {
-        static title = "Test";
-        static selector = ".test-options-target";
-        static template = xml`<BuilderButton classAction="'disabled_clone'">Disable clone</BuilderButton>`;
-    }
-
     class TestPlugin extends Plugin {
         static id = "test";
         resources = {
@@ -325,7 +298,11 @@ test("Option containers should update reactively", async () => {
     }
 
     addBuilderPlugin(TestPlugin);
-    addBuilderOption(Option);
+    addBuilderOption({
+        title: "Test",
+        selector: ".test-options-target",
+        template: xml`<BuilderButton classAction="'disabled_clone'">Disable clone</BuilderButton>`,
+    });
     await setupHTMLBuilder(`
         <div data-name="Target" class="test-options-target target1">
             Homepage
@@ -341,15 +318,6 @@ test("Option containers should update reactively", async () => {
 });
 
 test("Option containers dispatched to plugins are updated reactively", async () => {
-    class Option extends BaseOptionComponent {
-        static title = "Test";
-        static selector = ".target";
-        static template = xml`
-            <BuilderButton classAction="'not_removable'">Disable remove</BuilderButton>
-            <BuilderButton action="'testAction'">Check if disabled</BuilderButton>
-        `;
-    }
-
     class TestPlugin extends Plugin {
         static id = "testPlugin";
         static shared = ["isRemoveDisabled"];
@@ -383,7 +351,14 @@ test("Option containers dispatched to plugins are updated reactively", async () 
     }
 
     addBuilderPlugin(TestPlugin);
-    addBuilderOption(Option);
+    addBuilderOption({
+        title: "Test",
+        selector: ".target",
+        template: xml`
+            <BuilderButton classAction="'not_removable'">Disable remove</BuilderButton>
+            <BuilderButton action="'testAction'">Check if disabled</BuilderButton>
+        `,
+    });
     await setupHTMLBuilder(`
         <div data-name="Target">
             <div> Is removable? <p class="target">-</p></div>

--- a/addons/html_builder/static/tests/clean_for_save_options.test.js
+++ b/addons/html_builder/static/tests/clean_for_save_options.test.js
@@ -7,19 +7,19 @@ import { contains } from "@web/../tests/web_test_helpers";
 describe.current.tags("desktop");
 
 test("clean for save of option with selector that matches an element on the page", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
+    addBuilderOption({
+        selector: ".test-options-target",
+        Component: class extends BaseOptionComponent {
             static template = xml`
-                    <BuilderButtonGroup>
-                        <BuilderButton classAction="'x'"/>
-                    </BuilderButtonGroup>
-                `;
+                <BuilderButtonGroup>
+                    <BuilderButton classAction="'x'"/>
+                </BuilderButtonGroup>
+            `;
             static cleanForSave() {
                 expect.step("clean for save option");
             }
-        }
-    );
+        },
+    });
     const { getEditor } = await setupHTMLBuilder(`<div class="test-options-target">a</div>`);
     const editor = getEditor();
     await contains(":iframe .test-options-target").click();
@@ -31,30 +31,28 @@ test("clean for save of option with selector that matches an element on the page
 });
 
 test("clean for save of option with selector and exclude that matches an element on the page", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
+    addBuilderOption({
+        selector: ".test-options-target",
+        exclude: "div",
+        Component: class extends BaseOptionComponent {
             static template = xml`
-                    <BuilderButtonGroup>
-                        <BuilderButton classAction="'x'"/>
-                    </BuilderButtonGroup>
-                `;
-            static exclude = "div";
+                <BuilderButtonGroup>
+                    <BuilderButton classAction="'x'"/>
+                </BuilderButtonGroup>
+            `;
             cleanForSave = (_) => {
                 expect.step("clean for save option");
             };
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
-                    <BuilderButtonGroup>
-                        <BuilderButton classAction="'y'"/>
-                    </BuilderButtonGroup>
-                `;
-        }
-    );
+        },
+    });
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderButtonGroup>
+                <BuilderButton classAction="'y'"/>
+            </BuilderButtonGroup>
+        `,
+    });
     const { getEditor } = await setupHTMLBuilder(`<div class="test-options-target">a</div>`);
     const editor = getEditor();
     await contains(":iframe .test-options-target").click();

--- a/addons/html_builder/static/tests/composite_action.test.js
+++ b/addons/html_builder/static/tests/composite_action.test.js
@@ -7,7 +7,6 @@ import { BuilderAction } from "@html_builder/core/builder_action";
 import { describe, expect, test } from "@odoo/hoot";
 import { xml } from "@odoo/owl";
 import { contains } from "@web/../tests/web_test_helpers";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 
 // TODO: test composite with each spec: prepare, load, getValue
 // TODO: test reloadComposite
@@ -39,20 +38,18 @@ test("can call 2 separate actions with composite action", async () => {
         Action1,
         Action2,
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".s_test";
-            static template = xml`
+    addBuilderOption({
+        selector: ".s_test",
+        template: xml`
             <BuilderButton
-                    action="'composite'"
-                    actionParam="[
-                        { action: 'action1', actionParam: { mainParam: 'class1' } },
-                        { action: 'action2', actionParam: { mainParam: 'class2' } },
-                    ]">
+                action="'composite'"
+                actionParam="[
+                    { action: 'action1', actionParam: { mainParam: 'class1' } },
+                    { action: 'action2', actionParam: { mainParam: 'class2' } },
+                ]">
                 Click
-            </BuilderButton>`;
-        }
-    );
+        </BuilderButton>`,
+    });
     await setupHTMLBuilder(`<section class="s_test">Test</section>`);
     await contains(":iframe .s_test").click();
     await contains("[data-action-id='composite']").click();
@@ -81,20 +78,18 @@ test("can call the same action twice with composite action", async () => {
     addBuilderAction({
         Action1,
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".s_test";
-            static template = xml`
+    addBuilderOption({
+        selector: ".s_test",
+        template: xml`
             <BuilderButton
-                    action="'composite'"
-                    actionParam="[
-                        { action: 'action1', actionParam: { mainParam: 'class1' } },
-                        { action: 'action1', actionParam: { mainParam: 'class2' } },
-                    ]">
+                action="'composite'"
+                actionParam="[
+                    { action: 'action1', actionParam: { mainParam: 'class1' } },
+                    { action: 'action1', actionParam: { mainParam: 'class2' } },
+                ]">
                 Click
-            </BuilderButton>`;
-        }
-    );
+        </BuilderButton>`,
+    });
     await setupHTMLBuilder(`<section class="s_test">Test</section>`);
     await contains(":iframe .s_test").click();
     await contains("[data-action-id='composite']").click();
@@ -119,20 +114,18 @@ test("composite action's isApplied returns false if no action defined it", async
     addBuilderAction({
         Action1,
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".s_test";
-            static template = xml`
+    addBuilderOption({
+        selector: ".s_test",
+        template: xml`
             <BuilderButton
-                    action="'composite'"
-                    actionParam="[
-                        { action: 'action1', actionParam: { mainParam: 'class1' } },
-                        { action: 'action1', actionParam: { mainParam: 'class2' } },
-                    ]">
+                action="'composite'"
+                actionParam="[
+                    { action: 'action1', actionParam: { mainParam: 'class1' } },
+                    { action: 'action1', actionParam: { mainParam: 'class2' } },
+                ]">
                 Click
-            </BuilderButton>`;
-        }
-    );
+        </BuilderButton>`,
+    });
     await setupHTMLBuilder(`<section class="s_test">Test</section>`);
     await contains(":iframe .s_test").click();
     expect("[data-action-id='composite']").not.toHaveClass("active");
@@ -164,20 +157,18 @@ test("composite action's isApplied returns true if at least one action defined i
         Action1,
         Action2,
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".s_test";
-            static template = xml`
+    addBuilderOption({
+        selector: ".s_test",
+        template: xml`
             <BuilderButton
-                    action="'composite'"
-                    actionParam="[
-                        { action: 'action1', actionParam: { mainParam: 'class1' } },
-                        { action: 'action2', actionParam: { mainParam: 'class2' } },
-                    ]">
+                action="'composite'"
+                actionParam="[
+                    { action: 'action1', actionParam: { mainParam: 'class1' } },
+                    { action: 'action2', actionParam: { mainParam: 'class2' } },
+                ]">
                 Click
-            </BuilderButton>`;
-        }
-    );
+        </BuilderButton>`,
+    });
     await setupHTMLBuilder(`<section class="s_test">Test</section>`);
     await contains(":iframe .s_test").click();
     expect("[data-action-id='composite']").not.toHaveClass("active");

--- a/addons/html_builder/static/tests/contenteditable.test.js
+++ b/addons/html_builder/static/tests/contenteditable.test.js
@@ -10,7 +10,6 @@ import { expect, test, describe } from "@odoo/hoot";
 import { xml } from "@odoo/owl";
 import { contains, onRpc } from "@web/../tests/web_test_helpers";
 import { BuilderAction } from "@html_builder/core/builder_action";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 
 describe.current.tags("desktop");
 
@@ -59,18 +58,14 @@ test("Media should not be replaceable if not inside a savable zone", async () =>
 
 test("clone of editable media inside not editable area should be editable", async () => {
     onRpc("/html_editor/get_image_info", () => ({}));
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = "section";
-            static template = xml`<BuilderButton classAction="'test'">Test</BuilderButton>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = "img";
-            static template = xml`<BuilderButton classAction="'test'">Test Image</BuilderButton>`;
-        }
-    );
+    addBuilderOption({
+        selector: "section",
+        template: xml`<BuilderButton classAction="'test'">Test</BuilderButton>`,
+    });
+    addBuilderOption({
+        selector: "img",
+        template: xml`<BuilderButton classAction="'test'">Test Image</BuilderButton>`,
+    });
     const { waitSidebarUpdated } = await setupHTMLBuilder(`
         <section>
             <div class="o_not_editable">
@@ -94,18 +89,14 @@ const setupEditable = async (contentEl) => {
         };
     }
     addBuilderPlugin(TestPlugin);
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent";
-            static template = xml`<BuilderButton action="'customAction'">Custom Action</BuilderButton>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent";
-            static template = xml`<BuilderButton classAction="'dummy'">Dummy action</BuilderButton>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".parent",
+        template: xml`<BuilderButton action="'customAction'">Custom Action</BuilderButton>`,
+    });
+    addBuilderOption({
+        selector: ".parent",
+        template: xml`<BuilderButton classAction="'dummy'">Dummy action</BuilderButton>`,
+    });
     addBuilderAction({
         customAction: class extends BuilderAction {
             static id = "customAction";

--- a/addons/html_builder/static/tests/custom_tab/builder_components/basic_many2many.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/basic_many2many.test.js
@@ -34,7 +34,6 @@ test("basic many2many: find tag, select tag, unselect tag", async () => {
     });
     const selection = reactive([]);
     class TestComponent extends BaseOptionComponent {
-        static selector = ".test-options-target";
         static template = xml`<BasicMany2Many selection="this.selection" model="'test'" setSelection="this.setSelection.bind(this)"/>`;
         selection = selection;
         setSelection(newSelection) {
@@ -44,7 +43,10 @@ test("basic many2many: find tag, select tag, unselect tag", async () => {
             }
         }
     }
-    addBuilderOption(TestComponent);
+    addBuilderOption({
+        selector: ".test-options-target",
+        Component: TestComponent,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
 
     await contains(":iframe .test-options-target").click();
@@ -91,7 +93,6 @@ test("basic many2many: toggle dropdown without changing search term or selection
     });
     const selection = reactive([]);
     class TestComponent extends BaseOptionComponent {
-        static selector = ".test-options-target";
         static template = xml`<BasicMany2Many selection="this.selection" model="'test'" setSelection="this.setSelection.bind(this)" limit="1"/>`;
         selection = selection;
         setSelection(newSelection) {
@@ -101,7 +102,10 @@ test("basic many2many: toggle dropdown without changing search term or selection
             }
         }
     }
-    addBuilderOption(TestComponent);
+    addBuilderOption({
+        selector: ".test-options-target",
+        Component: TestComponent,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
 
     await contains(":iframe .test-options-target").click();

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_button.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_button.test.js
@@ -25,12 +25,10 @@ test("call a specific action with some params and value", async () => {
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButton action="'customAction'" actionParam="'myParam'" actionValue="'myValue'">MyAction</BuilderButton>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton action="'customAction'" actionParam="'myParam'" actionValue="'myValue'">MyAction</BuilderButton>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeDisplayed();
@@ -41,12 +39,10 @@ test("call a specific action with some params and value", async () => {
     expect.verifySteps(["customAction myParam myValue", "customAction myParam myValue"]);
 });
 test("call a shorthand action", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButton classAction="'my-custom-class'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton classAction="'my-custom-class'"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeDisplayed();
@@ -64,12 +60,10 @@ test("call a shorthand action and a specific action", async () => {
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButton action="'customAction'" classAction="'my-custom-class'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton action="'customAction'" classAction="'my-custom-class'"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeDisplayed();
@@ -90,12 +84,10 @@ test("preview a shorthand action and a specific action", async () => {
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButton action="'customAction'" classAction="'my-custom-class'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton action="'customAction'" classAction="'my-custom-class'"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeDisplayed();
@@ -116,12 +108,10 @@ test("prevent preview of a specific action", async () => {
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButton action="'customAction'" preview="false"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton action="'customAction'" preview="false"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeDisplayed();
@@ -144,12 +134,10 @@ test("prevent preview of a specific action (2)", async () => {
     addBuilderAction({
         CustomAction,
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButton action="'customAction'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton action="'customAction'"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeDisplayed();
@@ -159,12 +147,10 @@ test("prevent preview of a specific action (2)", async () => {
     expect.verifySteps(["customAction"]);
 });
 test("should toggle when not in a BuilderButtonGroup", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButton classAction="'c1'" preview="false"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton classAction="'c1'" preview="false"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     await contains("[data-class-action='c1']").click();
@@ -181,12 +167,10 @@ test("should call apply when the button is active and none of its actions have a
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButton action="'customAction'" preview="false"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton action="'customAction'" preview="false"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     await contains("[data-action-id='customAction']").click();
@@ -196,15 +180,14 @@ test("should call apply when the button is active and none of its actions have a
 });
 
 test("should not toggle when in a BuilderButtonGroup", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
-                <BuilderButtonGroup>
-                    <BuilderButton classAction="'c1'" preview="false"/>
-                </BuilderButtonGroup>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderButtonGroup>
+                <BuilderButton classAction="'c1'" preview="false"/>
+            </BuilderButtonGroup>
+        `,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     await contains("[data-class-action='c1']").click();
@@ -213,16 +196,15 @@ test("should not toggle when in a BuilderButtonGroup", async () => {
     expect(":iframe .test-options-target").toHaveClass("test-options-target c1");
 });
 test("clean another action", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
-                    <BuilderButtonGroup>
-                        <BuilderButton classAction="'my-custom-class1'"/>
-                        <BuilderButton classAction="'my-custom-class2'"/>
-                    </BuilderButtonGroup>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderButtonGroup>
+                <BuilderButton classAction="'my-custom-class1'"/>
+                <BuilderButton classAction="'my-custom-class2'"/>
+            </BuilderButtonGroup>
+        `,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeDisplayed();
@@ -253,16 +235,15 @@ test("clean should provide the next action value", async () => {
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
-                    <BuilderButtonGroup>
-                        <BuilderButton classAction="'c1'" action="'customAction'"/>
-                        <BuilderButton classAction="'c2'" action="'customAction'" actionParam="'param2'" actionValue="'value2'"/>
-                    </BuilderButtonGroup>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderButtonGroup>
+                <BuilderButton classAction="'c1'" action="'customAction'"/>
+                <BuilderButton classAction="'c2'" action="'customAction'" actionParam="'param2'" actionValue="'value2'"/>
+            </BuilderButtonGroup>
+        `,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeDisplayed();
@@ -297,17 +278,16 @@ test("clean should only be called on the currently selected item", async () => {
         customAction2: makeAction(2).action,
         customAction3: makeAction(3).action,
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
             <BuilderButtonGroup>
                 <BuilderButton action="'customAction1'" classAction="'c1'" />
                 <BuilderButton action="'customAction2'" classAction="'c2'" />
                 <BuilderButton action="'customAction3'" classAction="'c3'" />
-            </BuilderButtonGroup>`;
-        }
-    );
+            </BuilderButtonGroup>
+        `,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     await click("[data-action-id='customAction1']");
@@ -346,16 +326,15 @@ test("clean should be async", async () => {
         customAction1: action1.action,
         customAction2: makeAction(2).action,
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
-                <BuilderButtonGroup preview="false">
-                    <BuilderButton action="'customAction1'" classAction="'c1'"/>
-                    <BuilderButton action="'customAction2'" />
-            </BuilderButtonGroup>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderButtonGroup preview="false">
+                <BuilderButton action="'customAction1'" classAction="'c1'"/>
+                <BuilderButton action="'customAction2'" />
+            </BuilderButtonGroup>
+        `,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     await click("[data-action-id='customAction1']");
@@ -372,32 +351,30 @@ test("clean should be async", async () => {
     ]);
 });
 test("add the active class if the condition is met", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
-                <BuilderButton classAction="'my-custom-class1'"/>
-                <BuilderButton classAction="'my-custom-class2'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderButton classAction="'my-custom-class1'"/>
+            <BuilderButton classAction="'my-custom-class2'"/>
+        `,
+    });
     await setupHTMLBuilder(`<div class="test-options-target my-custom-class1">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect("[data-class-action='my-custom-class1']").toHaveClass("active");
     expect("[data-class-action='my-custom-class2']").not.toHaveClass("active");
 });
 test("add classActive to class when active", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
             <BuilderButton classAction="'my-custom-class1'"
-                           className="'base-class btn1'"
-                           classActive="'active-class'"/>
+                className="'base-class btn1'"
+                classActive="'active-class'"/>
             <BuilderButton classAction="'my-custom-class2'"
-                            className="'base-class btn2'"
-                            classActive="'active-class'"/>`;
-        }
-    );
+                className="'base-class btn2'"
+                classActive="'active-class'"/>
+        `,
+    });
     await setupHTMLBuilder(`<div class="test-options-target my-custom-class1">b</div>`);
     await contains(":iframe .test-options-target").click();
     const permanentClass = "base-class";
@@ -414,12 +391,10 @@ test("add classActive to class when active", async () => {
     expect(".btn2").not.toHaveClass(activeClass);
 });
 test("apply classAction on multi elements", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButton applyTo="'.target-apply'" classAction="'my-custom-class'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton applyTo="'.target-apply'" classAction="'my-custom-class'"/>`,
+    });
     const { getEditableContent } = await setupHTMLBuilder(`
             <div class="test-options-target">
                 <p class="target-apply">a</p>
@@ -441,24 +416,22 @@ test("apply classAction on multi elements", async () => {
             </div>`);
 });
 test("hide/display base on applyTo", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`
-                <BuilderRow label="'my label'">
-                    <BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>
-                </BuilderRow>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`
-                <BuilderRow label="'my label'">
-                    <BuilderButton applyTo="'.my-custom-class'" classAction="'test'"/>
-                </BuilderRow>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`
+            <BuilderRow label="'my label'">
+                <BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>
+            </BuilderRow>
+        `,
+    });
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`
+            <BuilderRow label="'my label'">
+                <BuilderButton applyTo="'.my-custom-class'" classAction="'test'"/>
+            </BuilderRow>
+        `,
+    });
 
     const { getEditableContent } = await setupHTMLBuilder(
         `<div class="parent-target"><div class="child-target">b</div></div>`
@@ -512,18 +485,16 @@ describe("inherited actions", () => {
             customAction2: makeAction(2).action,
             customAction3: makeAction(3, { isApplied: falsy }).action,
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`
                 <BuilderButtonGroup>
                     <BuilderButton action="'customAction1'" actionParam="'myParam1'" actionValue="'myValue1'"  classAction="'class1'" id="'c1'">MyAction1</BuilderButton>
                     <BuilderButton action="'customAction2'" actionParam="'myParam2'" actionValue="'myValue2'">MyAction2</BuilderButton>
                 </BuilderButtonGroup>
                 <BuilderButton action="'customAction3'" actionParam="'myParam3'" actionValue="'myValue3'" inheritedActions="['c1']" >MyAction2</BuilderButton>
-            `;
-            }
-        );
+            `,
+        });
         await setupHTMLBuilder(`<div class="test-options-target class1">a</div>`);
         await contains(":iframe .test-options-target").click();
         await contains("[data-action-id='customAction3']").hover();
@@ -545,19 +516,17 @@ describe("inherited actions", () => {
             customAction3: action3.action,
             customAction4: action4.action,
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`
                 <BuilderButtonGroup>
                     <BuilderButton action="'customAction1'" actionParam="'myParam1'" actionValue="'myValue1'"  classAction="'class1'" id="'c1'">MyAction1</BuilderButton>
                     <BuilderButton action="'customAction2'" actionParam="'myParam2'" actionValue="'myValue2'">MyAction2</BuilderButton>
                 </BuilderButtonGroup>
                 <BuilderButton action="'customAction3'" actionParam="'myParam3'" actionValue="'myValue3'"  id="'c3'">MyAction1</BuilderButton>
                 <BuilderButton action="'customAction4'" actionParam="'myParam4'" actionValue="'myValue4'" inheritedActions="['c1', 'c3']" >MyAction2</BuilderButton>
-            `;
-            }
-        );
+            `,
+        });
         await setupHTMLBuilder(`<div class="test-options-target class1">a</div>`);
         await contains(":iframe .test-options-target").click();
 
@@ -584,19 +553,18 @@ describe("inherited actions", () => {
             customAction2: makeAction(2).action,
             customAction3: makeAction(3, { isApplied: falsy }).action,
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`
-                    <BuilderButtonGroup>
-                        <BuilderButton action="'customAction1'" actionParam="'myParam1'" actionValue="'myValue1'"  classAction="'class1'" id="'c1'">MyAction1</BuilderButton>
-                        <BuilderButton action="'customAction2'" actionParam="'myParam2'" actionValue="'myValue2'">MyAction2</BuilderButton>
-                    </BuilderButtonGroup>
-                    <BuilderContext inheritedActions="['c1']">
-                        <BuilderButton action="'customAction3'" actionParam="'myParam3'" actionValue="'myValue3'">MyAction2</BuilderButton>
-                    </BuilderContext>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`
+                <BuilderButtonGroup>
+                    <BuilderButton action="'customAction1'" actionParam="'myParam1'" actionValue="'myValue1'"  classAction="'class1'" id="'c1'">MyAction1</BuilderButton>
+                    <BuilderButton action="'customAction2'" actionParam="'myParam2'" actionValue="'myValue2'">MyAction2</BuilderButton>
+                </BuilderButtonGroup>
+                <BuilderContext inheritedActions="['c1']">
+                    <BuilderButton action="'customAction3'" actionParam="'myParam3'" actionValue="'myValue3'">MyAction2</BuilderButton>
+                </BuilderContext>
+            `,
+        });
         await setupHTMLBuilder(`<div class="test-options-target class1">a</div>`);
         await contains(":iframe .test-options-target").click();
         await contains("[data-action-id='customAction3']").hover();
@@ -648,18 +616,18 @@ describe("Operation", () => {
         makeActionItem("action1");
         makeActionItem("action2");
 
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderRow label="'my label'">
-                <BuilderButton action="'asyncAction1'"/>
-                <BuilderButton action="'asyncAction2'"/>
-                <BuilderButton action="'asyncAction3'"/>
-                <BuilderButton action="'action1'"/>
-                <BuilderButton action="'action2'"/>
-            </BuilderRow>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`
+                <BuilderRow label="'my label'">
+                    <BuilderButton action="'asyncAction1'"/>
+                    <BuilderButton action="'asyncAction2'"/>
+                    <BuilderButton action="'asyncAction3'"/>
+                    <BuilderButton action="'action1'"/>
+                    <BuilderButton action="'action2'"/>
+                </BuilderRow>
+            `,
+        });
 
         await setupHTMLBuilder(`<div class="test-options-target">a</div>`);
         await contains(":iframe .test-options-target").click();
@@ -700,18 +668,18 @@ describe("Operation", () => {
         makeActionItem("action1");
         makeActionItem("action2");
 
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderRow label="'my label'">
-                <BuilderButton action="'asyncAction1'"/>
-                <BuilderButton action="'asyncAction2'"/>
-                <BuilderButton action="'asyncAction3'"/>
-                <BuilderButton action="'action1'"/>
-                <BuilderButton action="'action2'"/>
-            </BuilderRow>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`
+                <BuilderRow label="'my label'">
+                    <BuilderButton action="'asyncAction1'"/>
+                    <BuilderButton action="'asyncAction2'"/>
+                    <BuilderButton action="'asyncAction3'"/>
+                    <BuilderButton action="'action1'"/>
+                    <BuilderButton action="'action2'"/>
+                </BuilderRow>
+            `,
+        });
 
         await setupHTMLBuilder(`<div class="test-options-target">a</div>`);
         await contains(":iframe .test-options-target").click();
@@ -752,12 +720,10 @@ describe("Operation", () => {
 });
 
 test("click on BuilderButton with inverseAction", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButton classAction="'my-custom-class'" inverseAction="true"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton classAction="'my-custom-class'" inverseAction="true"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(":iframe .test-options-target").not.toHaveClass("my-custom-class");
@@ -787,12 +753,10 @@ test("do not load when an operation is cleaned", async () => {
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButton action="'customAction'" preview="false"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton action="'customAction'" preview="false"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     await contains("[data-action-id='customAction']").click();
@@ -814,15 +778,13 @@ test("click on BuilderButton with async action", async () => {
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
-                <BuilderButton action="'customAction'" preview="false"/>
-                <BuilderButton classAction="'test'" preview="false"/>
-            `;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderButton action="'customAction'" preview="false"/>
+            <BuilderButton classAction="'test'" preview="false"/>
+        `,
+    });
     const { getEditor } = await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     const editor = getEditor();
     await contains(":iframe .test-options-target").click();
@@ -860,7 +822,6 @@ class SubTestOption extends BaseOptionComponent {
 }
 
 class TestOption extends BaseOptionComponent {
-    static selector = ".selector";
     static template = xml`
         <BuilderButton classAction="'secondCase'">secondCase</BuilderButton>
         <BuilderContext applyTo="this.domState.applyTo">
@@ -879,7 +840,10 @@ class TestOption extends BaseOptionComponent {
 }
 
 test("consecutive dynamic applyTo", async () => {
-    addBuilderOption(TestOption);
+    addBuilderOption({
+        selector: ".selector",
+        Component: TestOption,
+    });
     await setupHTMLBuilder(`
         <div class="selector">
             <div class="first">

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_button_group.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_button_group.test.js
@@ -17,7 +17,6 @@ import {
 import { hover } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
 import { contains } from "@web/../tests/web_test_helpers";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 
 describe.current.tags("desktop");
 
@@ -31,15 +30,14 @@ test("change the editingElement of sub widget through `applyTo` prop", async () 
     addBuilderAction({
         CustomAction,
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
-                    <BuilderButtonGroup applyTo="'.a'">
-                        <BuilderButton action="'customAction'"/>
-                    </BuilderButtonGroup>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderButtonGroup applyTo="'.a'">
+                <BuilderButton action="'customAction'"/>
+            </BuilderButtonGroup>
+        `,
+    });
     await setupHTMLBuilder(`
                 <div class="test-options-target">
                     <div class="a">b</div>
@@ -60,15 +58,14 @@ test("should propagate actionParam in the context", async () => {
     addBuilderAction({
         CustomAction,
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
-                    <BuilderButtonGroup actionParam="'myParam'">
-                        <BuilderButton action="'customAction'"/>
-                    </BuilderButtonGroup>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderButtonGroup actionParam="'myParam'">
+                <BuilderButton action="'customAction'"/>
+            </BuilderButtonGroup>
+        `,
+    });
     await setupHTMLBuilder(`
                 <div class="test-options-target">
                     <div class="a">b</div>
@@ -80,22 +77,21 @@ test("should propagate actionParam in the context", async () => {
     expect.verifySteps(["customAction myParam"]);
 });
 test("prevent preview of all buttons", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
-                    <BuilderButtonGroup preview="false">
-                        <BuilderButton action="'customAction1'"/>
-                        <BuilderButton action="'customAction2'" preview="true"/>
-                    </BuilderButtonGroup>
-                    <BuilderButtonGroup preview="true">
-                        <BuilderButton action="'customAction3'"/>
-                    </BuilderButtonGroup>
-                    <BuilderButtonGroup>
-                        <BuilderButton action="'customAction4'"/>
-                    </BuilderButtonGroup>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderButtonGroup preview="false">
+                <BuilderButton action="'customAction1'"/>
+                <BuilderButton action="'customAction2'" preview="true"/>
+            </BuilderButtonGroup>
+            <BuilderButtonGroup preview="true">
+                <BuilderButton action="'customAction3'"/>
+            </BuilderButtonGroup>
+            <BuilderButtonGroup>
+                <BuilderButton action="'customAction4'"/>
+            </BuilderButtonGroup>
+        `,
+    });
     class CustomAction1 extends BuilderAction {
         static id = "customAction1";
         apply() {
@@ -143,22 +139,19 @@ test("prevent preview of all buttons", async () => {
     expect.verifySteps(["customAction4"]);
 });
 test("hide/display base on applyTo", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`<BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`<BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>`,
+    });
 
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`
-                <BuilderButtonGroup applyTo="'.my-custom-class'">
-                    <BuilderButton classAction="'test'">Test</BuilderButton>
-                </BuilderButtonGroup>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`
+            <BuilderButtonGroup applyTo="'.my-custom-class'">
+                <BuilderButton classAction="'test'">Test</BuilderButton>
+            </BuilderButtonGroup>
+        `,
+    });
 
     await setupHTMLBuilder(`<div class="parent-target"><div class="child-target">b</div></div>`);
     await contains(":iframe .parent-target").click();
@@ -169,22 +162,19 @@ test("hide/display base on applyTo", async () => {
 });
 
 test("hide/display base on applyTo - 2", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`<BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`<BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>`,
+    });
 
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`
-                <BuilderButtonGroup>
-                    <BuilderButton applyTo="'.my-custom-class'" classAction="'test'">Test</BuilderButton>
-                </BuilderButtonGroup>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`
+            <BuilderButtonGroup>
+                <BuilderButton applyTo="'.my-custom-class'" classAction="'test'">Test</BuilderButton>
+            </BuilderButtonGroup>
+        `,
+    });
 
     await setupHTMLBuilder(`<div class="parent-target"><div class="child-target">b</div></div>`);
     await contains(":iframe .parent-target").click();
@@ -195,15 +185,15 @@ test("hide/display base on applyTo - 2", async () => {
 });
 
 test("click on BuilderButton with empty value should remove styleAction", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButtonGroup>
-            <BuilderButton styleAction="'width'" styleActionValue="''"/>
-            <BuilderButton styleAction="'width'" styleActionValue="'25%'"/>
-        </BuilderButtonGroup>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderButtonGroup>
+                <BuilderButton styleAction="'width'" styleActionValue="''"/>
+                <BuilderButton styleAction="'width'" styleActionValue="'25%'"/>
+            </BuilderButtonGroup>
+        `,
+    });
     const { contentEl } = await setupHTMLBuilder(`<p class="test-options-target">b</p>`);
     await contains(":iframe .test-options-target").click();
     await contains("[data-style-action='width'][data-style-action-value='25%']").click();
@@ -216,16 +206,16 @@ test("click on BuilderButton with empty value should remove styleAction", async 
 });
 
 test("button that matches with the highest priority should be active", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButtonGroup>
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderButtonGroup>
                 <BuilderButton classAction="'a'" >a</BuilderButton>
                 <BuilderButton classAction="'a b'">a b</BuilderButton>
                 <BuilderButton classAction="'a b c'">a b c</BuilderButton>
-        </BuilderButtonGroup>`;
-        }
-    );
+            </BuilderButtonGroup>
+        `,
+    });
     await setupHTMLBuilder(`<div class="test-options-target a b">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect("[data-class-action='a']").not.toHaveClass("active");
@@ -234,30 +224,26 @@ test("button that matches with the highest priority should be active", async () 
 });
 
 test("BuilderButton: no activation on preview", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
-                <BuilderButtonGroup>
-                    <BuilderButton id="'b1'" classAction="'b1'"/>
-                    <BuilderButton classAction="'b2'"/>
-                </BuilderButtonGroup>
-                <BuilderContext t-if="this.isActiveItem('b1')">
-                </BuilderContext>
-            `;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
-                <BuilderSelect>
-                    <BuilderSelectItem id="'s1'" classAction="'s1'"/>
-                    <BuilderSelectItem classAction="'s2'"/>
-                </BuilderSelect>
-            `;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderButtonGroup>
+                <BuilderButton id="'b1'" classAction="'b1'"/>
+                <BuilderButton classAction="'b2'"/>
+            </BuilderButtonGroup>
+            <BuilderContext t-if="this.isActiveItem('b1')">
+            </BuilderContext>
+        `,
+    });
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderSelect>
+                <BuilderSelectItem id="'s1'" classAction="'s1'"/>
+                <BuilderSelectItem classAction="'s2'"/>
+            </BuilderSelect>
+        `,
+    });
     await setupHTMLBuilder(`<div class="test-options-target s1 b1">Homepage</div>`);
 
     const targetEl = await waitFor(":iframe .test-options-target");

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_checkbox.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_checkbox.test.js
@@ -1,5 +1,4 @@
 import { addBuilderOption, setupHTMLBuilder } from "@html_builder/../tests/helpers";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 import { expect, test, describe } from "@odoo/hoot";
 import { xml } from "@odoo/owl";
 import { contains } from "@web/../tests/web_test_helpers";
@@ -7,12 +6,10 @@ import { contains } from "@web/../tests/web_test_helpers";
 describe.current.tags("desktop");
 
 test("Click on checkbox", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderCheckbox classAction="'checkbox-action'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderCheckbox classAction="'checkbox-action'"/>`,
+    });
     const { getEditableContent } = await setupHTMLBuilder(`<p class="test-options-target">b</p>`);
     const editableContent = getEditableContent();
 
@@ -30,18 +27,14 @@ test("Click on checkbox", async () => {
     expect(editableContent).toHaveInnerHTML(`<p class="test-options-target">b</p>`);
 });
 test("hide/display base on applyTo", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`<BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`<BuilderCheckbox classAction="'checkbox-action'" applyTo="'.my-custom-class'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`<BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>`,
+    });
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`<BuilderCheckbox classAction="'checkbox-action'" applyTo="'.my-custom-class'"/>`,
+    });
     const { getEditableContent } = await setupHTMLBuilder(
         `<div class="parent-target"><p class="child-target b">b</p></div>`
     );
@@ -63,12 +56,10 @@ test("hide/display base on applyTo", async () => {
 });
 
 test("click on BuilderCheckbox with inverseAction", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderCheckbox classAction="'my-custom-class'" inverseAction="true"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderCheckbox classAction="'my-custom-class'" inverseAction="true"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(":iframe .test-options-target").not.toHaveClass("my-custom-class");

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_colorpicker.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_colorpicker.test.js
@@ -5,7 +5,6 @@ import {
     waitForEndOfOperation,
 } from "@html_builder/../tests/helpers";
 import { BuilderAction } from "@html_builder/core/builder_action";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 import { undo } from "@html_editor/../tests/_helpers/user_actions";
 import { before, describe, expect, test } from "@odoo/hoot";
 import { animationFrame, click, hover, press, tick, waitFor } from "@odoo/hoot-dom";
@@ -15,12 +14,10 @@ import { contains } from "@web/../tests/web_test_helpers";
 describe.current.tags("desktop");
 
 test("should apply backgroundColor to the editing element", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderColorPicker enabledTabs="['solid']" styleAction="'background-color'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderColorPicker enabledTabs="['solid']" styleAction="'background-color'"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeDisplayed();
@@ -31,12 +28,10 @@ test("should apply backgroundColor to the editing element", async () => {
 });
 
 test("should apply color to the editing element", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderColorPicker enabledTabs="['solid']" styleAction="'color'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderColorPicker enabledTabs="['solid']" styleAction="'color'"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeDisplayed();
@@ -47,18 +42,14 @@ test("should apply color to the editing element", async () => {
 });
 
 test("hide/display base on applyTo", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`<BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`<BuilderColorPicker applyTo="'.my-custom-class'" styleAction="'background-color'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`<BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>`,
+    });
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`<BuilderColorPicker applyTo="'.my-custom-class'" styleAction="'background-color'"/>`,
+    });
     const { getEditableContent } = await setupHTMLBuilder(
         `<div class="parent-target"><p class="child-target b">b</p></div>`
     );
@@ -79,12 +70,10 @@ test("hide/display base on applyTo", async () => {
 });
 
 test("apply color to a different style than color or backgroundColor", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderColorPicker enabledTabs="['solid']" styleAction="'border-top-color'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderColorPicker enabledTabs="['solid']" styleAction="'border-top-color'"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeDisplayed();
@@ -113,12 +102,10 @@ test("apply custom action", async () => {
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderColorPicker enabledTabs="['solid']" styleAction="'${styleName}'" action="'customAction'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderColorPicker enabledTabs="['solid']" styleAction="'${styleName}'" action="'customAction'"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     await contains(".we-bg-options-container .o_we_color_preview").click();
@@ -141,15 +128,13 @@ test("apply custom async action", async () => {
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
-                <BuilderColorPicker action="'customAction'" enabledTabs="['solid']"/>
-                <BuilderButton classAction="'test'" preview="false"/>
-            `;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderColorPicker action="'customAction'" enabledTabs="['solid']"/>
+            <BuilderButton classAction="'test'" preview="false"/>
+        `,
+    });
     const { getEditor } = await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     const editor = getEditor();
     await contains(":iframe .test-options-target").click();
@@ -174,12 +159,10 @@ test("apply custom async action", async () => {
 });
 
 test("should revert preview on escape", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderColorPicker enabledTabs="['solid']" styleAction="'background-color'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderColorPicker enabledTabs="['solid']" styleAction="'background-color'"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(":iframe .test-options-target").toHaveStyle({ "background-color": "rgba(0, 0, 0, 0)" });
@@ -205,12 +188,10 @@ test("should apply transparent color if no color is defined", async () => {
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderColorPicker action="'customAction'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderColorPicker action="'customAction'"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeDisplayed();
@@ -241,12 +222,10 @@ describe("Custom colorpicker: preview and commit", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderColorPicker action="'customAction'"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderColorPicker action="'customAction'"/>`,
+        });
     });
 
     /****************************************
@@ -353,12 +332,10 @@ describe("Custom colorpicker: preview and commit", () => {
 });
 
 test("should open the last used tab", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderColorPicker styleAction="'background-color'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderColorPicker styleAction="'background-color'"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`, {
         styleContent: ":root { --900: #212527; }",
     });
@@ -408,17 +385,15 @@ test("the color picker opens on click after it has been remounted", async () => 
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
-                <BuilderColorPicker styleAction="'background-color'" applyTo="'.target'"/>
-                <BuilderRow label="'Target'">
-                    <BuilderCheckbox action="'toggleTarget'" />
-                </BuilderRow>
-            `;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderColorPicker styleAction="'background-color'" applyTo="'.target'"/>
+            <BuilderRow label="'Target'">
+                <BuilderCheckbox action="'toggleTarget'" />
+            </BuilderRow>
+        `,
+    });
     const { waitSidebarUpdated } = await setupHTMLBuilder(
         `<div class="test-options-target"><div class="target">Target</div></div>`
     );
@@ -446,18 +421,14 @@ test("the color picker opens on click after it has been remounted", async () => 
 });
 
 test("should work with force and allowImportant params", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderColorPicker styleAction="{ mainParam: 'color', force: true, allowImportant: false }" enabledTabs="['custom']"/>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderColorPicker styleAction="{ mainParam: 'background-color', force: true, allowImportant: true }" enabledTabs="['custom']"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderColorPicker styleAction="{ mainParam: 'color', force: true, allowImportant: false }" enabledTabs="['custom']"/>`,
+    });
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderColorPicker styleAction="{ mainParam: 'background-color', force: true, allowImportant: true }" enabledTabs="['custom']"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
 
     await contains(":iframe .test-options-target").click();

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_context.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_context.test.js
@@ -4,7 +4,6 @@ import {
     setupHTMLBuilder,
 } from "@html_builder/../tests/helpers";
 import { BuilderAction } from "@html_builder/core/builder_action";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 import { expect, test, describe } from "@odoo/hoot";
 import { xml } from "@odoo/owl";
 import { contains } from "@web/../tests/web_test_helpers";
@@ -20,16 +19,14 @@ test("should pass the context", async () => {
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
             <BuilderContext action="'customAction'" actionParam="'myParam'">
                 <BuilderButton actionValue="'myValue'">MyAction</BuilderButton>
             </BuilderContext>
-        `;
-        }
-    );
+        `,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     await contains(".we-bg-options-container button").click();

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_datetimepicker.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_datetimepicker.test.js
@@ -1,5 +1,4 @@
 import { addBuilderOption, setupHTMLBuilder } from "@html_builder/../tests/helpers";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 import { expect, test, describe } from "@odoo/hoot";
 import { queryOne } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
@@ -23,12 +22,10 @@ function isExpectedDateTime({
 }
 
 test("opens DateTimePicker on focus, closes on blur", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderDateTimePicker dataAttributeAction="'date'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderDateTimePicker dataAttributeAction="'date'"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
 
@@ -39,18 +36,14 @@ test("opens DateTimePicker on focus, closes on blur", async () => {
 });
 
 test("defaults to now if undefined", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderDateTimePicker dataAttributeAction="'date'" acceptEmptyDate="false"/>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderCheckbox classAction="'checkbox-action'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderDateTimePicker dataAttributeAction="'date'" acceptEmptyDate="false"/>`,
+    });
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderCheckbox classAction="'checkbox-action'"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
 
@@ -63,12 +56,10 @@ test("defaults to now if undefined", async () => {
 });
 
 test("defaults to last one when invalid date provided", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderDateTimePicker dataAttributeAction="'date'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderDateTimePicker dataAttributeAction="'date'"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target" data-date="1554219400">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".we-bg-options-container input").toHaveValue("04/02/2019 16:36");
@@ -84,12 +75,10 @@ test("defaults to last one when invalid date provided", async () => {
 });
 
 test("defaults to last one when invalid date provided (date)", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderDateTimePicker type="'date'" dataAttributeAction="'date'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderDateTimePicker type="'date'" dataAttributeAction="'date'"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target" data-date="1554219400">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".we-bg-options-container input").toHaveValue("04/02/2019");
@@ -105,12 +94,10 @@ test("defaults to last one when invalid date provided (date)", async () => {
 });
 
 test("defaults to now when no date is selected", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderDateTimePicker dataAttributeAction="'date'" acceptEmptyDate="false"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderDateTimePicker dataAttributeAction="'date'" acceptEmptyDate="false"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     await contains(".we-bg-options-container input").edit("04/01/2019 10:00");
@@ -122,12 +109,10 @@ test("defaults to now when no date is selected", async () => {
 });
 
 test("defaults to now when clicking on clear button", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderDateTimePicker dataAttributeAction="'date'" acceptEmptyDate="false"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderDateTimePicker dataAttributeAction="'date'" acceptEmptyDate="false"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     await contains(".we-bg-options-container input").edit("04/01/2019 10:00");
@@ -143,12 +128,10 @@ test("defaults to now when clicking on clear button", async () => {
 });
 
 test("selects a date and properly applies it", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderDateTimePicker dataAttributeAction="'date'" acceptEmptyDate="false"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderDateTimePicker dataAttributeAction="'date'" acceptEmptyDate="false"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
 
@@ -166,12 +149,10 @@ test("selects a date and properly applies it", async () => {
 });
 
 test("selects a date and synchronize the input field, while still in preview", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderDateTimePicker dataAttributeAction="'date'" acceptEmptyDate="false"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderDateTimePicker dataAttributeAction="'date'" acceptEmptyDate="false"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     await contains(".we-bg-options-container input").click();
@@ -187,12 +168,10 @@ test("selects a date and synchronize the input field, while still in preview", a
 });
 
 test("edit a date with the datetime picker should correctly apply the mutation", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderDateTimePicker dataAttributeAction="'date'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderDateTimePicker dataAttributeAction="'date'"/>`,
+    });
     await setupHTMLBuilder(`
         <div class="test-options-target" data-date="1554219400">b</div>
         <div class="another-target">c</div>`);

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_list.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_list.test.js
@@ -4,7 +4,6 @@ import {
     setupHTMLBuilder,
 } from "@html_builder/../tests/helpers";
 import { BuilderAction } from "@html_builder/core/builder_action";
-import { BuilderList } from "@html_builder/core/building_blocks/builder_list";
 import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 import { expect, test, describe } from "@odoo/hoot";
 import { onError, xml } from "@odoo/owl";
@@ -22,16 +21,16 @@ function defaultValueWithIds(ids) {
 }
 
 test("writes a list of numbers to a data attribute", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderList
-                          dataAttributeAction="'list'"
-                          itemShape="{ value: 'number', title: 'text' }"
-                          default="${defaultValueStr}"
-                      />`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderList
+                dataAttributeAction="'list'"
+                itemShape="{ value: 'number', title: 'text' }"
+                default="${defaultValueStr}"
+            />
+        `,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
 
@@ -55,16 +54,16 @@ test("writes a list of numbers to a data attribute", async () => {
 });
 
 test("supports arbitrary number of text and number inputs on entries", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderList
-                          dataAttributeAction="'list'"
-                          itemShape="{ a: 'number', b: 'text', c: 'text', d: 'number' }"
-                          default="{ a: '4', b: '3', c: '2', d: '1' }"
-                      />`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderList
+                dataAttributeAction="'list'"
+                itemShape="{ a: 'number', b: 'text', c: 'text', d: 'number' }"
+                default="{ a: '4', b: '3', c: '2', d: '1' }"
+            />
+        `,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     await contains(".we-bg-options-container .builder_list_add_item").click();
@@ -85,16 +84,16 @@ test("supports arbitrary number of text and number inputs on entries", async () 
 });
 
 test("delete an item", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderList
-                          dataAttributeAction="'list'"
-                          itemShape="{ value: 'number', title: 'text' }"
-                          default="${defaultValueStr}"
-                      />`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderList
+                dataAttributeAction="'list'"
+                itemShape="{ value: 'number', title: 'text' }"
+                default="${defaultValueStr}"
+            />
+        `,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
 
@@ -108,16 +107,16 @@ test("delete an item", async () => {
 });
 
 test("reorder items", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderList
-                          dataAttributeAction="'list'"
-                          itemShape="{ value: 'number', title: 'text' }"
-                          default="${defaultValueStr}"
-                      />`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderList
+                dataAttributeAction="'list'"
+                itemShape="{ value: 'number', title: 'text' }"
+                default="${defaultValueStr}"
+            />
+        `,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
 
@@ -157,7 +156,6 @@ test("reorder items", async () => {
 async function testBuilderListFaultyProps(template) {
     class Test extends BaseOptionComponent {
         static template = xml`${template}`;
-        static components = { BuilderList };
         static props = ["*"];
         setup() {
             onError(() => {
@@ -165,11 +163,10 @@ async function testBuilderListFaultyProps(template) {
             });
         }
     }
-    addBuilderOption(
-        class extends Test {
-            static selector = ".test-options-target";
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        Component: Test,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect.verifySteps(["threw"]);
@@ -215,17 +212,17 @@ test("throws error if itemShape contains reserved key '_id'", async () => {
 });
 
 test("hides hiddenProperties from options", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderList
-                          dataAttributeAction="'list'"
-                          itemShape="{ a: 'number', b: 'text', c: 'number', d: 'text' }"
-                          default="{ a: '4', b: 'three', c: '2', d: 'one' }"
-                          hiddenProperties="['b', 'c']"
-                      />`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderList
+                dataAttributeAction="'list'"
+                itemShape="{ a: 'number', b: 'text', c: 'number', d: 'text' }"
+                default="{ a: '4', b: 'three', c: '2', d: 'one' }"
+                hiddenProperties="['b', 'c']"
+            />
+        `,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
 
@@ -266,7 +263,6 @@ test("do not lose id when adjusting 'selected'", async () => {
                 itemShape="{ display_name: 'text', selected: 'boolean' }"
                 default="{ display_name: 'Extra', selected: false }"
                 records="availableRecords" />`;
-        static components = { BuilderList };
         static props = ["*"];
         setup() {
             this.availableRecords = JSON.stringify([
@@ -275,11 +271,10 @@ test("do not lose id when adjusting 'selected'", async () => {
             ]);
         }
     }
-    addBuilderOption(
-        class extends Test {
-            static selector = ".test-options-target";
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        Component: Test,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
 
@@ -349,7 +344,6 @@ test("can add item with string and integer ids", async () => {
                 itemShape="{ display_name: 'text', selected: 'boolean' }"
                 default="{ display_name: 'Extra', selected: false }"
                 records="availableRecords" />`;
-        static components = { BuilderList };
         static props = ["*"];
         setup() {
             this.availableRecords = JSON.stringify([
@@ -364,11 +358,10 @@ test("can add item with string and integer ids", async () => {
             ]);
         }
     }
-    addBuilderOption(
-        class extends Test {
-            static selector = ".test-options-target";
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        Component: Test,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
 
@@ -403,16 +396,15 @@ test("not editable builder list option", async () => {
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
+    addBuilderOption({
+        selector: ".test-options-target",
+        Component: class extends BaseOptionComponent {
             static template = xml`
                 <BuilderList
                     action="'customAction'"
                     addItemTitle="'Add'"
                     itemShape="{ display_name: 'text', selected: 'boolean' }"
                     isEditable="false"/>`;
-            static components = { BuilderList };
             static props = ["*"];
             setup() {
                 this.availableRecords = JSON.stringify([
@@ -420,8 +412,8 @@ test("not editable builder list option", async () => {
                     { id: 2, display_name: "B" },
                 ]);
             }
-        }
-    );
+        },
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".we-bg-options-container .builder_list_add_item").toHaveCount(0);

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_many2many.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_many2many.test.js
@@ -9,7 +9,6 @@ import { animationFrame } from "@odoo/hoot-mock";
 import { xml } from "@odoo/owl";
 import { contains, defineModels, fields, models, onRpc } from "@web/../tests/web_test_helpers";
 import { delay } from "@web/core/utils/concurrency";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 
 class Test extends models.Model {
     _name = "test";
@@ -36,12 +35,10 @@ test("many2many: find tag, select tag, unselect tag", async () => {
             expect(kwargs.domain).toEqual([["id", "not in", [1]]]);
         }
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderMany2Many dataAttributeAction="'test'" model="'test'" limit="10"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderMany2Many dataAttributeAction="'test'" model="'test'" limit="10"/>`,
+    });
     const { getEditableContent } = await setupHTMLBuilder(
         `<div class="test-options-target">b</div>`
     );
@@ -108,12 +105,10 @@ test("many2many: async load", async () => {
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderMany2Many action="'testAction'" model="'test'" limit="10"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderMany2Many action="'testAction'" model="'test'" limit="10"/>`,
+    });
     const { getEditableContent } = await setupHTMLBuilder(
         `<div class="test-options-target">b</div>`
     );

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_many2one.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_many2one.test.js
@@ -52,12 +52,10 @@ test("many2one: async load", async () => {
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderMany2One action="'testAction'" model="'test'" limit="10"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderMany2One action="'testAction'" model="'test'" limit="10"/>`,
+    });
     const { getEditableContent } = await setupHTMLBuilder(
         `<div class="test-options-target">b</div>`
     );
@@ -98,7 +96,6 @@ test("dependency definition should not be outdated", async () => {
         },
     });
     class TestMany2One extends BaseOptionComponent {
-        static selector = ".test-options-target";
         static template = xml`
             <BuilderMany2One action="'testAction'" model="'test'" limit="10" id="'test_many2one_opt'"/>
             <BuilderRow t-if="getItemValueJSON('test_many2one_opt')?.id === 2"><span>Dependant</span></BuilderRow>
@@ -112,7 +109,10 @@ test("dependency definition should not be outdated", async () => {
             return value && JSON.parse(value);
         }
     }
-    addBuilderOption(TestMany2One);
+    addBuilderOption({
+        selector: ".test-options-target",
+        Component: TestMany2One,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
 
     await contains(":iframe .test-options-target").click();
@@ -148,12 +148,10 @@ test("BuilderMany2One: add null_text option in website builder dropdown", async 
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderMany2One action="'testAction'" model="'test'" limit="10" nullText="'Remote'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderMany2One action="'testAction'" model="'test'" limit="10" nullText="'Remote'"/>`,
+    });
     const { getEditableContent } = await setupHTMLBuilder(`
         <div class="test-options-target">b</div>
     `);

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_number_input.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_number_input.test.js
@@ -18,7 +18,6 @@ import {
 } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
 import { contains, defineModels, models } from "@web/../tests/web_test_helpers";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 
 describe.current.tags("desktop");
 
@@ -34,12 +33,10 @@ test("should get the initial value of the input", async () => {
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderNumberInput action="'customAction'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderNumberInput action="'customAction'"/>`,
+    });
     await setupHTMLBuilder(`
                 <div class="test-options-target">10</div>
             `);
@@ -49,18 +46,14 @@ test("should get the initial value of the input", async () => {
     expect(input).toHaveValue(10);
 });
 test("hide/display base on applyTo", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`<BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`<BuilderNumberInput applyTo="'.my-custom-class'" action="'customAction'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`<BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>`,
+    });
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`<BuilderNumberInput applyTo="'.my-custom-class'" action="'customAction'"/>`,
+    });
     addBuilderAction({
         customAction: class extends BuilderAction {
             static id = "customAction";
@@ -90,12 +83,10 @@ test("hide/display base on applyTo", async () => {
     expect("[data-action-id='customAction'] input").toHaveValue(10);
 });
 test("input with classAction and styleAction", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderNumberInput classAction="'testAction'" styleAction="'--custom-property'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderNumberInput classAction="'testAction'" styleAction="'--custom-property'"/>`,
+    });
     await setupHTMLBuilder(`
                 <div class="test-options-target">10</div>
             `);
@@ -120,12 +111,10 @@ test("input kept on async action", async () => {
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderNumberInput action="'customAction'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderNumberInput action="'customAction'"/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target" data-test="1">Hello</div>`);
     await contains(":iframe .test-options-target").click();
     await contains(".options-container input").edit("2");
@@ -150,18 +139,14 @@ test("input should remove invalid char", async () => {
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderNumberInput action="'customAction'"/>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target-composable";
-            static template = xml`<BuilderNumberInput action="'customAction'" composable="true"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderNumberInput action="'customAction'"/>`,
+    });
+    addBuilderOption({
+        selector: ".test-options-target-composable",
+        template: xml`<BuilderNumberInput action="'customAction'" composable="true"/>`,
+    });
     await setupHTMLBuilder(
         `<div class="test-options-target" data-test="1">Hello</div><div class="test-options-target-composable" data-test="2">World</div>`
     );
@@ -206,18 +191,14 @@ test("should select input value on focus only if selectTextOnFocus prop is set",
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target-1";
-            static template = xml`<BuilderNumberInput action="'customAction'" selectTextOnFocus="true"/>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target-2";
-            static template = xml`<BuilderNumberInput action="'customAction'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target-1",
+        template: xml`<BuilderNumberInput action="'customAction'" selectTextOnFocus="true"/>`,
+    });
+    addBuilderOption({
+        selector: ".test-options-target-2",
+        template: xml`<BuilderNumberInput action="'customAction'"/>`,
+    });
     await setupHTMLBuilder(`
                 <div class="test-options-target-1">10</div>
                 <div class="test-options-target-2">10</div>
@@ -244,12 +225,10 @@ describe("default value", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput action="'customAction'" default="20"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customAction'" default="20"/>`,
+        });
         await setupHTMLBuilder(`
             <div class="test-options-target">10</div>
         `);
@@ -270,12 +249,10 @@ describe("default value", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput action="'customAction'" />`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customAction'" />`,
+        });
         await setupHTMLBuilder(`
                     <div class="test-options-target">10</div>
                 `);
@@ -302,12 +279,10 @@ describe("default value", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput action="'customAction'" default="1"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customAction'" default="1"/>`,
+        });
         await setupHTMLBuilder(`
                     <div class="test-options-target">10</div>
                 `);
@@ -335,12 +310,10 @@ describe("default value", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput action="'customAction'" default="null"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customAction'" default="null"/>`,
+        });
         await setupHTMLBuilder(`
                     <div class="test-options-target">10</div>
                 `);
@@ -372,12 +345,10 @@ describe("operations", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput action="'customAction'"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customAction'"/>`,
+        });
         await setupHTMLBuilder(`
                     <div class="test-options-target">10</div>
                 `);
@@ -403,12 +374,10 @@ describe("operations", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput action="'customAction'"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customAction'"/>`,
+        });
         await setupHTMLBuilder(`
                     <div class="test-options-target">10</div>
                 `);
@@ -437,12 +406,10 @@ describe("operations", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput action="'customAction'"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customAction'"/>`,
+        });
         await setupHTMLBuilder(`
                     <div class="test-options-target">10</div>
                 `);
@@ -475,12 +442,10 @@ describe("operations", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput action="'customAction'" preview="false"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customAction'" preview="false"/>`,
+        });
         await setupHTMLBuilder(`
                     <div class="test-options-target">10</div>
                 `);
@@ -507,12 +472,10 @@ describe("keyboard triggers", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput action="'customAction'" step="2"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customAction'" step="2"/>`,
+        });
         await setupHTMLBuilder(`
             <div class="test-options-target">10</div>
         `);
@@ -543,12 +506,10 @@ describe("keyboard triggers", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput action="'customAction'" composable="true"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customAction'" composable="true"/>`,
+        });
         await setupHTMLBuilder(`
             <div class="test-options-target">10 4 0</div>
         `);
@@ -579,12 +540,10 @@ describe("keyboard triggers", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput action="'customAction'" />`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customAction'" />`,
+        });
         await setupHTMLBuilder(`<div class="test-options-target">Non empty div.</div>`);
         await contains(":iframe .test-options-target").click();
         await click("[data-action-id='customAction'] input");
@@ -607,12 +566,10 @@ describe("keyboard triggers", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput action="'customAction'" />`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customAction'" />`,
+        });
         await setupHTMLBuilder(`<div class="test-options-target">Non empty div.</div>`);
         await contains(":iframe .test-options-target").click();
         await click("[data-action-id='customAction'] input");
@@ -638,12 +595,10 @@ describe("keyboard triggers", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput action="'customAction'"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customAction'"/>`,
+        });
         await setupHTMLBuilder(`
             <div class="test-options-target">10</div>
         `);
@@ -678,12 +633,10 @@ describe("unit & saveUnit", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput action="'customAction'" unit="'px'"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customAction'" unit="'px'"/>`,
+        });
         await setupHTMLBuilder(`
                     <div class="test-options-target">5px</div>
                 `);
@@ -709,12 +662,10 @@ describe("unit & saveUnit", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput action="'customAction'" unit="'s'" saveUnit="'ms'"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customAction'" unit="'s'" saveUnit="'ms'"/>`,
+        });
         await setupHTMLBuilder(`
                     <div class="test-options-target">5000ms</div>
                 `);
@@ -736,12 +687,10 @@ describe("unit & saveUnit", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput action="'customAction'" unit="'s'" saveUnit="'ms'"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customAction'" unit="'s'" saveUnit="'ms'"/>`,
+        });
         // note that 5000 has no unit of measure
         await setupHTMLBuilder(`
                     <div class="test-options-target">5000</div>
@@ -765,12 +714,10 @@ describe("unit & saveUnit", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput action="'customAction'" unit="'px'" saveUnit="''"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customAction'" unit="'px'" saveUnit="''"/>`,
+        });
         await setupHTMLBuilder(`
                     <div class="test-options-target">5</div>
                 `);
@@ -796,12 +743,10 @@ describe("unit & saveUnit", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput action="'customAction'" unit="'s'" saveUnit="'ms'"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customAction'" unit="'s'" saveUnit="'ms'"/>`,
+        });
         await setupHTMLBuilder(`
                     <div class="test-options-target">5s</div>
                 `);
@@ -841,18 +786,14 @@ describe("unit & saveUnit", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput action="'customActionText'" unit="'px'" placeholder="'placeholder'" default="null"/>`;
-            }
-        );
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderButton action="'customActionButton'">Empty</BuilderButton>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customActionText'" unit="'px'" placeholder="'placeholder'" default="null"/>`,
+        });
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderButton action="'customActionButton'">Empty</BuilderButton>`,
+        });
         await setupHTMLBuilder(`
                     <div class="test-options-target">5px</div>
                 `);
@@ -922,12 +863,10 @@ describe("unit & saveUnit", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput action="'customAction'" unit="'px'"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customAction'" unit="'px'"/>`,
+        });
         await setupHTMLBuilder(`
                     <div class="test-options-target">5px</div>
                 `);
@@ -969,12 +908,10 @@ describe("sanitized values", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput action="'customAction'"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customAction'"/>`,
+        });
         await setupHTMLBuilder(`
             <div class="test-options-target">10</div>
         `);
@@ -995,12 +932,10 @@ describe("sanitized values", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput action="'customAction'" min="0"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customAction'" min="0"/>`,
+        });
         await setupHTMLBuilder(`
             <div class="test-options-target">10</div>
         `);
@@ -1022,12 +957,10 @@ describe("sanitized values", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput action="'customAction'" min="1"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customAction'" min="1"/>`,
+        });
         await setupHTMLBuilder(`
             <div class="test-options-target">2</div>
         `);
@@ -1055,12 +988,10 @@ describe("sanitized values", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput action="'customAction'" max="10"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customAction'" max="10"/>`,
+        });
         await setupHTMLBuilder(`
             <div class="test-options-target">3</div>
         `);
@@ -1082,12 +1013,10 @@ describe("sanitized values", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput action="'customAction'" composable="true"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput action="'customAction'" composable="true"/>`,
+        });
         await setupHTMLBuilder(`
             <div class="test-options-target">10</div>
         `);
@@ -1097,12 +1026,10 @@ describe("sanitized values", () => {
         expect(".options-container input").toHaveValue("3 4 5");
     });
     test("after input, displayed value is cleaned to match only numbers", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput dataAttributeAction="'number'"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput dataAttributeAction="'number'"/>`,
+        });
         await setupHTMLBuilder(`
             <div class="test-options-target" data-number="10">Test</div>
         `);
@@ -1112,12 +1039,10 @@ describe("sanitized values", () => {
         expect(":iframe .test-options-target").toHaveAttribute("data-number", "0");
     });
     test("after input, displayed value is cleaned to match only numbers (default=null)", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput dataAttributeAction="'number'" default="null"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput dataAttributeAction="'number'" default="null"/>`,
+        });
         await setupHTMLBuilder(`
             <div class="test-options-target" data-number="10">Test</div>
         `);
@@ -1127,12 +1052,10 @@ describe("sanitized values", () => {
         expect(":iframe .test-options-target").not.toHaveAttribute("data-number");
     });
     test("after copy / pasting, displayed value is cleaned to match only numbers (non-composable)", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput dataAttributeAction="'number'"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput dataAttributeAction="'number'"/>`,
+        });
         await setupHTMLBuilder(`
             <div class="test-options-target" data-number="10">Test</div>
         `);
@@ -1142,12 +1065,10 @@ describe("sanitized values", () => {
         expect(":iframe .test-options-target").toHaveAttribute("data-number", 0);
     });
     test("after copy / pasting, displayed value is cleaned to match only numbers (composable)", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput dataAttributeAction="'number'" composable="true"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput dataAttributeAction="'number'" composable="true"/>`,
+        });
         await setupHTMLBuilder(`
             <div class="test-options-target" data-number="10">Test</div>
         `);
@@ -1157,12 +1078,10 @@ describe("sanitized values", () => {
         expect(":iframe .test-options-target").toHaveAttribute("data-number", -3);
     });
     test("accept decimal numbers", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput dataAttributeAction="'number'"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput dataAttributeAction="'number'"/>`,
+        });
         await setupHTMLBuilder(`
             <div class="test-options-target" data-number="10">Test</div>
         `);
@@ -1172,12 +1091,10 @@ describe("sanitized values", () => {
         expect(":iframe .test-options-target").toHaveAttribute("data-number", "3.3");
     });
     test("BuilderNumberInput transforms , into . (composable)", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput dataAttributeAction="'number'" composable="true"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput dataAttributeAction="'number'" composable="true"/>`,
+        });
         await setupHTMLBuilder(`
             <div class="test-options-target" data-number="10">Test</div>
         `);
@@ -1187,12 +1104,10 @@ describe("sanitized values", () => {
         expect(":iframe .test-options-target").toHaveAttribute("data-number", "3.3");
     });
     test("displays the correct value (no floating point precision error)", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput dataAttributeAction="'number'" step="0.1"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput dataAttributeAction="'number'" step="0.1"/>`,
+        });
         await setupHTMLBuilder(`
             <div class="test-options-target" data-number="10">Test</div>
         `);
@@ -1208,12 +1123,10 @@ describe("sanitized values", () => {
         expect(".options-container input").toHaveValue(0.2);
     });
     test("rounds the number to 3 decimals", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput dataAttributeAction="'number'"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput dataAttributeAction="'number'"/>`,
+        });
         await setupHTMLBuilder(`
             <div class="test-options-target" data-number="10">Test</div>
         `);
@@ -1232,12 +1145,10 @@ describe("sanitized values", () => {
             make_scss_customization() {}
         }
         defineModels([WebEditorAssets]);
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderNumberInput dataAttributeAction="'number'" unit="'px'" saveUnit="'rem'"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderNumberInput dataAttributeAction="'number'" unit="'px'" saveUnit="'rem'"/>`,
+        });
         await setupHTMLBuilder(`<div class="test-options-target">Test</div>`);
         await contains(":iframe .test-options-target").click();
         await contains(".options-container input").edit("19");

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_range.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_range.test.js
@@ -10,7 +10,6 @@ import { expect, test, describe } from "@odoo/hoot";
 import { advanceTime, animationFrame, click, edit, fill, freezeTime, press } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
 import { contains, patchWithCleanup } from "@web/../tests/web_test_helpers";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 
 describe.current.tags("desktop");
 
@@ -27,12 +26,10 @@ test("should commit changes", async () => {
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderRange action="'customAction'" displayRangeValue="true"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderRange action="'customAction'" displayRangeValue="true"/>`,
+    });
     await setupHTMLBuilder(`
         <div class="test-options-target">10</div>
     `);
@@ -62,18 +59,14 @@ test("range input should step up or down with arrow keys", async () => {
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-integer-step";
-            static template = xml`<BuilderRange action="'customAction'" step="2" displayRangeValue="true"/>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-fractional-step";
-            static template = xml`<BuilderRange action="'customAction'" step="0.15" displayRangeValue="true"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-integer-step",
+        template: xml`<BuilderRange action="'customAction'" step="2" displayRangeValue="true"/>`,
+    });
+    addBuilderOption({
+        selector: ".test-fractional-step",
+        template: xml`<BuilderRange action="'customAction'" step="0.15" displayRangeValue="true"/>`,
+    });
     await setupHTMLBuilder(`
         <div class="test-integer-step">10</div>
         <div class="test-fractional-step">14.85</div>
@@ -158,12 +151,10 @@ test("keeping an arrow key pressed should commit only once", async () => {
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderRange action="'customAction'" step="2" displayRangeValue="true"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderRange action="'customAction'" step="2" displayRangeValue="true"/>`,
+    });
     freezeTime();
     await setupHTMLBuilder(`
         <div class="test-options-target">10</div>
@@ -201,12 +192,10 @@ test("should syncronize previews", async () => {
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderRange withNumberInput="true" action="'customAction'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderRange withNumberInput="true" action="'customAction'"/>`,
+    });
     await setupHTMLBuilder(`
         <div class="test-options-target">10</div>
     `);
@@ -259,12 +248,10 @@ describe("unit & saveUnit", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderRange action="'customAction'" unit="'px'"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderRange action="'customAction'" unit="'px'"/>`,
+        });
         await setupHTMLBuilder(`
                     <div class="test-options-target">5px</div>
                 `);
@@ -289,12 +276,10 @@ describe("unit & saveUnit", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderRange action="'customAction'" unit="'s'" saveUnit="'ms'"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderRange action="'customAction'" unit="'s'" saveUnit="'ms'"/>`,
+        });
         await setupHTMLBuilder(`
                     <div class="test-options-target">5000ms</div>
                 `);
@@ -316,12 +301,10 @@ describe("unit & saveUnit", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderRange action="'customAction'" unit="'s'" saveUnit="'ms'"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderRange action="'customAction'" unit="'s'" saveUnit="'ms'"/>`,
+        });
         // note that 5000 has no unit of measure
         await setupHTMLBuilder(`
                     <div class="test-options-target">5000</div>
@@ -344,12 +327,10 @@ describe("unit & saveUnit", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderRange action="'customAction'" unit="'px'" saveUnit="''"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderRange action="'customAction'" unit="'px'" saveUnit="''"/>`,
+        });
         await setupHTMLBuilder(`
                     <div class="test-options-target">5</div>
                 `);
@@ -375,12 +356,10 @@ describe("unit & saveUnit", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderRange action="'customAction'" unit="'s'" saveUnit="'ms'"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderRange action="'customAction'" unit="'s'" saveUnit="'ms'"/>`,
+        });
         await setupHTMLBuilder(`
                     <div class="test-options-target">5s</div>
                 `);

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_row.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_row.test.js
@@ -1,6 +1,5 @@
 import { addBuilderOption, setupHTMLBuilder } from "@html_builder/../tests/helpers";
 import { refreshSublevelLines } from "@html_builder/core/building_blocks/builder_row";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 import { describe, expect, test } from "@odoo/hoot";
 import {
     advanceTime,
@@ -26,24 +25,20 @@ function reapplyCollapseTransition() {
 describe.current.tags("desktop");
 
 test("show row title", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderRow label="'my label'">row text</BuilderRow>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderRow label="'my label'">row text</BuilderRow>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeVisible();
     expect(".hb-row .text-nowrap").toHaveText("my label");
 });
 test("show row tooltip", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderRow label="'my label'" tooltip="'my tooltip'">row text</BuilderRow>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderRow label="'my label'" tooltip="'my tooltip'">row text</BuilderRow>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeVisible();
@@ -57,30 +52,30 @@ test("show row tooltip", async () => {
     expect(".o-tooltip").not.toHaveCount();
 });
 test("hide empty row and display row with content", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`<BuilderRow label="'Row 1'">
-                        <BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>
-                    </BuilderRow>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`<BuilderRow label="'Row 2'">
-                        <BuilderButton applyTo="':not(.my-custom-class)'" classAction="'test'"/>
-                    </BuilderRow>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`<BuilderRow label="'Row 3'">
-                        <BuilderButton applyTo="'.my-custom-class'" classAction="'test'"/>
-                    </BuilderRow>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`
+            <BuilderRow label="'Row 1'">
+                <BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>
+            </BuilderRow>
+        `,
+    });
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`
+            <BuilderRow label="'Row 2'">
+                <BuilderButton applyTo="':not(.my-custom-class)'" classAction="'test'"/>
+            </BuilderRow>
+        `,
+    });
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`
+            <BuilderRow label="'Row 3'">
+                <BuilderButton applyTo="'.my-custom-class'" classAction="'test'"/>
+            </BuilderRow>
+        `,
+    });
     await setupHTMLBuilder(`<div class="parent-target"><div class="child-target">b</div></div>`);
     const selectorRowLabel = ".options-container .hb-row:not(.d-none) .hb-row-label";
     await contains(":iframe .parent-target").click();
@@ -91,26 +86,25 @@ test("hide empty row and display row with content", async () => {
 });
 
 test("reconnects lines across mixed levels", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
-                <div class="options-container">
-                    <BuilderRow label="'root-1'">root-1</BuilderRow>
-                    <BuilderRow label="'level-1'" level="1">A</BuilderRow>
-                    <BuilderRow label="'level-2'" level="2">B</BuilderRow>
-                    <BuilderRow label="'level-1'" level="1">C</BuilderRow>
-                    <BuilderRow label="'root-2'">root-2</BuilderRow>
-                    <BuilderRow label="'level-1'" level="1">D</BuilderRow>
-                    <BuilderRow label="'level-2'" level="2">E</BuilderRow>
-                    <BuilderRow label="'level-2'" level="2">F</BuilderRow>
-                    <BuilderRow label="'level-3'" level="3">G</BuilderRow>
-                    <BuilderRow label="'level-3'" level="3">H</BuilderRow>
-                    <BuilderRow label="'level-2'" level="2">I</BuilderRow>
-                    <BuilderRow label="'level-1'" level="1">J</BuilderRow>
-                </div>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <div class="options-container">
+                <BuilderRow label="'root-1'">root-1</BuilderRow>
+                <BuilderRow label="'level-1'" level="1">A</BuilderRow>
+                <BuilderRow label="'level-2'" level="2">B</BuilderRow>
+                <BuilderRow label="'level-1'" level="1">C</BuilderRow>
+                <BuilderRow label="'root-2'">root-2</BuilderRow>
+                <BuilderRow label="'level-1'" level="1">D</BuilderRow>
+                <BuilderRow label="'level-2'" level="2">E</BuilderRow>
+                <BuilderRow label="'level-2'" level="2">F</BuilderRow>
+                <BuilderRow label="'level-3'" level="3">G</BuilderRow>
+                <BuilderRow label="'level-3'" level="3">H</BuilderRow>
+                <BuilderRow label="'level-2'" level="2">I</BuilderRow>
+                <BuilderRow label="'level-1'" level="1">J</BuilderRow>
+            </div>
+        `,
+    });
 
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
@@ -165,12 +159,10 @@ const collapseOptionTemplate = ({
 
 describe("BuilderRow with collapse content", () => {
     test("expand=false is collapsed by default", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = collapseOptionTemplate();
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: collapseOptionTemplate(),
+        });
         await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
         await contains(":iframe .test-options-target").click();
         expect(".options-container").toBeVisible();
@@ -178,12 +170,10 @@ describe("BuilderRow with collapse content", () => {
     });
 
     test("expand=true is expanded by default", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = collapseOptionTemplate({ dependency: false, expand: true });
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: collapseOptionTemplate({ dependency: false, expand: true }),
+        });
         await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
         await contains(":iframe .test-options-target").click();
         expect(".options-container").toBeVisible();
@@ -192,15 +182,13 @@ describe("BuilderRow with collapse content", () => {
     });
 
     test("Toggler button is not visible if no dependency is active", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = collapseOptionTemplate({
-                    dependency: true,
-                    observeCollapseContent: true,
-                });
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: collapseOptionTemplate({
+                dependency: true,
+                observeCollapseContent: true,
+            }),
+        });
         await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
         await contains(":iframe .test-options-target").click();
         expect(".options-container").toBeVisible();
@@ -208,12 +196,10 @@ describe("BuilderRow with collapse content", () => {
     });
 
     test("expand=true works when a dependency becomes active", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = collapseOptionTemplate({ dependency: true, expand: true });
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: collapseOptionTemplate({ dependency: true, expand: true }),
+        });
         await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
         await contains(":iframe .test-options-target").click();
         expect(".options-container").toBeVisible();
@@ -225,26 +211,25 @@ describe("BuilderRow with collapse content", () => {
     });
 
     test("Collapse works with several dependencies", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`
-                    <BuilderRow label="'Test Collapse'" expand="true">
-                        <BuilderSelect>
-                            <BuilderSelectItem classAction="'a'" id="'test_opt'">A</BuilderSelectItem>
-                            <BuilderSelectItem classAction="'c'" id="'random_opt'">C</BuilderSelectItem>
-                        </BuilderSelect>
-                        <t t-set-slot="collapse">
-                            <BuilderRow level="1" t-if="isActiveItem('test_opt')" label="'B'">
-                                <BuilderButton classAction="'b'">B</BuilderButton>
-                            </BuilderRow>
-                            <BuilderRow level="1" t-if="isActiveItem('random_opt')" label="'D'">
-                                <BuilderButton classAction="'d'">D</BuilderButton>
-                            </BuilderRow>
-                        </t>
-                    </BuilderRow>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`
+                <BuilderRow label="'Test Collapse'" expand="true">
+                    <BuilderSelect>
+                        <BuilderSelectItem classAction="'a'" id="'test_opt'">A</BuilderSelectItem>
+                        <BuilderSelectItem classAction="'c'" id="'random_opt'">C</BuilderSelectItem>
+                    </BuilderSelect>
+                    <t t-set-slot="collapse">
+                        <BuilderRow level="1" t-if="isActiveItem('test_opt')" label="'B'">
+                            <BuilderButton classAction="'b'">B</BuilderButton>
+                        </BuilderRow>
+                        <BuilderRow level="1" t-if="isActiveItem('random_opt')" label="'D'">
+                            <BuilderButton classAction="'d'">D</BuilderButton>
+                        </BuilderRow>
+                    </t>
+                </BuilderRow>
+            `,
+        });
         await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
         await contains(":iframe .test-options-target").click();
         expect(".options-container").toBeVisible();
@@ -265,12 +250,10 @@ describe("BuilderRow with collapse content", () => {
 
     test("Click on toggler collapses / expands the BuilderRow", async () => {
         reapplyCollapseTransition();
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = collapseOptionTemplate();
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: collapseOptionTemplate(),
+        });
         await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
         await contains(":iframe .test-options-target").click();
         expect(".options-container").toBeVisible();
@@ -287,12 +270,10 @@ describe("BuilderRow with collapse content", () => {
     });
 
     test("Click on toggler collapses / expands the BuilderRow (with observeCollapseContent)", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = collapseOptionTemplate({ observeCollapseContent: true });
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: collapseOptionTemplate({ observeCollapseContent: true }),
+        });
         await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
         await contains(":iframe .test-options-target").click();
         expect(".options-container").toBeVisible();
@@ -310,12 +291,10 @@ describe("BuilderRow with collapse content", () => {
 
     test("Click header row's label collapses / expands the BuilderRow", async () => {
         reapplyCollapseTransition();
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = collapseOptionTemplate();
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: collapseOptionTemplate(),
+        });
         await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
         await contains(":iframe .test-options-target").click();
         expect(".options-container").toBeVisible();
@@ -332,12 +311,10 @@ describe("BuilderRow with collapse content", () => {
     });
 
     test("Click header row's label collapses / expands the BuilderRow (with observeCollapseContent)", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = collapseOptionTemplate({ observeCollapseContent: true });
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: collapseOptionTemplate({ observeCollapseContent: true }),
+        });
         await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
         await contains(":iframe .test-options-target").click();
         expect(".options-container").toBeVisible();
@@ -354,18 +331,14 @@ describe("BuilderRow with collapse content", () => {
     });
 
     test("Two BuilderRows with collapse content on the same option are toggled independently", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = collapseOptionTemplate({ dependency: true, expand: true });
-            }
-        );
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = collapseOptionTemplate();
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: collapseOptionTemplate({ dependency: true, expand: true }),
+        });
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: collapseOptionTemplate(),
+        });
         await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
         await contains(":iframe .test-options-target").click();
         expect(".options-container").toBeVisible();
@@ -388,12 +361,10 @@ describe("BuilderRow with collapse content", () => {
 describe.tags("desktop");
 describe("HTML builder tests", () => {
     test("add tooltip when label is too long", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderRow label="'Supercalifragilisticexpalidocious'">Palais chatouille</BuilderRow>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderRow label="'Supercalifragilisticexpalidocious'">Palais chatouille</BuilderRow>`,
+        });
         await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
         await contains(":iframe .test-options-target").click();
         await hover("[data-label='Supercalifragilisticexpalidocious'] .text-truncate");

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_select_item.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_select_item.test.js
@@ -17,7 +17,6 @@ import {
 } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
 import { contains } from "@web/../tests/web_test_helpers";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 
 describe.current.tags("desktop");
 
@@ -30,15 +29,14 @@ test("call a specific action with some params and value (BuilderSelectItem)", as
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
-                <BuilderSelect>
-                    <BuilderSelectItem action="'customAction'" actionParam="'myParam'" actionValue="'myValue'">MyAction</BuilderSelectItem>
-                </BuilderSelect>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderSelect>
+                <BuilderSelectItem action="'customAction'" actionParam="'myParam'" actionValue="'myValue'">MyAction</BuilderSelectItem>
+            </BuilderSelect>
+        `,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeVisible();
@@ -51,17 +49,16 @@ test("call a specific action with some params and value (BuilderSelectItem)", as
     expect.verifySteps(["customAction myParam myValue", "customAction myParam myValue"]);
 });
 test("set the label of the select from the active select item and be updated on undo/redo", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
-                <BuilderSelect attributeAction="'customAttribute'">
-                    <BuilderSelectItem attributeActionValue="null">None</BuilderSelectItem>
-                    <BuilderSelectItem attributeActionValue="'a'">A</BuilderSelectItem>
-                    <BuilderSelectItem attributeActionValue="'b'">B</BuilderSelectItem>
-                </BuilderSelect>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderSelect attributeAction="'customAttribute'">
+                <BuilderSelectItem attributeActionValue="null">None</BuilderSelectItem>
+                <BuilderSelectItem attributeActionValue="'a'">A</BuilderSelectItem>
+                <BuilderSelectItem attributeActionValue="'b'">B</BuilderSelectItem>
+            </BuilderSelect>
+        `,
+    });
     await setupHTMLBuilder(`<div class="test-options-target" customAttribute="a">x</div>`);
     setSelection({
         anchorNode: queryFirst(":iframe .test-options-target").childNodes[0],
@@ -81,17 +78,16 @@ test("set the label of the select from the active select item and be updated on 
     expect(".we-bg-options-container .dropdown").toHaveText("B");
 });
 test("consider the priority of the select item", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
-                <BuilderSelect>
-                    <BuilderSelectItem classAction="''">None</BuilderSelectItem>
-                    <BuilderSelectItem classAction="'a'">A</BuilderSelectItem>
-                    <BuilderSelectItem classAction="'a b'">A B</BuilderSelectItem>
-                </BuilderSelect>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderSelect>
+                <BuilderSelectItem classAction="''">None</BuilderSelectItem>
+                <BuilderSelectItem classAction="'a'">A</BuilderSelectItem>
+                <BuilderSelectItem classAction="'a b'">A B</BuilderSelectItem>
+            </BuilderSelect>
+        `,
+    });
     await setupHTMLBuilder(`<div class="test-options-target a">x</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeVisible();
@@ -107,22 +103,19 @@ test("consider the priority of the select item", async () => {
     expect(".we-bg-options-container .dropdown").toHaveText("A B");
 });
 test("hide/display BuilderSelect based on applyTo", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`<BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`
-                    <BuilderSelect applyTo="'.my-custom-class'">
-                        <BuilderSelectItem classAction="'a'">A</BuilderSelectItem>
-                        <BuilderSelectItem classAction="'b'">B</BuilderSelectItem>
-                    </BuilderSelect>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`<BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>`,
+    });
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`
+            <BuilderSelect applyTo="'.my-custom-class'">
+                <BuilderSelectItem classAction="'a'">A</BuilderSelectItem>
+                <BuilderSelectItem classAction="'b'">B</BuilderSelectItem>
+            </BuilderSelect>
+        `,
+    });
     const { getEditableContent } = await setupHTMLBuilder(
         `<div class="parent-target"><div class="child-target b">b</div></div>`
     );
@@ -145,23 +138,20 @@ test("hide/display BuilderSelect based on applyTo", async () => {
 });
 
 test("hide/display BuilderSelectItem base on applyTo", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`<BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`
-                    <BuilderSelect>
-                        <BuilderSelectItem classAction="'a'">A</BuilderSelectItem>
-                        <BuilderSelectItem applyTo="'.my-custom-class'" classAction="'b'">B</BuilderSelectItem>
-                        <BuilderSelectItem classAction="'c'">C</BuilderSelectItem>
-                    </BuilderSelect>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`<BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>`,
+    });
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`
+            <BuilderSelect>
+                <BuilderSelectItem classAction="'a'">A</BuilderSelectItem>
+                <BuilderSelectItem applyTo="'.my-custom-class'" classAction="'b'">B</BuilderSelectItem>
+                <BuilderSelectItem classAction="'c'">C</BuilderSelectItem>
+            </BuilderSelect>
+        `,
+    });
     const { getEditableContent } = await setupHTMLBuilder(
         `<div class="parent-target"><div class="child-target">b</div></div>`
     );
@@ -185,21 +175,18 @@ test("hide/display BuilderSelectItem base on applyTo", async () => {
 });
 
 test("hide/display BuilderSelect base on applyTo in BuilderSelectItem", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`<BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`
-                    <BuilderSelect>
-                        <BuilderSelectItem applyTo="'.my-custom-class'" classAction="'a'">A</BuilderSelectItem>
-                    </BuilderSelect>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`<BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>`,
+    });
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`
+            <BuilderSelect>
+                <BuilderSelectItem applyTo="'.my-custom-class'" classAction="'a'">A</BuilderSelectItem>
+            </BuilderSelect>
+        `,
+    });
     await setupHTMLBuilder(`<div class="parent-target"><div class="child-target b">b</div></div>`);
     await contains(":iframe .parent-target").click();
     expect(".options-container button.dropdown-toggle").not.toBeVisible();
@@ -209,17 +196,16 @@ test("hide/display BuilderSelect base on applyTo in BuilderSelectItem", async ()
 });
 
 test("use BuilderSelect with styleAction", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`
-                    <BuilderSelect styleAction="'border-style'">
-                        <BuilderSelectItem styleActionValue="'dotted'">dotted</BuilderSelectItem>
-                        <BuilderSelectItem styleActionValue="'inset'">inset</BuilderSelectItem>
-                        <BuilderSelectItem styleActionValue="'none'">none</BuilderSelectItem>
-                    </BuilderSelect>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`
+            <BuilderSelect styleAction="'border-style'">
+                <BuilderSelectItem styleActionValue="'dotted'">dotted</BuilderSelectItem>
+                <BuilderSelectItem styleActionValue="'inset'">inset</BuilderSelectItem>
+                <BuilderSelectItem styleActionValue="'none'">none</BuilderSelectItem>
+            </BuilderSelect>
+        `,
+    });
     const { getEditableContent } = await setupHTMLBuilder(`<div class="parent-target">b</div>`);
     const editableContent = getEditableContent();
     await contains(":iframe .parent-target").click();
@@ -239,16 +225,15 @@ test("use BuilderSelect with styleAction", async () => {
     expect(".we-bg-options-container .dropdown").toHaveText("dotted");
 });
 test("do not put inline style on an element which already has this style through css stylesheets", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test";
-            static template = xml`
-                    <BuilderSelect applyTo="'hr'" styleAction="'border-top-style'">
-                        <BuilderSelectItem styleActionValue="'dotted'">dotted</BuilderSelectItem>
-                        <BuilderSelectItem styleActionValue="'inset'">inset</BuilderSelectItem>
-                    </BuilderSelect>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test",
+        template: xml`
+            <BuilderSelect applyTo="'hr'" styleAction="'border-top-style'">
+                <BuilderSelectItem styleActionValue="'dotted'">dotted</BuilderSelectItem>
+                <BuilderSelectItem styleActionValue="'inset'">inset</BuilderSelectItem>
+            </BuilderSelect>
+        `,
+    });
     await setupHTMLBuilder(`
             <div class="test">
                 <hr class="w-100">
@@ -264,16 +249,15 @@ test("do not put inline style on an element which already has this style through
     expect(":iframe hr").not.toHaveStyle("border-top-style", { inline: true });
 });
 test("revert a preview when cancelling a BuilderSelect by clicking outside of it", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test";
-            static template = xml`
-                    <BuilderSelect dataAttributeAction="'choice'">
-                        <BuilderSelectItem dataAttributeActionValue="'0'">0</BuilderSelectItem>
-                        <BuilderSelectItem dataAttributeActionValue="'1'">1</BuilderSelectItem>
-                    </BuilderSelect>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test",
+        template: xml`
+            <BuilderSelect dataAttributeAction="'choice'">
+                <BuilderSelectItem dataAttributeActionValue="'0'">0</BuilderSelectItem>
+                <BuilderSelectItem dataAttributeActionValue="'1'">1</BuilderSelectItem>
+            </BuilderSelect>
+    `,
+    });
     await setupHTMLBuilder(`<div class="test">Test</div>`);
     await contains(":iframe .test").click();
     expect(":iframe .test").not.toHaveAttribute("data-choice");
@@ -284,16 +268,15 @@ test("revert a preview when cancelling a BuilderSelect by clicking outside of it
     expect(":iframe .test").not.toHaveAttribute("data-choice");
 });
 test("revert a preview when cancelling a BuilderSelect with escape", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test";
-            static template = xml`
-                    <BuilderSelect dataAttributeAction="'choice'">
-                        <BuilderSelectItem dataAttributeActionValue="'0'">0</BuilderSelectItem>
-                        <BuilderSelectItem dataAttributeActionValue="'1'">1</BuilderSelectItem>
-                    </BuilderSelect>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test",
+        template: xml`
+            <BuilderSelect dataAttributeAction="'choice'">
+                <BuilderSelectItem dataAttributeActionValue="'0'">0</BuilderSelectItem>
+                <BuilderSelectItem dataAttributeActionValue="'1'">1</BuilderSelectItem>
+            </BuilderSelect>
+    `,
+    });
     await setupHTMLBuilder(`<div class="test">Test</div>`);
     await contains(":iframe .test").click();
     expect(":iframe .test").not.toHaveAttribute("data-choice");
@@ -304,16 +287,15 @@ test("revert a preview when cancelling a BuilderSelect with escape", async () =>
     expect(":iframe .test").not.toHaveAttribute("data-choice");
 });
 test("preview when cycling through options with the keyboard", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test";
-            static template = xml`
-                    <BuilderSelect dataAttributeAction="'choice'">
-                        <BuilderSelectItem dataAttributeActionValue="'0'">0</BuilderSelectItem>
-                        <BuilderSelectItem dataAttributeActionValue="'1'">1</BuilderSelectItem>
-                    </BuilderSelect>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test",
+        template: xml`
+            <BuilderSelect dataAttributeAction="'choice'">
+                <BuilderSelectItem dataAttributeActionValue="'0'">0</BuilderSelectItem>
+                <BuilderSelectItem dataAttributeActionValue="'1'">1</BuilderSelectItem>
+            </BuilderSelect>
+    `,
+    });
     await setupHTMLBuilder(`<div class="test">Test</div>`);
     await contains(":iframe .test").click();
     expect(":iframe .test").not.toHaveAttribute("data-choice");
@@ -322,16 +304,15 @@ test("preview when cycling through options with the keyboard", async () => {
     expect(":iframe .test").toHaveAttribute("data-choice", "0");
 });
 test("revert a preview selected with the keyboard when cancelling with escape", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test";
-            static template = xml`
-                    <BuilderSelect dataAttributeAction="'choice'">
-                        <BuilderSelectItem dataAttributeActionValue="'0'">0</BuilderSelectItem>
-                        <BuilderSelectItem dataAttributeActionValue="'1'">1</BuilderSelectItem>
-                    </BuilderSelect>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test",
+        template: xml`
+            <BuilderSelect dataAttributeAction="'choice'">
+                <BuilderSelectItem dataAttributeActionValue="'0'">0</BuilderSelectItem>
+                <BuilderSelectItem dataAttributeActionValue="'1'">1</BuilderSelectItem>
+            </BuilderSelect>
+    `,
+    });
     await setupHTMLBuilder(`<div class="test">Test</div>`);
     await contains(":iframe .test").click();
     expect(":iframe .test").not.toHaveAttribute("data-choice");
@@ -352,16 +333,15 @@ test("isApplied shouldn't be called when the element is removed from the DOM", a
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test";
-            static template = xml`
-                    <BuilderSelect action="'customAction'">
-                        <BuilderSelectItem actionParam="'0'">0</BuilderSelectItem>
-                        <BuilderSelectItem actionParam="'1'">1</BuilderSelectItem>
-                    </BuilderSelect>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test",
+        template: xml`
+            <BuilderSelect action="'customAction'">
+                <BuilderSelectItem actionParam="'0'">0</BuilderSelectItem>
+                <BuilderSelectItem actionParam="'1'">1</BuilderSelectItem>
+            </BuilderSelect>
+    `,
+    });
     await setupHTMLBuilder(`<div class="test">Test</div>`);
     await contains(":iframe .test").click();
     await contains(".fa-trash ").click();

--- a/addons/html_builder/static/tests/custom_tab/builder_components/builder_text_input.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/builder_text_input.test.js
@@ -4,7 +4,6 @@ import {
     setupHTMLBuilder,
 } from "@html_builder/../tests/helpers";
 import { BuilderAction } from "@html_builder/core/builder_action";
-import { BuilderTextInput } from "@html_builder/core/building_blocks/builder_text_input";
 import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 import { expect, test, describe } from "@odoo/hoot";
 import { reactive, useState, xml } from "@odoo/owl";
@@ -13,18 +12,14 @@ import { contains } from "@web/../tests/web_test_helpers";
 describe.current.tags("desktop");
 
 test("hide/display base on applyTo", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`<BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`<BuilderTextInput applyTo="'.my-custom-class'" action="'customAction'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`<BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>`,
+    });
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`<BuilderTextInput applyTo="'.my-custom-class'" action="'customAction'"/>`,
+    });
     addBuilderAction({
         customAction: class extends BuilderAction {
             static id = "customAction";
@@ -58,17 +53,16 @@ test("update default prop", async () => {
     const defaultValueA = "Default Value A";
     const defaultValueB = "Default Value B";
     const state = reactive({ default: defaultValueA });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
+    addBuilderOption({
+        selector: ".parent-target",
+        Component: class extends BaseOptionComponent {
             static template = xml`<BuilderTextInput action="'customAction'" default="state.default"/>`;
-            static components = { BuilderTextInput };
 
             setup() {
                 this.state = useState(state);
             }
-        }
-    );
+        },
+    });
     addBuilderAction({
         customAction: class extends BuilderAction {
             static id = "customAction";

--- a/addons/html_builder/static/tests/custom_tab/builder_components/model_many2many.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_components/model_many2many.test.js
@@ -4,7 +4,6 @@ import { animationFrame } from "@odoo/hoot-mock";
 import { xml } from "@odoo/owl";
 import { contains, defineModels, fields, models, onRpc } from "@web/../tests/web_test_helpers";
 import { delay } from "@web/core/utils/concurrency";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 
 class Test extends models.Model {
     _name = "test";
@@ -44,12 +43,10 @@ test("model many2many: find tag, select tag, unselect tag", async () => {
             expect(kwargs.domain).toEqual([["id", "not in", [1]]]);
         }
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<ModelMany2Many baseModel="'test.base'" m2oField="'rel'" recordId="1"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<ModelMany2Many baseModel="'test.base'" m2oField="'rel'" recordId="1"/>`,
+    });
     const { getEditor } = await setupHTMLBuilder(
         `<div class="test-options-target" data-res-model="test.base" data-res-id="1">b</div>`
     );

--- a/addons/html_builder/static/tests/custom_tab/builder_shorthand_action.test.js
+++ b/addons/html_builder/static/tests/custom_tab/builder_shorthand_action.test.js
@@ -1,5 +1,4 @@
 import { addBuilderOption, setupHTMLBuilder } from "@html_builder/../tests/helpers";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 import { describe, expect, test } from "@odoo/hoot";
 import { fill } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
@@ -9,17 +8,15 @@ describe.current.tags("desktop");
 
 describe("classAction", () => {
     test("should reset when cliking on an empty classAction", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`
-                    <BuilderButtonGroup>
-                        <BuilderButton classAction="''"/>
-                        <BuilderButton classAction="'x'"/>
-                    </BuilderButtonGroup>
-                `;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`
+                <BuilderButtonGroup>
+                    <BuilderButton classAction="''"/>
+                    <BuilderButton classAction="'x'"/>
+                </BuilderButtonGroup>
+            `,
+        });
         await setupHTMLBuilder(`<div class="test-options-target x">a</div>`);
         await contains(":iframe .test-options-target").click();
         expect(".options-container").toBeDisplayed();
@@ -30,17 +27,15 @@ describe("classAction", () => {
         expect(":iframe .test-options-target").not.toHaveClass("x");
     });
     test("set multiples classes", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`
-                    <BuilderButtonGroup>
-                        <BuilderButton classAction="'x'"/>
-                        <BuilderButton classAction="'x y z'"/>
-                    </BuilderButtonGroup>
-                `;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`
+                <BuilderButtonGroup>
+                    <BuilderButton classAction="'x'"/>
+                    <BuilderButton classAction="'x y z'"/>
+                </BuilderButtonGroup>
+            `,
+        });
         await setupHTMLBuilder(`<div class="test-options-target x">b</div>`);
         await contains(":iframe .test-options-target").click();
         expect(".options-container").toBeDisplayed();
@@ -60,17 +55,15 @@ describe("classAction", () => {
         expect("[data-class-action='x y z']").not.toHaveClass("active");
     });
     test("toggle class when not inside a BuilderButtonGroup", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`
-                    <BuilderButton classAction="'x'"/>
-                    <BuilderButtonGroup>
-                        <BuilderButton classAction="'y'"/>
-                    </BuilderButtonGroup>
-                `;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`
+                <BuilderButton classAction="'x'"/>
+                <BuilderButtonGroup>
+                    <BuilderButton classAction="'y'"/>
+                </BuilderButtonGroup>
+            `,
+        });
         await setupHTMLBuilder(`<div class="test-options-target">a</div>`);
         await contains(":iframe .test-options-target").click();
         expect(".options-container").toBeDisplayed();
@@ -88,15 +81,13 @@ describe("classAction", () => {
 
 describe("styleAction", () => {
     test("should set a plain style", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`
-                    <BuilderNumberInput styleAction="'width'" unit="'px'"
-                    />
-                `;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`
+                <BuilderNumberInput styleAction="'width'" unit="'px'"
+                />
+            `,
+        });
         await setupHTMLBuilder(`<div class="test-options-target" style="width: 10px;">a</div>`);
         await contains(":iframe .test-options-target").click();
         expect("input").toHaveValue(10);
@@ -114,15 +105,13 @@ describe("styleAction", () => {
         expect(":iframe .test-options-target").toHaveAttribute("style", "width: 0px;");
     });
     test("should set a style with its associated class", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`
-                    <BuilderNumberInput styleAction="{ mainParam: 'border-width', extraClass: 'border' }" unit="'px'" min="0" composable="true"
-                    />
-                `;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`
+                <BuilderNumberInput styleAction="{ mainParam: 'border-width', extraClass: 'border' }" unit="'px'" min="0" composable="true"
+                />
+            `,
+        });
         await setupHTMLBuilder(`<div class="test-options-target border">a</div>`, {
             styleContent: ".border { border: solid; border-width: 1px !important; }",
         });
@@ -149,15 +138,13 @@ describe("styleAction", () => {
         expect(":iframe .test-options-target").toHaveClass("border");
     });
     test("should set a composite style with its associated class", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`
-                    <BuilderNumberInput styleAction="{ mainParam: 'border-width', extraClass: 'border' }" unit="'px'" min="0" composable="true"
-                    />
-                `;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`
+                <BuilderNumberInput styleAction="{ mainParam: 'border-width', extraClass: 'border' }" unit="'px'" min="0" composable="true"
+                />
+            `,
+        });
         await setupHTMLBuilder(`<div class="test-options-target">a</div>`, {
             styleContent: ".border { border: solid; border-width: 1px !important; }",
         });
@@ -224,17 +211,15 @@ describe("styleAction", () => {
     });
 
     test("button isApplied is properly computed with percentage width values", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`
-                    <BuilderButtonGroup styleAction="'width'">
-                        <BuilderButton styleActionValue="''">Default</BuilderButton>
-                        <BuilderButton styleActionValue="'50%'">50%</BuilderButton>
-                    </BuilderButtonGroup>
-                `;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`
+                <BuilderButtonGroup styleAction="'width'">
+                    <BuilderButton styleActionValue="''">Default</BuilderButton>
+                    <BuilderButton styleActionValue="'50%'">50%</BuilderButton>
+                </BuilderButtonGroup>
+            `,
+        });
         await setupHTMLBuilder(`<div class="test-options-target x">a</div>`);
         await contains(":iframe .test-options-target").click();
         expect(".options-container").toBeDisplayed();

--- a/addons/html_builder/static/tests/custom_tab/misc.test.js
+++ b/addons/html_builder/static/tests/custom_tab/misc.test.js
@@ -21,15 +21,14 @@ import { contains, patchWithCleanup } from "@web/../tests/web_test_helpers";
 describe.current.tags("desktop");
 
 test("Open custom tab with template option", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
-                <BuilderRow label="'Row 1'">
-                    Test
-                </BuilderRow>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderRow label="'Row 1'">
+                Test
+            </BuilderRow>
+        `,
+    });
     await setupHTMLBuilder(`<div class="test-options-target" data-name="Yop">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeVisible();
@@ -37,14 +36,14 @@ test("Open custom tab with template option", async () => {
 });
 
 test("Open custom tab with Component option", async () => {
-    class TestOption extends BaseOptionComponent {
-        static selector = ".test-options-target";
-        static template = xml`
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
             <BuilderRow label="'Row 1'">
                 Test
-            </BuilderRow>`;
-    }
-    addBuilderOption(TestOption);
+            </BuilderRow>
+        `,
+    });
     await setupHTMLBuilder(`<div class="test-options-target" data-name="Yop">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeVisible();
@@ -52,16 +51,15 @@ test("Open custom tab with Component option", async () => {
 });
 
 test("OptionContainer should display custom title", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
-                <BuilderRow label="'Row 1'">
-                    Test
-                </BuilderRow>`;
-            static title = "My custom title";
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        title: "My custom title",
+        template: xml`
+            <BuilderRow label="'Row 1'">
+                Test
+            </BuilderRow>
+        `,
+    });
     await setupHTMLBuilder(`<div class="test-options-target" data-name="Yop">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeVisible();
@@ -69,28 +67,24 @@ test("OptionContainer should display custom title", async () => {
 });
 
 test("Don't display option base on exclude", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static exclude = ".test-exclude";
-            static template = xml`<BuilderRow label="'Row 1'">a</BuilderRow>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static exclude = ".test-exclude-2";
-            static template = xml`<BuilderRow label="'Row 2'">b</BuilderRow>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderRow label="'Row 3'">
+    addBuilderOption({
+        selector: ".test-options-target",
+        exclude: ".test-exclude",
+        template: xml`<BuilderRow label="'Row 1'">a</BuilderRow>`,
+    });
+    addBuilderOption({
+        selector: ".test-options-target",
+        exclude: ".test-exclude-2",
+        template: xml`<BuilderRow label="'Row 2'">b</BuilderRow>`,
+    });
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderRow label="'Row 3'">
                 <BuilderButton classAction="'test-exclude-2'">c</BuilderButton>
-            </BuilderRow>`;
-        }
-    );
+            </BuilderRow>
+        `,
+    });
     await setupHTMLBuilder(`<div class="test-options-target test-exclude">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(queryAllTexts(".options-container .hb-row")).toEqual(["Row 2\nb", "Row 3\nc"]);
@@ -100,22 +94,20 @@ test("Don't display option base on exclude", async () => {
 });
 
 test("Don't display option base on applyTo", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static applyTo = ".test-target";
-            static template = xml`<BuilderRow label="'Row 1'">
+    addBuilderOption({
+        selector: ".test-options-target",
+        applyTo: ".test-target",
+        template: xml`
+            <BuilderRow label="'Row 1'">
                 <BuilderButton classAction="'test-target-2'">a</BuilderButton>
-            </BuilderRow>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static applyTo = ".test-target-2";
-            static template = xml`<BuilderRow label="'Row 2'">b</BuilderRow>`;
-        }
-    );
+            </BuilderRow>
+        `,
+    });
+    addBuilderOption({
+        selector: ".test-options-target",
+        applyTo: ".test-target-2",
+        template: xml`<BuilderRow label="'Row 2'">b</BuilderRow>`,
+    });
     await setupHTMLBuilder(`
         <div class="test-options-target">
             <div class="test-target">b</div>
@@ -129,27 +121,18 @@ test("Don't display option base on applyTo", async () => {
 });
 
 test("basic multi options containers", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
-            <BuilderRow label="'Row 1'">A</BuilderRow>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".a";
-            static template = xml`
-            <BuilderRow label="'Row 2'">B</BuilderRow>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".main";
-            static template = xml`
-            <BuilderRow label="'Row 3'">C</BuilderRow>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderRow label="'Row 1'">A</BuilderRow>`,
+    });
+    addBuilderOption({
+        selector: ".a",
+        template: xml`<BuilderRow label="'Row 2'">B</BuilderRow>`,
+    });
+    addBuilderOption({
+        selector: ".main",
+        template: xml`<BuilderRow label="'Row 3'">C</BuilderRow>`,
+    });
     await setupHTMLBuilder(`<div class="main"><p class="test-options-target a">b</p></div>`);
     await contains(":iframe .test-options-target").click();
     expect(".options-container-header i.fa-caret-right").toHaveCount(1);
@@ -168,24 +151,18 @@ test("basic multi options containers", async () => {
 });
 
 test("option group stay unfolded when clicking 'Select only this block'", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-parent";
-            static template = xml`<BuilderRow label="'Row 1'">A</BuilderRow>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderRow label="'Row 2'">B</BuilderRow>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-child";
-            static template = xml`<BuilderRow label="'Row 3'">C</BuilderRow>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-parent",
+        template: xml`<BuilderRow label="'Row 1'">A</BuilderRow>`,
+    });
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderRow label="'Row 2'">B</BuilderRow>`,
+    });
+    addBuilderOption({
+        selector: ".test-options-child",
+        template: xml`<BuilderRow label="'Row 3'">C</BuilderRow>`,
+    });
     await setupHTMLBuilder(
         `<div class="test-options-parent" data-name="Parent">
             <section class="test-options-target" data-name="Target">
@@ -208,20 +185,18 @@ test("option group stay unfolded when clicking 'Select only this block'", async 
 });
 
 test("option group stay unfolded when changing an option", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderRow label="'Row 1'">
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderRow label="'Row 1'">
                 <BuilderButton classAction="'test-class'">A</BuilderButton>
-            </BuilderRow>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-child";
-            static template = xml`<BuilderRow label="'Row 2'">B</BuilderRow>`;
-        }
-    );
+            </BuilderRow>
+        `,
+    });
+    addBuilderOption({
+        selector: ".test-options-child",
+        template: xml`<BuilderRow label="'Row 2'">B</BuilderRow>`,
+    });
     await setupHTMLBuilder(
         `<section class="test-options-target" data-name="Target">
             <div class="test-options-child" data-name="Child">
@@ -240,14 +215,14 @@ test("option group stay unfolded when changing an option", async () => {
 });
 
 test("last container with options is unfolded regardless of containers without options", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderRow label="'Row 1'">
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderRow label="'Row 1'">
                 <BuilderButton classAction="'test-class'">A</BuilderButton>
-            </BuilderRow>`;
-        }
-    );
+            </BuilderRow>
+        `,
+    });
     addBuilderPlugin(
         class extends Plugin {
             static id = "testOverlayWithoutOptions";
@@ -269,14 +244,14 @@ test("last container with options is unfolded regardless of containers without o
 });
 
 test("option that matches several elements", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".a";
-            static template = xml`<BuilderRow label="'Row'">
+    addBuilderOption({
+        selector: ".a",
+        template: xml`
+            <BuilderRow label="'Row'">
                 <BuilderButton classAction="'my-custom-class'">Test</BuilderButton>
-            </BuilderRow>`;
-        }
-    );
+            </BuilderRow>
+        `,
+    });
 
     await setupHTMLBuilder(`<div class="a"><div class="a test-target">b</div></div>`);
     await contains(":iframe .test-target").click();
@@ -289,22 +264,22 @@ test("option that matches several elements", async () => {
 });
 
 test("hide empty OptionContainer and display OptionContainer with content", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`<BuilderRow label="'Row 1'">
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`
+            <BuilderRow label="'Row 1'">
                 <BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>
-            </BuilderRow>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target > div";
-            static template = xml`<BuilderRow label="'Row 3'">
+            </BuilderRow>
+        `,
+    });
+    addBuilderOption({
+        selector: ".parent-target > div",
+        template: xml`
+            <BuilderRow label="'Row 3'">
                 <BuilderButton applyTo="'.my-custom-class'" classAction="'test'"/>
-            </BuilderRow>`;
-        }
-    );
+            </BuilderRow>
+        `,
+    });
     await setupHTMLBuilder(
         `<div class="parent-target"><div><div class="child-target">b</div></div></div>`
     );
@@ -319,26 +294,25 @@ test("hide empty OptionContainer and display OptionContainer with content", asyn
 });
 
 test("hide empty OptionContainer and display OptionContainer with content (with BuilderButtonGroup)", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`<BuilderRow label="'Row 1'">
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`
+            <BuilderRow label="'Row 1'">
                 <BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>
-            </BuilderRow>`;
-        }
-    );
+            </BuilderRow>
+        `,
+    });
 
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target > div";
-            static template = xml`
-                <BuilderRow label="'Row 2'">
-                    <BuilderButtonGroup>
-                        <BuilderButton applyTo="'.my-custom-class'" classAction="'test'">Test</BuilderButton>
-                    </BuilderButtonGroup>
-                </BuilderRow>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".parent-target > div",
+        template: xml`
+            <BuilderRow label="'Row 2'">
+                <BuilderButtonGroup>
+                    <BuilderButton applyTo="'.my-custom-class'" classAction="'test'">Test</BuilderButton>
+                </BuilderButtonGroup>
+            </BuilderRow>
+        `,
+    });
 
     await setupHTMLBuilder(
         `<div class="parent-target"><div><div class="child-target">b</div></div></div>`
@@ -354,26 +328,25 @@ test("hide empty OptionContainer and display OptionContainer with content (with 
 });
 
 test("hide empty OptionContainer and display OptionContainer with content (with BuilderButtonGroup) - 2", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`<BuilderRow label="'Row 1'">
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`
+            <BuilderRow label="'Row 1'">
                 <BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>
-            </BuilderRow>`;
-        }
-    );
+            </BuilderRow>
+        `,
+    });
 
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target > div";
-            static template = xml`
-                <BuilderRow label="'Row 2'">
-                    <BuilderButtonGroup applyTo="'.my-custom-class'">
-                        <BuilderButton  classAction="'test'">Test</BuilderButton>
-                    </BuilderButtonGroup>
-                </BuilderRow>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".parent-target > div",
+        template: xml`
+            <BuilderRow label="'Row 2'">
+                <BuilderButtonGroup applyTo="'.my-custom-class'">
+                    <BuilderButton  classAction="'test'">Test</BuilderButton>
+                </BuilderButtonGroup>
+            </BuilderRow>
+        `,
+    });
 
     await setupHTMLBuilder(
         `<div class="parent-target"><div><div class="child-target">b</div></div></div>`
@@ -395,14 +368,14 @@ test("fallback on the 'Blocks' tab if no option match the selected element", asy
 });
 
 test("move back on the 'Blocks' tab if no more option match the selected element", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`<BuilderRow label="'Row 1'">
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`
+            <BuilderRow label="'Row 1'">
                 <BuilderButton classAction="'my-custom-class'"/>
-            </BuilderRow>`;
-        }
-    );
+            </BuilderRow>
+        `,
+    });
     await setupHTMLBuilder(`<div class="parent-target"><div class="child-target">b</div></div>`);
     await contains(":iframe .parent-target > div").click();
     expect(".o-snippets-tabs button[data-name=customize]").toHaveClass("active");
@@ -420,14 +393,14 @@ test("stay on the 'Theme' tab if no more option match the selected element", asy
             };
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`<BuilderRow label="'Row 1'">
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`
+            <BuilderRow label="'Row 1'">
                 <BuilderButton classAction="'my-custom-class'"/>
-            </BuilderRow>`;
-        }
-    );
+            </BuilderRow>
+        `,
+    });
     const { getEditor } = await setupHTMLBuilder(
         `<div class="parent-target"><div class="child-target">b</div></div>`
     );
@@ -438,14 +411,14 @@ test("stay on the 'Theme' tab if no more option match the selected element", asy
 });
 
 test("display empty message if no option container is visible", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`<BuilderRow label="'Row 1'">
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`
+            <BuilderRow label="'Row 1'">
                 <BuilderButton applyTo="'.invalid'" classAction="'my-custom-class'"/>
-            </BuilderRow>`;
-        }
-    );
+            </BuilderRow>
+        `,
+    });
 
     await setupHTMLBuilder(`<div class="parent-target"><div class="child-target">b</div></div>`);
     await contains(":iframe .parent-target > div").click();
@@ -453,22 +426,22 @@ test("display empty message if no option container is visible", async () => {
     expect(".o_customize_tab").toHaveText("Select a block on your page to style it.");
 });
 test("hide/display option base on selector", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`<BuilderRow label="'Row 1'">
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`
+            <BuilderRow label="'Row 1'">
                 <BuilderButton classAction="'my-custom-class'"/>
-            </BuilderRow>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".my-custom-class";
-            static template = xml`<BuilderRow label="'Row 2'">
+            </BuilderRow>
+        `,
+    });
+    addBuilderOption({
+        selector: ".my-custom-class",
+        template: xml`
+            <BuilderRow label="'Row 2'">
                 <BuilderButton classAction="'test'"/>
-            </BuilderRow>`;
-        }
-    );
+            </BuilderRow>
+        `,
+    });
 
     await setupHTMLBuilder(`<div class="parent-target"><div class="child-target">b</div></div>`);
     await contains(":iframe .parent-target").click();
@@ -481,31 +454,31 @@ test("hide/display option base on selector", async () => {
 });
 
 test("hide/display option container base on selector", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`<BuilderRow label="'Row 1'">
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`
+            <BuilderRow label="'Row 1'">
                 <BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>
-            </BuilderRow>`;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".my-custom-class";
-            static template = xml`<BuilderRow label="'Row 2'">
+            </BuilderRow>
+        `,
+    });
+    addBuilderOption({
+        selector: ".my-custom-class",
+        template: xml`
+            <BuilderRow label="'Row 2'">
                 <BuilderButton classAction="'test'"/>
-            </BuilderRow>`;
-        }
-    );
+            </BuilderRow>
+        `,
+    });
 
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".sub-child-target";
-            static template = xml`<BuilderRow label="'Row 3'">
+    addBuilderOption({
+        selector: ".sub-child-target",
+        template: xml`
+            <BuilderRow label="'Row 3'">
                 <BuilderButton classAction="'another-custom-class'"/>
-            </BuilderRow>`;
-        }
-    );
+            </BuilderRow>
+        `,
+    });
 
     await setupHTMLBuilder(`
         <div class="parent-target">
@@ -526,14 +499,14 @@ test("hide/display option container base on selector", async () => {
 });
 
 test("don't rerender the OptionsContainer every time you click on the same element", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`<BuilderRow label="'Row 1'">
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`
+            <BuilderRow label="'Row 1'">
                 <BuilderButton applyTo="'.child-target'" classAction="'my-custom-class'"/>
-            </BuilderRow>`;
-        }
-    );
+            </BuilderRow>
+        `,
+    });
 
     patchWithCleanup(OptionsContainer.prototype, {
         setup() {
@@ -567,18 +540,16 @@ test("no need to define 'isApplied' method for custom action if the widget alrea
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".s_test";
-            static template = xml`
+    addBuilderOption({
+        selector: ".s_test",
+        template: xml`
             <BuilderRow label.translate="Type">
                 <BuilderSelect>
                     <BuilderSelectItem classAction="'A-class'" action="'customAction'" actionParam="'A'">A</BuilderSelectItem>
                 </BuilderSelect>
             </BuilderRow>
-        `;
-        }
-    );
+        `,
+    });
 
     await setupHTMLBuilder(`
         <div class="s_test A-class">
@@ -593,9 +564,6 @@ test("useDomState callback shouldn't be called when the editingElement is remove
     let count = 0;
     class TestOption extends BaseOptionComponent {
         static template = xml`<div class="test_option">test</div>`;
-        static selector = ".s_test";
-        static editableOnly = false;
-        static props = {};
 
         setup() {
             useDomState(() => {
@@ -606,13 +574,15 @@ test("useDomState callback shouldn't be called when the editingElement is remove
             });
         }
     }
-    addBuilderOption(TestOption);
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = "*";
-            static template = xml`<BuilderButton action="'addTestSnippet'">Add</BuilderButton>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".s_test",
+        editableOnly: false,
+        Component: TestOption,
+    });
+    addBuilderOption({
+        selector: "*",
+        template: xml`<BuilderButton action="'addTestSnippet'">Add</BuilderButton>`,
+    });
     addBuilderAction({
         addTestSnippet: class extends BuilderAction {
             static id = "addTestSnippet";
@@ -655,15 +625,15 @@ test("Update editing elements at dom change with multiple levels of applyTo", as
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".parent-target";
-            static template = xml`<BuilderRow label="'Row 1'" applyTo="'.child-target'">
+    addBuilderOption({
+        selector: ".parent-target",
+        template: xml`
+            <BuilderRow label="'Row 1'" applyTo="'.child-target'">
                 <BuilderButton action="'customAction'" />
                 <BuilderButton applyTo="'.sub-child-target'" classAction="'my-custom-class'"/>
-            </BuilderRow>`;
-        }
-    );
+            </BuilderRow>
+        `,
+    });
 
     await setupHTMLBuilder(`
         <div class="parent-target">
@@ -678,23 +648,19 @@ test("Update editing elements at dom change with multiple levels of applyTo", as
 });
 
 test("An option should only appear if its target is inside an editable area, unless specified otherwise", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-target";
-            static template = xml`
-                <BuilderButton classAction="'dummy-class-a'">Option A</BuilderButton>
-            `;
-        }
-    );
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-target";
-            static editableOnly = false;
-            static template = xml`
-                <BuilderButton classAction="'dummy-class-b'">Option B</BuilderButton>
-            `;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-target",
+        template: xml`
+            <BuilderButton classAction="'dummy-class-a'">Option A</BuilderButton>
+        `,
+    });
+    addBuilderOption({
+        selector: ".test-target",
+        editableOnly: false,
+        template: xml`
+            <BuilderButton classAction="'dummy-class-b'">Option B</BuilderButton>
+        `,
+    });
     const { getEditor } = await setupHTMLBuilder(`<div></div>`);
     const editor = getEditor();
     setContent(
@@ -720,17 +686,15 @@ test("An option should only appear if its target is inside an editable area, unl
 
 describe("isActiveItem", () => {
     test("a button should not be visible if its dependency isn't (with undo)", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`
-                    <BuilderButton attributeAction="'my-attribute1'" attributeActionValue="'x'" id="'id1'">b1</BuilderButton>
-                    <BuilderButton attributeAction="'my-attribute1'" attributeActionValue="'y'"  id="'id2'">b2</BuilderButton>
-                    <BuilderButton attributeAction="'my-attribute2'" attributeActionValue="'1'" t-if="this.isActiveItem('id1')">b3</BuilderButton>
-                    <BuilderButton attributeAction="'my-attribute2'" attributeActionValue="'2'" t-if="this.isActiveItem('id2')">b4</BuilderButton>
-                `;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`
+                <BuilderButton attributeAction="'my-attribute1'" attributeActionValue="'x'" id="'id1'">b1</BuilderButton>
+                <BuilderButton attributeAction="'my-attribute1'" attributeActionValue="'y'"  id="'id2'">b2</BuilderButton>
+                <BuilderButton attributeAction="'my-attribute2'" attributeActionValue="'1'" t-if="this.isActiveItem('id1')">b3</BuilderButton>
+                <BuilderButton attributeAction="'my-attribute2'" attributeActionValue="'2'" t-if="this.isActiveItem('id2')">b4</BuilderButton>
+            `,
+        });
         await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
         setSelection({
             anchorNode: queryFirst(":iframe .test-options-target").childNodes[0],
@@ -781,19 +745,17 @@ describe("isActiveItem", () => {
         ).not.toHaveCount();
     });
     test("a button should not be visible if its dependency isn't (in a BuilderSelect with priority)", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`
-                    <BuilderSelect>
-                        <BuilderSelectItem classAction="'a'" id="'x'">x</BuilderSelectItem>
-                        <BuilderSelectItem classAction="'a b'" id="'y'">y</BuilderSelectItem>
-                    </BuilderSelect>
-                    <BuilderButton classAction="'b1'" t-if="this.isActiveItem('x')">b1</BuilderButton>
-                    <BuilderButton classAction="'b2'" t-if="this.isActiveItem('y')">b2</BuilderButton>
-                `;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`
+                <BuilderSelect>
+                    <BuilderSelectItem classAction="'a'" id="'x'">x</BuilderSelectItem>
+                    <BuilderSelectItem classAction="'a b'" id="'y'">y</BuilderSelectItem>
+                </BuilderSelect>
+                <BuilderButton classAction="'b1'" t-if="this.isActiveItem('x')">b1</BuilderButton>
+                <BuilderButton classAction="'b2'" t-if="this.isActiveItem('y')">b2</BuilderButton>
+            `,
+        });
         await setupHTMLBuilder(`<div class="test-options-target a">a</div>`);
         setSelection({
             anchorNode: queryFirst(":iframe .test-options-target").childNodes[0],
@@ -814,15 +776,13 @@ describe("isActiveItem", () => {
         expect("[data-class-action='b2']").toBeVisible();
     });
     test("a button should not be visible if the dependency is active", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`
-                    <BuilderButton attributeAction="'my-attribute1'" attributeActionValue="'x'" id="'id1'">b1</BuilderButton>
-                    <BuilderButton attributeAction="'my-attribute2'" attributeActionValue="'1'" t-if="!this.isActiveItem('id1')">b3</BuilderButton>
-                `;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`
+                <BuilderButton attributeAction="'my-attribute1'" attributeActionValue="'x'" id="'id1'">b1</BuilderButton>
+                <BuilderButton attributeAction="'my-attribute2'" attributeActionValue="'1'" t-if="!this.isActiveItem('id1')">b3</BuilderButton>
+            `,
+        });
         await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
         await contains(":iframe .test-options-target").click();
         expect(".options-container").toBeVisible();
@@ -838,18 +798,16 @@ describe("isActiveItem", () => {
         ).not.toHaveCount();
     });
     test("a button should not be visible if the dependency is active (when a dependency is added after a dependent)", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`
-                    <BuilderButton attributeAction="'my-attribute2'" attributeActionValue="'1'" t-if="this.isActiveItem('id')">b1</BuilderButton>
-                    <BuilderButton attributeAction="'my-attribute2'" attributeActionValue="'2'" t-if="!this.isActiveItem('id')">b2</BuilderButton>
-                    <BuilderRow label="'dependency'">
-                        <BuilderButton attributeAction="'my-attribute1'" attributeActionValue="'x'" id="'id'">b3</BuilderButton>
-                    </BuilderRow>
-                `;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`
+                <BuilderButton attributeAction="'my-attribute2'" attributeActionValue="'1'" t-if="this.isActiveItem('id')">b1</BuilderButton>
+                <BuilderButton attributeAction="'my-attribute2'" attributeActionValue="'2'" t-if="!this.isActiveItem('id')">b2</BuilderButton>
+                <BuilderRow label="'dependency'">
+                    <BuilderButton attributeAction="'my-attribute1'" attributeActionValue="'x'" id="'id'">b3</BuilderButton>
+                </BuilderRow>
+            `,
+        });
         await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
         await contains(":iframe .test-options-target").click();
         expect(".options-container").toBeVisible();
@@ -870,16 +828,14 @@ describe("isActiveItem", () => {
         ).not.toHaveCount();
     });
     test("a button should not be visible if its dependency is removed from the DOM", async () => {
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`
-                    <BuilderButton classAction="'my-class1'" id="'id1'">b1</BuilderButton>
-                    <BuilderButton classAction="'my-class2'" id="'id2'" t-if="this.isActiveItem('id1')">b2</BuilderButton>
-                    <BuilderButton classAction="'my-class3'" t-if="this.isActiveItem('id2')">b3</BuilderButton>
-                `;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`
+                <BuilderButton classAction="'my-class1'" id="'id1'">b1</BuilderButton>
+                <BuilderButton classAction="'my-class2'" id="'id2'" t-if="this.isActiveItem('id1')">b2</BuilderButton>
+                <BuilderButton classAction="'my-class3'" t-if="this.isActiveItem('id2')">b3</BuilderButton>
+            `,
+        });
         await setupHTMLBuilder(`<div class="test-options-target my-class1 my-class2">b</div>`);
         await contains(":iframe .test-options-target").click();
         await contains("[data-class-action='my-class1']").click();

--- a/addons/html_builder/static/tests/helpers.js
+++ b/addons/html_builder/static/tests/helpers.js
@@ -361,10 +361,19 @@ export function addBuilderOption(option) {
         patchWithCleanup(BuilderOptionsPlugin.prototype, {
             computeBuilderOptionsFromTemplate() {
                 const options = super.computeBuilderOptionsFromTemplate();
-                const normalizedTestOptions = testBuilderOptions.map((option, index) => {
-                    const optionName = `TestBuilderOption${index}`;
-                    return this.createOptionClass(optionName, {}, option);
-                });
+                const normalizedTestOptions = testBuilderOptions.map(
+                    ({ optionAttributes, OptionComponent }, index) => {
+                        const optionName = `TestBuilderOption${index}`;
+                        if (!OptionComponent) {
+                            return this.createOptionClass(optionName, optionAttributes);
+                        }
+                        return this.createOptionClass(
+                            optionName,
+                            optionAttributes,
+                            OptionComponent
+                        );
+                    }
+                );
                 return [...options, ...normalizedTestOptions];
             },
         });
@@ -374,7 +383,16 @@ export function addBuilderOption(option) {
         });
         isBuilderOptionPatched = true;
     }
-    testBuilderOptions.push(option);
+
+    const normalizeBuilderOption = (option) => {
+        const { Component: OptionComponent, ...optionAttributes } = option;
+        return {
+            optionAttributes,
+            OptionComponent,
+        };
+    };
+
+    testBuilderOptions.push(normalizeBuilderOption(option));
 }
 
 export function addBuilderAction(actions = {}) {

--- a/addons/html_builder/static/tests/operation.test.js
+++ b/addons/html_builder/static/tests/operation.test.js
@@ -5,7 +5,6 @@ import {
 } from "@html_builder/../tests/helpers";
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { Operation } from "@html_builder/core/operation";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 import { HistoryPlugin } from "@html_editor/core/history_plugin";
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { advanceTime, delay, hover, press, tick } from "@odoo/hoot-dom";
@@ -133,12 +132,10 @@ describe("Block editable", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderButton action="'customAction'"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderButton action="'customAction'"/>`,
+        });
         await setupHTMLBuilder(`<div class="test-options-target">TEST</div>`, {
             loadIframeBundles: true,
         });
@@ -191,19 +188,17 @@ describe("Async operations", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`
-                    <BuilderRow label.translate="Type">
-                        <BuilderSelect>
-                            <BuilderSelectItem action="'customAction'" actionValue="'first'">first</BuilderSelectItem>
-                            <BuilderSelectItem action="'customAction2'" actionValue="'second'">second</BuilderSelectItem>
-                        </BuilderSelect>
-                    </BuilderRow>
-                `;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`
+                <BuilderRow label.translate="Type">
+                    <BuilderSelect>
+                        <BuilderSelectItem action="'customAction'" actionValue="'first'">first</BuilderSelectItem>
+                        <BuilderSelectItem action="'customAction2'" actionValue="'second'">second</BuilderSelectItem>
+                    </BuilderSelect>
+                </BuilderRow>
+            `,
+        });
 
         await setupHTMLBuilder(`<div class="test-options-target">TEST</div>`);
         await contains(":iframe .test-options-target").click();
@@ -239,14 +234,14 @@ describe("Async operations", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderRow>
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`
+                <BuilderRow>
                     <BuilderColorPicker enabledTabs="['solid']" styleAction="'background-color'" action="'customAction'"/>
-                </BuilderRow>`;
-            }
-        );
+                </BuilderRow>
+            `,
+        });
 
         await setupHTMLBuilder(`<div class="test-options-target">TEST</div>`);
         await contains(":iframe .test-options-target").click();
@@ -278,14 +273,13 @@ describe("Operation that will fail", () => {
         addBuilderAction({
             TestAction,
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`
-                    <BuilderButton action="'testAction'"/>
-                    <BuilderButton classAction="'test'"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`
+                <BuilderButton action="'testAction'"/>
+                <BuilderButton classAction="'test'"/>
+            `,
+        });
         await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
         await contains(":iframe .test-options-target").click();
         await contains("[data-action-id='testAction']").hover();
@@ -308,14 +302,13 @@ describe("Operation that will fail", () => {
         addBuilderAction({
             TestAction,
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`
-                    <BuilderButton action="'testAction'"/>
-                    <BuilderButton classAction="'test'"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`
+                <BuilderButton action="'testAction'"/>
+                <BuilderButton classAction="'test'"/>
+            `,
+        });
         await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
         await contains(":iframe .test-options-target").click();
         await contains("[data-action-id='testAction']").click();

--- a/addons/html_builder/static/tests/shadow_option.test.js
+++ b/addons/html_builder/static/tests/shadow_option.test.js
@@ -4,19 +4,13 @@ import { queryAllTexts, queryAllValues, waitFor } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
 import { contains } from "@web/../tests/web_test_helpers";
 
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
-import { ShadowOption } from "@html_builder/plugins/shadow_option";
-
 describe.current.tags("desktop");
 
 test("edit box-shadow with ShadowOption", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<ShadowOption/>`;
-            static components = { ShadowOption };
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<ShadowOption/>`,
+    });
     await setupHTMLBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     await waitFor(".hb-row");

--- a/addons/html_builder/static/tests/utils.test.js
+++ b/addons/html_builder/static/tests/utils.test.js
@@ -18,9 +18,9 @@ describe.current.tags("desktop");
 describe("useDomState", () => {
     test("Should not update the state of an async useDomState if a new step has been made", async () => {
         let currentResolve;
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
+        addBuilderOption({
+            selector: ".test-options-target",
+            Component: class extends BaseOptionComponent {
                 static template = xml`<div t-att-data-letter="getLetter()"/>`;
                 setup() {
                     super.setup(...arguments);
@@ -37,8 +37,8 @@ describe("useDomState", () => {
                     expect.step(`state: ${this.state.delay}`);
                     return this.state.delay;
                 }
-            }
-        );
+            },
+        });
         const { getEditor } = await setupHTMLBuilder(`<div class="test-options-target">a</div>`);
         await animationFrame();
         await contains(":iframe .test-options-target").click();
@@ -95,7 +95,6 @@ describe("waitSidebarUpdated", () => {
             }
         }
         class TestOptionComponent extends BaseOptionComponent {
-            static selector = "div.test";
             static template = xml`
                 <div class="test-value-parent">
                     <t t-out="state.value"/>
@@ -120,7 +119,10 @@ describe("waitSidebarUpdated", () => {
                 });
             }
         }
-        addBuilderOption(TestOptionComponent);
+        addBuilderOption({
+            selector: "div.test",
+            Component: TestOptionComponent,
+        });
         const { waitSidebarUpdated } = await setupHTMLBuilder(
             `<div class="test" data-value="a">a</div>`
         );
@@ -192,12 +194,10 @@ test("Shouldn't reload(save, etc) when a reload is canceled", async () => {
         },
     });
 
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButton action="'testCancelReload'">Click</BuilderButton>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton action="'testCancelReload'">Click</BuilderButton>`,
+    });
 
     await setupHTMLBuilder(`<div class="test-options-target">Target</div>`);
     await contains(":iframe .test-options-target").click();
@@ -237,12 +237,10 @@ test("UI is blocked when doing the reloadable operation", async () => {
         },
     });
 
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButton action="'testReload'">Click</BuilderButton>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton action="'testReload'">Click</BuilderButton>`,
+    });
 
     const { waitSidebarUpdated } = await setupHTMLBuilder(
         `<div class="test-options-target">Target</div>`
@@ -259,7 +257,6 @@ test("System should not crash if an asynchronous useDomState is working with rem
     let editingElRemoved;
     class TestOptionComponent extends BaseOptionComponent {
         static template = xml`<BuilderButton t-if="state.showOption" classAction="'y'">Click</BuilderButton>`;
-        static selector = "div.test";
         setup() {
             super.setup();
             this.state = useDomState(async (el) => {
@@ -271,7 +268,10 @@ test("System should not crash if an asynchronous useDomState is working with rem
             });
         }
     }
-    addBuilderOption(TestOptionComponent);
+    addBuilderOption({
+        selector: "div.test",
+        Component: TestOptionComponent,
+    });
     const { waitSidebarUpdated } = await setupHTMLBuilder(`<div class="test">a</div>`);
     await contains(":iframe .test").click();
     await waitSidebarUpdated();

--- a/addons/website/static/tests/builder/builder_action.test.js
+++ b/addons/website/static/tests/builder/builder_action.test.js
@@ -11,7 +11,6 @@ import {
     waitForEndOfOperation,
 } from "@html_builder/../tests/helpers";
 import { BuilderAction } from "@html_builder/core/builder_action";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 import {
     contains,
     defineModels,
@@ -153,12 +152,10 @@ describe("BuilderMany2One: exit editor when previewing", () => {
                 }
             },
         });
-        addBuilderOption(
-            class extends BaseOptionComponent {
-                static selector = ".test-options-target";
-                static template = xml`<BuilderMany2One action="'testAction'" model="'test'" limit="10" preview="true"/>`;
-            }
-        );
+        addBuilderOption({
+            selector: ".test-options-target",
+            template: xml`<BuilderMany2One action="'testAction'" model="'test'" limit="10" preview="true"/>`,
+        });
 
         await setupWebsiteBuilder(`<div class="test-options-target">Homepage</div>`);
         await contains(":iframe .test-options-target").click();
@@ -210,12 +207,10 @@ test("Builder is disabled when reloading", async () => {
         },
     });
 
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".target";
-            static template = xml`<BuilderButton action="'testReload'">Reload editor</BuilderButton>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".target",
+        template: xml`<BuilderButton action="'testReload'">Reload editor</BuilderButton>`,
+    });
     const { waitSidebarUpdated } = await setupWebsiteBuilder(
         `<section class="target">Section</section>`
     );

--- a/addons/website/static/tests/builder/content_editable.test.js
+++ b/addons/website/static/tests/builder/content_editable.test.js
@@ -2,7 +2,6 @@ import { expect, test } from "@odoo/hoot";
 import { queryOne } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
 import { addBuilderOption } from "@html_builder/../tests/helpers";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 import { contains, onRpc } from "@web/../tests/web_test_helpers";
 import {
     addPlugin,
@@ -71,12 +70,10 @@ test("Do not set contenteditable attribute on data-oe-readonly", async () => {
         };
     }
     addPlugin(TestPlugin);
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".target";
-            static template = xml`<BuilderButton classAction="'test-class'">Test</BuilderButton>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".target",
+        template: xml`<BuilderButton classAction="'test-class'">Test</BuilderButton>`,
+    });
     await setupWebsiteBuilder(`
         <section>
             <div class="non-editable">

--- a/addons/website/static/tests/builder/custom_tab/builder_components/website_colorpicker.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/website_colorpicker.test.js
@@ -2,7 +2,6 @@ import { expect, test } from "@odoo/hoot";
 import { animationFrame, click } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
 import { addBuilderOption, waitForEndOfOperation } from "@html_builder/../tests/helpers";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 import { contains } from "@web/../tests/web_test_helpers";
 import {
     defineWebsiteModels,
@@ -11,13 +10,11 @@ import {
 
 defineWebsiteModels();
 
-const ColorPickerOption = class extends BaseOptionComponent {
-    static selector = ".test-options-target";
-    static template = xml`<BuilderColorPicker styleAction="'background-color'"/>`;
-};
-
 test("should apply o_cc color", async () => {
-    addBuilderOption(ColorPickerOption);
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderColorPicker styleAction="'background-color'"/>`,
+    });
     await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeDisplayed();
@@ -28,7 +25,10 @@ test("should apply o_cc color", async () => {
 });
 
 test("should remove o_cc color on reset", async () => {
-    addBuilderOption(ColorPickerOption);
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderColorPicker styleAction="'background-color'"/>`,
+    });
     await setupWebsiteBuilder(`<div class="test-options-target o_cc o_cc3">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeDisplayed();
@@ -40,12 +40,10 @@ test("should remove o_cc color on reset", async () => {
 });
 
 test("should have the theme tab", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderColorPicker enabledTabs="['custom', 'theme']" styleAction="'background-color'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderColorPicker enabledTabs="['custom', 'theme']" styleAction="'background-color'"/>`,
+    });
     await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeDisplayed();
@@ -59,12 +57,10 @@ test("should have the theme tab", async () => {
 });
 
 test("should work with color transition", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderColorPicker styleAction="'color'" enabledTabs="['custom']" />`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderColorPicker styleAction="'color'" enabledTabs="['custom']" />`,
+    });
     await setupWebsiteBuilder(`<div class="test-options-target">b</div>`, {
         // The CSS for the class "o_we_force_no_transition" is needed
         loadIframeBundles: true,

--- a/addons/website/static/tests/builder/custom_tab/builder_components/website_urlpicker.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/website_urlpicker.test.js
@@ -2,7 +2,6 @@ import { after, before, expect, test } from "@odoo/hoot";
 import { xml } from "@odoo/owl";
 import { contains, onRpc } from "@web/../tests/web_test_helpers";
 import { addBuilderOption } from "@html_builder/../tests/helpers";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 import {
     defineWebsiteModels,
     setupWebsiteBuilder,
@@ -10,11 +9,6 @@ import {
 import { advanceTime } from "@odoo/hoot-dom";
 
 defineWebsiteModels();
-
-const UrlPickerOption = class extends BaseOptionComponent {
-    static selector = ".test-options-target";
-    static template = xml`<BuilderUrlPicker dataAttributeAction="'url'"/>`;
-};
 
 let originalWindowOpen;
 function mockWindowOpen() {
@@ -73,7 +67,10 @@ after(() => {
 });
 
 test("link button opens in new window if url not empty", async () => {
-    addBuilderOption(UrlPickerOption);
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderUrlPicker dataAttributeAction="'url'"/>`,
+    });
     await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
 
@@ -91,7 +88,10 @@ test("opens dropdown when typing /", async () => {
     mockGetSuggestedLinks(() => {
         expect.step("button_immediate_install");
     });
-    addBuilderOption(UrlPickerOption);
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderUrlPicker dataAttributeAction="'url'"/>`,
+    });
     await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
 
@@ -103,7 +103,10 @@ test("opens dropdown when typing /", async () => {
 
 test("selects and commits value from dropdown", async () => {
     mockGetSuggestedLinks();
-    addBuilderOption(UrlPickerOption);
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderUrlPicker dataAttributeAction="'url'"/>`,
+    });
     await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
 
@@ -117,7 +120,10 @@ test("selects and commits value from dropdown", async () => {
 
 test("collects anchors in current page and suggests them", async () => {
     mockGetSuggestedLinks();
-    addBuilderOption(UrlPickerOption);
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderUrlPicker dataAttributeAction="'url'"/>`,
+    });
     await setupWebsiteBuilder(`
         <div class="test-options-target">b</div>
         <div id="anchor1" data-anchor="true">anchor1</div>

--- a/addons/website/static/tests/builder/custom_tab/container_buttons.test.js
+++ b/addons/website/static/tests/builder/custom_tab/container_buttons.test.js
@@ -20,7 +20,6 @@ import { animationFrame, queryText, tick } from "@odoo/hoot-dom";
 import { undo } from "@html_editor/../tests/_helpers/user_actions";
 import { Plugin } from "@html_editor/plugin";
 import { BuilderAction } from "@html_builder/core/builder_action";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 
 defineWebsiteModels();
 
@@ -87,12 +86,10 @@ test("Use the sidebar 'clone' buttons", async () => {
 });
 
 test("Use the sidebar 'save snippet' buttons", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = "a.btn";
-            static template = xml`<BuilderButton classAction="'dummy-class'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: "a.btn",
+        template: xml`<BuilderButton classAction="'dummy-class'"/>`,
+    });
     const structureSnippetDesc = {
         name: "Dummy Section",
         groupName: "a",
@@ -361,12 +358,10 @@ test("applying option container button should wait for actions in progress", asy
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButton action="'customAction'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton action="'customAction'"/>`,
+    });
 
     const { getEditableContent, getEditor } = await setupWebsiteBuilder(`
         <p class="test-options-target">plop</p>

--- a/addons/website/static/tests/builder/custom_tab/main_page_option.test.js
+++ b/addons/website/static/tests/builder/custom_tab/main_page_option.test.js
@@ -6,17 +6,14 @@ import {
     setupWebsiteBuilder,
 } from "@website/../tests/builder/website_helpers";
 import { addBuilderOption } from "@html_builder/../tests/helpers";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 
 defineWebsiteModels();
 
 test("switch to custom tab and click on a main page option", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = "main";
-            static template = xml`<BuilderButton classAction="'my-custom-class'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: "main",
+        template: xml`<BuilderButton classAction="'my-custom-class'"/>`,
+    });
     await setupWebsiteBuilder(`<main>b</main>`);
     await contains('[id="customize-tab"]').click();
     await contains("[data-class-action='my-custom-class']").click();

--- a/addons/website/static/tests/builder/edit_interaction.test.js
+++ b/addons/website/static/tests/builder/edit_interaction.test.js
@@ -15,7 +15,6 @@ import {
     confirmAddSnippet,
     waitForEndOfOperation,
 } from "@html_builder/../tests/helpers";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 
 defineWebsiteModels();
 
@@ -51,12 +50,10 @@ test("ensure order of operations when hovering an option", async () => {
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButton action="'customAction'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton action="'customAction'"/>`,
+    });
     patchWithCleanup(EditInteractionPlugin.prototype, {
         refreshInteractions(element) {
             expect.step("refreshInteractions");

--- a/addons/website/static/tests/builder/invisible_elements.test.js
+++ b/addons/website/static/tests/builder/invisible_elements.test.js
@@ -4,7 +4,6 @@ import {
     getSnippetStructure,
     waitForEndOfOperation,
 } from "@html_builder/../tests/helpers";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 import { unformat } from "@html_editor/../tests/_helpers/format";
 import { expect, test } from "@odoo/hoot";
 import { click, queryAllTexts, queryFirst, queryOne } from "@odoo/hoot-dom";
@@ -37,12 +36,10 @@ test("click on invisible elements in the invisible elements tab (check eye icon)
 });
 
 test("click on invisible elements in the invisible elements tab (check sidebar tab)", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".s_test";
-            static template = xml`<BuilderButton classAction="'my-custom-class'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".s_test",
+        template: xml`<BuilderButton classAction="'my-custom-class'"/>`,
+    });
     await setupWebsiteBuilder(
         '<div class="s_test d-lg-none o_snippet_desktop_invisible" data-invisible="1">a</div>'
     );

--- a/addons/website/static/tests/builder/options/border_configurator_option.test.js
+++ b/addons/website/static/tests/builder/options/border_configurator_option.test.js
@@ -8,7 +8,6 @@ import {
     defineWebsiteModels,
     setupWebsiteBuilder,
 } from "@website/../tests/builder/website_helpers";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 
 defineWebsiteModels();
 
@@ -31,12 +30,10 @@ test("empty border input is treated as 0", async () => {
             return hasBorder;
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BorderConfigurator label="'Border'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BorderConfigurator label="'Border'"/>`,
+    });
     await setupWebsiteBuilder(`<section class="test-options-target">Bordered block</section>`, {
         loadIframeBundles: true,
     });
@@ -63,12 +60,10 @@ test("empty border input is treated as 0", async () => {
     expect.verifySteps(["hasBorder"]);
 });
 test("hasBorder is true when multiple-value border starts by 0", async () => {
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BorderConfigurator label="'Border'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BorderConfigurator label="'Border'"/>`,
+    });
     await setupWebsiteBuilder(`<section class="test-options-target">Bordered block</section>`, {
         loadIframeBundles: true,
     });

--- a/addons/website/static/tests/builder/overlay_buttons.test.js
+++ b/addons/website/static/tests/builder/overlay_buttons.test.js
@@ -14,7 +14,6 @@ import {
     setupWebsiteBuilderWithSnippet,
 } from "./website_helpers";
 import { BuilderAction } from "@html_builder/core/builder_action";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 
 defineWebsiteModels();
 
@@ -351,12 +350,10 @@ test("Applying an overlay button action should wait for the actions in progress"
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButton action="'customAction'"/>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton action="'customAction'"/>`,
+    });
 
     const { getEditableContent, getEditor } = await setupWebsiteBuilder(`
         <div class="test-options-target">plop</div>

--- a/addons/website/static/tests/builder/preview_mode.test.js
+++ b/addons/website/static/tests/builder/preview_mode.test.js
@@ -6,7 +6,6 @@ import { contains } from "@web/../tests/web_test_helpers";
 import { uniqueId } from "@web/core/utils/functions";
 import { addPlugin, defineWebsiteModels, setupWebsiteBuilder } from "./website_helpers";
 import { BuilderAction } from "@html_builder/core/builder_action";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 
 defineWebsiteModels();
 
@@ -22,13 +21,13 @@ test("do not update builder if in preview mode", async () => {
         };
     }
     addPlugin(P);
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`<BuilderButton id="'id1'" action="'customAction'">b1</BuilderButton>
-        <BuilderButton classAction="'b2_class'" t-if="this.isActiveItem('id1')">b2</BuilderButton>`;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderButton id="'id1'" action="'customAction'">b1</BuilderButton>
+            <BuilderButton classAction="'b2_class'" t-if="this.isActiveItem('id1')">b2</BuilderButton>
+        `,
+    });
     await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     await contains("[data-action-id='customAction']").hover();

--- a/addons/website/static/tests/builder/save.test.js
+++ b/addons/website/static/tests/builder/save.test.js
@@ -29,7 +29,6 @@ import {
 } from "@html_builder/../tests/helpers";
 import { Component, xml } from "@odoo/owl";
 import { BuilderAction } from "@html_builder/core/builder_action";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
 import { WebsiteBuilder } from "@website/builder/website_builder";
@@ -193,13 +192,11 @@ test("reload save with target, then discard and edit again should not reselect t
             }
         },
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-option";
-            static template = xml`<BuilderButton action="'testAction'"/>`;
-            static reloadTarget = true;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-option",
+        template: xml`<BuilderButton action="'testAction'"/>`,
+        reloadTarget: true,
+    });
     const deferred = Promise.withResolvers();
     await setupWebsiteBuilder(`<div class="test-option">b</div>`, {
         delayReload: async () => await deferred.promise,
@@ -245,13 +242,11 @@ test("preview shouldn't let o_dirty", async () => {
         };
     }
     addPlugin(TestPlugin);
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-option";
-            static template = xml`<BuilderButton action="'testAction'"/>`;
-            static reloadTarget = true;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-option",
+        template: xml`<BuilderButton action="'testAction'"/>`,
+        reloadTarget: true,
+    });
     await setupWebsiteBuilder(`<div class="test-option">b</div>`);
     editorIsStart = true;
     await contains(":iframe .test-option").click();
@@ -590,13 +585,11 @@ test("attempt to prevent closing window with unsaved changes", async () => {
 test("Modifying an element inside '.o_not_editable' should not mark this element as 'dirty'", async () => {
     // An example of such a situation is a change of the blog author that makes
     // a change of the author avatar accordingly.
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test";
-            static template = xml`<BuilderButton classAction="'x'"/>`;
-            static editableOnly = false;
-        }
-    );
+    addBuilderOption({
+        selector: ".test",
+        editableOnly: false,
+        template: xml`<BuilderButton classAction="'x'"/>`,
+    });
     await setupWebsiteBuilder(`
         <div class="o_not_editable" data-oe-model="model" data-oe-id="1" data-oe-field="field">
             <p class="test">Test</p>

--- a/addons/website/static/tests/builder/website_builder/background_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/background_option.test.js
@@ -20,10 +20,10 @@ const HEX_GREEN = "#00ff00";
 defineWebsiteModels();
 
 test("change the background shape of elements", async () => {
-    addBuilderOption(
-        class TestBackgroundOption extends BackgroundOption {
-            static selector = ".selector";
-            static applyTo = ".applyTo";
+    addBuilderOption({
+        selector: ".selector",
+        applyTo: ".applyTo",
+        Component: class TestBackgroundOption extends BackgroundOption {
             static props = {
                 ...BackgroundOption.props,
                 withColors: { type: Boolean, optional: true },
@@ -37,8 +37,8 @@ test("change the background shape of elements", async () => {
                 withShapes: true,
                 withColorCombinations: false,
             };
-        }
-    );
+        },
+    });
     await setupWebsiteBuilder(`
         <div class="selector">
             <div id="first" class="applyTo" data-oe-shape-data='{"shape":"html_builder/Connections/01","flip":[],"showOnMobile":false,"shapeAnimationSpeed":"0"}'>

--- a/addons/website/static/tests/builder/website_builder/customize_website.test.js
+++ b/addons/website/static/tests/builder/website_builder/customize_website.test.js
@@ -16,7 +16,6 @@ import {
 import { redo, undo } from "@html_editor/../tests/_helpers/user_actions";
 import { ReplaceBgImageAction } from "@html_builder/plugins/background_option/background_image_option_plugin";
 import { renderToString } from "@web/core/utils/render";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 
 defineWebsiteModels();
 
@@ -29,15 +28,13 @@ test("BuilderButton with action “websiteConfig” are correctly displayed", as
         await def.promise;
         return ["test_template_2"];
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
             <BuilderButton action="'websiteConfig'" actionParam="{views: ['test_template_1']}">1</BuilderButton>
             <BuilderButton action="'websiteConfig'" actionParam="{views: ['test_template_2']}">2</BuilderButton>
-        `;
-        }
-    );
+        `,
+    });
     await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".o-tab-content > .o_customize_tab").toHaveCount(0);
@@ -68,16 +65,14 @@ test("click on BuilderButton with action “websiteConfig”", async () => {
         return true;
     });
 
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
             <BuilderButton action="'websiteConfig'" actionParam="{views: ['test_template_1']}">1</BuilderButton>
             <BuilderButton action="'websiteConfig'" actionParam="{views: ['test_template_2']}">2</BuilderButton>
             <BuilderButton classAction="'a'">a</BuilderButton>
-        `;
-        }
-    );
+        `,
+    });
     await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect.verifySteps(["theme_customize_data_get"]);
@@ -105,17 +100,15 @@ test("click on BuilderSelectItem with action “websiteConfig”", async () => {
         return true;
     });
 
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
             <BuilderSelect action="'websiteConfig'">
                 <BuilderSelectItem actionParam="{views: ['test_template_1']}">1</BuilderSelectItem>
                 <BuilderSelectItem actionParam="{views: ['test_template_2']}">2</BuilderSelectItem>
             </BuilderSelect>
-        `;
-        }
-    );
+        `,
+    });
     await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect.verifySteps(["theme_customize_data_get"]);
@@ -134,15 +127,13 @@ test("use isActiveItem base on BuilderButton with 'websiteConfig'", async () => 
         await def.promise;
         return ["test_template_1"];
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
             <BuilderButton id="'a'" action="'websiteConfig'" actionParam="{views: ['test_template_1']}">1</BuilderButton>
             <div t-if="isActiveItem('a')" class="test">a</div>
-        `;
-        }
-    );
+        `,
+    });
     await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".o-tab-content > .o_customize_tab").toHaveCount(0);
@@ -164,15 +155,13 @@ test("use isActiveItem base on BuilderCheckbox with 'websiteConfig'", async () =
         await def.promise;
         return ["test_template_1"];
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
             <BuilderCheckbox id="'a'" action="'websiteConfig'" actionParam="{views: ['test_template_1']}"/>
             <div t-if="isActiveItem('a')" class="test">a</div>
-        `;
-        }
-    );
+        `,
+    });
     await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect(".o-tab-content > .o_customize_tab").toHaveCount(0);
@@ -199,14 +188,12 @@ test("click on BuilderCheckbox with action “websiteConfig”", async () => {
         expect(params.disable).toEqual(["test_template_2"]);
     });
 
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
             <BuilderCheckbox action="'websiteConfig'" actionParam="{views: ['!test_template_1', 'test_template_2']}"/>
-        `;
-        }
-    );
+        `,
+    });
     await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     expect.verifySteps(["theme_customize_data_get"]);
@@ -230,10 +217,9 @@ test("use isActiveItem base on BuilderSelectItem with websiteConfig", async () =
         expect(params.disable).toEqual([]);
     });
 
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
             <BuilderRow label.translate="Test">
                 <BuilderSelect action="'websiteConfig'">
                     <BuilderSelectItem actionParam="{views: ['test_template_1']}">a</BuilderSelectItem>
@@ -241,9 +227,8 @@ test("use isActiveItem base on BuilderSelectItem with websiteConfig", async () =
                 </BuilderSelect>
                 <div class="my-test" t-if="this.isActiveItem('test')">test</div>
             </BuilderRow>
-        `;
-        }
-    );
+        `,
+    });
 
     await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
@@ -272,10 +257,9 @@ test("isApplied with action “websiteConfig” depends on views, assets and var
         }
         return params.is_view_data ? ["test_template_1"] : ["test_asset_1"];
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
             <BuilderCheckbox action="'websiteConfig'"
                 actionParam="{
                     views: ['test_template_1'], assets: ['test_asset_1'], vars: { foo: 'bar', cat: 'cat' }
@@ -292,9 +276,8 @@ test("isApplied with action “websiteConfig” depends on views, assets and var
                 actionParam="{
                     views: ['test_template_1'], assets: ['test_asset_2'], vars: { foo: 'bar' }
                 }"/>
-        `;
-        }
-    );
+        `,
+    });
     const { getEditableContent } = await setupWebsiteBuilder(
         `<div class="test-options-target">b</div>`
     );
@@ -322,18 +305,16 @@ test("BuilderButton with action “previewableWebsiteConfig”", async () => {
         expect.step("websiteSave");
         return true;
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
             <BuilderButtonGroup action="'previewableWebsiteConfig'">
                 <BuilderButton actionParam="{views: ['test_template_1'], previewClass: 'test_class_1'}">1</BuilderButton>
                 <BuilderButton actionParam="{views: ['test_template_2', '!test_template_negation'], previewClass: 'test_class_2'}">2</BuilderButton>
                 <BuilderButton actionParam="{views: [], previewClass: ''}">3</BuilderButton>
             </BuilderButtonGroup>
-        `;
-        }
-    );
+        `,
+    });
 
     await setupWebsiteBuilder(`<div class="test-options-target test_class_1">b</div>`);
     await contains(":iframe .test-options-target").click();
@@ -381,18 +362,16 @@ test("Undo and redo “previewableWebsiteConfig” action", async () => {
         expect.step("websiteSave");
         return true;
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
             <BuilderButtonGroup action="'previewableWebsiteConfig'">
                 <BuilderButton actionParam="{views: ['test_template_1'], previewClass: 'test_class_1'}">1</BuilderButton>
                 <BuilderButton actionParam="{views: ['test_template_2'], previewClass: 'test_class_2'}">2</BuilderButton>
                 <BuilderButton actionParam="{views: [], previewClass: ''}">3</BuilderButton>
             </BuilderButtonGroup>
-        `;
-        }
-    );
+        `,
+    });
     const { getEditor } = await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
     const editor = getEditor();
 
@@ -437,17 +416,15 @@ test("No rpc call if “previewableWebsiteConfig” action is undone", async () 
         expect.step("websiteSave");
         return true;
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
             <BuilderButtonGroup action="'previewableWebsiteConfig'">
                 <BuilderButton actionParam="{views: [], previewClass: ''}">1</BuilderButton>
                 <BuilderButton actionParam="{views: ['test_template'], previewClass: 'test_class'}">2</BuilderButton>
             </BuilderButtonGroup>
-        `;
-        }
-    );
+        `,
+    });
     const { getEditor } = await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
     const editor = getEditor();
 
@@ -515,48 +492,46 @@ test("BuilderButton with action “templatePreviewableWebsiteConfig”", async (
         expect.step("websiteSave");
         return true;
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
-        <BuilderButtonGroup>
-            <BuilderButton
-                    action="'websiteConfig'"
-                    actionParam="{views: []}"
-            >Item1</BuilderButton>
-            <BuilderButton
-                    action="'templatePreviewableWebsiteConfig'"
-                    actionParam="{
-                        views: ['test_template_1'],
-                        previewClass: 'preview_class_1',
-                        templateId: 'test.template.1',
-                        placeBefore: '.target1',
-                    }"
-            >Item2</BuilderButton>
-            <BuilderButton
-                    action="'templatePreviewableWebsiteConfig'"
-                    actionParam="{
-                        views: ['test_template_2'],
-                        previewClass: 'preview_class_2',
-                        templateId: 'test.template.2',
-                        placeAfter: '.target1',
-                        placeExcludeRootClosest: '#o_wsale_container.o_wsale_has_sidebar',
-                    }"
-            >Item3</BuilderButton>
-            <BuilderButton
-                    action="'templatePreviewableWebsiteConfig'"
-                    actionParam="{
-                        views: ['test_template_3'],
-                        previewClass: 'preview_class_3',
-                        templateId: 'test.template.3',
-                        placeAfter: '.target2',
-                        placeExcludeRootClosest: '.excluded-class',
-                    }"
-            >Item4</BuilderButton>
-        </BuilderButtonGroup>
-            `;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderButtonGroup>
+                <BuilderButton
+                        action="'websiteConfig'"
+                        actionParam="{views: []}"
+                >Item1</BuilderButton>
+                <BuilderButton
+                        action="'templatePreviewableWebsiteConfig'"
+                        actionParam="{
+                            views: ['test_template_1'],
+                            previewClass: 'preview_class_1',
+                            templateId: 'test.template.1',
+                            placeBefore: '.target1',
+                        }"
+                >Item2</BuilderButton>
+                <BuilderButton
+                        action="'templatePreviewableWebsiteConfig'"
+                        actionParam="{
+                            views: ['test_template_2'],
+                            previewClass: 'preview_class_2',
+                            templateId: 'test.template.2',
+                            placeAfter: '.target1',
+                            placeExcludeRootClosest: '#o_wsale_container.o_wsale_has_sidebar',
+                        }"
+                >Item3</BuilderButton>
+                <BuilderButton
+                        action="'templatePreviewableWebsiteConfig'"
+                        actionParam="{
+                            views: ['test_template_3'],
+                            previewClass: 'preview_class_3',
+                            templateId: 'test.template.3',
+                            placeAfter: '.target2',
+                            placeExcludeRootClosest: '.excluded-class',
+                        }"
+                >Item4</BuilderButton>
+            </BuilderButtonGroup>
+        `,
+    });
 
     await setupWebsiteBuilder(
         `<div class="test-options-target excluded-class">

--- a/addons/website/static/tests/builder/website_builder/customize_website_color.test.js
+++ b/addons/website/static/tests/builder/website_builder/customize_website_color.test.js
@@ -2,7 +2,6 @@ import { expect, test } from "@odoo/hoot";
 import { animationFrame } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
 import { addBuilderOption } from "@html_builder/../tests/helpers";
-import { BaseOptionComponent } from "@html_builder/core/base_option_component";
 import { contains, defineModels, models, onRpc } from "@web/../tests/web_test_helpers";
 import {
     defineWebsiteModels,
@@ -26,25 +25,23 @@ test("BuilderColorPicker with action “customizeWebsiteColor” is correctly di
         def.resolve();
         return "";
     });
-    addBuilderOption(
-        class extends BaseOptionComponent {
-            static selector = ".test-options-target";
-            static template = xml`
-        <BuilderColorPicker
-            enabledTabs="['theme', 'custom', 'gradient']"
-            preview="false"
-            defaultColor="''"
-            action="'customizeWebsiteColor'"
-            actionParam="{
-                mainParam: 'test-custom',
-                gradientColor: 'test-gradient',
-                combinationColor: 'test',
-                nullValue: 'NULL',
-            }"
-        />
-        `;
-        }
-    );
+    addBuilderOption({
+        selector: ".test-options-target",
+        template: xml`
+            <BuilderColorPicker
+                enabledTabs="['theme', 'custom', 'gradient']"
+                preview="false"
+                defaultColor="''"
+                action="'customizeWebsiteColor'"
+                actionParam="{
+                    mainParam: 'test-custom',
+                    gradientColor: 'test-gradient',
+                    combinationColor: 'test',
+                    nullValue: 'NULL',
+                }"
+            />
+        `,
+    });
     await setupWebsiteBuilder(`<div class="test-options-target">b</div>`, {
         loadIframeBundles: true,
     });


### PR DESCRIPTION
Following the change to an XML-based options API [1], this commit
updates `addBuilderOption` tests utility to accept a configuration object instead
of a `BaseOptionComponent`.

The object now contains the attributes typically found in XML
(e.g., `selector`, `exclude`).

To align with the regular API and OWL conventions:
- If no custom JS class is required, the `template` is passed directly
  within the attribute object.
- If a JS class is necessary, it is passed via the `Component` key,
  and the template is defined on that class.

task-5358660

[1]: https://github.com/odoo/odoo/commit/3f63c76da0b867facd5ed021beea79efabea15f1