### PR TITLE
[IMP] orm: deprecate env.clear

### DIFF
--- a/addons/base_automation/tests/test_automation.py
+++ b/addons/base_automation/tests/test_automation.py
@@ -65,7 +65,7 @@ class TestAutomation(TransactionCaseWithUserDemo):
         action.flush_recordset()
         automation.write({"action_server_ids": [Command.link(action.id)]})
         # action cached was cached with admin, force CacheMiss
-        automation.env.clear()
+        automation.env.transaction.clear()
 
         self_portal = self.env["ir.filters"].with_user(self.user_demo.id)
         # verify the portal user can create ir.filters but can not read base.automation
@@ -103,7 +103,7 @@ class TestAutomation(TransactionCaseWithUserDemo):
         })
         automation.write({"action_server_ids": [Command.link(action.id)]})
         # action cached was cached with admin, force CacheMiss
-        automation.env.clear()
+        automation.env.transaction.clear()
 
         self_portal = self.env["ir.filters"].with_user(self.user_demo.id)
 
@@ -133,7 +133,7 @@ class TestAutomation(TransactionCaseWithUserDemo):
         action.flush_recordset()
         automation.write({"action_server_ids": [Command.link(action.id)]})
         # action cached was cached with admin, force CacheMiss
-        automation.env.clear()
+        automation.env.transaction.clear()
 
         server_action = self.env["ir.actions.server"].create({
             "name": "Empty write",

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -2098,7 +2098,7 @@ class TestPointOfSaleFlow(CommonPosTest):
             'lst_price': 200.0,
             'company_id': new_company.id,
         })
-        self.env.clear()
+        self.env.transaction.clear()
         data = current_session.with_company(self.env.company).filter_local_data({'product.product': [product.id]})
         self.assertIn(product.id, data['product.product'])
 

--- a/addons/pos_sale/tests/test_pos_sale_report.py
+++ b/addons/pos_sale/tests/test_pos_sale_report.py
@@ -182,7 +182,7 @@ class TestPoSSaleReport(TestPoSCommon, TestPointOfSaleHttpCommon):
         order.picking_ids.button_validate()
         # flush computations and clear the cache before checking again the report
         self.env.flush_all()
-        self.env.clear()
+        self.env.transaction.clear()
 
         report = self.env['sale.report'].sudo().search([('product_id', '=', self.product0.id)], order='id')
 

--- a/odoo/addons/test_orm/tests/test_api.py
+++ b/odoo/addons/test_orm/tests/test_api.py
@@ -528,14 +528,14 @@ class TestAPI(SavepointCaseWithUserDemo):
         self.assertEqual(partner1.child_ids, partner2)
 
         # reading partner1 should not prefetch 'vat_label' on partner2
-        self.env.clear()
+        self.env.transaction.clear()
         partner1 = partner1.with_prefetch()
         partner1.read(['vat_label'])
         self.assertIn('vat_label', partner1._cache)
         self.assertNotIn('vat_label', partner2._cache)
 
         # reading partner1 should not prefetch 'vat_label' on partner2
-        self.env.clear()
+        self.env.transaction.clear()
         partner1 = partner1.with_prefetch()
         partner1.read(['child_ids', 'vat_label'])
         self.assertIn('vat_label', partner1._cache)

--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -1927,7 +1927,7 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
         cat2 = Category.create({'name': 'ACCESS', 'parent': cat1.id})
         cats = cat1 + cat2
 
-        self.env.clear()
+        self.env.transaction.clear()
 
         cat1, cat2 = cats
         self.assertEqual(cat2.name, 'ACCESS')

--- a/odoo/orm/environments.py
+++ b/odoo/orm/environments.py
@@ -18,6 +18,7 @@ from zoneinfo import ZoneInfo
 from odoo.exceptions import AccessError, UserError, CacheMiss
 from odoo.sql_db import BaseCursor
 from odoo.tools import clean_context, frozendict, reset_cached_properties, OrderedSet, SQL
+from odoo.tools.func import deprecated
 from odoo.tools.translate import get_translation, get_translated_module, LazyGettext
 from odoo.tools.misc import StackMap, SENTINEL
 
@@ -359,6 +360,7 @@ class Environment(Mapping[str, "BaseModel"]):
             _logger.debug('translation went wrong for "%r", skipped', source, exc_info=True)
         return source
 
+    @deprecated("Since 20.0, use transaction.clear or transaction.reset")
     def clear(self) -> None:
         """ Clear all record caches, and discard all fields to recompute.
             This may be useful when recovering from a failed ORM operation.

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1200,7 +1200,6 @@ class TransactionCase(BaseCase):
 
         # This prevents precommit functions and data from piling up
         # until cr.flush is called in 'assertRaises' clauses
-        # (these are not cleared in self.env.clear or envs.clear)
         def _reset(cb, funcs, data):
             cb._funcs = funcs
             cb.data = data

--- a/odoo/tests/form.py
+++ b/odoo/tests/form.py
@@ -324,7 +324,7 @@ class Form:
 
         [record_values] = self._record.web_read(self._view['fields_spec'])
         self._env.flush_all()
-        self._env.clear()  # discard cache and pending recomputations
+        self._env.transaction.clear()
 
         values = convert_read_to_form(record_values, self._view['fields'])
         self._values.update(values)
@@ -453,7 +453,7 @@ class Form:
             # save and reload
             [record_values] = self._record.web_save(values, self._view['fields_spec'])
             self._env.flush_all()
-            self._env.clear()  # discard cache and pending recomputations
+            self._env.transaction.clear()  # discard cache and pending recomputations
 
             if not self._record:
                 record = self._record.browse(record_values['id'])
@@ -578,7 +578,7 @@ class Form:
         values = self._get_onchange_values()
         result = record.onchange(values, field_names, self._view['fields_spec'])
         self._env.flush_all()
-        self._env.clear()  # discard cache and pending recomputations
+        self._env.transaction.clear()  # discard cache and pending recomputations
 
         if w := result.get('warning'):
             if isinstance(w, collections.abc.Mapping) and w.keys() >= {'title', 'message'}:


### PR DESCRIPTION
The function does the same as `transaction.clear`, but resets the properties of the current environment. This is misleading, because we did not clear properties on other environments which may keep the wrong state. The user should call the right method on the transaction.

https://github.com/odoo/upgrade-util/pull/394


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
