### PR TITLE
[FIX] mail: correct messaging menu counter when not using Discuss

### DIFF
--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -19,7 +19,14 @@ class DiscussChannelWebclientController(WebclientController):
         store.add_global_values(
             has_unpinned_channels=request.env["discuss.channel.member"]
             .sudo()
-            .search_count([("is_self", "=", True), ("is_pinned", "=", False)], limit=1)
+            .search_count(
+                [
+                    ("is_self", "=", True),
+                    ("is_pinned", "=", False),
+                    ("channel_id.active", "=", True),
+                ],
+                limit=1,
+            )
             > 0,
         )
 
@@ -95,9 +102,18 @@ class DiscussChannelWebclientController(WebclientController):
     @classmethod
     def _store_init_messaging_global_fields(cls, res: Store.FieldList, bus_last_id):
         members = request.env["discuss.channel.member"].search_fetch(
-            [("is_self", "=", True), ("is_pinned", "=", True)],
+            [
+                ("is_self", "=", True),
+                ("is_pinned", "=", True),
+                ("channel_id.active", "=", True),
+                ("mute_until_dt", "=", False),
+            ],
         )
-        members_with_unread = members.filtered(lambda member: member.message_unread_counter)
+        members_with_unread = members.filtered(
+            lambda member: (
+                member.message_unread_counter or member.channel_id.message_needaction_counter
+            )
+        )
         res.attr("initChannelsUnreadCounter", len(members_with_unread))
         # fetch channels data before calling super to benefit from prefetching (channel info might
         # prefetch a lot of data that super could use, about the current user in particular)

--- a/addons/mail/static/src/discuss/core/web/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/web/store_service_patch.js
@@ -18,6 +18,7 @@ const StorePatch = {
             this.channels.status !== "fetched"
                 ? this.initChannelsUnreadCounter
                 : Object.values(this.store["discuss.channel"].records).filter(
+                      // Same conditions as the computed value of `initChannelsUnreadCounter`
                       (channel) =>
                           channel.self_member_id?.is_pinned &&
                           !channel.self_member_id?.mute_until_dt &&

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
 from unittest.mock import patch, PropertyMock
@@ -228,6 +229,14 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             name="group restricted channel 2", group_id=self.env.ref("base.group_user").id
         )
         self.channel_channel_group_2._add_members(users=self.users[0] | self.users[2] | self.users[6] | self.users[7] | self.users[13])
+        self.channel_channel_group_3 = Channel._create_channel(
+            name="group restricted channel 3 (archived)", group_id=self.env.ref("base.group_user").id
+        )
+        self.channel_channel_group_3._add_members(users=self.users[0] | self.users[2])
+        self.channel_channel_group_4 = Channel._create_channel(
+            name="group restricted channel 4 (muted)", group_id=self.env.ref("base.group_user").id
+        )
+        self.channel_channel_group_4._add_members(users=self.users[0] | self.users[2])
         # create chats
         self.channel_chat_1 = Channel._get_or_create_chat((self.users[0] + self.users[14]).partner_id.ids)
         self.channel_chat_2 = Channel._get_or_create_chat((self.users[0] + self.users[15]).partner_id.ids)
@@ -274,7 +283,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         }, cookies={
             self.guest._cookie_name: self.guest._format_auth_cookie(),
         })
-        # add needaction
+        # add needaction messages
         self.users[0].notification_type = 'inbox'
         message_0 = self.channel_channel_public_1.message_post(
             body="test",
@@ -285,6 +294,17 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         members = self.channel_channel_public_1.channel_member_ids
         member = members.filtered(lambda m: m.partner_id == self.users[0].partner_id).with_user(self.users[0])
         member._mark_as_read(message_0.id)
+        # add unread messages
+        self.channel_channel_group_3.with_user(self.users[2]).message_post(
+            body="archived_channel's message",
+            message_type="comment",
+            author_id=self.users[2].partner_id.id,
+        )
+        self.channel_channel_group_4.with_user(self.users[2]).message_post(
+            body="muted_channel's message",
+            message_type="comment",
+            author_id=self.users[2].partner_id.id,
+        )
         # add star
         message_0.toggle_message_starred()
         self.env.company.sudo().name = 'YourCompany'
@@ -313,6 +333,10 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         self.authenticate(self.users[2].login, self.password)
         self._add_reactions(message_0, ["😊", "😁"])
         self._add_reactions(message_1, ["😊", "😁", "👍"])
+        # add archive / muted on channels
+        self.channel_channel_group_3.active = False
+        channel_group_4_member = self.channel_channel_group_4.channel_member_ids.filtered(lambda m: m.partner_id == self.users[0].partner_id)
+        channel_group_4_member.mute_until_dt = datetime.max
         self.env.cr.precommit.run()  # trigger the creation of bus.bus records
 
     def _add_reactions(self, message, reactions):
@@ -508,7 +532,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                     "id": "starred",
                     "model": "mail.box",
                 },
-                "initChannelsUnreadCounter": 3,
+                "initChannelsUnreadCounter": 4,
             },
         }
 
@@ -530,6 +554,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 self._expected_result_for_channel(self.channel_channel_public_2),
                 self._expected_result_for_channel(self.channel_channel_group_1),
                 self._expected_result_for_channel(self.channel_channel_group_2),
+                self._expected_result_for_channel(self.channel_channel_group_4),
                 self._expected_result_for_channel(self.channel_chat_1),
                 self._expected_result_for_channel(self.channel_chat_2),
                 self._expected_result_for_channel(self.channel_chat_3),
@@ -545,6 +570,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 self._res_for_member(self.channel_channel_group_1, self.users[0].partner_id),
                 self._res_for_member(self.channel_channel_group_1, self.users[2].partner_id),
                 self._res_for_member(self.channel_channel_group_2, self.users[0].partner_id),
+                self._res_for_member(self.channel_channel_group_4, self.users[0].partner_id),
                 self._res_for_member(self.channel_chat_1, self.users[0].partner_id),
                 self._res_for_member(self.channel_chat_1, self.users[14].partner_id),
                 self._res_for_member(self.channel_chat_2, self.users[0].partner_id),
@@ -579,6 +605,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 self._expected_result_for_message(self.channel_channel_public_2),
                 self._expected_result_for_message(self.channel_channel_group_1),
                 self._expected_result_for_message(self.channel_channel_group_2),
+                self._expected_result_for_message(self.channel_channel_group_4),
                 self._expected_result_for_message(self.channel_livechat_1),
                 self._expected_result_for_message(self.channel_livechat_2),
             ),
@@ -595,6 +622,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 self._expected_result_for_thread(self.channel_channel_public_2),
                 self._expected_result_for_thread(self.channel_channel_group_1),
                 self._expected_result_for_thread(self.channel_channel_group_2),
+                self._expected_result_for_thread(self.channel_channel_group_4),
                 self._expected_result_for_thread(self.channel_livechat_1),
                 self._expected_result_for_thread(self.channel_livechat_2),
             ),
@@ -763,6 +791,28 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "parent_channel_id": False,
                 "uuid": channel.uuid,
             }
+        if channel == self.channel_channel_group_4:
+            return {
+                "avatar_cache_key": channel.avatar_cache_key,
+                "channel_type": "channel",
+                "create_uid": self.env.user.id,
+                "default_display_mode": False,
+                "description": False,
+                "discuss_category_id": False,
+                "fetchChannelInfoState": "fetched",
+                "from_message_id": False,
+                "group_ids": [],
+                "group_public_id": self.env.ref("base.group_user").id,
+                "id": channel.id,
+                "is_editable": True,
+                "last_interest_dt": last_interest_dt,
+                "member_count": 2,
+                "message_needaction_counter_bus_id": bus_last_id,
+                "message_needaction_counter": 0,
+                "name": "group restricted channel 4 (muted)",
+                "parent_channel_id": False,
+                "uuid": channel.uuid,
+            }
         if channel == self.channel_group_1:
             return {
                 "avatar_cache_key": channel.avatar_cache_key,
@@ -924,6 +974,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         member_12 = members.filtered(lambda m: m.partner_id == self.users[12].partner_id)
         member_14 = members.filtered(lambda m: m.partner_id == self.users[14].partner_id)
         member_15 = members.filtered(lambda m: m.partner_id == self.users[15].partner_id)
+        first_message = channel.message_ids.sorted(lambda message: message.id)[:1]
         last_message = channel._get_last_messages()
         last_message_of_partner_0 = self.env["mail.message"].search(
             Domain("author_id", "=", member_0.partner_id.id)
@@ -1044,6 +1095,48 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "partner_id": self.users[0].partner_id.id,
                 "rtc_inviting_session_id": False,
                 "seen_message_id": last_message.id,
+                "unpin_dt": False,
+                "channel_id": channel.id,
+            }
+        if channel == self.channel_channel_group_4 and partner == self.users[0].partner_id:
+            return {
+                "channel_role": "owner",
+                "create_date": member_0_create_date,
+                "custom_channel_name": False,
+                "custom_notifications": False,
+                "fetched_message_id": first_message.id,
+                "id": member_0.id,
+                "is_favorite": False,
+                "last_interest_dt": member_0_last_interest_dt,
+                "message_unread_counter": 1,
+                "message_unread_counter_bus_id": bus_last_id,
+                "mute_until_dt": "9999-12-31 23:59:59",
+                "last_seen_dt": member_0_last_seen_dt,
+                "new_message_separator": first_message.id + 1,
+                "partner_id": self.users[0].partner_id.id,
+                "rtc_inviting_session_id": False,
+                "seen_message_id": first_message.id,
+                "unpin_dt": False,
+                "channel_id": channel.id,
+            }
+        if channel == self.channel_channel_group_4 and partner == self.users[2].partner_id:
+            return {
+                "channel_role": False,
+                "create_date": member_0_create_date,
+                "custom_channel_name": False,
+                "custom_notifications": False,
+                "fetched_message_id": first_message.id,
+                "id": member_2.id,
+                "is_favorite": False,
+                "last_interest_dt": member_0_last_interest_dt,
+                "message_unread_counter": 1,
+                "message_unread_counter_bus_id": bus_last_id,
+                "mute_until_dt": "9999-12-31 23:59:59",
+                "last_seen_dt": member_0_last_seen_dt,
+                "new_message_separator": first_message.id + 1,
+                "partner_id": self.users[0].partner_id.id,
+                "rtc_inviting_session_id": False,
+                "seen_message_id": first_message.id,
                 "unpin_dt": False,
                 "channel_id": channel.id,
             }
@@ -1508,6 +1601,39 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "trackingValues": [],
                 "write_date": write_date,
             }
