### PR TITLE
[IMP] mail, hr_holidays: send mail to inactive users for unread messages

### DIFF
--- a/addons/hr_holidays/models/res_partner.py
+++ b/addons/hr_holidays/models/res_partner.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, fields
+from odoo import models, fields, api
 
 
 class ResPartner(models.Model):
@@ -14,3 +14,18 @@ class ResPartner(models.Model):
             # possible return date
             dates = partner.user_ids.mapped("leave_date_to")
             partner.leave_date_to = min(dates) if dates and all(dates) else False
+
+    @api.model
+    def _get_inactive_partners_data(self):
+        inactive_partner_ids = super()._get_inactive_partners_data()
+        absent_employees = self.env["hr.employee"].search_fetch([
+            ("user_id", "in", {p["user_id"] for p in inactive_partner_ids if p["user_id"]}),
+            ("is_absent", "=", True),
+        ])
+        # return only partners with employees that are not absent (holiday, sick leave, etc.)
+        # This avoids sending notifications to users that are on leave
+        return [
+            p
+            for p in inactive_partner_ids
+            if p["user_id"] not in absent_employees.user_id.ids
+        ]

--- a/addons/hr_holidays/tests/test_holidays_mail.py
+++ b/addons/hr_holidays/tests/test_holidays_mail.py
@@ -1,16 +1,17 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import time
-from datetime import date
+from datetime import date, timedelta
 from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
 
+from odoo import fields
 from odoo.tools import mute_logger
 
 from .common import TestHrHolidaysCommon
 from odoo.tests import tagged
 
-from odoo.addons.mail.tests.common import MailCase
+from odoo.addons.mail.tests.common import MailCase, MailCommon, freeze_all_time
 
 
 class TestHolidaysMail(TestHrHolidaysCommon, MailCase):
@@ -69,3 +70,44 @@ class TestHolidaysMail(TestHrHolidaysCommon, MailCase):
                 admin_emails = self._new_mails.filtered(lambda x: x.partner_ids.employee_ids.id == self.admin_employee.id)
                 self.assertEqual(len(admin_emails), 1, "Mitchell Admin should receive an email")
                 self.assertTrue("has been accepted" in admin_emails.preview)
+
+
+class TestMissedMessagesMail(MailCommon):
+    def test_notify_missed_messages_presence(self):
+        """Test that a partner is considered active if their main user is on leave,
+        and that they are considered inactive when not on leave, based on the presence status."""
+        with freeze_all_time("2026-03-13 18:00:00"):
+            self.env["mail.presence"].sudo().create({
+                "user_id": self.user_employee.id,
+                "last_poll": fields.Datetime.now() - timedelta(days=4),
+                "status": "offline",
+            })
+            work_entry_type = self.env['hr.work.entry.type'].create({
+                'requires_allocation': False,
+                'name': 'Legal Leaves',
+                'code': 'Legal Leaves',
+                'count_as': 'absence',
+                'request_unit': 'day',
+                'unit_of_measure': 'day',
+            })
+            employee = self.env["hr.employee"].create({
+                "user_id": self.user_employee.id,
+            })
+            leave = self.env["hr.leave"].with_context(leave_skip_state_check=True).create({
+                "request_date_from": fields.Date.today(),
+                "request_date_to": fields.Date.today(),
+                "employee_id": employee.id,
+                "state": "validate",
+                "work_entry_type_id": work_entry_type.id,
+            })
+            self.assertNotIn(
+                self.user_employee.partner_id.id,
+                [p["id"] for p in self.env["res.partner"]._get_inactive_partners_data()],
+                "The employee partner should be considered active due to leave",
+            )
+            leave.unlink()
+            self.assertIn(
+                self.user_employee.partner_id.id,
+                [p["id"] for p in self.env["res.partner"]._get_inactive_partners_data()],
+                "The employee partner should be considered inactive when not on leave",
+            )

--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -96,6 +96,7 @@ For more specific needs, you may also assign custom-defined actions
         'data/res_partner_data.xml',
         'data/mail_message_subtype_data.xml',
         'data/mail_templates_chatter.xml',
+        'data/mail_templates_discuss_channel.xml',
         'data/mail_templates_email_layouts.xml',
         'data/mail_templates_mailgateway.xml',
         'data/discuss_channel_data.xml',

--- a/addons/mail/data/ir_cron_data.xml
+++ b/addons/mail/data/ir_cron_data.xml
@@ -92,5 +92,13 @@
             <field name="code">model._cleanup_expired_mutes()</field>
             <field name="state">code</field>
         </record>
