### PR TITLE
[FIX] pos_sale,sale: ignore fixed tax downpayment

### DIFF
--- a/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
+++ b/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
@@ -388,8 +388,6 @@ export class SaleOrderManagementScreen extends ControlButtonsMixin(Component) {
         });
 
         // We need one unique line for the fixed amount taxes
-        let fixed_taxes_downpayment = 0;
-        const fixed_taxes_tab = [];
         const down_payment_line_to_create = [];
 
         Object.keys(grouped).forEach((key) => {
@@ -405,14 +403,7 @@ export class SaleOrderManagementScreen extends ControlButtonsMixin(Component) {
             const fixed_taxes = group[0].tax_id.filter(
                 (id) => this.pos.taxes_by_id[id].amount_type === "fixed"
             );
-            const total_qty = group.reduce((total, line) => (total += line.product_uom_qty), 0);
-            fixed_taxes.forEach((tax_id) => {
-                const tax = this.pos.taxes_by_id[tax_id];
-                fixed_taxes_downpayment += tax.amount * total_qty * percentage;
-                fixed_taxes_tab.push(tab);
-            });
 
-            // We need to remove the amount of the fixed tax as they will have a separate line
             const fixed_tax_total_amount = fixed_taxes.reduce((total, tax_id) => {
                 const tax = this.pos.taxes_by_id[tax_id];
                 return total + tax.amount;
@@ -448,19 +439,6 @@ export class SaleOrderManagementScreen extends ControlButtonsMixin(Component) {
             });
         });
 
-        if (fixed_taxes_downpayment !== 0) {
-            // We try to merge the fixed taxes in one line that has no tax if possible
-            const line = down_payment_line_to_create.find((line) => !line.tax_ids.length);
-            if (line) {
-                line.price += fixed_taxes_downpayment;
-            } else {
-                down_payment_line_to_create.push({
-                    price: fixed_taxes_downpayment,
-                    tab: fixed_taxes_tab.flat(),
-                    tax_ids: [],
-                });
-            }
-        }
         for (const down_payment_line of down_payment_line_to_create) {
             this.pos.get_order().add_orderline(
                 new Orderline(

--- a/addons/pos_sale/static/tests/tours/PosSaleTour.js
+++ b/addons/pos_sale/static/tests/tours/PosSaleTour.js
@@ -363,7 +363,7 @@ registry.category("web_tour.tours").add("PoSDownPaymentFixedTax", {
             Order.hasLine({
                 productName: "Down Payment",
                 quantity: "1.0",
-                price: "22.00",
+                price: "20.00",
             }),
         ].flat(),
 });

--- a/addons/sale/tests/test_sale_order_down_payment.py
+++ b/addons/sale/tests/test_sale_order_down_payment.py
@@ -356,15 +356,14 @@ class TestSaleOrderDownPayment(TestSaleCommon):
             # keys
             ['account_id',               'tax_ids',                 'balance',    'price_total'],
             # base lines
-            [self.revenue_account.id,    (tax_10_a + tax_10_b).ids, -110,         132          ],
-            [self.revenue_account.id,    tax_10_b.ids,              -10,          11           ],
+            [self.revenue_account.id,    (tax_10_a + tax_10_b).ids, -100,         120          ],
             [self.revenue_account.id,    tax_10_a.ids,              -200,         220          ],
-            [self.revenue_account.id,    self.env['account.tax'],   -110,         110          ],
+            [self.revenue_account.id,    self.env['account.tax'],   -100,         100          ],
             # taxes
-            [self.tax_account.id,        self.env['account.tax'],   -31,          0            ],
-            [self.tax_account.id,        self.env['account.tax'],   -12,          0            ],
+            [self.tax_account.id,        self.env['account.tax'],   -30,          0            ],
+            [self.tax_account.id,        self.env['account.tax'],   -10,          0            ],
             # receivable
-            [self.receivable_account.id, self.env['account.tax'],   473,          0            ],
+            [self.receivable_account.id, self.env['account.tax'],   440,          0            ],
         ]
         self._assert_invoice_lines_values(invoice.line_ids, expected)
 
@@ -503,15 +502,14 @@ class TestSaleOrderDownPayment(TestSaleCommon):
             # keys
             ['account_id',               'tax_ids',                 'balance',    'price_total', 'analytic_distribution'],
             # base lines
-            [self.revenue_account.id,    (tax_10_a + tax_10_b).ids, -110,         132,            {an_acc_01: 50, an_acc_02: 50}],
-            [self.revenue_account.id,    tax_10_b.ids,              -10,          11,             {an_acc_01: 50, an_acc_02: 50}],
+            [self.revenue_account.id,    (tax_10_a + tax_10_b).ids, -100,         120,            {an_acc_01: 50, an_acc_02: 50}],
             [self.revenue_account.id,    tax_10_a.ids,              -200,         220,            False                         ],
-            [self.revenue_account.id,    self.env['account.tax'],   -110,         110,            False                         ],
+            [self.revenue_account.id,    self.env['account.tax'],   -100,         100,            False                         ],
             # taxes
-            [self.tax_account.id,        self.env['account.tax'],   -31,          0,              False                         ],
-            [self.tax_account.id,        self.env['account.tax'],   -12,          0,              False                         ],
+            [self.tax_account.id,        self.env['account.tax'],   -30,          0,              False                         ],
+            [self.tax_account.id,        self.env['account.tax'],   -10,          0,              False                         ],
             # receivable
-            [self.receivable_account.id, self.env['account.tax'],   473,          0,              False                         ],
+            [self.receivable_account.id, self.env['account.tax'],   440,          0,              False                         ],
         ]
         self._assert_invoice_lines_values(invoice.line_ids, expected)
 

--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -335,24 +335,6 @@ class SaleAdvancePaymentInv(models.TransientModel):
                 line['analytic_distribution'],
                 tax_repartition['price_subtotal']
             ])
-            for fixed_tax in fixed_taxes:
-                # Fixed taxes cannot be set as taxes on down payments as they always amounts to 100%
-                # of the tax amount. Therefore fixed taxes are removed and are replace by a new line
-                # with appropriate amount, and non fixed taxes if the fixed tax affected the base of
-                # any other non fixed tax.
-                if fixed_tax.price_include:
-                    continue
-
-                if fixed_tax.include_base_amount:
-                    pct_tax = taxes[list(taxes).index(fixed_tax) + 1:]\
-                        .filtered(lambda t: t.is_base_affected and t.amount_type != 'fixed')
-                else:
-                    pct_tax = self.env['account.tax']
-                down_payment_values.append([
-                    pct_tax,
-                    line['analytic_distribution'],
-                    line['quantity'] * fixed_tax.amount
-                ])
 
         downpayment_line_map = {}
         analytic_map = {}


### PR DESCRIPTION
When making a downpayment for an order containing product using fixed taxes, the downpayment invoice would contain line without tax associated This is an issue when sending these invoices to Peppol.

Steps to reproduce:
-------------------
* Create a fixed tax of 5€
* Set this tax on any product along another tax
* Create a sale order for this product
* Make a downpayment of 10%
* The invoice created has a line without any tax set
> Observation: When sending to Peppol we get an error

Why the fix:
------------
We remove the downpayment part that concerns fixed tax to avoid having lines without tax set.

opw-5853070