### PR TITLE
[REM] account_peppol: remove country code validation

### DIFF
--- a/addons/account_peppol/models/res_company.py
+++ b/addons/account_peppol/models/res_company.py
@@ -93,8 +93,7 @@ class ResCompany(models.Model):
 
         error_message = _(
             "Please enter the mobile number in the correct international format.\n"
-            "For example: +32123456789, where +32 is the country code.\n"
-            "Currently, only European countries are supported.")
+            "For example: +32123456789, where +32 is the country code.")
 
         if not phonenumbers:
             raise ValidationError(_("Please install the phonenumbers library."))
@@ -111,8 +110,7 @@ class ResCompany(models.Model):
         except phonenumbers.phonenumberutil.NumberParseException:
             raise ValidationError(error_message)
 
-        country_code = phonenumbers.phonenumberutil.region_code_for_number(phone_nbr)
-        if country_code not in PEPPOL_LIST or not phonenumbers.is_valid_number(phone_nbr):
+        if not phonenumbers.is_valid_number(phone_nbr):
             raise ValidationError(error_message)
 
     def _reset_peppol_configuration(self):


### PR DESCRIPTION
Before this commit, only numbers on the peppol list were able to be registered. Now is possible to add numbers from other countries.

Task-6033336

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