+        <record id="ir_cron_notify_missed_messages" model="ir.cron">
+            <field name="name">Mail: Notify about missed messages</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="model_id" ref="model_discuss_channel"/>
+            <field name="code">model._notify_missed_messages_cron()</field>
+            <field name="state">code</field>
+        </record>
     </data>
 </odoo>

--- a/addons/mail/data/mail_templates_discuss_channel.xml
+++ b/addons/mail/data/mail_templates_discuss_channel.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <template id="email_template_missed_message_notification">
+            <div style="padding: 16px; background-color: #F1F1F1; font-family: Verdana, Arial, sans-serif; color: #454748; width: 100%; display: flex; flex-direction: column; justify-content: center; align-items: center;">
+                <div style="max-width: 590px; width: 100%; background-color: #ffffff; border-radius: 8px; padding: 20px; margin: 20px; display: flex; flex-direction: column; align-items: center;">
+                    <t t-set="mentioned_messages" t-value="messages_data[0]"/>
+                    <t t-set="other_messages" t-value="messages_data[1]"/>
+                    <t t-if="mentioned_messages">
+                        <h2 style="color: {{company.email_secondary_color or '#875A7B'}}; text-align: center;">You were mentioned in the following messages</h2>
+                        <t t-foreach="mentioned_messages" t-as="module">
+                            <t t-set="messages_by_model" t-value="mentioned_messages[module]"/>
+                            <t t-foreach="messages_by_model" t-as="model">
+                                <h4 style="padding: 8px;">
+                                    <img
+                                        t-att-src="module.icon"
+                                        t-attf-alt="{{module.name}}:"/>
+                                    <t t-out="model._description"/>
+                                </h4>
+                                <t t-set="messages" t-value="messages_by_model[model]"/>
+                                <t t-foreach="messages" t-as="message">
+                                    <div style="width: 100%; font-size: 14px; line-height: 1.5; text-align: left; border-top: 1px solid #E0E0E0;">
+                                        <p style="padding: 8px;">
+                                            <p style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                                                <img
+                                                    t-attf-src="{{base_url}}{{message['partner_avatar_url']}}"
+                                                    t-attf-alt="Avatar of {{message['author'].display_name}}"
+                                                    style="heigh: 24px; width: 24px; margin-right: 12px"
+                                                    />
+                                                <b><t t-out="message['author'].display_name"/></b> in <t t-out="message['thread_name']"/>
+                                            </p>
+                                            On <t t-out="message['date']"/><br/>
+                                            <p style="border-left: 1px solid lightgray; margin: 24px; padding-left: 16px;"><t t-out="message['mail_message_body']"/></p><br/>
+                                            <a
+                                                t-attf-href="{{base_url}}{{message['url']}}"
+                                                t-attf-style="margin-top: 16px; padding: 10px 20px; background-color: {{company.email_secondary_color or '#875A7B'}}; color: {{company.email_primary_color or '#FFFFFF'}}; border: none; border-radius: 4px; text-decoration: none !important; font-size: 14px;"
+                                             >View Message
+                                            </a>
+                                        </p>
+                                    </div>
+                                </t>
+                            </t>
+                        </t>
+                    </t>
+                    <t t-if="other_messages">
+                        <h2 style="color: {{company.email_secondary_color or '#875A7B'}}; text-align: center;">Messages you might have missed</h2>
+                        <t t-foreach="other_messages" t-as="module">
+                            <t t-set="messages_by_model" t-value="other_messages[module]"/>
+                            <t t-foreach="messages_by_model" t-as="model">
+                                <h4 style="padding: 8px;">
+                                    <img
+                                        t-att-src="module.icon"
+                                        t-attf-alt="{{module.name}}:"/>
+                                    <t t-out="model._description"/>
+                                </h4>
+                                <t t-set="messages" t-value="messages_by_model[model]"/>
+                                <t t-foreach="messages" t-as="message">
+                                    <div style="width: 100%; font-size: 14px; line-height: 1.5; text-align: left; border-top: 1px solid #E0E0E0; justify-content: space-between; display: flex;">
+                                        <p style="padding: 8px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                                            <t t-out="message['thread_name']"/>
+                                        </p>
+                                        <p style="padding: 8px; white-space: nowrap;">
+                                            <a
+                                                t-attf-href="{{base_url}}{{message['url']}}"
+                                                t-attf-style="margin-top: 16px; padding: 10px 20px; background-color: {{company.email_secondary_color or '#875A7B'}}; color: {{company.email_primary_color or '#FFFFFF'}}; border: none; border-radius: 4px; text-decoration: none !important; font-size: 14px;"
+                                             >View Message
+                                            </a>
+                                        </p>
+                                    </div>
+                                </t>
+                            </t>
+                        </t>
+                    </t>
+                </div>
+            </div>
+        </template>
+    </data>
+</odoo>

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1676,3 +1676,61 @@ class DiscussChannel(models.Model):
         else:
             msg = _("You are alone in this channel.")
         self.env.user._bus_send_transient_message(self, msg)
