### PR TITLE
[IMP] mrp: add reset component quantities button on MO form

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -3147,6 +3147,11 @@ class MrpProduction(models.Model):
         self.qty_producing = 0
         self._set_qty_producing(False)
 
+    def action_reset_component_quantity(self):
+        self.ensure_one()
+        for move in self.move_raw_ids.filtered(lambda m: not m.picked and m.quantity != m.product_uom_qty):
+            move.quantity = move.product_uom_qty
+
     def _track_execute(self, track_init_values, trackings, track_records=None):
         """
            Extend tracking behavior to manage the `previous_date_start` field

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -236,6 +236,8 @@
                     <button name="action_assign" invisible="state in ('draft', 'done', 'cancel') or not reserve_visible" string="Check availability" type="object" data-hotkey="c"/>
                     <button name="do_unreserve" type="object" string="Unreserve" invisible="not unreserve_visible" data-hotkey="w"/>
                     <field name="state" widget="statusbar" statusbar_visible="draft,confirmed,done"/>
+                    <button name="action_reset_component_quantity" type="object" string="Reset Quantity" data-hotkey="o"
+                            invisible="state in ('done', 'cancel') or not move_raw_ids or qty_producing in (0, product_qty)"/>
                     <button name="action_cancel" type="object" string="Cancel" data-hotkey="x"
                             invisible="not id or state in ('done', 'cancel')"
                             confirm="Are you sure you want to cancel this manufacturing order?&#10;This action cannot be undone."


### PR DESCRIPTION
When the produced quantity in MO is updated, Odoo automatically recalculates 
the component consumption quantities. In some cases, users must manually adjust 
these quantities to match the original demand when actual production differs 
from the planned quantity. 

This commit adds a `Reset Quantity` button to restore component quantities to 
their original demand for components that have not been manually modified, 
reducing manual effort.

TaskId-5946591