### PR TITLE
[FIX] base: Related One2many should not require relation_field

### DIFF
--- a/odoo/addons/base/views/ir_model_views.xml
+++ b/odoo/addons/base/views/ir_model_views.xml
@@ -70,9 +70,9 @@
                                                         invisible="ttype != 'many2one'"
                                                         readonly="ttype != 'many2one'"/>
                                                     <field name="relation_field"
-                                                        invisible="ttype != 'one2many'"
+                                                        invisible="ttype != 'one2many' or related or compute"
                                                         readonly="ttype != 'one2many'"
-                                                        required="ttype == 'one2many'"/>
+                                                        required="ttype == 'one2many' and not related and not compute"/>
                                                     <field name="relation_table" groups="base.group_no_one"
                                                         invisible="ttype != 'many2many' or state != 'manual'"
                                                         readonly="ttype != 'many2many' or state != 'manual'"/>
@@ -97,7 +97,7 @@
                                                 </field>
                                             </group>
                                         </page>
-                                        <page name="compute" string="Compute" groups="base.group_no_one">
+                                        <page name="compute" string="Compute" groups="base.group_no_one" invisible="ttype == 'one2many' and relation_field">
                                             <group>
                                                 <field name="related"/>
                                                 <field name="depends" required="compute not in [False, '']"/>
@@ -262,9 +262,9 @@
                                             invisible="ttype != 'many2one'"
                                             readonly="ttype != 'many2one'"/>
                                         <field name="relation_field"
-                                            invisible="ttype != 'one2many'"
+                                            invisible="ttype != 'one2many' or related or compute"
                                             readonly="ttype != 'one2many'"
-                                            required="ttype == 'one2many'"/>
+                                            required="ttype == 'one2many' and not related and not compute"/>
                                         <field name="relation_model_field"
                                             invisible="ttype != 'many2one_reference'"
                                             readonly="ttype != 'many2one_reference'"
@@ -326,7 +326,7 @@
                                     </field>
                                 </group>
                             </page>
-                            <page name="compute" string="Compute" groups="base.group_no_one">
+                            <page name="compute" string="Compute" groups="base.group_no_one" invisible="ttype == 'one2many' and relation_field">
                                 <group>
                                     <field name="related"/>
                                     <field name="depends" required="bool(compute) and store"/>


### PR DESCRIPTION
Related One2many fields should not have a relation_field like a normal One2many field does, but the form view requires it for all One2many fields.

Steps to reproduce
- Create a related field that gets its value from a One2many field.
- Go to settings > technical > fields and search for the field you made.
- The Relation Field will be empty but required, preventing any changes to the field without adding one.

Solution
Make the relation_field invisible and not required if the related field is set.

opw-6042504