### PR TITLE
[FIX] l10n_sa_edi_pos: support updated settle-due line detection

### DIFF
--- a/addons/l10n_sa_edi_pos/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/l10n_sa_edi_pos/static/src/overrides/components/payment_screen/payment_screen.js
@@ -39,8 +39,8 @@ patch(PaymentScreen.prototype, {
 
     async validateOrder(isForceValidate) {
         const order = this.currentOrder;
-        // the isSettleDueLine() is only available if enterprise:pos_settle_due module is installed
-        const settleLineCount = order.lines.filter((line) => line.isSettleDueLine?.()).length;
+        // the isAnySettleLine() is only available if enterprise:pos_settle_due module is installed.
+        const settleLineCount = order.lines.filter((line) => line.isAnySettleLine?.()).length;
         if (settleLineCount && settleLineCount !== order.lines.length) {
             return this.dialog.add(AlertDialog, {
                 title: _t("Settlement Error"),


### PR DESCRIPTION
# Description of the issue/feature this PR addresses:

From saas-18.3 onward, the pos_settle_due module updated the method used to
identify settlement lines from isSettleDueLine() to isAnySettleLine().

This change was not reflected in the Saudi POS EDI integration during forward-porting,
which caused incorrect validation when processing POS orders containing both
regular sale lines and settlement lines.

# Current behavior before PR:

- Orders containing a mix of new sale lines and settlement lines could bypass
the intended validation.

- The validation logic relied on the deprecated isSettleDueLine() method,
which is no longer available in newer versions when the pos_settle_due
module is installed.

# Desired behavior after PR is merged:

- Update the validation flow to use isAnySettleLine() (when available) to
correctly detect settlement lines.

- Prevent validation of POS orders that contain both settlement lines and new
sale lines.

- Ensure compatibility with newer versions of the pos_settle_due module and
restore the intended settlement validation behavior.

I confirm I have signed the CLA and read the PR guidelines at
[www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)