### PR TITLE
[FIX] stock: reset inventory on product inventory tracking change

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -1117,13 +1117,48 @@ class ProductTemplate(models.Model):
                     raise UserError(_("This product's company cannot be changed as long as there are quantities of it belonging to another company."))
 
         clean_inventory = False
+        templates_to_reset = self.env['product.template']
         if 'is_storable' in vals and any(vals['is_storable'] != prod_tmpl.is_storable and not prod_tmpl.is_storable for prod_tmpl in self):
             clean_inventory = True
+            if vals['is_storable']:
+                templates_to_reset = self.filtered(lambda tmpl: not tmpl.is_storable)
 
         res = super().write(vals)
         if clean_inventory:
             self.env['stock.quant'].sudo()._clean_reservations()
+            templates_to_reset._reset_inventory()
         return res
+
+    def _reset_inventory(self):
+        """
+        This methods create quants to match the move history of products that become storable
+        and make inventory adjustments to resets their inventory quantities.
+
+        These adjustments are necessary to ensure the integrity of the product valuation.
+        """
+        move_line_domain = Domain([
+            ('product_id', 'in', self.product_variant_ids.ids),
+            ('state', '=', 'done'),
+            '|',
+                ('location_usage', 'in', ('internal', 'transit')),
+                ('location_dest_usage', 'in', ('internal', 'transit')),
+        ])
+        move_lines_to_match = self.env['stock.move.line'].search_fetch(domain=move_line_domain, field_names=('product_id', 'location_id', 'quantity_product_uom'))
+        inventory_ledger = defaultdict(float)
+        for move_line in move_lines_to_match:
+            if move_line.location_usage in ('internal', 'transit'):
+                inventory_ledger[move_line.product_id, move_line.location_id] -= move_line.quantity_product_uom
+            if move_line.location_dest_usage in ('internal', 'transit'):
+                inventory_ledger[move_line.product_id, move_line.location_dest_id] += move_line.quantity_product_uom
+        quants_to_reset = self.env['stock.quant'].create([
+            {
+                'product_id': product.id,
+                'location_id': location.id,
+                'quantity': quantity,
+                'inventory_quantity': 0.0,
+            } for (product, location), quantity in inventory_ledger.items() if not product.uom_id.is_zero(quantity)
+        ])
+        quants_to_reset._apply_inventory()
 
     def copy(self, default=None):
         new_products = super().copy(default=default)

--- a/addons/stock/tests/test_product.py
+++ b/addons/stock/tests/test_product.py
@@ -6,7 +6,8 @@
 
 from odoo.addons.stock.tests.common import TestStockCommon
 from odoo.exceptions import UserError
-from odoo.tests import Form
+from odoo.fields import Command
+from odoo.tests import Form, tagged
 
 
 class TestVirtualAvailable(TestStockCommon):
@@ -385,3 +386,74 @@ class TestVirtualAvailable(TestStockCommon):
         with Form(product) as product_form:
             product_form.qty_available = 0.0
         self.assertEqual(product.qty_available, 0.0)
+
+
+@tagged('post_install', '-at_install')
+class TestProductPostInstall(TestStockCommon):
+    def test_change_product_inventory_tracking_inventory_adjustment(self):
+        """
+        This test checks that inventory adjustments are performed to counter balance done stock
+        moves in order to reset the product quantity once a product is set as storable.
+
+        This adjustment is necessary to ensure a proper valorisation of goods.
+        """
+        product = self.product
+        self.assertFalse(product.is_storable)
+        product.uom_ids += self.uom_dozen
+        transit_location = self.env['stock.location'].create({
+            'name': 'Lovely transit-location',
+            'usage': 'transit',
+            'location_id': self.stock_location.id,
+        })
+        # validate a receipt an internal transfer and a delivery
+        pickings = self.env['stock.picking'].create([
+            {
+                'location_id': self.supplier_location.id,
+                'location_dest_id': self.stock_location.id,
+                'picking_type_id': self.picking_type_in.id,
+                'move_ids': [
+                    Command.create({
+                        'product_id': product.id,
+                        'product_uom_qty': 1.0,
+                        'product_uom': self.uom_dozen.id,
+                        'location_id': self.supplier_location.id,
+                        'location_dest_id': self.stock_location.id,
+                    })
+                ]
+            },
+            {
+                'location_id': self.stock_location.id,
+                'location_dest_id': transit_location.id,
+                'picking_type_id': self.picking_type_int.id,
+                'move_ids': [
+                    Command.create({
+                        'product_id': product.id,
+                        'product_uom_qty': 3.0,
+                        'location_id': self.stock_location.id,
+                        'location_dest_id': transit_location.id,
+                    })
+                ]
+            },
+            {
+                'location_id': self.stock_location.id,
+                'location_dest_id': self.customer_location.id,
+                'picking_type_id': self.picking_type_out.id,
+                'move_ids': [
+                    Command.create({
+                        'product_id': product.id,
+                        'product_uom_qty': 5.0,
+                        'location_id': self.stock_location.id,
+                        'location_dest_id': self.customer_location.id,
+                    })
+                ]
+            }
+        ])
+        pickings.action_confirm()
+        pickings.button_validate()
+        product.is_storable = True
+        self.assertEqual(product.qty_available, 0.0)
+        inventory_adjustments = self.env['stock.move'].search([('location_dest_usage', '=', 'inventory')], order='product_qty')
+        self.assertRecordValues(inventory_adjustments, [
+            {'location_id': transit_location.id, 'quantity': 3.0},
+            {'location_id': self.stock_location.id, 'quantity': 4.0},
+        ])


### PR DESCRIPTION
### Steps to reproduce:

- Create a product that is not track inventory (`is_storable = False`)
- Set its cost to 50$ and put it in an avco perpetual valuation category
- Create and receive a purchase order for 10 units
- Set the product as track inventory (`is_storable = True`)
- Inventory > Reporting > Stock
- Click on the `unit cost` of your product line
#### > This opens the `stock.avco.report` according to which the total value of your stock is 500$ and the total quantity is 10 units even though do not have any unit in stock.

### Expected behavior:

The line of the receipt should have been counter balanced by an inventory adjustment line to resets the valuation at the same time as the product has been set to `is_storable`

### Cause of the issue:

There is currently no mechanism to counter balance the stock that should have been present in internal locations if the moves done had been processed with a storable product.

opw-5472902

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
