### PR TITLE
[PERF] stock_account: filter products with stock in valuation report

### DIFF
--- a/addons/stock_account/models/res_company.py
+++ b/addons/stock_account/models/res_company.py
@@ -98,9 +98,7 @@ class ResCompany(models.Model):
         if not accounts_by_product:
             accounts_by_product = self._get_accounts_by_product()
         account_data = defaultdict(float)
-        stock_valuation_accounts_ids = set()
-        for dummy, accounts in accounts_by_product.items():
-            stock_valuation_accounts_ids.add(accounts['valuation'].id)
+        stock_valuation_accounts_ids = {accounts['valuation'].id for accounts in accounts_by_product.values()}
         stock_valuation_accounts = self.env['account.account'].browse(stock_valuation_accounts_ids)
         domain = Domain([
             ('account_id', 'in', stock_valuation_accounts.ids),
@@ -146,7 +144,9 @@ class ResCompany(models.Model):
 
     def _get_accounts_by_product(self, products=None):
         if not products:
-            products = self.env['product.product'].with_company(self).search(self._get_valuation_product_domain())
+            products = self.env['product.product'].with_company(self).search_fetch(
+                self._get_valuation_product_domain(), ['categ_id'],
+            )
 
         accounts_by_product = {}
         for product in products:

--- a/addons/stock_account/models/res_company.py
+++ b/addons/stock_account/models/res_company.py
@@ -95,12 +95,11 @@ class ResCompany(models.Model):
 
     def stock_accounting_value(self, accounts_by_product=None, at_date=None):
         self.ensure_one()
-        if not accounts_by_product:
-            accounts_by_product = self._get_accounts_by_product()
         account_data = defaultdict(float)
-        stock_valuation_accounts_ids = set()
-        for dummy, accounts in accounts_by_product.items():
-            stock_valuation_accounts_ids.add(accounts['valuation'].id)
+        if accounts_by_product:
+            stock_valuation_accounts_ids = {accounts['valuation'].id for accounts in accounts_by_product.values()}
+        else:
+            stock_valuation_accounts_ids = self._get_valuation_accounts()
         stock_valuation_accounts = self.env['account.account'].browse(stock_valuation_accounts_ids)
         domain = Domain([
             ('account_id', 'in', stock_valuation_accounts.ids),
@@ -154,6 +153,33 @@ class ResCompany(models.Model):
                 'expense': accounts['expense'],
             }
         return accounts_by_product
+
+    def _get_valued_product_ids(self):
+        """ Return product ids that have quants in valued internal locations.
+        Same location/owner criteria as product._with_valuation_context().
+        """
+        valued_locations = self.env['stock.location'].search([('is_valued_internal', '=', True)])
+        domain = [
+            ('location_id', 'in', valued_locations.ids),
+            ('owner_id', 'in', [False, self.partner_id.id]),
+        ]
+        return {
+            product.id
+            for product, in self.env['stock.quant']._read_group(domain, groupby=['product_id'])
+        }
+
+    def _get_valuation_accounts(self):
+        """ Return the set of stock valuation account IDs from product categories.
+        Lightweight alternative to _get_accounts_by_product() when only account IDs are needed.
+        """
+        categs = self.env['product.category'].with_company(self).search([
+            ('property_stock_valuation_account_id', '!=', False),
+        ])
+        valuation_account_ids = {categ.property_stock_valuation_account_id.id for categ in categs}
+        if self.account_stock_valuation_id:
+            valuation_account_ids.add(self.account_stock_valuation_id.id)
+        valuation_account_ids.discard(False)
+        return valuation_account_ids
 
     @api.model
     def _get_extra_balance(self, vals_list=None):
@@ -233,7 +259,7 @@ class ResCompany(models.Model):
             inventory_data = self.env.context.get('inventory_data')
         else:
             inventory_data = self.stock_value(accounts_by_product, at_date)
-        accounting_data = self.stock_accounting_value(accounts_by_product, at_date)
+        accounting_data = self.stock_accounting_value(at_date=at_date)
 
         accounts = inventory_data.keys() | accounting_data.keys()
         for account in accounts:

--- a/addons/stock_account/report/stock_valuation_report.py
+++ b/addons/stock_account/report/stock_valuation_report.py
@@ -32,12 +32,24 @@ class StockValuationReport(models.AbstractModel):
             date = fields.Date.from_string(date)
         if date == fields.Date.context_today(self):
             date = False
+        # PERF: only products holding stock contribute to the valuation. Match the
+        # context used by total_value so qty_available scopes to valued internal locations.
+        # Lot-valuated products are kept regardless because their value is summed from lots.
+        # sudo: qty_available expands kit BoMs (mrp.bom) which accounting users cannot read.
+        valued_product_context = self.env['product.product'].sudo().with_company(company)._with_valuation_context()
+        if date:
+            valued_product_context = valued_product_context.with_context(at_date=date, to_date=date)
+        valued_products = valued_product_context.search([
+            ('is_storable', '=', True),
+            '|', ('qty_available', '!=', 0), ('lot_valuated', '=', True),
+        ])
+        accounts_by_product = company._get_accounts_by_product(products=valued_products)
         if not date:
-            inventory_data = company.stock_value()
-            accounting_data = company.stock_accounting_value()
+            inventory_data = company.stock_value(accounts_by_product)
+            accounting_data = company.stock_accounting_value(accounts_by_product)
         else:
-            inventory_data = company.stock_value(at_date=date)
-            accounting_data = company.stock_accounting_value(at_date=date)
+            inventory_data = company.stock_value(accounts_by_product, at_date=date)
+            accounting_data = company.stock_accounting_value(accounts_by_product, at_date=date)
 
         accounts = inventory_data.keys() | accounting_data.keys()
         account_ids = {acc.id for acc in accounts}
@@ -70,7 +82,6 @@ class StockValuationReport(models.AbstractModel):
                 ending_stock['lines_by_account_id'][account.id]['value'] += ending_balance
 
         # Get accounting data.
-        accounts_by_product = company._get_accounts_by_product()
         location_valuation_vals = company._get_location_valuation_vals(
             date, location_domain=[('usage', '=', 'inventory')],
         )

--- a/addons/stock_account/report/stock_valuation_report.py
+++ b/addons/stock_account/report/stock_valuation_report.py
@@ -32,11 +32,18 @@ class StockValuationReport(models.AbstractModel):
             date = fields.Date.from_string(date)
         if date == fields.Date.today():
             date = False
+        # PERF: only load products that have quants in valued locations
+        valued_product_ids = company._get_valued_product_ids()
+        valued_products = self.env['product.product'].with_company(company).search([
+            ('is_storable', '=', True),
+            ('id', 'in', valued_product_ids),
+        ])
+        accounts_by_product = company._get_accounts_by_product(products=valued_products)
         if not date:
-            inventory_data = company.stock_value()
+            inventory_data = company.stock_value(accounts_by_product)
             accounting_data = company.stock_accounting_value()
         else:
-            inventory_data = company.stock_value(at_date=date)
+            inventory_data = company.stock_value(accounts_by_product, at_date=date)
             accounting_data = company.stock_accounting_value(at_date=date)
 
         accounts = inventory_data.keys() | accounting_data.keys()
@@ -72,7 +79,6 @@ class StockValuationReport(models.AbstractModel):
                 ending_stock['lines_by_account_id'][account.id]['value'] += ending_balance
 
         # Get accounting data.
-        accounts_by_product = company._get_accounts_by_product()
         location_valuation_vals = company._get_location_valuation_vals(
             date, location_domain=[('usage', '=', 'inventory')],
         )


### PR DESCRIPTION
Opening the Inventory Valuation report iterated every storable product to compute total_value, which on large catalogs used several GB of RAM and timed out workers.

The report now searches only products that have stock (under the same valuation context that total_value uses) or that are lot-valuated, and feeds that smaller set into stock_value and stock_accounting_value. For historical (at_date) reports the search runs with to_date in context so qty_available is scoped to that date. _get_accounts_by_product() also switches to search_fetch so only categ_id is loaded upfront.

Benchmarks were measured on a customer database restore with ~360k storable products. After filtering, ~2.5k products feed into the valuation today and ~2.2k for a historical date.

Benchmark opening Inventory Valuation report (Accounting)
| Date       | Before | After  | Speed up |
|------------|--------|--------|----------|
| Today      | ~88s   | ~2s    | 41x      |
| Historical | ~245s  | ~173s  | 1.4x     |

The historical improvement is more modest because stock_value still has to compute total_value at the historical date for the remaining products, which traces SVL/stock.move history; the filter eliminates the dominant per-product overhead today but only the tail in the historical case.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr