### PR TITLE
[IMP] html_editor: second ` should not create code if first is followed by space

### DIFF
--- a/addons/html_editor/static/src/main/hint_plugin.js
+++ b/addons/html_editor/static/src/main/hint_plugin.js
@@ -1,7 +1,7 @@
 import { Plugin } from "@html_editor/plugin";
-import { isEditorTab, isEmptyBlock, isProtected } from "@html_editor/utils/dom_info";
+import { isEmptyBlock, isProtected } from "@html_editor/utils/dom_info";
 import { removeClass } from "@html_editor/utils/dom";
-import { descendants, selectElements } from "@html_editor/utils/dom_traversal";
+import { selectElements } from "@html_editor/utils/dom_traversal";
 import { closestBlock } from "../utils/blocks";
 import { debounce } from "@web/core/utils/timing";
 
@@ -102,7 +102,7 @@ export class HintPlugin extends Plugin {
                         nodeHint &&
                         isEmptyBlock(target) &&
                         !isProtected(target) &&
-                        !descendants(target).some(isEditorTab)
+                        (this.checkPredicates("should_show_hint_predicates", target) ?? true)
                     ) {
                         this.makeHint(target, nodeHint);
                     }

--- a/addons/html_editor/static/src/main/inline_code.js
+++ b/addons/html_editor/static/src/main/inline_code.js
@@ -117,7 +117,7 @@ export class InlineCodePlugin extends Plugin {
         // one in the text.
         let textNode = selection.startContainer;
         const wholeText = textNode.wholeText;
-        const textHasTwoTicks = /`[^`]+`/.test(wholeText);
+        const textHasTwoTicks = /`[^ `][^`]*`/.test(wholeText);
         // We don't apply the code tag if there is no content between the two `
         if (textHasTwoTicks && wholeText.replace(/`/g, "").length) {
             let offset = selection.startOffset;

--- a/addons/html_editor/static/src/main/inline_code.js
+++ b/addons/html_editor/static/src/main/inline_code.js
@@ -19,6 +19,9 @@ export class InlineCodePlugin extends Plugin {
             selectElements(root, ".o_inline_code").flatMap((code) =>
                 this.dependencies.feff.surroundWithFeffs(code, cursors)
             ),
+        should_show_hint_predicates: (node) => !node.querySelector(".o_inline_code"),
+        should_show_power_buttons_predicates: ({ anchorNode }) =>
+            !closestBlock(anchorNode).querySelector(".o_inline_code"),
     };
 
     setup() {

--- a/addons/html_editor/static/src/main/power_buttons_plugin.js
+++ b/addons/html_editor/static/src/main/power_buttons_plugin.js
@@ -1,8 +1,8 @@
 import { Plugin } from "@html_editor/plugin";
 import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
 import { closestBlock } from "@html_editor/utils/blocks";
-import { isEditorTab, isEmptyBlock } from "@html_editor/utils/dom_info";
-import { closestElement, descendants } from "@html_editor/utils/dom_traversal";
+import { isEmptyBlock } from "@html_editor/utils/dom_info";
+import { closestElement } from "@html_editor/utils/dom_traversal";
 import { omit, pick } from "@web/core/utils/objects";
 import { debounce } from "@web/core/utils/timing";
 
@@ -152,7 +152,6 @@ export class PowerButtonsPlugin extends Plugin {
             block?.matches(baseContainerGlobalSelector) &&
             editableRect.bottom > blockRect.top &&
             isEmptyBlock(block) &&
-            !descendants(block).some(isEditorTab) &&
             !this.services.ui.isSmall &&
             !closestElement(documentSelection.anchorNode, "td, th, li") &&
             !block.style.textAlign &&

--- a/addons/html_editor/static/src/main/tabulation_plugin.js
+++ b/addons/html_editor/static/src/main/tabulation_plugin.js
@@ -82,6 +82,9 @@ export class TabulationPlugin extends Plugin {
                 return false;
             }
         },
+        should_show_hint_predicates: (node) => !node.querySelector("span.oe-tabs"),
+        should_show_power_buttons_predicates: ({ anchorNode }) =>
+            !closestBlock(anchorNode).querySelector("span.oe-tabs"),
     };
 
     handleTab() {

--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -179,7 +179,7 @@ export function isWhitespace(value) {
 }
 
 // eslint-disable-next-line no-control-regex
-const visibleCharRegex = /[^\s\u200b]|[\u00A0\u0009]$/; // contains at least a char that is always visible (TODO: 0009 shouldn't be included)
+const visibleCharRegex = /[^\s\u200b]|[\u00A0\u0009]/; // contains at least a char that is always visible (TODO: 0009 shouldn't be included)
 export function isVisibleTextNode(testedNode) {
     if (!testedNode || !testedNode.length || testedNode.nodeType !== Node.TEXT_NODE) {
         return false;

--- a/addons/html_editor/static/tests/format/inline_code.test.js
+++ b/addons/html_editor/static/tests/format/inline_code.test.js
@@ -138,3 +138,15 @@ test("should open toolbar for mixed selection and apply formatting outside inlin
         `<p>abc\ufeff<code class="o_inline_code">\ufefft[est\ufeff</code>\ufeff<span class="display-1-fs"><font style="color: rgb(0, 0, 255);"><strong>de]</strong></font></span>f</p>`
     );
 });
+
+test("hint should not be visible if inline code has a space", async () => {
+    const { el, editor } = await setupEditor(`<p><code class="o_inline_code"> a[]</code></p>`);
+    await animationFrame();
+    expect(getContent(el)).toBe(
+        `<p>\ufeff<code class="o_inline_code">\ufeff a[]\ufeff</code>\ufeff</p>`
+    );
+    deleteBackward(editor);
+    expect(getContent(el)).toBe(
+        `<p>\ufeff<code class="o_inline_code">\ufeff&nbsp;[]\ufeff</code>\ufeff<br></p>`
+    );
+});

--- a/addons/html_editor/static/tests/link/existing.test.js
+++ b/addons/html_editor/static/tests/link/existing.test.js
@@ -177,6 +177,15 @@ test("should not add a character in the link if start of paragraph", async () =>
     });
 });
 
+test("should not show hint for link with only &nbsp;", async () => {
+    await testEditor({
+        contentBefore: '<p><a href="http://test.test/">&nbsp;[]</a></p>',
+        contentAfterEdit:
+            '<p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff&nbsp;[]\ufeff</a>\ufeff</p>',
+        contentAfter: '<p><a href="http://test.test/">&nbsp;[]</a></p>',
+    });
+});
+
 // test.todo('should select and replace all text and add the next char in bold', async () => {
 //     await testEditor({
 //         contentBefore: '<div><p>[]123</p><p><a href="#">abc</a></p></div>',

--- a/addons/html_editor/static/tests/markdown.test.js
+++ b/addons/html_editor/static/tests/markdown.test.js
@@ -352,6 +352,17 @@ describe("inline code", () => {
             contentAfter: "<p>a`[]f</p>",
         });
     });
