### PR TITLE
[FIX] addons: auth_oauth: views: Added res_users_views.xml back

### DIFF
--- a/addons/auth_oauth/views/res_users_views.xml
+++ b/addons/auth_oauth/views/res_users_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+        <record id="view_users_form" model="ir.ui.view">
+            <field name="name">res.users.form.inherit</field>
+            <field name="model">res.users</field>
+            <field name="inherit_id" ref="base.view_users_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//page[@name='preferences']" position="after">
+                    <page string="Oauth" name="oauth">
+                        <group>
+                            <field name="oauth_provider_id"/>
+                            <field name="oauth_uid"/>
+                        </group>
+                    </page>
+                </xpath>
+            </field>
+        </record>
+</odoo>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Bug fix to let admins specify which users use what an OAuth provider and which OAuth uid


Current behavior before PR:

Currently an admin would have to edit database entries for users by hand to specify the OAuth provider and OAuth uid for each user

Desired behavior after PR is merged:

Admins would be able to do it without leaving the user settings page


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
