### PR TITLE
[FIX] product, web: fix product inline display

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -124,31 +124,26 @@
                                             options="{'no_quick_create': True}"
                                         />
                                     </div>
-                                    <div colspan="2" class="o_row" name="standard_price_uom" invisible="type == 'combo'
+                                    <div colspan="2" class="d-flex align-items-baseline gap-2" name="standard_price_uom" invisible="type == 'combo'
                                         or (not is_product_variant and (
                                             product_variant_count &gt; 1
                                             or (product_variant_count == 0 and is_dynamically_created)
                                         ))"
                                     >
-                                        <div class="o_cell d-flex">
-                                            <label for="standard_price" class="o_form_label"/>
-                                            <field
-                                                name="standard_price"
-                                                widget="monetary"
-                                                options="{
-                                                    'currency_field': 'cost_currency_id',
-                                                    'field_digits': True,
-                                                }"
-                                            />
-                                        </div>
-                                        <div class="o_cell  d-flex" groups="uom.group_uom">
-                                            <label for="uom_id" string="Per" class="o_form_label"/>
-                                            <field
-                                                name="uom_id" widget="many2one_uom"
-                                                options="{'no_quick_create': True}"
-                                                nolabel="1"
-                                            />
-                                        </div>
+                                        <label for="standard_price" class="o_form_label"/>
+                                        <field
+                                            name="standard_price"
+                                            widget="monetary"
+                                            options="{
+                                                'currency_field': 'cost_currency_id',
+                                                'field_digits': True,
+                                            }"
+                                        />
+                                        <span groups="uom.group_uom">per</span>
+                                        <field
+                                            groups="uom.group_uom" name="uom_id" widget="many2one_uom"
+                                            options="{'no_quick_create': True}"
+                                        />
                                     </div>
                                     <field name="categ_id" string="Category"/>
                                     <field name="company_id"

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -96,17 +96,18 @@
                                         invisible="not product_tooltip"
                                     />
                                     <field name="show_qty_update_button" invisible="1"/>
-                                    <div name="tracking_and_qty_no_stock" class="o_row w-100" invisible="type != 'consu'">
-                                        <label for="is_storable" invisible="type != 'consu'"/>
-                                        <field name="is_storable"/>
-                                        <div name="product_template_qty_field" class="o_input_box" invisible="is_product_variant or not is_storable">
-                                            <a type="action" name="%(product_variant_edit_qty_action)d" invisible="not show_qty_update_button" class="o_input_box_overlay_start">
+                                    <field name="is_storable" invisible="type != 'consu' or is_storable"/>
+                                    <label for="is_storable" invisible="type != 'consu'  or not is_storable"/>
+                                    <div name="tracking_and_qty_no_stock" class="o_input_box" invisible="type != 'consu' or not is_storable">
+                                        <field name="is_storable" class="o_input_box_overlay_start"/>
+                                        <div name="product_template_qty_field" invisible="is_product_variant">
+                                            <a type="action" name="%(product_variant_edit_qty_action)d" invisible="not show_qty_update_button">
                                                 <field name="qty_available" readonly="True"/>
                                             </a>
                                             <field name="qty_available" invisible="show_qty_update_button"/>
                                             <field name="uom_name" class="o_input_box_overlay_end" groups="uom.group_uom"/>
                                         </div>
-                                        <div name="product_product_qty_field" class="o_input_box" invisible="not is_product_variant or not is_storable">
+                                        <div name="product_product_qty_field" invisible="not is_product_variant">
                                             <field name="qty_available"/>
                                             <field name="uom_name" class="o_input_box_overlay_end" groups="uom.group_uom"/>
                                         </div>

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -185,7 +185,6 @@
                 </xpath>
                 <xpath expr="//div[@name='tracking_and_qty_no_stock']" position="replace">
                     <!-- Replace the single line tacking + qty without stock with 2 individual lines with stock (tracking + tracking method // qty) -->
-                    <field name="is_storable" widget="boolean_toggle" groups="!stock.group_production_lot"/>
                     <field name="tracking" placeholder="None" invisible="type != 'consu'" groups="stock.group_production_lot"/>
                     <!-- Qty line if storable -->
                     <label for="qty_available" invisible="not is_storable or not tracking" groups="stock.group_stock_user"/>
@@ -198,6 +197,11 @@
                         <field name="qty_available" readonly="True" groups="!stock.group_stock_manager"/>
                         <field groups="uom.group_uom" name="uom_name" class="o_input_box_overlay_end"/>
                     </div>
+                </xpath>
+                <xpath expr="//field[@name='is_storable']" position="attributes">
+                    <attribute name="groups">!stock.group_production_lot</attribute>
+                    <attribute name="widget">boolean_toggle</attribute>
+                    <attribute name="invisible"></attribute>
                 </xpath>
                 <xpath expr="//group[@name='group_lots_and_weight']" position="inside">
                     <label for="sale_delay" invisible="not sale_ok"/>

--- a/addons/web/static/src/core/input_box/input_box.scss
+++ b/addons/web/static/src/core/input_box/input_box.scss
@@ -52,21 +52,19 @@
         min-width: var(--inputbox-overlay-size);
         padding: 0 !important;
         z-index: 1;
-        pointer-events: none;
         display: inline-flex;
         align-items: center;
         justify-content: center;
 
-        &.btn, .btn, button {
+        &:is(button, .btn), :is(button, .btn){
             border-radius: calc(1.5 * var(--inputbox-spacing-unit));
             line-height: 0;
-            pointer-events: auto;
             padding: 0 !important;
         }
-        .btn {
-            display: block;
-            width: inherit;
-            height: inherit;
+        &:is(span, .fa), :is(span, .fa):not(button *, .btn *) {
+            &:not(button, .btn, :has(button, .btn)) {
+                pointer-events: none;
+            }
         }
         // prefix and suffix have a default value, but it can change when positionInputBoxOverlay is called since an InputBox can have multiple prefix/suffixes
         &.o_input_box_overlay_start {


### PR DESCRIPTION
Commit 1:
[FIX] product: fix inline field
This commit fixes the inline display when a unit of measure is
used after the 'standard_price' field in the product view.
Previously, the label was not stylized correctly, and the UX
wasn't consistent with the changes made with commit [1].

Now, the same layout is used for this inline field display.

[1]: https://github.com/odoo/odoo/commit/840cf7a122fa77aa9e49baf4146536d5681ed19e

Commit 2:
[FIX] product: fix checkbox with input and action link
This commit fixes the display of the checkbox, while also allowing
the input to be editable, and the action link to be clickable when needed
in the product form view.

A few InputBox styles have been reworked as well in this commit, to display
buttons in a correct way while keeping their ability to be clicked.
The 'pointer-events' rule has been moved directly on elements that are not
interactive (icons, overlay text for example), instead of targeting all
elements and having to re-enable it on buttons only.

task-6040133