### PR TITLE
[IMP] hr: move departure_date readonly control to base model/view

### DIFF
--- a/addons/hr/models/hr_employee_departure.py
+++ b/addons/hr/models/hr_employee_departure.py
@@ -33,7 +33,7 @@ class HrEmployeeDeparture(models.Model):
     dismissal_date = fields.Date(string="Dismissal Date", default=fields.Date.today, required=True,
         help="Date at which the departure process starts. Differs from the actual departure date in case of a notice period.")
     departure_date = fields.Date(string="Departure Date", compute="_compute_departure_date",
-        store=True, help="Date at which the departure actually takes place.")
+        store=True, readonly=False, help="Date at which the departure actually takes place.")
     action_at_departure = fields.Boolean(string="Action at", default=True)
     action_other_date = fields.Date(string="Apply date")
     is_user_employee = fields.Boolean(

--- a/addons/hr/views/hr_employee_departure_views.xml
+++ b/addons/hr/views/hr_employee_departure_views.xml
@@ -10,7 +10,7 @@
                     <group name="header_group">
                         <field name="departure_reason_id" options="{'no_edit': True, 'no_create': True, 'no_open': True}"/>
                         <field name="dismissal_date" class="oe_inline"/>
-                        <field name="departure_date" class="oe_inline"/>
+                        <field name="departure_date" class="oe_inline" readonly="1"/>
                     </group>
                     <notebook name="departure_notebook">
                         <page string="Planned Actions" name="planned_actions">


### PR DESCRIPTION
Before:
The field `departure_date` was defined as readonly at the model level. Even if a view set `readonly="0"`, the ORM ignored user input because readonly field values are stripped during `write()`. As a result, localizations attempting to allow manual edits could not update the field.

After:
`departure_date` is now defined with `readonly=False` at the model level so the ORM accepts writes to the stored computed field.

The base HR view keeps the field readonly (`readonly="1"`), ensuring the default behavior remains unchanged. Localizations can explicitly relax the restriction with `readonly="0"` in their own views when manual edits are required.

This approach avoids redefining the field in each localization and allows countries that require manual departure date adjustments to enable it cleanly via view inheritance.

Task-3505331