### PR TITLE
[IMP] orm: Add a 'first' method on recordsets

### DIFF
--- a/odoo/addons/test_orm/tests/test_models.py
+++ b/odoo/addons/test_orm/tests/test_models.py
@@ -154,6 +154,26 @@ class TestORM(TransactionCase):
         recs = partner.browse([-1])
         self.assertFalse(recs.exists())
 
+    def test_first(self):
+        partner = self.env['res.partner']
+
+        partner_1 = partner.create({
+            "name": "Partner 1",
+        })
+        partner_2 = partner.create({
+            "name": "Partner 2",
+        })
+
+        first_partner = (partner_1 | partner_2).first()
+        self.assertEqual(
+            partner_1,
+            first_partner,
+        )
+
+        browse_partner = partner.browse()
+        void_partner = browse_partner.first()
+        self.assertFalse(void_partner)
+
     def test_lock_for_update(self):
         partner = self.env['res.partner']
         p1, p2 = partner.search([], limit=2)

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -505,6 +505,14 @@ class BaseModel(metaclass=MetaModel):
         search='_search_display_name',
     )
 
+    def first(self) -> Self:
+        """
+            Returns the first record of the recordset or a void one.
+        """
+        if self:
+            return next(iter(self))
+        return self
+
     def _valid_field_parameter(self, field, name):
         """ Return whether the given parameter name is valid for the field. """
         return name == 'related_sudo'


### PR DESCRIPTION
Restore the lost method on `fields` but put in on recordset level for better consistance.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
