### PR TITLE
[IMP] sale: Add the ability to have multiple elements per combo choice

### DIFF
--- a/addons/point_of_sale/__init__.py
+++ b/addons/point_of_sale/__init__.py
@@ -11,3 +11,9 @@ from . import wizard
 def uninstall_hook(env):
     #The search domain is based on how the sequence is defined in the _get_sequence_values method in /addons/point_of_sale/models/stock_warehouse.py
     env['ir.sequence'].search([('name', 'ilike', '%Picking POS%'), ('prefix', 'ilike', '%/POS/%')]).unlink()
+
+def post_init_hook(env):
+    # Updates qty_max to qty_free during initialization to avoid breaking the constraint.
+    combos = env['product.combo'].search([]).sudo()
+    for combo in combos:
+        combo.qty_max = combo.qty_free

--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -8,6 +8,7 @@
     'summary': 'Handle checkouts and payments for shops and restaurants.',
     'depends': ['resource', 'stock_account', 'barcodes', 'html_editor', 'digest', 'phone_validation', 'google_address_autocomplete'],
     'uninstall_hook': 'uninstall_hook',
+    'post_init_hook': 'post_init_hook',
     'data': [
         'security/point_of_sale_security.xml',
         'security/ir.model.access.csv',

--- a/addons/point_of_sale/models/product_combo.py
+++ b/addons/point_of_sale/models/product_combo.py
@@ -9,8 +9,8 @@ class ProductCombo(models.Model):
     _inherit = ['product.combo', 'pos.load.mixin']
 
     qty_max = fields.Integer(string="Maximum quantity", default=1, help="Maximum number of items to select in the combo.")
-    qty_free = fields.Integer(string="Free quantity", default=1, help="Number of free items included in the combo.")
     is_upsell = fields.Boolean(string="Is Upsell", default=False, help="Indicates if the combo is an upsell to the customer. This can be compared to a minimum quantity of 0.")
+    from_sale = fields.Boolean(compute="_compute_from_sale", store=False)
 
     @api.model
     def _load_pos_data_domain(self, data, config):
@@ -26,6 +26,11 @@ class ProductCombo(models.Model):
             self.qty_free = 0
         if not self.is_upsell and self.qty_free == 0:
             self.qty_free = 1
+
+    @api.onchange('qty_free')
+    def _onchange_qty_free(self):
+        if self.qty_free > self.qty_max:
+            self.qty_max = self.qty_free
 
     @api.constrains('qty_max')
     def _check_qty_max(self):
@@ -43,3 +48,7 @@ class ProductCombo(models.Model):
     def _check_qty_max_greater_than_qty_free(self):
         if any(combo.qty_free > combo.qty_max for combo in self):
             raise ValidationError(_("The free quantity must be smaller or equal to the maximum quantity."))
+
+    def _compute_from_sale(self):
+        for rec in self:
+            rec.from_sale = self.env.context.get('from_sale', False)

--- a/addons/point_of_sale/views/product_combo_views.xml
+++ b/addons/point_of_sale/views/product_combo_views.xml
@@ -9,21 +9,12 @@
                 <attribute name="context">{'default_available_in_pos': True}</attribute>
             </field>
 
-            <xpath expr="//field[@name='company_id']" position="replace">
+            <xpath expr="//field[@name='qty_free']" position="replace">
                 <group>
-                    <field name="qty_max" string="Maximum items" />
-                    <field name="qty_free" string="Includes free" invisible="is_upsell"/>
-                    <field name="is_upsell" widget="boolean_toggle"/>
-                </group>
-                <group>
-                    <field name="base_price" widget="monetary" options="{'field_digits': True}"/>
-                    <field
-                        name="company_id"
-                        placeholder="Visible to all"
-                        groups="base.group_multi_company"
-                        options="{'no_create': True}"
-                        class="oe_inline"
-                    />
+                    <field name="qty_max" string="Maximum items" invisible="from_sale"/>
+                    <field name="qty_free" string="Includes" invisible="is_upsell"/>
+                    <p invisible="not (is_upsell == True and from_sale == True)">You must disable the <strong>Is Upsell</strong> setting in the <strong>Point of Sale</strong> module in order to select the included quantity.</p>
+                    <field name="is_upsell" widget="boolean_toggle" invisible="from_sale"/>
                 </group>
             </xpath>
         </field>

--- a/addons/product/models/product_combo.py
+++ b/addons/product/models/product_combo.py
@@ -12,6 +12,7 @@ class ProductCombo(models.Model):
     name = fields.Char(string="Name", required=True, translate=True)
     sequence = fields.Integer(default=10, copy=False)
     company_id = fields.Many2one(string="Company", comodel_name='res.company', index=True)
+    qty_free = fields.Integer(string="Free quantity", default=1, help="Number of free items included in the combo.")
     combo_item_ids = fields.One2many(
         comodel_name='product.combo.item',
         inverse_name='combo_id',
@@ -77,3 +78,8 @@ class ProductCombo(models.Model):
         templates = self.env['product.template'].sudo().search([('combo_ids', 'in', self.ids)])
         templates._check_company(fnames=['combo_ids'])
         self.combo_item_ids._check_company(fnames=['product_id'])
+
+    @api.constrains('qty_free')
+    def _check_qty_free(self):
+        if any(combo.qty_free < 1 for combo in self):
+            raise ValidationError(_("The free quantity of a combo must be greater or equal to 1."))

--- a/addons/product/views/product_combo_views.xml
+++ b/addons/product/views/product_combo_views.xml
@@ -17,31 +17,35 @@
                         />
                     </h1>
                 </div>
-                <group>
-                    <field
-                        name="company_id"
-                        placeholder="Visible to all"
-                        groups="base.group_multi_company"
-                        options="{'no_create': True}"
-                        class="oe_inline"
-                    />
+                <group col="2">
+                    <group>
+                        <field name="qty_free" string="Includes"/>
+                    </group>
+                    <group>
+                        <field
+                            name="company_id"
+                            placeholder="Visible to all"
+                            groups="base.group_multi_company"
+                            options="{'no_create': True}"
+                            class="oe_inline"
+                        />
+                    </group>
                 </group>
-                <field name="combo_item_ids">
-                    <list editable="bottom">
-                        <field name="currency_id" column_invisible="True"/>
-                        <field name="product_id"/>
-                        <field
-                            name="lst_price"
-                            widget="monetary"
-                            options="{'field_digits': True}"
-                        />
-                        <field
-                            name="extra_price"
-                            widget="monetary"
-                            options="{'field_digits': True}"
-                        />
-                    </list>
-                </field>
+                <notebook>
+                    <page string="Options">
+                        <field name="combo_item_ids">
+                            <list editable="bottom">
+                                <field name="currency_id" column_invisible="True"/>
+                                <field name="product_id"/>
+                                <field
+                                    name="extra_price"
+                                    widget="monetary"
+                                    options="{'field_digits': True}"
+                                />
+                            </list>
+                        </field>
+                    </page>
+                </notebook>
             </form>
         </field>
     </record>
@@ -54,7 +58,6 @@
                 <field name="currency_id" column_invisible="True"/>
                 <field name="sequence" widget="handle"/>
                 <field name="name"/>
-                <field name="base_price" widget="monetary" options="{'field_digits': True}"/>
                 <field name="combo_item_count"/>
             </list>
         </field>
@@ -65,5 +68,6 @@
         <field name="res_model">product.combo</field>
         <field name="path">combo-choices</field>
         <field name="view_mode">list,form</field>
+        <field name="context">{'from_sale': True}</field>
     </record>
 </odoo>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -72,7 +72,7 @@
                             </div>
                         </group>
                     </group>
-                    
+
                     <notebook>
                         <page string="General Information" name="general_information">
                             <group>
@@ -82,6 +82,7 @@
                                     <field
                                         name="combo_ids"
                                         widget="many2many_tags"
+                                        context="{'from_sale': True}"
                                         placeholder="e.g. Starter - Meal - Desert"
                                         invisible="type != 'combo'"
                                         options="{

--- a/addons/sale/controllers/combo_configurator.py
+++ b/addons/sale/controllers/combo_configurator.py
@@ -31,6 +31,7 @@ class SaleComboConfiguratorController(Controller):
         :param list(dict) selected_combo_items: The selected combo items, in the following format:
             {
                 'id': int,
+                'qty': int,
                 'no_variant_ptav_ids': list(int),
                 'custom_ptavs': list({
                     'id': int,
@@ -48,7 +49,14 @@ class SaleComboConfiguratorController(Controller):
         currency = request.env["res.currency"].browse(currency_id)
         pricelist = request.env["product.pricelist"].browse(pricelist_id)
         date = datetime.fromisoformat(date)
-        selected_combo_item_dict = {item["id"]: item for item in selected_combo_items or []}
+        selected_combo_item_dict = {}
+        selected_combo_item_qty_dict = {}
+        for selected_combo_item in selected_combo_items or []:
+            selected_combo_item_id = selected_combo_item["id"]
+            selected_combo_item_qty_dict[selected_combo_item_id] = selected_combo_item_qty_dict.get(
+                selected_combo_item_id, 0
+            ) + selected_combo_item.get("qty", 1)
+            selected_combo_item_dict.setdefault(selected_combo_item_id, selected_combo_item)
 
         return {
             "product_tmpl_id": product_tmpl_id,
@@ -61,11 +69,13 @@ class SaleComboConfiguratorController(Controller):
                 {
                     "id": combo.id,
                     "name": combo.name,
+                    "qty_free": combo.qty_free,
                     "combo_items": [
                         self._get_combo_item_data(
                             combo,
                             combo_item,
                             selected_combo_item_dict.get(combo_item.id, {}),
+                            selected_combo_item_qty_dict.get(combo_item.id, 0),
                             date,
                             currency,
                             pricelist,
@@ -122,7 +132,15 @@ class SaleComboConfiguratorController(Controller):
         )[0]
 
     def _get_combo_item_data(
-        self, combo, combo_item, selected_combo_item, date, currency, pricelist, **kwargs
+        self,
+        combo,
+        combo_item,
+        selected_combo_item,
+        selected_combo_item_qty,
+        date,
+        currency,
+        pricelist,
+        **kwargs,
     ):
         """Return the price of the specified combo product.
 
@@ -146,12 +164,14 @@ class SaleComboConfiguratorController(Controller):
         # A combo item can be preselected if its combo choice has only one combo item, and that
         # combo item isn't configurable.
         is_preselected = len(combo.combo_item_ids) == 1 and not is_configurable
+        selected_qty = selected_combo_item_qty or (combo.qty_free if is_preselected else 0)
 
         return {
             "id": combo_item.id,
             "extra_price": combo_item.extra_price,
             "is_preselected": is_preselected,
-            "is_selected": bool(selected_combo_item) or is_preselected,
+            "is_selected": bool(selected_qty),
+            "selected_qty": selected_qty,
             "is_configurable": is_configurable,
             "product": {
                 "id": combo_item.product_id.id,

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1233,15 +1233,42 @@ class SaleOrder(models.Model):
                     ]
             elif line.selected_combo_items:
                 selected_combo_items = json.loads(line.selected_combo_items)
-                if selected_combo_items and len(selected_combo_items) != len(
-                    line.product_template_id.sudo().combo_ids
-                ):
-                    raise ValidationError(
-                        _(
-                            "The number of selected combo items must match the number of available"
-                            " combo choices."
+                if selected_combo_items:
+                    combo_choices = line.product_template_id.sudo().combo_ids
+                    combo_items_by_id = {
+                        combo_item.id: combo_item for combo_item in combo_choices.combo_item_ids
+                    }
+                    selected_combo_items_qty_by_combo = defaultdict(int)
+                    for selected_combo_item in selected_combo_items:
+                        selected_combo_item_qty = int(selected_combo_item.get("qty", 1))
+                        if selected_combo_item_qty <= 0:
+                            raise ValidationError(
+                                _("Selected combo item quantities must be positive.")
+                            )
+                        combo_item = combo_items_by_id.get(selected_combo_item["combo_item_id"])
+                        if not combo_item:
+                            raise ValidationError(_("Some selected combo items are invalid."))
+                        selected_combo_items_qty_by_combo[combo_item.combo_id.id] += (
+                            selected_combo_item_qty
                         )
+
+                    invalid_combo_choice = next(
+                        (
+                            combo_choice
+                            for combo_choice in combo_choices
+                            if selected_combo_items_qty_by_combo[combo_choice.id]
+                            != combo_choice.qty_free
+                        ),
+                        False,
                     )
+                    if invalid_combo_choice:
+                        raise ValidationError(
+                            _(
+                                "You must select exactly %(required)s item(s) for '%(combo)s'.",
+                                required=invalid_combo_choice.qty_free,
+                                combo=invalid_combo_choice.name,
+                            )
+                        )
 
                 # Delete any existing combo item lines.
                 delete_commands = [
@@ -1251,7 +1278,7 @@ class SaleOrder(models.Model):
                 create_commands = [
                     Command.create({
                         "product_id": combo_item["product_id"],
-                        "product_uom_qty": line.product_uom_qty,
+                        "product_uom_qty": line.product_uom_qty * int(combo_item.get("qty", 1)),
                         "combo_item_id": combo_item["combo_item_id"],
                         "product_no_variant_attribute_value_ids": [
                             Command.set(combo_item["no_variant_attribute_value_ids"])
@@ -1274,7 +1301,7 @@ class SaleOrder(models.Model):
                 # come first.
                 update_commands = [
                     Command.update(
-                        order_line.id, {"sequence": order_line.sequence + len(selected_combo_items)}
+                        order_line.id, {"sequence": order_line.sequence + len(create_commands)}
                     )
                     for order_line in self.order_line
                     if order_line.sequence > line.sequence
@@ -1288,10 +1315,23 @@ class SaleOrder(models.Model):
                 # Only update the combo item lines if the line's combo choices haven't changed.
                 and combo_item_lines.combo_item_id.combo_id == line.product_template_id.combo_ids
             ):
-                combo_item_lines.update({
-                    "product_uom_qty": line.product_uom_qty,
-                    "discount": line.discount,
-                })
+                for combo_choice in line.product_template_id.combo_ids:
+                    combo_choice_lines = combo_item_lines.filtered(
+                        lambda combo_item_line: (
+                            combo_item_line.combo_item_id.combo_id == combo_choice
+                        )
+                    )
+                    if not combo_choice_lines:
+                        continue
+                    previous_combo_qty = (
+                        sum(combo_choice_lines.mapped("product_uom_qty")) / combo_choice.qty_free
+                    )
+                    for combo_item_line in combo_choice_lines:
+                        combo_item_ratio = combo_item_line.product_uom_qty / (
+                            previous_combo_qty or 1
+                        )
+                        combo_item_line.product_uom_qty = line.product_uom_qty * combo_item_ratio
+                        combo_item_line.discount = line.discount
 
     # === CRUD METHODS ===#
 

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -841,7 +841,9 @@ class SaleOrderLine(models.Model):
         # Compute the combo product's price.
         combo_line = self._get_linked_line()
         combo_product_price = combo_line._get_display_price_ignore_combo()
-        # Compute the combos' base prices.
+        # Compute the combos' weighted base prices.
+        # A combo can include several free items (`qty_free`), so the combo's contribution to the
+        # total base price must be weighted accordingly.
         combo_base_prices = {
             combo_id: combo_id.currency_id._convert(
                 from_amount=combo_id.base_price,
@@ -849,6 +851,7 @@ class SaleOrderLine(models.Model):
                 company=self.company_id,
                 date=self.order_id.date_order,
             )
+            * combo_id.qty_free
             for combo_id in combo_line.product_template_id.sudo().combo_ids
         }
         total_combo_base_price = sum(combo_base_prices.values())
@@ -867,10 +870,25 @@ class SaleOrderLine(models.Model):
         combo_price_delta = combo_product_price - sum(combo_prices.values())
         if combo_price_delta:
             combo_prices[combo_line.product_template_id.sudo().combo_ids[-1]] += combo_price_delta
+        # Compute unit price of combo item based on linked lines and combo quantity
+        combo_line_qty = combo_line.product_uom_qty or 1
+        selected_combo_items_qty = (
+            sum(
+                linked_line.product_uom_qty / combo_line_qty
+                for linked_line in combo_line.linked_line_ids.filtered(
+                    lambda line: line.combo_item_id.combo_id == self.combo_item_id.combo_id
+                )
+            )
+            or self.combo_item_id.combo_id.qty_free
+        )
+        combo_item_base_price = self.currency_id.round(
+            combo_prices[self.combo_item_id.combo_id] / selected_combo_items_qty
+        )
+
         # Add the extra price of this combo item, as well as the extra prices of any `no_variant`
         # attributes to the combo price.
         return (
-            combo_prices[self.combo_item_id.combo_id]
+            combo_item_base_price
             + self.combo_item_id.extra_price
             + self.product_id._get_no_variant_attributes_price_extra(
                 self.product_no_variant_attribute_value_ids

--- a/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
+++ b/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
@@ -45,10 +45,12 @@ export class ComboConfiguratorDialog extends Component {
         this.dialog = useService('dialog');
         this.env.dialogData.dismiss = !this.props.edit && this.props.discard.bind(this);
         this.state = useState({
-            // Maps combo ids to selected combo items.
+            // Maps combo item ids to selected combo items.
             // Note that selected combo items can be modified (i.e. their `no_variant` PTAVs can be
             // updated), so this map stores deep copies to avoid modifying the props.
             selectedComboItems: new Map(),
+            // Maps combo item ids to selected quantities.
+            selectedComboItemQuantities: new Map(),
             quantity: this.props.quantity,
             basePrice: this.props.price,
             isLoading: false,
@@ -65,14 +67,23 @@ export class ComboConfiguratorDialog extends Component {
      * Select the provided combo item, and open the product configurator iff the combo item's
      * product is configurable.
      *
-     * @param {Number} comboId The id of the combo to which the combo item belongs.
+     * @param {ProductCombo} combo The combo to which the combo item belongs.
      * @param {ProductComboItem} comboItem The combo item to select.
      */
-    async selectComboItem(comboId, comboItem) {
+    async selectComboItem(combo, comboItem) {
+        const comboId = combo.id;
+        let selectedQty = this.getComboItemQuantity(comboItem.id);
+        if (combo.qty_free === 1 && !selectedQty && this.totalQuantityForCombo(comboId) >= 1) {
+            this.clearComboSelection(combo);
+            selectedQty = this.getComboItemQuantity(comboItem.id);
+        }
         // Use up-to-date selected PTAVs and custom values to populate the product configurator.
-        comboItem = this.getSelectedOrProvidedComboItem(comboId, comboItem);
+        comboItem = this.getSelectedOrProvidedComboItem(comboItem);
         let product = comboItem.product;
         if (comboItem.is_configurable) {
+            if (selectedQty > 0 && this.totalQuantityForCombo(comboId) < combo.qty_free) {
+                return this.setComboItemQuantity(combo, comboItem, selectedQty + 1);
+            }
             this.dialog.add(ProductConfiguratorDialog, {
                 productTemplateId: product.product_tmpl_id,
                 ptavIds: product.selectedPtavIds,
@@ -95,13 +106,14 @@ export class ComboConfiguratorDialog extends Component {
                     selectedComboItem.product.ptals = configuredProduct.attribute_lines.map(
                         ProductTemplateAttributeLine.fromProductConfiguratorPtal
                     );
-                    this.state.selectedComboItems.set(comboId, selectedComboItem);
+                    this.state.selectedComboItems.set(comboItem.id, selectedComboItem);
+                    this.state.selectedComboItemQuantities.set(comboItem.id, selectedQty || 1);
                 },
                 discard: () => {},
                 ...this._getAdditionalDialogProps(),
             });
         } else {
-            this.state.selectedComboItems.set(comboId, comboItem.deepCopy());
+            this.setComboItemQuantity(combo, comboItem, selectedQty + 1);
         }
     }
 
@@ -131,18 +143,113 @@ export class ComboConfiguratorDialog extends Component {
      * selected PTAVs, custom values), and we should rely on the data in `state.selectedComboItems`
      * instead. Otherwise, the data in the provided combo item is up-to-date and can be used.
      *
-     * @param {Number} comboId The id of the combo to which the combo item belongs.
      * @param {ProductComboItem} comboItem The provided combo item.
      * @return {ProductComboItem} The selected or provided combo item.
      */
-    getSelectedOrProvidedComboItem(comboId, comboItem) {
-        const selectedComboItem = this.state.selectedComboItems.get(comboId);
-        const isComboItemAlreadySelected = selectedComboItem?.id === comboItem.id;
-        return isComboItemAlreadySelected ? selectedComboItem : comboItem;
+    getSelectedOrProvidedComboItem(comboItem) {
+        return this.state.selectedComboItems.get(comboItem.id) || comboItem;
+    }
+
+    /**
+     * Return the selected quantity of the provided combo item.
+     *
+     * @param {Number} comboItemId The combo item id.
+     * @return {Number} The selected quantity.
+     */
+    getComboItemQuantity(comboItemId) {
+        return this.state.selectedComboItemQuantities.get(comboItemId) || 0;
+    }
+
+    /**
+     * Set the selected quantity of the provided combo item.
+     *
+     * @param {ProductCombo} combo The combo to which the combo item belongs.
+     * @param {ProductComboItem} comboItem The combo item.
+     * @param {Number} quantity The new quantity.
+     * @return {Boolean} Whether the quantity was updated.
+     */
+    setComboItemQuantity(combo, comboItem, quantity) {
+        const comboId = combo.id;
+        const currentQty = this.getComboItemQuantity(comboItem.id);
+        const maxQtyAvailable = combo.qty_free - this.totalQuantityForCombo(comboId) + currentQty;
+        quantity = Math.floor(quantity || 0);
+        quantity = Math.max(0, Math.min(quantity, maxQtyAvailable));
+        if (quantity === currentQty) {
+            return false;
+        }
+        if (quantity === 0) {
+            this.state.selectedComboItemQuantities.delete(comboItem.id);
+            this.state.selectedComboItems.delete(comboItem.id);
+        } else {
+            this.state.selectedComboItemQuantities.set(comboItem.id, quantity);
+            this.state.selectedComboItems.set(
+                comboItem.id,
+                this.getSelectedOrProvidedComboItem(comboItem)
+            );
+        }
+        return true;
+    }
+
+    /**
+     * Return the total selected quantity for the provided combo.
+     *
+     * @param {Number} comboId The combo id.
+     * @return {Number} The total selected quantity for this combo.
+     */
+    totalQuantityForCombo(comboId) {
+        const combo = this.props.combos.find(combo => combo.id === comboId);
+        return combo?.combo_items.reduce(
+            (totalQty, comboItem) => totalQty + this.getComboItemQuantity(comboItem.id),
+            0,
+        ) || 0;
+    }
+
+    /**
+     * Clear all selected items for the provided combo.
+     *
+     * @param {ProductCombo} combo The combo.
+     */
+    clearComboSelection(combo) {
+        for (const comboItem of combo.combo_items) {
+            this.state.selectedComboItemQuantities.delete(comboItem.id);
+            this.state.selectedComboItems.delete(comboItem.id);
+        }
+    }
+
+    /**
+     * Check whether quantity buttons should be displayed for the provided combo item.
+     *
+     * @param {ProductCombo} combo The combo to which the combo item belongs.
+     * @param {ProductComboItem} comboItem The combo item.
+     * @return {Boolean} Whether quantity buttons should be shown.
+     */
+    showQuantityButtons(combo, comboItem) {
+        return this.getComboItemQuantity(comboItem.id) > 0 && combo.qty_free > 1;
     }
 
     get totalMessage() {
         return _t("Total: %s", this.formattedTotalPrice);
+    }
+
+    /**
+     * Return the selected quantity for the provided combo.
+     *
+     * @param {Number} comboId The combo id.
+     * @return {Number} The selected quantity for this combo.
+     */
+    getSelectedComboItemsCount(comboId) {
+        return this.totalQuantityForCombo(comboId);
+    }
+
+    /**
+     * Return the selected quantity text for the provided combo.
+     *
+     * @param {ProductCombo} combo The combo.
+     * @return {String} The selected quantity text.
+     */
+    getSelectedComboItemsText(combo) {
+        const selectedQty = this.getSelectedComboItemsCount(combo.id);
+        return `${Math.min(selectedQty, combo.qty_free)}/${combo.qty_free}`;
     }
 
     /**
@@ -160,7 +267,9 @@ export class ComboConfiguratorDialog extends Component {
      * @return {Boolean} Whether a combo item has been selected for each combo.
      */
     get areAllCombosSelected() {
-        return this.state.selectedComboItems.size === this.props.combos.length;
+        return this.props.combos.every(
+            combo => this.totalQuantityForCombo(combo.id) >= combo.qty_free
+        );
     }
 
     async confirm(options) {
@@ -183,9 +292,11 @@ export class ComboConfiguratorDialog extends Component {
      */
     _initSelectedComboItems() {
         for (const combo of this.props.combos) {
-            const comboItem = combo.selectedComboItem;
-            if (comboItem) {
-                this.state.selectedComboItems.set(combo.id, comboItem.deepCopy());
+            for (const comboItem of combo.combo_items) {
+                if (comboItem.selected_qty > 0) {
+                    this.state.selectedComboItems.set(comboItem.id, comboItem.deepCopy());
+                    this.state.selectedComboItemQuantities.set(comboItem.id, comboItem.selected_qty);
+                }
             }
         }
     }
@@ -201,8 +312,10 @@ export class ComboConfiguratorDialog extends Component {
      * @return {Number} The total price.
      */
     get _comboPrice() {
-        const extraPrice = Array.from(this.state.selectedComboItems.values()).reduce(
-            (price, item) => price + item.totalExtraPrice, 0
+        const extraPrice = Array.from(this.state.selectedComboItemQuantities.entries()).reduce(
+            (price, [comboItemId, quantity]) =>
+                price + (this.state.selectedComboItems.get(comboItemId)?.totalExtraPrice || 0) * quantity,
+            0,
         );
         return this.state.basePrice + extraPrice;
     }
@@ -222,12 +335,19 @@ export class ComboConfiguratorDialog extends Component {
      * @return {ProductComboItem[]} The sorted selected combo items.
      */
     get _selectedComboItems() {
-        const sortedItems = new Map([...this.state.selectedComboItems.entries()].sort(
-            (entry1, entry2) =>
-                this.props.combos.findIndex(combo => combo.id === entry1[0])
-                - this.props.combos.findIndex(combo => combo.id === entry2[0])
-        ));
-        return Array.from(sortedItems.values());
+        const selectedItems = [];
+        for (const combo of this.props.combos) {
+            for (const comboItem of combo.combo_items) {
+                const selectedQty = this.getComboItemQuantity(comboItem.id);
+                if (!selectedQty) {
+                    continue;
+                }
+                const selectedComboItem = this.getSelectedOrProvidedComboItem(comboItem).deepCopy();
+                selectedComboItem.selected_qty = selectedQty;
+                selectedItems.push(selectedComboItem);
+            }
+        }
+        return selectedItems;
     }
 
     /**

--- a/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.xml
+++ b/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.xml
@@ -50,15 +50,32 @@
                     t-attf-class="d-inline-block mb-3 h4 {{combo_index !== 0? 'mt-4' : ''}}"
                     t-out="combo.name"
                 />
+                <t t-if="combo.qty_free > 0">
+                    <h5 class="text-muted ms-2 mb-0">
+                        <t t-out="this.getSelectedComboItemsText(combo)"/>
+                        <span class="fst-italic"> included</span>
+                    </h5>
+                </t>
                 <div class="row row-cols-1 row-cols-md-3 g-3">
                     <t t-foreach="combo.combo_items" t-as="comboItem" t-key="comboItem.id">
                         <ProductCard
-                            product="this.getSelectedOrProvidedComboItem(combo.id, comboItem).product"
+                            product="this.getSelectedOrProvidedComboItem(comboItem).product"
                             extraPrice="comboItem.extra_price"
-                            onClick="() => this.selectComboItem(combo.id, comboItem)"
-                            isSelected="this.state.selectedComboItems.get(combo.id)?.id === comboItem.id"
+                            onClick="() => this.selectComboItem(combo, comboItem)"
+                            isSelected="this.getComboItemQuantity(comboItem.id) > 0"
                             isConfigurable="comboItem.is_configurable"
-                        />
+                        >
+                            <t t-if="this.showQuantityButtons(combo, comboItem)" t-set-slot="quantityButtons">
+                                <div class="mt-2">
+                                    <QuantityButtons
+                                        quantity="this.getComboItemQuantity(comboItem.id)"
+                                        setQuantity="quantity => this.setComboItemQuantity(combo, comboItem, quantity)"
+                                        isPlusButtonDisabled="this.totalQuantityForCombo(combo.id) >= combo.qty_free"
+                                        btnClasses="'d-inline-block w-auto'"
+                                    />
+                                </div>
+                            </t>
+                        </ProductCard>
                     </t>
                 </div>
             </div>

--- a/addons/sale/static/src/js/models/product_combo.js
+++ b/addons/sale/static/src/js/models/product_combo.js
@@ -4,11 +4,13 @@ export class ProductCombo {
     /**
      * @param {number} id
      * @param {string} name
+     * @param {number} qty_free
      * @param {ProductComboItem[]|object[]} combo_items
      */
-    constructor({id, name, combo_items}) {
+    constructor({id, name, qty_free, combo_items}) {
         this.id = id;
         this.name = name;
+        this.qty_free = qty_free ?? 1;
         this.combo_items = combo_items.map(item => new ProductComboItem(item));
     }
 

--- a/addons/sale/static/src/js/models/product_combo_item.js
+++ b/addons/sale/static/src/js/models/product_combo_item.js
@@ -6,14 +6,16 @@ export class ProductComboItem {
      * @param {number} extra_price
      * @param {boolean} is_preselected
      * @param {boolean} is_selected
+     * @param {number} selected_qty
      * @param {boolean} is_configurable
      * @param {ProductProduct|object} product
      */
-    constructor({id, extra_price, is_preselected, is_selected, is_configurable, product}) {
+    constructor({id, extra_price, is_preselected, is_selected, selected_qty, is_configurable, product}) {
         this.id = id;
         this.extra_price = extra_price;
         this.is_preselected = is_preselected;
         this.is_selected = is_selected;
+        this.selected_qty = selected_qty || 0;
         this.is_configurable = is_configurable;
         this.product = new ProductProduct(product);
     }

--- a/addons/sale/static/src/js/product_card/product_card.xml
+++ b/addons/sale/static/src/js/product_card/product_card.xml
@@ -33,6 +33,7 @@
                         price="this.props.extraPrice"
                         currencyId="this.env.currency.id"
                     />
+                    <t t-slot="quantityButtons"/>
                 </div>
             </article>
         </div>

--- a/addons/sale/static/src/js/quantity_buttons/quantity_buttons.xml
+++ b/addons/sale/static/src/js/quantity_buttons/quantity_buttons.xml
@@ -7,7 +7,7 @@
                 t-attf-class="px-2 px-md-3 btn btn-secondary {{ this.props.btnClasses or 'd-md-inline-block' }}"
                 aria-label="Remove one"
                 t-att-disabled="this.props.isMinusButtonDisabled"
-                t-on-click="this.decreaseQuantity"
+                t-on-click.stop="this.decreaseQuantity"
             >
                 <i class="oi oi-minus"/>
             </button>
@@ -16,6 +16,7 @@
                 name="sale_quantity"
                 type="number"
                 t-att-value="this.props.quantity"
+                t-on-click.stop=""
                 t-on-change="this.setQuantity"
             />
             <button
@@ -23,7 +24,7 @@
                 name="sale_quantity_button_plus"
                 aria-label="Add one"
                 t-att-disabled="this.props.isPlusButtonDisabled"
-                t-on-click="this.increaseQuantity"
+                t-on-click.stop="this.increaseQuantity"
             >
                 <i class="oi oi-plus"/>
             </button>

--- a/addons/sale/static/src/js/sale_product_field.js
+++ b/addons/sale/static/src/js/sale_product_field.js
@@ -295,9 +295,11 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
     async _openComboConfigurator(edit = false, hasOptionalProducts = false) {
         const saleOrder = this.props.record.model.root.data;
         const comboLineRecord = this.props.record;
+        const comboLineQuantity = comboLineRecord.data.product_uom_qty || 1;
         const comboItemLineRecords = getLinkedSaleOrderLines(comboLineRecord).filter(record => !!record.data.combo_item_id);
         const selectedComboItems = await Promise.all(comboItemLineRecords.map(async record => ({
             id: record.data.combo_item_id.id,
+            qty: Math.max(1, Math.round(record.data.product_uom_qty / comboLineQuantity)),
             no_variant_ptav_ids: edit ? this._getNoVariantPtavIds(record.data) : [],
             custom_ptavs: edit ? await this._getCustomPtavs(record.data) : [],
         })));
@@ -313,10 +315,15 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
         });
 
         const comboChoices = combos.map(combo => new ProductCombo(combo));
-        const preselectedComboItems = comboChoices
-            .map(combo => combo.preselectedComboItem)
-            .filter(Boolean);
-        if (preselectedComboItems.length === comboChoices.length) {
+        const allCombosPreselected = comboChoices.every(combo => !!combo.preselectedComboItem);
+        const preselectedComboItems = allCombosPreselected
+            ? comboChoices.map(combo => {
+                const comboItem = combo.preselectedComboItem.deepCopy();
+                comboItem.selected_qty = combo.qty_free;
+                return comboItem;
+            })
+            : [];
+        if (allCombosPreselected) {
             return this.handleComboSave(
                 { 'quantity' : remainingData.quantity },
                 preselectedComboItems,

--- a/addons/sale/static/src/js/sale_utils.js
+++ b/addons/sale/static/src/js/sale_utils.js
@@ -38,6 +38,7 @@ export function getLinkedSaleOrderLines(saleOrderLine) {
 export function serializeComboItem(comboItem) {
     return {
         combo_item_id: comboItem.id,
+        qty: comboItem.selected_qty || 1,
         product_id: comboItem.product.id,
         no_variant_attribute_value_ids: comboItem.product.selectedNoVariantPtavIds,
         product_custom_attribute_values: comboItem.product.selectedCustomPtavs.map(


### PR DESCRIPTION
This PR adds the ability to select multiple elements per combo choice in Sales and E-commerce. This feature comes from the capability to do so in the POS app. 

- Some fields have been modified or removed to make the interface clearer. 
- Fields in the Combo Choice view are dynamically shown or hidden depending on whether the user comes from the Sales application or not
- The price calculation behavior in a quotation has been modified to account for the possibility of selecting multiple elements in a combo choice (a line in the quotation with the quantity field > 1).

tasks-5943173