### PR TITLE
[FIX] account: allow preview for invoice with early discount and no date

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2028,7 +2028,7 @@ class AccountMove(models.Model):
         return self.currency_id == currency \
             and self.move_type in ('out_invoice', 'out_receipt', 'in_invoice', 'in_receipt') \
             and self.invoice_payment_term_id.early_discount \
-            and (not reference_date or reference_date <= self.invoice_payment_term_id._get_last_discount_date(self.invoice_date)) \
+            and (not reference_date or reference_date <= self.invoice_payment_term_id._get_last_discount_date(self.invoice_date or fields.Date.context_today(self))) \
             and self.payment_state == 'not_paid'
 
     # -------------------------------------------------------------------------

--- a/addons/account/models/account_payment_term.py
+++ b/addons/account/models/account_payment_term.py
@@ -275,9 +275,7 @@ class AccountPaymentTerm(models.Model):
 
     def _get_last_discount_date_formatted(self, date_ref):
         self.ensure_one()
-        if not date_ref:
-            return None
-        return format_date(self.env, self._get_last_discount_date(date_ref))
+        return format_date(self.env, self._get_last_discount_date(date_ref or fields.Date.context_today(self)))
 
     def copy(self, default=None):
         default = dict(default or {})

--- a/addons/account/tests/test_portal_attachment.py
+++ b/addons/account/tests/test_portal_attachment.py
@@ -4,8 +4,9 @@ from odoo.addons.account.tests.common import AccountTestInvoicingHttpCommon
 from odoo.tests.common import tagged
 
 import json
+from freezegun import freeze_time
 
-from odoo import http
+from odoo import Command, http
 from odoo.tools import mute_logger
 
 
@@ -285,3 +286,47 @@ class TestPortalAttachment(AccountTestInvoicingHttpCommon):
         self.assertEqual(len(self.out_invoice.message_ids), 3)
         self.assertEqual(self.out_invoice.message_ids[0].body, "<p>test message 3</p>")
         self.assertEqual(len(self.out_invoice.message_ids[0].attachment_ids), 1)
+
+    @freeze_time('2026-01-01')
+    def test_preview_early_discount_draft_invoice(self):
+        """
+        Ensures that loading the preview of a draft invoice with an early discount
+        payment term does not result in an error, and that today is used a default
+        date to compute the early discount limit
+        """
+        early_discount_payment_terms = self.env['account.payment.term'].create({
+            'name': 'Early Discount Payment Terms',
+            'company_id': self.env.company.id,
+            'early_discount': True,
+            'discount_percentage': 10,
+            'discount_days': 5,
+            'line_ids': [Command.create({
+                'value': 'percent',
+                'nb_days': 10,
+                'value_amount': 100,
+            })]
+        })
+        no_date_invoice = self.env['account.move'].create([{
+            'move_type': 'out_invoice',
+            'invoice_payment_term_id': early_discount_payment_terms.id,
+            'invoice_line_ids': [Command.create({
+                'product_id': self.product_a.id,
+                'price_unit': 10.0,
+            })]
+        }])
+        self.authenticate(None, None)  # Authenticate as an anonymous user
+        res = self.url_open(
+            url=f'{no_date_invoice.get_base_url()}/my/invoices/{no_date_invoice.id}',
+            data={
+                'res_model': 'account.move',
+                'res_id': no_date_invoice.id,
+                'csrf_token': http.Request.csrf_token(self),
+                'access_token': no_date_invoice._portal_ensure_token(),
+            }
+        )
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(
+            early_discount_payment_terms._get_last_discount_date_formatted(False),
+            '01/06/2026',  # today + 5 (discount_days)
+            'Last discount date should use today as a start date when no invoice date is given.'
+        )


### PR DESCRIPTION
## Issue
When clicking the *Preview* button on a draft invoice with an early discount payment term and no invoice date, the following traceback would appear:

```
File ".../addons/account/models/account_payment_term.py", line 274, in _get_last_discount_date
    return date_ref + relativedelta(days=self.discount_days or 0) if self.early_discount else False
           ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for +: 'bool' and 'relativedelta'
```

## Steps to reproduce
1. Install *Accounting* (`account_accountant`)
2. In Accounting > Configuration > Payment Terms, chose a Payment Term PT and toggle its *Early Discount* field
3. In Accounting > Customers > Invoices, create **but do not confirm** a new Invoice
    - Any Customer
    - Payment Term PT
    - Any Product
    - **No Invoice Date**
4. Click the *Preview* button
5. **A _500: Internal Server Error_ traceback appears**

## Cause
The traceback occurs in `AccountPaymentTerm._get_last_discount_date`:

https://github.com/odoo/odoo/blob/6cc36886c612c7ed8878117637ee11bc6234d0e4/addons/account/models/account_payment_term.py#L272-L274

where `date_ref` is False. This method is called by `AccountMove._is_eligible_for_early_payment_discount`:

https://github.com/odoo/odoo/blob/6cc36886c612c7ed8878117637ee11bc6234d0e4/addons/account/models/account_move.py#L2026-L2032

where `self.invoice_date` is False, because that field is not required, and the user can click the *Preview* button before a date is set. If the invoice is confirmed before being previewed, the issue does not occur, as confirming an invoice with no date will use today's date by default. This is done in `AccountMove._post`:

https://github.com/odoo/odoo/blob/6cc36886c612c7ed8878117637ee11bc6234d0e4/addons/account/models/account_move.py#L3967-L3971

## Fix
We can apply the same behavior as if the invoice was confirmed, and use today's date by default if no invoice date is given when trying to preview a draft invoice. The same logic should be applied to `_get_last_discount_date_formatted` for the date to be correctly evaluated in `account/views/report_invoice.xml`:

https://github.com/odoo/odoo/blob/6cc36886c612c7ed8878117637ee11bc6234d0e4/addons/account/views/report_invoice.xml#L252-L254

where `o.invoice_date` is also `False`, leading to `AccountPaymentTerm._get_last_discount_date_formatted` to return None:

https://github.com/odoo/odoo/blob/6cc36886c612c7ed8878117637ee11bc6234d0e4/addons/account/models/account_payment_term.py#L276-L280

which then displays the default date (`2024-01-01`) instead of *today + the early discount time limit*.

## Test
[The test](https://github.com/odoo/odoo/blob/6cc36886c612c7ed8878117637ee11bc6234d0e4/addons/account/tests/test_early_payment_discount.py#L92-L116) added by https://github.com/odoo/odoo/commit/572a6a82576a91005d9eedb673acfb088eb52cd1 and edited by https://github.com/odoo/odoo/commit/abe7fb51235dc3d47e6352505065fcd15100b21b does not follow the same execution flow as the *Preview* button. In the test case, the `reference_date` passed to the `is_eligible_for_early_payment_discount` method is `False`, skipping the problematic section of the condition. When using the *Preview* button, a `reference_date` is passed from `AccountMoveLine._get_epd_data` since https://github.com/odoo/odoo/commit/b9abe46c1492b09e369434e76ec8196c6b02dd19:

https://github.com/odoo/odoo/blob/6cc36886c612c7ed8878117637ee11bc6234d0e4/addons/account/models/account_move_line.py#L3287-L3295

opw-6008959