### PR TITLE
[FIX] point_of_sale: fix test failure due to debounced sync

### DIFF
--- a/addons/point_of_sale/static/tests/tours/chrome_tour.js
+++ b/addons/point_of_sale/static/tests/tours/chrome_tour.js
@@ -241,6 +241,11 @@ registry.category("web_tour.tours").add("CustomerNoteIsPresentAfterRefresh", {
                     customerNote: "Test customer note",
                 }),
             ]),
+            {
+                content: "Wait for the debouncedSync to be complete",
+                trigger: "body",
+                run: async () => await new Promise((resolve) => setTimeout(resolve, 250)),
+            },
             Utils.refresh(),
             inLeftSide([
                 { ...ProductScreen.clickLine("Desk Organizer")[0], isActive: ["mobile"] },


### PR DESCRIPTION
During the tour test `CustomerNoteIsPresentAfterRefresh`, we set a customer note on an order line and then refresh the page. Even though we wait for the customer note to be written on the `pos.order.line` record, the change must also be saved in IndexedDB before the refresh. Otherwise, the data reloaded after the refresh does not contain the customer note, causing the test to fail.

The issue was that the page refresh could happen before the debounced `syncDataWithIndexedDB` was completed. To fix this, an additional step was added in the tour to wait briefly, ensuring that `syncDataWithIndexedDB` finishes before refreshing the page.

---

Runbot error: https://runbot.odoo.com/odoo/runbot.build.error/231435