### PR TITLE
[FIX] point_of_sale: add fallback for bank_partner_id

### DIFF
--- a/addons/l10n_ch_pos/tests/__init__.py
+++ b/addons/l10n_ch_pos/tests/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_ch_pos
+from . import test_frontend

--- a/addons/l10n_ch_pos/tests/test_frontend.py
+++ b/addons/l10n_ch_pos/tests/test_frontend.py
@@ -1,0 +1,66 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo.tests
+from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
+from odoo import Command
+
+
+@odoo.tests.tagged('post_install_l10n', 'post_install', '-at_install')
+class TestUi(TestPointOfSaleHttpCommon):
+    @classmethod
+    def _get_main_company(cls):
+        cls.company_data["company"].country_id = cls.env.ref("base.ch").id
+        cls.company_data["company"].currency_id = cls.env.ref("base.CHF").id
+        cls.company_data["company"].vat = "CHE-530.781.296 TVA"
+        return cls.company_data["company"]
+
+    def test_l10n_ch_pos_pay_later_invoice_has_bank_partner(self):
+        customer_account_payment_method = self.env['pos.payment.method'].create({
+            'name': 'Customer Account',
+            'split_transactions': True,
+        })
+        self.main_pos_config.write({
+            'payment_method_ids': [Command.link(customer_account_payment_method.id)],
+        })
+        swiss_bank = self.env['res.partner.bank'].create({
+            'acc_number': 'CH11 3000 5228 1308 3501 F',
+            'allow_out_payment': True,
+            'partner_id': self.company.partner_id.id,
+            'acc_type': 'bank',
+            'bank_name': 'swiss_bank'
+        })
+        self.partner_test_1.write({
+            "email": "test@partner1.com",
+            "vat": "CHE-123.456.788 TVA",
+            "contact_address_complete": "street 1, street 2, 23432 Zürich, Argovie, Switzerland"
+        })
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+        current_session = self.main_pos_config.current_session_id
+
+        order = self.env['pos.order'].create({
+            'company_id': self.env.company.id,
+            'session_id': current_session.id,
+            'partner_id': self.partner_test_1.id,
+            'lines': [Command.create({
+                'product_id': self.product_a.id,
+                'price_unit': 10,
+                'discount': 0,
+                'qty': 1,
+                'price_subtotal': 10,
+                'price_subtotal_incl': 10,
+            })],
+            'amount_paid': 10.0,
+            'amount_total': 10.0,
+            'amount_tax': 0.0,
+            'amount_return': 0.0,
+            'to_invoice': True,
+            'last_order_preparation_change': '{}'
+        })
+
+        payment_context = {"active_ids": order.ids, "active_id": order.id}
+        order_payment = self.env['pos.make.payment'].with_context(**payment_context).create({
+            'amount': 10.0,
+            'payment_method_id': customer_account_payment_method.id
+        })
+        order_payment.with_context(**payment_context).check()
+        self.assertEqual(order.account_move.partner_bank_id, swiss_bank)

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -698,7 +698,7 @@ class PosOrder(models.Model):
                 partner_bank_id = journal_bank
 
         # Case 3: fallback → company bank
-        elif self.amount_total >= 0 and self.company_id.partner_id.bank_ids:
+        if not partner_bank_id and self.amount_total >= 0 and self.company_id.partner_id.bank_ids:
             partner_bank_id = _first_allowed(self.company_id.partner_id.bank_ids)
 
         return partner_bank_id.id if partner_bank_id else False


### PR DESCRIPTION
Step to reproduce:
- Install l10n_ch_pos and make sure swiss company has tax id filled
- Create a swiss customer with an email address and vat, add full address
- Open a pos session, and make an invoice  for a product with tax,
- select payment method, which allows `pay_later`, i.e. payment without journal_id

Observation:
- the invoiced order, do not have qr for payment, because the invoice do not have `bank_partner_id`

Cause:
- `_get_partner_bank_id` is recently updated in commit[1], which do not considered `pay_later` option

[1] https://github.com/odoo/odoo/commit/7e63991dceb6e443b950e6a1b94454a82d5668c7

Fix:
- Fixed the fallback logic for `_get_partner_bank_id`

opw-6023060


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
