### PR TITLE
[IMP] purchase{_stock}: align mobile PO line controls with desktop

### DIFF
--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -365,6 +365,12 @@
                                 <kanban class="o_kanban_mobile">
                                      <field name="display_type"/>
                                      <field name="tax_calculation_rounding_method"/>
+                                     <control>
+                                        <create name="add_product_control" string="Add product"/>
+                                        <create name="add_section_control" string="Add section" context="{'default_display_type': 'line_section'}"/>
+                                        <create name="add_note_control" string="Add note" context="{'default_display_type': 'line_note'}"/>
+                                        <button name="action_add_from_catalog" string="Catalog" type="object" context="{'order_id': parent.id}"/>
+                                     </control>
                                      <templates>
                                          <t t-name="card">
                                             <t t-if="!record.display_type.raw_value">

--- a/addons/purchase_stock/static/src/product_catalog/search/search_panel.js
+++ b/addons/purchase_stock/static/src/product_catalog/search/search_panel.js
@@ -7,7 +7,10 @@ import { clamp } from "@web/core/utils/numbers";
 
 export class PurchaseSuggestCatalogSearchPanel extends AccountProductCatalogSearchPanel {
     static template = "purchase_stock.ProductCatalogSearchPanel";
-    static components = { TimePeriodSelectionField };
+    static components = {
+        ...AccountProductCatalogSearchPanel.components,
+        TimePeriodSelectionField,
+    };
     static basedOnOptions = [
         ["actual_demand", _t("Forecasted")],
         ["one_week", _t("Last 7 days")],


### PR DESCRIPTION
In mobile view, purchase order lines are displayed in a kanban layout where controls such as “Add a section”, “Add a note”, and “Catalog” were missing, while they are available in the desktop list view. This creates inconsistent behavior and prevents users from performing these actions on mobile.

- This improvement adds the missing controls to the mobile view, ensuring feature parity and enabling users to manage PO lines efficiently.

- Fixes the catalog opening issue on mobile caused by overriding (instead of extending) the parent component, which prevented the Dropdown component from loading.

TaskID-6026092