### PR TITLE
[IMP] html_editor: make `FontSizeSelector` responsive

### DIFF
--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -34,7 +34,7 @@ import {
     SUPPORTED_BASE_CONTAINER_NAMES,
 } from "@html_editor/utils/base_container";
 import { READ, withSequence } from "@html_editor/utils/resource";
-import { FontSizeSelector } from "./font_size_selector";
+import { FontSizeSelector, MAX_FONT_SIZE } from "./font_size_selector";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 import { weakMemoize } from "@html_editor/utils/functions";
 
@@ -180,10 +180,18 @@ export class FontPlugin extends Plugin {
                     getItems: () => this.fontSizeItems,
                     getDisplay: () => this.fontSize,
                     onFontSizeInput: (size) => {
-                        this.dependencies.format.formatSelection("fontSize", {
-                            formatProps: { size },
-                            applyStyle: true,
-                        });
+                        const resolvedSize = this.resolveFontSize(parseFloat(size));
+                        if (resolvedSize === null) {
+                            // Desired size matches the inherited value
+                            this.dependencies.format.formatSelection("fontSize", {
+                                applyStyle: false,
+                            });
+                        } else {
+                            this.dependencies.format.formatSelection("fontSize", {
+                                formatProps: { size: resolvedSize },
+                                applyStyle: true,
+                            });
+                        }
                         this.updateFontSizeSelectorParams();
                     },
                     onSelected: (item) => {
@@ -319,7 +327,7 @@ export class FontPlugin extends Plugin {
         before_insert_processors: this.handleInsertWithinPre.bind(this),
 
         is_format_class_predicates: (className) => {
-            if ([...FONT_SIZE_CLASSES, "o_default_font_size"].includes(className)) {
+            if ([...FONT_SIZE_CLASSES, "o_default_font_size", "o_rfs"].includes(className)) {
                 return true;
             }
         },
@@ -577,6 +585,52 @@ export class FontPlugin extends Plugin {
         closestHandledElement.replaceWith(baseContainer);
         this.dependencies.selection.setCursorStart(baseContainer);
         return true;
+    }
+
+    /**
+     * Resolves the CSS font-size value to apply for a desired pixel size typed
+     * by the user in the toolbar input.
+     *
+     * Strategy:
+     *  - If the value falls within the range of system-defined font sizes,
+     *    a plain `px` value is returned, those sizes are already designed by
+     *    the user to work at any viewport.
+     *  - If the value is outside that range (smaller than the smallest system
+     *    size, or larger than the largest), a responsive `clamp()` expression
+     *    is returned so the text scales gracefully with the viewport:
+     *      `clamp(8px, 1em + UIvalue*vw, MAX_FONT_SIZE)`
+     *    where `UIvalue` is derived from the difference between what the user
+     *    wants and what the parent block already provides at the current viewport.
+     *
+     * Returns `null` when the desired size matches the inherited size (within a
+     * 0.01 vw tolerance), signalling that any existing inline override should
+     * simply be removed.
+     *
+     * @param {number} desiredPx  The pixel value the user typed in the toolbar.
+     * @returns {string|null}     A CSS font-size value, or `null`.
+     */
+    resolveFontSize(desiredPx) {
+        const items = this.fontSizeItems;
+        if (items.length) {
+            const minPx = items[0].name;
+            const maxPx = items[items.length - 1].name;
+            if (desiredPx >= minPx && desiredPx <= maxPx) {
+                // Within the system-defined range: plain px is fine.
+                return `${desiredPx}px`;
+            }
+        }
+        // Outside the system range => produce responsive value.
+        const sel = this.dependencies.selection.getEditableSelection();
+        const blockEl = closestBlock(sel.anchorNode);
+        const parentComputedPx = parseFloat(this.window.getComputedStyle(blockEl).fontSize);
+        const viewportWidth = this.window.innerWidth;
+        const uiValue = (desiredPx - parentComputedPx) / (viewportWidth / 100);
+        if (Math.abs(uiValue) < 0.01) {
+            // Desired size matches the inherited size — clear any existing
+            // existing inline override.
+            return null;
+        }
+        return `clamp(8px, 1em + ${uiValue.toFixed(4)}vw, ${MAX_FONT_SIZE}px)`;
     }
 
     updateFontSelectorParams() {

--- a/addons/html_editor/static/src/main/font/font_size_selector.js
+++ b/addons/html_editor/static/src/main/font/font_size_selector.js
@@ -10,7 +10,7 @@ import { getCSSVariableValue, getHtmlStyle } from "@html_editor/utils/formatting
 import { useDropdownAutoVisibility } from "@html_editor/dropdown_autovisibility_hook";
 import { useChildRef } from "@web/core/utils/hooks";
 
-const MAX_FONT_SIZE = 144;
+export const MAX_FONT_SIZE = 400;
 
 export class FontSizeSelector extends Component {
     static template = "html_editor.FontSizeSelector";
@@ -32,7 +32,7 @@ export class FontSizeSelector extends Component {
         this.menuRef = useChildRef();
         useDropdownAutoVisibility(this.env.overlayState, this.menuRef);
         this.iframeContentRef = useRef("iframeContent");
-        this.debouncedCustomFontSizeInput = useDebounced(this.onCustomFontSizeInput, 200);
+        this.debouncedCustomFontSizeInput = useDebounced(this.onCustomFontSizeInput, 1000);
 
         onMounted(() => {
             const iframeEl = this.iframeContentRef.el;

--- a/addons/html_editor/static/src/utils/formatting.js
+++ b/addons/html_editor/static/src/utils/formatting.js
@@ -117,8 +117,12 @@ export const formatsSpecs = {
         addStyle: (node, props) => {
             node.style["font-size"] = props.size;
             removeClass(node, ...FONT_SIZE_CLASSES);
+            node.classList.toggle("o_rfs", props.size && props.size.startsWith("clamp("));
         },
-        removeStyle: (node) => removeStyle(node, "font-size"),
+        removeStyle: (node) => {
+            removeStyle(node, "font-size");
+            removeClass(node, "o_rfs");
+        },
     },
     setFontSizeClassName: {
         isFormatted: (node, props) =>
@@ -145,6 +149,7 @@ export const formatsSpecs = {
             ),
         addStyle: (node, props) => {
             node.style.removeProperty("font-size");
+            removeClass(node, "o_rfs");
             node.classList.add(props.className);
         },
         removeStyle: (node) => {

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -622,7 +622,8 @@ test("toolbar works: display correct font size on select all", async () => {
 });
 
 test("toolbar works: displays correct font size on input", async () => {
-    const { el } = await setupEditor("<p>[test]</p>");
+    const { el } = await setupEditor("<p>test</p>");
+    setContent(el, "<p>[test]</p>");
     await waitFor(".o-we-toolbar");
 
     const iframeEl = queryOne(".o-we-toolbar [name='font_size_selector'] iframe");
@@ -638,9 +639,12 @@ test("toolbar works: displays correct font size on input", async () => {
 
     await press("8");
     expect(inputEl).toHaveValue("8");
-    await advanceTime(200);
+    await advanceTime(1000);
     expectElementCount(".o_font_size_selector_menu", 1);
-    expect(getContent(el)).toBe(`<p><span style="font-size: 8px;">[test]</span></p>`);
+    // Responsive font-size: check for o_rfs class and clamp() value
+    const rfsSpan = el.querySelector("span.o_rfs");
+    expect(rfsSpan !== null).toBe(true);
+    expect(rfsSpan.style.fontSize.startsWith("clamp(")).toBe(true);
     await expectElementCount(".o-we-toolbar", 1);
 });
 

--- a/addons/website/static/src/builder/plugins/theme/theme_headings_option.xml
+++ b/addons/website/static/src/builder/plugins/theme/theme_headings_option.xml
@@ -8,16 +8,16 @@
         <!-- We don't use `display-font-sizes.5` and `display-font-sizes.6` -->
         <t t-set="used_display_font_sizes" t-value="[1, 2, 3, 4]"/>
         <BuilderRow label.translate="Font Size" action="'customizeWebsiteVariable'">
-            <BuilderNumberInput title.translate="Heading 1" actionParam="'h1-font-size'" default="null" unit="'px'" saveUnit="'rem'"/>
+            <BuilderNumberInput title.translate="Heading 1" actionParam="'h1-font-size'" default="null" unit="'px'" saveUnit="'rem'" max="144"/>
             <t t-set-slot="collapse">
                 <t t-foreach="[2, 3, 4, 5, 6]" t-as="depth" t-key="depth">
                     <BuilderRow level="1" label="heading_label + ' ' + depth">
-                        <BuilderNumberInput actionParam="'h' + depth + '-font-size'" default="null" unit="'px'" saveUnit="'rem'"/>
+                        <BuilderNumberInput actionParam="'h' + depth + '-font-size'" default="null" unit="'px'" saveUnit="'rem'" max="144"/>
                     </BuilderRow>
                 </t>
                 <t t-foreach="used_display_font_sizes" t-as="depth" t-key="depth">
                     <BuilderRow level="1" label="display_label + ' ' + depth">
-                        <BuilderNumberInput actionParam="'display-' + depth + '-font-size'" default="null" unit="'px'" saveUnit="'rem'"/>
+                        <BuilderNumberInput actionParam="'display-' + depth + '-font-size'" default="null" unit="'px'" saveUnit="'rem'" max="144"/>
                     </BuilderRow>
                 </t>
             </t>

--- a/addons/website/static/src/builder/plugins/theme/theme_tab.xml
+++ b/addons/website/static/src/builder/plugins/theme/theme_tab.xml
@@ -90,10 +90,10 @@
 <t t-name="website.ThemeParagraphOption">
     <BuilderContext preview="false">
         <BuilderRow label.translate="Font Size">
-            <BuilderNumberInput action="'customizeWebsiteVariable'" actionParam="'font-size-base'" default="null" unit="'px'" saveUnit="'rem'"/>
+            <BuilderNumberInput action="'customizeWebsiteVariable'" actionParam="'font-size-base'" default="null" unit="'px'" saveUnit="'rem'" max="144"/>
             <t t-set-slot="collapse">
                 <BuilderRow label.translate="Small" level="1">
-                    <BuilderNumberInput action="'customizeWebsiteVariable'" actionParam="'small-font-size'" default="null" unit="'px'" saveUnit="'rem'"/>
+                    <BuilderNumberInput action="'customizeWebsiteVariable'" actionParam="'small-font-size'" default="null" unit="'px'" saveUnit="'rem'" max="144"/>
                 </BuilderRow>
             </t>
         </BuilderRow>


### PR DESCRIPTION
Before this PR, when a user changed the font size using the toolbar input, the editor saved a fixed pixel value (eg `font-size: 120px`). This looked correct on desktop but was too large on mobile because the value never changed with the screen width.

| Desktop | Mobile |
|--------|--------|
| <img width="642" height="381" alt="image" src="https://github.com/user-attachments/assets/a7e04ce8-8db4-4ad9-8e8d-5e6480afb12f" /> | <img width="287" height="373" alt="image" src="https://github.com/user-attachments/assets/93b61e0e-5642-42da-b672-62516cb6a614" /> |

After this commit, the editor saves a responsive CSS value instead (`font-size: clamp(8px, 1em + Xvw, 144px)`). The size still matches what the user sees on screen when they type a number, but it now scales down on narrow screens and up on wide screens.
The span that holds this style is marked with the class `o_rfs_span` so it can be identified and targeted for migration and maintenance in the future. Re-editing the same span updates it in place instead of creating a new nested span each time.

| Desktop | Mobile |
|--------|--------|
| <img width="1230" height="601" alt="image" src="https://github.com/user-attachments/assets/dd340af2-4e6c-4a45-96f4-440c238d879d" /> | <img width="629" height="661" alt="image" src="https://github.com/user-attachments/assets/8afc2f2b-8d5d-4a50-842a-0bb4b6550bc3" /> | 


task-6041270


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
