### PR TITLE
[FIX] pos_discount: move discount logic to pos_discount

### DIFF
--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -118,14 +118,3 @@ class AccountMoveLine(models.Model):
     def _compute_name(self):
         amls = self.filtered(lambda l: not l.move_id.pos_session_ids)
         super(AccountMoveLine, amls)._compute_name()
-
-    def _get_discount_lines(self):
-        lines = super()._get_discount_lines()
-        discount_line_ids = []
-        for line in self - lines:
-            pos_orders = line.move_id.sudo().pos_order_ids
-            if pos_orders and line.product_id in pos_orders.config_id.discount_product_id:
-                discount_line_ids.append(line.id)
-        if discount_line_ids:
-            lines |= self.browse(discount_line_ids)
-        return lines

--- a/addons/pos_discount/models/__init__.py
+++ b/addons/pos_discount/models/__init__.py
@@ -4,3 +4,4 @@
 from . import pos_config
 from . import res_config_settings
 from . import product_product
+from . import account_move_line

--- a/addons/pos_discount/models/account_move_line.py
+++ b/addons/pos_discount/models/account_move_line.py
@@ -1,0 +1,18 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = 'account.move.line'
+
+    def _get_discount_lines(self):
+        lines = super()._get_discount_lines()
+        discount_line_ids = []
+        for line in self - lines:
+            pos_orders = line.move_id.sudo().pos_order_ids
+            if pos_orders and line.product_id in pos_orders.config_id.discount_product_id:
+                discount_line_ids.append(line.id)
+        if discount_line_ids:
+            lines |= self.browse(discount_line_ids)
+        return lines


### PR DESCRIPTION
Previously, the logic for retrieving discount lines was implemented in the `point_of_sale` module, while the `discount_product_id` was managed in the `pos_discount` module. This commit fixes the logic by moving the `_get_discount_lines` method into the `pos_discount` module.

task-5875158