### PR TITLE
[FIX] website: set a truly unique id on image gallery

### DIFF
--- a/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/image_gallery_option_plugin.js
@@ -7,9 +7,9 @@ import { updateCarouselIndicators } from "../carousel_option_plugin";
 import { BuilderAction } from "@html_builder/core/builder_action";
 import { withSequence } from "@html_editor/utils/resource";
 import { SNIPPET_SPECIFIC, SNIPPET_SPECIFIC_END } from "@html_builder/utils/option_sequence";
-import { uniqueId } from "@web/core/utils/functions";
 import { BaseOptionComponent } from "@html_builder/core/utils";
 import { forwardToThumbnail } from "@html_builder/utils/utils_css";
+import { uuid } from "@web/core/utils/strings";
 
 /**
  * @typedef { Object } ImageGalleryOptionShared
@@ -82,7 +82,7 @@ class ImageGalleryOption extends Plugin {
 
     addUniqueIds(carousels) {
         for (const carousel of carousels) {
-            const id = uniqueId("slideshow_");
+            const id = `slideshow_${uuid()}`;
             carousel.id = id;
             const controllerButtons = carousel.querySelectorAll(".o_carousel_controllers button");
             for (const button of controllerButtons) {


### PR DESCRIPTION
Commit [86a3f41] called `uniqueId()` to generate the image gallery id in the builder options. However, `uniqueId()` is only unique in the course of the current client session. As a result, you could drop a gallery, save your page, refresh it, edit the page and drop another gallery with the same id as the 1st one.

Steps to reproduce:
- Drop an image gallery
- Save
- Refresh
- Go back to edit
- Drop another image gallery => Check their ids. It's very probable that they are the same.
- Save
- Click on the "Previous" or "Next" arrow of the 2nd gallery => it updates the 1st carousel, not the 2nd one.

[86a3f41]: https://github.com/odoo/odoo/commit/86a3f41a71a91c656a9969a4ef251f8c2ce3a266