### PR TITLE
[FIX] point_of_sale: traceback when opening pos order form view

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1558,6 +1558,7 @@ class PosOrderLine(models.Model):
     product_uom_id = fields.Many2one('uom.uom', string='Product Unit', related='product_id.uom_id')
     currency_id = fields.Many2one('res.currency', related='order_id.currency_id')
     full_product_name = fields.Char('Full Product Name')
+    translated_product_name = fields.Text(compute='_compute_translated_product_name')
     customer_note = fields.Char('Customer Note')
     refund_orderline_ids = fields.One2many('pos.order.line', 'refunded_orderline_id', 'Refund Order Lines', help='Orderlines in this field are the lines that refunded this orderline.')
     refunded_orderline_id = fields.Many2one('pos.order.line', 'Refunded Order Line', index='btree_not_null', help='If this orderline is a refund, then the refunded orderline is specified in this field.')
@@ -1574,6 +1575,13 @@ class PosOrderLine(models.Model):
     extra_tax_data = fields.Json()
 
     _unique_uuid = models.Constraint('unique (uuid)', 'An order line with this uuid already exists')
+
+    @api.depends('product_id')
+    def _compute_translated_product_name(self):
+        for line in self:
+            line.translated_product_name = line.product_id.with_context(
+                lang=line.order_id.partner_id.lang or self.env.user.lang,
+            ).display_name
 
     @api.model
     def _load_pos_data_domain(self, data, config):


### PR DESCRIPTION
Steps to reproduce:
=
- Open the `Point of Sale` app in the backend.
- Open the order list view and open any order in form view.

Issue:
=
- A traceback is raised: `KeyError: 'translated_product_name'`.

Reason:
=
- The `product_label_section_and_note_field` widget introduced a dependency on the `translated_product_name` field, which is not present in `pos.order.line`.

Fix:
=
- Added a computed field `translated_product_name` in the `pos.order.line` model to ensure the widget's dependent fields are available.

Reference PR:
=
- https://github.com/odoo/odoo/pull/248401

task-6040210