+
+    def _get_messages_by_inactive_partner(self, inactive_partners_ids):
+        self.env.cr.execute(SQL("""
+                SELECT dm.partner_id,
+                       MIN(mm.id) AS first_unseen_message_in_range
+                  FROM discuss_channel dc
+                  JOIN discuss_channel_member dm ON dc.id = dm.channel_id
+                  JOIN res_partner rp ON rp.id = dm.partner_id
+                  JOIN res_users ru ON ru.partner_id = rp.id
+                   AND ru.active
+             LEFT JOIN res_users_settings rus ON rus.user_id = ru.id
+                  JOIN mail_message mm ON mm.model = 'discuss.channel'
+                   AND mm.res_id = dm.channel_id
+             LEFT JOIN mail_message_res_partner_rel mp ON mp.mail_message_id = mm.id
+                   AND mp.res_partner_id = dm.partner_id
+                 WHERE (
+                       dm.mute_until_dt IS NULL
+                       OR dm.mute_until_dt < timezone('utc', NOW())
+                   )
+                   AND NOT (
+                       dc.channel_type = 'channel'
+                       AND
+                       COALESCE(
+                           dm.custom_notifications,
+                           rus.channel_notifications,
+                           'mentions'
+                       ) = 'no_notif'
+                   )
+                   AND rp.id IN %(partner_ids)s
+                   AND (
+                       (
+                            dc.channel_type != 'group' AND (
+                                dc.channel_type != 'channel' OR
+                                COALESCE(
+                                     dm.custom_notifications,
+                                     rus.channel_notifications,
+                                     'mentions'
+                                 ) != 'mentions'
+                            )
+                       )
+                       OR mp.mail_message_id IS NOT NULL
+                   )
+                   AND mm.create_date > (timezone('utc', NOW()) - INTERVAL '8 days')
+                   AND mm.create_date < (timezone('utc', NOW()) - INTERVAL '1 day')
+                   AND mm.message_type = 'comment'
+                   AND (dm.seen_message_id IS NULL OR mm.id > dm.seen_message_id)
+                   AND mm.author_id != dm.partner_id
+              GROUP BY dm.partner_id, dm.channel_id
+            """,
+            partner_ids=tuple(inactive_partners_ids)
+        ))
+        res = self.env.cr.dictfetchall()
+        message_by_partner = super()._get_messages_by_inactive_partner(inactive_partners_ids)
+        for member_data in res:
+            message_by_partner[member_data["partner_id"]] |= self.env["mail.message"].browse(
+                member_data["first_unseen_message_in_range"]
+            )
+        return message_by_partner

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -300,6 +300,7 @@ class MailMessage(models.Model):
 
     _model_res_id_idx = models.Index("(model, res_id)")
     _model_res_id_id_idx = models.Index("(model, res_id, id)")
+    _create_date_message_type_idx = models.Index("(create_date, message_type)")
 
     @api.depends('body')
     def _compute_preview(self):

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -21,6 +21,7 @@ from collections.abc import Iterable
 from email import message_from_string
 from email.message import EmailMessage
 from xmlrpc import client as xmlrpclib
+from zoneinfo import ZoneInfo
 
 from lxml import etree, html
 from markupsafe import Markup, escape
@@ -46,6 +47,7 @@ from odoo.tools.mail import (
     email_normalize, email_normalize_all, email_split,
     email_split_and_format, email_split_and_format_normalize, email_split_and_normalize,
     formataddr, html_sanitize,
+    html_to_inner_content,
     generate_tracking_message_id,
     unfold_references,
 )
@@ -5275,3 +5277,178 @@ class MailThread(models.AbstractModel):
         ).has_access(mode):
             return thread
         return self.browse()
