### PR TITLE
[FIX] mail, *: adapt presence tests to enterprise changes

### DIFF
--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -326,6 +326,7 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                         ),
                         "res.users": self._filter_users_fields({
                             "employee_ids": [],
+                            "should_display_in_call_im_status": False,
                             "id": self.user_employee.id,
                             "im_status": "offline",
                             "im_status_access_token": self.user_employee._get_im_status_access_token(),

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -175,6 +175,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                 },
                 {
                     "employee_ids": [],
+                    "should_display_in_call_im_status": False,
                     "id": test_user.id,
                     "im_status": "offline",
                     "im_status_access_token": test_user._get_im_status_access_token(),
@@ -187,6 +188,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                     "share": False,
                 },
                 {
+                    "should_display_in_call_im_status": False,
                     "id": operator.id,
                     "im_status": "offline",
                     "im_status_access_token": operator._get_im_status_access_token(),
@@ -313,6 +315,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                 },
                 {
                     "employee_ids": [],
+                    "should_display_in_call_im_status": False,
                     "id": operator.id,
                     "im_status": "offline",
                     "im_status_access_token": operator._get_im_status_access_token(),

--- a/addons/mail/controllers/im_status.py
+++ b/addons/mail/controllers/im_status.py
@@ -2,7 +2,7 @@
 
 from odoo import _, http
 
-from odoo.addons.mail.tools.discuss import Store, mail_route
+from odoo.addons.mail.tools.discuss import mail_route, Store
 
 
 class ImStatusController(http.Controller):
@@ -13,5 +13,5 @@ class ImStatusController(http.Controller):
         self.env.user.manual_im_status = False if status == "online" else status
         Store(bus_channel=self.env.user, bus_subchannel="presence").add(
             self.env.user,
-            ["im_status"],
+            "_store_manual_im_status_fields",
         ).bus_send()

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -434,6 +434,9 @@ class ResUsers(models.Model):
         res.attr("im_status_access_token", lambda p: p._get_im_status_access_token())
         res.one("partner_id", "_store_im_status_fields")
 
+    def _store_manual_im_status_fields(self, res: Store.FieldList):
+        res.attr("im_status")
+
     def _store_bookmark_box_global_fields(self, res: Store.FieldList, bus_last_id=None):
         """ Update the bookmark box info in the given store."""
         self.ensure_one()

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -2013,6 +2013,9 @@ class MailCommon(MailCase):
         if "hr.employee" not in self.env:
             for data in users_data:
                 data.pop("employee_ids", None)
+        if "has_active_call" not in self.env["res.users"]._fields:
+            for data in users_data:
+                data.pop("has_active_call", None)
         return list(users_data)
 
     def _filter_threads_fields(self, /, *threads_data):

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -214,6 +214,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                         ),
                         "res.users": self._filter_users_fields(
                             {
+                                "should_display_in_call_im_status": False,
                                 "employee_ids": [],
                                 "id": self.test_user.id,
                                 "im_status": "offline",
@@ -266,6 +267,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                         "res.users": self._filter_users_fields(
                             {
                                 "active": True,
+                                "should_display_in_call_im_status": False,
                                 "id": self.test_user.id,
                                 "im_status": "offline",
                                 "im_status_access_token": self.test_user._get_im_status_access_token(),
@@ -512,6 +514,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                         ),
                         "res.users": self._filter_users_fields(
                             {
+                                "should_display_in_call_im_status": False,
                                 "employee_ids": [],
                                 "id": self.test_user.id,
                                 "im_status": self.test_user.im_status,
@@ -567,6 +570,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                         ),
                         "res.users": self._filter_users_fields(
                             {
+                                "should_display_in_call_im_status": False,
                                 "employee_ids": [],
                                 "id": self.test_user.id,
                                 "im_status": self.test_user.im_status,

--- a/addons/mail/tests/discuss/test_discuss_mail_presence.py
+++ b/addons/mail/tests/discuss/test_discuss_mail_presence.py
@@ -75,14 +75,20 @@ class TestMailPresence(WebsocketCase, MailCommon):
     def test_manual_im_status(self):
         bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
         session = self.authenticate(bob.login, bob.login)
-        with self.assertBus(
-            BusResult(
-                (bob, "presence"),
-                "mail.record/insert",
+        expected_payload = {}
+        if "has_active_call" in self.env["res.users"]._fields:
+            expected_payload["res.users"] = [
                 {
-                    "res.users": [{"id": bob.id, "im_status": "offline"}],
+                    "should_display_in_call_im_status": False,
+                    "id": bob.id,
+                    "im_status": "offline",
                 },
-            ),
+            ]
+        else:
+            expected_payload["res.users"] = [{"id": bob.id, "im_status": "offline"}]
+
+        with self.assertBus(
+            BusResult((bob, "presence"), "mail.record/insert", expected_payload),
         ):
             self.make_jsonrpc_request(
                 "/mail/set_manual_im_status",

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -1236,6 +1236,7 @@ class TestChannelRTC(MailCommon, HttpCase):
     def _res_for_user(self, user, internal=False):
         res = {
             "employee_ids": [],
+            "should_display_in_call_im_status": False,
             "id": user.id,
             "partner_id": user.partner_id.id,
         }

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -462,6 +462,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                     "active": False,
                 },
                 {
+                    "should_display_in_call_im_status": False,
                     "id": user_0.id,
                     "im_status": "online",
                     "im_status_access_token": user_0._get_im_status_access_token(),
@@ -1993,6 +1994,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "im_status": "online",
                 "im_status_access_token": user._get_im_status_access_token(),
                 "employee_ids": user.employee_ids.ids,
+                "should_display_in_call_im_status": False,
                 "partner_id": partner.id,
                 "share": False,
             }
@@ -2002,6 +2004,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "im_status": "offline",
                 "im_status_access_token": user._get_im_status_access_token(),
                 "employee_ids": user.employee_ids.ids,
+                "should_display_in_call_im_status": False,
                 "partner_id": partner.id,
                 "share": False,
             }
@@ -2015,6 +2018,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                     "im_status": "offline",
                     "im_status_access_token": user._get_im_status_access_token(),
                     "employee_ids": user.employee_ids.ids,
+                    "should_display_in_call_im_status": False,
                     "partner_id": partner.id,
                 }
             return {
@@ -2023,6 +2027,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "im_status": "offline",
                 "im_status_access_token": user._get_im_status_access_token(),
                 "employee_ids": user.employee_ids.ids,
+                "should_display_in_call_im_status": False,
                 "partner_id": partner.id,
                 "share": False,
             }
@@ -2033,6 +2038,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "im_status": "offline",
                 "im_status_access_token": user._get_im_status_access_token(),
                 "employee_ids": user.employee_ids.ids,
+                "should_display_in_call_im_status": False,
                 "partner_id": partner.id,
                 "share": False,
             }
@@ -2043,6 +2049,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "im_status": "offline",
                 "im_status_access_token": user._get_im_status_access_token(),
                 "employee_ids": user.employee_ids.ids,
+                "should_display_in_call_im_status": False,
                 "partner_id": partner.id,
                 "share": False,
             }
@@ -2053,6 +2060,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "im_status": "offline",
                 "im_status_access_token": user._get_im_status_access_token(),
                 "employee_ids": user.employee_ids.ids,
+                "should_display_in_call_im_status": False,
                 "partner_id": partner.id,
                 "share": False,
             }
@@ -2063,6 +2071,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "im_status": "offline",
                 "im_status_access_token": user._get_im_status_access_token(),
                 "employee_ids": user.employee_ids.ids,
+                "should_display_in_call_im_status": False,
                 "partner_id": partner.id,
                 "share": False,
             }

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -275,6 +275,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                 ),
                 "res.users": self._filter_users_fields(
                     {
+                        "should_display_in_call_im_status": False,
                         "id": self.operator.id,
                         "im_status": "online",
                         "im_status_access_token": self.operator._get_im_status_access_token(),


### PR DESCRIPTION
*: im_livechat, test_discuss_full, website_livechat

When a user changes their manual IM status, VOIP should resend
`has_active_call` on the `presence` notification.

Add a mail test override point so enterprise can extend the common
presence assertions, then adapt the related tests to the enterprise
behaviour. Also keep `has_active_call` limited to the manual status path
and hidden when the effective status is offline.

enterprise PR: https://github.com/odoo/enterprise/pull/106567

task-5478885
