### PR TITLE
[FIX] l10n_be_hr_payroll: Adding inverse for editting departure date

### DIFF
--- a/addons/hr/models/hr_employee_departure.py
+++ b/addons/hr/models/hr_employee_departure.py
@@ -32,7 +32,7 @@ class HrEmployeeDeparture(models.Model):
     departure_description = fields.Html(string="Additional Information")
     dismissal_date = fields.Date(string="Dismissal Date", default=fields.Date.today, required=True,
         help="Date at which the departure process starts. Differs from the actual departure date in case of a notice period.")
-    departure_date = fields.Date(string="Departure Date", compute="_compute_departure_date",
+    departure_date = fields.Date(string="Departure Date", compute="_compute_departure_date", inverse="_set_departure_date",
         store=True, help="Date at which the departure actually takes place.")
     action_at_departure = fields.Boolean(string="Action at", default=True)
     action_other_date = fields.Date(string="Apply date")
@@ -118,6 +118,9 @@ class HrEmployeeDeparture(models.Model):
                 'departure_id': departure.id,
             })
         return res
+
+    def _set_departure_date(self):
+        pass
 
     def _cron_apply_departure(self):
         today = fields.Date.today()


### PR DESCRIPTION
Steps to reproduce:
- Create an employee with a valid contract in a belgian company
- End their colloboration with the reason 'Fired'
- Set their notice_respect to 'partial working'
- Edit the departure date to any date other than the pre-computed one and save your changes
- The date will be automatically reverted to the precomputed one

Cause:
The cyclic dependency between the departure_date and the actual_notice_period fields where causing a conflict while trying to set the desired dates.

Solution:
Added a dummy inverse function that just permits manual changing of the departure date without triggering the computation function

Task: 6036368

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