+
+    @api.model
+    def _get_messages_by_inactive_partner(self, inactive_partners_ids):
+        # custom sql since impossible to link mail_message.partner_ids
+        # and notification_ids.partner_id through ORM
+        self.env.cr.execute(SQL("""
+            SELECT partner_ids.res_partner_id, MIN(mm.id) as mail_message_id
+              FROM mail_notification notif
+              JOIN mail_message mm ON mm.id = notif.mail_message_id
+              JOIN mail_message_res_partner_rel partner_ids
+                ON partner_ids.mail_message_id = mm.id
+               AND partner_ids.res_partner_id = notif.res_partner_id
+             WHERE partner_ids.res_partner_id in %(inactive_partners_ids)s
+               AND notif.is_read IS NULL
+               AND mm.message_type = 'comment' --might not be what we want
+               AND mm.create_date > timezone('utc', NOW()) - INTERVAL '8 days'
+               AND mm.create_date < timezone('utc', NOW()) - INTERVAL '1 day'
+               AND notif.notification_type = 'inbox'
+               AND mm.model != 'discuss.channel'
+          GROUP BY partner_ids.res_partner_id, mm.res_id, mm.model
+        """, inactive_partners_ids=tuple(inactive_partners_ids)))
+        res = self.env.cr.fetchall()
+        message_by_partner = defaultdict(self.env["mail.message"].browse)
+        for partner_id, message_id in res:
+            message_by_partner[partner_id] |= self.env["mail.message"].browse(message_id)
+        return message_by_partner
+
+    @api.model
+    def _notify_missed_messages_cron(self):
+        inactive_partners_ids = {
+            p["id"] for p in self.env["res.partner"]._get_inactive_partners_data()
+        }
+        if not inactive_partners_ids:
+            return
+        # prefetching threads, partners and messages to avoid fetching in the mail generation loop
+        messages_by_partner = self._get_messages_by_inactive_partner(inactive_partners_ids)
+        if not messages_by_partner:
+            return
+        all_messages = self.env["mail.message"]
+        all_threads = {}
+        inactive_partners_to_notify = self.env["res.partner"].browse(messages_by_partner.keys())
+        all_partners = inactive_partners_to_notify
+        for messages in messages_by_partner.values():
+            all_messages |= messages
+        all_messages.fetch(("author_id", "body", "create_date", "partner_ids", "model", "res_id"))
+        all_partners |= all_messages.author_id
+        all_partners.fetch()
+        for message in all_messages:
+            if message.model not in all_threads:
+                all_threads[message.model] = self.env[message.model].browse(message.res_id)
+            else:
+                all_threads[message.model] |= self.env[message.model].browse(message.res_id)
+        for thread_model, threads in all_threads.items():
+            threads.fetch(("display_name",))
+
+        def derive_mail_value(partner_id, messages):
+            """Derive mail data for the given partner
+            with all its related members having new messages to notify."""
+            partner = self.env["res.partner"].browse(partner_id)
+            email_from = (
+                messages[0].author_id.email
+                if len(messages) == 1
+                else partner.main_user_id.company_id.catchall_formatted
+                or partner.main_user_id.company_id.email_formatted
+            )
+            email_to = partner.email
+            if not email_to:
+                return None
+            messages_mentioned = messages.filtered(lambda m: partner in m.partner_ids)
+            messages_not_mentioned = messages - messages_mentioned
+
+            def get_messages_groups(messages):
+                """ Group messages by model and format them for the qweb template.
+
+                :returns: A dict of {module: {model: [message_data]}}
+                where message_data is a dict containing the following keys:
+                    author: the author of the message;
+                    thread_name: the name of the thread the message belongs to;
+                    date: the date of the message, formatted in the user's timezone;
+                    mail_message_body: the body of the message, shortened to 190 characters
+                        and stripped of html tags;
+                    partner_avatar_url: the URL of the author's avatar;
+                    url: the URL to access the message in Odoo.
+                """
+                messages_by_model = messages.grouped("model")
+                modules = self.env["ir.module.module"].search_fetch(
+                    [
+                        (
+                            "name",
+                            "in",
+                            {self.env[model]._original_module for model in messages_by_model},
+                        )
+                    ]
+                )
+                messages_groups = defaultdict(dict)
+                for model, messages in messages_by_model.items():
+                    module_name = self.env[model]._original_module
+                    module = modules.filtered(lambda m: m.name == module_name)
+                    messages_groups[module][self.env[model]] = messages.mapped(
+                        lambda m: {
+                            "author": m.author_id,
+                            "thread_name": self.env[model].browse(m.res_id).display_name,
+                            "date": fields.Datetime.to_string(
+                                m.create_date.astimezone(ZoneInfo(partner.tz or "UTC"))
+                            ),
+                            "mail_message_body": textwrap.shorten(
+                                html_to_inner_content(m.body or ""),
+                                190,
+                            ),
+                            "partner_avatar_url": "/web/image/res.partner"
+                                f"/{m.author_id.id}/avatar_128"
+                                f"?access_token={m.author_id._get_avatar_128_access_token()}",
+                            "url": f"/mail/message/{m.id}",
+                        }
+                    )
+                return messages_groups
+
+            messages_data = (
+                get_messages_groups(messages_mentioned),
+                get_messages_groups(messages_not_mentioned),
+            )
+            body = (
+                self.env["ir.qweb"]
+                .with_context(lang=partner.lang or self.env.lang)
+                ._render(
+                    "mail.email_template_missed_message_notification",
+                    {
+                        "base_url": self.env["ir.config_parameter"].get_base_url(),
+                        "company": partner.company_id,
+                        "messages_data": messages_data,
+                        "user": partner.main_user_id,
+                    },
+                    minimal_qcontext=True,
+                )
+            )
+            body = self.env["mail.render.mixin"]._replace_local_links(body)
+            body_html = (
+                self.env["mail.render.mixin"]
+                .with_context(lang=partner.lang or self.env.lang)
+                ._render_encapsulate(
+                    "mail.mail_notification_layout",
+                    body,
+                    add_context={
+                        "email_notification_force_header": True,
+                        "email_notification_force_footer": True,
+                        "has_button_access": True,
+                        "button_access": {
+                            "url": "/odoo/discuss",
+                            "title": self.env._("Open Discuss"),
+                        },
+                        "subtitles": [
+                            self.env._("You have unread messages since your last visit."),
+                        ],
+                    },
+                )
+            )
+            return {
+                "body": body,
+                "body_html": body_html,
+                "email_from": email_normalize(email_from),
+                "email_to": email_normalize(email_to),
+                "message_type": "user_notification",
+                "subject": self.env._("You have unread messages in Discuss"),
+            }
+
+        mails = (
+            self.env["mail.mail"]
+            .create([
+                val
+                for partner, messages in messages_by_partner.items()
+                if (val := derive_mail_value(partner, messages)) is not None
+            ])
+        )
+        mails.send()
+        inactive_partners_to_notify.user_ids.last_notified = fields.Datetime.now()

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -7,6 +7,7 @@ from odoo.fields import Domain
 from odoo.tools.misc import limited_field_access_token
 from odoo.addons.mail.tools.discuss import Store
 from odoo.exceptions import AccessError
