### PR TITLE
[FIX] stock_account: use valuation context when computing total_value

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -202,7 +202,7 @@ will update the cost of every lot/serial number in stock."),
             "value_svl": value_svl,
             "quantity_svl": quantity_sum,
             "avg_cost": avg_cost,
-            "total_value": avg_cost * self.sudo(False).qty_available if avg_cost else 0
+            "total_value": avg_cost * self.sudo(False)._with_valuation_context().qty_available if avg_cost else 0
         }
 
     @api.depends('stock_valuation_layer_ids')
@@ -217,6 +217,10 @@ will update the cost of every lot/serial number in stock."),
             aggregates = group_mapping.get(product._origin, (0, 0))
             vals = product._prepare_valuation_layer_field_values(aggregates)
             product.update(vals)
+
+    def _with_valuation_context(self):
+        valued_locations = self.env['stock.location'].search([('company_id', 'in', self.env.companies.ids), ('usage', 'in', ['internal', 'transit'])])
+        return self.with_context(location=valued_locations.ids)
 
     # -------------------------------------------------------------------------
     # Actions

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -4420,3 +4420,49 @@ class TestStockValuation(TestStockValuationBase):
         self.assertEqual(delivery.move_ids.product_qty, 0.01)
         self.assertEqual(delivery.move_ids.stock_valuation_layer_ids.quantity, -0.01)
         self.assertEqual(self.product1.qty_available, 0.00)
+
+    def test_transit_move_does_not_change_valuation(self):
+        category = self.env['product.category'].create({
+            'name': 'Test Category',
+            'property_cost_method': 'fifo',
+            'property_valuation': 'real_time',
+        })
+        product = self.env['product.product'].create({
+            'name': 'Transit Valuation Product',
+            'is_storable': True,
+            'categ_id': category.id,
+        })
+        transit_location = self.env['stock.location'].create({
+            'name': 'Test Transit Location',
+            'usage': 'transit',
+        })
+
+        self._make_in_move(product, 100, unit_cost=10)
+        self._make_out_move(product, 10)
+
+        initial_value = product.total_value
+        self.assertEqual(initial_value, 900)
+        self.assertEqual(product.qty_available, 90)
+
+        move_internal = self.env['stock.move'].create({
+            'name': 'Stock → Transit',
+            'product_id': product.id,
+            'product_uom_qty': 20,
+            'product_uom': product.uom_id.id,
+            'location_id': self.env.ref('stock.stock_location_stock').id,
+            'location_dest_id': transit_location.id,
+        })
+        move_internal._action_confirm()
+        move_internal._action_assign()
+        move_internal.move_line_ids.quantity = 20
+        move_internal.picked = True
+        move_internal._action_done()
+
+        self.assertEqual(product.qty_available, 70)
+        product._compute_value_svl()
+
+        self.assertEqual(
+            product.total_value,
+            initial_value,
+            "Valuation should not change when moving to transit location"
+        )


### PR DESCRIPTION
**Steps to reproduce**
- Create a database in v18.0.
- Install the stock and sale modules.
- Create a storable product.
- Add 100 units as on-hand quantity using an inventory adjustment in the internal location (e.g., WH/Stock).
- Create a transit location.
- Create an internal transfer and move 20 units from the internal location (WH/Stock) to the Transit location.
- WH/Stock now contains 80 quantities.
- Transit location contains 20 quantities.
- See stock valuation of product.

**Issue**

- In v18, `value_svl` and `quantity_svl` are computed from [Stock Valuation Layers](https://github.com/odoo/odoo/blob/18.0/addons/stock_account/models/product.py#L213) After that, `total_value` is calculated using the formula [`avg_cost * qty_available`](https://github.com/odoo/odoo/blob/18.0/addons/stock_account/models/product.py#L205). However, when calling `qty_available`, no location context is passed to specify which locations should be considered. Because of this, `qty_available` only considers quantities from internal locations. As a result, the final `total_value` is computed based only on the internal location quantity (80).

- When the customer migrates the database to v19, the displayed `total_value` changes. In v19, both (100 qty) internal and transit locations are considered when computing the quantity used for valuation. This happens because a valuation [context](https://github.com/odoo/odoo/blob/19.0/addons/stock_account/models/product.py#L203) is passed when selecting the locations for the quantity computation. Due to this change, the quantity used in the calculation includes both internal and transit locations, which can lead to a different `total_value` being displayed compared to v18.

**Solution**

- To resolve this issue, the valuation context has been passed when computing the value in the function. This context includes both internal and transit locations. As a result, when `qty_available` is computed, it considers these locations, and the resulting `total_value` remains consistent with the valuation logic.

opw-5924110
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
