### PR TITLE
[IMP] Add sequence ordering to hr.employee.type

### DIFF
--- a/addons/hr/data/hr_employee_type_data.xml
+++ b/addons/hr/data/hr_employee_type_data.xml
@@ -3,34 +3,42 @@
     <data noupdate="1">
         <record id="contract_type_interim" model="hr.employee.type" forcecreate="1">
             <field name="name">Interim</field>
+            <field name="sequence">5</field>
         </record>
 
         <record id="contract_type_seasonal" model="hr.employee.type">
             <field name="name">Seasonal</field>
+            <field name="sequence">7</field>
         </record>
 
         <record id="contract_type_intern" model="hr.employee.type">
             <field name="name">Intern</field>
+            <field name="sequence">4</field>
         </record>
 
         <record id="contract_type_student" model="hr.employee.type">
             <field name="name">Student</field>
+            <field name="sequence">3</field>
         </record>
 
         <record id="contract_type_apprenticeship" model="hr.employee.type">
             <field name="name">Apprenticeship</field>
+            <field name="sequence">6</field>
         </record>
 
         <record id="contract_type_thesis" model="hr.employee.type">
             <field name="name">Thesis</field>
+            <field name="sequence">8</field>
         </record>
 
         <record id="contract_type_employee" model="hr.employee.type">
             <field name="name">Employee</field>
+            <field name="sequence">1</field>
         </record>
 
         <record id="contract_type_company_executive" model="hr.employee.type">
             <field name="name">Company Executive</field>
+            <field name="sequence">2</field>
         </record>
     </data>
 </odoo>

--- a/addons/hr/models/hr_employee_type.py
+++ b/addons/hr/models/hr_employee_type.py
@@ -4,12 +4,13 @@ from odoo import api, fields, models
 class HrEmployeeType(models.Model):
     _name = 'hr.employee.type'
     _description = 'Employee Type'
-    _order = 'name'
+    _order = 'sequence, name'
 
     name = fields.Char(required=True, translate=True)
     code = fields.Char(compute='_compute_code', store=True, readonly=False)
     country_id = fields.Many2one('res.country', domain=lambda self: [('id', 'in', self.env.companies.country_id.ids)])
     employees_count = fields.Integer(compute='_compute_employee_count', string='Employees')
+    sequence = fields.Integer(default=10)
 
     @api.depends('name')
     def _compute_code(self):

--- a/addons/hr/views/hr_employee_type_views.xml
+++ b/addons/hr/views/hr_employee_type_views.xml
@@ -4,7 +4,8 @@
         <record id="hr_contract_type_view_tree" model="ir.ui.view">
             <field name="model">hr.employee.type</field>
             <field name="arch" type="xml">
-                <list string="Employee Types" editable="bottom" default_order="name">
+                <list string="Employee Types" editable="bottom">
+                    <field name="sequence" widget="handle"/>
                     <field name="name"/>
                     <field name="country_id"/>
                     <field name="employees_count" string="Employees"/>


### PR DESCRIPTION
Add a sequence field to hr.employee.type to allow manual ordering of employee types. 
New records automatically get assigned the next available sequence number. 
Update _order to sort by sequence instead of name. 

This commit makes it easier for the user to select and manage employee types, so the most useful types can be the fist in the list.

Task: 6040364
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
