### PR TITLE
[IMP] web: Make popover reposition on dom mutation

### DIFF
--- a/addons/web/static/src/core/position/position_hook.js
+++ b/addons/web/static/src/core/position/position_hook.js
@@ -4,6 +4,15 @@ import { omit } from "@web/core/utils/objects";
 import { useThrottleForAnimation } from "@web/core/utils/timing";
 import { EventBus, onWillDestroy } from "@odoo/owl";
 
+function getRectHash(element) {
+    if (element) {
+        const { x, y, height, width } = element.getBoundingClientRect();
+        return JSON.stringify([x, y, height, width]);
+    } else {
+        return null;
+    }
+}
+
 /**
  * @typedef {import("@web/core/position/utils").ComputePositionOptions} ComputePositionOptions
  * @typedef {import("@web/core/position/utils").PositioningSolution} PositioningSolution
@@ -41,6 +50,9 @@ export const POSITION_BUS = Symbol("position-bus");
 export function usePosition(refName, getTarget, options = {}) {
     const ref = useRef(refName);
     let lock = false;
+    let lastSolution = null;
+    let lastTargetRect = null;
+    const component = useComponent();
     const update = () => {
         const targetEl = getTarget();
         if (!ref.el || !targetEl?.isConnected || lock) {
@@ -53,10 +65,14 @@ export function usePosition(refName, getTarget, options = {}) {
         if (solution.direction !== "center") {
             options.position = `${solution.direction}-${solution.variant}`; // memorize last position
         }
-        options.onPositioned?.(ref.el, solution);
+
+        lastTargetRect = getRectHash(targetEl);
+        if (JSON.stringify(solution) !== lastSolution) {
+            lastSolution = JSON.stringify(solution);
+            options.onPositioned?.(ref.el, solution);
+        }
     };
 
-    const component = useComponent();
     const bus = component.env[POSITION_BUS] || new EventBus();
 
     let executingUpdate = false;
@@ -78,6 +94,12 @@ export function usePosition(refName, getTarget, options = {}) {
     }
 
     const throttledUpdate = useThrottleForAnimation(() => bus.trigger("update"));
+    const mutationObserver = new MutationObserver(() => {
+        if (getRectHash(getTarget()) !== lastTargetRect) {
+            throttledUpdate();
+        }
+    });
+
     useLayoutEffect(() => {
         // Reposition
         bus.trigger("update");
@@ -113,6 +135,10 @@ export function usePosition(refName, getTarget, options = {}) {
             for (const document of documents) {
                 document.addEventListener("scroll", scrollListener, { capture: true });
                 document.addEventListener("load", throttledUpdate, { capture: true });
+                mutationObserver.observe(document, {
+                    childList: true,
+                    subtree: true,
+                });
             }
             window.addEventListener("resize", throttledUpdate);
             return () => {
@@ -121,6 +147,7 @@ export function usePosition(refName, getTarget, options = {}) {
                     document.removeEventListener("load", throttledUpdate, { capture: true });
                 }
                 window.removeEventListener("resize", throttledUpdate);
+                mutationObserver.disconnect();
             };
         }
     });

--- a/addons/web/static/tests/core/popover/popover.test.js
+++ b/addons/web/static/tests/core/popover/popover.test.js
@@ -274,7 +274,7 @@ test("within iframe", async () => {
 
     await scroll(popoverTarget.ownerDocument.documentElement, { y: 100 }, { scrollable: false });
     await animationFrame();
-    expect.verifySteps(["bottom", "bottom"]);
+    expect.verifySteps(["bottom"]);
     popoverBox = comp.popoverRef.el.getBoundingClientRect();
     expectedTop -= 100;
     expect(Math.floor(popoverBox.top)).toBe(Math.floor(expectedTop));
@@ -371,12 +371,7 @@ test("popover with arrow and onPositioned", async () => {
         },
     });
 
-    expect.verifySteps([
-        "onPositioned (from override)",
-        "onPositioned (from props)", // On mounted
-        "onPositioned (from override)",
-        "onPositioned (from props)", // arrow repositionning -> triggers resize observer
-    ]);
+    expect.verifySteps(["onPositioned (from override)", "onPositioned (from props)"]);
     expect(".o_popover").toHaveClass("o_popover popover mw-100 bs-popover-auto");
     expect(".o_popover").toHaveAttribute("data-popper-placement", "center");
     expect(".o_popover > .popover-arrow").toHaveClass("position-absolute z-n1");
@@ -437,10 +432,7 @@ test("popover repositions when content changes", async () => {
     });
 
     expect(".o_popover").toHaveCount(1);
-    await expect.waitForSteps([
-        "onPositioned", // Initial positioning
-        "onPositioned", // Resize on render
-    ]);
+    await expect.waitForSteps(["onPositioned"]);
 
     // Click to expand content
     await contains("#popover button").click();

--- a/addons/web/static/tests/core/position/position_hook.test.js
+++ b/addons/web/static/tests/core/position/position_hook.test.js
@@ -1,16 +1,11 @@
 import { before, destroy, expect, getFixture, test } from "@odoo/hoot";
-import {
-    manuallyDispatchProgrammaticEvent,
-    queryOne,
-    queryRect,
-    resize,
-    scroll,
-} from "@odoo/hoot-dom";
+import { queryOne, queryRect, resize, scroll, click } from "@odoo/hoot-dom";
 import { Deferred, animationFrame } from "@odoo/hoot-mock";
 import { Component, onMounted, useRef, xml } from "@odoo/owl";
 import { defineParams, defineStyle, mountWithCleanup } from "@web/../tests/web_test_helpers";
 
 import { usePosition } from "@web/core/position/position_hook";
+import { useState } from "@web/owl2/utils";
 
 before(
     () =>
@@ -224,22 +219,6 @@ test("has no effect when component is destroyed", async () => {
     await animationFrame();
     // onPositioned not called even if scroll happened right before the component destroys
     expect.verifySteps([]);
-});
-
-test("reposition popper when a load event occurs", async () => {
-    const TestComp = getTestComponent({
-        onPositioned: () => {
-            expect.step("onPositioned called");
-        },
-    });
-
-    await mountWithCleanup(TestComp);
-    // onPositioned called when component mounted
-    expect.verifySteps(["onPositioned called"]);
-    manuallyDispatchProgrammaticEvent(queryOne("#popper"), "load");
-    await animationFrame();
-    // onPositioned called when load event is triggered
-    expect.verifySteps(["onPositioned called"]);
 });
 
 test("reposition popper when a scroll event occurs", async () => {
@@ -714,12 +693,13 @@ test("batch update call", async () => {
     class TestComponent extends Component {
         static template = xml`
             <div id="container" t-ref="container" style="background-color: salmon; display: flex; align-items: center; justify-content: center; width: 450px; height: 450px; margin: 25px; overflow: auto">
-                <div id="target" t-ref="target" style="background-color: tomato; width: 200px; height: 600px"/>
+                <div id="target" t-ref="target" style="background-color: tomato; width: 200px;" t-att-style="this.state.style"/>
                 <div id="popper" t-ref="popper" style="background-color: olive; height: 50px; width: 50px"/>
             </div>
         `;
         static props = ["*"];
         setup() {
+            this.state = useState({ style: "height: 600px" });
             const target = useRef("target");
             position = usePosition("popper", () => target.el, {
                 onPositioned: () => {
@@ -729,11 +709,14 @@ test("batch update call", async () => {
         }
     }
 
-    await mountWithCleanup(TestComponent);
+    const comp = await mountWithCleanup(TestComponent);
     expect.verifySteps(["positioned"]);
 
+    comp.state.style = "height: 650px";
     position.unlock();
+    comp.state.style = "height: 700px";
     position.unlock();
+    comp.state.style = "height: 750px";
     position.unlock();
     await animationFrame();
     expect.verifySteps(["positioned"]);
@@ -768,6 +751,57 @@ test("not positioned if target not connected", async () => {
     comp.position.unlock();
     await animationFrame();
     expect.verifySteps([]);
+});
+
+test("reposition on body dom mutation", async () => {
+    // We have to use two separate components to avoid re-render to
+    // cause the position update and instead be triggered by dom mutation
+
+    class TestComponentA extends Component {
+        static template = xml`
+            <button t-on-click="() => this.state.expanded = true">Expand</button>
+            <div t-if="this.state.expanded" style="height: 200px; width: 200px;">
+                Large content
+            </div>
+        `;
+        static props = ["*"];
+        setup() {
+            this.state = useState({ expanded: false });
+        }
+    }
+
+    class TestComponentB extends Component {
+        static template = xml`
+            <div t-ref="target">Target</div>
+            <div t-ref="popper" style="background: red">Popper</div>
+        `;
+        static props = ["*"];
+        setup() {
+            this.target = useRef("target");
+            this.position = usePosition("popper", () => this.target.el, {
+                onPositioned: () => {
+                    expect.step("positioned");
+                },
+            });
+        }
+    }
+
+    class Parent extends Component {
+        static template = xml`
+            <TestComponentA/>
+            <TestComponentB/>
+        `;
+        static components = { TestComponentA, TestComponentB };
+        static props = ["*"];
+    }
+
+    await mountWithCleanup(Parent);
+    await animationFrame();
+    expect.verifySteps(["positioned"]);
+
+    await click("button:contains(Expand)");
+    await animationFrame();
+    expect.verifySteps(["positioned"]);
 });
 
 function shrinkPopperTest(position, offset, onPositioned, popperStyle = {}) {


### PR DESCRIPTION
Popovers now reposition when a dom mutation happens on the document body

onPositioned callback is now also called only if the calculated position is different.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
