### PR TITLE
[FIX] hr_holidays: fix traceback on group allocations

### DIFF
--- a/addons/hr_holidays/tests/test_allocations.py
+++ b/addons/hr_holidays/tests/test_allocations.py
@@ -105,6 +105,16 @@ class TestAllocations(TestHrHolidaysCommon):
         })
         allocation_wizard.action_generate_allocations()
 
+    def test_group_allocation_wizard_work_entry_type_domain(self):
+        """Test that work_entry_type_id field can be accessed without domain errors."""
+        wizard = self.env['hr.leave.allocation.generate.multi.wizard'].create({
+            'work_entry_type_id': self.work_entry_type.id,
+        })
+        self.env['hr.work.entry.type'].search(
+            wizard._domain_work_entry_type_id()
+        )
+        self.assertTrue(True, "Domain evaluation succeeded")
+
     def test_allocation_request_day(self):
         self.work_entry_type.write({
             'name': 'Custom Time Off Test',


### PR DESCRIPTION
Steps to reproduce:
--------------------------------------
1. Install Time off module
2. Navigate to Time off > Management > Allocations
3. Click on the 'New Group Allocation' button
4. Click on the Time Off Type field to open the selection dropdown.

Observation:
--------------------------------------
Traceback occurs:
```
  File '/home/odoo/odoo/community/odoo/orm/domains.py', line 920, in _raise
    raise error(message % (*args, self.field_expr, self.operator, self.value))
ValueError: Invalid field hr.work.entry.type.company_id in condition ('company_id', 'in', [1, False])
```

Issue:
--------------------------------------
In the commit https://github.com/odoo/odoo/pull/244436/changes/5b9570e4bd4cc0ae7d9a81e33f49dc538ae5acd3 model name changed from `hr.leave.type` to
`hr.work.entry.type`. With this change `company_id` field is removed too. However, the domain on the field still referenced `company_id`, leading to an invalid domain and traceback.

Solution:
--------------------------------------
Remove the company_id condition from the domain since the field no longer exists on `hr.work.entry.type`.

opw-6037286