### PR TITLE
[FIX] stock_account: compute total_value with allowed companies only

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -359,7 +359,9 @@ class ProductProduct(models.Model):
         return last_in
 
     def _with_valuation_context(self):
-        valued_locations = self.env['stock.location'].search([('is_valued_internal', '=', True)])
+        valued_locations = self.env['stock.location'].search(
+            [('is_valued_internal', '=', True), ('company_id', '=', self.env.companies.ids + [False])]
+        )
         return self.with_context(location=valued_locations.ids, owners=[False, self.env.company.partner_id.id])
 
     def _get_remaining_moves(self):

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -3122,3 +3122,37 @@ class TestStockValuation(TestStockValuationCommon):
         recs[-2:]._compute_cumulative_fields()
         self.assertEqual(recs[-1].total_quantity, 3)
         self.assertEqual(recs[-1].total_value, 30)
+
+    def test_total_value_multi_company(self):
+        # Ensure that total_value is computed with the allowed_companies data only
+
+        # Company A
+        product_cp_a = self.product_standard_auto.with_company(self.company)
+        product_cp_a.standard_price = 10
+        self._make_in_move(product_cp_a, 1)
+
+        # Company B
+        company_b = self.env['res.company'].sudo().create({'name': 'Company B'})
+        self.patch(self, 'env', company_b.with_company(company_b).env)
+
+        product_cp_b = self.product_standard_auto.with_context(allowed_company_ids=company_b.ids)
+        product_cp_b.standard_price = 10
+        wh_b = self.env['stock.warehouse'].search([('company_id', '=', company_b.id)], limit=1)
+        self._make_in_move(product_cp_b, 2, location_dest_id=wh_b.lot_stock_id.id, picking_type_id=wh_b.in_type_id.id)
+
+        # Multi Companies
+        product_multi_cp = self.product_standard_auto.with_context(allowed_company_ids=(self.company | company_b).ids)
+
+        # Company A: 1 unit * $10 = $10
+        self.assertEqual(product_cp_a.qty_available, 1)
+        self.assertEqual(product_cp_a.total_value, 10)
+
+        # Company B: 2 unit * $10 = $20
+        self.assertEqual(product_cp_b.qty_available, 2)
+        self.assertEqual(product_cp_b.total_value, 20)
+
+        # Company A & B: 3 unit * $10 = $30
+        # Clear cache because product_multi_cp still has 'self.env.company' as main company
+        (product_cp_a | product_cp_b).invalidate_recordset()
+        self.assertEqual(product_multi_cp.qty_available, 3)
+        self.assertEqual(product_multi_cp.total_value, 30)


### PR DESCRIPTION
Field `total_value` is computed in sudo.
Hence, when doing a search on the valued locations in '_with_valuation_context', this will returns the valued locations of all the companies in the database.

This would create a discrepancy between the 'Unit Cost' * 'On Hand' and the 'Total Value' on the Stock report. To fix this issue, we re-affirm the multi company record rule for the valued location search.

OPW-5991650

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
