### PR TITLE
[FIX] partner_autocomplete: VAT autocomplete fails for VAT with country code

### DIFF
--- a/addons/partner_autocomplete/models/res_partner.py
+++ b/addons/partner_autocomplete/models/res_partner.py
@@ -108,8 +108,12 @@ class ResPartner(models.Model):
     def autocomplete_by_vat(self, vat, query_country_id, timeout=15):
         query_country_id = query_country_id or self.env.company.country_id.id
         query_country_code = self.env['res.country'].browse(query_country_id).code
+        vat_query = vat.upper()
+        if vat_query.startswith(query_country_code):
+            vat_query = vat_query[len(query_country_code):]
+
         response, _ = self.env['iap.autocomplete.api']._request_partner_autocomplete('search_by_vat', {
-            'query': vat,
+            'query': vat_query,
             'query_country_code': query_country_code,
         }, timeout=timeout)
         if response and not response.get("error"):


### PR DESCRIPTION
**Steps to reproduce:**
* Go to the Contacts app and create a new partner.
* In the VAT field, type a valid VAT number that includes the country code prefix (e.g., a Danish VAT like DK12345678).
* Trigger the autocomplete suggestion.

**Observed behavior:**
* The autocomplete by VAT does not return any results. It falls back to an autocomplete by name, which relies on the VAT string and also yields no results.

**Cause:**
* The `jsvat` frontend library requires the VAT string to include the country code prefix (e.g. DK12345678) to evaluate it correctly as a VAT number and trigger the VAT autocomplete flow.
* However, the backend IAP `search_by_vat` API expects the VAT number without the country prefix in the `query` field, as the country code is provided as a separate `query_country_code` parameter. Passing the full VAT string prevents the IAP service from finding matches.

**Fix:**
* Modified `autocomplete_by_vat` in `res_partner.py` to strip the `query_country_code` prefix from the `vat` string before passing it to the IAP API `search_by_vat`.
* The full, unmodified VAT string is still preserved for the `check_vies` fallback, as VIES requires the full country code prefix.

opw-5974250