### PR TITLE
[IMP] crm_sale_project: link project, sale order, and opportunity

### DIFF
--- a/addons/crm_sale_project/models/__init__.py
+++ b/addons/crm_sale_project/models/__init__.py
@@ -1,2 +1,3 @@
 from . import project_project
 from . import crm_lead
+from . import sale_order

--- a/addons/crm_sale_project/models/crm_lead.py
+++ b/addons/crm_sale_project/models/crm_lead.py
@@ -42,6 +42,9 @@ class CrmLead(models.Model):
             default_lead_id=self.id,
             default_partner_id=self.partner_id.id,
             default_allow_billable=True,
+            default_reinvoiced_sale_order_id=(
+                self.order_ids[0].id if self.order_ids else False
+            ),
         )
 
     def action_create_project(self):
@@ -74,3 +77,11 @@ class CrmLead(models.Model):
                 'context': self._get_project_create_from_lead_context(),
             }
         return action
+
+    def _prepare_opportunity_quotation_context(self):
+        context = super()._prepare_opportunity_quotation_context()
+        context.update({
+            'is_sale_order': True,
+            'default_project_id': self.project_ids[-1].id if self.project_ids else False,
+        })
+        return context

--- a/addons/crm_sale_project/models/sale_order.py
+++ b/addons/crm_sale_project/models/sale_order.py
@@ -1,0 +1,17 @@
+from odoo import api, models
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        sale_orders = super().create(vals_list)
+        if self.env.context.get('is_sale_order') and sale_orders and self.env.user.has_group('project.group_project_user'):
+            first_so = sale_orders[0]
+            projects = first_so.opportunity_id.project_ids.filtered(lambda p: not p.reinvoiced_sale_order_id)
+            if projects:
+                projects.sudo().write({
+                    'reinvoiced_sale_order_id': first_so.id
+                })
+        return sale_orders

--- a/addons/crm_sale_project/tests/__init__.py
+++ b/addons/crm_sale_project/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_crm_project_multicompany
+from . import test_crm_sale_project

--- a/addons/crm_sale_project/tests/test_crm_sale_project.py
+++ b/addons/crm_sale_project/tests/test_crm_sale_project.py
@@ -1,0 +1,44 @@
+from odoo.fields import Command
+from odoo.tests import tagged
+
+from odoo.addons.crm.tests.common import TestCrmCommon
+
+
+@tagged('at_install', '-post_install')
+class TestCrmSaleOrderProject(TestCrmCommon):
+
+    def test_sale_order_project_opportunity_link(self):
+        action = self.lead_1.action_create_project()
+        projects = self.env['project.project'].with_context(action['context']).create([
+            {'name': 'Project 1'},
+            {'name': 'Project 2'},
+        ])
+        product = self.env['product.product'].create({
+            'name': 'Test Rental Product',
+        })
+        partner = self.env['res.partner'].create({'name': 'test partner'})
+        self.lead_1.partner_id = partner
+        sale_order_action = self.lead_1.action_sale_quotations_new()
+        so1, so2 = self.env['sale.order'].with_context(sale_order_action['context']).create([{
+            'partner_id': partner.id,
+            'order_line': [Command.create({'product_id': product.id})],
+        } for _dummy in range(2)])
+        self.assertEqual(so1.project_id, projects[1], "Sale Order should be linked to recent project.")
+        self.assertEqual(so2.project_id, projects[1], "Sale Order should be linked to recent project.")
+        self.assertEqual(projects[0].reinvoiced_sale_order_id, so1, "Project should be linked to first sale order.")
+        self.assertEqual(projects[1].reinvoiced_sale_order_id, so1, "Project should be linked to first sale order.")
+
+    def test_project_links_sale_order_when_created_after_so(self):
+        product = self.env['product.product'].create({
+            'name': 'Test Rental Product',
+        })
+        partner = self.env['res.partner'].create({'name': 'test partner'})
+        self.lead_1.partner_id = partner
+        sale_order_action = self.lead_1.action_sale_quotations_new()
+        sole_order = self.env['sale.order'].with_context(sale_order_action['context']).create({
+            'partner_id': partner.id,
+            'order_line': [Command.create({'product_id': product.id})],
+        })
+        action = self.lead_1.action_create_project()
+        project = self.env['project.project'].with_context(action['context']).create({'name': 'Project 1'})
+        self.assertEqual(project.reinvoiced_sale_order_id, sole_order, "Project should be linked to sale order.")


### PR DESCRIPTION
Purpose of this commit is to ensure consistent linkage between opportunity, project, and SO across the sales workflow.

- Set the project with the highest id on the SO when the opportunity is linked to multiple projects
- Link the created Sale Order to the project if not already set

Task-6024387

