### PR TITLE
[FIX] test_website: remove undeterministicTour key

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
@@ -819,7 +819,8 @@ export function addInternalNote(note, buttonLabel = "Note") {
     return [
         clickInternalNoteButton(buttonLabel),
         TextInputPopup.inputText(note),
-        Dialog.confirm(),
+        Dialog.proceed({ button: "Apply", title: "add note" }),
+        Dialog.isNot({ title: "add note" }),
     ].flat();
 }
 

--- a/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/control_buttons_tour.js
@@ -10,10 +10,8 @@ import * as ChromePos from "@point_of_sale/../tests/pos/tours/utils/chrome_util"
 import * as ChromeRestaurant from "@pos_restaurant/../tests/tours/utils/chrome";
 const Chrome = { ...ChromePos, ...ChromeRestaurant };
 import { registry } from "@web/core/registry";
-import { delay } from "@web/core/utils/concurrency";
 
 registry.category("web_tour.tours").add("ControlButtonsTour", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             // Test merging table, transfer is already tested in pos_restaurant_sync_second_login.
@@ -30,13 +28,7 @@ registry.category("web_tour.tours").add("ControlButtonsTour", {
             ProductScreen.selectedOrderlineHas("Coca-Cola", "1"),
 
             ProductScreen.clickControlButton("Transfer"),
-            {
-                trigger: ".table:contains(2)",
-                async run(helpers) {
-                    await delay(500);
-                    await helpers.click();
-                },
-            },
+            FloorScreen.clickTable("2"),
             Order.hasLine({ productName: "Water", quantity: "5" }),
             Order.hasLine({ productName: "Minute Maid", quantity: "3" }),
             Order.hasLine({ productName: "Coca-Cola", quantity: "1" }),
@@ -44,7 +36,9 @@ registry.category("web_tour.tours").add("ControlButtonsTour", {
             // Test SplitBillButton
             ProductScreen.clickControlButton("Split"),
             SplitBillScreen.clickBack(),
+            ProductScreen.checkTotalAmount(18.2),
             ProductScreen.clickLine("Water", "5"),
+            ProductScreen.selectedOrderlineHas("Water", "5"),
             ProductScreen.addInternalNote("test note", "Note"),
             Order.hasLine({
                 productName: "Water",
@@ -64,6 +58,7 @@ registry.category("web_tour.tours").add("ControlButtonsTour", {
             }),
 
             ProductScreen.addOrderline("Water", "8", "1", "8.0"),
+            ProductScreen.checkTotalAmount(26.2),
 
             // Test GuestButton
             ProductScreen.clickControlButton("Guests"),
@@ -95,10 +90,10 @@ registry.category("web_tour.tours").add("ControlButtonsTour", {
             ProductScreen.guestNumberIs("5"),
 
             // Test Cancel Order Button
-            Dialog.cancel(),
+            Dialog.cancel({ title: "Actions" }),
             Order.hasLine({ productName: "Water", quantity: "5" }),
             ProductScreen.clickControlButton("Cancel Order"),
-            Dialog.confirm(),
+            Dialog.proceed({ button: "ok", title: "Existing orderlines" }),
             Order.doesNotHaveLine(),
             FloorScreen.isShown(),
 

--- a/addons/pos_restaurant/static/tests/tours/floor_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/floor_screen_tour.js
@@ -37,7 +37,6 @@ registry.category("web_tour.tours").add("FloorScreenTour", {
 });
 
 registry.category("web_tour.tours").add("TableMergeUnmergeTour", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -27,7 +27,6 @@ import {
 const ProductScreen = { ...ProductScreenPos, ...ProductScreenResto };
 
 registry.category("web_tour.tours").add("pos_restaurant_sync", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),
@@ -97,6 +96,13 @@ registry.category("web_tour.tours").add("pos_restaurant_sync", {
             ProductScreen.totalAmountIs("5.87"),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Bank"),
+            {
+                trigger: ".paymentline:contains(bank):contains(5.87)",
+                async run() {
+                    // Can't explain why we need this delay to ensure the order is then well paid.
+                    await new Promise((r) => setTimeout(r, 50));
+                },
+            },
             PaymentScreen.clickValidate(),
             FeedbackScreen.clickNextOrder(),
 
@@ -119,7 +125,7 @@ registry.category("web_tour.tours").add("pos_restaurant_sync", {
             // The order ref ends with -00002 because it is actually the 2nd order made in the session.
             // The first order made in the session is a floating order.
             TicketScreen.deleteOrder("002"),
-            Dialog.confirm(),
+            Dialog.proceed({ title: "existing orderlines", button: "ok" }),
             Chrome.closePrintingWarning(),
             Chrome.isSyncStatusConnected(),
             TicketScreen.selectOrder("005"),
@@ -138,7 +144,6 @@ registry.category("web_tour.tours").add("pos_restaurant_sync", {
  * This tour should be run after the first tour is done.
  */
 registry.category("web_tour.tours").add("pos_restaurant_sync_second_login", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             // There is one draft synced order from the previous tour
@@ -336,7 +341,6 @@ registry.category("web_tour.tours").add("CategLabelCheck", {
         ].flat(),
 });
 registry.category("web_tour.tours").add("OrderChangeTour", {
-    undeterministicTour_doNotCopy: true, // Remove this key to make the tour failed. ( It removes delay between steps )
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_restaurant/static/tests/tours/utils/floor_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/floor_screen_util.js
@@ -160,6 +160,9 @@ export function goTo(name) {
         ...clickTableSelectorButton(),
         ...Numpad.enterValue(name),
         {
+            trigger: `.input-value:contains(${name})`,
+        },
+        {
             trigger: ".floor-screen .jump-button",
             run: "click",
         },


### PR DESCRIPTION
Fix undeterministic tours by making some triggers more precise in a few steps.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
