### PR TITLE
[FIX] stock: split line with receipt date

### DIFF
--- a/addons/stock/static/src/stock_forecasted/forecasted_details.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_details.js
@@ -173,7 +173,12 @@ export class ForecastedDetails extends Component {
     _sameLineRule(line, nextLine){
         const OnHand = this.OnHandLinesPerProduct[line.product.id] || [];
         const NotAvailable = this.NotAvailableLinesPerProduct[line.product.id] || [];
-        return  this.sameDocumentIn(line, nextLine) || (OnHand.includes(line) && OnHand.includes(nextLine)) || (NotAvailable.includes(line) && NotAvailable.includes(nextLine));
+        const sameReceiptDate = line.receipt_date === nextLine.receipt_date;
+        return (
+            (this.sameDocumentIn(line, nextLine) && sameReceiptDate) ||
+            (OnHand.includes(line) && OnHand.includes(nextLine)) ||
+            (NotAvailable.includes(line) && NotAvailable.includes(nextLine))
+        );
     }
 
     displayReserve(line){

--- a/addons/stock/static/tests/forecasted_details.test.js
+++ b/addons/stock/static/tests/forecasted_details.test.js
@@ -1,0 +1,23 @@
+import { expect, test } from "@odoo/hoot";
+import { ForecastedDetails } from "@stock/stock_forecasted/forecasted_details";
+
+test("forecast detail sameDocument receipt date", async () => {
+    const document_in = { id: 10, _name: "stock.picking", name: "PICK/001" };
+    const line1 = { receipt_date: "2024-01-01", product: { id: 1 }, document_in };
+    const line2 = { receipt_date: "2024-01-01", product: { id: 1 }, document_in };
+    const doc1 = { lines: [line1, line2] };
+    const forecast1 = new ForecastedDetails({ docs: doc1 });
+    forecast1.OnHandLinesPerProduct = {};
+    forecast1.NotAvailableLinesPerProduct = {};
+    forecast1._mergeLines();
+    expect(forecast1.mergesLinesData[0]["rowcount"]).toBe(2);
+
+    const line3 = { receipt_date: "2024-01-01", product: { id: 1 }, document_in };
+    const line4 = { receipt_date: "2024-01-03", product: { id: 1 }, document_in };
+    const doc2 = { lines: [line3, line4] };
+    const forecast2 = new ForecastedDetails({ docs: doc2 });
+    forecast2.OnHandLinesPerProduct = {};
+    forecast2.NotAvailableLinesPerProduct = {};
+    forecast2._mergeLines();
+    expect(forecast2.mergesLinesData).toEqual({});
+});


### PR DESCRIPTION
If you make a purchase order with 2 quantity of the same product, and set 2 different receipt date. The forecast report details would incorrectly group them as the same line.

Steps to reproduce:
-------------------
* Create a purchase order
* Add 2 lines with the same product
* Change the receipt date for one of the 2 lines
* Go to the forecast report of the product
> Observation: In the forecast details there is only one line for the
  first receipt date.

Why the fix:
------------
We add a condition in the `_sameDocument` function to check that the 2 documents being compared have the same receipt date

opw-5361583