### PR TITLE
[IMP] account: add transaction_uuid to payment list view

### DIFF
--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -18,6 +18,7 @@
                     <field name="date" readonly="state in ['cancel', 'paid']"/>
                     <field name="name"/>
                     <field name="journal_id"/>
+                    <field name="transaction_uuid" optional="hide"/>
                     <field name="company_id" optional="hide" groups="base.group_multi_company"/>
                     <field name="payment_method_line_id" context="{'hide_payment_journal_id': 1}"/>
                     <field name="partner_id" string="Customer"/>


### PR DESCRIPTION
This commit adds the `transaction_uuid` (Transaction ID) as `optional="hide"`
column in the payment list view.

This allows users to easily track and match grouped payments
(e.g., AMEX daily files) directly from the list view.

task-6042089
