### PR TITLE
[FIX] website_project: avoid portal AccessError on task submission page

### DIFF
--- a/addons/website_project/views/project_portal_project_task_template.xml
+++ b/addons/website_project/views/project_portal_project_task_template.xml
@@ -13,7 +13,7 @@
                         <t t-if="task">
                             <p class="lead mb-0">Your task has been sent.</p>
                             <p class="lead">Our team will get right on it.</p>
-                            <a t-if="request.session.uid and task.sudo().project_id.id and task.project_privacy_visibility != 'followers'" class="my-3 border rounded px-4 py-3 bg-100 fs-5 fw-bold shadow-sm text-decoration-none" t-attf-href="/my/task/#{task.id}" t-att-title="'Ticket #' + str(task.id)">
+                            <a t-if="request.session.uid and task.sudo().project_id.id and task.sudo().project_privacy_visibility != 'followers'" class="my-3 border rounded px-4 py-3 bg-100 fs-5 fw-bold shadow-sm text-decoration-none" t-attf-href="/my/task/#{task.id}" t-att-title="'Ticket #' + str(task.id)">
                                 Task #<span t-field="task.id"/>
                             </a>
                             <span t-else="" class="my-3 border rounded px-4 py-3 fs-5 fw-bold shadow-sm">


### PR DESCRIPTION
Currently, submitting a website form that creates a task crash for portal users on the confirmation page.

### **Steps to reproduce:**
1) Install website_project with demo data
2) Create a website form that creates a task
3) Set a project on the form
4) Submit the form as a portal user

### **Error:**
`AccessError: You do not have enough rights to access the field project_privacy_visibility on Task (project.task)`

### **Root Cause:**
The confirmation template evaluates `task.project_privacy_visibility` in a t-if condition at [1].

since [commit](https://github.com/odoo/odoo/pull/203891/changes/17664b3f118491f954dd6a810521ce5865d51a43), project task restricts portal users to a whitelist of fields defined by [_portal_accessible_fields()](https://github.com/odoo/odoo/blob/b9e3ca44ceb2b0b35b5e91a06f2905e042aa7f89/addons/project/models/project_task.py#L1015-L1019). Field access is then validated in [_has_field_access()](https://github.com/odoo/odoo/blob/b9e3ca44ceb2b0b35b5e91a06f2905e042aa7f89/addons/project/models/project_task.py#L1021-L1031), which denies read access to fields not present in this whitelist.

`project_privacy_visibility` is not part of the portal readable fields list. When the template tries to read it, _has_field_access() rejects the operation and raises an AccessError.

[1]- https://github.com/odoo/odoo/blob/b9e3ca44ceb2b0b35b5e91a06f2905e042aa7f89/addons/website_project/views/project_portal_project_task_template.xml#L13-L16

### **Fix:**
Use `sudo()` when reading `project_privacy_visibility` in the template to avoid the portal field access restriction.

**opw-6010622**