### PR TITLE
[18.0][FIX] Inactive mail templates should not send mail.

### DIFF
--- a/addons/calendar/models/calendar_attendee.py
+++ b/addons/calendar/models/calendar_attendee.py
@@ -128,6 +128,8 @@ class Attendee(models.Model):
         if not mail_template:
             _logger.warning("No template passed to %s notification process. Skipped.", self)
             return False
+        if not mail_template.active:
+            return False
 
         # get ics file for all meetings
         ics_files = notified_attendees.event_id._get_ics_file()

--- a/addons/calendar/tests/test_event_notifications.py
+++ b/addons/calendar/tests/test_event_notifications.py
@@ -78,6 +78,11 @@ class TestEventNotifications(TransactionCase, MailCase, CronMixinCase):
         with self.assertNoNotifications():
             self.event.partner_ids = self.partner
 
+    def test_message_inactive_template(self):
+        self.env['mail.template'].search([]).active = False
+        with self.assertNoNotifications():
+            self.event.partner_ids = self.partner
+
     def test_message_set_inactive_invite(self):
         self.event.active = False
         with self.assertNoNotifications():


### PR DESCRIPTION
#### Description of the issue/feature this PR addresses:

The `active` field on `mail.template` is ignored.

#### Current behavior before PR:

Inactive `mail.template` records send email.

#### Desired behavior after PR is merged:

Inactive `mail.template` records do not send email.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
