### PR TITLE
[FIX] account: Fix Manual Edit Tax Rounded Globally with Price Included

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2241,6 +2241,12 @@ class AccountMove(models.Model):
 
                             if not move.currency_id.is_zero(delta_amount):
                                 first_tax_line.amount_currency -= delta_amount * sign
+                                is_price_include = tax_group.get('is_price_include', first_tax_line.tax_line_id.price_include)
+                                if is_price_include:
+                                    base_lines = move.line_ids.filtered(lambda l: l.display_type == 'product' and first_tax_line.tax_line_id in l.tax_ids)
+                                    if base_lines:
+                                        base_lines[0].amount_currency += delta_amount * sign
+
             self._compute_amount()
 
     def _inverse_amount_total(self):

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -2178,6 +2178,7 @@ class AccountTax(models.Model):
                     {
                         'factor': tax_data[f'tax_amount{delta_currency_indicator}'],
                         'tax_data': tax_data,
+                        'base_line': _base_line,
                     }
                     for _base_line, taxes_data in values['base_line_x_taxes_data']
                     for tax_data in taxes_data
@@ -2190,6 +2191,10 @@ class AccountTax(models.Model):
                 for target_factor, amount_to_distribute in zip(target_factors, amounts_to_distribute):
                     tax_data = target_factor['tax_data']
                     tax_data[f'tax_amount{delta_currency_indicator}'] += amount_to_distribute
+
+                    if tax_data.get('price_include'):
+                        base_line = target_factor['base_line']
+                        base_line['tax_details'][f'total_excluded{delta_currency_indicator}'] -= amount_to_distribute
 
     @api.model
     def _round_base_lines_tax_details(self, base_lines, company, tax_lines=None):
@@ -2879,6 +2884,7 @@ class AccountTax(models.Model):
                 'display_base_amount': display_base_amount,
                 'group_name': tax_group.name,
                 'group_label': tax_group.pos_receipt_label,
+                'is_price_include': any(t.price_include for t in involved_taxes),
             })
 
         # Subtotals.

--- a/addons/account/static/src/components/tax_totals/tax_totals.js
+++ b/addons/account/static/src/components/tax_totals/tax_totals.js
@@ -105,7 +105,14 @@ class TaxGroupComponent extends Component {
         this.props.taxGroup.tax_amount_currency += deltaValue;
         this.props.subtotal.tax_amount_currency += deltaValue;
         this.props.totals.tax_amount_currency += deltaValue;
-        this.props.totals.total_amount_currency += deltaValue;
+        if (this.props.taxGroup.is_price_include) {
+            this.props.taxGroup.base_amount_currency -= deltaValue;
+            this.props.subtotal.base_amount_currency -= deltaValue;
+            this.props.totals.base_amount_currency -= deltaValue;
+        }
+        else {
+            this.props.totals.total_amount_currency += deltaValue;
+        }
 
         this.props.onChangeTaxGroup({
             oldValue,

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -1019,6 +1019,7 @@ class AccountTestInvoicingCommon(ProductCommon):
         excluded_fields.add('company_currency_pd')
         excluded_fields.add('currency_pd')
         excluded_fields.add('has_tax_groups')
+        excluded_fields.add('is_price_include')
         monetary_fields = {
             'tax_amount_currency': currency,
             'tax_amount': company_currency,

--- a/addons/account/tests/test_invoice_taxes.py
+++ b/addons/account/tests/test_invoice_taxes.py
@@ -934,3 +934,30 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
         )
         self.assertEqual(results['value']['tax_totals']['base_amount'], 2000.0)
         self.assertEqual(results['value']['tax_totals']['total_amount'], 2600.0)
+
+    def test_vendor_bill_manual_tax_edit_anchors_total(self):
+        """
+        Test that manually editing the tax amount on a Vendor Bill with price_include tax keeps
+        the Total fixed and adjusts the Untaxed Amount instead.
+        """
+        invoice = self._create_invoice([(105.0, self.percent_tax_3_incl)], inv_type='in_invoice')
+        self.assertEqual(invoice.amount_untaxed, 100.0)
+        self.assertEqual(invoice.amount_tax, 5.0)
+        self.assertEqual(invoice.amount_total, 105.0)
+
+        delta_value = -0.01
+        tax_totals = invoice.tax_totals
+
+        tax_totals['subtotals'][0]['tax_groups'][0]['tax_amount_currency'] += delta_value
+        tax_totals['subtotals'][0]['tax_amount_currency'] += delta_value
+        tax_totals['tax_amount_currency'] += delta_value
+
+        tax_totals['subtotals'][0]['tax_groups'][0]['base_amount_currency'] -= delta_value
+        tax_totals['subtotals'][0]['base_amount_currency'] -= delta_value
+        tax_totals['base_amount_currency'] -= delta_value
+
+        invoice.tax_totals = tax_totals
+
+        self.assertEqual(invoice.amount_total, 105.0)
+        self.assertEqual(invoice.amount_untaxed, 100.01)
+        self.assertEqual(invoice.amount_tax, 4.99)


### PR DESCRIPTION
For rounded globally with price included tax:

When the user edits the tax amount, the expected behavior is a modification of the Untaxed Amount and the Total stays the same.

task-5270236

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