+from odoo.tools.sql import SQL
 
 
 class ResPartner(models.Model):
@@ -323,3 +324,23 @@ class ResPartner(models.Model):
             query = self._search(Domain('id', 'not in', partners.ids) & domain, limit=remaining_limit)
             partners |= self.browse(query)
         return partners
+
+    @api.model
+    def _get_inactive_partners_data(self):
+        self.env.cr.execute(SQL(
+            """
+            SELECT res_partner.id, res_users.id as user_id
+              FROM res_partner
+              JOIN res_users ON res_partner.id = res_users.partner_id
+              JOIN mail_presence ON mail_presence.user_id = res_users.id
+             WHERE mail_presence.status = 'offline'
+                -- 1 week - 8 hours (avoid cron sync issues)
+               AND (
+                    res_users.last_notified < timezone('utc', NOW()) - INTERVAL '160 hours'
+                    OR res_users.last_notified IS NULL
+                )
+          GROUP BY res_partner.id, res_users.id
+            HAVING MAX(mail_presence.last_poll) < timezone('utc', NOW()) - INTERVAL '72 hours'
+            """
+        ))
+        return self.env.cr.dictfetchall()

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -61,6 +61,10 @@ class ResUsers(models.Model):
         default='default',
     )
     has_external_mail_server = fields.Boolean(compute='_compute_has_external_mail_server', compute_sudo=True)
