### PR TITLE
[FIX] hr_attendance: recompute expected_hours when attendance change

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -320,6 +320,7 @@ class HrAttendance(models.Model):
         self.env.add_to_compute(self._fields['overtime_hours'], all_attendances)
         self.env.add_to_compute(self._fields['validated_overtime_hours'], all_attendances)
         self.env.add_to_compute(self._fields['overtime_status'], all_attendances)
+        self.env.add_to_compute(self._fields['expected_hours'], all_attendances)
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -333,6 +333,8 @@ class TestHrAttendanceOvertime(HttpCase):
 
         # 8:00 -> 21:00 should contain 4 hours of overtime
         self.assertAlmostEqual(attendance.overtime_hours, 4, 2)
+        self.assertAlmostEqual(attendance.worked_hours, 12, 2)
+        self.assertAlmostEqual(attendance.expected_hours, 8, 2)
 
         # Total overtime for that day : 4 hours
         overtime_1 = self.env['hr.attendance.overtime.line'].search([('employee_id', '=', self.employee.id),
@@ -348,6 +350,8 @@ class TestHrAttendanceOvertime(HttpCase):
         })
         # 8:00 -> 19:00 should contain 2 hours of overtime
         self.assertAlmostEqual(m_attendance_1.overtime_hours, 2, 2)
+        self.assertAlmostEqual(m_attendance_1.worked_hours, 10, 2)
+        self.assertAlmostEqual(m_attendance_1.expected_hours, 8, 2)
 
         m_attendance_2 = self.env['hr.attendance'].create({
             'employee_id': self.employee.id,
@@ -356,6 +360,8 @@ class TestHrAttendanceOvertime(HttpCase):
         })
         # 19:00 -> 20:00 should contain 1 hour of overtime
         self.assertAlmostEqual(m_attendance_2.overtime_hours, 1, 2)
+        self.assertAlmostEqual(m_attendance_2.worked_hours, 1, 2)
+        self.assertAlmostEqual(m_attendance_2.expected_hours, 0, 2)
 
         m_attendance_3 = self.env['hr.attendance'].create({
             'employee_id': self.employee.id,
@@ -364,6 +370,8 @@ class TestHrAttendanceOvertime(HttpCase):
         })
         # 21:00 -> 23:00 should contain 2 hours of overtime
         self.assertAlmostEqual(m_attendance_3.overtime_hours, 2, 2)
+        self.assertAlmostEqual(m_attendance_3.worked_hours, 2, 2)
+        self.assertAlmostEqual(m_attendance_3.expected_hours, 0, 2)
 
         overtime_2 = self.env['hr.attendance.overtime.line'].search([('employee_id', '=', self.employee.id),
                                                                 ('date', '=', datetime(2023, 1, 3))])
@@ -377,6 +385,8 @@ class TestHrAttendanceOvertime(HttpCase):
         })
 
         self.assertEqual(m_attendance_3.overtime_hours, 1.5)
+        self.assertAlmostEqual(m_attendance_3.worked_hours, 1.5, 2)
+        self.assertAlmostEqual(m_attendance_3.expected_hours, 0, 2)
 
         # Deleting previous attendances should update correctly the overtime hours in other attendances
         m_attendance_2.unlink()
@@ -387,6 +397,11 @@ class TestHrAttendanceOvertime(HttpCase):
             'check_out': datetime(2023, 1, 3, 21, 30)
         })
         self.assertEqual(m_attendance_3.overtime_hours, 0.5)
+        self.assertAlmostEqual(m_attendance_1.worked_hours, 8, 2)
+        self.assertAlmostEqual(m_attendance_1.expected_hours, 8, 2)
+
+        self.assertAlmostEqual(m_attendance_3.worked_hours, 0.5, 2)
+        self.assertAlmostEqual(m_attendance_3.expected_hours, 0, 2)
 
         self.europe_employee.ruleset_id = self.ruleset
         # Create an attendance record for early check-in


### PR DESCRIPTION
### Issue before this commit:
The expected_hours field on hr.attendance records could become inconsistent after overtime lines were regenerated. When attendances were modified (for example by updating check_out, deleting another attendance of the same day, or triggering overtime regeneration), the system correctly recomputed overtime_hours and related overtime lines, but expected_hours was not recomputed. As a result, expected_hours could keep a stale value that no longer matched the updated overtime calculation.

### Steps to reproduce the issue:
1. Install Attendencies app
2. Go in Settings > Attendencies
3. Activate Display Extra Hours and Absence Management
4. Go to Attendencies > New
5. Insert an employee with a valid contract
6. Set first shift of worked hours
7. Set a second shift
8. Go to Reporting > Attendencies
9. Filter for the employee and day as a date groupby
10. See the Expected Hours are wrong computed

### Cause of the issue:
The issue was caused by the _update_overtime method, which regenerates hr.attendance.overtime.line records and explicitly schedules recomputation of several fields on the affected attendances (overtime_hours, validated_overtime_hours, and overtime_status). However, the expected_hours field depends on worked_hours and overtime_hours, and it was not included in the recompute scheduling. Consequently, when overtime values changed after the regeneration of overtime lines, expected_hours was not recomputed and could remain outdated.

### Reason to introduce the fix:
The fix ensures that expected_hours is recomputed whenever overtime lines are updated by adding it to the fields scheduled for recomputation in _update_overtime. This guarantees that expected_hours always remains consistent with the latest worked_hours and overtime_hours values, preventing incorrect totals or inconsistencies in reports after attendance updates.

opw-5993409

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
