### PR TITLE
[FIX] mail: fix addLink url encoding

### DIFF
--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -17,25 +17,6 @@ const urlRegexp =
     /\b(?:https?:\/\/\d{1,3}(?:\.\d{1,3}){3}|(?:https?:\/\/|(?:www\.))[-a-z0-9@:%._+~#=\u00C0-\u024F\u1E00-\u1EFF]{1,256}\.[a-z]{2,13})\b(?:[-a-z0-9@:%_+~#?&[\]^|{}`\\'$//=\u00C0-\u024F\u1E00-\u1EFF]|[.]*[-a-z0-9@:%_+~#?&[\]^|{}`\\'$//=\u00C0-\u024F\u1E00-\u1EFF]|,(?!$| )|\.(?!$| |\.)|;(?!$| ))*/gi;
 
 /**
- * Escape < > & as html entities
- *
- * @param {string}
- * @return {string}
- */
-const _escapeEntities = (function () {
-    const map = { "&": "&amp;", "<": "&lt;", ">": "&gt;" };
-    const escaper = function (match) {
-        return map[match];
-    };
-    const testRegexp = RegExp("(?:&|<|>)");
-    const replaceRegexp = RegExp("(?:&|<|>)", "g");
-    return function (string) {
-        string = string == null ? "" : "" + string;
-        return testRegexp.test(string) ? string.replace(replaceRegexp, escaper) : string;
-    };
-})();
-
-/**
  * @param rawBody {string|ReturnType<markup>}
  * @param validRecords {Object}
  * @param validRecords.partners {Partner}
@@ -114,17 +95,17 @@ function linkify(text) {
     let result = "";
     let match;
     while ((match = urlRegexp.exec(text)) !== null) {
+        const url = match[0];
+        const fixedUrl = !/^https?:\/\//i.test(url) ? `http://${url}` : url;
+        if (!URL.canParse(fixedUrl)) {
+            continue;
+        }
         result = htmlJoin(result, text.slice(curIndex, match.index));
         // Decode the url first, in case it's already an encoded url
-        const url = decodeURI(match[0]);
-        const href = encodeURI(!/^https?:\/\//i.test(url) ? "http://" + url : url);
+        const { href } = URL.parse(fixedUrl);
         result = htmlJoin(
             result,
-            markup(
-                `<a target="_blank" rel="noreferrer noopener" href="${href}">${_escapeEntities(
-                    url
-                )}</a>`
-            )
+            markup`<a target="_blank" rel="noreferrer noopener" href="${href}">${url}</a>`
         );
         curIndex = match.index + match[0].length;
     }

--- a/addons/mail/static/tests/mail_utils.test.js
+++ b/addons/mail/static/tests/mail_utils.test.js
@@ -84,8 +84,27 @@ test("addLink: utility function and special entities", () => {
         ["<3", "&lt;3"],
         // Already encoded url should not be encoded twice
         [
-            markup("https://odoo.com/%5B%5D"),
-            `<a target="_blank" rel="noreferrer noopener" href="https://odoo.com/%5B%5D">https://odoo.com/[]</a>`,
+            markup`https://odoo.com/%5B%5D`,
+            `<a target="_blank" rel="noreferrer noopener" href="https://odoo.com/%5B%5D">https://odoo.com/%5B%5D</a>`,
+        ],
+        [
+            markup`https://www.odoo.com/appointment/10552?filter_appointment_type_ids=%5B6706%2C%2B6705%2C%2B5292%2C%2B10552%5D`,
+            `<a target="_blank" rel="noreferrer noopener" href="https://www.odoo.com/appointment/10552?filter_appointment_type_ids=%5B6706%2C%2B6705%2C%2B5292%2C%2B10552%5D">https://www.odoo.com/appointment/10552?filter_appointment_type_ids=%5B6706%2C%2B6705%2C%2B5292%2C%2B10552%5D</a>`,
+        ],
+        [
+            markup`www.odoo.com`,
+            `<a target="_blank" rel="noreferrer noopener" href="http://www.odoo.com/">www.odoo.com</a>`,
+        ],
+        [
+            markup`https://odoo.com/?q=ỗ`,
+            `<a target="_blank" rel="noreferrer noopener" href="https://odoo.com/?q=%E1%BB%97">https://odoo.com/?q=ỗ</a>`,
+        ],
+        [markup`http://999.999.999.999`, "http://999.999.999.999"],
+        [markup`www.example.com:999999`, "www.example.com:999999"],
+        [markup`www.example.com:abc`, "www.example.com:abc"],
+        [
+            markup`http://999.999.999.999 www.odoo.com`,
+            `http://999.999.999.999 <a target="_blank" rel="noreferrer noopener" href="http://www.odoo.com/">www.odoo.com</a>`,
         ],
     ];
 


### PR DESCRIPTION
Before this commit, the URL was fully encoded using encodeUrl.
This commit replaces this approach with the more modern [URL api](https://developer.mozilla.org/en-US/docs/Web/API/URL), which [handles encoding](https://url.spec.whatwg.org/#dom-url-href) properly.

This commit also removes decodeUrl. It was possible for a user to send a URL and have a different one displayed in the UI due to decoding.

Task-6041689
