### PR TITLE
[FIX] calendar: test_calendar_month_view_start_hour_displayed tour

### DIFF
--- a/addons/calendar/static/tests/tours/calendar_tour.js
+++ b/addons/calendar/static/tests/tours/calendar_tour.js
@@ -11,7 +11,6 @@ const todayDate = function () {
 };
 
 registry.category("web_tour.tours").add("calendar_appointments_hour_tour", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {
@@ -33,6 +32,9 @@ registry.category("web_tour.tours").add("calendar_appointments_hour_tour", {
             trigger: "div[name='start'] button",
             content: "Open the date picker",
             run: "click",
+        },
+        {
+            trigger: ".o_datetime_picker",
         },
         {
             trigger: "#start_0",


### PR DESCRIPTION
This commit marks the 'calendar_appointments_hour_tour' as stable by removing the 'undeterministicTour_doNotCopy' flag. A new step has been added to explicitly wait for the datetime picker widget to appear after clicking the date field, to ensure the input is ready for edits.