### PR TITLE
[FIX] stock: component lot click in tracability report

### DIFF
--- a/addons/stock/static/src/client_actions/stock_traceability_report_backend.xml
+++ b/addons/stock/static/src/client_actions/stock_traceability_report_backend.xml
@@ -65,7 +65,7 @@
                             <a class="o_stock_reports_web_action" href="#" t-on-click.prevent="() => this.onClickBoundLink(line)" t-esc="col"/>
                         </span>
                         <span t-elif="col and line.lot_name === col">
-                            <span class="o_stock_report_lot_action" t-esc="col" />
+                            <a class="o_stock_report_lot_action" t-esc="col" t-on-click.prevent="() => this.onCLickOpenLot(line)"/>
                         </span>
                         <t t-elif="col" t-esc="col"/>
                     </td>


### PR DESCRIPTION
commit d7f81c25555c800bf296da2507d010257292aa55

It was removed in order to limit the breadcrump size. However it was a stupid solution and it's better to let the feature rather than limiting the breadcrump size.