### PR TITLE
[FIX] project: fix non-deterministic tour

### DIFF
--- a/addons/project/static/tests/tours/project_task_history.js
+++ b/addons/project/static/tests/tours/project_task_history.js
@@ -20,8 +20,11 @@ function changeDescriptionContentAndSave(newContent) {
             run: "click",
         },
         {
-            trigger: `div.note-editable[spellcheck='true'].odoo-editor-editable`,
+            trigger: `div.note-editable[spellcheck='true'].odoo-editor-editable .o-paragraph`,
             run: `editor ${newText}`,
+        },
+        {
+            trigger: `div.note-editable.odoo-editor-editable .o-paragraph:contains(${newText})`,
         },
         ...stepUtils.saveForm(),
     ];


### PR DESCRIPTION
Prior to this fix, `changeDescriptionContentAndSave` in `project_task_history_tour` did not check that the inserted content was actually inside the editor prior to saving.

Measured failure rate before the fix: 11/30.
After the fix: 0/30.

runbot-241987