### PR TITLE
[IMP] account: invoice form view company domain

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -180,6 +180,11 @@ class AccountMove(models.Model):
         string='Ledger',
         store=False,
     )
+    journal_company_id = fields.Many2one(
+        'res.company',
+        related='journal_id.company_id',
+        string='Company of the Journal',
+    )
     company_id = fields.Many2one(
         comodel_name='res.company',
         string='Company',

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1567,7 +1567,7 @@
                                     </group>
                                     <group string="Accounting"
                                            name="accounting_info_group">
-                                        <field name="company_id" groups="base.group_multi_company"/>
+                                        <field name="company_id" groups="base.group_multi_company" domain="[('id', 'child_of', journal_company_id)]"/>
                                         <field name="invoice_incoterm_placeholder" invisible="1"/>    <!-- Needed for placeholder_field -->
                                         <field name="invoice_incoterm_id" options="{'placeholder_field': 'invoice_incoterm_placeholder'}" invisible="move_type in ('out_receipt', 'in_receipt')"/>
                                         <field name="incoterm_location" invisible="move_type in ('out_receipt', 'in_receipt')"/>


### PR DESCRIPTION
It only makes sense to change the company to one
of the children of the journal.  Whenever you change it to something else you get access errors anyways.

Hence, the idea to limit the domain of the company_id on the invoice.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
