### PR TITLE
[FIX] l10n_{pe,ec}: use country id in csv data file

### DIFF
--- a/addons/l10n_ec/data/res.bank.csv
+++ b/addons/l10n_ec/data/res.bank.csv
@@ -1,460 +1,460 @@
-id,bic,name,country
-bank_1,1,Banco Central Del Ecuador,Ecuador
-bank_2,10,Banco Pichincha C.A.,Ecuador
-bank_3,17,Banco De Guayaquil S.A,Ecuador
-bank_4,24,Banco City Bank,Ecuador
-bank_5,25,Banco Machala,Ecuador
-bank_6,29,Banco De Loja,Ecuador
-bank_7,30,Banco Del Pacifico,Ecuador
-bank_8,32,Banco Internacional,Ecuador
-bank_9,34,Banco Amazonas,Ecuador
-bank_10,35,Banco Del Austro,Ecuador
-bank_11,36,Produbanco / Promerica,Ecuador
-bank_12,37,Banco Bolivariano,Ecuador
-bank_13,39,Banco Comercial De Manabi,Ecuador
-bank_14,42,Banco General Ruminahui S.A.,Ecuador
-bank_15,43,Banco Del Litoral S.A.,Ecuador
-bank_16,59,Banco Solidario,Ecuador
-bank_17,60,Banco Procredit S.A.,Ecuador
-bank_18,61,Banco Capital,Ecuador
-bank_19,65,Banco Desarrollo De Los Pueblos S.A.,Ecuador
-bank_20,66,Banecuador B.P.,Ecuador
-bank_21,70,Coop. Ahorro Y Credito 15 De Abril Ltda,Ecuador
-bank_22,76,Coop. Jardin Azuayo,Ecuador
-bank_23,79,Coop.De Ahorro Y Credito Policia Nacional,Ecuador
-bank_24,82,Financoop,Ecuador
-bank_25,201,Banco Delbank S.A.,Ecuador
-bank_26,202,Banco Ecuatoriano De La Vivienda,Ecuador
-bank_27,203,Cacpeco Ltda,Ecuador
-bank_28,204,C.Peq.Empresa De Pastaza,Ecuador
-bank_29,205,Coop. Ahorro Y Credito 23 De Julio,Ecuador
-bank_30,206,Coop. Ahorro Y Credito 29 De Octubre,Ecuador
-bank_31,207,Coop. Ahorro Y Credito Andalucia,Ecuador
-bank_32,208,Coop. Ahorro Y Credito Cotocollao,Ecuador
-bank_33,210,Coop. Ahorro Y Credito El Sagrario,Ecuador
-bank_34,211,Coop. Ahorro Y Credito Guaranda Ltda,Ecuador
-bank_35,213,Coop. Juventud Ecuatoriana Progresista Ltda.,Ecuador
-bank_36,214,Coop. Ahorro Y Credito Manuel,Ecuador
-bank_37,216,Coop. Ahorro Y Credito Oscus,Ecuador
-bank_38,217,Coop. Ahorro Y Credito Pablo Munoz Vega,Ecuador
-bank_39,218,Coop. Ahorro Y Credito Progreso,Ecuador
-bank_40,219,Coop. Ahorro Y Credito Riobamba,Ecuador
-bank_41,220,Coop. Ahorro Y Credito San Francisco,Ecuador
-bank_42,222,Coop. Ahorro Y Credito Tulcan,Ecuador
-bank_43,223,Coop. De Ahorro Y Credito Atuntaqui Ltda.,Ecuador
-bank_44,224,Coop. De Ahorro Y Credito Comercio Ltda Portoviejo,Ecuador
-bank_45,225,Coop. De Ahorro Y Credito La Dolorosa Ltda,Ecuador
-bank_46,226,Coop. Prevision Ahorro Y Desarrollo,Ecuador
-bank_47,227,Coop.Ahorro Y Credito Alianza Del Valle Ltda,Ecuador
-bank_48,228,Coop Ahorro Y Credito Constrc Comercio Y Produc,Ecuador
-bank_49,229,Coop.Ahorro Y Credito Chone Ltda,Ecuador
-bank_50,231,Cooperativa De Ahorro Y Credito Santa Ana Ltda,Ecuador
-bank_51,232,Financiera - Diners Club Del Ecuador,Ecuador
-bank_52,233,Mutualista Ambato,Ecuador
-bank_53,234,Mutualista Azuay,Ecuador
-bank_54,236,Mutualista Imbabura,Ecuador
-bank_55,238,Mutualista Pichincha,Ecuador
-bank_56,240,Coop De A. Y C. Corporacion Centro Ltda.,Ecuador
-bank_57,242,Coop. De A. Y C. Cordillera De Los Andes Ltda.,Ecuador
-bank_58,243,Coop. De A. Y C. Puerto Francisco De Orellana,Ecuador
-bank_59,244,Coop. De A Y C. Luz Del Valle,Ecuador
-bank_60,245,Coop. De A Y C. Esperanza Y Progreso Del Valle,Ecuador
-bank_61,246,Coop. De A. Y C. Choco Tungurahua Runa Ltda,Ecuador
-bank_62,247,Coop. De A. Y C. Coopartamos Ltda,Ecuador
-bank_63,249,Coop. De A. Y C. Emprendedores Coopemprender Ltda.,Ecuador
-bank_64,250,Coop. De A. Y C. Nueva Loja Ltda.,Ecuador
-bank_65,251,Coop. De A. Y C. Pichncha Ltda.,Ecuador
-bank_66,252,Coop. Credito Y Ahorro San Francisco De Asis,Ecuador
-bank_67,253,Coop.De Ahorro Y Credito Cacec Ltda. (Cotopaxi),Ecuador
-bank_68,254,Coop.De A. Y C. Vencedores De Pichincha Ltda.,Ecuador
-bank_69,255,Cooperativa De Ahorro Y Credito San Bartolo Ltda,Ecuador
-bank_70,257,Coop. De A. Y C. Del Emigrante Ecuatoriano Y Su Fa,Ecuador
-bank_71,258,Coop. Ahorro Y Credito La Libertad Ltda,Ecuador
-bank_72,259,Coac Cuna De La Nacionalidad Ltda.,Ecuador
-bank_73,260,Cooperativa De Ahorro Y Credito Macodes Ltda,Ecuador
-bank_74,262,Cooperativa De Ahorro Y Credito Santa Isabel Ltda.,Ecuador
-bank_75,263,Cooperativa De Ahorro Y Credito Ganansol Ltda,Ecuador
-bank_76,264,Cooperativa De Ahorro Y Credito Del Azuay,Ecuador
-bank_77,265,Cooperativa De Ahorro Y Credito Del Colegio De Arq,Ecuador
-bank_78,266,Cooperativa De Ahorro Y Credito Nukanchik,Ecuador
-bank_79,267,Coop De Ahorro Y Credito Santa Ana Cuenca,Ecuador
-bank_80,268,Cooperativa De Ahorro Y Credito Multiempresarial L,Ecuador
-bank_81,269,Coac Del Sindicato De Choferes Profesionales Del A,Ecuador
-bank_82,270,Coop. Ahorro Y Credito Juan De Salinas Ltda.,Ecuador
-bank_83,271,Coop. Ahorro Y Credito Puellaro Ltda,Ecuador
-bank_84,272,Coop. Ahorro Y Credito Nueva Jerusalen,Ecuador
-bank_85,273,Coop. Ahorro Y Credito Malchingui Ltda.,Ecuador
-bank_86,275,Coop. De Ahorro Y Credito Chola Cuencana Ltda.,Ecuador
-bank_87,276,Coop. Ahorro Y Credito Tena Ltda.,Ecuador
-bank_88,277,Coop. Ahorro Y Credito De La Pequena Empresa Guala,Ecuador
-bank_89,278,Coop. Ahorro Y Credito Alianza Minas Ltda.,Ecuador
-bank_90,279,Coop. De Ahorro Y Credito Pedro Moncayo Ltda.,Ecuador
-bank_91,281,Cooperativa De Ahorro Y Credito Provida,Ecuador
-bank_92,283,Cooperativa De Ahorro Y Credito San Jose S.J.,Ecuador
-bank_93,285,Coop. Ahorro Y Credito Senor De Giron,Ecuador
-bank_94,287,Coop. De Ahorro Y Credito Educ.Del Tungurahua Ltda,Ecuador
-bank_95,290,Cooperativa 15 De Agosto Pilacoto,Ecuador
-bank_96,291,Coop. De Ahorro Y Credito Cristo Rey,Ecuador
-bank_97,292,Coop. De Ahorro Y Credito Educadores De Chimborazo,Ecuador
-bank_98,293,Cooperativa De Ahorro Y Credito Minga Ltda.,Ecuador
-bank_99,294,Coop. De Ahorro Y Credito 4 De Octubre Ltda.,Ecuador
-bank_100,295,Coop. De Ahorro Y Credito Credi Facil Ltda.,Ecuador
-bank_101,296,Coop. De Ahorro Y Credito Alfonso Jaramillo C.C.C.,Ecuador
-bank_102,297,Coop. De A. Y C. Indigena Sac Pelileo,Ecuador
-bank_103,298,Coop. De A. Y C. Intercultural Tawantinsuyu Ltda.,Ecuador
-bank_104,299,Coop. De A. Y C. Ocipsa,Ecuador
-bank_105,300,Coop. De A. Y C. 21 De Noviembre Ltda.,Ecuador
-bank_106,301,Coop. De A. Y C. La Floresta Ltda.,Ecuador
-bank_107,302,Coop. De A. Y C. Corp. Org. Campesinas De Quisapin,Ecuador
-bank_108,303,Coop. De A. Y C. Multicultural Banco Indigena Ltda,Ecuador
-bank_109,304,Coop De A. Y C. Crecer Winari Ltda.,Ecuador
-bank_110,305,Coop. De A. Y C. Banos De Agua Santa Ltda.,Ecuador
-bank_111,306,Coop. De Ahorro Y Credito 1 De Julio,Ecuador
-bank_112,307,Coop. De A. Y C. Sumak Nan Ltda.,Ecuador
-bank_113,308,Cooperativa De Ahorro Y Credito Canar Ltda.,Ecuador
-bank_114,309,Cooperativa De Ahorro Y Credito San Antonio Ltda.,Ecuador
-bank_115,310,Coop. De Ahorro Y Credito Fundar,Ecuador
-bank_116,312,Coop. Ahorro Y Credito Metropolis Ltda.,Ecuador
-bank_117,313,Coop. De Ahorro Y Credito El Cafetal,Ecuador
-bank_118,314,Coop.De Ahorro Y Credito Microempresarial Sucre,Ecuador
-bank_119,315,Coop. De A. Y C. Afroecuatoriana De La Peq. Emp. L,Ecuador
-bank_120,316,Cooperativa De Ahorro Y Credito Joyocoto Ltda.,Ecuador
-bank_121,317,Coop. Ahorro Y Credito San Antonio Ltda.,Ecuador
-bank_122,318,Coop. De A. Y C. Uniotavalo Ltda.,Ecuador
-bank_123,319,Coop. De A. Y C. Union El Ejido,Ecuador
-bank_124,320,Coop. De A. Y C. Genesis Ltda.,Ecuador
-bank_125,321,Coop. De A Y C. Maria Auxiliadora De Quiroga Ltda,Ecuador
-bank_126,322,Coop. De A. Y C. Fortaleza,Ecuador
-bank_127,323,Banco Para La Asistencia Comunitaria Finca S.A.,Ecuador
-bank_128,324,Coop. Calceta Ltda,Ecuador
-bank_129,325,Coop. Ahorro Y Credito 9 De Octubre Ltda,Ecuador
-bank_130,327,Coop. Ahorro Y Credito D La Peq Empr Cacpe Biblian,Ecuador
-bank_131,328,Coop. Ahorro Y Credito San Gabriel Ltda.,Ecuador
-bank_132,329,Coop. Ahorro Y Credito San Jose Ltda,Ecuador
-bank_133,330,Coop. Ahorro Y Credito San Miguel De Los Bancos,Ecuador
-bank_134,332,Coop. Ahorro Y Credito Semilla Del Progreso Ltda,Ecuador
-bank_135,333,Coop. Ahorro. Y Credi. Mujeres Unidas Tantanakushk,Ecuador
-bank_136,334,Coop. De Ahorro Y Cred. Santa Rosa Ltda,Ecuador
-bank_137,335,Coop. De Ahorro Y Credito Once De Junio,Ecuador
-bank_138,336,Coop. De A. Y C. Pujili Ltda,Ecuador
-bank_139,337,Coop. De A. Y C. Credil Ltda.,Ecuador
-bank_140,339,Coop. De A. Y C. Mushuk Pakari Ltda.,Ecuador
-bank_141,340,Coop. De A. Y C. Uniblock Y Servicios Ltda.,Ecuador
-bank_142,341,Coop. De A. Y C. San Fernando Limitada,Ecuador
-bank_143,342,Coop. De A. Y C. Futuro Lamanense,Ecuador
-bank_144,343,Coop. De A. Y C. Saquisili Ltda.,Ecuador
-bank_145,344,Coop. De A. Y C. Innovacion Andina Ltda.,Ecuador
-bank_146,345,Coop.De A.Y C. El Comerciante Ltda (Mies),Ecuador
-bank_147,346,Coop. De A. Y C. Mushuk Wasi Ltda ( Mies ),Ecuador
-bank_148,347,Cooperativa De Ahorro Y Credito Solidaria Ltda,Ecuador
-bank_149,348,Cooperativa De Ahorro Y Credito Llanganates,Ecuador
-bank_150,349,Interdin S.A.,Ecuador
-bank_151,350,Coop.Aho Y Credito De La Peq. Emp. De Loja Cacpe,Ecuador
-bank_152,351,Cooperativa De Ahorro Y Credito Economia Del Sur C,Ecuador
-bank_153,352,Cooperativa De Ahorro Y Credito Migrantes Y Empren,Ecuador
-bank_154,353,Cooperativa De Ahorro Y Credito San Sebastian,Ecuador
-bank_155,354,Coop. De A. Y C. Del Sindicato De Choferes Profesi,Ecuador
-bank_156,355,Coop.De Ahorro Y Credito 29 De Enero,Ecuador
-bank_157,356,Coop. Ahorro Y Credito Agraria Mushuk Kawsay Ltda.,Ecuador
-bank_158,357,Cooperativa De Ahorro Y Credito Runa Shungo Ltda.,Ecuador
-bank_159,358,Coop. De A. Y C. San Marcos,Ecuador
-bank_160,359,Coop. De A. Y C. Antorcha Ltda.,Ecuador
-bank_161,360,Cooperativa De Ahorro Y Credito Socio Amigo,Ecuador
-bank_162,361,Coop. De A. Y C. Indigenas Galapagos Ltda.,Ecuador
-bank_163,362,Coop. Ahorro Y Credito Camara De Comercio Del Cant,Ecuador
-bank_164,363,Cooperativa De Ahorro Y Credito La Benefica Ltda.,Ecuador
-bank_165,364,Coop.De Ahorro Y Credito Abdon Calderon Ltda.,Ecuador
-bank_166,365,Coop. A Y C Camara De Comercio Canton -El Carmen L,Ecuador
-bank_167,366,Coop.De Ahorro Y Credito Agroproductiva Manabi Ltd,Ecuador
-bank_168,367,Coop. De Ahorro Y Cred. La Inmaculada De San Placi,Ecuador
-bank_169,368,Coop. Ahorro Y Credito Cacpe Manabi,Ecuador
-bank_170,369,Coop.Ahorro Y Credito Magisterio Manabita Limitada,Ecuador
-bank_171,370,Coac Tienda De Dinero Ltda.,Ecuador
-bank_172,371,Coop.A.Y C. Santa Maria De La Manga Del Cura Ltda.,Ecuador
-bank_173,375,Coop. Ahorro Y Credito Camara De Comercio Indigena,Ecuador
-bank_174,379,Coop. De A. Y C. Guamote Ltda.,Ecuador
-bank_175,382,Coop. De A.Y C. Produc. Ahorro Invers. Servicio P.,Ecuador
-bank_176,383,Coop. De A. Y C. Frandesc Ltda.,Ecuador
-bank_177,384,Coop. De A. Y C. Nuka Llakta Ltda.,Ecuador
-bank_178,385,Coop. De A Y C. Camara De Comercio Riobamba,Ecuador
-bank_179,386,Coop. De A. Y C. Bashalan Ltda.,Ecuador
-bank_180,387,Coop. De A. Y C. Camara De Comercio Santo Domingo,Ecuador
-bank_181,388,Coop. De A. Y C. Educadores Tulcan Ltda.,Ecuador
-bank_182,400,Coop. Warmikunapak Rikchari,Ecuador
-bank_183,403,Coop Ahorro Y Credito Mi Tierra,Ecuador
-bank_184,404,Coop Ahorro Y Credito De La Peq Emp Cacpe Yanzatza,Ecuador
-bank_185,405,Coop Ahorro Y Credito Fundesarrollo,Ecuador
-bank_186,406,Caja Ecuaespana,Ecuador
-bank_187,408,Coop De Ahorro Y Credito Nueva Huancavilca,Ecuador
-bank_188,410,Coop De Ahorro Y Credito Erco Ltda,Ecuador
-bank_189,411,Coop Ahorro Y Credito Camara Comercio De Ambato,Ecuador
-bank_190,412,Coop Ahorro Y Credito Mushuc Runa Ltda,Ecuador
-bank_191,414,Coop De Ahorro Y Credito Ambato Ltda,Ecuador
-bank_192,415,Coop De Ahorro Y Credito Dorado Ltda,Ecuador
-bank_193,416,Coop De Ahorro Y Credito Nuestros Abuelos Ltda,Ecuador
-bank_194,417,Coop De Ahorro Y Credito Artesanos Ltda,Ecuador
-bank_195,418,Coop De Ahorro Y Credito Santa Anita Ltda,Ecuador
-bank_196,419,Coop De Ahorro Y Credito Huayco Pungo Ltda,Ecuador
-bank_197,420,Coop Manuel Esteban Godoy Ortega Ltda Coopmego,Ecuador
-bank_198,421,Coop Ahorro Y Credito Padre Julian Lorente Ltda,Ecuador
-bank_199,422,Coop Ahorro Y Credito Cariamanga Ltda,Ecuador
-bank_200,423,Coop De Ahorro Y Credito Marcabeli Ltda,Ecuador
-bank_201,424,Coop De Ahorro Y Credito Agricola Junin Ltda,Ecuador
-bank_202,425,Coop De Ahorro Y Credito Puerto Lopez Ltda,Ecuador
-bank_203,427,Coop De Ahorro Y Credito Nueva Esperanza,Ecuador
-bank_204,428,Coop De Ahorro Y Credito San Jorge Ltda,Ecuador
-bank_205,429,Coop De Ahorro Y Credito Fernando Daquilema,Ecuador
-bank_206,435,Coop De A Y C Educadores De Pastaza Ltda,Ecuador
-bank_207,450,Coop. A. Y C. De La Peq. Emp. Cacpe Zamora Ltda,Ecuador
-bank_208,451,Coop. De A. Y C. Desarrollo Integral Ltda,Ecuador
-bank_209,452,Coop. De Ahorro Y Credito El Calvario Ltda,Ecuador
-bank_210,453,Coop. De A. Y C. Juan Pio De Mora Ltda,Ecuador
-bank_211,454,Coop. De Ahorro Y Credito Pilahuin,Ecuador
-bank_212,455,Coop. De Ahorro Y Credito Pucara Ltda,Ecuador
-bank_213,456,Coop. A. Y C. Camara De Comercio De Pindal Cadecop,Ecuador
-bank_214,461,Banco Del Instituto Ecuatoriano De Seguridad Social,Ecuador
-bank_215,462,Coop De A Y C De Serv Publ Del Min Educacion Y Cul,Ecuador
-bank_216,463,Coop De A Y C 23 De Mayo Ltda,Ecuador
-bank_217,464,Coop De A Y C Coca Ltda,Ecuador
-bank_218,465,Coop De Ahorro Y Credito Pilahuin Tio Ltda,Ecuador
-bank_219,467,Coop De Ahorro Y Credito Huaicana Ltda,Ecuador
-bank_220,468,Coop De A Y C Credisur Ltda,Ecuador
-bank_221,469,Fondo De Cesantia Del Magisterio Ecuat Fcme-Fcpc,Ecuador
-bank_222,471,Coop De Ahorro Y Credito Huaquillas Ltda,Ecuador
-bank_223,472,Coop De A Y C Banos Ltda,Ecuador
-bank_224,473,Coop De Ahorro Y Credito Cac-Cica Mies,Ecuador
-bank_225,475,Coop De A Y C Vencedores De Tungurahua,Ecuador
-bank_226,476,Coop A Y C Ecuafuturo Ltda,Ecuador
-bank_227,477,Coop De A Y C Maquita Cushun Ltda,Ecuador
-bank_228,478,Coop De A Y C Valles Del Lirio,Ecuador
-bank_229,479,Coop Esfuerzo Unido Para El Desarr Del Chilco,Ecuador
-bank_230,480,Coop A Y C Carroceros De Tungurahua,Ecuador
-bank_231,481,Coop De Ahorro Y Credito Simiatug Ltda,Ecuador
-bank_232,482,Coop De A Y C Sinchi Runa Ltda,Ecuador
-bank_233,483,Coop De A Y C Santa Rosa De Pautan Ltda,Ecuador
-bank_234,484,Coop De Ahorro Y Credito San Miguel De Sigchos,Ecuador
-bank_235,485,Coop De A Y C Sierra Centro Ltda,Ecuador
-bank_236,486,Coop De A Y C Gonzanama Mies,Ecuador
-bank_237,487,Coop De Ahorro Y Credito Quilanga Ltda,Ecuador
-bank_238,488,Coop De Ahorro Y Credito 27 De Abril Loja,Ecuador
-bank_239,489,Coop De A Y C Crediamigo Ltda Loja Mies,Ecuador
-bank_240,490,Coop De Ahorro Y Credito Fortuna Mies,Ecuador
-bank_241,491,Coop A Y C Profesionales Del Volante Union Ltda,Ecuador
-bank_242,492,Coop De Ahorro Y Credito Cacpe Celica,Ecuador
-bank_243,493,Coop De A Y C Futuro Y Progreso De Galapagos Ltda,Ecuador
-bank_244,494,Coop De A Y C Sumac Llacta Ltda,Ecuador
-bank_245,495,Coop De A Y C Lucha Campesina Ltda,Ecuador
-bank_246,497,Coop De A Y C Maquita Cushunchic Ltda,Ecuador
-bank_247,498,Coop A Y C Focla,Ecuador
-bank_248,499,Coop De A Y C Casag Ltda,Ecuador
-bank_249,500,Banco D Miro Sa,Ecuador
-bank_250,501,Coop De A Y C General Ruminahui,Ecuador
-bank_251,502,Coop De A Y C Financiera Indigena Ltda,Ecuador
-bank_252,503,Coop A Y C 20 Febrero Ltda,Ecuador
-bank_253,504,Coop De A Y C Del Col. Fisc. Vicente Rocafuerte,Ecuador
-bank_254,505,Coop De A Y C Jadan Ltda (Mies),Ecuador
-bank_255,509,Coop De A Y C Inka Kipu Ltda,Ecuador
-bank_256,510,Coop De A Y C Accion Tungurahua Ltda,Ecuador
-bank_257,511,Coop De A Y C Pijal,Ecuador
-bank_258,512,Coop De A Y C Escencia Indigena Ltda,Ecuador
-bank_259,513,Coop De A Y C Union Mercedaria Ltda,Ecuador
-bank_260,514,Coop De A Y C Catamayo Ltda,Ecuador
-bank_261,515,Coop De A Y C De La Peq Empresa Cacpe Macara,Ecuador
-bank_262,516,Coop A Y C Nuevos Horizontes El Oro Ltda,Ecuador
-bank_263,517,Banco Coopnacional Sa,Ecuador
-bank_264,518,Coop De A Y C 16 De Junio,Ecuador
-bank_265,519,Coop A Y C Esc Sup Politec Agrop De Manabi Manuel,Ecuador
-bank_266,526,Coop De Ahorro Y Credito Fasaynan Ltda,Ecuador
-bank_267,546,Coop Cacique Guritave,Ecuador
-bank_268,547,Coop Solidaridad Y Progreso Oriental,Ecuador
-bank_269,567,Coop. De Aho Y Cred Los Andes Latinos Ltda.,Ecuador
-bank_270,569,C. De A. Y C Coopac Austro Ltda (Miess),Ecuador
-bank_271,570,Coop. De A. Y C. Salasaca,Ecuador
-bank_272,571,Coop. De A. Y C. Sumak Samy Ltda.,Ecuador
-bank_273,572,C. A. Y C. Intercult. Tarpuk Runa Ltda.,Ecuador
-bank_274,573,Coop. De A. Y C. Virgen Del Cisne,Ecuador
-bank_275,574,C. De A Y C Educad. De Zamora Chinchipe,Ecuador
-bank_276,575,C. De Ah. Y Credito Las Lagunas (Miess),Ecuador
-bank_277,577,C. De A Y C. Educadores De El Oro Ltd,Ecuador
-bank_278,578,C De A Y C Emplead Bancar Del Oro Ltda,Ecuador
-bank_279,579,Cooperativa De Ah. Y Credito Riochico,Ecuador
-bank_280,580,C. De A. Y C. San Martin De Tisaleo Ltda.,Ecuador
-bank_281,581,Coop. De A. Y C. Alli Tarpuc Ltda.,Ecuador
-bank_282,582,C. De A Y C. San Miguel De Pallatanga,Ecuador
-bank_283,590,Coop De A Y C Fenix,Ecuador
-bank_284,591,Coop.De Ahorro Y Credito Camara De Comercio De Loj,Ecuador
-bank_285,592,Coop.De A. Y C. De Crecimiento Economico Rentable,Ecuador
-bank_286,593,Cooperativa De Ahorro Y Credito Santiago Ltda,Ecuador
-bank_287,594,Coop.De A. Y C. Popular Y Solidaria,Ecuador
-bank_288,595,Coop.De Ahorro Y Credito San Placido Ltda.,Ecuador
-bank_289,596,Coop.De Ahorro Y Credito Ciudad De Zamora,Ecuador
-bank_290,597,Coop. De A Y C De La Pequena Empresa De Palora,Ecuador
-bank_291,600,Coop. De A. Y C. Indigena Alfa Y Omega Ltda,Ecuador
-bank_292,603,Cooperativa De Ahorro Y Credito Crea Ltda ( Mies),Ecuador
-bank_293,604,Coop. De A. Y C. Chibuleo Ltda.,Ecuador
-bank_294,605,Coop. De A. Y C. El Tesoro Pillareno,Ecuador
-bank_295,606,Coop. De A. Y C. Kisapincha Ltda.,Ecuador
-bank_296,607,Coop. De A. Y C. Juventud Unida Ltda.,Ecuador
-bank_297,608,Coop. De A. Y C. Union Quisapincha Ltda.,Ecuador
-bank_298,609,Coop. De A. Y C. 13 De Abril Ltda,Ecuador
-bank_299,610,Coop. De A. Y C. Salinas Ltda.,Ecuador
-bank_300,611,Coop. De A. Y C. San Pedro Ltda.,Ecuador
-bank_301,612,Coop. De A. Y C. Los Chasquis Pastocalle Ltda.,Ecuador
-bank_302,613,Coop. De A. Y C. Coopindigena Ltda.,Ecuador
-bank_303,614,Coop. De A. Y C. La Union Ltda.,Ecuador
-bank_304,615,Coop. De A. Y C. Padre Vicente Ponce Rubio,Ecuador
-bank_305,633,Coop. De A. Y C. Mushug Causay Ltda.,Ecuador
-bank_306,634,Coop. De A. Y C. 29 De Agosto,Ecuador
-bank_307,641,Coop. De A. Y C. Credisocio,Ecuador
-bank_308,673,Coop. De A. Y C. Fondo Para El Desarrollo Y La Vid,Ecuador
-bank_309,674,Cooperativa De A Y C Nueva Vision,Ecuador
-bank_310,675,Coop. De Ahorro Y Credito Focash Ltda.,Ecuador
-bank_311,676,Coop. De A. Y C. San Vicente Del Sur Ltda.,Ecuador
-bank_312,677,Coop. De A. Y C. Para La Vivienda Orden Y Segurida,Ecuador
-bank_313,678,Coop De A. Y C. Camara De Comercio Joya De Los Sac,Ecuador
-bank_314,679,Coop. De A. Y C. Focap,Ecuador
-bank_315,680,Coop. De A. Y C. 18 De Noviembre,Ecuador
-bank_316,681,Cooperativa De Ahorro Y Credito Dr. Cornelio Saenz,Ecuador
-bank_317,682,Coop De A. Y C. Educadores Del Azuay,Ecuador
-bank_318,683,Coop. De A. Y C. Indigena Sac Ltda,Ecuador
-bank_319,684,Coop. De A. Y C. Credi Ya Ltda,Ecuador
-bank_320,685,Coop. De A. Y C. San Bartolome Ltda,Ecuador
-bank_321,686,Coop. De Ahorro Y Credito Mushuk Yuyay,Ecuador
-bank_322,687,Coop De A. Y C. Sisay Kanari,Ecuador
-bank_323,688,Cooperativa De A Y C Accion Imbaburapak Ltda.,Ecuador
-bank_324,689,Coop De A. Y C. Hermes Gaibor Verdesoto,Ecuador
-bank_325,690,Coop. De A. Y C. Semillas De Pangua,Ecuador
-bank_326,691,Cooperativa De A Y C Mushuk Solidaria,Ecuador
-bank_327,692,Coop De A. Y C. Panamericana Ltda,Ecuador
-bank_328,693,Coop. De A. Y C. Vilcabamba Cacvil,Ecuador
-bank_329,694,Coop. De A. Y C. Familia Solidaria,Ecuador
-bank_330,695,Cooperativa De Ahorro Y Credito El Paraiso Manga D,Ecuador
-bank_331,696,Coac De Los Profesores Empleados Y Trabajadores De,Ecuador
-bank_332,697,Coac. Santa Rosa De San Carlos Ltda.,Ecuador
-bank_333,698,Coop. De A. Y C. Constructor Del Desarrollo Solida,Ecuador
-bank_334,699,Coop De A. Y C. Mushuk Yuyay Ltda,Ecuador
-bank_335,700,Corporacion Financiera,Ecuador
-bank_336,701,Coop. De A. Y C. Alianza Social Ecu. Alsec,Ecuador
-bank_337,702,Coop. De A. Y C. Renovadora Ecu,Ecuador
-bank_338,703,Coop. De A. Y C. Mushuk Yuyay - Napo,Ecuador
-bank_339,704,Coop. De A. Y C. Santa Ana De Nayon,Ecuador
-bank_340,705,Coop. De A. Y C. Educadores Del Napo,Ecuador
-bank_341,706,Cooperativa De A. Y C. Textil 14 De Marzo,Ecuador
-bank_342,707,Coop. De A Y C San Carlos Ltda.,Ecuador
-bank_343,708,Coac A Y C Esperanza De Valle De La Virgen Ltda.,Ecuador
-bank_344,709,Coac A Y C Zona De Capital Corcimol,Ecuador
-bank_345,710,Coop.De A. Y C. Artesanal Del Azuay,Ecuador
-bank_346,711,Cooperativa De Ahorro Y Credito Sumak Sisa,Ecuador
-bank_347,712,Coop. De A. Y C. Rey David Ltda,Ecuador
-bank_348,713,Coop. De A. Y C. Kullki Wasi Ltda.,Ecuador
-bank_349,714,Coop De A. Y C. Sinchi Codefis,Ecuador
-bank_350,715,Coop. De A. Y C. Fuerza De Los Andes,Ecuador
-bank_351,716,Coop De A. Y C. Camino De Luz Ltda.,Ecuador
-bank_352,717,Coac A Y C Educadores De Bolivar,Ecuador
-bank_353,718,Coac San Miguel Ltda.,Ecuador
-bank_354,719,Coop. De A. Y C. Salinerita,Ecuador
-bank_355,720,Coop. De A. Y C. Bola Amarilla,Ecuador
-bank_356,721,Coop A Y C Vision De Los Andes Visandes,Ecuador
-bank_357,722,Coop. De A. Y C. Senor Del Arbol,Ecuador
-bank_358,724,Coop. De A. Y C. Camara De Comercio De La Mana,Ecuador
-bank_359,725,Coop De A. Y C. Educadores De Loja,Ecuador
-bank_360,726,Coop De A. Y C. Indigena Sac Latacunga Ltda,Ecuador
-bank_361,727,Coop De A.Y C. Cadecog Gonzanama,Ecuador
-bank_362,728,Coac Coopymec Macara,Ecuador
-bank_363,729,Coac Cadecom Macara,Ecuador
-bank_364,730,Coop De A. Y C. 22 De Junio-Orianga,Ecuador
-bank_365,732,Coop. A.Yc.Sagrada Familia Solidaridad,Ecuador
-bank_366,733,Coop. De A. Y C. Naupa Kausay,Ecuador
-bank_367,734,Ccop A Y C De Apecap Cac Apecap,Ecuador
-bank_368,248,Coop De A. Y C. San Juan De Cotogchoa,Ecuador
-bank_369,2557,Coop De Ahorro Y Credito La Merced,Ecuador
-bank_370,338,Coop. De A. Y C. Cooptopaxi Ltda.,Ecuador
-bank_371,620,Coop. De A. Y C. Grameen Amazonas,Ecuador
-bank_372,621,Coop. De A. Y C. El Transportista Cacet,Ecuador
-bank_373,626,Coop. De A Y C. Servidores Municipales De Cuenca,Ecuador
-bank_374,628,Coop. De Ahorro Y Credito Profuturo Ltda.,Ecuador
-bank_375,640,Coop. De A. Y C. Iliniza Ltda.,Ecuador
-bank_376,642,Coop. De Ahorro Y Credito Saraguros,Ecuador
-bank_377,643,Cooperativa De Ahorro Y Credito Inti Wasi Ltda.,Ecuador
-bank_378,647,Cooperativa De Ahorro Y Credito San Isidro Ltda.,Ecuador
-bank_379,722,Coop. De A. Y C. Empresas Comunitarias Coocredito,Ecuador
-bank_380,723,Silvercross S.A Casa De Valores Sccv,Ecuador
-bank_381,724,Real Casa De Valores De Guayaquil S.A.,Ecuador
-bank_382,725,Cooperativa De Ahorro Y Credito Etapa,Ecuador
-bank_383,726,Coop. Ahorro Y Credito Mascoop,Ecuador
-bank_384,727,Coop. De A. Y C. Saint Michel Ltda.,Ecuador
-bank_385,8000,Coop. Ahorro Y Credito Manantial De Oro Ltda.,Ecuador
-bank_386,8001,Coop. De Ahorro Y Credito Andina Ltda.,Ecuador
-bank_387,8002,Coop. De Ahorro Y Credito Accion Y Desarrollo Ltda,Ecuador
-bank_388,9901,Coop. De A. Y C. Union Y Desarrollo,Ecuador
-bank_389,9902,Coop. De A. Y C. Esperanza Del Futuro Ltda.,Ecuador
-bank_390,9903,Coop. De A. Y C. 17 De Marzo Ltda,Ecuador
-bank_391,9904,Coop. De A. Y C. Catar Ltda,Ecuador
-bank_392,9905,Coop. De A. Y C. De Accion Popular,Ecuador
-bank_393,9906,Coop. De A. Y C. Alli Tarpuk Ltda,Ecuador
-bank_394,9907,Coop. De A. Y C. 16 De Julio Ltda,Ecuador
-bank_395,9908,Coop. De A. Y C. Suboficiales De La Policia Nacion,Ecuador
-bank_396,9909,Coop. De A. Y C. Politecnica Ltda.,Ecuador
-bank_397,9910,Coop. De A. Y C. Nacional Llano Grande Ltda.,Ecuador
-bank_398,9911,Coop. De A. Y C. San Valentin,Ecuador
-bank_399,9912,Coop. De A. Y C. Totalife Ltda,Ecuador
-bank_400,9913,Acciones Valores Casa De Valores S.A. Accival,Ecuador
-bank_401,9914,Santa Fe Casa De Valores S.A. Santafevalores,Ecuador
-bank_402,9915,Picaval Casa De Valores S.A,Ecuador
-bank_403,9916,Analytica Securties C.A. Casa De Valores,Ecuador
-bank_404,9917,Orion Casa De Valores S.A,Ecuador
-bank_405,9918,Stratega Casa De Valores S.A.,Ecuador
-bank_406,9919,Ecofsa Casa De Valores S.A.,Ecuador
-bank_407,9920,Merchantvalores Casa De Valores S.A.,Ecuador
-bank_408,9921,Casa De Valores Value S.A.,Ecuador
-bank_409,9922,Inmovalor Casa De Valores S.A.,Ecuador
-bank_410,9923,Ecuabursatil Casa De Valores S.A.,Ecuador
-bank_411,9924,Plus Valores Casa De Valores S.A.,Ecuador
-bank_412,9925,Mercapital Casa De Valores S.A.,Ecuador
-bank_413,9926,Portafolio Casa De Valores S.A. Portavalor,Ecuador
-bank_414,9927,Metrovalores Casa De Valores S.A.,Ecuador
-bank_415,9928,Vectorglobal Wmg Casa De Valores S.A.,Ecuador
-bank_416,9929,Holdunpartners Casa De Valores S.A.,Ecuador
-bank_417,9930,Coop. De Ahorro Y Credito Base De Taura,Ecuador
-bank_418,9931,Casa De Valores Banrio S.A.,Ecuador
-bank_419,9932,Albion Casa De Valores S.A.,Ecuador
-bank_420,9933,Masvalores Casa De Valores S.A Cavamasa,Ecuador
-bank_421,9934,Casa De Valores Del Pacifico (Valpacifico) S.A.,Ecuador
-bank_422,9935,Casa De Valores Advfin S.A.,Ecuador
-bank_423,9936,Kapital One Casa De Valores S.A. Kaovalsa,Ecuador
-bank_424,9937,Plusbursatil Casa De Valores S.A,Ecuador
-bank_425,9938,Activa Ases.E Intermed.Valores Activalores Casa De,Ecuador
-bank_426,9939,Citadel Casa De Valores S.A.,Ecuador
-bank_427,9940,Decevale S.A.,Ecuador
-bank_428,9941,Coop. De A. Y C. Santa Lucia Ltda,Ecuador
-bank_429,9942,Coop. De A. Y C. Produactiva Ltda,Ecuador
-bank_430,9943,Coop. De A. Y C. Tamboloma Ltda.,Ecuador
-bank_431,9944,Coop De A. Y C. Pushak Runa Hombre Lider,Ecuador
-bank_432,9945,Coop. De A. Y C. 15 De Agosto Ltda.,Ecuador
-bank_433,9946,Coop. De A. Y C. Migrantes Del Ecuador Ltda,Ecuador
-bank_434,9947,Cooperativa De Ahorro Y Credito Wuamanloma Ltda.,Ecuador
-bank_435,9948,Coop. De A. Y C. Salate Ltda.,Ecuador
-bank_436,9949,Coop. De A. Y C. Union Popular Ltda.,Ecuador
-bank_437,9950,Coac Achik Inti Ltda,Ecuador
-bank_438,9951,Coac El Migrante Solidario,Ecuador
-bank_439,9952,Coop Ac Las Naves,Ecuador
-bank_440,9953,Coop. De A. Y C. De Imbabura Amazonas,Ecuador
-bank_441,9954,Coop. A. Y C. De Indigenas Chuchuqui Ltda,Ecuador
-bank_442,9955,Coop. Ahorro Y Credito Focazsum Ltda.,Ecuador
-bank_443,9956,Coop. De A. Y C. Solidaria Ltda.- Cotopaxi,Ecuador
-bank_444,9957,Coop. De A. Y C. Unidad Y Progreso,Ecuador
-bank_445,9958,Coac Loja Internacional Ltda.,Ecuador
-bank_446,9959,Coac 23 De Enero,Ecuador
-bank_447,9960,Coac Obras Publicas Fiscales De Loja Y Zamora,Ecuador
-bank_448,9961,Coac Del Sind Chof Prof Virgen Del Cisne,Ecuador
-bank_449,9962,Coac San Miguel De Chirijos Ltda,Ecuador
-bank_450,9963,Coop. Ahorro Y Credito Quevedo Ltda.,Ecuador
-bank_451,9964,Coop. De A. Y C. El Altar Ltda.,Ecuador
-bank_452,9965,Coop. De A. Y C. Nueva Alianza De Chimborazo Ltda,Ecuador
-bank_453,9966,Coop. De A. Y C. Luis Felipe Duchicela Xxvii,Ecuador
-bank_454,9967,Coop. De A. Y C. Nizag Ltda.,Ecuador
-bank_455,9968,Coop. De A. Y C. Makita Kunchik,Ecuador
-bank_456,9969,Coop. De A. Y C. Cerrada Manuela Leon,Ecuador
-bank_457,9970,Coop. De A. Y C. El Buen Sembrador Ltda.,Ecuador
-bank_458,9971,Coac Sindicato De Choferes Profesionales De Yantza,Ecuador
-bank_459,9972,Coop. De A. Y C. 5 De Mayo De Santa Martha De Cuba,Ecuador
+id,bic,name,country:id
+bank_1,1,Banco Central Del Ecuador,base.ec
+bank_2,10,Banco Pichincha C.A.,base.ec
+bank_3,17,Banco De Guayaquil S.A,base.ec
+bank_4,24,Banco City Bank,base.ec
+bank_5,25,Banco Machala,base.ec
+bank_6,29,Banco De Loja,base.ec
+bank_7,30,Banco Del Pacifico,base.ec
+bank_8,32,Banco Internacional,base.ec
+bank_9,34,Banco Amazonas,base.ec
+bank_10,35,Banco Del Austro,base.ec
+bank_11,36,Produbanco / Promerica,base.ec
+bank_12,37,Banco Bolivariano,base.ec
+bank_13,39,Banco Comercial De Manabi,base.ec
+bank_14,42,Banco General Ruminahui S.A.,base.ec
+bank_15,43,Banco Del Litoral S.A.,base.ec
+bank_16,59,Banco Solidario,base.ec
+bank_17,60,Banco Procredit S.A.,base.ec
+bank_18,61,Banco Capital,base.ec
+bank_19,65,Banco Desarrollo De Los Pueblos S.A.,base.ec
+bank_20,66,Banecuador B.P.,base.ec
+bank_21,70,Coop. Ahorro Y Credito 15 De Abril Ltda,base.ec
+bank_22,76,Coop. Jardin Azuayo,base.ec
+bank_23,79,Coop.De Ahorro Y Credito Policia Nacional,base.ec
+bank_24,82,Financoop,base.ec
+bank_25,201,Banco Delbank S.A.,base.ec
+bank_26,202,Banco Ecuatoriano De La Vivienda,base.ec
+bank_27,203,Cacpeco Ltda,base.ec
+bank_28,204,C.Peq.Empresa De Pastaza,base.ec
+bank_29,205,Coop. Ahorro Y Credito 23 De Julio,base.ec
+bank_30,206,Coop. Ahorro Y Credito 29 De Octubre,base.ec
+bank_31,207,Coop. Ahorro Y Credito Andalucia,base.ec
+bank_32,208,Coop. Ahorro Y Credito Cotocollao,base.ec
+bank_33,210,Coop. Ahorro Y Credito El Sagrario,base.ec
+bank_34,211,Coop. Ahorro Y Credito Guaranda Ltda,base.ec
+bank_35,213,Coop. Juventud Ecuatoriana Progresista Ltda.,base.ec
+bank_36,214,Coop. Ahorro Y Credito Manuel,base.ec
+bank_37,216,Coop. Ahorro Y Credito Oscus,base.ec
+bank_38,217,Coop. Ahorro Y Credito Pablo Munoz Vega,base.ec
+bank_39,218,Coop. Ahorro Y Credito Progreso,base.ec
+bank_40,219,Coop. Ahorro Y Credito Riobamba,base.ec
+bank_41,220,Coop. Ahorro Y Credito San Francisco,base.ec
+bank_42,222,Coop. Ahorro Y Credito Tulcan,base.ec
+bank_43,223,Coop. De Ahorro Y Credito Atuntaqui Ltda.,base.ec
+bank_44,224,Coop. De Ahorro Y Credito Comercio Ltda Portoviejo,base.ec
+bank_45,225,Coop. De Ahorro Y Credito La Dolorosa Ltda,base.ec
+bank_46,226,Coop. Prevision Ahorro Y Desarrollo,base.ec
+bank_47,227,Coop.Ahorro Y Credito Alianza Del Valle Ltda,base.ec
+bank_48,228,Coop Ahorro Y Credito Constrc Comercio Y Produc,base.ec
+bank_49,229,Coop.Ahorro Y Credito Chone Ltda,base.ec
+bank_50,231,Cooperativa De Ahorro Y Credito Santa Ana Ltda,base.ec
+bank_51,232,Financiera - Diners Club Del Ecuador,base.ec
+bank_52,233,Mutualista Ambato,base.ec
+bank_53,234,Mutualista Azuay,base.ec
+bank_54,236,Mutualista Imbabura,base.ec
+bank_55,238,Mutualista Pichincha,base.ec
+bank_56,240,Coop De A. Y C. Corporacion Centro Ltda.,base.ec
+bank_57,242,Coop. De A. Y C. Cordillera De Los Andes Ltda.,base.ec
+bank_58,243,Coop. De A. Y C. Puerto Francisco De Orellana,base.ec
+bank_59,244,Coop. De A Y C. Luz Del Valle,base.ec
+bank_60,245,Coop. De A Y C. Esperanza Y Progreso Del Valle,base.ec
+bank_61,246,Coop. De A. Y C. Choco Tungurahua Runa Ltda,base.ec
+bank_62,247,Coop. De A. Y C. Coopartamos Ltda,base.ec
+bank_63,249,Coop. De A. Y C. Emprendedores Coopemprender Ltda.,base.ec
+bank_64,250,Coop. De A. Y C. Nueva Loja Ltda.,base.ec
+bank_65,251,Coop. De A. Y C. Pichncha Ltda.,base.ec
+bank_66,252,Coop. Credito Y Ahorro San Francisco De Asis,base.ec
+bank_67,253,Coop.De Ahorro Y Credito Cacec Ltda. (Cotopaxi),base.ec
+bank_68,254,Coop.De A. Y C. Vencedores De Pichincha Ltda.,base.ec
+bank_69,255,Cooperativa De Ahorro Y Credito San Bartolo Ltda,base.ec
+bank_70,257,Coop. De A. Y C. Del Emigrante Ecuatoriano Y Su Fa,base.ec
+bank_71,258,Coop. Ahorro Y Credito La Libertad Ltda,base.ec
+bank_72,259,Coac Cuna De La Nacionalidad Ltda.,base.ec
+bank_73,260,Cooperativa De Ahorro Y Credito Macodes Ltda,base.ec
+bank_74,262,Cooperativa De Ahorro Y Credito Santa Isabel Ltda.,base.ec
+bank_75,263,Cooperativa De Ahorro Y Credito Ganansol Ltda,base.ec
+bank_76,264,Cooperativa De Ahorro Y Credito Del Azuay,base.ec
+bank_77,265,Cooperativa De Ahorro Y Credito Del Colegio De Arq,base.ec
+bank_78,266,Cooperativa De Ahorro Y Credito Nukanchik,base.ec
+bank_79,267,Coop De Ahorro Y Credito Santa Ana Cuenca,base.ec
+bank_80,268,Cooperativa De Ahorro Y Credito Multiempresarial L,base.ec
+bank_81,269,Coac Del Sindicato De Choferes Profesionales Del A,base.ec
+bank_82,270,Coop. Ahorro Y Credito Juan De Salinas Ltda.,base.ec
+bank_83,271,Coop. Ahorro Y Credito Puellaro Ltda,base.ec
+bank_84,272,Coop. Ahorro Y Credito Nueva Jerusalen,base.ec
+bank_85,273,Coop. Ahorro Y Credito Malchingui Ltda.,base.ec
+bank_86,275,Coop. De Ahorro Y Credito Chola Cuencana Ltda.,base.ec
+bank_87,276,Coop. Ahorro Y Credito Tena Ltda.,base.ec
+bank_88,277,Coop. Ahorro Y Credito De La Pequena Empresa Guala,base.ec
+bank_89,278,Coop. Ahorro Y Credito Alianza Minas Ltda.,base.ec
+bank_90,279,Coop. De Ahorro Y Credito Pedro Moncayo Ltda.,base.ec
+bank_91,281,Cooperativa De Ahorro Y Credito Provida,base.ec
+bank_92,283,Cooperativa De Ahorro Y Credito San Jose S.J.,base.ec
+bank_93,285,Coop. Ahorro Y Credito Senor De Giron,base.ec
+bank_94,287,Coop. De Ahorro Y Credito Educ.Del Tungurahua Ltda,base.ec
+bank_95,290,Cooperativa 15 De Agosto Pilacoto,base.ec
+bank_96,291,Coop. De Ahorro Y Credito Cristo Rey,base.ec
+bank_97,292,Coop. De Ahorro Y Credito Educadores De Chimborazo,base.ec
+bank_98,293,Cooperativa De Ahorro Y Credito Minga Ltda.,base.ec
+bank_99,294,Coop. De Ahorro Y Credito 4 De Octubre Ltda.,base.ec
+bank_100,295,Coop. De Ahorro Y Credito Credi Facil Ltda.,base.ec
+bank_101,296,Coop. De Ahorro Y Credito Alfonso Jaramillo C.C.C.,base.ec
+bank_102,297,Coop. De A. Y C. Indigena Sac Pelileo,base.ec
+bank_103,298,Coop. De A. Y C. Intercultural Tawantinsuyu Ltda.,base.ec
+bank_104,299,Coop. De A. Y C. Ocipsa,base.ec
+bank_105,300,Coop. De A. Y C. 21 De Noviembre Ltda.,base.ec
+bank_106,301,Coop. De A. Y C. La Floresta Ltda.,base.ec
+bank_107,302,Coop. De A. Y C. Corp. Org. Campesinas De Quisapin,base.ec
+bank_108,303,Coop. De A. Y C. Multicultural Banco Indigena Ltda,base.ec
+bank_109,304,Coop De A. Y C. Crecer Winari Ltda.,base.ec
+bank_110,305,Coop. De A. Y C. Banos De Agua Santa Ltda.,base.ec
+bank_111,306,Coop. De Ahorro Y Credito 1 De Julio,base.ec
+bank_112,307,Coop. De A. Y C. Sumak Nan Ltda.,base.ec
+bank_113,308,Cooperativa De Ahorro Y Credito Canar Ltda.,base.ec
+bank_114,309,Cooperativa De Ahorro Y Credito San Antonio Ltda.,base.ec
+bank_115,310,Coop. De Ahorro Y Credito Fundar,base.ec
+bank_116,312,Coop. Ahorro Y Credito Metropolis Ltda.,base.ec
+bank_117,313,Coop. De Ahorro Y Credito El Cafetal,base.ec
+bank_118,314,Coop.De Ahorro Y Credito Microempresarial Sucre,base.ec
+bank_119,315,Coop. De A. Y C. Afroecuatoriana De La Peq. Emp. L,base.ec
+bank_120,316,Cooperativa De Ahorro Y Credito Joyocoto Ltda.,base.ec
+bank_121,317,Coop. Ahorro Y Credito San Antonio Ltda.,base.ec
+bank_122,318,Coop. De A. Y C. Uniotavalo Ltda.,base.ec
+bank_123,319,Coop. De A. Y C. Union El Ejido,base.ec
+bank_124,320,Coop. De A. Y C. Genesis Ltda.,base.ec
+bank_125,321,Coop. De A Y C. Maria Auxiliadora De Quiroga Ltda,base.ec
+bank_126,322,Coop. De A. Y C. Fortaleza,base.ec
+bank_127,323,Banco Para La Asistencia Comunitaria Finca S.A.,base.ec
+bank_128,324,Coop. Calceta Ltda,base.ec
+bank_129,325,Coop. Ahorro Y Credito 9 De Octubre Ltda,base.ec
+bank_130,327,Coop. Ahorro Y Credito D La Peq Empr Cacpe Biblian,base.ec
+bank_131,328,Coop. Ahorro Y Credito San Gabriel Ltda.,base.ec
+bank_132,329,Coop. Ahorro Y Credito San Jose Ltda,base.ec
+bank_133,330,Coop. Ahorro Y Credito San Miguel De Los Bancos,base.ec
+bank_134,332,Coop. Ahorro Y Credito Semilla Del Progreso Ltda,base.ec
+bank_135,333,Coop. Ahorro. Y Credi. Mujeres Unidas Tantanakushk,base.ec
+bank_136,334,Coop. De Ahorro Y Cred. Santa Rosa Ltda,base.ec
+bank_137,335,Coop. De Ahorro Y Credito Once De Junio,base.ec
+bank_138,336,Coop. De A. Y C. Pujili Ltda,base.ec
+bank_139,337,Coop. De A. Y C. Credil Ltda.,base.ec
+bank_140,339,Coop. De A. Y C. Mushuk Pakari Ltda.,base.ec
+bank_141,340,Coop. De A. Y C. Uniblock Y Servicios Ltda.,base.ec
+bank_142,341,Coop. De A. Y C. San Fernando Limitada,base.ec
+bank_143,342,Coop. De A. Y C. Futuro Lamanense,base.ec
+bank_144,343,Coop. De A. Y C. Saquisili Ltda.,base.ec
+bank_145,344,Coop. De A. Y C. Innovacion Andina Ltda.,base.ec
+bank_146,345,Coop.De A.Y C. El Comerciante Ltda (Mies),base.ec
+bank_147,346,Coop. De A. Y C. Mushuk Wasi Ltda ( Mies ),base.ec
+bank_148,347,Cooperativa De Ahorro Y Credito Solidaria Ltda,base.ec
+bank_149,348,Cooperativa De Ahorro Y Credito Llanganates,base.ec
+bank_150,349,Interdin S.A.,base.ec
+bank_151,350,Coop.Aho Y Credito De La Peq. Emp. De Loja Cacpe,base.ec
+bank_152,351,Cooperativa De Ahorro Y Credito Economia Del Sur C,base.ec
+bank_153,352,Cooperativa De Ahorro Y Credito Migrantes Y Empren,base.ec
+bank_154,353,Cooperativa De Ahorro Y Credito San Sebastian,base.ec
+bank_155,354,Coop. De A. Y C. Del Sindicato De Choferes Profesi,base.ec
+bank_156,355,Coop.De Ahorro Y Credito 29 De Enero,base.ec
+bank_157,356,Coop. Ahorro Y Credito Agraria Mushuk Kawsay Ltda.,base.ec
+bank_158,357,Cooperativa De Ahorro Y Credito Runa Shungo Ltda.,base.ec
+bank_159,358,Coop. De A. Y C. San Marcos,base.ec
+bank_160,359,Coop. De A. Y C. Antorcha Ltda.,base.ec
+bank_161,360,Cooperativa De Ahorro Y Credito Socio Amigo,base.ec
+bank_162,361,Coop. De A. Y C. Indigenas Galapagos Ltda.,base.ec
+bank_163,362,Coop. Ahorro Y Credito Camara De Comercio Del Cant,base.ec
+bank_164,363,Cooperativa De Ahorro Y Credito La Benefica Ltda.,base.ec
+bank_165,364,Coop.De Ahorro Y Credito Abdon Calderon Ltda.,base.ec
+bank_166,365,Coop. A Y C Camara De Comercio Canton -El Carmen L,base.ec
+bank_167,366,Coop.De Ahorro Y Credito Agroproductiva Manabi Ltd,base.ec
+bank_168,367,Coop. De Ahorro Y Cred. La Inmaculada De San Placi,base.ec
+bank_169,368,Coop. Ahorro Y Credito Cacpe Manabi,base.ec
+bank_170,369,Coop.Ahorro Y Credito Magisterio Manabita Limitada,base.ec
+bank_171,370,Coac Tienda De Dinero Ltda.,base.ec
+bank_172,371,Coop.A.Y C. Santa Maria De La Manga Del Cura Ltda.,base.ec
+bank_173,375,Coop. Ahorro Y Credito Camara De Comercio Indigena,base.ec
+bank_174,379,Coop. De A. Y C. Guamote Ltda.,base.ec
+bank_175,382,Coop. De A.Y C. Produc. Ahorro Invers. Servicio P.,base.ec
+bank_176,383,Coop. De A. Y C. Frandesc Ltda.,base.ec
+bank_177,384,Coop. De A. Y C. Nuka Llakta Ltda.,base.ec
+bank_178,385,Coop. De A Y C. Camara De Comercio Riobamba,base.ec
+bank_179,386,Coop. De A. Y C. Bashalan Ltda.,base.ec
+bank_180,387,Coop. De A. Y C. Camara De Comercio Santo Domingo,base.ec
+bank_181,388,Coop. De A. Y C. Educadores Tulcan Ltda.,base.ec
+bank_182,400,Coop. Warmikunapak Rikchari,base.ec
+bank_183,403,Coop Ahorro Y Credito Mi Tierra,base.ec
+bank_184,404,Coop Ahorro Y Credito De La Peq Emp Cacpe Yanzatza,base.ec
+bank_185,405,Coop Ahorro Y Credito Fundesarrollo,base.ec
+bank_186,406,Caja Ecuaespana,base.ec
+bank_187,408,Coop De Ahorro Y Credito Nueva Huancavilca,base.ec
+bank_188,410,Coop De Ahorro Y Credito Erco Ltda,base.ec
+bank_189,411,Coop Ahorro Y Credito Camara Comercio De Ambato,base.ec
+bank_190,412,Coop Ahorro Y Credito Mushuc Runa Ltda,base.ec
+bank_191,414,Coop De Ahorro Y Credito Ambato Ltda,base.ec
+bank_192,415,Coop De Ahorro Y Credito Dorado Ltda,base.ec
+bank_193,416,Coop De Ahorro Y Credito Nuestros Abuelos Ltda,base.ec
+bank_194,417,Coop De Ahorro Y Credito Artesanos Ltda,base.ec
+bank_195,418,Coop De Ahorro Y Credito Santa Anita Ltda,base.ec
+bank_196,419,Coop De Ahorro Y Credito Huayco Pungo Ltda,base.ec
+bank_197,420,Coop Manuel Esteban Godoy Ortega Ltda Coopmego,base.ec
+bank_198,421,Coop Ahorro Y Credito Padre Julian Lorente Ltda,base.ec
+bank_199,422,Coop Ahorro Y Credito Cariamanga Ltda,base.ec
+bank_200,423,Coop De Ahorro Y Credito Marcabeli Ltda,base.ec
+bank_201,424,Coop De Ahorro Y Credito Agricola Junin Ltda,base.ec
+bank_202,425,Coop De Ahorro Y Credito Puerto Lopez Ltda,base.ec
+bank_203,427,Coop De Ahorro Y Credito Nueva Esperanza,base.ec
+bank_204,428,Coop De Ahorro Y Credito San Jorge Ltda,base.ec
+bank_205,429,Coop De Ahorro Y Credito Fernando Daquilema,base.ec
+bank_206,435,Coop De A Y C Educadores De Pastaza Ltda,base.ec
+bank_207,450,Coop. A. Y C. De La Peq. Emp. Cacpe Zamora Ltda,base.ec
+bank_208,451,Coop. De A. Y C. Desarrollo Integral Ltda,base.ec
+bank_209,452,Coop. De Ahorro Y Credito El Calvario Ltda,base.ec
+bank_210,453,Coop. De A. Y C. Juan Pio De Mora Ltda,base.ec
+bank_211,454,Coop. De Ahorro Y Credito Pilahuin,base.ec
+bank_212,455,Coop. De Ahorro Y Credito Pucara Ltda,base.ec
+bank_213,456,Coop. A. Y C. Camara De Comercio De Pindal Cadecop,base.ec
+bank_214,461,Banco Del Instituto Ecuatoriano De Seguridad Social,base.ec
+bank_215,462,Coop De A Y C De Serv Publ Del Min Educacion Y Cul,base.ec
+bank_216,463,Coop De A Y C 23 De Mayo Ltda,base.ec
+bank_217,464,Coop De A Y C Coca Ltda,base.ec
+bank_218,465,Coop De Ahorro Y Credito Pilahuin Tio Ltda,base.ec
+bank_219,467,Coop De Ahorro Y Credito Huaicana Ltda,base.ec
+bank_220,468,Coop De A Y C Credisur Ltda,base.ec
+bank_221,469,Fondo De Cesantia Del Magisterio Ecuat Fcme-Fcpc,base.ec
+bank_222,471,Coop De Ahorro Y Credito Huaquillas Ltda,base.ec
+bank_223,472,Coop De A Y C Banos Ltda,base.ec
+bank_224,473,Coop De Ahorro Y Credito Cac-Cica Mies,base.ec
+bank_225,475,Coop De A Y C Vencedores De Tungurahua,base.ec
+bank_226,476,Coop A Y C Ecuafuturo Ltda,base.ec
+bank_227,477,Coop De A Y C Maquita Cushun Ltda,base.ec
+bank_228,478,Coop De A Y C Valles Del Lirio,base.ec
+bank_229,479,Coop Esfuerzo Unido Para El Desarr Del Chilco,base.ec
+bank_230,480,Coop A Y C Carroceros De Tungurahua,base.ec
+bank_231,481,Coop De Ahorro Y Credito Simiatug Ltda,base.ec
+bank_232,482,Coop De A Y C Sinchi Runa Ltda,base.ec
+bank_233,483,Coop De A Y C Santa Rosa De Pautan Ltda,base.ec
+bank_234,484,Coop De Ahorro Y Credito San Miguel De Sigchos,base.ec
+bank_235,485,Coop De A Y C Sierra Centro Ltda,base.ec
+bank_236,486,Coop De A Y C Gonzanama Mies,base.ec
+bank_237,487,Coop De Ahorro Y Credito Quilanga Ltda,base.ec
+bank_238,488,Coop De Ahorro Y Credito 27 De Abril Loja,base.ec
+bank_239,489,Coop De A Y C Crediamigo Ltda Loja Mies,base.ec
+bank_240,490,Coop De Ahorro Y Credito Fortuna Mies,base.ec
+bank_241,491,Coop A Y C Profesionales Del Volante Union Ltda,base.ec
+bank_242,492,Coop De Ahorro Y Credito Cacpe Celica,base.ec
+bank_243,493,Coop De A Y C Futuro Y Progreso De Galapagos Ltda,base.ec
+bank_244,494,Coop De A Y C Sumac Llacta Ltda,base.ec
+bank_245,495,Coop De A Y C Lucha Campesina Ltda,base.ec
+bank_246,497,Coop De A Y C Maquita Cushunchic Ltda,base.ec
+bank_247,498,Coop A Y C Focla,base.ec
+bank_248,499,Coop De A Y C Casag Ltda,base.ec
+bank_249,500,Banco D Miro Sa,base.ec
+bank_250,501,Coop De A Y C General Ruminahui,base.ec
+bank_251,502,Coop De A Y C Financiera Indigena Ltda,base.ec
+bank_252,503,Coop A Y C 20 Febrero Ltda,base.ec
+bank_253,504,Coop De A Y C Del Col. Fisc. Vicente Rocafuerte,base.ec
+bank_254,505,Coop De A Y C Jadan Ltda (Mies),base.ec
+bank_255,509,Coop De A Y C Inka Kipu Ltda,base.ec
+bank_256,510,Coop De A Y C Accion Tungurahua Ltda,base.ec
+bank_257,511,Coop De A Y C Pijal,base.ec
+bank_258,512,Coop De A Y C Escencia Indigena Ltda,base.ec
+bank_259,513,Coop De A Y C Union Mercedaria Ltda,base.ec
+bank_260,514,Coop De A Y C Catamayo Ltda,base.ec
+bank_261,515,Coop De A Y C De La Peq Empresa Cacpe Macara,base.ec
+bank_262,516,Coop A Y C Nuevos Horizontes El Oro Ltda,base.ec
+bank_263,517,Banco Coopnacional Sa,base.ec
+bank_264,518,Coop De A Y C 16 De Junio,base.ec
+bank_265,519,Coop A Y C Esc Sup Politec Agrop De Manabi Manuel,base.ec
+bank_266,526,Coop De Ahorro Y Credito Fasaynan Ltda,base.ec
+bank_267,546,Coop Cacique Guritave,base.ec
+bank_268,547,Coop Solidaridad Y Progreso Oriental,base.ec
+bank_269,567,Coop. De Aho Y Cred Los Andes Latinos Ltda.,base.ec
+bank_270,569,C. De A. Y C Coopac Austro Ltda (Miess),base.ec
+bank_271,570,Coop. De A. Y C. Salasaca,base.ec
+bank_272,571,Coop. De A. Y C. Sumak Samy Ltda.,base.ec
+bank_273,572,C. A. Y C. Intercult. Tarpuk Runa Ltda.,base.ec
+bank_274,573,Coop. De A. Y C. Virgen Del Cisne,base.ec
+bank_275,574,C. De A Y C Educad. De Zamora Chinchipe,base.ec
+bank_276,575,C. De Ah. Y Credito Las Lagunas (Miess),base.ec
+bank_277,577,C. De A Y C. Educadores De El Oro Ltd,base.ec
+bank_278,578,C De A Y C Emplead Bancar Del Oro Ltda,base.ec
+bank_279,579,Cooperativa De Ah. Y Credito Riochico,base.ec
+bank_280,580,C. De A. Y C. San Martin De Tisaleo Ltda.,base.ec
+bank_281,581,Coop. De A. Y C. Alli Tarpuc Ltda.,base.ec
+bank_282,582,C. De A Y C. San Miguel De Pallatanga,base.ec
+bank_283,590,Coop De A Y C Fenix,base.ec
+bank_284,591,Coop.De Ahorro Y Credito Camara De Comercio De Loj,base.ec
+bank_285,592,Coop.De A. Y C. De Crecimiento Economico Rentable,base.ec
+bank_286,593,Cooperativa De Ahorro Y Credito Santiago Ltda,base.ec
+bank_287,594,Coop.De A. Y C. Popular Y Solidaria,base.ec
+bank_288,595,Coop.De Ahorro Y Credito San Placido Ltda.,base.ec
+bank_289,596,Coop.De Ahorro Y Credito Ciudad De Zamora,base.ec
+bank_290,597,Coop. De A Y C De La Pequena Empresa De Palora,base.ec
+bank_291,600,Coop. De A. Y C. Indigena Alfa Y Omega Ltda,base.ec
+bank_292,603,Cooperativa De Ahorro Y Credito Crea Ltda ( Mies),base.ec
+bank_293,604,Coop. De A. Y C. Chibuleo Ltda.,base.ec
+bank_294,605,Coop. De A. Y C. El Tesoro Pillareno,base.ec
+bank_295,606,Coop. De A. Y C. Kisapincha Ltda.,base.ec
+bank_296,607,Coop. De A. Y C. Juventud Unida Ltda.,base.ec
+bank_297,608,Coop. De A. Y C. Union Quisapincha Ltda.,base.ec
+bank_298,609,Coop. De A. Y C. 13 De Abril Ltda,base.ec
+bank_299,610,Coop. De A. Y C. Salinas Ltda.,base.ec
+bank_300,611,Coop. De A. Y C. San Pedro Ltda.,base.ec
+bank_301,612,Coop. De A. Y C. Los Chasquis Pastocalle Ltda.,base.ec
+bank_302,613,Coop. De A. Y C. Coopindigena Ltda.,base.ec
+bank_303,614,Coop. De A. Y C. La Union Ltda.,base.ec
+bank_304,615,Coop. De A. Y C. Padre Vicente Ponce Rubio,base.ec
+bank_305,633,Coop. De A. Y C. Mushug Causay Ltda.,base.ec
+bank_306,634,Coop. De A. Y C. 29 De Agosto,base.ec
+bank_307,641,Coop. De A. Y C. Credisocio,base.ec
+bank_308,673,Coop. De A. Y C. Fondo Para El Desarrollo Y La Vid,base.ec
+bank_309,674,Cooperativa De A Y C Nueva Vision,base.ec
+bank_310,675,Coop. De Ahorro Y Credito Focash Ltda.,base.ec
+bank_311,676,Coop. De A. Y C. San Vicente Del Sur Ltda.,base.ec
+bank_312,677,Coop. De A. Y C. Para La Vivienda Orden Y Segurida,base.ec
+bank_313,678,Coop De A. Y C. Camara De Comercio Joya De Los Sac,base.ec
+bank_314,679,Coop. De A. Y C. Focap,base.ec
+bank_315,680,Coop. De A. Y C. 18 De Noviembre,base.ec
+bank_316,681,Cooperativa De Ahorro Y Credito Dr. Cornelio Saenz,base.ec
+bank_317,682,Coop De A. Y C. Educadores Del Azuay,base.ec
+bank_318,683,Coop. De A. Y C. Indigena Sac Ltda,base.ec
+bank_319,684,Coop. De A. Y C. Credi Ya Ltda,base.ec
+bank_320,685,Coop. De A. Y C. San Bartolome Ltda,base.ec
+bank_321,686,Coop. De Ahorro Y Credito Mushuk Yuyay,base.ec
+bank_322,687,Coop De A. Y C. Sisay Kanari,base.ec
+bank_323,688,Cooperativa De A Y C Accion Imbaburapak Ltda.,base.ec
+bank_324,689,Coop De A. Y C. Hermes Gaibor Verdesoto,base.ec
+bank_325,690,Coop. De A. Y C. Semillas De Pangua,base.ec
+bank_326,691,Cooperativa De A Y C Mushuk Solidaria,base.ec
+bank_327,692,Coop De A. Y C. Panamericana Ltda,base.ec
+bank_328,693,Coop. De A. Y C. Vilcabamba Cacvil,base.ec
+bank_329,694,Coop. De A. Y C. Familia Solidaria,base.ec
+bank_330,695,Cooperativa De Ahorro Y Credito El Paraiso Manga D,base.ec
+bank_331,696,Coac De Los Profesores Empleados Y Trabajadores De,base.ec
+bank_332,697,Coac. Santa Rosa De San Carlos Ltda.,base.ec
+bank_333,698,Coop. De A. Y C. Constructor Del Desarrollo Solida,base.ec
+bank_334,699,Coop De A. Y C. Mushuk Yuyay Ltda,base.ec
+bank_335,700,Corporacion Financiera,base.ec
+bank_336,701,Coop. De A. Y C. Alianza Social Ecu. Alsec,base.ec
+bank_337,702,Coop. De A. Y C. Renovadora Ecu,base.ec
+bank_338,703,Coop. De A. Y C. Mushuk Yuyay - Napo,base.ec
+bank_339,704,Coop. De A. Y C. Santa Ana De Nayon,base.ec
+bank_340,705,Coop. De A. Y C. Educadores Del Napo,base.ec
+bank_341,706,Cooperativa De A. Y C. Textil 14 De Marzo,base.ec
+bank_342,707,Coop. De A Y C San Carlos Ltda.,base.ec
+bank_343,708,Coac A Y C Esperanza De Valle De La Virgen Ltda.,base.ec
+bank_344,709,Coac A Y C Zona De Capital Corcimol,base.ec
+bank_345,710,Coop.De A. Y C. Artesanal Del Azuay,base.ec
+bank_346,711,Cooperativa De Ahorro Y Credito Sumak Sisa,base.ec
+bank_347,712,Coop. De A. Y C. Rey David Ltda,base.ec
+bank_348,713,Coop. De A. Y C. Kullki Wasi Ltda.,base.ec
+bank_349,714,Coop De A. Y C. Sinchi Codefis,base.ec
+bank_350,715,Coop. De A. Y C. Fuerza De Los Andes,base.ec
+bank_351,716,Coop De A. Y C. Camino De Luz Ltda.,base.ec
+bank_352,717,Coac A Y C Educadores De Bolivar,base.ec
+bank_353,718,Coac San Miguel Ltda.,base.ec
+bank_354,719,Coop. De A. Y C. Salinerita,base.ec
+bank_355,720,Coop. De A. Y C. Bola Amarilla,base.ec
+bank_356,721,Coop A Y C Vision De Los Andes Visandes,base.ec
+bank_357,722,Coop. De A. Y C. Senor Del Arbol,base.ec
+bank_358,724,Coop. De A. Y C. Camara De Comercio De La Mana,base.ec
+bank_359,725,Coop De A. Y C. Educadores De Loja,base.ec
+bank_360,726,Coop De A. Y C. Indigena Sac Latacunga Ltda,base.ec
+bank_361,727,Coop De A.Y C. Cadecog Gonzanama,base.ec
+bank_362,728,Coac Coopymec Macara,base.ec
+bank_363,729,Coac Cadecom Macara,base.ec
+bank_364,730,Coop De A. Y C. 22 De Junio-Orianga,base.ec
+bank_365,732,Coop. A.Yc.Sagrada Familia Solidaridad,base.ec
+bank_366,733,Coop. De A. Y C. Naupa Kausay,base.ec
+bank_367,734,Ccop A Y C De Apecap Cac Apecap,base.ec
+bank_368,248,Coop De A. Y C. San Juan De Cotogchoa,base.ec
+bank_369,2557,Coop De Ahorro Y Credito La Merced,base.ec
+bank_370,338,Coop. De A. Y C. Cooptopaxi Ltda.,base.ec
+bank_371,620,Coop. De A. Y C. Grameen Amazonas,base.ec
+bank_372,621,Coop. De A. Y C. El Transportista Cacet,base.ec
+bank_373,626,Coop. De A Y C. Servidores Municipales De Cuenca,base.ec
+bank_374,628,Coop. De Ahorro Y Credito Profuturo Ltda.,base.ec
+bank_375,640,Coop. De A. Y C. Iliniza Ltda.,base.ec
+bank_376,642,Coop. De Ahorro Y Credito Saraguros,base.ec
+bank_377,643,Cooperativa De Ahorro Y Credito Inti Wasi Ltda.,base.ec
+bank_378,647,Cooperativa De Ahorro Y Credito San Isidro Ltda.,base.ec
+bank_379,722,Coop. De A. Y C. Empresas Comunitarias Coocredito,base.ec
+bank_380,723,Silvercross S.A Casa De Valores Sccv,base.ec
+bank_381,724,Real Casa De Valores De Guayaquil S.A.,base.ec
+bank_382,725,Cooperativa De Ahorro Y Credito Etapa,base.ec
+bank_383,726,Coop. Ahorro Y Credito Mascoop,base.ec
+bank_384,727,Coop. De A. Y C. Saint Michel Ltda.,base.ec
+bank_385,8000,Coop. Ahorro Y Credito Manantial De Oro Ltda.,base.ec
+bank_386,8001,Coop. De Ahorro Y Credito Andina Ltda.,base.ec
+bank_387,8002,Coop. De Ahorro Y Credito Accion Y Desarrollo Ltda,base.ec
+bank_388,9901,Coop. De A. Y C. Union Y Desarrollo,base.ec
+bank_389,9902,Coop. De A. Y C. Esperanza Del Futuro Ltda.,base.ec
+bank_390,9903,Coop. De A. Y C. 17 De Marzo Ltda,base.ec
+bank_391,9904,Coop. De A. Y C. Catar Ltda,base.ec
+bank_392,9905,Coop. De A. Y C. De Accion Popular,base.ec
+bank_393,9906,Coop. De A. Y C. Alli Tarpuk Ltda,base.ec
+bank_394,9907,Coop. De A. Y C. 16 De Julio Ltda,base.ec
+bank_395,9908,Coop. De A. Y C. Suboficiales De La Policia Nacion,base.ec
+bank_396,9909,Coop. De A. Y C. Politecnica Ltda.,base.ec
+bank_397,9910,Coop. De A. Y C. Nacional Llano Grande Ltda.,base.ec
+bank_398,9911,Coop. De A. Y C. San Valentin,base.ec
+bank_399,9912,Coop. De A. Y C. Totalife Ltda,base.ec
+bank_400,9913,Acciones Valores Casa De Valores S.A. Accival,base.ec
+bank_401,9914,Santa Fe Casa De Valores S.A. Santafevalores,base.ec
+bank_402,9915,Picaval Casa De Valores S.A,base.ec
+bank_403,9916,Analytica Securties C.A. Casa De Valores,base.ec
+bank_404,9917,Orion Casa De Valores S.A,base.ec
+bank_405,9918,Stratega Casa De Valores S.A.,base.ec
+bank_406,9919,Ecofsa Casa De Valores S.A.,base.ec
+bank_407,9920,Merchantvalores Casa De Valores S.A.,base.ec
+bank_408,9921,Casa De Valores Value S.A.,base.ec
+bank_409,9922,Inmovalor Casa De Valores S.A.,base.ec
+bank_410,9923,Ecuabursatil Casa De Valores S.A.,base.ec
+bank_411,9924,Plus Valores Casa De Valores S.A.,base.ec
+bank_412,9925,Mercapital Casa De Valores S.A.,base.ec
+bank_413,9926,Portafolio Casa De Valores S.A. Portavalor,base.ec
+bank_414,9927,Metrovalores Casa De Valores S.A.,base.ec
+bank_415,9928,Vectorglobal Wmg Casa De Valores S.A.,base.ec
+bank_416,9929,Holdunpartners Casa De Valores S.A.,base.ec
+bank_417,9930,Coop. De Ahorro Y Credito Base De Taura,base.ec
+bank_418,9931,Casa De Valores Banrio S.A.,base.ec
+bank_419,9932,Albion Casa De Valores S.A.,base.ec
+bank_420,9933,Masvalores Casa De Valores S.A Cavamasa,base.ec
+bank_421,9934,Casa De Valores Del Pacifico (Valpacifico) S.A.,base.ec
+bank_422,9935,Casa De Valores Advfin S.A.,base.ec
+bank_423,9936,Kapital One Casa De Valores S.A. Kaovalsa,base.ec
+bank_424,9937,Plusbursatil Casa De Valores S.A,base.ec
+bank_425,9938,Activa Ases.E Intermed.Valores Activalores Casa De,base.ec
+bank_426,9939,Citadel Casa De Valores S.A.,base.ec
+bank_427,9940,Decevale S.A.,base.ec
+bank_428,9941,Coop. De A. Y C. Santa Lucia Ltda,base.ec
+bank_429,9942,Coop. De A. Y C. Produactiva Ltda,base.ec
+bank_430,9943,Coop. De A. Y C. Tamboloma Ltda.,base.ec
+bank_431,9944,Coop De A. Y C. Pushak Runa Hombre Lider,base.ec
+bank_432,9945,Coop. De A. Y C. 15 De Agosto Ltda.,base.ec
+bank_433,9946,Coop. De A. Y C. Migrantes Del Ecuador Ltda,base.ec
+bank_434,9947,Cooperativa De Ahorro Y Credito Wuamanloma Ltda.,base.ec
+bank_435,9948,Coop. De A. Y C. Salate Ltda.,base.ec
+bank_436,9949,Coop. De A. Y C. Union Popular Ltda.,base.ec
+bank_437,9950,Coac Achik Inti Ltda,base.ec
+bank_438,9951,Coac El Migrante Solidario,base.ec
+bank_439,9952,Coop Ac Las Naves,base.ec
+bank_440,9953,Coop. De A. Y C. De Imbabura Amazonas,base.ec
+bank_441,9954,Coop. A. Y C. De Indigenas Chuchuqui Ltda,base.ec
+bank_442,9955,Coop. Ahorro Y Credito Focazsum Ltda.,base.ec
+bank_443,9956,Coop. De A. Y C. Solidaria Ltda.- Cotopaxi,base.ec
+bank_444,9957,Coop. De A. Y C. Unidad Y Progreso,base.ec
+bank_445,9958,Coac Loja Internacional Ltda.,base.ec
+bank_446,9959,Coac 23 De Enero,base.ec
+bank_447,9960,Coac Obras Publicas Fiscales De Loja Y Zamora,base.ec
+bank_448,9961,Coac Del Sind Chof Prof Virgen Del Cisne,base.ec
+bank_449,9962,Coac San Miguel De Chirijos Ltda,base.ec
+bank_450,9963,Coop. Ahorro Y Credito Quevedo Ltda.,base.ec
+bank_451,9964,Coop. De A. Y C. El Altar Ltda.,base.ec
+bank_452,9965,Coop. De A. Y C. Nueva Alianza De Chimborazo Ltda,base.ec
+bank_453,9966,Coop. De A. Y C. Luis Felipe Duchicela Xxvii,base.ec
+bank_454,9967,Coop. De A. Y C. Nizag Ltda.,base.ec
+bank_455,9968,Coop. De A. Y C. Makita Kunchik,base.ec
+bank_456,9969,Coop. De A. Y C. Cerrada Manuela Leon,base.ec
+bank_457,9970,Coop. De A. Y C. El Buen Sembrador Ltda.,base.ec
+bank_458,9971,Coac Sindicato De Choferes Profesionales De Yantza,base.ec
+bank_459,9972,Coop. De A. Y C. 5 De Mayo De Santa Martha De Cuba,base.ec

