### PR TITLE
[FIX] hr_expense: avoid singleton error when opening expenses

### DIFF
--- a/addons/hr_expense/models/account_payment.py
+++ b/addons/hr_expense/models/account_payment.py
@@ -28,14 +28,7 @@ class AccountPayment(models.Model):
 
     def action_open_expense(self):
         self.ensure_one()
-        return {
-            'name': self.expense_ids.name,
-            'type': 'ir.actions.act_window',
-            'view_mode': 'form',
-            'views': [(False, 'form')],
-            'res_model': 'hr.expense',
-            'res_id': self.expense_ids.id,
-        }
+        return self.expense_ids._get_records_action(name=_("Expenses"))
 
     def _creation_message(self):
         # EXTENDS mail


### PR DESCRIPTION
**Description:**

In previous versions, a single move could have multiple payments linked to it, and that move could also be linked to multiple
expenses. When opening expenses from the payment action, which caused a singleton error when multiple expenses were linked.

This situation can occur during upgrades because older versions https://github.com/odoo/upgrade/pull/9685/changes here is identified allowed creating such records. However, after the removal of expense reports [^1], this type of record can no longer be created in newer versions.

**To fix the issue**

the code now handles multiple expenses instead of assuming a singleton.

```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/19.0/odoo/http.py", line 2283, in _serve_db
    return service_model.retrying(serve_func, env=self.env)
  File "/home/odoo/src/odoo/19.0/odoo/service/model.py", line 185, in retrying
    result = func()
  File "/home/odoo/src/odoo/19.0/odoo/http.py", line 2338, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/home/odoo/src/odoo/19.0/odoo/http.py", line 2553, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/home/odoo/src/odoo/19.0/odoo/addons/base/models/ir_http.py", line 355, in _dispatch
    result = endpoint(**request.params)
  File "/home/odoo/src/odoo/19.0/odoo/http.py", line 794, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/home/odoo/src/odoo/19.0/addons/web/controllers/dataset.py", line 38, in call_button
    action = call_kw(request.env[model], method, args, kwargs)
  File "/home/odoo/src/odoo/19.0/odoo/service/model.py", line 94, in call_kw
    result = method(recs, *args, **kwargs)
  File "/home/odoo/src/odoo/19.0/addons/hr_expense/models/account_payment.py", line 37, in action_open_expense
    'name': self.expense_ids.name,
  File "/home/odoo/src/odoo/19.0/odoo/orm/fields.py", line 1659, in __get__
    record.ensure_one()
  File "/home/odoo/src/odoo/19.0/odoo/orm/models.py", line 5940, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: hr.expense(22, 21)
```

opw-5494047
upg-3974547

[^1]: https://github.com/odoo/odoo/pull/189701