### PR TITLE
[FIX] payment_mollie: ensure billing address fields are strings

### DIFF
--- a/addons/payment_mollie/models/payment_transaction.py
+++ b/addons/payment_mollie/models/payment_transaction.py
@@ -102,11 +102,11 @@ class PaymentTransaction(models.Model):
         return {
             "givenName": given_name,
             "familyName": family_name,
-            "streetAndNumber": self.partner_address,
-            "postalCode": self.partner_zip,
-            "city": self.partner_city,
-            "country": self.partner_country_id.code,
-            "email": self.partner_email,
+            "streetAndNumber": self.partner_address or "",
+            "postalCode": self.partner_zip or "",
+            "city": self.partner_city or "",
+            "country": self.partner_country_id.code or "",
+            "email": self.partner_email or "",
         }
 
     @api.model


### PR DESCRIPTION
When a partner has no country (or other address fields) set, accessing `partner_country_id.code` (and similar Char fields) returns `False` in Odoo instead of an empty string. This caused Mollie's API to return a 422 error because it expects a string for `billingAddress.country`.

Add `or ""` fallbacks to all string fields in
`_mollie_prepare_billing_address_payload` to ensure valid JSON types are always sent.

opw-6037640

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
