### PR TITLE
[FIX] account,sale: restore correct backend URL on portal preview

### DIFF
--- a/addons/account/controllers/portal.py
+++ b/addons/account/controllers/portal.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import OrderedDict
+from urllib.parse import urlparse
 
 from odoo import fields, http, _
 from odoo.osv import expression
@@ -36,12 +37,27 @@ class PortalAccount(CustomerPortal):
             if request.env['account.move'].has_access('read') else 0
         return overdue_invoice_count
 
+    def _invoice_get_backend_url(self, invoice):
+        """Return the URL for the 'Back to edit mode' button.
+
+        preview_invoice() embeds the current backend URL in the portal URL as a
+        'back' query parameter. Falls back to the action URL per direction.
+        """
+        back = request and request.params.get('back', '')
+        if back:
+            parsed = urlparse(back)
+            return parsed.path + (('?' + parsed.query) if parsed.query else '')
+        if invoice.move_type in ('in_invoice', 'in_refund'):
+            return '/odoo/action-account.action_move_in_invoice/%s' % invoice.id
+        return '/odoo/action-account.action_move_out_invoice/%s' % invoice.id
+
     def _invoice_get_page_view_values(self, invoice, access_token, **kwargs):
         custom_amount = None
         if kwargs.get('amount'):
             custom_amount = float(kwargs['amount'])
         values = {
             'page_name': 'invoice',
+            'backend_url': self._invoice_get_backend_url(invoice),
             **invoice._get_invoice_portal_extra_values(custom_amount=custom_amount),
         }
         return self._get_page_view_values(invoice, access_token, values, 'my_invoices_history', False, **kwargs)

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5493,10 +5493,12 @@ class AccountMove(models.Model):
 
     def preview_invoice(self):
         self.ensure_one()
+        from odoo.http import request  # noqa: PLC0415
+        back = request and request.httprequest.referrer or ''
         return {
             'type': 'ir.actions.act_url',
             'target': 'self',
-            'url': self.get_portal_url(),
+            'url': self.get_portal_url(query_string=back and '&back=%s' % back),
         }
 
     def action_reverse(self):

--- a/addons/account/tests/test_portal_invoice.py
+++ b/addons/account/tests/test_portal_invoice.py
@@ -1,5 +1,8 @@
+from unittest.mock import patch
+
 from odoo.fields import Command
 from odoo.tests.common import tagged
+from odoo.addons.account.controllers.portal import PortalAccount
 from odoo.addons.account.tests.common import AccountTestInvoicingHttpCommon
 from odoo.addons.base.tests.common import BaseUsersCommon
 
@@ -54,3 +57,38 @@ class TestPortalInvoice(BaseUsersCommon, AccountTestInvoicingHttpCommon):
         res = self.url_open(url)
         self.assertEqual(res.status_code, 200)
         self.assertIn("<span>PROFORMA</span>", res.content.decode('utf-8'))
+
+    def test_invoice_page_view_values_backend_url(self):
+        """backend_url is present in portal page view values and falls back
+        to the action URL per direction when there is no HTTP Referer.
+        """
+        out_invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.portal_partner.id,
+            'invoice_line_ids': [Command.create({'price_unit': 100})],
+        })
+        in_invoice = self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'partner_id': self.portal_partner.id,
+            'invoice_line_ids': [Command.create({'price_unit': 100})],
+        })
+
+        def _bypass(self, document, access_token, values, *args, **kwargs):
+            return values
+
+        with patch.object(PortalAccount, '_get_page_view_values', _bypass):
+            out_values = PortalAccount()._invoice_get_page_view_values(
+                out_invoice, out_invoice.access_token,
+            )
+            in_values = PortalAccount()._invoice_get_page_view_values(
+                in_invoice, in_invoice.access_token,
+            )
+
+        self.assertEqual(
+            out_values['backend_url'],
+            '/odoo/action-account.action_move_out_invoice_type/%s' % out_invoice.id,
+        )
+        self.assertEqual(
+            in_values['backend_url'],
+            '/odoo/action-account.action_move_in_invoice_type/%s' % in_invoice.id,
+        )

--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -113,7 +113,7 @@
         <xpath expr="//div[hasclass('o_portal_sidebar')]" position="inside">
             <t t-set="o_portal_fullwidth_alert" groups="sales_team.group_sale_salesman,account.group_account_invoice,account.group_account_readonly">
                 <t t-call="portal.portal_back_in_edit_mode">
-                    <t t-set="backend_url" t-value="'/odoo/action-account.action_move_out_invoice_type/%s' % invoice.id"/>
+                    <t t-set="backend_url" t-value="backend_url"/>
                 </t>
             </t>
 

--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import binascii
+from urllib.parse import urlparse
 
 from odoo import fields, http, _
 from odoo.exceptions import AccessError, MissingError, ValidationError
@@ -160,7 +161,12 @@ class CustomerPortal(payment_portal.PaymentPortal):
                     subtype_xmlid="sale.mt_order_viewed",
                 )
 
-        backend_url = f'/odoo/action-{order_sudo._get_portal_return_action().id}/{order_sudo.id}'
+        back = request.params.get('back', '')
+        if back:
+            parsed = urlparse(back)
+            backend_url = parsed.path + (('?' + parsed.query) if parsed.query else '')
+        else:
+            backend_url = f'/odoo/action-{order_sudo._get_portal_return_action().id}/{order_sudo.id}'
         values = {
             'sale_order': order_sudo,
             'product_documents': order_sudo._get_product_documents(),

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1326,10 +1326,13 @@ class SaleOrder(models.Model):
 
     def action_preview_sale_order(self):
         self.ensure_one()
+        back = request and request.httprequest.referrer or ''
         return {
             'type': 'ir.actions.act_url',
             'target': 'self',
-            'url': self.get_portal_url(),
+            'url': self.get_portal_url(
+                query_string=back and '&back=%s' % back,
+            ),
         }
 
     def action_update_taxes(self):


### PR DESCRIPTION
Before this commit when the user clicks "Back to edit mode", the backend would perform an action. this loses the browser url and causes the user to go back and land in website module.

This commit aims to fix the issue by saving the current url, and simply navigating back to it instead of doing hardcoded actions.

task-5882256