--- a/addons/l10n_pe/data/res.bank.csv
+++ b/addons/l10n_pe/data/res.bank.csv
@@ -1,19 +1,19 @@
-id,name,bic,country
-peruvian_national_bank,Banco de la nación,BANCPEPL,Peru
-peruvian_baiopep1_bank,Banco Iberoamericano,BAIOPEP1,Peru
-peruvian_bconpepl_bank,Banco Continental,BCONPEPL,Peru
-peruvian_bcplpepl_bank,Banco De Credito Del Peru,BCPLPEPL,Peru
-peruvian_bdcmpepl_bank,Banco De Comercio,BDCMPEPL,Peru
-peruvian_belppepl_bank,Cetco S.a.,BELPPEPL,Peru
-peruvian_bifspepl_bank,Banco Interamericano De Finanzas,BIFSPEPL,Peru
-peruvian_binppepl_bank,Banco Internacional Del Peru,BINPPEPL,Peru
-peruvian_bnpepep1_bank,Banco Nor Peru,BNPEPEP1,Peru
-peruvian_bsappepl_bank,Banco Santander Peru S.a.,BSAPPEPL,Peru
-peruvian_bsudpepl_bank,Scotiabank Peru,BSUDPEPL,Peru
-peruvian_cbolpep1_bank,Credibolsa Sociedad Agente De Bolsa S.a.,CBOLPEP1,Peru
-peruvian_citipep1_bank,Citibank Del Peru Sa,CITIPEP1,Peru
-peruvian_citipepl_bank,Citibank Del Peru S.a.,CITIPEPL,Peru
-peruvian_cjsipep1_bank,Caja Rural De Ahorro Y Credito Sipan S.a.,CJSIPEP1,Peru
-peruvian_cofdpepl_bank,Corporacion Financiera De Desarrollo S.A.,COFDPEPL,Peru
-peruvian_crhcpep1_bank,Caja Rural De Ahorro Y Credito Chavin Saa,CRHCPEP1,Peru
-peruvian_crhcpep1001_bank,Caja Rural De Ahorro Y Credito Chavin Saa,CRHCPEP1001,Peru
+id,name,bic,country:id
+peruvian_national_bank,Banco de la nación,BANCPEPL,base.pe
+peruvian_baiopep1_bank,Banco Iberoamericano,BAIOPEP1,base.pe
+peruvian_bconpepl_bank,Banco Continental,BCONPEPL,base.pe
+peruvian_bcplpepl_bank,Banco De Credito Del Peru,BCPLPEPL,base.pe
+peruvian_bdcmpepl_bank,Banco De Comercio,BDCMPEPL,base.pe
+peruvian_belppepl_bank,Cetco S.a.,BELPPEPL,base.pe
+peruvian_bifspepl_bank,Banco Interamericano De Finanzas,BIFSPEPL,base.pe
+peruvian_binppepl_bank,Banco Internacional Del Peru,BINPPEPL,base.pe
+peruvian_bnpepep1_bank,Banco Nor Peru,BNPEPEP1,base.pe
+peruvian_bsappepl_bank,Banco Santander Peru S.a.,BSAPPEPL,base.pe
+peruvian_bsudpepl_bank,Scotiabank Peru,BSUDPEPL,base.pe
+peruvian_cbolpep1_bank,Credibolsa Sociedad Agente De Bolsa S.a.,CBOLPEP1,base.pe
+peruvian_citipep1_bank,Citibank Del Peru Sa,CITIPEP1,base.pe
+peruvian_citipepl_bank,Citibank Del Peru S.a.,CITIPEPL,base.pe
+peruvian_cjsipep1_bank,Caja Rural De Ahorro Y Credito Sipan S.a.,CJSIPEP1,base.pe
+peruvian_cofdpepl_bank,Corporacion Financiera De Desarrollo S.A.,COFDPEPL,base.pe
+peruvian_crhcpep1_bank,Caja Rural De Ahorro Y Credito Chavin Saa,CRHCPEP1,base.pe
+peruvian_crhcpep1001_bank,Caja Rural De Ahorro Y Credito Chavin Saa,CRHCPEP1001,base.pe


