### PR TITLE
[FIX] mrp_subcontracting: prevent duplicate RFQs by reusing stock ref

### DIFF
--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -155,6 +155,7 @@ class StockMove(models.Model):
                 move.picking_id.partner_id.with_company(company).property_stock_subcontractor \
                 or company.subcontracting_location_id
             move.write({
+                'production_group_id': False,
                 'is_subcontract': True,
                 'location_id': subcontracting_location.id
             })

--- a/addons/mrp_subcontracting/models/stock_picking.py
+++ b/addons/mrp_subcontracting/models/stock_picking.py
@@ -104,10 +104,14 @@ class StockPicking(models.Model):
 
     def _prepare_subcontract_mo_vals(self, subcontract_move, bom):
         subcontract_move.ensure_one()
-        reference = self.env['stock.reference'].create({
-            'name': self.name,
-            'move_ids': [Command.link(subcontract_move.id)],
-        })
+        if not self.reference_ids:
+            references = self.env['stock.reference'].create({
+                'name': self.name,
+                'move_ids': [Command.link(subcontract_move.id)],
+            })
+        else:
+            references = self.reference_ids
+
         product = subcontract_move.product_id
         warehouse = self._get_warehouse(subcontract_move)
         subcontracting_location = \
@@ -126,7 +130,7 @@ class StockPicking(models.Model):
             'picking_type_id': warehouse.subcontracting_type_id.id,
             'date_start': subcontract_move.date - relativedelta(days=bom.produce_delay),
             'origin': self.name,
-            'reference_ids': [Command.link(reference.id)],
+            'reference_ids': [Command.link(ref.id) for ref in references],
         }
         return vals
 

--- a/addons/mrp_subcontracting_dropshipping/tests/test_purchase_subcontracting.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_purchase_subcontracting.py
@@ -472,3 +472,34 @@ class TestSubcontractingDropshippingFlows(TestMrpSubcontractingCommon, TestStock
         self.assertRecordValues(move._get_subcontract_production()[1], [{
             'qty_producing': 0.0, 'lot_producing_ids': finished_serial.ids, 'state': 'confirmed',
         }])
+
+    def test_single_dropship_po_created_for_subcontracted_products(self):
+        """Create a subcontracting BoM with dropshipped components.
+        Confirm a purchase order containing subcontracted products and verify that
+        only one dropship purchase order is created for the components.
+        """
+        self.comp2_bom.type = 'subcontract'
+        self.comp2_bom.subcontractor_ids = [Command.link(self.subcontractor_partner1.id)]
+        dropship_route = self.env['stock.route'].search([('name', '=', 'Dropship')], limit=1)
+        (self.comp1 | self.comp2comp).route_ids = [Command.link(dropship_route.id)]
+        (self.comp1 | self.comp2comp).seller_ids = [Command.create({'partner_id': self.vendor.id})]
+        po = self.env['purchase.order'].create({
+            "partner_id": self.subcontractor_partner1.id,
+            "picking_type_id": self.warehouse.in_type_id.id,
+            "order_line": [
+                Command.create({
+                    'product_id': self.finished.id,
+                    'name': self.finished.name,
+                    'product_qty': 1.0,
+                }),
+                Command.create({
+                    'product_id': self.comp2.id,
+                    'name': self.comp2.name,
+                    'product_qty': 1.0,
+                }),
+            ],
+        })
+        po.button_confirm()
+        dropship_po = self.env['purchase.order'].search([('reference_ids', '=', po.reference_ids.id), ('id', '!=', po.id)])
+        self.assertEqual(len(dropship_po), 1, 'A single PO should be created for the dropshipped component')
+        self.assertEqual(dropship_po.order_line.product_id, (self.comp1 | self.comp2comp))


### PR DESCRIPTION
Steps to reproduce:
- Go to Azure Interior contact form:
  - Sales & Purchase tab > Group RFQs > Always
- Create a storable product "P1":
  - Route: Resupply Subcontractor
  - BoM:
    - Type: Subcontracting
    - Component: C1 with Dropship route and azure interior as vendor
- Create a storable product "P2":
  - Route: Resupply Subcontractor
  - BoM:
    - Type: Subcontracting
    - Component: C2 with Dropship route and azure interior as vendor
- Create a purchase order with one unit of P1 and P2
- Confirm the purchase order

Problem:
Two RFQs are generated (one for C1 and one for C2) instead of a single grouped RFQ.

When confirming the purchase order, a stock reference is created and assigned to it. This reference is correctly propagated to the picking and stock moves.

However, when the two manufacturing orders are created, new stock references are generated instead of reusing the original one. As a result, each MO ends up with a different reference:

https://github.com/odoo/odoo/blob/2713876dbc70d3984e584a9037a2206dcda4e84a/addons/mrp_subcontracting/models/stock_picking.py#L69-L72

This prevents from grouping RFQs, since the grouping logic relies on identical references. When the first RFQ is created for C1, it uses the MO reference, and when searching for a candidate RFQ for C2, none is found due to the reference mismatch:
https://github.com/odoo/odoo/commit/77dc92e4a0db0575a1a0e865cdd0c82978d593f6#diff-201f9fd7ec1067f7530aafeaa88420021930be82ce89e912d595ed55bb885f26R370-R372

Solution:
Reuse existing stock references when creating subcontracting MOs instead of creating new ones.

opw-5895378
