### PR TITLE
[IMP] account: mass edit partner on move list

### DIFF
--- a/addons/account/static/src/views/fields/partner_field.js
+++ b/addons/account/static/src/views/fields/partner_field.js
@@ -1,0 +1,27 @@
+import { Component } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { standardFieldProps } from "@web/views/fields/standard_field_props";
+import { Field } from "@web/views/fields/field";
+
+export class PartnerField extends Component {
+    static components = { Field };
+    static props = {
+        ...standardFieldProps,
+    };
+
+    static template = "account.PartnerField";
+
+    get nameToDisplay() {
+        // If the user is mass editing the partner_id on a move list, this will trigger the list_confirmation_dialog.js that will use this widget again.
+        // record.partner_id is already updated in cache with the new partner while record.invoice_partner_display_name is not yet recomputed. So we
+        // need to base the output on the partner_id if it's set, and on the computed field if not
+        if (this.props.record.data.partner_id) {
+            return this.props.record.data.partner_id.display_name;
+        }
+        return this.props.record.data.invoice_partner_display_name;
+    }
+
+}
+registry.category("fields").add("partner_field", {
+    component: PartnerField,
+});

--- a/addons/account/static/src/views/fields/partner_field.xml
+++ b/addons/account/static/src/views/fields/partner_field.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="account.PartnerField">
+        <t t-if="props.readonly">
+            <t t-out="nameToDisplay"/>
+        </t>
+        <t t-else="">
+            <Field name="'partner_id'" record="props.record"/>
+        </t>
+    </t>
+</templates>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -542,8 +542,8 @@
                     <field name="made_sequence_gap" column_invisible="True"/>
                     <field name="duplicated_ref_ids" column_invisible="True"/>  <!-- Needed for custome view account_tree-->
                     <field name="name" decoration-bf="1" decoration-danger="made_sequence_gap and state == 'posted'" widget="char_with_placeholder_field" placeholder="/"/>
-                    <field name="invoice_partner_display_name" column_invisible="context.get('default_move_type') not in ('in_invoice', 'in_refund', 'in_receipt')" groups="base.group_user" string="Vendor" />
-                    <field name="invoice_partner_display_name" column_invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund', 'out_receipt')" groups="base.group_user" string="Customer" />
+                    <field name="partner_id" widget="partner_field" column_invisible="context.get('default_move_type') not in ('in_invoice', 'in_refund', 'in_receipt')" groups="base.group_user" string="Vendor" readonly="state != 'draft'"/>
+                    <field name="partner_id" widget="partner_field" column_invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund', 'out_receipt')" groups="base.group_user" string="Customer" readonly="state != 'draft'"/>
                     <field name="journal_id" optional="hide"/>
                     <field name="invoice_date" optional="show" column_invisible="context.get('default_move_type') not in ('in_invoice', 'in_refund', 'in_receipt')" readonly="state != 'draft'" string="Bill Date" decoration-warning="abnormal_date_warning"/>
                     <field name="invoice_date" optional="show" column_invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund', 'out_receipt')" readonly="state != 'draft'" string="Invoice Date" decoration-warning="abnormal_date_warning"/>
@@ -592,6 +592,7 @@
                     <field name="move_type" column_invisible="context.get('default_move_type', True)"/>
                     <field name="abnormal_amount_warning" column_invisible="1"/>
                     <field name="abnormal_date_warning" column_invisible="1"/>
+                    <field name="invoice_partner_display_name" column_invisible="1"/>
                   </list>
             </field>
         </record>


### PR DESCRIPTION
[IMP] account: mass edit partner on move list

This commit adds the feature to mass edit the partner field on moves when the user is in a move list view.
A widget is created to display either the Many2one `partner_id` field (in case we're editing multiple moves) or the `invoice_partner_display_name` (in case we're displaying without editing)

task-5986025
