### PR TITLE
[FIX] project: add empty python_method for Milestones action

### DIFF
--- a/addons/project/views/project_milestone_views.xml
+++ b/addons/project/views/project_milestone_views.xml
@@ -127,6 +127,7 @@
         <field name="name">Milestones</field>
         <field name="parent_action_id" ref="project.act_project_project_2_project_task_all"/>
         <field name="action_id" ref="project.project_milestone_action"/>
+        <field name="python_method" eval="False"/>
         <field name="domain">[('allow_milestones', '=', True)]</field>
         <field name="groups_ids" eval="[(4, ref('project.group_project_milestone'))]" />
     </record>
@@ -137,6 +138,7 @@
         <field name="name">Milestones</field>
         <field name="parent_action_id" ref="project.project_update_all_action"/>
         <field name="action_id" ref="project.project_milestone_action"/>
+        <field name="python_method" eval="False"/>
         <field name="domain">[('allow_milestones', '=', True)]</field>
         <field name="groups_ids" eval="[(4, ref('project.group_project_milestone'))]" />
     </record>


### PR DESCRIPTION
Add an empty `python_method` field to the Milestones embedded actions.

This is necessary to satisfy the `_check_only_one_action_defined` constraint during database upgrades. The `ir.embedded.actions` model enforces an XOR constraint between `action_id` and `python_method`, preventing both fields from being set simultaneously.

Related PR: https://github.com/odoo/odoo/pull/254102

task-5993183
