### PR TITLE
[FIX] purchase_{requisition, stock}: cancel all the alternate unselected po

### DIFF
--- a/addons/purchase_requisition/models/purchase.py
+++ b/addons/purchase_requisition/models/purchase.py
@@ -315,10 +315,12 @@ class PurchaseOrderLine(models.Model):
         return False
 
     def action_choose(self):
+        if self.order_id.state == 'cancel':
+            self.order_id.button_draft()
         order_lines = (self.order_id | self.order_id.alternative_po_ids).mapped('order_line')
         order_lines = order_lines.filtered(lambda l: l.product_qty and l.product_id.id in self.product_id.ids and l.id not in self.ids)
         if order_lines:
-            return order_lines.action_clear_quantities()
+            return order_lines.order_id.button_cancel()
         return {
             'type': 'ir.actions.client',
             'tag': 'display_notification',

--- a/addons/purchase_requisition/tests/test_purchase_requisition.py
+++ b/addons/purchase_requisition/tests/test_purchase_requisition.py
@@ -262,14 +262,22 @@ class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
         self.assertEqual(len(groups), 0, "The group should have auto-deleted")
 
     def test_09_alternative_po_line_price_unit(self):
-        """Checks PO line's `price_unit` is keep even if a line from an
-        alternative is chosen and thus the PO line's quantity was set to 0. """
+        """Checks PO line's `price_unit` is kept even if a line from an
+        alternative is chosen. """
+        self.product_09.seller_ids = [
+            Command.create({
+                'partner_id': self.res_partner_1.id,
+                'price': 100,
+                'min_qty': 1,
+            })
+        ]
+
         # Creates a first Purchase Order.
         po_form = Form(self.env['purchase.order'])
         po_form.partner_id = self.res_partner_1
         with po_form.order_line.new() as line:
             line.product_id = self.product_09
-            line.product_qty = 1
+            line.product_qty = 2
             line.price_unit = 16
         po_1 = po_form.save()
 
@@ -287,11 +295,33 @@ class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
         po_2.order_line.action_choose()
 
         self.assertEqual(
-            po_1.order_line.product_uom_qty, 0,
-            "Line's quantity from the original PO should be reset to 0")
+            po_1.order_line.product_uom_qty, 2,
+            "The original PO line quantity should remain 2")
         self.assertEqual(
             po_1.order_line.price_unit, 16,
             "Line's unit price from the original PO shouldn't be changed")
+        self.assertEqual(
+            po_1.state, 'cancel',
+            "The original PO should be cancelled"
+        )
+
+        po_1.order_line.action_choose()
+        self.assertEqual(
+            po_1.state, 'draft',
+            "The original PO should be reset to draft"
+        )
+        self.assertEqual(
+            po_2.state, 'cancel',
+            "The second PO should be cancelled"
+        )
+        self.assertEqual(
+            po_2.order_line.product_uom_qty, 2,
+            "Line's quantity from the second PO should remain 2"
+        )
+        self.assertEqual(
+            po_2.order_line.price_unit, 12,
+            "Line's unit price from the second PO shouldn't be changed"
+        )
 
     def test_10_alternative_po_line_price_unit_different_uom(self):
         """ Check that the uom is copied in the alternative PO, and the "unit_price"


### PR DESCRIPTION
**Issue**:
Choosing a PO among several alternative POs resets the price of all the unselected ones.

**Steps to reproduce**:
- Create a storable product with a standard price of 1
- Add two vendors for a quantity of 1 with a unit price 1.1 and 1.2
- Create a PO for one vendor with 10 units at price 1.3
- Create an alternative PO for the other vendor with 10 units at price 1.4
- Compare the POs and choose the first one
-> The unit price of the second one (1.4) is reset to the standard price (1)

**Cause**:
When choosing a PO, the quantities of alternative POs are reset to 0:
https://github.com/odoo/odoo/blob/1b5072c0e0af6be340389e0c429ca370d8dc169d/addons/purchase_requisition/models/purchase.py#L317-L321
https://github.com/odoo/odoo/blob/1b5072c0e0af6be340389e0c429ca370d8dc169d/addons/purchase_requisition/models/purchase.py#L304
which will trigger the `_compute_price_unit_and_date_planned_and_name`.
Since the quantity no longer matches any vendor, no seller is found (10 on the pol and 1 in vendor):
https://github.com/odoo/odoo/blob/f5a24b10cb3a4cf32c6c185df65f3099c8da3ff1/addons/purchase/models/purchase.py#L1198-L1203
but `unavailable_seller` is found, since the quantity is not in the search
https://github.com/odoo/odoo/blob/f5a24b10cb3a4cf32c6c185df65f3099c8da3ff1/addons/purchase/models/purchase.py#L1210-L1215
As a result, the price is recomputed using `standard_price`:
https://github.com/odoo/odoo/blob/f5a24b10cb3a4cf32c6c185df65f3099c8da3ff1/addons/purchase/models/purchase.py#L1218

**Solution**
Cancel unselected alternative POs instead of resetting their quantities to 0.
This avoids triggering `_compute_price_unit_and_date_planned_and_name` and preserves original prices.

opw-[6022718](https://www.odoo.com/web#id=6022718&view_type=form&model=project.task)