### PR TITLE
[FIX] point_of_sale: remove widget `product_label_section_and_note_field` from pos order form view

### DIFF
--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -84,7 +84,7 @@
                             <list string="Order lines" editable="bottom">
                                 <field name="name" column_invisible="True"/>
                                 <field name="full_product_name" optional="hide" readonly="1"/>
-                                <field name="product_id" widget="product_label_section_and_note_field" />
+                                <field name="product_id"/>
                                 <field name="is_edited" readonly="1" column_invisible="not parent.order_edit_tracking"/>
                                 <field name="pack_lot_ids" widget="many2many_tags" groups="stock.group_production_lot"/>
                                 <field name="qty"/>


### PR DESCRIPTION
Steps to reproduce:
=
- Open the `Point of Sale` app in the backend.
- Open the order list view and try to open any order.

Issue:
=
- A traceback is raised: `KeyError: 'translated_product_name'`.

Reason:
=
- The `product_label_section_and_note_field` widget introduced a dependency
  on the `translated_product_name` field, which is not present in
  `pos.order.line`.

Fix:
=
- Removed the widget `product_label_section_and_note_field` from pos order form view as it is not required in pos. 

Reference PR:
=
- https://github.com/odoo/odoo/pull/248401

task-6040210