+
+    test("should not show placeholder when inline code is available", async () => {
+        await testEditor({
+            contentBefore: '<p><code class="o_inline_code">[] </code></p>',
+            contentBeforeEdit:
+                '<p>\ufeff<code class="o_inline_code">\ufeff[] \ufeff</code>\ufeff</p>',
+            contentAfterEdit:
+                '<p>\ufeff<code class="o_inline_code">\ufeff[] \ufeff</code>\ufeff</p>',
+            contentAfter: '<p><code class="o_inline_code">[]&nbsp;</code></p>',
+        });
+    });
 });
 
 describe("pre", () => {

--- a/addons/html_editor/static/tests/markdown.test.js
+++ b/addons/html_editor/static/tests/markdown.test.js
@@ -97,6 +97,14 @@ describe("inline code", () => {
         });
     });
 
+    test("should not convert text into inline code when space is avaialbe right after first backtick", async () => {
+        await testEditor({
+            contentBefore: "<p>ab` test[]</p>",
+            stepFunction: async (editor) => await insertText(editor, "`"),
+            contentAfter: "<p>ab` test`[]</p>",
+        });
+    });
+
     test("should not convert text into inline code when interrupted by linebreak", async () => {
         await testEditor({
             contentBefore: "<p>ab`c<br>d[]ef</p>",

--- a/addons/html_editor/static/tests/power_buttons.test.js
+++ b/addons/html_editor/static/tests/power_buttons.test.js
@@ -137,6 +137,11 @@ describe("visibility", () => {
         await new Promise((resolve) => setTimeout(resolve, 30));
         expect(".o_we_power_buttons").toBeVisible();
     });
+
+    test("should not show powerButtons when inline code is available", async () => {
+        await setupEditor(`<p><code class="o_inline_code">[] </code></p>`);
+        expect(".o_we_power_buttons").not.toBeVisible();
+    });
 });
 
 describe.tags("desktop");

--- a/addons/html_editor/static/tests/tabs.test.js
+++ b/addons/html_editor/static/tests/tabs.test.js
@@ -745,7 +745,7 @@ describe("insert tabulation", () => {
                     tabAfterA,
                     false
                 )}b</p>` +
-                `<p>${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}<br></p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}</p>` +
                 `<h1>${oeTab(TAB_WIDTH, false)}c${oeTab(tabAfterCinH1, false)}</h1>` +
                 `<h1>${oeTab(TAB_WIDTH, false)}d${oeTab(tabAfterDinH1, false)}</h1>` +
                 `<blockquote>${oeTab(tabInBlockquote, false)}e${oeTab(
@@ -756,7 +756,7 @@ describe("insert tabulation", () => {
             contentAfter:
                 `<p>xxx</p>` +
                 `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}a[${oeTab(tabAfterA)}b</p>` +
-                `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}<br></p>` +
+                `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}</p>` +
                 `<h1>${oeTab(TAB_WIDTH)}c${oeTab(tabAfterCinH1)}</h1>` +
                 `<h1>${oeTab(TAB_WIDTH)}d${oeTab(tabAfterDinH1)}</h1>` +
                 `<blockquote>${oeTab(tabInBlockquote)}e${oeTab(
@@ -787,7 +787,7 @@ describe("insert tabulation", () => {
                     tabAfterA,
                     false
                 )}b</p>` +
-                `<p>${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}<br></p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}</p>` +
                 `<h1>${oeTab(TAB_WIDTH, false)}c${oeTab(tabAfterCinH1, false)}</h1>` +
                 `<h1>${oeTab(TAB_WIDTH, false)}d${oeTab(tabAfterDinH1, false)}</h1>` +
                 `<blockquote>${oeTab(tabInBlockquote, false)}e${oeTab(
@@ -798,7 +798,7 @@ describe("insert tabulation", () => {
             contentAfter:
                 `<p>xxx</p>` +
                 `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}a]${oeTab(tabAfterA)}b</p>` +
-                `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}<br></p>` +
+                `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}</p>` +
                 `<h1>${oeTab(TAB_WIDTH)}c${oeTab(tabAfterCinH1)}</h1>` +
                 `<h1>${oeTab(TAB_WIDTH)}d${oeTab(tabAfterDinH1)}</h1>` +
                 `<blockquote>${oeTab(tabInBlockquote)}e${oeTab(
@@ -890,7 +890,7 @@ describe("insert tabulation", () => {
             contentAfterEdit:
                 `<p>${oeTab(TAB_WIDTH, false)}a</p>` +
                 `<p>[${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}b</p>` +
-                `<p>${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}<br></p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}</p>` +
                 `<ul>` +
                     `<li class="oe-nested">` +
                         `<ul>` +
@@ -907,7 +907,7 @@ describe("insert tabulation", () => {
             contentAfter:
                 `<p>${oeTab(TAB_WIDTH)}a</p>` +
                 `<p>[${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}b</p>` +
-                `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}<br></p>` +
+                `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}</p>` +
                 `<ul>` +
                     `<li class="oe-nested">` +
                         `<ul>` +
@@ -950,7 +950,7 @@ describe("insert tabulation", () => {
             contentAfterEdit:
                 `<p>${oeTab(TAB_WIDTH, false)}a</p>` +
                 `<p>]${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}b</p>` +
-                `<p>${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}<br></p>` +
+                `<p>${oeTab(TAB_WIDTH, false)}${oeTab(TAB_WIDTH, false)}</p>` +
                 `<ul>` +
                     `<li class="oe-nested">` +
                         `<ul>` +
@@ -967,7 +967,7 @@ describe("insert tabulation", () => {
             contentAfter:
                 `<p>${oeTab(TAB_WIDTH)}a</p>` +
                 `<p>]${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}b</p>` +
-                `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}<br></p>` +
+                `<p>${oeTab(TAB_WIDTH)}${oeTab(TAB_WIDTH)}</p>` +
                 `<ul>` +
                     `<li class="oe-nested">` +
                         `<ul>` +


### PR DESCRIPTION
Purpose:

- If a first backtick(`) is immediately followed by a space, inserting second backtick should not create an inline code block.
- If a paragraph block contains only inline code, the hint should not be visible, even when the inline code is empty.

task- 5392061