### PR TITLE
[FIX] stock_account: avoid zero division on return valuation

### DIFF
--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -453,8 +453,11 @@ class StockMove(models.Model):
     def _get_value_from_returns(self, quantity, at_date=None):
         if self.origin_returned_move_id and self.origin_returned_move_id.is_out:
             origin_move = self.origin_returned_move_id
+            origin_qty = origin_move._get_valued_qty()
+            if not origin_qty:
+                return dict(VALUATION_DICT)
             return {
-                'value': origin_move.value * quantity / origin_move._get_valued_qty(),
+                'value': origin_move.value * quantity / origin_qty,
                 'quantity': quantity,
                 'description': _('Value based on original move %(reference)s', reference=origin_move.reference),
             }

--- a/addons/stock_account/tests/test_stockvaluationlayer.py
+++ b/addons/stock_account/tests/test_stockvaluationlayer.py
@@ -686,6 +686,22 @@ class TestStockValuationFIFO(TestStockValuationCommon):
         self.assertEqual(self.product.total_value, 0.0)
         self.assertEqual(self.product.avg_cost, 42.0)
 
+    def test_return_value_fallback_zero_valued_qty(self):
+        self.product.standard_price = 42.0
+        self._make_in_move(self.product, 1, create_picking=True)
+        move_out = self._make_out_move(self.product, 1, create_picking=True)
+
+        external_owner = self.env['res.partner'].create({'name': 'External Owner'})
+        move_out.move_line_ids.owner_id = external_owner
+        self.assertEqual(move_out._get_valued_qty(), 0.0)
+
+        returned = self._make_return(move_out, 1)
+        self.assertEqual(returned._get_value_from_returns(1), {
+            'value': 0,
+            'quantity': 0,
+            'description': False,
+        })
+
     def test_multicompany(self):
         """FIFO: value computed from each company's own move stack."""
         self.category_fifo.with_company(self.other_company).property_cost_method = 'fifo'


### PR DESCRIPTION
When computing inventory valuation for a past date, AVCO valuation may re-evaluate return moves through `_get_value_from_returns()`.

That method values the return from the original outbound move and assumes that the original move always has a non-zero valued quantity. However, `_get_valued_qty()` can be zero, for instance when the original move has no valued move lines.

In that case, the report crashes with a `ZeroDivisionError` instead of continuing safely.

This change guards against a zero valued quantity and falls back to an empty valuation contribution.

opw-5944584

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
