### PR TITLE
[FIX] web: render preview of reports

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -816,7 +816,8 @@
     <!-- Demo reports definition -->
     <template id="preview_internalreport">
         <t t-set="company" t-value="env.company"/>
-        <t t-call="web.html_container" o="res_company">
+        <t t-call="web.html_container">
+            <t t-set="o" t-value="res_company"/>
             <t t-call="web.internal_layout">
                 <div class="page">
                     <p>This is a sample of an internal report.</p>
@@ -826,7 +827,8 @@
     </template>
     <template id="preview_externalreport">
         <t t-set="company" t-value="env.company"/>
-        <t t-call="web.html_container" o="res_company">
+        <t t-call="web.html_container">
+            <t t-set="o" t-value="res_company"/>
             <t t-call="web.external_layout">
                 <div class="page">
                     <p>This is a sample of an external report.</p>
@@ -837,7 +839,8 @@
 
     <template id="preview_layout_report">
         <t t-set="company" t-value="env.company"/>
-        <t t-call="web.html_container" o="res_company">
+        <t t-call="web.html_container">
+            <t t-set="o" t-value="res_company"/>
             <t t-call="web.report_invoice_wizard_preview"/>
         </t>
     </template>


### PR DESCRIPTION
Under some conditions, it is currently not possible to render the preview of
some layouts

To reproduce the issue:
(Need `l10n_din5008`)
1. Open Settings more times than the number of companies in the database
   - (We actually need to increase the psql sequence of its table...)
2. Configure your document layout
   - Layout: DIN 5008
3. Click "Preview Document"

Error: an error is displayed: "Missing record: Record does not exist or has
been deleted. (Record: res.company(4,), User: 2)"

When clicking on _Preview Document_, we are actually requesting
`/report/pdf/web.preview_externalreport/4`
Where we have both the report name and the `docids` (equal to `4` in the above
example). Since we are calling it from the `res.config.settings`, we provide
the doc IDs with the ID of the `res.config.settings`. However, the report is
based on the `res.company` model:
https://github.com/odoo/odoo/blob/2f64f909d2f20cc8c0a8e95ba7d17348b9b015e6/addons/base_setup/views/res_config_settings_views.xml#L90
https://github.com/odoo/odoo/blob/e602fc2279e85b66c9983741df5d84fab42a3c44/addons/web/views/report_templates.xml#L1006-L1010
As a consequence, the mechanism will try to render the report using the
company with ID equal to the ID of the config settings, which does not make
sense. This is the reason why, at some point, it can lead to a `Missing
Record` error.

That said, the case is working well on previous versions because we were
defining a global `o` variable before rendering the template, cf for
instance on Odoo 19, L896:
https://github.com/odoo/odoo/blob/1c2e17718e6f2a11d93585f0ea3ba3abee5a4a41/addons/web/views/report_templates.xml#L893-L897
Thanks to that variable, DIN 5008 side, we ignore the `docs`, cf here for
instance:
https://github.com/odoo/odoo/blob/dae4fd0000080ba6395b370e25d3f13f1becd74e/addons/l10n_din5008/report/din5008_report.xml#L96

On Odoo 19.1+, this global variable has been removed by [1]. This commit is
actually the result of a script (cf its description). Since the script
hasn't detected the use of `o`, it moved its declaration inside the previous
`t-call`, L829:
https://github.com/odoo/odoo/blob/e602fc2279e85b66c9983741df5d84fab42a3c44/addons/web/views/report_templates.xml#L827-L830
This was a mistake since the global variable is sometimes used. Long story
short, the script didn't see the dynamic `t-call` inside the template of
`web.external_layout`:
https://github.com/odoo/odoo/blob/e602fc2279e85b66c9983741df5d84fab42a3c44/addons/web/views/report_templates.xml#L758-L761

We have therefore decided to revert this part of the commit and apply the
same logic to its siblings `preview_internalreport` and `preview_layout_report`

[1] https://github.com/odoo/odoo/commit/b7ec60d68c6ee23f7684960e33e5bd6290c9d829

OPW-5951003