### PR TITLE
[FIX] hr_job: No Rights issue in Recruitment list view

### DIFF
--- a/addons/hr/models/hr_job.py
+++ b/addons/hr/models/hr_job.py
@@ -14,9 +14,9 @@ class HrJob(models.Model):
     active = fields.Boolean(default=True)
     name = fields.Char(string='Job Position', required=True, index='trigram', translate=True)
     sequence = fields.Integer(default=10)
-    expected_employees = fields.Integer(compute='_compute_employees', string='Total Forecasted Employees',
+    expected_employees = fields.Integer(compute='_compute_employees', string='Total Forecasted Employees', compute_sudo=True,
         help='Expected number of employees for this job position after new recruitment.', groups="hr.group_hr_user")
-    no_of_employee = fields.Integer(compute='_compute_employees', string="Current Number of Employees",
+    no_of_employee = fields.Integer(compute='_compute_employees', string="Current Number of Employees", compute_sudo=True,
         help='Number of employees currently occupying this job position.', groups="hr.group_hr_user")
     no_of_recruitment = fields.Integer(string='Target', copy=False,
         help='Number of new employees you expect to recruit.', default=1)

--- a/addons/hr/models/hr_job.py
+++ b/addons/hr/models/hr_job.py
@@ -14,9 +14,9 @@ class HrJob(models.Model):
     active = fields.Boolean(default=True)
     name = fields.Char(string='Job Position', required=True, index='trigram', translate=True)
     sequence = fields.Integer(default=10)
-    expected_employees = fields.Integer(compute='_compute_employees', string='Total Forecasted Employees', compute_sudo=True,
+    expected_employees = fields.Integer(compute='_compute_employees', string='Total Forecasted Employees',
         help='Expected number of employees for this job position after new recruitment.', groups="hr.group_hr_user")
-    no_of_employee = fields.Integer(compute='_compute_employees', string="Current Number of Employees", compute_sudo=True,
+    no_of_employee = fields.Integer(compute='_compute_employees', string="Current Number of Employees",
         help='Number of employees currently occupying this job position.', groups="hr.group_hr_user")
     no_of_recruitment = fields.Integer(string='Target', copy=False,
         help='Number of new employees you expect to recruit.', default=1)
@@ -50,7 +50,7 @@ class HrJob(models.Model):
 
     @api.depends('no_of_recruitment', 'employee_ids.job_id', 'employee_ids.active')
     def _compute_employees(self):
-        employee_data = self.env['hr.employee']._read_group([('job_id', 'in', self.ids)], ['job_id'], ['__count'])
+        employee_data = self.env['hr.employee.public']._read_group([('job_id', 'in', self.ids)], ['job_id'], ['__count'])
         result = {job.id: count for job, count in employee_data}
         for job in self:
             job.no_of_employee = result.get(job.id, 0)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When a user has access to the Recruitment module (hr_recruitment) but does not have HR rights (lacks the group hr.group_hr_user), they can open the Kanban view for Job Postings, but get a rights error message when trying to open the List view.

Current behavior before PR:
_compute_employees performs a read on hr.employee, which requires HR rights. This is in conflict with hr_recruitment.hr_job_view_tree_inherit which adds the fields this function computes (expected_employees, no_of_employee) to a list view accessible to anyone with the group hr_recruitment.group_hr_recruitment_interviewer, which does not require to be in hr.group_hr_user and thus causes a rights issue.

Desired behavior after PR is merged:
The compute method uses the public employee model to ensure they can be calculated independent of the rights of the person viewing the fields. 



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
