### PR TITLE
[FIX] account_edi_ubl_cii : define can export selfbilling

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -829,6 +829,10 @@ class AccountEdiCommon(models.AbstractModel):
     def _correct_invoice_tax_amount(self, tree, invoice):
         pass  # To be implemented by the format if needed
 
+    def _can_export_selfbilling(self):
+        # Overridden in `account_peppol_selfbilling`
+        return False
+
     # -------------------------------------------------------------------------
     # Check xml using the free API from Ph. Helger, don't abuse it !
     # -------------------------------------------------------------------------

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -258,10 +258,6 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
 
         return vals
 
-    def _can_export_selfbilling(self):
-        # Overridden in `account_peppol_selfbilling`
-        return False
-
     def _export_invoice_vals(self, invoice):
         # EXTENDS account.edi.xml.ubl_21
         vals = super()._export_invoice_vals(invoice)


### PR DESCRIPTION
# How to reproduce
- Install the Peppol Self-Billing module (account_peppol_selfbilling)
- Go to any contact
- In the accounting tab, set the Electroing Invoicing to "Factur-X (CII)"
- Try to access any Vendor Bill

# The problem
A traceback is shown

# Why
This commit (https://github.com/odoo/odoo/commit/c696a11ee735b0689ef6a00f1a189916724d4854) backported the peppol self-billing feature.

When the user try to access a Vendor Bill, this check is run :

```py
def _is_exportable_as_self_invoice(self):
        return (
            self.state == 'posted'
            and self.is_purchase_document()
            and self.commercial_partner_id.ubl_cii_format
            and (edi_builder := self.commercial_partner_id._get_edi_builder()) is not None
            and edi_builder._can_export_selfbilling()
            and self.journal_id.is_self_billing
        )
```

In the case of Factur-X invoicing (account.edi.xml.cii), ```_can_export_selfbilling()```is not defined.

opw-6022938

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
