### PR TITLE
[FIX] l10n_sa_edi_pos: support updated settle-due line detection

### DIFF
--- a/addons/l10n_sa_edi_pos/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/l10n_sa_edi_pos/static/src/overrides/components/payment_screen/payment_screen.js
@@ -39,8 +39,8 @@ patch(PaymentScreen.prototype, {
 
     async validateOrder(isForceValidate) {
         const order = this.currentOrder;
-        // the isSettleDueLine() is only available if enterprise:pos_settle_due module is installed
-        const settleLineCount = order.lines.filter((line) => line.isSettleDueLine?.()).length;
+        // the isAnySettleLine() is only available if enterprise:pos_settle_due module is installed.
+        const settleLineCount = order.lines.filter((line) => line.isAnySettleLine?.()).length;
         if (settleLineCount && settleLineCount !== order.lines.length) {
             return this.dialog.add(AlertDialog, {
                 title: _t("Settlement Error"),

--- a/addons/l10n_sa_edi_pos/static/tests/tours/test_zatca_pos_invoice.js
+++ b/addons/l10n_sa_edi_pos/static/tests/tours/test_zatca_pos_invoice.js
@@ -3,6 +3,8 @@
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
+import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
+import * as PartnerList from "@point_of_sale/../tests/pos/tours/utils/partner_list_util";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("ZATCA_invoice_not_mandatory_if_deposit", {
@@ -43,5 +45,27 @@ registry.category("web_tour.tours").add("ZATCA_invoice_mandatory_if_regular_orde
             // Try to uncheck it and verify it remains checked
             PaymentScreen.clickInvoiceButton(),
             PaymentScreen.isInvoiceButtonChecked(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("ZATCA_blocks_settle_due_and_sale_on_same_order", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickPartnerButton(),
+            PartnerList.settleCustomerAccount(
+                "AAAA Generic Partner",
+                "23.0",
+                "TSJ/2026/",
+                "",
+                false,
+                false
+            ),
+            ProductScreen.addOrderline("Whiteboard Pen"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            Dialog.is({ title: "Settlement Error" }),
         ].flat(),
 });

--- a/addons/l10n_sa_edi_pos/tests/test_sa_edi_pos.py
+++ b/addons/l10n_sa_edi_pos/tests/test_sa_edi_pos.py
@@ -1,10 +1,10 @@
 from unittest.mock import patch
 
+from odoo.fields import Command
 from odoo.tests import tagged
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.l10n_sa_edi.tests.common import AccountEdiTestCommon
-from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
 from odoo.addons.point_of_sale.tests.test_generic_localization import TestGenericLocalization
 
 
@@ -35,12 +35,16 @@ class TestGenericSAEdi(TestGenericLocalization):
 
 
 @tagged('post_install_l10n', 'post_install', '-at_install')
-class TestUi(TestPointOfSaleHttpCommon):
+class TestUi(TestGenericSAEdi):
 
-    @classmethod
-    @AccountEdiTestCommon.setup_country('sa')
-    def setUpClass(cls):
-        super().setUpClass()
+    def make_payment(self, order, payment_method, amount):
+        """ Make payment for the order using the given payment method.
+        """
+        payment_context = {"active_id": order.id, "active_ids": order.ids}
+        return self.env['pos.make.payment'].with_context(**payment_context).create({
+            'amount': amount,
+            'payment_method_id': payment_method.id,
+        }).check()
 
     @patch('odoo.addons.l10n_sa_edi.models.account_journal.AccountJournal._l10n_sa_ready_to_submit_einvoices',
            new=lambda self: True)
@@ -69,4 +73,70 @@ class TestUi(TestPointOfSaleHttpCommon):
             "/pos/ui?config_id=%d" % self.main_pos_config.id,
             'ZATCA_invoice_mandatory_if_regular_order',
             login="pos_admin",
+        )
+
+    @patch(
+        "odoo.addons.l10n_sa_edi.models.account_journal.AccountJournal._l10n_sa_ready_to_submit_einvoices",
+        new=lambda self: True,
+    )
+    def test_ZATCA_blocks_settle_due_and_sale_on_same_order(self):
+        """
+        Tests that the invoice is mandatory in POS payment for ZATCA.
+        Also is by default checked.
+        """
+        if not self.env["ir.module.module"].search([("name", "=", "pos_settle_due"), ("state", "=", "installed")]):
+            self.skipTest("pos_settle_due module is required for this test")
+
+        self.customer_account_payment_method = self.env["pos.payment.method"].create(
+            {
+                "name": "Customer Account",
+                "split_transactions": True,
+            },
+        )
+        self.main_pos_config.write(
+            {"payment_method_ids": [(4, self.customer_account_payment_method.id)]},
+        )
+
+        self.assertEqual(self.partner_a.total_due, 0)
+
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+        current_session = self.main_pos_config.current_session_id
+
+        order = self.env["pos.order"].create(
+            {
+                "company_id": self.env.company.id,
+                "session_id": current_session.id,
+                "partner_id": self.partner_a.id,
+                "lines": [
+                    Command.create(
+                        {
+                            "product_id": self.whiteboard_pen.product_variant_id.id,
+                            "price_unit": 20,
+                            "discount": 0,
+                            "qty": 1,
+                            "price_subtotal": 10,
+                            "tax_ids": [Command.link(self.tax_sale_a.id)],
+                            "price_subtotal_incl": 23,
+                        },
+                    ),
+                ],
+                "amount_paid": 23,
+                "amount_total": 23.0,
+                "amount_tax": 3,
+                "amount_return": 0.0,
+                "to_invoice": True,
+                "last_order_preparation_change": "{}",
+            },
+        )
+
+        self.make_payment(order, self.customer_account_payment_method, 23)
+        current_session.action_pos_session_closing_control()
+        self.assertEqual(self.partner_a.total_due, 23)
+
+        self.main_pos_config.open_ui()
+
+        self.start_tour(
+            "/pos/ui?config_id=%d" % self.main_pos_config.id,
+            "ZATCA_blocks_settle_due_and_sale_on_same_order",
+            login="accountman",
         )


### PR DESCRIPTION
# Description of the issue/feature this PR addresses:

From saas-18.3 onward, the pos_settle_due module introduced a new method to identify settlement lines. 
While the old method **isSettleDueLine()** is still there, 
the new **isAnySettleLine()** covers both order settlement and invoice settlement. 

This change was not reflected in the Saudi POS EDI integration during forward-porting,
which caused incorrect validation when processing POS orders containing both
regular sale lines and settlement lines.

# Current behavior before PR:

- Orders containing a mix of new sale lines and settlement lines could bypass
the intended validation.

- The validation logic relied on the old isSettleDueLine() method

# Desired behavior after PR is merged:

- Update the validation flow to use isAnySettleLine() (when available) to
correctly detect settlement lines.

- Prevent validation of POS orders that contain both settlement lines and new
sale lines.

- Ensure compatibility with newer versions of the pos_settle_due module and
restore the intended settlement validation behavior.

- Test case to ensure no regression on this feature

I confirm I have signed the CLA and read the PR guidelines at
[www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)