+        if channel == self.channel_channel_group_4:
+            return {
+                "attachment_ids": [],
+                "author_guest_id": False,
+                "author_id": user_2.partner_id.id,
+                "body": ["markup", "<p>muted_channel's message</p>"],
+                "create_date": create_date,
+                "date": date,
+                "default_subject": "group restricted channel 4 (muted)",
+                "email_from": '"test2" <test2@example.com>',
+                "id": last_message.id,
+                "incoming_email_cc": False,
+                "incoming_email_to": False,
+                "message_link_preview_ids": [],
+                "message_type": "comment",
+                "model": "discuss.channel",
+                "needaction": False,
+                "notification_ids": [],
+                "parent_id": False,
+                "partner_ids": [],
+                "pinned_at": False,
+                "rating_id": False,
+                "reactions": [],
+                "record_name": "group restricted channel 4 (muted)",
+                "res_id": channel.id,
+                "scheduledDatetime": False,
+                "starred": False,
+                "subject": False,
+                "subtype_id": self.env.ref("mail.mt_note").id,
+                "thread": {"id": channel.id, "model": "discuss.channel"},
+                "trackingValues": [],
+                "write_date": write_date,
+            }
         if channel == self.channel_livechat_1:
             return {
                 "attachment_ids": [],
@@ -1849,6 +1975,8 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             return {**common_data, "display_name": "group restricted channel 1"}
         if channel == self.channel_channel_group_2:
             return {**common_data, "display_name": "group restricted channel 2"}
+        if channel == self.channel_channel_group_4:
+            return {**common_data, "display_name": "group restricted channel 4 (muted)"}
         if channel == self.channel_livechat_1:
             return {**common_data, "display_name": "test1 Ernest Employee"}
         if channel == self.channel_livechat_2:


### PR DESCRIPTION
Before this commit, when page loading in the webclient while not using Discuss (Discuss app closed, no chat window and bubble), the messaging menu counter could be wrong.

Steps to reproduce:
- Open Discuss app
- Make a new channel
- Post a message in this channel
- Mark conversation as unread
- Open Advanced settings of this channel
- Archive this channel
- Go back to home menu
- (make sure no chat windows and chat bubbles are open)
- Reload the page

=> The counter of messaging menu should be over-estimated by 1. For example if all conversations are read, counter is 1 instead of 0. Opening the messaging menu refreshes the counter to correct value 0.

This happens because when using Discuss, the counter is deduced from all channels that have been fetched and for which current user is a member of these channels. Implicitly, archived channels are filtered out.

However when not using discuss, the channels as member have not been fetched, and instead an estimation of the counter is fetched from server. This counter was computed on channel members that have unread messages. When a channel is archived, that doesn't mean the members are archived too. In the steps listed above, the self member is still active. As a result, the self member of this archived channel had contribution to the counter estimation, hence the value of 1 instead of 0.

This commit fixes the issue by keeping computation on channel members but it checks also that the channel is active, as the resulting counter is based on active channels.

This commit also fixed a similar issue where the counter was wrongly taking muted channels into account on the global counter when not using Discuss. This lead to a similar problem on non-archived but muted channels were they contribute in the estimated counter but not in the actual in-use counter.

Task-6014754