### PR TITLE
[FIX] point_of_sale: cancel empty order causes traceback with loyalty

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -129,6 +129,11 @@ export class ControlButtons extends Component {
             ? "btn btn-secondary btn-lg py-5"
             : "btn btn-secondary btn-lg lh-lg";
     }
+
+    onCancelOrder() {
+        this.props.close();
+        this.pos.onDeleteOrder(this.currentOrder);
+    }
 }
 
 export class ControlButtonsPopup extends Component {

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/control_buttons.xml
@@ -47,7 +47,7 @@
                     <t t-if="currentOrder?.fiscal_position_id" t-esc="currentOrder.fiscal_position_id.display_name" />
                     <t t-else="">Tax</t>
                 </button>
-                <button t-if="this.pos.cashier._role != 'minimal'" class="btn btn-secondary btn-lg py-5" t-on-click="() => this.pos.onDeleteOrder(this.pos.getOrder())">
+                <button t-if="this.pos.cashier._role != 'minimal'" class="btn btn-secondary btn-lg py-5" t-on-click="this.onCancelOrder">
                     <i class="fa fa-trash me-1" role="img" /> Cancel Order 
                 </button>
             </div>


### PR DESCRIPTION
Steps to reproduce:
=
- Enable loyalty in the POS configuration.
- Add an eWallet program for this POS.
- Open a table and cancel the (empty) order using the "Cancel Order" control button.

Issue:
=
- A traceback occurs: `TypeError: Cannot read properties of undefined (reading 'getTotalWithTax')`

Reason:
=
- When clicking "Cancel Order", the order is deleted and `currentOrder` becomes `undefined`.
- During the re-render of `ControlButtons` on the product screen, there is no active order,  which leads to the traceback.

Fix:
=
- Ensure the `ControlButtons` dialog is closed before deleting the order to prevents the re-render of `ControlButtons` without an active order and avoids the traceback.

task-6030182
