### PR TITLE
[IMP] account: restrict invoice company change

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1567,7 +1567,7 @@
                                     </group>
                                     <group string="Accounting"
                                            name="accounting_info_group">
-                                        <field name="company_id" groups="base.group_multi_company" domain="[('id', 'child_of', journal_company_id)]"/>
+                                        <field name="company_id" groups="base.group_multi_company" readonly="state in ['cancel', 'posted']" domain="[('id', 'child_of', journal_company_id)]"/>
                                         <field name="invoice_incoterm_placeholder" invisible="1"/>    <!-- Needed for placeholder_field -->
                                         <field name="invoice_incoterm_id" options="{'placeholder_field': 'invoice_incoterm_placeholder'}" invisible="move_type in ('out_receipt', 'in_receipt')"/>
                                         <field name="incoterm_location" invisible="move_type in ('out_receipt', 'in_receipt')"/>


### PR DESCRIPTION
Before this commit-
Even after the invoice is posted or cancelled you can still change the company on the invoice, which is still weird to do so

After this commit-
We don't allow changing of the company once the invoice is posted or cancelled


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
