### PR TITLE
[FIX] website: use span to show translation state of el with background

### DIFF
--- a/addons/website/static/src/@types/plugins.d.ts
+++ b/addons/website/static/src/@types/plugins.d.ts
@@ -28,6 +28,7 @@ declare module "plugins" {
     import { PopupVisibilityShared } from "@website/builder/plugins/popup_visibility_plugin";
     import { SwitchableViewsShared } from "@website/builder/plugins/switchable_views_plugin";
     import { theme_options, ThemeTabShared } from "@website/builder/plugins/theme/theme_tab_plugin";
+    import { force_background_translation_state_selectors } from "@website/builder/plugins/translation/repeat_translation_state_plugin";
     import { translate_options } from "@html_builder/core/builder_options_plugin_translate";
     import { WebsiteSessionShared } from "@website/builder/plugins/website_session_plugin";
 
@@ -84,6 +85,7 @@ declare module "plugins" {
         // Data
         searchbar_option_display_items: searchbar_option_display_items;
         searchbar_option_order_by_items: searchbar_option_order_by_items;
+        force_background_translation_state_selectors: force_background_translation_state_selectors;
         theme_options: theme_options;
         translate_options: translate_options;
         visibility_selector_parameters: visibility_selector_parameters;

--- a/addons/website/static/src/builder/plugins/options/badge_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/badge_option_plugin.js
@@ -19,4 +19,13 @@ class BadgeOptionPlugin extends Plugin {
         unsplittable_node_predicates: (node) => node.classList?.contains("s_badge"),
     };
 }
+
+export class BadgeTranslationPlugin extends Plugin {
+    static id = "badgeTranslation";
+    /** @type {import("plugins").WebsiteResources} */
+    resources = {
+        force_background_translation_state_selectors: "span.s_badge",
+    };
+}
+
 registry.category("website-plugins").add(BadgeOptionPlugin.id, BadgeOptionPlugin);

--- a/addons/website/static/src/builder/plugins/options/button_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/button_option_plugin.js
@@ -122,4 +122,12 @@ class ButtonOptionPlugin extends Plugin {
     }
 }
 
+export class ButtonTranslationPlugin extends Plugin {
+    static id = "buttonTranslation";
+    /** @type {import("plugins").WebsiteResources} */
+    resources = {
+        force_background_translation_state_selectors: "a.btn",
+    };
+}
+
 registry.category("website-plugins").add(ButtonOptionPlugin.id, ButtonOptionPlugin);

--- a/addons/website/static/src/builder/plugins/translation/repeat_translation_state_plugin.js
+++ b/addons/website/static/src/builder/plugins/translation/repeat_translation_state_plugin.js
@@ -1,0 +1,44 @@
+import { Plugin } from "@html_editor/plugin";
+import { selectElements } from "@html_editor/utils/dom_traversal";
+import { withSequence } from "@html_editor/utils/resource";
+import { unwrapContents } from "@html_editor/utils/dom";
+
+/**
+ * @typedef {import("plugins").CSSSelector} force_background_translation_state_selectors
+ * elements that may be inside a translation span and have a background-color
+ * hiding the span's color showing the translation state
+ */
+
+export class RepeatTranslationStatePlugin extends Plugin {
+    static id = "translateStateInButton";
+    static dependencies = ["selection"];
+
+    /** @type {import("plugins").WebsiteResources} */
+    resources = {
+        // lower sequence than the default to run before FeffPlugin's handler
+        normalize_handlers: withSequence(5, (root) => {
+            const cursors = this.dependencies.selection.preserveSelection();
+            for (const el of root.querySelectorAll(".o_translation_state_inner_span")) {
+                unwrapContents(el);
+            }
+            for (const el of selectElements(
+                root,
+                `[data-oe-translation-state] :is(${this.getResource(
+                    "force_background_translation_state_selectors"
+                ).join(",")})`
+            )) {
+                // wrap content in span.o_translation_state_inner_span
+                const repeater = this.document.createElement("span");
+                repeater.classList.add("o_translation_state_inner_span");
+                repeater.replaceChildren(...el.childNodes);
+                el.replaceChildren(repeater);
+            }
+            cursors.restore();
+        }),
+        clean_for_save_handlers: ({ root }) => {
+            for (const el of selectElements(root, ".o_translation_state_inner_span")) {
+                unwrapContents(el);
+            }
+        },
+    };
+}

