### PR TITLE
[IMP] mail: allow searching members in list

### DIFF
--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -4,6 +4,7 @@ from markupsafe import Markup
 from werkzeug.exceptions import NotFound
 
 from odoo import fields, http
+from odoo.fields import Domain
 from odoo.http import request
 from odoo.addons.mail.controllers.webclient import WebclientController, WRITE_FETCH_PARAMS
 from odoo.addons.mail.tools.discuss import mail_route, Store
@@ -80,11 +81,16 @@ class DiscussChannelWebclientController(WebclientController):
         if name == "/discuss/channel/members":
             channel = request.env["discuss.channel"].search([("id", "=", params["channel_id"])])
             if channel:
-                unknown_members = request.env["discuss.channel.member"].search(
-                    domain=[
-                        ("id", "not in", params["known_member_ids"]),
-                        ("channel_id", "=", channel.id),
-                    ],
+                search_term = params.get("search_term")
+                known_member_ids = params.get("known_member_ids", [])
+                domain = Domain("channel_id", "=", channel.id) & Domain("id", "not in", known_member_ids)
+                if search_term:
+                    domain &= (
+                        Domain("partner_id.name", "ilike", search_term)
+                        | Domain("guest_id.name", "ilike", search_term)
+                    )
+                unknown_members = request.env["discuss.channel.member"].search_fetch(
+                    domain,
                     limit=100,
                 )
                 store.add(channel, ["member_count"]).add(unknown_members, "_store_member_fields")

--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -133,14 +133,17 @@ class DiscussChannelWebclientController(WebclientController):
 
 class ChannelController(http.Controller):
     @mail_route("/discuss/channel/members", methods=["POST"], type="jsonrpc", auth="public", readonly=True)
-    def discuss_channel_members(self, channel_id, known_member_ids):
+    def discuss_channel_members(self, channel_id, known_member_ids=None, search_term=None):
         channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
         if not channel:
             raise NotFound()
-        unknown_members = self.env["discuss.channel.member"].search(
-            domain=[("id", "not in", known_member_ids), ("channel_id", "=", channel.id)],
-            limit=100,
-        )
+        known_member_ids = known_member_ids or []
+        domain = [("channel_id", "=", channel.id)]
+        if search_term:
+            domain.extend(["|", ("partner_id.name", "ilike", search_term), ("guest_id.name", "ilike", search_term)])
+        else:
+            domain.append(("id", "not in", known_member_ids))
+        unknown_members = request.env["discuss.channel.member"].search(domain=domain, limit=100)
         store = Store()
         store.add(channel, ["member_count"])
         store.add(unknown_members, "_store_member_fields")

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.js
@@ -5,9 +5,21 @@ import { ChannelInvitation } from "@mail/discuss/core/common/channel_invitation"
 
 import { Component, onWillUpdateProps, onWillStart } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
+import { useState } from "@web/owl2/utils";
 
 import { useService } from "@web/core/utils/hooks";
+import { useSequential } from "@mail/utils/common/hooks";
 
+let nextId = 0;
+
+/**
+ * @typedef {Object} Props
+ * @property {import("models").DiscussChannel} channel
+ * @property {string} [className]
+ * @property {Function} [openChannelInvitePanel]
+ * @property {Function} [close]
+ * @extends {Component<Props, Env>}
+ */
 export class ChannelMemberList extends Component {
     static components = { ActionPanel, ChannelActionDialog, ChannelMember };
     static props = ["channel", "close?", "openChannelInvitePanel", "className?"];
@@ -15,8 +27,12 @@ export class ChannelMemberList extends Component {
 
     setup() {
         super.setup();
+        this.uniqueId = `discuss.ChannelMemberList.${nextId++}`;
         this.store = useService("mail.store");
         this.dialogService = useService("dialog");
+        this.state = useState({ searchTerm: "", isSearching: false });
+        this.lastFetchedSearch = undefined;
+        this.sequential = useSequential();
         onWillStart(() => {
             if (this.props.channel.fetchMembersState === "not_fetched") {
                 this.props.channel.fetchChannelMembers();
@@ -26,24 +42,150 @@ export class ChannelMemberList extends Component {
             if (nextProps.channel.fetchMembersState === "not_fetched") {
                 nextProps.channel.fetchChannelMembers();
             }
+            if (nextProps.channel.notEq(this.props.channel) && this.state.searchTerm) {
+                this.state.searchTerm = "";
+                this.state.isSearching = false;
+            }
+            if (nextProps.channel.notEq(this.props.channel)) {
+                this.lastFetchedSearch = undefined;
+            }
         });
+    }
+
+    /* @param {import("models").ChannelMember[]} members */
+    _getFilteredByTerm(members) {
+        if (!this.state.searchTerm) {
+            return members;
+        }
+        const term = this.state.searchTerm.toLowerCase();
+        return members.filter((m) => m.name?.toLowerCase().includes(term));
+    }
+
+    get matchingOnlineMembers() {
+        return this._getFilteredByTerm(this.props.channel.onlineMembers);
+    }
+
+    get matchingOfflineMembers() {
+        return this._getFilteredByTerm(this.props.channel.offlineMembers);
+    }
+
+    get matchingUnknownStatusMembers() {
+        return this._getFilteredByTerm(this.props.channel.unknownStatusMembers);
+    }
+
+    get filteredOnlineMembers() {
+        if (!this.state.searchTerm) {
+            return this.matchingOnlineMembers;
+        }
+        return this.matchingOnlineMembers.slice(0, 100);
+    }
+
+    get filteredOfflineMembers() {
+        if (!this.state.searchTerm) {
+            return this.matchingOfflineMembers;
+        }
+        const remaining = 100 - this.filteredOnlineMembers.length;
+        return this.matchingOfflineMembers.slice(0, Math.max(0, remaining));
+    }
+
+    get filteredUnknownStatusMembers() {
+        if (!this.state.searchTerm) {
+            return this.matchingUnknownStatusMembers;
+        }
+        const remaining =
+            100 - this.filteredOnlineMembers.length - this.filteredOfflineMembers.length;
+        return this.matchingUnknownStatusMembers.slice(0, Math.max(0, remaining));
     }
 
     get onlineSectionText() {
         return _t("Online - %(online_count)s", {
-            online_count: this.props.channel.onlineMembers.length,
+            online_count: this.filteredOnlineMembers.length,
         });
     }
 
     get offlineSectionText() {
         return _t("Offline - %(offline_count)s", {
-            offline_count: this.props.channel.offlineMembers.length,
+            offline_count: this.filteredOfflineMembers.length,
         });
     }
 
     get unknownStatusSectionText() {
         return _t("Others - %(unknown_status_count)s", {
-            unknown_status_count: this.props.channel.unknownStatusMembers.length,
+            unknown_status_count: this.filteredUnknownStatusMembers.length,
+        });
+    }
+
+    get isSearchResultCapped() {
+        if (!this.state.searchTerm) {
+            return false;
+        }
+        return (
+            this.matchingOnlineMembers.length +
+                this.matchingOfflineMembers.length +
+                this.matchingUnknownStatusMembers.length >=
+            100
+        );
+    }
+
+    get hasFilteredMembers() {
+        return (
+            this.filteredOnlineMembers.length > 0 ||
+            this.filteredOfflineMembers.length > 0 ||
+            this.filteredUnknownStatusMembers.length > 0
+        );
+    }
+
+    get filteredMembersCount() {
+        return (
+            this.filteredOnlineMembers.length +
+            this.filteredOfflineMembers.length +
+            this.filteredUnknownStatusMembers.length
+        );
+    }
+
+    isSearchMoreSpecificThanLastFetch(searchTerm) {
+        return (
+            this.lastFetchedSearch?.channelId === this.props.channel.id &&
+            searchTerm.startsWith(this.lastFetchedSearch.searchTerm)
+        );
+    }
+
+    get searchResultCapHint() {
+        return _t("Showing first 100 members. Narrow your search to see more.");
+    }
+
+    /** @param {KeyboardEvent} ev */
+    onInputSearch(ev) {
+        const searchTerm = ev.target.value;
+        this.state.searchTerm = searchTerm;
+        if (!searchTerm) {
+            this.lastFetchedSearch = undefined;
+            this.state.isSearching = false;
+            return;
+        }
+        if (
+            this.lastFetchedSearch?.count === 0 &&
+            this.isSearchMoreSpecificThanLastFetch(searchTerm)
+        ) {
+            this.state.isSearching = false;
+            return;
+        }
+        this.state.isSearching = true;
+        this.sequential(async () => {
+            try {
+                await this.props.channel.searchChannelMembers(searchTerm);
+                if (this.state.searchTerm === searchTerm) {
+                    this.lastFetchedSearch = {
+                        channelId: this.props.channel.id,
+                        searchTerm,
+                        count: this.filteredMembersCount,
+                    };
+                }
+            } finally {
+                if (this.state.searchTerm === searchTerm) {
+                    this.state.isSearching = false;
+                }
+            }
         });
     }
 

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.js
@@ -5,8 +5,10 @@ import { ChannelInvitation } from "@mail/discuss/core/common/channel_invitation"
 
 import { Component, onWillUpdateProps, onWillStart } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
+import { useState } from "@web/owl2/utils";
 
 import { useService } from "@web/core/utils/hooks";
+import { useSequential } from "@mail/utils/common/hooks";
 
 export class ChannelMemberList extends Component {
     static components = { ActionPanel, ChannelActionDialog, ChannelMember };
@@ -17,6 +19,8 @@ export class ChannelMemberList extends Component {
         super.setup();
         this.store = useService("mail.store");
         this.dialogService = useService("dialog");
+        this.state = useState({ searchTerm: "" });
+        this.sequential = useSequential();
         onWillStart(() => {
             if (this.props.channel.fetchMembersState === "not_fetched") {
                 this.props.channel.fetchChannelMembers();
@@ -26,19 +30,56 @@ export class ChannelMemberList extends Component {
             if (nextProps.channel.fetchMembersState === "not_fetched") {
                 nextProps.channel.fetchChannelMembers();
             }
+            if (nextProps.channel !== this.props.channel && this.state.searchTerm) {
+                this.state.searchTerm = "";
+            }
         });
+    }
+
+    get filteredOnlineMembers() {
+        if (!this.state.searchTerm) {
+            return this.props.channel.onlineMembers;
+        }
+        const term = this.state.searchTerm.toLowerCase();
+        return this.props.channel.onlineMembers.filter((m) => m.name?.toLowerCase().includes(term));
+    }
+
+    get filteredOfflineMembers() {
+        if (!this.state.searchTerm) {
+            return this.props.channel.offlineMembers;
+        }
+        const term = this.state.searchTerm.toLowerCase();
+        return this.props.channel.offlineMembers.filter((m) =>
+            m.name?.toLowerCase().includes(term)
+        );
     }
 
     get onlineSectionText() {
         return _t("Online - %(online_count)s", {
-            online_count: this.props.channel.onlineMembers.length,
+            online_count: this.filteredOnlineMembers.length,
         });
     }
 
     get offlineSectionText() {
         return _t("Offline - %(offline_count)s", {
-            offline_count: this.props.channel.offlineMembers.length,
+            offline_count: this.filteredOfflineMembers.length,
         });
+    }
+
+    get isSearchResultCapped() {
+        if (!this.state.searchTerm) {
+            return false;
+        }
+        return this.filteredOnlineMembers.length + this.filteredOfflineMembers.length >= 100;
+    }
+
+    get searchResultCapHint() {
+        return _t("Showing first 100 members. Narrow your search to see more.");
+    }
+
+    onSearchInput(ev) {
+        this.state.searchTerm = ev.target.value;
+        this.sequential(() => this.props.channel.searchChannelMembers(this.state.searchTerm));
     }
 
     onClickInviteButton() {

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -3,41 +3,71 @@
 
     <t t-name="discuss.ChannelMemberList">
         <ActionPanel close="this.props.close" title.translate="Members" minWidth="200" initialWidth="this.env.inMeetingView ? 400 : 250" icon="'oi oi-users'">
-            <button name="inviteButton" t-on-click="() => this.onClickInviteButton()" class="btn btn-sm btn-secondary mt-2 d-flex align-items-center justify-content-center gap-1 rounded-3" title="Invite People"><i class="oi oi-user-plus"/><span>Invite People</span></button>
-            <t t-if="this.props.channel.onlineMembers.length > 0">
+            <div class="o-discuss-ChannelMemberList-search input-group input-group-sm flex-nowrap">
+                <div class="position-relative flex-grow-1">
+                    <label
+                        t-att-id="`${this.uniqueId}-searchStatusIcon`"
+                        t-att-for="`${this.uniqueId}-search`"
+                        class="position-absolute top-50 px-2 translate-middle-y smaller opacity-50"
+                        role="status"
+                    >
+                        <t t-if="this.state.isSearching">
+                            <i class="fa fa-spin fa-circle-o-notch" title="Loading..." aria-hidden="true"/>
+                            <p class="visually-hidden">Member search is loading...</p>
+                        </t>
+                        <i t-else="" class="oi oi-search" aria-hidden="true"/>
+                    </label>
+                    <input
+                        t-att-id="`${this.uniqueId}-search`"
+                        type="text"
+                        class="form-control bg-view ps-4"
+                        placeholder="Search members"
+                        aria-label="Search members"
+                        t-custom-model="this.state.searchTerm"
+                        t-on-input="(...args) => this.onInputSearch(...args)"
+                        autocomplete="off"
+                    />
+                </div>
+                <button name="inviteButton" t-on-click="() => this.onClickInviteButton()" class="btn btn-outline-secondary" title="Invite People" aria-label="Invite People"><i class="oi oi-user-plus"/></button>
+            </div>
+            <t t-if="this.filteredOnlineMembers.length > 0">
                 <t t-call="discuss.ChannelMemberList.section">
                     <t t-set="sectionName" t-value="this.onlineSectionText"/>
                 </t>
                 <div class="d-flex flex-column bg-inherit gap-1">
-                    <ChannelMember t-foreach="this.props.channel.onlineMembers" t-as="member" t-key="member.id" member="member"/>
+                    <ChannelMember t-foreach="this.filteredOnlineMembers" t-as="member" t-key="member.id" member="member"/>
                 </div>
             </t>
-            <t name="offlineMembers" t-if="this.props.channel.offlineMembers.length > 0">
+            <t name="offlineMembers" t-if="this.filteredOfflineMembers.length > 0">
                 <t t-call="discuss.ChannelMemberList.section">
                     <t t-set="sectionName" t-value="this.offlineSectionText"/>
                 </t>
                 <div class="d-flex flex-column bg-inherit gap-1">
-                    <ChannelMember t-foreach="this.props.channel.offlineMembers" t-as="member" t-key="member.id" member="member"/>
+                    <ChannelMember t-foreach="this.filteredOfflineMembers" t-as="member" t-key="member.id" member="member"/>
                 </div>
             </t>
-            <t name="unknownStatusMembers" t-if="this.props.channel.unknownStatusMembers.length > 0">
+            <t t-if="this.filteredUnknownStatusMembers.length > 0">
                 <t t-call="discuss.ChannelMemberList.section">
                     <t t-set="sectionName" t-value="this.unknownStatusSectionText"/>
                 </t>
                 <div class="d-flex flex-column bg-inherit gap-1">
-                    <ChannelMember t-foreach="this.props.channel.unknownStatusMembers" t-as="member" t-key="member.id" member="member"/>
+                    <ChannelMember t-foreach="this.filteredUnknownStatusMembers" t-as="member" t-key="member.id" member="member"/>
                 </div>
             </t>
-            <span t-if="this.props.channel.unknownMembersCount === 1" class="mx-2 mt-2">And 1 other member.</span>
-            <span t-if="this.props.channel.unknownMembersCount > 1" class="mx-2 mt-2">And <t t-out="this.props.channel.unknownMembersCount"/> other members.</span>
-            <div t-if="!this.props.channel.areAllMembersLoaded" class="mx-2 my-1">
-                <button class="btn btn-secondary" title="Load more" t-on-click.stop="() => this.props.channel.fetchChannelMembers()">Load more</button>
-            </div>
+            <span t-if="this.state.searchTerm and !this.state.isSearching and !this.hasFilteredMembers" class="mx-2 mt-2 text-muted">No members found.</span>
+            <span t-if="this.isSearchResultCapped" class="smaller text-muted mx-1 mb-1 fst-italic" t-out="this.searchResultCapHint"/>
+            <t t-if="!this.state.searchTerm">
+                <span t-if="this.props.channel.unknownMembersCount === 1" class="mx-2 mt-2">And 1 other member.</span>
+                <span t-if="this.props.channel.unknownMembersCount > 1" class="mx-2 mt-2">And <t t-out="this.props.channel.unknownMembersCount"/> other members.</span>
+                <div t-if="!this.props.channel.areAllMembersLoaded" class="mx-2 my-1">
+                    <button class="btn btn-secondary" title="Load more" t-on-click.stop="() => this.props.channel.fetchChannelMembers()">Load more</button>
+                </div>
+            </t>
         </ActionPanel>
     </t>
 
     <t t-name="discuss.ChannelMemberList.section">
-        <h6 class="text-muted pt-4 text-uppercase o-xsmaller opacity-75" t-out="sectionName"/>
+        <h6 class="text-muted pt-3 text-uppercase o-xsmaller opacity-75" t-out="sectionName"/>
     </t>
 
 </templates>

--- a/addons/mail/static/src/discuss/core/common/channel_member_list.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_member_list.xml
@@ -3,33 +3,47 @@
 
     <t t-name="discuss.ChannelMemberList">
         <ActionPanel close="this.props.close" title.translate="Members" minWidth="200" initialWidth="this.env.inMeetingView ? 400 : 250" icon="'oi oi-users'">
-            <button name="inviteButton" t-on-click="() => this.onClickInviteButton()" class="btn btn-sm btn-secondary mt-2 d-flex align-items-center justify-content-center gap-1 rounded-3" title="Invite People"><i class="oi oi-user-plus"/><span>Invite People</span></button>
-            <t t-if="this.props.channel.onlineMembers.length > 0">
+            <div class="o-discuss-ChannelMemberList-search input-group input-group-sm">
+                <input
+                    type="text"
+                    class="form-control bg-view"
+                    placeholder="Search members"
+                    t-custom-model="this.state.searchTerm"
+                    t-on-input="this.onSearchInput"
+                    autocomplete="off"
+                />
+                <button name="inviteButton" t-on-click="() => this.onClickInviteButton()" class="btn btn-outline-secondary" title="Invite People"><i class="oi oi-user-plus"/></button>
+            </div>
+            <t t-if="this.filteredOnlineMembers.length > 0">
                 <t t-call="discuss.ChannelMemberList.section">
                     <t t-set="sectionName" t-value="this.onlineSectionText"/>
                 </t>
                 <div class="d-flex flex-column bg-inherit gap-1">
-                    <ChannelMember t-foreach="this.props.channel.onlineMembers" t-as="member" t-key="member.id" member="member"/>
+                    <ChannelMember t-foreach="this.filteredOnlineMembers" t-as="member" t-key="member.id" member="member"/>
                 </div>
             </t>
-            <t name="offlineMembers" t-if="this.props.channel.offlineMembers.length > 0">
+            <t name="offlineMembers" t-if="this.filteredOfflineMembers.length > 0">
                 <t t-call="discuss.ChannelMemberList.section">
                     <t t-set="sectionName" t-value="this.offlineSectionText"/>
                 </t>
                 <div class="d-flex flex-column bg-inherit gap-1">
-                    <ChannelMember t-foreach="this.props.channel.offlineMembers" t-as="member" t-key="member.id" member="member"/>
+                    <ChannelMember t-foreach="this.filteredOfflineMembers" t-as="member" t-key="member.id" member="member"/>
                 </div>
             </t>
-            <span t-if="this.props.channel.unknownMembersCount === 1" class="mx-2 mt-2">And 1 other member.</span>
-            <span t-if="this.props.channel.unknownMembersCount > 1" class="mx-2 mt-2">And <t t-out="this.props.channel.unknownMembersCount"/> other members.</span>
-            <div t-if="!this.props.channel.areAllMembersLoaded" class="mx-2 my-1">
-                <button class="btn btn-secondary" title="Load more" t-on-click.stop="() => this.props.channel.fetchChannelMembers()">Load more</button>
-            </div>
+            <span t-if="this.state.searchTerm and !this.state.isSearching and this.filteredOnlineMembers.length === 0 and this.filteredOfflineMembers.length === 0" class="mx-2 mt-2 text-muted">No members found.</span>
+            <span t-if="this.isSearchResultCapped" class="smaller text-muted mx-1 mb-1 fst-italic" t-out="this.searchResultCapHint"/>
+            <t t-if="!this.state.searchTerm">
+                <span t-if="this.props.channel.unknownMembersCount === 1" class="mx-2 mt-2">And 1 other member.</span>
+                <span t-if="this.props.channel.unknownMembersCount > 1" class="mx-2 mt-2">And <t t-out="this.props.channel.unknownMembersCount"/> other members.</span>
+                <div t-if="!this.props.channel.areAllMembersLoaded" class="mx-2 my-1">
+                    <button class="btn btn-secondary" title="Load more" t-on-click.stop="() => this.props.channel.fetchChannelMembers()">Load more</button>
+                </div>
+            </t>
         </ActionPanel>
     </t>
 
     <t t-name="discuss.ChannelMemberList.section">
-        <h6 class="text-muted pt-4 text-uppercase o-xsmaller opacity-75" t-out="sectionName"/>
+        <h6 class="text-muted pt-3 text-uppercase o-xsmaller opacity-75" t-out="sectionName"/>
     </t>
 
 </templates>

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -602,6 +602,16 @@ export class DiscussChannel extends Record {
         this.fetchMembersState = "fetched";
     }
 
+    /* @param {string} searchTerm */
+    async searchChannelMembers(searchTerm) {
+        const known_member_ids = this.channel_member_ids.map((channelMember) => channelMember.id);
+        await this.store.fetchStoreData("/discuss/channel/members", {
+            channel_id: this.id,
+            known_member_ids,
+            search_term: searchTerm,
+        });
+    }
+
     async fetchPinnedMessages() {
         if (["loaded", "loading"].includes(this.pinnedMessagesState)) {
             return;

--- a/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_channel_model.js
@@ -585,6 +585,14 @@ export class DiscussChannel extends Record {
         this.store.insert(data);
     }
 
+    async searchChannelMembers(searchTerm) {
+        const data = await rpc("/discuss/channel/members", {
+            channel_id: this.id,
+            search_term: searchTerm,
+        });
+        this.store.insert(data);
+    }
+
     async fetchPinnedMessages() {
         if (["loaded", "loading"].includes(this.pinnedMessagesState)) {
             return;

--- a/addons/mail/static/tests/discuss/core/channel_member_list.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_member_list.test.js
@@ -2,6 +2,8 @@ import {
     click,
     contains,
     defineMailModels,
+    editInput,
+    insertText,
     listenStoreFetch,
     openDiscuss,
     start,
@@ -9,7 +11,8 @@ import {
     waitStoreFetch,
 } from "@mail/../tests/mail_test_helpers";
 import { AvatarCard } from "@mail/core/web/avatar_card/avatar_card";
-import { animationFrame, describe, test } from "@odoo/hoot";
+import { animationFrame, describe, expect, test } from "@odoo/hoot";
+import { press } from "@odoo/hoot-dom";
 import { mockDate } from "@odoo/hoot-mock";
 
 import {
@@ -262,6 +265,91 @@ test("Channel member count update after user left", async () => {
         getService("orm").call("discuss.channel", "action_unfollow", [channelId])
     );
     await contains(".o-discuss-ChannelMember", { count: 1 });
+});
+
+test("Can search member", async () => {
+    const pyEnv = await startServer();
+    const [partnerId1, partnerId2] = pyEnv["res.partner"].create([
+        { name: "Alice" },
+        { name: "Bob" },
+    ]);
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "TestChannel",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: partnerId1 }),
+            Command.create({ partner_id: partnerId2 }),
+        ],
+        channel_type: "channel",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMemberList"); // This is from auto-open of member list panel
+    await contains(".o-discuss-ChannelMember", { count: 3 });
+    await insertText("input[placeholder='Search members']", "Alice");
+    await contains(".o-discuss-ChannelMember", { count: 1 });
+    await contains(".o-discuss-ChannelMember:text('Alice')");
+});
+
+test("Search does not fetch when term is more specific after empty result", async () => {
+    const pyEnv = await startServer();
+    const [partnerId1, partnerId2] = pyEnv["res.partner"].create([
+        { name: "Alice" },
+        { name: "Bob" },
+    ]);
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "TestChannel",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: partnerId1 }),
+            Command.create({ partner_id: partnerId2 }),
+        ],
+        channel_type: "channel",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMemberList");
+    listenStoreFetch("/discuss/channel/members");
+    await editInput(document.body, "input[placeholder='Search members']", "zzzz");
+    await waitStoreFetch("/discuss/channel/members");
+    await contains(".o-discuss-ChannelMember", { count: 0 });
+    await contains(".o-discuss-ChannelMemberList span:text('No members found.')");
+    await press("backspace");
+    await waitStoreFetch("/discuss/channel/members");
+    await contains(".o-discuss-ChannelMember", { count: 0 });
+    await insertText("input[placeholder='Search members']", "zz");
+    await contains(".o-discuss-ChannelMemberList span:text('No members found.')");
+    await expect.waitForSteps([]);
+});
+
+test("Shows a hint to narrow member search when there's more than 100 matches", async () => {
+    const pyEnv = await startServer();
+    const channel_member_ids = [Command.create({ partner_id: serverState.partnerId })];
+    for (let i = 0; i < 120; i++) {
+        const partnerId = pyEnv["res.partner"].create({ name: `Alice ${i}` });
+        channel_member_ids.push(Command.create({ partner_id: partnerId }));
+    }
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "TestChannel",
+        channel_member_ids,
+        channel_type: "channel",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMemberList");
+    await contains(
+        ".o-mail-ActionPanel:has(.o-mail-ActionPanel-header:contains('Members')) button:text('Load more')"
+    );
+    await contains(".o-discuss-ChannelMember", { count: 101 });
+    await insertText("input[placeholder='Search members']", "Alice");
+    await contains(".o-discuss-ChannelMember", { count: 100 });
+    await contains(
+        ".o-discuss-ChannelMemberList span:text('Showing first 100 members. Narrow your search to see more.')"
+    );
+    await contains(
+        ".o-mail-ActionPanel:has(.o-mail-ActionPanel-header:contains('Members')) button:text('Load more')",
+        { count: 0 }
+    );
 });
 
 test("Members are partitioned by online/offline", async () => {

--- a/addons/mail/static/tests/discuss/core/channel_member_list.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_member_list.test.js
@@ -2,6 +2,7 @@ import {
     click,
     contains,
     defineMailModels,
+    insertText,
     listenStoreFetch,
     openDiscuss,
     start,
@@ -256,6 +257,56 @@ test("Channel member count update after user left", async () => {
         getService("orm").call("discuss.channel", "action_unfollow", [channelId])
     );
     await contains(".o-discuss-ChannelMember", { count: 1 });
+});
+
+test("Can search member", async () => {
+    const pyEnv = await startServer();
+    const [partnerId1, partnerId2] = pyEnv["res.partner"].create([
+        { name: "Alice" },
+        { name: "Bob" },
+    ]);
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "TestChannel",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ partner_id: partnerId1 }),
+            Command.create({ partner_id: partnerId2 }),
+        ],
+        channel_type: "channel",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMemberList"); // This is from auto-open of member list panel
+    await contains(".o-discuss-ChannelMember", { count: 3 });
+    await insertText("input[placeholder='Search members']", "Alice");
+    await contains(".o-discuss-ChannelMember", { count: 1 });
+    await contains(".o-discuss-ChannelMember:text('Alice')");
+});
+
+test("Shows a hint to narrow member search when results are capped", async () => {
+    const pyEnv = await startServer();
+    const channel_member_ids = [Command.create({ partner_id: serverState.partnerId })];
+    for (let i = 0; i < 120; i++) {
+        const partnerId = pyEnv["res.partner"].create({ name: `Alice ${i}` });
+        channel_member_ids.push(Command.create({ partner_id: partnerId }));
+    }
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "TestChannel",
+        channel_member_ids,
+        channel_type: "channel",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-discuss-ChannelMemberList");
+    await insertText("input[placeholder='Search members']", "Alice");
+    await contains(".o-discuss-ChannelMember", { count: 100 });
+    await contains(
+        ".o-discuss-ChannelMemberList span:text('Showing first 100 members. Narrow your search to see more.')"
+    );
+    await contains(
+        ".o-mail-ActionPanel:has(.o-mail-ActionPanel-header:contains('Members')) button:text('Load more')",
+        { count: 0 }
+    );
 });
 
 test("Members are partitioned by online/offline", async () => {

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -1005,17 +1005,32 @@ function _process_request_for_all(store, name, params, context = {}) {
         store.add(ResUsers.browse(userId));
     }
     if (name === "/discuss/channel/members") {
-        const memberIds = DiscussChannelMember.search(
+        const { channel_id, known_member_ids = [], search_term } = params;
+        let memberIds = DiscussChannelMember.search(
             [
-                ["id", "not in", params.known_member_ids || []],
-                ["channel_id", "=", params.channel_id],
+                ["id", "not in", known_member_ids],
+                ["channel_id", "=", channel_id],
             ],
             makeKwArgs({ limit: 100 })
         );
-        const memberCount = DiscussChannelMember.search_count([
-            ["channel_id", "=", params.channel_id],
-        ]);
-        store.add(DiscussChannel.browse(params.channel_id), { member_count: memberCount });
+        if (search_term) {
+            const lowerTerm = search_term.toLowerCase();
+            memberIds = DiscussChannelMember.browse(memberIds)
+                .filter((member) => {
+                    if (member.partner_id) {
+                        const [partner] = ResPartner.browse(member.partner_id);
+                        return partner?.name?.toLowerCase().includes(lowerTerm);
+                    }
+                    if (member.guest_id) {
+                        const [guest] = MailGuest.browse(member.guest_id);
+                        return guest?.name?.toLowerCase().includes(lowerTerm);
+                    }
+                    return false;
+                })
+                .map((member) => member.id);
+        }
+        const memberCount = DiscussChannelMember.search_count([["channel_id", "=", channel_id]]);
+        store.add(DiscussChannel.browse(channel_id), { member_count: memberCount });
         store.add(DiscussChannelMember.browse(memberIds));
     }
     if (name === "/discuss/channel/messages") {

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -280,9 +280,47 @@ registerRoute("/discuss/channel/members", discuss_channel_members);
 async function discuss_channel_members(request) {
     /** @type {import("mock_models").DiscussChannel} */
     const DiscussChannel = this.env["discuss.channel"];
+    /** @type {import("mock_models").DiscussChannelMember} */
+    const DiscussChannelMember = this.env["discuss.channel.member"];
+    /** @type {import("mock_models").MailGuest} */
+    const MailGuest = this.env["mail.guest"];
+    /** @type {import("mock_models").ResPartner} */
+    const ResPartner = this.env["res.partner"];
 
-    const { channel_id, known_member_ids } = await parseRequestParams(request);
-    return DiscussChannel._load_more_members([channel_id], known_member_ids);
+    const { channel_id, known_member_ids = [], search_term } = await parseRequestParams(request);
+    let memberIds;
+    if (search_term) {
+        const lowerTerm = search_term.toLowerCase();
+        const allMemberIds = DiscussChannelMember.search(
+            [["channel_id", "=", channel_id]],
+            makeKwArgs({ limit: 100 })
+        );
+        memberIds = DiscussChannelMember.browse(allMemberIds)
+            .filter((member) => {
+                if (member.partner_id) {
+                    const [partner] = ResPartner.browse(member.partner_id);
+                    return partner?.name?.toLowerCase().includes(lowerTerm);
+                }
+                if (member.guest_id) {
+                    const [guest] = MailGuest.browse(member.guest_id);
+                    return guest?.name?.toLowerCase().includes(lowerTerm);
+                }
+                return false;
+            })
+            .map((member) => member.id);
+    } else {
+        memberIds = DiscussChannelMember.search(
+            [
+                ["channel_id", "=", channel_id],
+                ["id", "not in", known_member_ids],
+            ],
+            makeKwArgs({ limit: 100 })
+        );
+    }
+    const member_count = DiscussChannelMember.search_count([["channel_id", "=", channel_id]]);
+    return new mailDataHelpers.Store(DiscussChannel.browse(channel_id), { member_count })
+        .add(DiscussChannelMember.browse(memberIds))
+        .get_result();
 }
 
 registerRoute("/discuss/channel/sub_channel/create", discuss_channel_sub_channel_create);


### PR DESCRIPTION
Add a search input on the top of the member list. This is not only filter locally, but also fetch more members from the server according to search term.

task-4819585


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
