### PR TITLE
[FIX] l10n_es_pos: remove id from pricelist_id in payment_screen

### DIFF
--- a/addons/l10n_es_pos/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/l10n_es_pos/static/src/overrides/components/payment_screen/payment_screen.js
@@ -28,7 +28,7 @@ patch(PaymentScreen.prototype, {
                 if (!order.partner_id && order.to_invoice) {
                     const setPricelist =
                         this.pos.config.pricelist_id?.id != order.pricelist_id?.id
-                            ? order.pricelist_id.id
+                            ? order.pricelist_id
                             : false;
                     const setFiscalPosition =
                         this.pos.config.default_fiscal_position_id?.id !=


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

pass id

Desired behavior after PR is merged:

pass object, same that 19.0 

https://github.com/odoo/odoo/blob/2e20e9a1a328757cc8a19261af3ba2287fb23558/addons/l10n_es_pos/static/src/app/utils/order_payment_validation.js#L44


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
