### PR TITLE
[FIX] point_of_sale: fix getPriceListRule

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -206,7 +206,22 @@ export class ProductProduct extends Base {
 
     getPricelistRule(pricelist, quantity) {
         const rules = !pricelist ? [] : this.cachedPricelistRules[pricelist?.id] || [];
-        return rules.find((rule) => !rule.min_quantity || quantity >= rule.min_quantity);
+        const applicableRules = rules.filter(
+            (rule) => !rule.min_quantity || quantity >= rule.min_quantity
+        );
+        if (!applicableRules) {
+            return undefined;
+        }
+        const productIdRule = applicableRules?.find(
+            (rule) => rule.product_id && rule.product_id.id === this.id
+        );
+        const productTmplIdRule = applicableRules?.find(
+            (rule) => rule.product_tmpl_id && rule.product_tmpl_id.id === this.raw.product_tmpl_id
+        );
+        const categoryRule = applicableRules?.find(
+            (rule) => rule.categ_id && this.parentCategories.includes(rule.categ_id.id)
+        );
+        return productIdRule || productTmplIdRule || categoryRule || applicableRules[0];
     }
     getImageUrl() {
         return (


### PR DESCRIPTION
When a product has multiple variant, and each product.product has a specific rule in a pricelist. It was possible that the wrong rule is selected from `cachedPricelistRules` as it would contain all the rules for a product.

Why the fix:
------------
We add a condition to make sure that the rule is linked to the specific product.product.

runbot-108050