### PR DESCRIPTION
### Steps to reproduce
------------------
- Install `l10n_pe` or `l10n_ec` module.
- Go to *Settings → Countries* and rename the country (e.g. "Peru" → "PERÚ",
  "Ecuador" → "ECUADOR").
- Upgrade the module.

### Issue
-----
The files `l10n_pe/data/res.bank.csv` and `l10n_ec/data/res.bank.csv`
reference countries using their names (e.g. "Peru", "Ecuador").

During module upgrade, the CSV import resolves many2one relations using
the country name. If the country name has been modified by the user,
the lookup fails and the module upgrade crashes with:


```python3
2026-03-06 23:48:11,112 27 CRITICAL db_3950261 odoo.service.server: Failed to initialize database `db_3950261`.
Traceback (most recent call last):
  File "/home/odoo/src/odoo/19.0/odoo/service/server.py", line 1510, in preload_registries
    registry = Registry.new(dbname, update_module=update_module, install_modules=config['init'], upgrade_modules=config['update'], reinit_modules=config['reinit'])
  File "/home/odoo/src/odoo/19.0/odoo/tools/func.py", line 88, in locked
    return func(inst, *args, **kwargs)
  File "/home/odoo/src/odoo/19.0/odoo/orm/registry.py", line 199, in new
    load_modules(
  File "/home/odoo/src/odoo/19.0/odoo/modules/loading.py", line 456, in load_modules
    load_module_graph(
  File "/home/odoo/src/odoo/19.0/odoo/modules/loading.py", line 216, in load_module_graph
    load_data(env, idref, mode, kind='data', package=package)
  File "/home/odoo/src/odoo/19.0/odoo/modules/loading.py", line 59, in load_data
    convert_file(env, package.name, filename, idref, mode, noupdate=kind == 'demo')
  File "/home/odoo/src/odoo/19.0/odoo/tools/convert.py", line 689, in convert_file
    convert_csv_import(env, module, pathname, fp.read(), idref, mode, noupdate)
  File "/home/odoo/src/odoo/19.0/odoo/tools/convert.py", line 754, in convert_csv_import
    raise Exception(env._(
Exception: Module loading l10n_pe failed: file l10n_pe/data/res.bank.csv could not be processed:
No matching record found for name 'Peru' in field 'Country'
No matching record found for name 'Peru' in field 'Country'
No matching record found for name 'Peru' in field 'Country'
No matching record found for name 'Peru' in field 'Country'
No matching record found for name 'Peru' in field 'Country'
No matching record found for name 'Peru' in field 'Country'
No matching record found for name 'Peru' in field 'Country'
No matching record found for name 'Peru' in field 'Country'
No matching record found for name 'Peru' in field 'Country'
No matching record found for name 'Peru' in field 'Country'
No matching record found for name 'Peru' in field 'Country'
No matching record found for name 'Peru' in field 'Country'
No matching record found for name 'Peru' in field 'Country'
No matching record found for name 'Peru' in field 'Country'
No matching record found for name 'Peru' in field 'Country'
No matching record found for name 'Peru' in field 'Country'
No matching record found for name 'Peru' in field 'Country'
No matching record found for name 'Peru' in field 'Country'

 select id,name,code from res_country where code='PE'
+-----+----------------------------------------------------------------------+------+
| id  | name                                                                 | code |
|-----+----------------------------------------------------------------------+------|
| 173 | {"de_DE": "Peru", "en_US": "PERÚ", "es_ES": "PERÚ", "es_PE": "Perú"} | PE   |
+-----+----------------------------------------------------------------------+------+
```


### Root Cause
----------
Using translatable/display names in CSV data is not reliable, as these
values can be customized or translated.

### Fix
---
Replace country name references with stable XMLIDs:
- `base.pe` for Peru
- `base.ec` for Ecuador

Using XMLIDs ensures consistent resolution regardless of name changes
or translations.

opw-6015302
upg-3950261
tbg-2492

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
