### PR TITLE
[REF] html_editor, *: improve createBaseContainer handling of empty blocks 

### DIFF
--- a/addons/html_editor/static/src/core/base_container_plugin.js
+++ b/addons/html_editor/static/src/core/base_container_plugin.js
@@ -18,6 +18,7 @@ import {
 import { withSequence } from "@html_editor/utils/resource";
 import { selectElements } from "@html_editor/utils/dom_traversal";
 import { childNodeIndex } from "@html_editor/utils/position";
+import { callbacksForCursorUpdate } from "@html_editor/utils/selection";
 
 /**
  * @typedef { Object } BaseContainerShared
@@ -92,8 +93,17 @@ export class BaseContainerPlugin extends Plugin {
         system_classes: [BASE_CONTAINER_CLASS],
     };
 
-    createBaseContainer(nodeName = this.getDefaultNodeName()) {
-        return createBaseContainer(nodeName, this.document);
+    createBaseContainer({ nodeName = this.getDefaultNodeName(), children } = {}) {
+        const container = createBaseContainer(nodeName, this.document, children);
+        if (children?.length) {
+            // Update cursors for moved children so callers don't have to.
+            const cursors = this.dependencies.selection.preserveSelection();
+            for (const child of children) {
+                cursors.update(callbacksForCursorUpdate.append(container, child));
+            }
+            cursors.restore();
+        }
+        return container;
     }
 
     getDefaultNodeName() {
@@ -110,7 +120,9 @@ export class BaseContainerPlugin extends Plugin {
         const closestEditable = (n) =>
             isContentEditable(n.parentElement) ? closestEditable(n.parentElement) : n;
 
-        const isUnsplittable = !(this.checkPredicates("is_node_splittable_predicates", node) ?? true);
+        const isUnsplittable = !(
+            this.checkPredicates("is_node_splittable_predicates", node) ?? true
+        );
         const isCandidateForBase = this.isCandidateForBaseContainerAllowUnsplittable(node);
 
         if (isUnsplittable || !isCandidateForBase) {

--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -6,7 +6,7 @@ import {
 } from "../utils/dom_info";
 import { Plugin } from "../plugin";
 import { closestBlock } from "../utils/blocks";
-import { unwrapContents, splitTextNode, fillEmpty } from "../utils/dom";
+import { unwrapContents, splitTextNode } from "../utils/dom";
 import { fillHtmlTransferData } from "../utils/clipboard";
 import { childNodes, closestElement } from "../utils/dom_traversal";
 import { parseHTML } from "../utils/html";
@@ -355,11 +355,12 @@ export class ClipboardPlugin extends Plugin {
                     ) {
                         // Do something only if blockBefore is not a DIV (which is the no-margin option)
                         // replace blockBefore by a DIV.
-                        const div = this.dependencies.baseContainer.createBaseContainer("DIV");
+                        const div = this.dependencies.baseContainer.createBaseContainer({
+                            nodeName: "DIV",
+                            children: [...childNodes(blockBefore)],
+                        });
                         const cursors = this.dependencies.selection.preserveSelection();
-                        blockBefore.before(div);
-                        div.replaceChildren(...childNodes(blockBefore));
-                        blockBefore.remove();
+                        blockBefore.replaceWith(div);
                         cursors.remapNode(blockBefore, div).restore();
                     }
                 }
@@ -483,13 +484,13 @@ export class ClipboardPlugin extends Plugin {
                         if (whiteSpace && !["normal", "nowrap"].includes(whiteSpace)) {
                             node.innerHTML = node.innerHTML.replace(/\n/g, "<br>");
                         }
-                        const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+                        const baseContainer = this.dependencies.baseContainer.createBaseContainer({
+                            children: [...node.childNodes],
+                        });
                         const dir = node.getAttribute("dir");
                         if (dir) {
                             baseContainer.setAttribute("dir", dir);
                         }
-                        baseContainer.append(...node.childNodes);
-
                         node.replaceWith(baseContainer);
                         childrenNodes = childNodes(baseContainer);
                     } else {
@@ -508,7 +509,6 @@ export class ClipboardPlugin extends Plugin {
                 // Insert base container into empty TD.
                 if (isEmptyBlock(node)) {
                     const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-                    fillEmpty(baseContainer);
                     node.replaceChildren(baseContainer);
                 }
 

--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -556,7 +556,6 @@ export class DeletePlugin extends Plugin {
             ) {
                 // @todo: not sure we want this when allowInlineAtRoot is true
                 const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-                baseContainer.appendChild(this.document.createElement("br"));
                 block.appendChild(baseContainer);
             } else {
                 block.appendChild(this.document.createElement("br"));

--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -151,21 +151,19 @@ export class DomPlugin extends Plugin {
     ) {
         // Helpers to manipulate preserving selection.
         const wrapInBlock = (node, cursors) => {
-            const block = isPhrasingContent(node)
-                ? createBaseContainer(baseContainerNodeName, node.ownerDocument)
-                : node.ownerDocument.createElement("DIV");
+            const nextSibling = node.nextSibling;
+            const parent = node.parentElement;
+            let block;
+            if (isPhrasingContent(node)) {
+                block = createBaseContainer(baseContainerNodeName, node.ownerDocument, [node]);
+            } else {
+                block = node.ownerDocument.createElement("DIV");
+                node.remove();
+                block.append(node);
+            }
             cursors.update(callbacksForCursorUpdate.append(block, node));
             cursors.update(callbacksForCursorUpdate.before(node, block));
-            if (node.nextSibling) {
-                const sibling = node.nextSibling;
-                node.remove();
-                sibling.before(block);
-            } else {
-                const parent = node.parentElement;
-                node.remove();
-                parent.append(block);
-            }
-            block.append(node);
+            nextSibling ? nextSibling.before(block) : parent.append(block);
             return block;
         };
         const appendToCurrentBlock = (currentBlock, node, cursors) => {
@@ -731,9 +729,9 @@ export class DomPlugin extends Plugin {
                 newCandidate.classList.add(extraClass);
             }
             if (this.dependencies.baseContainer.isCandidateForBaseContainer(newCandidate)) {
-                const baseContainer = this.dependencies.baseContainer.createBaseContainer(
-                    newCandidate.nodeName
-                );
+                const baseContainer = this.dependencies.baseContainer.createBaseContainer({
+                    nodeName: newCandidate.nodeName,
+                });
                 this.copyAttributes(newCandidate, baseContainer);
                 newCandidate = baseContainer;
             }
@@ -771,7 +769,7 @@ export class DomPlugin extends Plugin {
             } else {
                 // eg do not change a <div> into a h1: insert the h1
                 // into it instead.
-                newCandidate.append(...childNodes(block));
+                newCandidate.replaceChildren(...childNodes(block));
                 block.append(newCandidate);
                 cursors.remapNode(block, newCandidate);
                 newCandidate = createNewCandidate();

--- a/addons/html_editor/static/src/core/split_plugin.js
+++ b/addons/html_editor/static/src/core/split_plugin.js
@@ -445,7 +445,7 @@ export class SplitPlugin extends Plugin {
                     // of the BR.
                     block = this.dependencies.baseContainer.createBaseContainer();
                     childrenToInsert[0]?.before(block);
-                    block.append(...childrenToInsert);
+                    block.replaceChildren(...childrenToInsert);
                     cursors.restore();
                 } else {
                     // If we can't insert a base container here, there's nothing

--- a/addons/html_editor/static/src/editor.js
+++ b/addons/html_editor/static/src/editor.js
@@ -1,6 +1,6 @@
 import { MAIN_PLUGINS, TOUCH_EXCLUDED_PLUGINS } from "./plugin_sets";
 import { createBaseContainer, SUPPORTED_BASE_CONTAINER_NAMES } from "./utils/base_container";
-import { fillShrunkPhrasingParent, removeClass } from "./utils/dom";
+import { removeClass } from "./utils/dom";
 import { isEmpty } from "./utils/dom_info";
 import { resourceSequenceSymbol, warnOfNamingConvention, withSequence } from "./utils/resource";
 import { fixInvalidHTML, initElementForEdition } from "./utils/sanitize";
@@ -137,7 +137,6 @@ export class Editor {
                     this.config.baseContainers[0],
                     this.document
                 );
-                fillShrunkPhrasingParent(baseContainer);
                 editable.replaceChildren(baseContainer);
             }
         }

--- a/addons/html_editor/static/src/main/banner_plugin.js
+++ b/addons/html_editor/static/src/main/banner_plugin.js
@@ -1,5 +1,5 @@
 import { Plugin } from "@html_editor/plugin";
-import { fillEmpty, fillShrunkPhrasingParent } from "@html_editor/utils/dom";
+import { fillShrunkPhrasingParent } from "@html_editor/utils/dom";
 import { closestElement, descendants, selectElements } from "@html_editor/utils/dom_traversal";
 import { parseHTML } from "@html_editor/utils/html";
 import { withSequence } from "@html_editor/utils/resource";
@@ -175,12 +175,12 @@ export class BannerPlugin extends Plugin {
             baseContainer = this.document.createElement(blockEl.nodeName);
             baseContainer.append(...blockEl.childNodes);
         } else if (blockEl.nodeName === "LI") {
-            baseContainer = this.dependencies.baseContainer.createBaseContainer();
-            baseContainer.append(...blockEl.childNodes);
+            baseContainer = this.dependencies.baseContainer.createBaseContainer({
+                children: [...blockEl.childNodes],
+            });
             fillShrunkPhrasingParent(blockEl);
         } else {
             baseContainer = this.dependencies.baseContainer.createBaseContainer();
-            fillShrunkPhrasingParent(baseContainer);
         }
         const baseContainerHtml = baseContainer.outerHTML;
         const bannerElement = parseHTML(
@@ -217,7 +217,6 @@ export class BannerPlugin extends Plugin {
         }
         const bannerElement = closestElement(editorBannerContent, ".o_editor_banner");
         const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-        fillEmpty(baseContainer);
         bannerElement.replaceWith(baseContainer);
         this.dependencies.selection.setCursorStart(baseContainer);
         return true;

--- a/addons/html_editor/static/src/main/column_plugin.js
+++ b/addons/html_editor/static/src/main/column_plugin.js
@@ -220,7 +220,6 @@ export class ColumnPlugin extends Plugin {
 
     createEmptyParagraph() {
         const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-        baseContainer.append(this.document.createElement("br"));
         return baseContainer;
     }
 
@@ -245,7 +244,6 @@ export class ColumnPlugin extends Plugin {
                 const column = this.document.createElement("div");
                 column.classList.add(`col-${columnSize}`, "o-contenteditable-true");
                 const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-                baseContainer.append(this.document.createElement("br"));
                 column.append(baseContainer);
                 lastColumn.after(column);
                 lastColumn = column;

--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -440,10 +440,11 @@ export class FontPlugin extends Plugin {
             });
             const isPreBlock = beforeElement.nodeName === "PRE";
             const baseContainer = isPreBlock
-                ? this.dependencies.baseContainer.createBaseContainer()
+                ? this.dependencies.baseContainer.createBaseContainer({
+                      children: [...afterElement.childNodes],
+                  })
                 : afterElement;
             if (isPreBlock) {
-                baseContainer.replaceChildren(...afterElement.childNodes);
                 afterElement.replaceWith(baseContainer);
             } else {
                 beforeElement.remove();
@@ -536,12 +537,13 @@ export class FontPlugin extends Plugin {
                 headingTags.includes(newElement.tagName) &&
                 !descendants(newElement).some(isVisibleTextNode)
             ) {
-                const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+                const baseContainer = this.dependencies.baseContainer.createBaseContainer({
+                    children: [...newElement.childNodes],
+                });
                 const dir = newElement.getAttribute("dir");
                 if (dir) {
                     baseContainer.setAttribute("dir", dir);
                 }
-                baseContainer.replaceChildren(...newElement.childNodes);
                 newElement.replaceWith(baseContainer);
                 this.dependencies.selection.setCursorStart(baseContainer);
             }
@@ -569,10 +571,10 @@ export class FontPlugin extends Plugin {
         if (this.dependencies.delete.isUnremovable(closestHandledElement)) {
             return;
         }
-        const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-        baseContainer.append(...closestHandledElement.childNodes);
-        closestHandledElement.after(baseContainer);
-        closestHandledElement.remove();
+        const baseContainer = this.dependencies.baseContainer.createBaseContainer({
+            children: [...closestHandledElement.childNodes],
+        });
+        closestHandledElement.replaceWith(baseContainer);
         this.dependencies.selection.setCursorStart(baseContainer);
         return true;
     }

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -584,7 +584,7 @@ export class LinkPlugin extends Plugin {
                             const baseContainer =
                                 this.dependencies.baseContainer.createBaseContainer();
                             link.before(baseContainer);
-                            baseContainer.append(link);
+                            baseContainer.replaceChildren(link);
                         }
                     } else {
                         const content = this.dependencies.selection.extractContent(selection);

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -19,7 +19,6 @@ import {
     isPhrasingContent,
     isProtected,
     isProtecting,
-    isShrunkBlock,
     isVisibleTextNode,
     listElementSelector,
 } from "@html_editor/utils/dom_info";
@@ -736,14 +735,9 @@ export class ListPlugin extends Plugin {
         const ul = li.parentNode;
         const children = childNodes(li);
         if (!children.every(isBlock)) {
-            const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-            for (const child of children) {
-                cursors.update(callbacksForCursorUpdate.append(baseContainer, child));
-                baseContainer.append(child);
-            }
-            if (isShrunkBlock(baseContainer)) {
-                baseContainer.append(this.document.createElement("br"));
-            }
+            const baseContainer = this.dependencies.baseContainer.createBaseContainer({
+                children: [...children],
+            });
             li.append(baseContainer);
             cursors.remapNode(li, baseContainer);
         }

--- a/addons/html_editor/static/src/main/movenode_plugin.js
+++ b/addons/html_editor/static/src/main/movenode_plugin.js
@@ -478,8 +478,6 @@ export class MoveNodePlugin extends Plugin {
                     previousParent.remove();
                 } else {
                     const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-                    const br = document.createElement("br");
-                    baseContainer.append(br);
                     previousParent.append(baseContainer);
                 }
             }

--- a/addons/html_editor/static/src/main/selection_placeholder_plugin.js
+++ b/addons/html_editor/static/src/main/selection_placeholder_plugin.js
@@ -1,6 +1,5 @@
 import { Plugin } from "@html_editor/plugin";
 import { closestBlock, isBlock } from "@html_editor/utils/blocks";
-import { fillEmpty } from "@html_editor/utils/dom";
 import {
     allowsParagraphRelatedElements,
     isEmpty,
@@ -127,7 +126,6 @@ export class SelectionPlaceholderPlugin extends Plugin {
                 if (!sibling || isSelectionBlocker(sibling)) {
                     // Create the placeholder.
                     const placeholder = this.dependencies.baseContainer.createBaseContainer();
-                    fillEmpty(placeholder);
                     placeholder.setAttribute(PLACEHOLDER_ATTRIBUTE, "");
                     // Position the placeholder.
                     const siblings = side === "before" ? [sibling, blocker] : [blocker, sibling];

--- a/addons/html_editor/static/src/main/separator_plugin.js
+++ b/addons/html_editor/static/src/main/separator_plugin.js
@@ -4,7 +4,7 @@ import { closestBlock } from "../utils/blocks";
 import { closestElement, firstLeaf, lastLeaf, selectElements } from "../utils/dom_traversal";
 import { isEmptyBlock, paragraphRelatedElementsSelector } from "../utils/dom_info";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
-import { fillEmpty, removeClass, splitTextNode } from "@html_editor/utils/dom";
+import { removeClass, splitTextNode } from "@html_editor/utils/dom";
 import { DIRECTIONS, nodeSize, rightPos } from "@html_editor/utils/position";
 import { withSequence } from "@html_editor/utils/resource";
 
@@ -80,7 +80,6 @@ export class SeparatorPlugin extends Plugin {
             } else if (isSelectionAtEnd) {
                 element.after(sep);
                 const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-                fillEmpty(baseContainer);
                 sep.after(baseContainer);
                 this.dependencies.selection.setCursorStart(baseContainer);
             } else {

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -1,12 +1,7 @@
 import { Plugin } from "@html_editor/plugin";
 import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
 import { isBlock } from "@html_editor/utils/blocks";
-import {
-    fillEmpty,
-    fillShrunkPhrasingParent,
-    removeClass,
-    removeStyle,
-} from "@html_editor/utils/dom";
+import { removeClass, removeStyle } from "@html_editor/utils/dom";
 import {
     getDeepestPosition,
     isProtected,
@@ -390,7 +385,6 @@ export class TablePlugin extends Plugin {
 
     createTable({ rows = 2, cols = 2 } = {}) {
         const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-        fillShrunkPhrasingParent(baseContainer);
         const baseContainerHtml = baseContainer.outerHTML;
         const tdsHtml = new Array(cols).fill(`<td>${baseContainerHtml}</td>`).join("");
         const trsHtml = new Array(rows).fill(`<tr>${tdsHtml}</tr>`).join("");
@@ -461,7 +455,6 @@ export class TablePlugin extends Plugin {
                 }
                 const newCell = this.document.createElement(cell.tagName);
                 const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-                fillEmpty(baseContainer);
                 newCell.append(baseContainer);
                 if (rows[rowIndex].contains(cell)) {
                     cell[position](newCell);
@@ -538,7 +531,6 @@ export class TablePlugin extends Plugin {
                 } else {
                     const td = this.document.createElement("td");
                     const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-                    fillEmpty(baseContainer);
                     td.append(baseContainer);
                     newRow.append(td);
                 }
@@ -608,7 +600,6 @@ export class TablePlugin extends Plugin {
             if (td && td.colSpan > minColSpanToRemove) {
                 td.colSpan -= minColSpanToRemove;
                 const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-                baseContainer.appendChild(this.document.createElement("br"));
                 td.replaceChildren(baseContainer);
             } else if (td) {
                 td.remove();
@@ -656,7 +647,6 @@ export class TablePlugin extends Plugin {
                 cell.removeAttribute("rowspan");
             }
             const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-            baseContainer.appendChild(this.document.createElement("br"));
             cell.replaceChildren(baseContainer);
         });
         for (let i = 0; i < minRowSpanToRemove; i++) {
@@ -895,7 +885,6 @@ export class TablePlugin extends Plugin {
         const index = cells.findIndex((td) => td === cell);
         table.querySelectorAll(`tr :is(td, th):nth-of-type(${index + 1})`).forEach((td) => {
             const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-            fillEmpty(baseContainer);
             td.replaceChildren(baseContainer);
         });
     }
@@ -905,7 +894,6 @@ export class TablePlugin extends Plugin {
     clearRowContent(row) {
         row.querySelectorAll("td, th").forEach((td) => {
             const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-            fillEmpty(baseContainer);
             td.replaceChildren(baseContainer);
         });
     }
@@ -926,7 +914,6 @@ export class TablePlugin extends Plugin {
             return;
         }
         const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-        baseContainer.appendChild(this.document.createElement("br"));
         table.before(baseContainer);
         table.remove();
         this.dependencies.selection.setCursorStart(baseContainer);
@@ -986,7 +973,6 @@ export class TablePlugin extends Plugin {
                     if (nextTr) {
                         const newTd = this.document.createElement("td");
                         const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-                        fillEmpty(baseContainer);
                         newTd.append(baseContainer);
                         const targetTd = nextTr.childNodes[colIndex];
                         if (targetTd) {
@@ -1005,7 +991,6 @@ export class TablePlugin extends Plugin {
                         newCell.classList.add("o_table_header");
                     }
                     const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-                    fillEmpty(baseContainer);
                     newCell.append(baseContainer);
                     cell.after(newCell);
                 }
@@ -1075,7 +1060,6 @@ export class TablePlugin extends Plugin {
 
         for (const td of selectedTds) {
             const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-            baseContainer.appendChild(this.document.createElement("br"));
             td.replaceChildren(baseContainer);
         }
         this.dependencies.selection.setCursorStart(firstCell.firstChild);

--- a/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
@@ -197,10 +197,10 @@ export class CaptionPlugin extends Plugin {
                 const baseContainer = this.dependencies.baseContainer.createBaseContainer();
                 if (figure.parentElement.nodeName === "A") {
                     figure.parentElement.before(baseContainer);
-                    baseContainer.append(figure.parentElement);
+                    baseContainer.replaceChildren(figure.parentElement);
                 } else {
                     figure.before(baseContainer);
-                    baseContainer.append(figure);
+                    baseContainer.replaceChildren(figure);
                 }
             }
             unwrapContents(figure);

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.js
@@ -129,8 +129,9 @@ export class SyntaxHighlightingPlugin extends Plugin {
                     this.dependencies.history.stageSelection();
                     const component = target.closest(`[data-embedded='${name}']`);
                     const embeddedProps = getEmbeddedProps(component);
-                    const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-                    baseContainer.textContent = embeddedProps.value;
+                    const baseContainer = this.dependencies.baseContainer.createBaseContainer({
+                        children: [this.document.createTextNode(embeddedProps.value)],
+                    });
                     component.replaceWith(baseContainer);
                     newlinesToLineBreaks(baseContainer);
                     this.dependencies.selection.setCursorStart(baseContainer);

--- a/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
@@ -464,7 +464,6 @@ export class ToggleBlockPlugin extends Plugin {
                     toggle.after(...children(content));
                 }
                 const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-                baseContainer.appendChild(this.document.createElement("br"));
                 toggle.replaceWith(baseContainer);
                 this.dependencies.selection.setCursorStart(baseContainer);
                 return true;
@@ -593,7 +592,6 @@ export class ToggleBlockPlugin extends Plugin {
             `${toggleSelector} [data-embedded-editable]:empty`
         )) {
             const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-            baseContainer.appendChild(this.document.createElement("br"));
             emptyToggleNode.replaceChildren(baseContainer);
         }
     }

--- a/addons/html_editor/static/src/utils/base_container.js
+++ b/addons/html_editor/static/src/utils/base_container.js
@@ -31,9 +31,13 @@ export const baseContainerGlobalSelector = `:is(${SUPPORTED_BASE_CONTAINER_NAMES
  *                   For iframes, preferably use the iframe document.
  *                   Fallbacks to the window document if possible and unspecified.
  *                   Has to be specified otherwise.
+ * @param {Node[]} [children] Optional children to append inside the container.
+ *                   If provided, the children are appended to the container.
+ *                   If not provided or empty, a trailing <br> is inserted to keep
+ *                   container editable when empty.
  * @returns {HTMLElement}
  */
-export function createBaseContainer(nodeName, document) {
+export function createBaseContainer(nodeName, document, children) {
     if (!document && window) {
         document = window.document;
     }
@@ -41,6 +45,11 @@ export function createBaseContainer(nodeName, document) {
     const el = document.createElement(nodeName);
     if (nodeName !== "P") {
         el.className = BASE_CONTAINER_CLASS;
+    }
+    if (children?.length) {
+        el.append(...children);
+    } else {
+        el.appendChild(document.createElement("br"));
     }
     return el;
 }

--- a/addons/mail/static/src/core/common/plugin/mention_plugin.js
+++ b/addons/mail/static/src/core/common/plugin/mention_plugin.js
@@ -95,8 +95,9 @@ export class MentionPlugin extends Plugin {
             // This will lead to issues where the mention cannot be deleted or edited properly.
             // In this case, we wrap the mention with a base container.
             if (el.parentElement === this.editable) {
-                const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-                baseContainer.appendChild(el.cloneNode(true));
+                const baseContainer = this.dependencies.baseContainer.createBaseContainer({
+                    children: [el.cloneNode(true)],
+                });
                 this.editable.replaceChild(baseContainer, el);
                 this.dependencies.history.addStep();
             }

--- a/addons/mass_mailing/static/src/builder/plugins/empty_mailing_plugin.js
+++ b/addons/mass_mailing/static/src/builder/plugins/empty_mailing_plugin.js
@@ -27,7 +27,6 @@ export class EmptyMailingPlugin extends Plugin {
                 .getSnippetByName("snippet_structure", "s_text_block")
                 .content.cloneNode(true);
             const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-            baseContainer.append(this.document.createElement("br"));
             const container = textSnippet.querySelector(".container");
             container.replaceChildren(baseContainer);
             wrapperTd.replaceChildren(textSnippet);


### PR DESCRIPTION
*: mail, mass_mailing
### Purpose of this commit:

- Previously, `createBaseContainer` returned an empty container and callers were responsible for ensuring it remained editable. In practice, some code paths manually inserted a `<br>` while others relied on `fillEmpty()`, leading to inconsistent handling of empty blocks.
- This PR updates `createBaseContainer` to handle empty containers directly by inserting a `<br>` when no children are provided.
- The function now also accepts optional `children`, allowing callers to create a populated container.

enterprise - https://github.com/odoo/enterprise/pull/110761

task-6014415

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
