### PR TITLE
[FIX] point_of_sale: reintroduce widget

### DIFF
--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -84,7 +84,7 @@
                             <list string="Order lines" editable="bottom">
                                 <field name="name" column_invisible="True"/>
                                 <field name="full_product_name" optional="hide" readonly="1"/>
-                                <field name="product_id"/>
+                                <field name="product_id" widget="product_label_section_and_note_field" />
                                 <field name="is_edited" readonly="1" column_invisible="not parent.order_edit_tracking"/>
                                 <field name="pack_lot_ids" widget="many2many_tags" groups="stock.group_production_lot"/>
                                 <field name="qty"/>


### PR DESCRIPTION
Following this commit https://github.com/odoo/odoo/commit/937363e5786eeab02b06c2dc63e1d9e743fc1874 that completely broke the pos the following commit was merged to remove the broken widget from the pos. https://github.com/odoo/odoo/commit/51474f8d0c56c4458830acb4a16a51bbf9384c9c

However this widget is also beneficial to the pos. For example, it allows to redirect to the product form when clicking on the product on the pos order line.

Since a revert of the original commit has been mered already it is not necessary to remove this widget. We therefore re-introduce it to the pos to have access to its features.

<img width="1260" height="425" alt="image" src="https://github.com/user-attachments/assets/9348feed-17b7-401a-a52d-1bfa7447a6b4" />
<img width="1232" height="717" alt="image" src="https://github.com/user-attachments/assets/874ffe2e-0edd-4a69-80a9-dd8b1ea101ef" />


opw-6040334