### PR TITLE
[FIX] l10n_de: fix the access-error in test

### DIFF
--- a/addons/l10n_de/tests/test_account_move.py
+++ b/addons/l10n_de/tests/test_account_move.py
@@ -55,7 +55,14 @@ class TestAccountMoveDE(AccountTestInvoicingCommon):
         self.assertRecordValues(move.line_ids, expected_lines_vals)
 
     def test_public_user_invoice_creation_with_product_record_rule(self):
-        public_user = self.env['res.users'].create({'name': 'Public User test', 'login': 'blablabla', 'is_public': True})
+        public_user = self.env['res.users'].create({
+            'name': 'Public User test',
+            'login': 'blablabla',
+            'is_public': True,
+            'group_ids': [
+                Command.set([self.env.ref('account.group_account_invoice').id]),
+            ],
+        })
         self.product_a.write({'property_account_income_id': False, 'property_account_expense_id': False})
         model = self.env['ir.model']._get('product.template')
         self.env['ir.rule'].create({


### PR DESCRIPTION
The crash occurs due to the test case introduced in PR #246920. While creating the user, no accounting group was assigned, so when this user attempts to create a Journal Entry, an AccessError is raised.

**Root cause:**
- In the previous version, when a public user was created, the required groups
  for creating an account move were assigned by default. However, in the
  current version, only a single group is assigned by default, which is
  Role/Member. As a result, when attempting to create an account move,
  an access error.

In this commit, the required accounting group is added during user creation to ensure the test runs correctly.

Runbot-241930