+    last_notified = fields.Datetime(
+        help="Date and time of the last notification sent to the user."
+            " Used to avoid sending too many notifications in a short period of time."
+    )
 
     def _compute_has_external_mail_server(self):
         self.has_external_mail_server = self.env['ir.config_parameter'].sudo().get_str(

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -4,6 +4,7 @@ import json
 from datetime import datetime, timedelta
 from freezegun import freeze_time
 from unittest.mock import patch
+from lxml import html
 from markupsafe import Markup
 
 from odoo import Command, fields
@@ -11,7 +12,7 @@ from odoo.addons.base.models.avatar_mixin import get_random_ui_color_from_seed
 from odoo.addons.bus.models.bus import channel_with_db, json_dump
 from odoo.addons.bus.tests.common import BusResult
 from odoo.addons.mail.models.discuss.discuss_channel import channel_avatar, group_avatar
-from odoo.addons.mail.tests.common import MailCommon, mail_new_test_user
+from odoo.addons.mail.tests.common import MailCommon, mail_new_test_user, freeze_all_time
 from odoo.addons.mail.tools.discuss import Store
 from odoo.exceptions import ValidationError
 from odoo.tests import HttpCase, users
@@ -1050,3 +1051,159 @@ class TestChannelInternals(MailCommon, HttpCase):
         actual_member_ids = [m.partner_id.id if m.partner_id else m.guest_id.id for m in channel.channel_member_ids]
         expected_member_ids = [self.partner_employee.id, self.guest.id, self.env.user.partner_id.id]
         self.assertCountEqual(actual_member_ids, expected_member_ids)
+
+
+class TestDiscussChannelNotifyMissedMessages(MailCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.registry_enter_test_mode_cls()
+        # remove current data to avoid interferences with the test
+        cls.env["discuss.channel.member"].search([
+            ("partner_id", "=", cls.partner_employee.id),
+        ]).unlink()
+        date_past = fields.Datetime.now() - timedelta(days=5)
+        cls.env["mail.presence"].sudo().create(
+            {
+                "user_id": cls.user_employee.id,
+                "last_poll": fields.Datetime.to_datetime(date_past),
+                "status": "offline",
+            }
+        )
+        with freeze_all_time(date_past):
+            cls.channel = cls.env["discuss.channel"].create({"name": "test channel"})
+            members = cls.channel._add_members(users=cls.user_employee)
+            cls.employee_member = members.filtered(lambda m: m.partner_id == cls.partner_employee)
+
+            cls.message = cls.channel.message_post(
+                body="Message 1",
+                message_type="comment",
+            )
+        with freeze_all_time(date_past + timedelta(minutes=1)):
+            cls.message_with_mention = cls.channel.message_post(
+                body="Message 2 with mention",
+                message_type="comment",
+                partner_ids=(cls.partner_employee | cls.env.user.partner_id).ids,
+            )
+        with freeze_all_time(date_past + timedelta(minutes=2)):
+            cls.channel.message_post(
+                body="Message 3 with mention",
+                message_type="comment",
+                partner_ids=cls.partner_employee.ids,
+            )
+        cls.env.user.partner_id.active = True
+
+    def test_notify_missed_messages_no_message_when_present(self):
+        self.env["mail.presence"].search([]).write({"status": "online"})
+        with self.mock_mail_gateway():
+            self.env.ref("mail.ir_cron_notify_missed_messages").sudo().method_direct_trigger()
+        self.assertNotSentEmail()
+
+    def test_notify_missed_messages(self):
+        self.assertFalse(
+            self.user_employee.last_notified,
+            "The employee member should not be marked as notified",
+        )
+        with self.mock_mail_gateway():
+            self.env.ref("mail.ir_cron_notify_missed_messages").sudo().method_direct_trigger()
+        self.assertMailMailWEmails(
+            [self.partner_employee.email],
+            email_values={
+                "email_from": self.env.user.email,
+            },
+            status="sent",
+        )
+        mail = self.env["mail.mail"].search_fetch([("email_from", "=", self.env.user.email)])
+        body_html = html.fromstring(mail.body_html)
+        body_subtitle_0 = body_html.xpath(
+            '//span[contains(., "You have unread messages since your last visit.")]'
+        )
+        self.assertTrue(body_subtitle_0, "The email should contain the correct subtitle")
+        view_link = body_html.xpath('//a[normalize-space(text())="View Message"]')
+        self.assertTrue(view_link, "The email should contain a link to view the message")
+        self.assertEqual(
+            view_link[0].get("href"),
+            f"{self.env['ir.config_parameter'].get_base_url()}/mail/message/{self.message_with_mention.id}",
+            "The view message link should point to the correct message",
+        )
+        mentioned_text = body_html.xpath(
+            '//h2[contains(normalize-space(.), "You were mentioned")]'
+        )
+        self.assertTrue(mentioned_text, "The email should show that the user was mentioned")
+        unread_text = body_html.xpath(
+            '//h2[contains(normalize-space(.), "Messages you might have missed")]'
+        )
+        self.assertFalse(unread_text, "The email should not specify that there are unread messages")
+        message_metadata = body_html.xpath(
+            '//p[contains(normalize-space(.), "OdooBot in test channel")]'
+        )
+        self.assertTrue(message_metadata, "The email should contain the message metadata")
+        message_html = body_html.xpath('//p[normalize-space(text())="Message 2 with mention"]')
+        self.assertTrue(message_html, "Mentioned messages should show the message body")
+        self.assertTrue(
+            self.user_employee.last_notified > fields.Datetime.now() - timedelta(minutes=1),
+            "The employee member should be marked as notified",
+        )
+        with self.mock_mail_gateway():
+            self.env.ref("mail.ir_cron_notify_missed_messages").sudo().method_direct_trigger()
+        self.assertNotSentEmail()
+
+    def test_notify_missed_messages_all_messages(self):
+        self.employee_member.write({"custom_notifications": "all"})
+        with self.mock_mail_gateway():
+            self.env.ref("mail.ir_cron_notify_missed_messages").sudo().method_direct_trigger()
+        self.assertMailMailWEmails(
+            [self.partner_employee.email],
+            email_values={
+                "email_from": self.env.user.email,
+            },
+            status="sent",
+        )
+        mail = self.env["mail.mail"].search_fetch([("email_from", "=", self.env.user.email)])
+        body_html = html.fromstring(mail.body_html)
+        message_html = body_html.xpath('//p[contains(normalize-space(.), "test channel")]')
+        self.assertTrue(message_html, "The email should contain channel name")
+        mentioned_text = body_html.xpath(
+            '//h2[contains(normalize-space(.), "You were mentioned")]'
+        )
+        self.assertFalse(mentioned_text, "The email should not specify the mention information")
+        unread_text = body_html.xpath(
+            '//h2[contains(normalize-space(.), "Messages you might have missed")]'
+        )
+        self.assertTrue(unread_text, "The email should specify that there are unread messages")
+
+    def test_notify_missed_messages_mention_only(self):
+        self.user_employee.res_users_settings_id.write({"channel_notifications": "all"})
+        self.employee_member.write({"custom_notifications": "mentions"})
+        with self.mock_mail_gateway():
+            self.env.ref("mail.ir_cron_notify_missed_messages").sudo().method_direct_trigger()
+        self.assertMailMailWEmails(
+            [self.partner_employee.email],
+            author=self.env.user.partner_id,
+            email_values={
+                "email_from": self.env.user.email,
+            },
+            status="sent",
+        )
+        mail = self.env["mail.mail"].search_fetch([("email_from", "=", self.env.user.email)])
+        body_html = html.fromstring(mail.body_html)
+        message_html = body_html.xpath('//p[normalize-space(text())="Message 2 with mention"]')
+        self.assertTrue(message_html, "The email should contain the first message body")
+
+    def test_notify_missed_messages_no_notification(self):
+        self.employee_member.write({"custom_notifications": "no_notif"})
+        with self.mock_mail_gateway():
+            self.env.ref("mail.ir_cron_notify_missed_messages").sudo().method_direct_trigger()
+        self.assertNotSentEmail()
+
+    def test_notify_missed_messages_muted(self):
+        self.employee_member.write(
+            {
+                "mute_until_dt": fields.Datetime.to_datetime(
+                    datetime.now() + timedelta(minutes=1)
+                )
+            },
+        )
+        with self.mock_mail_gateway():
+            self.env.ref("mail.ir_cron_notify_missed_messages").sudo().method_direct_trigger()
+        self.assertNotSentEmail()

--- a/addons/test_mail/tests/test_mail_message.py
+++ b/addons/test_mail/tests/test_mail_message.py
@@ -1,11 +1,13 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import contextlib
+import datetime
 
 from markupsafe import Markup
 
+from odoo import fields
 from odoo.addons.base.models.ir_mail_server import MailDeliveryException
-from odoo.addons.mail.tests.common import mail_new_test_user, MailCommon
+from odoo.addons.mail.tests.common import mail_new_test_user, MailCommon, freeze_all_time
 from odoo.addons.mail.tools.discuss import Store
 from odoo.exceptions import UserError
 from odoo.tests.common import tagged, users, HttpCase
@@ -470,3 +472,94 @@ class TestMessageValues(MailCommon):
         msg = self.env['mail.message'].create({'model': self.alias_record._name, 'res_id': self.alias_record.id})
         self.assertEqual(msg.message_type, 'comment', 'Message should be comments by default')
 
+
+class TestMissedMessagesMail(MailCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.registry_enter_test_mode_cls()
+
+        cls.test_record = cls.env["mail.test.simple"].create(
+            {"name": "Test", "email_from": "ignasse@example.com"}
+        )
+        cls.user_employee_2 = mail_new_test_user(
+            cls.env,
+            email='eglantine@example.com',
+            groups='base.group_user',
+            login='employee2',
+            notification_type='email',
+            name='Eglantine Employee',
+        )
+        cls.partner_employee_2 = cls.user_employee_2.partner_id
+        date_past = datetime.datetime.now() - datetime.timedelta(days=5)
+        cls.env["mail.presence"].sudo().create(
+            {
+                "user_id": cls.user_employee.id,
+                "last_poll": fields.Datetime.to_datetime(date_past),
+                "status": "offline",
+            }
+        )
+        cls.env.user.partner_id.active = True
+
+    def _send_message_on_record(self, dt, to_partner):
+        with freeze_all_time(dt), self.mock_mail_gateway():
+            self.test_record.message_post(
+                body=f"Hey @{to_partner.name}, you should see this message"
+                    " and get a notification email since you are mentioned.",
+                message_type='comment',
+                partner_ids=to_partner.ids,
+                subtype_id=self.env.ref('mail.mt_comment').id,
+            )
+
+    def test_mentioned_message_missed_sends_mail(self):
+        self._send_message_on_record(
+            fields.Datetime.now() - datetime.timedelta(days=5), self.partner_employee
+        )
+        self.assertNotSentEmail()
+        with self.mock_mail_gateway():
+            self.env.ref("mail.ir_cron_notify_missed_messages").sudo().method_direct_trigger()
+        self.assertMailMailWEmails(
+            [self.partner_employee.email],
+            email_values={
+                "email_from": self.env.user.email,
+            },
+            status="sent",
+        )
+        with self.mock_mail_gateway():
+            self.env.ref("mail.ir_cron_notify_missed_messages").sudo().method_direct_trigger()
+        self.assertNotSentEmail()
+
+    def test_notification_read_no_mail(self):
+        self._send_message_on_record(
+            fields.Datetime.now() - datetime.timedelta(days=5), self.partner_employee
+        )
+        self.assertNotSentEmail()
+        notification = self.env['mail.notification'].search([
+            ('res_partner_id', '=', self.partner_employee.id),
+            ('mail_message_id', 'in', self.test_record.message_ids.ids),
+        ], limit=1)
+        notification.is_read = True
+        with self.mock_mail_gateway():
+            self.env.ref("mail.ir_cron_notify_missed_messages").sudo().method_direct_trigger()
+        self.assertNotSentEmail()
+
+    def test_message_out_of_range_no_mail(self):
+        self._send_message_on_record(
+            fields.Datetime.now() - datetime.timedelta(days=9), self.partner_employee
+        )
+        self.assertNotSentEmail()
+        self._send_message_on_record(
+            fields.Datetime.now() - datetime.timedelta(hours=6), self.partner_employee
+        )
+        with self.mock_mail_gateway():
+            self.env.ref("mail.ir_cron_notify_missed_messages").sudo().method_direct_trigger()
+        self.assertNotSentEmail()
+
+    def test_user_mail_notif_settings_no_mail(self):
+        self._send_message_on_record(
+            fields.Datetime.now() - datetime.timedelta(days=5), self.partner_employee_2
+        )
+        with self.mock_mail_gateway():
+            self.env.ref("mail.ir_cron_notify_missed_messages").sudo().method_direct_trigger()
+        self.assertNotSentEmail()


### PR DESCRIPTION
Before this commit, users (especially the ones working offline on the
field) could easily miss a message in odoo even though they are working.

With this commit, we notify by mail users that are offline for more than
72 hours of new messages received. Each user will be notified at most
once per week with newer message using a technical field stored on the
user itself. Those messages need to be at least one day old and should
respect the user's settings (discuss channels and chatters).

Those mails are created during a cron job running once a day, and work
in three phases:
- getting the inactive partners that are not notified in the previous
week
- getting the unread messages respecting the users' settings
- sending the mail to the different users with all those messages.

task-4937044

> [!WARNING]
> upgrade script to be updated when this PR is more stable

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
