### PR TITLE
[FIX] mail: fix addLink url encoding

### DIFF
--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -134,15 +134,15 @@ function linkify(text) {
     while ((match = urlRegexp.exec(text)) !== null) {
         result = htmlJoin([result, text.slice(curIndex, match.index)]);
         // Decode the url first, in case it's already an encoded url
-        const inputUrl = decodeURI(match[0]);
-        const url = !/^https?:\/\//i.test(inputUrl) ? "http://" + inputUrl : inputUrl;
+        const textContent = match[0];
+        const url = new URL(!/^https?:\/\//i.test(match[0]) ? "http://" + match[0] : match[0]);
         const link = document.createElement("a");
         setAttributes(link, {
             target: "_blank",
             rel: "noreferrer noopener",
-            href: encodeURI(url),
+            href: url.href,
         });
-        link.textContent = inputUrl;
+        link.textContent = textContent;
         const messageMatch = messageUrlRegExp.exec(url);
         if (messageMatch !== null) {
             setAttributes(link, {

--- a/addons/mail/static/tests/mail_utils.test.js
+++ b/addons/mail/static/tests/mail_utils.test.js
@@ -85,7 +85,19 @@ test("addLink: utility function and special entities", () => {
         // Already encoded url should not be encoded twice
         [
             markup`https://odoo.com/%5B%5D`,
-            `<a target="_blank" rel="noreferrer noopener" href="https://odoo.com/%5B%5D">https://odoo.com/[]</a>`,
+            `<a target="_blank" rel="noreferrer noopener" href="https://odoo.com/%5B%5D">https://odoo.com/%5B%5D</a>`,
+        ],
+        [
+            markup`https://www.odoo.com/appointment/10552?filter_appointment_type_ids=%5B6706%2C%2B6705%2C%2B5292%2C%2B10552%5D`,
+            `<a target="_blank" rel="noreferrer noopener" href="https://www.odoo.com/appointment/10552?filter_appointment_type_ids=%5B6706%2C%2B6705%2C%2B5292%2C%2B10552%5D">https://www.odoo.com/appointment/10552?filter_appointment_type_ids=%5B6706%2C%2B6705%2C%2B5292%2C%2B10552%5D</a>`,
+        ],
+        [
+            markup`www.odoo.com`,
+            `<a target="_blank" rel="noreferrer noopener" href="http://www.odoo.com/">www.odoo.com</a>`,
+        ],
+        [
+            markup`https://odoo.com/?q=ỗ`,
+            `<a target="_blank" rel="noreferrer noopener" href="https://odoo.com/?q=%E1%BB%97">https://odoo.com/?q=ỗ</a>`,
         ],
     ];
 

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -484,7 +484,7 @@ async function mail_link_preview(request) {
     const { message_id } = await parseRequestParams(request);
     const [message] = MailMessage.search_read([["id", "=", message_id]]);
     const link = createDocumentFragmentFromContent(markup(message.body)).querySelector(
-        "a[href^='https://tenor.com'], a[href='https://make-link-preview.com']"
+        "a[href^='https://tenor.com'], a[href^='https://make-link-preview.com']"
     );
     if (link) {
         const isGifPreview = link.href.startsWith("https://tenor.com");


### PR DESCRIPTION
Before this commit, the URL was fully encoded using encodeUrl.
This commit replaces this approach with the more modern [URL api](https://developer.mozilla.org/en-US/docs/Web/API/URL), which [handles encoding](https://url.spec.whatwg.org/#dom-url-href) properly.

This commit also removes decodeUrl. It was possible for a user to send a URL and have a different one displayed in the UI due to decoding.

Task-6041689
