### PR TITLE
[FIX] calendar: add csrf token, use keepquery, remove decline url

### DIFF
--- a/addons/calendar/data/mail_template_data.xml
+++ b/addons/calendar/data/mail_template_data.xml
@@ -256,12 +256,6 @@
         This is a reminder for the below event:
     </p>
     <div style="text-align: center; padding: 16px 0px 16px 0px;">
-        <a t-attf-href="/calendar/{{ 'recurrence' if recurrent else 'meeting' }}/accept?token={{ object.access_token }}&amp;id={{ object.event_id.id }}"
-            style="padding: 5px 10px; color: #FFFFFF; text-decoration: none; background-color: #875A7B; border: 1px solid #875A7B; border-radius: 3px">
-            Accept</a>
-        <a t-attf-href="/calendar/{{ 'recurrence' if recurrent else 'meeting' }}/decline?token={{ object.access_token }}&amp;id={{ object.event_id.id }}"
-            style="padding: 5px 10px; color: #FFFFFF; text-decoration: none; background-color: #875A7B; border: 1px solid #875A7B; border-radius: 3px">
-            Decline</a>
         <a t-attf-href="/calendar/meeting/view?token={{ object.access_token }}&amp;id={{ object.event_id.id }}" 
             style="padding: 5px 10px; color: #FFFFFF; text-decoration: none; background-color: #875A7B; border: 1px solid #875A7B; border-radius: 3px">
             View</a>

--- a/addons/calendar/views/calendar_templates.xml
+++ b/addons/calendar/views/calendar_templates.xml
@@ -19,14 +19,12 @@
                     <div class="card-body">
                         <div class="clearfix mb16 d-flex justify-content-between align-content-center flex-grow-0">
                             <div class="col d-flex">
-                                <form t-if="attendee.state != 'accepted'" method="POST" action="/calendar/meeting/accept" class="me-1 d-inline-block">
-                                    <input t-foreach="request.httprequest.args.items()" t-as="request_arg" t-if="request_arg[0] != 'confirm_needed'"
-                                           type="hidden" t-att-name="request_arg[0]" t-att-value="request_arg[1]"/>
+                                <form t-if="attendee.state != 'accepted'" method="POST" t-attf-action="/calendar/meeting/accept?{{keep_query()}}" class="me-1 d-inline-block">
+                                    <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
                                     <button type="submit" role="button" class="btn btn-primary btn-block">Accept</button>
                                 </form>
-                                <form t-if="attendee.state != 'declined'" method="POST" action="/calendar/meeting/decline" class="ms-1 d-inline-block">
-                                    <input t-foreach="request.httprequest.args.items()" t-as="request_arg" t-if="request_arg[0] != 'confirm_needed'"
-                                           type="hidden" t-att-name="request_arg[0]" t-att-value="request_arg[1]"/>
+                                <form t-if="attendee.state != 'declined'" method="POST" t-attf-action="/calendar/meeting/decline?{{keep_query()}}" class="ms-1 d-inline-block">
+                                    <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
                                     <button type="submit" role="button" class="btn btn-danger btn-block">Decline</button>
                                 </form>
                             </div>


### PR DESCRIPTION
Add a csrf token in the form which is required for post requests.

Additionally, post requests form values are stored on the form
attribute of the request rather than args which makes the
keep_query implementation janky, as the form is only filled
if coming from a get url.

Instead just keep using keep_query in the action, only including
csrf in post values.

Finally a couple action urls were missed in mail templates.

related: 0e57ff9cbc87c83276bdb823c5fb08cd4d2806f9

task-4555579
