### PR TITLE
[FIX] mail, portal: prevent error when message author is missing

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -232,7 +232,7 @@ export class Message extends Component {
         if (this.message.author) {
             return this.message.author.name;
         }
-        return this.message.email_from;
+        return this.message.email_from || _t("Unnamed");
     }
 
     get authorAvatarUrl() {

--- a/addons/portal/models/mail_message.py
+++ b/addons/portal/models/mail_message.py
@@ -135,7 +135,7 @@ class MailMessage(models.Model):
                         "id": message.author_id.id,
                         "name": message.author_id.name,
                         "type": "partner",
-                    },
+                    } if message.author_id else False,
                     "thread": {"model": values["model"], "id": values["res_id"]},
                 }
             )

--- a/addons/portal/tests/test_message_format_portal.py
+++ b/addons/portal/tests/test_message_format_portal.py
@@ -39,3 +39,13 @@ class TestMessageFormatPortal(common.TransactionCase):
         formatted_result = message_note.portal_message_format()
         # subtype is note -> should return True
         self.assertTrue(formatted_result[0].get('is_message_subtype_note'))
+
+    def test_portal_message_format_without_author(self):
+        message = self.env['mail.message'].create({
+            'model': 'res.partner',
+            'res_id': self.env.user.partner_id.id,
+            'author_id': False,
+            'body': 'Hello',
+        })
+        result = message.portal_message_format()
+        self.assertEqual(result[0]['author'], False)


### PR DESCRIPTION
Currently, an error occurs when opening a shared helpdesk ticket link if the message author has been deleted.

**Steps to Reproduce:(v19.2)**
- Install Contacts and Helpdesk modules (with demo data).
- Log in as "**Marc Demo**".
- Create a helpdesk ticket and send a message via the chatter.
- Log in as **Admin**.
- Delete the demo user and the related partner from Contacts.
- Go to Helpdesk > All Tickets and open the created ticket.
- Click "**Share Ticket**" and open the generated link in another browser.

Error:
`ValueError - Expected singleton: res.partner()`

**Cause:**
When the partner linked to `message.author_id` is deleted, the recordset becomes empty, which raises a singleton error.

Fix:
This commit ensures that the author details are only included when the message author exists.

sentry-7337698605