### PR TITLE
[FIX] pos_event: allow unlimited tickets with multi slots in pos

### DIFF
--- a/addons/pos_event/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/pos_event/static/src/app/screens/product_screen/product_screen.js
@@ -95,7 +95,7 @@ patch(ProductScreen.prototype, {
                 return acc;
             }, {});
             const isAvailable = Object.values(avaibilityByTicket).some((av) =>
-                Object.values(av).some((a) => typeof a === "number" && a > 0)
+                Object.values(av).some((a) => (typeof a === "number" && a > 0) || a === "unlimited")
             );
             if (!isAvailable || eventSeats === 0) {
                 this.notification.add("All slots are booked out for this event.", {

--- a/addons/pos_event/static/tests/tours/pos_multi_slot_event_tour.js
+++ b/addons/pos_event/static/tests/tours/pos_multi_slot_event_tour.js
@@ -54,3 +54,17 @@ registry.category("web_tour.tours").add("SellingMultiSlotEventInPos", {
             SlotSelectionScreen.assertDisabledSlot("08:00"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_multislot_unlimited_qty", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("My Awesome Event"),
+            SlotSelectionScreen.clickDisplayedSlot("08:00"),
+            Dialog.confirm(),
+            EventTourUtils.increaseQuantityOfTicket("Ticket Basic"),
+            Dialog.confirm(),
+            Dialog.confirm(),
+        ].flat(),
+});

--- a/addons/pos_event/tests/test_frontend.py
+++ b/addons/pos_event/tests/test_frontend.py
@@ -303,3 +303,32 @@ class TestUi(TestPointOfSaleHttpCommon):
         r_empty = partner_registrations.filtered(lambda r: r.name == "Event Parter")
         self.assertEqual(len(r_empty), 1)
         self.assertEqual(r_empty.email, "event@partner.com")
+
+    def test_multislot_unlimited_qty(self):
+        self.pos_user.write({
+            'group_ids': [
+                (4, self.env.ref('event.group_event_user').id),
+            ]
+        })
+        self.main_pos_config.write({
+            "limit_categories": True,
+            "iface_available_categ_ids": [(6, 0, [self.event_category.id])],
+        })
+
+        slot_1 = self.env['event.slot'].create([
+            {
+                'date': self.test_event.date_begin.date() + datetime.timedelta(days=2),
+                'start_hour': 8,
+                'end_hour': 9,
+                'event_id': self.test_event.id,
+            },
+        ])
+        self.test_event.write({
+            'is_multi_slots': True,
+            'seats_limited': False,
+            'seats_max': 0,
+            'event_slot_ids': [(6, 0, slot_1.ids)],
+        })
+        self.test_event.event_ticket_ids.write({'seats_max': 0})
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_multislot_unlimited_qty', login="pos_user")


### PR DESCRIPTION
**Steps to reproduce:**
- Make an event, put it to announced state
- Allow multi slots and create a product
- Go to the pos and try to order it
- "All slots are booked out for this event" appears

**Why the fix:**
When we set 0 as a maximum quantity for an event slot, the quantity is unlimited, in the code, the availability is set to a string "unlimited".
This was not taken into account in the case of multi slots, as we only checked if the availability was a number greater than 0.
As "unlimited" is not a number, we thought we didn't have any slots available and returned the error that said all slots were full.

We now add the unlimited tickets to the availability list.

opw-6006696