### PR TITLE
[FIX] account: stabilize transfer wizard test setup

### DIFF
--- a/addons/account/tests/test_transfer_wizard.py
+++ b/addons/account/tests/test_transfer_wizard.py
@@ -17,7 +17,7 @@ class TestTransferWizard(AccountTestInvoicingCommon):
         cls.company = cls.company_data['company']
         cls.receivable_account = cls.company_data['default_account_receivable']
         cls.payable_account = cls.company_data['default_account_payable']
-        cls.accounts = cls.env['account.account'].search([('reconcile', '=', False), ('company_ids', '=', cls.company.id)], limit=5)
+        cls.accounts = cls.env['account.account'].search([('reconcile', '=', False), ('currency_id', '=', False), ('company_ids', '=', cls.company.id)], limit=5)
         cls.journal = cls.company_data['default_journal_misc']
 
         # Set rate for base currency to 1


### PR DESCRIPTION
Description of the issue this commit addresses:

test_transfer_wizard setUpClass selected generic non-reconcile accounts. In some charts one account enforces a secondary currency causing move_1.action_post() to fail with a UserError.

---

Desired behavior after this commit is merged:

This commit filters accounts to those without forced account currency so setup moves always post without changing tested business flows.

---

runbot-241090

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr