### PR TITLE
[IMP] orm: access_domain and explicit record rules

### DIFF
--- a/addons/crm/tests/test_crm_lead_convert_mass.py
+++ b/addons/crm/tests/test_crm_lead_convert_mass.py
@@ -49,7 +49,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         with self.assertQueryCount(user_sales_manager=0):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
-        with self.assertQueryCount(user_sales_manager=520):  # crm 497 / com 497 / ent 520
+        with self.assertQueryCount(user_sales_manager=526):  # crm 500 / com 500 / ent 526
             test_leads._handle_salesmen_assignment(user_ids=user_ids, team_id=team_id)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert)

--- a/addons/crm/tests/test_performances.py
+++ b/addons/crm/tests/test_performances.py
@@ -183,9 +183,9 @@ class TestLeadAssignPerf(TestLeadAssignCommon):
         # commit probability and related fields
         leads.flush_recordset()
 
-        # randomness: 5232, add 2 queries
+        # randomness: 5236, add 2 queries
         with self.with_user('user_sales_manager'):
-            with self.assertQueryCount(user_sales_manager=5234):
+            with self.assertQueryCount(user_sales_manager=5238):
                 self.env['crm.team'].browse(sales_teams.ids)._action_assign_leads()
 
         # teams assign

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -1358,15 +1358,16 @@ class HrEmployee(models.Model):
                 public.mapped(field_name)
         self._copy_cache_from(public, field_names)
 
-    def _check_access(self, operation):
+    def _access_domain(self, operation):
         # This method override provides read access to 'hr.employee' in some
         # situations, like setting a many2many field to comodel 'hr.employee'.
         # Since Odoo 19, one must have read access to the comodel to modify the
         # relation.
+        # HACK with context key
         if operation == 'read' and self.env.context.get('_allow_read_hr_employee') is _ALLOW_READ_HR_EMPLOYEE:
-            return None
+            return Domain.TRUE
 
-        return super()._check_access(operation)
+        return super()._access_domain(operation)
 
     def _check_private_fields(self, field_names):
         """ Check whether ``field_names`` contain private fields. """

--- a/addons/hr_recruitment/security/hr_recruitment_security.xml
+++ b/addons/hr_recruitment/security/hr_recruitment_security.xml
@@ -80,13 +80,6 @@
         <field name="groups" eval="[(4, ref('hr_recruitment.group_hr_recruitment_user'))]"/>
     </record>
 
-    <record id="mail_message_user_rule" model="ir.rule">
-        <field name="name">User: All Chatter</field>
-        <field name="model_id" ref="mail.model_mail_message"/>
-        <field name="domain_force">[(1, '=', 1)]</field>
-        <field name="groups" eval="[(4, ref('hr_recruitment.group_hr_recruitment_user'))]"/>
-    </record>
-
     <record id="mail_plan_rule_group_hr_recruitment_manager_applicant" model="ir.rule">
         <field name="name">Manager can manage applicant plans</field>
         <field name="groups" eval="[(4, ref('hr_recruitment.group_hr_recruitment_manager'))]"/>

--- a/addons/hr_timesheet/models/account_analytic_line.py
+++ b/addons/hr_timesheet/models/account_analytic_line.py
@@ -405,7 +405,7 @@ class AccountAnalyticLine(models.Model):
     def _timesheet_get_portal_domain(self):
         if self.env.user.has_group('hr_timesheet.group_hr_timesheet_user'):
             # Then, he is internal user, and we take the domain for this current user
