### PR TITLE
[FIX] mail: fix traceback when selecting items from @ mention in composer

### DIFF
--- a/addons/mail/static/src/core/web/mention_list.js
+++ b/addons/mail/static/src/core/web/mention_list.js
@@ -98,6 +98,7 @@ export class MentionList extends Component {
                     return {
                         label: suggestion.displayName,
                         thread: suggestion,
+                        channel: suggestion,
                         classList: "o-mail-Composer-suggestion",
                     };
                 });

--- a/addons/mail/static/tests/tours/mail_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_composer_test_tour.js
@@ -99,6 +99,33 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
             },
         },
         {
+            content: "Trigger channel mention with #",
+            trigger: ".odoo-editor-editable",
+            run() {
+                this.anchor.dispatchEvent(
+                    new InputEvent("beforeinput", {
+                        inputType: "insertText",
+                        data: "#",
+                        bubbles: true,
+                    })
+                );
+            },
+        },
+        {
+            content: "Search for general channel",
+            trigger: ".o-mail-MentionList input",
+            run: "edit gen",
+        },
+        {
+            content: "Select channel from suggestion",
+            trigger: ".o-mail-Composer-suggestion:contains(general)",
+            run: "click",
+        },
+        {
+            content: "Check channel mention is present in body",
+            trigger: '.o_field_html[name="body"] .o_channel_redirect:contains(general)',
+        },
+        {
             content: "Drop a file on the full composer",
             trigger: ".o_mail_composer_form_view",
             async run() {


### PR DESCRIPTION
Problem:
Opening the composer, typing "@" and selecting any item causes a traceback.

Cause:
After 8c99b17fcc3a612fd897da9ee29e2f53254d5933, the attribute `channel` was renamed to `thread`. Some code still referenced the old `channel` attribute, leading to errors when selecting mentions.

Steps to reproduce:
- Open the composer.
- Type "@" to trigger mentions.
- Select any item from the suggestions.
- Observe a traceback.

opw-6030307

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
