### PR TITLE
[IMP] tools: add generator hook (`safe_eval`)

### DIFF
--- a/odoo/addons/test_tools/tests/test_safe_eval.py
+++ b/odoo/addons/test_tools/tests/test_safe_eval.py
@@ -1,4 +1,5 @@
 import ast
+import inspect
 
 from textwrap import dedent
 from unittest.mock import patch
@@ -9,6 +10,7 @@ from odoo.tools import mute_logger
 from odoo.tools.safe_eval import (
     const_eval,
     expr_eval,
+    safe_checker,
     safe_eval,
     UnsafeObjectError,
     UnsafePolicy,
@@ -347,3 +349,128 @@ class TestSafeEvalRuntime(TransactionCase):
         """
         with self.assertRaises(SyntaxError):
             safe_eval(dedent(expr), self.unsafe_context, mode='exec')
+
+    @mute_logger('odoo.tools.safe_eval.runtime')
+    def test_check_generator(self):
+        # Not listen `YIELD` event for external generator
+        expr = """
+            gen = get_generator()
+            list(gen)
+        """
+
+        def get_generator():
+            _local_var = self.unsafe_context['UnsafeClass']
+            yield self.unsafe_context['UnsafeClass']
+
+        safe_ctx = {
+            'get_generator': get_generator,
+        }
+        safe_eval(dedent(expr), safe_ctx, mode='exec')
+
+        # Attempt to use a dangerous object (caught in `safe_call`)
+        expr = """
+            g = (UnsafeClass() for _ in [0])
+        """
+        safe_eval(dedent(expr), self.unsafe_context, mode='exec')
+        with self.assertRaises(UnsafeObjectError):
+            list(self.unsafe_context['g'])
+
+        # Attempt to hide a dangerous object (caught by the `YIELD` event)
+        expr = """
+            g = (UnsafeClass for _ in [0])
+            use_generator(g)
+        """
+        self.unsafe_context.update(
+            # External logic that uses a generator
+            # Regardless of the usage, the context must be checked
+            use_generator=lambda g: list(g),  # noqa: PLW0108
+        )
+        with self.assertRaisesRegex(ValueError, '^UnsafeObjectError'):
+            safe_eval(dedent(expr), self.unsafe_context, mode='exec')
+
+        # Attempt to alter the generator's context by modifying globals
+        # (caught by the `YIELD` event)
+        expr = """
+            d['g'] = (d['foo'] for _ in [0])
+            use_generator(d)
+        """
+
+        def use_generator_1(d):
+            # Make the generator's context unsafe
+            d['foo'] = self.unsafe_context['UnsafeClass']
+            # Attempt to consume the generator
+            list(d['g'])  # Triggers `UnsafeObjectError`
+
+        safe_ctx = {
+            'd': {},
+            'use_generator': use_generator_1,
+        }
+        with self.assertRaisesRegex(ValueError, '^UnsafeObjectError'):
+            safe_eval(dedent(expr), safe_ctx, mode='exec')
+
+        # Attempt to alter the generator's context by modifying locals
+        # (caught by the `YIELD` event)
+        expr = """
+            d={}
+            g = (d['foo'] for d in [d])
+            use_generator(g, d)
+        """
+
+        def use_generator_2(g, d):
+            # Make the generator's context unsafe
+            d['foo'] = self.unsafe_context['UnsafeClass']
+            # Attempt to consume the generator
+            return list(g)  # Triggers `UnsafeObjectError`
+
+        safe_ctx = {
+            'use_generator': use_generator_2,
+        }
+        with self.assertRaisesRegex(ValueError, '^UnsafeObjectError'):
+            safe_eval(dedent(expr), safe_ctx, mode='exec')
+
+        # Attempt to alter the generator's context by modifying builtins
+        # and shadow them in globals (caught by the `YIELD` event)
+        expr = """
+            g = (foo for _ in [0])
+            use_generator(g)
+        """
+
+        def use_generator_3(g):
+            # Make the generator's context unsafe
+            frame = inspect.currentframe()
+            safe_call_frame = frame.f_back
+            generator_frame = safe_call_frame.f_back
+            generator_frame.f_builtins['foo'] = self.unsafe_context['UnsafeClass']
+            # Attempt to consume the generator
+            list(g)  # Triggers `UnsafeObjectError`
+
+        safe_ctx = {
+            'foo': '',  # Shadow builtin
+            'use_generator': use_generator_3,
+        }
+        with self.assertRaisesRegex(ValueError, '^UnsafeObjectError'):
+            safe_eval(dedent(expr), safe_ctx, mode='exec')
+
+    def test_trust_iterators(self):
+        iterators = (
+            iter(''),
+            iter(b''),
+            iter(bytearray()),
+            iter({}.keys()),
+            iter({}.values()),
+            iter({}.items()),
+            iter([]),
+            iter(()),
+            iter(set()),
+            iter(reversed([])),
+            iter(range(0)),
+            iter(range(1 << 1000)),
+            # No-operation iterators
+            iter(zip()),
+            iter(map(lambda: 0, [])),
+            iter(filter(lambda: 0, [])),
+            iter(sorted([])),
+            iter(enumerate([])),
+        )
+        for iterator in iterators:
+            safe_checker.check(iterator)

--- a/odoo/tools/safe_eval.py
+++ b/odoo/tools/safe_eval.py
@@ -18,7 +18,7 @@ import ast
 import contextvars
 import dis
 import functools
-import gc
+import inspect
 import logging
 import os
 import re
@@ -672,6 +672,13 @@ class _SafeChecker:
 
     MAPPINGS = frozenset((dict, defaultdict, OrderedDict, types.MappingProxyType))
     SEQUENCES = frozenset((list, tuple, set, frozenset, OrderedSet))
+    ITERATORS = frozenset((
+        type(iter('')), type(iter(b'')), type(iter(bytearray())),
+        type(iter([])), type(iter(())), type(iter(set())),
+        type(iter(reversed([]))),
+        type(iter({}.keys())), type(iter({}.values())), type(iter({}.items())),
+        type(iter(range(0))), type(iter(range(1 << 1000))),  # `range_iterator` vs `longrange_iterator`
+    ))
 
     def __init__(self):
         self.__hooks: WeakKeyDictionary[type, typing.Callable | None] = WeakKeyDictionary()
@@ -679,6 +686,7 @@ class _SafeChecker:
         for t in _SafeWhitelist.TRUSTED_TYPES: self.add_hook(t, None)  # Optimization to save time when serializing these types  # noqa: E701
         for t in self.SEQUENCES: self.add_hook(t, list)  # noqa: E701
         for t in self.MAPPINGS: self.add_hook(t, dict)  # noqa: E701
+        for t in self.ITERATORS: self.add_hook(t, self._hook_iterator)  # noqa: E701
         self.add_hook(type, self._hook_class)
         self.add_hook(types.ModuleType, self._hook_module)
         self.add_hook(types.BuiltinFunctionType, self._hook_builtin_function)
@@ -688,7 +696,7 @@ class _SafeChecker:
         self.add_hook(types.MethodDescriptorType, self._hook_descriptor)
         self.add_hook(functools.partial, self._hook_partial)
         self.add_hook(lazy, self._hook_lazy)
-        self.add_hook(type(reversed([])), self._hook_simple_iterator)
+        self.add_hook(types.GeneratorType, None)
         d = {}
         self.add_hook(type(d.items()), list)
         self.add_hook(type(d.keys()), list)
@@ -697,7 +705,6 @@ class _SafeChecker:
         self.add_hook(type(d.items()), list)
         self.add_hook(type(d.keys()), list)
         self.add_hook(type(d.values()), list)
-        self.add_hook(types.GeneratorType, None)  # TODO: Make the hook (to listen for the yield event)
 
     def add_hook(self, type_: type, hook: typing.Callable | None = None) -> None:
         self.__hooks[type_] = hook
@@ -770,8 +777,8 @@ class _SafeChecker:
 
         return hook(obj)
 
-    def _hook_simple_iterator(self, obj):
-        return gc.get_referents(obj)[-1]
+    def _hook_iterator(self, obj):
+        return obj.__reduce__()
 
     def _hook_module(self, obj):
         safe_whitelist.check_module(obj)
@@ -833,7 +840,7 @@ class _SafeWhitelist:
     ))
     TRUSTED_BUILTIN_FUNCTIONS = frozenset((
         min, max, sum, abs, sorted, round, len, repr, all, any, ord, chr, divmod,
-        isinstance, hasattr,
+        isinstance, hasattr, iter,
     ))
 
     @staticmethod
@@ -942,16 +949,20 @@ safe_checker = _SafeChecker()
 safe_whitelist = _SafeWhitelist()
 
 
+def handle_unsafe_error(error):
+    _logger_runtime.warning(error)
+    if unsafe_policy() is UnsafePolicy.RAISE:
+        raise error
+    if unsafe_policy() is UnsafePolicy.TERMINATE:
+        os._exit(1)
+
+
 def safe_call(callee, /, *args, **kwargs):
     """ Ensure objects used for the call are safe """
     try:
         safe_checker.check((callee, args, kwargs))
     except UnsafeError as e:
-        _logger_runtime.warning(e)
-        if unsafe_policy() is UnsafePolicy.RAISE:
-            raise
-        if unsafe_policy() is UnsafePolicy.TERMINATE:
-            os._exit(1)
+        handle_unsafe_error(e)
     return callee(*args, **kwargs)
 
 
@@ -971,12 +982,28 @@ def monitoring_call(code, instruction_offset, callee, arg0):
         raise UnsafeContextError(f'{call_id} is overridden')
 
 
+def monitoring_yield(code, instruction_offset, retval):
+    """ Ensure mutating context of generator is safe """
+    frame = sys._getframe(1)
+    objs = list(frame.f_locals.values())
+    for name in code.co_names:
+        if name in frame.f_globals:
+            objs.append(frame.f_globals[name])
+        if name in frame.f_builtins:
+            objs.append(frame.f_builtins[name])
+    try:
+        safe_checker.check(objs)
+    except UnsafeObjectError as e:
+        handle_unsafe_error(e)
+
+
 _BUILTINS[safe_transformer.CALL_ID] = safe_call
 
 EVENTS = sys.monitoring.events
 TOOL_ID = 4  # Not prevent other tools from using "official IDs"
 sys.monitoring.use_tool_id(TOOL_ID, 'ODOO_UNSAFE_POLICY_TOOL')
 sys.monitoring.register_callback(TOOL_ID, EVENTS.CALL, monitoring_call)
+sys.monitoring.register_callback(TOOL_ID, EVENTS.PY_YIELD, monitoring_yield)
 
 
 def add_monitoring(code):
@@ -984,6 +1011,8 @@ def add_monitoring(code):
     while codes:
         code = codes.pop()
         sys.monitoring.set_local_events(TOOL_ID, code, EVENTS.CALL)
+        if code.co_flags & inspect.CO_GENERATOR:
+            sys.monitoring.set_local_events(TOOL_ID, code, EVENTS.PY_YIELD)
         codes.extend(const for const in code.co_consts if isinstance(const, types.CodeType))
 
 


### PR DESCRIPTION
Commit https://github.com/odoo/odoo/commit/598d2b77f6d3267aadb2ceee271cde2969197962 introduces dynamic
analysis during the execution of arbitrary code.

Because the frame of a generator is not destroyed. It is moved from the
call stack to the heap. Local variables are conserved between calls.
The frame maintains a reference to the global namespace (the module
where the generator is defined). Consequently, even if a generator is
defined in a safe evaluation context, it may become unsafe if that
referenced context is later compromised.

The generators that need to be checked are those created in arbitrary
code.

Even if a generator attempts to use a dangerous object at a later time
via external logic, the generator's code itself is monitored.
As a result, the action will be blocked.

Generators can also be used to "hide" a dangerous object for use outside
of arbitrary code, thereby bypassing the `safe_call` check. In such
cases, the generator may perform operations using a dangerous object
that is not necessarily yielded.

These actions use the generator's context: `f_locals`, `f_globals`,
and `f_builtins`. To avoid the computationally intensive operation of
checking the entire context, we can limit checks to the locals and the
lookups (`<generator_instance>.gi_code.co_names`).

Checking these objects ensures that if the generator's context is
altered, we will detect any dangerous objects within it. Since the
context changes throughout the generator's lifetime, this check must be
performed at every `PY_YIELD` event.

Performing the check at the `PY_YIELD` event is not too late. If any
dangerous operations are performed before the yield, they will be caught
and stopped during the `safe_call` check.

Task-6033166