### PR TITLE
[REV] account, product, sale: add product name in invoice line

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -42,24 +42,15 @@ export class ProductLabelSectionAndNoteField extends ProductNameAndDescriptionFi
         return this.isSection || this.isSubSection;
     }
 
-    get translatedProductName() {
-        return this.props.record.data.translated_product_name;
-    }
-
-    get label() {
-        let label = this.props.record.data[this.descriptionColumn];
-        if (this.translatedProductName && label.startsWith(this.translatedProductName)) {
-            label = label.slice(this.translatedProductName.length + 1);
-        }
-        else if (this.productName && label.startsWith(this.productName)) {
-            label = label.slice(this.productName.length + 1);
-        }
-        return label;
-    }
-
     isNote(record = null) {
         record = record || this.props.record;
         return record.data.display_type === "line_note";
+    }
+
+    parseLabel(value) {
+        return (this.productName && value && this.productName.concat("\n", value))
+            || (this.productName && !value && this.productName)
+            || (value || "");
     }
 
     shouldShowWarning() {
@@ -69,16 +60,6 @@ export class ProductLabelSectionAndNoteField extends ProductNameAndDescriptionFi
             !this.isSectionOrSubSection &&
             !this.isNote()
         );
-    }
-
-    parseLabel(value) {
-        if(!value){
-            return this.productName;
-        }
-        if(this.translatedProductName){
-            return this.translatedProductName.concat("\n", value);
-        }
-        return this.productName.concat("\n", value);
     }
 }
 
@@ -99,9 +80,6 @@ export const productLabelSectionAndNoteField = {
         props.show_label_warning = options.show_label_warning;
         return props;
     },
-    fieldDependencies: [
-        { name: 'translated_product_name', type: 'char' },
-    ],
 };
 registry
     .category("fields")

--- a/addons/product/static/src/product_name_and_description/product_name_and_description.js
+++ b/addons/product/static/src/product_name_and_description/product_name_and_description.js
@@ -104,6 +104,14 @@ export class ProductNameAndDescriptionField extends Component {
         return this.props.record.data[this.props.name].display_name || "";
     }
 
+    get label() {
+        let label = this.props.record.data[this.descriptionColumn];
+        if (label.includes(this.productName)) {
+            label = label.replace(this.productName, "");
+        }
+        return label.trim();
+    }
+
     get m2oProps() {
         const p = computeM2OProps(this.props);
         let value = p.value && { ...p.value };
@@ -130,6 +138,10 @@ export class ProductNameAndDescriptionField extends Component {
     switchLabelVisibility() {
         this.labelVisibility.value = !this.labelVisibility.value;
         this.switchToLabel = true;
+    }
+
+    parseLabel(value) {
+        return value || this.productName;
     }
 
     /**

--- a/addons/sale/static/src/js/sale_product_field.js
+++ b/addons/sale/static/src/js/sale_product_field.js
@@ -137,6 +137,28 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
         };
     }
 
+    get label() {
+        let label = this.props.record.data.name;
+        if (this.translatedProductName && label.startsWith(this.translatedProductName)) {
+            // Remove the translated name as it is already shown to the salesman on the SOL.
+            label = label.slice(this.translatedProductName.length + 1);  // + "\n"
+        } else {
+            label = super.label;
+        }
+        return label;
+    }
+
+    get translatedProductName() {
+        return this.props.record.data.translated_product_name;
+    }
+
+    parseLabel(value) {
+        if (!this.translatedProductName) {
+            return super.parseLabel(value);
+        }
+        return value && this.translatedProductName.concat("\n", value) || this.translatedProductName;
+    }
+
     get m2oProps() {
         const p = super.m2oProps;
         const value = p.value && { ...p.value };
@@ -437,11 +459,11 @@ export const saleOrderLineProductField = {
         };
     },
     fieldDependencies: [
-        ...(productLabelSectionAndNoteField.fieldDependencies || []),
         { name: 'is_configurable_product', type: 'boolean' },
         { name: 'product_type', type: 'selection' },
         { name: 'service_tracking', type: 'selection' },
         { name: 'product_template_attribute_value_ids', type: 'many2many' },
+        { name: 'translated_product_name', type: 'char' },
     ],
 };
 


### PR DESCRIPTION
Steps to reproduce:
-------------------
* Go to point of sale
* Open list of orders
* Select any order
> Traceback

Why the fix:
------------
Partially reverting https://github.com/odoo/odoo/commit/937363e5786eeab02b06c2dc63e1d9e743fc1874 as it broke a widget. Pos order are using this widget but the dependency on the field `translated_product_name` makes it impossible to open any order in the backend as this field does not exist on pos order line model.

We're only partially reverting the fix to keep the computed fields. This will allow to properly fix the original issue without requiring an exception later.

opw-6040334