### PR TITLE
[FIX] sale_timesheet: prevent reinvoicing on partial credit

### DIFF
--- a/addons/sale_timesheet/models/account_move.py
+++ b/addons/sale_timesheet/models/account_move.py
@@ -92,7 +92,7 @@ class AccountMove(models.Model):
         credit_notes = self.filtered(lambda move: move.move_type == 'out_refund' and move.reversed_entry_id)
         timesheets_sudo = self.env['account.analytic.line'].sudo().search([
             ('timesheet_invoice_id', 'in', credit_notes.reversed_entry_id.ids),
-            ('so_line', 'in', credit_notes.invoice_line_ids.sale_line_ids.ids),
+            ('so_line', 'in', credit_notes.invoice_line_ids.filtered(lambda l: l.quantity).sale_line_ids.ids),
             ('project_id', '!=', False),
         ])
         timesheets_sudo.write({'timesheet_invoice_id': False})

--- a/addons/sale_timesheet/models/sale_order.py
+++ b/addons/sale_timesheet/models/sale_order.py
@@ -310,7 +310,11 @@ class SaleOrderLine(models.Model):
         """
         lines_by_timesheet = self.filtered(lambda sol: sol.product_id and sol.product_id._is_delivered_timesheet())
         domain = lines_by_timesheet._timesheet_compute_delivered_quantity_domain()
-        refund_account_moves = self.order_id.invoice_ids.filtered(lambda am: am.state == 'posted' and am.move_type == 'out_refund').reversed_entry_id
+        refund_account_moves = self.order_id.invoice_ids.filtered(
+            lambda am: am.state == 'posted'
+            and am.move_type == 'out_refund'
+            and am.invoice_line_ids.filtered(lambda l: l.quantity).sale_line_ids & lines_by_timesheet
+        ).reversed_entry_id
         timesheet_domain = [
             '|',
             ('timesheet_invoice_id', '=', False),
@@ -328,7 +332,7 @@ class SaleOrderLine(models.Model):
         for line in lines_by_timesheet:
             qty_to_invoice = mapping.get(line.id, 0.0)
             if qty_to_invoice:
-                line.qty_to_invoice = qty_to_invoice
+                line.qty_to_invoice = min(qty_to_invoice, line.qty_delivered - line.qty_invoiced)
             else:
                 prev_inv_status = line.invoice_status
                 line.qty_to_invoice = qty_to_invoice

--- a/addons/sale_timesheet/models/sale_order.py
+++ b/addons/sale_timesheet/models/sale_order.py
@@ -327,6 +327,19 @@ class SaleOrderLine(models.Model):
 
         for line in lines_by_timesheet:
             qty_to_invoice = mapping.get(line.id, 0.0)
+            if refund_account_moves:
+                invoice_lines_to_calculate = line._get_invoice_lines().filtered(
+                    lambda inv: inv.move_id in refund_account_moves or inv.move_id.reversed_entry_id in refund_account_moves
+                )
+                invoiced_qty = 0.0
+                for invoice_line in invoice_lines_to_calculate:
+                    qty = invoice_line.product_uom_id._compute_quantity(invoice_line.quantity, line.product_uom)
+                    if invoice_line.move_id.move_type == 'out_invoice':
+                        invoiced_qty += qty
+                    elif invoice_line.move_id.move_type == 'out_refund':
+                        invoiced_qty -= qty
+                qty_to_invoice -= invoiced_qty
+
             if qty_to_invoice:
                 line.qty_to_invoice = qty_to_invoice
             else:

--- a/addons/sale_timesheet/tests/test_sale_timesheet.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet.py
@@ -1204,6 +1204,44 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
             "Portal user should not see the timesheet of another SO line (line 2)."
         )
 
+    def test_timesheet_rebilling_after_partial_credit(self):
+        """Credit notes should only make timesheets rebillable proportional to credited hours."""
+        jan, feb = date(2024, 1, 15), date(2024, 2, 15)
+        jan_start, jan_end, full_end = date(2024, 1, 1), date(2024, 1, 31), date(2024, 2, 28)
+
+        for credit_qty, jan_hours, feb_hours, reinvoice_end, expected in [
+            (0, 1, 2, full_end, 2),  # Zero credit: only Feb rebillable
+            (1, 5, 3, full_end, 4),  # Partial credit, full range: 1h credited + 3h Feb
+            (1, 5, 3, jan_end, 1),  # Partial credit, Jan-only: only 1h credited
+        ]:
+            with self.subTest(credit_qty=credit_qty, expected=expected):
+                sale_order = self.env['sale.order'].create({'partner_id': self.partner_a.id})
+                self.env['sale.order.line'].create({
+                    'order_id': sale_order.id,
+                    'product_id': self.product_delivery_timesheet2.id,
+                })
+                sale_order.action_confirm()
+                task = sale_order.order_line.task_id
+                self.env['account.analytic.line'].create([
+                    {'name': 'Jan', 'project_id': task.project_id.id, 'task_id': task.id,
+                     'unit_amount': jan_hours, 'employee_id': self.employee_user.id, 'date': jan},
+                    {'name': 'Feb', 'project_id': task.project_id.id, 'task_id': task.id,
+                     'unit_amount': feb_hours, 'employee_id': self.employee_user.id, 'date': feb},
+                ])
+                sale_order.order_line._recompute_qty_to_invoice(jan_start, jan_end)
+                invoice = sale_order.with_context(
+                    timesheet_start_date=jan_start, timesheet_end_date=jan_end,
+                )._create_invoices()
+                invoice.action_post()
+                credit_note = invoice._reverse_moves()
+                credit_note.invoice_line_ids.quantity = credit_qty
+                credit_note.action_post()
+                sale_order.order_line._recompute_qty_to_invoice(jan_start, reinvoice_end)
+                invoice2 = sale_order.with_context(
+                    timesheet_start_date=jan_start, timesheet_end_date=reinvoice_end,
+                )._create_invoices()
+                self.assertEqual(invoice2.invoice_line_ids.quantity, expected)
+
 
 class TestSaleTimesheetView(TestCommonTimesheet):
     def test_get_view_timesheet_encode_uom(self):

--- a/addons/sale_timesheet/tests/test_sale_timesheet.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet.py
@@ -1139,6 +1139,43 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
         self.assertFalse(timesheet1.timesheet_invoice_id, "Timesheet1 should be cleared after partial refund of its task")
         self.assertEqual(timesheet2.timesheet_invoice_id, invoice2, "Timesheet2 should still be linked to the original invoice")
 
+    def test_timesheet_rebilling_after_partial_credit(self):
+        """Credit notes should only make timesheets rebillable proportional to credited hours."""
+        jan, feb = date(2024, 1, 15), date(2024, 2, 15)
+        jan_start, jan_end, full_end = date(2024, 1, 1), date(2024, 1, 31), date(2024, 2, 28)
+
+        for credit_qty, jan_hours, feb_hours, expected in [
+            (0, 1, 2, 2),  # Zero credit: only Feb rebillable
+            (1, 5, 3, 4),  # Partial credit: 1h credited + 3h Feb
+        ]:
+            with self.subTest(credit_qty=credit_qty, expected=expected):
+                sale_order = self.env['sale.order'].create({'partner_id': self.partner_a.id})
+                self.env['sale.order.line'].create({
+                    'order_id': sale_order.id,
+                    'product_id': self.product_delivery_timesheet2.id,
+                })
+                sale_order.action_confirm()
+                task = sale_order.order_line.task_id
+                self.env['account.analytic.line'].create([
+                    {'name': 'Jan', 'project_id': task.project_id.id, 'task_id': task.id,
+                     'unit_amount': jan_hours, 'employee_id': self.employee_user.id, 'date': jan},
+                    {'name': 'Feb', 'project_id': task.project_id.id, 'task_id': task.id,
+                     'unit_amount': feb_hours, 'employee_id': self.employee_user.id, 'date': feb},
+                ])
+                sale_order.order_line._recompute_qty_to_invoice(jan_start, jan_end)
+                invoice = sale_order.with_context(
+                    timesheet_start_date=jan_start, timesheet_end_date=jan_end,
+                )._create_invoices()
+                invoice.action_post()
+                credit_note = invoice._reverse_moves()
+                credit_note.invoice_line_ids.quantity = credit_qty
+                credit_note.action_post()
+                sale_order.order_line._recompute_qty_to_invoice(jan_start, full_end)
+                invoice2 = sale_order.with_context(
+                    timesheet_start_date=jan_start, timesheet_end_date=full_end,
+                )._create_invoices()
+                self.assertEqual(invoice2.invoice_line_ids.quantity, expected)
+
 
 class TestSaleTimesheetView(TestCommonTimesheet):
     def test_get_view_timesheet_encode_uom(self):


### PR DESCRIPTION
Refunding products must not make already billed service time billable again.
If only part of service time is refunded, only that refunded part can be
billed again.

Steps to reproduce:
- Create SO with one storable line and one timesheet service line.
- Log Jan 1h and Feb 2h, then invoice January.
- Create a credit note with timesheet qty = 0, then reinvoice Jan-Feb.
- Create a partial timesheet credit (ex: credit 1h out of 5h), then
  reinvoice.

Current behavior:
- Already billed, non-credited hours can become billable again.
- Partial credits may reopen more hours than actually credited.

Expected behavior:
- Product-only credit: only remaining unbilled hours are invoiceable.
- Partial timesheet credit: only credited hours + new hours are invoiceable.

Issue:
- Zero-qty credit lines were considered in timesheet refund matching.
- Reinvoice quantity could exceed remaining billable balance.

Fix:
- Ignore zero-quantity credit lines in timesheet refund matching.
- Cap qty_to_invoice to remaining billable quantity.

task-5991283

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
