### PR TITLE
[FIX] hr_attendance: ensure expected_hours recompute after overtime update

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -328,6 +328,7 @@ class HrAttendance(models.Model):
         self.env.add_to_compute(self._fields['overtime_hours'], all_attendances)
         self.env.add_to_compute(self._fields['validated_overtime_hours'], all_attendances)
         self.env.add_to_compute(self._fields['overtime_status'], all_attendances)
+        self.env.add_to_compute(self._fields['expected_hours'], all_attendances)
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -161,11 +161,6 @@ class TestHrAttendanceOvertime(HttpCase):
             'employee_id': self.employee.id,
             'check_in': datetime(2021, 1, 4, 8, 0)
         })
-        self.env['hr.attendance'].create({
-            'employee_id': self.other_employee.id,
-            'check_in': datetime(2021, 1, 4, 8, 0),
-            'check_out': datetime(2021, 1, 4, 22, 0)
-        })
 
         overtime = self.env['hr.attendance.overtime.line'].search([('employee_id', '=', self.employee.id), ('date', '=', date(2021, 1, 4))])
         self.assertFalse(overtime, 'No overtime record should exist for that employee')
@@ -182,6 +177,14 @@ class TestHrAttendanceOvertime(HttpCase):
         overtime = self.env['hr.attendance.overtime.line'].search([('employee_id', '=', self.employee.id), ('date', '=', date(2021, 1, 4))])
         self.assertAlmostEqual(overtime.duration, 1)
         self.assertAlmostEqual(self.employee.total_overtime, 1)
+        # Check that expected_hours is correctly calculated
+        attendance = self.env['hr.attendance'].create({
+            'employee_id': self.employee.id,
+            'check_in': datetime(2021, 1, 5, 8, 0),
+            'check_out': datetime(2021, 1, 5, 22, 0)
+        })
+        calendar = self.employee.resource_calendar_id
+        self.assertEqual(attendance.expected_hours, calendar.hours_per_day)
 
     def test_overtime_weekend(self):
         self.env['hr.attendance.overtime.rule'].create({


### PR DESCRIPTION
Steps to reproduce:
-----------------------
1. Install hr_attendance
2. Configure an employee:
   - Set contract start date (Payroll tab)
   - Configure an overtime ruleset (Settings tab)
3. Create multiple attendance records generating overtime(within the same week)
4. Go to Attendances > Reporting > Attendances (filter by day)
5. Check expected hours

Issue:
-------
Expected hours are displaying the same value as working hours, even with overtime.

Cause:
--------
https://github.com/odoo/odoo/blob/9dfd673465e4a3326a6caa64c8d61fe7319cbc44/addons/hr_attendance/models/hr_attendance.py#L287 Inside the `_update_overtime` method, existing `hr.attendance.overtime.line`
records are unlinked at the start. This triggers the [recomputation](https://github.com/odoo/odoo/blob/b509b3607cb13186985933cc4a35ef649347dbad/odoo/orm/models.py#L4218) of `overtime_hours` (setting it to 0)
before the new overtime lines are created at the end of the method. Consequently, `expected_hours`
(which depends on overtime) is calculated using this temporary 0 value, making it equal to `worked_hours`.
https://github.com/odoo/odoo/blob/9dfd673465e4a3326a6caa64c8d61fe7319cbc44/addons/hr_attendance/models/hr_attendance.py#L319

Solution:
----------
Explicitly add `expected_hours` to the computation queue (`add_to_compute`) at the end
of the `_update_overtime` method. This ensures that once the new overtime lines are successfully
created and re-calculate the correct `expected_hours` value.

opw-5408503



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