--- a/addons/website/static/src/builder/translate.inside.scss
+++ b/addons/website/static/src/builder/translate.inside.scss
@@ -1,20 +1,20 @@
 html[lang] > body.editor_enable [data-oe-translation-state] {
-    &, .o_translation_select_option, &[data-oe-field="mega_menu_content"] * {
-        background-color: rgba($o-we-content-to-translate-color, 0.5) !important;
+    &, .o_translation_select_option {
+        --text-translate-highlight-color: #{rgba($o-we-content-to-translate-color, 0.5)};
     }
 
     &[data-oe-translation-state="translated"] {
-        &, .o_translation_select_option, &[data-oe-field="mega_menu_content"] * {
-            background-color: rgba($o-we-translated-content-color, 0.5) !important;
+        &, .o_translation_select_option {
+            --text-translate-highlight-color: #{rgba($o-we-translated-content-color, 0.5)};
         }
     }
 
     &.o_dirty, &.oe_translated, .oe_translated {
-        background-color: rgba($o-we-translated-content-color, 0.25) !important;
-
-        &[data-oe-field="mega_menu_content"] * {
-            background-color: rgba($o-we-translated-content-color, 0.25) !important;
-        }
+        --text-translate-highlight-color: #{rgba($o-we-translated-content-color, 0.25)};
+    }
+    
+    &, .o_translation_select_option, .oe_translated, &[data-oe-field="mega_menu_content"] *, .o_translation_state_inner_span {
+        background-color: var(--text-translate-highlight-color) !important;
     }
 }
 

--- a/addons/website/static/src/builder/website_builder.js
+++ b/addons/website/static/src/builder/website_builder.js
@@ -16,6 +16,9 @@ import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { useSetupAction } from "@web/search/action_hook";
 import { HighlightPlugin } from "./plugins/highlight/highlight_plugin";
+import { RepeatTranslationStatePlugin } from "./plugins/translation/repeat_translation_state_plugin";
+import { BadgeTranslationPlugin } from "./plugins/options/badge_option_plugin";
+import { ButtonTranslationPlugin } from "./plugins/options/button_option_plugin";
 import { PopupVisibilityPlugin } from "./plugins/popup_visibility_plugin";
 import { SaveTranslationPlugin } from "./plugins/save_translation_plugin";
 import { TranslateLinkInlinePlugin } from "./plugins/translate_link_inline_plugin";
@@ -58,6 +61,9 @@ const TRANSLATION_PLUGINS = [
     WebsiteVisibilityPlugin,
     AnimateOptionPlugin,
     HighlightPlugin,
+    RepeatTranslationStatePlugin,
+    BadgeTranslationPlugin,
+    ButtonTranslationPlugin,
     OperationPlugin,
     EditInteractionPlugin,
     TranslateTableOfContentOptionPlugin,

--- a/addons/website/static/tests/builder/translation.test.js
+++ b/addons/website/static/tests/builder/translation.test.js
@@ -215,6 +215,16 @@ test("404 page in translate mode", async () => {
     expect(".o_popover .o_edit_website_dropdown_item:contains('Create page')").toHaveCount(1);
 });
 
+test("color span is inserted in a.btn (and s_badge) with a background to show the translation state", async () => {
+    await setupSidebarBuilderForTranslation({
+        websiteContent: getTranslateEditable({
+            inWrap: `<a class="btn">Hello</a> <span class="s_badge">Badge</span>`,
+        }),
+    });
+    expect(":iframe a .o_translation_state_inner_span").toHaveCount(1);
+    expect(":iframe .s_badge .o_translation_state_inner_span").toHaveCount(1);
+});
+
 test("translate attribute", async () => {
     const resultSave = [];
     onRpc("/web_editor/field/translation/update", async (data) => {


### PR DESCRIPTION
When buttons (`a.btn` elements) are translated inline, or badges (`span.s_badge`), the background color that shows the status of the translation appears under the background of the button/badge. The status is thus only visible on the surrounding text, and completely invisible when the button is alone (unless it has a transparent background).

This commit adds a plugin in translate mode which adds a span with the color of the translation status in the problematic elements if they are inside a translation span and have a background color.

Steps to reproduce:
- Open website builder
- Drop the `s_banner` snippet (or add a button by typing `/button`)
- Add a second language
- Open in translate mode
- Bug: the text of the button does not have the green/yellow highlight that shows the translation state (technically, it is hidden under the background of the button, which you can see if you set a transparent background on the button)

`o_translate_inline` on links:
  - 8fe88de0d5cc61395721cd8bda7b7ef2ea961760
  - f65ac79631180e77aca5a53fc557b3e1acfcbd65
  - 6aef5ee411656ec400e92fcc2bbd62e420645e0e

task-6038029