### PR TITLE
[FIX] l10n_it: fix VP14 credit and debit formulas

### DIFF
--- a/addons/l10n_it/data/tax_report/account_monthly_tax_report_data.xml
+++ b/addons/l10n_it/data/tax_report/account_monthly_tax_report_data.xml
@@ -294,7 +294,7 @@
                             <record id="tax_monthly_report_line_vp14_vp14a_debit" model="account.report.expression">
                                 <field name="label">debit</field>
                                 <field name="engine">aggregation</field>
-                                <field name="formula">(VP6.debit + VP7.debit + VP12.debit) - (VP8.credit + VP9.credit + VP10.credit + VP11.credit + VP13.credit)</field>
+                                <field name="formula">(VP6.debit + VP7.debit + VP12.debit) - (VP6.credit + VP8.credit + VP9.credit + VP10.credit + VP11.credit + VP13.credit)</field>
                                 <field name="subformula">if_above(EUR(0))</field>
                             </record>
                             <record id="tax_monthly_report_line_vp14_vp14a_carryover" model="account.report.expression">
@@ -307,7 +307,7 @@
                             <record id="tax_monthly_report_line_vp14_vp14b_credit" model="account.report.expression">
                                 <field name="label">credit</field>
                                 <field name="engine">aggregation</field>
-                                <field name="formula">(VP6.credit + VP8.credit + VP9.credit + VP10.credit + VP11.credit + VP13.credit) - (VP7.debit + VP12.debit)</field>
+                                <field name="formula">(VP6.credit + VP8.credit + VP9.credit + VP10.credit + VP11.credit + VP13.credit) - (VP6.debit + VP7.debit + VP12.debit)</field>
                                 <field name="subformula">if_above(EUR(0))</field>
                             </record>
                             <record id="tax_monthly_report_line_vp14_vp14b_carryover" model="account.report.expression">


### PR DESCRIPTION
The VP14 formulas for both debit and credit were incorrect, leading to wrong values in the monthly VAT report
For example, this occurs when there is a carryover from the previous period in VP8

## Steps to reproduce:
- Install l10n_it_reports and switch to the IT company
- Create and confirm a Bill (Bill Date: 01/01/2026, Price: 100, Taxes: 10% G)
- Create and confirm an Invoice (Invoice Date: 01/02/2026, Price: 200, Taxes: 10%)
- Go to Reporting → Tax Report and select Monthly VAT Report (IT)
- Select January, then click Returns
- Select the period 01/01–31/12 with Monthly periodicity
- Review the December and January tax returns by setting all errors to Reviewed, then Validate → Close (to trigger the VP8 carryover)
- Return to the report view for February 2026 Check the VP14 credit value: it should be 0 (since the computed amount is negative)

opw-6032147