### PR TITLE
[FIX] project: use same view for milestones top bar action

### DIFF
--- a/addons/project/views/project_milestone_views.xml
+++ b/addons/project/views/project_milestone_views.xml
@@ -126,8 +126,8 @@
         <field name="sequence">10</field>
         <field name="name">Milestones</field>
         <field name="parent_action_id" ref="project.act_project_project_2_project_task_all"/>
-        <field name="action_id" ref="project.project_milestone_action"/>
-        <field name="python_method" eval="False"/>
+        <field name="action_id" eval="False"/>
+        <field name="python_method">action_get_list_view</field>
         <field name="domain">[('allow_milestones', '=', True)]</field>
         <field name="groups_ids" eval="[(4, ref('project.group_project_milestone'))]" />
     </record>
@@ -137,8 +137,8 @@
         <field name="sequence">25</field>
         <field name="name">Milestones</field>
         <field name="parent_action_id" ref="project.project_update_all_action"/>
-        <field name="action_id" ref="project.project_milestone_action"/>
-        <field name="python_method" eval="False"/>
+        <field name="action_id" eval="False"/>
+        <field name="python_method">action_get_list_view</field>
         <field name="domain">[('allow_milestones', '=', True)]</field>
         <field name="groups_ids" eval="[(4, ref('project.group_project_milestone'))]" />
     </record>


### PR DESCRIPTION
Steps to reproduce:
-
   1. Install the sale_project module.
   2. Open a project and ensure it is billable.
   3. Compare the view opened from the "Milestones" link in the Kanban view with the view opened from the "Milestones" top bar action.

Issue:
-
The milestone list view opened from the top bar action does not display sales-related fields (e.g., "Quantity (%)").

Cause:
-
The Kanban view calls the `action_get_list_view` python method, which is overridden in sale_project to add a custom list view including sales-related fields. The top bar action was using a static XML action, bypassing this python logic.

Fix:
-
Update the Milestones embedded actions to call the `action_get_list_view` python method instead of using a static XML action, ensuring top bar uses the same view as others.

task-5993183