### PR TITLE
[FIX] hr_holidays: apply negative allocation limit correctly

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -303,18 +303,37 @@ class HrLeaveAllocation(models.Model):
 
     @api.constrains('number_of_days', 'work_entry_type_id', 'employee_id')
     def _check_negative_allocation(self):
-        for allocation in self:
-            if allocation.number_of_days >= 0:
-                continue
+        for allocation in self.filtered(lambda allocation: allocation.number_of_days < 0):
             if not allocation.work_entry_type_id.allows_negative:
                 raise ValidationError(self.env._("Negative allocations are not allowed for this time type."))
-            allocation_unit = allocation.type_request_unit
-            if allocation_unit != 'hour' and abs(allocation.number_of_days_display) > allocation.work_entry_type_id.max_allowed_negative:
-                raise ValidationError(self.env._("The negative allocation cannot exceed the maximum allowed negative value of %(max)s day(s).",
-                      max=allocation.work_entry_type_id.max_allowed_negative))
-            if allocation_unit == 'hour' and abs(allocation.number_of_hours_display) > allocation.work_entry_type_id.max_allowed_negative:
-                raise ValidationError(self.env._("The negative allocation cannot exceed the maximum allowed negative value of %(max)s hour(s).",
-                      max=allocation.work_entry_type_id.max_allowed_negative))
+            domain = [
+                ('id', '!=', allocation.id),
+                ('employee_id', '=', allocation.employee_id.id),
+                ('work_entry_type_id', '=', allocation.work_entry_type_id.id),
+                ('state', 'in', ('confirm', 'validate', 'validate1')),
+                ('number_of_days', '<', 0),
+            ]
+            if allocation.date_to:
+                domain += [('date_from', '<=', allocation.date_to)]
+            domain += [
+                '|',
+                ('date_to', '=', False),
+                ('date_to', '>=', allocation.date_from),
+            ]
+            is_hour_allocation = allocation.type_request_unit == 'hour'
+            aggregate_field = 'number_of_hours_display' if is_hour_allocation else 'number_of_days'
+            current_amount = allocation.number_of_hours_display if is_hour_allocation else allocation.number_of_days
+            negative_total, = self.env['hr.leave.allocation']._read_group(domain, aggregates=[f'{aggregate_field}:sum'])[0]
+            total_negative = -(current_amount + (negative_total or 0))
+            max_negative = allocation.work_entry_type_id.max_allowed_negative
+
+            if total_negative > max_negative:
+                raise ValidationError(self.env._(
+                    "The total negative allocation within this validity period "
+                    "cannot exceed %(max)s %(unit)s.",
+                    max=max_negative,
+                    unit='hours' if is_hour_allocation else 'days',
+                ))
 
     @api.depends('allocation_type')
     def _compute_accrual_plan_id(self):

--- a/addons/hr_holidays/tests/test_allocations.py
+++ b/addons/hr_holidays/tests/test_allocations.py
@@ -639,3 +639,31 @@ class TestAllocations(TestHrHolidaysCommon):
             'date_from': '2023-12-25'
         })
         self.assertEqual(1, self.work_entry_type.allocation_count)
+
+    def test_negative_allocation_open_end_overlap_limit(self):
+        """Ensure ValidationError is raised when overlapping negative allocations exceed max limit
+        """
+        self.work_entry_type.write({
+            'allows_negative': True,
+            'max_allowed_negative': 5,
+        })
+        allocation_1 = self.env['hr.leave.allocation'].create({
+            'name': 'Negative Allocation 1',
+            'employee_id': self.employee.id,
+            'work_entry_type_id': self.work_entry_type.id,
+            'number_of_days': -3,
+            'allocation_type': 'regular',
+            'date_from': date(2024, 1, 1),
+        })
+        allocation_1.action_approve()
+        with self.assertRaises(ValidationError):
+            allocation_2 = self.env['hr.leave.allocation'].create({
+                'name': 'Negative Allocation 2',
+                'employee_id': self.employee.id,
+                'work_entry_type_id': self.work_entry_type.id,
+                'number_of_days': -3,
+                'allocation_type': 'regular',
+                'date_from': date(2024, 6, 1),
+                'date_to': date(2024, 6, 30),
+            })
+            allocation_2.action_approve()


### PR DESCRIPTION
### Issue:
- Negative limit (`max_allowed_negative`) was not applied on total balance.
- It was checked per allocation only.
- Because of this, user could create multiple negative allocations and go below the allowed limit.

### Example:
- Limit: -5
  - First allocation:  -3 -> OK
  - Second allocation: -2 -> OK
  - Third allocation:  -1 -> Should NOT be allowed

### Fix:
- Now system checks total negative amount for the employee and time off type.
- It includes all overlapping allocations.
- If total is more than allowed limit, system raises error.

### Impact:
- Prevents going below allowed negative limit.
- Keeps employee balance correct.
- Behavior is now as expected.

---

Task: 6023657





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
