### PR TITLE
[FIX] auth_oauth: remove from USER_PRIVATE_FIELDS on uninstall

### DIFF
--- a/addons/auth_oauth/models/res_users.py
+++ b/addons/auth_oauth/models/res_users.py
@@ -16,7 +16,6 @@ from odoo.exceptions import AccessDenied, UserError
 from odoo.addons.auth_signup.models.res_users import SignupError
 
 from odoo.addons import base
-base.models.res_users.USER_PRIVATE_FIELDS.append('oauth_access_token')
 
 class ResUsers(models.Model):
     _inherit = 'res.users'
@@ -147,3 +146,7 @@ class ResUsers(models.Model):
 
     def _get_session_token_fields(self):
         return super(ResUsers, self)._get_session_token_fields() | {'oauth_access_token'}
+
+    @property
+    def USER_PRIVATE_FIELDS(self):
+        return super().USER_PRIVATE_FIELDS + ['oauth_access_token']

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -542,12 +542,16 @@ class Users(models.Model):
     def onchange_parent_id(self):
         return self.partner_id.onchange_parent_id()
 
+    @property
+    def USER_PRIVATE_FIELDS(self):
+        return list(USER_PRIVATE_FIELDS)
+
     def _fetch_query(self, query, fields):
         records = super()._fetch_query(query, fields)
-        if not set(USER_PRIVATE_FIELDS).isdisjoint(field.name for field in fields):
+        if not set(self.USER_PRIVATE_FIELDS).isdisjoint(field.name for field in fields):
             if self.check_access_rights('write', raise_exception=False):
                 return records
-            for fname in USER_PRIVATE_FIELDS:
+            for fname in self.USER_PRIVATE_FIELDS:
                 self.env.cache.update(records, self._fields[fname], repeat('********'))
         return records
 
@@ -655,14 +659,14 @@ class Users(models.Model):
     @api.model
     def _read_group_check_field_access_rights(self, field_names):
         super()._read_group_check_field_access_rights(field_names)
-        if set(field_names).intersection(USER_PRIVATE_FIELDS):
+        if set(field_names).intersection(self.USER_PRIVATE_FIELDS):
             raise AccessError(_("Invalid 'group by' parameter"))
 
     @api.model
     def _search(self, domain, offset=0, limit=None, order=None, access_rights_uid=None):
         if not self.env.su and domain:
             domain_fields = {term[0] for term in domain if isinstance(term, (tuple, list))}
-            if domain_fields.intersection(USER_PRIVATE_FIELDS):
+            if domain_fields.intersection(self.USER_PRIVATE_FIELDS):
                 raise AccessError(_('Invalid search criterion'))
         return super()._search(domain, offset, limit, order, access_rights_uid)
 
@@ -853,7 +857,7 @@ class Users(models.Model):
     def _get_invalidation_fields(self):
         return {
             'groups_id', 'active', 'lang', 'tz', 'company_id', 'company_ids',
-            *USER_PRIVATE_FIELDS,
+            *self.USER_PRIVATE_FIELDS,
             *self._get_session_token_fields()
         }
 


### PR DESCRIPTION
At install, the `auth_oauth` module adds `oauth_access_token`
to the constant list `base.models.res_users.USER_PRIVATE_FIELDS`.

At uninstall, it doesn't get removed automatically,
it stays in the list until a server restart or a worker
reload.

This causes problem when other/custom modules also add fields
to this `USER_PRIVATE_FIELDS` and then perform a read
with one of these private fields.
in `odoo/addons/base/models/res_users.py` in the method `def _fetch_query`
`self.env.cache.update(records, self._fields[fname], repeat('********'))`
raises a crash as it tries to access `self._fields['oauth_access_token']`
while it no longer exist.

Actually it's also a multi-tenant problem: If one database installs the
`auth_oauth` module on the server, `oauth_access_token` is added to the list
`USER_PRIVATE_FIELDS` for all databases, not just the one which installed
the `auth_oauth` module.

The solution is to convert this list with a property method,
and override that property method in `auth_oauth` to add
`oauth_access_token` when the module is installed.
It also solves the multi-tenant issue.

Steps to reproduce:

- Use this diff to add temporary a private field
```diff
diff --git a/odoo/addons/base/models/res_users.py b/odoo/addons/base/models/res_users.py
index 2c8da7ec529c..ac973205e6ef 100644
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -87,7 +87,7 @@ class CryptContext:

  # Only users who can modify the user (incl. the user herself) see the real contents of these fields
-USER_PRIVATE_FIELDS = []
+USER_PRIVATE_FIELDS = ['login']
  MIN_ROUNDS = 600_000
  concat = chain.from_iterable
```

- Start the server, preferably in threaded mode rather than worker mode
- Then, in the web interface, install and uninstall `auth_oauth`
- Then, using RPC, do a read on `res.users` with `login` as field

```py
import xmlrpc.client
URL, DB, UID, PASSWORD = 'http://localhost:8069', '17.0', 6, 'demo'
models = xmlrpc.client.ServerProxy('{}/xmlrpc/2/object'.format(URL))
print(models.execute_kw(DB, UID, PASSWORD, 'res.users', 'read', [[1], ['login']]))

```

```
Traceback (most recent call last):
  File "/home/odoo/src/odoo/17.0/odoo/http.py", line 2410, in __call__
    response = request._serve_db()
  File "/home/odoo/src/odoo/17.0/odoo/http.py", line 1985, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/home/odoo/src/odoo/17.0/odoo/service/model.py", line 153, in retrying
    result = func()
  File "/home/odoo/src/odoo/17.0/odoo/http.py", line 2013, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/home/odoo/src/odoo/17.0/odoo/http.py", line 2217, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/home/odoo/src/odoo/17.0/odoo/addons/base/models/ir_http.py", line 221, in _dispatch
    result = endpoint(**request.params)
  File "/home/odoo/src/odoo/17.0/odoo/http.py", line 799, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/home/odoo/src/odoo/17.0/addons/web/controllers/dataset.py", line 25, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/home/odoo/src/odoo/17.0/addons/web/controllers/dataset.py", line 21, in _call_kw
    return call_kw(Model, method, args, kwargs)
  File "/home/odoo/src/odoo/17.0/odoo/api.py", line 484, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/home/odoo/src/odoo/17.0/odoo/api.py", line 469, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/home/odoo/src/odoo/17.0/odoo/addons/base/models/res_users.py", line 1913, in read
    res = super(UsersView, self).read(other_fields, load=load)
  File "/home/odoo/src/odoo/17.0/odoo/addons/base/models/res_users.py", line 645, in read
    return super(Users, self).read(fields=fields, load=load)
  File "/home/odoo/src/odoo/17.0/odoo/models.py", line 3583, in read
    self._origin.fetch(fields)
  File "/home/odoo/src/odoo/17.0/odoo/models.py", line 3874, in fetch
    fetched = self._fetch_query(query, fields_to_fetch)
  File "/home/odoo/src/odoo/17.0/odoo/addons/base/models/res_users.py", line 551, in _fetch_query
    self.env.cache.update(records, self._fields[fname], repeat('********'))
KeyError: 'oauth_access_token'
```

opw-6042456