### PR TITLE
[FIX] account: include missing company_dependent on avatax settings

### DIFF
--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -63,7 +63,7 @@
                                 <field name="module_account_taxcloud" widget="upgrade_boolean"/>
                             </setting>
                             <setting id="avatax_settings" string="AvaTax" help="Automatically compute tax rates"
-                                documentation="/applications/finance/accounting/taxation/taxes/avatax.html">
+                                documentation="/applications/finance/accounting/taxation/taxes/avatax.html" company_dependent="1">
                                 <field name="module_account_avatax" widget="upgrade_boolean"/>
                             </setting>
                             <setting id="eu_service" title="If you sell goods and services to customers in a foreign EU country, you must charge VAT based on the delivery address. This rule applies regardless of where you are located." documentation="/applications/finance/accounting/taxation/taxes/eu_distance_selling.html" help="Apply VAT of the EU country to which goods and services are delivered.">


### PR DESCRIPTION
Since the beginning `account_avatax` has had all of it's data stored on the company, however, it missed the company_dependent key in settings to mark it as such.

This commit fixes that.

task-none