### PR TITLE
[IMP] mail: use insert instead of custom im_status notification

### DIFF
--- a/addons/hr_holidays/static/tests/im_status.test.js
+++ b/addons/hr_holidays/static/tests/im_status.test.js
@@ -1,10 +1,16 @@
 import { describe, test } from "@odoo/hoot";
 
-import { Store } from "@mail/core/common/store_service";
-import { startServer, start, openDiscuss, contains } from "@mail/../tests/mail_test_helpers";
+import {
+    contains,
+    openDiscuss,
+    sendPresenceUpdate,
+    start,
+    startServer,
+} from "@mail/../tests/mail_test_helpers";
+import { ImStatusMixin } from "@mail/core/common/im_status_mixin";
 
-import { serverState, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { defineHrHolidaysModels } from "@hr_holidays/../tests/hr_holidays_test_helpers";
+import { patchWithCleanup, serverState } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 defineHrHolidaysModels();
@@ -14,33 +20,21 @@ test("change icon on change partner im_status for leave variants", async () => {
     pyEnv["res.partner"].write([serverState.partnerId], { im_status: "online" });
     pyEnv["hr.employee"].create({ user_id: serverState.userId, leave_date_to: "2023-01-01" });
     const channelId = pyEnv["discuss.channel"].create({ channel_type: "chat" });
-    patchWithCleanup(Store, { IM_STATUS_DEBOUNCE_DELAY: 0 });
+    patchWithCleanup(ImStatusMixin, { IM_STATUS_DEBOUNCE_DELAY: 0 });
     await start();
     await openDiscuss(channelId);
     await contains(
         ".o-mail-DiscussContent-header .o-mail-ImStatus.fa-plane[title='User is on leave and online']"
     );
-    pyEnv["bus.bus"]._sendone("broadcast", "bus.bus/im_status_updated", {
-        partner_id: serverState.partnerId,
-        im_status: "offline",
-        presence_status: "offline",
-    });
+    sendPresenceUpdate("res.partner", serverState.partnerId, "offline");
     await contains(
         ".o-mail-DiscussContent-header .o-mail-ImStatus.fa-plane[title='User is on leave']"
     );
-    pyEnv["bus.bus"]._sendone("broadcast", "bus.bus/im_status_updated", {
-        partner_id: serverState.partnerId,
-        im_status: "away",
-        presence_status: "away",
-    });
+    sendPresenceUpdate("res.partner", serverState.partnerId, "away");
     await contains(
         ".o-mail-DiscussContent-header .o-mail-ImStatus.fa-plane[title='User is on leave and idle']"
     );
-    pyEnv["bus.bus"]._sendone("broadcast", "bus.bus/im_status_updated", {
-        partner_id: serverState.partnerId,
-        im_status: "online",
-        presence_status: "online",
-    });
+    sendPresenceUpdate("res.partner", serverState.partnerId, "online");
     await contains(
         ".o-mail-DiscussContent-header .o-mail-ImStatus.fa-plane[title='User is on leave and online']"
     );

--- a/addons/im_livechat/static/src/core/common/thread_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_patch.js
@@ -2,40 +2,15 @@ import { Thread } from "@mail/core/common/thread";
 import { _t } from "@web/core/l10n/translation";
 import { user } from "@web/core/user";
 import { patch } from "@web/core/utils/patch";
-import { useLayoutEffect } from "@web/owl2/utils";
 
 const { DateTime } = luxon;
 
 patch(Thread.prototype, {
-    setup() {
-        super.setup(...arguments);
-        this.IM_STATUS_DELAY = 1500;
-        this.state.isVisitorOffline = false; // starting online avoids flickering
-        useLayoutEffect(
-            (im_status) => {
-                if (!im_status) {
-                    return;
-                }
-                clearTimeout(this.imStatusTimeoutId);
-                if (im_status === "offline") {
-                    this.imStatusTimeoutId = setTimeout(
-                        () => (this.state.isVisitorOffline = true),
-                        this.IM_STATUS_DELAY
-                    );
-                } else {
-                    this.state.isVisitorOffline = false;
-                }
-                return () => clearTimeout(this.imStatusTimeoutId);
-            },
-            () => [this.props.thread.channel?.livechatVisitorMember?.im_status]
-        );
-    },
     get showVisitorDisconnected() {
         return (
             this.store.self.notEq(this.channel?.livechatVisitorMember?.persona) &&
             !this.channel?.livechat_end_dt &&
-            this.channel?.livechatVisitorMember &&
-            this.state.isVisitorOffline
+            this.channel?.livechatVisitorMember?.persona?.offline_since
         );
     },
     get disconnectedText() {

--- a/addons/im_livechat/static/tests/visitor_disconnection.test.js
+++ b/addons/im_livechat/static/tests/visitor_disconnection.test.js
@@ -1,28 +1,22 @@
-import { Command, patchWithCleanup, serverState } from "@web/../tests/web_test_helpers";
 import { defineLivechatModels } from "@im_livechat/../tests/livechat_test_helpers";
 import {
+    click,
     contains,
+    sendPresenceUpdate,
     setupChatHub,
     start,
     startServer,
-    click,
 } from "@mail/../tests/mail_test_helpers";
+import { ImStatusMixin } from "@mail/core/common/im_status_mixin";
 import { describe, test } from "@odoo/hoot";
 import { mockDate } from "@odoo/hoot-mock";
-import { Store } from "@mail/core/common/store_service";
-import { Thread } from "@mail/core/common/thread";
+import { Command, patchWithCleanup, serverState } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 defineLivechatModels();
 
 test("Visitor going offline shows disconnection banner to operator", async () => {
-    patchWithCleanup(Store, { IM_STATUS_DEBOUNCE_DELAY: 0 });
-    patchWithCleanup(Thread.prototype, {
-        setup() {
-            super.setup();
-            this.IM_STATUS_DELAY = 0;
-        },
-    });
+    patchWithCleanup(ImStatusMixin, { IM_STATUS_DEBOUNCE_DELAY: 0 });
     const pyEnv = await startServer();
     pyEnv["res.users"].write([serverState.userId], {
         group_ids: pyEnv["res.groups"]
@@ -47,12 +41,7 @@ test("Visitor going offline shows disconnection banner to operator", async () =>
     await start();
     await contains(".o-mail-ChatWindow");
     mockDate("2025-01-01 12:00:00", +1);
-    pyEnv["mail.guest"].write(guestId, { im_status: "offline" });
-    pyEnv["bus.bus"]._sendone(guestId, "bus.bus/im_status_updated", {
-        partner_id: false,
-        guest_id: guestId,
-        im_status: "offline",
-    });
+    sendPresenceUpdate("mail.guest", guestId, "offline");
     await contains(".o-livechat-VisitorDisconnected", {
         text: "Visitor is disconnected since 1:00 PM",
     });
@@ -66,10 +55,6 @@ test("Visitor going offline shows disconnection banner to operator", async () =>
     await click("button[title*='Fold']");
     await click(".o-mail-ChatBubble");
     await contains(".o-livechat-VisitorDisconnected", { text: `Visitor is disconnected` });
-    pyEnv["bus.bus"]._sendone(guestId, "bus.bus/im_status_updated", {
-        partner_id: false,
-        guest_id: guestId,
-        im_status: "online",
-    });
+    sendPresenceUpdate("mail.guest", guestId, "online");
     await contains(".o-livechat-VisitorDisconnected", { count: 0 });
 });

--- a/addons/mail/controllers/im_status.py
+++ b/addons/mail/controllers/im_status.py
@@ -1,21 +1,17 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import http, _
-from odoo.http import request
+from odoo import _, http
+
+from odoo.addons.mail.tools.discuss import Store, mail_route
 
 
 class ImStatusController(http.Controller):
-    @http.route("/mail/set_manual_im_status", methods=["POST"], type="jsonrpc", auth="user")
+    @mail_route("/mail/set_manual_im_status", methods=["POST"], type="jsonrpc", auth="user")
     def set_manual_im_status(self, status):
         if status not in ["online", "away", "busy", "offline"]:
             raise ValueError(_("Unexpected IM status %(status)s", status=status))
-        user = request.env.user
-        user.manual_im_status = False if status == "online" else status
-        user._bus_send(
-            "bus.bus/im_status_updated",
-            {
-                "im_status": user.partner_id.im_status,
-                "partner_id": user.partner_id.id,
-            },
-            subchannel="presence",
-        )
+        self.env.user.manual_im_status = False if status == "online" else status
+        Store(bus_channel=self.env.user, bus_subchannel="presence").add(
+            self.env.user.partner_id,
+            ["im_status"],
+        ).bus_send()

--- a/addons/mail/models/ir_websocket.py
+++ b/addons/mail/models/ir_websocket.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 
 from odoo import models
 from odoo.fields import Domain
-from odoo.addons.mail.tools.discuss import add_guest_to_context
+from odoo.addons.mail.tools.discuss import add_guest_to_context, store_version
 from odoo.tools.misc import verify_limited_field_access_token
 
 PRESENCE_CHANNEL_PREFIX = "odoo-presence-"
@@ -34,6 +34,7 @@ class IrWebsocket(models.AbstractModel):
     def _subscribe(self, og_data):
         super()._subscribe(og_data)
 
+    @store_version
     @add_guest_to_context
     def _update_mail_presence(self, inactivity_period):
         user, guest = self.env["res.users"]._get_current_persona()
@@ -104,6 +105,7 @@ class IrWebsocket(models.AbstractModel):
         data["missed_presences"] = self.env["mail.presence"].sudo().search(presence_domain)
         return data
 
+    @store_version
     def _after_subscribe_data(self, data):
         user, guest = self.env["res.users"]._get_current_persona()
         if user or guest:

--- a/addons/mail/models/mail_presence.py
+++ b/addons/mail/models/mail_presence.py
@@ -5,6 +5,8 @@ from datetime import timedelta
 from odoo import api, fields, models, tools
 from odoo.sql_db import PG_CONCURRENCY_EXCEPTIONS_TO_RETRY
 
+from odoo.addons.mail.tools.discuss import Store
+
 UPDATE_PRESENCE_DELAY = 60
 DISCONNECTION_TIMER = UPDATE_PRESENCE_DELAY + 5
 AWAY_TIMER = 1800  # 30 minutes
@@ -96,19 +98,22 @@ class MailPresence(models.Model):
 
         :param im_status: 'online', 'away' or 'offline'
         """
+        stores = Store.Stores()
         for presence in self:
             persona = presence.guest_id or presence.user_id
             target = bus_target or (persona, "presence")
-            self.env["bus.bus"]._sendone(
-                target,
-                "bus.bus/im_status_updated",
-                {
-                    "presence_status": im_status or presence.status,
-                    "im_status": im_status or persona.im_status,
-                    "guest_id": presence.guest_id.id,
-                    "partner_id": presence.user_id.partner_id.id,
-                },
+            stores[target].add(
+                presence.guest_id or presence.user_id.partner_id,
+                {"im_status": im_status or persona.im_status},
             )
+            if bus_target is None or persona == bus_target:
+                stores[persona].add(
+                    persona
+                    if isinstance(persona, self.env.registry["mail.guest"])
+                    else persona.partner_id,
+                    {"presence_status": im_status or presence.status},
+                )
+        stores.bus_send()
 
     @api.autovacuum
     def _gc_bus_presence(self):

--- a/addons/mail/static/src/core/common/im_status.js
+++ b/addons/mail/static/src/core/common/im_status.js
@@ -75,16 +75,16 @@ export class ImStatus extends Component {
 
     get icon() {
         const data = this.activeImStatusData;
-        return data.icon[this.persona.im_status] || data.icon.default || data.icon;
+        return data.icon[this.persona.imStatusUI] || data.icon.default || data.icon;
     }
 
     get title() {
         const data = this.activeImStatusData;
-        return data.title[this.persona.im_status] || data.title.default || data.title;
+        return data.title[this.persona.imStatusUI] || data.title.default || data.title;
     }
 
     get colorClass() {
-        switch (this.persona.im_status) {
+        switch (this.persona.imStatusUI) {
             case "bot":
             case "online":
                 return "text-success";

--- a/addons/mail/static/src/core/common/im_status_dropdown.js
+++ b/addons/mail/static/src/core/common/im_status_dropdown.js
@@ -23,12 +23,12 @@ export class ImStatusDropdown extends Component {
     }
 
     setManualImStatus(status) {
-        this.store.self.updateImStatus(status);
+        this.store.self.forceImStatus(status);
         rpc("/mail/set_manual_im_status", { status });
     }
 
     get readableImStatus() {
-        const imStatus = this.store.self.im_status || "offline";
+        const imStatus = this.store.self.imStatusUI || "offline";
         return this.readableImStatusByCode[imStatus];
     }
 }

--- a/addons/mail/static/src/core/common/im_status_dropdown.xml
+++ b/addons/mail/static/src/core/common/im_status_dropdown.xml
@@ -6,14 +6,14 @@
                 <ImStatus user="this.store.self_user"/> <span t-out="this.readableImStatus"/> <i t-if="this.env.isSmall" class="oi oi-chevron-right ms-auto mt-1"/>
             </a>
             <t t-set-slot="content">
-                <DropdownItem class="{ 'active': this.store.self.im_status === 'online' }" onSelected="() => this.setManualImStatus('online')"><i class="fa fa-circle text-success me-1" title="Online" role="img"/> Online</DropdownItem>
+                <DropdownItem class="{ 'active': this.store.self.imStatusUI === 'online' }" onSelected="() => this.setManualImStatus('online')"><i class="fa fa-circle text-success me-1" title="Online" role="img"/> Online</DropdownItem>
                 <hr class="my-1"/>
-                <DropdownItem class="{ 'active': this.store.self.im_status === 'away' }" onSelected="() => this.setManualImStatus('away')"><i class="fa fa-adjust o-yellow me-1" title="Away" role="img"/> Away</DropdownItem>
-                <DropdownItem class="{ 'active': this.store.self.im_status === 'busy' }" onSelected="() => this.setManualImStatus('busy')">
+                <DropdownItem class="{ 'active': this.store.self.imStatusUI === 'away' }" onSelected="() => this.setManualImStatus('away')"><i class="fa fa-adjust o-yellow me-1" title="Away" role="img"/> Away</DropdownItem>
+                <DropdownItem class="{ 'active': this.store.self.imStatusUI === 'busy' }" onSelected="() => this.setManualImStatus('busy')">
                     <i class="fa fa-minus-circle text-danger me-1" title="Busy" role="img"/> Do Not Disturb
                     <div class="small text-muted">You will not receive any notifications</div>
                 </DropdownItem>
-                <DropdownItem class="{ 'active': this.store.self.im_status === 'offline' }" onSelected="() => this.setManualImStatus('offline')"><i class="fa fa-circle-o text-700 opacity-75 me-1" title="Offline" role="img"/> Offline</DropdownItem>
+                <DropdownItem class="{ 'active': this.store.self.imStatusUI === 'offline' }" onSelected="() => this.setManualImStatus('offline')"><i class="fa fa-circle-o text-700 opacity-75 me-1" title="Offline" role="img"/> Offline</DropdownItem>
             </t>
         </Dropdown>
     </t>

--- a/addons/mail/static/src/core/common/im_status_mixin.js
+++ b/addons/mail/static/src/core/common/im_status_mixin.js
@@ -1,0 +1,121 @@
+import { AWAY_DELAY } from "@mail/core/common/im_status_service";
+import { fields } from "@mail/model/misc";
+import { Record } from "@mail/model/record";
+import { effectWithCleanup } from "@mail/utils/common/misc";
+
+import { effect } from "@web/core/utils/reactive";
+import { debounce } from "@web/core/utils/timing";
+
+/** @typedef {'offline' | 'bot' | 'online' | 'away' | 'im_partner' | undefined} ImStatus */
+
+const { DateTime } = luxon;
+
+/**
+ * Both ResPartner and MailGuest models need to react to `presence_status` updates and
+ * debounce updates to their `im_status` field to avoid flickering. This common class
+ * groups the logic used by both models.
+ */
+export class ImStatusMixin extends Record {
+    static IM_STATUS_DEBOUNCE_DELAY = 1500;
+
+    static new() {
+        /** @type {ImStatusMixin} */
+        const record = super.new(...arguments);
+        const setImStatusDebounced = debounce(
+            (status) => (record.imStatusUI = status),
+            ImStatusMixin.IM_STATUS_DEBOUNCE_DELAY
+        );
+        record.setImStatusDebounced = setImStatusDebounced;
+        record.cancelSetImStatusDebounced = setImStatusDebounced.cancel;
+        effect(
+            (record, store, presenceService, statusService) => {
+                if (record.notEq(store.self)) {
+                    return;
+                }
+                const isOnline = presenceService.getInactivityPeriod() < AWAY_DELAY;
+                if (
+                    (record.presence_status === "away" && isOnline) ||
+                    record.presence_status === "offline"
+                ) {
+                    statusService.updateBusPresence();
+                }
+            },
+            [
+                record,
+                record.store,
+                record.store.env.services.presence,
+                record.store.env.services.im_status,
+            ]
+        );
+        effectWithCleanup({
+            effect: (busService, presenceChannel) => {
+                if (presenceChannel) {
+                    busService.addChannel(presenceChannel);
+                    return () => busService.deleteChannel(presenceChannel);
+                }
+            },
+            dependencies: (record) => [
+                record.store.env.services.bus_service,
+                record.monitorPresence && record.presenceChannel,
+            ],
+            reactiveTargets: [record],
+        });
+        return record;
+    }
+    /** @type {(status) => void} */
+    setImStatusDebounced;
+    /** @type {() => void} */
+    cancelSetImStatusDebounced;
+    /** @type {ImStatus} */
+    im_status = fields.Attr(undefined, {
+        onUpdate() {
+            // Flickering occurs during im_status correction when switching from
+            // away/offline to online. If we don't know the status, or if the status is
+            // already "online", flickering cannot occur, so it's better to update the
+            // field immediately.
+            if (this.imStatusUI === undefined || this.im_status === "online") {
+                this.forceImStatus(this.im_status);
+            } else {
+                this.setImStatusDebounced(this.im_status);
+            }
+        },
+    });
+    /**
+     * Debounced im_status, to avoid flickering. Should be used whenever the im_status has
+     * an impact on the UI.
+     * @type {ImStatus}
+     */
+    imStatusUI = fields.Attr(undefined, {
+        onUpdate() {
+            this.offline_since = this.imStatusUI === "offline" ? DateTime.now() : null;
+        },
+    });
+    /** @type {string|undefined} */
+    im_status_access_token;
+    monitorPresence = fields.Attr(false, {
+        compute() {
+            return this._computeMonitorPresence();
+        },
+    });
+    offline_since = fields.Datetime();
+    /** @type {ImStatus} */
+    presence_status;
+    presenceChannel = fields.Attr(undefined, {
+        compute() {
+            const channel = `odoo-presence-${this.Model.getName()}_${this.id}`;
+            if (this.im_status_access_token) {
+                return channel + `-${this.im_status_access_token}`;
+            }
+            return channel;
+        },
+    });
+
+    _computeMonitorPresence() {
+        return this.store.env.services.bus_service.isActive && this.id > 0;
+    }
+
+    forceImStatus(status) {
+        this.cancelSetImStatusDebounced();
+        this.imStatusUI = status;
+    }
+}

--- a/addons/mail/static/src/core/common/im_status_service.js
+++ b/addons/mail/static/src/core/common/im_status_service.js
@@ -18,7 +18,6 @@ export const AWAY_DELAY = 30 * 60 * 1000; // 30 minutes
  */
 export const imStatusService = {
     dependencies: ["bus_service", "presence"],
-    // and cyclic dependecy with "mail.store" (both services should be merged together)
 
     start(env, { bus_service, presence }) {
         let lastSentInactivity;
@@ -38,25 +37,6 @@ export const imStatusService = {
             }
         };
         bus_service.addEventListener("BUS:CONNECT", () => updateBusPresence(), { once: true });
-        bus_service.subscribe(
-            "bus.bus/im_status_updated",
-            async ({ presence_status, im_status, partner_id, guest_id }) => {
-                const store = env.services["mail.store"];
-                const partner = store["res.partner"].get(partner_id);
-                const guest = store["mail.guest"].get(guest_id);
-                if (!partner && !guest) {
-                    return; // Do not store unknown persona's status
-                }
-                partner?.debouncedSetImStatus(im_status);
-                guest?.debouncedSetImStatus(im_status);
-                if (partner?.eq(store.self_user?.partner_id) || guest?.eq(store.self_guest)) {
-                    const isOnline = presence.getInactivityPeriod() < AWAY_DELAY;
-                    if ((presence_status === "away" && isOnline) || presence_status === "offline") {
-                        updateBusPresence();
-                    }
-                }
-            }
-        );
         presence.bus.addEventListener("presence", () => {
             if (!lastSentInactivity || lastSentInactivity >= AWAY_DELAY) {
                 updateBusPresence();

--- a/addons/mail/static/src/core/common/mail_guest_model.js
+++ b/addons/mail/static/src/core/common/mail_guest_model.js
@@ -1,87 +1,24 @@
-import { fields, Record } from "@mail/model/export";
-import { imageUrl } from "@web/core/utils/urls";
+import { ImStatusMixin } from "@mail/core/common/im_status_mixin";
+import { fields } from "@mail/model/export";
+
 import { rpc } from "@web/core/network/rpc";
-import { debounce } from "@web/core/utils/timing";
-import { Store } from "@mail/core/common/store_service";
+import { imageUrl } from "@web/core/utils/urls";
 
 const TRANSPARENT_AVATAR =
     "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAQAAABpN6lAAAAAqElEQVR42u3QMQEAAAwCoNm/9GJ4CBHIjYsAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBAgQIAAAQIECBDQ9+KgAIHd5IbMAAAAAElFTkSuQmCC";
-const { DateTime } = luxon;
 
-/**
- * @typedef {'offline' | 'bot' | 'online' | 'away' | 'im_partner' | undefined} ImStatus
- * @typedef Data
- * @property {number} id
- * @property {string} name
- * @property {string} email
- * @property {ImStatus} im_status
- */
-
-export class MailGuest extends Record {
+export class MailGuest extends ImStatusMixin {
     static _name = "mail.guest";
-    static new() {
-        const record = super.new(...arguments);
-        record.debouncedSetImStatus = debounce(
-            (newStatus) => record.updateImStatus(newStatus),
-            Store.IM_STATUS_DEBOUNCE_DELAY
-        );
-        return record;
-    }
 
     /** @type {string} */
     avatar_128_access_token;
     /** @type {number} */
     id;
-    debouncedSetImStatus;
-    monitorPresence = fields.Attr(false, {
-        compute() {
-            return this.store.env.services.bus_service.isActive && this.id > 0;
-        },
-    });
-    _triggerPresenceSubscription = fields.Attr(null, {
-        compute() {
-            return this.monitorPresence && this.presenceChannel;
-        },
-        onUpdate() {
-            if (this.previousPresencechannel) {
-                this.store.env.services.bus_service.deleteChannel(this.previousPresencechannel);
-            }
-            if (this._triggerPresenceSubscription) {
-                this.store.env.services.bus_service.addChannel(this.presenceChannel);
-            }
-            this.previousPresencechannel = this.presenceChannel;
-        },
-        eager: true,
-    });
     /** @type {string} */
     name;
     country_id = fields.One("res.country");
     /** @type {string} */
     email;
-    /** @type {ImStatus} */
-    im_status = fields.Attr(null, {
-        onUpdate() {
-            if (this.eq(this.store.self_guest) && this.im_status === "offline" && this.id < 0) {
-                this.store.env.services.im_status.updateBusPresence();
-            }
-        },
-    });
-    /** @type {string|undefined} */
-    im_status_access_token;
-
-    /** @type {luxon.DateTime} */
-    offline_since = fields.Datetime();
-    /** @type {string|undefined} */
-    previousPresencechannel;
-    presenceChannel = fields.Attr(null, {
-        compute() {
-            const channel = `odoo-presence-mail.guest_${this.id}`;
-            if (this.im_status_access_token) {
-                return `${channel}-${this.im_status_access_token}`;
-            }
-            return channel;
-        },
-    });
     write_date = fields.Datetime();
 
     get avatarUrl() {
@@ -103,13 +40,6 @@ export class MailGuest extends Record {
             guest_id: this.id,
             name,
         });
-    }
-
-    updateImStatus(newStatus) {
-        if (newStatus === "offline") {
-            this.offline_since = DateTime.now();
-        }
-        this.im_status = newStatus;
     }
 }
 

--- a/addons/mail/static/src/core/common/res_partner_model.js
+++ b/addons/mail/static/src/core/common/res_partner_model.js
@@ -1,42 +1,16 @@
-import { Store } from "@mail/core/common/store_service";
-import { fields, Record } from "@mail/model/export";
+import { ImStatusMixin } from "@mail/core/common/im_status_mixin";
+import { fields } from "@mail/model/misc";
+
 import { imageUrl } from "@web/core/utils/urls";
-import { debounce } from "@web/core/utils/timing";
 
-const { DateTime } = luxon;
-
-export class ResPartner extends Record {
+export class ResPartner extends ImStatusMixin {
     static _name = "res.partner";
-    static new() {
-        const record = super.new(...arguments);
-        record.debouncedSetImStatus = debounce(
-            (newStatus) => record.updateImStatus(newStatus),
-            Store.IM_STATUS_DEBOUNCE_DELAY
-        );
-        return record;
-    }
 
-    _triggerPresenceSubscription = fields.Attr(null, {
-        compute() {
-            return this.monitorPresence && this.presenceChannel;
-        },
-        onUpdate() {
-            if (this.previousPresencechannel) {
-                this.store.env.services.bus_service.deleteChannel(this.previousPresencechannel);
-            }
-            if (this._triggerPresenceSubscription) {
-                this.store.env.services.bus_service.addChannel(this.presenceChannel);
-            }
-            this.previousPresencechannel = this.presenceChannel;
-        },
-        eager: true,
-    });
     /** @type {string} */
     avatar_128_access_token;
     /** @type {string} */
     commercial_company_name;
     country_id = fields.One("res.country");
-    debouncedSetImStatus;
     /** @type {string} */
     email;
     /**
@@ -48,48 +22,17 @@ export class ResPartner extends Record {
     group_ids = fields.Many("res.groups", { inverse: "partners" });
     /** @type {number} */
     id;
-    /** @type {ImStatus} */
-    im_status = fields.Attr(null, {
-        onUpdate() {
-            if (this.eq(this.store.self_user?.partner_id) && this.im_status === "offline") {
-                this.store.env.services.im_status.updateBusPresence();
-            }
-        },
-    });
-    /** @type {string|undefined} */
-    im_status_access_token;
     /** @type {boolean | undefined} */
     is_company;
     /** @type {boolean} */
     is_public;
     main_user_id = fields.One("res.users");
-    monitorPresence = fields.Attr(false, {
-        compute() {
-            if (!this.store.env.services.bus_service.isActive || this.id <= 0) {
-                return false;
-            }
-            return this.im_status !== "im_partner" && !this.is_public;
-        },
-    });
     /** @type {string} */
     name;
     /** @type {string} */
     display_name;
     /** @type {string} */
     phone;
-    /** @type {luxon.DateTime} */
-    offline_since = fields.Datetime();
-    presenceChannel = fields.Attr(null, {
-        compute() {
-            const channel = `odoo-presence-res.partner_${this.id}`;
-            if (this.im_status_access_token) {
-                return channel + `-${this.im_status_access_token}`;
-            }
-            return channel;
-        },
-    });
-    /** @type {string|undefined} */
-    previousPresencechannel;
     user_ids = fields.Many("res.users", { inverse: "partner_id" });
     write_date = fields.Datetime();
 
@@ -117,18 +60,17 @@ export class ResPartner extends Record {
         return this.name || this.display_name;
     }
 
+    _computeMonitorPresence() {
+        return (
+            super._computeMonitorPresence() && this.im_status !== "im_partner" && !this.is_public
+        );
+    }
+
     searchChat() {
         return Object.values(this.store["discuss.channel"].records).find(
             (channel) =>
                 channel.channel_type === "chat" && channel.correspondent?.partner_id?.eq(this)
         );
-    }
-
-    updateImStatus(newStatus) {
-        if (newStatus === "offline") {
-            this.offline_since = DateTime.now();
-        }
-        this.im_status = newStatus;
     }
 }
 

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -31,7 +31,6 @@ let temporaryIdOffset = 0.01;
 export class Store extends BaseStore {
     static FETCH_DATA_DEBOUNCE_DELAY = 1;
     static OTHER_LONG_TYPING = 60000;
-    static IM_STATUS_DEBOUNCE_DELAY = 1000;
 
     FETCH_LIMIT = 30;
     DEFAULT_AVATAR = "/mail/static/src/img/smiley/avatar.jpg";

--- a/addons/mail/static/src/core/common/thread_icon.xml
+++ b/addons/mail/static/src/core/common/thread_icon.xml
@@ -17,7 +17,7 @@
         <t t-elif="this.channel?.showImStatus and this.channel?.channel_type?.includes('chat') and this.correspondent">
             <t name="chat">
                 <t name="chat_static">
-                    <ImStatus t-if="this.correspondent.im_status" className="class" member="this.correspondent" size="this.props.size" typing="this.props.typing"/>
+                    <ImStatus t-if="this.correspondent.imStatusUI" className="class" member="this.correspondent" size="this.props.size" typing="this.props.typing"/>
                     <div t-else="" class="d-flex rounded-circle bg-inherit">
                         <i class="fa-fw" t-att="attr" t-attf-class="#{ this.defaultChatIcon.class }" t-att-title="this.defaultChatIcon.title"/>
                     </div>

--- a/addons/mail/static/src/discuss/core/common/channel_member_model.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_model.js
@@ -178,12 +178,12 @@ export class ChannelMember extends Record {
         return this.partner_id?.avatarUrl || this.guest_id?.avatarUrl;
     }
 
-    get im_status() {
-        return this.partner_id?.im_status || this.guest_id?.im_status;
+    get imStatusUI() {
+        return this.partner_id?.imStatusUI || this.guest_id?.imStatusUI;
     }
 
     get isOnline() {
-        return this.store.onlineMemberStatuses.includes(this.im_status);
+        return this.store.onlineMemberStatuses.includes(this.imStatusUI);
     }
 
     /**

--- a/addons/mail/static/tests/discuss/im_status.test.js
+++ b/addons/mail/static/tests/discuss/im_status.test.js
@@ -1,10 +1,14 @@
+import {
+    defineMailModels,
+    sendPresenceUpdate,
+    start,
+    startServer,
+} from "@mail/../tests/mail_test_helpers";
 import { AWAY_DELAY } from "@mail/core/common/im_status_service";
-import { defineMailModels, start, startServer } from "@mail/../tests/mail_test_helpers";
 
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { advanceTime, freezeTime } from "@odoo/hoot-dom";
 
-import { registry } from "@web/core/registry";
 import {
     makeMockEnv,
     mockService,
@@ -12,6 +16,7 @@ import {
     restoreRegistry,
     serverState,
 } from "@web/../tests/web_test_helpers";
+import { registry } from "@web/core/registry";
 
 defineMailModels();
 beforeEach(freezeTime);
@@ -23,11 +28,7 @@ test("update presence if IM status changes to offline while this device is onlin
     pyEnv["res.partner"].write(serverState.partnerId, { im_status: "online" });
     await start();
     await expect.waitForSteps(["update_presence"]);
-    pyEnv["bus.bus"]._sendone(serverState.partnerId, "bus.bus/im_status_updated", {
-        presence_status: "offline",
-        im_status: "offline",
-        partner_id: serverState.partnerId,
-    });
+    sendPresenceUpdate("res.partner", serverState.partnerId, "offline");
     await expect.waitForSteps(["update_presence"]);
 });
 
@@ -38,11 +39,7 @@ test("update presence if IM status changes to away while this device is online",
     pyEnv["res.partner"].write(serverState.partnerId, { im_status: "online" });
     await start();
     await expect.waitForSteps(["update_presence"]);
-    pyEnv["bus.bus"]._sendone(serverState.partnerId, "bus.bus/im_status_updated", {
-        presence_status: "away",
-        im_status: "away",
-        partner_id: serverState.partnerId,
-    });
+    sendPresenceUpdate("res.partner", serverState.partnerId, "away");
     await expect.waitForSteps(["update_presence"]);
 });
 
@@ -53,11 +50,7 @@ test("do not update presence if IM status changes to away while this device is a
     pyEnv["res.partner"].write(serverState.partnerId, { im_status: "away" });
     await start();
     await expect.waitForSteps(["update_presence"]);
-    pyEnv["bus.bus"]._sendone(serverState.partnerId, "bus.bus/im_status_updated", {
-        presence_status: "away",
-        im_status: "away",
-        partner_id: serverState.partnerId,
-    });
+    sendPresenceUpdate("res.partner", serverState.partnerId, "away");
     await expect.waitForSteps([]);
 });
 
@@ -66,13 +59,10 @@ test("do not update presence if other user's IM status changes to away", async (
     localStorage.setItem("presence.lastPresence", Date.now());
     const pyEnv = await startServer();
     pyEnv["res.partner"].write(serverState.partnerId, { im_status: "online" });
+    const bobPartnerId = pyEnv["res.partner"].create({ name: "bob", im_status: "online" });
     await start();
     await expect.waitForSteps(["update_presence"]);
-    pyEnv["bus.bus"]._sendone(serverState.partnerId, "bus.bus/im_status_updated", {
-        presence_status: "away",
-        im_status: "away",
-        partner_id: serverState.publicPartnerId,
-    });
+    sendPresenceUpdate("res.partner", bobPartnerId, "away");
     await expect.waitForSteps([]);
 });
 

--- a/addons/mail/static/tests/discuss_app/im_status.test.js
+++ b/addons/mail/static/tests/discuss_app/im_status.test.js
@@ -3,10 +3,11 @@ import {
     contains,
     defineMailModels,
     openDiscuss,
+    sendPresenceUpdate,
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
-import { Store } from "@mail/core/common/store_service";
+import { ImStatusMixin } from "@mail/core/common/im_status_mixin";
 import { describe, test } from "@odoo/hoot";
 import { Command, patchWithCleanup, serverState } from "@web/../tests/web_test_helpers";
 
@@ -59,33 +60,18 @@ test("initially away", async () => {
 });
 
 test("change icon on change partner im_status", async () => {
-    patchWithCleanup(Store, { IM_STATUS_DEBOUNCE_DELAY: 0 });
+    patchWithCleanup(ImStatusMixin, { IM_STATUS_DEBOUNCE_DELAY: 0 });
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ channel_type: "chat" });
     pyEnv["res.partner"].write([serverState.partnerId], { im_status: "online" });
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-DiscussContent-header .o-mail-ImStatus[title='User is online']");
-    pyEnv["res.partner"].write([serverState.partnerId], { im_status: "offline" });
-    pyEnv["bus.bus"]._sendone(serverState.partnerId, "bus.bus/im_status_updated", {
-        partner_id: serverState.partnerId,
-        im_status: "offline",
-        presence_status: "offline",
-    });
+    sendPresenceUpdate("res.partner", serverState.partnerId, "offline");
     await contains(".o-mail-DiscussContent-header .o-mail-ImStatus[title='User is offline']");
-    pyEnv["res.partner"].write([serverState.partnerId], { im_status: "away" });
-    pyEnv["bus.bus"]._sendone(serverState.partnerId, "bus.bus/im_status_updated", {
-        partner_id: serverState.partnerId,
-        im_status: "away",
-        presence_status: "away",
-    });
+    sendPresenceUpdate("res.partner", serverState.partnerId, "away");
     await contains(".o-mail-DiscussContent-header .o-mail-ImStatus[title='User is idle']");
-    pyEnv["res.partner"].write([serverState.partnerId], { im_status: "online" });
-    pyEnv["bus.bus"]._sendone(serverState.partnerId, "bus.bus/im_status_updated", {
-        partner_id: serverState.partnerId,
-        im_status: "online",
-        presence_status: "online",
-    });
+    sendPresenceUpdate("res.partner", serverState.partnerId, "online");
     await contains(".o-mail-DiscussContent-header .o-mail-ImStatus[title='User is online']");
 });
 

--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -1045,3 +1045,14 @@ export async function assertChatBubbleAndWindowImStatus(conversationName, count)
     ).toHaveCount(count);
     await click(`.o-mail-ChatWindow-header:has(:text(${conversationName}))`);
 }
+
+/** Sends an update presence for the given record through the bus. */
+export function sendPresenceUpdate(modelName, id, newPresence) {
+    const env = MockServer.env;
+    env[modelName].write(id, { im_status: newPresence });
+    const store = new mailDataHelpers.Store().add(env[modelName].browse(id), {
+        presence_status: newPresence,
+        im_status: newPresence,
+    });
+    env["bus.bus"]._sendone(serverState.partnerId, "mail.record/insert", store.get_result());
+}

--- a/addons/mail/static/tests/mock_server/mock_models/mail_guest.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_guest.js
@@ -26,7 +26,7 @@ export class MailGuest extends models.ServerModel {
                 data.write_date = guest.write_date;
             }
             if (fields.includes("im_status")) {
-                data.im_status = "offline";
+                data.im_status = guest.im_status || "offline";
                 data.im_status_access_token = guest.id;
             }
             if (Object.keys(data).length) {

--- a/addons/mail/tests/discuss/test_discuss_mail_presence.py
+++ b/addons/mail/tests/discuss/test_discuss_mail_presence.py
@@ -40,11 +40,13 @@ class TestMailPresence(WebsocketCase, MailCommon):
             bus_record.channel,
             json_dump(channel_with_db(self.env.cr.dbname, (target, "presence"))),
         )
-        self.assertEqual(notifications[0]["message"]["type"], "bus.bus/im_status_updated")
-        self.assertEqual(notifications[0]["message"]["payload"]["im_status"], "online")
-        self.assertEqual(notifications[0]["message"]["payload"]["presence_status"], "online")
+        self.assertEqual(notifications[0]["message"]["type"], "mail.record/insert")
         self.assertEqual(
-            notifications[0]["message"]["payload"]["partner_id" if target_user else "guest_id"],
+            notifications[0]["message"]["payload"][target_channel._name][0]["im_status"],
+            "online",
+        )
+        self.assertEqual(
+            notifications[0]["message"]["payload"][target_channel._name][0]["id"],
             target_channel.id,
         )
 
@@ -81,10 +83,9 @@ class TestMailPresence(WebsocketCase, MailCommon):
             [(bob, "presence")],
             [
                 {
-                    "type": "bus.bus/im_status_updated",
+                    "type": "mail.record/insert",
                     "payload": {
-                        "im_status": "offline",
-                        "partner_id": bob.partner_id.id,
+                        "res.partner": [{"id": bob.partner_id.id, "im_status": "offline"}],
                     },
                 },
             ],
@@ -94,3 +95,37 @@ class TestMailPresence(WebsocketCase, MailCommon):
                 {"status": "offline"},
                 cookies={"session_id": session.sid},
             )
+
+    def test_presence_status_only_sent_to_self(self):
+        bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
+        self._reset_bus()
+        self.env["mail.presence"].with_user(bob)._update_presence(bob)
+        self.env.cr.precommit.run()  # trigger the creation of bus.bus records
+        presence_channel_notif, self_channel_notif = self.env["bus.bus"].search([])
+        self.assertEqual(presence_channel_notif.channel, json_dump(channel_with_db(self.env.cr.dbname, (bob, "presence"))))
+        self.assertEqual(self_channel_notif.channel, json_dump(channel_with_db(self.env.cr.dbname, bob)))
+        presence_payload = json.loads(presence_channel_notif.message)["payload"]
+        self.assertEqual(
+            presence_payload,
+            {"res.partner": [{"id": bob.partner_id.id, "im_status": "online"}]},
+        )
+        self_payload = json.loads(self_channel_notif.message)["payload"]
+        self.assertEqual(
+            self_payload,
+            {"res.partner": [{"id": bob.partner_id.id, "presence_status": "online"}]},
+        )
+        other_user = new_test_user(self.env, login="other_user", groups="base.group_user")
+        self._reset_bus()
+        bob_presence = self.env["mail.presence"].search([("user_id", "=", bob.id)])
+        bob_presence._send_presence(bus_target=other_user)
+        self.env.cr.precommit.run()  # trigger the creation of bus.bus records
+        notifications = self.env["bus.bus"].search([])
+        self.assertEqual(len(notifications), 1)  # Only im_status notification was dispatched, and only for bus_target.
+        self.assertEqual(
+            notifications.channel,
+            json_dump(channel_with_db(self.env.cr.dbname, other_user)),
+        )
+        self.assertEqual(
+           json.loads(notifications.message)["payload"],
+            {"res.partner": [{"id": bob.partner_id.id, "im_status": "online"}]},
+        )

--- a/addons/mail/tests/test_ir_websocket.py
+++ b/addons/mail/tests/test_ir_websocket.py
@@ -28,30 +28,27 @@ class TestIrWebsocket(WebsocketCase):
         self.env["mail.presence"]._update_presence(bob)
         self.trigger_notification_dispatching([(bob, "presence")])
         message = json.loads(websocket.recv())[0]["message"]
-        self.assertEqual(message["type"], "bus.bus/im_status_updated")
-        self.assertEqual(message["payload"]["im_status"], "online")
-        self.assertEqual(message["payload"]["presence_status"], "online")
-        self.assertEqual(message["payload"]["partner_id"], bob.partner_id.id)
+        self.assertEqual(message["type"], "mail.record/insert")
+        self.assertEqual(message["payload"]["res.partner"][0]["im_status"], "online")
+        self.assertEqual(message["payload"]["res.partner"][0]["id"], bob.partner_id.id)
         # online => away
         away_timer_later = datetime.now() + timedelta(seconds=AWAY_TIMER + 1)
         with freeze_time(away_timer_later):
             self.env["mail.presence"]._update_presence(bob, (AWAY_TIMER + 1) * 1000)
             self.trigger_notification_dispatching([(bob, "presence")])
             message = json.loads(websocket.recv())[0]["message"]
-            self.assertEqual(message["type"], "bus.bus/im_status_updated")
-            self.assertEqual(message["payload"]["im_status"], "away")
-            self.assertEqual(message["payload"]["presence_status"], "away")
-            self.assertEqual(message["payload"]["partner_id"], bob.partner_id.id)
+            self.assertEqual(message["type"], "mail.record/insert")
+            self.assertEqual(message["payload"]["res.partner"][0]["im_status"], "away")
+            self.assertEqual(message["payload"]["res.partner"][0]["id"], bob.partner_id.id)
         # away => online
         ten_minutes_later = datetime.now() + timedelta(minutes=10)
         with freeze_time(ten_minutes_later):
             self.env["mail.presence"]._update_presence(bob)
             self.trigger_notification_dispatching([(bob, "presence")])
             message = json.loads(websocket.recv())[0]["message"]
-            self.assertEqual(message["type"], "bus.bus/im_status_updated")
-            self.assertEqual(message["payload"]["im_status"], "online")
-            self.assertEqual(message["payload"]["presence_status"], "online")
-            self.assertEqual(message["payload"]["partner_id"], bob.partner_id.id)
+            self.assertEqual(message["type"], "mail.record/insert")
+            self.assertEqual(message["payload"]["res.partner"][0]["im_status"], "online")
+            self.assertEqual(message["payload"]["res.partner"][0]["id"], bob.partner_id.id)
         # online => online, nothing happens
         ten_minutes_later = datetime.now() + timedelta(minutes=10)
         with freeze_time(ten_minutes_later):
@@ -85,7 +82,7 @@ class TestIrWebsocket(WebsocketCase):
             bus_record.channel,
             json_dump(channel_with_db(self.env.cr.dbname, bob)),
         )
-        self.assertEqual(notification["message"]["type"], "bus.bus/im_status_updated")
-        self.assertEqual(notification["message"]["payload"]["im_status"], "online")
-        self.assertEqual(notification["message"]["payload"]["presence_status"], "online")
-        self.assertEqual(notification["message"]["payload"]["partner_id"], bob.partner_id.id)
+        self.assertEqual(notification["message"]["type"], "mail.record/insert")
+        self.assertEqual(notification["message"]["payload"]["res.partner"][0]["im_status"], "online")
+        self.assertEqual(notification["message"]["payload"]["res.partner"][0]["presence_status"], "online")
+        self.assertEqual(notification["message"]["payload"]["res.partner"][0]["id"], bob.partner_id.id)

--- a/addons/mail/tests/test_websocket_controller.py
+++ b/addons/mail/tests/test_websocket_controller.py
@@ -18,18 +18,20 @@ class TestWebsocketController(HttpCaseWithUserDemo):
         self.env["bus.bus"].search([]).unlink()
         self.make_jsonrpc_request("/websocket/on_closed", {})
         self.env.cr.precommit.run()  # trigger the creation of bus.bus records
-        message = self.make_jsonrpc_request(
+        presence_notif, self_notif = self.make_jsonrpc_request(
             "/websocket/peek_notifications",
             {
                 "channels": [f"odoo-presence-res.partner_{self.partner_demo.id}"],
                 "last": 0,
                 "is_first_poll": True,
             },
-        )["notifications"][0]["message"]
-        self.assertEqual(message["type"], "bus.bus/im_status_updated")
-        self.assertEqual(message["payload"]["partner_id"], self.partner_demo.id)
-        self.assertEqual(message["payload"]["im_status"], "offline")
-        self.assertEqual(message["payload"]["presence_status"], "offline")
+        )["notifications"]
+        self.assertEqual(presence_notif["message"]["type"], "mail.record/insert")
+        self.assertEqual(presence_notif["message"]["payload"]["res.partner"][0]["id"], self.partner_demo.id)
+        self.assertEqual(presence_notif["message"]["payload"]["res.partner"][0]["im_status"], "offline")
+        self.assertEqual(self_notif["message"]["type"], "mail.record/insert")
+        self.assertEqual(self_notif["message"]["payload"]["res.partner"][0]["id"], self.partner_demo.id)
+        self.assertEqual(self_notif["message"]["payload"]["res.partner"][0]["presence_status"], "offline")
 
     def test_receive_missed_presences_on_peek_notifications(self):
         self.authenticate("demo", "demo")
@@ -47,7 +49,7 @@ class TestWebsocketController(HttpCaseWithUserDemo):
             },
         )
         self.env.cr.precommit.run()  # trigger the creation of bus.bus records
-        notification = self.make_jsonrpc_request(
+        notif = self.make_jsonrpc_request(
             "/websocket/peek_notifications",
             {
                 "channels": [f"odoo-presence-res.partner_{self.partner_demo.id}"],
@@ -55,14 +57,13 @@ class TestWebsocketController(HttpCaseWithUserDemo):
                 "is_first_poll": True,
             },
         )["notifications"][0]
-        bus_record = self.env["bus.bus"].search([("id", "=", int(notification["id"]))])
+        bus_record = self.env["bus.bus"].search([("id", "=", int(notif["id"]))])
         self.assertEqual(
             bus_record.channel, json_dump(channel_with_db(self.env.cr.dbname, self.user_demo)),
         )
-        self.assertEqual(notification["message"]["type"], "bus.bus/im_status_updated")
-        self.assertEqual(notification["message"]["payload"]["partner_id"], self.partner_demo.id)
-        self.assertEqual(notification["message"]["payload"]["im_status"], "online")
-        self.assertEqual(notification["message"]["payload"]["presence_status"], "online")
+        self.assertEqual(notif["message"]["type"], "mail.record/insert")
+        self.assertEqual(notif["message"]["payload"]["res.partner"][0]["id"], self.partner_demo.id)
+        self.assertEqual(notif["message"]["payload"]["res.partner"][0]["im_status"], "online")
 
     @freeze_time("2026-03-03", as_kwarg='clock')
     def test_do_not_rotate_session_when_updating_presence(self, clock):


### PR DESCRIPTION
Status is subject to race conditions: received from rpc, bus, debounced to avoid flickering. This commit sends the im_status field in a store insert format, benefiting from the versioning mechanism introduced in [1].

[1]:https://github.com/odoo/odoo/pull/246467