### PR TITLE
[FIX] mail: fix traceback when selecting items from @ mention in composer

### DIFF
--- a/addons/mail/static/src/core/web/mention_list.xml
+++ b/addons/mail/static/src/core/web/mention_list.xml
@@ -4,7 +4,7 @@
         <a
             t-att-href="href"
             t-att-class="option.partner ? 'o_mail_redirect' : 'o_channel_redirect'"
-            t-att-data-oe-id="option.partner ? option.partner.id : option.channel.id"
+            t-att-data-oe-id="option.partner ? option.partner.id : option.thread.id"
             t-att-data-oe-model="option.partner ? 'res.partner' : 'discuss.channel'"
             target="_blank"
             data-oe-protected="true"

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/mention_plugin.js
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/mention_plugin.js
@@ -26,7 +26,7 @@ export class MentionPlugin extends Plugin {
             href: url(
                 stateToUrl({
                     model: option.partner ? "res.partner" : "discuss.channel",
-                    resId: option.partner ? option.partner.id : option.channel.id,
+                    resId: option.partner ? option.partner.id : option.thread.id,
                 })
             ),
         });


### PR DESCRIPTION

Problem:
Opening the composer, typing "@" and selecting any item causes a traceback.

Cause:
After 8c99b17fcc3a612fd897da9ee29e2f53254d5933, the attribute `channel` was renamed to `thread`. Some code still referenced the old `channel` attribute, leading to errors when selecting mentions.

Steps to reproduce:
- Open the composer.
- Type "@" to trigger mentions.
- Select any item from the suggestions.
- Observe a traceback.

opw-6030307

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
