### PR TITLE
[FIX] stock_account: allow accounting admin to see Inventory Valuation

### DIFF
--- a/addons/stock_account/models/res_company.py
+++ b/addons/stock_account/models/res_company.py
@@ -338,7 +338,7 @@ class ResCompany(models.Model):
             closing = self.env['account.move'].browse(closing_id).exists().filtered(lambda am: am.state == 'posted')
         if not closing:
             return False
-        am_state_field = self.env['ir.model.fields'].search([('model', '=', 'account.move'), ('name', '=', 'state')], limit=1)
+        am_state_field = self.env['ir.model.fields'].sudo().search([('model', '=', 'account.move'), ('name', '=', 'state')], limit=1)
         state_tracking = closing.message_ids.sudo().tracking_value_ids.filtered(lambda t: t.field_id == am_state_field).sorted('id')
         create_date = state_tracking[-1:].create_date
         if create_date and create_date.date() == closing.date:

--- a/addons/stock_account/tests/test_stockvaluation.py
+++ b/addons/stock_account/tests/test_stockvaluation.py
@@ -3179,3 +3179,23 @@ class TestStockValuation(TestStockValuationCommon):
                 {'added_value': -100, 'total_quantity': 10, 'total_value': 200, 'avco_value': 20},
             ]
         )
+
+    def test_accounting_user_can_reopen_inventory_valuation_report_after_closing(self):
+        """Ensure users with accounting privileges but not stock can reopen the Inventory Valuation
+        report after closing, without triggering access errors on technical models.
+        """
+
+        accounting_user = self._create_new_internal_user(
+            name='Accounting User',
+            login='accounting_user',
+            groups='account.group_account_manager',
+        )
+        accounting_user.write({
+            'company_id': self.company.id,
+            'company_ids': [Command.set(self.company.ids)],
+        })
+
+        self._make_in_move(self.product_standard, 10, unit_cost=10)
+        self.company.with_user(accounting_user).action_close_stock_valuation(at_date=Date.today(), auto_post=True)
+        report = self.env['stock_account.stock.valuation.report'].with_user(accounting_user)._get_report_data(date=Date.today())
+        self.assertTrue(report)


### PR DESCRIPTION
### Issue before this commit:
After generating a stock valuation closing entry from the Inventory Valuation report, reopening the report raised an access rights error. Users with Accounting permissions could no longer access the report.

### Steps to reproduce the issue:
1. Access the database with a user having Accounting Admin rights.
2. Go to the Inventory Valuation report.
3. Click to generate a closing entry.
4. Try to open the Inventory Valuation report again.
5. Result: System shows an access rights error.

### Cause of the issue:
The method _get_last_closing_date() retrieves the field state of the model account.move by querying the technical model ir.model.fields. However, accounting users do not have read access to this model. When the report tries to compute the last closing date after a closing entry exists, this lookup triggers an error.

### Reason to introduce the fix:
The lookup of account.move.state is only used internally to inspect tracking values in the chatter and determine the posting date of the closing entry. Since this requires reading a technical metadata model, the query is executed with sudo() to bypass the restriction while keeping the functional access to accounting data unchanged.

opw-5998151

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
