### PR TITLE
[IMP] hr_holidays_att: Allow giving time off at custom rate for overtime

### DIFF
--- a/addons/hr_holidays_attendance/models/hr_attendance_overtime.py
+++ b/addons/hr_holidays_attendance/models/hr_attendance_overtime.py
@@ -8,3 +8,4 @@ class HrAttendanceOvertimeLine(models.Model):
     _inherit = 'hr.attendance.overtime.line'
 
     compensable_as_leave = fields.Boolean("Compensable as Time Off")
+    leave_compensation_rate = fields.Float("Rate of leave compensation")

--- a/addons/hr_holidays_attendance/models/hr_attendance_overtime_rule.py
+++ b/addons/hr_holidays_attendance/models/hr_attendance_overtime_rule.py
@@ -9,23 +9,21 @@ class HrAttendanceOvertimeRule(models.Model):
     _inherit = 'hr.attendance.overtime.rule'
 
     compensable_as_leave = fields.Boolean("Give back as time off", default=False)
+    leave_compensation_rate = fields.Float(default=1.0)
 
     def _extra_overtime_vals(self):
-        if not self:
-            return {
-                **super()._extra_overtime_vals(),
-                'compensable_as_leave': False,
-            }
 
-        res = super()._extra_overtime_vals()
-        res['compensable_as_leave'] = any(self.mapped('compensable_as_leave'))
-        if self.ruleset_id.rate_combination_mode == 'sum' and any(self.mapped('paid')):
-            combined_rate = 1.0
-            combined_rate += sum(r.amount_rate - 1.0 for r in self.filtered(
-                lambda r: r.paid and not r.compensable_as_leave
-            ))
-            combined_rate += sum(r.amount_rate for r in self.filtered(
-                lambda r: r.paid and r.compensable_as_leave
-            ))
-            res['amount_rate'] = combined_rate
-        return res
+        cal_rules = self.filtered('compensable_as_leave')
+
+        total_leave_compensation_rate = 0.0
+        if cal_rules:
+            if self.ruleset_id.rate_combination_mode == 'sum':
+                total_leave_compensation_rate = sum((r.leave_compensation_rate - 1.0 for r in cal_rules), start=1.0)
+            elif self.ruleset_id.rate_combination_mode == 'max':
+                total_leave_compensation_rate = max(r.leave_compensation_rate for r in cal_rules)
+
+        return {
+            **super()._extra_overtime_vals(),
+            'compensable_as_leave': any(self.mapped('compensable_as_leave')),
+            'leave_compensation_rate': total_leave_compensation_rate,
+        }

--- a/addons/hr_holidays_attendance/models/hr_employee.py
+++ b/addons/hr_holidays_attendance/models/hr_employee.py
@@ -9,16 +9,15 @@ class HrEmployee(models.Model):
     def _get_deductible_employee_overtime(self):
         # return dict {employee: number of hours}
         diff_by_employee = defaultdict(lambda: 0)
-        for employee, hours in self.env['hr.attendance.overtime.line'].sudo()._read_group(
-            domain=[
-                ('compensable_as_leave', '=', True),
+        for _, lines in self.env['hr.attendance.overtime.line'].sudo()._read_group(
+            domain=[('compensable_as_leave', '=', True),
                 ('employee_id', 'in', self.ids),
-                ('status', '=', 'approved'),
-            ],
+                ('status', '=', 'approved')],
             groupby=['employee_id'],
-            aggregates=['manual_duration:sum'],
+            aggregates=['id:recordset']
         ):
-            diff_by_employee[employee] += hours
+            for line in lines:
+                diff_by_employee[line.employee_id] += line.manual_duration * line.leave_compensation_rate
         for employee, hours in self.env['hr.leave']._read_group(
             domain=[
                 ('work_entry_type_id.overtime_deductible', '=', True),

--- a/addons/hr_holidays_attendance/views/hr_attendance_overtime_views.xml
+++ b/addons/hr_holidays_attendance/views/hr_attendance_overtime_views.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <field name="manual_duration" position="after">
                 <field name="compensable_as_leave" optional="show"/>
+                <field name="leave_compensation_rate" optional="show"/>
             </field>
         </field>
     </record>
@@ -17,7 +18,12 @@
         <field name="inherit_id" ref="hr_attendance.hr_attendance_overtime_rule_view_form"/>
         <field name="arch" type="xml">
             <group name="action_section" position="inside">
-                <field name="compensable_as_leave"/>
+                <label for="compensable_as_leave" string="Give back as time off"/>
+                <span class="d-flex gap-1" name="compensable_as_leave">
+                    <field class="w-auto" nolabel="1" name="compensable_as_leave"/>
+                    <label for="leave_compensation_rate" string="with a rate of" invisible="not compensable_as_leave"/>
+                    <field name="leave_compensation_rate" style="width:10ch" widget="percentage" invisible="not compensable_as_leave"/>
+                </span>
             </group>
         </field>
     </record>


### PR DESCRIPTION
Currently there is an option on overtime rules to award additional time off based on worked overtime. The conversion is 1:1 and we want to allow custom rates for this use case. Here we add a new field for that purpose so that if an overtime of x hours uses a rule with compensable_as_leave = True and with rate of y, the awarded time off will be x*y instead of x

Task: 6036802