### PR TITLE
[FIX] barcodes: rescan deleted line rfid

### DIFF
--- a/addons/barcodes/static/src/js/barcode_parser.js
+++ b/addons/barcodes/static/src/js/barcode_parser.js
@@ -289,6 +289,16 @@ export class BarcodeParser {
         ];
     }
 
+    convertProductAndTrackingIntoNumberURIGTINData(product_barcode, lot_number) {
+        const prod_barcode = product_barcode.slice(0, -1)
+        const indicator = prod_barcode[0]
+        const gs1CompanyPrefix = prod_barcode.slice(1,7)
+        const itemRef = prod_barcode.slice(7)
+        const data = [gs1CompanyPrefix, indicator+itemRef,lot_number]
+        const barcode_uri_numbers = data.join(".")
+        return barcode_uri_numbers
+    }
+
     convertURISSCCDataIntoPackage(base_code, data) {
         const [gs1CompanyPrefix, serialReference] = data;
         const extension = serialReference[0];


### PR DESCRIPTION
**Problem:**
When using rfid scan, a deleted line can 
not be scanned again

**Steps to reproduce on localhost:**
1) create a new db with stock_barcode module
2) enable lot and sn setting
3) create a storable serial number product with 
barcode 06016478556455
4) open barcode/ Count Inventory
5)  to simulate a rfid scan of 3 serial numbers [1,2 and 3]: 
- open browser console
- enter the following command : 
`odoo.__WOWL_DEBUG__.root.env.services.mobile.bus.trigger("mobile_reader_scanned", { data: [
"urn:epc:id:sgtin:601647.0855645.1urn:epc:id:sgtin:601647.0855645.2urn:epc:id:sgtin:601647.0855645.3"
]});`
6) click the line with serial number "2", click on 
the "-1" and then bin red button
7) repeat step 5

**Current behavior:**
the line for sn 2 is not added to the product 

**Expected behavior:**
it should be added when rescanned

**Cause of the issue:**
When the uri barcodes are first scanned at step 5, 
every uri is added to the uri cache, to be sure that 
they are not mistakenly rescanned. 
https://github.com/odoo/enterprise/blob/4296be6a81909dcdb094f728f8be45a8617ff54b/stock_barcode/static/src/models/barcode_model.js#L1615

Then when we scan again at step 7, because the uri 
is in the cache, it's not added to filteredBarcodes and 
it will not be processed. 
https://github.com/odoo/enterprise/blob/4296be6a81909dcdb094f728f8be45a8617ff54b/stock_barcode/static/src/models/barcode_model.js#L688-L696

**fix**
we remove the uri from the cache when the line is deleted.

opw-5193250