### PR TITLE
[FIX] hr_holidays: Fix tour overtime ruleset

### DIFF
--- a/addons/hr_holidays/views/hr_work_entry_type_views.xml
+++ b/addons/hr_holidays/views/hr_work_entry_type_views.xml
@@ -58,8 +58,8 @@
                             <field name="leave_validation_type" string="Approval" widget="radio"/>
                         </group>
                         <group name="allocation_validation" id="allocation_requests" string="Allocation Requests">
-                            <field name="requires_allocation" widget="checkbox"/>
-                            <field name="employee_requests" widget="checkbox" invisible="not requires_allocation"/>
+                            <field name="requires_allocation"/>
+                            <field name="employee_requests" invisible="not requires_allocation"/>
                             <field name="allocation_validation_type" string="Approval" widget="radio" invisible="not requires_allocation"/>
                         </group>
                     </group>


### PR DESCRIPTION
Remove legacy widget="checkbox" usages that triggered the "Missing widget: checkbox" console warning; boolean fields now use the default boolean widget rendering.

task-5945764

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
