### PR TITLE
[FIX] mail: protect against void date and create_date in msg

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2998,7 +2998,7 @@ class MailThread(models.AbstractModel):
                 order='date desc, id desc',
                 limit=200,  # arbitrary, but sometimes loops / spam may creater a long history
             ).sorted(
-                lambda msg: (msg.message_type in ('comment', 'email'), msg.date or msg.create_date, msg.id),
+                lambda msg: (msg.message_type in ('comment', 'email'), msg.date or msg.create_date or datetime.datetime.min, msg.id),
                 reverse=True,
             )
             current_ancestor = current_ancestor[:1]

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -1546,6 +1546,15 @@ class TestMailgateway(MailGatewayCommon):
                 date=False,
                 parent_id=reply1.id,
             )
+
+        self.env.cr.execute("""
+            UPDATE mail_message
+            SET date = NULL, create_date = NULL
+            WHERE id = %s
+        """, (old_disturbing_msg.id,))
+        self.env.invalidate_all()
+
+        self.assertFalse(old_disturbing_msg.create_date)
         self.assertFalse(old_disturbing_msg.date)
 
         with self.mock_datetime_and_now(datetime(2025, 11, 19, 10, 30, 0)):


### PR DESCRIPTION
Background:
In odoo.com, due to some migration scripts, there are messages without neither a date nor create_date

Issue:
When sending mass emails to applicants, when determining the parent email, emails are sorted using their date, but since some emails have a date and some don't, comparing them results in an exception (comparing datetime with bool).

Fix:
Add datetime.min as a fallback for the email's date if neither date nor create_date are set.

Task-6041584
