### PR TITLE
[IMP] mail: type `Stores` return value

### DIFF
--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -532,7 +532,7 @@ class Store:
             return frozenset(Store._deep_freeze(i) for i in obj)
         return obj
 
-    class Stores(dict):
+    class Stores(dict[object | tuple, "Store"]):
         """Lazy mapping to manage a list of Store indexed by bus target.
         Store methods are forwarded to all contained Store instances."""
 


### PR DESCRIPTION
Follow up of [1], the store lazy mapping doesn't type its objects. Manipulating any objects while we know those are store objects is cumbersome.

[1]: https://github.com/odoo/odoo/pull/253668

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
