### PR TITLE
[FIX] account, purchase: prevent test_catalog_vendor_uom tour failure

### DIFF
--- a/addons/account/static/src/components/product_catalog/kanban_record.js
+++ b/addons/account/static/src/components/product_catalog/kanban_record.js
@@ -23,7 +23,7 @@ patch(ProductCatalogKanbanRecord.prototype, {
     _getUpdateQuantityAndGetPriceParams() {
         return {
             ...super._getUpdateQuantityAndGetPriceParams(),
-            section_id: this.env.selectedSectionId,
+            section_id: this.env.selectedSectionId ?? this.env.searchModel.selectedSection.sectionId,
         };
     },
 

--- a/addons/purchase/static/tests/tours/purchase_catalog.js
+++ b/addons/purchase/static/tests/tours/purchase_catalog.js
@@ -16,11 +16,6 @@ registry.category("web_tour.tours").add("test_catalog_vendor_uom", {
         { trigger: "td[data-tooltip='PO/TEST/00002']", run: "click" },
         ...purchaseForm.displayOptionalField("discount"),
         ...purchaseForm.openCatalog(),
-        {
-            content: "Check 'No section' is selected in the catalog",
-            trigger: ".o_search_panel_sections .o_selected_section:contains('No Section') span.o_section_name",
-            run: "click",
-        },
         ...productCatalog.checkProductPrice("Crab Juice", "$ 2.50"),
         // Add 6 units and check the price is correctly updated.
         ...productCatalog.addProduct("Crab Juice"),


### PR DESCRIPTION
Cause:
The `selectedSectionId` was not yet updated in the environment when the product
was added, resulting in a `None` value being passed to `_update_order_line_info`.

Fix:
Use `this.env.selectedSectionId` when available, and fall back to
`this.env.searchModel.selectedSection.sectionId` only if it is undefined or null.

runbot-241960