-            return self.env['ir.rule']._compute_domain(self._name)
+            return self._access_domain('read')
         return (
             (
                 Domain('message_partner_ids', 'child_of', [self.env.user.partner_id.commercial_partner_id.id])

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -248,24 +248,20 @@ class MailActivity(models.Model):
         for activity in self:
             activity[field_name] = activity.id in allowed
 
-    def _check_access(self, operation):
-        res = super()._check_access(operation)
-        if not res:
-            return None
-        forbidden = res[0]
-        forbidden.invalidate_recordset()  # avoid cache pollution
-        return forbidden, lambda: (
-            AccessError(self.env._(
+    def _make_access_error_message(self, operation, domain):
+        self.invalidate_recordset()  # avoid cache pollution
+        if not domain.is_false():
+            return AccessError(self.env._(
                 "The requested operation cannot be completed due to security restrictions. "
                 "Please contact your system administrator.\n\n"
                 "(Document type: %(type)s, Operation: %(operation)s)\n\n"
                 "Records: %(records)s, User: %(user)s",
                 type=self._description,
                 operation=operation,
-                records=forbidden.ids[:6],
+                records=self.ids[:6],
                 user=self.env.uid,
             ))
-        )
+        return super()._make_access_error_message(operation, domain)
 
     # ------------------------------------------------------
     # ORM overrides

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -8,14 +8,14 @@ from datetime import date, datetime, timedelta
 from dateutil.relativedelta import MO, relativedelta
 
 from odoo import api, fields, models, _
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, UserError
 from odoo.fields import Domain
 from odoo.tools import OrderedSet, is_html_empty
 from odoo.tools.misc import clean_context, get_lang, groupby
 from odoo.tools.translate import LazyTranslate
 from odoo.addons.base.models.ir_attachment import condition_values
 from odoo.addons.mail.tools.discuss import Store
-from .mail_message import MAX_COMODELS_FOR_DOMAIN, _find_allowed_doc_ids, exists_in_cache
+from .mail_message import MAX_COMODELS_FOR_DOMAIN, MAX_SEARCH_LIMIT, _find_allowed_doc_ids, exists_in_cache
 
 _logger = logging.getLogger(__name__)
 _lt = LazyTranslate(__name__)
@@ -69,6 +69,27 @@ class MailActivity(models.Model):
     res_name = fields.Char(
         'Document Name', compute='_compute_res_name', compute_sudo=True, store=True,
         readonly=True)
+    res_access_read = fields.Boolean(
+        groups=fields.NO_ACCESS,
+        compute=lambda self: self._compute_res_access('read'),
+        search=lambda self, operator, value: self._search_res_access('read', operator),
+        compute_sudo=True, depends_context=('uid',))
+    res_access_write = fields.Boolean(
+        groups=fields.NO_ACCESS,
+        compute=lambda self: self._compute_res_access('write'),
+        search=lambda self, operator, value: self._search_res_access('write', operator),
+        compute_sudo=True, depends_context=('uid',))
+    res_access_create = fields.Boolean(
+        groups=fields.NO_ACCESS,
+        compute=lambda self: self._compute_res_access('create'),
+        search=lambda self, operator, value: self._search_res_access('create', operator),
+        compute_sudo=True, depends_context=('uid',))
+    res_access_unlink = fields.Boolean(
+        groups=fields.NO_ACCESS,
+        compute=lambda self: self._compute_res_access('unlink'),
+        search=lambda self, operator, value: self._search_res_access('unlink', operator),
+        compute_sudo=True, depends_context=('uid',))
+
     # activity
     activity_type_id = fields.Many2one(
         'mail.activity.type', string='Activity Type',
@@ -203,82 +224,48 @@ class MailActivity(models.Model):
             elif not activity.user_id:
                 activity.user_id = self.env.user
 
-    def _check_access(self, operation: str) -> tuple | None:
+    def _compute_res_access(self, operation: str):
         """ Determine the subset of ``self`` for which ``operation`` is allowed.
         A custom implementation is done on activities as this document has some
         access rules and is based on related document for activities that are
         not covered by those rules.
-
-        Access on activities are the following :
-
-          * read: access rule AND (assigned to user OR read rights on related documents);
-          * write: access rule OR (``mail_post_access`` or write) rights on related documents);
-          * create: access rule AND (``mail_post_access`` or write) right on related documents;
-          * unlink: access rule OR (``mail_post_access`` or write) rights on related documents);
         """
-        result = super()._check_access(operation)
-        if not self:
-            return result
+        assert self.env.su
+        field_name = f'res_access_{operation}'
 
-        # determine activities on which to check the related document
-        if operation == 'read':
-            # check activities allowed by access rules
-            activities = self - result[0] if result else self
-            activities -= activities.sudo().filtered_domain([('user_id', '=', self.env.uid)])
-        elif operation == 'create':
-            # check activities allowed by access rules
-            activities = self - result[0] if result else self
-        else:
-            assert operation in ('write', 'unlink'), f"Unexpected operation {operation!r}"
-            # check access to the model, and check the forbidden records only
-            if self.browse()._check_access(operation):
-                return result
-            activities = result[0] if result else self.browse()
-            result = None
-
-        if not activities:
-            return result
+        if not self or not self.browse().sudo(False).has_access(operation):
+            self[field_name] = False
+            return
 
         # now check access on related document of 'activities', and collect the
-        # ids of forbidden activities; free activities are checked against user_id
+        # ids of forbidden activities
         model_docid_actids = defaultdict(lambda: defaultdict(list))
-        forbidden_ids = []
-        for activity in activities.sudo():
+        for activity in self:
             if activity.res_model and activity.res_id:
                 model_docid_actids[activity.res_model][activity.res_id].append(activity.id)
-            elif activity.user_id.id != self.env.uid:
-                forbidden_ids.append(activity.id)
 
-        allowed = _find_allowed_doc_ids(self.env, model_docid_actids, operation)
-        forbidden_ids.extend(
-            act_id
-            for docid_actids in model_docid_actids.values()
-            for act_ids in docid_actids.values()
-            for act_id in act_ids
-            if act_id not in allowed
+        allowed = _find_allowed_doc_ids(self.env(su=False), model_docid_actids, operation)
+        for activity in self:
+            activity[field_name] = activity.id in allowed
+
+    def _check_access(self, operation):
+        res = super()._check_access(operation)
+        if not res:
+            return None
+        forbidden = res[0]
+        forbidden.invalidate_recordset()  # avoid cache pollution
+        return forbidden, lambda: (
+            AccessError(self.env._(
+                "The requested operation cannot be completed due to security restrictions. "
+                "Please contact your system administrator.\n\n"
+                "(Document type: %(type)s, Operation: %(operation)s)\n\n"
+                "Records: %(records)s, User: %(user)s",
+                type=self._description,
+                operation=operation,
+                records=forbidden.ids[:6],
+                user=self.env.uid,
+            ))
         )
-
-        if forbidden_ids:
-            forbidden = self.browse(forbidden_ids)
-            if result:
-                result = (result[0] + forbidden, result[1])
-            else:
-                result = (forbidden, lambda: forbidden._make_access_error(operation))
-            forbidden.invalidate_recordset()  # avoid cache pollution
-
-        return result
-
-    def _make_access_error(self, operation: str) -> AccessError:
-        return AccessError(_(
-            "The requested operation cannot be completed due to security restrictions. "
-            "Please contact your system administrator.\n\n"
-            "(Document type: %(type)s, Operation: %(operation)s)\n\n"
-            "Records: %(records)s, User: %(user)s",
-            type=self._description,
-            operation=operation,
-            records=self.ids[:6],
-            user=self.env.uid,
-        ))
 
     # ------------------------------------------------------
     # ORM overrides
@@ -388,7 +375,7 @@ class MailActivity(models.Model):
             activities the current user is allowed to see. An activity is
             accessible if the user is the assignee (`user_id`), or if they have
             read access to the related document (`res_model`, `res_id`). This
-            logic is detailed in :meth:`~._check_access`.
+            logic is detailed in res_access* fields.
             Superusers bypass this and perform a standard search.
         """
         domain = Domain(domain).optimize(self)
@@ -430,8 +417,29 @@ class MailActivity(models.Model):
             records = self._fetch_query(query, [self._fields[f] for f in SECURITY_FIELDS])
             return records._filtered_access('read')._as_query(ordered=bool(order))
 
+        return super()._search(domain, offset, limit, order, bypass_access=bypass_access, **kwargs)
+
+    def _search_res_access(self, operation, domain_operator):
+        assert self.env.su
+        if domain_operator != 'in':
+            return NotImplemented
+        domain = self.env.context.get('search_domain')
+        if not isinstance(domain, Domain):
+            domain = Domain.TRUE
+        self = self.sudo(False)  # noqa: PLW0642
+
+        res_model_names = condition_values(self, 'res_model', domain)
+        if operation != 'read' or res_model_names is None:
+            records = self.sudo().with_context(active_test=False).search_fetch(
+                domain, SECURITY_FIELDS, order='id', limit=MAX_SEARCH_LIMIT)
+            if len(records) == MAX_SEARCH_LIMIT:  # avoid out of memory
+                raise UserError(self.env._("Cannot search, too many activities"))
+            records = records.sudo(False)._filtered_access(operation)
+            # [('id', 'any!', query_with_ids)] is optimized in sec_domain
+            return Domain('id', 'any!', records._as_query(ordered=False))
+
         # search by model and res_id
-        sec_domain = Domain('user_id', '=', self.env.uid)
+        sec_domain = Domain.FALSE
         env = self.with_context(active_test=False).env
         for res_model_name in res_model_names:
             if res_model_name not in env:
@@ -466,7 +474,7 @@ class MailActivity(models.Model):
                 codomain &= Domain('res_id', 'any!', query)
             sec_domain |= codomain
 
-        return super()._search(domain & sec_domain, offset, limit, order, **kwargs)
+        return sec_domain
 
     @api.depends('summary', 'activity_type_id')
     def _compute_display_name(self):

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -453,12 +453,11 @@ class MailActivity(models.Model):
                     comodel_domain_remaining & domain_operation,
                     comodel_domain_remaining & ~domain_operation,
                 )
-                if not comodel.has_access(doc_operation):
+                comodel_rule = comodel._access_domain(doc_operation)
+                if comodel_rule.is_false():
                     continue
                 if doc_operation == 'read':
                     comodel_rule = Domain.TRUE  # covered by the search below
-                else:
-                    comodel_rule = self.env['ir.rule']._compute_domain(comodel._name, doc_operation)
                 comodel_domain |= (domain_operation & comodel_rule)
             if comodel_res_ids is not None:
                 comodel_domain &= Domain('id', 'in', comodel_res_ids)

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -31,6 +31,12 @@ class MailMail(models.Model):
     _order = 'id desc'
     _rec_name = 'subject'
 
+    def _access_domain(self, operation):
+        domain = super()._access_domain(operation)
+        if domain.is_false():
+            return domain
+        return self.env['ir.rule']._compute_domain(self._name, operation, include_inherits=False)
+
     @api.model
     def default_get(self, fields):
         # protection for `default_type` values leaking from menu action context (e.g. for invoices)

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -684,23 +684,19 @@ class MailMessage(models.Model):
 
         return accessible - self.browse(messages_to_check)
 
-    def _check_access(self, operation):
-        res = super()._check_access(operation)
-        if not res:
-            return None
-        forbidden = res[0]
-        return forbidden, lambda: (
-            AccessError(self.env._(
+    def _make_access_error_message(self, operation, domain):
+        if not domain.is_false():
+            return AccessError(self.env._(
                 "The requested operation cannot be completed due to security restrictions. "
                 "Please contact your system administrator.\n\n"
                 "(Document type: %(type)s, Operation: %(operation)s)\n\n"
                 "Records: %(records)s, User: %(user)s",
                 type=self._description,
                 operation=operation,
-                records=forbidden.ids[:6],
+                records=self.ids[:6],
                 user=self.env.uid,
             ))
-        )
+        return super()._make_access_error_message(operation, domain)
 
     def _get_with_access(self, mode="read", **kwargs):
         if not self:

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -489,12 +489,11 @@ class MailMessage(models.Model):
                     comodel_domain_remaining & domain_operation,
                     comodel_domain_remaining & ~domain_operation,
                 )
-                if not comodel.has_access(doc_operation):
+                comodel_rule = comodel._access_domain(doc_operation)
+                if comodel_rule.is_false():
                     continue
                 if doc_operation == 'read':
                     comodel_rule = Domain.TRUE  # covered by the search below
-                else:
-                    comodel_rule = self.env['ir.rule']._compute_domain(comodel._name, doc_operation)
                 comodel_domain |= (domain_operation & comodel_rule)
             if comodel_res_ids is not None:
                 comodel_domain &= Domain('id', 'in', comodel_res_ids)

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -12,9 +12,10 @@ from lxml import html
 from typing import Self
 
 from odoo import _, api, fields, models, modules, tools
-from odoo.exceptions import AccessError, MissingError
+from odoo.exceptions import AccessError, MissingError, UserError
 from odoo.fields import Domain
 from odoo.tools import clean_context, groupby, SQL
+from odoo.tools.constants import PREFETCH_MAX
 from odoo.tools.misc import OrderedSet
 from odoo.addons.base.models.ir_attachment import condition_values
 from odoo.addons.mail.tools.discuss import Store
@@ -27,6 +28,7 @@ _logger = logging.getLogger(__name__)
 _image_dataurl = re.compile(r'(data:image/[a-z]+?);base64,([a-z0-9+/\n]{3,}=*)\n*([\'"])(?: data-filename="([^"]*)")?', re.I)
 
 MAX_COMODELS_FOR_DOMAIN = 5
+MAX_SEARCH_LIMIT = PREFETCH_MAX * 10
 
 
 def exists_in_cache(records, *, hint_field=''):
@@ -68,6 +70,8 @@ def _find_allowed_doc_ids(env, model_ids, operation):
     """
     allowed_ids = set()
     for doc_model, doc_dict in model_ids.items():
+        if doc_model not in env:
+            continue
         documents = exists_in_cache(env[doc_model].browse(doc_dict))
         for document_domain, operation_res_ids in documents._mail_get_operation_for_mail_message_operation(operation):
             if not documents:
@@ -173,6 +177,30 @@ class MailMessage(models.Model):
     # related document
     model = fields.Char('Related Document Model')
     res_id = fields.Many2oneReference('Related Document ID', model_field='model')
+    res_access_read = fields.Boolean(
+        groups=fields.NO_ACCESS,
+        compute=lambda self: self._compute_res_access('read'),
+        search=lambda self, operator, value: self._search_res_access('read', operator),
+        compute_sudo=True,
+        depends_context=('uid',))
+    res_access_write = fields.Boolean(
+        groups=fields.NO_ACCESS,
+        compute=lambda self: self._compute_res_access('write'),
+        search=lambda self, operator, value: self._search_res_access('write', operator),
+        compute_sudo=True,
+        depends_context=('uid',))
+    res_access_create = fields.Boolean(
+        groups=fields.NO_ACCESS,
+        compute=lambda self: self._compute_res_access('create'),
+        search=lambda self, operator, value: self._search_res_access('create', operator),
+        compute_sudo=True,
+        depends_context=('uid',))
+    res_access_unlink = fields.Boolean(
+        groups=fields.NO_ACCESS,
+        compute=lambda self: self._compute_res_access('unlink'),
+        search=lambda self, operator, value: self._search_res_access('unlink', operator),
+        compute_sudo=True,
+        depends_context=('uid',))
     record_name = fields.Char('Message Record Name', compute='_compute_record_name', store=False)
     record_alias_domain_id = fields.Many2one('mail.alias.domain', 'Alias Domain', ondelete='set null')
     record_company_id = fields.Many2one('res.company', 'Company', ondelete='set null')
@@ -393,7 +421,7 @@ class MailMessage(models.Model):
     def _search(self, domain, offset=0, limit=None, order=None, *, bypass_access=False, **kwargs):
         """ Override that adds specific access rights of mail.message, to remove
         ids uid could not see according to our custom rules. Please refer to
-        :meth:`_check_access` for more details about those rules.
+        res_access fields for more details about those rules.
         """
         domain = Domain(domain).optimize(self)
         if self.env.su or bypass_access or domain.is_false():
@@ -401,26 +429,40 @@ class MailMessage(models.Model):
         if self.env.context.get('_generating_sql_for_fields'):
             raise ValueError("Cannot generate SQL for whole mail.message")
 
+        return super()._search(domain, offset, limit, order, bypass_access=bypass_access, **kwargs)
+
+    def _compute_res_access(self, operation: str):
+        assert self.env.su
+        field_name = f'res_access_{operation}'
+
+        if not self or not self.browse().sudo(False).has_access(operation):
+            self[field_name] = False
+            return
+
+        # Non-employee see only messages with a subtype and not internal
+        query = self.sudo()._search(self._get_search_domain_share() & Domain('id', 'in', self.ids))
+        accessible_messages = self.sudo(False)._filter_accessible_from_query(query, operation)
+        accessible_messages[field_name] = True
+        (self - accessible_messages)[field_name] = False
+
+    def _search_res_access(self, operation, domain_operator):
+        assert self.env.su
+        if domain_operator != 'in':
+            return NotImplemented
+        domain = self.env.context.get('search_domain')
+        if not isinstance(domain, Domain):
+            domain = Domain.TRUE
         # Non-employee see only messages with a subtype and not internal
         domain = self._get_search_domain_share() & domain
-        domain = domain.optimize_dynamic(self)
-
-        # search by ids
-        if condition_values(self, 'id', domain) is not None:
-            query = super()._search(domain, order=order, **kwargs)
-            records = self.browse()._filter_accessible_from_query(query, 'read')
-            if offset > 0:
-                records = records[offset:]
-            if limit is not None:
-                records = records[:limit]
-            return records._as_query(ordered=bool(order))
+        self = self.sudo(False)  # noqa: PLW0642
 
         # searching for all messages or a subset of models
         res_model_names = condition_values(self, 'model', domain) or ()
-        if not (0 < len(res_model_names) <= MAX_COMODELS_FOR_DOMAIN):
-            query = super()._search(domain, offset, limit, order, **kwargs)
-            records = self.browse()._filter_accessible_from_query(query, 'read')
-            return records._as_query(ordered=bool(order))
+        if operation != 'read' or not (0 < len(res_model_names) <= MAX_COMODELS_FOR_DOMAIN):
+            query = super(MailMessage, self.sudo())._search(domain, order='id')
+            records = self.browse()._filter_accessible_from_query(query, operation)
+            # [('id', 'any!', query_with_ids)] is optimized in sec_domain
+            return Domain('id', 'any!', records._as_query(ordered=False))
 
         # search by model and res_id
         model_codomains = Domain.FALSE  # (model = a & res_id in ...) | (model = b & ...)
@@ -442,7 +484,7 @@ class MailMessage(models.Model):
             # (because the rules are applied with sudo permissions) and search.
             comodel_domain = Domain.FALSE
             comodel_domain_remaining = Domain.TRUE
-            for domain_operation, doc_operation in comodel._mail_get_operation_for_mail_message_operation('read'):
+            for domain_operation, doc_operation in comodel._mail_get_operation_for_mail_message_operation(operation):
                 domain_operation, comodel_domain_remaining = (
                     comodel_domain_remaining & domain_operation,
                     comodel_domain_remaining & ~domain_operation,
@@ -477,15 +519,18 @@ class MailMessage(models.Model):
             model_codomains & Domain('message_type', '!=', 'user_notification'),
         ))
 
-        return super()._search(domain, offset, limit, order, **kwargs)
+        return domain
 
     def _get_search_domain_share(self):
         if self.env.user._is_internal():
             return Domain.TRUE
         return Domain('is_internal', '=', False) & Domain('subtype_id.internal', '=', False)
 
-    def _check_access(self, operation: str) -> tuple | None:
-        """ Access rules of mail.message:
+    def _filter_accessible_from_query(self, query: models.Query, operation: str) -> Self:
+        """ Return the subset of ``self`` that satisfies the specific conditions
+        for messages. Flush current recordset or the model on empty self.
+
+        Access rules of mail.message:
             - read: if any
                 - author_id == pid, uid is the author
                 - create_uid == uid, uid is the creator
@@ -511,27 +556,6 @@ class MailMessage(models.Model):
         Global restriction: non employee users cannot see internal messages (aka logs):
         'is_internal' flag on message, 'internal' flag on subtype.
         """
-        result = super()._check_access(operation)
-        if not self:
-            return result
-
-        # discard forbidden records, and check remaining ones
-        messages = self - result[0] if result else self
-
-        query = self.sudo()._search(self._get_search_domain_share() & Domain('id', 'in', messages.ids), active_test=False)
-        accessible_messages = messages._filter_accessible_from_query(query, operation)
-        if messages != accessible_messages:
-            forbidden = messages - accessible_messages
-            if result:
-                result = (result[0] + forbidden, result[1])
-            else:
-                result = (forbidden, lambda: forbidden._make_access_error(operation))
-        return result
-
-    def _filter_accessible_from_query(self, query: models.Query, operation: str) -> Self:
-        """ Return the subset of ``self`` that satisfies the specific conditions
-        for messages. Flush current recordset or the model on empty self.
-        """
         assert query._model._name == self._name
         if query.is_empty():
             return self.browse()
@@ -549,6 +573,8 @@ class MailMessage(models.Model):
 
         # Non internal users see only non-private messages
         table = query.table
+        if query.limit is None:
+            query.limit = MAX_SEARCH_LIMIT
         if operation in ('read', 'write'):
             id_sql = table.id
             query.groupby = id_sql
@@ -574,6 +600,8 @@ class MailMessage(models.Model):
             values['id']: values
             for values in self.env.cr.dictfetchall()
         }
+        if len(messages_to_check) == MAX_SEARCH_LIMIT:  # avoid out of memory
+            raise UserError(self.env._("Cannot search, too many messages"))
         accessible = self.browse(messages_to_check)
         if not messages_to_check:
             return accessible
@@ -656,17 +684,23 @@ class MailMessage(models.Model):
 
         return accessible - self.browse(messages_to_check)
 
-    def _make_access_error(self, operation: str) -> AccessError:
-        return AccessError(_(
-            "The requested operation cannot be completed due to security restrictions. "
-            "Please contact your system administrator.\n\n"
-            "(Document type: %(type)s, Operation: %(operation)s)\n\n"
-            "Records: %(records)s, User: %(user)s",
-            type=self._description,
-            operation=operation,
-            records=self.ids[:6],
-            user=self.env.uid,
-        ))
+    def _check_access(self, operation):
+        res = super()._check_access(operation)
+        if not res:
+            return None
+        forbidden = res[0]
+        return forbidden, lambda: (
+            AccessError(self.env._(
+                "The requested operation cannot be completed due to security restrictions. "
+                "Please contact your system administrator.\n\n"
+                "(Document type: %(type)s, Operation: %(operation)s)\n\n"
+                "Records: %(records)s, User: %(user)s",
+                type=self._description,
+                operation=operation,
+                records=forbidden.ids[:6],
+                user=self.env.uid,
+            ))
+        )
 
     def _get_with_access(self, mode="read", **kwargs):
         if not self:

--- a/addons/mail/security/mail_security.xml
+++ b/addons/mail/security/mail_security.xml
@@ -283,14 +283,101 @@
             <field name="groups" eval="[Command.link(ref('base.group_portal')), Command.link(ref('base.group_public'))]"/>
         </record>
 
-        <record id="mail_activity_rule_user" model="ir.rule">
-            <field name="name">mail.activity: user: write/unlink only (created or assigned)</field>
+        <record model="ir.rule" id="mail_message_rule_access_read">
+            <field name="name">read res_model</field>
+            <field name="model_id" ref="model_mail_message"/>
+            <field name="groups" eval="[Command.set([ref('base.group_everyone')])]"/>
+            <field name="domain_force">[('res_access_read', '=', True)]</field>
+            <field name="perm_read" eval="True"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
+        </record>
+        <record model="ir.rule" id="mail_message_rule_access_write">
+            <field name="name">write res_model</field>
+            <field name="model_id" ref="model_mail_message"/>
+            <field name="groups" eval="[Command.set([ref('base.group_everyone')])]"/>
+            <field name="domain_force">[('res_access_write', '=', True)]</field>
+            <field name="perm_read" eval="False"/>
+            <field name="perm_write" eval="True"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
+        </record>
+        <record model="ir.rule" id="mail_message_rule_access_create">
+            <field name="name">create res_model</field>
+            <field name="model_id" ref="model_mail_message"/>
+            <field name="groups" eval="[Command.set([ref('base.group_everyone')])]"/>
+            <field name="domain_force">[('res_access_create', '=', True)]</field>
+            <field name="perm_read" eval="False"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_create" eval="True"/>
+            <field name="perm_unlink" eval="False"/>
+        </record>
+        <record model="ir.rule" id="mail_message_rule_access_unlink">
+            <field name="name">unlink res_model</field>
+            <field name="model_id" ref="model_mail_message"/>
+            <field name="groups" eval="[Command.set([ref('base.group_everyone')])]"/>
+            <field name="domain_force">[('res_access_unlink', '=', True)]</field>
+            <field name="perm_read" eval="False"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_unlink" eval="True"/>
+        </record>
+
+        <record model="ir.rule" id="mail_activity_rule_access_read">
+            <field name="name">read res_model</field>
+            <field name="model_id" ref="model_mail_activity"/>
+            <field name="groups" eval="[Command.set([ref('base.group_everyone')])]"/>
+            <field name="domain_force">['|', ('user_id', '=', user.id), ('res_access_read', '=', True)]</field>
+            <field name="perm_read" eval="True"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
+        </record>
+        <record model="ir.rule" id="mail_activity_rule_user">
+            <field name="name">mail.activity: write/unlink only (created or assigned)</field>
             <field name="model_id" ref="model_mail_activity"/>
             <field name="domain_force">['|', ('user_id', '=', user.id), ('create_uid', '=', user.id)]</field>
             <field name="groups" eval="[Command.link(ref('base.group_user'))]"/>
             <field name="perm_create" eval="False"/>
             <field name="perm_read" eval="False"/>
             <field name="perm_write" eval="True"/>
+            <field name="perm_unlink" eval="True"/>
+        </record>
+        <record model="ir.rule" id="mail_activity_rule_access_write">
+            <field name="name">write res_model</field>
+            <field name="model_id" ref="model_mail_activity"/>
+            <field name="groups" eval="[Command.set([ref('base.group_everyone')])]"/>
+            <field name="domain_force">['|', 
+                '&amp;', ('res_model', '=', False), ('user_id', '=', user.id),
+                ('res_access_write', '=', True)]</field>
+            <field name="perm_read" eval="False"/>
+            <field name="perm_write" eval="True"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
+        </record>
+        <record model="ir.rule" id="mail_activity_rule_access_create">
+            <field name="name">create res_model</field>
+            <field name="model_id" ref="model_mail_activity"/>
+            <field name="groups" eval="[Command.set([ref('base.group_everyone')])]"/>
+            <field name="domain_force">['|', 
+                '&amp;', ('res_model', '=', False), ('user_id', '=', user.id),
+                ('res_access_create', '=', True)]</field>
+            <field name="perm_read" eval="False"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_create" eval="True"/>
+            <field name="perm_unlink" eval="False"/>
+        </record>
+        <record model="ir.rule" id="mail_activity_rule_access_unlink">
+            <field name="name">unlink res_model</field>
+            <field name="model_id" ref="model_mail_activity"/>
+            <field name="groups" eval="[Command.set([ref('base.group_everyone')])]"/>
+            <field name="domain_force">['|', 
+                '&amp;', ('res_model', '=', False), ('user_id', '=', user.id),
+                ('res_access_unlink', '=', True)]</field>
+            <field name="perm_read" eval="False"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_create" eval="False"/>
             <field name="perm_unlink" eval="True"/>
         </record>
 

--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -384,7 +384,7 @@ class ProjectCustomerPortal(CustomerPortal):
 
         domain = Domain.AND([domain or [], [('has_template_ancestor', '=', False)]])
         if not su and Task.has_access('read'):
-            domain &= Domain(request.env['ir.rule']._compute_domain(Task._name, 'read'))
+            domain &= Task._access_domain('read').optimize_full(Task.sudo())
         Task_sudo = Task.sudo()
         milestone_domain = domain & Domain('allow_milestones', '=', True) & Domain('milestone_id', '!=', False)
         milestones_allowed = Task_sudo.search_count(milestone_domain, limit=1) == 1

--- a/addons/sale_pdf_quote_builder/models/quotation_document.py
+++ b/addons/sale_pdf_quote_builder/models/quotation_document.py
@@ -46,6 +46,14 @@ class QuotationDocument(models.Model):
         default=False,
     )
 
+    def _access_domain(self, operation):
+        # this override gets the record rules only from the current model and
+        # ignores record rules on ir.attachment (inherits)
+        domain = super()._access_domain(operation)
+        if domain.is_false():
+            return domain
+        return self.env['ir.rule']._compute_domain(self._name, operation, include_inherits=False)
+
     # === CONSTRAINT METHODS ===#
 
     @api.constrains("raw")

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -165,12 +165,6 @@ class TestActivityRights(TestActivityCommon):
             activity2.write({'user_id': self.user_employee.id})
 
     def test_activity_security_user_noaccess_manual(self):
-        def _employee_crash(records, operation):
-            """ If employee is test employee, consider they have no access on document """
-            if records.env.uid == self.user_employee.id and not records.env.su:
-                raise exceptions.AccessError('Hop hop hop Ernest, please step back.')
-            return DEFAULT
-
         test_activity = self.env['mail.activity'].with_user(self.user_admin).create({
             'activity_type_id': self.env.ref('test_mail.mail_act_test_todo').id,
             'res_model_id': self.env.ref('test_mail.model_mail_test_activity').id,
@@ -181,14 +175,9 @@ class TestActivityRights(TestActivityCommon):
         test_activity.flush_recordset()
 
         # can _search activities if access to the document
-        self.env['mail.activity'].with_user(self.user_employee)._search(
+        searched_activity = self.env['mail.activity'].with_user(self.user_employee)._search(
             [('id', '=', test_activity.id)])
-
-        # cannot _search activities if no access to the document
-        with patch.object(MailTestActivity, '_check_access', autospec=True, side_effect=_employee_crash):
-            with self.assertRaises(exceptions.AccessError):
-                searched_activity = self.env['mail.activity'].with_user(self.user_employee)._search(
-                    [('id', '=', test_activity.id)])
+        self.assertTrue(searched_activity, "Activity not found by employee")
 
         # can formatted_read_group activities if access to the document
         read_group_result = self.env['mail.activity'].with_user(self.user_employee).formatted_read_group(
@@ -199,64 +188,70 @@ class TestActivityRights(TestActivityCommon):
         self.assertEqual(1, read_group_result[0]['__count'])
         self.assertEqual('Summary', read_group_result[0]['summary'])
 
+        # ---------------------------------------
+        # Let only the creator access an activity
+        self.env['ir.rule'].create({
+            'name': 'Hop hop hop Ernest',
+            'domain_force': '[("user_id", "=", user.id)]',
+            'model_id': self.env['ir.model']._get('mail.activity').id,
+        })
+
+        # cannot _search activities if no access to the document
+        searched_activity = self.env['mail.activity'].with_user(self.user_employee)._search(
+            [('id', '=', test_activity.id)])
+        self.assertFalse(searched_activity)
+
         # cannot read_group activities if no access to the document
-        with patch.object(MailTestActivity, '_check_access', autospec=True, side_effect=_employee_crash):
-            with self.assertRaises(exceptions.AccessError):
-                self.env['mail.activity'].with_user(self.user_employee).formatted_read_group(
-                    [('id', '=', test_activity.id)],
-                    ['summary'],
-                    ['__count'],
-                )
+        result = self.env['mail.activity'].with_user(self.user_employee).formatted_read_group(
+            [('id', '=', test_activity.id)],
+            ['summary'],
+            ['__count'],
+        )
+        self.assertFalse(result)
 
         # cannot read activities if no access to the document
-        with patch.object(MailTestActivity, '_check_access', autospec=True, side_effect=_employee_crash):
-            with self.assertRaises(exceptions.AccessError):
-                searched_activity = self.env['mail.activity'].with_user(self.user_employee).search(
-                    [('id', '=', test_activity.id)])
-                searched_activity.read(['summary'])
+        with self.assertRaises(exceptions.AccessError):
+            test_activity.with_user(self.user_employee).read(['summary'])
 
         # cannot search_read activities if no access to the document
-        with patch.object(MailTestActivity, '_check_access', autospec=True, side_effect=_employee_crash):
-            with self.assertRaises(exceptions.AccessError):
-                self.env['mail.activity'].with_user(self.user_employee).search_read(
-                    [('id', '=', test_activity.id)],
-                    ['summary'])
+        result = self.env['mail.activity'].with_user(self.user_employee).search_read(
+            [('id', '=', test_activity.id)],
+            ['summary'])
+        self.assertFalse(result)
 
         # can create activities for people that cannot access record
-        with patch.object(MailTestActivity, '_check_access', autospec=True, side_effect=_employee_crash):
-            self.env['mail.activity'].create({
-                'activity_type_id': self.env.ref('test_mail.mail_act_test_todo').id,
-                'res_model_id': self.env.ref('test_mail.model_mail_test_activity').id,
-                'res_id': self.test_record.id,
-                'user_id': self.user_employee.id,
-            })
+        self.env['mail.activity'].create({
+            'activity_type_id': self.env.ref('test_mail.mail_act_test_todo').id,
+            'res_model_id': self.env.ref('test_mail.model_mail_test_activity').id,
+            'res_id': self.test_record.id,
+            'user_id': self.user_employee.id,
+        })
 
         # cannot create activities if no access to the document
-        with patch.object(MailTestActivity, '_check_access', autospec=True, side_effect=_employee_crash):
-            with self.assertRaises(exceptions.AccessError):
-                activity = self.test_record.with_user(self.user_employee).activity_schedule(
-                    'test_mail.mail_act_test_todo',
-                    user_id=self.user_admin.id)
+        with self.assertRaises(exceptions.AccessError):
+            self.test_record.with_user(self.user_employee).activity_schedule(
+                'test_mail.mail_act_test_todo',
+                user_id=self.user_admin.id)
 
+        # ---------------------------------------
+        # Assign the activity to the user
         test_activity.user_id = self.user_employee
         test_activity.flush_recordset()
 
         # user can read activities assigned to him even if he has no access to the document
-        with patch.object(MailTestActivity, '_check_access', autospec=True, side_effect=_employee_crash):
-            found = self.env['mail.activity'].with_user(self.user_employee).search(
-                [('id', '=', test_activity.id)])
-            self.assertEqual(found, test_activity)
-            found.read(['summary'])
+        found = self.env['mail.activity'].with_user(self.user_employee).search(
+            [('id', '=', test_activity.id)])
+        self.assertEqual(found, test_activity)
+        found.read(['summary'])
 
         # user can read_group activities assigned to him even if he has no access to the document
-        with patch.object(MailTestActivity, '_check_access', autospec=True, side_effect=_employee_crash):
-            read_group_result = self.env['mail.activity'].with_user(self.user_employee).formatted_read_group(
-                [('id', '=', test_activity.id)],
-                ['summary'],
-                ['__count'],
-            )
-            self.assertEqual(1, read_group_result[0]['__count'])
-            self.assertEqual('Summary', read_group_result[0]['summary'])
+        read_group_result = self.env['mail.activity'].with_user(self.user_employee).formatted_read_group(
+            [('id', '=', test_activity.id)],
+            ['summary'],
+            ['__count'],
+        )
+        self.assertEqual(1, read_group_result[0]['__count'])
+        self.assertEqual('Summary', read_group_result[0]['summary'])
 
 
 @tests.tagged('mail_activity')
@@ -502,11 +497,10 @@ class TestActivitySystray(TestActivityCommon, HttpCase):
 
         # In the mean time, some FK deletes the record where the message is
         # scheduled, skipping its unlink() override
+        cls.env.invalidate_all()
         cls.env.cr.execute(
             f"DELETE FROM {cls.test_lead_records._table} WHERE id = %s", (cls.deleted_record.id,)
         )
-
-        cls.env.invalidate_all()
 
     @users("employee")
     def test_systray_activities_for_various_records(self):

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -14,6 +14,7 @@ from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.mail.tests.common_activity import ActivityScheduleCase
 from odoo.addons.test_mail.models.test_mail_models import MailTestActivity
 from odoo.tests import tagged, Form, HttpCase, users
+from odoo.fields import Domain
 from odoo.tests.common import freeze_time
 from odoo.tools import mute_logger
 
@@ -36,7 +37,7 @@ class TestActivityRights(TestActivityCommon):
         def _employee_no_access(records, operation):
             """Simulates employee having no access to the document"""
             if records.env.uid == self.user_employee.id and not records.env.su:
-                return records, lambda: exceptions.AccessError('Access denied to document')
+                return Domain.FALSE
             return DEFAULT
 
         test_activity = self.env['mail.activity'].with_user(self.user_admin).create({
@@ -52,7 +53,7 @@ class TestActivityRights(TestActivityCommon):
         self.assertEqual(action['res_id'], self.test_record.id)
 
         # If user has no access to the record, should return activity view instead
-        with patch.object(MailTestActivity, '_check_access', autospec=True, side_effect=_employee_no_access):
+        with patch.object(MailTestActivity, '_access_domain', autospec=True, side_effect=_employee_no_access):
             self.env.transaction.clear_access_cache()
             self.assertFalse(self.test_record.with_user(self.user_employee).has_access('read'))
 
@@ -66,7 +67,7 @@ class TestActivityRights(TestActivityCommon):
         def _employee_crash(records, operation):
             """ If employee is test employee, consider they have no access on document """
             if records.env.uid == self.user_employee.id and not records.env.su:
-                return records, lambda: exceptions.AccessError('Hop hop hop Ernest, please step back.')
+                return Domain.FALSE
             return DEFAULT
 
         act_emp_for_adm = self.test_record.with_user(self.user_employee).activity_schedule(
@@ -92,7 +93,7 @@ class TestActivityRights(TestActivityCommon):
         ]:
             with self.subTest(user=activity.user_id.name, creator=activity.create_uid.name):
                 # no document access -> based on create_uid / user_id
-                with patch.object(MailTestActivity, '_check_access', autospec=True, side_effect=_employee_crash):
+                with patch.object(MailTestActivity, '_access_domain', autospec=True, side_effect=_employee_crash):
                     activity = activity.with_user(self.user_employee)
                     self.assertEqual(activity.can_write, can_write)
                     if can_write:
@@ -153,10 +154,10 @@ class TestActivityRights(TestActivityCommon):
         def _employee_crash(records, operation):
             """ If employee is test employee, consider they have no access on document """
             if records.env.uid == self.user_employee.id and not records.env.su:
-                return records, lambda: exceptions.AccessError('Hop hop hop Ernest, please step back.')
+                return Domain.FALSE
             return DEFAULT
 
-        with patch.object(MailTestActivity, '_check_access', autospec=True, side_effect=_employee_crash):
+        with patch.object(MailTestActivity, '_access_domain', autospec=True, side_effect=_employee_crash):
             _activity = self.test_record.activity_schedule(
                 'test_mail.mail_act_test_todo',
                 user_id=self.user_employee.id)

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -8,13 +8,12 @@ from datetime import timedelta
 from itertools import chain, product
 from unittest.mock import patch
 
-from odoo import Command
 from odoo.addons.base.tests.test_ir_cron import CronMixinCase
 from odoo.addons.mail.tests.common import mail_new_test_user, MailCommon
 from odoo.addons.mail.wizard.mail_compose_message import MailComposeMessage
 from odoo.addons.test_mail.models.mail_test_ticket import MailTestTicket
 from odoo.addons.test_mail.tests.common import TestRecipients
-from odoo.fields import Datetime as FieldDatetime
+from odoo.fields import Command, Datetime as FieldDatetime, Domain
 from odoo.exceptions import AccessError, UserError
 from odoo.tests import Form, tagged, users
 from odoo.tools import email_normalize, mute_logger, formataddr
@@ -1232,7 +1231,7 @@ class TestComposerInternals(TestMailComposer):
         self.test_record.message_subscribe(partner_ids=portal_user.partner_id.ids)
 
         # patch check access rights for write access, required to post a message by default
-        with patch.object(MailTestTicket, '_check_access', return_value=None):
+        with patch.object(MailTestTicket, '_access_domain', return_value=Domain.TRUE):
             with self.assertRaises(AccessError):
                 # ensure portal can not send messages
                 self.env['mail.compose.message'].with_user(portal_user).with_context(

--- a/addons/test_mail/tests/test_mail_mail.py
+++ b/addons/test_mail/tests/test_mail_mail.py
@@ -17,6 +17,7 @@ from odoo import api, Command, fields, SUPERUSER_ID
 from odoo.addons.base.models.ir_mail_server import MailDeliveryException
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.exceptions import AccessError, LockError
+from odoo.fields import Domain
 from odoo.tests import common, tagged, users
 from odoo.tools import formataddr, mute_logger
 
@@ -75,11 +76,8 @@ class TestMailMail(MailCommon):
 
         def _patched_check_access(self, *args, **kwargs):
             if self.env.su:
-                return None
-            inaccessible = self.filtered(lambda att: att.name in ('file 2', 'file 4'))
-            if inaccessible:
-                return inaccessible, lambda: AccessError(self.env._("No access"))
-            return None
+                return Domain.TRUE
+            return Domain('name', 'not in', ('file 2', 'file 4'))
 
         mail.invalidate_recordset()
 
@@ -88,7 +86,7 @@ class TestMailMail(MailCommon):
             'raw': b'secret',
         })
 
-        with patch.object(self.env.registry['ir.attachment'], '_check_access', _patched_check_access):
+        with patch.object(self.env.registry['ir.attachment'], '_access_domain', _patched_check_access):
             # Sanity check
             self.env.transaction.clear_access_cache()
             self.assertEqual(mail.restricted_attachment_count, 2)

--- a/addons/test_mail/tests/test_mail_message_security.py
+++ b/addons/test_mail/tests/test_mail_message_security.py
@@ -6,6 +6,7 @@ from odoo.addons.mail.tests.common import mail_new_test_user, MailCommon
 from odoo.addons.test_mail.models.mail_test_access import MailTestAccess
 from odoo.addons.test_mail.models.test_mail_models import MailTestSimple
 from odoo.exceptions import AccessError
+from odoo.fields import Domain
 from odoo.tools import mute_logger
 from odoo.tests import HttpCase, tagged
 
@@ -390,7 +391,7 @@ class TestMailMessageAccess(MessageAccessCommon):
         with self.assertRaises(AccessError):
             message.with_user(self.user_portal).read(['subject', 'body'])
 
-        with patch.object(MailTestSimple, '_check_access', return_value=None):
+        with patch.object(MailTestSimple, '_access_domain', return_value=Domain.TRUE):
             with self.assertRaises(AccessError):
                 message.with_user(self.user_portal).read(['subject', 'body'])
 

--- a/addons/test_mail/tests/test_mail_multicompany.py
+++ b/addons/test_mail/tests/test_mail_multicompany.py
@@ -146,19 +146,16 @@ class TestMultiCompanySetup(TestMailMCCommon, HttpCase):
         # Other company (no access)
         # ------------------------------------------------------------
 
-        _original_car = MailMessage._check_access
-        with patch.object(MailMessage, '_check_access',
-                          autospec=True, side_effect=_original_car) as mock_msg_car:
-            with self.assertRaises(AccessError):
-                test_records_mc_c1.message_post(
-                    body='<p>Hello</p>',
-                    force_record_name='CustomName',  # avoid ACL on display_name
-                    message_type='comment',
-                    reply_to='custom.reply.to@test.example.com',  # avoid ACL in notify_get_reply_to
-                    subtype_xmlid='mail.mt_comment',
-                )
-            self.assertEqual(mock_msg_car.call_count, 2,
-                             'Check at model level succeeds and check at record level fails')
+        self.assertTrue(self.env['mail.message'].has_access('create'), 'Check at model level succeeds')
+        with self.assertRaises(AccessError):
+            # check at record level fails
+            test_records_mc_c1.message_post(
+                body='<p>Hello</p>',
+                force_record_name='CustomName',  # avoid ACL on display_name
+                message_type='comment',
+                reply_to='custom.reply.to@test.example.com',  # avoid ACL in notify_get_reply_to
+                subtype_xmlid='mail.mt_comment',
+            )
         with self.assertRaises(AccessError):
             _name = test_records_mc_c1.name
 

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -8,6 +8,7 @@ from odoo.addons.mail.tests.common import mail_new_test_user, MailCommon
 from odoo.addons.test_mail.models.test_mail_models import MailTestSimple
 from odoo.addons.test_mail.tests.common import TestRecipients
 from odoo.addons.mail.tools.discuss import Store
+from odoo.fields import Domain
 from odoo.tests import Form, users, warmup, tagged
 from odoo.tools import mute_logger
 
@@ -1161,10 +1162,10 @@ class TestDiscuss(MailCommon, TestRecipients):
         def _employee_crash(recordset, operation):
             """ If employee is test employee, consider they have no access on document """
             if recordset.env.uid == self.user_employee.id and not recordset.env.su:
-                return recordset, lambda: exceptions.AccessError('Hop hop hop Ernest, please step back.')
+                return Domain.FALSE
             return DEFAULT
 
-        with patch.object(MailTestSimple, '_check_access', autospec=True, side_effect=_employee_crash):
+        with patch.object(MailTestSimple, '_access_domain', autospec=True, side_effect=_employee_crash):
             with self.assertRaises(exceptions.AccessError):
                 self.env['mail.test.simple'].with_user(self.user_employee).browse(self.test_record.ids).read(['name'])
 

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -14,6 +14,7 @@ from odoo.addons.test_mail.models.test_mail_models import MailTestSimple
 from odoo.addons.test_mail.tests.common import TestRecipients
 from odoo.service.model import call_kw
 from odoo.exceptions import AccessError
+from odoo.fields import Domain
 from odoo.tests import tagged
 from odoo.tools import email_normalize, formataddr, mute_logger
 from odoo.tests.common import users
@@ -1622,7 +1623,7 @@ class TestMessagePost(TestMessagePostCommon, CronMixinCase):
                     {'partner': self.partner_employee, 'type': 'inbox'},
                     {'partner': self.partner_1, 'type': 'email'}]}
                 ]
-            ), patch.object(MailTestSimple, '_check_access', return_value=None):
+            ), patch.object(MailTestSimple, '_access_domain', return_value=Domain.TRUE):
             new_msg = self.test_record.with_user(self.user_portal).message_post(
                 body=Markup('<p>Test</p>'),
                 message_type='comment',

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1387,11 +1387,11 @@ class TestMailAccessPerformance(BaseMailPerformance):
     def test_activity_search(self):
         # queries
         # select mail.activity: 1
-        # filter records: 3 (1 / model)
+        # filter records: 4 (1 / model)
         self.env.invalidate_all()
         self.env.transaction.clear_access_cache()
         profile = self.profile() if self.warm else nullcontext()
-        with self.assertQueryCount(employee=4), profile:
+        with self.assertQueryCount(employee=5), profile:
             found = self.activities.with_env(self.env).search([('summary', 'ilike', 'TestActivity')])
         self.assertEqual(found, self.activities - self.activities_emp_nope)
 
@@ -1420,7 +1420,7 @@ class TestMailAccessPerformance(BaseMailPerformance):
         # filter records: 1 / model (access rules done in batch)
         # _get_mail_message_access: 3 on custom implementation, no prefetching
         profile = self.profile() if self.warm else nullcontext()
-        with self.assertQueryCount(employee=4), profile:
+        with self.assertQueryCount(employee=5), profile:
             found = self.messages.with_env(self.env).search([('body', 'ilike', 'Posting on ')])
         self.assertEqual(found, self.messages - self.messages_emp_nope)
 

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1419,8 +1419,9 @@ class TestMailAccessPerformance(BaseMailPerformance):
         # select mail.message: 1
         # filter records: 1 / model (access rules done in batch)
         # _get_mail_message_access: 3 on custom implementation, no prefetching
+        # recheck condition: 1
         profile = self.profile() if self.warm else nullcontext()
-        with self.assertQueryCount(employee=5), profile:
+        with self.assertQueryCount(employee=6), profile:
             found = self.messages.with_env(self.env).search([('body', 'ilike', 'Posting on ')])
         self.assertEqual(found, self.messages - self.messages_emp_nope)
 

--- a/addons/web/tests/test_res_partner_properties.py
+++ b/addons/web/tests/test_res_partner_properties.py
@@ -1,19 +1,19 @@
 from unittest.mock import patch
 
 from odoo.exceptions import AccessError
-from odoo.tests import tagged, TransactionCase
+from odoo.tests import TransactionCase, tagged, users
 
 
-@tagged('at_install', '-post_install')  # LEGACY at_install
+@tagged('at_install', '-post_install')
 class TestWebProperties(TransactionCase):
+    @users('admin')
     def test_get_properties_base_definition(self):
         """Check that we can not get the base definition if we can not read the model."""
         self.env["properties.base.definition"].get_properties_base_definition("res.partner", "properties")
 
-        def _check_access(mode):
-            if mode == "read":
-                raise AccessError("")
+        def raise_access(*a, **kw):
+            raise AccessError('no access')
 
-        with patch.object(self.registry['res.partner'], 'check_access', side_effect=_check_access), \
+        with patch.object(self.registry['res.partner'], 'check_access', raise_access), \
              self.assertRaises(AccessError):
             self.env["properties.base.definition"].get_properties_base_definition("res.partner", "properties")

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -618,7 +618,7 @@ class IrAttachment(models.Model):
                 ))
                 comodel_domain = Domain('id', 'in', comodel_res_ids) if comodel_res_ids else Domain.TRUE
                 if operation != 'read':
-                    comodel_domain &= self.env['ir.rule']._compute_domain(res_model_name, operation).optimize_full(comodel.sudo())
+                    comodel_domain &= comodel._access_domain(operation).optimize_full(comodel.sudo())
                 query = comodel._search(comodel_domain)
                 if query.is_empty():
                     continue

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -519,22 +519,18 @@ class IrAttachment(models.Model):
         if values and any(self._inaccessible_comodel_records({values.get('res_model'): [values.get('res_id')]}, mode)):
             raise AccessError(_("Sorry, you are not allowed to access this document."))
 
-    def _check_access(self, operation):
-        res = super()._check_access(operation)
-        if not res:
-            return None
-        forbidden = res[0]
-        return forbidden, lambda: (
-            AccessError(self.env._(
+    def _make_access_error_message(self, operation, domain):
+        if not domain.is_false():
+            return AccessError(self.env._(
                 "Sorry, you are not allowed to access this document. "
                 "Please contact your system administrator.\n\n"
                 "(Operation: %(operation)s)\n\n"
                 "Records: %(records)s, User: %(user)s",
                 operation=operation,
-                records=forbidden[:6],
+                records=self[:6],
                 user=self.env.uid,
             ))
-        )
+        return super()._make_access_error_message(operation, domain)
 
     def _compute_res_access(self, operation: str):
         """Check access for attachments.

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -41,6 +41,8 @@ if typing.TYPE_CHECKING:
 
 _logger = logging.getLogger(__name__)
 SECURITY_FIELDS = ('res_model', 'res_id', 'create_uid', 'public', 'res_field')
+MAX_COMODELS_FOR_DOMAIN = 5
+MAX_SEARCH_LIMIT = PREFETCH_MAX * 10
 CREATE_FROM_STREAM_FLAG = object()  # sentinel that cannot be given over RPC
 
 
@@ -470,6 +472,16 @@ class IrAttachment(models.Model):
                             help="You can either upload a file from your computer or copy/paste an internet link to your file.")
     url = fields.Char('Url', index='btree_not_null', size=1024)
     public = fields.Boolean('Is public document')
+    res_access_read = fields.Boolean(
+        groups=fields.NO_ACCESS,
+        compute=lambda self: self._compute_res_access('read'),
+        search=lambda self, operator, value: self._search_res_access('read', operator),
+        compute_sudo=True, depends_context=('uid',))
+    res_access_write = fields.Boolean(
+        groups=fields.NO_ACCESS,
+        compute=lambda self: self._compute_res_access('write'),
+        search=lambda self, operator, value: self._search_res_access('write', operator),
+        compute_sudo=True, depends_context=('uid',))
 
     # for external access
     access_token = fields.Char('Access Token', groups="base.group_user")
@@ -508,46 +520,47 @@ class IrAttachment(models.Model):
             raise AccessError(_("Sorry, you are not allowed to access this document."))
 
     def _check_access(self, operation):
+        res = super()._check_access(operation)
+        if not res:
+            return None
+        forbidden = res[0]
+        return forbidden, lambda: (
+            AccessError(self.env._(
+                "Sorry, you are not allowed to access this document. "
+                "Please contact your system administrator.\n\n"
+                "(Operation: %(operation)s)\n\n"
+                "Records: %(records)s, User: %(user)s",
+                operation=operation,
+                records=forbidden[:6],
+                user=self.env.uid,
+            ))
+        )
+
+    def _compute_res_access(self, operation: str):
         """Check access for attachments.
 
         Rules:
-        - `public` is always accessible for reading.
+
         - If we have `res_model and res_id`, the attachment is accessible if the
           referenced model is accessible. Also, when `res_field != False` and
           the user is not an administrator, we check the access on the field.
         - If we don't have a referenced record, the attachment is accessible to
           the administrator and the creator of the attachment.
         """
-        res = super()._check_access(operation)
-        remaining = self
-        error_func = None
-        forbidden_ids = OrderedSet()
-        if res:
-            forbidden, error_func = res
-            if forbidden == self:
-                return res
-            remaining -= forbidden
-            forbidden_ids.update(forbidden._ids)
-        elif not self:
-            return None
-
-        if operation in ('create', 'unlink'):
-            # check write operation instead of unlinking and creating for
-            # related models and field access
-            operation = 'write'
+        assert operation in ('read', 'write') and self.env.su
+        field_name = f'res_access_{operation}'
 
         # collect the records to check (by model)
         model_ids = defaultdict(set)            # {model_name: set(ids)}
         att_model_ids = []                      # [(att_id, (res_model, res_id))]
         # DLE P173: `test_01_portal_attachment`
-        remaining = remaining.sudo()
-        remaining.fetch(SECURITY_FIELDS)  # fetch only these fields
-        for attachment in remaining:
-            if attachment.public and operation == 'read':
-                continue
+        self.fetch(SECURITY_FIELDS)  # fetch only these fields
+        user_model = self.sudo(False)
+        forbidden_ids = set()
+        for attachment in self:
             att_id = attachment.id
             res_model, res_id = attachment.res_model, attachment.res_id
-            if not self.env.is_system():
+            if not user_model.env.is_system():
                 if not res_id and attachment.create_uid.id != self.env.uid:
                     forbidden_ids.add(att_id)
                     continue
@@ -557,31 +570,86 @@ class IrAttachment(models.Model):
                     except KeyError:
                         # field does not exist
                         field = None
-                    if field is None or not self.has_field_access(field, operation):
+                    if field is None or not user_model.has_field_access(field, operation):
                         forbidden_ids.add(att_id)
                         continue
             if res_model and res_id:
                 model_ids[res_model].add(res_id)
                 att_model_ids.append((att_id, (res_model, res_id)))
-        forbidden_res_model_id = set(self._inaccessible_comodel_records(model_ids, operation))
+        forbidden_res_model_id = set(user_model._inaccessible_comodel_records(model_ids, operation))
         forbidden_ids.update(att_id for att_id, res in att_model_ids if res in forbidden_res_model_id)
 
         if forbidden_ids:
             forbidden = self.browse(forbidden_ids)
             forbidden.invalidate_recordset(SECURITY_FIELDS)  # avoid cache pollution
-            if error_func is None:
-                def error_func():
-                    return AccessError(self.env._(
-                        "Sorry, you are not allowed to access this document. "
-                        "Please contact your system administrator.\n\n"
-                        "(Operation: %(operation)s)\n\n"
-                        "Records: %(records)s, User: %(user)s",
-                        operation=operation,
-                        records=forbidden[:6],
-                        user=self.env.uid,
-                    ))
-            return forbidden, error_func
-        return None
+            for attachment in self:
+                attachment[field_name] = attachment.id not in forbidden_ids
+        else:
+            self[field_name] = True
+
+    def _search_res_access(self, operation, domain_operator):
+        assert operation in ('read', 'write') and self.env.su
+        if domain_operator != 'in':
+            return NotImplemented
+        domain = self.env.context.get('search_domain')
+        if not isinstance(domain, Domain):
+            domain = Domain.TRUE
+        sec_domain = Domain.FALSE
+        self = self.sudo(False)  # noqa: PLW0642
+
+        # - res_id == False needs to be system user or creator
+        res_ids = condition_values(self, 'res_id', domain)
+        if not res_ids or False in res_ids:
+            if self.env.is_system():
+                sec_domain |= Domain('res_id', '=', False)
+            else:
+                sec_domain |= Domain('res_id', '=', False) & Domain('create_uid', '=', self.env.uid)
+
+        # Search by res_model and res_id, filter using permissions from res_model
+        # - res_id != False needs then check access on the linked res_model record
+        # - res_field != False needs to check field access on the res_model
+        res_model_names = condition_values(self, 'res_model', domain)
+        if 0 < len(res_model_names or ()) <= MAX_COMODELS_FOR_DOMAIN:
+            env = self.with_context(active_test=False).env
+            check_res_fields = not self.env.is_system() and tuple(condition_values(self, 'res_field', domain) or ()) != (False,)
+            for res_model_name in res_model_names:
+                comodel = env.get(res_model_name)
+                if comodel is None:
+                    continue
+                codomain = Domain('res_model', '=', comodel._name)
+                comodel_res_ids = condition_values(self, 'res_id', domain.map_conditions(
+                    lambda cond: codomain & cond if cond.field_expr == 'res_model' else cond
+                ))
+                comodel_domain = Domain('id', 'in', comodel_res_ids) if comodel_res_ids else Domain.TRUE
+                if operation != 'read':
+                    comodel_domain &= self.env['ir.rule']._compute_domain(res_model_name, operation).optimize_full(comodel.sudo())
+                query = comodel._search(comodel_domain)
+                if query.is_empty():
+                    continue
+                if query.where_clause:
+                    codomain &= Domain('res_id', 'in', query)
+                if check_res_fields:
+                    accessible_fields = [
+                        field.name
+                        for field in comodel._fields.values()
+                        if field.type == 'binary' or (field.relational and field.comodel_name == self._name)
+                        if comodel.has_field_access(field, operation)
+                    ]
+                    accessible_fields.append(False)
+                    codomain &= Domain('res_field', 'in', accessible_fields)
+                sec_domain |= codomain
+
+            return sec_domain
+
+        # We do not have a small restriction on res_model. We still need to
+        # support other queries such as: `('id', 'in' ...)`.
+        records = self.sudo().with_context(active_test=False).search_fetch(
+            domain & Domain('res_model', '!=', False) & ~sec_domain, SECURITY_FIELDS, order='id', limit=MAX_SEARCH_LIMIT).sudo(False)
+        if len(records) == MAX_SEARCH_LIMIT:  # avoid out of memory
+            raise UserError(self.env._("Cannot search, too many attachments"))
+        records = records._filtered_access(operation)
+        # [('id', 'any!', query_with_ids)] is optimized in sec_domain
+        return sec_domain | Domain('id', 'any!', records._as_query(ordered=False))
 
     def _inaccessible_comodel_records(self, model_and_ids: dict[str, Collection[int]], operation: str):
         # check access rights on the records
@@ -615,73 +683,26 @@ class IrAttachment(models.Model):
     @api.model
     def _search(self, domain, offset=0, limit=None, order=None, *, active_test=True, bypass_access=False):
         assert not self._active_name, "active name not supported on ir.attachment"
-        disable_binary_fields_attachments = False
         domain = Domain(domain)
         if (
             not self.env.context.get('skip_res_field_check')
             and not any(d.field_expr in ('id', 'res_field') for d in domain.iter_conditions())
             and not bypass_access
         ):
-            disable_binary_fields_attachments = True
             domain &= Domain('res_field', '=', False)
 
-        domain = domain.optimize(self)
+        domain = domain.optimize_full(self)
         if self.env.su or bypass_access or domain.is_false():
             return super()._search(domain, offset, limit, order, active_test=active_test, bypass_access=bypass_access)
         if self.env.context.get('_generating_sql_for_fields'):
             raise ValueError("Cannot generate SQL for whole ir.attachment")
+        if 0 < len(condition_values(self, 'res_model', domain) or ()) <= MAX_COMODELS_FOR_DOMAIN:
+            return super()._search(domain, offset, limit, order, active_test=active_test, bypass_access=bypass_access)
 
-        # General access rules
-        # - public == True are always accessible
-        sec_domain = Domain('public', '=', True)
-        # - res_id == False needs to be system user or creator
-        res_ids = condition_values(self, 'res_id', domain)
-        if not res_ids or False in res_ids:
-            if self.env.is_system():
-                sec_domain |= Domain('res_id', '=', False)
-            else:
-                sec_domain |= Domain('res_id', '=', False) & Domain('create_uid', '=', self.env.uid)
-
-        # Search by res_model and res_id, filter using permissions from res_model
-        # - res_id != False needs then check access on the linked res_model record
-        # - res_field != False needs to check field access on the res_model
-        res_model_names = condition_values(self, 'res_model', domain)
-        if 0 < len(res_model_names or ()) <= 5:
-            env = self.with_context(active_test=False).env
-            for res_model_name in res_model_names:
-                comodel = env.get(res_model_name)
-                if comodel is None:
-                    continue
-                codomain = Domain('res_model', '=', comodel._name)
-                comodel_res_ids = condition_values(self, 'res_id', domain.map_conditions(
-                    lambda cond: codomain & cond if cond.field_expr == 'res_model' else cond
-                ))
-                query = comodel._search(Domain('id', 'in', comodel_res_ids) if comodel_res_ids else Domain.TRUE)
-                if query.is_empty():
-                    continue
-                if query.where_clause:
-                    codomain &= Domain('res_id', 'in', query)
-                if not disable_binary_fields_attachments and not self.env.is_system():
-                    accessible_fields = [
-                        field.name
-                        for field in comodel._fields.values()
-                        if field.type == 'binary' or (field.relational and field.comodel_name == self._name)
-                        if comodel.has_field_access(field, 'read')
-                    ]
-                    accessible_fields.append(False)
-                    codomain &= Domain('res_field', 'in', accessible_fields)
-                sec_domain |= codomain
-
-            return super()._search(domain & sec_domain, offset, limit, order, active_test=active_test)
-
-        # We do not have a small restriction on res_model. We still need to
-        # support other queries such as: `('id', 'in' ...)`.
-        # Restrict with domain and add all attachments linked to a model.
-        domain &= sec_domain | Domain('res_model', '!=', False)
-        domain = domain.optimize_full(self)
+        self_sudo = self.sudo().with_context(active_test=False)
         ordered = bool(order)
         if limit is None:
-            records = self.sudo().with_context(active_test=False).search_fetch(
+            records = self_sudo.search_fetch(
                 domain, SECURITY_FIELDS, order=order).sudo(False)
             return records._filtered_access('read')[offset:]._as_query(ordered)
         # Fetch by small batches
@@ -692,7 +713,7 @@ class IrAttachment(models.Model):
             # By default, order by model to batch access checks.
             order = 'res_model nulls first, id'
         while len(result) < limit:
-            records = self.sudo().with_context(active_test=False).search_fetch(
+            records = self_sudo.search_fetch(
                 domain,
                 SECURITY_FIELDS,
                 offset=sub_offset,

--- a/odoo/addons/base/models/ir_filters.py
+++ b/odoo/addons/base/models/ir_filters.py
@@ -66,7 +66,7 @@ class IrFilters(models.Model):
         try:
             return ast.literal_eval(self.domain)
         except ValueError as e:
-            raise ValueError("Invalid domain: {self.domain}") from e
+            raise ValueError(f"Invalid domain: {self.domain}") from e
 
     @api.model
     def _get_action_domain(self, action_id=None, embedded_action_id=None, embedded_parent_res_id=None):

--- a/odoo/addons/base/models/ir_rule.py
+++ b/odoo/addons/base/models/ir_rule.py
@@ -70,8 +70,8 @@ class IrRule(models.Model):
                     domain = safe_eval(rule.domain_force, eval_context)
                     model = self.env[rule.model_id.model].sudo()
                     Domain(domain).validate(model)
-                except Exception as e:
-                    raise ValidationError(_('Invalid domain: %s', e))
+                except Exception as e:  # noqa: BLE001
+                    raise ValidationError(_('Invalid domain %(domain)s: %(error)s', domain=rule.domain_force, error=e))
 
     def _compute_domain_keys(self):
         """ Return the list of context keys to use for caching ``_compute_domain``. """

--- a/odoo/addons/base/models/ir_rule.py
+++ b/odoo/addons/base/models/ir_rule.py
@@ -134,19 +134,20 @@ class IrRule(models.Model):
     @api.model
     @tools.conditional(
         'xml' not in config['dev_mode'],
-        tools.ormcache('self.env.uid', 'self.env.su', 'model_name', 'mode',
+        tools.ormcache('self.env.uid', 'self.env.su', 'model_name', 'mode', 'include_inherits',
                        'tuple(self._compute_domain_context_values())'),
     )
-    def _compute_domain(self, model_name: str, mode: str = "read") -> Domain:
+    def _compute_domain(self, model_name: str, mode: str = "read", *, include_inherits=True) -> Domain:
         model = self.env[model_name]
 
         # add rules for parent models
         global_domains: list[Domain] = []
-        for parent_model_name, parent_field_name in model._inherits.items():
-            if not model._fields[parent_field_name].store:
-                continue
-            if domain := self._compute_domain(parent_model_name, mode):
-                global_domains.append(Domain(parent_field_name, 'any', domain))
+        if include_inherits:
+            for parent_model_name, parent_field_name in model._inherits.items():
+                if not model._fields[parent_field_name].store:
+                    continue
+                if domain := self._compute_domain(parent_model_name, mode):
+                    global_domains.append(Domain(parent_field_name, 'any', domain))
 
         rules = self._get_rules(model_name, mode=mode)
         if not rules:

--- a/odoo/addons/base/security/base_security.xml
+++ b/odoo/addons/base/security/base_security.xml
@@ -78,6 +78,37 @@
             <field name="perm_read" eval="False"/>
         </record>
 
+        <record model="ir.rule" id="ir_attachment_public_rule">
+            <field name="name">read public attachments</field>
+            <field name="model_id" ref="model_ir_attachment"/>
+            <field name="groups" eval="[Command.set([ref('base.group_everyone')])]"/>
+            <field name="domain_force">[('public', '=', True)]</field>
+            <field name="perm_read" eval="True"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
+        </record>
+        <record model="ir.rule" id="ir_attachment_access_read_rule">
+            <field name="name">read res_model</field>
+            <field name="model_id" ref="model_ir_attachment"/>
+            <field name="groups" eval="[Command.set([ref('base.group_everyone')])]"/>
+            <field name="domain_force">[('res_access_read', '=', True)]</field>
+            <field name="perm_read" eval="True"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
+        </record>
+        <record model="ir.rule" id="ir_attachment_res_access_write">
+            <field name="name">write res_model</field>
+            <field name="model_id" ref="model_ir_attachment"/>
+            <field name="groups" eval="[Command.set([ref('base.group_everyone')])]"/>
+            <field name="domain_force">[('res_access_write', '=', True)]</field>
+            <field name="perm_read" eval="False"/>
+            <field name="perm_write" eval="True"/>
+            <field name="perm_create" eval="True"/>
+            <field name="perm_unlink" eval="True"/>
+        </record>
+
         <!-- Used for dashboard customizations, users should only be able to edit their own dashboards -->
         <!-- Remove me? users never create those directly -->
         <record model="ir.rule" id="ir_ui_view_custom_personal">

--- a/odoo/addons/base/tests/test_ir_attachment.py
+++ b/odoo/addons/base/tests/test_ir_attachment.py
@@ -363,7 +363,7 @@ class TestPermissions(TransactionCaseWithUserDemo):
             """
             SELECT "ir_attachment"."id"
             FROM "ir_attachment"
-            WHERE ("ir_attachment"."res_field" IN %s AND "ir_attachment"."res_id" IN %s AND "ir_attachment"."res_model" IN %s AND (
+            WHERE ("ir_attachment"."res_field" IN %s AND "ir_attachment"."res_id" IN %s AND "ir_attachment"."res_model" IN %s) AND (
                 "ir_attachment"."public" IS TRUE
                 OR (
                     ("ir_attachment"."res_field" IN %s OR "ir_attachment"."res_field" IS NULL)
@@ -377,7 +377,7 @@ class TestPermissions(TransactionCaseWithUserDemo):
                     )
                     AND "ir_attachment"."res_model" IN %s
                 )
-            ))
+            )
             ORDER BY "ir_attachment"."id" DESC
             """
         ]):

--- a/odoo/addons/test_orm/tests/test_domain.py
+++ b/odoo/addons/test_orm/tests/test_domain.py
@@ -417,6 +417,36 @@ class TestDomainOptimize(TransactionCase):
         self.assertEqual(Domain('a', 'in', Domain.TRUE).operator, 'in')
         self.assertIsInstance(Domain('a', 'any', [('x', '>', 1)]).value, list)
 
+    def test_condition_methods(self):
+        dom = Domain.TRUE
+        conditions = list(dom.iter_conditions())
+        self.assertEqual(len(conditions), 0)
+        self.assertFalse(dom.is_condition())
+
+        dom = Domain('a', '>=', 1)
+        conditions = list(dom.iter_conditions())
+        self.assertEqual(len(conditions), 1)
+        self.assertIs(conditions[0], dom)
+        self.assertTrue(dom.is_condition())
+        self.assertTrue(dom.is_condition('a', '>='))
+        self.assertTrue(dom.is_condition(operator=('>=', 'in')))
+        self.assertTrue(dom.is_condition(value=int))
+        self.assertTrue(dom.is_condition(value=(int, float)))
+        self.assertFalse(dom.is_condition('b', '>='))
+        self.assertFalse(dom.is_condition(operator='='))
+        self.assertFalse(dom.is_condition(value=str))
+
+        dom = dom & Domain('b', '=', 1)
+        conditions = list(dom.iter_conditions())
+        self.assertEqual(len(conditions), 2)
+        self.assertFalse(dom.is_condition())
+        self.assertTrue(all(c.is_condition() for c in dom.iter_conditions()))
+
+        dom = Domain.custom(to_sql=lambda table: SQL(''))
+        conditions = list(dom.iter_conditions())
+        self.assertEqual(len(conditions), 0)
+        self.assertFalse(dom.is_condition())
+
     def test_condition_optimize_optimal(self):
         model = self.env['test_orm.mixed']
         domain = self.number_domain

--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -1999,7 +1999,7 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
         with self.assertQueryCount(5):
             # <categories>.__get__(existing)
             #  -> records.check_access('read')
-            #      -> records._check_access('read')
+            #      -> records.has_access('read')
             #          -> records.sudo().filtered_domain(...)
             #              -> <name>.__get__(existing)
             #                  -> records._fetch_field(<name>)

--- a/odoo/addons/test_orm/tests/test_many2many.py
+++ b/odoo/addons/test_orm/tests/test_many2many.py
@@ -74,21 +74,21 @@ class Many2manyCase(TransactionCase):
         # check that attachments are searched with bypass_access, and filtered with _check_access()
         Attachment = type(attachment)
         with (
-            patch.object(Attachment, '_search', autospec=True, side_effect=Attachment._search) as _search,
-            patch.object(Attachment, '_check_access', autospec=True, return_value=None) as _check_access,
+            patch.object(Attachment, '_search', autospec=True, side_effect=Attachment._search) as p_search,
+            patch.object(Attachment, '_access_domain', autospec=True, side_effect=Attachment._access_domain) as p_access,
         ):
             record.invalidate_model()
             record.m2m_attachment_ids
-            _search.assert_called_once_with(attachment.browse(), Domain.TRUE, order='id', bypass_access=True)
-            _check_access.assert_called_once_with(attachment, 'read')
+            p_search.assert_called_once_with(attachment.browse(), Domain.TRUE, order='id', bypass_access=True)
+            p_access.assert_called_once_with(attachment, 'read')
 
         # check that otherwise, attachments are searched without bypass_access
         self.patch(field, 'bypass_search_access', False)
         with (
-            patch.object(Attachment, '_search', autospec=True, side_effect=Attachment._search) as _search,
-            patch.object(Attachment, '_check_access', autospec=True, return_value=None) as _check_access,
+            patch.object(Attachment, '_search', autospec=True, side_effect=Attachment._search) as p_search,
+            patch.object(Attachment, '_access_domain', autospec=True, side_effect=Attachment._access_domain) as p_access,
         ):
             record.invalidate_model()
             record.m2m_attachment_ids
-            _search.assert_called_once_with(attachment.browse(), Domain.TRUE, order='id', bypass_access=False)
-            _check_access.assert_called_once_with(attachment.browse(), 'read')
+            p_search.assert_called_once_with(attachment.browse(), Domain.TRUE, order='id', bypass_access=False)
+            p_access.assert_called_once_with(attachment.browse(), 'read')

--- a/odoo/addons/test_orm/tests/test_properties.py
+++ b/odoo/addons/test_orm/tests/test_properties.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 from odoo.addons.test_orm.tests.test_domain_expression import TransactionExpressionCase
 from odoo.exceptions import AccessError, UserError, ValidationError
-from odoo.fields import Command
+from odoo.fields import Command, Domain
 from odoo.tests import tagged, TransactionCase, users
 from odoo.tools import mute_logger
 
@@ -1536,11 +1536,8 @@ class PropertiesCase(TestPropertiesMixin):
     @users('test')
     def test_properties_field_security(self):
         """Check the access right related to the Properties fields."""
-        def _mocked_check_access(records, operation):
-            if records.env.su:
-                return
-            msg = ''
-            raise AccessError(msg)
+        def _mocked_access_domain(records, operation):
+            return Domain(records.env.su)
 
         message = self.message_1.with_user(self.test_user)
 
@@ -1557,14 +1554,14 @@ class PropertiesCase(TestPropertiesMixin):
         values = message.read(['attributes'])[0]['attributes'][0]
         self.assertEqual(values['value'], (tag.id, 'Test Tag'))
         self.env.invalidate_all()
-        with patch('odoo.addons.test_orm.models.test_orm.TestOrmMultiTag.check_access', _mocked_check_access):
+        with patch('odoo.addons.test_orm.models.test_orm.TestOrmMultiTag._access_domain', _mocked_access_domain):
             values = message.read(['attributes'])[0]['attributes'][0]
         self.assertEqual(values['value'], (tag.id, None))
 
         # a user read a properties with a many2one to a record
         # but doesn't have access to its parent
         self.env.invalidate_all()
-        with patch('odoo.addons.test_orm.models.test_orm.TestOrmDiscussion.check_access', _mocked_check_access):
+        with patch('odoo.addons.test_orm.models.test_orm.TestOrmDiscussion._access_domain', _mocked_access_domain):
             values = message.read(['attributes'])[0]['attributes'][0]
         self.assertEqual(values['value'], (tag.id, 'Test Tag'))
 

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -1397,13 +1397,29 @@ def _optimize_any_domain_at_level(level: OptimizationLevel, condition, model):
     domain = condition.value
     if not isinstance(domain, Domain):
         return condition
+
     field = condition._field(model)
     if not field.relational:
         condition._raise("Cannot use 'any' with non-relational fields")
+
     try:
         comodel = model.env[field.comodel_name]
     except KeyError:
         condition._raise("Cannot determine the comodel relation")
+
+    if isinstance(search_domain := model.env.context.get('search_domain'), Domain):
+        # model with search_domain like (field, 'any', comodel_domain)
+        # => comodel with comodel_domain
+        comodel_domain = Domain.OR(
+            c.value
+            for c in search_domain.iter_conditions()
+            if c.is_condition(condition.field_expr, value=Domain)
+        )
+        if comodel_domain.is_false():
+            # we don't know the condition, accept all
+            comodel_domain = Domain.TRUE
+        comodel = comodel.with_context(search_domain=comodel_domain)
+
     domain = domain._optimize(comodel, level)
     # const if the domain is empty, the result is a constant
     # if the domain is True, we keep it as is

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -391,6 +391,17 @@ class Domain:
         """Return whether self is FALSE"""
         return False
 
+    def is_condition(self,
+        field_expr: str = '',
+        operator: str | tuple[str] = (),
+        value: type | tuple[type] = (),
+    ) -> bool:
+        """Return whether this domain is a simple condition, and whether it
+        matches the ``field_expr`` (if given), the ``operator`` (if given), and
+        the ``value`` type (if given).
+        """
+        return False
+
     def iter_conditions(self) -> Iterable[DomainCondition]:
         """Yield simple conditions of the domain"""
         yield from ()
@@ -905,6 +916,19 @@ class DomainCondition(Domain):
 
     def __hash__(self):
         return hash(self.field_expr) ^ hash(self.operator) ^ hash(self.value)
+
+    def is_condition(self,
+        field_expr: str = '',
+        operator: str | tuple[str] = (),
+        value: type | tuple[type] = (),
+    ) -> bool:
+        return (
+            not field_expr or self.field_expr == field_expr
+        ) and (
+            not operator or self.operator in ((operator,) if isinstance(operator, str) else operator)
+        ) and (
+            not value or isinstance(self.value, value)
+        )
 
     def iter_conditions(self):
         yield self

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -282,16 +282,19 @@ class Domain:
     @staticmethod
     def custom(
         *,
-        to_sql: Callable[[TableSQL], SQL],
+        to_sql: Callable[[TableSQL], SQL] | None = None,
         predicate: Callable[[BaseModel], bool] | None = None,
+        optimize: Callable[[DomainCustom, BaseModel], Domain] | None = None,
     ) -> DomainCustom:
         """Create a custom domain.
 
         :param to_sql: callable(model, alias, query) that returns the SQL
+        :param optimize: callable(custom_domain, model) that runs for full
+                         optimization in order to translate to a normal domain
         :param predicate: callable(record) that checks whether a record is kept
                           when filtering
         """
-        return DomainCustom(to_sql, predicate)
+        return DomainCustom(to_sql, predicate, optimize)
 
     @staticmethod
     def AND(items: Iterable) -> Domain:
@@ -763,15 +766,17 @@ class DomainOr(DomainNary):
 
 class DomainCustom(Domain):
     """Domain condition that generates directly SQL and possibly a ``filtered`` predicate."""
-    __slots__ = ('_filtered', '_sql')
+    __slots__ = ('_filtered', '_optimize_func', '_sql')
 
     _filtered: Callable[[BaseModel], bool] | None
-    _sql: Callable[[BaseModel, str, Query], SQL]
+    _optimize_func: Callable[[DomainCustom, BaseModel], Domain] | None
+    _sql: Callable[[BaseModel, str, Query], SQL] | None
 
     def __new__(
         cls,
-        sql: Callable[[TableSQL], SQL],
+        sql: Callable[[TableSQL], SQL] | None = None,
         filtered: Callable[[BaseModel], bool] | None = None,
+        optimize_func: Callable[[DomainCustom, BaseModel], Domain] | None = None,
     ):
         """Create a new domain.
 
@@ -779,11 +784,21 @@ class DomainCustom(Domain):
                        which is used to generate the query for searching
         :param predicate: callable(record) that checks whether a record is kept
                           when filtering (``Model.filtered``)
+        :param optimize_func: callable(custom_domain, model) when set this
+                              domain is at dynamic level and can be fully
+                              optimized by that function
         """
+        assert sql or optimize_func, "Need optimization or sql function"
         self = object.__new__(cls)
         object.__setattr__(self, '_sql', sql)
         object.__setattr__(self, '_filtered', filtered)
-        object.__setattr__(self, '_opt_level', OptimizationLevel.FULL)
+        object.__setattr__(self, '_optimize_func', optimize_func)
+        object.__setattr__(self, '_opt_level', OptimizationLevel.FULL if optimize_func is None else OptimizationLevel.DYNAMIC_VALUES)
+        return self
+
+    def _optimize_step(self, model, level):
+        if level == OptimizationLevel.FULL and self._optimize_func:
+            return self._optimize_func(self, model)
         return self
 
     def _as_predicate(self, records):
@@ -801,10 +816,11 @@ class DomainCustom(Domain):
             isinstance(other, DomainCustom)
             and self._sql == other._sql
             and self._filtered == other._filtered
+            and self._optimize_func == other._optimize_func
         )
 
     def __hash__(self):
-        return hash(self._sql)
+        return hash(self._sql or self._optimize_func)
 
     def __iter__(self):
         yield self
@@ -813,6 +829,8 @@ class DomainCustom(Domain):
         return object.__repr__(self)
 
     def _to_sql(self, table: TableSQL) -> SQL:
+        assert self._sql is not None, \
+            f"Must fully optimize before generating the query {self}"
         return self._sql(table)
 
 

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -4710,7 +4710,7 @@ class BaseModel(metaclass=MetaModel):
 
         # security access domain
         if check_access:
-            self_sudo = self.sudo().with_context(active_test=False)
+            self_sudo = self.sudo().with_context(active_test=False, search_domain=domain)
             sec_domain = self.env['ir.rule']._compute_domain(self._name, 'read')
             sec_domain = sec_domain.optimize_full(self_sudo)
             if sec_domain.is_false():

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -3354,6 +3354,7 @@ class BaseModel(metaclass=MetaModel):
             raise UserError("\n".join(lines))
 
     @api.private  # use has_access
+    @typing.final
     def check_access(self, operation: str) -> None:
         """ Verify that the current user is allowed to perform ``operation`` on
         all the records in ``self``. The method raises an :class:`AccessError`
@@ -3368,45 +3369,44 @@ class BaseModel(metaclass=MetaModel):
             records.browse().check_access(operation)
 
         """
-        # special cases (su or no real records) or no cache
-        if self.env.su:
+        if self.has_access(operation):
             return
-        if operation != 'read' or not any(self._ids):
-            if result := self._check_access(operation):
-                raise result[1]()
-            return
+        inaccessible = self - self._filtered_access(operation)
+        domain = self._access_domain(operation)
+        raise inaccessible._make_access_error_message(operation, domain)
 
-        # check the cache
-        access = self.env._access_cache[self._name]
-        if all(map(access.get, self._ids)):
-            return
-        self.__check_access_fill_cache(access, operation)
-        inaccessible = self.browse(id_ for id_ in self._ids if not access[id_])
-        if not inaccessible:
-            return
-        # generate the exception
-        result = inaccessible._check_access(operation)
-        assert result is not None, "_check_access is non-deterministic or issue with fill cache"
-        raise result[1]()
-
+    @typing.final
     def has_access(self, operation: str) -> bool:
         """ Return whether the current user is allowed to perform ``operation``
         on all the records in ``self``. The method is fully consistent with
         method :meth:`check_access` but returns a boolean instead.
         """
-        # special cases (su or no real records) or no cache
         if self.env.su:
             return True
-        if operation != 'read' or not any(self._ids):
-            return not self._check_access(operation)
+
+        if not any(self._ids):  # new ids or empty
+            return (
+                self.env['ir.model.access'].check(self._name, operation, raise_exception=False)
+                or not self._access_domain(operation).is_false()  # check for overrides
+            )
+
+        if operation != 'read':
+            domain = self._access_domain(operation)
+            if domain.is_true():
+                return True
+            if domain.is_false():
+                return False
+            return self == self.sudo().with_context(active_test=False).filtered_domain(domain)
 
         # check the cache
         access = self.env._access_cache[self._name]
         if all(map(access.get, self._ids)):
             return True
-        self.__check_access_fill_cache(access, operation)
+        domain = self._access_domain(operation)
+        self.__check_access_fill_cache(access, domain)
         return all(map(access.__getitem__, self._ids))
 
+    @typing.final
     def _filtered_access(self, operation: str) -> typing.Self:
         """ Return the subset of ``self`` for which the current user is allowed
         to perform ``operation``. The method is fully equivalent to::
@@ -3414,22 +3414,34 @@ class BaseModel(metaclass=MetaModel):
             self.filtered(lambda record: record.has_access(operation))
 
         """
-        # special cases (su or no real records)
-        if self.env.su or not self:
+        if self.env.su or not self:  # su or empty
             return self
-        if operation != 'read' or not any(self._ids):
-            if result := self._check_access(operation):
-                return self - result[0]
-            return self
+
+        if not any(self._ids):  # new ids
+            if (
+                self.env['ir.model.access'].check(self._name, operation, raise_exception=False)
+                or not self._access_domain(operation).is_false()  # check for overrides
+            ):
+                return self
+            return self.browse()
+
+        if operation != 'read':
+            domain = self._access_domain(operation)
+            if domain.is_true():
+                return self
+            if domain.is_false():
+                return self.browse()
+            return self.sudo().with_context(active_test=False).filtered_domain(domain).with_env(self.env)
 
         # filter using the cache
         access = self.env._access_cache[self._name]
         if all(map(access.get, self._ids)):
             return self
-        self.__check_access_fill_cache(access, operation)
+        domain = self._access_domain(operation)
+        self.__check_access_fill_cache(access, domain)
         return self.filtered(lambda rec: access[rec._ids[0]])
 
-    def __check_access_fill_cache(self, access: dict[IdType, bool], operation: str) -> None:
+    def __check_access_fill_cache(self, access: dict[IdType, bool], domain: Domain) -> None:
         """ Fill the access cache for records in self. """
         ids = self._ids
 
@@ -3446,11 +3458,11 @@ class BaseModel(metaclass=MetaModel):
                 if id_ not in access
             ))
             ids_to_check = itertools.islice(unique(ids_to_check), PREFETCH_MAX)
-        records = self.browse(ids_to_check)
+        records = self.browse(ids_to_check).sudo().with_context(active_test=False)
 
         # Check access
         try:
-            result = records._check_access(operation)
+            accessible = records.filtered_domain(domain)
         except MissingError:
             existing = records.exists()
             missing_ids = set(records._ids) - set(existing._ids)
@@ -3458,17 +3470,17 @@ class BaseModel(metaclass=MetaModel):
                 # raise if initial ids intersect with missing ids
                 raise
             records = existing
-            result = records._check_access(operation)
+            accessible = records.filtered_domain(domain)
 
         # Update the cache
-        if result is None:
-            for id_ in records._ids:
-                access[id_] = True
+        if len(accessible) == len(records):
+            access.update(dict.fromkeys(records._ids, True))
         else:
-            inaccessible_record_ids = set(result[0]._ids)
+            accessible_ids = set(accessible._ids)
             for id_ in records._ids:
-                access[id_] = id_ not in inaccessible_record_ids
+                access[id_] = id_ in accessible_ids
 
+    @deprecated("Use Model._access_domain instead")
     def _check_access(self, operation: str) -> tuple[Self, Callable] | None:
         """ Return ``None`` if the current user has permission to perform
         ``operation`` on the records ``self``. Otherwise, return a pair
@@ -3480,19 +3492,43 @@ class BaseModel(metaclass=MetaModel):
         and :meth:`_filtered_access`. The method may be overridden in order to
         restrict the access to ``self``.
         """
-        Access = self.env['ir.model.access']
-        if not Access.check(self._name, operation, raise_exception=False):
-            return self, functools.partial(Access._make_access_error, self._name, operation)
+        domain = self._access_domain(operation)
+        if domain.is_false() and not self.env['ir.model.access'].check(self._name, operation, raise_exception=False):
+            return self, functools.partial(self._make_access_error_message, operation, domain)
 
         # we only check access rules on real records, which should not be mixed
         # with new records
-        if any(self._ids):
-            Rule = self.env['ir.rule']
-            domain = Rule._compute_domain(self._name, operation)
-            if domain and (forbidden := self - self.sudo().with_context(active_test=False).filtered_domain(domain)):
-                return forbidden, functools.partial(Rule._make_access_error, operation, forbidden)
+        if (
+            any(self._ids)
+            and domain
+            and (forbidden := self - self.with_context(active_test=False).sudo().filtered_domain(domain))
+        ):
+            return forbidden, functools.partial(forbidden._make_access_error_message, operation, domain)
 
         return None
+
+    @api.model
+    def _access_domain(self, operation: str) -> Domain:
+        """Get the security domain for the given operation.
+
+        If the user has no model access, return the false domain.
+        Otherwise, the default implementation returns the access rule domain.
+        """
+        if not self.env['ir.model.access'].check(self._name, operation, raise_exception=False):
+            return Domain.FALSE
+
+        return self.env['ir.rule']._compute_domain(self._name, operation)
+
+    def _make_access_error_message(self, operation: str, domain: Domain) -> AccessError:
+        """Create the access error for the given operation.
+        :param operation: operation performed
+        :param domain: security domain from :meth:`_access_domain`
+        """
+        Access = self.env['ir.model.access']
+        if domain.is_false() and not Access.check(self._name, operation, raise_exception=False):
+            return Access._make_access_error(self._name, operation)
+
+        return self.env['ir.rule']._make_access_error(operation, self)
 
     def unlink(self) -> typing.Literal[True]:
         """ Delete the records in ``self``.
@@ -4684,9 +4720,13 @@ class BaseModel(metaclass=MetaModel):
         The `bypass_access` controls whether or not permissions should be
         checked on the model and record rules should be applied.
         """
-        check_access = not (self.env.su or bypass_access)
-        if check_access:
-            self.browse().check_access('read')
+        if self.env.su or bypass_access:
+            sec_domain = Domain.TRUE
+        else:
+            sec_domain = self._access_domain('read')
+            if sec_domain.is_false():
+                # raise here if we don't have any access
+                self.browse().check_access('read')
 
         domain = Domain(domain)
         # inactive records unless they were explicitly asked for
@@ -4709,9 +4749,8 @@ class BaseModel(metaclass=MetaModel):
             query.add_where(domain._to_sql(query.table))
 
         # security access domain
-        if check_access:
+        if not sec_domain.is_true():
             self_sudo = self.sudo().with_context(active_test=False, search_domain=domain)
-            sec_domain = self.env['ir.rule']._compute_domain(self._name, 'read')
             sec_domain = sec_domain.optimize_full(self_sudo)
             if sec_domain.is_false():
                 return self.browse()._as_query()

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -4715,6 +4715,21 @@ class BaseModel(metaclass=MetaModel):
             sec_domain = sec_domain.optimize_full(self_sudo)
             if sec_domain.is_false():
                 return self.browse()._as_query()
+            if (
+                sec_domain.is_condition('id', 'any!', Query)
+                and (ids := sec_domain.value._ids) is not None
+            ):
+                # optimization: browse ids and filter using the domain
+                records = self.browse(ids)
+                self.env._add_to_access_cache(records)
+                records = records.filtered_domain(domain)
+                if order:
+                    records = records.with_prefetch().sorted(order)
+                if offset:
+                    records = records[offset:]
+                if limit:
+                    records = records[:limit]
+                return records._as_query(ordered=bool(order))
             if not sec_domain.is_true():
                 query.add_where(sec_domain._to_sql(query.table._with_model(self_sudo)))
 


### PR DESCRIPTION
Odoo has record rules as a way of defining per record access. Some rules can become complex and some models overwrite `_check_access` to implement them. As a side-effect, such implementations are not visible when browsing record rules and may not be applied in some flows (that get rules directly from ir.rules).

We rewrite the custom access rules with a computed user-dependent field so that they are explicit in the rules.
However, some models that *inherits* from attachments or mails, want to bypass these access. So we need a way to overwrite what are the record rules on a model.

`Model._access_domain` can replace `_check_access` and return a Domain that indicates accessible records. We need rules to be explicit to implement it (or have again tons of not so easy overrides).

Other uses of `_access_domain` like operator 'access' or replacing uses of ir.rules.get_domains will follow.

odoo/enterprise#110965

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
