### PR TITLE
[FIX] sale_timesheet: convert timesheet hours to SOL UoM in invoice quantity

### DIFF
--- a/addons/sale_timesheet/models/sale_order_line.py
+++ b/addons/sale_timesheet/models/sale_order_line.py
@@ -172,11 +172,14 @@ class SaleOrderLine(models.Model):
         if end_date:
             domain = expression.AND([domain, [('date', '<=', end_date)]])
         mapping = lines_by_timesheet.sudo()._get_delivered_quantity_by_analytic(domain)
+        timesheet_uom = self.order_id.timesheet_encode_uom_id
 
         for line in lines_by_timesheet:
             qty_to_invoice = mapping.get(line.id, 0.0)
+            is_different_uom_category = line.product_uom.category_id == timesheet_uom.category_id
             if qty_to_invoice:
-                units_to_invoice = sum(line.timesheet_ids.filtered(lambda ts: start_date <= ts.date <= end_date and not ts.timesheet_invoice_id).mapped('unit_amount'))
+                unit_amount = sum(line.timesheet_ids.filtered(lambda ts: start_date <= ts.date <= end_date and not ts.timesheet_invoice_id).mapped('unit_amount'))
+                units_to_invoice = timesheet_uom._compute_quantity(unit_amount, line.product_uom, rounding_method='HALF-UP') if is_different_uom_category else unit_amount
                 line.qty_to_invoice = units_to_invoice
             else:
                 prev_inv_status = line.invoice_status

--- a/addons/sale_timesheet/tests/test_sale_timesheet.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet.py
@@ -1292,6 +1292,59 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
         with self.assertRaises(UserError, msg='Should not be able to invoice already invoiced timesheets'):
             wizard_2.create_invoices()
 
+    def test_invoice_timesheet_uom_conversion_with_period(self):
+        """
+        Ensure that invoice quantities are correctly computed when the
+        sale order line UoM differs from the timesheet UoM.
+        """
+        self.env.company.timesheet_encode_uom_id = self.uom_hour.id
+        product = self.env['product.product'].create({
+            'name': "Test service product",
+            'standard_price': 30,
+            'list_price': 90,
+            'type': 'service',
+            'service_policy': 'delivered_timesheet',
+            'invoice_policy': 'delivery',
+            'service_type': 'timesheet',
+            'service_tracking': 'task_global_project',
+            'project_id': self.project_global.id,
+            'taxes_id': False,
+            'uom_id': self.uom_hour.id,
+        })
+        uom_days = self.env.ref('uom.product_uom_day')
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [
+                Command.create({'product_id': product.id, 'product_uom_qty': 3, 'product_uom': uom_days.id}),
+            ],
+        })
+        sale_order.action_confirm()
+        task = sale_order.tasks_ids
+        self.env['account.analytic.line'].create({
+            'name': 'Test Line',
+            'date': '2026-03-16',
+            'project_id': task.project_id.id,
+            'task_id': task.id,
+            'unit_amount': 16,
+            'employee_id': self.employee_user.id,
+            'company_id': self.company_data['company'].id,
+        })
+        context = {
+            'active_model': 'sale.order',
+            'active_ids': [sale_order.id],
+            'active_id': sale_order.id,
+            'default_journal_id': self.company_data['default_journal_sale'].id
+        }
+        wizard = self.env['sale.advance.payment.inv'].with_context(context).create({
+            'advance_payment_method': 'delivered',
+            'date_start_invoice_timesheet': '2026-03-16',
+            'date_end_invoice_timesheet': '2026-03-20',
+            'sale_order_ids': [(6, 0, sale_order.ids)],
+        })
+        invoice_dict = wizard.create_invoices()
+        invoice = self.env['account.move'].browse(invoice_dict['res_id'])
+        self.assertEqual(invoice.invoice_line_ids.quantity, 2)
+
 @tagged('-at_install', 'post_install')
 class TestSaleTimesheetAnalyticPlan(TestCommonSaleTimesheet):
 


### PR DESCRIPTION
Steps to reproduce:
--------------------------
1. Install sale_timesheet
2. Create a quotation with a timesheet-based product
   - Set quantity = 3
   - Set UoM to Days (timesheet UoM is Hours)
3. Confirm the quotation and click on the smart button Recorded.
4. Record 16 hours of timesheets.
5. Create an invoice using a timesheet period (starting from SO date)
6. Check the invoice quantity

Issue:
-----------
The invoice quantity is incorrect. It assigns the hour value (e.g., 16) to the invoice line even though the SOL is configured in "Days" (expected 2 days for 16 hours).

Cause:
-----------
After this commit c3b6053, The `_recompute_qty_to_invoice` method sums timesheet `unit_amount` (in hours) and assigns it directly to `qty_to_invoice` without converting it to the sale order line UoM when a timesheet period is applied.

Solution:
---------------
Convert the aggregated timesheet hours into the SOL UoM before assigning it to qty_to_invoice.

opw-6024804





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
