### PR TITLE
[FIX] pos_loyalty: gift card reward line tax computation

### DIFF
--- a/addons/pos_loyalty/static/src/app/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/app/models/pos_order.js
@@ -1175,25 +1175,41 @@ patch(PosOrder.prototype, {
         // These are considered payments and do not require to be either taxed or split by tax
         const discountProduct = reward.discount_line_product_id;
         if (["ewallet", "gift_card"].includes(reward.program_id.program_type)) {
+            let taxes = discountProduct.taxes_id;
+            if (this.fiscal_position_id) {
+                taxes = this.fiscal_position_id.getTaxesAfterFiscalPosition(taxes);
+            }
             const price = discountProduct.getTaxDetails({
                 overridedValues: {
-                    tax_ids: discountProduct.taxes_id,
+                    tax_ids: taxes,
                     price_unit: -Math.min(maxDiscount, discountable),
                     special_mode: "total_included",
                 },
             });
-
+            let priceUnit = price.total_excluded;
+            let rewardTaxIds = [];
+            if (reward.program_id.program_type === "gift_card" && taxes.length) {
+                const priceInclTaxIds = new Set(
+                    taxes.filter((t) => t.price_include).map((t) => t.id)
+                );
+                for (const taxData of price.taxes_data) {
+                    if (priceInclTaxIds.has(taxData.tax.id)) {
+                        priceUnit += taxData.tax_amount_currency;
+                    }
+                }
+                rewardTaxIds = discountProduct.taxes_id;
+            }
             return [
                 {
                     product_id: discountProduct,
-                    price_unit: price.total_excluded,
+                    price_unit: priceUnit,
                     qty: 1,
                     reward_id: reward,
                     is_reward_line: true,
                     coupon_id: coupon_id,
                     points_cost: pointCost,
                     reward_identifier_code: rewardCode,
-                    tax_ids: discountProduct.taxes_id,
+                    tax_ids: rewardTaxIds,
                 },
             ];
         }

--- a/addons/pos_loyalty/static/tests/unit/data/loyalty_program.data.js
+++ b/addons/pos_loyalty/static/tests/unit/data/loyalty_program.data.js
@@ -80,7 +80,7 @@ export class LoyaltyProgram extends models.ServerModel {
             portal_point_name: "Gift Card Points",
             trigger_product_ids: [],
             rule_ids: [1],
-            reward_ids: [],
+            reward_ids: [5],
         },
         {
             id: 4,

--- a/addons/pos_loyalty/static/tests/unit/data/loyalty_reward.data.js
+++ b/addons/pos_loyalty/static/tests/unit/data/loyalty_reward.data.js
@@ -118,6 +118,28 @@ export class LoyaltyReward extends models.ServerModel {
             reward_product_uom_id: false,
             reward_product_domain: "[]",
         },
+        {
+            id: 5,
+            description: "Gift Card Discount",
+            program_id: 3,
+            reward_type: "discount",
+            required_points: 0,
+            clear_wallet: true,
+            currency_id: 1,
+            discount: 1,
+            discount_mode: "per_point",
+            discount_applicability: "order",
+            all_discount_product_ids: [],
+            is_global_discount: false,
+            discount_max_amount: 0,
+            discount_line_product_id: 301,
+            reward_product_id: false,
+            multi_product: false,
+            reward_product_ids: [],
+            reward_product_qty: 1,
+            reward_product_uom_id: false,
+            reward_product_domain: "[]",
+        },
     ];
 }
 

--- a/addons/pos_loyalty/static/tests/unit/data/product_product.data.js
+++ b/addons/pos_loyalty/static/tests/unit/data/product_product.data.js
@@ -6,3 +6,19 @@ patch(ProductProduct.prototype, {
         return [...super._load_pos_data_fields(), "all_product_tag_ids"];
     },
 });
+
+ProductProduct._records = [
+    ...ProductProduct._records,
+    {
+        id: 301,
+        product_tmpl_id: 301,
+        lst_price: 0,
+        standard_price: 0,
+        display_name: "Gift Card Discount Product",
+        product_tag_ids: [],
+        barcode: false,
+        default_code: false,
+        product_template_attribute_value_ids: [],
+        product_template_variant_value_ids: [],
+    },
+];

--- a/addons/pos_loyalty/static/tests/unit/data/product_template.data.js
+++ b/addons/pos_loyalty/static/tests/unit/data/product_template.data.js
@@ -1,0 +1,21 @@
+import { ProductTemplate } from "@point_of_sale/../tests/unit/data/product_template.data";
+
+ProductTemplate._records = [
+    ...ProductTemplate._records,
+    {
+        id: 301,
+        name: "Gift Card Discount Product",
+        display_name: "Gift Card Discount Product",
+        list_price: 0,
+        standard_price: 0,
+        taxes_id: [4],
+        type: "service",
+        service_tracking: "no",
+        categ_id: false,
+        pos_categ_ids: [],
+        uom_id: 1,
+        available_in_pos: true,
+        active: true,
+        product_variant_ids: [301],
+    },
+];

--- a/addons/pos_loyalty/static/tests/unit/models/pos_order.test.js
+++ b/addons/pos_loyalty/static/tests/unit/models/pos_order.test.js
@@ -356,4 +356,32 @@ describe("pos.order - loyalty", () => {
         const rewardLine = order._get_reward_lines()[0];
         expect(rewardLine.prices.total_included).toBe(-10);
     });
+
+    test("gift card reward with tax-included discount product", async () => {
+        const store = await setupPosEnv();
+        const models = store.models;
+        const order = store.addNewOrder();
+
+        // Product with tax_incl tax
+        const line = await addProductLineToOrder(store, order, {
+            productId: 24,
+            templateId: 24,
+            qty: 1,
+        });
+        expect(line.prices.total_included).toBe(10);
+        expect(line.prices.total_excluded).toBe(8.7);
+
+        // Discount product also with tax_incl tax
+        const reward = models["loyalty.reward"].get(5);
+        const card = models["loyalty.card"].get(3);
+
+        const result = order._applyReward(reward, card.id);
+        expect(result).toBe(true);
+
+        const rewardLines = order._get_reward_lines();
+        expect(rewardLines.length).toBe(1);
+
+        // The gift card should discount the full tax-included amount, not just the base.
+        expect(rewardLines[0].prices.total_included).toBe(-10);
+    });
 });


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Create a product with a 15% tax-included tax (e.g. list price $10,
   total $10, base $8.70).
2. Create a gift card program with a discount product that has the
   same 15% tax-included tax.
3. Create a gift card with a $10 balance.
4. In PoS, add the product to the order and apply the gift card code.

-> The gift card only discounts $8.70 instead of $10.00.

What's happening:
-----------------
The reward line is created with `price_unit = total_excluded` ($8.70)
but when the discount product has price-included taxes, PoS treats
that value as already containing tax. The tax portion ($1.30) is
therefore lost.

The fix:
--------
Mirror what's done in `sale_loyalty` in https://github.com/odoo/odoo/commit/a1aeb1dbe1093aa9229e01662f311f7cb3f98389, by adding back the
price-included tax amounts to `total_excluded` so the reward line total
matches the full discount.

Note: also mirror tax manipulation done in that commit, by applying
fiscal positions on the discount product taxes, and only keeping taxes
on gift card reward lines (not on ewallet).

opw-6022212