### PR TITLE
[FIX] sale: always allow printing a quote if user has access to it

### DIFF
--- a/addons/sale/models/ir_actions_report.py
+++ b/addons/sale/models/ir_actions_report.py
@@ -32,7 +32,7 @@ class IrActionsReport(models.Model):
 
             # Generate and attach EDI documents from each builder
             for builder in builders:
-                xml_content = builder._export_order(sale_order)
+                xml_content = builder._export_order(sale_order.sudo())
 
                 writer.addAttachment(
                     builder._export_invoice_filename(sale_order),  # works even if it's a SO or PO


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting, Sales and account_intrastat

- Create a user with Sales rights only
- Create a product with an Intrastat Commodity Code

- Connect with the created user
- Create a SO with the Intrastat product
- Print PDF Quote

**Issue:**
An access error is raised while trying to access "account.intrastat.code" field.
The user needs to have an Accounting group in order to access this field.

**Cause:**
When printing the quote, the SO is exported in a XML to be embedded in the PDF.
The field is accessed at that moment.

opw-5976725




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
