### PR TITLE
[FIX] website : correct text highlight display on firefox

### DIFF
--- a/addons/website/static/src/interactions/text_highlights.js
+++ b/addons/website/static/src/interactions/text_highlights.js
@@ -60,8 +60,9 @@ export class TextHighlight extends Interaction {
                     svg.remove();
                 }
                 const svgs = makeHighlightSvgs(el, highlightID);
-                for (const svg of svgs) {
-                    this.insert(svg, el);
+
+                for (const svg of svgs.toReversed()) {
+                    this.insert(svg, el, "afterbegin");
                     adaptHighlightPosition(el, svg);
                 }
             }

--- a/addons/website/static/src/js/highlight_utils.js
+++ b/addons/website/static/src/js/highlight_utils.js
@@ -282,8 +282,8 @@ export function makeHighlightSvgs(highlightEl, highlightID) {
 }
 export function applyTextHighlight(highlightEl, highlightID) {
     const svgs = makeHighlightSvgs(highlightEl, highlightID);
-    for (const svg of svgs) {
-        highlightEl.appendChild(svg);
+    for (const svg of svgs.toReversed()) {
+        highlightEl.insertBefore(svg, highlightEl.lastElementChild);
         adaptHighlightPosition(highlightEl, svg);
     }
 }


### PR DESCRIPTION
# How to reproduce
- Go to the website editor
- Select some text that wraps
- Add text highlight to that text

# The problem
On firefox, for every line of text that wraps, the highlight is displayed in front of the text instead of behind.

# Why
The highlights are made of SVG's that are added to the html element of the selected text. To be sure that theses SVG's are displayed behind the text, they have position: absolute and z-index: -1.

Sadly, z-index and absolute positionning in an inline context (like in a span) is browser specific and in the case of firefox, seems to be kind of ignored. Since the SVG's are added in the html element after the text, they are rendered after the text.

This fix aims to add the SVG's in the html element before the text to make the rendering order is correct

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
